### PR TITLE
fix(daemon): drop pending Telegram backlog on connect

### DIFF
--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -170,7 +170,13 @@ function defaultFactory(token: string): TelegramBotHandle {
       bot.on('callback_query:data', (ctx) => handler(ctx.callbackQuery as unknown as TelegramCallbackQuery))
     },
     start(onStart) {
-      void bot.start(onStart ? { onStart: () => onStart() } : undefined)
+      // drop_pending_updates: on (re)connect, skip the backlog Telegram buffered while
+      // this daemon was down. grammY otherwise resumes from the last un-acked getUpdates
+      // offset and replays stale updates — and since a fresh top-level @mention keys a new
+      // session on its own message_id (canonicalizeTelegramThread), each replayed mention
+      // would mint a duplicate session. We trade at-least-once for at-most-once here:
+      // messages sent during a brief restart are dropped rather than answered late.
+      void bot.start({ drop_pending_updates: true, ...(onStart ? { onStart: () => onStart() } : {}) })
     },
     stop: () => bot.stop()
   }
@@ -253,7 +259,7 @@ export class TelegramConnection {
       log?.debug(`telegram: setMyCommands failed: ${(err as Error).message}`)
     }
 
-    log?.debug('telegram: bot.start → opening long-poll (getUpdates)…')
+    log?.debug('telegram: bot.start → opening long-poll (getUpdates), dropping pending backlog…')
     this.bot.start(() => log?.debug('telegram: long-poll established'))
   }
 

--- a/packages/daemon/test/telegram-connection.test.ts
+++ b/packages/daemon/test/telegram-connection.test.ts
@@ -10,6 +10,21 @@ import {
 import type { TelegramMessage } from '../src/telegram/normalize.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
+// Capture the options grammY's real Bot.start() receives, so we can assert the
+// default factory drops the pending backlog on connect (regression: replayed stale
+// @mentions each minted a duplicate session).
+const { startSpy } = vi.hoisted(() => ({ startSpy: vi.fn() }))
+vi.mock('grammy', () => ({
+  Bot: class {
+    api = {}
+    botInfo = { id: 1, username: 'grammybot' }
+    init = vi.fn(async () => {})
+    on = vi.fn()
+    start = startSpy
+    stop = vi.fn(async () => {})
+  }
+}))
+
 function fakeApi(over: Partial<TelegramApi> = {}): TelegramApi {
   return {
     sendMessage: vi.fn(async () => ({ message_id: 777 })),
@@ -125,6 +140,20 @@ describe('TelegramConnection.start', () => {
       'permission',
       'queue'
     ])
+  })
+
+  it('drops the pending backlog on connect (default grammY factory)', async () => {
+    startSpy.mockClear()
+    // No injected factory → exercises defaultFactory, which builds the mocked grammY Bot.
+    const conn = new TelegramConnection({
+      group: { botToken: 'TKN', integrations: [{ agentId: 'a1', integrationId: 'i1' }] },
+      onMessage: () => {},
+      newTraceId: () => 'trace-x',
+      sendIntervalMs: 0
+    })
+    await conn.start()
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy.mock.calls[0]![0]).toMatchObject({ drop_pending_updates: true })
   })
 
   it('start() survives a setMyCommands failure (best-effort menu)', async () => {


### PR DESCRIPTION
## Problem

A single Telegram `@cs_bot hello` produced **two** agent sessions. Investigating the live data, the two sessions came from **two distinct Telegram messages** (`message_id` 26 and 92, both `hello`, same sender/agent/daemon) processed in the same 07:05:24 burst — with different thread keys (`tg:26` / `tg:92`), so the `(platform, channel, thread)` session key never deduped them.

The older message (`26`) had **not** been processed when it was originally sent — its session row was created at 07:05:24, not earlier. It sat unprocessed until the daemon reconnected, then flushed alongside the freshly-sent `92`.

## Root cause

`TelegramConnection` started grammY long-polling with no options:

```js
void bot.start(onStart ? { onStart: () => onStart() } : undefined)
```

grammY then resumes from Telegram's last un-acknowledged `getUpdates` offset and **replays the buffered backlog** on every (re)connect. Since a fresh top-level `@mention` keys a brand-new session on its own `message_id` (`canonicalizeTelegramThread` → `tg:<message_id>`), each replayed stale mention mints a duplicate session.

## Fix

Start long-polling with `drop_pending_updates: true` in the default grammY factory, so a reconnecting daemon skips anything Telegram buffered while it was down.

**Tradeoff:** at-least-once → at-most-once. Messages sent during a brief restart are dropped rather than answered late (and duplicated). A future follow-up could persist the `getUpdates` offset across restarts for exactly-once instead.

## Testing

- Added a regression test that mocks grammY and asserts `Bot.start()` is called with `{ drop_pending_updates: true }`.
- `pnpm --filter @agentconnect.md/daemon test` (telegram-connection): 18/18 pass.
- `pnpm --filter @agentconnect.md/daemon typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)