### PR TITLE
ci(docker): build images on GitHub runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,13 @@ name: Build & Push Images
 # creating redundant downstream workflow work. scripts/component-versions.sh
 # computes, per component, the most recent same-channel tag (rc walks rc tags,
 # stable walks stable tags) that actually changed it. Changed components build
-# concurrently in one Buildx Bake invocation; unchanged components skip the
-# build and instead get this release's tag as an ALIAS of their effective image
-# (same manifest digest), so `<comp>:<version>` exists for every component at
-# every release regardless.
+# concurrently on separate GitHub-hosted runners. `docker-bake.hcl` remains the
+# source of truth for each target's Dockerfile, args, labels, contexts, tags, and
+# platform; the prepare job renders it into the dynamic matrix consumed by
+# Docker's official build-push action. Unchanged components skip the build and
+# instead get this release's tag as an ALIAS of their effective image (same
+# manifest digest), so `<comp>:<version>` exists for every component at every
+# release regardless.
 #
 # After pushing, mints a short-lived GitHub App token for the configured
 # workflow repository and fires an `images-pushed` repository_dispatch
@@ -45,14 +48,16 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-push:
-    name: Build & push
-    runs-on: self-hosted
+  prepare:
+    name: Prepare image builds
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     outputs:
       version: ${{ steps.meta.outputs.version }}
