### PR TITLE
ci(release): use GitHub-hosted cut runner

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Mint GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- run the manually dispatched cut-release job on `ubuntu-latest`
- remove the repository's remaining GitHub Actions dependency on a persistent self-hosted runner

## Why

The workflow only requires standard Git, checkout, and GitHub App token support. A GitHub-hosted runner provides those capabilities while avoiding persistent runner state for this release control path.

## Validation

- `pnpm exec prettier --check .github/workflows/cut-release.yaml`
- `git diff --check`
- pre-push repository lint completed with two pre-existing warnings and no errors

Created by Codex . GPT-5
