### PR TITLE
fix(ci): build images within release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,11 +4,10 @@ name: Build & Push Images
 # and pushes them to GHCR tagged with the semantic-release version (the git tag:
 # `v1.2.3` stable, `v1.2.3-rc.4` prerelease). Stable releases also move `:latest`.
 #
-# Subscribes to the v* tags semantic-release pushes (rc from `main`, stable
-# from `release`) — release.yaml pushes them with a GitHub App token because the
-# built-in GITHUB_TOKEN's pushes never trigger workflows. Plain pushes to `main`
-# that don't produce a release don't build images. Manual rebuild:
-# workflow_dispatch, picking a vX.Y.Z(-rc.N) tag as the ref.
+# Called by release.yaml after semantic-release publishes a version, so image
+# publication appears in the same Release run. Plain pushes that don't produce
+# a release don't call this workflow. Manual rebuild: workflow_dispatch, picking
+# a vX.Y.Z(-rc.N) tag as the ref.
 #
 # Per-component effective versions: most releases don't touch every component,
 # and a component whose build inputs are unchanged since the previous release
@@ -30,20 +29,27 @@ name: Build & Push Images
 # repository's concern and is documented there.
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release tag produced by semantic-release'
+        required: true
+        type: string
   workflow_dispatch:
 
 concurrency:
-  group: build-${{ github.ref }}
+  group: build-${{ inputs.version || github.ref }}
   cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
+  # Bake runs after the release summary is written. Suppress its automatic job
+  # summary so the release notes remain the first summary on the Release run.
+  DOCKER_BUILD_SUMMARY: false
 
 jobs:
   build-push:
+    name: Build & push
     runs-on: self-hosted
     permissions:
       contents: read
@@ -56,24 +62,29 @@ jobs:
       mem0: ${{ steps.components.outputs.mem0 }}
       mem0Backend: ${{ steps.components.outputs.mem0Backend }}
     steps:
-      # Image tags come from the release tag this run fired on. The guard only
-      # bites manual workflow_dispatch runs: refuse anything that isn't a v*
-      # tag ref — a branch ref would mint a mutable image tag like `main` and
-      # break version→commit provenance.
+      # Reusable calls receive the tag semantic-release just published. Manual
+      # runs still derive it from the selected ref and reject branch refs, which
+      # would otherwise mint a mutable image tag such as `main`.
       - name: Resolve release version
         id: meta
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          if [ "$GITHUB_REF_TYPE" != "tag" ]; then
-            echo "::error::Must run at a release tag ref, got ${GITHUB_REF}. Re-run picking a vX.Y.Z(-rc.N) tag."
-            exit 1
+          version="$RELEASE_VERSION"
+          if [ -z "$version" ]; then
+            if [ "$GITHUB_REF_TYPE" != "tag" ]; then
+              echo "::error::Must run at a release tag ref, got ${GITHUB_REF}. Re-run picking a vX.Y.Z(-rc.N) tag."
+              exit 1
+            fi
+            version="$GITHUB_REF_NAME"
           fi
-          case "$GITHUB_REF_NAME" in
+          case "$version" in
             v[0-9]*) ;;
-            *) echo "::error::'${GITHUB_REF_NAME}' is not a vX.Y.Z(-rc.N) release tag."; exit 1 ;;
+            *) echo "::error::'${version}' is not a vX.Y.Z(-rc.N) release tag."; exit 1 ;;
           esac
-          echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           # Only stable releases (no prerelease suffix) move `:latest`.
-          case "$GITHUB_REF_NAME" in
+          case "$version" in
             *-*) echo "latest=false" >> "$GITHUB_OUTPUT" ;;
             *)   echo "latest=true"  >> "$GITHUB_OUTPUT" ;;
           esac
@@ -85,6 +96,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.version || github.ref }}
 
       # Per-component effective versions on this tag's channel (see the
       # header): a component whose inputs didn't change since the channel's
@@ -197,6 +209,7 @@ jobs:
           alias_unchanged mem0-server "$MEM0_BACKEND_EFFECTIVE"
 
   notify-workflow:
+    name: Notify workflow
     needs: build-push
     runs-on: self-hosted
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,11 @@ name: Release
 # release → stable `x.y.z` (npm dist-tag `latest`)
 # See release.config.js for the branch/channel mapping.
 #
-# Every published version also ships Docker images: semantic-release pushes the
-# vX.Y.Z(-rc.N) tag with a GitHub App installation token (minted per-run below;
-# the built-in GITHUB_TOKEN's pushes never trigger workflows, but an App token's
-# do), so the tag-push event fires build.yaml, which builds/pushes the images
-# tagged with the version and notifies the configured workflow repository,
-# which owns all downstream actions.
+# Every published version also ships Docker images: semantic-release exposes the
+# vX.Y.Z(-rc.N) tag as a job output, then this workflow calls build.yaml to
+# build/push the images and notify the configured workflow repository. Keeping
+# that call downstream of `release` also keeps the release summary first on the
+# run summary page.
 # App: needs RELEASE_APP_CLIENT_ID (var) + RELEASE_APP_PRIVATE_KEY
 # (secret), installed on this repo with Contents + Issues write.
 on:
@@ -32,6 +31,8 @@ jobs:
 
   release:
     needs: test
+    outputs:
+      version: ${{ steps.semantic-release.outputs.version }}
     # Serialize only publication, not the quality gate above. Never cancel:
     # semantic-release pushes the tag before the git note
     # (refs/notes/semantic-release), so cancellation between the two can strand
