### PR TITLE
fix(github): hide repositories without user access

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -881,12 +881,10 @@ an explicit grant, so the daemon cannot name an arbitrary repository.
      no commits; choose a nonempty repository or use scratch," rather than
      sending a guaranteed-failing `--branch main` clone. Show guidance when
      the feature is disabled or no installation exists.
-   - **"Public repository URL":** preserve the existing free-form input.
-     **However,** if normalization produces the github.com host without an App
-     selection, show an inline hint: "Does this look like a private GitHub
-     repository? Use 'Select from GitHub App'." Otherwise it attempts an
-     anonymous clone and a private repository produces an opaque git
-     authentication error.
+   - **"Public repository URL":** preserve the existing free-form input only
+     when the deployment has no GitHub App configured. Once the App-backed
+     picker is enabled, do not supplement it with anonymous public-repository
+     search: every result must pass the caller's GitHub permission filter.
    - An **"Allow push (write)"** switch is enabled by default.
    - Submit `installationId` / `gitAccess` in the workspace body. Do not
      send `repoFullName`; the CP derives it from `gitRepo`. Put these fields on
@@ -1119,10 +1117,11 @@ the cache and stops requesting.
    the Logto Management API. It then uses an installation metadata token to
    query
    `GET /repos/{owner}/{repo}/collaborators/{username}/permission`, which
-   includes team- and organization-derived access. Read operations accept an
-   effective permission or a public repository; write operations require
-   write/admin. Missing identity metadata requires the user to refresh their
-   GitHub sign-in and never silently grants access.
+   includes team- and organization-derived access. Read operations require an
+   effective permission; write operations require write/admin. Public
+   visibility alone does not authorize repository selection. Missing identity
+   metadata requires the user to refresh their GitHub sign-in and never
+   silently grants access.
 
    **Remaining limits:**
 
@@ -1155,9 +1154,9 @@ the cache and stops requesting.
      both supported login shapes -> GitHub login ->
      installation metadata token ->
      `GET /repos/{o}/{r}/collaborators/{login}/permission`. For need=read,
-     accept any effective permission **or a public repository**. For
-     need=write, require write/admin. GitHub folds maintain into write and
-     triage into read; a public repository alone does not confer write.
+     require any effective permission. For need=write, require write/admin.
+     GitHub folds maintain into write and triage into read; repository
+     visibility alone does not confer either access tier.
      Missing GitHub identity, such as Google sign-in, returns
      `GITHUB_IDENTITY_REQUIRED` and never silently permits access.
    - **Enforcement points:** (1)
@@ -1175,11 +1174,11 @@ the cache and stops requesting.
      (installation, repo, login)->access for 5 minutes. All use the injected
      Clock.
    - **List filtering:** when the gateway is enabled, the repository
-     list is **filtered per user**. Public repositories are retained directly.
-     Each private repository is checked for effective permission and removed
-     on `none`, so the **name** of an unauthorized repository never reaches the
-     console. Cost model: probe only private repositories, at most 100 per
-     page, with bounded concurrency of 8, and share the same
+     list is **filtered per user**. Every repository is checked for effective
+     permission and removed on `none`, including public repositories, so the
+     **name** of an unauthorized repository never reaches the console. Cost
+     model: probe at most 100 repositories per page, with bounded concurrency
+     of 8, and share the same
      (installation, repo, login)->permission 5-minute cache with the
      branches/create gates. Cold cost is one page of Metadata:read probes per
      user every 5 minutes. A GraphQL alias batch query is the scale-up path when

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -218,6 +218,11 @@ workspace files and cannot be undone. Use an explicit `Replace workspace` save l
 for that destructive case. A working-subdirectory or access-only edit preserves the
 current checkout.
 
+GitHub App repository searches show only repositories on which the caller has an
+effective GitHub permission. Public visibility alone is not repository access. Exact
+owner/repository input must pass the same server-side gate and must not restore an
+otherwise hidden result.
+
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes
 write workspace authority for a repository must be rejected while an enabled GitHub

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -165,14 +165,16 @@ describe('GithubUserAuthzService', () => {
     })
   })
 
