### PR TITLE
fix(orchestration): preserve workspace edits across reconnects

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -119,6 +119,7 @@ import { replayMemoryConnectionsTo, syncMemoryConnectionsToDaemons } from './orc
 import { relayHttpOrigin } from './orchestrator/mcpProvider.js'
 import { CollabRoutesService } from './orchestrator/collabRoutes.service.js'
 import { AgentMutationGate } from './orchestrator/agentMutationGate.js'
+import { AgentMoveService } from './orchestrator/agentMove.js'
 import { ExclusiveMutationGate } from './orchestrator/exclusiveMutationGate.js'
 import { createDaemonWsServer } from './ws/gateway.js'
 import type { DaemonWsServerDeps } from './ws/gateway.js'
@@ -401,6 +402,23 @@ export function buildContainer(
       debug: (o, m) => http.log.debug(o, m)
     }
   )
+  const stagedAgentMoves = new AgentMoveService({
+    agents: repos.agent,
+    assignments: repos.assignment,
+    integrations: repos.integration,
+    integrationChannels: repos.integrationChannel,
+    bots: repos.bot,
+    botSecrets: repos.botSecret,
+    specs: agentSpecs,
+    crons: repos.cron,
+    control: sender,
+    hooks: hookService,
+    sharedBot,
+    collabRoutes,
+    mutations: agentMutations,
+    sessionOwners: connReg,
+    log: { warn: (o, m) => http.log.warn(o, m) }
+  })
 
   // C3 orchestrator with the live placement/rebalance surface fully wired.
   const orchestrator = new Placement(
@@ -750,6 +768,7 @@ export function buildContainer(
     integration: repos.integration,
     integrationChannel: repos.integrationChannel,
     agentMutations,
+    recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),
     collabRoutes,
     cron: repos.cron,
     hook: repos.hook,

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -27,6 +27,7 @@ const CRON = CronId('44444444-4444-4444-8444-444444444444')
 const MODIFIED_AT = new Date('2026-07-11T00:00:00.000Z')
 const SESSION_KEY = { platform: 'slack' as const, channel: 'C-move', thread: 'T-move' }
 const WORKSPACE_REPO_ID = 4242n
+const STAGED_MOVE = '77777777-7777-4777-8777-777777777777'
 const GITHUB_WORKSPACE = {
   mode: 'github',
   gitRepo: 'https://github.com/acme/repo.git',
@@ -256,6 +257,14 @@ function make(
 }
 
 describe('AgentMoveService', () => {
+  it('reconciles workspace materialization during placement repair', async () => {
+    const t = make({ workspace: GITHUB_WORKSPACE })
+
+    await expect(t.service.ensureActive(t.current())).resolves.toMatchObject({ daemonId: SOURCE })
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]?.reconcileWorkspace).toBe(true)
+  })
+
   it('detaches source, bootstraps the complete target bundle, and activates last', async () => {
     const t = make()
     const moved = await t.service.move(t.current(), TARGET)
@@ -406,6 +415,37 @@ describe('AgentMoveService', () => {
         .slice(0, 2)
         .map((value) => value.moveId)
     ).toEqual(targetActivations.map((value) => value.moveId))
+  })
+
+  it('waits behind the interrupted mutation then resumes its exact staged token', async () => {
+    const t = make()
+    const releaseInterrupted = t.mutations.tryBeginMove(AGENT)!
+
+    const recovery = t.service.recoverStaged(AGENT, SOURCE, STAGED_MOVE)
+    await Promise.resolve()
+    expect(t.activations).toEqual([])
+
+    releaseInterrupted()
+    await recovery
+    expect(t.detaches).toEqual([])
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]).toMatchObject({
+      agentId: AGENT,
+      moveId: STAGED_MOVE,
+      reconcileWorkspace: true
+    })
+    expect(t.calls).toEqual([`activate:${SOURCE}`, 'hooks', 'collab'])
+  })
+
+  it('supersedes a staged token when its one-shot workspace guard rejects resume', async () => {
+    const t = make({ rejectWorkspaceActivate: true })
+
+    await t.service.recoverStaged(AGENT, SOURCE, STAGED_MOVE)
+    expect(t.activations).toHaveLength(2)
+    expect(t.activations[0]?.moveId).toBe(STAGED_MOVE)
+    expect(t.detaches).toHaveLength(1)
+    expect(t.detaches[0]?.moveId).toBe(t.activations[1]?.moveId)
+    expect(t.activations[1]?.moveId).not.toBe(STAGED_MOVE)
   })
 
   it('serializes concurrent moves and rejects mutations while the first move holds the gate', async () => {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -145,6 +145,17 @@ export class AgentMoveService {
     return this.withMoveGate(agent.id, async () => this.ensureActiveLocked(await this.reloadAfterGate(agent)))
   }
 
+  /** Resume a durable daemon-side staging fence reported during register. The
+   * queued gate waits for the request that lost its socket to settle first, then
+   * re-checks authoritative placement before sending any activation material. */
+  async recoverStaged(agentId: AgentId, daemonId: DaemonId, moveId: string): Promise<void> {
+    try {
+      await this.recoverStagedOnce(agentId, daemonId, moveId)
+    } catch (err) {
+      this.deps.log?.warn({ err, agentId, daemonId }, 'agent move: staged reconnect recovery failed')
+    }
+  }
+
   async move(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
     return this.withMoveGate(agent.id, async () =>
       this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor)
@@ -187,11 +198,52 @@ export class AgentMoveService {
     }
   }
 
+  private async recoverStagedOnce(agentId: AgentId, daemonId: DaemonId, moveId: string): Promise<void> {
+    const release = await this.deps.mutations.beginMoveWhenIdle(agentId)
+    try {
+      const current = await this.deps.agents.get(agentId)
+      if (!current || current.daemonId !== daemonId) return
+
+      const candidate = await this.snapshotOwned(agentId, daemonId)
+      const resumed = await this.deps.control.agentActivate(daemonId, {
+        ...this.activationDefinition(candidate.agent, candidate.bundle),
+        moveId,
+        reconcileWorkspace: true
+      })
+
+      let stable: ActivationSnapshot
+      if (resumed.ok) {
+        const observed = await this.snapshotOwned(agentId, daemonId)
+        if (candidate.fingerprint === observed.fingerprint) {
+          const confirmed = await this.deps.agents.get(agentId)
+          if (!confirmed || confirmed.daemonId !== daemonId) return this.failClosedOwnership(agentId, daemonId)
+          stable = { ...observed, agent: confirmed }
+        } else {
+          stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', {
+            reconcileWorkspace: true
+          })
+        }
+      } else {
+        // A conversion may have crashed after swapping its checkout, where the
+        // old token retains a one-shot empty-workspace guard. A fresh generic
+        // token safely supersedes that fence and completes from current CP state.
+        stable = await this.activateUntilStable(agentId, daemonId, 'staged reconnect recovery', {
+          reconcileWorkspace: true
+        })
+      }
+      await this.convergeDerived(stable.agent, stable.bundle.sharedBotIds)
+    } finally {
+      release()
+    }
+  }
+
   private async ensureActiveLocked(agent: AgentRecord): Promise<AgentRecord> {
     if (!agent.daemonId) throw new AgentMoveConflict('agent is not placed')
     let stable: ActivationSnapshot
     try {
-      stable = await this.activateUntilStable(agent.id, agent.daemonId, 'target repair')
+      stable = await this.activateUntilStable(agent.id, agent.daemonId, 'target repair', {
+        reconcileWorkspace: true
+      })
     } catch (err) {
       if (err instanceof AgentMoveFailed) throw err
       throw new AgentMoveFailed('target daemon repair failed', err)

--- a/packages/control-plane/src/orchestrator/agentMutationGate.ts
+++ b/packages/control-plane/src/orchestrator/agentMutationGate.ts
@@ -3,41 +3,79 @@
  *
  * Agent moves take the exclusive side. Ordinary agent/integration/cron writes
  * take the shared side, so they may still run concurrently with each other but
- * never overlap a cold move. Acquisition never waits: callers return 409 and
- * let the operator retry against fresh state.
+ * never overlap a cold move. User-initiated acquisition never waits: callers
+ * return 409 and let the operator retry against fresh state. Reconnect recovery
+ * may queue one of the same exclusive moves behind the interrupted request.
  *
  * This matches the current single-control-plane deployment. A future multi-CP
  * topology must replace it with a distributed lock or transactional lease.
  */
 export class AgentMutationGate {
-  private readonly states = new Map<string, { moving: boolean; mutations: number }>()
+  private readonly states = new Map<
+    string,
+    { moving: boolean; mutations: number; moveWaiters: Array<(release: () => void) => void> }
+  >()
 
   tryBeginMove(agentId: string): (() => void) | null {
     const state = this.states.get(agentId)
-    if (state?.moving || (state?.mutations ?? 0) > 0) return null
-    this.states.set(agentId, { moving: true, mutations: 0 })
-    return this.releaseOnce(() => this.states.delete(agentId))
+    if (state) return null
+    this.states.set(agentId, { moving: true, mutations: 0, moveWaiters: [] })
+    return this.moveRelease(agentId)
+  }
+
+  /** Queue an internal recovery behind the current holder and reserve the next
+   * exclusive slot so new user mutations cannot overtake it. */
+  beginMoveWhenIdle(agentId: string): Promise<() => void> {
+    const release = this.tryBeginMove(agentId)
+    if (release) return Promise.resolve(release)
+    return new Promise((resolve) => {
+      this.states.get(agentId)!.moveWaiters.push(resolve)
+    })
   }
 
   tryBeginMutation(agentIds: string | readonly string[]): (() => void) | null {
     const ids = [...new Set(typeof agentIds === 'string' ? [agentIds] : agentIds)].sort()
-    if (ids.some((id) => this.states.get(id)?.moving)) return null
+    if (ids.some((id) => (this.states.get(id)?.moveWaiters.length ?? 0) > 0 || this.states.get(id)?.moving)) return null
     for (const id of ids) {
       const state = this.states.get(id)
-      this.states.set(id, { moving: false, mutations: (state?.mutations ?? 0) + 1 })
+      this.states.set(id, {
+        moving: false,
+        mutations: (state?.mutations ?? 0) + 1,
+        moveWaiters: state?.moveWaiters ?? []
+      })
     }
     return this.releaseOnce(() => {
       for (const id of ids) {
         const state = this.states.get(id)
         if (!state || state.moving) continue
-        if (state.mutations <= 1) this.states.delete(id)
-        else state.mutations -= 1
+        state.mutations -= 1
+        if (state.mutations > 0) continue
+        const next = state.moveWaiters.shift()
+        if (!next) {
+          this.states.delete(id)
+          continue
+        }
+        state.moving = true
+        next(this.moveRelease(id))
       }
     })
   }
 
   isMoving(agentId: string): boolean {
     return this.states.get(agentId)?.moving === true
+  }
+
+  private moveRelease(agentId: string): () => void {
+    return this.releaseOnce(() => {
+      const state = this.states.get(agentId)
+      if (!state?.moving) return
+      const next = state.moveWaiters.shift()
+      if (!next) {
+        this.states.delete(agentId)
+        return
+      }
+      next(this.moveRelease(agentId))
+    })
   }
 
   private releaseOnce(release: () => void): () => void {

--- a/packages/control-plane/src/orchestrator/outbound.agent-move.test.ts
+++ b/packages/control-plane/src/orchestrator/outbound.agent-move.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Ack } from '@agentconnect.md/protocol'
 import type { LaunchRepo } from '../persistence/ports.js'
-import { ConnectionRegistry, type ConnChannel, type DaemonConnState } from '../ws/registry.js'
+import { ConnectionClosed, ConnectionRegistry, type ConnChannel, type DaemonConnState } from '../ws/registry.js'
 import { ControlSender } from './outbound.js'
 
 const DAEMON = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const AGENT = '11111111-1111-4111-8111-111111111111'
 const MOVE = '22222222-2222-4222-8222-222222222222'
 
-function state(conn: ConnChannel): DaemonConnState {
+function state(conn: ConnChannel, sessionEpoch = 7): DaemonConnState {
   return {
     daemonId: DAEMON,
     conn,
-    sessionEpoch: 7,
+    sessionEpoch,
     state: 'READY',
     maxAgents: 2,
     load: { cpu: 0, mem: 0, agents: 1 },
@@ -54,6 +54,47 @@ describe('ControlSender agent move controls', () => {
       'agent/activate',
       { agentId: AGENT, moveId: MOVE, spec: { name: 'mover' }, integrations: [], crons: [] },
       { epoch: 7, agentId: AGENT },
+      { ackTimeoutMs: 60_000, maxTries: 5 }
+    )
+  })
+
+  it('resumes an idempotent activation on the next READY connection', async () => {
+    const firstRequest = vi.fn(async () => {
+      throw new ConnectionClosed()
+    })
+    const first = {
+      daemonId: DAEMON,
+      request: firstRequest,
+      send: vi.fn(),
+      close: vi.fn()
+    } as unknown as ConnChannel
+    const registry = new ConnectionRegistry()
+    registry.add(state(first))
+    const sender = new ControlSender(registry, {} as LaunchRepo)
+
+    const activation = sender.agentActivate(DAEMON, {
+      agentId: AGENT,
+      moveId: MOVE,
+      spec: { name: 'mover' },
+      integrations: [],
+      crons: []
+    })
+    await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce())
+
+    const nextRequest = vi.fn(async () => ({ ok: true }) as Ack)
+    const next = {
+      daemonId: DAEMON,
+      request: nextRequest,
+      send: vi.fn(),
+      close: vi.fn()
+    } as unknown as ConnChannel
+    registry.add(state(next, 8))
+
+    await expect(activation).resolves.toEqual({ ok: true })
+    expect(nextRequest).toHaveBeenCalledWith(
+      'agent/activate',
+      { agentId: AGENT, moveId: MOVE, spec: { name: 'mover' }, integrations: [], crons: [] },
+      { epoch: 8, agentId: AGENT },
       { ackTimeoutMs: 60_000, maxTries: 5 }
     )
   })

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -73,7 +73,7 @@ import type {
   AgentPermissionDecision
 } from '@agentconnect.md/protocol'
 import type { LaunchRepo } from '../persistence/ports.js'
-import type { ConnectionRegistry, DaemonConnState } from '../ws/registry.js'
+import { ConnectionClosed, type ConnectionRegistry, type DaemonConnState } from '../ws/registry.js'
 import { AgentId, DaemonId, LaunchId } from '../domain/ids.js'
 import { ProtocolError } from '../domain/errors.js'
 
@@ -82,6 +82,7 @@ import { ProtocolError } from '../domain/errors.js'
 // idempotent operation enough time to return its acknowledgement.
 const COLD_ACTIVATE_ACK_TIMEOUT_MS = 60_000
 const COLD_ACTIVATE_MAX_TRIES = 5
+const COLD_ACTIVATE_MAX_CONNECTIONS = 5
 
 /** Raised when no live/READY connection exists for a daemon. */
 export class NoConnection extends Error {
@@ -236,12 +237,33 @@ export class ControlSender {
 
   /** Activate a fully bootstrapped/restored agent after a cold daemon move (REQ → ack). */
   async agentActivate(daemonId: string, a: AgentActivate): Promise<Ack> {
-    const c = this.must(daemonId)
-    return c.conn.request<Ack>(
-      'agent/activate',
-      a,
-      { epoch: c.sessionEpoch, agentId: a.agentId },
-      { ackTimeoutMs: COLD_ACTIVATE_ACK_TIMEOUT_MS, maxTries: COLD_ACTIVATE_MAX_TRIES }
+    let c = await this.activationConnection(daemonId)
+    for (let connectionTry = 1; ; connectionTry += 1) {
+      try {
+        return await c.conn.request<Ack>(
+          'agent/activate',
+          a,
+          { epoch: c.sessionEpoch, agentId: a.agentId },
+          { ackTimeoutMs: COLD_ACTIVATE_ACK_TIMEOUT_MS, maxTries: COLD_ACTIVATE_MAX_TRIES }
+        )
+      } catch (err) {
+        if (!(err instanceof ConnectionClosed) || connectionTry >= COLD_ACTIVATE_MAX_CONNECTIONS) throw err
+        c = await this.registry.waitForReadyAfter(
+          daemonId,
+          c.sessionEpoch,
+          AbortSignal.timeout(COLD_ACTIVATE_ACK_TIMEOUT_MS)
+        )
+      }
+    }
+  }
+
+  private async activationConnection(daemonId: string): Promise<DaemonConnState> {
+    const current = this.registry.get(daemonId)
+    if (current?.state === 'READY' || current?.state === 'DRAINING') return current
+    return this.registry.waitForReadyAfter(
+      daemonId,
+      Math.max(0, (current?.sessionEpoch ?? 1) - 1),
+      AbortSignal.timeout(COLD_ACTIVATE_ACK_TIMEOUT_MS)
     )
   }
 

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -16,7 +16,7 @@ import { AnyFrame, type ControlExt, type ErrorCode, isFrame } from '@agentconnec
 import { decodeEnvelope, buildEnvelope, encode, type InboundControlExt } from './codec.js'
 import { ReqRep, type RequestOpts } from './correlator.js'
 import type { Transport } from './transport.js'
-import type { ConnChannel, LifecycleState } from './registry.js'
+import { ConnectionClosed, type ConnChannel, type LifecycleState } from './registry.js'
 import type { DaemonWsDeps } from './deps.js'
 import type { FrameRouter } from './handlers/index.js'
 import { FencingState, checkFencing } from '../orchestrator/fencing.js'
@@ -190,7 +190,7 @@ export class DaemonConnection implements ConnChannel {
 
   private onClose(_code: number, _reason: string): void {
     this.state = 'CLOSED'
-    this.correlator.rejectAll(new Error('connection closed'))
+    this.correlator.rejectAll(new ConnectionClosed())
     // Remove the registry entry only while it is still OURS. On reconnect the new
     // connection's auth overwrites the entry (keyed by daemonId), and a half-dead
     // old socket's close event can arrive AFTER that — it must not evict the live

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -30,6 +30,7 @@ import type { Clock } from '../domain/clock.js'
 import type { SessionEventSink } from '../events/sink.js'
 import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
+import type { AgentId, DaemonId } from '../domain/ids.js'
 
 /** Config slice the WS edge reads. */
 export interface WsConfig {
@@ -56,6 +57,8 @@ export interface DaemonWsDeps {
   integrationChannel: IntegrationChannelRepo
   /** Shares the HTTP agent-move boundary with daemon-originated channel snapshots. */
   agentMutations: AgentMutationGate
+  /** Resumes durable move tombstones advertised by a reconnecting daemon. */
+  recoverStagedAgent: (agentId: AgentId, daemonId: DaemonId, moveId: string) => Promise<void>
   /** Refreshes relay and daemon collaboration snapshots after accepted membership changes. */
   collabRoutes: CollabRoutesService
   /** Stamps `lastRunAt` from the `cron/report` EVT (daemon-scoped, latest-wins). */

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -11,7 +11,7 @@
  * snapshot (CP wins all conflicts) — reconnect is convergence, not replay.
  */
 import { isFrame } from '@agentconnect.md/protocol'
-import { DaemonId } from '../../domain/ids.js'
+import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
 
 export const handleRegister: Handler = async (frame, conn, deps) => {
@@ -27,7 +27,6 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
   if (state) {
     state.capabilities = req.capabilities
     state.maxAgents = req.maxAgents
-    state.state = 'READY'
     state.assignments.clear()
   }
   for (const a of snap.assignments) {
@@ -45,9 +44,21 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
     ...(gitCommitIdentity ? { gitCommitIdentity } : {}),
     serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1']
   })
+  deps.connReg.markReady(conn.daemonId, conn)
 
   // Now that this connection has actually reached READY (reconcile succeeded above),
   // close any CP-commanded restart/upgrade op it was relaunching for (§7). Best-effort
   // — register/ok is already sent, so a settle failure must not disrupt registration.
   await deps.registry.settleLifecycleOpOnReady(did).catch(() => {})
+
+  // A socket can disappear after daemon-side detach/activate work but before its
+  // ACK reaches the request that initiated it. The durable staging fence rides
+  // reconnect registration; resume it only after register/ok made this socket
+  // READY. AgentMoveService waits behind that request's mutation gate and
+  // re-checks current DB placement before activating anything.
+  await Promise.all(
+    req.localState.stagedAgents.map(({ agentId, moveId }) =>
+      moveId ? deps.recoverStagedAgent(AgentId(agentId), did, moveId) : Promise.resolve()
+    )
+  )
 }

--- a/packages/control-plane/src/ws/registry.ts
+++ b/packages/control-plane/src/ws/registry.ts
@@ -12,6 +12,7 @@
  * `ws/connection.ts`.
  */
 import type { ControlExt, RegisterReq } from '@agentconnect.md/protocol'
+import { EventEmitter, once } from 'node:events'
 import { sessionKeyStr, type SessionKey } from '../domain/sessionKey.js'
 import type { RequestOpts } from './correlator.js'
 
@@ -47,12 +48,22 @@ export interface DaemonConnState {
   launches: Map<string, { launchId: string; acpSessionId?: string; runtime: string }> // agentId → launch
 }
 
+/** A request was dispatched, but its daemon connection closed before a reply. */
+export class ConnectionClosed extends Error {
+  constructor() {
+    super('connection closed')
+    this.name = 'ConnectionClosed'
+  }
+}
+
 export class ConnectionRegistry {
   private byDaemon = new Map<string, DaemonConnState>()
   private ownerByKey = new Map<string, string>() // sessionKeyStr → daemonId
+  private readonly readyEvents = new EventEmitter().setMaxListeners(0)
 
   add(s: DaemonConnState): void {
     this.byDaemon.set(s.daemonId, s)
+    if (s.state === 'READY') this.readyEvents.emit(s.daemonId, s)
   }
 
   get(daemonId: string): DaemonConnState | undefined {
@@ -61,6 +72,25 @@ export class ConnectionRegistry {
 
   has(daemonId: string): boolean {
     return this.byDaemon.has(daemonId)
+  }
+
+  /** Publish the point at which a newly-authenticated connection may accept
+   * control frames, waking idempotent commands interrupted on an older epoch. */
+  markReady(daemonId: string, conn: ConnChannel): DaemonConnState | undefined {
+    const state = this.byDaemon.get(daemonId)
+    if (!state || state.conn !== conn) return undefined
+    state.state = 'READY'
+    this.readyEvents.emit(daemonId, state)
+    return state
+  }
+
+  async waitForReadyAfter(daemonId: string, afterEpoch: number, signal: AbortSignal): Promise<DaemonConnState> {
+    for (;;) {
+      const current = this.byDaemon.get(daemonId)
+      if (current?.state === 'READY' && current.sessionEpoch > afterEpoch) return current
+      const [ready] = (await once(this.readyEvents, daemonId, { signal })) as [DaemonConnState]
+      if (ready.sessionEpoch > afterEpoch) return ready
+    }
   }
 
   /** The live connection state that currently owns a sessionKey, if any. */

--- a/packages/control-plane/test/fakes/build-app.ts
+++ b/packages/control-plane/test/fakes/build-app.ts
@@ -116,6 +116,7 @@ export function buildDaemonApp(prisma: PrismaClient): DaemonApp {
       integration: repos.integration,
       integrationChannel: repos.integrationChannel,
       agentMutations: new AgentMutationGate(),
+      recoverStagedAgent: async () => {},
       collabRoutes: { broadcast: async () => undefined } as unknown as DaemonWsDeps['collabRoutes'],
       cron: repos.cron,
       hook: repos.hook,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -170,6 +170,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     integration: repos.integration,
     integrationChannel: repos.integrationChannel,
     agentMutations: new AgentMutationGate(),
+    recoverStagedAgent: async () => {},
     collabRoutes,
     cron: repos.cron,
     hook: repos.hook,

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -854,7 +854,7 @@ describe('lifecycle op closure on register→READY', () => {
     host: 'macbook-pro',
     capabilities: { platforms: [] as never[], runtimes: [] as string[], acp: true, features: [] as string[] },
     maxAgents: 3,
-    localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [] }
+    localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
   }
   const makeRegistry = (ops: PgDaemonLifecycleOpRepo) =>
     new DaemonRegistryService(new PgDaemonRepo(prisma), new PgRuntimeProfileRepo(prisma), ops, systemClock)

--- a/packages/control-plane/test/protocol/drain.test.ts
+++ b/packages/control-plane/test/protocol/drain.test.ts
@@ -134,6 +134,7 @@ function build(): Built {
     integration: {} as DaemonWsDeps['integration'],
     integrationChannel: {} as DaemonWsDeps['integrationChannel'],
     agentMutations: new AgentMutationGate(),
+    recoverStagedAgent: async () => {},
     collabRoutes: {} as DaemonWsDeps['collabRoutes'],
     cron: {} as DaemonWsDeps['cron'],
     hook: {} as DaemonWsDeps['hook'],

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -44,6 +44,7 @@ function fencingDeps(clock: FakeClock): DaemonWsDeps {
     integration: {} as DaemonWsDeps['integration'],
     integrationChannel: {} as DaemonWsDeps['integrationChannel'],
     agentMutations: new AgentMutationGate(),
+    recoverStagedAgent: async () => {},
     collabRoutes: {} as DaemonWsDeps['collabRoutes'],
     cron: {} as DaemonWsDeps['cron'],
     hook: {} as DaemonWsDeps['hook'],

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -9,7 +9,7 @@
  *
  * Runs over the `InMemoryDaemonStub` against real Testcontainers Postgres.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { isFrame } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
@@ -25,6 +25,7 @@ const LEASE = '11ea5e00-0000-4000-8000-000000000001'
 const AUTH_ID = '11111111-1111-4111-8111-111111111111'
 const REG_ID = '22222222-2222-4222-8222-222222222222'
 const REG_ID2 = '33333333-3333-4333-8333-333333333333'
+const MOVE_ID = '44444444-4444-4444-8444-444444444444'
 
 /**
  * Seed a daemon + agent + workspace, one ACTIVE assignment for the daemon, one
@@ -106,7 +107,8 @@ function registerPayload() {
       crons: [CRON, 'deadcron-0000-4000-8000-000000000000'], // second is stale → drop
       leases: [LEASE],
       agents: [],
-      integrations: []
+      integrations: [],
+      stagedAgents: [] as Array<{ agentId: string; moveId?: string }>
     }
   }
 }
@@ -120,6 +122,23 @@ async function authThenAwaitOk(h: ReturnType<typeof buildWsHarness>) {
 }
 
 describe('register handler — authoritative reconcile snapshot + idempotency + state gate', () => {
+  it('replies READY before handing durable staged moves to reconnect recovery', async () => {
+    await seedReconcileState()
+    const h = buildWsHarness(prisma)
+    const { stub } = await authThenAwaitOk(h)
+    const recover = vi.fn(async () => {
+      expect(stub.lastSent('register/ok')).toBeDefined()
+      expect(h.deps.connReg.get(DAEMON)?.state).toBe('READY')
+    })
+    h.deps.recoverStagedAgent = recover
+
+    const payload = registerPayload()
+    payload.localState.stagedAgents = [{ agentId: AGENT, moveId: MOVE_ID }]
+    stub.inject('register', payload, { id: REG_ID })
+    await stub.expectFrame('register/ok')
+    await vi.waitFor(() => expect(recover).toHaveBeenCalledWith(AGENT, DAEMON, MOVE_ID))
+  })
+
   it('after auth/ok, register → register/ok with the seeded reconcile snapshot', async () => {
     await seedReconcileState()
     const h = buildWsHarness(prisma)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -136,6 +136,7 @@ import { RelayManager } from './cp/relay-manager.js'
 import { CpCollabRoutes } from './cp/cp-collab-routes.js'
 import { ClientTransport, systemClock, type Clock, type TimerHandle } from '@agentconnect.md/connection'
 import {
+  AgentActivate as AgentActivateSchema,
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HookReport,
@@ -10289,7 +10290,16 @@ export class Daemon {
           integrationId: integration.id,
           origin: integration.origin === 'cp' ? 'cp' : 'unknown'
         }))
-      )
+      ),
+      stagedAgents: this.opts.agentName
+        ? []
+        : [...this.moveStageMetadata]
+            .filter(([, stage]) => stage.state === 'staging')
+            .map(([agentId, stage]) => ({
+              agentId,
+              ...(AgentActivateSchema.shape.moveId.safeParse(stage.moveId).success ? { moveId: stage.moveId } : {})
+            }))
+            .sort((left, right) => left.agentId.localeCompare(right.agentId))
     }
   }
 

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -88,7 +88,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
     maxAgents: 4,
     capabilities: () => ({ platforms: ['slack'], runtimes: [], acp: true, features: [] }),
     runtimeProfiles: () => [],
-    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [] }),
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
     loadSnapshot: () => ({ cpu: 0.1, mem: 0.2, agents: 1 }),
     activeSessions: () => 2,
     configApply,

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -26,7 +26,7 @@ function makeDeps(transport: FakeTransport, over: Partial<CpClientDeps> = {}): C
     maxAgents: 4,
     capabilities: () => ({ platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] }),
     runtimeProfiles: () => [],
-    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [] }),
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
     loadSnapshot: () => ({ cpu: 0, mem: 0, agents: 0 }),
     activeSessions: () => 0,
     configApply: snap,
@@ -90,6 +90,7 @@ describe('CpClient handshake', () => {
     expect(reg.payload.capabilities.runtimes).toEqual(['claude'])
     expect(reg.payload.localState.agents).toEqual([])
     expect(reg.payload.localState.integrations).toEqual([])
+    expect(reg.payload.localState.stagedAgents).toEqual([])
 
     // 4. CP replies register/ok → snapshot applied, READY
     t.pushInbound(

--- a/packages/daemon/test/cp/client-reconnect.test.ts
+++ b/packages/daemon/test/cp/client-reconnect.test.ts
@@ -18,7 +18,7 @@ function deps(connect: () => Promise<FakeTransport>, clock: FakeClock): CpClient
     maxAgents: 4,
     capabilities: () => ({ platforms: ['slack'], runtimes: [], acp: true, features: [] }),
     runtimeProfiles: () => [],
-    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [] }),
+    localState: () => ({ assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }),
     loadSnapshot: () => ({ cpu: 0, mem: 0, agents: 0 }),
     activeSessions: () => 0,
     configApply: {

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../../src/daemon.js'
 import { detachedAgentDir, readAgentMoveStage, stageAgentMove, stagedAgentDir } from '../../src/agents/write-agent.js'
-import type { AgentSpec } from '@agentconnect.md/protocol'
+import { RegisterReq, type AgentSpec } from '@agentconnect.md/protocol'
 
 const MOVE_ID = '77777777-7777-4777-8777-777777777777'
 const MOVE_ID_2 = '88888888-8888-4888-8888-888888888888'
@@ -65,6 +65,30 @@ function makeDaemon(root: string) {
 const seam = (d: Daemon) => (d as any).cpConfigApply()
 
 describe('Daemon CP agent → disk + reconcile', () => {
+  it('keeps a corrupt move tombstone fail-closed without poisoning reconnect registration', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const stageDir = stagedAgentDir(join(root, 'agents'), 'bot-a')
+    mkdirSync(stageDir, { recursive: true })
+    writeFileSync(join(stageDir, 'metadata.json'), '{')
+
+    const { daemon } = makeDaemon(root)
+    await daemon.start()
+
+    expect((daemon as any).drainingAgents.has('bot-a')).toBe(true)
+    const localState = (daemon as any).cpLocalState()
+    expect(localState.stagedAgents).toEqual([{ agentId: 'bot-a' }])
+    expect(
+      RegisterReq.safeParse({
+        host: 'test',
+        capabilities: { platforms: [], runtimes: [], acp: true },
+        maxAgents: 1,
+        localState
+      }).success
+    ).toBe(true)
+    await daemon.stop()
+  })
+
   it('writes a CP spec onto the matching file agent.json (merge), keeping file runtime/workspace', async () => {
     const root = root1()
     writeAgent(root, 'bot-a')
@@ -156,6 +180,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect((daemon as any).agents.has('bot-a')).toBe(false)
     expect((daemon as any).drainingAgents.has('bot-a')).toBe(true)
     expect(existsSync(stagedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(true)
+    expect((daemon as any).cpLocalState().stagedAgents).toEqual([{ agentId: 'bot-a', moveId: MOVE_ID }])
     expect(
       readFileSync(join(detachedAgentDir(join(root, 'agents'), 'bot-a'), 'agent', 'memory', 'keep.md'), 'utf8')
     ).toBe('local-memory')
@@ -213,6 +238,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true) // activate proves ACP can start before ACK
     expect((daemon as any).drainingAgents.has('bot-a')).toBe(false)
     expect(readAgentMoveStage(join(root, 'agents'), 'bot-a')).toEqual({ moveId: MOVE_ID, state: 'committed' })
+    expect((daemon as any).cpLocalState().stagedAgents).toEqual([])
     expect(readFileSync(join(root, 'agents', 'bot-a', 'memory', 'keep.md'), 'utf8')).toBe('local-memory')
     expect(existsSync(detachedAgentDir(join(root, 'agents'), 'bot-a'))).toBe(false)
     // ACK-loss retransmit: committed metadata makes the identical activate a no-op ACK.

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -107,6 +107,7 @@ describe('decodeEnvelope — additional codec/frame units', () => {
     // Rolling upgrade: older daemons omit replica inventories.
     expect(r.frame.payload.localState.agents).toEqual([])
     expect(r.frame.payload.localState.integrations).toEqual([])
+    expect(r.frame.payload.localState.stagedAgents).toEqual([])
   })
 
   it('register accepts discord in capabilities.platforms (handshake regression)', () => {
@@ -124,6 +125,25 @@ describe('decodeEnvelope — additional codec/frame units', () => {
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('register')(r.frame)) throw new Error('expected a register frame')
     expect(r.frame.payload.capabilities.platforms).toEqual(['slack', 'discord'])
+  })
+
+  it('register accepts a fail-closed staged tombstone without a recoverable token', () => {
+    const r = decodeEnvelope(
+      envelope('register', {
+        host: 'host-1',
+        capabilities: { platforms: [], runtimes: [], acp: true },
+        maxAgents: 4,
+        localState: {
+          assignments: [],
+          crons: [],
+          leases: [],
+          stagedAgents: [{ agentId: AGENT_ID }]
+        }
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('register')(r.frame)) throw new Error('expected a register frame')
+    expect(r.frame.payload.localState.stagedAgents).toEqual([{ agentId: AGENT_ID }])
   })
 
   it('round-trips an error frame through build → encode → decode', () => {

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -35,7 +35,12 @@ export const RegisterReq = z.object({
     // the CP may prune it only when the durable row proves the replica moved.
     // Defaults keep an older daemon compatible with a newer CP.
     agents: z.array(z.object({ agentId: z.string(), origin: z.enum(['cp', 'unknown']) })).default([]),
-    integrations: z.array(z.object({ integrationId: z.string(), origin: z.enum(['cp', 'unknown']) })).default([])
+    integrations: z.array(z.object({ integrationId: z.string(), origin: z.enum(['cp', 'unknown']) })).default([]),
+    // Durable fail-closed move tombstones. A newer CP repairs entries with a
+    // valid token after register/ok. A missing token represents corrupt local
+    // metadata: the daemon keeps that agent drained for manual repair without
+    // making the whole registration undecodable.
+    stagedAgents: z.array(z.object({ agentId: z.string(), moveId: z.string().uuid().optional() })).default([])
   })
 })
 export type RegisterReq = z.infer<typeof RegisterReq>


### PR DESCRIPTION
## Summary

- continue an idempotent workspace `agent/activate` on the same daemon's next READY WebSocket epoch, so the original workspace edit can complete after a transient disconnect
- advertise durable staged moves for recovery when the initiating request or Control Plane process is gone, while keeping corrupt tombstones fail-closed without blocking daemon registration
- serialize reconnect recovery behind the interrupted mutation and reconcile workspace materialization during both automatic recovery and manual placement repair

## Root cause

The activation sender retried only on the WebSocket where the request started. If that connection closed while the daemon was materializing the workspace, the HTTP request reported an uncertain failure even though the daemon could reconnect under a higher epoch. The generic repair path also restarted the agent without reconciling workspace materialization, which could leave the Control Plane's GitHub definition paired with a stale scratch checkout.

## Validation

- `pnpm --filter @agentconnect.md/protocol test` (165 tests)
- targeted daemon reconnect, handshake, dispatch, and agent-reconcile tests (62 tests)
- `pnpm --filter @agentconnect.md/control-plane test:unit` (610 tests)
- register-handler integration tests (8 tests)
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint` (passes with two pre-existing duplicate-import warnings)

Created by Codex . GPT-5.6
