### PR TITLE
fix(web): hide bot platform tab scrollbar

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -633,7 +633,11 @@ function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | n
 
   return (
     <div className="card mt-[18px]">
-      <div className="cardhead gap-0 overflow-x-auto py-0" role="tablist" aria-label="Bot platform">
+      <div
+        className="cardhead gap-0 overflow-x-auto py-0 [scrollbar-width:none] desktop:overflow-x-visible [&::-webkit-scrollbar]:hidden"
+        role="tablist"
+        aria-label="Bot platform"
+      >
         {BOT_PLATFORMS.map((item) => {
           const selected = item.platform === platform
           return (


### PR DESCRIPTION
## Summary

- keep the IM bot platform tabs out of a scroll container on desktop
- retain horizontal scrolling on narrow screens while hiding the cosmetic scrollbar

## Root cause

`overflow-x-auto` also made the tab strip's computed vertical overflow `auto`. The selected tab underline extends 1px into the card border, so that harmless vertical overflow produced a visible scrollbar.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `git diff --check`
- local visual verification at desktop width and a 320px mobile viewport

Created by Codex . GPT-5
