### PR TITLE
fix(release): add npm package repository metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0-dev",
   "description": "AgentConnect CLI — daemon version management, service install, restart/upgrade",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agentconnect-md/agentconnect.git",
+    "directory": "packages/cli"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0-dev",
   "description": "AgentConnect daemon — edge message + agent execution unit",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agentconnect-md/agentconnect.git",
+    "directory": "packages/daemon"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- add repository metadata to the npm-published daemon and CLI packages

## Validation

- `git diff --check`
- `pnpm exec prettier --check packages/daemon/package.json packages/cli/package.json`
- `npm pkg get repository` for both packages

Created by Codex . GPT-5