+      latest: ${{ steps.meta.outputs.latest }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_builds: ${{ steps.build-matrix.outputs.has_builds }}
       controlPlane: ${{ steps.components.outputs.controlPlane }}
       web: ${{ steps.components.outputs.web }}
       relay: ${{ steps.components.outputs.relay }}
@@ -104,11 +109,21 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: bash scripts/component-versions.sh "$VERSION" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Select changed image targets
-        id: build-targets
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Render the existing Bake definition so image-specific configuration
+      # stays centralized there even though each target builds in its own job.
+      # The non-empty fallback keeps strategy.matrix valid when all components
+      # are unchanged; has_builds prevents that sentinel from allocating a runner.
+      - name: Select changed image matrix
+        id: build-matrix
         shell: bash
         env:
+          OWNER: ${{ github.repository_owner }}
           VERSION: ${{ steps.meta.outputs.version }}
+          LATEST: ${{ steps.meta.outputs.latest }}
+          GIT_SHA: ${{ github.sha }}
           CP_EFFECTIVE: ${{ steps.components.outputs.controlPlane }}
           WEB_EFFECTIVE: ${{ steps.components.outputs.web }}
           RELAY_EFFECTIVE: ${{ steps.components.outputs.relay }}
@@ -116,13 +131,90 @@ jobs:
           MEM0_BACKEND_EFFECTIVE: ${{ steps.components.outputs.mem0Backend }}
         run: |
           set -euo pipefail
-          targets=()
-          [ "$CP_EFFECTIVE" = "$VERSION" ] && targets+=(control-plane)
-          [ "$RELAY_EFFECTIVE" = "$VERSION" ] && targets+=(relay)
-          [ "$WEB_EFFECTIVE" = "$VERSION" ] && targets+=(web)
-          [ "$MEM0_EFFECTIVE" = "$VERSION" ] && targets+=(mem0)
-          [ "$MEM0_BACKEND_EFFECTIVE" = "$VERSION" ] && targets+=(mem0-backend)
-          (IFS=,; echo "targets=${targets[*]}" >> "$GITHUB_OUTPUT")
+          changed='[]'
+          add_changed() {
+            changed="$(jq -cn \
+              --argjson current "$changed" \
+              --arg target "$1" \
+              '$current + [$target]')"
+          }
+
+          [ "$CP_EFFECTIVE" = "$VERSION" ] && add_changed control-plane
+          [ "$RELAY_EFFECTIVE" = "$VERSION" ] && add_changed relay
+          [ "$WEB_EFFECTIVE" = "$VERSION" ] && add_changed web
+          [ "$MEM0_EFFECTIVE" = "$VERSION" ] && add_changed mem0
+          [ "$MEM0_BACKEND_EFFECTIVE" = "$VERSION" ] && add_changed mem0-backend
+
+          bake_config="${RUNNER_TEMP}/agentconnect-image-bake.json"
+          docker buildx bake --print > "$bake_config"
+          matrix="$(jq -c --argjson targets "$changed" '
+            [
+              $targets[] as $name
+              | .target[$name] as $config
+              | {
+                  target: $name,
+                  context: ($config.context // "."),
+                  dockerfile: ($config.dockerfile // "Dockerfile"),
+                  build_target: ($config.target // ""),
+                  platforms: (($config.platforms // []) | join(",")),
+                  tags: (($config.tags // []) | join("\n")),
+                  build_args: (
+                    ($config.args // {})
+                    | to_entries
+                    | map("\(.key)=\(.value)")
+                    | join("\n")
+                  ),
+                  build_contexts: (
+                    ($config.contexts // {})
+                    | to_entries
+                    | map("\(.key)=\(.value)")
+                    | join("\n")
+                  ),
+                  labels: (
+                    ($config.labels // {})
+                    | to_entries
+                    | map("\(.key)=\(.value)")
+                    | join("\n")
+                  ),
+                  cache_ref: (
+                    $config.tags[0]
+                    | sub(":[^/]+$"; ":buildcache")
+                  )
+                }
+            ]
+          ' "$bake_config")"
+
+          if [ "$matrix" = '[]' ]; then
+            echo "has_builds=false" >> "$GITHUB_OUTPUT"
+            matrix='[{"target":"none","context":".","dockerfile":"docker/Dockerfile","build_target":"","platforms":"linux/amd64","tags":"","build_args":"","build_contexts":"","labels":"","cache_ref":""}]'
+          else
+            echo "has_builds=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "matrix=$(jq -cn --argjson include "$matrix" '{include: $include}')" >> "$GITHUB_OUTPUT"
+
+  build-images:
+    name: Build & push ${{ matrix.target }}
+    needs: prepare
+    if: ${{ needs.prepare.outputs.has_builds == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    # Registry cache refs are mutable performance hints. Serialize each target
+    # across release runs so two channels cannot overwrite one simultaneously.
+    concurrency:
+      group: image-build-${{ matrix.target }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.version }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -133,30 +225,56 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          name: agentconnect-images
-          keep-state: true
-          cleanup: false
 
-      # One Bake invocation gives BuildKit all changed targets at once, so it
-      # schedules them concurrently while deduplicating their shared base and
-      # manifest stages. If no component changed, Bake is skipped and the
-      # release tags are aliased below.
-      - name: Build & push changed images in parallel
-        if: steps.build-targets.outputs.targets != ''
-        uses: docker/bake-action@v7
-        # Bake reads declared variables from the environment. Keep them out of
-        # the action's `vars` input because older Buildx releases do not support
-        # `buildx bake --var`.
-        env:
-          OWNER: ${{ github.repository_owner }}
-          VERSION: ${{ steps.meta.outputs.version }}
-          LATEST: ${{ steps.meta.outputs.latest }}
-          GIT_SHA: ${{ github.sha }}
+      # A target-specific registry cache keeps all intermediate builder layers
+      # (`mode=max`) without consuming the GitHub Actions cache quota.
+      - name: Build and push
+        uses: docker/build-push-action@v7
         with:
-          source: .
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.build_target }}
+          platforms: ${{ matrix.platforms }}
           push: true
-          targets: ${{ steps.build-targets.outputs.targets }}
+          tags: ${{ matrix.tags }}
+          build-args: ${{ matrix.build_args }}
+          build-contexts: ${{ matrix.build_contexts }}
+          labels: ${{ matrix.labels }}
+          cache-from: type=registry,ref=${{ matrix.cache_ref }}
+          cache-to: type=registry,ref=${{ matrix.cache_ref }},mode=max
+
+  finalize:
+    name: Finalize image tags
+    needs:
+      - prepare
+      - build-images
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        (needs.build-images.result == 'success' || needs.build-images.result == 'skipped')
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      version: ${{ needs.prepare.outputs.version }}
+      controlPlane: ${{ needs.prepare.outputs.controlPlane }}
+      web: ${{ needs.prepare.outputs.web }}
+      relay: ${{ needs.prepare.outputs.relay }}
+      mem0: ${{ needs.prepare.outputs.mem0 }}
+      mem0Backend: ${{ needs.prepare.outputs.mem0Backend }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
 
       # Components skipped above still get this release's tag: an alias of the
       # effective image (imagetools create adds tags to the SAME manifest
@@ -177,13 +295,13 @@ jobs:
       # avoid.
       - name: Alias unchanged components to this release tag
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
-          LATEST: ${{ steps.meta.outputs.latest }}
-          CP_EFFECTIVE: ${{ steps.components.outputs.controlPlane }}
-          WEB_EFFECTIVE: ${{ steps.components.outputs.web }}
-          RELAY_EFFECTIVE: ${{ steps.components.outputs.relay }}
-          MEM0_EFFECTIVE: ${{ steps.components.outputs.mem0 }}
-          MEM0_BACKEND_EFFECTIVE: ${{ steps.components.outputs.mem0Backend }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          LATEST: ${{ needs.prepare.outputs.latest }}
+          CP_EFFECTIVE: ${{ needs.prepare.outputs.controlPlane }}
+          WEB_EFFECTIVE: ${{ needs.prepare.outputs.web }}
+          RELAY_EFFECTIVE: ${{ needs.prepare.outputs.relay }}
+          MEM0_EFFECTIVE: ${{ needs.prepare.outputs.mem0 }}
+          MEM0_BACKEND_EFFECTIVE: ${{ needs.prepare.outputs.mem0Backend }}
           OWNER: ${{ github.repository_owner }}
         run: |
           set -eu
@@ -207,8 +325,8 @@ jobs:
 
   notify-workflow:
     name: Notify workflow
-    needs: build-push
-    runs-on: self-hosted
+    needs: finalize
+    runs-on: ubuntu-latest
     steps:
       - name: Resolve workflow repository
         id: workflow-repository
@@ -245,13 +363,13 @@ jobs:
         env:
           DISPATCH_TOKEN: ${{ steps.workflow-app-token.outputs.token }}
           WORKFLOW_REPOSITORY: ${{ secrets.WORKFLOW_REPOSITORY }}
-          VERSION: ${{ needs.build-push.outputs.version }}
+          VERSION: ${{ needs.finalize.outputs.version }}
           SHA: ${{ github.sha }}
-          CP: ${{ needs.build-push.outputs.controlPlane }}
-          WEB: ${{ needs.build-push.outputs.web }}
-          RELAY: ${{ needs.build-push.outputs.relay }}
-          MEM0: ${{ needs.build-push.outputs.mem0 }}
-          MEM0_BACKEND: ${{ needs.build-push.outputs.mem0Backend }}
+          CP: ${{ needs.finalize.outputs.controlPlane }}
+          WEB: ${{ needs.finalize.outputs.web }}
+          RELAY: ${{ needs.finalize.outputs.relay }}
+          MEM0: ${{ needs.finalize.outputs.mem0 }}
+          MEM0_BACKEND: ${{ needs.finalize.outputs.mem0Backend }}
         run: |
           curl --fail-with-body -sS -X POST \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \


### PR DESCRIPTION
## Summary

- move image builds from the self-hosted runner to a dynamic GitHub-hosted matrix
- build each changed image with Docker's official build-push action and an image-specific GHCR registry cache in mode=max
- keep docker-bake.hcl as the image configuration source of truth
- preserve the existing behavior that unchanged images are not rebuilt and only receive manifest aliases

## Validation

- rendered and asserted relay-only, no-build, and all-image stable matrices
- verified web build args and Mem0 backend context, args, labels, and cache refs survive Bake rendering
- actionlint 1.7.12 (excluding two stale create-github-app-token v3 metadata diagnostics verified against the current upstream action.yml)
- Prettier
- ESLint (0 errors; 2 pre-existing import warnings)
- git diff --check

Created by Codex . GPT-5
