### PR TITLE
fix(web): preserve Slack manifest through new app flow

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -56,7 +56,13 @@ import {
   type HookReportingMode,
   type HookReviewPolicy
 } from '@/lib/github-review-settings'
-import { slackAppIdFromAppToken, slackAppOAuthUrl, slackAppSettingsUrl, slackCreateAppUrl } from '@/lib/slack-manifest'
+import {
+  slackAppIdFromAppToken,
+  slackAppOAuthUrl,
+  slackAppSettingsUrl,
+  slackCreateAppUrl,
+  slackManifestJson
+} from '@/lib/slack-manifest'
 import { agentIconBackgroundColor } from '@/lib/agent-icon'
 import { discordApplicationIdFromToken, discordBotInviteUrl } from '@/lib/discord-invite'
 
@@ -584,6 +590,7 @@ export default function AddIntegrationModal({
     backgroundColor: agentIconBackgroundColor(agent.icon),
     ...(relayPublicUrl ? { relayUrl: relayPublicUrl } : {})
   }
+  const manifestJson = slackManifestJson(manifestNames, manifestOpts)
   const createUrl = slackCreateAppUrl(manifestNames, manifestOpts)
 
   // Webhook path: create the hook (secret always minted), then flip to the reveal
@@ -1949,8 +1956,8 @@ export default function AddIntegrationModal({
               </div>
             ) : (
               <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-                {/* Step 1 — create & install from our manifest. The app name is
-                    prefilled INTO the manifest (agent name), so no name field here. */}
+                {/* Step 1 — create & install from our manifest. The agent name is
+                    built into the manifest, so no separate name field here. */}
                 <div className="mb-3 flex gap-[10px]">
                   <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
                     1
@@ -1963,16 +1970,18 @@ export default function AddIntegrationModal({
                       href={createUrl}
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={() => void navigator.clipboard?.writeText?.(manifestJson)?.catch?.(() => {})}
                       className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
                     >
                       <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
                         <PlatformMark platform="slack" />
                       </span>
-                      Add to Slack with manifest
+                      Copy manifest &amp; open Slack
                       <Icon name="external-link" size={14} />
                     </a>
                     <div className="mt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                      Opens Slack with our manifest prefilled. Install the app, then paste its tokens.
+                      In Slack, choose <span className="font-medium text-(--text-secondary)">From a manifest</span>,
+                      paste, select a workspace, then create and install the app.
                     </div>
                     <SlackDeliveryLine
                       transport={effTransport}

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildSlackManifest } from './slack-manifest'
+import { buildSlackManifest, slackCreateAppUrl } from './slack-manifest'
 
 describe('buildSlackManifest', () => {
   it('brands the app with the given background_color, and omits it otherwise', () => {
@@ -8,5 +8,12 @@ describe('buildSlackManifest', () => {
     // A color (from the owning agent's icon) ⇒ display_information.background_color.
     const branded = buildSlackManifest({ name: 'acme' }, { backgroundColor: '#c62a78' })
     expect(branded.display_information.background_color).toBe('#c62a78')
+  })
+
+  it('prefills the Slack create-app link with the manifest', () => {
+    const url = new URL(slackCreateAppUrl({ name: 'acme' }))
+
+    expect(url.searchParams.get('new_app')).toBe('1')
+    expect(JSON.parse(url.searchParams.get('manifest_json')!)).toEqual(buildSlackManifest({ name: 'acme' }))
   })
 })

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -1,7 +1,6 @@
-// The Slack app manifest AgentConnect installs from. A user creates their own
-// Slack app pre-filled with this manifest (the "create app from manifest" deep
-// link below), installs it to their workspace, then pastes the tokens back into
-// the Add-integration modal.
+// The Slack app manifest AgentConnect installs from. The create-app link includes
+// it for Slack's documented prefill flow; the UI also copies it as a fallback for
+// Slack's newer creation dialog, which currently drops the prefilled value.
 //
 // TWO transports, selected via `buildSlackManifest`'s `mode` option:
 //   - `socket` (default): the daemon opens a Socket Mode connection with the
@@ -153,8 +152,9 @@ export function slackManifestJson(names: SlackAppNames, opts?: SlackManifestOpts
 }
 
 /**
- * Slack's "create a new app from a manifest" deep link. Opens api.slack.com with
- * the manifest pre-loaded so the user only has to pick a workspace and create.
+ * Slack's documented "create a new app from a manifest" deep link. Slack's newer
+ * creation dialog currently drops the prefilled value, so callers should also
+ * offer the manifest on the clipboard as a fallback.
  */
 export function slackCreateAppUrl(names: SlackAppNames, opts?: SlackManifestOpts): string {
   const manifest = encodeURIComponent(JSON.stringify(buildSlackManifest(names, opts)))


### PR DESCRIPTION
## Summary

- keep Slack's documented `manifest_json` deep link intact for accounts where URL prefill still works
- copy the same manifest when opening Slack so users on the new creation flow can paste it into **From a manifest**
- update the setup guidance and add coverage for the deep-link payload

## Root cause

Slack's new app-creation UI still receives the manifest from the URL, but the new template-picker path drops that initial value before rendering the manifest editor. This leaves affected users with an empty editor even though the documented URL is valid.

## User impact

Creating a personal Slack app remains one click. Existing/older Slack flows can prefill normally; affected users have the manifest ready on their clipboard and concise paste instructions.

## Validation

- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/slack-manifest.test.ts`
- `pnpm exec eslint packages/web/src/lib/slack-manifest.ts packages/web/src/lib/slack-manifest.test.ts packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit`
- `pnpm --filter @agentconnect.md/web build`
- pre-push repository lint (passes with two pre-existing warnings)

Created by Codex . GPT-5
