### PR TITLE
fix(ci): reduce minimum release age to one hour

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ allowBuilds:
   '@swc/core': false
   core-js: false
 
+minimumReleaseAge: 60
 minimumReleaseAgeExclude:
   - '@posthog/browser-common@0.2.0'
   - posthog-js@1.406.2


### PR DESCRIPTION
## Summary

- set pnpm's `minimumReleaseAge` to 60 minutes
- retain the existing package-specific exclusions

## Why

Dependabot security updates can regenerate the shared lockfile with newly published transitive packages. pnpm 11's default 24-hour release-age gate then rejects the frozen lockfile before build and test jobs run. A one-hour gate keeps a meaningful publication quarantine without blocking automated security updates for a full day.

## Validation

- `pnpm config get minimum-release-age`
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check pnpm-workspace.yaml`
- `git diff --check`
- pre-push `eslint .` (0 errors; 2 existing duplicate-import warnings)

Created by Codex . GPT-5