-  it('private + none ⇒ no read; public + none ⇒ read but never write', async () => {
+  it('none denies read regardless of repository visibility', async () => {
     const closed = authz({ login: 'me', repo: { private: true }, permission: 'none' })
     await expect(closed.svc.assertAccess('u1', INS, 'o', 'r', 'read')).rejects.toMatchObject({
       code: 'USER_NO_ACCESS'
     })
 
     const open = authz({ login: 'me', repo: { private: false }, permission: 'none' })
-    await expect(open.svc.assertAccess('u1', INS, 'o', 'r', 'read')).resolves.toMatchObject({ canRead: true })
+    await expect(open.svc.assertAccess('u1', INS, 'o', 'r', 'read')).rejects.toMatchObject({
+      code: 'USER_NO_ACCESS'
+    })
     await expect(open.svc.assertAccess('u1', INS, 'o', 'r', 'write')).rejects.toMatchObject({
       code: 'USER_NO_ACCESS'
     })
@@ -207,19 +209,20 @@ describe('GithubUserAuthzService', () => {
     expect(calls.permission).toBe(2)
   })
 
-  it('filters the repo list: public stays, readable private stays, no-access private drops', async () => {
+  it('filters the repo list by effective permission, including public repositories', async () => {
     const { svc, calls } = authz({
       login: 'me',
-      permissions: { 'o/readable': 'read', 'o/secret': 'none' }
+      permissions: { 'o/pub': 'none', 'o/public-member': 'read', 'o/readable': 'read', 'o/secret': 'none' }
     })
     const page = [
       { fullName: 'o/pub', private: false },
+      { fullName: 'o/public-member', private: false },
       { fullName: 'o/readable', private: true },
       { fullName: 'o/secret', private: true }
     ]
     const visible = await svc.filterReposForUser('u1', INS, page)
-    expect(visible.map((r) => r.fullName)).toEqual(['o/pub', 'o/readable'])
-    expect(calls.permission).toBe(2) // public repos are never probed
+    expect(visible.map((r) => r.fullName)).toEqual(['o/public-member', 'o/readable'])
+    expect(calls.permission).toBe(4)
   })
 
   it('list filter reuses the same permission cache as the gates', async () => {

--- a/packages/control-plane/src/github/user-authz.ts
+++ b/packages/control-plane/src/github/user-authz.ts
@@ -16,9 +16,9 @@
  * is an authorization gate, availability never widens it.
  *
  * Semantics (design open question #7):
- *  - need=read  ⇒ any effective permission, or the repo is public;
+ *  - need=read  ⇒ any effective permission;
  *  - need=write ⇒ effective write/admin (GitHub collapses maintain→write) —
- *    public repos do NOT satisfy write;
+ *    repository visibility alone never satisfies either tier;
  *  - no GitHub identity on the account (Google sign-in, deleted at provider)
  *    ⇒ GITHUB_IDENTITY_REQUIRED, never a silent allow;
  *  - authorization is asserted at pick/create time; the daemon keeps running
@@ -161,21 +161,22 @@ export class GithubUserAuthzService {
     return {
       permission,
       repoPrivate,
-      canRead: permission !== 'none' || !repoPrivate,
+      canRead: permission !== 'none',
       canWrite: permission === 'admin' || permission === 'write'
     }
   }
 
   /**
-   * List filter for the picker: keep public repos and private repos the caller
-   * can read on GitHub — so no-access repo NAMES never render in the console.
-   * Private repos are probed with the same cached permission unit as the gates
-   * (bounded concurrency; a cold 100-private page costs that many Metadata:read
+   * List filter for the picker: keep only repos on which the caller has an
+   * effective GitHub permission — so no-access repo NAMES never render in the
+   * console, even when the repository is public. Repos are probed with the same
+   * cached permission unit as the gates
+   * (bounded concurrency; a cold 100-repository page costs that many Metadata:read
    * calls once per user per 5 minutes — fine at realistic grant sizes, and the
    * GraphQL alias batch is the tracked upgrade if an org outgrows it). Throws
    * GITHUB_IDENTITY_REQUIRED like every other check — never a silent allow.
    */
-  async filterReposForUser<T extends { fullName: string; private: boolean }>(
+  async filterReposForUser<T extends { fullName: string }>(
     userId: string,
     ins: GithubInstallationRecord,
     repos: T[]
@@ -188,10 +189,6 @@ export class GithubUserAuthzService {
         const i = next++
         if (i >= repos.length) return
         const r = repos[i]!
-        if (!r.private) {
-          results[i] = true
-          continue
-        }
         const [owner, repo] = r.fullName.split('/')
         if (!owner || !repo) continue
         results[i] = (await this.permissionOf(login, ins, owner, repo)) !== 'none'

--- a/packages/control-plane/src/http/routes/github.ts
+++ b/packages/control-plane/src/http/routes/github.ts
@@ -258,7 +258,7 @@ export function githubRoutes(deps: HttpDeps) {
           tags: [Tag.GitHub],
           summary: 'List installation repositories',
           description:
-            'Repositories the installation is granted (paged, max 100/page). With the per-user authorization gate configured, the page is filtered to repositories the CALLER can read on GitHub (public, or any effective permission) — no-access repo names never reach the console. GitHub offers NO server-side search on this listing — the console filters client-side.',
+            'Repositories the installation is granted (paged, max 100/page). With the per-user authorization gate configured, the page is filtered to repositories on which the CALLER has an effective GitHub permission — public visibility alone does not qualify, and no-access repo names never reach the console. GitHub offers NO server-side search on this listing — the console filters client-side.',
           operationId: 'listGithubInstallationRepositories',
           params: IdParam,
           querystring: GithubRepoPageQuery,

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -102,25 +102,6 @@ function fmtAgo(iso: string): string {
   return d < 30 ? `${d}d ago` : `${Math.floor(d / 30)}mo ago`
 }
 
-type GithubApiRepo = {
-  full_name?: string
-  private?: boolean
-  default_branch?: string
-  description?: string | null
-  updated_at?: string | null
-}
-
-function repoFromGithubApi(row: GithubApiRepo): GithubRepoDto | null {
-  if (!row.full_name) return null
-  return {
-    fullName: row.full_name,
-    private: !!row.private,
-    defaultBranch: row.default_branch || 'main',
-    description: row.description ?? null,
-    updatedAt: row.updated_at ?? null
-  }
-}
-
 function githubRepoLabelFromInput(input: string): string | null {
   const raw = input
     .trim()
@@ -137,36 +118,6 @@ function githubRepoLabelFromInput(input: string): string | null {
   if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(owner)) return null
   if (!/^[a-z0-9._-]+$/i.test(repo)) return null
   return `${owner}/${repo}`
-}
-
-async function fetchPublicGithubRepo(fullName: string, signal?: AbortSignal): Promise<GithubRepoDto | null> {
-  const label = githubRepoLabelFromInput(fullName)
-  if (!label) return null
-  const res = await fetch(`https://api.github.com/repos/${label}`, { signal, cache: 'no-store' })
-  if (!res.ok) return null
-  const repo = repoFromGithubApi((await res.json()) as GithubApiRepo)
-  return repo && !repo.private ? repo : null
-}
-
-async function fetchPublicGithubBranches(fullName: string, signal?: AbortSignal): Promise<string[] | null> {
-  const label = githubRepoLabelFromInput(fullName)
-  if (!label) return null
-  const res = await fetch(`https://api.github.com/repos/${label}/branches?per_page=100`, { signal, cache: 'no-store' })
-  if (!res.ok) return null
-  const rows = (await res.json()) as Array<{ name?: string }>
-  return rows.map((r) => r.name).filter((name): name is string => !!name)
-}
-
-async function searchPublicGithubRepos(query: string, signal?: AbortSignal): Promise<GithubRepoDto[]> {
-  const q = query.trim()
-  if (q.length < 3) return []
-  const res = await fetch(
-    `https://api.github.com/search/repositories?q=${encodeURIComponent(`${q} in:name is:public`)}&per_page=5`,
-    { signal, cache: 'no-store' }
-  )
-  if (!res.ok) return []
-  const body = (await res.json()) as { items?: GithubApiRepo[] }
-  return (body.items ?? []).map(repoFromGithubApi).filter((repo): repo is GithubRepoDto => !!repo && !repo.private)
 }
 
 export default function AddAgentModal({ onClose }: { onClose: () => void }) {
@@ -226,17 +177,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [ghBranchOpen, setGhBranchOpen] = useState(false)
   const [ghAccessOpen, setGhAccessOpen] = useState(false)
   const [ghQ, setGhQ] = useState('')
-  const [ghPublicRepos, setGhPublicRepos] = useState<GithubRepoDto[]>([])
-  const [ghPublicLoading, setGhPublicLoading] = useState(false)
   // An exact owner/repo lookup through an App installation. This supplements
-  // the first page of the roster, so private repositories never fall through
-  // to anonymous public GitHub search.
+  // the paged roster without exposing repositories the caller cannot access.
   const [ghInstalledExactRepo, setGhInstalledExactRepo] = useState<(GithubRepoDto & { installationId: string }) | null>(
     null
   )
-  const [ghPublicExactRepo, setGhPublicExactRepo] = useState<GithubRepoDto | null>(null)
   const [ghExactRepoState, setGhExactRepoState] = useState<RepoCheckState>('idle')
-  const [ghManualPublicRepo, setGhManualPublicRepo] = useState<GithubRepoDto | null>(null)
   const [sharing, setSharing] = useState<SharingValue>({ visibility: 'org', sharedWith: [] })
   // Agent-call visibility: which peer agents may call this one as a sub-agent.
   // Default 'all' (the CP's default); selected callers are picked from peers.
@@ -447,76 +393,33 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     }
   }, [usingPicker, ghInstalls, ghReposNonce])
 
-  // Bonus autocomplete for public GitHub repos outside the installation grant
-  // set. The exact owner/repo free-text path below still works if GitHub search
-  // is rate-limited or unavailable in the browser.
-  useEffect(() => {
-    if (!usingPicker || !ghRepoOpen || ghQ.trim().length < 3) {
-      setGhPublicRepos([])
-      setGhPublicLoading(false)
-      return
-    }
-    const ctrl = new AbortController()
-    const t = window.setTimeout(() => {
-      setGhPublicLoading(true)
-      searchPublicGithubRepos(ghQ, ctrl.signal)
-        .then((repos) => setGhPublicRepos(repos))
-        .catch(() => setGhPublicRepos([]))
-        .finally(() => {
-          if (!ctrl.signal.aborted) setGhPublicLoading(false)
-        })
-    }, 250)
-    return () => {
-      ctrl.abort()
-      window.clearTimeout(t)
-    }
-  }, [usingPicker, ghRepoOpen, ghQ])
-
   const ghRepoQuery = ghQ.trim()
-  const typedPublicRepo = githubRepoLabelFromInput(ghRepoQuery)
+  const typedGithubRepo = githubRepoLabelFromInput(ghRepoQuery)
   const syncedRepoMatches = ghRepos.filter(
     (r) => !ghRepoQuery || r.fullName.toLowerCase().includes(ghRepoQuery.toLowerCase())
   )
-  const typedPublicRepoLower = typedPublicRepo?.toLowerCase()
-  const exactSyncedRepoMatch = typedPublicRepoLower
-    ? ghRepos.find((r) => r.fullName.toLowerCase() === typedPublicRepoLower)
+  const typedGithubRepoLower = typedGithubRepo?.toLowerCase()
+  const exactSyncedRepoMatch = typedGithubRepoLower
+    ? ghRepos.find((r) => r.fullName.toLowerCase() === typedGithubRepoLower)
     : undefined
   const exactInstalledRepoMatch =
-    typedPublicRepoLower && ghInstalledExactRepo?.fullName.toLowerCase() === typedPublicRepoLower
+    typedGithubRepoLower && ghInstalledExactRepo?.fullName.toLowerCase() === typedGithubRepoLower
       ? ghInstalledExactRepo
       : undefined
   const picked = ghRepos.find((r) => r.fullName === ghRepo)
-  const manualPublicRepo = !!ghManualPublicRepo && ghManualPublicRepo.fullName === ghRepo && !picked
-  const publicRepo = manualPublicRepo ? ghManualPublicRepo.fullName : null
-  const publicRepoMatches = ghPublicRepos.filter((r) => {
-    const fullName = r.fullName.toLowerCase()
-    return (
-      fullName !== typedPublicRepoLower &&
-      !ghRepos.some((repo) => repo.fullName.toLowerCase() === fullName) &&
-      fullName !== exactInstalledRepoMatch?.fullName.toLowerCase()
-    )
-  })
-  const canUseTypedPublicRepo =
-    !!typedPublicRepo &&
-    !exactSyncedRepoMatch &&
-    !exactInstalledRepoMatch &&
-    !!ghPublicExactRepo &&
-    ghPublicExactRepo.fullName.toLowerCase() === typedPublicRepoLower
 
   useEffect(() => {
-    if (!usingPicker || !ghRepoOpen || !typedPublicRepo || exactSyncedRepoMatch) {
+    if (!usingPicker || !ghRepoOpen || !typedGithubRepo || exactSyncedRepoMatch) {
       setGhInstalledExactRepo(null)
-      setGhPublicExactRepo(null)
       setGhExactRepoState('idle')
       return
     }
     let alive = true
     const ctrl = new AbortController()
     const t = window.setTimeout(() => {
-      const [owner, repo] = typedPublicRepo.split('/')
+      const [owner, repo] = typedGithubRepo.split('/')
       if (!owner || !repo) return
       setGhInstalledExactRepo(null)
-      setGhPublicExactRepo(null)
       setGhExactRepoState('checking')
       void Promise.all(
         ghInstalls.map(async (installation) => {
@@ -531,18 +434,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           setGhExactRepoState('found')
           return
         }
-        fetchPublicGithubRepo(typedPublicRepo, ctrl.signal)
-          .then((publicRepo) => {
-            if (!alive) return
-            setGhPublicExactRepo(publicRepo)
-            setGhExactRepoState(publicRepo ? 'found' : 'missing')
-          })
-          .catch(() => {
-            if (alive && !ctrl.signal.aborted) {
-              setGhPublicExactRepo(null)
-              setGhExactRepoState('missing')
-            }
-          })
+        setGhExactRepoState('missing')
       })
     }, 250)
     return () => {
@@ -550,14 +442,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       ctrl.abort()
       window.clearTimeout(t)
     }
-  }, [usingPicker, ghRepoOpen, ghInstalls, typedPublicRepo, exactSyncedRepoMatch])
+  }, [usingPicker, ghRepoOpen, ghInstalls, typedGithubRepo, exactSyncedRepoMatch])
 
   // The gate's two UI shapes: an outright denial (no read → block create with a
   // note), and read-but-not-write (pin the agent to read-only).
   const ghDenied = ghAccess?.gated && !ghAccess.canRead ? ghAccess : null
   const ghReadOnly = !!ghAccess?.gated && ghAccess.canRead && !ghAccess.canWrite
-  const ghPushDisabled = ghReadOnly || manualPublicRepo
-  const ghPushChecked = manualPublicRepo ? false : ghPush
 
   // A read-only user must not submit gitAccess=write — clamp the toggle state
   // itself so the request body follows.
@@ -575,21 +465,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         ? repos
         : [...repos, r]
     )
-    setGhManualPublicRepo(null)
     setGhRepo(r.fullName)
     setBranch(r.defaultBranch)
-    setGhRepoOpen(false)
-  }
-
-  const pickPublicGithubRepo = (r: GithubRepoDto) => {
-    const label = githubRepoLabelFromInput(r.fullName)
-    if (!label) return
-    setGhRepo(label)
-    setGhManualPublicRepo({ ...r, fullName: label })
-    setBranch(r.defaultBranch)
-    setGhAccess(null)
-    setGhBranches(null)
-    setGhBranchOpen(false)
     setGhRepoOpen(false)
   }
 
@@ -602,12 +479,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       pickSyncedGithubRepo(exactInstalledRepoMatch)
       return
     }
-    if (canUseTypedPublicRepo && ghPublicExactRepo) pickPublicGithubRepo(ghPublicExactRepo)
   }
 
   // Repo picked → branch to its real default (never assume 'main' for synced
-  // repos); a failed listing degrades to a free-text branch input. Manually
-  // typed public repos use anonymous GitHub reads only as a UX enhancement.
+  // repos); a failed branch listing degrades to a free-text branch input.
   useEffect(() => {
     if (!usingPicker) return
     if (!ghRepo) {
@@ -615,37 +490,14 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       setGhBranches([])
       setGhBranchOpen(false)
       setGhAccess(null)
-      setGhManualPublicRepo(null)
       return
     }
     if (!picked) {
       setGhAccess(null)
       setGhBranchOpen(false)
       setGhBranches(null)
-      const manualRepo = manualPublicRepo ? ghManualPublicRepo : null
-      if (!manualRepo) {
-        setBranch('')
-        setGhManualPublicRepo(null)
-        return
-      }
-      const label = manualRepo.fullName
-      let alive = true
-      const ctrl = new AbortController()
-      void fetchPublicGithubRepo(label, ctrl.signal)
-        .then((repo) => {
-          if (alive && repo?.defaultBranch)
-            setBranch((cur) => (!cur.trim() || cur === 'main' ? repo.defaultBranch : cur))
-        })
-        .catch(() => {})
-      void fetchPublicGithubBranches(label, ctrl.signal)
-        .then((names) => {
-          if (alive && names?.length) setGhBranches(names)
-        })
-        .catch(() => {})
-      return () => {
-        alive = false
-        ctrl.abort()
-      }
+      setBranch('')
+      return
     }
     setBranch(picked.defaultBranch)
     const [owner, repo] = picked.fullName.split('/')
@@ -662,15 +514,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     return () => {
       alive = false
     }
-  }, [
-    usingPicker,
-    ghRepo,
-    manualPublicRepo,
-    ghManualPublicRepo?.fullName,
-    picked?.defaultBranch,
-    picked?.fullName,
-    picked?.installationId
-  ])
+  }, [usingPicker, ghRepo, picked?.defaultBranch, picked?.fullName, picked?.installationId])
 
   const submit = async () => {
     // The name input sanitizes as you type, so finalize only trims a trailing
@@ -688,11 +532,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       return
     }
     if (usingPicker && !ghRepo) {
-      setErr('Pick a repository, type an authorized GitHub repository, or switch to “From scratch”.')
+      setErr('Pick a repository, or switch to “From scratch”.')
       return
     }
-    if (usingPicker && !picked && !publicRepo) {
-      setErr('Type an authorized GitHub repository as owner/repo, or pick a synced repository.')
+    if (usingPicker && !picked) {
+      setErr('Pick a repository you can access on GitHub.')
       return
     }
     if (usingPicker && ghDenied) {
@@ -725,21 +569,14 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     const workspace: AgentWorkspaceDto =
       wsMode === 'github'
         ? usingPicker
-          ? picked
-            ? {
-                mode: 'github',
-                gitRepo: picked.fullName, // owner/repo — the CP normalizes to the full address
-                ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
-                ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
-                installationId: picked.installationId,
-                gitAccess: ghPush ? ('write' as const) : ('read' as const)
-              }
-            : {
-                mode: 'github',
-                gitRepo: publicRepo ?? ghRepo.trim(),
-                ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
-                ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
-              }
+          ? {
+              mode: 'github',
+              gitRepo: picked!.fullName, // guarded above; the CP normalizes owner/repo to the full address
+              ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
+              ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
+              installationId: picked!.installationId,
+              gitAccess: ghPush ? ('write' as const) : ('read' as const)
+            }
           : {
               mode: 'github',
               gitRepo: repo.trim(),
@@ -825,7 +662,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   else if (!daemon) blockers.basics = 'no daemon available'
   if (usingPicker && !ghRepo) blockers.workspace = 'pick a repository'
   else if (usingPicker && ghDenied) blockers.workspace = 'no access to this repository'
-  else if (usingPicker && !picked && !publicRepo) blockers.workspace = 'pick a repository'
+  else if (usingPicker && !picked) blockers.workspace = 'pick a repository'
   else if (wsMode === 'github' && !usingPicker && !repo.trim()) blockers.workspace = 'add a repository'
   if (memoryProvider === 'external' && !externalMemory.connectionId) blockers.memory = 'select a connection'
   const firstBlocker = SECTIONS.find((s) => blockers[s.id])
@@ -1099,9 +936,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   <GithubConnectedBanner onManage={manageGithubAccess} />
 
                   <GithubRepositoryField
-                    value={picked?.fullName ?? publicRepo ?? ''}
+                    value={picked?.fullName ?? ''}
                     icon={picked?.private ? 'lock' : 'book-marked'}
-                    badge={manualPublicRepo ? 'public' : undefined}
                     loading={ghLoading}
                     open={ghRepoOpen}
                     query={ghQ}
@@ -1145,7 +981,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       </>
                     }
                   >
-                    {ghExactRepoState === 'checking' && typedPublicRepo && !exactSyncedRepoMatch && (
+                    {ghExactRepoState === 'checking' && typedGithubRepo && !exactSyncedRepoMatch && (
                       <div className="px-2 py-[7px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
                         Checking GitHub repository…
                       </div>
@@ -1158,16 +994,6 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                         description="Available through the GitHub App"
                         selected={ghRepo === exactInstalledRepoMatch.fullName}
                         onSelect={() => pickSyncedGithubRepo(exactInstalledRepoMatch)}
-                      />
-                    )}
-                    {canUseTypedPublicRepo && ghPublicExactRepo && (
-                      <GithubRepositoryOption
-                        key={`public:${ghPublicExactRepo.fullName}`}
-                        fullName={ghPublicExactRepo.fullName}
-                        icon="book-marked"
-                        description="Use public repository"
-                        selected={ghRepo === ghPublicExactRepo.fullName}
-                        onSelect={() => pickPublicGithubRepo(ghPublicExactRepo)}
                       />
                     )}
                     {syncedRepoMatches.map((repo) => (
@@ -1185,54 +1011,29 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                         onSelect={() => pickSyncedGithubRepo(repo)}
                       />
                     ))}
-                    {publicRepoMatches.map((repo) => (
-                      <GithubRepositoryOption
-                        key={`public-search:${repo.fullName}`}
-                        fullName={repo.fullName}
-                        icon="book-marked"
-                        description={
-                          <>
-                            {repo.description ?? 'Public GitHub repository'}
-                            {repo.updatedAt ? ` · updated ${fmtAgo(repo.updatedAt)}` : ''}
-                          </>
-                        }
-                        selected={ghRepo === repo.fullName}
-                        onSelect={() => pickPublicGithubRepo(repo)}
-                      />
-                    ))}
-                    {ghPublicLoading && (
-                      <div className="px-2 py-[7px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                        Searching public repositories…
-                      </div>
-                    )}
-                    {!canUseTypedPublicRepo &&
-                      !exactInstalledRepoMatch &&
+                    {!exactInstalledRepoMatch &&
                       ghExactRepoState !== 'checking' &&
-                      !ghPublicLoading &&
                       !ghReposFailed &&
                       ghRepoQuery &&
-                      syncedRepoMatches.length === 0 &&
-                      publicRepoMatches.length === 0 && (
+                      syncedRepoMatches.length === 0 && (
                         <div className="fnohit">
-                          {typedPublicRepo && ghExactRepoState === 'missing'
-                            ? `No GitHub repository found for "${typedPublicRepo}"`
+                          {typedGithubRepo && ghExactRepoState === 'missing'
+                            ? `No accessible GitHub repository found for "${typedGithubRepo}"`
                             : `No repositories match "${ghQ}"`}
                         </div>
                       )}
                   </GithubRepositoryField>
 
                   <RepositoryAccessField
-                    repositorySelected={!!picked || manualPublicRepo}
-                    value={ghPushChecked ? 'write' : 'read'}
+                    repositorySelected={!!picked}
+                    value={ghPush ? 'write' : 'read'}
                     open={ghAccessOpen}
-                    readOnly={ghPushDisabled}
+                    readOnly={ghReadOnly}
                     readOnlyNote={
-                      ghPushDisabled ? (
+                      ghReadOnly ? (
                         <span className="mt-[6px] inline-flex items-start gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                           <Icon name="info" size={13} className="mt-[1px] flex-none" />
-                          {manualPublicRepo
-                            ? 'Public repository — read-only clone.'
-                            : 'You have read-only access to this repository on GitHub.'}
+                          You have read-only access to this repository on GitHub.
                         </span>
                       ) : undefined
                     }

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -211,10 +211,7 @@ export default function AddAgentRepoModal({
 
   const q1 = q.trim().toLowerCase()
   const matches = (repos ?? []).filter((r) => !q1 || r.fullName.toLowerCase().includes(q1))
-  // A typed owner/repo missing from a failed or stale roster refresh — the CP
-  // re-validates it against the installations either way.
   const typedRepo = /^[^/\s]+\/[^/\s]+$/.test(q.trim()) ? q.trim() : null
-  const typedIsListed = !!typedRepo && matches.some((r) => r.fullName.toLowerCase() === typedRepo.toLowerCase())
   const typedTaken = !!typedRepo && (isWorkspace(typedRepo) || isAuthorized(typedRepo))
 
   const canSubmit = !!pick && !isWorkspace(pick) && !isAuthorized(pick) && !uncovered && !probeDenies
@@ -425,26 +422,6 @@ export default function AddAgentRepoModal({
                           </button>
                         )
                       })}
-                      {typedRepo && !typedIsListed && !typedTaken && (
-                        <button
-                          key={`typed:${typedRepo}`}
-                          className="fopt min-h-[46px] items-center gap-3 px-2 py-2"
-                          onClick={() => {
-                            setPick(typedRepo)
-                            setPickOpen(false)
-                          }}
-                        >
-                          <Icon name="book-marked" size={16} color="var(--text-tertiary)" className="flex-none" />
-                          <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
-                            <span className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)">
-                              {typedRepo}
-                            </span>
-                            <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                              Use this repository — must be covered by an installation
-                            </span>
-                          </span>
-                        </button>
-                      )}
                       {typedRepo && typedTaken && (
                         <div className="fnohit">
                           {isWorkspace(typedRepo)
@@ -452,7 +429,7 @@ export default function AddAgentRepoModal({
                             : `${typedRepo} is already authorized`}
                         </div>
                       )}
-                      {repos !== null && matches.length === 0 && !typedRepo && !reposError && (
+                      {repos !== null && matches.length === 0 && !typedTaken && !reposError && (
                         <div className="fnohit">No repositories match &ldquo;{q}&rdquo;</div>
                       )}
                       {repos === null && (

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -207,10 +207,6 @@ export default function EditWorkspaceModal({
 
   const q1 = q.trim().toLowerCase()
   const matches = (repos ?? []).filter((r) => !q1 || r.fullName.toLowerCase().includes(q1))
-  // A typed owner/repo missing from a failed or stale roster refresh — the CP
-  // re-validates it against the installations either way.
-  const typedRepo = /^[^/\s]+\/[^/\s]+$/.test(q.trim()) ? q.trim() : null
-  const typedIsListed = !!typedRepo && matches.some((r) => r.fullName.toLowerCase() === typedRepo.toLowerCase())
 
   let normalizedAgentDir: string | undefined
   let agentDirError: string | null = null
@@ -409,16 +405,7 @@ export default function EditWorkspaceModal({
                       />
                     )
                   })}
-                  {typedRepo && !typedIsListed && (
-                    <GithubRepositoryOption
-                      key={`typed:${typedRepo}`}
-                      fullName={typedRepo}
-                      icon="book-marked"
-                      description="Use this repository — must be covered by an installation"
-                      onSelect={() => selectRepo(typedRepo)}
-                    />
-                  )}
-                  {repos !== null && matches.length === 0 && !typedRepo && !reposError && (
+                  {repos !== null && matches.length === 0 && !reposError && (
                     <div className="fnohit">No repositories match &ldquo;{q}&rdquo;</div>
                   )}
                   {repos === null && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2969,7 +2969,7 @@ export async function fetchGithubRepos(
   }, signal)
 }
 
-/** Load the complete App-visible repository roster for client-side searching.
+/** Load the complete caller-visible repository roster for client-side searching.
  *  GitHub exposes only pagination here, so fetch the remaining pages after the
  *  first response reveals the installation's total repository count. */
 export async function fetchAllGithubRepos(installationId: string, signal?: AbortSignal): Promise<GithubRepoDto[]> {


### PR DESCRIPTION
## Summary

- Require an effective GitHub repository permission before a repository appears in App-backed pickers, including public repositories.
- Remove anonymous public-repository search and unverified typed-result fallbacks from workspace and repository selectors.
- Document the visibility invariant and cover public repositories with and without effective user permission.

## Root cause

Public repository visibility was treated as read access by the user-authorization service. The Add Agent flow also queried GitHub's public search directly, so a user whose effective repository permission had become `none` could still see and select a public repository.

## Impact

Users removed from a GitHub organization or repository no longer see that repository in AgentConnect search results merely because it is public. Read, write, and admin permissions continue to expose the repository at the appropriate tier.

## Validation

- `pnpm --filter @agentconnect.md/control-plane test:unit` (596 tests)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web test` (254 tests)
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm lint` (0 errors; 2 pre-existing warnings in `icon-upload.ts`)
- Targeted Prettier and ESLint checks

Created by Codex . GPT-5
