### PR TITLE
fix(daemon): restrict workspace Git origins

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -270,7 +270,12 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
 
     // Default false. true / --require-sandbox requires every agent to run in an OS sandbox.
     // If bwrap (Linux) or sandbox-exec (macOS) is unavailable, daemon refuses to start.
-    "requireSandbox": false
+    "requireSandbox": false,
+
+    // Exact origins that daemon-managed workspace clone/pull may target.
+    // Scheme and non-default port are part of the match; no wildcards or paths.
+    // Add self-managed Git origins explicitly. [] disables remote Git workspaces.
+    "workspaceGitAllowedOrigins": ["https://github.com", "ssh://github.com"]
   },
 
   // Daemon-local config.json / agent.json are secret-bearing files: CP API keys and
@@ -296,6 +301,25 @@ On POSIX hosts, AgentConnect removes group/other access from existing
 `config.json` and `agent.json` files; newly created or rewritten files use mode
 `0600`. Agent directories created by the daemon use `0700`; existing custom
 agent directories and higher custom parents are left unchanged.
+
+`security.workspaceGitAllowedOrigins` is a daemon-local remote-origin policy. Tenant
+workspace configuration cannot widen it, and the control plane intentionally
+keeps only transport/credential validation because different daemons may permit
+different self-managed Git services. A manual GitLab or self-managed workspace
+therefore requires the daemon operator to add its exact HTTPS or SSH origin and
+restart the daemon. A configured array replaces the defaults, so deployments
+that still use GitHub or GitHub App workspaces must keep the corresponding
+GitHub origins in the array.
+
+Daemon-managed workspace clone/pull does not inherit proxy variables, system or
+user Git routing config, or user SSH config. It refuses HTTPS redirects and
+secondary bundle/packfile URI downloads, disables automatic submodule and Git
+LFS fetching, and rejects checkout-local URL rewrites, includes, and proxy
+overrides before pull. Operators should use an explicit repository URL
+(including an SSH port when needed) instead of redirects, proxies, or SSH host
+aliases. This policy covers daemon-managed workspace materialization only;
+agent-initiated Git commands and configured skill-source installation have
+separate trust boundaries.
 
 #### 3.3.1 Default Runtimes Come from the ACP Registry
 

--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -32,7 +32,9 @@
 AgentConnect supports anonymous public-URL workspaces and GitHub App
 workspaces. GitHub App mode lets the console select an authorized repository
 and lets both daemon-managed and agent-initiated Git operations authenticate
-without a host PAT, SSH key, or credential-manager entry.
+without a host PAT, SSH key, or credential-manager entry. Both App-backed and
+manual workspace URLs remain subject to the daemon operator's exact
+`security.workspaceGitAllowedOrigins` policy.
 
 The sign-in and repository-access flows may share one GitHub App while using
 independent credential tracks. Sign-in uses the App's user authorization

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -482,7 +482,9 @@ function applySpecFields(
     delete existing.agentDir
     if (ws.mode === 'github') {
       // Keep old CPs safe too: strip historical URL secrets, then reject any
-      // transport a current daemon would refuse at the clone boundary.
+      // transport a current daemon would refuse. Origin authorization remains
+      // daemon-local and happens at the clone/pull boundary: one incompatible
+      // roster entry must not prevent the daemon from completing CP register.
       existing.gitRepo =
         ws.gitCredential === 'github-app'
           ? normalizeGithubRepoUrl(ws.gitRepo)

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -7,6 +7,7 @@ import { agentChildEnv } from '../agents/agent-env.js'
 import { cleanupConfigFiles, materializeConfigFiles } from '../agents/config-file-env.js'
 import { memoryKindOf, memoryProviderFor } from '../agents/memory-provider.js'
 import { prepareWorkspace } from '../workspace/workspace-manager.js'
+import { configureWorkspaceGitOrigins } from '../workspace/git-origin-policy.js'
 import { AcpHost } from '../acp/acp-host.js'
 import { effectiveRunInSandbox } from '../acp/runtime-launch.js'
 import { detectSandbox } from '../acp/sandbox.js'
@@ -54,6 +55,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     optional: true,
     overrides: { agentsDir: opts.agentsDir }
   })
+  configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
   const agent = selectAgent(cfg.agentsDir!, opts.agentName)
 
   const catalog = opts.resolveCatalog

--- a/packages/daemon/src/cli/run-foreground.ts
+++ b/packages/daemon/src/cli/run-foreground.ts
@@ -7,6 +7,7 @@ import type { FlatOverrides } from '../config/load-config.js'
 
 export interface ForegroundOpts {
   root?: string
+  configPath?: string
   agentName?: string
   overrides?: FlatOverrides
   /** Supervisor marker (AGENTCONNECT_SUPERVISOR) forwarded to the Daemon so it

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
-import { RelayRosterEntry } from '@agentconnect.md/protocol'
+import {
+  DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  normalizeWorkspaceGitOrigin,
+  RelayRosterEntry
+} from '@agentconnect.md/protocol'
 
 /** The `{name, value}[]` shape shared by runtime env, MCP env, and MCP headers. */
 const NameValueList = z.array(z.object({ name: z.string(), value: z.string() })).default([])
@@ -44,6 +48,17 @@ const ProcessValue = z
   .string()
   .max(16 * 1024)
   .refine((value) => !value.includes('\0'), 'process value contains NUL')
+const WorkspaceGitOrigin = z.string().transform((value, ctx) => {
+  try {
+    return normalizeWorkspaceGitOrigin(value)
+  } catch {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'workspace Git origins must be exact credential-free HTTPS or SSH origins without a path'
+    })
+    return z.NEVER
+  }
+})
 
 /** Operator-owned local memory-plugin allowlist. A tenant/CP sends only the map
  * key (`commandRef`); command, args, static env, and logical-secret→env mapping
@@ -116,9 +131,16 @@ export const ConfigSchema = z.object({
       // Daemon-wide sandbox policy (issue #642). When true, startup fails unless
       // bwrap / sandbox-exec is available and every agent runs sandboxed; the
       // console locks the per-agent option on. false leaves it agent-selectable.
-      requireSandbox: z.boolean().default(false)
+      requireSandbox: z.boolean().default(false),
+      // Operator-owned remote-origin policy for daemon-managed workspace clone/pull.
+      // Exact scheme + host + port only; [] disables remote Git workspaces.
+      workspaceGitAllowedOrigins: z.array(WorkspaceGitOrigin).default([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
     })
-    .default({ isolateAccountApps: true, requireSandbox: false }),
+    .default({
+      isolateAccountApps: true,
+      requireSandbox: false,
+      workspaceGitAllowedOrigins: [...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]
+    }),
   // Relay roster the CP last published (shared-bot-relay.md §5). Persisted whole so
   // the daemon can re-dial its relays at boot while the CP is unreachable (graceful
   // degradation); the CP's register/ok snapshot re-converges it authoritatively once

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -83,9 +83,9 @@ export function loadConfig(
  * per install. Best-effort: a write failure is swallowed (the daemon still runs
  * with the in-memory id this session).
  */
