### PR TITLE
fix(oauth): require interactive consent authentication

### DIFF
--- a/docs/designs/agent-assistant.md
+++ b/docs/designs/agent-assistant.md
@@ -291,7 +291,7 @@ console /oauth/consent page (new):
   signed in → show client name (DCR/CIMD registration), organization picker (user orgs + roles),
               scope picker (mcp:read / mcp:read+write), Approve / Deny
   approve → POST /api/v1/oauth/consent { requestId, orgId, scopes }
-            (existing user bearer, validated by humanAuth)
+            (console OIDC identity, or devAuth locally; API/OAuth keys are rejected)
   → CP creates authorization code bound to userId+orgId+scopes+PKCE challenge+resource
   → browser 302 redirect_uri?code&state
 
@@ -300,6 +300,7 @@ POST /oauth/token(code + code_verifier [+ client_id])
 ```
 
 - **Organization selection happens on the consent page** because keys bind to one organization. This matches Atlassian per-site authorization and Sentry path-constrained sessions. Switching organizations means reauthorizing; a client may add a second connector.
+- Consent context, approval, and grant list/revocation require the interactive console identity. Existing personal keys and OAuth access tokens cannot mint or manage further credentials.
 - In local devAuth, consent passes through as DEFAULT_OWNER, allowing end-to-end testing.
 
 ### 7.4 Token Model (Two New Tables + ApiKey Reuse)

--- a/packages/control-plane/src/http/oauth/consent.ts
+++ b/packages/control-plane/src/http/oauth/consent.ts
@@ -1,8 +1,9 @@
 /**
  * `http/oauth/consent.ts` — the consent-page BACKEND (agent-assistant.md §7.3),
- * mounted under `/api/v1` with `humanAuth` (Logto / devAuth identity). The web
- * console's consent page (which is where the human actually logs in — the CP holds
- * no browser session) calls these:
+ * mounted under `/api/v1` with interactive human authentication (Logto / devAuth;
+ * API keys and OAuth access tokens are rejected). The web console's consent page
+ * (which is where the human actually logs in — the CP holds no browser session)
+ * calls these:
  *
  *   - `GET  /oauth/consent/context` — the client name, the requested scopes, and the
  *     caller's orgs (the org picker), so the page can render the approval screen.
@@ -22,8 +23,17 @@ const str = (v: unknown): string | undefined => (typeof v === 'string' && v.leng
 
 export function oauthConsentRoutes(deps: HttpDeps) {
   return async function oauthConsentPlugin(app: FastifyInstance): Promise<void> {
+    app.addHook('preHandler', app.humanAuth)
+    app.addHook('preHandler', async (req, reply) => {
+      // Derived credentials may exercise their existing authority, but must not
+      // mint, enumerate, or revoke OAuth grants.
+      if (req.apiKeyId !== undefined) {
+        return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'interactive sign-in required' })
+      }
+    })
+
     // Approval-screen data: who's asking, for what, and which org to bind.
-    app.get('/oauth/consent/context', { preHandler: app.humanAuth, schema: { hide: true } }, async (req, reply) => {
+    app.get('/oauth/consent/context', { schema: { hide: true } }, async (req, reply) => {
       const q = req.query as Record<string, unknown>
       const clientId = str(q.client_id)
       if (!clientId)
@@ -41,7 +51,7 @@ export function oauthConsentRoutes(deps: HttpDeps) {
     })
 
     // Approve/deny. On approve, mint a single-use code bound to the consenting user+org.
-    app.post('/oauth/consent', { preHandler: app.humanAuth, schema: { hide: true } }, async (req, reply) => {
+    app.post('/oauth/consent', { schema: { hide: true } }, async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>
       const clientId = str(b.clientId)
       const redirectUri = str(b.redirectUri)
@@ -103,7 +113,7 @@ export function oauthConsentRoutes(deps: HttpDeps) {
     })
 
     // Profile "Connected AI tools": list the caller's active grants.
-    app.get('/oauth/grants', { preHandler: app.humanAuth, schema: { hide: true } }, async (req) => {
+    app.get('/oauth/grants', { schema: { hide: true } }, async (req) => {
       const grants = await deps.oauth.listGrants(req.principal!.userId)
       const named = await Promise.all(
         grants.map(async (g) => {
@@ -123,7 +133,7 @@ export function oauthConsentRoutes(deps: HttpDeps) {
     })
 
     // Disconnect: revoke the grant + cascade-revoke its access tokens.
-    app.delete('/oauth/grants/:id', { preHandler: app.humanAuth, schema: { hide: true } }, async (req, reply) => {
+    app.delete('/oauth/grants/:id', { schema: { hide: true } }, async (req, reply) => {
       const { id } = req.params as { id: string }
       const ok = await deps.oauth.revokeGrant(req.principal!.userId, id)
       if (!ok) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'grant not found' })

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -157,8 +157,8 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
       await api.register(meKeyRoutes(deps))
       await api.register(waitlistRoutes(deps))
       await api.register(orgInviteAcceptRoutes(deps))
-      // OAuth consent BACKEND (agent-assistant.md §7.3) — version root, per-route
-      // humanAuth (the web console consent page calls it with the user's session).
+      // OAuth consent BACKEND (agent-assistant.md §7.3) — version root, guarded
+      // inside its plugin by interactive human auth for the console session.
       await api.register(oauthConsentRoutes(deps))
       // Unauthenticated GitHub setup callback (browser redirect; org rides the
       // signed state) — version root, deliberately OUTSIDE the org subtree.

--- a/packages/control-plane/test/integration/oauth.route.test.ts
+++ b/packages/control-plane/test/integration/oauth.route.test.ts
@@ -310,6 +310,74 @@ describe('OAuth refresh + disconnect', () => {
 })
 
 describe('OAuth security rejections', () => {
+  it('requires interactive sign-in for consent and grant management', async () => {
+    const { base } = await start()
+    const accessToken = ((await fullFlow(base, { scope: 'mcp:read' })).tok.json() as Tokens).access_token
+    const personalKeyResponse = await req(base, 'POST', '/api/v1/me/keys', {
+      json: { orgId: DEFAULT_ORG_ID }
+    })
+    expect(personalKeyResponse.status).toBe(201)
+    const personalKey = (personalKeyResponse.json() as { apiKey: string }).apiKey
+
+    const grants = (await req(base, 'GET', '/api/v1/oauth/grants')).json() as {
+      grants: { id: string }[]
+    }
+    expect(grants.grants).toHaveLength(1)
+    const grantId = grants.grants[0]!.id
+
+    const clientId = await registerClient(base)
+    const { challenge } = pkce()
+    const attempts = [
+      {
+        name: 'read consent context',
+        run: (bearer: string) =>
+          req(
+            base,
+            'GET',
+            `/api/v1/oauth/consent/context?client_id=${clientId}&scope=${encodeURIComponent('mcp:read mcp:write')}`,
+            { bearer }
+          )
+      },
+      {
+        name: 'approve broader scopes',
+        run: (bearer: string) =>
+          req(base, 'POST', '/api/v1/oauth/consent', {
+            bearer,
+            json: {
+              clientId,
+              redirectUri: REDIRECT,
+              codeChallenge: challenge,
+              codeChallengeMethod: 'S256',
+              orgId: DEFAULT_ORG_ID,
+              scope: 'mcp:read mcp:write',
+              grantedScopes: ['mcp:read', 'mcp:write'],
+              decision: 'allow'
+            }
+          })
+      },
+      {
+        name: 'list grants',
+        run: (bearer: string) => req(base, 'GET', '/api/v1/oauth/grants', { bearer })
+      },
+      {
+        name: 'revoke a grant',
+        run: (bearer: string) => req(base, 'DELETE', `/api/v1/oauth/grants/${grantId}`, { bearer })
+      }
+    ]
+
+    for (const [credential, bearer] of [
+      ['personal API key', personalKey],
+      ['OAuth access token', accessToken]
+    ] as const) {
+      for (const attempt of attempts) {
+        expect((await attempt.run(bearer)).status, `${credential} cannot ${attempt.name}`).toBe(403)
+      }
+    }
+
+    // The rejected revoke did not damage the existing grant.
+    expect((await mcpWhoami(base, accessToken)).status).toBe(200)
+  })
+
   it('rejects an unregistered redirect_uri at /authorize (no open redirect)', async () => {
     const { base } = await start()
     const clientId = await registerClient(base)


### PR DESCRIPTION
## Summary

- require an interactive console identity for OAuth consent context, approval, grant listing, and grant revocation
- reject personal API keys and existing OAuth access tokens at the shared plugin boundary
- add regression coverage for scope regrant, grant enumeration, and revocation attempts
- document the primary-user authentication requirement

## Security impact

Previously, a valid `mcp:read` OAuth token could call the root-level consent endpoint and request a new `mcp:write` authorization, bypassing the organization-scope guard used by `/orgs/:orgId` routes. The same credential class could also enumerate or revoke grants. This change prevents derived credentials from minting or managing further OAuth credentials while preserving production OIDC and local devAuth flows.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/oauth.route.test.ts` — 15/15 passed
- full control-plane integration suite — 55 files, 606 tests passed
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- targeted ESLint and Prettier checks
- `git diff --check`
- pre-push repository lint completed with no errors

Created by Codex . GPT-5
