### PR TITLE
feat(slack): optional config-token refresh + config-token create flow

### DIFF
--- a/docs/designs/slack-install-smoothing.md
+++ b/docs/designs/slack-install-smoothing.md
@@ -21,21 +21,32 @@ the created Slack app belongs to that person.
 
 The organization-scoped routes are:
 
-| Endpoint               | Behavior                                                   |
-| ---------------------- | ---------------------------------------------------------- |
-| `GET /slack/config`    | Returns availability and timestamps only.                  |
-| `PUT /slack/config`    | Validates, normalizes, and stores the caller's token pair. |
-| `DELETE /slack/config` | Removes the caller's stored configuration.                 |
+| Endpoint               | Behavior                                                            |
+| ---------------------- | ------------------------------------------------------------------- |
+| `GET /slack/config`    | Returns availability, durability, and timestamps only.              |
+| `PUT /slack/config`    | Validates and stores the caller's token; refresh token is optional. |
+| `DELETE /slack/config` | Removes the caller's stored configuration.                          |
 
 No read response returns either the access token or refresh token.
 
 `PgSlackUserConfigStore` seals every token through `SecretCipher`. The
 repository supports multiple cipher implementations; runtime configuration
-selects which one is active.
+selects which one is active. The refresh-token column is nullable.
+
+The access (config) token is required; the refresh token is optional:
+
+- **With a refresh token** the pair is validated and normalized by rotating it
+  once on save, and rotated again whenever the access token nears expiry — so it
+  auto-renews and never needs re-entry. This row is **durable**.
+- **Access token only** — nothing to rotate. It is stored as-is with Slack's
+  documented ~12h lifetime and verified when the caller starts an install
+  (`apps.manifest.create` rejects a bad or expired token). Once it lapses the
+  resolution is `expired` and the Console asks the caller to re-enter it (or add
+  a refresh token to make it durable).
 
 Slack configuration access tokens are short-lived. Before creating an app, the
-Control Plane rotates a stored token when it is close to expiry and persists
-the replacement pair. Because refresh rotation is single-use, a failed rotate
+Control Plane rotates a stored token when it is close to expiry and persists the
+replacement pair. Because refresh rotation is single-use, a failed rotate
 reloads the row once in case another request already rotated and saved a fresh
 pair.
 
@@ -46,11 +57,14 @@ pair.
 Automatic installation is available only when:
 
 - the Slack configuration API is enabled;
-- the caller has stored a valid App Configuration token; and
+- the caller has stored an App Configuration token that is usable right now —
+  durable (a refresh token is stored) or its access token is still fresh; and
 - a public HTTPS Control Plane callback base is configured.
 
-`GET /slack/config` reports this as metadata such as `configured`,
-`funnelEnabled`, and `autoAvailable`.
+`GET /slack/config` reports this as metadata such as `configured`, `durable`,
+`funnelEnabled`, `autoAvailable`, and `accessExpiresAt`. `autoAvailable` is true
+only when the funnel is enabled and the stored token is usable; a stored but
+expired access-only token reports `configured: true` with `autoAvailable: false`.
 
 HTTP-mode installation additionally requires:
 

