### PR TITLE
fix(ci): put release summary first

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  # Bake runs after the release summary is written. Suppress its automatic job
-  # summary so the release notes remain the first summary on the Release run.
-  DOCKER_BUILD_SUMMARY: false
 
 jobs:
   build-push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,9 @@ name: Release
 #
 # Every published version also ships Docker images: semantic-release exposes the
 # vX.Y.Z(-rc.N) tag as a job output, then this workflow calls build.yaml to
-# build/push the images and notify the configured workflow repository. Keeping
-# that call downstream of `release` also keeps the release summary first on the
-# run summary page.
+# build/push the images and notify the configured workflow repository. Test
+# summaries are deferred to the release job so its release notes are written
+# first on the run summary page.
 # App: needs RELEASE_APP_CLIENT_ID (var) + RELEASE_APP_PRIVATE_KEY
 # (secret), installed on this repo with Contents + Issues write.
 on:
@@ -28,6 +28,8 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yaml
+    with:
+      defer_summaries: true
 
   release:
     needs: test
@@ -88,6 +90,20 @@ jobs:
           # this step's `version` output; no-release runs leave it empty.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # GitHub orders job summaries by job completion. The quality-gate jobs
+      # therefore return their markdown instead of publishing it before this
+      # job starts; append it only after semantic-release writes the notes.
+      - name: Append Build & Test summary
+        if: ${{ !cancelled() && needs.test.outputs.build_test_summary != '' }}
+        env:
+          TEST_SUMMARY: ${{ needs.test.outputs.build_test_summary }}
+        run: printf '\n---\n\n%s\n' "$TEST_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+      - name: Append integration test summary
+        if: ${{ !cancelled() && needs.test.outputs.integration_test_summary != '' }}
+        env:
+          TEST_SUMMARY: ${{ needs.test.outputs.integration_test_summary }}
+        run: printf '\n---\n\n%s\n' "$TEST_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
       # Stable releases only (the `release` branch): refresh the public API
       # reference on ReadMe using the configured external API contract.
       - name: Publish API docs to ReadMe
@@ -104,8 +120,7 @@ jobs:
             --branch stable \
             --confirm-overwrite
 
-  # build.yaml suppresses Bake's downstream auto-summary, leaving this release
-  # job as the last summary-producing job so its release notes stay at the top.
+  # Docker Bake publishes its own downstream summary after the release card.
   build-images:
     name: Build & Push Images
     needs: release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,19 @@ on:
   # Release calls this workflow as its quality gate for main/release pushes.
   # Keeping the jobs here avoids duplicating CI logic between PRs and releases.
   workflow_call:
+    inputs:
+      defer_summaries:
+        description: 'Return job summaries to the caller instead of publishing them here'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      build_test_summary:
+        description: 'Build and unit test summary markdown'
+        value: ${{ jobs.test.outputs.summary }}
+      integration_test_summary:
+        description: 'Integration test summary markdown'
+        value: ${{ jobs.integration.outputs.summary }}
 
 # Cancel superseded runs for the same PR (a newer push makes the old one moot).
 # Reusable release-gate calls use a run-scoped group so their tests can proceed
@@ -30,6 +43,8 @@ jobs:
   test:
     name: Build & Test
     runs-on: self-hosted
+    outputs:
+      summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -56,19 +71,22 @@ jobs:
         run: pnpm --workspace-concurrency=5 run "/^(build|lint|format:check|typecheck:ci)$/"
       - name: Unit tests
         env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: pnpm test:unit
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm test:unit
       - name: Evaluation contracts
         env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
           PROMPTFOO_DISABLE_TELEMETRY: '1'
-        run: pnpm eval:contracts
-      - name: Publish unit test summary
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm eval:contracts
+      - name: Merge unit test summaries
         if: ${{ !cancelled() }}
         env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
-          node scripts/merge-vitest-summaries.mjs \
+          GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
             'Unit test report' \
             'protocol=@agentconnect.md/protocol' \
             'connection=@agentconnect.md/connection' \
@@ -76,6 +94,22 @@ jobs:
             'relay=@agentconnect.md/relay' \
             'daemon=@agentconnect.md/daemon' \
             'cli=@agentconnect.md/cli'
+      - name: Publish unit test summary
+        if: ${{ !cancelled() && !inputs.defer_summaries }}
+        env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+        run: cat "$CAPTURED_JOB_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+      - name: Export unit test summary
+        id: export-summary
+        if: ${{ !cancelled() && inputs.defer_summaries }}
+        env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/build-test-summary.md
+        run: |
+          {
+            echo 'markdown<<__AGENTCONNECT_BUILD_TEST_SUMMARY__'
+            cat "$CAPTURED_JOB_SUMMARY"
+            echo '__AGENTCONNECT_BUILD_TEST_SUMMARY__'
+          } >> "$GITHUB_OUTPUT"
 
   # control-plane integration tests against a real Postgres booted by
   # Testcontainers. Each Vitest worker gets an isolated database cloned from one
@@ -85,6 +119,8 @@ jobs:
   integration:
     name: Integration tests
     runs-on: self-hosted
+    outputs:
+      summary: ${{ steps.export-summary.outputs.markdown }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -101,13 +137,31 @@ jobs:
         run: pnpm -r prisma:generate
       - name: Integration tests
         env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: pnpm --filter @agentconnect.md/control-plane test:int
-      - name: Publish integration test summary
+        run: GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" pnpm --filter @agentconnect.md/control-plane test:int
+      - name: Merge integration test summaries
         if: ${{ !cancelled() }}
         env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
-          node scripts/merge-vitest-summaries.mjs \
+          GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
             'Integration test report' \
             'control-plane=@agentconnect.md/control-plane'
+      - name: Publish integration test summary
+        if: ${{ !cancelled() && !inputs.defer_summaries }}
+        env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
+        run: cat "$CAPTURED_JOB_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+      - name: Export integration test summary
+        id: export-summary
+        if: ${{ !cancelled() && inputs.defer_summaries }}
+        env:
+          CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/integration-test-summary.md
+        run: |
+          {
+            echo 'markdown<<__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
+            cat "$CAPTURED_JOB_SUMMARY"
+            echo '__AGENTCONNECT_INTEGRATION_TEST_SUMMARY__'
+          } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed

- defer the two Test job summaries when the reusable workflow is called by Release
- publish the release notes first, then append the captured Build & Test and Integration reports to the release job summary
- restore Docker Bake's automatic build summary

## Why

GitHub groups job summaries by job completion time. The quality-gate jobs finish before the release job, so their summaries appeared above the release information. Disabling Docker's later summary did not address that ordering.

With this change, the quality gate still runs before publication, but it no longer publishes an earlier summary during Release runs. The release card is therefore first and starts with the release notes; test reports follow in the same card, and the Docker build summary remains available afterward. Pull-request Test runs keep their existing standalone summaries.

## Validation

- Prettier check for all changed workflows
- YAML parse for all changed workflows
- actionlint v1.7.12
- structural assertions for reusable outputs, release step order, and restored Docker summary
- pre-push ESLint (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
