### PR TITLE
fix(ci): publish releases on GitHub-hosted runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
@@ -65,6 +65,8 @@ jobs:
       # publishing needs pnpm >= 11.1.3 (drops the unresolved ${NODE_AUTH_TOKEN}
       # placeholder that setup-node writes to .npmrc); 11.9.0 satisfies this.
       - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       # registry-url makes pnpm publish target npmjs; no token is set, so pnpm
       # authenticates via the OIDC id-token granted above.
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- use a GitHub-hosted runner for release publishing
- enable pnpm store caching

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/release.yaml`

Created by Codex . GPT-5