--- a/packages/control-plane/prisma/migrations/20260724120000_slack_config_optional_refresh/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260724120000_slack_config_optional_refresh/migration.sql
@@ -1,0 +1,5 @@
+-- The Slack App Configuration refresh token is now OPTIONAL. When a caller stores
+-- only the access (config) token, the row keeps no refresh token; the access token
+-- works until it expires (~12h), after which the caller re-enters it. A stored
+-- refresh token still auto-rotates the pair so it never needs re-entry.
+ALTER TABLE "public"."slack_user_config" ALTER COLUMN "refreshToken" DROP NOT NULL;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1438,8 +1438,8 @@ model SlackUserConfig {
   orgId           String
   userId          String
   accessToken     String // xoxe.xoxp-… — the App Configuration access token
-  refreshToken    String // xoxe-… — used to rotate a fresh access token
-  accessExpiresAt DateTime @db.Timestamptz(6) // when accessToken expires (~12h; drives rotation)
+  refreshToken    String? // xoxe-… — used to rotate a fresh access token; null ⇒ access-only (expires ~12h, then re-enter)
+  accessExpiresAt DateTime @db.Timestamptz(6) // when accessToken expires (~12h; drives rotation / re-entry)
   createdAt       DateTime @default(now()) @db.Timestamptz(6)
   updatedAt       DateTime @updatedAt @db.Timestamptz(6)
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1013,11 +1013,13 @@ export const SlackAppStartBody = z.object({
 })
 
 /** `PUT /slack/config` — store (or replace) the CALLER's Slack App Configuration token.
- *  Both are needed: the access token (`xoxe.xoxp-…`) and its refresh token
- *  (`xoxe-…`, used to rotate a fresh access token once the 12h one expires). */
+ *  The access (config) token (`xoxe.xoxp-…`) is required and enough on its own for
+ *  installs while it is fresh (~12h). The refresh token (`xoxe-…`) is OPTIONAL: when
+ *  provided the pair auto-rotates so it never expires; when omitted the caller re-enters
+ *  the access token once it lapses. */
 export const SlackConfigBody = z.object({
   accessToken: z.string().min(1),
-  refreshToken: z.string().min(1)
+  refreshToken: z.string().min(1).optional()
 })
 
 /** `GET /slack/config` — whether the CALLER has stored their own config token, and
@@ -1025,9 +1027,16 @@ export const SlackConfigBody = z.object({
  *  the tokens. Per-user: the status reflects the signed-in caller, not the org. */
 export const SlackConfigDto = z.object({
   configured: z.boolean(), // the caller has stored their own token
+  /** A refresh token is stored ⇒ the pair auto-rotates and never needs re-entry. When
+   *  false, the stored token is access-only and lapses at `accessExpiresAt`. */
+  durable: z.boolean(),
   funnelEnabled: z.boolean(), // deployment supports auto-install (public callback)
-  /** configured AND funnelEnabled — drives the modal's forced auto/manual mode. */
+  /** funnelEnabled AND the stored token is usable right now (durable, or the access
+   *  token is still fresh) — drives the modal's forced auto/manual mode. */
   autoAvailable: z.boolean(),
+  /** ISO-8601 expiry of the stored access token; drives the "expires / expired" copy
+   *  on the config card. Null when unconfigured. (Meaningful mainly when !durable.) */
+  accessExpiresAt: z.string().nullable(),
   /** Slack HTTP mode is offerable here: PUBLIC_RELAY_URL is set AND ≥1 relay is
    *  connected to receive the Events API POSTs (slack-http-mode). */
   relayAvailable: z.boolean(),

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -165,24 +165,46 @@ export function slackInstallRoutes(deps: HttpDeps) {
         // Brand the created app with the agent's icon color (Slack has no API to set
         // the app image itself) — its avatar plate → the manifest background_color.
         const bgColor = agentIconBackgroundColor(agent.icon)
-        const created = await api.createApp(
-          config.accessToken,
-          buildInstallManifest(name, redirectUri, httpBase, bgColor)
-        )
+        const manifest = buildInstallManifest(name, redirectUri, httpBase, bgColor)
+        // Snapshot the credential we're about to attempt (post-resolve, so it reflects any
+        // rotation resolve already did). If the attempt fails we invalidate exactly THIS
+        // version — never a fresher token a concurrent tab may have written since.
+        let snapshot = await deps.repos.slackUserConfig.get(orgId, req.principal.userId)
+        let created = await api.createApp(config.accessToken, manifest)
+
+        // Slack rejected the config token as invalid/expired. resolve() hands back a fresh
+        // (unexpired) access token WITHOUT re-validating it, so a DURABLE (refresh-backed)
+        // config can still hold a bad-but-unexpired access token: force one rotation to mint
+        // a genuinely new token from Slack and retry. If that still auth-fails the config is
+        // unrecoverable and gets invalidated; an ACCESS-ONLY config (no refresh) can't be
+        // rotated, so it's invalidated outright. Non-auth errors (rate limit, etc.) and
+        // transient unreachable keep the row. Every delete is conditional on the attempted
+        // row's version, so a concurrent replacement is never erased.
+        if (!created.ok && SLACK_CONFIG_AUTH_ERRORS.has(created.error) && snapshot) {
+          if (snapshot.refreshToken) {
+            const rotated = await api.rotateConfigToken(snapshot.refreshToken)
+            if (rotated.ok) {
+              await deps.repos.slackUserConfig.put(orgId, req.principal.userId, rotated.rotated)
+              snapshot = (await deps.repos.slackUserConfig.get(orgId, req.principal.userId)) ?? snapshot
+              created = await api.createApp(rotated.rotated.accessToken, manifest)
+            } else if (rotated.error === 'unreachable') {
+              // Couldn't reach Slack to rotate — transient, not a dead config. Keep the row.
+              return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
+            }
+            // rotate ok but the retry still auth-failed, OR rotate itself was rejected
+            // (refresh revoked): the config can't produce a working token ⇒ invalidate it.
+            if (!created.ok && created.error !== 'unreachable' && SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
+              await deps.repos.slackUserConfig.deleteIfUnchanged(orgId, req.principal.userId, snapshot.updatedAt)
+            }
+          } else {
+            // Access-only, definitively rejected ⇒ drop it (conditional on the attempted version).
+            await deps.repos.slackUserConfig.deleteIfUnchanged(orgId, req.principal.userId, snapshot.updatedAt)
+          }
+        }
+
         if (!created.ok) {
           if (created.error === 'unreachable') {
             return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
-          }
-          // Slack rejected the config token as invalid/expired. An ACCESS-ONLY row (no
-          // refresh, so no recovery, and never validated before now) is dead — drop it so
-          // the console re-prompts on the next status. A DURABLE (refresh-backed) config is
-          // retained: its refresh was just validated by the rotate on resolve, so a create
-          // rejection isn't its fault; non-auth errors (rate limit, etc.) keep the row too.
-          if (SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
-            const stored = await deps.repos.slackUserConfig.get(orgId, req.principal.userId)
-            if (stored && !stored.refreshToken) {
-              await deps.repos.slackUserConfig.delete(orgId, req.principal.userId)
-            }
           }
           return reply.code(400).send({
             error: 'Bad Request',

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -30,7 +30,7 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { buildInstallManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
 import { agentIconBackgroundColor } from '../../agents/agent-icon.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
-import { resolveUserConfigAccessToken } from '../slack-user-config.js'
+import { CONFIG_ACCESS_TTL_MS, configUsable, resolveUserConfigAccessToken } from '../slack-user-config.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
   SlackAppStartBody,
@@ -127,7 +127,9 @@ export function slackInstallRoutes(deps: HttpDeps) {
           const message =
             config.reason === 'not_configured'
               ? 'You haven’t stored your Slack App Configuration token — add it to enable one-click installs.'
-              : 'Your stored Slack App Configuration token is invalid or expired — re-add it.'
+              : config.reason === 'expired'
+                ? 'Your Slack App Configuration token expired — re-enter it (add a refresh token to keep it from expiring).'
+                : 'Your stored Slack App Configuration token is invalid or expired — re-add it.'
           return reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
         }
 
@@ -409,12 +411,17 @@ export function slackConfigRoutes(deps: HttpDeps) {
     // paste into Slack), ws→http normalized. Null when PUBLIC_RELAY_URL is unset.
     const relayPublicUrl = relayHttpBase(deps.config.PUBLIC_RELAY_URL)
 
-    const statusOf = async (orgId: OrgId, userId: string) => {
+    const statusOf = async (orgId: OrgId, userId: string, now = new Date()) => {
       const row = await deps.repos.slackUserConfig.get(orgId, userId)
+      // Durable = a refresh token is stored (the pair auto-rotates). Usable now = durable
+      // or the access-only token is still fresh; a lapsed access-only token forces re-entry.
+      const durable = !!row?.refreshToken
       return {
         configured: !!row,
+        durable,
         funnelEnabled,
-        autoAvailable: !!row && funnelEnabled,
+        autoAvailable: funnelEnabled && configUsable(row, now),
+        accessExpiresAt: row ? row.accessExpiresAt.toISOString() : null,
         // HTTP mode is offerable here: a public relay origin is configured AND ≥1 relay
         // is connected to receive the Events API POSTs.
         relayAvailable: !!relayPublicUrl && deps.sharedBot.hasConnectedRelay(),
@@ -450,7 +457,7 @@ export function slackConfigRoutes(deps: HttpDeps) {
           tags: [Tag.Integrations],
           summary: 'Store Slack config token',
           description:
-            'Save (or replace) the caller’s own Slack App Configuration token, validated + normalized by rotating it once. Forces the create modal into auto-install for this caller.',
+            'Save (or replace) the caller’s own Slack App Configuration token. With a refresh token it is validated + normalized by rotating once (durable, never expires); access-token-only is stored as-is with Slack’s ~12h lifetime and verified at install time. Forces the create modal into auto-install for this caller.',
           operationId: 'putSlackConfig',
           body: SlackConfigBody,
           response: { 200: SlackConfigDto, 400: ErrorDto, 401: ErrorDto, 403: ErrorDto, 502: ErrorDto }
@@ -462,22 +469,36 @@ export function slackConfigRoutes(deps: HttpDeps) {
           return reply.code(401).send({ error: 'Unauthorized', statusCode: 401, message: 'authentication required' })
         }
         const orgId = orgIdOf(req)
-        // Validate + normalize by rotating the refresh token: confirms it works AND
-        // yields the exact expiry. Each rotate issues a NEW pair (the pasted access
-        // token is accepted for parity with Slack's UI but superseded by the rotate).
-        const rotated = await api.rotateConfigToken(req.body.refreshToken)
-        if (!rotated.ok) {
-          if (rotated.error === 'unreachable') {
-            return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
+        const now = new Date()
+        if (req.body.refreshToken) {
+          // Refresh token supplied ⇒ validate + normalize by rotating it: confirms the
+          // pair works AND yields the exact expiry. Each rotate issues a NEW pair (the
+          // pasted access token is accepted for parity with Slack's UI but superseded by
+          // the rotate). The stored pair auto-rotates from here on — durable.
+          const rotated = await api.rotateConfigToken(req.body.refreshToken)
+          if (!rotated.ok) {
+            if (rotated.error === 'unreachable') {
+              return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
+            }
+            return reply.code(400).send({
+              error: 'Bad Request',
+              statusCode: 400,
+              message: `Slack rejected the config token (${rotated.error}). Regenerate it at api.slack.com/apps → “Your App Configuration Tokens”.`
+            })
           }
-          return reply.code(400).send({
-            error: 'Bad Request',
-            statusCode: 400,
-            message: `Slack rejected the config token (${rotated.error}). Regenerate it at api.slack.com/apps → “Your App Configuration Tokens”.`
+          await deps.repos.slackUserConfig.put(orgId, req.principal.userId, rotated.rotated)
+        } else {
+          // Access-only ⇒ nothing to rotate. Store the access token as-is with Slack's
+          // documented ~12h lifetime; it is verified when the caller starts an install
+          // (apps.manifest.create rejects a bad/expired token with a clear message). Once
+          // it lapses the caller re-enters it, or adds a refresh token to make it durable.
+          await deps.repos.slackUserConfig.put(orgId, req.principal.userId, {
+            accessToken: req.body.accessToken,
+            refreshToken: null,
+            accessExpiresAt: new Date(now.getTime() + CONFIG_ACCESS_TTL_MS)
           })
         }
-        await deps.repos.slackUserConfig.put(orgId, req.principal.userId, rotated.rotated)
-        return statusOf(orgId, req.principal.userId)
+        return statusOf(orgId, req.principal.userId, now)
       }
     )
 

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -166,39 +166,28 @@ export function slackInstallRoutes(deps: HttpDeps) {
         // the app image itself) — its avatar plate → the manifest background_color.
         const bgColor = agentIconBackgroundColor(agent.icon)
         const manifest = buildInstallManifest(name, redirectUri, httpBase, bgColor)
-        // Snapshot the credential we're about to attempt (post-resolve, so it reflects any
-        // rotation resolve already did). If the attempt fails we invalidate exactly THIS
-        // version — never a fresher token a concurrent tab may have written since.
-        let snapshot = await deps.repos.slackUserConfig.get(orgId, req.principal.userId)
         let created = await api.createApp(config.accessToken, manifest)
 
-        // Slack rejected the config token as invalid/expired. resolve() hands back a fresh
-        // (unexpired) access token WITHOUT re-validating it, so a DURABLE (refresh-backed)
-        // config can still hold a bad-but-unexpired access token: force one rotation to mint
-        // a genuinely new token from Slack and retry. If that still auth-fails the config is
-        // unrecoverable and gets invalidated; an ACCESS-ONLY config (no refresh) can't be
-        // rotated, so it's invalidated outright. Non-auth errors (rate limit, etc.) and
-        // transient unreachable keep the row. Every delete is conditional on the attempted
-        // row's version, so a concurrent replacement is never erased.
-        if (!created.ok && SLACK_CONFIG_AUTH_ERRORS.has(created.error) && snapshot) {
-          if (snapshot.refreshToken) {
-            const rotated = await api.rotateConfigToken(snapshot.refreshToken)
+        // Slack rejected the config token. resolve() hands back a fresh (unexpired) access
+        // token WITHOUT re-validating it, so a refresh-backed config may still hold a
+        // bad-but-unexpired token: force one rotation to mint a new token and retry. If the
+        // retry still auth-fails — or the token is access-only, with nothing to rotate — the
+        // config can't work, so drop it and the console re-prompts. Non-auth errors (rate
+        // limit, etc.) and transient unreachable keep the row.
+        if (!created.ok && SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
+          const stored = await deps.repos.slackUserConfig.get(orgId, req.principal.userId)
+          if (stored?.refreshToken) {
+            const rotated = await api.rotateConfigToken(stored.refreshToken)
             if (rotated.ok) {
               await deps.repos.slackUserConfig.put(orgId, req.principal.userId, rotated.rotated)
-              snapshot = (await deps.repos.slackUserConfig.get(orgId, req.principal.userId)) ?? snapshot
               created = await api.createApp(rotated.rotated.accessToken, manifest)
             } else if (rotated.error === 'unreachable') {
               // Couldn't reach Slack to rotate — transient, not a dead config. Keep the row.
               return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
             }
-            // rotate ok but the retry still auth-failed, OR rotate itself was rejected
-            // (refresh revoked): the config can't produce a working token ⇒ invalidate it.
-            if (!created.ok && created.error !== 'unreachable' && SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
-              await deps.repos.slackUserConfig.deleteIfUnchanged(orgId, req.principal.userId, snapshot.updatedAt)
-            }
-          } else {
-            // Access-only, definitively rejected ⇒ drop it (conditional on the attempted version).
-            await deps.repos.slackUserConfig.deleteIfUnchanged(orgId, req.principal.userId, snapshot.updatedAt)
+          }
+          if (!created.ok && SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
+            await deps.repos.slackUserConfig.delete(orgId, req.principal.userId)
           }
         }
 

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -52,6 +52,19 @@ export function relayHttpBase(publicRelayUrl: string | undefined): string | null
   return publicRelayUrl.replace(/^ws(s?):\/\//i, 'http$1://').replace(/\/$/, '')
 }
 
+/** Slack error strings from `apps.manifest.create` that mean the config token itself is
+ *  invalid/expired (as opposed to a transient error or a rate limit). An ACCESS-ONLY stored
+ *  token that hits one of these is dropped so the console re-prompts; other errors keep it. */
+const SLACK_CONFIG_AUTH_ERRORS = new Set([
+  'invalid_auth',
+  'not_authed',
+  'token_expired',
+  'token_revoked',
+  'account_inactive',
+  'no_permission',
+  'missing_scope'
+])
+
 export function slackInstallRoutes(deps: HttpDeps) {
   return async function slackInstallRoutesPlugin(app: FastifyInstance): Promise<void> {
     const api = deps.slackConfigApi
@@ -159,6 +172,17 @@ export function slackInstallRoutes(deps: HttpDeps) {
         if (!created.ok) {
           if (created.error === 'unreachable') {
             return reply.code(502).send({ error: 'Bad Gateway', statusCode: 502, message: 'could not reach Slack' })
+          }
+          // Slack rejected the config token as invalid/expired. An ACCESS-ONLY row (no
+          // refresh, so no recovery, and never validated before now) is dead — drop it so
+          // the console re-prompts on the next status. A DURABLE (refresh-backed) config is
+          // retained: its refresh was just validated by the rotate on resolve, so a create
+          // rejection isn't its fault; non-auth errors (rate limit, etc.) keep the row too.
+          if (SLACK_CONFIG_AUTH_ERRORS.has(created.error)) {
+            const stored = await deps.repos.slackUserConfig.get(orgId, req.principal.userId)
+            if (stored && !stored.refreshToken) {
+              await deps.repos.slackUserConfig.delete(orgId, req.principal.userId)
+            }
           }
           return reply.code(400).send({
             error: 'Bad Request',

--- a/packages/control-plane/src/http/slack-user-config.test.ts
+++ b/packages/control-plane/src/http/slack-user-config.test.ts
@@ -9,18 +9,21 @@ const ORG = OrgId('org_test')
 const USER = 'user_test'
 const NOW = new Date('2026-01-01T00:00:00Z')
 
-function row(expiresAt: Date, access = 'access'): SlackUserConfigRecord {
+function row(expiresAt: Date, access = 'access', refreshToken: string | null = 'refresh'): SlackUserConfigRecord {
   return {
     orgId: ORG,
     userId: USER,
     accessToken: access,
-    refreshToken: 'refresh',
+    refreshToken,
     accessExpiresAt: expiresAt,
     updatedAt: NOW
   }
 }
 const fresh = (access?: string) => row(new Date(NOW.getTime() + 3600_000), access) // +1h ⇒ fresh
 const stale = (access?: string) => row(new Date(NOW.getTime() + 60_000), access) // +1m ⇒ within margin ⇒ stale
+// Access-only rows (no refresh token to rotate).
+const freshAccessOnly = (access?: string) => row(new Date(NOW.getTime() + 3600_000), access, null)
+const staleAccessOnly = (access?: string) => row(new Date(NOW.getTime() + 60_000), access, null)
 
 /** Fake deps: `rows` are returned by successive get() calls; captures rotate calls + puts. */
 function makeDeps(rows: (SlackUserConfigRecord | null)[], rotate: SlackRotateResult) {
@@ -98,5 +101,18 @@ describe('resolveUserConfigAccessToken', () => {
   it('is rotate_failed when the rotate is rejected and the reloaded row is still stale', async () => {
     const { deps } = makeDeps([stale(), stale()], { ok: false, error: 'invalid_refresh_token' })
     expect(await resolveUserConfigAccessToken(deps, ORG, USER, NOW)).toEqual({ ok: false, reason: 'rotate_failed' })
+  })
+
+  it('returns an access-only token as-is while fresh (no refresh, no rotate)', async () => {
+    const { deps, rotateCalls } = makeDeps([freshAccessOnly('live')], okRotate)
+    expect(await resolveUserConfigAccessToken(deps, ORG, USER, NOW)).toEqual({ ok: true, accessToken: 'live' })
+    expect(rotateCalls).toHaveLength(0)
+  })
+
+  it('is expired for a stale access-only token (nothing to rotate)', async () => {
+    const { deps, rotateCalls, puts } = makeDeps([staleAccessOnly()], okRotate)
+    expect(await resolveUserConfigAccessToken(deps, ORG, USER, NOW)).toEqual({ ok: false, reason: 'expired' })
+    expect(rotateCalls).toHaveLength(0) // no refresh token ⇒ never calls rotate
+    expect(puts).toHaveLength(0)
   })
 })

--- a/packages/control-plane/src/http/slack-user-config.ts
+++ b/packages/control-plane/src/http/slack-user-config.ts
@@ -5,13 +5,17 @@
  * PER-USER: the token belongs to whoever initiates the install, so the app the
  * funnel creates is owned by them (and only they can mint its app-level token).
  *
- * App Configuration access tokens expire ~12h after issue, so this rotates the
- * stored refresh token (`tooling.tokens.rotate`) when the access token is within
- * `ROTATE_MARGIN_MS` of expiry, persisting the fresh pair. Rotation is single-use
- * (each rotate invalidates the old refresh), so a rotate that fails is retried once
- * by reloading the row — under a concurrent install by the same user another request
- * may have just rotated and persisted a fresh token we can use. Never logs token
- * material.
+ * App Configuration access tokens expire ~12h after issue. When the caller stored a
+ * refresh token, this rotates it (`tooling.tokens.rotate`) once the access token is
+ * within `ROTATE_MARGIN_MS` of expiry, persisting the fresh pair. Rotation is
+ * single-use (each rotate invalidates the old refresh), so a rotate that fails is
+ * retried once by reloading the row — under a concurrent install by the same user
+ * another request may have just rotated and persisted a fresh token we can use.
+ *
+ * When the caller stored ONLY the access (config) token — no refresh token — there is
+ * nothing to rotate: the access token is used as-is while fresh, and once it lapses the
+ * resolution is `expired`, so the console asks the caller to re-enter it. Never logs
+ * token material.
  */
 import type { HttpDeps } from './deps.js'
 import type { OrgId } from '../domain/ids.js'
@@ -20,11 +24,24 @@ import type { OrgId } from '../domain/ids.js'
  *  + the install round-trip that follows). */
 export const ROTATE_MARGIN_MS = 5 * 60 * 1000
 
-export type UserConfigResolution =
-  { ok: true; accessToken: string } | { ok: false; reason: 'not_configured' | 'rotate_failed' | 'unreachable' }
+/** Slack App Configuration access tokens live ~12h from issue. When only the access
+ *  token is stored (no refresh to rotate), the row's expiry is stamped this far out. */
+export const CONFIG_ACCESS_TTL_MS = 12 * 60 * 60 * 1000
 
-function fresh(expiresAt: Date, now: Date): boolean {
+export type UserConfigResolution =
+  | { ok: true; accessToken: string }
+  // `expired`: an access-only token (no refresh) has lapsed — the caller must re-enter it.
+  | { ok: false; reason: 'not_configured' | 'expired' | 'rotate_failed' | 'unreachable' }
+
+/** True while the stored access token has enough life left to use as-is. */
+export function accessTokenFresh(expiresAt: Date, now: Date): boolean {
   return expiresAt.getTime() - now.getTime() > ROTATE_MARGIN_MS
+}
+
+/** Whether the stored config can start an install right now: a refresh token can always
+ *  mint a fresh access token; without one, the access token must still be fresh. */
+export function configUsable(row: { refreshToken: string | null; accessExpiresAt: Date } | null, now: Date): boolean {
+  return !!row && (!!row.refreshToken || accessTokenFresh(row.accessExpiresAt, now))
 }
 
 export async function resolveUserConfigAccessToken(
@@ -37,7 +54,9 @@ export async function resolveUserConfigAccessToken(
   if (!api) return { ok: false, reason: 'unreachable' } // funnel off — shouldn't be reached
   const row = await deps.repos.slackUserConfig.get(orgId, userId)
   if (!row) return { ok: false, reason: 'not_configured' }
-  if (fresh(row.accessExpiresAt, now)) return { ok: true, accessToken: row.accessToken }
+  if (accessTokenFresh(row.accessExpiresAt, now)) return { ok: true, accessToken: row.accessToken }
+  // Stale access token and no refresh token to rotate ⇒ the caller must re-enter it.
+  if (!row.refreshToken) return { ok: false, reason: 'expired' }
 
   const rotated = await api.rotateConfigToken(row.refreshToken)
   if (rotated.ok) {
@@ -48,6 +67,8 @@ export async function resolveUserConfigAccessToken(
   // Rotate rejected — the refresh may already have been spent by a concurrent
   // install by the same user that persisted a fresh pair. Reload once and use it.
   const reloaded = await deps.repos.slackUserConfig.get(orgId, userId)
-  if (reloaded && fresh(reloaded.accessExpiresAt, now)) return { ok: true, accessToken: reloaded.accessToken }
+  if (reloaded && accessTokenFresh(reloaded.accessExpiresAt, now)) {
+    return { ok: true, accessToken: reloaded.accessToken }
+  }
   return { ok: false, reason: 'rotate_failed' }
 }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2026,8 +2026,8 @@ export interface SlackInstallStore {
 /** The token material + its rotation clock. Written on save and on each rotate. */
 export interface SlackUserConfigMaterial {
   accessToken: string // xoxe.xoxp-…
-  refreshToken: string // xoxe-…
-  accessExpiresAt: Date // when accessToken expires (drives rotation)
+  refreshToken: string | null // xoxe-… — null ⇒ access-only (no auto-rotate; re-enter after it expires)
+  accessExpiresAt: Date // when accessToken expires (drives rotation / re-entry)
 }
 
 export interface SlackUserConfigRecord extends SlackUserConfigMaterial {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2041,13 +2041,6 @@ export interface SlackUserConfigStore {
   /** Upsert the caller's config (save from the console, or overwrite with a rotated pair). */
   put(orgId: OrgId, userId: string, material: SlackUserConfigMaterial): Promise<void>
   delete(orgId: OrgId, userId: string): Promise<void>
-  /**
-   * Compare-and-delete: remove the row ONLY if it still carries the `updatedAt` of the
-   * credential the caller actually attempted. A concurrent replacement (another tab
-   * saving a fresh config while an install was mid-flight) bumps `updatedAt`, so this
-   * no-ops rather than erasing the newer token. Returns the rows deleted (0 ⇒ superseded).
-   */
-  deleteIfUnchanged(orgId: OrgId, userId: string, updatedAt: Date): Promise<number>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2041,6 +2041,13 @@ export interface SlackUserConfigStore {
   /** Upsert the caller's config (save from the console, or overwrite with a rotated pair). */
   put(orgId: OrgId, userId: string, material: SlackUserConfigMaterial): Promise<void>
   delete(orgId: OrgId, userId: string): Promise<void>
+  /**
+   * Compare-and-delete: remove the row ONLY if it still carries the `updatedAt` of the
+   * credential the caller actually attempted. A concurrent replacement (another tab
+   * saving a fresh config while an install was mid-flight) bumps `updatedAt`, so this
+   * no-ops rather than erasing the newer token. Returns the rows deleted (0 ⇒ superseded).
+   */
+  deleteIfUnchanged(orgId: OrgId, userId: string, updatedAt: Date): Promise<number>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
@@ -54,4 +54,12 @@ export class PgSlackUserConfigStore implements SlackUserConfigStore {
   async delete(orgId: OrgId, userId: string): Promise<void> {
     await this.prisma.slackUserConfig.deleteMany({ where: { orgId, userId } })
   }
+
+  async deleteIfUnchanged(orgId: OrgId, userId: string, updatedAt: Date): Promise<number> {
+    // `updatedAt` is the optimistic-concurrency version: a concurrent upsert bumps it
+    // (@updatedAt), so scoping the delete to the attempted value drops the row iff nothing
+    // replaced it in the meantime. One atomic statement — no read-then-delete race.
+    const res = await this.prisma.slackUserConfig.deleteMany({ where: { orgId, userId, updatedAt } })
+    return res.count
+  }
 }

--- a/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
@@ -26,7 +26,8 @@ export class PgSlackUserConfigStore implements SlackUserConfigStore {
       orgId: OrgId(r.orgId),
       userId: r.userId,
       accessToken: await this.cipher.open(r.accessToken),
-      refreshToken: await this.cipher.open(r.refreshToken),
+      // Access-only rows have no refresh token (the column is nullable).
+      refreshToken: r.refreshToken ? await this.cipher.open(r.refreshToken) : null,
       accessExpiresAt: r.accessExpiresAt,
       updatedAt: r.updatedAt
     }
@@ -40,7 +41,7 @@ export class PgSlackUserConfigStore implements SlackUserConfigStore {
   async put(orgId: OrgId, userId: string, m: SlackUserConfigMaterial): Promise<void> {
     const tokens = {
       accessToken: await this.cipher.seal(m.accessToken),
-      refreshToken: await this.cipher.seal(m.refreshToken),
+      refreshToken: m.refreshToken ? await this.cipher.seal(m.refreshToken) : null,
       accessExpiresAt: m.accessExpiresAt
     }
     await this.prisma.slackUserConfig.upsert({

--- a/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/slack-user-config.repo.ts
@@ -54,12 +54,4 @@ export class PgSlackUserConfigStore implements SlackUserConfigStore {
   async delete(orgId: OrgId, userId: string): Promise<void> {
     await this.prisma.slackUserConfig.deleteMany({ where: { orgId, userId } })
   }
-
-  async deleteIfUnchanged(orgId: OrgId, userId: string, updatedAt: Date): Promise<number> {
-    // `updatedAt` is the optimistic-concurrency version: a concurrent upsert bumps it
-    // (@updatedAt), so scoping the delete to the attempted value drops the row iff nothing
-    // replaced it in the meantime. One atomic statement — no read-then-delete race.
-    const res = await this.prisma.slackUserConfig.deleteMany({ where: { orgId, userId, updatedAt } })
-    return res.count
-  }
 }

--- a/packages/control-plane/src/secrets/rewrap.ts
+++ b/packages/control-plane/src/secrets/rewrap.ts
@@ -215,19 +215,24 @@ export async function rewrapAllSecrets(
 
   {
     let rows = 0
+    let values = 0
     let skipped = 0
     for (const r of await prisma.slackUserConfig.findMany()) {
       const res = await prisma.slackUserConfig.updateMany({
         where: { orgId: r.orgId, userId: r.userId, accessToken: r.accessToken, refreshToken: r.refreshToken },
         data: {
           accessToken: await reseal(r.accessToken),
-          refreshToken: await reseal(r.refreshToken)
+          // Access-only rows have no refresh token to reseal (the column is nullable).
+          refreshToken: r.refreshToken ? await reseal(r.refreshToken) : null
         }
       })
       if (res.count === 0) skipped += 1
-      else rows += 1
+      else {
+        rows += 1
+        values += r.refreshToken ? 2 : 1
+      }
     }
-    done('slack_user_config', rows, rows * 2, skipped)
+    done('slack_user_config', rows, values, skipped)
   }
 
   return stats

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -625,6 +625,34 @@ describe('slack per-user config storage', () => {
     expect((res.json() as { message: string }).message).toMatch(/expired/i)
   })
 
+  it('POST /app DROPS a rejected access-only config (auth error) so the console re-prompts', async () => {
+    const { app, stub } = withFunnel()
+    stub.createResult = { ok: false, error: 'invalid_auth' } // Slack rejects the token at create
+    const agentId = await placedAgent()
+    await prisma.slackUserConfig.create({
+      data: {
+        orgId: DEFAULT_ORG_ID,
+        userId: DEFAULT_OWNER_ID,
+        accessToken: 'xoxe.xoxp-bad',
+        refreshToken: null, // access-only ⇒ no recovery
+        accessExpiresAt: new Date(Date.now() + 3600_000) // fresh window, but the token is bad
+      }
+    })
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
+    expect(res.statusCode).toBe(400)
+    expect(await prisma.slackUserConfig.count()).toBe(0) // dropped ⇒ next status re-prompts
+  })
+
+  it('POST /app KEEPS a durable config when Slack rejects app creation', async () => {
+    const { app, stub } = withFunnel()
+    stub.createResult = { ok: false, error: 'invalid_auth' }
+    const agentId = await placedAgent()
+    await seedUserConfig() // durable (has a refresh token)
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
+    expect(res.statusCode).toBe(400)
+    expect(await prisma.slackUserConfig.count()).toBe(1) // retained — its refresh was just validated
+  })
+
   it('PUT maps a rotate rejection to 400 and stores nothing', async () => {
     const { app, stub } = withFunnel()
     stub.rotateResult = { ok: false, error: 'invalid_refresh_token' }

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -572,7 +572,7 @@ describe('slack per-user config storage', () => {
       payload: { accessToken: 'xoxe.xoxp-pasted', refreshToken: 'xoxe-pasted' }
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toMatchObject({ configured: true, autoAvailable: true })
+    expect(res.json()).toMatchObject({ configured: true, durable: true, autoAvailable: true })
     expect(stub.rotateCalls).toEqual(['xoxe-pasted'])
     // Stored the rotated pair — never the pasted one; and no token leaks to the DTO.
     const row = await prisma.slackUserConfig.findUnique({
@@ -580,6 +580,49 @@ describe('slack per-user config storage', () => {
     })
     expect(row).toMatchObject({ accessToken: 'xoxe.xoxp-rotated', refreshToken: 'xoxe-rotated' })
     expect(JSON.stringify(res.json())).not.toContain('xoxe')
+  })
+
+  it('PUT with only the config token stores an access-only row (durable:false, no rotate)', async () => {
+    const { app, stub } = withFunnel()
+    const res = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/slack/config`,
+      payload: { accessToken: 'xoxe.xoxp-access-only' } // no refresh token
+    })
+    expect(res.statusCode).toBe(200)
+    // Usable right now (fresh ~12h access token) even though it isn't durable.
+    expect(res.json()).toMatchObject({ configured: true, durable: false, autoAvailable: true })
+    expect((res.json() as { accessExpiresAt: string | null }).accessExpiresAt).toBeTruthy()
+    expect(stub.rotateCalls).toHaveLength(0) // nothing to rotate
+    // Stored the pasted access token as-is with no refresh token.
+    const row = await prisma.slackUserConfig.findUnique({
+      where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } }
+    })
+    expect(row?.accessToken).toBe('xoxe.xoxp-access-only')
+    expect(row?.refreshToken).toBeNull()
+    expect(JSON.stringify(res.json())).not.toContain('xoxe')
+  })
+
+  it('POST /app is 409 (expired) when only an EXPIRED access-only token is stored', async () => {
+    const { app } = withFunnel()
+    const agentId = await placedAgent()
+    // Access-only, already past expiry ⇒ nothing to rotate ⇒ must re-enter.
+    await prisma.slackUserConfig.create({
+      data: {
+        orgId: DEFAULT_ORG_ID,
+        userId: DEFAULT_OWNER_ID,
+        accessToken: 'xoxe.xoxp-old',
+        refreshToken: null,
+        accessExpiresAt: new Date(Date.now() - 60_000)
+      }
+    })
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/slack/app`,
+      payload: { agentId }
+    })
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toMatch(/expired/i)
   })
 
   it('PUT maps a rotate rejection to 400 and stores nothing', async () => {

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -80,15 +80,11 @@ class StubConfigApi implements SlackConfigApi {
   }
   // When non-empty, createApp shifts one result per call (models create → rotate → retry).
   createResultQueue: SlackAppCreateResult[] = []
-  // Runs at the START of createApp — lets a test mutate the stored row mid-request to
-  // exercise the concurrent-replacement race.
-  onCreateApp?: () => Promise<void>
   createCalls: Array<{ configToken: string; manifest: unknown }> = []
   exchangeCalls: Array<{ clientId: string; clientSecret: string; code: string; redirectUri: string }> = []
   rotateCalls: string[] = []
   async createApp(configToken: string, manifest: unknown): Promise<SlackAppCreateResult> {
     this.createCalls.push({ configToken, manifest })
-    if (this.onCreateApp) await this.onCreateApp()
     return this.createResultQueue.length ? this.createResultQueue.shift()! : this.createResult
   }
   async exportApp(): Promise<SlackManifestExportResult> {
@@ -685,35 +681,6 @@ describe('slack per-user config storage', () => {
     expect(res.statusCode).toBe(400)
     expect(stub.rotateCalls).toEqual(['xoxe-stored']) // attempted recovery before giving up
     expect(await prisma.slackUserConfig.count()).toBe(0) // dropped ⇒ next status re-prompts
-  })
-
-  it('POST /app does NOT erase a config replaced concurrently while create was in flight', async () => {
-    const { app, stub } = withFunnel()
-    stub.createResult = { ok: false, error: 'invalid_auth' }
-    const agentId = await placedAgent()
-    await prisma.slackUserConfig.create({
-      data: {
-        orgId: DEFAULT_ORG_ID,
-        userId: DEFAULT_OWNER_ID,
-        accessToken: 'xoxe.xoxp-attempted',
-        refreshToken: null,
-        accessExpiresAt: new Date(Date.now() + 3600_000)
-      }
-    })
-    // Another tab saves a fresh access-only token while apps.manifest.create is mid-flight;
-    // this bumps updatedAt, so the version-scoped invalidation must NOT delete the newcomer.
-    stub.onCreateApp = async () => {
-      await prisma.slackUserConfig.update({
-        where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } },
-        data: { accessToken: 'xoxe.xoxp-replacement', accessExpiresAt: new Date(Date.now() + 3600_000) }
-      })
-    }
-    const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
-    expect(res.statusCode).toBe(400) // the token we attempted was still rejected
-    const cfg = await prisma.slackUserConfig.findUnique({
-      where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } }
-    })
-    expect(cfg?.accessToken).toBe('xoxe.xoxp-replacement') // preserved — a different version than we attempted
   })
 
   it('PUT maps a rotate rejection to 400 and stores nothing', async () => {

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -78,12 +78,18 @@ class StubConfigApi implements SlackConfigApi {
       accessExpiresAt: new Date(Date.now() + 12 * 3600_000)
     }
   }
+  // When non-empty, createApp shifts one result per call (models create → rotate → retry).
+  createResultQueue: SlackAppCreateResult[] = []
+  // Runs at the START of createApp — lets a test mutate the stored row mid-request to
+  // exercise the concurrent-replacement race.
+  onCreateApp?: () => Promise<void>
   createCalls: Array<{ configToken: string; manifest: unknown }> = []
   exchangeCalls: Array<{ clientId: string; clientSecret: string; code: string; redirectUri: string }> = []
   rotateCalls: string[] = []
   async createApp(configToken: string, manifest: unknown): Promise<SlackAppCreateResult> {
     this.createCalls.push({ configToken, manifest })
-    return this.createResult
+    if (this.onCreateApp) await this.onCreateApp()
+    return this.createResultQueue.length ? this.createResultQueue.shift()! : this.createResult
   }
   async exportApp(): Promise<SlackManifestExportResult> {
     return { ok: false, error: 'unused' }
@@ -259,16 +265,22 @@ describe('slack auto-install funnel', () => {
 
   it('POST /app maps a Slack rejection to 400 and an unreachable to 502', async () => {
     const agentId = await placedAgent()
-    await seedUserConfig()
     const { app, stub } = withFunnel()
+
+    await seedUserConfig()
+    // Auth rejection on both the create and the durable retry ⇒ 400 (and the config, proven
+    // unrecoverable, is invalidated — so the next case re-seeds).
     stub.createResult = { ok: false, error: 'token_expired' }
     const bad = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
     expect(bad.statusCode).toBe(400)
 
+    await seedUserConfig()
+    // unreachable is transient (not an auth error) ⇒ 502, and the config is kept.
     stub.createResult = { ok: false, error: 'unreachable' }
     const down = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
     expect(down.statusCode).toBe(502)
     expect(await prisma.slackInstall.count()).toBe(0)
+    expect(await prisma.slackUserConfig.count()).toBe(1) // transient failure keeps the config
   })
 
   it('the OAuth callback exchanges the code and stashes the bot token (never in a response)', async () => {
@@ -643,14 +655,65 @@ describe('slack per-user config storage', () => {
     expect(await prisma.slackUserConfig.count()).toBe(0) // dropped ⇒ next status re-prompts
   })
 
-  it('POST /app KEEPS a durable config when Slack rejects app creation', async () => {
+  it('POST /app RECOVERS a durable config on auth rejection by rotating a fresh token and retrying', async () => {
+    const { app, stub } = withFunnel()
+    // resolve() returns the fresh (unexpired) access token WITHOUT re-validating it, so the
+    // first create is rejected. A durable config force-rotates and retries — that succeeds
+    // (the 2nd create falls back to the default ok result once the queue drains).
+    stub.createResultQueue = [{ ok: false, error: 'invalid_auth' }]
+    const agentId = await placedAgent()
+    await seedUserConfig() // durable + fresh
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
+    expect(res.statusCode).toBe(201) // recovered — no re-prompt
+    expect(stub.rotateCalls).toEqual(['xoxe-stored']) // forced a rotation despite the fresh window
+    expect(stub.createCalls.map((c) => c.configToken)).toEqual(['xoxe.xoxp-stored', 'xoxe.xoxp-rotated'])
+    const cfg = await prisma.slackUserConfig.findUnique({
+      where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } }
+    })
+    expect(cfg).toMatchObject({ accessToken: 'xoxe.xoxp-rotated', refreshToken: 'xoxe-rotated' }) // fresh pair kept
+  })
+
+  it('POST /app INVALIDATES a durable config when even a rotated token is rejected', async () => {
+    const { app, stub } = withFunnel()
+    stub.createResultQueue = [
+      { ok: false, error: 'invalid_auth' }, // stored token rejected
+      { ok: false, error: 'invalid_auth' } // rotated token also rejected ⇒ unrecoverable
+    ]
+    const agentId = await placedAgent()
+    await seedUserConfig() // durable + fresh
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
+    expect(res.statusCode).toBe(400)
+    expect(stub.rotateCalls).toEqual(['xoxe-stored']) // attempted recovery before giving up
+    expect(await prisma.slackUserConfig.count()).toBe(0) // dropped ⇒ next status re-prompts
+  })
+
+  it('POST /app does NOT erase a config replaced concurrently while create was in flight', async () => {
     const { app, stub } = withFunnel()
     stub.createResult = { ok: false, error: 'invalid_auth' }
     const agentId = await placedAgent()
-    await seedUserConfig() // durable (has a refresh token)
+    await prisma.slackUserConfig.create({
+      data: {
+        orgId: DEFAULT_ORG_ID,
+        userId: DEFAULT_OWNER_ID,
+        accessToken: 'xoxe.xoxp-attempted',
+        refreshToken: null,
+        accessExpiresAt: new Date(Date.now() + 3600_000)
+      }
+    })
+    // Another tab saves a fresh access-only token while apps.manifest.create is mid-flight;
+    // this bumps updatedAt, so the version-scoped invalidation must NOT delete the newcomer.
+    stub.onCreateApp = async () => {
+      await prisma.slackUserConfig.update({
+        where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } },
+        data: { accessToken: 'xoxe.xoxp-replacement', accessExpiresAt: new Date(Date.now() + 3600_000) }
+      })
+    }
     const res = await app.app.inject({ method: 'POST', url: `${ORG}/integrations/slack/app`, payload: { agentId } })
-    expect(res.statusCode).toBe(400)
-    expect(await prisma.slackUserConfig.count()).toBe(1) // retained — its refresh was just validated
+    expect(res.statusCode).toBe(400) // the token we attempted was still rejected
+    const cfg = await prisma.slackUserConfig.findUnique({
+      where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } }
+    })
+    expect(cfg?.accessToken).toBe('xoxe.xoxp-replacement') // preserved — a different version than we attempted
   })
 
   it('PUT maps a rotate rejection to 400 and stores nothing', async () => {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2866,3 +2866,20 @@
     transform: scale(0.9);
   }
 }
+
+/* Plain animation classes — reference the keyframes above from WITHIN this file so the
+   CSS optimizer keeps them. Tailwind arbitrary `animate-[name_…]` utilities live in a
+   separate output the optimizer can't see as a reference, so it would otherwise prune
+   these @keyframes and the animations would silently not play. */
+.slack-hint-blink {
+  animation: slackHintBlink 1.1s ease-in-out infinite;
+}
+.cfg-scroll {
+  animation: cfgScroll 4.6s ease-in-out infinite;
+}
+.cfg-click-a {
+  animation: cfgClickA 4.6s ease-in-out infinite;
+}
+.cfg-click-b {
+  animation: cfgClickB 4.6s ease-in-out infinite;
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2753,3 +2753,116 @@
     transition-duration: 1ms !important;
   }
 }
+
+/* Slack manifest hover-preview: blink the highlighted "From a manifest" tile. */
+@keyframes slackHintBlink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.15;
+  }
+}
+
+/* Config-token hover popover (design: .cfgtok / .cfgtok-pop) — sits above the
+   "Open Slack app config tokens" button with a downward caret. */
+.cfgtok {
+  position: relative;
+}
+.cfgtok-pop {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 9px);
+  z-index: 30;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition:
+    opacity 0.16s var(--ease-out),
+    transform 0.16s var(--ease-out),
+    visibility 0.16s;
+  pointer-events: none;
+}
+.cfgtok:hover .cfgtok-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.cfgtok-pop::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--surface-card);
+  filter: drop-shadow(0 1px 0 var(--border-default));
+}
+/* The popover's animated mini-screen: auto-scroll to the bottom "Your App
+   Configuration Tokens" section, then pulse each token's Copy button in turn. */
+@keyframes cfgScroll {
+  0%,
+  10% {
+    transform: translateY(0);
+  }
+  36%,
+  82% {
+    transform: translateY(calc(-100% + 140px));
+  }
+  96%,
+  100% {
+    transform: translateY(0);
+  }
+}
+/* Two Copy pulses in sequence: the access token first (cfgClickA), then the
+   refresh token (cfgClickB), both while scrolled to the bottom. */
+@keyframes cfgClickA {
+  0%,
+  40% {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  46% {
+    opacity: 1;
+    transform: scale(1.18);
+  }
+  52% {
+    opacity: 0.85;
+    transform: scale(0.9);
+  }
+  58% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+  64%,
+  100% {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+}
+@keyframes cfgClickB {
+  0%,
+  62% {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  68% {
+    opacity: 1;
+    transform: scale(1.18);
+  }
+  74% {
+    opacity: 0.85;
+    transform: scale(0.9);
+  }
+  80% {
+    opacity: 1;
+    transform: scale(1.12);
+  }
+  86%,
+  100% {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2883,3 +2883,21 @@
 .cfg-click-b {
   animation: cfgClickB 4.6s ease-in-out infinite;
 }
+
+/* Reduced motion: no loops. Leave a useful STATIC preview — the config-token popover is
+   parked at the bottom (the "Your App Configuration Tokens" section, the destination), the
+   Copy-pulse rings are hidden, and the manifest tile keeps its (static) highlight. */
+@media (prefers-reduced-motion: reduce) {
+  .slack-hint-blink {
+    animation: none;
+  }
+  .cfg-scroll {
+    animation: none;
+    transform: translateY(calc(-100% + 140px));
+  }
+  .cfg-click-a,
+  .cfg-click-b {
+    animation: none;
+    opacity: 0;
+  }
+}

--- a/packages/web/src/components/console/SlackConfigCard.tsx
+++ b/packages/web/src/components/console/SlackConfigCard.tsx
@@ -7,10 +7,12 @@
 // modal runs the one-click auto-install for the apps YOU create; absent ⇒ you either
 // paste it inline when installing, or fall back to the manual flow.
 //
-// The token pair is secret — the CP validates it (by rotating) on save, keeps it
-// fresh, and never returns it; this card only ever sees status. Org-scoped (keyed by
-// the active org), so the fetch waits for OrgProvider to resolve — mirroring the
-// org-gated pattern the rest of the console uses.
+// The config (access) token is required; the refresh token is optional — with it the
+// pair auto-rotates and never expires (durable), without it the access token is stored
+// as-is and lapses after ~12h (then re-enter). The tokens are secret — the CP validates
+// + normalizes on save and never returns them; this card only ever sees status.
+// Org-scoped (keyed by the active org), so the fetch waits for OrgProvider to resolve —
+// mirroring the org-gated pattern the rest of the console uses.
 
 import { useEffect, useState } from 'react'
 import { Button, Icon } from '@/components/ui'
@@ -19,8 +21,10 @@ import { useOrgs } from '@/lib/org-context'
 
 const EMPTY: SlackConfigDto = {
   configured: false,
+  durable: false,
   funnelEnabled: false,
   autoAvailable: false,
+  accessExpiresAt: null,
   relayAvailable: false,
   relayPublicUrl: null,
   updatedAt: null
@@ -51,11 +55,19 @@ export default function SlackConfigCard() {
   }, [activeOrg])
 
   const save = async () => {
-    if (busy || !access.trim() || !refresh.trim()) return
+    // The access (config) token is required; the refresh token is optional — omit it and
+    // the CP stores an access-only token that works until it expires (~12h), then re-enter.
+    if (busy || !access.trim()) return
     setBusy(true)
     setErr(null)
     try {
-      setStatus(await saveSlackConfig({ accessToken: access.trim(), refreshToken: refresh.trim() }))
+      const refreshTrim = refresh.trim()
+      setStatus(
+        await saveSlackConfig({
+          accessToken: access.trim(),
+          ...(refreshTrim ? { refreshToken: refreshTrim } : {})
+        })
+      )
       setEditing(false)
       setAccess('')
       setRefresh('')
@@ -83,6 +95,13 @@ export default function SlackConfigCard() {
 
   const configured = status !== 'loading' && status.configured
   const showForm = status !== 'loading' && (!configured || editing)
+  // An access-only token (no refresh) that has passed its ~12h expiry — the caller must
+  // re-enter it. Durable tokens auto-rotate and never reach this state.
+  const accessExpired =
+    status !== 'loading' &&
+    status.configured &&
+    !status.durable &&
+    (status.accessExpiresAt == null || new Date(status.accessExpiresAt).getTime() <= Date.now())
 
   return (
     <div className="card mt-[18px]">
@@ -99,25 +118,34 @@ export default function SlackConfigCard() {
               <div className="flex items-center justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-2">
                   <Icon
-                    name={status.autoAvailable ? 'circle-check' : 'circle-alert'}
+                    name={status.durable && status.autoAvailable ? 'circle-check' : 'circle-alert'}
                     size={15}
-                    color={status.autoAvailable ? 'var(--brand)' : 'var(--status-paused)'}
+                    color={
+                      accessExpired
+                        ? 'var(--status-error)'
+                        : status.durable && status.autoAvailable
+                          ? 'var(--brand)'
+                          : 'var(--status-paused)'
+                    }
                     className="flex-none"
                   />
                   <span className="flex-none font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary)">
-                    Stored
+                    {accessExpired ? 'Expired' : 'Stored'}
                   </span>
                   <span className="truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                    {status.autoAvailable
-                      ? 'your quick Slack installs are ready'
-                      : 'quick install is unavailable on this server'}
-                    {status.updatedAt ? ` · updated ${fmtDate(status.updatedAt)}` : ''}
+                    {!status.funnelEnabled
+                      ? 'quick install is unavailable on this server'
+                      : accessExpired
+                        ? 're-enter your config token to run quick installs again'
+                        : status.durable
+                          ? `auto-renews — quick Slack installs stay ready${status.updatedAt ? ` · updated ${fmtDate(status.updatedAt)}` : ''}`
+                          : `expires ${status.accessExpiresAt ? fmtDate(status.accessExpiresAt) : 'soon'} — add a refresh token so it never expires`}
                   </span>
                 </div>
                 <span className="flex flex-none items-center gap-2">
                   <Button variant="ghost" onClick={() => setEditing(true)}>
                     <Icon name="pencil" size={13} />
-                    Replace
+                    {accessExpired ? 'Re-enter' : 'Replace'}
                   </Button>
                   <Button variant="ghost" onClick={() => void clear()}>
                     <Icon name="trash-2" size={13} />
@@ -136,17 +164,19 @@ export default function SlackConfigCard() {
 
             {showForm && (
               <div className={configured ? 'mt-1' : ''}>
-                <div className="mb-3 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-                  The app the installer creates will belong to you, so you can generate its App-Level token yourself.
-                  Generate the pair at{' '}
+                <div className="mb-3 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-tertiary)">
+                  Store your Slack App Configuration token to get one-click installs for the apps you create. The{' '}
+                  <span className="font-medium text-(--text-secondary)">config token alone is enough</span> — it works
+                  for about 12 hours. Add the refresh token too and it auto-renews, so it never expires. Generate them
+                  at{' '}
                   <a href="https://api.slack.com/apps" target="_blank" rel="noopener noreferrer" className="lnk">
                     api.slack.com/apps
-                  </a>
-                  .
+                  </a>{' '}
+                  → Your App Configuration Tokens.
                 </div>
                 <div className="grid grid-cols-1 gap-[10px] min-[440px]:grid-cols-2">
                   <div className="fld">
-                    <span className="fldlbl">Access token</span>
+                    <span className="fldlbl">Config token</span>
                     <input
                       className="inp mn"
                       placeholder="xoxe.xoxp-…"
@@ -155,7 +185,9 @@ export default function SlackConfigCard() {
                     />
                   </div>
                   <div className="fld">
-                    <span className="fldlbl">Refresh token</span>
+                    <span className="fldlbl">
+                      Refresh token <span className="font-normal text-(--text-tertiary)">(optional)</span>
+                    </span>
                     <input
                       className="inp mn"
                       placeholder="xoxe-…"
@@ -167,7 +199,7 @@ export default function SlackConfigCard() {
                 <div className="mt-3 flex items-center gap-2">
                   <Button
                     onClick={() => void save()}
-                    className={access.trim() && refresh.trim() && !busy ? undefined : 'cursor-default opacity-50'}
+                    className={access.trim() && !busy ? undefined : 'cursor-default opacity-50'}
                   >
                     <Icon name="check" size={14} />
                     {busy ? 'Saving…' : 'Save'}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -17,6 +17,7 @@ import {
   getSlackInstall,
   fetchSlackConfig,
   saveSlackConfig,
+  deleteSlackConfig,
   fetchAgentHooks,
   fetchAgentRepos,
   fetchAllGithubRepos,
@@ -1101,23 +1102,33 @@ export default function AddIntegrationModal({
         accessToken: cfgAccess.trim(),
         ...(refreshTrim ? { refreshToken: refreshTrim } : {})
       })
-      setAutoUsable(s.autoAvailable)
       setRelayAvailable(s.relayAvailable)
       setRelayPublicUrl(s.relayPublicUrl)
-      setCfgAccess('')
-      setCfgRefresh('')
-      // Create the app with the just-stored config token and open the Slack OAuth tab.
+      // Create the app BEFORE flipping to the auto flow: this is where Slack first
+      // validates the config token (access-only tokens aren't validated on save). Keeping
+      // the flip until AFTER success means a rejected/typo'd or already-expired token stays
+      // recoverable in the inline entry (fields kept, still on the config-setup branch).
       const nextTransport = transport ?? (s.relayAvailable ? 'http' : 'socket')
       const started = await startSlackInstall({
         agentId: agent.id,
         transport: nextTransport,
         ...(appName.trim() ? { name: appName.trim() } : {})
       })
+      // App + pending install created ⇒ now it's safe to move to the auto flow.
+      setAutoUsable(true)
       setInstall(started)
       setAutoPhase('authorizing')
+      setCfgAccess('')
+      setCfgRefresh('')
       window.open(started.installUrl, '_blank', 'noopener,noreferrer')
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
+      // The token we just stored was never validated (Slack rejected it, or the call
+      // failed). Drop it so this stays on the inline entry and a reopen re-prompts instead
+      // of trusting an unverified row until its 12h deadline. Fields are kept so the caller
+      // can correct the token and retry in place.
+      await deleteSlackConfig().catch(() => {})
+      setAutoUsable(false)
     } finally {
       setSaving(false)
       busyRef.current = false
@@ -1240,6 +1251,9 @@ export default function AddIntegrationModal({
   // fallback the user can switch to. Default to config when the funnel is enabled.
   const slackMethod: 'config' | 'bot' = createMethod ?? (slackFunnel === true ? 'config' : 'bot')
   const selectMethod = (m: 'config' | 'bot') => {
+    // Locked once an auto-install has created the app + pending row: switching methods
+    // here would route the footer through the manual `submit()` and orphan that install.
+    if (install) return
     setCreateMethod(m)
     setShowErrors(false)
     setErr(null)
@@ -2013,10 +2027,12 @@ export default function AddIntegrationModal({
                           <button
                             key={m}
                             type="button"
+                            disabled={!!install}
                             onClick={() => selectMethod(m)}
+                            title={install ? 'Install in progress — “Start over” to switch method' : undefined}
                             className={`rounded-[6px] px-[11px] py-[5px] font-sans text-[12px] font-semibold leading-normal ${
                               on ? 'bg-(--brand-soft) text-(--brand)' : 'bg-transparent text-(--text-tertiary)'
-                            }`}
+                            } ${install ? 'cursor-not-allowed opacity-50' : ''}`}
                           >
                             {m === 'config' ? 'Config token' : 'Bot token'}
                           </button>

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -310,7 +310,7 @@ function SlackManifestPreview() {
         </div>
         <div className="grid grid-cols-2 gap-2">
           <div className="relative rounded-lg border-2 border-[#1264a3] bg-white p-2.5">
-            <span className="pointer-events-none absolute -inset-0.5 animate-[slackHintBlink_1.1s_ease-in-out_infinite] rounded-[10px] ring-2 ring-[#1264a3]" />
+            <span className="pointer-events-none absolute -inset-0.5 slack-hint-blink rounded-[10px] ring-2 ring-[#1264a3]" />
             <span className="mb-1.5 flex h-6 w-6 items-center justify-center rounded-md bg-[#f4f4f4] text-[#454545]">
               <Icon name="scroll-text" size={14} />
             </span>
@@ -354,7 +354,7 @@ function SlackConfigTokenPreview() {
           </span>
         </div>
         <div className="h-[140px] overflow-hidden bg-(--surface-card)">
-          <div className="animate-[cfgScroll_4.6s_ease-in-out_infinite] px-2.5 py-2">
+          <div className="cfg-scroll px-2.5 py-2">
             <div className="mb-1.5 font-sans text-[10px] font-bold leading-tight text-(--text-primary)">Your apps</div>
             {[0, 1].map((i) => (
               <div
@@ -387,11 +387,11 @@ function SlackConfigTokenPreview() {
                 <span className="font-mono text-[9px] leading-normal text-(--text-secondary)">your-workspace</span>
                 <span className="relative rounded border border-(--border-default) bg-(--surface-card) px-1.5 py-[3px] font-sans text-[8.5px] font-semibold leading-normal text-(--text-secondary)">
                   Copy
-                  <span className="pointer-events-none absolute -inset-[3px] animate-[cfgClickA_4.6s_ease-in-out_infinite] rounded ring-2 ring-(--brand)" />
+                  <span className="pointer-events-none absolute -inset-[3px] cfg-click-a rounded ring-2 ring-(--brand)" />
                 </span>
                 <span className="relative rounded border border-(--border-default) bg-(--surface-card) px-1.5 py-[3px] font-sans text-[8.5px] font-semibold leading-normal text-(--text-secondary)">
                   Copy
-                  <span className="pointer-events-none absolute -inset-[3px] animate-[cfgClickB_4.6s_ease-in-out_infinite] rounded ring-2 ring-(--brand)" />
+                  <span className="pointer-events-none absolute -inset-[3px] cfg-click-b rounded ring-2 ring-(--brand)" />
                 </span>
               </div>
               <div className="mt-1 font-sans text-[8px] leading-normal text-(--text-tertiary)">Expires in 5 hours</div>

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -17,7 +17,6 @@ import {
   getSlackInstall,
   fetchSlackConfig,
   saveSlackConfig,
-  deleteSlackConfig,
   fetchAgentHooks,
   fetchAgentRepos,
   fetchAllGithubRepos,
@@ -1123,12 +1122,19 @@ export default function AddIntegrationModal({
       window.open(started.installUrl, '_blank', 'noopener,noreferrer')
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
-      // The token we just stored was never validated (Slack rejected it, or the call
-      // failed). Drop it so this stays on the inline entry and a reopen re-prompts instead
-      // of trusting an unverified row until its 12h deadline. Fields are kept so the caller
-      // can correct the token and retry in place.
-      await deleteSlackConfig().catch(() => {})
-      setAutoUsable(false)
+      // The app wasn't created. Re-read status rather than blindly deleting: the CP drops
+      // only a rejected ACCESS-ONLY token server-side, so autoAvailable now reflects reality
+      // — a rejected access-only token flips false and stays on the inline entry (re-prompt,
+      // fields kept for correction), while a durable config or a transient failure stays
+      // usable so a retry works.
+      try {
+        const c = await fetchSlackConfig()
+        setAutoUsable(c.autoAvailable)
+        setRelayAvailable(c.relayAvailable)
+        setRelayPublicUrl(c.relayPublicUrl)
+      } catch {
+        setAutoUsable(false)
+      }
     } finally {
       setSaving(false)
       busyRef.current = false
@@ -1154,6 +1160,16 @@ export default function AddIntegrationModal({
       window.open(started.installUrl, '_blank', 'noopener,noreferrer')
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
+      // Re-read status: if the CP invalidated a rejected access-only token (incl. one saved
+      // from Profile), autoAvailable flips false and the modal falls back to the inline
+      // config-token entry so the caller can re-enter it; a durable config stays usable so
+      // "Create & install" can retry.
+      try {
+        const c = await fetchSlackConfig()
+        setAutoUsable(c.autoAvailable)
+      } catch {
+        /* keep current state */
+      }
     } finally {
       setSaving(false)
       busyRef.current = false

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import useSWR from 'swr'
-import Link from 'next/link'
 import { GithubMark, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
@@ -17,6 +16,7 @@ import {
   startSlackInstall,
   getSlackInstall,
   fetchSlackConfig,
+  saveSlackConfig,
   fetchAgentHooks,
   fetchAgentRepos,
   fetchAllGithubRepos,
@@ -292,6 +292,121 @@ function SlackDeliveryLine({
   )
 }
 
+// Hover preview for the "Copy manifest & open Slack" button — a miniature of Slack's
+// "Create new app" dialog cropped to the two "Or start your own way" tiles, with the
+// "From a manifest" tile blinking so the user knows exactly which option to click once the
+// manifest is on their clipboard. Styled like Slack's own (light) dialog; pointer-events-none
+// so it never intercepts the button's click.
+function SlackManifestPreview() {
+  return (
+    <div className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-[320px] -translate-x-1/2 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+      <div className="rounded-xl border border-[#e0e0e2] bg-white p-3 shadow-(--shadow-xl)">
+        <div className="mb-2 flex items-center gap-1.5 font-sans text-[11px] font-semibold leading-normal text-[#616061]">
+          <Icon name="mouse-pointer-click" size={12} />
+          In Slack, pick &ldquo;From a manifest&rdquo;
+        </div>
+        <div className="mb-1.5 font-sans text-[9.5px] font-semibold uppercase leading-normal tracking-wide text-[#8d8d8d]">
+          Or start your own way
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="relative rounded-lg border-2 border-[#1264a3] bg-white p-2.5">
+            <span className="pointer-events-none absolute -inset-0.5 animate-[slackHintBlink_1.1s_ease-in-out_infinite] rounded-[10px] ring-2 ring-[#1264a3]" />
+            <span className="mb-1.5 flex h-6 w-6 items-center justify-center rounded-md bg-[#f4f4f4] text-[#454545]">
+              <Icon name="scroll-text" size={14} />
+            </span>
+            <div className="font-sans text-[11.5px] font-bold leading-tight text-[#1d1c1d]">From a manifest</div>
+            <div className="mt-0.5 font-sans text-[10px] leading-tight text-[#616061]">Upload JSON or YAML config.</div>
+          </div>
+          <div className="rounded-lg border border-[#e0e0e2] bg-white p-2.5">
+            <span className="mb-1.5 flex h-6 w-6 items-center justify-center rounded-md bg-[#f4f4f4] text-[#454545]">
+              <Icon name="clapperboard" size={14} />
+            </span>
+            <div className="font-sans text-[11.5px] font-bold leading-tight text-[#1d1c1d]">Blank app</div>
+            <div className="mt-0.5 font-sans text-[10px] leading-tight text-[#616061]">
+              Empty app with minimal setup.
+            </div>
+          </div>
+        </div>
+        <div className="mt-2 font-sans text-[10px] leading-snug text-[#616061]">
+          Then paste the copied manifest, choose a workspace, and create the app.
+        </div>
+      </div>
+      <div className="absolute -bottom-1 left-1/2 h-2.5 w-2.5 -translate-x-1/2 rotate-45 border-r border-b border-[#e0e0e2] bg-white" />
+    </div>
+  )
+}
+
+// Hover preview for "Open Slack app config tokens" — an animated mock of Slack's apps page
+// scrolling down to the "Your App Configuration Tokens" section and pulsing the access
+// token's Copy button (then the refresh token's), so the user sees exactly where the pair
+// lives. Uses the design's .cfgtok-pop container (above the button, surface-card, downward
+// caret). pointer-events-none.
+function SlackConfigTokenPreview() {
+  return (
+    <div className="cfgtok-pop rounded-xl border border-(--border-default) bg-(--surface-card) p-2 shadow-(--shadow-xl)">
+      <div className="overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-app)">
+        <div className="flex items-center gap-1.5 border-b border-(--border-subtle) px-2.5 py-1.5">
+          <span className="h-2 w-2 flex-none rounded-full bg-[#e0605a]" />
+          <span className="h-2 w-2 flex-none rounded-full bg-[#e8b13a]" />
+          <span className="h-2 w-2 flex-none rounded-full bg-[#4aa564]" />
+          <span className="ml-1 min-w-0 truncate font-mono text-[9px] leading-normal text-(--text-tertiary)">
+            api.slack.com/apps
+          </span>
+        </div>
+        <div className="h-[140px] overflow-hidden bg-(--surface-card)">
+          <div className="animate-[cfgScroll_4.6s_ease-in-out_infinite] px-2.5 py-2">
+            <div className="mb-1.5 font-sans text-[10px] font-bold leading-tight text-(--text-primary)">Your apps</div>
+            {[0, 1].map((i) => (
+              <div
+                key={i}
+                className="mb-1.5 flex items-center gap-2 rounded-md border border-(--border-subtle) px-2 py-1.5"
+              >
+                <span className="h-4 w-4 flex-none rounded bg-(--surface-active)" />
+                <span className="h-1.5 w-24 rounded-full bg-(--surface-active)" />
+              </div>
+            ))}
+            <div className="mt-2 rounded-md border border-(--border-subtle) bg-(--surface-app) p-2">
+              <div className="mb-1.5 flex items-center justify-between gap-2">
+                <span className="font-sans text-[10px] font-bold leading-tight text-(--text-primary)">
+                  Your App Configuration Tokens
+                </span>
+                <span className="flex-none rounded bg-(--surface-active) px-1.5 py-[3px] font-sans text-[8px] font-semibold leading-normal text-(--text-secondary)">
+                  Generate Token
+                </span>
+              </div>
+              <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-2 gap-y-1">
+                <span className="font-sans text-[8px] font-semibold uppercase leading-normal text-(--text-tertiary)">
+                  Workspace
+                </span>
+                <span className="font-sans text-[8px] font-semibold uppercase leading-normal text-(--text-tertiary)">
+                  Access
+                </span>
+                <span className="font-sans text-[8px] font-semibold uppercase leading-normal text-(--text-tertiary)">
+                  Refresh
+                </span>
+                <span className="font-mono text-[9px] leading-normal text-(--text-secondary)">your-workspace</span>
+                <span className="relative rounded border border-(--border-default) bg-(--surface-card) px-1.5 py-[3px] font-sans text-[8.5px] font-semibold leading-normal text-(--text-secondary)">
+                  Copy
+                  <span className="pointer-events-none absolute -inset-[3px] animate-[cfgClickA_4.6s_ease-in-out_infinite] rounded ring-2 ring-(--brand)" />
+                </span>
+                <span className="relative rounded border border-(--border-default) bg-(--surface-card) px-1.5 py-[3px] font-sans text-[8.5px] font-semibold leading-normal text-(--text-secondary)">
+                  Copy
+                  <span className="pointer-events-none absolute -inset-[3px] animate-[cfgClickB_4.6s_ease-in-out_infinite] rounded ring-2 ring-(--brand)" />
+                </span>
+              </div>
+              <div className="mt-1 font-sans text-[8px] leading-normal text-(--text-tertiary)">Expires in 5 hours</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-1.5 px-1 font-sans text-[10.5px] font-normal leading-[1.45] text-(--text-secondary)">
+        Scroll to the bottom of <span className="mono">Your apps</span> — the token pair lives under &ldquo;App
+        configuration tokens&rdquo;.
+      </div>
+    </div>
+  )
+}
+
 // The integration is owned by one agent; that agent's daemon opens the connection.
 // The dialog is only reachable from a specific agent (its row / detail page), so the
 // agent is fixed — no picker. `initialPlatform` lets a caller land on a specific
@@ -338,11 +453,21 @@ export default function AddIntegrationModal({
   // PER-USER: the app is created with the CALLER's own config token, so it belongs to
   // them and only they can mint its app-level token. `slackFunnel`: null = still
   // checking, true = this deployment supports auto-install (public callback), false =
-  // manual (create the app yourself). `myConfig` = the caller has stored their own
-  // token; without it, the modal stays on the manual app-token + bot-token flow and
-  // points them to Profile for an easier setup next time. Fetched on open.
+  // manual (create the app yourself). Fetched on open; `autoUsable` (below) tracks whether
+  // the caller's stored config token can one-click right now.
   const [slackFunnel, setSlackFunnel] = useState<boolean | null>(null)
-  const [myConfig, setMyConfig] = useState(false)
+  // The caller's stored config token is USABLE for a one-click install right now: it
+  // auto-rotates (durable) or its access token is still fresh. False when they've stored
+  // nothing OR their access-only token expired — either way the config method shows the
+  // inline token entry instead.
+  const [autoUsable, setAutoUsable] = useState(false)
+  // "Create a new bot" method (Slack): 'config' = recommended config-token quick install
+  // (works for socket AND http), 'bot' = manual bot-token flow. Null ⇒ derive the default.
+  const [createMethod, setCreateMethod] = useState<'config' | 'bot' | null>(null)
+  // Inline config-token entry, shown under the config method — saved to the same per-user
+  // store as the Profile card (so it appears there too).
+  const [cfgAccess, setCfgAccess] = useState('')
+  const [cfgRefresh, setCfgRefresh] = useState('')
   // Slack inbound transport (locked rule): `http` (Events API via relay) is the
   // default when a relay is available; `socket` (Socket Mode) is the only choice
   // when none. `transport` null = not yet chosen ⇒ derive the default from
@@ -398,7 +523,7 @@ export default function AddIntegrationModal({
   const [ghWorkspaceAccessOverride, setGhWorkspaceAccessOverride] = useState<'write' | null>(null)
   // Repos this agent ALREADY watches — offered rows are disabled, free-typed
   // duplicates rejected inline (the CP 409s them as the backstop).
-  const { activeOrg, orgPath } = useOrgs()
+  const { activeOrg } = useOrgs()
   const agentHooksKey = consoleKeys.agentHooks(activeOrg?.id, agent.id)
   const { data: agentHooksData } = useSWR(agentHooksKey, ([, orgId, , agentId]) => fetchAgentHooks(agentId, orgId))
   const watchedRepos = useMemo(
@@ -494,6 +619,9 @@ export default function AddIntegrationModal({
     setAppName(agent.name)
     setBotToken('')
     setAppToken('')
+    setCreateMethod(null)
+    setCfgAccess('')
+    setCfgRefresh('')
     setShowErrors(false)
     setErr(null)
   }
@@ -957,6 +1085,45 @@ export default function AddIntegrationModal({
     }
   }
 
+  // Config-token method commit: store the pasted configuration token (same per-user store
+  // as the Profile card), then immediately create the Slack app + open OAuth — the CP uses
+  // the stored config token to mint the app. Refresh token optional (access-only lasts ~12h;
+  // a refresh token keeps it from expiring).
+  const saveConfigAndStart = async () => {
+    setShowErrors(true)
+    if (busyRef.current || !cfgAccess.trim() || install) return
+    busyRef.current = true
+    setSaving(true)
+    setErr(null)
+    try {
+      const refreshTrim = cfgRefresh.trim()
+      const s = await saveSlackConfig({
+        accessToken: cfgAccess.trim(),
+        ...(refreshTrim ? { refreshToken: refreshTrim } : {})
+      })
+      setAutoUsable(s.autoAvailable)
+      setRelayAvailable(s.relayAvailable)
+      setRelayPublicUrl(s.relayPublicUrl)
+      setCfgAccess('')
+      setCfgRefresh('')
+      // Create the app with the just-stored config token and open the Slack OAuth tab.
+      const nextTransport = transport ?? (s.relayAvailable ? 'http' : 'socket')
+      const started = await startSlackInstall({
+        agentId: agent.id,
+        transport: nextTransport,
+        ...(appName.trim() ? { name: appName.trim() } : {})
+      })
+      setInstall(started)
+      setAutoPhase('authorizing')
+      window.open(started.installUrl, '_blank', 'noopener,noreferrer')
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+      busyRef.current = false
+    }
+  }
+
   // Auto flow — step 1: create the app (with the caller's stored config token) + open
   // the Slack OAuth install in a new tab.
   const startAuto = async () => {
@@ -1029,7 +1196,7 @@ export default function AddIntegrationModal({
       .then((c) => {
         if (!alive) return
         setSlackFunnel(c.funnelEnabled)
-        setMyConfig(c.configured)
+        setAutoUsable(c.autoAvailable)
         setRelayAvailable(c.relayAvailable)
         setRelayPublicUrl(c.relayPublicUrl)
       })
@@ -1069,7 +1236,20 @@ export default function AddIntegrationModal({
   // operator pasting the app-level (xapp) token; http is fully automatic — the CP builds
   // an Events-API manifest and captures the signing secret from apps.manifest.create, so
   // there's no paste step. `shareable` is threaded through `startAuto`.
-  const isAuto = mode === 'create' && platform === 'slack' && slackFunnel === true && myConfig
+  // Config token is the recommended method for both transports; `bot` is the manual
+  // fallback the user can switch to. Default to config when the funnel is enabled.
+  const slackMethod: 'config' | 'bot' = createMethod ?? (slackFunnel === true ? 'config' : 'bot')
+  const selectMethod = (m: 'config' | 'bot') => {
+    setCreateMethod(m)
+    setShowErrors(false)
+    setErr(null)
+  }
+  const isAuto =
+    mode === 'create' && platform === 'slack' && slackFunnel === true && slackMethod === 'config' && autoUsable
+  // Config method chosen but nothing usable stored yet ⇒ the inline config-token entry
+  // is shown and the footer commits it (save + create the app).
+  const isConfigSetup =
+    mode === 'create' && platform === 'slack' && slackFunnel === true && slackMethod === 'config' && !autoUsable
   const footer =
     platform === 'webhook'
       ? createdHook
@@ -1089,7 +1269,9 @@ export default function AddIntegrationModal({
               // app-level token; http finalizes with none (signing secret already captured).
               enabled: autoPhase === 'appToken' && (effTransport === 'http' || appOk)
             }
-          : { label: 'Connect & authorize', act: () => void submit(), enabled: valid }
+          : isConfigSetup
+            ? { label: 'Connect & authorize', act: () => void saveConfigAndStart(), enabled: !!cfgAccess.trim() }
+            : { label: 'Connect & authorize', act: () => void submit(), enabled: valid }
 
   return (
     <>
@@ -1820,272 +2002,371 @@ export default function AddIntegrationModal({
                 <Icon name="loader" size={15} className="flex-none animate-spin" />
                 Checking your Slack setup…
               </div>
-            ) : slackFunnel && myConfig ? (
-              <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-                <div className="mb-[14px]">
-                  <SlackDeliveryLine
-                    transport={effTransport}
-                    relayAvailable={relayAvailable}
-                    locked={!!install}
-                    onSwitch={switchTransport}
-                  />
-                </div>
-
-                {/* Step 1 — create & install (content changes by phase). */}
-                <div className="flex gap-[10px]">
-                  {autoPhase === 'appToken' ? (
-                    <span className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--brand-soft)">
-                      <Icon name="check" size={12} color="var(--brand)" />
-                    </span>
-                  ) : (
-                    <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
-                      1
-                    </span>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    {autoPhase === 'config' && (
-                      <>
-                        <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                          Name &amp; create the app (name optional)
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <div className="fld flex-1">
-                            <input
-                              className="inp mn"
-                              placeholder={
-                                manifestNames.name
-                                  ? `${manifestNames.name} — from the agent's name`
-                                  : 'Bot name (optional) — e.g. acme-agent'
-                              }
-                              value={appName}
-                              onChange={(e) => setAppName(e.target.value)}
-                            />
-                          </div>
-                          <Button
-                            onClick={() => void startAuto()}
-                            className={saving ? 'flex-none cursor-default opacity-50' : 'flex-none'}
+            ) : (
+              <>
+                {slackFunnel === true && (
+                  <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-[6px]">
+                    <div className="inline-flex flex-none rounded-lg border border-(--border-default) bg-(--surface-card) p-[3px]">
+                      {(['config', 'bot'] as const).map((m) => {
+                        const on = slackMethod === m
+                        return (
+                          <button
+                            key={m}
+                            type="button"
+                            onClick={() => selectMethod(m)}
+                            className={`rounded-[6px] px-[11px] py-[5px] font-sans text-[12px] font-semibold leading-normal ${
+                              on ? 'bg-(--brand-soft) text-(--brand)' : 'bg-transparent text-(--text-tertiary)'
+                            }`}
                           >
-                            <Icon name="plus" size={14} />
-                            {saving ? 'Creating…' : 'Create & install'}
-                          </Button>
-                        </div>
-                        <div className="mt-[10px] flex items-center gap-[6px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                          <Icon name="sparkles" size={13} color="var(--brand)" className="flex-none" />
-                          Quick install is on for this workspace
-                        </div>
-                      </>
-                    )}
-                    {autoPhase === 'authorizing' && (
-                      <>
-                        <div className="flex items-center gap-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                          <Icon name="loader" size={14} className="flex-none animate-spin" />
-                          Approve the install in Slack
-                        </div>
-                        <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
-                          We opened Slack in a new tab — click &ldquo;Allow&rdquo;, then come back. This updates
-                          automatically.
-                        </div>
-                        {install && (
-                          <div className="mt-2 flex items-center gap-[14px]">
-                            <a
-                              href={install.installUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="lnk inline-flex items-center gap-[5px]"
-                            >
-                              Reopen the Slack install
-                              <Icon name="external-link" size={12} />
-                            </a>
-                            <button type="button" className="lnk" onClick={restartAuto}>
-                              Start over
-                            </button>
+                            {m === 'config' ? 'Config token' : 'Bot token'}
+                          </button>
+                        )
+                      })}
+                    </div>
+                    <span className="min-w-0 flex-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                      {slackMethod === 'config'
+                        ? 'Recommended — one-click install, no manifest to copy or tokens to paste.'
+                        : 'Manual — copy our manifest into Slack, install, and paste the tokens back.'}
+                    </span>
+                  </div>
+                )}
+                {slackMethod === 'config' && autoUsable ? (
+                  <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+                    <div className="mb-[14px]">
+                      <SlackDeliveryLine
+                        transport={effTransport}
+                        relayAvailable={relayAvailable}
+                        locked={!!install}
+                        onSwitch={switchTransport}
+                      />
+                    </div>
+
+                    {/* Step 1 — create & install (content changes by phase). */}
+                    <div className="flex gap-[10px]">
+                      {autoPhase === 'appToken' ? (
+                        <span className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--brand-soft)">
+                          <Icon name="check" size={12} color="var(--brand)" />
+                        </span>
+                      ) : (
+                        <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                          1
+                        </span>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        {autoPhase === 'config' && (
+                          <>
+                            <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                              Name &amp; create the app (name optional)
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <div className="fld flex-1">
+                                <input
+                                  className="inp mn"
+                                  placeholder={
+                                    manifestNames.name
+                                      ? `${manifestNames.name} — from the agent's name`
+                                      : 'Bot name (optional) — e.g. acme-agent'
+                                  }
+                                  value={appName}
+                                  onChange={(e) => setAppName(e.target.value)}
+                                />
+                              </div>
+                              <Button
+                                onClick={() => void startAuto()}
+                                className={saving ? 'flex-none cursor-default opacity-50' : 'flex-none'}
+                              >
+                                <Icon name="plus" size={14} />
+                                {saving ? 'Creating…' : 'Create & install'}
+                              </Button>
+                            </div>
+                          </>
+                        )}
+                        {autoPhase === 'authorizing' && (
+                          <>
+                            <div className="flex items-center gap-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                              <Icon name="loader" size={14} className="flex-none animate-spin" />
+                              Approve the install in Slack
+                            </div>
+                            <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                              We opened Slack in a new tab — click &ldquo;Allow&rdquo;, then come back. This updates
+                              automatically.
+                            </div>
+                            {install && (
+                              <div className="mt-2 flex items-center gap-[14px]">
+                                <a
+                                  href={install.installUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="lnk inline-flex items-center gap-[5px]"
+                                >
+                                  Reopen the Slack install
+                                  <Icon name="external-link" size={12} />
+                                </a>
+                                <button type="button" className="lnk" onClick={restartAuto}>
+                                  Start over
+                                </button>
+                              </div>
+                            )}
+                          </>
+                        )}
+                        {autoPhase === 'appToken' && (
+                          <div className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                            {effTransport === 'http'
+                              ? 'App created & installed — click Connect to finish'
+                              : 'App created & installed — bot token secured'}
                           </div>
                         )}
-                      </>
-                    )}
-                    {autoPhase === 'appToken' && (
-                      <div className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                        {effTransport === 'http'
-                          ? 'App created & installed — click Connect to finish'
-                          : 'App created & installed — bot token secured'}
+                      </div>
+                    </div>
+
+                    {/* Step 2 — app-level token. Socket only: http needs no xapp paste
+                    (the CP reads the signing secret itself), so the footer Connect
+                    finalizes directly once the install is approved. */}
+                    {effTransport === 'socket' && (
+                      <div
+                        className={`mt-[14px] border-t border-dashed border-(--border-default) pt-[13px] ${
+                          autoPhase === 'appToken' ? '' : 'opacity-55'
+                        }`}
+                      >
+                        <div className="flex gap-[10px]">
+                          <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                            2
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                              Generate the App-Level token &amp; paste it{' '}
+                              <span className="font-normal text-(--text-tertiary)">
+                                (Slack has no API for this one)
+                              </span>
+                            </div>
+                            <div className="fld">
+                              <input
+                                className={`inp mn ${showErrors && !appOk ? 'border-(--status-error)' : ''}`}
+                                placeholder="xapp-…"
+                                value={appToken}
+                                onChange={(e) => setAppToken(e.target.value)}
+                                disabled={autoPhase !== 'appToken'}
+                              />
+                            </div>
+                            {autoPhase === 'appToken' && install ? (
+                              <a
+                                href={slackAppSettingsUrl(install.appId)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="lnk mt-[10px] inline-flex items-center gap-[5px]"
+                              >
+                                Generate the App-Level token
+                                <Icon name="external-link" size={12} />
+                              </a>
+                            ) : (
+                              <div className="mt-[8px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                                Unlocks once you approve the install in Slack.
+                              </div>
+                            )}
+                          </div>
+                        </div>
                       </div>
                     )}
                   </div>
-                </div>
-
-                {/* Step 2 — app-level token. Socket only: http needs no xapp paste
-                    (the CP reads the signing secret itself), so the footer Connect
-                    finalizes directly once the install is approved. */}
-                {effTransport === 'socket' && (
-                  <div
-                    className={`mt-[14px] border-t border-dashed border-(--border-default) pt-[13px] ${
-                      autoPhase === 'appToken' ? '' : 'opacity-55'
-                    }`}
-                  >
+                ) : slackMethod === 'config' ? (
+                  <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+                    {/* Step 1 — open Slack's App Configuration Tokens page (hover previews
+                    where it lives: scroll to the bottom of Your apps, then Copy). */}
                     <div className="flex gap-[10px]">
+                      <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                        1
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="cfgtok relative">
+                          <SlackConfigTokenPreview />
+                          <a
+                            href="https://api.slack.com/apps"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
+                          >
+                            <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
+                              <PlatformMark platform="slack" />
+                            </span>
+                            Open Slack app config tokens
+                            <Icon name="external-link" size={14} />
+                          </a>
+                        </div>
+                        <div className="mt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                          Under <span className="mono">Your apps</span> →{' '}
+                          <span className="mono">configuration tokens</span>, pick the workspace and generate a token
+                          pair. The app is created in that workspace.
+                        </div>
+                      </div>
+                    </div>
+                    {/* Step 2 — paste the configuration token pair (one row; hints inline). */}
+                    <div className="mt-[14px] mb-[11px] flex items-center gap-[10px] border-t border-dashed border-(--border-default) pt-[13px]">
                       <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
                         2
                       </span>
+                      <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                        Paste your configuration token
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-1 gap-[10px] pl-[30px] min-[440px]:grid-cols-2">
+                      <div className="fld">
+                        <span className="fldlbl">
+                          Access Token <span className="font-normal text-(--text-tertiary)">· required</span>
+                        </span>
+                        <input
+                          className={`inp mn ${showErrors && !cfgAccess.trim() ? 'border-(--status-error)' : ''}`}
+                          placeholder="xoxe.xoxp-1-…"
+                          value={cfgAccess}
+                          onChange={(e) => setCfgAccess(e.target.value)}
+                        />
+                      </div>
+                      <div className="fld">
+                        <span className="fldlbl">
+                          Refresh Token{' '}
+                          <span className="font-normal text-(--text-tertiary)">· optional, saved for reuse</span>
+                        </span>
+                        <input
+                          className="inp mn"
+                          placeholder="xoxe-1-…"
+                          value={cfgRefresh}
+                          onChange={(e) => setCfgRefresh(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+                    {/* Step 1 — create & install from our manifest. The agent name is
+                    built into the manifest, so no separate name field here. */}
+                    <div className="mb-3 flex gap-[10px]">
+                      <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                        1
+                      </span>
                       <div className="min-w-0 flex-1">
                         <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                          Generate the App-Level token &amp; paste it{' '}
-                          <span className="font-normal text-(--text-tertiary)">(Slack has no API for this one)</span>
+                          Create &amp; install the Slack app from our manifest
                         </div>
-                        <div className="fld">
-                          <input
-                            className={`inp mn ${showErrors && !appOk ? 'border-(--status-error)' : ''}`}
-                            placeholder="xapp-…"
-                            value={appToken}
-                            onChange={(e) => setAppToken(e.target.value)}
-                            disabled={autoPhase !== 'appToken'}
-                          />
-                        </div>
-                        {autoPhase === 'appToken' && install ? (
+                        <div className="group relative">
                           <a
-                            href={slackAppSettingsUrl(install.appId)}
+                            href={createUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="lnk mt-[10px] inline-flex items-center gap-[5px]"
+                            onClick={() => void navigator.clipboard?.writeText?.(manifestJson)?.catch?.(() => {})}
+                            className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
                           >
-                            Generate the App-Level token
-                            <Icon name="external-link" size={12} />
+                            <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
+                              <PlatformMark platform="slack" />
+                            </span>
+                            Copy manifest &amp; open Slack
+                            <Icon name="external-link" size={14} />
                           </a>
+                          <SlackManifestPreview />
+                        </div>
+                        <div className="mt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                          In Slack, choose <span className="font-medium text-(--text-secondary)">From a manifest</span>,
+                          paste, select a workspace, then create and install the app.
+                        </div>
+                        <SlackDeliveryLine
+                          transport={effTransport}
+                          relayAvailable={relayAvailable}
+                          locked={false}
+                          onSwitch={switchTransport}
+                        />
+                      </div>
+                    </div>
+                    {/* Step 2 — paste the tokens the install gives back. */}
+                    <div className="mt-[14px] mb-[11px] flex items-center gap-[10px] border-t border-dashed border-(--border-default) pt-[13px]">
+                      <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                        2
+                      </span>
+                      <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                        Paste the tokens it gives you — required to connect
+                      </span>
+                    </div>
+                    <div className="pl-[30px]">
+                      <div className="grid grid-cols-1 gap-[10px] min-[440px]:grid-cols-2">
+                        <div className="fld">
+                          <span className="fldlbl">Bot token</span>
+                          <input
+                            className={`inp mn ${showErrors && !botOk ? 'border-(--status-error)' : ''}`}
+                            placeholder="xoxb-…"
+                            value={botToken}
+                            onChange={(e) => setBotToken(e.target.value)}
+                          />
+                        </div>
+                        {effTransport === 'http' ? (
+                          <div className="fld">
+                            <span className="fldlbl">Signing secret</span>
+                            <input
+                              className={`inp mn ${showErrors && !slackSigningOk ? 'border-(--status-error)' : ''}`}
+                              placeholder="Signing secret (Basic Information → App Credentials)"
+                              value={signingSecret}
+                              onChange={(e) => setSigningSecret(e.target.value)}
+                            />
+                          </div>
                         ) : (
-                          <div className="mt-[8px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                            Unlocks once you approve the install in Slack.
+                          <div className="fld">
+                            <span className="fldlbl">App-level token</span>
+                            <input
+                              className={`inp mn ${showErrors && !appOk ? 'border-(--status-error)' : ''}`}
+                              placeholder="xapp-…"
+                              value={appToken}
+                              onChange={(e) => setAppToken(e.target.value)}
+                            />
                           </div>
                         )}
+                      </div>
+                      {/* Socket: once the app-level token decodes, deep-link to the app's
+                      Bot-token + settings pages (progressive — hidden until pasted). */}
+                      {effTransport === 'socket' && appId && (
+                        <div className="mt-[10px] flex flex-wrap items-center gap-x-[14px] gap-y-1 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                          <span className="flex items-center gap-[5px]">
+                            <Icon name="corner-down-right" size={12} className="flex-none" />
+                            App&nbsp;<span className="mono">{appId}</span>
+                          </span>
+                          <a
+                            href={slackAppOAuthUrl(appId)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="lnk inline-flex items-center gap-[5px]"
+                          >
+                            Copy the Bot token
+                            <Icon name="external-link" size={12} />
+                          </a>
+                          <a
+                            href={slackAppSettingsUrl(appId)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="lnk inline-flex items-center gap-[5px]"
+                          >
+                            Open app settings
+                            <Icon name="external-link" size={12} />
+                          </a>
+                        </div>
+                      )}
+                      {/* Bot-token path only: getting the Bot User OAuth token means installing
+                      the app, and if Slack flags changed scopes it shows a "reinstall your
+                      app" banner — reinstalling once is what activates the token pasted above. */}
+                      <div className="mt-[11px] flex items-start gap-2 rounded-lg bg-(--status-paused-soft) px-[11px] py-[9px]">
+                        <Icon
+                          name="triangle-alert"
+                          size={14}
+                          color="var(--status-paused)"
+                          className="mt-[1px] flex-none"
+                        />
+                        <span className="min-w-0 flex-1 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                          If Slack shows{' '}
+                          <span className="font-medium">
+                            “You’ve changed the permission scopes… reinstall your app”
+                          </span>
+                          , click <span className="font-medium">Reinstall</span> once — that’s what activates the Bot
+                          User OAuth token you paste above.
+                        </span>
                       </div>
                     </div>
                   </div>
                 )}
-              </div>
-            ) : (
-              <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-                {/* Step 1 — create & install from our manifest. The agent name is
-                    built into the manifest, so no separate name field here. */}
-                <div className="mb-3 flex gap-[10px]">
-                  <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
-                    1
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                      Create &amp; install the Slack app from our manifest
-                    </div>
-                    <a
-                      href={createUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => void navigator.clipboard?.writeText?.(manifestJson)?.catch?.(() => {})}
-                      className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
-                    >
-                      <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
-                        <PlatformMark platform="slack" />
-                      </span>
-                      Copy manifest &amp; open Slack
-                      <Icon name="external-link" size={14} />
-                    </a>
-                    <div className="mt-[7px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                      In Slack, choose <span className="font-medium text-(--text-secondary)">From a manifest</span>,
-                      paste, select a workspace, then create and install the app.
-                    </div>
-                    <SlackDeliveryLine
-                      transport={effTransport}
-                      relayAvailable={relayAvailable}
-                      locked={false}
-                      onSwitch={switchTransport}
-                    />
-                  </div>
-                </div>
-                {/* Step 2 — paste the tokens the install gives back. */}
-                <div className="mt-[14px] mb-[11px] flex items-center gap-[10px] border-t border-dashed border-(--border-default) pt-[13px]">
-                  <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
-                    2
-                  </span>
-                  <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                    Paste the tokens it gives you — required to connect
-                  </span>
-                </div>
-                <div className="pl-[30px]">
-                  <div className="grid grid-cols-1 gap-[10px] min-[440px]:grid-cols-2">
-                    <div className="fld">
-                      <span className="fldlbl">Bot token</span>
-                      <input
-                        className={`inp mn ${showErrors && !botOk ? 'border-(--status-error)' : ''}`}
-                        placeholder="xoxb-…"
-                        value={botToken}
-                        onChange={(e) => setBotToken(e.target.value)}
-                      />
-                    </div>
-                    {effTransport === 'http' ? (
-                      <div className="fld">
-                        <span className="fldlbl">Signing secret</span>
-                        <input
-                          className={`inp mn ${showErrors && !slackSigningOk ? 'border-(--status-error)' : ''}`}
-                          placeholder="Signing secret (Basic Information → App Credentials)"
-                          value={signingSecret}
-                          onChange={(e) => setSigningSecret(e.target.value)}
-                        />
-                      </div>
-                    ) : (
-                      <div className="fld">
-                        <span className="fldlbl">App-level token</span>
-                        <input
-                          className={`inp mn ${showErrors && !appOk ? 'border-(--status-error)' : ''}`}
-                          placeholder="xapp-…"
-                          value={appToken}
-                          onChange={(e) => setAppToken(e.target.value)}
-                        />
-                      </div>
-                    )}
-                  </div>
-                  {/* Socket: once the app-level token decodes, deep-link to the app's
-                      Bot-token + settings pages (progressive — hidden until pasted). */}
-                  {effTransport === 'socket' && appId && (
-                    <div className="mt-[10px] flex flex-wrap items-center gap-x-[14px] gap-y-1 font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                      <span className="flex items-center gap-[5px]">
-                        <Icon name="corner-down-right" size={12} className="flex-none" />
-                        App&nbsp;<span className="mono">{appId}</span>
-                      </span>
-                      <a
-                        href={slackAppOAuthUrl(appId)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="lnk inline-flex items-center gap-[5px]"
-                      >
-                        Copy the Bot token
-                        <Icon name="external-link" size={12} />
-                      </a>
-                      <a
-                        href={slackAppSettingsUrl(appId)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="lnk inline-flex items-center gap-[5px]"
-                      >
-                        Open app settings
-                        <Icon name="external-link" size={12} />
-                      </a>
-                    </div>
-                  )}
-                  {/* Quick-install nudge — only when this deployment's funnel is on but
-                      the caller hasn't stored their own config token yet. */}
-                  {slackFunnel && !myConfig && (
-                    <Link
-                      href={orgPath('/profile')}
-                      onClick={onClose}
-                      className="mt-[11px] flex items-center gap-[7px] rounded-lg bg-(--brand-soft) px-[11px] py-[9px] no-underline"
-                    >
-                      <Icon name="zap" size={14} color="var(--brand-soft-text)" className="flex-none" />
-                      <span className="min-w-0 flex-1 font-sans text-[11.5px] font-normal leading-normal text-(--brand-soft-text)">
-                        Want a quick install without pasting tokens?
-                      </span>
-                      <span className="flex-none whitespace-nowrap font-sans text-[11.5px] font-semibold leading-normal text-(--brand)">
-                        Set up quick install →
-                      </span>
-                    </Link>
-                  )}
-                </div>
-              </div>
+              </>
             )}
           </>
         )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -487,17 +487,20 @@ export interface SlackInstallStatusDto {
  *  modal's forced auto/manual mode). Per-user. NEVER carries the token. */
 export interface SlackConfigDto {
   configured: boolean // the signed-in caller has stored their own token
+  durable: boolean // a refresh token is stored ⇒ the pair auto-rotates and never expires
   funnelEnabled: boolean // this deployment supports auto-install (public callback)
-  autoAvailable: boolean // configured AND funnelEnabled
+  autoAvailable: boolean // funnelEnabled AND the stored token is usable right now
+  accessExpiresAt: string | null // ISO expiry of the stored access token (drives the expires/expired copy)
   // The sole signal the console has for the "http default vs socket-only" rule:
   relayAvailable: boolean // PUBLIC_RELAY_URL set AND ≥1 relay connected
   relayPublicUrl: string | null // https(s) LB URL for the http manifest request_url; null when unavailable
   updatedAt: string | null
 }
-/** `PUT /slack/config` body — the caller's own Slack App Configuration token pair. */
+/** `PUT /slack/config` body — the caller's own Slack App Configuration token. The
+ *  access (config) token is required; the refresh token is optional (adds durability). */
 export interface SlackConfigInput {
   accessToken: string // xoxe.xoxp-…
-  refreshToken: string // xoxe-…
+  refreshToken?: string // xoxe-… — optional; omit to store an access-only (expiring) token
 }
 
 // How the bot activates in one channel: only when @-mentioned, or on any message.


### PR DESCRIPTION
## What

Makes the Slack **App Configuration refresh token optional** and reworks the
**"Create a new bot"** modal around a config-token method (design sync).

### Backend (control plane)
- `refresh_token` column is now **nullable** (migration + schema).
- **Resolution**: fresh access token → used as-is; stale **with** a refresh token → rotate;
  stale **access-only** → new `expired` reason (the console re-prompts).
- `PUT /slack/config`: refresh token optional. With one it rotates (durable, never
  expires); access-only is stored as-is with Slack's ~12h lifetime and verified at
  install time.
- DTO/api gain `durable` + `accessExpiresAt`; `autoAvailable` now means *usable right
  now* (`funnelEnabled && (durable || access still fresh)`).
- `rewrap` re-seal is null-safe.

### Console
- **Profile → Slack config token card**: refresh token optional; tri-state status
  (durable ✓ / access-only "expires …" / "expired — re-enter").
- **Add integration → Create a new bot (Slack)**:
  - **Config token / Bot token** method toggle (config is the default when the funnel is on).
  - Config path: design's 2-step panel — **"Open Slack app config tokens"** button with an
    **animated hover popover** (scrolls to *Your App Configuration Tokens*, then pulses the
    Access then Refresh Copy buttons), plus one-row Access/Refresh fields; the footer saves
    the token and creates the app.
  - Bot path: reinstall hint + a hover preview of Slack's *From a manifest* dialog.
  - **Socket mode is preserved** end-to-end (the config-token funnel supports both socket
    and http).

## Why

Recommend the config token as the easy path (it alone installs for ~12h); the refresh
token is opt-in durability. The modal is synced to the design so config-token quick
install is the recommended default, with a switch back to the manual bot-token flow.

## Notes for the reviewer

- The popover animations use **plain `.cfg-*` classes in `globals.css`** rather than
  Tailwind arbitrary `animate-[…]` utilities: the CSS optimizer was pruning the
  `@keyframes` because only the arbitrary utilities referenced them, so the animation
  rendered static. The plain classes keep the keyframes referenced within the file.
- The config-token 2-step entry is **relay-independent** — it renders identically with or
  without a connected relay; relay only decides the eventual install transport (socket vs
  http) and whether the auto/manual flows offer a Socket↔HTTP switch.
- The animation mock uses a generic `your-workspace` placeholder (no real workspace name).

## Tests

- CP: 621 unit + 618 integration (new access-only resolve, access-only `PUT`, expired
  install 409, rewrap re-seal, clean migration apply; durable auth-rejection
  rotate-and-retry recovery, and invalidation of an unrecoverable/access-only config).
- Web: 256 tests; typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
