### PR TITLE
fix(security): harden local credential file permissions

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -292,6 +292,11 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
 }
 ```
 
+On POSIX hosts, AgentConnect removes group/other access from existing
+`config.json` and `agent.json` files; newly created or rewritten files use mode
+`0600`. Agent directories created by the daemon use `0700`; existing custom
+agent directories and higher custom parents are left unchanged.
+
 #### 3.3.1 Default Runtimes Come from the ACP Registry
 
 `config.json.runtimes` is **optional**. At daemon/`chat` startup, `resolveRuntimes` merges registry defaults with configuration overrides by name, with config taking priority. An `agent.json` containing only `"runtime": "claude-acp"` therefore works without runtime setup.

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -9,7 +9,7 @@
  * `daemonId` is omitted unless given — the first connect adopts it from the
  * token's `sub`). `runLogin` is the orchestrator, with injectable deps for tests.
  */
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
+import { chmodSync, readFileSync, existsSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { createInterface } from 'node:readline'
 import { resolveRoot, configPath } from './paths.js'
@@ -45,10 +45,32 @@ function assertValidControlPlane(raw: Record<string, unknown>): void {
   }
 }
 
+function protectCredentialsFile(file: string): void {
+  if (!existsSync(file)) return
+  try {
+    if ((statSync(file).mode & 0o777) !== 0o600) chmodSync(file, 0o600)
+  } catch (err) {
+    // A login must never put a fresh key into a broadly readable file. Windows
+    // does not provide enforceable POSIX mode semantics, so retain its existing
+    // best-effort behavior.
+    if (process.platform !== 'win32') throw err
+  }
+}
+
+function writeCredentialsFile(file: string, raw: Record<string, unknown>): void {
+  // `mode` protects a new credential file; chmod-before-write repairs an
+  // existing config before fresh secrets reach it. Leave a custom parent alone.
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
+  protectCredentialsFile(file)
+  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 })
+  protectCredentialsFile(file)
+}
+
 /** Merge url/token into config.json (validated), returning the written path. */
 export function persistCredentials(opts: PersistCredsOpts): string {
   const root = resolveRoot(opts.root)
   const file = opts.configPath ?? configPath(root)
+  protectCredentialsFile(file)
   const raw: Record<string, unknown> = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
 
   const cp = (raw.controlPlane as Record<string, unknown> | undefined) ?? {}
@@ -57,8 +79,7 @@ export function persistCredentials(opts: PersistCredsOpts): string {
 
   assertValidControlPlane(raw) // fail before writing if the merge is invalid
 
-  mkdirSync(dirname(file), { recursive: true })
-  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  writeCredentialsFile(file, raw)
   return file
 }
 

--- a/packages/cli/test/login.test.ts
+++ b/packages/cli/test/login.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs'
+import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -46,6 +46,7 @@ describe('persistCredentials', () => {
     expect(raw.controlPlane.url).toBe('wss://cp.example/daemon/ws')
     expect(raw.controlPlane.key).toBe('tok-123')
     expect(raw.controlPlane.enabled).toBe(true)
+    if (process.platform !== 'win32') expect(statSync(join(root, 'config.json')).mode & 0o777).toBe(0o600)
   })
 
   it('persists daemonId only when explicitly provided', () => {
@@ -69,6 +70,17 @@ describe('persistCredentials', () => {
     expect(raw.logging.level).toBe('debug')
     expect(raw.runtimes.claude.command).toBe('npx')
     expect(raw.controlPlane.key).toBe('tok')
+  })
+
+  it.skipIf(process.platform === 'win32')('repairs an existing credential file to owner-only permissions', () => {
+    const root = emptyRoot()
+    const file = join(root, 'config.json')
+    writeFileSync(file, JSON.stringify({ version: 1 }), { mode: 0o644 })
+    chmodSync(file, 0o644)
+
+    persistCredentials({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' })
+
+    expect(statSync(file).mode & 0o777).toBe(0o600)
   })
 })
 

--- a/packages/daemon/src/agents/agent-json-file.ts
+++ b/packages/daemon/src/agents/agent-json-file.ts
@@ -1,0 +1,34 @@
+import { chmodSync, existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const PRIVATE_DIR_MODE = 0o700
+const PRIVATE_FILE_MODE = 0o600
+
+function chmodIfNeeded(path: string, target: number | ((current: number) => number)): void {
+  try {
+    const current = statSync(path).mode & 0o777
+    const mode = typeof target === 'function' ? target(current) : target
+    if (current !== mode) chmodSync(path, mode)
+  } catch (err) {
+    if (process.platform !== 'win32') throw err
+  }
+}
+
+export function ensurePrivateAgentDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: PRIVATE_DIR_MODE })
+  chmodIfNeeded(path, PRIVATE_DIR_MODE)
+}
+
+/** Tighten a hand-authored or legacy agent.json before reading its secrets. */
+export function protectAgentJson(file: string, writable = false): void {
+  if (!existsSync(file)) return
+  chmodIfNeeded(file, (current) => (writable ? PRIVATE_FILE_MODE : current & 0o700))
+}
+
+/** Preserve the existing inode/symlink while enforcing owner-only access. */
+export function writeAgentJson(file: string, contents: string): void {
+  if (!existsSync(file)) ensurePrivateAgentDirectory(dirname(file))
+  protectAgentJson(file, true)
+  writeFileSync(file, contents, { encoding: 'utf8', mode: PRIVATE_FILE_MODE })
+  protectAgentJson(file, true)
+}

--- a/packages/daemon/src/agents/load-agents.ts
+++ b/packages/daemon/src/agents/load-agents.ts
@@ -1,15 +1,18 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { join, resolve, isAbsolute, dirname } from 'node:path'
 import { AgentSchema, type Agent } from './agent-schema.js'
+import { protectAgentJson } from './agent-json-file.js'
 
 const IGNORED_DIRS = new Set(['node_modules', '.git'])
 const MAX_DEPTH = 4
+const DETACHED_DIR = '.detached'
 
 // Agent plus loader-derived data: the directory containing agent.json.
 export type LoadedAgent = Agent & { dir: string }
 
 // Parse one agent.json, then resolve workspace.path relative to the agent dir.
 function parseAgentFile(file: string): LoadedAgent {
+  protectAgentJson(file)
   const dir = dirname(file)
   const agent = AgentSchema.parse(JSON.parse(readFileSync(file, 'utf8')))
   if (!isAbsolute(agent.workspace.path)) {
@@ -41,9 +44,18 @@ export function findAgentFiles(dir: string, depth = 0): string[] {
   return out
 }
 
+function protectDetachedAgentFiles(agentsDir: string): void {
+  for (const file of findAgentFiles(join(agentsDir, DETACHED_DIR))) {
+    protectAgentJson(file)
+  }
+}
+
 // All parsed agents under `agentsDir`, no status filter. `dir` is the directory
 // holding each agent.json.
 export function discoverAgents(agentsDir: string): { agent: LoadedAgent; dir: string }[] {
+  // Hidden cold-move archives are intentionally excluded from discovery, but
+  // legacy copies may still contain runtime secrets and must converge too.
+  protectDetachedAgentFiles(agentsDir)
   return findAgentFiles(agentsDir).map((file) => {
     try {
       return { agent: parseAgentFile(file), dir: dirname(file) }

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -22,6 +22,7 @@
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, renameSync, readdirSync } from 'node:fs'
 import { join, dirname, relative, resolve, isAbsolute, sep } from 'node:path'
 import { normalizeGitUrl, normalizeRepoSubdir, type AgentSpec } from '@agentconnect.md/protocol'
+import { ensurePrivateAgentDirectory, protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 
 export interface WriteAgentDeps {
@@ -64,7 +65,7 @@ function writeMoveStage(agentsDir: string, agentId: string, metadata: AgentMoveS
   const root = stagedAgentDir(agentsDir, agentId)
   const file = join(root, MOVE_META_FILE)
   const temp = join(root, `${MOVE_META_FILE}.tmp`)
-  mkdirSync(root, { recursive: true })
+  ensurePrivateAgentDirectory(root)
   try {
     writeFileSync(temp, JSON.stringify(metadata, null, 2) + '\n')
     renameSync(temp, file)
@@ -91,6 +92,7 @@ export function stageAgentMove(
 export function readAgentMoveStage(agentsDir: string, agentId: string): AgentMoveStageMetadata | undefined {
   const root = stagedAgentDir(agentsDir, agentId)
   if (!existsSync(root)) return undefined
+  ensurePrivateAgentDirectory(root)
   try {
     const raw = JSON.parse(readFileSync(join(root, MOVE_META_FILE), 'utf8')) as Partial<AgentMoveStageMetadata>
     if (typeof raw.moveId === 'string' && (raw.state === 'staging' || raw.state === 'committed')) {
@@ -146,11 +148,12 @@ function detachedDataDir(agentsDir: string, agentId: string): string {
 }
 
 function scrubAgentIntegrations(file: string): string {
+  protectAgentJson(file)
   const original = readFileSync(file, 'utf8')
   const raw = JSON.parse(original) as Record<string, unknown>
   if (Array.isArray(raw.integrations) && raw.integrations.length === 0) return original
   raw.integrations = []
-  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
   return original
 }
 
@@ -164,6 +167,7 @@ export function archiveAgent(agentsDir: string, agentId: string): 'archived' | '
   const archived = detachedDataDir(agentsDir, agentId)
   if (!file) {
     if (!existsSync(archived)) return 'missing'
+    ensurePrivateAgentDirectory(detachedAgentDir(agentsDir, agentId))
     const archivedFile = findAgentFileById(archived, agentId)
     if (!archivedFile) throw new Error(`cannot detach agent "${agentId}": detached archive is incomplete`)
     // Idempotent security convergence: an archive produced by an interrupted or
@@ -193,7 +197,7 @@ export function archiveAgent(agentsDir: string, agentId: string): 'archived' | '
   try {
     // The archive keeps workspace/memory/local files, but bot credentials are CP
     // authority and must not remain forever on the historical source daemon.
-    mkdirSync(archiveRoot, { recursive: true })
+    ensurePrivateAgentDirectory(archiveRoot)
     scrubAgentIntegrations(file)
     writeFileSync(join(archiveRoot, DETACHED_META_FILE), JSON.stringify(metadata, null, 2) + '\n')
     renameSync(activeDir, archived)
@@ -203,7 +207,7 @@ export function archiveAgent(agentsDir: string, agentId: string): 'archived' | '
     // either metadata write or rename fails, so rolling this root back is safe.
     // rename is atomic: on failure the active file remains at `file`, so put its
     // exact original text (including local formatting/templates) back.
-    if (existsSync(file)) writeFileSync(file, originalAgentJson)
+    if (existsSync(file)) writeAgentJson(file, originalAgentJson)
     rmSync(archiveRoot, { recursive: true, force: true })
     throw err
   }
@@ -215,6 +219,7 @@ export function restoreArchivedAgent(agentsDir: string, agentId: string): boolea
   const archiveRoot = detachedAgentDir(agentsDir, agentId)
   const archived = detachedDataDir(agentsDir, agentId)
   if (!existsSync(archiveRoot)) return false
+  ensurePrivateAgentDirectory(archiveRoot)
   if (!existsSync(archived)) throw new Error(`cannot activate agent "${agentId}": detached archive is incomplete`)
 
   let metadata: DetachedAgentMetadata
@@ -300,7 +305,7 @@ export function pruneMovedAgentDependents(
       changed = true
     }
   }
-  if (changed) writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  if (changed) writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
 
   const finalIntegrations = new Set(
     (Array.isArray(raw.integrations) ? raw.integrations : []).flatMap((integration) => {
@@ -343,6 +348,7 @@ function mapWorkspaceMode(mode: 'scratch' | 'github'): 'from-scratch' | 'git-rep
  */
 export function findAgentFileById(agentsDir: string, agentId: string): string | undefined {
   for (const file of findAgentFiles(agentsDir)) {
+    protectAgentJson(file)
     try {
       const raw = JSON.parse(readFileSync(file, 'utf8')) as { id?: unknown }
       if (raw.id === agentId) return file
@@ -522,7 +528,7 @@ export function writeAgentSpec(agentsDir: string, agentId: string, spec: AgentSp
   if (existingFile) {
     const raw = JSON.parse(readFileSync(existingFile, 'utf8')) as Record<string, unknown>
     applySpecFields(raw, spec, { agentId, agentDir: dirname(existingFile), creating: false })
-    writeFileSync(existingFile, JSON.stringify(raw, null, 2) + '\n')
+    writeAgentJson(existingFile, JSON.stringify(raw, null, 2) + '\n')
     return
   }
 
@@ -546,8 +552,7 @@ export function writeAgentSpec(agentsDir: string, agentId: string, spec: AgentSp
   }
   applySpecFields(raw, spec, { agentId, agentDir, creating: true })
 
-  mkdirSync(agentDir, { recursive: true })
-  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
 }
 
 /**

--- a/packages/daemon/src/agents/write-cron.ts
+++ b/packages/daemon/src/agents/write-cron.ts
@@ -12,9 +12,10 @@
  * parsed `LoadedAgent`, whose `workspace.path` has been rewritten absolute.
  * Editing the raw file preserves the original relative path.
  */
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import type { CronUpsert } from '@agentconnect.md/protocol'
 import type { CronDef } from './agent-schema.js'
+import { protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 import { findAgentFileById } from './write-agent.js'
 
@@ -86,7 +87,7 @@ export function writeCronDef(agentsDir: string, cron: CronUpsert, deps: WriteCro
     list[idx] = next
   } else list.push(next)
   raw.crons = list
-  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
   return true
 }
 
@@ -98,6 +99,7 @@ export function writeCronDef(agentsDir: string, cron: CronUpsert, deps: WriteCro
  */
 export function removeCronDef(agentsDir: string, cronId: string): boolean {
   for (const file of findAgentFiles(agentsDir)) {
+    protectAgentJson(file)
     let raw: Record<string, unknown>
     try {
       raw = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
@@ -115,7 +117,7 @@ export function removeCronDef(agentsDir: string, cronId: string): boolean {
     )
     if (idx === -1) continue
     list.splice(idx, 1)
-    writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+    writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
     return true
   }
   return false

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -14,9 +14,10 @@
  * the parsed `LoadedAgent`, whose `workspace.path` has been rewritten absolute.
  * Editing the raw file preserves the original relative path.
  */
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import type { IntegrationSpec } from '@agentconnect.md/protocol'
 import type { Integration } from './agent-schema.js'
+import { protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 import { findAgentFileById } from './write-agent.js'
 
@@ -108,7 +109,7 @@ export function writeIntegrationSpec(agentsDir: string, spec: IntegrationSpec, d
   if (idx >= 0) list[idx] = next
   else list.push(next)
   raw.integrations = list
-  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+  writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
   return true
 }
 
@@ -119,6 +120,7 @@ export function writeIntegrationSpec(agentsDir: string, spec: IntegrationSpec, d
  */
 export function removeIntegration(agentsDir: string, integrationId: string): boolean {
   for (const file of findAgentFiles(agentsDir)) {
+    protectAgentJson(file)
     let raw: Record<string, unknown>
     try {
       raw = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
@@ -132,7 +134,7 @@ export function removeIntegration(agentsDir: string, integrationId: string): boo
     )
     if (idx === -1) continue
     list.splice(idx, 1)
-    writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+    writeAgentJson(file, JSON.stringify(raw, null, 2) + '\n')
     return true
   }
   return false

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
+import { chmodSync, readFileSync, existsSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import type { RelayRosterEntry } from '@agentconnect.md/protocol'
 import { ConfigSchema, type Config } from './config-schema.js'
@@ -15,6 +15,29 @@ export interface FlatOverrides {
   requireSandbox?: boolean
 }
 
+function protectConfigFile(file: string, writable = false): void {
+  if (!existsSync(file)) return
+  try {
+    const current = statSync(file).mode & 0o777
+    const desired = writable ? 0o600 : current & 0o700
+    if (current !== desired) chmodSync(file, desired)
+  } catch (err) {
+    // Windows does not provide enforceable POSIX mode semantics. On POSIX,
+    // never keep using a secret-bearing config if owner-only access cannot be
+    // established.
+    if (process.platform !== 'win32') throw err
+  }
+}
+
+function writeConfigFile(file: string, raw: unknown): void {
+  // `mode` protects new paths; chmod also repairs a legacy file created under a
+  // loose umask. Do not chmod an existing custom parent directory.
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
+  protectConfigFile(file, true)
+  writeFileSync(file, JSON.stringify(raw, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 })
+  protectConfigFile(file, true)
+}
+
 export function loadConfig(
   opts: { root?: string; configPath?: string; overrides?: FlatOverrides; optional?: boolean; autoCreate?: boolean } = {}
 ): Config {
@@ -27,11 +50,11 @@ export function loadConfig(
   // user has a file to edit later — no `agentconnect login` required.
   let raw: unknown
   if (existsSync(file)) {
+    protectConfigFile(file)
     raw = JSON.parse(readFileSync(file, 'utf8'))
   } else if (opts.autoCreate) {
     raw = { version: 1 }
-    mkdirSync(dirname(file), { recursive: true })
-    writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+    writeConfigFile(file, raw)
   } else if (opts.optional) {
     raw = { version: 1 }
   } else {
@@ -63,10 +86,10 @@ export function loadConfig(
 export function persistDaemonId(root: string | undefined, daemonId: string): void {
   try {
     const file = configPath(resolveRoot(root))
+    protectConfigFile(file)
     const raw = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
     raw.daemonId = daemonId
-    mkdirSync(dirname(file), { recursive: true })
-    writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+    writeConfigFile(file, raw)
   } catch {
     // ignore — non-fatal
   }
@@ -82,10 +105,10 @@ export function persistDaemonId(root: string | undefined, daemonId: string): voi
 export function persistRelays(root: string | undefined, relays: RelayRosterEntry[]): void {
   try {
     const file = configPath(resolveRoot(root))
+    protectConfigFile(file)
     const raw = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
     raw.relays = relays
-    mkdirSync(dirname(file), { recursive: true })
-    writeFileSync(file, JSON.stringify(raw, null, 2) + '\n')
+    writeConfigFile(file, raw)
   } catch {
     // ignore — non-fatal
   }

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, isAbsolute } from 'node:path'
 import { loadAgents, discoverAgents, selectAgent } from '../src/agents/load-agents.js'
@@ -71,6 +71,32 @@ describe('loadAgents', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-agents-'))
     writeAgent(dir, 'bad', { id: 'bad' }) // missing required fields
     expect(() => loadAgents(dir)).toThrow(/bad/)
+  })
+
+  it.skipIf(process.platform === 'win32')('repairs a legacy detached agent.json without discovering it', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-agents-'))
+    writeAgent(dir, 'bot-a', slackAgent('bot-a'))
+    const archivedDir = join(dir, '.detached', 'bot-old', 'agent')
+    mkdirSync(archivedDir, { recursive: true })
+    const archivedFile = join(archivedDir, 'agent.json')
+    writeFileSync(
+      archivedFile,
+      JSON.stringify({ ...slackAgent('bot-old'), runtimeOverrides: { secrets: { API_TOKEN: 'secret' } } })
+    )
+    chmodSync(archivedFile, 0o644)
+
+    expect(loadAgents(dir).map((agent) => agent.id)).toEqual(['bot-a'])
+    expect(statSync(archivedFile).mode & 0o777).toBe(0o600)
+  })
+
+  it.skipIf(process.platform === 'win32')('preserves an owner-only read-only agent.json while loading it', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-agents-'))
+    writeAgent(dir, 'bot-a', slackAgent('bot-a'))
+    const file = join(dir, 'bot-a', 'agent.json')
+    chmodSync(file, 0o400)
+
+    expect(loadAgents(dir)).toHaveLength(1)
+    expect(statSync(file).mode & 0o777).toBe(0o400)
   })
 })
 

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { loadConfig } from '../src/config/load-config.js'
@@ -25,6 +25,16 @@ describe('loadConfig', () => {
     expect(cfg.security.isolateAccountApps).toBe(true)
     expect(cfg.limits.maxAgents).toBeGreaterThan(0) // default applied
     expect(cfg.agentsDir).toContain('agents')
+  })
+
+  it.skipIf(process.platform === 'win32')('repairs an existing config file to owner-only permissions', () => {
+    const root = tmpRoot({ version: 1 })
+    const file = join(root, 'config.json')
+    chmodSync(file, 0o644)
+
+    loadConfig({ root })
+
+    expect(statSync(file).mode & 0o777).toBe(0o600)
   })
 
   it('rejects an invalid config (bad version)', () => {
@@ -53,6 +63,7 @@ describe('loadConfig', () => {
     const cfg = loadConfig({ root, autoCreate: true })
     expect(existsSync(file)).toBe(true) // file was generated
     expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({ version: 1 })
+    if (process.platform !== 'win32') expect(statSync(file).mode & 0o777).toBe(0o600)
     expect(cfg.controlPlane?.enabled).toBe(false) // fully local, no CP
     expect(cfg.limits.maxAgents).toBeGreaterThan(0) // defaults applied
   })

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { AgentSpec, CronUpsert, IntegrationSpec } from '@agentconnect.md/protocol'
@@ -431,6 +431,16 @@ describe('writeAgentSpec — merge (agent.json exists)', () => {
 })
 
 describe('writeAgentSpec — create (no agent.json)', () => {
+  it.skipIf(process.platform === 'win32')('creates the agent root and agent.json with owner-only modes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
+
+    writeAgentSpec(dir, 'bot-new', baseSpec({ name: 'bot-new' }), deps)
+
+    const file = join(dir, 'bot-new', 'agent.json')
+    expect(statSync(join(dir, 'bot-new')).mode & 0o777).toBe(0o700)
+    expect(statSync(file).mode & 0o777).toBe(0o600)
+  })
+
   it('persists displayName for a fresh agent', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
 
@@ -459,6 +469,41 @@ describe('writeAgentSpec — create (no agent.json)', () => {
 
     const file = findAgentFileById(dir, 'bot-new')
     expect(readJson(file!).runtime).toBe('claude')
+  })
+
+  it.skipIf(process.platform === 'win32')('repairs legacy modes when an integration rewrites agent.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
+    const file = seedAgent(dir, 'bot-a', {
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: './workspace' }
+    })
+    chmodSync(join(dir, 'bot-a'), 0o755)
+    chmodSync(file, 0o644)
+
+    expect(
+      writeIntegrationSpec(
+        dir,
+        {
+          integrationId: 'int-a',
+          agentId: 'bot-a',
+          platform: 'slack',
+          slack: {
+            mode: 'direct',
+            shareable: false,
+            botToken: 'xoxb-secret',
+            appToken: 'xapp-secret',
+            allowedUserIds: [],
+            bindRules: []
+          }
+        },
+        {}
+      )
+    ).toBe(true)
+    expect(statSync(join(dir, 'bot-a')).mode & 0o777).toBe(0o755)
+    expect(statSync(file).mode & 0o777).toBe(0o600)
   })
 })
 


### PR DESCRIPTION
## Summary

- enforce owner-only POSIX permissions for secret-bearing `config.json` and `agent.json` files
- route agent, integration, cron, login, daemon-id, and relay-roster writes through permission-safe writers
- self-heal legacy active and detached agent configs while preserving owner-only read-only files and custom parent-directory permissions
- fail closed on POSIX when a file cannot be made private before new credentials are written

## Root cause

The affected writes relied on the process umask. New files could therefore be created as `0644`, and passing a mode during later writes would not repair an existing file. The same `agent.json` root cause covered both runtime secrets and integration tokens (security report findings F7/F8); daemon credentials in `config.json` were affected separately (F13).

## Impact

On shared POSIX hosts, other local users can no longer read newly created or legacy AgentConnect credential files through broad group/other mode bits. New daemon-managed agent directories are created as `0700`, while existing custom directory permissions and symlink/inode behavior remain unchanged.

## Validation

- daemon full suite with polling: 123 files passed, 1 skipped; 1962 tests passed, 2 skipped
- CLI full suite: 15 files passed; 99 tests passed
- focused daemon/CLI permission tests: 87 tests passed
- daemon and CLI TypeScript checks
- ESLint on all changed TypeScript files
- Prettier and `git diff --check`
- pre-push repository lint: 0 errors (2 pre-existing warnings)

Created by Codex . GPT-5
