### PR TITLE
fix(slack): restrict authenticated file downloads

### DIFF
--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -269,6 +269,7 @@ function isRoutableMessageEvent(ev: SlackMessageEvent): boolean {
 
 /** Cap on members enriched per `listChannelMembers` call (bounds users.info fan-out). */
 const MEMBER_ENRICH_CAP = 50
+const SLACK_FILE_ORIGIN = 'https://files.slack.com'
 
 /**
  * Build a chat.postMessage/update payload that renders the body as a Block Kit
@@ -809,33 +810,48 @@ export class SlackConnection {
    * stay daemon-local.
    */
   async downloadFile(sourceUrl: string, maxBytes = 8 * 1024 * 1024): Promise<Buffer | null> {
+    let url: URL
     try {
-      const res = await fetch(sourceUrl, { headers: { Authorization: `Bearer ${this.deps.group.botToken}` } })
+      url = new URL(sourceUrl)
+    } catch {
+      this.deps.log?.debug('slack: downloadFile rejected an invalid file URL')
+      return null
+    }
+    if (url.protocol !== 'https:' || url.origin !== SLACK_FILE_ORIGIN || url.username || url.password) {
+      this.deps.log?.debug('slack: downloadFile rejected a non-Slack file URL')
+      return null
+    }
+
+    try {
+      const res = await fetch(url.href, {
+        headers: { Authorization: `Bearer ${this.deps.group.botToken}` },
+        redirect: 'error'
+      })
       if (!res.ok) {
-        this.deps.log?.debug(`slack: downloadFile ${sourceUrl} → HTTP ${res.status}`)
+        this.deps.log?.debug(`slack: downloadFile ${url.href} → HTTP ${res.status}`)
         return null
       }
       const declared = Number(res.headers.get('content-length'))
       if (Number.isFinite(declared) && declared > maxBytes) {
-        this.deps.log?.debug(`slack: downloadFile ${sourceUrl} skipped — ${declared} bytes > cap ${maxBytes}`)
+        this.deps.log?.debug(`slack: downloadFile ${url.href} skipped — ${declared} bytes > cap ${maxBytes}`)
         return null
       }
       // An unauthorized url_private fetch is redirected to an HTML login page
       // (HTTP 200, text/html) rather than 401 — never mistake that for the file.
       const ctype = res.headers.get('content-type') ?? ''
       if (ctype.includes('text/html')) {
-        this.deps.log?.debug(`slack: downloadFile ${sourceUrl} got text/html (login page?) — treating as inaccessible`)
+        this.deps.log?.debug(`slack: downloadFile ${url.href} got text/html (login page?) — treating as inaccessible`)
         return null
       }
       // Defensively bound the read even when content-length is absent/untrustworthy.
       const buf = Buffer.from(await res.arrayBuffer())
       if (buf.byteLength > maxBytes) {
-        this.deps.log?.debug(`slack: downloadFile ${sourceUrl} discarded — ${buf.byteLength} bytes > cap ${maxBytes}`)
+        this.deps.log?.debug(`slack: downloadFile ${url.href} discarded — ${buf.byteLength} bytes > cap ${maxBytes}`)
         return null
       }
       return buf
     } catch (err) {
-      this.deps.log?.debug(`slack: downloadFile ${sourceUrl} failed: ${(err as Error).message}`)
+      this.deps.log?.debug(`slack: downloadFile ${url.href} failed: ${(err as Error).message}`)
       return null
     }
   }

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { encodeSlackStatusOverflowValue } from '@agentconnect.md/protocol'
 import { consolidate, SlackConnection } from '../src/slack/connection.js'
 import type { Agent } from '../src/agents/agent-schema.js'
@@ -58,6 +58,43 @@ const deps = () => ({
   group: { appToken: 'xapp-1', botToken: 'xoxb-a', integrations: [] },
   onMessage: () => {},
   newTraceId: () => 't'
+})
+
+describe('SlackConnection.downloadFile', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('sends the bot token only to canonical Slack file URLs and disables redirects', async () => {
+    const fetchMock = vi.fn(async () => new Response('file contents', { headers: { 'content-type': 'text/plain' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const conn = new SlackConnection(deps() as any, () => fakeAppWith(async () => undefined) as any)
+    const url = 'https://files.slack.com/files-pri/T0123-F0456/download/note.txt'
+
+    await expect(conn.downloadFile(url)).resolves.toEqual(Buffer.from('file contents'))
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      headers: { Authorization: 'Bearer xoxb-a' },
+      redirect: 'error'
+    })
+  })
+
+  it('rejects URL confusion and off-origin destinations before making a request', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const conn = new SlackConnection(deps() as any, () => fakeAppWith(async () => undefined) as any)
+
+    for (const url of [
+      'not a URL',
+      'blob:https://files.slack.com/files-pri/T-F/file',
+      'http://files.slack.com/files-pri/T-F/file',
+      'https://files.slack.com.evil.example/files-pri/T-F/file',
+      'https://user@files.slack.com/files-pri/T-F/file',
+      'https://files.slack.com:8443/files-pri/T-F/file',
+      'https://attacker.example/file'
+    ]) {
+      await expect(conn.downloadFile(url)).resolves.toBeNull()
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('SlackConnection.listBotChannels', () => {


### PR DESCRIPTION
## Summary

- restrict bot-authenticated Slack file downloads to canonical HTTPS `files.slack.com` URLs without embedded credentials
- disable redirect following so the bot token is never forwarded to a second destination
- add focused regression coverage for the valid download path and URL-confusion/off-origin inputs

## Root cause

The `readSlackFile` tool accepted a model-supplied string and passed it to the Slack download gateway. The gateway attached the bot bearer token without first proving that the destination was Slack-controlled.

## Security impact

An attacker-controlled URL can no longer receive the Slack bot token. Invalid schemes, alternate origins, non-default ports, embedded credentials, inherited-origin URLs, and redirects all fail closed before a token-bearing request leaves the daemon.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/connection.test.ts` — 28 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon test:unit` — 1,934 passed, 2 skipped
- focused ESLint and Prettier checks
- `git diff --check`
- pre-push repository lint completed with two pre-existing warnings and no errors

Created by Codex . GPT-5
