### PR TITLE
fix(security): harden git clone targets

### DIFF
--- a/packages/control-plane/prisma/migrations/20260725120000_redact_agent_git_repo_secrets/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260725120000_redact_agent_git_repo_secrets/migration.sql
@@ -1,0 +1,34 @@
+-- Historical workspace URLs could persist HTTP(S) userinfo or SSH passwords and
+-- query/fragment secrets before clone-target validation was introduced.
+-- Keep this cleanup deliberately narrow: sanitize only hierarchical HTTP(S)/SSH
+-- gitRepo values, preserve well-formed hosts and paths, and leave workspace mode
+-- plus every other transport unchanged. Ambiguous malformed authorities are
+-- cleared rather than risk retaining a secret or rewriting to an attacker host.
+WITH sanitized AS (
+  SELECT
+    "id",
+    regexp_replace(
+      CASE
+        -- Greedy authority match removes through the LAST @, including malformed
+        -- historical passwords that contained an unescaped @. Ambiguous
+        -- `password?metadata@host` / `#metadata@host` rows are cleared instead
+        -- of guessing whether text after the delimiter is a host or query data.
+        WHEN "gitRepo" ~* '^https?://[^/?#]+:[^/?#]*[?#].*@'
+          THEN NULL
+        WHEN "gitRepo" ~* '^https?://'
+          THEN regexp_replace("gitRepo", '^(https?://)[^/?#]*@', '\1', 'i')
+        WHEN "gitRepo" ~* '^ssh://[^:/@?#]+:[^/?#]*[?#].*@'
+          THEN NULL
+        ELSE regexp_replace("gitRepo", '^(ssh://[^:/@?#]+):[^/?#]*@', '\1@', 'i')
+      END,
+      '[?#].*$',
+      ''
+    ) AS "gitRepo"
+  FROM "agent"
+  WHERE "gitRepo" ~* '^(https?|ssh)://'
+)
+UPDATE "agent" a
+SET "gitRepo" = s."gitRepo"
+FROM sanitized s
+WHERE a."id" = s."id"
+  AND a."gitRepo" IS DISTINCT FROM s."gitRepo";

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -14,8 +14,10 @@ import {
   MemoryPluginHistoryEvent,
   MemoryPluginOperation,
   RESERVED_MCP_SERVER_NAME,
+  GitCloneUrlError,
   RepoSubdirError,
-  normalizeGitUrl,
+  normalizeGitCloneUrl,
+  redactGitUrlSecrets,
   normalizeRepoSubdir
 } from '@agentconnect.md/protocol'
 import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
@@ -233,15 +235,12 @@ export const MintedKeyDto = z.object({
 })
 
 // ── agents ────────────────────────────────────────────────────────────────
