### PR TITLE
fix(control-plane): scope thread fallback by bot

### DIFF
--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -98,6 +98,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   let upserts: { daemonId: string; spec: { platform: string; slack?: { mode?: string } } }[]
   // Drives the SessionRepo.findThreadOwner fallback in lookupThread (null = no daemon session).
   let threadOwner: { agentId: string; daemonId: string } | null
+  let threadOwnerLookup: { botId: BotId; channel: string; thread: string } | null
 
   function makeOrch(): SharedBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
@@ -153,7 +154,10 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       integrationUpsert: async (daemonId: string, spec: unknown) => void upserts.push({ daemonId, spec: spec as never })
     }
     const sessions: Pick<SessionRepo, 'findThreadOwner'> = {
-      findThreadOwner: async () => threadOwner
+      findThreadOwner: async (botId, channel, thread) => {
+        threadOwnerLookup = { botId, channel, thread }
+        return threadOwner
+      }
     }
     return new SharedBotOrchestrator(
       bots as BotRepo,
@@ -178,6 +182,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: BOB, trigger: 'mention' })]
     upserts = []
     threadOwner = null
+    threadOwnerLookup = null
   })
 
   describe('lookupThread — SessionMeta fallback on affinity miss (§7.2 case 2a)', () => {
@@ -191,6 +196,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       threadOwner = { agentId: ALICE, daemonId: D1 }
       const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
       expect(res).toEqual({ botId: BOT, sessionKey: SK, target: { agentId: ALICE, daemonId: D1 } })
+      expect(threadOwnerLookup).toEqual({ botId: BOT, channel: 'C1', thread: '1784297789.871789' })
     })
 
     it('returns null when neither affinity nor a SessionMeta owner exists', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -220,7 +220,7 @@ export class SharedBotOrchestrator {
     if (slash > 0) {
       const channel = m.sessionKey.slice(0, slash)
       const thread = m.sessionKey.slice(slash + 1)
-      const owner = await this.sessions.findThreadOwner(channel, thread)
+      const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
       if (owner) return { botId: m.botId, sessionKey: m.sessionKey, target: owner }
     }
     return { botId: m.botId, sessionKey: m.sessionKey, target: null }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -888,12 +888,13 @@ export interface SessionRepo {
   /** Visible-child lookup for the session detail page. Parent ids are opaque and
    *  deliberately not foreign-keyed, so this remains a metadata query. */
   listChildren(parentSessionId: SessionId, agentIds: AgentId[]): Promise<SessionMetaRecord[]>
-  /** Resolve the agent that owns a `(channel, thread)` — the most-recently-active, still-open
-   *  session keyed there that has a routable daemon. Backstop for shared-bot thread-affinity
-   *  lookup: a daemon-created session (e.g. an agent's own channel-root post, session-concept
-   *  §7.2 case 2a) never goes through the relay's mention/switch REPORT leg, so no `thread-assign`
-   *  seeds the affinity store — this lets `lookupThread` still find the owner. Null when none. */
-  findThreadOwner(channel: string, thread: string): Promise<{ agentId: string; daemonId: string } | null>
+  /** Resolve the agent that owns a bot's `(channel, thread)` — the most-recently-active session
+   *  keyed there whose agent still has an active integration for that bot and a current daemon
+   *  placement. Backstop for shared-bot thread-affinity lookup: a daemon-created session (e.g.
+   *  an agent's own channel-root post, session-concept §7.2 case 2a) never goes through the
+   *  relay's mention/switch REPORT leg, so no `thread-assign` seeds the affinity store — this
+   *  lets `lookupThread` still find the owner. Null when none. */
+  findThreadOwner(botId: BotId, channel: string, thread: string): Promise<{ agentId: string; daemonId: string } | null>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -24,7 +24,7 @@ import type {
   SessionPhase,
   ActivityState
 } from '../ports.js'
-import { AgentId, DaemonId, LaunchId, SessionId } from '../../domain/ids.js'
+import { AgentId, BotId, DaemonId, LaunchId, SessionId } from '../../domain/ids.js'
 
 function toRecord(s: SessionMeta): SessionMetaRecord {
   return {
@@ -458,19 +458,31 @@ export class PgSessionRepo implements SessionRepo {
     return rows.map(toRecord)
   }
 
-  async findThreadOwner(channel: string, thread: string): Promise<{ agentId: string; daemonId: string } | null> {
-    // Most-recently-active session on this (channel, thread) that has a routable daemon
-    // (`daemonId` is stamped by the CP from the authenticated WS conn — trusted).
+  async findThreadOwner(
+    botId: BotId,
+    channel: string,
+    thread: string
+  ): Promise<{ agentId: string; daemonId: string } | null> {
+    // Most-recently-active session on this bot's (channel, thread) whose agent is currently
+    // placed. The session's daemonId is provenance; routing follows current agent placement.
     // NOTE: do NOT filter on `endedAt` — a session emits `phase:'end'` (→ `endedAt`) at the end
     // of EVERY turn, so an idle-between-turns session (the normal state of a thread's owner
     // between messages) has `endedAt` set yet is still the valid target; the daemon resumes it on
     // delivery. Filtering `endedAt: null` here made the affinity fallback miss essentially every
     // real thread (incl. a case-2a spawned session after its one headless turn).
     const row = await this.db.sessionMeta.findFirst({
-      where: { channel, thread, daemonId: { not: null } },
+      where: {
+        channel,
+        thread,
+        daemonId: { not: null },
+        agent: {
+          daemonId: { not: null },
+          integrations: { some: { botId, status: 'active' } }
+        }
+      },
       orderBy: [{ lastActivityAt: 'desc' }, { startedAt: 'desc' }],
-      select: { agentId: true, daemonId: true }
+      select: { agentId: true, agent: { select: { daemonId: true } } }
     })
-    return row && row.daemonId ? { agentId: row.agentId, daemonId: row.daemonId } : null
+    return row?.agent.daemonId ? { agentId: row.agentId, daemonId: row.agent.daemonId } : null
   }
 }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -464,7 +464,8 @@ export class PgSessionRepo implements SessionRepo {
     thread: string
   ): Promise<{ agentId: string; daemonId: string } | null> {
     // Most-recently-active session on this bot's (channel, thread) whose agent is currently
-    // placed. The session's daemonId is provenance; routing follows current agent placement.
+    // placed. The session's daemonId is provenance only and may be null after its reporting
+    // daemon is deleted; routing follows current agent placement.
     // NOTE: do NOT filter on `endedAt` — a session emits `phase:'end'` (→ `endedAt`) at the end
     // of EVERY turn, so an idle-between-turns session (the normal state of a thread's owner
     // between messages) has `endedAt` set yet is still the valid target; the daemon resumes it on
@@ -474,7 +475,6 @@ export class PgSessionRepo implements SessionRepo {
       where: {
         channel,
         thread,
-        daemonId: { not: null },
         agent: {
           daemonId: { not: null },
           integrations: { some: { botId, status: 'active' } }

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -10,12 +10,13 @@
 import { describe, it, expect } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
-import { seedAgent, seedDaemon, seedLaunch } from '../fixtures/seed.js'
-import { AgentId, DaemonId, LaunchId, SessionId } from '../../src/domain/ids.js'
+import { DEF_ORG, seedAgent, seedDaemon, seedLaunch } from '../fixtures/seed.js'
+import { AgentId, BotId, DaemonId, LaunchId, SessionId } from '../../src/domain/ids.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const OTHER_AGENT = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const DAEMON = 'd1111111-1111-4111-8111-111111111111'
+const OTHER_DAEMON = 'd2222222-2222-4222-8222-222222222222'
 const LAUNCH = '11111111-1111-4111-8111-111111111111'
 const SESSION = '55555555-5555-4555-8555-555555555555'
 
@@ -222,6 +223,74 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
 
     expect(await repo.list({ platform: 'slack', channel: 'C1' })).toHaveLength(1)
     expect(await repo.list({ platform: 'telegram' })).toHaveLength(0)
+  })
+
+  it("scopes shared-bot thread fallback to the bot's active, currently placed agent", async () => {
+    await fixtures()
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, OTHER_AGENT, { daemonId: OTHER_DAEMON })
+    await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: DAEMON, status: 'active' } })
+    const repo = new PgSessionRepo(prisma)
+    const botId = '22222222-2222-4222-8222-222222222221'
+    const otherBotId = '22222222-2222-4222-8222-222222222222'
+    const integrationId = '66666666-6666-4666-8666-666666666661'
+
+    await prisma.bot.createMany({
+      data: [
+        { id: botId, orgId: DEF_ORG, platform: 'slack', name: 'requested-bot' },
+        { id: otherBotId, orgId: DEF_ORG, platform: 'slack', name: 'other-bot' }
+      ]
+    })
+    await prisma.integration.createMany({
+      data: [
+        { id: integrationId, orgId: DEF_ORG, agentId: AGENT, botId, name: 'requested-bot' },
+        {
+          id: '66666666-6666-4666-8666-666666666662',
+          orgId: DEF_ORG,
+          agentId: OTHER_AGENT,
+          botId: otherBotId,
+          name: 'other-bot'
+        }
+      ]
+    })
+    await repo.recordMilestone(
+      ev('start', {
+        sessionId: SessionId('requested-bot-session'),
+        daemonId: DaemonId(DAEMON),
+        lastActivityAt: new Date('2026-07-05T08:08:00.000Z')
+      })
+    )
+    await repo.recordMilestone(
+      ev('start', {
+        sessionId: SessionId('other-bot-session'),
+        agentId: AgentId(OTHER_AGENT),
+        launchId: undefined,
+        daemonId: DaemonId(OTHER_DAEMON),
+        lastActivityAt: new Date('2026-07-05T10:51:00.000Z')
+      })
+    )
+
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
+      agentId: AGENT,
+      daemonId: DAEMON
+    })
+    expect(await repo.findThreadOwner(BotId(otherBotId), 'C1', 'T1')).toEqual({
+      agentId: OTHER_AGENT,
+      daemonId: OTHER_DAEMON
+    })
+
+    await prisma.integration.update({ where: { id: integrationId }, data: { status: 'revoked' } })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toBeNull()
+
+    await prisma.integration.update({ where: { id: integrationId }, data: { status: 'active' } })
+    await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: OTHER_DAEMON } })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
+      agentId: AGENT,
+      daemonId: OTHER_DAEMON
+    })
+
+    await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: null, status: 'inactive' } })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toBeNull()
   })
 
   it('joins usage into list() and sorts by latest activity', async () => {

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -289,6 +289,12 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
       daemonId: OTHER_DAEMON
     })
 