-export function persistDaemonId(root: string | undefined, daemonId: string): void {
+export function persistDaemonId(root: string | undefined, daemonId: string, customConfigPath?: string): void {
   try {
-    const file = configPath(resolveRoot(root))
+    const file = customConfigPath ?? configPath(resolveRoot(root))
     protectConfigFile(file)
     const raw = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
     raw.daemonId = daemonId
@@ -102,9 +102,9 @@ export function persistDaemonId(root: string | undefined, daemonId: string): voi
  * Best-effort — a write failure is swallowed (the in-memory roster still drives
  * this session's dials).
  */
-export function persistRelays(root: string | undefined, relays: RelayRosterEntry[]): void {
+export function persistRelays(root: string | undefined, relays: RelayRosterEntry[], customConfigPath?: string): void {
   try {
-    const file = configPath(resolveRoot(root))
+    const file = customConfigPath ?? configPath(resolveRoot(root))
     protectConfigFile(file)
     const raw = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
     raw.relays = relays

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -16,14 +16,20 @@ import { existsSync, promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import type { SimpleGit } from 'simple-git'
 import {
-  normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   type WorkspaceGitStatus,
   type WorkspaceGitPullResult,
   type WorkspaceGitFile,
   type WorkspaceGitCommit
 } from '@agentconnect.md/protocol'
-import { gitFor, pullWorkspaceRef, workspaceGitEnvBase } from '../workspace/git-injection.js'
+import {
+  assertSafeWorkspaceGitConfig,
+  gitFor,
+  pullWorkspaceRef,
+  workspaceGitLocalEnv,
+  workspaceGitPullTarget
+} from '../workspace/git-injection.js'
+import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
 import { WorkspaceViolationError } from './workspace-reader.js'
 
 /** On-demand pull is interactive, so allow more headroom than the 4.5s
@@ -70,7 +76,7 @@ export function createWorkspaceGit(
     const raw = input.trim()
     if (!/^(?:https|ssh):\/\//i.test(raw) && !/^[\w.-]+@[\w.-]+:/.test(raw)) return undefined
     try {
-      return normalizeGitCloneUrl(raw)
+      return authorizeWorkspaceGitUrl(raw)
     } catch {
       return undefined
     }
@@ -81,7 +87,7 @@ export function createWorkspaceGit(
       const root = rootFor(agentId)
       if (!isRepo(root)) return { agentId, isRepo: false, clean: true }
 
-      const git = gitFor(root).env(workspaceGitEnvBase())
+      const git = gitFor(root).env(workspaceGitLocalEnv())
       const s = await git.status()
       const files: WorkspaceGitFile[] = s.files
         .slice(0, MAX_STATUS_FILES)
@@ -111,35 +117,36 @@ export function createWorkspaceGit(
       // forced reset. Bounded by a timeout so an offline remote can't hang the REP.
       let timer: ReturnType<typeof setTimeout> | undefined
       try {
-        const git = gitFor(root).env(workspaceGitEnvBase())
+        const git = gitFor(root).env(workspaceGitLocalEnv())
         const target = workspaceTargetByAgent(agentId)
         let currentOrigin: string | undefined
-        let expectedOrigin: string | undefined
+        let expectedOrigin: string
         try {
           currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
-          expectedOrigin =
-            target === undefined
-              ? undefined
-              : target.githubApp
-                ? normalizeGithubRepoUrl(target.repo)
-                : normalizeGitCloneUrl(target.repo)
+          if (!target) throw new Error('workspace target is unavailable')
+          expectedOrigin = authorizeWorkspaceGitUrl(
+            target.githubApp ? normalizeGithubRepoUrl(target.repo) : target.repo
+          )
         } catch {
           return { agentId, isRepo: true, ok: false, detail: 'workspace origin is not a safe remote' }
         }
         if (
           !currentOrigin ||
-          (target?.githubApp === true &&
-            expectedOrigin !== undefined &&
-            currentOrigin.toLowerCase() !== expectedOrigin.toLowerCase())
+          (target.githubApp === true && currentOrigin.toLowerCase() !== expectedOrigin.toLowerCase())
         ) {
           return { agentId, isRepo: true, ok: false, detail: 'workspace origin is not a safe remote' }
         }
-        const pullOrigin = expectedOrigin ?? currentOrigin
-        const pullBranch = target?.branch ?? 'HEAD'
+        await assertSafeWorkspaceGitConfig(root)
+        const pullBranch = target.branch
+        const pullTarget = workspaceGitPullTarget(expectedOrigin)
         const res = await Promise.race([
           pullWorkspaceRef(
-            git.env({ ...workspaceGitEnvBase(), ...credentialEnvByAgent(agentId), GIT_TERMINAL_PROMPT: '0' }),
-            pullOrigin,
+            git.env({
+              ...pullTarget.env,
+              ...credentialEnvByAgent(agentId),
+              GIT_TERMINAL_PROMPT: '0'
+            }),
+            pullTarget.remote,
             pullBranch
           ),
           new Promise<never>((_, rej) => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -44,6 +44,7 @@ import { cleanupConfigFiles, materializeConfigFiles } from './agents/config-file
 import { writeGhShim } from './cp/gh-shim.js'
 import { GitCredServer, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
 import { gitCredentialEnv, initGitInjection, probeGitVersion, sessionGitEnv } from './workspace/git-injection.js'
+import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
 import { buildMcpServers } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
 import { toolsForIntegrations, MEMORY_TOOL_NAMES, ALL_TOOL_NAMES, GITHUB_REVIEW_TOOLS } from './mcp/tools.js'
@@ -1365,6 +1366,7 @@ export class Daemon {
   constructor(
     private opts: {
       root?: string
+      configPath?: string
       overrides?: FlatOverrides
       agentName?: string
       hostFactory?: (agent: Agent, onUpdate: (sid: string, u: any) => void) => AcpHost
@@ -1509,8 +1511,15 @@ export class Daemon {
 
   async start(): Promise<void> {
     const root = resolveRoot(this.opts.root)
-    const cfg = loadConfig({ root, overrides: this.opts.overrides, optional: !!this.opts.agentName, autoCreate: true })
+    const cfg = loadConfig({
+      root,
+      configPath: this.opts.configPath,
+      overrides: this.opts.overrides,
+      optional: !!this.opts.agentName,
+      autoCreate: true
+    })
     this.cfg = cfg
+    configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     if (cfg.security.requireSandbox && !this.sandboxMechanism) {
       throw new Error('daemon startup refused: security.requireSandbox is true but this host has no bwrap/sandbox-exec')
     }
@@ -1566,7 +1575,7 @@ export class Daemon {
     probeGitVersion((m) => this.log.warn(m))
     if (!cfg.daemonId && !cpKeyOnboarding) {
       cfg.daemonId = randomUUID()
-      persistDaemonId(root, cfg.daemonId)
+      persistDaemonId(root, cfg.daemonId, this.opts.configPath)
     }
     this.log = makeLogger(cfg.logging.level)
     this.log.info(`starting daemon (root=${root})`)
@@ -11721,7 +11730,7 @@ export class Daemon {
       cur.length === next.length && next.every((r) => cur.some((c) => c.relayId === r.relayId && c.url === r.url))
     if (!same) {
       this.cfg.relays = next
-      persistRelays(this.root, next)
+      persistRelays(this.root, next, this.opts.configPath)
     }
   }
 
@@ -11966,7 +11975,7 @@ export class Daemon {
       ...(echoDaemonId ? { daemonId: echoDaemonId } : {}),
       onDaemonId: (id) => {
         this.cfg.daemonId = id
-        persistDaemonId(root, id)
+        persistDaemonId(root, id, this.opts.configPath)
         this.log.info(`cp: adopted daemonId ${id} from auth/ok`)
       },
       onWebAppUrl: (url) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -72,6 +72,7 @@ program
     try {
       await runForeground({
         root: opts.root,
+        configPath: opts.config,
         agentName: opts.agent,
         // The launcher (CLI respawn shell or launchd/systemd unit) declares how
         // this daemon is supervised; the daemon can no longer self-detect it now

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -27,11 +27,12 @@
  * Everything written here is a POINTER to the daemon — never a secret.
  */
 import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { simpleGit, type SimpleGit } from 'simple-git'
-import type { GitCommitIdentity } from '@agentconnect.md/protocol'
+import { normalizeGitCloneUrl, type GitCommitIdentity } from '@agentconnect.md/protocol'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../cp/gitcred-server.js'
 
 /**
@@ -54,7 +55,9 @@ import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../cp/gitcred-server.
 const UNSAFE_OPTS = {
   unsafe: {
     allowUnsafeCredentialHelper: true, // the daemon-built credential.https://github.com.helper pairs
-    allowUnsafeConfigEnvCount: true // the daemon-built GIT_CONFIG_COUNT/KEY_n/VALUE_n channel
+    allowUnsafeConfigEnvCount: true, // the daemon-built GIT_CONFIG_COUNT/KEY_n/VALUE_n channel
+    allowUnsafeConfigPaths: true, // the daemon-selected empty global/system config view
+    allowUnsafeSshCommand: true // the daemon-built ssh command that ignores user routing config
   }
 } as const
 
@@ -132,16 +135,125 @@ export function gitEnvBase(): Record<string, string> {
   return env
 }
 
-/** Workspace clone/pull policy. Keep this separate from `gitEnvBase`: skill
- * installation intentionally supports a broader set of operator-chosen sources. */
-export function workspaceGitEnvBase(): Record<string, string> {
+const WORKSPACE_GIT_PROXY_ENV = /^(?:all|ftp|http|https|no)_proxy$/i
+const EMPTY_GIT_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null'
+const WORKSPACE_SSH_COMMAND =
+  'ssh -F none -o ProxyCommand=none -o ProxyJump=none -o PermitLocalCommand=no -o ClearAllForwardings=yes'
+const UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG =
+  /^(?:url\..*\.insteadof|include(?:if\..*)?\.path|http(?:\..*)?\.(?:proxy|curloptresolve)|remote\..*\.proxy|core\.sshcommand|fetch\.bundleuri)$/i
+const WORKSPACE_GIT_CONTROLLED_ENV = new Set([
+  'GIT_ALLOW_PROTOCOL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_LFS_SKIP_SMUDGE',
+  'GIT_NO_LAZY_FETCH',
+  'GIT_SSH_VARIANT',
+  'GIT_TERMINAL_PROMPT'
+])
+
+function workspaceGitProcessEnv(): Record<string, string> {
   const env = gitEnvBase()
   for (const key of Object.keys(env)) {
-    if (key.toUpperCase() === 'GIT_ALLOW_PROTOCOL') delete env[key]
+    if (WORKSPACE_GIT_PROXY_ENV.test(key) || WORKSPACE_GIT_CONTROLLED_ENV.has(key.toUpperCase())) delete env[key]
   }
+  // Daemon-managed workspace Git must not inherit user-writable routing rules
+  // from ~/.gitconfig or system config. Local checkout config is audited
+  // separately before an existing workspace performs network I/O.
+  env.GIT_CONFIG_NOSYSTEM = '1'
+  env.GIT_CONFIG_GLOBAL = EMPTY_GIT_CONFIG
+  env.GIT_LFS_SKIP_SMUDGE = '1'
+  env.GIT_NO_LAZY_FETCH = '1'
+  return env
+}
+
+function workspaceGitConfigPairs(repository?: string): ReadonlyArray<readonly [string, string]> {
+  const pairs: Array<readonly [string, string]> = [
+    ['http.followRedirects', 'false'],
+    // Disable checkout- or server-selected secondary download locations.
+    ['fetch.bundleURI', ''],
+    ['transfer.bundleURI', 'false'],
+    ['fetch.uriProtocols', '']
+  ]
+  if (!repository) return pairs
+  const normalized = normalizeGitCloneUrl(repository)
+  // Pin the complete URL against broader url.*.insteadOf rules. Existing
+  // checkout config is also audited because Git keeps the earlier value when
+  // an untrusted rule has the same match length.
+  pairs.push([`url.${normalized}.insteadOf`, normalized])
+  if (normalized.toLowerCase().startsWith('https://')) {
+    // URL-specific values outrank generic http.* values. Disable redirects,
+    // proxies, and libcurl's host-to-address override for the explicit target.
+    pairs.push([`http.${normalized}.followRedirects`, 'false'])
+    pairs.push([`http.${normalized}.proxy`, ''])
+    pairs.push([`http.${normalized}.curloptResolve`, ''])
+  } else {
+    // Ignore ~/.ssh/config and checkout-controlled core.sshCommand routing.
+    pairs.push(['core.sshCommand', WORKSPACE_SSH_COMMAND])
+    pairs.push(['ssh.variant', 'ssh'])
+  }
+  return pairs
+}
+
+function gitConfigEnv(pairs: ReadonlyArray<readonly [string, string]>): Record<string, string> {
+  const env: Record<string, string> = { GIT_CONFIG_COUNT: String(pairs.length) }
+  pairs.forEach(([key, value], index) => {
+    env[`GIT_CONFIG_KEY_${index}`] = key
+    env[`GIT_CONFIG_VALUE_${index}`] = value
+  })
+  return env
+}
+
+/** Workspace clone/pull policy. Keep this separate from `gitEnvBase`: skill
+ * installation intentionally supports a broader set of operator-chosen sources. */
+export function workspaceGitEnvBase(repository?: string): Record<string, string> {
+  const env = workspaceGitProcessEnv()
   // Git applies this allowlist after url.*.insteadOf rewriting.
   env.GIT_ALLOW_PROTOCOL = 'https:ssh'
-  return env
+  // Do not let an otherwise allowed HTTPS origin redirect daemon egress to a
+  // second, unvalidated origin.
+  return { ...env, ...gitConfigEnv(workspaceGitConfigPairs(repository)) }
+}
+
+/**
+ * Bind a validated pull URL to an unguessable daemon-owned remote name.
+ * Git otherwise resolves a URL-shaped argument as a checkout-defined remote
+ * name first, which could replace the authorized target through remote.*.url.
+ */
+export function workspaceGitPullTarget(repository: string): {
+  remote: string
+  env: Record<string, string>
+} {
+  const normalized = normalizeGitCloneUrl(repository)
+  const remote = `agentconnect-${randomUUID()}`
+  const pairs = [
+    ...workspaceGitConfigPairs(normalized),
+    // An empty value clears lower-priority URL lists before the daemon target.
+    [`remote.${remote}.url`, ''] as const,
+    [`remote.${remote}.url`, normalized] as const,
+    [`remote.${remote}.proxy`, ''] as const
+  ]
+  const env = workspaceGitProcessEnv()
+  env.GIT_ALLOW_PROTOCOL = 'https:ssh'
+  return { remote, env: { ...env, ...gitConfigEnv(pairs) } }
+}
+
+/** Environment for workspace Git operations that must never contact a remote. */
+export function workspaceGitLocalEnv(): Record<string, string> {
+  return { ...workspaceGitProcessEnv(), GIT_ALLOW_PROTOCOL: '' }
+}
+
+/**
+ * Reject checkout-owned routing includes and URL rewrites before a daemon-run
+ * pull. Git has no switch that disables only repository config, so inspect the
+ * local/worktree keys with includes disabled, while global/system config is
+ * already excluded by the environment above.
+ */
+export async function assertSafeWorkspaceGitConfig(cwd: string): Promise<void> {
+  const names = await gitFor(cwd)
+    .env(workspaceGitLocalEnv())
+    .raw(['config', '--no-includes', '--name-only', '-z', '--list'])
+  if (names.split('\0').some((name) => UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG.test(name))) {
+    throw new Error('workspace Git configuration contains a disallowed network override')
+  }
 }
 
 /**
@@ -151,10 +263,10 @@ export function workspaceGitEnvBase(): Record<string, string> {
  * origin/<branch> current for status. check-ref-format prevents a configured
  * branch from being interpreted as an option or refspec.
  */
-export async function pullWorkspaceRef(git: SimpleGit, repository: string, branch: string) {
+export async function pullWorkspaceRef(git: SimpleGit, remote: string, branch: string) {
   await git.raw(['check-ref-format', '--branch', branch])
   const refspec = `+refs/heads/${branch}:refs/remotes/origin/${branch}`
-  return git.pull(repository, refspec, ['--ff-only'])
+  return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])
 }
 
 /** Module-level init (workspace-manager is functional; mirrors cloneInFlight). */
@@ -192,7 +304,7 @@ function quotedHelper(agentId: string): string {
 }
 
 /** The three github.com-scoped config pairs both channels share. */
-function configPairs(agentId: string): Array<[string, string]> {
+function credentialConfigPairs(agentId: string): Array<[string, string]> {
   return [
     ['credential.https://github.com.helper', ''], // reset: machine helpers must never answer for github.com
     ['credential.https://github.com.helper', quotedHelper(agentId)],
@@ -205,17 +317,13 @@ function configPairs(agentId: string): Array<[string, string]> {
  * Spread over `process.env` by the caller: simple-git's `.env()` REPLACES the
  * child environment (v3.36 verified), a bare object would strip PATH/HOME.
  */
-export function cloneGitEnv(agentId: string): Record<string, string> {
-  const pairs = configPairs(agentId)
+export function cloneGitEnv(agentId: string, repository?: string): Record<string, string> {
+  const pairs = [...workspaceGitConfigPairs(repository), ...credentialConfigPairs(agentId)]
   const env: Record<string, string> = {
     ...gitCredentialEnv(agentId),
     GIT_TERMINAL_PROMPT: '0',
-    GIT_CONFIG_COUNT: String(pairs.length)
+    ...gitConfigEnv(pairs)
   }
-  pairs.forEach(([k, v], i) => {
-    env[`GIT_CONFIG_KEY_${i}`] = k
-    env[`GIT_CONFIG_VALUE_${i}`] = v
-  })
   return env
 }
 
@@ -258,7 +366,7 @@ export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentit
 
 /** Post-clone: pin the repo-local helper so agent-run git in the checkout works. */
 export async function writeRepoHelperConfig(cwd: string, agentId: string): Promise<void> {
-  const git = gitFor(cwd).env(workspaceGitEnvBase())
+  const git = gitFor(cwd).env(workspaceGitLocalEnv())
   // `--replace-all` on the first write resets any stale helper list from a
   // previous agent generation; addConfig(append=true) accumulates the rest.
   await git.raw(['config', '--replace-all', 'credential.https://github.com.helper', ''])

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -1,0 +1,18 @@
+import {
+  DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  normalizeAllowedWorkspaceGitUrl,
+  normalizeWorkspaceGitOrigin
+} from '@agentconnect.md/protocol'
+
+// One daemon runs per process. Keep the operator-owned policy beside the
+// functional workspace helpers, like git-injection's process-local state.
+let allowedOrigins: readonly string[] = DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS
+
+export function configureWorkspaceGitOrigins(origins: readonly string[]): void {
+  allowedOrigins = origins.map(normalizeWorkspaceGitOrigin)
+}
+
+/** Final daemon boundary for every tenant-selected workspace network target. */
+export function authorizeWorkspaceGitUrl(input: string): string {
+  return normalizeAllowedWorkspaceGitUrl(input, allowedOrigins)
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -22,6 +22,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import { makeLogger } from '../log.js'
 import { installSkills } from '../skills/install-skills.js'
 import {
+  assertSafeWorkspaceGitConfig,
   cloneGitEnv,
   gitCredentialEnv,
   gitEnvBase,
@@ -29,8 +30,11 @@ import {
   preWarmGitCred,
   pullWorkspaceRef,
   workspaceGitEnvBase,
+  workspaceGitLocalEnv,
+  workspaceGitPullTarget,
   writeRepoHelperConfig
 } from './git-injection.js'
+import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 
 const skillsLog = makeLogger('info')
 
@@ -69,9 +73,9 @@ function gitRepoOf(agent: Agent): string {
   if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
     throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
   }
-  return usesGithubApp(agent)
-    ? normalizeGithubRepoUrl(agent.workspace.gitRepo)
-    : normalizeGitCloneUrl(agent.workspace.gitRepo)
+  return authorizeWorkspaceGitUrl(
+    usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
+  )
 }
 
 class UntrustedGithubWorkspaceOriginError extends Error {
@@ -99,7 +103,7 @@ async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path)
   if (clone) await clone
   if (!existsSync(join(cwd, '.git'))) return
   const expected = gitRepoOf(agent)
-  const git = gitFor(cwd).env(workspaceGitEnvBase())
+  const git = gitFor(cwd).env(workspaceGitLocalEnv())
   let current: string
   try {
     current = (await git.raw(['remote', 'get-url', 'origin'])).trim()
@@ -113,7 +117,7 @@ async function convergeWorkspaceOrigin(agent: Agent, cwd = agent.workspace.path)
   const normalizedCurrent = normalizeGitUrl(current)
   let unsafeCurrent = redactGitUrlSecrets(current) !== normalizedCurrent
   try {
-    normalizeGitCloneUrl(current)
+    authorizeWorkspaceGitUrl(current)
     if (!/^(?:https|ssh):\/\//i.test(current) && !/^[\w.-]+@[\w.-]+:/.test(current)) unsafeCurrent = true
   } catch {
     unsafeCurrent = true
@@ -266,12 +270,15 @@ export async function prepareWorkspace(agent: Agent): Promise<string> {
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
     try {
+      const repository = gitRepoOf(agent)
+      await assertSafeWorkspaceGitConfig(cwd)
+      const pullTarget = workspaceGitPullTarget(repository)
       const git = gitFor(cwd, abort.signal).env({
-        ...workspaceGitEnvBase(),
+        ...pullTarget.env,
         ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
         GIT_TERMINAL_PROMPT: '0'
       })
-      await pullWorkspaceRef(git, gitRepoOf(agent), agent.workspace.gitBranch)
+      await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
     } catch {
       // offline / timed out / non-fast-forward: proceed with the on-disk checkout
     } finally {
@@ -494,8 +501,8 @@ async function cloneRepoAt(agent: Agent, cwd: string): Promise<void> {
     // yet). SPREAD over process.env — simple-git's .env() REPLACES the child env.
     if (githubApp) await preWarmGitCred(agent.id, 'clone')
     const git = githubApp
-      ? gitFor().env({ ...workspaceGitEnvBase(), ...cloneGitEnv(agent.id) })
-      : gitFor().env({ ...workspaceGitEnvBase(), GIT_TERMINAL_PROMPT: '0' })
+      ? gitFor().env({ ...workspaceGitEnvBase(gitRepo), ...cloneGitEnv(agent.id, gitRepo) })
+      : gitFor().env({ ...workspaceGitEnvBase(gitRepo), GIT_TERMINAL_PROMPT: '0' })
     try {
       await git.clone(gitRepo, cwd, ['--branch', branch, '--single-branch'])
     } catch (e) {

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -23,6 +23,7 @@ describe('loadConfig', () => {
     expect(cfg.version).toBe(1)
     expect(cfg.runtimes.claude.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
+    expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['https://github.com', 'ssh://github.com'])
     expect(cfg.limits.maxAgents).toBeGreaterThan(0) // default applied
     expect(cfg.agentsDir).toContain('agents')
   })
@@ -86,6 +87,30 @@ describe('loadConfig', () => {
   it('allows the daemon to opt out of account-app isolation explicitly', () => {
     const root = tmpRoot({ version: 1, security: { isolateAccountApps: false } })
     expect(loadConfig({ root }).security.isolateAccountApps).toBe(false)
+  })
+
+  it('normalizes an operator-owned workspace Git origin allowlist', () => {
+    const root = tmpRoot({
+      version: 1,
+      security: {
+        workspaceGitAllowedOrigins: ['HTTPS://Git.Example.:443/', 'ssh://git.example:2222']
+      }
+    })
+    expect(loadConfig({ root }).security.workspaceGitAllowedOrigins).toEqual([
+      'https://git.example',
+      'ssh://git.example:2222'
+    ])
+  })
+
+  it('allows remote Git to be disabled and rejects path-scoped origin rules', () => {
+    expect(
+      loadConfig({ root: tmpRoot({ version: 1, security: { workspaceGitAllowedOrigins: [] } }) }).security
+    ).toMatchObject({ workspaceGitAllowedOrigins: [] })
+    const root = tmpRoot({
+      version: 1,
+      security: { workspaceGitAllowedOrigins: ['https://git.example/acme'] }
+    })
+    expect(() => loadConfig({ root })).toThrow(/workspace Git origins/)
   })
 
   it('passing --cp-url/--cp-key enables the control plane (defaults off)', () => {

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -284,7 +284,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
         workspace: {
           mode: 'git-repo',
           path: workspace,
-          gitRepo: 'https://example.com/acme/repo.git',
+          gitRepo: 'https://github.com/acme/repo.git',
           gitBranch: 'main'
         },
         integrations: [],
@@ -316,7 +316,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
           runtime: 'claude',
           workspace: {
             mode: 'github',
-            gitRepo: 'https://example.com/acme/repo.git',
+            gitRepo: 'https://github.com/acme/repo.git',
             branch: 'main'
           }
         },

--- a/packages/daemon/test/cp/cp-agent-registry.test.ts
+++ b/packages/daemon/test/cp/cp-agent-registry.test.ts
@@ -185,6 +185,20 @@ describe('CpAgentRegistry (filesystem-backed)', () => {
     expect(ws.path).toBe('./keep-me') // never overwritten on update
   })
 
+  it('persists a valid custom origin for daemon-local authorization at execution time', () => {
+    const dir = agentsDir()
+    const { reg } = makeReg(dir)
+
+    reg.upsert(
+      A1,
+      spec({
+        workspace: { mode: 'github', gitRepo: 'https://git.example/acme/repo.git', branch: 'main' }
+      })
+    )
+
+    expect((readAgent(dir, 'helper').workspace as any).gitRepo).toBe('https://git.example/acme/repo.git')
+  })
+
   it('upsert MERGES by internal id into a custom-named dir (dir name != id), not a duplicate at <dir>/<id>', () => {
     const dir = agentsDir()
     // hand-authored agent: id A1 but living under a differently-named folder

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -2,11 +2,11 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { pathToFileURL } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { simpleGit } from 'simple-git'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
 import {
+  assertSafeWorkspaceGitConfig,
   cloneGitEnv,
   gitEnvBase,
   gitFor,
@@ -14,7 +14,9 @@ import {
   parseGitVersion,
   pullWorkspaceRef,
   sessionGitEnv,
-  workspaceGitEnvBase
+  workspaceGitEnvBase,
+  workspaceGitLocalEnv,
+  workspaceGitPullTarget
 } from '../src/workspace/git-injection.js'
 
 // simple-git ≥3.36 refuses a NAME blocklist of env vars (presence-based, value
@@ -49,6 +51,13 @@ const POLLUTED = {
   GIT_CONFIG_KEY_0: 'core.editor',
   GIT_CONFIG_VALUE_0: 'vim'
 } as const
+
+function configPairs(env: Record<string, string>): Array<[string | undefined, string | undefined]> {
+  return Array.from({ length: Number(env.GIT_CONFIG_COUNT ?? 0) }, (_, index) => [
+    env[`GIT_CONFIG_KEY_${index}`],
+    env[`GIT_CONFIG_VALUE_${index}`]
+  ])
+}
 
 let tmpRun: string
 const saved = new Map<string, string | undefined>()
@@ -86,6 +95,43 @@ describe('gitEnvBase', () => {
   it('limits workspace git without narrowing skill-source git', () => {
     expect(gitEnvBase().GIT_ALLOW_PROTOCOL).toBe(POLLUTED.GIT_ALLOW_PROTOCOL)
     expect(workspaceGitEnvBase().GIT_ALLOW_PROTOCOL).toBe('https:ssh')
+    expect(workspaceGitLocalEnv().GIT_ALLOW_PROTOCOL).toBe('')
+    expect(workspaceGitEnvBase()).toMatchObject({
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_LFS_SKIP_SMUDGE: '1',
+      GIT_NO_LAZY_FETCH: '1'
+    })
+    expect(workspaceGitEnvBase().GIT_CONFIG_GLOBAL).toBe(process.platform === 'win32' ? 'NUL' : '/dev/null')
+    expect(Object.keys(workspaceGitEnvBase()).some((key) => /^(?:all|ftp|http|https|no)_proxy$/i.test(key))).toBe(false)
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['http.followRedirects', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.bundleURI', ''])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['transfer.bundleURI', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.uriProtocols', ''])
+  })
+
+  it('removes differently-cased inherited values before setting workspace policy', () => {
+    const inherited = {
+      git_allow_protocol: 'file:ext:https:ssh',
+      git_lfs_skip_smudge: '0',
+      git_no_lazy_fetch: '0',
+      git_terminal_prompt: '1'
+    }
+    const previous = new Map(Object.keys(inherited).map((key) => [key, process.env[key]]))
+    Object.assign(process.env, inherited)
+    try {
+      const env = workspaceGitEnvBase()
+      for (const key of Object.keys(inherited)) expect(env).not.toHaveProperty(key)
+      expect(env).toMatchObject({
+        GIT_ALLOW_PROTOCOL: 'https:ssh',
+        GIT_LFS_SKIP_SMUDGE: '1',
+        GIT_NO_LAZY_FETCH: '1'
+      })
+    } finally {
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
   })
 
   it('keeps an explicit checkout bound when the host exports GIT_COMMON_DIR', async () => {
@@ -118,6 +164,88 @@ describe('gitEnvBase', () => {
     }
   })
 
+  it('keeps redirects disabled when repo-local URL config tries to re-enable them', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-redirect-policy-test-'))
+    const repository = 'https://github.com/acme/repo.git'
+    try {
+      const cleanEnv = workspaceGitEnvBase()
+      execFileSync('git', ['init', workspace], { env: cleanEnv, stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', `http.${repository}.followRedirects`, 'true'], {
+        env: cleanEnv
+      })
+      expect(
+        execFileSync('git', ['-C', workspace, 'config', '--get-urlmatch', 'http.followRedirects', repository], {
+          encoding: 'utf8',
+          env: workspaceGitEnvBase(repository)
+        }).trim()
+      ).toBe('false')
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('pins a full target against broader URL rewrites and rejects checkout-owned rewrites', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-url-policy-test-'))
+    const repository = 'https://github.com/acme/repo.git'
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      execFileSync(
+        'git',
+        ['-C', workspace, 'config', 'url.https://127.0.0.1.invalid/redirected/.insteadOf', 'https://github.com/'],
+        { env: localEnv }
+      )
+      expect(
+        execFileSync('git', ['-C', workspace, 'ls-remote', '--get-url', repository], {
+          encoding: 'utf8',
+          env: workspaceGitEnvBase(repository)
+        }).trim()
+      ).toBe(repository)
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('uses a daemon-owned remote name instead of a URL-shaped checkout remote', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-remote-policy-test-'))
+    const repository = 'https://github.com/acme/repo.git'
+    const redirected = 'https://127.0.0.1/private.git'
+    try {
+      execFileSync('git', ['init', workspace], { env: workspaceGitLocalEnv(), stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', `remote.${repository}.url`, redirected], {
+        env: workspaceGitLocalEnv()
+      })
+
+      const target = workspaceGitPullTarget(repository)
+      expect(target.remote).toMatch(/^agentconnect-[0-9a-f-]+$/)
+      expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.url`, ''])
+      expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.url`, repository])
+      expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.proxy`, ''])
+      expect(
+        execFileSync('git', ['-C', workspace, 'ls-remote', '--get-url', target.remote], {
+          encoding: 'utf8',
+          env: target.env
+        }).trim()
+      ).toBe(repository)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a checkout-owned incremental bundle URI before pull', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-bundle-policy-test-'))
+    try {
+      execFileSync('git', ['init', workspace], { env: workspaceGitLocalEnv(), stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', 'fetch.bundleURI', 'https://127.0.0.1/private.bundle'], {
+        env: workspaceGitLocalEnv()
+      })
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
   it('updates the origin tracking ref when an explicit URL pull advances HEAD', async () => {
     const root = mkdtempSync(join(tmpdir(), 'git-pull-refspec-test-'))
     const remote = join(root, 'remote.git')
@@ -139,7 +267,7 @@ describe('gitEnvBase', () => {
       run(['-C', seed, 'push', 'origin', 'main'])
 
       const git = gitFor(workspace).env(env)
-      await pullWorkspaceRef(git, pathToFileURL(remote).href, 'main')
+      await pullWorkspaceRef(git, 'origin', 'main')
 
       const [head, tracking, status] = await Promise.all([
         git.raw(['rev-parse', 'HEAD']),
@@ -180,6 +308,28 @@ describe('cloneGitEnv', () => {
   it('mints the env identity as a pair with the capability (helper outranks config-embedded ids)', () => {
     expect(cloneGitEnv('agent-1')[GITCRED_AGENT_ENV]).toBe('agent-1')
     expect(sessionGitEnv('agent-1')[GITCRED_AGENT_ENV]).toBe('agent-1')
+  })
+
+  it('keeps the redirect guard alongside GitHub App credential config', () => {
+    const pairs = configPairs(cloneGitEnv('agent-1', 'https://github.com/acme/repo.git'))
+    expect(pairs).toContainEqual(['http.followRedirects', 'false'])
+    expect(pairs).toContainEqual(['url.https://github.com/acme/repo.git.insteadOf', 'https://github.com/acme/repo.git'])
+    expect(pairs).toContainEqual(['http.https://github.com/acme/repo.git.followRedirects', 'false'])
+    expect(pairs).toContainEqual(['http.https://github.com/acme/repo.git.proxy', ''])
+    expect(pairs).toContainEqual(['http.https://github.com/acme/repo.git.curloptResolve', ''])
+    expect(pairs).toContainEqual(['credential.https://github.com.useHttpPath', 'true'])
+  })
+
+  it('pins SSH routing to the explicit URL instead of user SSH config', () => {
+    const pairs = configPairs(workspaceGitEnvBase('ssh://git@github.com/acme/repo.git'))
+    expect(pairs).toContainEqual([
+      'url.ssh://git@github.com/acme/repo.git.insteadOf',
+      'ssh://git@github.com/acme/repo.git'
+    ])
+    expect(pairs).toContainEqual([
+      'core.sshCommand',
+      'ssh -F none -o ProxyCommand=none -o ProxyJump=none -o PermitLocalCommand=no -o ClearAllForwardings=yes'
+    ])
   })
 })
 
@@ -224,7 +374,15 @@ describe('simple-git unsafe checker', () => {
   it('passes the plain-mode env (sanitized host env + prompt guard)', async () => {
     await expect(
       gitFor()
-        .env({ ...gitEnvBase(), GIT_TERMINAL_PROMPT: '0' })
+        .env({ ...workspaceGitEnvBase(), GIT_TERMINAL_PROMPT: '0' })
+        .raw(['version'])
+    ).resolves.toContain('git version')
+  })
+
+  it('passes the isolated SSH workspace env', async () => {
+    await expect(
+      gitFor()
+        .env({ ...workspaceGitEnvBase('ssh://git@github.com/acme/repo.git'), GIT_TERMINAL_PROMPT: '0' })
         .raw(['version'])
     ).resolves.toContain('git version')
   })

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
+import { authorizeWorkspaceGitUrl, configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
+
+afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS))
+
+describe('workspace Git origin policy', () => {
+  it('denies an unconfigured host at the daemon boundary', () => {
+    expect(() => authorizeWorkspaceGitUrl('https://gitlab.com/acme/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+  })
+
+  it('treats an explicit empty policy as deny-all', () => {
+    configureWorkspaceGitOrigins([])
+    expect(() => authorizeWorkspaceGitUrl('https://github.com/acme/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+  })
+
+  it('allows an exact operator-configured origin without widening its port', () => {
+    configureWorkspaceGitOrigins(['https://git.example:8443'])
+
+    expect(authorizeWorkspaceGitUrl('https://git.example:8443/acme/repo.git')).toBe(
+      'https://git.example:8443/acme/repo.git'
+    )
+    expect(() => authorizeWorkspaceGitUrl('https://git.example/acme/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+  })
+})

--- a/packages/daemon/test/run-foreground.test.ts
+++ b/packages/daemon/test/run-foreground.test.ts
@@ -9,9 +9,12 @@ describe('runForeground', () => {
     let handler: (() => void) | undefined
 
     const p = runForeground(
-      {},
+      { configPath: '/operator/config.json' },
       {
-        createDaemon: () => ({ start, stop }),
+        createDaemon: (opts) => {
+          expect(opts.configPath).toBe('/operator/config.json')
+          return { start, stop }
+        },
         onSignal: (h) => {
           handler = h
         },

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -36,11 +36,17 @@ function ws(repo: boolean): string {
   return dir
 }
 
+const githubTarget = () => ({
+  repo: 'https://github.com/acme/repo.git',
+  branch: 'main',
+  githubApp: false
+})
+
 beforeEach(() => {
   statusImpl = vi.fn()
   pullImpl = vi.fn()
   envImpl = vi.fn()
-  rawImpl = vi.fn().mockResolvedValue('https://example.com/acme/repo.git\n')
+  rawImpl = vi.fn().mockResolvedValue('https://github.com/acme/repo.git\n')
   // Default: empty repo (no commits) ⇒ git log errors ⇒ lastCommit omitted.
   logImpl = vi.fn().mockRejectedValue(new Error('does not have any commits yet'))
 })
@@ -67,7 +73,7 @@ describe('createWorkspaceGit.status', () => {
     const s = await git.status('a')
     expect(s).toMatchObject({ agentId: 'a', isRepo: true, clean: true, branch: 'main', tracking: 'origin/main' })
     expect(s.files).toBeUndefined()
-    expect(envImpl).toHaveBeenCalledWith(expect.objectContaining({ GIT_ALLOW_PROTOCOL: 'https:ssh' }))
+    expect(envImpl).toHaveBeenCalledWith(expect.objectContaining({ GIT_ALLOW_PROTOCOL: '' }))
   })
 
   it('maps a dirty checkout: clean:false + changed files (index/workingDir chars)', async () => {
@@ -163,13 +169,14 @@ describe('createWorkspaceGit.pull', () => {
     pullImpl = vi.fn().mockResolvedValue({ files: ['a.ts', 'b.ts'], summary: { insertions: 10, deletions: 3 } })
     const git = createWorkspaceGit(
       () => dir,
-      () => ({ AC_GITCRED_CAPABILITY: 'cap-a' })
+      () => ({ AC_GITCRED_CAPABILITY: 'cap-a' }),
+      githubTarget
     )
     const r = await git.pull('a')
     expect(pullImpl).toHaveBeenCalledWith(
-      'https://example.com/acme/repo.git',
-      '+refs/heads/HEAD:refs/remotes/origin/HEAD',
-      ['--ff-only']
+      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
+      '+refs/heads/main:refs/remotes/origin/main',
+      ['--ff-only', '--no-recurse-submodules']
     )
     expect(envImpl).toHaveBeenCalledWith(
       expect.objectContaining({ AC_GITCRED_CAPABILITY: 'cap-a', GIT_ALLOW_PROTOCOL: 'https:ssh' })
@@ -186,13 +193,21 @@ describe('createWorkspaceGit.pull', () => {
       expect(envImpl).toHaveBeenCalled()
       const firstEnv = (envImpl as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, string>
       expect(firstEnv).not.toHaveProperty('GIT_DIR')
-      expect(firstEnv.GIT_ALLOW_PROTOCOL).toBe('https:ssh')
-      return 'https://example.com/acme/repo.git\n'
+      expect(firstEnv.GIT_ALLOW_PROTOCOL).toBe('')
+      return 'https://github.com/acme/repo.git\n'
     })
     pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
 
     try {
-      await expect(createWorkspaceGit(() => dir).pull('a')).resolves.toMatchObject({ ok: true })
+      await expect(
+        createWorkspaceGit(
+          () => dir,
+          () => ({}),
+          githubTarget
+        ).pull('a')
+      ).resolves.toMatchObject({
+        ok: true
+      })
     } finally {
       if (previousGitDir === undefined) delete process.env.GIT_DIR
       else process.env.GIT_DIR = previousGitDir
@@ -202,7 +217,11 @@ describe('createWorkspaceGit.pull', () => {
   it('reports "Already up to date." when nothing changed', async () => {
     const dir = ws(true)
     pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      githubTarget
+    )
     const r = await git.pull('a')
     expect(r.ok).toBe(true)
     expect(r.detail).toBe('Already up to date.')
@@ -211,7 +230,11 @@ describe('createWorkspaceGit.pull', () => {
   it('refuses an unsafe origin without running pull or echoing its secrets', async () => {
     const dir = ws(true)
     rawImpl = vi.fn().mockResolvedValue('https://legacy-user:super-secret@invalid.invalid/repo?token=query-secret\n')
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      githubTarget
+    )
 
     const result = await git.pull('a')
 
@@ -228,7 +251,7 @@ describe('createWorkspaceGit.pull', () => {
 
   it('refuses a safe but mismatched origin for an App-backed workspace', async () => {
     const dir = ws(true)
-    rawImpl = vi.fn().mockResolvedValue('https://other-host.example/acme/repo.git\n')
+    rawImpl = vi.fn().mockResolvedValue('git@github.com:acme/repo.git\n')
     const git = createWorkspaceGit(
       () => dir,
       () => ({}),
@@ -239,6 +262,41 @@ describe('createWorkspaceGit.pull', () => {
       isRepo: true,
       ok: false,
       detail: 'workspace origin is not a safe remote'
+    })
+    expect(pullImpl).not.toHaveBeenCalled()
+  })
+
+  it('refuses to pull without the configured workspace target', async () => {
+    const dir = ws(true)
+    const git = createWorkspaceGit(() => dir)
+
+    expect(await git.pull('a')).toMatchObject({
+      isRepo: true,
+      ok: false,
+      detail: 'workspace origin is not a safe remote'
+    })
+    expect(pullImpl).not.toHaveBeenCalled()
+  })
+
+  it('refuses checkout-owned URL rewrites before pull', async () => {
+    const dir = ws(true)
+    rawImpl = vi
+      .fn()
+      .mockImplementation(async (args: string[]) =>
+        args[0] === 'remote'
+          ? 'https://github.com/acme/repo.git\n'
+          : 'url.https://127.0.0.1.invalid/redirected/.insteadof\0'
+      )
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      githubTarget
+    )
+
+    expect(await git.pull('a')).toMatchObject({
+      isRepo: true,
+      ok: false,
+      detail: 'workspace Git configuration contains a disallowed network override'
     })
     expect(pullImpl).not.toHaveBeenCalled()
   })
@@ -258,16 +316,25 @@ describe('createWorkspaceGit.pull', () => {
     await expect(git.pull('a')).resolves.toMatchObject({ ok: true })
 
     expect(pullImpl).toHaveBeenCalledWith(
-      'https://github.com/acme/repo.git',
+      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
       '+refs/heads/release/v2:refs/remotes/origin/release/v2',
-      ['--ff-only']
+      ['--ff-only', '--no-recurse-submodules']
     )
+    expect(
+      (envImpl as ReturnType<typeof vi.fn>).mock.calls.some((call) =>
+        Object.values(call[0] as Record<string, string>).includes('https://github.com/acme/repo.git')
+      )
+    ).toBe(true)
   })
 
   it('surfaces a failed pull as ok:false and scrubs the host path out of the detail', async () => {
     const dir = ws(true)
     pullImpl = vi.fn().mockRejectedValue(new Error(`cannot fast-forward in ${dir}/x`))
-    const git = createWorkspaceGit(() => dir)
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      githubTarget
+    )
     const r = await git.pull('a')
     expect(r.ok).toBe(false)
     expect(r.detail).not.toContain(dir) // absolute host path must not leak

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -72,7 +72,7 @@ function gitRepoAgent(path: string, agentDir?: string): Agent {
     workspace: {
       mode: 'git-repo',
       path,
-      gitRepo: 'https://example.com/repo.git',
+      gitRepo: 'https://github.com/acme/repo.git',
       gitBranch: 'main',
       ...(agentDir !== undefined ? { agentDir } : {}),
       pullOnNewSession: true,
@@ -122,7 +122,7 @@ describe('prepareWorkspace', () => {
     const cwd = await prepareWorkspace(gitRepoAgent(path))
     expect(cwd).toBe(realpathSync(path))
     expect(cloneImpl).toHaveBeenCalledTimes(1)
-    expect(cloneImpl).toHaveBeenCalledWith('https://example.com/repo.git', path, [
+    expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', path, [
       '--branch',
       'main',
       '--single-branch'
@@ -134,26 +134,27 @@ describe('prepareWorkspace', () => {
   it('keeps ssh clone targets working', async () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     const agent = gitRepoAgent(path)
-    agent.workspace.gitRepo = 'ssh://git@example.com/acme/repo.git'
+    agent.workspace.gitRepo = 'ssh://git@github.com/acme/repo.git'
 
     await prepareWorkspace(agent)
 
-    expect(cloneImpl).toHaveBeenCalledWith('ssh://git@example.com/acme/repo.git', path, [
+    expect(cloneImpl).toHaveBeenCalledWith('ssh://git@github.com/acme/repo.git', path, [
       '--branch',
       'main',
       '--single-branch'
     ])
   })
 
-  it('rejects a hand-edited unsafe target before clone or pull', async () => {
-    const fresh = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'fresh')
-    const existing = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'existing')
-    mkdirSync(join(existing, '.git'), { recursive: true })
-
-    for (const path of [fresh, existing]) {
-      const agent = gitRepoAgent(path)
-      agent.workspace.gitRepo = 'file:///var/lib/agentconnect/other-workspace'
-      await expect(prepareWorkspace(agent)).rejects.toThrow()
+  it('rejects a hand-edited transport or unconfigured origin before clone or pull', async () => {
+    for (const gitRepo of ['file:///var/lib/agentconnect/other-workspace', 'https://git.example/acme/repo.git']) {
+      const fresh = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'fresh')
+      const existing = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'existing')
+      mkdirSync(join(existing, '.git'), { recursive: true })
+      for (const path of [fresh, existing]) {
+        const agent = gitRepoAgent(path)
+        agent.workspace.gitRepo = gitRepo
+        await expect(prepareWorkspace(agent)).rejects.toThrow()
+      }
     }
 
     expect(cloneImpl).not.toHaveBeenCalled()
@@ -188,9 +189,12 @@ describe('prepareWorkspace', () => {
     mkdirSync(join(dir, '.git'), { recursive: true })
     await prepareWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
-    expect(pullMock).toHaveBeenCalledWith('https://example.com/repo.git', '+refs/heads/main:refs/remotes/origin/main', [
-      '--ff-only'
-    ])
+    expect(pullMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
+      '+refs/heads/main:refs/remotes/origin/main',
+      ['--ff-only', '--no-recurse-submodules']
+    )
+    expect(Object.values(lastGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
 
   it('ignores a checkout-controlled upstream when pulling an existing workspace', async () => {
@@ -205,10 +209,11 @@ describe('prepareWorkspace', () => {
     await prepareWorkspace(agent)
 
     expect(pullMock).toHaveBeenCalledWith(
-      'https://example.com/repo.git',
+      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
       '+refs/heads/release/v2:refs/remotes/origin/release/v2',
-      ['--ff-only']
+      ['--ff-only', '--no-recurse-submodules']
     )
+    expect(Object.values(lastGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
 
   it('returns the canonical configured repository subdirectory', async () => {
@@ -265,7 +270,7 @@ describe('prefetchWorkspace (reconcile-time eager clone)', () => {
     const path = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     await prefetchWorkspace(gitRepoAgent(path))
     expect(cloneImpl).toHaveBeenCalledTimes(1)
-    expect(cloneImpl).toHaveBeenCalledWith('https://example.com/repo.git', path, [
+    expect(cloneImpl).toHaveBeenCalledWith('https://github.com/acme/repo.git', path, [
       '--branch',
       'main',
       '--single-branch'
@@ -472,7 +477,7 @@ describe('prepareWorkspaceForActivation', () => {
     })
     const target = {
       ...current,
-      workspace: { ...current.workspace, gitRepo: 'https://example.com/another.git', gitBranch: 'next' }
+      workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/another.git', gitBranch: 'next' }
     } as Agent
     // A crash can leave the target spec on disk before materialization. The next
     // detach must not overwrite the source marker merely because it sees that spec.
@@ -545,7 +550,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     process.env.GIT_DIR = '/tmp/attacker-controlled-git-dir'
     rawMock.mockImplementation(async (args: string[]) => {
       expect(lastGitEnv).not.toHaveProperty('GIT_DIR')
-      expect(lastGitEnv?.GIT_ALLOW_PROTOCOL).toBe('https:ssh')
+      expect(lastGitEnv?.GIT_ALLOW_PROTOCOL).toBe('')
       return args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/old-name\n' : ''
     })
 
@@ -594,7 +599,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
     mkdirSync(join(dir, '.git'))
     rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://example.com/repo.git\n' : ''
+      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
     )
 
     await prepareWorkspace(gitRepoAgent(dir))
@@ -604,7 +609,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'remote',
       'set-url',
       'origin',
-      'https://example.com/repo.git'
+      'https://github.com/acme/repo.git'
     ])
   })
 
@@ -613,7 +618,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     mkdirSync(join(dir, '.git'))
     rawMock.mockImplementation(async (args: string[]) =>
       args[0] === 'remote' && args[1] === 'get-url'
-        ? 'https://legacy-user:legacy-token@example.com/repo.git?token=query-secret\n'
+        ? 'https://legacy-user:legacy-token@github.com/acme/repo.git?token=query-secret\n'
         : ''
     )
 
@@ -623,7 +628,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'remote',
       'set-url',
       'origin',
-      'https://example.com/repo.git'
+      'https://github.com/acme/repo.git'
     ])
     expect(pullMock).toHaveBeenCalled()
   })

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import {
+  DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
   GitCloneUrlError,
+  normalizeAllowedWorkspaceGitUrl,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   normalizeGitUrl,
+  normalizeWorkspaceGitOrigin,
   redactGitUrlSecrets,
-  gitRepoLabel
+  gitRepoLabel,
+  workspaceGitOriginOf
 } from './git-url.js'
 
 describe('normalizeGitUrl', () => {
@@ -97,6 +101,51 @@ describe('normalizeGitCloneUrl', () => {
       'ssh://git@github.com/acme/infra#'
     ]) {
       expect(() => normalizeGitCloneUrl(url), url).toThrow(GitCloneUrlError)
+    }
+  })
+})
+
+describe('workspace git origin policy', () => {
+  it('canonicalizes exact HTTPS, SSH, and scp-style origins', () => {
+    expect(normalizeWorkspaceGitOrigin('HTTPS://GitHub.COM.:443/')).toBe('https://github.com')
+    expect(normalizeWorkspaceGitOrigin('ssh://GIT.EXAMPLE.:22')).toBe('ssh://git.example')
+    expect(workspaceGitOriginOf('git@github.com:acme/infra.git')).toBe('ssh://github.com')
+    expect(workspaceGitOriginOf('ssh://git@git.example:2222/acme/infra.git')).toBe('ssh://git.example:2222')
+  })
+
+  it('requires an exact allowed scheme, host, and port', () => {
+    expect(normalizeAllowedWorkspaceGitUrl('acme/infra', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)).toBe(
+      'https://github.com/acme/infra'
+    )
+    expect(
+      normalizeAllowedWorkspaceGitUrl('git@github.com:acme/infra.git', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
+    ).toBe('git@github.com:acme/infra.git')
+
+    for (const url of [
+      'https://gitlab.com/group/repo',
+      'https://github.com.evil.example/acme/infra',
+      'https://github.com:8443/acme/infra',
+      'ssh://git@github.com:2222/acme/infra'
+    ]) {
+      expect(() => normalizeAllowedWorkspaceGitUrl(url, DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS), url).toThrow(
+        'git clone origin is not allowed'
+      )
+    }
+  })
+
+  it('rejects ambiguous allowlist entries', () => {
+    for (const origin of [
+      'https://*.example.com',
+      'https://user@git.example',
+      'https://@git.example',
+      'https://git.example/group',
+      'https://git.example/./',
+      'https://git.example?target=other',
+      'https://git.example?',
+      'https://git.example#',
+      'git.example'
+    ]) {
+      expect(() => normalizeWorkspaceGitOrigin(origin), origin).toThrow(GitCloneUrlError)
     }
   })
 })

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -17,6 +17,10 @@ const SCP_RE = /^[\w.-]+@[\w.-]+:(.+)$/
 const SCP_PARTS_RE = /^([\w.-]+)@([\w.-]+):(.+)$/
 const CONTROL_RE = /[\u0000-\u001f\u007f]/
 
+/** Conservative daemon default. Operators may explicitly add exact origins
+ * for GitLab, Bitbucket, or self-managed Git services. */
+export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = ['https://github.com', 'ssh://github.com'] as const
+
 export class GitCloneUrlError extends Error {
   constructor(message: string) {
     super(message)
@@ -62,9 +66,10 @@ function hasLocalPathPrefix(value: string): boolean {
 /**
  * Normalize and validate an untrusted git clone target.
  *
- * Public Git hosts remain host-agnostic. Only credential-free HTTPS and SSH
- * transports are accepted; local paths and Git's executable/legacy transports
- * are rejected before the value can reach `git clone`.
+ * This shared codec remains host-agnostic so the CP can store repositories for
+ * different daemon deployments. Only credential-free HTTPS and SSH transports
+ * are accepted; the daemon applies its operator-owned exact-origin policy at
+ * the execution boundary.
  */
 export function normalizeGitCloneUrl(input: string): string {
   if (CONTROL_RE.test(input)) invalidCloneUrl('git clone url must not contain control characters')
@@ -120,6 +125,83 @@ export function normalizeGitCloneUrl(input: string): string {
     invalidCloneUrl('git clone url must identify a remote repository')
   }
 
+  return normalized
+}
+
+function canonicalGitOrigin(protocol: 'https:' | 'ssh:', hostname: string, port: string): string {
+  // A final DNS root dot does not select a different host. WHATWG already
+  // does this for special schemes; reparse through HTTPS because SSH is a
+  // non-special scheme and otherwise preserves case / percent-encoded IDNs.
+  let host: string
+  try {
+    host = new URL(`https://${hostname}`).hostname.toLowerCase().replace(/\.+$/, '')
+  } catch {
+    invalidCloneUrl('git origin must identify a valid host')
+  }
+  if (!host) invalidCloneUrl('git origin must identify a host')
+  const defaultPort = protocol === 'https:' ? '443' : '22'
+  return `${protocol}//${host}${port && port !== defaultPort ? `:${port}` : ''}`
+}
+
+/**
+ * Normalize an operator-owned allowlist entry to an exact scheme/host/port
+ * origin. Paths, credentials, wildcards, queries, and fragments are not policy
+ * syntax: repository paths remain tenant-selected within an allowed origin.
+ */
+export function normalizeWorkspaceGitOrigin(input: string): string {
+  if (CONTROL_RE.test(input)) invalidCloneUrl('git origin must not contain control characters')
+  const raw = input.trim()
+  if (!raw || /\s/.test(raw) || raw.includes('\\') || raw.includes('*')) {
+    invalidCloneUrl('git origin must be an exact https or ssh origin')
+  }
+
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    invalidCloneUrl('git origin must be a valid absolute URL')
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'ssh:') {
+    invalidCloneUrl('git origin must use https or ssh')
+  }
+  const authorityStart = raw.indexOf('://') + 3
+  const pathStart = raw.indexOf('/', authorityStart)
+  const authority = raw.slice(authorityStart, pathStart < 0 ? raw.length : pathStart)
+  const path = pathStart < 0 ? '' : raw.slice(pathStart)
+  if (
+    authority.includes('@') ||
+    raw.includes('?') ||
+    raw.includes('#') ||
+    url.username ||
+    url.password ||
+    (path !== '' && path !== '/')
+  ) {
+    invalidCloneUrl('git origin must not contain credentials, a path, query, or fragment')
+  }
+  return canonicalGitOrigin(url.protocol, url.hostname, url.port)
+}
+
+/** Return the canonical exact origin selected by a validated clone URL. */
+export function workspaceGitOriginOf(input: string): string {
+  const normalized = normalizeGitCloneUrl(input)
+  const scp = SCP_PARTS_RE.exec(normalized)
+  if (scp) return canonicalGitOrigin('ssh:', scp[2]!, '')
+
+  const url = new URL(normalized)
+  return canonicalGitOrigin(url.protocol as 'https:' | 'ssh:', url.hostname, url.port)
+}
+
+/**
+ * Normalize a clone URL and require its exact scheme/host/port origin to be in
+ * the deployment policy. The caller owns the list; tenant input can never add
+ * to it.
+ */
+export function normalizeAllowedWorkspaceGitUrl(input: string, allowedOrigins: readonly string[]): string {
+  const normalized = normalizeGitCloneUrl(input)
+  const allowed = new Set(allowedOrigins.map(normalizeWorkspaceGitOrigin))
+  if (!allowed.has(workspaceGitOriginOf(normalized))) {
+    invalidCloneUrl('git clone origin is not allowed by this daemon')
+  }
   return normalized
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -67,12 +67,16 @@ export type { DecodeResultOf } from './wire.js'
 
 // ── git repo address helpers (normalize on write, shorten for display) ──
 export {
+  DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
   GitCloneUrlError,
+  normalizeAllowedWorkspaceGitUrl,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   normalizeGitUrl,
+  normalizeWorkspaceGitOrigin,
   redactGitUrlSecrets,
-  gitRepoLabel
+  gitRepoLabel,
+  workspaceGitOriginOf
 } from './git-url.js'
 
 // ── Slack message visible-text extraction (shared by daemon + relay) ──


### PR DESCRIPTION
## Summary

- add a daemon-local exact HTTPS/SSH origin allowlist for managed workspace clone and pull, defaulting to GitHub
- enforce the policy at every execution boundary while keeping control-plane persistence host-agnostic for heterogeneous daemon deployments
- isolate daemon-run Git from inherited proxies and routing config, pin pull targets, reject checkout rewrites, and disable redirect, submodule, LFS, bundle, and packfile-URI escape paths
- make `agentconnect --config ... run` consistently load and persist daemon state through the selected config file

## Root cause

The existing validation rejected unsafe transports and URL credentials, but any HTTPS or SSH host could still become a daemon-managed clone target. Git could also reinterpret an approved URL through local/global routing configuration or secondary download mechanisms before opening the network connection.

## Operator impact

Custom GitLab or self-managed Git services must be listed in `security.workspaceGitAllowedOrigins` using exact origins. A configured array replaces the defaults; `[]` disables remote Git workspaces. Restart the daemon after changing the policy.

## Validation

- protocol tests: 180 passed
- daemon tests: 2001 passed, 2 skipped
- focused F11 regression suite: 96 passed
- protocol and daemon typechecks
- daemon production build and self-contained bundle assertion
- ESLint, Prettier, and `git diff --check`
- independent compatibility and security reviews

Created by Codex . GPT-5