-/** `gitRepo` is STORED as a full cloneable address — user shorthand ("acme/infra",
- *  "github.com/acme/infra") is expanded at this boundary; the console shortens it
- *  back to org/repo for display. A `codec` (not `.transform()`) because the schema
- *  is reused in response DTOs and the zod serializer runs the ENCODE direction —
- *  a one-way transform would throw there. Encode also normalizes, so responses
- *  repair pre-normalization rows. */
-const GitRepo = z.codec(z.string().min(1), z.string(), {
-  decode: normalizeGitUrl,
-  encode: normalizeGitUrl
+/** Response-only git address codec. Historical rows stay readable even when
+ * they predate clone-target validation; the total sanitizer only removes URL
+ * secrets and never rejects an old value during response serialization. */
+const GitRepoOutput = z.codec(z.string(), z.string(), {
+  decode: redactGitUrlSecrets,
+  encode: redactGitUrlSecrets
 })
 
 /** Where the agent runs (inline; path is daemon-generated). Mirrors protocol AgentWorkspace.
@@ -250,7 +249,7 @@ export const AgentWorkspaceBody = z.discriminatedUnion('mode', [
   z.object({ mode: z.literal('scratch') }),
   z.object({
     mode: z.literal('github'),
-    gitRepo: GitRepo,
+    gitRepo: GitRepoOutput,
     gitBranch: z.string().optional(),
     agentDir: z.string().optional(),
     // github-app credential mode: the GithubInstallation picked in the console
@@ -275,6 +274,22 @@ function normalizeAgentDir(value: string, ctx: z.RefinementCtx): string | undefi
   }
 }
 
+function normalizeAgentGitRepo(value: string, ctx: z.RefinementCtx): string {
+  try {
+    return normalizeGitCloneUrl(value)
+  } catch (err) {
+    if (!(err instanceof GitCloneUrlError)) throw err
+    // Deliberately do not include the supplied URL or the thrown message: URL
+    // userinfo/query fields may contain a credential.
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'gitRepo must be a credential-free HTTPS or SSH repository URL, or owner/repo shorthand'
+    })
+    return z.NEVER
+  }
+}
+
+const GitRepoInput = z.string().min(1).transform(normalizeAgentGitRepo)
 const AgentDirCreateInput = z.string().transform(normalizeAgentDir)
 const AgentDirPatchInput = z
   .union([z.string(), z.null()])
@@ -285,7 +300,7 @@ const AgentWorkspaceInputBody = z.discriminatedUnion('mode', [
   z.object({ mode: z.literal('scratch') }),
   z.object({
     mode: z.literal('github'),
-    gitRepo: GitRepo,
+    gitRepo: GitRepoInput,
     gitBranch: z.string().optional(),
     agentDir: AgentDirCreateInput.optional(),
     installationId: z.string().uuid().optional(),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -744,6 +744,7 @@ export function agentRoutes(deps: HttpDeps) {
         // these answer 409 — installations and their grant sets are org-level
         // infrastructure (visibility taxonomy), so a 409 is not an oracle.
         const ws = req.body.workspace
+        let workspace = ws
         let workspaceRepoId: bigint | undefined
         if (ws?.mode === 'github' && ws.installationId === undefined && ws.gitAccess === 'write') {
           return conflict('github write access requires a GitHub App installation')
@@ -754,8 +755,11 @@ export function agentRoutes(deps: HttpDeps) {
           if (!ins || ins.orgId !== req.orgCtx!.orgId || ins.revokedAt) {
             return conflict('github installation not found in this org')
           }
-          const [owner, repo] = gitRepoLabel(ws.gitRepo).split('/')
-          if (!owner || !repo) return conflict('workspace gitRepo is not a github repository')
+          const repoParts = gitRepoLabel(ws.gitRepo).split('/')
+          const [owner, repo] = repoParts
+          if (repoParts.length !== 2 || !owner || !repo) {
+            return conflict('workspace gitRepo is not a github repository')
+          }
           if (owner.toLowerCase() !== ins.accountLogin.toLowerCase()) {
             return conflict(`repo owner ${owner} does not match the installation account ${ins.accountLogin}`)
           }
@@ -765,6 +769,9 @@ export function agentRoutes(deps: HttpDeps) {
               return conflict(`${owner}/${repo} is not granted to the installation — re-select it on GitHub`)
             }
             workspaceRepoId = ref.repoId
+            // The installation lookup, not the caller's clone host/path, is the
+            // authority for an App-backed workspace.
+            workspace = { ...ws, gitRepo: normalizeGitUrl(ref.fullName) }
             // Per-user gate (identity assertion, open question #7) — the SECURITY check;
             // the picker's preflight is UX only. The creator must hold the
             // access level the agent will run with: gitAccess=write (the
@@ -865,7 +872,7 @@ export function agentRoutes(deps: HttpDeps) {
               ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
               ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
               ...(req.body.daemonId !== undefined ? { daemonId: DaemonId(req.body.daemonId) } : {}),
-              ...(req.body.workspace !== undefined ? { workspace: req.body.workspace } : {}),
+              ...(workspace !== undefined ? { workspace } : {}),
               ...(workspaceRepoId !== undefined ? { workspaceRepoId } : {}),
               ...(req.principal ? { createdByUserId: req.principal.userId } : {}),
               ...(req.body.visibility ? { visibility: req.body.visibility } : {}),

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
@@ -64,6 +64,22 @@ describe('AgentSpecAssembler', () => {
     expect(b!.secrets).toEqual({ B: '2' })
   })
 
+  it('assembleAll quarantines only unsafe historical clone targets', async () => {
+    const unsafe = {
+      ...AGENT,
+      id: AgentId('88888888-8888-4888-8888-888888888888'),
+      name: 'unsafe',
+      workspace: { mode: 'github' as const, gitRepo: 'file:///var/lib/agentconnect/other-workspace' }
+    }
+    const quarantined: string[] = []
+    const specs = new AgentSpecAssembler(storeWith({}))
+
+    const assembled = await specs.assembleAll([AGENT, unsafe], (agent) => quarantined.push(agent.id))
+
+    expect(assembled.map((spec) => spec.agentId)).toEqual([AGENT.id])
+    expect(quarantined).toEqual([unsafe.id])
+  })
+
   it('project trusts the caller-snapshotted secrets (never re-fetches)', async () => {
     let reads = 0
     const store = storeWith({ [AGENT.id]: { LIVE: 'now' } })
@@ -79,6 +95,64 @@ describe('AgentSpecAssembler', () => {
     expect(reads).toBe(1)
     expect(specs.project(AGENT, pinned, []).secrets).toEqual({ LIVE: 'now' })
     expect(reads).toBe(1) // project() added none
+  })
+
+  it('redacts legacy URL secrets before projecting an anonymous workspace onto the daemon wire', () => {
+    const specs = new AgentSpecAssembler(storeWith({}))
+    const spec = specs.project(
+      {
+        ...AGENT,
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://legacy-user:legacy-password@github.com/acme/legacy.git?token=query-secret#fragment'
+        }
+      },
+      {},
+      []
+    )
+
+    expect(spec.workspace).toMatchObject({
+      mode: 'github',
+      gitRepo: 'https://github.com/acme/legacy.git'
+    })
+    expect(JSON.stringify(spec.workspace)).not.toContain('legacy-password')
+    expect(JSON.stringify(spec.workspace)).not.toContain('query-secret')
+  })
+
+  it('binds a legacy App-backed workspace to its canonical GitHub repository', () => {
+    const specs = new AgentSpecAssembler(storeWith({}))
+    const spec = specs.project(
+      {
+        ...AGENT,
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://legacy-user:legacy-password@other-host.example/acme/legacy.git?token=query-secret',
+          installationId: 'installation-id'
+        }
+      },
+      {},
+      []
+    )
+
+    expect(spec.workspace).toMatchObject({
+      mode: 'github',
+      gitRepo: 'https://github.com/acme/legacy.git',
+      gitCredential: 'github-app'
+    })
+    expect(JSON.stringify(spec.workspace)).not.toContain('legacy-password')
+    expect(JSON.stringify(spec.workspace)).not.toContain('query-secret')
+    expect(JSON.stringify(spec.workspace)).not.toContain('other-host.example')
+  })
+
+  it('refuses to project an unsafe historical clone transport', () => {
+    const specs = new AgentSpecAssembler(storeWith({}))
+    expect(() =>
+      specs.project(
+        { ...AGENT, workspace: { mode: 'github', gitRepo: 'file:///var/lib/agentconnect/other-workspace' } },
+        {},
+        []
+      )
+    ).toThrow('git clone url must use https or ssh')
   })
 
   it('applies the instance-owned icon bases to the spec iconUrl', async () => {

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -14,7 +14,14 @@
  * The instance also owns the icon URL bases, so the four call sites stop
  * re-deriving `{cp, store}` from config independently.
  */
-import type { AgentSkillEntry, AgentSpec } from '@agentconnect.md/protocol'
+import {
+  GitCloneUrlError,
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  redactGitUrlSecrets,
+  type AgentSkillEntry,
+  type AgentSpec
+} from '@agentconnect.md/protocol'
 import type { AgentRecord, AgentSecretStore, SkillSourceRepo } from '../persistence/ports.js'
 import { resolveAgentIconUrl, type IconUrlBases } from '../agents/agent-icon.js'
 import { resolveAgentSkillEntries } from './skillSource.js'
@@ -40,9 +47,25 @@ export class AgentSpecAssembler {
     return this.project(a, secrets, skillEntries)
   }
 
-  /** Batch form for the reconcile roster (one store read per owned agent). */
-  assembleAll(agents: readonly AgentRecord[]): Promise<AssembledAgentSpec[]> {
-    return Promise.all(agents.map((a) => this.assemble(a)))
+  /** Batch form for the reconcile roster (one store read per owned agent).
+   * Historical unsafe clone targets are quarantined individually; every other
+   * failure still rejects the roster so infrastructure errors remain visible. */
+  async assembleAll(
+    agents: readonly AgentRecord[],
+    onUnsafeAgent?: (agent: AgentRecord, error: GitCloneUrlError) => void
+  ): Promise<AssembledAgentSpec[]> {
+    const settled = await Promise.allSettled(agents.map((a) => this.assemble(a)))
+    const assembled: AssembledAgentSpec[] = []
+    for (const [index, result] of settled.entries()) {
+      if (result.status === 'fulfilled') {
+        assembled.push(result.value)
+      } else if (result.reason instanceof GitCloneUrlError) {
+        onUnsafeAgent?.(agents[index]!, result.reason)
+      } else {
+        throw result.reason
+      }
+    }
+    return assembled
   }
 
   /** The store read the agent-move snapshot pins into its {@link MoveBundle} —
@@ -95,7 +118,12 @@ export function agentRecordToSpec(
     a.workspace.mode === 'github'
       ? {
           mode: 'github',
-          gitRepo: a.workspace.gitRepo,
+          // Defense in depth for historical/non-Prisma records: never send
+          // credentials or an unsupported transport to any daemon version.
+          gitRepo:
+            a.workspace.installationId !== undefined
+              ? normalizeGithubRepoUrl(a.workspace.gitRepo)
+              : normalizeGitCloneUrl(redactGitUrlSecrets(a.workspace.gitRepo)),
           branch: a.workspace.gitBranch ?? 'main',
           ...(a.workspace.agentDir !== undefined ? { agentDir: a.workspace.agentDir } : {}),
           ...(a.workspace.installationId !== undefined ? { gitCredential: 'github-app' as const } : {})

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -316,16 +316,13 @@ export class Placement implements ReconcileService {
       this.integrations.activeForDaemon(daemonId)
     ])
 
-    // Integrations FILTERED to this daemon (via agent.daemonId) — each carries
-    // plaintext tokens, so this must never be the org-wide set. Tokens are pulled
-    // from the secret store (the only decrypt/read seam); NEVER log this array.
-    // ALL platforms belong in the roster (Slack + Telegram): the roster is the
-    // backstop when the live integration/upsert was skipped (daemon offline) or
-    // no-op'd (agent.json not on disk yet), so filtering to one platform silently
-    // strands the others' tokens off the daemon. integrationToSpec emits the
-    // right per-platform variant.
-    const desiredIntegrations = (
-      await Promise.all(
+    const quarantinedAgentIds = new Set<string>()
+    const [desiredAgents, assembledIntegrations] = await Promise.all([
+      this.specs.assembleAll(ownedAgents, (agent) => {
+        quarantinedAgentIds.add(agent.id)
+        this.orch?.log?.warn({ agentId: agent.id }, 'quarantining agent with an unsafe historical git repository')
+      }),
+      Promise.all(
         activeIntegrations.map(async (i) => {
           const [secret, channels, bot] = await Promise.all([
             this.botSecrets.get(i.botId),
@@ -340,21 +337,37 @@ export class Placement implements ReconcileService {
             : integrationToSpec(i, secret, channels)
         })
       )
-    ).filter((s): s is IntegrationSpec => s !== null)
+    ])
 
-    const desiredAssignments = activeAssignments.map(assignmentToRoute)
+    // Integrations FILTERED to this daemon (via agent.daemonId) — each carries
+    // plaintext tokens, so this must never be the org-wide set. Tokens are pulled
+    // from the secret store (the only decrypt/read seam); NEVER log this array.
+    // ALL platforms belong in the roster (Slack + Telegram): the roster is the
+    // backstop when the live integration/upsert was skipped (daemon offline) or
+    // no-op'd (agent.json not on disk yet), so filtering to one platform silently
+    // strands the others' tokens off the daemon. integrationToSpec emits the
+    // right per-platform variant.
+    const desiredIntegrations = assembledIntegrations.filter(
+      (spec): spec is IntegrationSpec => spec !== null && !quarantinedAgentIds.has(spec.agentId)
+    )
+
+    const desiredAssignments = activeAssignments
+      .filter((assignment) => !quarantinedAgentIds.has(assignment.agentId))
+      .map(assignmentToRoute)
     // The agent-config replica for THIS daemon: only the agents placed on it
     // (1 agent : 1 machine). A daemon never receives specs for agents owned by
     // other machines. Unplaced agents (daemonId null) go to no daemon. The daemon
     // converges its replica to this set (CP wins); live edits ride
     // `agent/upsert`/`agent/remove`; this snapshot is the reconnect backstop.
     // The assembler owns secret loading + icon bases — same spec shape as the
-    // live agent/upsert emit, structurally.
-    const desiredAgents = await this.specs.assembleAll(ownedAgents)
+    // live agent/upsert emit, structurally. Historical unsafe repository rows
+    // are quarantined above without stranding the rest of this daemon's roster.
     // Crons FILTERED to this daemon (via agent.daemonId) — a cron drives one
     // agent, so its def lands only on that agent's daemon (same rule as
     // integrations above). Orphaned rows map to null and are never pushed.
-    const desiredCrons = daemonCrons.map(cronToUpsert).filter((c): c is CronUpsert => c !== null)
+    const desiredCrons = daemonCrons
+      .map(cronToUpsert)
+      .filter((cron): cron is CronUpsert => cron !== null && !quarantinedAgentIds.has(cron.agentId))
     const desiredLeases = activeLeases.map(leaseToGrant)
 
     // Bot-agnostic collaboration routing snapshot (agent-collaboration §2.3/§6.2/§6.5) —
@@ -393,6 +406,10 @@ export class Placement implements ReconcileService {
     const orgIntegrationIds = new Set(orgIntegrations.map((integration) => integration.id as string))
     const dropAgents: RegisterOk['drop']['agents'] = []
     for (const local of staleAgentCandidates) {
+      if (quarantinedAgentIds.has(local.agentId)) {
+        dropAgents.push({ agentId: local.agentId, action: 'detach' })
+        continue
+      }
       const record = orgAgentById.get(local.agentId)
       // An unplaced CP row (daemonId=null) belongs on no daemon, so detach its
       // preserved local workspace just like a replica moved to another daemon.

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -3,7 +3,7 @@
  */
 import { Prisma } from '../../generated/prisma/client.js'
 import type { Agent, PrismaClient, User } from '../../generated/prisma/client.js'
-import type { AgentMemoryBinding } from '@agentconnect.md/protocol'
+import { redactGitUrlSecrets, type AgentMemoryBinding } from '@agentconnect.md/protocol'
 import type { PrismaLike } from '../prisma.js'
 import type {
   AgentCallPolicy,
@@ -92,7 +92,10 @@ function workspaceOf(a: Agent): AgentWorkspace {
   if (a.workspaceMode === 'github') {
     return {
       mode: 'github',
-      gitRepo: a.gitRepo ?? '',
+      // Legacy rows may predate the credential-free clone URL invariant. Keep
+      // reads total, but never let URL userinfo/query secrets enter DTOs or wire
+      // projections through the domain record.
+      gitRepo: redactGitUrlSecrets(a.gitRepo ?? ''),
       ...(a.gitBranch !== null ? { gitBranch: a.gitBranch } : {}),
       ...(a.agentDir !== null ? { agentDir: a.agentDir } : {}),
       ...(a.installationId !== null ? { installationId: a.installationId, gitAccess: a.gitAccess } : {})

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -195,6 +195,38 @@ async function makeUser(sub: string, role: OrgMemberRole): Promise<string> {
 }
 
 describe('agent repo authorizations REST — grant, list, revoke, gates', () => {
+  it('canonicalizes an App-backed workspace to the repository authorized by GitHub', async () => {
+    await seedInstallation()
+    const installation = await prisma.githubInstallation.findFirstOrThrow({
+      where: { orgId: DEFAULT_ORG_ID, installationId: INSTALLATION }
+    })
+    const a = app()
+
+    const created = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: {
+        name: 'canonical-workspace',
+        runtime: 'claude',
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://other-host.example/acme/infra',
+          installationId: installation.id,
+          gitAccess: 'read'
+        }
+      }
+    })
+
+    expect(created.statusCode).toBe(201)
+    expect(created.json()).toMatchObject({
+      workspace: { gitRepo: 'https://github.com/acme/infra' },
+      workspaceRepoId: '100'
+    })
+    expect((await prisma.agent.findFirstOrThrow({ where: { name: 'canonical-workspace' } })).gitRepo).toBe(
+      'https://github.com/acme/infra'
+    )
+  })
+
   it('PATCH upgrades an App-backed workspace from read to write after checking the caller', async () => {
     await seedDaemon(prisma, DAEMON)
     const agentId = await workspaceAgent()

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -15,6 +15,7 @@
  */
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
@@ -24,6 +25,10 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 // Console routes are org-scoped: /orgs/:orgId/… (devAuth = seeded owner of the default org).
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const REDACT_GIT_REPO_MIGRATION = readFileSync(
+  new URL('../../prisma/migrations/20260725120000_redact_agent_git_repo_secrets/migration.sql', import.meta.url),
+  'utf8'
+)
 
 let running: HttpApp | undefined
 
@@ -406,6 +411,65 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect((scratch.json() as { workspace: { mode: string } }).workspace).toEqual({ mode: 'scratch' })
   })
 
+  it('POST /agents rejects unsafe and credential-bearing clone targets without persisting or echoing secrets', async () => {
+    const app = build()
+    const rejected = [
+      'http://github.com/acme/infra',
+      'file:///tmp/infra',
+      'git://github.com/acme/infra',
+      'ftp://example.com/acme/infra',
+      'ext::sh -c harmless'
+    ]
+
+    for (const [index, gitRepo] of rejected.entries()) {
+      const name = `unsafe-repo-${index}`
+      const response = await app.app.inject({
+        method: 'POST',
+        url: `${ORG}/agents`,
+        payload: { name, runtime: 'claude', workspace: { mode: 'github', gitRepo } }
+      })
+      expect(response.statusCode).toBe(400)
+      expect(await prisma.agent.findFirst({ where: { name } })).toBeNull()
+    }
+
+    const secret = 'super-secret-pat'
+    const credentialName = 'credential-repo'
+    const credential = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: {
+        name: credentialName,
+        runtime: 'claude',
+        workspace: {
+          mode: 'github',
+          gitRepo: `https://alice:${secret}@github.com/acme/infra?token=query-secret#fragment`
+        }
+      }
+    })
+    expect(credential.statusCode).toBe(400)
+    expect(credential.body).not.toContain(secret)
+    expect(credential.body).not.toContain('query-secret')
+    expect(await prisma.agent.findFirst({ where: { name: credentialName } })).toBeNull()
+
+    const ambiguousSecret = 'ambiguous-secret'
+    const ambiguousName = 'ambiguous-authority-repo'
+    const ambiguous = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: {
+        name: ambiguousName,
+        runtime: 'claude',
+        workspace: {
+          mode: 'github',
+          gitRepo: `https://good.example\\alice:${ambiguousSecret}@127.0.0.1/acme/infra`
+        }
+      }
+    })
+    expect(ambiguous.statusCode).toBe(400)
+    expect(ambiguous.body).not.toContain(ambiguousSecret)
+    expect(await prisma.agent.findFirst({ where: { name: ambiguousName } })).toBeNull()
+  })
+
   it('validates, updates, and clears a GitHub working subdirectory', async () => {
     const app = build()
     const create = await app.app.inject({
@@ -476,6 +540,62 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
 
     expect(get.statusCode).toBe(200)
     expect((get.json() as { workspace: { agentDir?: string } }).workspace.agentDir).toBe('../legacy-outside')
+  })
+
+  it('keeps a historical credential-bearing gitRepo readable without returning its secrets', async () => {
+    const app = build()
+    const agentId = randomUUID()
+    const missingRepoAgentId = randomUUID()
+    const stored = 'https://legacy-user:legacy-password@github.com/acme/legacy.git?access_token=query-secret#fragment'
+    await seedAgent(prisma, agentId, { gitRepo: stored })
+    await seedAgent(prisma, missingRepoAgentId)
+    await prisma.agent.update({
+      where: { id: missingRepoAgentId },
+      data: { workspaceMode: 'github', gitRepo: null }
+    })
+
+    const get = await app.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })
+    const getMissing = await app.app.inject({ method: 'GET', url: `${ORG}/agents/${missingRepoAgentId}` })
+
+    expect(get.statusCode).toBe(200)
+    expect(get.body).not.toContain('legacy-user')
+    expect(get.body).not.toContain('legacy-password')
+    expect(get.body).not.toContain('query-secret')
+    expect((get.json() as { workspace: { gitRepo: string } }).workspace.gitRepo).toBe(
+      'https://github.com/acme/legacy.git'
+    )
+    // Read sanitization is compatibility protection, not an implicit write.
+    expect((await prisma.agent.findUnique({ where: { id: agentId } }))?.gitRepo).toBe(stored)
+    expect(getMissing.statusCode).toBe(200)
+    expect((getMissing.json() as { workspace: { gitRepo: string } }).workspace.gitRepo).toBe('')
+  })
+
+  it('migration clears ambiguous userinfo while preserving a host-port path', async () => {
+    const cases = new Map<string, { stored: string; expected: string | null }>([
+      [randomUUID(), { stored: 'https://user:password?metadata@host.example/owner/repo', expected: null }],
+      [randomUUID(), { stored: 'https://user:password#metadata@host.example/owner/repo', expected: null }],
+      [randomUUID(), { stored: 'ssh://git:password?metadata@host.example/owner/repo', expected: null }],
+      [randomUUID(), { stored: 'ssh://git:password#metadata@host.example/owner/repo', expected: null }],
+      [
+        randomUUID(),
+        {
+          stored: 'https://example.com:443/repo?contact=user@example.com',
+          expected: 'https://example.com:443/repo'
+        }
+      ]
+    ])
+    await Promise.all([...cases].map(([id, testCase]) => seedAgent(prisma, id, { gitRepo: testCase.stored })))
+
+    // Re-run the exact committed migration against historical rows. The global
+    // setup already applied it before these fixtures existed.
+    await prisma.$executeRawUnsafe(REDACT_GIT_REPO_MIGRATION)
+
+    const migrated = await prisma.agent.findMany({
+      where: { id: { in: [...cases.keys()] } },
+      select: { id: true, gitRepo: true }
+    })
+    expect(migrated).toHaveLength(cases.size)
+    for (const agent of migrated) expect(agent.gitRepo).toBe(cases.get(agent.id)?.expected)
   })
 
   it('POST /agents rejects write access for anonymous GitHub workspaces', async () => {

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -233,6 +233,46 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
     expect(snap.drop.integrations).toEqual([])
   })
 
+  it('quarantines one historical unsafe workspace without stranding the rest of the daemon roster', async () => {
+    await seedReconcileState()
+    const SAFE_AGENT = 'b2b2b2b2-b2b2-4b2b-8b2b-b2b2b2b2b2b2'
+    await prisma.agent.update({
+      where: { id: AGENT },
+      data: { workspaceMode: 'github', gitRepo: 'file:///var/lib/agentconnect/other-workspace' }
+    })
+    await prisma.agent.create({
+      data: {
+        id: SAFE_AGENT,
+        orgId: DEFAULT_ORG_ID,
+        name: 'safe-agent',
+        runtime: 'claude',
+        daemonId: DAEMON
+      }
+    })
+
+    const base = registerPayload()
+    const payload = {
+      ...base,
+      localState: {
+        ...base.localState,
+        agents: [{ agentId: AGENT, origin: 'cp' as const }]
+      }
+    }
+    const h = buildWsHarness(prisma)
+    const { stub } = await authThenAwaitOk(h)
+
+    stub.inject('register', payload, { id: REG_ID })
+    const ok = await stub.expectFrame('register/ok')
+    if (!isFrame('register/ok')(ok)) throw new Error('expected register/ok')
+
+    expect(ok.payload.agents.map((agent) => agent.agentId)).toEqual([SAFE_AGENT])
+    expect(ok.payload.assignments).toEqual([])
+    expect(ok.payload.crons).toEqual([])
+    expect(ok.payload.drop.assignments).toContain('slack:C123:T9')
+    expect(ok.payload.drop.crons).toContain(CRON)
+    expect(ok.payload.drop.agents).toEqual([{ agentId: AGENT, action: 'detach' }])
+  })
+
   it('drops legacy moved and unplaced replicas, but preserves unknown local-only config', async () => {
     await seedReconcileState()
     const OTHER_DAEMON = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -21,7 +21,13 @@
  */
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, renameSync, readdirSync } from 'node:fs'
 import { join, dirname, relative, resolve, isAbsolute, sep } from 'node:path'
-import { normalizeGitUrl, normalizeRepoSubdir, type AgentSpec } from '@agentconnect.md/protocol'
+import {
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  normalizeRepoSubdir,
+  redactGitUrlSecrets,
+  type AgentSpec
+} from '@agentconnect.md/protocol'
 import { ensurePrivateAgentDirectory, protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 
@@ -475,9 +481,12 @@ function applySpecFields(
     // clears a previously replicated cwd rather than preserving a stale local value.
     delete existing.agentDir
     if (ws.mode === 'github') {
-      // agent.json stores the FULL cloneable address; a spec replicated from a
-      // pre-normalization CP row may still carry the "org/repo" shorthand.
-      existing.gitRepo = normalizeGitUrl(ws.gitRepo)
+      // Keep old CPs safe too: strip historical URL secrets, then reject any
+      // transport a current daemon would refuse at the clone boundary.
+      existing.gitRepo =
+        ws.gitCredential === 'github-app'
+          ? normalizeGithubRepoUrl(ws.gitRepo)
+          : normalizeGitCloneUrl(redactGitUrlSecrets(ws.gitRepo))
       existing.gitBranch = ws.branch
       if (ws.agentDir !== undefined) {
         try {

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -14,14 +14,16 @@
  */
 import { existsSync, promises as fs } from 'node:fs'
 import { join } from 'node:path'
-import { simpleGit } from 'simple-git'
-import type {
-  WorkspaceGitStatus,
-  WorkspaceGitPullResult,
-  WorkspaceGitFile,
-  WorkspaceGitCommit
+import type { SimpleGit } from 'simple-git'
+import {
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  type WorkspaceGitStatus,
+  type WorkspaceGitPullResult,
+  type WorkspaceGitFile,
+  type WorkspaceGitCommit
 } from '@agentconnect.md/protocol'
-import { gitEnvBase, gitFor } from '../workspace/git-injection.js'
+import { gitFor, pullWorkspaceRef, workspaceGitEnvBase } from '../workspace/git-injection.js'
 import { WorkspaceViolationError } from './workspace-reader.js'
 
 /** On-demand pull is interactive, so allow more headroom than the 4.5s
@@ -36,9 +38,16 @@ export interface WorkspaceGit {
   pull(agentId: string): Promise<WorkspaceGitPullResult>
 }
 
+export interface WorkspaceGitTarget {
+  repo: string
+  branch: string
+  githubApp: boolean
+}
+
 export function createWorkspaceGit(
   workspaceRootByAgent: (agentId: string) => string | undefined,
-  credentialEnvByAgent: (agentId: string) => Record<string, string> = () => ({})
+  credentialEnvByAgent: (agentId: string) => Record<string, string> = () => ({}),
+  workspaceTargetByAgent: (agentId: string) => WorkspaceGitTarget | undefined = () => undefined
 ): WorkspaceGit {
   function rootFor(agentId: string): string {
     const root = workspaceRootByAgent(agentId)
@@ -57,12 +66,22 @@ export function createWorkspaceGit(
     return msg.split(root).join('<workspace>').trim()
   }
 
+  function safeExplicitOrigin(input: string): string | undefined {
+    const raw = input.trim()
+    if (!/^(?:https|ssh):\/\//i.test(raw) && !/^[\w.-]+@[\w.-]+:/.test(raw)) return undefined
+    try {
+      return normalizeGitCloneUrl(raw)
+    } catch {
+      return undefined
+    }
+  }
+
   return {
     async status(agentId) {
       const root = rootFor(agentId)
       if (!isRepo(root)) return { agentId, isRepo: false, clean: true }
 
-      const git = simpleGit(root)
+      const git = gitFor(root).env(workspaceGitEnvBase())
       const s = await git.status()
       const files: WorkspaceGitFile[] = s.files
         .slice(0, MAX_STATUS_FILES)
@@ -92,10 +111,37 @@ export function createWorkspaceGit(
       // forced reset. Bounded by a timeout so an offline remote can't hang the REP.
       let timer: ReturnType<typeof setTimeout> | undefined
       try {
+        const git = gitFor(root).env(workspaceGitEnvBase())
+        const target = workspaceTargetByAgent(agentId)
+        let currentOrigin: string | undefined
+        let expectedOrigin: string | undefined
+        try {
+          currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
+          expectedOrigin =
+            target === undefined
+              ? undefined
+              : target.githubApp
+                ? normalizeGithubRepoUrl(target.repo)
+                : normalizeGitCloneUrl(target.repo)
+        } catch {
+          return { agentId, isRepo: true, ok: false, detail: 'workspace origin is not a safe remote' }
+        }
+        if (
+          !currentOrigin ||
+          (target?.githubApp === true &&
+            expectedOrigin !== undefined &&
+            currentOrigin.toLowerCase() !== expectedOrigin.toLowerCase())
+        ) {
+          return { agentId, isRepo: true, ok: false, detail: 'workspace origin is not a safe remote' }
+        }
+        const pullOrigin = expectedOrigin ?? currentOrigin
+        const pullBranch = target?.branch ?? 'HEAD'
         const res = await Promise.race([
-          gitFor(root)
-            .env({ ...gitEnvBase(), ...credentialEnvByAgent(agentId), GIT_TERMINAL_PROMPT: '0' })
-            .pull(['--ff-only']),
+          pullWorkspaceRef(
+            git.env({ ...workspaceGitEnvBase(), ...credentialEnvByAgent(agentId), GIT_TERMINAL_PROMPT: '0' }),
+            pullOrigin,
+            pullBranch
+          ),
           new Promise<never>((_, rej) => {
             timer = setTimeout(() => rej(new Error('pull timed out')), PULL_TIMEOUT_MS)
           })
@@ -122,7 +168,7 @@ export function createWorkspaceGit(
 
 /** The HEAD commit (sha / short sha / subject / committer date), or null for an
  *  empty repo with no commits yet. `%cI` is git's strict-ISO committer date. */
-async function headCommit(git: ReturnType<typeof simpleGit>): Promise<WorkspaceGitCommit | null> {
+async function headCommit(git: SimpleGit): Promise<WorkspaceGitCommit | null> {
   try {
     const log = await git.log({ maxCount: 1, format: { hash: '%H', date: '%cI', subject: '%s' } })
     const c = log.latest

--- a/packages/daemon/src/cp/workspace-reader.ts
+++ b/packages/daemon/src/cp/workspace-reader.ts
@@ -55,6 +55,10 @@ function under(root: string, p: string): boolean {
   return p === root || p.startsWith(root + path.sep)
 }
 
+function containsGitInternals(relPath: string): boolean {
+  return relPath.split(/[\\/]+/).some((part) => part.toLowerCase() === '.git')
+}
+
 export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) => string | undefined): WorkspaceReader {
   function rootFor(agentId: string): string {
     const root = workspaceRootByAgent(agentId)
@@ -71,6 +75,9 @@ export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) =>
     root: string,
     relPath: string
   ): Promise<{ resolved: string; realRoot: string | null }> {
+    if (containsGitInternals(relPath)) {
+      throw new WorkspaceViolationError('git internals are not readable')
+    }
     if (path.isAbsolute(relPath)) throw new WorkspaceViolationError('absolute paths are not allowed')
     const resolved = path.resolve(root, relPath)
     if (!under(root, resolved)) throw new WorkspaceViolationError('path escapes the workspace root')
@@ -88,6 +95,9 @@ export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) =>
   async function canonicalUnder(realRoot: string, abs: string): Promise<string> {
     const canon = await fs.realpath(abs)
     if (!under(realRoot, canon)) throw new WorkspaceViolationError('path resolves outside the workspace root')
+    if (containsGitInternals(path.relative(realRoot, canon))) {
+      throw new WorkspaceViolationError('git internals are not readable')
+    }
     return canon
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2140,14 +2140,21 @@ export class Daemon {
       if (previous?.allowRuntimeChangesInChat === true && !a.allowRuntimeChangesInChat) {
         this.restoreConfiguredRuntimeSettings(a as LoadedAgent)
       }
+      let workspaceNeedsColdRecovery = change.workspace
       // A GitHub rename changes only the canonical remote URL for the same
-      // App-backed repository. Keep active/queued turns and the cached host
-      // intact; update origin in place so subsequent git commands use the new
-      // address without waiting for another session to prepare the workspace.
+      // App-backed repository. Keep active/queued turns and the cached host only
+      // after origin convergence succeeds. Otherwise fall back to the ordinary
+      // cold workspace path so a live host cannot keep serving an untrusted or
+      // stale checkout.
       if (change.workspaceRepoRename) {
-        await convergeGithubAppWorkspaceRename(a as LoadedAgent).catch((err) =>
-          this.log.warn(`workspace: canonical rename convergence for "${a.id}" failed: ${formatErr(err)}`)
-        )
+        try {
+          await convergeGithubAppWorkspaceRename(a as LoadedAgent)
+        } catch (err) {
+          workspaceNeedsColdRecovery = true
+          this.log.warn(
+            `workspace: canonical rename convergence for "${a.id}" failed; evicting its host: ${formatErr(err)}`
+          )
+        }
       }
       // Pause is an operator stop, not merely a gate for the next message. Publish the
       // gate first so no new turn can enter, then interrupt every active logical session
@@ -2159,14 +2166,14 @@ export class Daemon {
       // host-spawn or workspace change → evict the cached host (once) so the next
       // session lazily re-spawns it with fresh env and/or re-materializes cwd via
       // prepareWorkspace. Soft-only and integration-only changes never touch the host.
-      if (change.hostRespawn || change.workspace) {
+      if (change.hostRespawn || workspaceNeedsColdRecovery) {
         // A config-triggered respawn keeps the agent in the roster, so install a
         // temporary admission gate around the generation-safe teardown, preserving any
         // older lifecycle gate intact.
         const wasDraining = this.drainingAgents.has(a.id)
         this.drainingAgents.add(a.id)
         this.interruptAgentTurns(a.id, 'stop')
-        if (change.workspace) {
+        if (workspaceNeedsColdRecovery) {
           this.gitCreds.remove(a.id)
           this.gitCredServer?.revoke(a.id)
         }
@@ -2191,7 +2198,7 @@ export class Daemon {
       // workspace change → eagerly (re-)materialize the checkout in the background so
       // a re-pointed git-repo is warm before the next message, instead of paying the
       // clone latency on that first session.
-      if (change.workspace) this.prefetchClone(a as LoadedAgent)
+      if (workspaceNeedsColdRecovery) this.prefetchClone(a as LoadedAgent)
       // Defer platform convergence until EVERY agent delta has been installed.
       // This preserves a token handed from one agent to another in the same batch:
       // reconciling midway through the diff would briefly see zero references and
@@ -12039,6 +12046,16 @@ export class Daemon {
         (id) => {
           const workspace = this.agents.get(id)?.workspace
           return workspace?.mode === 'git-repo' && workspace.gitCredential === 'github-app' ? gitCredentialEnv(id) : {}
+        },
+        (id) => {
+          const workspace = this.agents.get(id)?.workspace
+          return workspace?.mode === 'git-repo' && workspace.gitRepo
+            ? {
+                repo: workspace.gitRepo,
+                branch: workspace.gitBranch,
+                githubApp: workspace.gitCredential === 'github-app'
+              }
+            : undefined
         }
       ),
       memoryReader: createMemoryReader((id) => this.agents.get(id)?.dir, this.memory),

--- a/packages/daemon/src/reconciler/reconciler.ts
+++ b/packages/daemon/src/reconciler/reconciler.ts
@@ -1,3 +1,4 @@
+import { normalizeGitCloneUrl } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
 
 /** Stable identity-free signature of an agent's effective config. Excludes the
@@ -49,6 +50,18 @@ function workspaceSig(a: Agent): string {
   return JSON.stringify(a.workspace)
 }
 
+function isGithubRepoLocation(input: string): boolean {
+  try {
+    const normalized = normalizeGitCloneUrl(input)
+    const scp = /^[\w.-]+@([\w.-]+):/.exec(normalized)
+    if (scp) return scp[1]!.toLowerCase() === 'github.com'
+    if (!/^(?:https|ssh):\/\//i.test(input.trim())) return false
+    return new URL(normalized).hostname.toLowerCase() === 'github.com'
+  } catch {
+    return false
+  }
+}
+
 /**
  * A GitHub App workspace keeps the same checkout when GitHub changes only the
  * repository's canonical name. Genuine workspace edits are cold-fenced by the
@@ -63,7 +76,11 @@ function isGithubAppRepoRename(before: Agent, after: Agent): boolean {
     right.mode !== 'git-repo' ||
     left.gitCredential !== 'github-app' ||
     right.gitCredential !== 'github-app' ||
-    left.gitRepo === right.gitRepo
+    !left.gitRepo ||
+    !right.gitRepo ||
+    left.gitRepo === right.gitRepo ||
+    !isGithubRepoLocation(left.gitRepo) ||
+    !isGithubRepoLocation(right.gitRepo)
   ) {
     return false
   }

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -93,9 +93,19 @@ const HOST_ENV_STRIP = new Set([
   'GIT_EXTERNAL_DIFF',
   'GIT_PROXY_COMMAND',
   'GIT_TEMPLATE_DIR',
+  // `git rev-parse --local-env-vars`: none of the caller's repository context
+  // may redirect daemon-managed operations away from their explicit cwd.
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
   'GIT_DIR',
-  'GIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_IMPLICIT_WORK_TREE',
   'GIT_INDEX_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+  'GIT_WORK_TREE',
   'GIT_NAMESPACE',
   'GIT_CONFIG',
   'GIT_CONFIG_GLOBAL',
@@ -120,6 +130,31 @@ export function gitEnvBase(): Record<string, string> {
     env[k] = v
   }
   return env
+}
+
+/** Workspace clone/pull policy. Keep this separate from `gitEnvBase`: skill
+ * installation intentionally supports a broader set of operator-chosen sources. */
+export function workspaceGitEnvBase(): Record<string, string> {
+  const env = gitEnvBase()
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === 'GIT_ALLOW_PROTOCOL') delete env[key]
+  }
+  // Git applies this allowlist after url.*.insteadOf rewriting.
+  env.GIT_ALLOW_PROTOCOL = 'https:ssh'
+  return env
+}
+
+/**
+ * Pull exactly the daemon-authorized repository and branch. Supplying both
+ * operands keeps checkout-controlled branch.*.remote / branch.*.merge config
+ * out of daemon-managed network selection; the explicit destination also keeps
+ * origin/<branch> current for status. check-ref-format prevents a configured
+ * branch from being interpreted as an option or refspec.
+ */
+export async function pullWorkspaceRef(git: SimpleGit, repository: string, branch: string) {
+  await git.raw(['check-ref-format', '--branch', branch])
+  const refspec = `+refs/heads/${branch}:refs/remotes/origin/${branch}`
+  return git.pull(repository, refspec, ['--ff-only'])
 }
 
 /** Module-level init (workspace-manager is functional; mirrors cloneInFlight). */
@@ -223,7 +258,7 @@ export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentit
 
 /** Post-clone: pin the repo-local helper so agent-run git in the checkout works. */
 export async function writeRepoHelperConfig(cwd: string, agentId: string): Promise<void> {
-  const git = gitFor(cwd)
+  const git = gitFor(cwd).env(workspaceGitEnvBase())
   // `--replace-all` on the first write resets any stale helper list from a
   // previous agent generation; addConfig(append=true) accumulates the rest.
   await git.raw(['config', '--replace-all', 'credential.https://github.com.helper', ''])

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -11,7 +11,13 @@ import {
   writeFileSync
 } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
-import { normalizeGitUrl, normalizeRepoSubdir } from '@agentconnect.md/protocol'
+import {
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  normalizeGitUrl,
+  normalizeRepoSubdir,
+  redactGitUrlSecrets
+} from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
 import { makeLogger } from '../log.js'
 import { installSkills } from '../skills/install-skills.js'
@@ -21,6 +27,8 @@ import {
   gitEnvBase,
   gitFor,
   preWarmGitCred,
+  pullWorkspaceRef,
+  workspaceGitEnvBase,
   writeRepoHelperConfig
 } from './git-injection.js'
 
@@ -57,25 +65,75 @@ function usesGithubApp(agent: Agent): boolean {
   return agent.workspace.mode === 'git-repo' && agent.workspace.gitCredential === 'github-app'
 }
 
-async function convergeGithubAppOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
-  if (!usesGithubApp(agent)) return
+function gitRepoOf(agent: Agent): string {
+  if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
+    throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
+  }
+  return usesGithubApp(agent)
+    ? normalizeGithubRepoUrl(agent.workspace.gitRepo)
+    : normalizeGitCloneUrl(agent.workspace.gitRepo)
+}
+
+class UntrustedGithubWorkspaceOriginError extends Error {
+  constructor(options?: ErrorOptions) {
+    super('workspace origin is not a trusted GitHub remote', options)
+    this.name = 'UntrustedGithubWorkspaceOriginError'
+  }
+}
+
+function isTrustedGithubOrigin(input: string): boolean {
+  const raw = input.trim()
+  if (raw.includes('\\')) return false
+  const scp = /^[\w.-]+@([\w.-]+):/.exec(raw)
+  if (scp) return scp[1]!.toLowerCase() === 'github.com'
+  if (!/^(?:https|ssh):\/\//i.test(raw)) return false
+  try {
+    return new URL(normalizeGitCloneUrl(redactGitUrlSecrets(raw))).hostname.toLowerCase() === 'github.com'
+  } catch {
+    return false
+  }
+}
+
+async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path): Promise<void> {
   const clone = cloneInFlight.get(cwd)
   if (clone) await clone
   if (!existsSync(join(cwd, '.git'))) return
-  const expected = normalizeGitUrl(agent.workspace.gitRepo ?? '')
-  if (!expected) return
-  const git = gitFor(cwd)
-  const current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
-  if (normalizeGitUrl(current).toLowerCase() !== expected.toLowerCase()) {
-    await git.raw(['remote', 'set-url', 'origin', expected])
+  const expected = gitRepoOf(agent)
+  const git = gitFor(cwd).env(workspaceGitEnvBase())
+  let current: string
+  try {
+    current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
+  } catch (cause) {
+    if (usesGithubApp(agent)) throw new UntrustedGithubWorkspaceOriginError({ cause })
+    return
   }
+  if (usesGithubApp(agent) && !isTrustedGithubOrigin(current)) {
+    throw new UntrustedGithubWorkspaceOriginError()
+  }
+  const normalizedCurrent = normalizeGitUrl(current)
+  let unsafeCurrent = redactGitUrlSecrets(current) !== normalizedCurrent
+  try {
+    normalizeGitCloneUrl(current)
+    if (!/^(?:https|ssh):\/\//i.test(current) && !/^[\w.-]+@[\w.-]+:/.test(current)) unsafeCurrent = true
+  } catch {
+    unsafeCurrent = true
+  }
+  const mismatched = normalizedCurrent.toLowerCase() !== expected.toLowerCase()
+  if ((!mismatched && !unsafeCurrent) || (!unsafeCurrent && !usesGithubApp(agent))) return
+  // App-backed mismatches and unsafe anonymous origins must converge before
+  // daemon-managed Git can proceed. A failed rewrite is fail-closed.
+  await git.raw(['remote', 'set-url', 'origin', expected])
 }
 
 function materializationKey(agent: Agent): string {
   if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
+  const repo = gitRepoOf(agent)
   return JSON.stringify({
     mode: 'github',
-    repo: normalizeGitUrl(agent.workspace.gitRepo ?? '').toLowerCase(),
+    // GitHub treats the conventional `.git` suffix as the same repository.
+    // Ignoring it here prevents a harmless CP canonicalization from replacing
+    // an existing checkout during an access/agentDir-only edit.
+    repo: (usesGithubApp(agent) ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
     branch: agent.workspace.gitBranch
   })
 }
@@ -94,6 +152,29 @@ function readMaterialization(agent: Agent): string | undefined {
   }
 }
 
+function sameMaterialization(agent: Agent, previous: string | undefined, target: string): boolean {
+  if (previous === target) return true
+  if (!usesGithubApp(agent) || previous === undefined) return false
+  try {
+    const left = JSON.parse(previous) as { mode?: unknown; repo?: unknown; branch?: unknown }
+    const right = JSON.parse(target) as { mode?: unknown; repo?: unknown; branch?: unknown }
+    if (
+      left.mode !== 'github' ||
+      right.mode !== 'github' ||
+      typeof left.repo !== 'string' ||
+      typeof right.repo !== 'string'
+    ) {
+      return false
+    }
+    return (
+      left.repo.replace(/\.git$/i, '').toLowerCase() === right.repo.replace(/\.git$/i, '').toLowerCase() &&
+      left.branch === right.branch
+    )
+  } catch {
+    return false
+  }
+}
+
 /** Snapshot the currently-live workspace definition before a cold detach. */
 export function recordWorkspaceMaterialization(agent: Agent): void {
   const file = materializationFile(agent)
@@ -109,13 +190,12 @@ export function recordWorkspaceMaterialization(agent: Agent): void {
 }
 
 /** Converge the durable identity and remote of an App-backed checkout after a
- * canonical GitHub rename. Record the new materialization first: a failed
- * best-effort origin update may safely retry later, while a stale marker could
- * make a subsequent preservation-only edit replace local files. */
+ * canonical GitHub rename. Advance the marker first within this update so
+ * origin convergence is fail-closed and retryable while the target marker holds. */
 export async function convergeGithubAppWorkspaceRename(agent: Agent): Promise<void> {
   if (!usesGithubApp(agent)) return
   recordWorkspaceMaterialization(agent)
-  await convergeGithubAppOrigin(agent)
+  await convergeWorkspaceOrigin(agent)
 }
 
 /** Seed the marker for a pre-v2 workspace without overwriting an earlier
@@ -137,8 +217,9 @@ function restoreWorkspaceMaterialization(agent: Agent, key: string | undefined):
 
 export async function prepareWorkspace(agent: Agent): Promise<string> {
   const cwd = agent.workspace.path
-  // Fail unsafe lexical config before any clone/pull or filesystem mutation.
+  // Fail unsafe config before using either a fresh or existing checkout.
   const agentDir = agent.workspace.mode === 'git-repo' ? normalizeRepoSubdir(agent.workspace.agentDir) : undefined
+  if (agent.workspace.mode === 'git-repo') gitRepoOf(agent)
   mkdirSync(cwd, { recursive: true })
 
   if (agent.workspace.mode === 'from-scratch') {
@@ -164,8 +245,12 @@ export async function prepareWorkspace(agent: Agent): Promise<string> {
   if (usesGithubApp(agent)) {
     // The CP follows repository renames by numeric repo id. Repoint the existing
     // checkout instead of treating that canonical URL refresh as a new workspace.
-    await convergeGithubAppOrigin(agent, cwd).catch(() => undefined)
+    await convergeWorkspaceOrigin(agent, cwd)
     await writeRepoHelperConfig(cwd, agent.id).catch(() => undefined)
+  } else {
+    // Historical anonymous checkouts may still have credential-bearing or
+    // disallowed origins even after their CP row has been sanitized.
+    await convergeWorkspaceOrigin(agent, cwd)
   }
 
   // Best-effort ff-only pull; never block/throw on offline (design §4.3) —
@@ -181,13 +266,12 @@ export async function prepareWorkspace(agent: Agent): Promise<string> {
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
     try {
-      await gitFor(cwd, abort.signal)
-        .env({
-          ...gitEnvBase(),
-          ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
-          GIT_TERMINAL_PROMPT: '0'
-        })
-        .pull(['--ff-only'])
+      const git = gitFor(cwd, abort.signal).env({
+        ...workspaceGitEnvBase(),
+        ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
+        GIT_TERMINAL_PROMPT: '0'
+      })
+      await pullWorkspaceRef(git, gitRepoOf(agent), agent.workspace.gitBranch)
     } catch {
       // offline / timed out / non-fast-forward: proceed with the on-disk checkout
     } finally {
@@ -268,7 +352,7 @@ export async function prepareWorkspaceForActivation(
   mkdirSync(cwd, { recursive: true })
   const previousMaterialization = reconcileMaterialization ? readMaterialization(agent) : undefined
   const targetMaterialization = materializationKey(agent)
-  const replace = reconcileMaterialization && previousMaterialization !== targetMaterialization
+  let replace = reconcileMaterialization && !sameMaterialization(agent, previousMaterialization, targetMaterialization)
   const restoreMarker = () => {
     if (reconcileMaterialization) restoreWorkspaceMaterialization(agent, previousMaterialization)
   }
@@ -292,9 +376,20 @@ export async function prepareWorkspaceForActivation(
       if (!allowExistingCheckout) {
         throw new Error('workspace changed after its empty check; retry after making it empty')
       }
-      resolveAcpCwd(cwd, normalizeRepoSubdir(agent.workspace.agentDir))
-      if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-      return restoreMarker
+      try {
+        await convergeWorkspaceOrigin(agent, cwd)
+      } catch (err) {
+        if (!(reconcileMaterialization && err instanceof UntrustedGithubWorkspaceOriginError)) throw err
+        // A historical App-backed checkout from a non-GitHub origin cannot be
+        // trusted merely by rewriting .git/config: replace its working tree
+        // from the installation-authorized GitHub repository.
+        replace = true
+      }
+      if (!replace) {
+        resolveAcpCwd(cwd, normalizeRepoSubdir(agent.workspace.agentDir))
+        if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
+        return restoreMarker
+      }
     }
     // A different repo/branch is cloned below before the old checkout is
     // removed, so network/auth failures leave the current workspace intact.
@@ -370,7 +465,11 @@ export async function prepareWorkspaceForActivation(
 export async function prefetchWorkspace(agent: Agent): Promise<void> {
   if (agent.workspace.mode !== 'git-repo') return
   const cwd = agent.workspace.path
-  if (existsSync(join(cwd, '.git'))) return
+  gitRepoOf(agent)
+  if (existsSync(join(cwd, '.git'))) {
+    await convergeWorkspaceOrigin(agent, cwd)
+    return
+  }
   mkdirSync(cwd, { recursive: true })
   await cloneRepo(agent)
 }
@@ -384,11 +483,9 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
   const inflight = cloneInFlight.get(cwd)
   if (inflight) return inflight
 
-  // Stored value should already be a full address, but normalize defensively —
-  // a hand-edited or pre-normalization agent.json may still say "org/repo",
-  // which git would treat as a local path ("repository ... does not exist").
-  const gitRepo = agent.workspace.gitRepo && normalizeGitUrl(agent.workspace.gitRepo)
-  if (!gitRepo) throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
+  // Validate again at the execution boundary: a hand-edited/legacy agent.json
+  // must not turn daemon-managed git into a local-path or remote-helper launcher.
+  const gitRepo = gitRepoOf(agent)
   const branch = agent.workspace.gitBranch
   const githubApp = usesGithubApp(agent)
 
@@ -397,8 +494,8 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
     // yet). SPREAD over process.env — simple-git's .env() REPLACES the child env.
     if (githubApp) await preWarmGitCred(agent.id, 'clone')
     const git = githubApp
-      ? gitFor().env({ ...gitEnvBase(), ...cloneGitEnv(agent.id) })
-      : gitFor().env({ ...gitEnvBase(), GIT_TERMINAL_PROMPT: '0' })
+      ? gitFor().env({ ...workspaceGitEnvBase(), ...cloneGitEnv(agent.id) })
+      : gitFor().env({ ...workspaceGitEnvBase(), GIT_TERMINAL_PROMPT: '0' })
     try {
       await git.clone(gitRepo, cwd, ['--branch', branch, '--single-branch'])
     } catch (e) {

--- a/packages/daemon/test/daemon-serial-gate.test.ts
+++ b/packages/daemon/test/daemon-serial-gate.test.ts
@@ -199,6 +199,59 @@ describe('P4 serial gate', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('evicts a cached host when App-backed rename convergence fails closed', async () => {
+    const root = scaffold()
+    const workspace = join(root, 'agents', 'bot-a', 'workspace')
+    mkdirSync(workspace, { recursive: true })
+    execFileSync('git', ['init', workspace], { stdio: 'ignore' })
+    execFileSync('git', ['-C', workspace, 'remote', 'add', 'origin', 'https://github.com/acme/old-name'])
+    writeFileSync(
+      join(root, 'agents', 'bot-a', 'agent.json'),
+      JSON.stringify({
+        id: 'bot-a',
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        workspace: {
+          mode: 'git-repo',
+          path: workspace,
+          gitRepo: 'https://github.com/acme/old-name',
+          gitBranch: 'main',
+          gitCredential: 'github-app',
+          pullOnNewSession: false
+        },
+        integrations: [],
+        output: { mode: 'low' }
+      })
+    )
+
+    const g = gatedHost()
+    const daemon = new Daemon({ root, hostFactory: () => g.host as any })
+    await daemon.start()
+    await (daemon as any).ensureHostAsync('bot-a')
+    expect((daemon as any).hosts.has('bot-a')).toBe(true)
+
+    // Simulate a historical checkout whose actual origin does not match the
+    // App-authorized GitHub repository, then deliver a canonical rename update.
+    execFileSync('git', ['-C', workspace, 'remote', 'set-url', 'origin', 'https://other-host.example/acme/old-name'])
+    await seam(daemon).applyAgentUpsert({
+      agentId: 'bot-a',
+      spec: {
+        name: 'bot-a',
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://github.com/acme/new-name',
+          branch: 'main',
+          gitCredential: 'github-app'
+        }
+      }
+    })
+
+    expect(g.host.stop).toHaveBeenCalledTimes(1)
+    expect((daemon as any).hosts.has('bot-a')).toBe(false)
+    await daemon.stop()
+  }, 15_000)
+
   it('uses a stale Slack event only as a wake-up and suppresses later delivery of messages already covered by the snapshot watermark', async () => {
     const g = gatedHost()
     const daemon = await boot(g.host)

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { simpleGit } from 'simple-git'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
@@ -11,7 +12,9 @@ import {
   gitFor,
   initGitInjection,
   parseGitVersion,
-  sessionGitEnv
+  pullWorkspaceRef,
+  sessionGitEnv,
+  workspaceGitEnvBase
 } from '../src/workspace/git-injection.js'
 
 // simple-git ≥3.36 refuses a NAME blocklist of env vars (presence-based, value
@@ -31,7 +34,17 @@ const POLLUTED = {
   GIT_SSH_COMMAND: 'ssh -i /k',
   GIT_ASKPASS: '/bin/echo',
   SSH_ASKPASS: '/bin/echo',
+  GIT_ALTERNATE_OBJECT_DIRECTORIES: '/elsewhere/alternate-objects',
+  GIT_COMMON_DIR: '/elsewhere/common.git',
   GIT_DIR: '/elsewhere/.git',
+  GIT_GRAFT_FILE: '/elsewhere/grafts',
+  GIT_IMPLICIT_WORK_TREE: '0',
+  GIT_INDEX_FILE: '/elsewhere/index',
+  GIT_NO_REPLACE_OBJECTS: '1',
+  GIT_OBJECT_DIRECTORY: '/elsewhere/objects',
+  GIT_REPLACE_REF_BASE: 'refs/elsewhere/',
+  GIT_SHALLOW_FILE: '/elsewhere/shallow',
+  GIT_ALLOW_PROTOCOL: 'file:ext:git:https:ssh',
   GIT_CONFIG_COUNT: '1',
   GIT_CONFIG_KEY_0: 'core.editor',
   GIT_CONFIG_VALUE_0: 'vim'
@@ -65,7 +78,80 @@ afterAll(() => {
 describe('gitEnvBase', () => {
   it('strips every checker-blocked name (case-insensitively) and host GIT_CONFIG_*', () => {
     const env = gitEnvBase()
-    for (const k of Object.keys(POLLUTED)) expect(env, k).not.toHaveProperty(k)
+    for (const k of Object.keys(POLLUTED)) {
+      if (k !== 'GIT_ALLOW_PROTOCOL') expect(env, k).not.toHaveProperty(k)
+    }
+  })
+
+  it('limits workspace git without narrowing skill-source git', () => {
+    expect(gitEnvBase().GIT_ALLOW_PROTOCOL).toBe(POLLUTED.GIT_ALLOW_PROTOCOL)
+    expect(workspaceGitEnvBase().GIT_ALLOW_PROTOCOL).toBe('https:ssh')
+  })
+
+  it('keeps an explicit checkout bound when the host exports GIT_COMMON_DIR', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-context-test-'))
+    const workspace = join(root, 'workspace')
+    const override = join(root, 'override')
+    const cleanEnv = workspaceGitEnvBase()
+    execFileSync('git', ['init', workspace], { env: cleanEnv, stdio: 'ignore' })
+    execFileSync('git', ['init', override], { env: cleanEnv, stdio: 'ignore' })
+    execFileSync('git', ['-C', workspace, 'remote', 'add', 'origin', 'https://other-host.example/acme/repo'], {
+      env: cleanEnv
+    })
+    execFileSync('git', ['-C', override, 'remote', 'add', 'origin', 'https://github.com/acme/repo'], {
+      env: cleanEnv
+    })
+    const poisonedEnv = { ...cleanEnv, GIT_COMMON_DIR: join(override, '.git') }
+    expect(
+      execFileSync('git', ['-C', workspace, 'remote', 'get-url', 'origin'], {
+        encoding: 'utf8',
+        env: poisonedEnv
+      }).trim()
+    ).toBe('https://github.com/acme/repo')
+
+    try {
+      await expect(
+        gitFor(workspace).env(workspaceGitEnvBase()).raw(['remote', 'get-url', 'origin'])
+      ).resolves.toContain('https://other-host.example/acme/repo')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('updates the origin tracking ref when an explicit URL pull advances HEAD', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-pull-refspec-test-'))
+    const remote = join(root, 'remote.git')
+    const seed = join(root, 'seed')
+    const workspace = join(root, 'workspace')
+    const env = { ...workspaceGitEnvBase(), GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+    const run = (args: string[]) => execFileSync('git', args, { env, stdio: 'ignore' })
+
+    try {
+      run(['init', '--bare', remote])
+      run(['init', '-b', 'main', seed])
+      run(['-C', seed, 'config', 'user.name', 'Test'])
+      run(['-C', seed, 'config', 'user.email', 'test@example.invalid'])
+      run(['-C', seed, 'commit', '--allow-empty', '-m', 'initial'])
+      run(['-C', seed, 'remote', 'add', 'origin', remote])
+      run(['-C', seed, 'push', 'origin', 'main'])
+      run(['clone', '--branch', 'main', remote, workspace])
+      run(['-C', seed, 'commit', '--allow-empty', '-m', 'advance'])
+      run(['-C', seed, 'push', 'origin', 'main'])
+
+      const git = gitFor(workspace).env(env)
+      await pullWorkspaceRef(git, pathToFileURL(remote).href, 'main')
+
+      const [head, tracking, status] = await Promise.all([
+        git.raw(['rev-parse', 'HEAD']),
+        git.raw(['rev-parse', 'refs/remotes/origin/main']),
+        git.status()
+      ])
+      expect(head.trim()).toBe(tracking.trim())
+      expect(status.ahead).toBe(0)
+      expect(status.behind).toBe(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   it('keeps ambient host capabilities', () => {

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -119,6 +119,24 @@ describe('diffAgents', () => {
       workspace: true,
       workspaceRepoRename: false
     })
+
+    const wrongHost = {
+      ...before,
+      workspace: { ...before.workspace, gitRepo: 'https://other-host.example/acme/new-name' }
+    } as Agent
+    expect(diffAgents([after], actual(wrongHost)).toChange[0]).toMatchObject({
+      workspace: true,
+      workspaceRepoRename: false
+    })
+
+    const shorthand = {
+      ...before,
+      workspace: { ...before.workspace, gitRepo: 'acme/old-name' }
+    } as Agent
+    expect(diffAgents([after], actual(shorthand)).toChange[0]).toMatchObject({
+      workspace: true,
+      workspaceRepoRename: false
+    })
   })
 
   it('respawns for an external connection switch but keeps policy-only edits hot', () => {

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 let statusImpl: (...args: any[]) => Promise<unknown>
 let pullImpl: (...args: any[]) => Promise<unknown>
 let logImpl: (...args: any[]) => Promise<unknown>
+let rawImpl: (...args: any[]) => Promise<unknown>
 let envImpl: (...args: any[]) => unknown
 vi.mock('simple-git', () => ({
   simpleGit: (_cwd?: unknown) => {
@@ -14,6 +15,7 @@ vi.mock('simple-git', () => ({
       status: (...a: any[]) => statusImpl(...a),
       pull: (...a: any[]) => pullImpl(...a),
       log: (...a: any[]) => logImpl(...a),
+      raw: (...a: any[]) => rawImpl(...a),
       env: (...a: any[]) => {
         envImpl(...a)
         return git
@@ -38,6 +40,7 @@ beforeEach(() => {
   statusImpl = vi.fn()
   pullImpl = vi.fn()
   envImpl = vi.fn()
+  rawImpl = vi.fn().mockResolvedValue('https://example.com/acme/repo.git\n')
   // Default: empty repo (no commits) ⇒ git log errors ⇒ lastCommit omitted.
   logImpl = vi.fn().mockRejectedValue(new Error('does not have any commits yet'))
 })
@@ -64,6 +67,7 @@ describe('createWorkspaceGit.status', () => {
     const s = await git.status('a')
     expect(s).toMatchObject({ agentId: 'a', isRepo: true, clean: true, branch: 'main', tracking: 'origin/main' })
     expect(s.files).toBeUndefined()
+    expect(envImpl).toHaveBeenCalledWith(expect.objectContaining({ GIT_ALLOW_PROTOCOL: 'https:ssh' }))
   })
 
   it('maps a dirty checkout: clean:false + changed files (index/workingDir chars)', async () => {
@@ -162,10 +166,37 @@ describe('createWorkspaceGit.pull', () => {
       () => ({ AC_GITCRED_CAPABILITY: 'cap-a' })
     )
     const r = await git.pull('a')
-    expect(pullImpl).toHaveBeenCalledWith(['--ff-only'])
-    expect(envImpl).toHaveBeenCalledWith(expect.objectContaining({ AC_GITCRED_CAPABILITY: 'cap-a' }))
+    expect(pullImpl).toHaveBeenCalledWith(
+      'https://example.com/acme/repo.git',
+      '+refs/heads/HEAD:refs/remotes/origin/HEAD',
+      ['--ff-only']
+    )
+    expect(envImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ AC_GITCRED_CAPABILITY: 'cap-a', GIT_ALLOW_PROTOCOL: 'https:ssh' })
+    )
     expect(r).toMatchObject({ isRepo: true, ok: true, changed: 2, insertions: 10, deletions: 3 })
     expect(r.detail).toMatch(/updated 2 files/i)
+  })
+
+  it('sanitizes host git context before inspecting the origin', async () => {
+    const dir = ws(true)
+    const previousGitDir = process.env.GIT_DIR
+    process.env.GIT_DIR = '/tmp/attacker-controlled-git-dir'
+    rawImpl = vi.fn().mockImplementation(async () => {
+      expect(envImpl).toHaveBeenCalled()
+      const firstEnv = (envImpl as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, string>
+      expect(firstEnv).not.toHaveProperty('GIT_DIR')
+      expect(firstEnv.GIT_ALLOW_PROTOCOL).toBe('https:ssh')
+      return 'https://example.com/acme/repo.git\n'
+    })
+    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+
+    try {
+      await expect(createWorkspaceGit(() => dir).pull('a')).resolves.toMatchObject({ ok: true })
+    } finally {
+      if (previousGitDir === undefined) delete process.env.GIT_DIR
+      else process.env.GIT_DIR = previousGitDir
+    }
   })
 
   it('reports "Already up to date." when nothing changed', async () => {
@@ -175,6 +206,62 @@ describe('createWorkspaceGit.pull', () => {
     const r = await git.pull('a')
     expect(r.ok).toBe(true)
     expect(r.detail).toBe('Already up to date.')
+  })
+
+  it('refuses an unsafe origin without running pull or echoing its secrets', async () => {
+    const dir = ws(true)
+    rawImpl = vi.fn().mockResolvedValue('https://legacy-user:super-secret@invalid.invalid/repo?token=query-secret\n')
+    const git = createWorkspaceGit(() => dir)
+
+    const result = await git.pull('a')
+
+    expect(result).toEqual({
+      agentId: 'a',
+      isRepo: true,
+      ok: false,
+      detail: 'workspace origin is not a safe remote'
+    })
+    expect(JSON.stringify(result)).not.toContain('super-secret')
+    expect(JSON.stringify(result)).not.toContain('query-secret')
+    expect(pullImpl).not.toHaveBeenCalled()
+  })
+
+  it('refuses a safe but mismatched origin for an App-backed workspace', async () => {
+    const dir = ws(true)
+    rawImpl = vi.fn().mockResolvedValue('https://other-host.example/acme/repo.git\n')
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      () => ({ repo: 'https://github.com/acme/repo.git', branch: 'main', githubApp: true })
+    )
+
+    expect(await git.pull('a')).toMatchObject({
+      isRepo: true,
+      ok: false,
+      detail: 'workspace origin is not a safe remote'
+    })
+    expect(pullImpl).not.toHaveBeenCalled()
+  })
+
+  it('ignores a checkout-controlled upstream and pulls the configured target explicitly', async () => {
+    const dir = ws(true)
+    rawImpl = vi
+      .fn()
+      .mockImplementation(async (args: string[]) => (args[0] === 'remote' ? 'https://github.com/acme/repo.git\n' : ''))
+    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      () => ({ repo: 'https://github.com/acme/repo.git', branch: 'release/v2', githubApp: true })
+    )
+
+    await expect(git.pull('a')).resolves.toMatchObject({ ok: true })
+
+    expect(pullImpl).toHaveBeenCalledWith(
+      'https://github.com/acme/repo.git',
+      '+refs/heads/release/v2:refs/remotes/origin/release/v2',
+      ['--ff-only']
+    )
   })
 
   it('surfaces a failed pull as ok:false and scrubs the host path out of the detail', async () => {

--- a/packages/daemon/test/workspace-reader.test.ts
+++ b/packages/daemon/test/workspace-reader.test.ts
@@ -104,6 +104,17 @@ describe('workspace list', () => {
 })
 
 describe('path containment', () => {
+  it('rejects direct reads of git internals', async () => {
+    mkdirSync(join(ws, '.git'))
+    writeFileSync(join(ws, '.git', 'config'), 'url = https://user:token@example.test/repo')
+    symlinkSync(join(ws, '.git'), join(ws, 'metadata'))
+
+    await expect(reader.list(listReq({ path: '.git' }))).rejects.toBeInstanceOf(WorkspaceViolationError)
+    await expect(reader.read(readReq('.git/config'))).rejects.toBeInstanceOf(WorkspaceViolationError)
+    await expect(reader.list(listReq({ path: 'metadata' }))).rejects.toBeInstanceOf(WorkspaceViolationError)
+    await expect(reader.read(readReq('metadata/config'))).rejects.toBeInstanceOf(WorkspaceViolationError)
+  })
+
   it("rejects '..' escapes on list and read", async () => {
     writeFileSync(join(outside, 'secret.env'), 'TOKEN=x')
     await expect(reader.list(listReq({ path: '../outside' }))).rejects.toBeInstanceOf(WorkspaceViolationError)

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import type { Agent } from '../src/agents/agent-schema.js'
 
 // Mock simple-git so clone/pull don't touch the network. The clone mock is
@@ -88,11 +88,20 @@ function gitRepoAgent(path: string, agentDir?: string): Agent {
 /** gitRepoAgent + the github-app credential channel (usesGithubApp true). */
 function githubAppAgent(path: string): Agent {
   const agent = gitRepoAgent(path)
-  return { ...agent, id: 'bot-git-app', workspace: { ...agent.workspace, gitCredential: 'github-app' } } as Agent
+  return {
+    ...agent,
+    id: 'bot-git-app',
+    workspace: {
+      ...agent.workspace,
+      gitRepo: 'https://github.com/acme/repo.git',
+      gitCredential: 'github-app'
+    }
+  } as Agent
 }
 
 beforeEach(() => {
   cloneImpl = vi.fn().mockResolvedValue(undefined)
+  lastGitEnv = undefined
   pullMock.mockClear()
   rawMock.mockReset().mockResolvedValue('')
 })
@@ -119,6 +128,35 @@ describe('prepareWorkspace', () => {
       '--single-branch'
     ])
     // clone, not pull, on a fresh checkout
+    expect(pullMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps ssh clone targets working', async () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
+    const agent = gitRepoAgent(path)
+    agent.workspace.gitRepo = 'ssh://git@example.com/acme/repo.git'
+
+    await prepareWorkspace(agent)
+
+    expect(cloneImpl).toHaveBeenCalledWith('ssh://git@example.com/acme/repo.git', path, [
+      '--branch',
+      'main',
+      '--single-branch'
+    ])
+  })
+
+  it('rejects a hand-edited unsafe target before clone or pull', async () => {
+    const fresh = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'fresh')
+    const existing = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'existing')
+    mkdirSync(join(existing, '.git'), { recursive: true })
+
+    for (const path of [fresh, existing]) {
+      const agent = gitRepoAgent(path)
+      agent.workspace.gitRepo = 'file:///var/lib/agentconnect/other-workspace'
+      await expect(prepareWorkspace(agent)).rejects.toThrow()
+    }
+
+    expect(cloneImpl).not.toHaveBeenCalled()
     expect(pullMock).not.toHaveBeenCalled()
   })
 
@@ -150,7 +188,27 @@ describe('prepareWorkspace', () => {
     mkdirSync(join(dir, '.git'), { recursive: true })
     await prepareWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
-    expect(pullMock).toHaveBeenCalledTimes(1)
+    expect(pullMock).toHaveBeenCalledWith('https://example.com/repo.git', '+refs/heads/main:refs/remotes/origin/main', [
+      '--ff-only'
+    ])
+  })
+
+  it('ignores a checkout-controlled upstream when pulling an existing workspace', async () => {
+    const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
+    mkdirSync(join(dir, '.git'), { recursive: true })
+    const agent = gitRepoAgent(dir)
+    agent.workspace.gitBranch = 'release/v2'
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://attacker.example/other.git\n' : ''
+    )
+
+    await prepareWorkspace(agent)
+
+    expect(pullMock).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      '+refs/heads/release/v2:refs/remotes/origin/release/v2',
+      ['--ff-only']
+    )
   })
 
   it('returns the canonical configured repository subdirectory', async () => {
@@ -293,13 +351,34 @@ describe('prepareWorkspaceForActivation', () => {
 
   it('preserves local files when repository and branch materialization are unchanged', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-edit-')), 'workspace')
-    const current = gitRepoAgent(path)
+    const current = githubAppAgent(path)
+    initGitInjection({
+      shimPath: '/run/helper.sh',
+      runDir: mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')),
+      preWarm: async () => undefined,
+      capabilityFor: (agentId) => `cap-${agentId}`
+    })
     mkdirSync(join(path, '.git'), { recursive: true })
     writeFileSync(join(path, 'local.txt'), 'keep me')
     recordWorkspaceMaterialization(current)
+    // Older daemons recorded the conventional `.git` suffix in this marker.
+    writeFileSync(
+      join(dirname(path), `.${basename(path)}.workspace-materialization.json`),
+      JSON.stringify({
+        version: 1,
+        key: JSON.stringify({
+          mode: 'github',
+          repo: 'https://github.com/acme/repo.git',
+          branch: 'main'
+        })
+      })
+    )
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
+    )
 
     const rollback = await prepareWorkspaceForActivation(
-      { ...current, workspace: { ...current.workspace, gitCredential: 'github-app' } } as Agent,
+      { ...current, workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/repo' } } as Agent,
       { reconcileMaterialization: true }
     )
 
@@ -309,7 +388,39 @@ describe('prepareWorkspaceForActivation', () => {
     expect(existsSync(join(path, 'local.txt'))).toBe(true)
   })
 
-  it('preserves a renamed checkout on a later agentDir-only workspace edit', async () => {
+  it('replaces a historical App-backed checkout materialized from a non-GitHub origin', async () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-edit-')), 'workspace')
+    const agent = githubAppAgent(path)
+    initGitInjection({
+      shimPath: '/run/helper.sh',
+      runDir: mkdtempSync(join(tmpdir(), 'ac-ws-gitcred-')),
+      preWarm: async () => undefined,
+      capabilityFor: (agentId) => `cap-${agentId}`
+    })
+    mkdirSync(join(path, '.git'), { recursive: true })
+    writeFileSync(join(path, 'untrusted.txt'), 'wrong-host content')
+    recordWorkspaceMaterialization(agent)
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://other-host.example/acme/repo.git\n' : ''
+    )
+    cloneImpl = vi.fn().mockImplementation(async (_repo: string, target: string) => {
+      mkdirSync(join(target, '.git'), { recursive: true })
+      writeFileSync(join(target, 'README.md'), 'authorized GitHub content')
+    })
+
+    const rollback = await prepareWorkspaceForActivation(agent, { reconcileMaterialization: true })
+
+    expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', expect.any(String), [
+      '--branch',
+      'main',
+      '--single-branch'
+    ])
+    expect(existsSync(join(path, 'untrusted.txt'))).toBe(false)
+    expect(readFileSync(join(path, 'README.md'), 'utf8')).toBe('authorized GitHub content')
+    rollback()
+  })
+
+  it('retries a failed rename convergence without replacing local files on a later agentDir-only edit', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-edit-')), 'workspace')
     const current = githubAppAgent(path)
     current.workspace.gitRepo = 'https://github.com/acme/old-name'
@@ -317,27 +428,32 @@ describe('prepareWorkspaceForActivation', () => {
     mkdirSync(join(path, 'packages', 'service'), { recursive: true })
     writeFileSync(join(path, 'local.txt'), 'keep me')
     recordWorkspaceMaterialization(current)
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/old-name\n' : ''
-    )
+    let failSetUrl = true
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/old-name\n'
+      if (args[0] === 'remote' && args[1] === 'set-url' && failSetUrl) throw new Error('config locked')
+      return ''
+    })
 
     const renamed = {
       ...current,
       workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/new-name' }
     } as Agent
-    await convergeGithubAppWorkspaceRename(renamed)
+    await expect(convergeGithubAppWorkspaceRename(renamed)).rejects.toThrow('config locked')
+    failSetUrl = false
 
     const rollback = await prepareWorkspaceForActivation(
       { ...renamed, workspace: { ...renamed.workspace, agentDir: 'packages/service' } } as Agent,
       { reconcileMaterialization: true }
     )
 
-    expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
-      'remote',
-      'set-url',
-      'origin',
-      'https://github.com/acme/new-name'
-    ])
+    expect(
+      rawMock.mock.calls.filter(
+        (call) =>
+          JSON.stringify(call[0]) ===
+          JSON.stringify(['remote', 'set-url', 'origin', 'https://github.com/acme/new-name'])
+      )
+    ).toHaveLength(2)
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(readFileSync(join(path, 'local.txt'), 'utf8')).toBe('keep me')
     rollback()
@@ -379,6 +495,9 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       preWarm: async () => undefined,
       capabilityFor: (agentId) => `cap-${agentId}`
     })
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
+    )
   })
 
   it('re-pins an existing checkout to the CURRENT agent id (a recreated agent adopts a stale pin)', async () => {
@@ -417,12 +536,115 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     expect(cloneImpl).not.toHaveBeenCalled()
   })
 
-  it('leaves a non-github-app checkout untouched (machine credentials stay machine-managed)', async () => {
+  it('sanitizes host git context before inspecting and repointing an origin', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
     mkdirSync(join(dir, '.git'))
+    const agent = githubAppAgent(dir)
+    agent.workspace.gitRepo = 'https://github.com/acme/new-name'
+    const previousGitDir = process.env.GIT_DIR
+    process.env.GIT_DIR = '/tmp/attacker-controlled-git-dir'
+    rawMock.mockImplementation(async (args: string[]) => {
+      expect(lastGitEnv).not.toHaveProperty('GIT_DIR')
+      expect(lastGitEnv?.GIT_ALLOW_PROTOCOL).toBe('https:ssh')
+      return args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/old-name\n' : ''
+    })
+
+    try {
+      await prepareWorkspace(agent)
+    } finally {
+      if (previousGitDir === undefined) delete process.env.GIT_DIR
+      else process.env.GIT_DIR = previousGitDir
+    }
+
+    expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'remote',
+      'set-url',
+      'origin',
+      'https://github.com/acme/new-name'
+    ])
+  })
+
+  it('refuses to run an App-backed checkout whose origin is not GitHub', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
+    mkdirSync(join(dir, '.git'))
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://other-host.example/acme/repo.git\n' : ''
+    )
+
+    await expect(prepareWorkspace(githubAppAgent(dir))).rejects.toThrow('origin is not a trusted GitHub remote')
+    expect(pullMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when an App-backed origin cannot be rewritten', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
+    mkdirSync(join(dir, '.git'))
+    const agent = githubAppAgent(dir)
+    agent.workspace.gitRepo = 'https://github.com/acme/new-name'
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/old-name\n'
+      if (args[0] === 'remote' && args[1] === 'set-url') throw new Error('config locked')
+      return ''
+    })
+
+    await expect(prepareWorkspace(agent)).rejects.toThrow('config locked')
+    expect(pullMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a credential-free non-github-app origin untouched', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
+    mkdirSync(join(dir, '.git'))
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://example.com/repo.git\n' : ''
+    )
 
     await prepareWorkspace(gitRepoAgent(dir))
 
-    expect(rawMock).not.toHaveBeenCalled()
+    expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual(['remote', 'get-url', 'origin'])
+    expect(rawMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'remote',
+      'set-url',
+      'origin',
+      'https://example.com/repo.git'
+    ])
+  })
+
+  it('removes credentials from a historical anonymous origin before pull', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
+    mkdirSync(join(dir, '.git'))
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url'
+        ? 'https://legacy-user:legacy-token@example.com/repo.git?token=query-secret\n'
+        : ''
+    )
+
+    await prepareWorkspace(gitRepoAgent(dir))
+
+    expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'remote',
+      'set-url',
+      'origin',
+      'https://example.com/repo.git'
+    ])
+    expect(pullMock).toHaveBeenCalled()
+  })
+
+  it('repoints a historical shorthand origin before pull', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
+    mkdirSync(join(dir, '.git'))
+    const agent = gitRepoAgent(dir)
+    agent.workspace.gitRepo = 'https://github.com/acme/repo'
+    rawMock.mockImplementation(async (args: string[]) =>
+      args[0] === 'remote' && args[1] === 'get-url' ? 'acme/repo\n' : ''
+    )
+
+    await prepareWorkspace(agent)
+
+    expect(rawMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'remote',
+      'set-url',
+      'origin',
+      'https://github.com/acme/repo'
+    ])
+    expect(pullMock).toHaveBeenCalled()
   })
 })

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -382,6 +382,55 @@ describe('writeAgentSpec — merge (agent.json exists)', () => {
     expect((readJson(file).workspace as { agentDir?: string }).agentDir).toBe('services/api')
   })
 