+    await prisma.daemon.delete({ where: { id: DAEMON } })
+    expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toEqual({
+      agentId: AGENT,
+      daemonId: OTHER_DAEMON
+    })
+
     await prisma.agent.update({ where: { id: AGENT }, data: { daemonId: null, status: 'inactive' } })
     expect(await repo.findThreadOwner(BotId(botId), 'C1', 'T1')).toBeNull()
   })


### PR DESCRIPTION
## Summary

- scope the SessionMeta thread-owner fallback to agents with an active integration on the requested shared bot
- route fallback delivery through the agent's current daemon placement instead of historical session provenance
- cover cross-bot collisions, revoked integrations, moves, and unplaced agents with focused tests

## Why

On an affinity miss, the fallback previously searched all session metadata by channel and thread. A newer session owned by an agent on another bot could win that global lookup and return an unrelated routing target. The same lookup also treated the daemon that originally reported a session as current routing authority after an agent moved.

## Impact

Unmentioned shared-bot thread follow-ups can now fall back only to an agent that is actively integrated with that bot and currently placed. This requires no database migration or wire-schema change.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` (619 tests)
- focused shared-bot unit test (10 tests)
- real PostgreSQL SessionRepo integration test (10 tests)
- ESLint on changed files
- Prettier check and `git diff --check`
- pre-push repository lint (0 errors; 2 existing warnings in `icon-upload.ts`)

Created by Codex . GPT-5
