### PR TITLE
fix(control-plane): enforce daemon telemetry tenancy

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -438,7 +438,10 @@ const EventSession = z.object({
 The exact schema in `packages/protocol/src/frames/telemetry.ts` also carries
 the dashboard metadata and effective execution configuration. It remains
 metadata-only. The reporting daemon is not echoed; CP stamps `daemonId` from
-the authenticated WebSocket connection.
+the authenticated WebSocket connection. CP accepts `event/session` and
+`usage/report` only when the reported agent is currently placed on that daemon,
+with placement moves excluded while the write runs. A `sessionId` is bound to
+the first accepted `agentId` and can never be reassigned by a later report.
 
 Phase state machine: `start → (plan ↔ problem)* → end`. The daemon collapses
 ACP `session/update` streams into these milestones; CP persists the metadata,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -872,8 +872,9 @@ export interface SessionFacetIndex {
 }
 
 export interface SessionRepo {
-  /** Upsert the converged milestone for a session (advance `phase`; NO message body). */
-  recordMilestone(ev: EventSessionInput): Promise<void>
+  /** Upsert the converged milestone for a session (advance `phase`; NO message body).
+   *  False means the global session id is already bound to a different agent. */
+  recordMilestone(ev: EventSessionInput): Promise<boolean>
   /** Filter, keyset-page, and order in Postgres; usage is hydrated only for the
    *  returned page. `total` is computed only when explicitly requested. */
   listPage(q: SessionPageQuery): Promise<SessionPageRecord>

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -238,27 +238,6 @@ function toFacetRecord(row: SessionFacetDbRow): SessionFacetRecord {
   }
 }
 
-function phaseRank(phase: SessionPhase): number {
-  switch (phase) {
-    case 'start':
-      return 0
-    case 'plan':
-      return 1
-    case 'problem':
-    case 'end':
-      return 2
-  }
-}
-
-function mergePhase(current: SessionPhase | null | undefined, incoming: SessionPhase): SessionPhase {
-  if (!current) return incoming
-  const currentRank = phaseRank(current)
-  const incomingRank = phaseRank(incoming)
-  if (incomingRank < currentRank) return current
-  if (incomingRank === currentRank && currentRank === 2) return current
-  return incoming
-}
-
 export class PgSessionRepo implements SessionRepo {
   constructor(private readonly db: PrismaLike) {}
 
@@ -274,74 +253,72 @@ export class PgSessionRepo implements SessionRepo {
     })
   }
 
-  async recordMilestone(ev: EventSessionInput): Promise<void> {
+  async recordMilestone(ev: EventSessionInput): Promise<boolean> {
     const endedAt = ev.phase === 'end' ? ev.at : undefined
     const lastActivityAt = ev.lastActivityAt ?? ev.at
-    const existing = await this.db.sessionMeta.findUnique({
-      where: { id: ev.sessionId },
-      select: { phase: true, parentSessionId: true }
-    })
-    const phase = mergePhase((existing?.phase as SessionPhase | undefined) ?? undefined, ev.phase)
-    await this.db.sessionMeta.upsert({
-      where: { id: ev.sessionId },
-      create: {
-        id: ev.sessionId,
-        parentSessionId: ev.parentSessionId,
-        agentId: ev.agentId,
-        launchId: ev.launchId,
-        platform: ev.platform,
-        channel: ev.channel,
-        thread: ev.thread,
-        phase,
-        link: ev.link,
-        summary: ev.summary,
-        title: ev.title,
-        status: ev.status,
-        lastActivityAt,
-        triggeredBy: ev.triggeredBy,
-        channelName: ev.channelName,
-        triggeredByName: ev.triggeredByName,
-        threadUrl: ev.threadUrl,
-        runtime: ev.runtime,
-        model: ev.model,
-        effort: ev.effort,
-        fastMode: ev.fastMode,
-        permissionMode: ev.permissionMode,
-        outputMode: ev.outputMode,
-        daemonId: ev.daemonId,
-        startedAt: ev.at,
-        endedAt
-      },
-      update: {
-        phase,
-        lastActivityAt,
-        // Like the daemon-local origin link, lineage is first-wins. Older
-        // daemons omit it, and later snapshots must never re-parent a session.
-        ...(ev.parentSessionId !== undefined && !existing?.parentSessionId
-          ? { parentSessionId: ev.parentSessionId }
-          : {}),
-        ...(ev.platform !== undefined ? { platform: ev.platform } : {}),
-        ...(ev.channel !== undefined ? { channel: ev.channel } : {}),
-        ...(ev.thread !== undefined ? { thread: ev.thread } : {}),
-        // Keep latest non-empty metadata; never overwrite with undefined.
-        ...(ev.link !== undefined ? { link: ev.link } : {}),
-        ...(ev.summary !== undefined ? { summary: ev.summary } : {}),
-        ...(ev.title !== undefined ? { title: ev.title } : {}),
-        ...(ev.status !== undefined ? { status: ev.status } : {}),
-        ...(ev.triggeredBy !== undefined ? { triggeredBy: ev.triggeredBy } : {}),
-        ...(ev.channelName !== undefined ? { channelName: ev.channelName } : {}),
-        ...(ev.triggeredByName !== undefined ? { triggeredByName: ev.triggeredByName } : {}),
-        ...(ev.threadUrl !== undefined ? { threadUrl: ev.threadUrl } : {}),
-        ...(ev.runtime !== undefined ? { runtime: ev.runtime } : {}),
-        ...(ev.model !== undefined ? { model: ev.model } : {}),
-        ...(ev.effort !== undefined ? { effort: ev.effort } : {}),
-        ...(ev.fastMode !== undefined ? { fastMode: ev.fastMode } : {}),
-        ...(ev.permissionMode !== undefined ? { permissionMode: ev.permissionMode } : {}),
-        ...(ev.outputMode !== undefined ? { outputMode: ev.outputMode } : {}),
-        ...(ev.daemonId !== undefined ? { daemonId: ev.daemonId } : {}),
-        ...(endedAt ? { endedAt } : {})
-      }
-    })
+    const rows = await this.db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      INSERT INTO "session_meta" (
+        "id", "parentSessionId", "agentId", "launchId", "platform", "channel",
+        "thread", "phase", "link", "summary", "title", "status",
+        "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
+        "threadUrl", "runtime", "model", "effort", "fastMode",
+        "permissionMode", "outputMode", "daemonId", "startedAt", "endedAt",
+        "updatedAt"
+      ) VALUES (
+        ${ev.sessionId}, ${ev.parentSessionId ?? null}, ${ev.agentId},
+        ${ev.launchId ?? null}, ${ev.platform ?? null}, ${ev.channel ?? null},
+        ${ev.thread ?? null}, ${ev.phase}::"SessionPhase", ${ev.link ?? null},
+        ${ev.summary ?? null}, ${ev.title ?? null}, ${ev.status ?? null},
+        ${lastActivityAt}, ${ev.triggeredBy ?? null}, ${ev.channelName ?? null},
+        ${ev.triggeredByName ?? null}, ${ev.threadUrl ?? null},
+        ${ev.runtime ?? null}, ${ev.model ?? null}, ${ev.effort ?? null},
+        ${ev.fastMode ?? null}, ${ev.permissionMode ?? null},
+        ${ev.outputMode ?? null}, ${ev.daemonId ?? null}, ${ev.at},
+        ${endedAt ?? null}, CURRENT_TIMESTAMP
+      )
+      ON CONFLICT ("id") DO UPDATE SET
+        "parentSessionId" = COALESCE(
+          "session_meta"."parentSessionId",
+          EXCLUDED."parentSessionId"
+        ),
+        "phase" = CASE
+          WHEN "session_meta"."phase" IN ('problem', 'end') THEN "session_meta"."phase"
+          WHEN EXCLUDED."phase" IN ('problem', 'end') THEN EXCLUDED."phase"
+          WHEN "session_meta"."phase" = 'plan' AND EXCLUDED."phase" = 'start'
+            THEN "session_meta"."phase"
+          ELSE EXCLUDED."phase"
+        END,
+        "lastActivityAt" = EXCLUDED."lastActivityAt",
+        "platform" = COALESCE(EXCLUDED."platform", "session_meta"."platform"),
+        "channel" = COALESCE(EXCLUDED."channel", "session_meta"."channel"),
+        "thread" = COALESCE(EXCLUDED."thread", "session_meta"."thread"),
+        "link" = COALESCE(EXCLUDED."link", "session_meta"."link"),
+        "summary" = COALESCE(EXCLUDED."summary", "session_meta"."summary"),
+        "title" = COALESCE(EXCLUDED."title", "session_meta"."title"),
+        "status" = COALESCE(EXCLUDED."status", "session_meta"."status"),
+        "triggeredBy" = COALESCE(EXCLUDED."triggeredBy", "session_meta"."triggeredBy"),
+        "channelName" = COALESCE(EXCLUDED."channelName", "session_meta"."channelName"),
+        "triggeredByName" = COALESCE(
+          EXCLUDED."triggeredByName",
+          "session_meta"."triggeredByName"
+        ),
+        "threadUrl" = COALESCE(EXCLUDED."threadUrl", "session_meta"."threadUrl"),
+        "runtime" = COALESCE(EXCLUDED."runtime", "session_meta"."runtime"),
+        "model" = COALESCE(EXCLUDED."model", "session_meta"."model"),
+        "effort" = COALESCE(EXCLUDED."effort", "session_meta"."effort"),
+        "fastMode" = COALESCE(EXCLUDED."fastMode", "session_meta"."fastMode"),
+        "permissionMode" = COALESCE(
+          EXCLUDED."permissionMode",
+          "session_meta"."permissionMode"
+        ),
+        "outputMode" = COALESCE(EXCLUDED."outputMode", "session_meta"."outputMode"),
+        "daemonId" = COALESCE(EXCLUDED."daemonId", "session_meta"."daemonId"),
+        "endedAt" = COALESCE(EXCLUDED."endedAt", "session_meta"."endedAt"),
+        "updatedAt" = CURRENT_TIMESTAMP
+      WHERE "session_meta"."agentId" = EXCLUDED."agentId"
+      RETURNING "id"
+    `)
+    return rows.length === 1
   }
 
   async listPage(q: SessionPageQuery): Promise<SessionPageRecord> {

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -7,6 +7,14 @@ import { handleEventSession } from './event-session.js'
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 
+function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
+  return {
+    agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+    agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
+    ...extra
+  } as unknown as DaemonWsDeps
+}
+
 function eventSessionFrame(): AnyFrame {
   return {
     v: 1,
@@ -31,25 +39,26 @@ describe('handleEventSession', () => {
     let finishPersist!: () => void
     const recordMilestone = vi.fn(() => {
       order.push('persist:start')
-      return new Promise<void>((resolve) => {
+      return new Promise<boolean>((resolve) => {
         finishPersist = () => {
           order.push('persist:finish')
-          resolve()
+          resolve(true)
         }
       })
     })
     const publish = vi.fn(() => {
       order.push('publish')
     })
-    const deps = {
+    const deps = scopedDeps({
       session: { recordMilestone },
       events: { publish }
-    } as unknown as DaemonWsDeps
+    })
     const conn = { daemonId: DAEMON_ID } as DaemonConnection
     const frame = eventSessionFrame()
 
     const handling = handleEventSession(frame, conn, deps)
 
+    await vi.waitFor(() => expect(order).toEqual(['persist:start']))
     expect(order).toEqual(['persist:start'])
     expect(publish).not.toHaveBeenCalled()
 
@@ -61,11 +70,11 @@ describe('handleEventSession', () => {
   })
 
   it('passes the execution-config snapshot through and stamps daemonId from the connection', async () => {
-    const recordMilestone = vi.fn().mockResolvedValue(undefined)
-    const deps = {
+    const recordMilestone = vi.fn().mockResolvedValue(true)
+    const deps = scopedDeps({
       session: { recordMilestone },
       events: { publish: vi.fn() }
-    } as unknown as DaemonWsDeps
+    })
     const frame = eventSessionFrame()
     Object.assign(frame.payload as Record<string, unknown>, {
       runtime: 'claude',
@@ -96,14 +105,44 @@ describe('handleEventSession', () => {
   it('does not publish when persistence fails', async () => {
     const failure = new Error('write failed')
     const publish = vi.fn()
-    const deps = {
+    const deps = scopedDeps({
       session: { recordMilestone: vi.fn().mockRejectedValue(failure) },
       events: { publish }
-    } as unknown as DaemonWsDeps
+    })
 
     await expect(
       handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
     ).rejects.toBe(failure)
     expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a milestone rejected by the session ownership fence', async () => {
+    const publish = vi.fn()
+    const deps = scopedDeps({
+      session: { recordMilestone: vi.fn().mockResolvedValue(false) },
+      events: { publish }
+    })
+
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it('drops a milestone for an agent not placed on the reporting daemon', async () => {
+    const release = vi.fn()
+    const recordMilestone = vi.fn()
+    const publish = vi.fn()
+    const deps = scopedDeps({
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee' }) },
+      agentMutations: { tryBeginMutation: vi.fn(() => release) },
+      session: { recordMilestone },
+      events: { publish }
+    })
+
+    await handleEventSession(eventSessionFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).not.toHaveBeenCalled()
+    expect(publish).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledOnce()
   })
 })

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -8,45 +8,54 @@
  * deep-link (`…/sessions/:id`) resolvable from CP-stored metadata, even when the
  * daemon is offline. Metadata only — list/detail fields and sessionKey echo —
  * never the message stream (that stays daemon-local, §1/§12).
+ *
+ * Trust boundary: the reported agent must still be placed on the authenticated
+ * daemon, and an existing sessionId remains bound to its first agent.
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, LaunchId, SessionId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
+import { runForReportingAgent } from './reporting-agent.js'
 
 export const handleEventSession: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session')(frame)) return
   const p = frame.payload
-  await deps.session.recordMilestone({
-    sessionId: SessionId(p.sessionId),
-    ...(p.parentSessionId !== undefined ? { parentSessionId: SessionId(p.parentSessionId) } : {}),
-    agentId: AgentId(p.agentId),
-    ...(p.launchId !== undefined ? { launchId: LaunchId(p.launchId) } : {}),
-    phase: p.phase,
-    ...(p.platform !== undefined ? { platform: p.platform } : {}),
-    ...(p.channel !== undefined ? { channel: p.channel } : {}),
-    ...(p.thread !== undefined ? { thread: p.thread } : {}),
-    ...(p.link !== undefined ? { link: p.link } : {}),
-    ...(p.summary !== undefined ? { summary: p.summary } : {}),
-    ...(p.title !== undefined ? { title: p.title } : {}),
-    ...(p.status !== undefined ? { status: p.status } : {}),
-    ...(p.lastActivityAt !== undefined ? { lastActivityAt: new Date(p.lastActivityAt) } : {}),
-    ...(p.triggeredBy !== undefined ? { triggeredBy: p.triggeredBy } : {}),
-    ...(p.channelName !== undefined ? { channelName: p.channelName } : {}),
-    ...(p.triggeredByName !== undefined ? { triggeredByName: p.triggeredByName } : {}),
-    ...(p.threadUrl !== undefined ? { threadUrl: p.threadUrl } : {}),
-    ...(p.runtime !== undefined ? { runtime: p.runtime } : {}),
-    ...(p.model !== undefined ? { model: p.model } : {}),
-    ...(p.effort !== undefined ? { effort: p.effort } : {}),
-    ...(p.fastMode !== undefined ? { fastMode: p.fastMode } : {}),
-    ...(p.permissionMode !== undefined ? { permissionMode: p.permissionMode } : {}),
-    ...(p.outputMode !== undefined ? { outputMode: p.outputMode } : {}),
-    // The reporting daemon comes from the AUTHENTICATED connection, not the
-    // frame payload — a daemon cannot attribute a session to another daemon.
-    daemonId: DaemonId(conn.daemonId),
-    at: new Date(p.ts)
+  const agentId = AgentId(p.agentId)
+  const daemonId = DaemonId(conn.daemonId)
+  await runForReportingAgent(agentId, daemonId, deps, async () => {
+    const recorded = await deps.session.recordMilestone({
+      sessionId: SessionId(p.sessionId),
+      ...(p.parentSessionId !== undefined ? { parentSessionId: SessionId(p.parentSessionId) } : {}),
+      agentId,
+      ...(p.launchId !== undefined ? { launchId: LaunchId(p.launchId) } : {}),
+      phase: p.phase,
+      ...(p.platform !== undefined ? { platform: p.platform } : {}),
+      ...(p.channel !== undefined ? { channel: p.channel } : {}),
+      ...(p.thread !== undefined ? { thread: p.thread } : {}),
+      ...(p.link !== undefined ? { link: p.link } : {}),
+      ...(p.summary !== undefined ? { summary: p.summary } : {}),
+      ...(p.title !== undefined ? { title: p.title } : {}),
+      ...(p.status !== undefined ? { status: p.status } : {}),
+      ...(p.lastActivityAt !== undefined ? { lastActivityAt: new Date(p.lastActivityAt) } : {}),
+      ...(p.triggeredBy !== undefined ? { triggeredBy: p.triggeredBy } : {}),
+      ...(p.channelName !== undefined ? { channelName: p.channelName } : {}),
+      ...(p.triggeredByName !== undefined ? { triggeredByName: p.triggeredByName } : {}),
+      ...(p.threadUrl !== undefined ? { threadUrl: p.threadUrl } : {}),
+      ...(p.runtime !== undefined ? { runtime: p.runtime } : {}),
+      ...(p.model !== undefined ? { model: p.model } : {}),
+      ...(p.effort !== undefined ? { effort: p.effort } : {}),
+      ...(p.fastMode !== undefined ? { fastMode: p.fastMode } : {}),
+      ...(p.permissionMode !== undefined ? { permissionMode: p.permissionMode } : {}),
+      ...(p.outputMode !== undefined ? { outputMode: p.outputMode } : {}),
+      // The reporting daemon comes from the AUTHENTICATED connection, not the
+      // frame payload.
+      daemonId,
+      at: new Date(p.ts)
+    })
+    if (!recorded) return
+    // Publish only after the metadata commit. Browser subscribers use this as an
+    // invalidation signal and immediately re-read `/sessions`; publishing first
+    // would race that GET against the upsert and leave the new row invisible.
+    deps.events.publish(daemonId, p)
   })
-  // Publish only after the metadata commit. Browser subscribers use this as an
-  // invalidation signal and immediately re-read `/sessions`; publishing first
-  // would race that GET against the upsert and leave the new row invisible.
-  deps.events.publish(DaemonId(conn.daemonId), p)
 }

--- a/packages/control-plane/src/ws/handlers/reporting-agent.ts
+++ b/packages/control-plane/src/ws/handlers/reporting-agent.ts
@@ -1,0 +1,25 @@
+import type { AgentId, DaemonId } from '../../domain/ids.js'
+import type { DaemonWsDeps } from '../deps.js'
+
+/**
+ * Run one daemon-originated agent write only while that agent is placed on the
+ * authenticated reporting daemon. The shared mutation lease prevents a cold
+ * move from racing the placement check and the write.
+ */
+export async function runForReportingAgent(
+  agentId: AgentId,
+  daemonId: DaemonId,
+  deps: Pick<DaemonWsDeps, 'agent' | 'agentMutations'>,
+  write: () => Promise<void>
+): Promise<boolean> {
+  const release = deps.agentMutations.tryBeginMutation(agentId)
+  if (!release) return false
+  try {
+    const agent = await deps.agent.get(agentId)
+    if (agent?.daemonId !== daemonId) return false
+    await write()
+    return true
+  } finally {
+    release()
+  }
+}

--- a/packages/control-plane/src/ws/handlers/usage-report.ts
+++ b/packages/control-plane/src/ws/handlers/usage-report.ts
@@ -6,20 +6,26 @@
  * row per `(agentId, sessionId)` (latest-wins, idempotent) so the `/usage`
  * dashboard can aggregate real usage over time. Token counts + cost are metadata,
  * never the message stream (which stays daemon-local, §1/§12).
+ * Reports are accepted only for agents currently placed on the authenticated
+ * daemon.
  */
 import { isFrame } from '@agentconnect.md/protocol'
-import { AgentId } from '../../domain/ids.js'
+import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
+import { runForReportingAgent } from './reporting-agent.js'
 
-export const handleUsageReport: Handler = async (frame, _conn, deps) => {
+export const handleUsageReport: Handler = async (frame, conn, deps) => {
   if (!isFrame('usage/report')(frame)) return
   const p = frame.payload
-  await deps.sessionUsage.record({
-    sessionId: p.sessionId,
-    agentId: AgentId(p.agentId),
-    platform: p.platform ?? null,
-    channel: p.channel ?? null,
-    lastActivityAt: new Date(p.lastActivityAt),
-    usage: p.usage
+  const agentId = AgentId(p.agentId)
+  await runForReportingAgent(agentId, DaemonId(conn.daemonId), deps, async () => {
+    await deps.sessionUsage.record({
+      sessionId: p.sessionId,
+      agentId,
+      platform: p.platform ?? null,
+      channel: p.channel ?? null,
+      lastActivityAt: new Date(p.lastActivityAt),
+      usage: p.usage
+    })
   })
 }

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -12,13 +12,14 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedLaunch } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { PgSessionRepo } from '../../src/persistence/index.js'
+import { PgAgentRepo, PgSessionRepo } from '../../src/persistence/index.js'
 import { handleEventSession } from '../../src/ws/handlers/index.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import type { AnyFrame } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { InMemorySessionEventSink } from '../../src/events/sink.js'
+import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 
@@ -34,7 +35,7 @@ const LAUNCH = '10101010-1111-4111-8111-111111111111'
 const SESSION = '4691f21b-3911-4d7f-a45d-28ce75d79337'
 
 /** Dispatch an `event/session` EVT through the real handler (stores SessionMeta). */
-async function reportSession(payload: Record<string, unknown>): Promise<void> {
+async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON): Promise<void> {
   const frame = {
     v: 1,
     id: randomUUID(),
@@ -43,13 +44,34 @@ async function reportSession(payload: Record<string, unknown>): Promise<void> {
     payload
   } as AnyFrame
   const deps = {
+    agent: new PgAgentRepo(prisma),
+    agentMutations: new AgentMutationGate(),
     session: new PgSessionRepo(prisma),
     events: new InMemorySessionEventSink()
   } as unknown as DaemonWsDeps
-  await handleEventSession(frame, { daemonId: DAEMON } as DaemonConnection, deps)
+  await handleEventSession(frame, { daemonId } as DaemonConnection, deps)
 }
 
 describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
+  it('drops a foreign daemon report before it reaches session storage', async () => {
+    const otherDaemon = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, otherDaemon)
+    await seedAgent(prisma, AGENT, { daemonId: otherDaemon })
+
+    await reportSession({
+      sessionId: SESSION,
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C123',
+      title: 'Forged',
+      ts: '2026-07-05T00:00:00.000Z'
+    })
+
+    expect(await prisma.sessionMeta.findUnique({ where: { id: SESSION } })).toBeNull()
+  })
+
   it('stores a daemon-reported session and serves it at the deep-link detail route', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -49,7 +49,7 @@ describe('usage/report handler — persists per-session token usage', () => {
   it('upserts the session usage; re-sending the cumulative snapshot is latest-wins (not additive)', async () => {
     const h = buildWsHarness(prisma)
     const { stub } = await connectReady(h)
-    await seedAgent(prisma, AGENT_A)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
 
     stub.inject('usage/report', {
       sessionId: 'acp-sess-1',
@@ -85,6 +85,41 @@ describe('usage/report handler — persists per-session token usage', () => {
     expect(row!.totalTokens).toBe(9000) // replaced, not 4820 + 9000
     expect(row!.outputTokens).toBe(2200)
     expect(stub.lastSent('error')).toBeUndefined()
+  })
+
+  it('drops usage for an agent not placed on the reporting daemon', async () => {
+    const h = buildWsHarness(prisma)
+    const { stub } = await connectReady(h)
+    await seedAgent(prisma, AGENT_B)
+    const recordUsage = vi.spyOn(h.deps.sessionUsage, 'record')
+    const beginMutation = h.deps.agentMutations.tryBeginMutation.bind(h.deps.agentMutations)
+    let finish!: () => void
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    vi.spyOn(h.deps.agentMutations, 'tryBeginMutation').mockImplementation((agentIds) => {
+      const release = beginMutation(agentIds)
+      if (!release) return null
+      return () => {
+        release()
+        finish()
+      }
+    })
+
+    stub.inject('usage/report', {
+      sessionId: 'foreign-session',
+      agentId: AGENT_B,
+      lastActivityAt: new Date().toISOString(),
+      usage: { totalTokens: 1234 }
+    })
+
+    await finished
+    expect(recordUsage).not.toHaveBeenCalled()
+    expect(
+      await prisma.sessionUsage.findUnique({
+        where: { agentId_sessionId: { agentId: AGENT_B, sessionId: 'foreign-session' } }
+      })
+    ).toBeNull()
   })
 })
 

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -14,6 +14,7 @@ import { seedAgent, seedDaemon, seedLaunch } from '../fixtures/seed.js'
 import { AgentId, DaemonId, LaunchId, SessionId } from '../../src/domain/ids.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const OTHER_AGENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const DAEMON = 'd1111111-1111-4111-8111-111111111111'
 const LAUNCH = '11111111-1111-4111-8111-111111111111'
 const SESSION = '55555555-5555-4555-8555-555555555555'
@@ -128,6 +129,55 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     // still exactly one row — it's an upsert, not an append
     const all = await repo.list({ agentId: AgentId(AGENT) })
     expect(all).toHaveLength(1)
+  })
+
+  it('never rebinds an existing session id to another agent', async () => {
+    await fixtures()
+    await seedAgent(prisma, OTHER_AGENT, { daemonId: DAEMON })
+    const repo = new PgSessionRepo(prisma)
+
+    expect(await repo.recordMilestone(ev('start', { title: 'Original', daemonId: DaemonId(DAEMON) }))).toBe(true)
+    expect(
+      await repo.recordMilestone(
+        ev('end', {
+          agentId: AgentId(OTHER_AGENT),
+          launchId: undefined,
+          title: 'Forged',
+          daemonId: DaemonId(DAEMON)
+        })
+      )
+    ).toBe(false)
+
+    const got = await repo.get(SessionId(SESSION))
+    expect(got?.agentId).toBe(AGENT)
+    expect(got?.title).toBe('Original')
+    expect(got?.phase).toBe('start')
+  })
+
+  it('atomically assigns a concurrently reported session id to only one agent', async () => {
+    await fixtures()
+    await seedAgent(prisma, OTHER_AGENT, { daemonId: DAEMON })
+    const repo = new PgSessionRepo(prisma)
+
+    const accepted = await Promise.all([
+      repo.recordMilestone(ev('start', { title: 'Agent A', daemonId: DaemonId(DAEMON) })),
+      repo.recordMilestone(
+        ev('end', {
+          agentId: AgentId(OTHER_AGENT),
+          launchId: undefined,
+          title: 'Agent B',
+          daemonId: DaemonId(DAEMON)
+        })
+      )
+    ])
+
+    expect(accepted.filter(Boolean)).toHaveLength(1)
+    const got = await repo.get(SessionId(SESSION))
+    if (accepted[0]) {
+      expect(got).toMatchObject({ agentId: AGENT, title: 'Agent A', phase: 'start' })
+    } else {
+      expect(got).toMatchObject({ agentId: OTHER_AGENT, title: 'Agent B', phase: 'end' })
+    }
   })
 
   it('does not regress a terminal phase on later metadata refreshes', async () => {


### PR DESCRIPTION
## Summary

- accept session and usage telemetry only while the reported agent is placed on the authenticated daemon
- bind each global session ID atomically to the first accepted agent, including concurrent first reports
- publish session invalidations only after an authorized metadata write succeeds

## Root cause

The WebSocket handlers trusted the payload `agentId` without checking it against the authenticated daemon's current placement. Session metadata was also upserted by globally unique `sessionId`, so a forged or racing report could overwrite another agent's metadata.

## Security impact

This prevents a connected daemon from polluting another agent's session metadata or usage totals, and closes the concurrent cross-agent session-ID overwrite race at the database conflict boundary.

## Validation

- control-plane typecheck
- changed-file ESLint and Prettier checks
- focused event/session unit tests: 5 passed
- full control-plane integration suite: 55 files, 610 tests passed
- 30-round same-agent and cross-agent concurrency probe

Created by Codex . GPT-5