+  it('sanitizes legacy clone credentials and refuses unsafe replicated transports', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
+    const file = seedAgent(dir, 'bot-a', {
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'git-repo', path: './workspace' }
+    })
+
+    writeAgentSpec(
+      dir,
+      'bot-a',
+      baseSpec({
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://legacy-user:legacy-token@example.com/repo?token=query-secret',
+          branch: 'main'
+        }
+      }),
+      deps
+    )
+    expect((readJson(file).workspace as { gitRepo: string }).gitRepo).toBe('https://example.com/repo')
+
+    writeAgentSpec(
+      dir,
+      'bot-a',
+      baseSpec({
+        workspace: {
+          mode: 'github',
+          gitRepo: 'https://legacy-user:legacy-token@other-host.example/acme/repo?token=query-secret',
+          branch: 'main',
+          gitCredential: 'github-app'
+        }
+      }),
+      deps
+    )
+    expect((readJson(file).workspace as { gitRepo: string }).gitRepo).toBe('https://github.com/acme/repo')
+
+    expect(() =>
+      writeAgentSpec(
+        dir,
+        'bot-a',
+        baseSpec({ workspace: { mode: 'github', gitRepo: 'file:///tmp/repo', branch: 'main' } }),
+        deps
+      )
+    ).toThrow('git clone url must use https or ssh')
+  })
+
   it('clears a stale working subdirectory for repo-root and scratch specs', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-write-agent-'))
     const file = seedAgent(dir, 'bot-a', {

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeGitUrl, gitRepoLabel } from './git-url.js'
+import {
+  GitCloneUrlError,
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  normalizeGitUrl,
+  redactGitUrlSecrets,
+  gitRepoLabel
+} from './git-url.js'
 
 describe('normalizeGitUrl', () => {
   it('expands bare org/repo to a full GitHub https address', () => {
@@ -31,6 +38,115 @@ describe('normalizeGitUrl', () => {
   it('leaves unrecognized inputs (single segment, empty) untouched', () => {
     expect(normalizeGitUrl('just-a-name')).toBe('just-a-name')
     expect(normalizeGitUrl('')).toBe('')
+  })
+})
+
+describe('normalizeGitCloneUrl', () => {
+  it('normalizes GitHub and public-host shorthand', () => {
+    expect(normalizeGitCloneUrl('acme/infra')).toBe('https://github.com/acme/infra')
+    expect(normalizeGitCloneUrl('github.com/acme/infra')).toBe('https://github.com/acme/infra')
+    expect(normalizeGitCloneUrl('gitlab.com/group/sub/repo')).toBe('https://gitlab.com/group/sub/repo')
+  })
+
+  it('accepts credential-free HTTPS and SSH remotes', () => {
+    for (const url of [
+      'https://gitlab.com/group/sub/repo.git',
+      'ssh://git@github.com/acme/infra.git',
+      'git@github.com:acme/infra.git'
+    ]) {
+      expect(normalizeGitCloneUrl(url)).toBe(url)
+    }
+  })
+
+  it('rejects local, option-like, malformed, and control-character targets', () => {
+    for (const url of [
+      '',
+      'repo',
+      '/tmp/repo',
+      './repo',
+      '../repo',
+      '~/repo',
+      '-uploader',
+      'acme/\ninfra',
+      'https://good.example\\user:token@127.0.0.1/repo'
+    ]) {
+      expect(() => normalizeGitCloneUrl(url), url).toThrow(GitCloneUrlError)
+    }
+  })
+
+  it('rejects unsafe and unsupported transports', () => {
+    for (const url of [
+      'http://github.com/acme/infra',
+      'file:///tmp/repo',
+      'git://github.com/acme/infra',
+      'ext::sh -c id',
+      'ftp://example.com/acme/infra'
+    ]) {
+      expect(() => normalizeGitCloneUrl(url), url).toThrow(GitCloneUrlError)
+    }
+  })
+
+  it('rejects credentials, passwords, queries, and fragments', () => {
+    for (const url of [
+      'https://user@github.com/acme/infra',
+      'https://user:token@github.com/acme/infra',
+      'ssh://git:secret@github.com/acme/infra',
+      'https://github.com/acme/infra?token=secret',
+      'ssh://git@github.com/acme/infra#main',
+      'https://github.com/acme/infra?',
+      'ssh://git@github.com/acme/infra#'
+    ]) {
+      expect(() => normalizeGitCloneUrl(url), url).toThrow(GitCloneUrlError)
+    }
+  })
+})
+
+describe('redactGitUrlSecrets', () => {
+  it('normalizes shorthand and removes URL secrets', () => {
+    expect(redactGitUrlSecrets('acme/infra')).toBe('https://github.com/acme/infra')
+    expect(redactGitUrlSecrets('https://user:token@github.com/acme/infra.git?token=secret#main')).toBe(
+      'https://github.com/acme/infra.git'
+    )
+    expect(redactGitUrlSecrets('ftp://user:token@example.com/acme/infra?token=secret')).toBe(
+      'ftp://example.com/acme/infra'
+    )
+  })
+
+  it('keeps SSH and scp usernames while removing secret-bearing suffixes', () => {
+    expect(redactGitUrlSecrets('ssh://git:secret@github.com/acme/infra.git?token=secret#main')).toBe(
+      'ssh://git@github.com/acme/infra.git'
+    )
+    expect(redactGitUrlSecrets('git@github.com:acme/infra.git?token=secret#main')).toBe('git@github.com:acme/infra.git')
+  })
+
+  it('redacts ambiguous backslash authority credentials without leaking them as path text', () => {
+    const redacted = redactGitUrlSecrets('https://good.example\\user:token@127.0.0.1/repo')
+    expect(redacted).toBe('https://127.0.0.1/repo')
+    expect(redacted).not.toContain('token')
+    expect(redacted).not.toContain('good.example')
+  })
+
+  it('quarantines ambiguous malformed userinfo without changing a valid query URL host', () => {
+    expect(redactGitUrlSecrets('https://user:secret?@host.example/repo')).toBe('https://')
+    expect(redactGitUrlSecrets('https://user:secret#@host.example/repo')).toBe('https://')
+    expect(redactGitUrlSecrets('https://example.com?ref=@evil.test/owner/repo')).toBe('https://example.com')
+  })
+
+  it('never throws for malformed or empty historical values', () => {
+    expect(redactGitUrlSecrets('')).toBe('')
+    expect(redactGitUrlSecrets('not a url')).toBe('not a url')
+    expect(() => redactGitUrlSecrets('https://user:secret@')).not.toThrow()
+    expect(redactGitUrlSecrets('https://user:secret@')).not.toContain('secret')
+  })
+})
+
+describe('normalizeGithubRepoUrl', () => {
+  it('binds App-backed repositories to canonical GitHub owner/repo URLs', () => {
+    expect(normalizeGithubRepoUrl('https://other-host.example/acme/infra')).toBe('https://github.com/acme/infra')
+    expect(normalizeGithubRepoUrl('ssh://git@other-host.example/acme/infra.git')).toBe(
+      'https://github.com/acme/infra.git'
+    )
+    expect(() => normalizeGithubRepoUrl('https://other-host.example/acme/infra/extra')).toThrow(GitCloneUrlError)
   })
 })
 

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -10,8 +10,19 @@
 
 /** Scheme-full address: https://, ssh://, git://, file://, … */
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i
+/** Any URI scheme, including non-hierarchical forms such as `ext::…`. */
+const ANY_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i
 /** scp-like ssh address: git@github.com:acme/infra(.git) */
 const SCP_RE = /^[\w.-]+@[\w.-]+:(.+)$/
+const SCP_PARTS_RE = /^([\w.-]+)@([\w.-]+):(.+)$/
+const CONTROL_RE = /[\u0000-\u001f\u007f]/
+
+export class GitCloneUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GitCloneUrlError'
+  }
+}
 
 /**
  * Normalize a user-supplied repo reference into a full cloneable git address.
@@ -31,6 +42,163 @@ export function normalizeGitUrl(input: string): string {
   // bare org/repo → GitHub by default
   if (segments.length === 2 && segments.every((p) => p.length > 0)) return `https://github.com/${s}`
   return s
+}
+
+function invalidCloneUrl(message: string): never {
+  throw new GitCloneUrlError(message)
+}
+
+function hasLocalPathPrefix(value: string): boolean {
+  return (
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    value.startsWith('~/') ||
+    /^[a-z]:[\\/]/i.test(value)
+  )
+}
+
+/**
+ * Normalize and validate an untrusted git clone target.
+ *
+ * Public Git hosts remain host-agnostic. Only credential-free HTTPS and SSH
+ * transports are accepted; local paths and Git's executable/legacy transports
+ * are rejected before the value can reach `git clone`.
+ */
+export function normalizeGitCloneUrl(input: string): string {
+  if (CONTROL_RE.test(input)) invalidCloneUrl('git clone url must not contain control characters')
+
+  const s = input.trim().replace(/\/+$/, '')
+  if (!s) invalidCloneUrl('git clone url must not be empty')
+  if (s.startsWith('-')) invalidCloneUrl('git clone url must not start with "-"')
+  if (/\s/.test(s)) invalidCloneUrl('git clone url must not contain whitespace')
+  // Git and WHATWG URLs disagree about whether a backslash terminates the
+  // authority. Reject it outright so validation, redaction, and Git cannot
+  // select different credentials or hosts.
+  if (s.includes('\\')) invalidCloneUrl('git clone url must not contain backslashes')
+  if (hasLocalPathPrefix(s)) invalidCloneUrl('local git paths are not supported')
+
+  const scp = SCP_PARTS_RE.exec(s)
+  if (scp) {
+    const path = scp[3]!
+    if (!path || path.startsWith('-') || path.includes('?') || path.includes('#')) {
+      invalidCloneUrl('invalid scp-style git clone url')
+    }
+    return s
+  }
+
+  // Reject ext::, file:, Windows drive-like values, and every other
+  // non-hierarchical/unsupported scheme before shorthand normalization.
+  if (ANY_SCHEME_RE.test(s) && !SCHEME_RE.test(s)) {
+    invalidCloneUrl('git clone url must use https or ssh')
+  }
+
+  const normalized = normalizeGitUrl(s)
+  if (!SCHEME_RE.test(normalized)) invalidCloneUrl('git clone url must identify a remote repository')
+
+  let url: URL
+  try {
+    url = new URL(normalized)
+  } catch {
+    invalidCloneUrl('git clone url must be a valid absolute URL')
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'ssh:') {
+    invalidCloneUrl('git clone url must use https or ssh')
+  }
+  if (url.protocol === 'https:' && (url.username || url.password)) {
+    invalidCloneUrl('https git clone url must not contain credentials')
+  }
+  if (url.protocol === 'ssh:' && url.password) {
+    invalidCloneUrl('ssh git clone url must not contain a password')
+  }
+  if (normalized.includes('?') || normalized.includes('#')) {
+    invalidCloneUrl('git clone url must not contain a query or fragment')
+  }
+  if (!url.hostname || !url.pathname || url.pathname === '/') {
+    invalidCloneUrl('git clone url must identify a remote repository')
+  }
+
+  return normalized
+}
+
+function withoutQueryOrFragment(value: string): string {
+  const query = value.indexOf('?')
+  const fragment = value.indexOf('#')
+  const cut = query < 0 ? fragment : fragment < 0 ? query : Math.min(query, fragment)
+  return cut < 0 ? value : value.slice(0, cut)
+}
+
+function redactHierarchicalUrlFallback(value: string): string {
+  const match = /^([a-z][a-z0-9+.-]*:\/\/)([^/]*)(.*)$/i.exec(value)
+  if (!match) return value
+  const [, prefix, authority, path] = match
+  const at = authority!.lastIndexOf('@')
+  if (at < 0) return value
+  const host = authority!.slice(at + 1)
+  if (prefix!.toLowerCase() !== 'ssh://') return `${prefix}${host}${path}`
+  const username = authority!.slice(0, at).split(':', 1)[0]
+  return `${prefix}${username ? `${username}@` : ''}${host}${path}`
+}
+
+function redactMalformedHierarchicalUrl(value: string): string {
+  const withoutTail = withoutQueryOrFragment(value)
+  const redacted = redactHierarchicalUrlFallback(withoutTail)
+  if (redacted !== withoutTail) return redacted
+  const authority = /^([a-z][a-z0-9+.-]*:\/\/)([^/]*)/i.exec(withoutTail)
+  // An unparseable colon-bearing authority may be user:password or a malformed
+  // host/port. Returning only the scheme is conservative, non-secret, and
+  // deliberately non-cloneable.
+  return authority?.[2]?.includes(':') ? authority[1]! : redacted
+}
+
+/**
+ * Best-effort redaction for stored or historical git addresses.
+ *
+ * This function is deliberately total: response serialization and logging must
+ * not fail merely because a legacy value is malformed. Existing shorthand
+ * normalization is retained, HTTPS/other URL userinfo is removed, SSH keeps
+ * its non-secret username while dropping a password, and query/fragment data
+ * is discarded.
+ */
+export function redactGitUrlSecrets(input: string): string {
+  const normalized = normalizeGitUrl(input)
+  if (SCP_RE.test(normalized) || !SCHEME_RE.test(normalized)) return withoutQueryOrFragment(normalized)
+  // Git and WHATWG disagree on backslashes, so never let WHATWG reserialize an
+  // ambiguous password as apparent path text.
+  if (normalized.includes('\\')) return redactMalformedHierarchicalUrl(normalized)
+
+  try {
+    const url = new URL(normalized)
+    if (url.protocol === 'ssh:') {
+      url.password = ''
+    } else {
+      url.username = ''
+      url.password = ''
+    }
+    url.search = ''
+    url.hash = ''
+    return normalizeGitUrl(url.toString())
+  } catch {
+    // Malformed hierarchical URLs still receive a conservative string-level
+    // redaction so the total fallback cannot echo obvious credentials.
+    return redactMalformedHierarchicalUrl(normalized)
+  }
+}
+
+/** Canonical GitHub clone URL for an App-backed workspace. The GitHub
+ * installation grant is tied to owner/repo, so a caller-supplied host or extra
+ * path must never select different content while retaining that authority. */
+export function normalizeGithubRepoUrl(input: string): string {
+  const redacted = redactGitUrlSecrets(input)
+  const hasGitSuffix = redacted.endsWith('.git')
+  const label = gitRepoLabel(redacted)
+  const parts = label.split('/')
+  if (parts.length !== 2 || parts.some((part) => !part)) {
+    invalidCloneUrl('github repository must be exactly owner/repo')
+  }
+  return normalizeGitCloneUrl(`${label}${hasGitSuffix ? '.git' : ''}`)
 }
 
 /**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -66,7 +66,14 @@ export { decodeEnvelopeWith, buildEnvelopeRaw } from './wire.js'
 export type { DecodeResultOf } from './wire.js'
 
 // ── git repo address helpers (normalize on write, shorten for display) ──
-export { normalizeGitUrl, gitRepoLabel } from './git-url.js'
+export {
+  GitCloneUrlError,
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl,
+  normalizeGitUrl,
+  redactGitUrlSecrets,
+  gitRepoLabel
+} from './git-url.js'
 
 // ── Slack message visible-text extraction (shared by daemon + relay) ──
 export { extractSlackMessageText } from './slack-message-text.js'


### PR DESCRIPTION
## Summary

- validate workspace clone targets as credential-free HTTPS or SSH and reject local, legacy, and executable Git transports at both CP and daemon boundaries
- bind GitHub App workspaces to the installation-authorized GitHub repository, sanitize historical URLs, and quarantine unsafe legacy rows without breaking the rest of a daemon roster
- constrain daemon-managed workspace Git to the intended checkout and transport policy, block `.git` reads, and fail closed when origin convergence or on-demand pull validation fails
- migrate stored HTTP(S)/SSH URL credentials and query/fragment data out of existing agent rows

## Root cause

Workspace repository input was normalized for convenience but was not validated as a safe clone target. Historical values could therefore retain embedded credentials or reach daemon-managed Git through unsupported transports, and ambient Git repository-context variables could redirect safety checks away from the intended checkout.

## Scope

Manual workspaces intentionally continue to support credential-free HTTPS and SSH repositories on arbitrary hosts. Deployment-specific host/private-network allowlisting and egress controls are a separate follow-up; this PR does not claim to eliminate arbitrary-host SSRF.

## Validation

- protocol tests: 177 passed
- daemon targeted tests: 140 passed (with polling on macOS)
- control-plane unit tests: 17 passed
- control-plane integration tests: 63 passed against PostgreSQL, including the migration
- protocol, daemon, and control-plane typechecks
- pre-push full-repository ESLint: 0 errors
- two independent adversarial diff reviews: no remaining blocker

Created by Codex . GPT-5