@@ -46,10 +47,9 @@ jobs:
       pull-requests: write
       id-token: write # npm OIDC trusted publishing — no NPM_TOKEN needed
     steps:
-      # Mint a short-lived GitHub App installation token. semantic-release pushes
-      # the release tag with it (see the Semantic Release step) so the tag-push
-      # fires build.yaml — a built-in GITHUB_TOKEN push wouldn't. Scoped to this
-      # repo, expires in ~1h, nothing long-lived to rotate.
+      # Mint a short-lived GitHub App installation token for semantic-release to
+      # publish the tag and stable GitHub Release. Scoped to this repo, expires
+      # in ~1h, nothing long-lived to rotate.
       - name: Mint GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -80,14 +80,12 @@ jobs:
       # build step: the daemon's prepack build compiles its workspace deps
       # (@agentconnect.md/protocol) first, so dist/ exists when the bundle runs.
       - name: Semantic Release
+        id: semantic-release
         run: pnpm exec semantic-release
         env:
-          # The App token (NOT the built-in one): semantic-release pushes every
-          # tag and creates GitHub Releases for stable versions only. Events from
-          # the built-in GITHUB_TOKEN never trigger workflows, but App-token
-          # pushes do — the v* tag push must fire build.yaml (which builds the
-          # images and notifies downstream workflow automation). Tags and stable
-          # Releases are authored by the configured release App.
+          # Tags and stable GitHub Releases are authored by the configured
+          # release App. release.config.js exposes the published tag through
+          # this step's `version` output; no-release runs leave it empty.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Stable releases only (the `release` branch): refresh the public API
@@ -105,3 +103,17 @@ jobs:
             --slug openapi.json \
             --branch stable \
             --confirm-overwrite
+
+  # build.yaml suppresses Bake's downstream auto-summary, leaving this release
+  # job as the last summary-producing job so its release notes stay at the top.
+  build-images:
+    name: Build & Push Images
+    needs: release
+    if: needs.release.outputs.version != ''
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build.yaml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit

--- a/release.config.js
+++ b/release.config.js
@@ -30,9 +30,9 @@ export default {
     ],
     [
       // Publish ONLY the daemon to npm, as the self-contained build bundle.
-      // The CP/web ship as Docker images (build.yaml), not npm packages. tsdown
-      // inlines every dependency into dist/, so the published manifest is
-      // stripped to zero runtime deps before publish.
+      // The CP/web ship as Docker images through build.yaml, not npm packages.
+      // tsdown inlines every dependency into dist/, so the published manifest
+      // is stripped to zero runtime deps before publish.
       // pnpm (not @semantic-release/npm → npm) because this is a pnpm workspace:
       // npm cannot resolve the `workspace:` protocol on the daemon's deps.
       '@semantic-release/exec',
@@ -59,14 +59,13 @@ export default {
         // the manifest changed by prepareCmd before any later release step runs.
         publishCmd:
           'sh scripts/publish-daemon-if-changed.sh "${lastRelease.gitTag}" "${nextRelease.version.includes("-") ? "rc" : "latest"}"',
-        // Write the version + notes to the GitHub Actions job summary — restores
-        // the "Release Summary" we lost when moving off cycjimmy/semantic-release-
-        // action (whose step outputs went away) to `pnpm exec semantic-release`.
-        // Notes come straight from semantic-release's release context; the quoted
-        // heredoc keeps markdown/backticks/$ literal under /bin/sh. Runs only when
-        // a release is actually published.
+        // Expose the published tag to release.yaml so image publication can run
+        // next in the same workflow. Also write the version + notes to the job
+        // summary. Both happen only when a release is actually published. Notes
+        // come straight from semantic-release's release context; the quoted
+        // heredoc keeps markdown/backticks/$ literal under /bin/sh.
         successCmd:
-          '[ -n "$GITHUB_STEP_SUMMARY" ] && cat >> "$GITHUB_STEP_SUMMARY" <<\'__ACP_NOTES__\'\n### 🚀 Released ${nextRelease.gitTag}\n\n${nextRelease.notes}\n__ACP_NOTES__\n'
+          '[ -n "$GITHUB_OUTPUT" ] && echo \'version=${nextRelease.gitTag}\' >> "$GITHUB_OUTPUT"; [ -n "$GITHUB_STEP_SUMMARY" ] && cat >> "$GITHUB_STEP_SUMMARY" <<\'__ACP_NOTES__\'\n### 🚀 Released ${nextRelease.gitTag}\n\n${nextRelease.notes}\n__ACP_NOTES__\n'
       }
     ],
     [


### PR DESCRIPTION
## Summary

- call the reusable image workflow directly after `semantic-release` publishes a version, so image jobs appear in the same Release run
- pass the published tag through a release job output and skip image work when no release is produced
- remove the automatic `v*` tag trigger while preserving manual tag rebuilds
- disable Docker Bake's automatic job summary so the release summary remains first on the run page

## Validation

- `pnpm exec prettier --check .github/workflows/build.yaml .github/workflows/release.yaml release.config.js`
- `node --check release.config.js`
- `actionlint` 1.7.12 (excluding its stale `create-github-app-token@v3` `client-id` metadata warnings)
- exercised release output/summary generation plus reusable and manual version resolution paths
- pre-push `eslint .` completed with two existing duplicate-import warnings

Created by Codex . GPT-5
