### PR TITLE
fix(ci): trigger full image rebuild after alias failure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1.7
+
 #
 # Unified image build for the deployable services. The build context is the repo
 # root; pick a service with --target:

--- a/docker/mem0-backend.Dockerfile
+++ b/docker/mem0-backend.Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
+#
 # AgentConnect's pinned build of the upstream Mem0 OSS REST server.
 #
 # `mem0_source` is a BuildKit named context supplied by docker-bake.hcl. It is


### PR DESCRIPTION
## Summary

- Add one blank line to `docker/Dockerfile` to trigger a one-time rebuild of control plane, web, relay, and the Mem0 wrapper.
- Add one bare `#` line to `docker/mem0-backend.Dockerfile` so the separately built Mem0 backend is rebuilt in the same release without changing behavior.
- Leave `scripts/component-versions.sh` unchanged.

## Root cause

The previous release built only the changed web image, then failed while aliasing an older control-plane tag whose manifest was missing. The external Mem0 backend's effective historical tag is also missing, so both Dockerfile paths need a no-op change for the next release to publish a complete image set.

## Validation

- Simulated the expected next RC tag and verified `controlPlane`, `web`, `relay`, `mem0`, and `mem0Backend` all resolve to that new tag.
- `git diff --check origin/main...HEAD`
- Confirmed the PR diff contains only one blank line, one bare `#`, and no resolver changes.
- `pnpm exec prettier --check docker/Dockerfile docker/mem0-backend.Dockerfile`
- Pre-push `eslint .` completed with 0 errors and 2 pre-existing duplicate-import warnings.

Created by Codex . GPT-5
