### PR TITLE
ci: parallelize tests on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Reuse the same two-job quality gate as pull requests. The reusable workflow
-  # runs Build & Test and Integration tests in parallel against this exact SHA;
-  # the publishing job below cannot start unless both succeed.
+  # Reuse the same quality gate as pull requests. The reusable workflow runs
+  # Build & Check, Unit Test, and sharded Integration tests in parallel against
+  # this exact SHA; the publishing job below waits for all of them.
   test:
     name: Test
     uses: ./.github/workflows/test.yaml
@@ -93,7 +93,7 @@ jobs:
       # GitHub orders job summaries by job completion. The quality-gate jobs
       # therefore return their markdown instead of publishing it before this
       # job starts; append it only after semantic-release writes the notes.
-      - name: Append Build & Test summary
+      - name: Append Unit Test summary
         if: ${{ !cancelled() && needs.test.outputs.build_test_summary != '' }}
         env:
           TEST_SUMMARY: ${{ needs.test.outputs.build_test_summary }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   # Reuse the same quality gate as pull requests. The reusable workflow runs
-  # Build & Check, Unit Test, and sharded Integration tests in parallel against
+  # Build, Check, Unit Test, and sharded Integration tests in parallel against
   # this exact SHA; the publishing job below waits for all of them.
   test:
     name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
   # per-test timeouts measure code rather than runner scheduling delay.
   test:
     name: Build & Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
@@ -52,6 +52,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -118,7 +120,7 @@ jobs:
   # No build needed — the suite resolves workspace deps from source.
   integration:
     name: Integration tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
@@ -128,6 +130,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,11 @@ on:
         default: false
     outputs:
       build_test_summary:
-        description: 'Build and unit test summary markdown'
-        value: ${{ jobs.test.outputs.summary }}
+        description: 'Unit test summary markdown'
+        value: ${{ jobs.unit.outputs.summary }}
       integration_test_summary:
         description: 'Integration test summary markdown'
-        value: ${{ jobs.integration.outputs.summary }}
+        value: ${{ format('{0}{1}', jobs.integration.outputs.summary_1, jobs.integration.outputs.summary_2) }}
 
 # Cancel superseded runs for the same PR (a newer push makes the old one moot).
 # Reusable release-gate calls use a run-scoped group so their tests can proceed
@@ -31,20 +31,15 @@ concurrency:
   group: test-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Keep the Docker-bound integration suite separate from static checks and unit
-# tests so either workload can be scheduled independently.
+# Keep static checks, Docker-free unit tests, and the Docker-bound integration
+# suite separate so all three workloads can be scheduled independently.
 jobs:
-  # Build + all static analysis + the fast (Docker-free) unit tests. The tsc and
-  # Next builds already typecheck their packages; the parallel no-emit check only
-  # covers daemon (tsdown) and control-plane files excluded from its production build.
-  # Prisma is generated once before the group, and CI skips duplicate pre-hooks.
-  # Unit tests run after the resource-heavy build/static group so their short
-  # per-test timeouts measure code rather than runner scheduling delay.
-  test:
-    name: Build & Test
+  # The tsc and Next builds already typecheck their packages; the parallel
+  # no-emit check only covers daemon (tsdown) and control-plane files excluded
+  # from their production builds. CI skips duplicate pre-hooks.
+  build:
+    name: Build & Check
     runs-on: ubuntu-latest
-    outputs:
-      summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,21 +73,45 @@ jobs:
         env:
           pnpm_config_enable_pre_post_scripts: false
         run: pnpm --workspace-concurrency=5 run "/^(build|lint|format:check|typecheck:ci)$/"
+
+  # Keep the fast, Docker-free suites away from the resource-heavy build group
+  # so their short per-test timeouts measure code rather than runner contention.
+  unit:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    outputs:
+      summary: ${{ steps.export-summary.outputs.markdown }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Generate Prisma client
+        run: pnpm -r prisma:generate
       - name: Unit tests
         env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm test:unit
       - name: Evaluation contracts
         env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
           PROMPTFOO_DISABLE_TELEMETRY: '1'
         run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm eval:contracts
       - name: Merge unit test summaries
         if: ${{ !cancelled() }}
         env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
           GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
@@ -106,34 +125,39 @@ jobs:
       - name: Publish unit test summary
         if: ${{ !cancelled() && !inputs.defer_summaries }}
         env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
         run: cat "$CAPTURED_JOB_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
       - name: Export unit test summary
         id: export-summary
         if: ${{ !cancelled() && inputs.defer_summaries }}
         env:
-          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
         run: |
           {
-            echo 'markdown<<__AGENTCONNECT_BUILD_TEST_SUMMARY__'
+            echo 'markdown<<__AGENTCONNECT_UNIT_TEST_SUMMARY__'
             cat "$CAPTURED_JOB_SUMMARY"
-            echo '__AGENTCONNECT_BUILD_TEST_SUMMARY__'
+            echo '__AGENTCONNECT_UNIT_TEST_SUMMARY__'
           } >> "$GITHUB_OUTPUT"
 
   # control-plane integration tests against a real Postgres booted by
   # Testcontainers. Each Vitest worker gets an isolated database cloned from one
   # migrated template, so files run concurrently without cross-test TRUNCATEs.
-  # It needs Docker, so it gets its own runner off the critical path.
+  # Each shard needs Docker, so it gets its own runner off the critical path.
   # No build needed — the suite resolves workspace deps from source.
   integration:
     name: Integration tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     outputs:
-      summary: ${{ steps.export-summary.outputs.markdown }}
+      summary_1: ${{ steps.export-summary.outputs.summary_1 }}
+      summary_2: ${{ steps.export-summary.outputs.summary_2 }}
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/2', '2/2']
+        include:
+          - shard: '1/2'
+            summary_output: summary_1
+          - shard: '2/2'
+            summary_output: summary_2
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -176,7 +200,7 @@ jobs:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
         run: |
           {
-            echo 'markdown<<__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
+            echo '${{ matrix.summary_output }}<<__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
             cat "$CAPTURED_JOB_SUMMARY"
             echo '__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,14 +31,11 @@ concurrency:
   group: test-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Keep static checks, Docker-free unit tests, and the Docker-bound integration
-# suite separate so all three workloads can be scheduled independently.
+# Keep builds, static checks, Docker-free unit tests, and the Docker-bound
+# integration suite separate so all four workloads can be scheduled independently.
 jobs:
-  # The tsc and Next builds already typecheck their packages; the parallel
-  # no-emit check only covers daemon (tsdown) and control-plane files excluded
-  # from their production builds. CI skips duplicate pre-hooks.
   build:
-    name: Build & Check
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,6 +58,33 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Install
         run: pnpm install --frozen-lockfile
+      - name: Generate Prisma client
+        run: pnpm -r prisma:generate
+      - name: Build
+        env:
+          pnpm_config_enable_pre_post_scripts: false
+        run: pnpm build
+
+  # The tsc and Next builds already typecheck their packages; the parallel
+  # no-emit check only covers daemon (tsdown) and control-plane files excluded
+  # from their production builds. CI skips duplicate pre-hooks.
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install
+        run: pnpm install --frozen-lockfile
       # Run before any workspace build so source-checkout export resolution
       # cannot be accidentally masked by protocol/connection dist artifacts.
       - name: Evaluation config validation · clean checkout
@@ -69,10 +93,10 @@ jobs:
         run: pnpm eval:validate
       - name: Generate Prisma client
         run: pnpm -r prisma:generate
-      - name: Build · Lint · Format · Typecheck
+      - name: Lint · Format · Typecheck
         env:
           pnpm_config_enable_pre_post_scripts: false
-        run: pnpm --workspace-concurrency=5 run "/^(build|lint|format:check|typecheck:ci)$/"
+        run: pnpm --workspace-concurrency=5 run "/^(lint|format:check|typecheck:ci)$/"
 
   # Keep the fast, Docker-free suites away from the resource-heavy build group
   # so their short per-test timeouts measure code rather than runner contention.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,13 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Restore Next.js build cache
+        uses: actions/cache@v6
+        with:
+          path: packages/web/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/web/**') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Install
         run: pnpm install --frozen-lockfile
       # Run before any workspace build so source-checkout export resolution
@@ -119,10 +126,14 @@ jobs:
   # It needs Docker, so it gets its own runner off the critical path.
   # No build needed — the suite resolves workspace deps from source.
   integration:
-    name: Integration tests
+    name: Integration tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     outputs:
       summary: ${{ steps.export-summary.outputs.markdown }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -143,7 +154,7 @@ jobs:
         env:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm --filter @agentconnect.md/control-plane test:int
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm --filter @agentconnect.md/control-plane test:int --shard=${{ matrix.shard }}
       - name: Merge integration test summaries
         if: ${{ !cancelled() }}
         env:
@@ -151,7 +162,7 @@ jobs:
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
           GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
-            'Integration test report' \
+            'Integration test report · shard ${{ matrix.shard }}' \
             'control-plane=@agentconnect.md/control-plane'
       - name: Publish integration test summary
         if: ${{ !cancelled() && !inputs.defer_summaries }}


### PR DESCRIPTION
## Summary

- run CI workloads on GitHub-hosted `ubuntu-latest` runners
- enable pnpm store caching for the ephemeral runners
- split integration tests across two native Vitest shards that run in parallel
- persist `packages/web/.next/cache` across GitHub-hosted runs
- split the former `Build & Test` job into parallel `Build`, `Check`, and
  `Unit Test` jobs; `Unit Test` also owns the evaluation contract suite
- preserve deferred unit and integration summaries for reusable release runs

## Benchmark

Across the five most recent successful self-hosted runs before this change:

- `Build & Test`: median 2m31s (range 2m27s–2m37s)
- `Integration tests`: median 2m03s (range 1m45s–2m57s)

Both GitHub-hosted attempts restored the existing 726 MB pnpm cache:

| Job | Self-hosted baseline | GitHub-hosted attempt 1 | GitHub-hosted attempt 2 |
| --- | --- | --- | --- |
| `Build & Test` | 2m31s median | 3m09s (+25%) | 3m48s (+51%) |
| `Integration tests` | 2m03s median | 2m57s (+44%) | 3m04s (+50%) |

After sharding integration tests and adding the Next.js cache:

| Attempt | `Build & Test` | Integration `1/2` | Integration `2/2` | Integration critical path |
| --- | --- | --- | --- | --- |
| cold Next.js cache | 4m00s | 1m42s | 2m12s | 2m12s |
| warm Next.js cache | 3m42s | 1m32s | 2m02s | 2m02s |

Integration sharding reduced the GitHub-hosted critical path by 25–34% versus
the two unsharded attempts and brought it in line with the 2m03s self-hosted
median. Both shards passed in both attempts.

The warm run confirmed an exact Next.js cache hit and removed Next's
`No build cache found` warning. In this sample, however, the production compile
was effectively unchanged (32.1s cold, 32.8s warm); the combined
build/lint/format/typecheck step moved from 95s to 92s.

After splitting build/static checks from unit/evaluation tests, one complete
GitHub-hosted run measured:

| `Build & Check` | `Unit Test` | Integration `1/2` | Integration `2/2` | Workflow critical path |
| --- | --- | --- | --- | --- |
| 2m29s | 1m59s | 1m40s | 2m12s | 2m29s |

Compared with the preceding warm-cache monolithic `Build & Test` run, the
critical path fell from 3m42s to 2m29s (73s / 33%) and is effectively level with
the original 2m31s self-hosted median.

After splitting `Build & Check` into independent jobs, the next complete run
measured:

| `Build` | `Check` | `Unit Test` | Integration `1/2` | Integration `2/2` | Workflow critical path |
| --- | --- | --- | --- | --- | --- |
| 1m22s | 1m48s | 1m55s | 2m15s | 2m03s | 2m15s |

The build/check split removed another 14s (9%) from the preceding 2m29s
critical path. `Build` and `Check` are now both below two minutes; the slowest
integration shard determines the workflow duration.

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/test.yaml .github/workflows/release.yaml`
- workflow YAML structure assertions
- standalone `Build` command
- standalone `Check` command group
- full `pnpm test:unit`
- evaluation contracts: 8 files, 39 tests passed
- local integration shard `1/2`: 27 files, 269 tests passed
- local integration shard `2/2`: 27 files, 329 tests passed
- final five-job GitHub-hosted workflow passed
- pre-push `eslint .` (0 errors; 2 pre-existing duplicate-import warnings in `icon-upload.ts`)

Created by Codex . GPT-5
