### PR TITLE
feat(workspace): create and edit scratch files

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -215,6 +215,15 @@ its scratch label opens the agent's Workspace tab. Do not add a second "View
 workspace" action to the row. A single right-aligned `Edit` action owns workspace
 type, repository, branch, working-subdirectory, and repository-access settings.
 
+In the Workspace tab, callers who can edit the agent may create or edit one UTF-8
+file at a time when the workspace is scratch. New files use exclusive creation and
+never overwrite an existing path. Existing-file edits load the complete file and
+save against the mtime they opened. Saving while the agent is working surfaces a
+conflict; otherwise the daemon quiesces its runtime before atomically publishing the
+file, so an agent write is never silently overwritten. GitHub workspace files remain
+read-only, and workspace bodies continue to transit the control plane without being
+persisted.
+
 For a GitHub workspace, show the effective `read` or `write` access beside the
 repository. The editor may switch freely between scratch and GitHub, choose another
 repository or branch, change the working subdirectory, edit read/write access, or bind

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -16,6 +16,7 @@ import {
   RESERVED_MCP_SERVER_NAME,
   GitCloneUrlError,
   RepoSubdirError,
+  MAX_WORKSPACE_EDIT_BYTES,
   normalizeGitCloneUrl,
   redactGitUrlSecrets,
   normalizeRepoSubdir
@@ -1945,6 +1946,24 @@ export const WorkspaceFileDto = z.object({
   offset: z.number().nullable(), // byte offset this slice starts at
   nextOffset: z.number().nullable(), // byte offset to request next; clients must NOT recompute from content
   truncated: z.boolean().nullable() // true ⇒ nextOffset < size (more bytes remain)
+})
+
+/** `PUT /agents/:id/workspace/file` query — one scratch-workspace file. */
+export const PutWorkspaceFileQueryDto = z.object({
+  path: z.string().min(1).max(4096)
+})
+/** Omit `ifMatchMtime` for exclusive create; provide it for optimistic replace.
+ * Byte length is rechecked because zod counts characters, not encoded bytes. */
+export const PutWorkspaceFileBody = z
+  .object({
+    content: z.string().max(MAX_WORKSPACE_EDIT_BYTES),
+    ifMatchMtime: z.string().datetime().optional()
+  })
+  .strict()
+export const WorkspaceFileWriteDto = z.object({
+  path: z.string(),
+  size: z.number().int().nonnegative(),
+  mtime: z.string()
 })
 
 // ── agent memory (a directory at the agent root: MEMORY.md index + topic files; proxied daemon-local) ──

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -27,7 +27,7 @@ import type {
   DreamFilesPage,
   DreamFileReadContent
 } from '@agentconnect.md/protocol'
-import { gitRepoLabel, normalizeGitUrl } from '@agentconnect.md/protocol'
+import { MAX_WORKSPACE_EDIT_BYTES, gitRepoLabel, normalizeGitUrl } from '@agentconnect.md/protocol'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { type AgentRecord, type AgentWorkspace, isSyntheticEmail } from '../../persistence/ports.js'
@@ -61,6 +61,9 @@ import {
   WorkspaceFilesDto,
   WorkspaceFileQueryDto,
   WorkspaceFileDto,
+  PutWorkspaceFileQueryDto,
+  PutWorkspaceFileBody,
+  WorkspaceFileWriteDto,
   WorkspaceGitStatusDto,
   WorkspaceGitPullDto,
   AgentMemoryDto,
@@ -1854,6 +1857,91 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return toWorkspaceFileDto(rep)
         } catch (err) {
+          const unavailable = daemonEdgeFailure(err)
+          if (unavailable !== null) {
+            return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
+          }
+          throw err
+        }
+      }
+    )
+
+    // Create or replace one scratch-workspace text file. The caller must be able
+    // to edit the agent; bytes transit to the daemon and are never persisted here.
+    r.put(
+      '/agents/:id/workspace/file',
+      {
+        schema: {
+          tags: [Tag.Workspace],
+          summary: 'Create or replace a scratch workspace file',
+          description:
+            'Atomically create or replace one UTF-8 file in a scratch workspace on the owning daemon. Requires edit access to the agent. Creation never overwrites an existing file; replacement requires the mtime returned by the last read. Conflicts return 409. GitHub workspaces remain read-only. The control plane stores no file content.',
+          operationId: 'putAgentWorkspaceFile',
+          params: IdParam,
+          querystring: PutWorkspaceFileQueryDto,
+          body: PutWorkspaceFileBody,
+          response: {
+            200: WorkspaceFileWriteDto,
+            400: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            503: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const agent = await getOrgAgent(req, req.params.id)
+        if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        if (!canEdit(agent, ctxOf(req))) {
+          return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
+        }
+        if (agent.workspace.mode !== 'scratch') {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            statusCode: 400,
+            message: 'workspace files are editable only in scratch workspaces'
+          })
+        }
+        if (Buffer.byteLength(req.body.content, 'utf8') > MAX_WORKSPACE_EDIT_BYTES) {
+          return reply.code(400).send({
+            error: 'Bad Request',
+            statusCode: 400,
+            message: `workspace file exceeds the ${MAX_WORKSPACE_EDIT_BYTES}-byte edit limit`
+          })
+        }
+        if (!agent.daemonId) {
+          return reply
+            .code(503)
+            .send({ error: 'Service Unavailable', statusCode: 503, message: 'agent has no live daemon' })
+        }
+
+        const daemon = await deps.registry.get(agent.daemonId)
+        if (!daemon?.capabilities.features.includes('workspace-file-edit-v1')) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message: 'this agent version does not support workspace file editing'
+          })
+        }
+
+        try {
+          const writeReq = {
+            agentId: agent.id,
+            path: req.query.path,
+            contentBase64: Buffer.from(req.body.content, 'utf8').toString('base64'),
+            ...(req.body.ifMatchMtime ? { ifMatchMtime: req.body.ifMatchMtime } : {})
+          }
+          const ok = await deps.control.workspaceWrite(agent.daemonId, writeReq)
+          return { path: ok.path, size: ok.size, mtime: ok.mtime }
+        } catch (err) {
+          if (err instanceof ProtocolError && err.code === 'CONFLICT') {
+            return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: err.message })
+          }
+          if (err instanceof ProtocolError && err.code === 'BAD_PAYLOAD') {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: err.message })
+          }
           const unavailable = daemonEdgeFailure(err)
           if (unavailable !== null) {
             return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -40,6 +40,8 @@ import type {
   WorkspaceListPage,
   WorkspaceReadReq,
   WorkspaceReadContent,
+  WorkspaceWriteReq,
+  WorkspaceWriteOk,
   WorkspaceGitStatusReq,
   WorkspaceGitStatus,
   WorkspaceGitPullReq,
@@ -418,6 +420,12 @@ export class ControlSender {
   async workspaceRead(daemonId: string, req: WorkspaceReadReq): Promise<WorkspaceReadContent> {
     const c = this.must(daemonId)
     return c.conn.request<WorkspaceReadContent>('workspace/read', req, { epoch: c.sessionEpoch })
+  }
+
+  /** Create or replace one scratch-workspace text file on the owning daemon. */
+  async workspaceWrite(daemonId: string, req: WorkspaceWriteReq): Promise<WorkspaceWriteOk> {
+    const c = this.must(daemonId)
+    return c.conn.request<WorkspaceWriteOk>('workspace/write', req, { epoch: c.sessionEpoch })
   }
 
   /**

--- a/packages/control-plane/test/integration/agents.workspace-files.route.test.ts
+++ b/packages/control-plane/test/integration/agents.workspace-files.route.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Scratch workspace file edits stay daemon-local: the CP authorizes the agent
+ * manager, verifies scratch mode, and proxies one exclusive create or optimistic
+ * whole-file replacement.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type { WorkspaceWriteOk, WorkspaceWriteReq } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import type { ControlSender } from '../../src/orchestrator/outbound.js'
+import type { DaemonLiveness } from '../../src/ports.js'
+import { ProtocolError } from '../../src/domain/errors.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT = 'a1a1a1a1-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const MTIME = '2026-07-25T00:00:00.000Z'
+const CAPABILITIES = {
+  platforms: ['slack'],
+  runtimes: ['claude'],
+  acp: true,
+  features: ['workspace-file-edit-v1']
+}
+const LIVE: DaemonLiveness = {
+  get: (id) => (id === DAEMON ? { state: 'READY', reachable: true, sessionEpoch: 1 } : undefined)
+}
+
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((app) => app.close()))
+})
+
+class WorkspaceWriteSpy {
+  calls: Array<{ daemonId: string; req: WorkspaceWriteReq }> = []
+
+  async workspaceWrite(daemonId: string, req: WorkspaceWriteReq): Promise<WorkspaceWriteOk> {
+    this.calls.push({ daemonId, req })
+    return { agentId: req.agentId, path: req.path, size: 8, mtime: '2026-07-25T00:01:00.000Z' }
+  }
+}
+
+async function seedScratch(): Promise<void> {
+  await seedDaemon(prisma, DAEMON, { capabilities: CAPABILITIES })
+  await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+}
+
+function app(control: WorkspaceWriteSpy, userId?: string): HttpApp {
+  const running = buildHttpApp(
+    prisma,
+    userId ? { DEFAULT_OWNER_ID: userId } : undefined,
+    LIVE,
+    control as unknown as ControlSender
+  )
+  opened.push(running)
+  return running
+}
+
+describe('PUT /agents/:id/workspace/file', () => {
+  it('proxies an optimistic replacement without storing content', async () => {
+    await seedScratch()
+    const control = new WorkspaceWriteSpy()
+    const running = app(control)
+
+    const response = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${AGENT}/workspace/file?path=notes/todo.md`,
+      payload: { content: '# After\n', ifMatchMtime: MTIME }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(control.calls[0]).toMatchObject({
+      daemonId: DAEMON,
+      req: { agentId: AGENT, path: 'notes/todo.md', ifMatchMtime: MTIME }
+    })
+    expect(Buffer.from(control.calls[0]!.req.contentBase64, 'base64').toString('utf8')).toBe('# After\n')
+  })
+
+  it('keeps GitHub workspaces read-only and rejects a viewer before daemon I/O', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: CAPABILITIES })
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON, gitRepo: 'https://github.com/acme/repo' })
+    const control = new WorkspaceWriteSpy()
+
+    const github = await app(control).app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${AGENT}/workspace/file?path=README.md`,
+      payload: { content: 'changed', ifMatchMtime: MTIME }
+    })
+    expect(github.statusCode).toBe(400)
+
+    const users = new PgUserRepo(prisma)
+    const email = `workspace-viewer-${randomUUID()}@acme.dev`
+    const { userId } = await users.provisionOidcUser({
+      oidcSubject: `workspace-viewer-${randomUUID()}`,
+      email,
+      emailVerified: true
+    })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'viewer')
+    await prisma.agent.update({ where: { id: AGENT }, data: { workspaceMode: 'scratch', gitRepo: null } })
+
+    const viewer = await app(control, userId).app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${AGENT}/workspace/file?path=README.md`,
+      payload: { content: 'changed', ifMatchMtime: MTIME }
+    })
+    expect(viewer.statusCode).toBe(403)
+    expect(control.calls).toHaveLength(0)
+  })
+
+  it('maps a stale daemon write to HTTP 409', async () => {
+    await seedScratch()
+    const control = new WorkspaceWriteSpy()
+    control.workspaceWrite = async () => {
+      throw new ProtocolError('CONFLICT', 'the workspace file changed; reload and retry')
+    }
+    const running = app(control)
+
+    const res = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${AGENT}/workspace/file?path=notes.md`,
+      payload: { content: 'stale', ifMatchMtime: MTIME }
+    })
+    expect(res.statusCode).toBe(409)
+  })
+})

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -33,6 +33,7 @@ import type {
   SessionToolBodyReq,
   WorkspaceListReq,
   WorkspaceReadReq,
+  WorkspaceWriteReq,
   WorkspaceGitStatusReq,
   WorkspaceGitPullReq,
   GitCredRequest,
@@ -63,7 +64,7 @@ import type {
 } from '@agentconnect.md/protocol'
 import { buildEnvelope, decodeEnvelope, encode, MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
 import type { SessionReader } from './session-reader.js'
-import { WorkspaceViolationError, type WorkspaceReader } from './workspace-reader.js'
+import { WorkspaceConflictError, WorkspaceViolationError, type WorkspaceReader } from './workspace-reader.js'
 import {
   MemoryViolationError,
   MemoryPathError,
@@ -115,7 +116,7 @@ export interface CpClientDeps {
   configApply: ConfigApply
   /** Read-only session list/history seam over the local store (§1/§12). */
   sessionRead: SessionReader
-  /** Read-only workspace list/read seam over the agents' workspace dirs (§1/§12). */
+  /** Live workspace file seam over the agents' workspace dirs (§1/§12). */
   workspaceRead: WorkspaceReader
   /** Git status/pull seam over the agents' git-repo workspace dirs (§1/§12). */
   workspaceGit: WorkspaceGit
@@ -821,6 +822,14 @@ export class CpClient {
           .catch((err) => this.workspaceError(frame.id, 'workspace/read', err))
         return
       }
+      case 'workspace/write': {
+        // Console manager edit: bounded scratch text create/replace; never log content.
+        this.deps.workspaceRead
+          .write(frame.payload as WorkspaceWriteReq)
+          .then((ok) => this.reply(frame, 'workspace/write/ok', ok))
+          .catch((err) => this.workspaceError(frame.id, 'workspace/write', err))
+        return
+      }
       case 'workspace/gitstatus': {
         // git status of a git-repo workspace — a dirty tree / non-repo is DATA, not an error.
         this.deps.workspaceGit
@@ -995,11 +1004,16 @@ export class CpClient {
     }
   }
 
-  /** Map a workspace read failure onto the wire: containment/bad-request
+  /** Map a workspace file failure onto the wire: stale writes → CONFLICT;
+   *  containment/bad-request
    *  violations → BAD_PAYLOAD (their messages are hand-written and path-free);
    *  anything else → INTERNAL with a GENERIC message — raw fs errors (ELOOP,
    *  EACCES, …) embed absolute host paths that must not leak to the CP/UI. */
   private workspaceError(corr: string, op: string, err: unknown): void {
+    if (err instanceof WorkspaceConflictError) {
+      this.sendError(corr, 'CONFLICT', `${op} failed: ${err.message}`, false)
+      return
+    }
     if (err instanceof WorkspaceViolationError) {
       this.sendError(corr, 'BAD_PAYLOAD', `${op} failed: ${err.message}`, false)
       return

--- a/packages/daemon/src/cp/workspace-reader.ts
+++ b/packages/daemon/src/cp/workspace-reader.ts
@@ -1,8 +1,8 @@
 /**
- * `WorkspaceReader` — the read-only seam answering the CP's `workspace/list` and
- * `workspace/read` REQs from the agent's local workspace directory. File bytes
- * live only on the daemon (§1/§12); this streams single pages/slices to the CP,
- * never whole trees or files.
+ * `WorkspaceReader` — the daemon-local seam answering the CP's workspace file
+ * list/read/write REQs. File bytes live only on the daemon (§1/§12); the CP
+ * proxies single pages/slices or one bounded scratch-file create/replace and
+ * never persists them.
  *
  * Containment is to `workspace.path` EXACTLY — the parent directory holds
  * `agent.json` and other daemon-local secrets/state, so escaping even one level
@@ -15,11 +15,17 @@
  * which the dispatcher maps to a `BAD_PAYLOAD` error frame; missing paths are
  * data (`exists:false`), not errors. Never log file contents.
  *
+ * Writes are scratch-only and coordinated with the daemon's agent runtime.
+ * Once the runtime is quiescent, creation uses an exclusive hard-link publish
+ * and replacement uses an atomic rename, so the target path is always either
+ * the complete old file or the complete new file.
+ *
  * Frame-size safety: every REP must serialise under the 256 KiB wire cap. JSON
  * escaping of control bytes is a 6× blowup, so `read` bounds the slice by the
  * *encoded* reply size (not the raw byte `limit`) and `list` stops a page early
  * when the encoded entries would overflow — both leave headroom for the envelope.
  */
+import { randomUUID } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import * as path from 'node:path'
 import type {
@@ -27,8 +33,11 @@ import type {
   WorkspaceListPage,
   WorkspaceReadReq,
   WorkspaceReadContent,
+  WorkspaceWriteReq,
+  WorkspaceWriteOk,
   WorkspaceEntry
 } from '@agentconnect.md/protocol'
+import { MAX_WORKSPACE_EDIT_BYTES } from '@agentconnect.md/protocol'
 import { REPLY_BUDGET, encodedBytes, utf8Boundary, fitToBudget } from './wire-slice.js'
 
 /** Bytes sniffed from the head of a file for binary (NUL byte) detection. */
@@ -42,10 +51,26 @@ export class WorkspaceViolationError extends Error {
   }
 }
 
+/** Optimistic-concurrency failure → `CONFLICT` on the wire. */
+export class WorkspaceConflictError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorkspaceConflictError'
+  }
+}
+
+export interface WorkspaceLocation {
+  root: string
+  scratch: boolean
+}
+
 export interface WorkspaceReader {
   list(req: WorkspaceListReq): Promise<WorkspaceListPage>
   read(req: WorkspaceReadReq): Promise<WorkspaceReadContent>
+  write(req: WorkspaceWriteReq): Promise<WorkspaceWriteOk>
 }
+
+export type WorkspaceWriteCoordinator = <T>(agentId: string, write: () => Promise<T>) => Promise<T>
 
 function isErrno(err: unknown, code: string): boolean {
   return (err as NodeJS.ErrnoException | null)?.code === code
@@ -59,11 +84,14 @@ function containsGitInternals(relPath: string): boolean {
   return relPath.split(/[\\/]+/).some((part) => part.toLowerCase() === '.git')
 }
 
-export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) => string | undefined): WorkspaceReader {
-  function rootFor(agentId: string): string {
-    const root = workspaceRootByAgent(agentId)
-    if (!root) throw new WorkspaceViolationError(`unknown agent "${agentId}"`)
-    return root
+export function createWorkspaceReader(
+  workspaceByAgent: (agentId: string) => WorkspaceLocation | undefined,
+  coordinateWrite: WorkspaceWriteCoordinator
+): WorkspaceReader {
+  function locationFor(agentId: string): WorkspaceLocation {
+    const location = workspaceByAgent(agentId)
+    if (!location) throw new WorkspaceViolationError(`unknown agent "${agentId}"`)
+    return location
   }
 
   /**
@@ -103,7 +131,7 @@ export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) =>
 
   return {
     async list(req) {
-      const root = rootFor(req.agentId)
+      const root = locationFor(req.agentId).root
       const { resolved, realRoot } = await resolveContained(root, req.path)
       const notFound = { agentId: req.agentId, path: req.path, exists: false, entries: [] as WorkspaceEntry[] }
       if (realRoot === null) return notFound // workspace root missing
@@ -175,7 +203,7 @@ export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) =>
     },
 
     async read(req) {
-      const root = rootFor(req.agentId)
+      const root = locationFor(req.agentId).root
       const { resolved, realRoot } = await resolveContained(root, req.path)
       const notFound = { agentId: req.agentId, path: req.path, exists: false }
       if (realRoot === null) return notFound
@@ -242,8 +270,158 @@ export function createWorkspaceReader(workspaceRootByAgent: (agentId: string) =>
       } finally {
         await fh.close()
       }
+    },
+
+    async write(req) {
+      if (!locationFor(req.agentId).scratch) {
+        throw new WorkspaceViolationError('workspace files are editable only in scratch workspaces')
+      }
+
+      const bytes = Buffer.from(req.contentBase64, 'base64')
+      if (bytes.byteLength > MAX_WORKSPACE_EDIT_BYTES) {
+        throw new WorkspaceViolationError(`workspace file exceeds the ${MAX_WORKSPACE_EDIT_BYTES}-byte edit limit`)
+      }
+      if (bytes.includes(0)) throw new WorkspaceViolationError('binary files are not editable')
+      try {
+        new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+      } catch {
+        throw new WorkspaceViolationError('workspace file content must be valid UTF-8')
+      }
+
+      return coordinateWrite(req.agentId, async () => {
+        const location = locationFor(req.agentId)
+        if (!location.scratch) {
+          throw new WorkspaceViolationError('workspace files are editable only in scratch workspaces')
+        }
+
+        let { resolved, realRoot } = await resolveContained(location.root, req.path)
+        if (realRoot === null && req.ifMatchMtime === undefined) {
+          await fs.mkdir(location.root, { recursive: true })
+          ;({ resolved, realRoot } = await resolveContained(location.root, req.path))
+        }
+        if (realRoot === null) throw changedFile()
+
+        if (req.ifMatchMtime === undefined) {
+          let parent: string
+          try {
+            parent = await canonicalUnder(realRoot, path.dirname(resolved))
+          } catch (err) {
+            if (isErrno(err, 'ENOENT')) {
+              throw new WorkspaceViolationError('the parent directory does not exist')
+            }
+            throw err
+          }
+          const parentStat = await fs.stat(parent)
+          if (!parentStat.isDirectory()) {
+            throw new WorkspaceViolationError('the parent path is not a directory')
+          }
+
+          const target = path.join(parent, path.basename(resolved))
+          try {
+            await fs.lstat(target)
+            throw existingFile()
+          } catch (err) {
+            if (!isErrno(err, 'ENOENT')) throw err
+          }
+
+          const temp = path.join(parent, `.agentconnect-edit-${randomUUID()}.tmp`)
+          try {
+            await fs.writeFile(temp, bytes, { flag: 'wx', mode: 0o666 })
+            try {
+              await fs.link(temp, target)
+            } catch (err) {
+              if (isErrno(err, 'EEXIST')) throw existingFile()
+              throw err
+            }
+          } finally {
+            await fs.rm(temp, { force: true }).catch(() => {})
+          }
+
+          const written = await fs.stat(target)
+          return {
+            agentId: req.agentId,
+            path: req.path,
+            size: written.size,
+            mtime: written.mtime.toISOString()
+          }
+        }
+
+        let initial
+        try {
+          initial = await fs.lstat(resolved)
+        } catch (err) {
+          if (isErrno(err, 'ENOENT')) throw changedFile()
+          throw err
+        }
+        if (!initial.isFile()) throw new WorkspaceViolationError('not a regular file')
+        if (initial.mtime.toISOString() !== req.ifMatchMtime) throw changedFile()
+
+        let target: string
+        try {
+          target = await canonicalUnder(realRoot, resolved)
+        } catch (err) {
+          if (isErrno(err, 'ENOENT')) throw changedFile()
+          throw err
+        }
+
+        // Match the read path's binary guard. The editor never turns a binary file
+        // into text merely because a caller bypassed the console UI.
+        const fh = await fs.open(target, 'r')
+        try {
+          const sniffLen = Math.min(SNIFF_BYTES, initial.size)
+          if (sniffLen > 0) {
+            const sniff = Buffer.alloc(sniffLen)
+            const { bytesRead } = await fh.read(sniff, 0, sniffLen, 0)
+            if (sniff.subarray(0, bytesRead).includes(0)) {
+              throw new WorkspaceViolationError('binary files are not editable')
+            }
+          }
+        } finally {
+          await fh.close()
+        }
+
+        const temp = path.join(path.dirname(target), `.agentconnect-edit-${randomUUID()}.tmp`)
+        try {
+          await fs.writeFile(temp, bytes, { flag: 'wx', mode: initial.mode & 0o777 })
+          await fs.chmod(temp, initial.mode & 0o777)
+
+          let latest
+          try {
+            latest = await fs.lstat(target)
+          } catch (err) {
+            if (isErrno(err, 'ENOENT')) throw changedFile()
+            throw err
+          }
+          if (!sameFileVersion(initial, latest)) throw changedFile()
+
+          await fs.rename(temp, target)
+        } catch (err) {
+          await fs.rm(temp, { force: true }).catch(() => {})
+          throw err
+        }
+
+        const written = await fs.stat(target)
+        return {
+          agentId: req.agentId,
+          path: req.path,
+          size: written.size,
+          mtime: written.mtime.toISOString()
+        }
+      })
     }
   }
+}
+
+function sameFileVersion(a: Awaited<ReturnType<typeof fs.lstat>>, b: Awaited<ReturnType<typeof fs.lstat>>): boolean {
+  return b.isFile() && a.dev === b.dev && a.ino === b.ino && a.size === b.size && a.mtimeMs === b.mtimeMs
+}
+
+function changedFile(): WorkspaceConflictError {
+  return new WorkspaceConflictError('the workspace file changed since it was read; reload and retry')
+}
+
+function existingFile(): WorkspaceConflictError {
+  return new WorkspaceConflictError('the workspace file already exists; open it to edit')
 }
 
 /** dirs first, then case-insensitive alphabetical (stable within the page). */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -149,7 +149,7 @@ import {
   gitRepoLabel
 } from '@agentconnect.md/protocol'
 import { createSessionReader } from './cp/session-reader.js'
-import { createWorkspaceReader } from './cp/workspace-reader.js'
+import { createWorkspaceReader, WorkspaceConflictError } from './cp/workspace-reader.js'
 import { createMemoryReader } from './cp/memory-reader.js'
 import {
   createMemoryProvider,
@@ -1320,6 +1320,7 @@ export class Daemon {
   // Agent detach waits these leases before archiving/closing the last connection.
   private activeDispatchesByAgent = new Map<string, Set<Promise<void>>>()
   private activeDispatchDoneByKey = new Map<string, Promise<void>>()
+  private workspaceFileWrites = new Map<string, Promise<void>>()
   // Connection-specific half of the same lease. Unlike `pending[].conn`, this is
   // acquired immediately when dispatchOne captures replyConn, before its first
   // await, so ordinary config reconciliation cannot close that pre-pending use.
@@ -7096,6 +7097,34 @@ export class Daemon {
     }
   }
 
+  private async admitActiveDispatch(agentId: string, key: string): Promise<() => void> {
+    while (this.workspaceFileWrites.has(agentId)) await this.workspaceFileWrites.get(agentId)
+    return this.beginActiveDispatch(agentId, key)
+  }
+
+  private async withWorkspaceFileWrite<T>(agentId: string, write: () => Promise<T>): Promise<T> {
+    while (this.workspaceFileWrites.has(agentId)) await this.workspaceFileWrites.get(agentId)
+    let release!: () => void
+    const done = new Promise<void>((resolve) => (release = resolve))
+    this.workspaceFileWrites.set(agentId, done)
+    try {
+      if (
+        this.draining ||
+        this.drainingAgents.has(agentId) ||
+        this.safetyDrainingAgents.has(agentId) ||
+        (this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0 ||
+        this.agentHasLiveSdkWork(agentId)
+      ) {
+        throw new WorkspaceConflictError('the agent is working in this workspace; retry when it is idle')
+      }
+      await this.stopHost(agentId)
+      return await write()
+    } finally {
+      if (this.workspaceFileWrites.get(agentId) === done) this.workspaceFileWrites.delete(agentId)
+      release()
+    }
+  }
+
   private holdReplyConnection(
     conn: SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection | undefined
   ): () => void {
@@ -7169,7 +7198,7 @@ export class Daemon {
           return
         }
         try {
-          const releaseDispatch = this.beginActiveDispatch(entry.agentId, key)
+          const releaseDispatch = await this.admitActiveDispatch(entry.agentId, key)
           let sessionId: string | null
           try {
             sessionId = await this.dispatchOne(entry, key)
@@ -10328,6 +10357,9 @@ export class Daemon {
   private async ensureHostAsync(agentId: string, opts: { allowAgentDrain?: boolean } = {}): Promise<AcpHost> {
     const assertStartAllowed = (): void => {
       if (this.draining) throw new Error(`host start blocked while daemon is draining (${agentId})`)
+      if (this.workspaceFileWrites.has(agentId)) {
+        throw new Error(`host start blocked while a workspace file is being written (${agentId})`)
+      }
       // Already-admitted work in another logical session may keep using the warm
       // host while a conversation-scoped interrupt drains. It may not allocate a
       // replacement after that host/start generation has been evicted.
@@ -11999,6 +12031,7 @@ export class Daemon {
         acp: true,
         features: [
           ...(this.opts.agentName ? [] : ['agent-move-v1', 'workspace-convert-v1', 'workspace-edit-v2']),
+          'workspace-file-edit-v1',
           // Host can confine agent processes (issue #642) — the console uses this to
           // enable/disable the per-agent Run in sandbox toggle.
           ...(this.sandboxMechanism ? ['sandbox'] : []),
@@ -12049,7 +12082,13 @@ export class Daemon {
       degradedScopes: () => this.cpDegradedScopes(),
       configApply: this.cpConfigApply(),
       sessionRead: createSessionReader(this.store, (agentId) => this.replyConnFor(agentId)?.workspaceUrl),
-      workspaceRead: createWorkspaceReader((id) => this.agents.get(id)?.workspace.path),
+      workspaceRead: createWorkspaceReader(
+        (id) => {
+          const workspace = this.agents.get(id)?.workspace
+          return workspace ? { root: workspace.path, scratch: workspace.mode === 'from-scratch' } : undefined
+        },
+        (id, write) => this.withWorkspaceFileWrite(id, write)
+      ),
       workspaceGit: createWorkspaceGit(
         (id) => this.agents.get(id)?.workspace.path,
         (id) => {

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -71,6 +71,7 @@ async function readyClient(over: Partial<CpClientDeps> = {}, serverFeatures: str
   const workspaceRead = {
     list: vi.fn(async () => ({ agentId: 'a', path: '', exists: true, entries: [] })),
     read: vi.fn(async () => ({ agentId: 'a', path: 'f', exists: false })),
+    write: vi.fn(async () => ({ agentId: 'a', path: 'f', size: 0, mtime: '2026-06-26T00:00:00.000Z' })),
     ...((over.workspaceRead as any) ?? {})
   }
   const workspaceGit = {
@@ -510,6 +511,30 @@ describe('CpClient dispatch', () => {
     expect(ack.type).toBe('ack')
     expect(ack.payload.ok).toBe(true)
     expect(ack.corr).toBe(f.id)
+  })
+
+  it('replies workspace/write/ok from the scratch workspace file seam', async () => {
+    const write = vi.fn(async () => ({
+      agentId: 'a1',
+      path: 'notes.md',
+      size: 7,
+      mtime: '2026-06-26T00:01:00.000Z'
+    }))
+    const { t, workspaceRead } = await readyClient({ workspaceRead: { write } as any })
+    const payload = {
+      agentId: 'a1',
+      path: 'notes.md',
+      contentBase64: Buffer.from('updated').toString('base64'),
+      ifMatchMtime: '2026-06-26T00:00:00.000Z'
+    }
+    const f = JSON.parse(frame('workspace/write', payload, { epoch: 5 }))
+    t.pushInbound(JSON.stringify(f))
+    await tick()
+    expect(workspaceRead.write).toHaveBeenCalledWith(payload)
+    const rep = JSON.parse(t.sent[0]!)
+    expect(rep.type).toBe('workspace/write/ok')
+    expect(rep.corr).toBe(f.id)
+    expect(rep.payload.size).toBe(7)
   })
 
   it('replies workspace/gitstatus/result from the workspaceGit seam', async () => {

--- a/packages/daemon/test/workspace-reader.test.ts
+++ b/packages/daemon/test/workspace-reader.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync, symlinkSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
-import { createWorkspaceReader, WorkspaceViolationError, type WorkspaceReader } from '../src/cp/workspace-reader.js'
+import {
+  createWorkspaceReader,
+  WorkspaceConflictError,
+  WorkspaceViolationError,
+  type WorkspaceReader,
+  type WorkspaceWriteCoordinator
+} from '../src/cp/workspace-reader.js'
 
 const AGENT = 'bot-a'
 
@@ -11,6 +17,7 @@ let base: string // scratch dir; ws = the workspace root, outside/ = sibling sec
 let ws: string
 let outside: string
 let reader: WorkspaceReader
+const directWrite: WorkspaceWriteCoordinator = (_agentId, write) => write()
 
 const listReq = (over: Partial<Parameters<WorkspaceReader['list']>[0]> = {}) => ({
   agentId: AGENT,
@@ -25,6 +32,23 @@ const readReq = (path: string, over: Partial<Parameters<WorkspaceReader['read']>
   limit: 65536,
   ...over
 })
+const writeReq = (
+  path: string,
+  content: string,
+  ifMatchMtime: string,
+  over: Partial<Parameters<WorkspaceReader['write']>[0]> = {}
+) => ({
+  agentId: AGENT,
+  path,
+  contentBase64: Buffer.from(content, 'utf8').toString('base64'),
+  ifMatchMtime,
+  ...over
+})
+const createReq = (path: string, content: string): Parameters<WorkspaceReader['write']>[0] => ({
+  agentId: AGENT,
+  path,
+  contentBase64: Buffer.from(content, 'utf8').toString('base64')
+})
 
 beforeEach(() => {
   base = mkdtempSync(join(tmpdir(), 'ws-reader-'))
@@ -32,7 +56,7 @@ beforeEach(() => {
   outside = join(base, 'outside')
   mkdirSync(ws)
   mkdirSync(outside)
-  reader = createWorkspaceReader((id) => (id === AGENT ? ws : undefined))
+  reader = createWorkspaceReader((id) => (id === AGENT ? { root: ws, scratch: true } : undefined), directWrite)
 })
 
 afterEach(() => {
@@ -119,6 +143,11 @@ describe('path containment', () => {
     writeFileSync(join(outside, 'secret.env'), 'TOKEN=x')
     await expect(reader.list(listReq({ path: '../outside' }))).rejects.toBeInstanceOf(WorkspaceViolationError)
     await expect(reader.read(readReq('../outside/secret.env'))).rejects.toBeInstanceOf(WorkspaceViolationError)
+    await expect(
+      reader.write(
+        writeReq('../outside/secret.env', 'changed', statSync(join(outside, 'secret.env')).mtime.toISOString())
+      )
+    ).rejects.toBeInstanceOf(WorkspaceViolationError)
     // deeper mixed escape too
     await expect(reader.read(readReq('src/../../outside/secret.env'))).rejects.toBeInstanceOf(WorkspaceViolationError)
   })
@@ -222,6 +251,52 @@ describe('workspace read', () => {
     expect(r.encoding).toBe('utf8')
     expect(r.truncated).toBe(true) // shrunk below the raw 64 KiB request
     expect(Buffer.byteLength(JSON.stringify(r))).toBeLessThan(MAX_FRAME_BYTES)
+  })
+})
+
+describe('workspace write', () => {
+  it('creates a new text file without overwriting a concurrent creator', async () => {
+    mkdirSync(join(ws, 'notes'))
+
+    const outcomes = await Promise.allSettled([
+      reader.write(createReq('notes/todo.md', 'first')),
+      reader.write(createReq('notes/todo.md', 'second'))
+    ])
+
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1)
+    const rejected = outcomes.find((outcome) => outcome.status === 'rejected')
+    expect(rejected).toMatchObject({ reason: expect.any(WorkspaceConflictError) })
+    expect(['first', 'second']).toContain(readFileSync(join(ws, 'notes', 'todo.md'), 'utf8'))
+  })
+
+  it('atomically replaces one existing scratch text file and returns its new state', async () => {
+    const target = join(ws, 'notes.md')
+    writeFileSync(target, '# Before\n')
+    const before = statSync(target)
+
+    const result = await reader.write(writeReq('notes.md', '# After\n', before.mtime.toISOString()))
+
+    expect(readFileSync(target, 'utf8')).toBe('# After\n')
+    expect(result).toMatchObject({ agentId: AGENT, path: 'notes.md', size: 8 })
+    expect(result.mtime).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('rejects stale edits and any write outside a scratch workspace', async () => {
+    const target = join(ws, 'notes.md')
+    writeFileSync(target, 'current')
+
+    await expect(reader.write(writeReq('notes.md', 'stale', '2026-01-01T00:00:00.000Z'))).rejects.toBeInstanceOf(
+      WorkspaceConflictError
+    )
+
+    const repoReader = createWorkspaceReader(
+      (id) => (id === AGENT ? { root: ws, scratch: false } : undefined),
+      directWrite
+    )
+    await expect(
+      repoReader.write(writeReq('notes.md', 'changed', statSync(target).mtime.toISOString()))
+    ).rejects.toBeInstanceOf(WorkspaceViolationError)
+    expect(readFileSync(target, 'utf8')).toBe('current')
   })
 })
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -801,7 +801,7 @@ describe('milestone A4 gate — the CP is off the webchat hot path', () => {
   })
 })
 
-describe('workspace file browsing frames (console live pull)', () => {
+describe('workspace file access frames (console live proxy)', () => {
   it('workspace/list REQ round-trips with the CP epoch ext (no seq/launchId)', () => {
     const r = decodeEnvelope(
       envelope(

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -47,6 +47,8 @@ import {
   WorkspaceListPage,
   WorkspaceReadReq,
   WorkspaceReadContent,
+  WorkspaceWriteReq,
+  WorkspaceWriteOk,
   WorkspaceGitStatusReq,
   WorkspaceGitStatus,
   WorkspaceGitPullReq,
@@ -198,11 +200,13 @@ export const FRAME_SCHEMAS = {
   // ── channel agent directory (agent collaboration; D→C REQ → REP) ──
   'channel/agents': ChannelAgentsReq,
   'channel/agents/ok': ChannelAgentsOk,
-  // ── workspace file browsing (console live pull; bytes transit, never stored) ──
+  // ── workspace files (console live access; bytes transit, never stored) ──
   'workspace/list': WorkspaceListReq,
   'workspace/list/page': WorkspaceListPage,
   'workspace/read': WorkspaceReadReq,
   'workspace/read/content': WorkspaceReadContent,
+  'workspace/write': WorkspaceWriteReq,
+  'workspace/write/ok': WorkspaceWriteOk,
   'workspace/gitstatus': WorkspaceGitStatusReq,
   'workspace/gitstatus/result': WorkspaceGitStatus,
   'workspace/gitpull': WorkspaceGitPullReq,
@@ -365,6 +369,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('workspace/list/page', FRAME_SCHEMAS['workspace/list/page']),
   frame('workspace/read', FRAME_SCHEMAS['workspace/read']),
   frame('workspace/read/content', FRAME_SCHEMAS['workspace/read/content']),
+  frame('workspace/write', FRAME_SCHEMAS['workspace/write']),
+  frame('workspace/write/ok', FRAME_SCHEMAS['workspace/write/ok']),
   frame('workspace/gitstatus', FRAME_SCHEMAS['workspace/gitstatus']),
   frame('workspace/gitstatus/result', FRAME_SCHEMAS['workspace/gitstatus/result']),
   frame('workspace/gitpull', FRAME_SCHEMAS['workspace/gitpull']),

--- a/packages/protocol/src/frames/workspace.ts
+++ b/packages/protocol/src/frames/workspace.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 /**
- * Agent workspace file browsing (C→D REQ → REP) — the console's on-demand pulls.
+ * Agent workspace files (C→D REQ → REP) — the console's on-demand access.
  *
  * The CP stores NO workspace data — directory listings and file bytes are pulled
  * live from the owning daemon and proxied to the console, never persisted
@@ -16,7 +16,14 @@ import { z } from 'zod'
  *   ends the slice on a UTF-8 character boundary. `nextOffset` is the authoritative
  *   byte offset to request next — callers must NOT recompute it from the decoded
  *   `content` (a split multi-byte char would make the byte count drift).
+ * - `workspace/write`: create a text file when `ifMatchMtime` is absent, or
+ *   replace one when it matches the last read. Content is base64 so arbitrary
+ *   UTF-8 text has a predictable wire size.
  */
+
+/** Raw UTF-8 ceiling for one console workspace-file edit. Base64 expansion still
+ * leaves enough envelope headroom under the shared 256 KiB frame cap. */
+export const MAX_WORKSPACE_EDIT_BYTES = 180_000
 
 /** One directory entry in a workspace listing (name-only; not a full path). */
 export const WorkspaceEntry = z.object({
@@ -69,6 +76,31 @@ export const WorkspaceReadContent = z.object({
   truncated: z.boolean().optional() // true ⇒ nextOffset < size (more bytes remain)
 })
 export type WorkspaceReadContent = z.infer<typeof WorkspaceReadContent>
+
+const CanonicalBase64 = z
+  .string()
+  .max(Math.ceil(MAX_WORKSPACE_EDIT_BYTES / 3) * 4)
+  .regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/)
+
+/** C→D REQ: atomically create or replace one scratch-workspace text file.
+ * Omitting `ifMatchMtime` is an exclusive create; supplying it is an optimistic
+ * replace, so neither operation silently overwrites a concurrent change. */
+export const WorkspaceWriteReq = z.object({
+  agentId: z.string().min(1), // local agent id (NOT a wire UUID)
+  path: z.string().min(1).max(4096), // workspace-relative POSIX path to a regular file
+  contentBase64: CanonicalBase64, // complete new UTF-8 contents
+  ifMatchMtime: z.string().datetime().optional()
+})
+export type WorkspaceWriteReq = z.infer<typeof WorkspaceWriteReq>
+
+/** D→C REP (corr = the req id): the atomically written file state. */
+export const WorkspaceWriteOk = z.object({
+  agentId: z.string(),
+  path: z.string(),
+  size: z.number().int().nonnegative(),
+  mtime: z.string()
+})
+export type WorkspaceWriteOk = z.infer<typeof WorkspaceWriteOk>
 
 /**
  * Agent workspace git ops (C→D REQ → REP) — the console's on-demand controls for

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { expect, it, vi } from 'vitest'
+
+vi.mock('next/dynamic', () => ({ default: () => () => null }))
+vi.mock('@/lib/api', () => ({
+  ApiError: class ApiError extends Error {},
+  fetchWorkspaceFile: vi.fn(),
+  fetchWorkspaceFileFull: vi.fn(),
+  fetchWorkspaceFiles: vi.fn(),
+  fetchWorkspaceGitStatus: vi.fn(),
+  writeWorkspaceFile: vi.fn(),
+  workspaceGitPull: vi.fn()
+}))
+vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => false }))
+
+import { WorkspaceFiles } from './WorkspaceFiles'
+
+it('uses configured edit access even before runtime Git status loads', () => {
+  const html = renderToStaticMarkup(<WorkspaceFiles agentId="agent-a" workdir="/workspace" canEdit />)
+  expect(html).toContain('New file')
+})

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -10,19 +10,22 @@
 // This component owns the whole workspace surface for a live agent (repo card +
 // Files card); the parent just mounts it. Demo agents use <WorkspaceFilesMock>.
 
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import {
+  ApiError,
   fetchWorkspaceFile,
+  fetchWorkspaceFileFull,
   fetchWorkspaceFiles,
   fetchWorkspaceGitStatus,
+  writeWorkspaceFile,
   workspaceGitPull,
   type WorkspaceEntryDto,
   type WorkspaceFileDto,
   type WorkspaceGitStatusDto
 } from '@/lib/api'
 import { GithubMark, Spinner } from '@/components/marks'
-import { Icon } from '@/components/ui'
+import { Button, Icon } from '@/components/ui'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { escapeHtml, highlight, linkifyHtml, loadHljs } from '@/lib/highlight'
 import { resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
@@ -138,11 +141,12 @@ type Viewer = {
   loadingMore: boolean
 }
 
-export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?: string }) {
+export function WorkspaceFiles({ agentId, workdir, canEdit }: { agentId: string; workdir?: string; canEdit: boolean }) {
   const isMobile = useIsMobile()
   const [dirs, setDirs] = useState<Record<string, DirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [viewer, setViewer] = useState<Viewer | null>(null)
+  const [editPath, setEditPath] = useState<string | null>(null) // '' creates; a path replaces
   // git-repo workspaces: current-checkout status + on-demand pull. `scratch` is set
   // only on a successful non-repo response — an offline daemon leaves both unset so
   // we don't mislabel a repo as scratch.
@@ -284,6 +288,7 @@ export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?
     viewerRequestRef.current += 1
     setGitMsg(null)
     setViewer(null)
+    setEditPath(null)
     autoOpenedRef.current = false
     return () => {
       viewerRequestRef.current += 1
@@ -370,6 +375,12 @@ export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?
             : cur
         )
     )
+  }
+
+  const onFileSaved = (path: string) => {
+    setEditPath(null)
+    setRefreshTick((tick) => tick + 1)
+    selectFile(path, path.split('/').at(-1) ?? path)
   }
 
   // Map browse-relative path → git status letter for the tree badges. git file paths
@@ -488,11 +499,25 @@ export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?
       <FileBrowserShell
         title="Files"
         headerEnd={
-          summary ? (
-            <span className="mono text-[11px] text-(--text-tertiary)" title={workdir}>
-              {summary}
-            </span>
-          ) : undefined
+          <div className="flex min-w-0 items-center gap-2">
+            {summary ? (
+              <span className="mono truncate text-[11px] text-(--text-tertiary)" title={workdir}>
+                {summary}
+              </span>
+            ) : null}
+            {canEdit ? (
+              <Button
+                variant="secondary"
+                size="xs"
+                className="flex-none"
+                onClick={() => setEditPath('')}
+                disabled={editPath !== null}
+              >
+                <Icon name="file-plus" size={13} />
+                New file
+              </Button>
+            ) : null}
+          </div>
         }
       >
         {root?.loading && !root.entries && (
@@ -530,6 +555,8 @@ export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?
                       onMore={onViewerMore}
                       resolveLink={resolveWorkspaceLink}
                       onBack={onBack}
+                      canEdit={canEdit}
+                      onEdit={() => setEditPath(viewer.path)}
                     />
                   )
                 : null
@@ -537,6 +564,14 @@ export function WorkspaceFiles({ agentId, workdir }: { agentId: string; workdir?
           />
         )}
       </FileBrowserShell>
+      {editPath !== null && (
+        <WorkspaceFileEditor
+          agentId={agentId}
+          editPath={editPath}
+          onClose={() => setEditPath(null)}
+          onSaved={onFileSaved}
+        />
+      )}
     </div>
   )
 }
@@ -572,12 +607,16 @@ function FilePreview({
   viewer,
   onMore,
   resolveLink,
-  onBack
+  onBack,
+  canEdit,
+  onEdit
 }: {
   viewer: Viewer
   onMore: () => void
   resolveLink: (href: string) => MarkdownLinkResolution | undefined
   onBack?: () => void
+  canEdit: boolean
+  onEdit: () => void
 }) {
   const isMd = MARKDOWN_FILE_RE.test(viewer.name)
   const [mode, setMode] = useState<'preview' | 'code'>(isMd ? 'preview' : 'code')
@@ -624,15 +663,25 @@ function FilePreview({
         meta={meta}
         onBack={onBack}
         actions={
-          isMd && isText ? (
-            <span className="pillbar flex-none">
-              <button className={mode === 'preview' ? 'pill on' : 'pill'} onClick={() => setMode('preview')}>
-                Preview
-              </button>
-              <button className={mode === 'code' ? 'pill on' : 'pill'} onClick={() => setMode('code')}>
-                Code
-              </button>
-            </span>
+          (canEdit && isText && !!viewer.file?.mtime) || (isMd && isText) ? (
+            <div className="flex flex-none items-center gap-2">
+              {canEdit && isText && viewer.file?.mtime ? (
+                <Button variant="secondary" size="xs" onClick={onEdit}>
+                  <Icon name="pencil" size={14} />
+                  Edit
+                </Button>
+              ) : null}
+              {isMd && isText ? (
+                <span className="pillbar flex-none">
+                  <button className={mode === 'preview' ? 'pill on' : 'pill'} onClick={() => setMode('preview')}>
+                    Preview
+                  </button>
+                  <button className={mode === 'code' ? 'pill on' : 'pill'} onClick={() => setMode('code')}>
+                    Code
+                  </button>
+                </span>
+              ) : null}
+            </div>
           ) : undefined
         }
       />
@@ -690,6 +739,145 @@ function FilePreview({
         </>
       )}
     </>
+  )
+}
+
+function WorkspaceFileEditor({
+  agentId,
+  editPath,
+  onClose,
+  onSaved
+}: {
+  agentId: string
+  editPath: string
+  onClose: () => void
+  onSaved: (path: string) => void
+}) {
+  const creating = editPath === ''
+  const titleId = useId()
+  const [path, setPath] = useState(editPath)
+  const [content, setContent] = useState('')
+  const [mtime, setMtime] = useState<string | null>(null)
+  const [loading, setLoading] = useState(!creating)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (creating) return
+    let active = true
+    fetchWorkspaceFileFull(agentId, editPath).then(
+      (file) => {
+        if (!active) return
+        if (!file.exists || file.encoding !== 'utf8' || !file.mtime) {
+          setError('Only existing text files can be edited.')
+        } else {
+          setContent(file.content ?? '')
+          setMtime(file.mtime)
+        }
+        setLoading(false)
+      },
+      (e) => {
+        if (active) {
+          setError(msg(e))
+          setLoading(false)
+        }
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [agentId, creating, editPath])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !saving) onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose, saving])
+
+  const save = async () => {
+    const filePath = path.trim()
+    if (!filePath) {
+      setError('Enter a workspace-relative file path.')
+      return
+    }
+    if (saving || loading || (!creating && !mtime)) return
+    setSaving(true)
+    setError(null)
+    try {
+      await writeWorkspaceFile(agentId, filePath, creating ? { content } : { content, ifMatchMtime: mtime! })
+      onSaved(filePath)
+    } catch (e) {
+      setError(
+        e instanceof ApiError && e.status === 409
+          ? 'The agent is working or the file changed. Retry when it is idle.'
+          : msg(e)
+      )
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="scrim">
+      <div className="modal desktop:max-w-[760px]" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="modalhead">
+          <Icon name={creating ? 'file-plus' : 'pencil'} size={16} />
+          <span id={titleId} className="flex-1 font-sans text-[16px] font-semibold leading-normal">
+            {creating ? 'New workspace file' : `Edit ${editPath}`}
+          </span>
+          <button className="iconbtn" aria-label="Close" disabled={saving} onClick={onClose}>
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+        <div className="modalbody">
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Spinner size={28} />
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {creating && (
+                <label className="fld">
+                  <span className="fldlbl">Workspace-relative path</span>
+                  <input
+                    className="inp mono"
+                    value={path}
+                    onChange={(event) => setPath(event.target.value)}
+                    placeholder="notes.md"
+                    aria-label="New file path"
+                    autoFocus
+                  />
+                </label>
+              )}
+              <textarea
+                className="inp mono min-h-[320px] resize-y px-3 py-[10px] leading-[1.6] focus:border-(--brand) focus:outline-none"
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                aria-label={creating ? 'New file content' : `Edit ${editPath}`}
+                spellCheck={false}
+                disabled={saving || (!creating && !mtime)}
+                autoFocus={!creating}
+              />
+            </div>
+          )}
+          {error && (
+            <div className="mt-3 text-[12.5px] text-(--status-error)" role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="modalfoot">
+          <div className="flex-1" />
+          <Button variant="ghost" disabled={saving} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={saving || loading || (!creating && !mtime)} onClick={() => void save()}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1469,7 +1469,11 @@ export default function AgentDetailView() {
       {tab === 'workspace' &&
         (!da.name.startsWith(MOCK_PREFIX) ? (
           <div className="p-4 desktop:p-0">
-            <WorkspaceFiles agentId={id} workdir={da.workdir} />
+            <WorkspaceFiles
+              agentId={id}
+              workdir={da.workdir}
+              canEdit={da.workspace.mode === 'scratch' && da.canManageSharing}
+            />
           </div>
         ) : (
           <div className="flex flex-col gap-4 p-4 desktop:p-0">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1651,6 +1651,9 @@ export interface WorkspaceFileDto {
   truncated: boolean | null
 }
 
+/** Mirrors the daemon wire ceiling; base64 expansion still fits one control frame. */
+export const MAX_WORKSPACE_EDIT_BYTES = 180_000
+
 // One page of a workspace directory listing (GET /agents/:id/workspace/files),
 // proxied live from the agent's owning daemon — the CP never stores workspace
 // bytes (body-locality). 503 when that daemon is offline / the agent is unplaced.
@@ -1677,6 +1680,41 @@ export async function fetchWorkspaceFile(
   if (opts.offset) q.set('offset', String(opts.offset))
   if (opts.limit) q.set('limit', String(opts.limit))
   return apiGet<WorkspaceFileDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/file?${q.toString()}`)
+}
+
+/** Read one workspace text file whole before editing it. Every slice must describe
+ * the same mtime so a multi-page load cannot assemble two agent revisions. */
+export async function fetchWorkspaceFileFull(agentId: string, path: string): Promise<WorkspaceFileDto> {
+  let offset = 0
+  let content = ''
+  let mtime: string | null | undefined
+  for (let page = 0; page < 16; page++) {
+    const slice = await fetchWorkspaceFile(agentId, { path, offset })
+    if (!slice.exists || slice.encoding !== 'utf8') return slice
+    if ((slice.size ?? 0) > MAX_WORKSPACE_EDIT_BYTES) {
+      throw new Error('Files larger than 180 KB cannot be edited here.')
+    }
+    if (mtime === undefined) mtime = slice.mtime
+    else if (slice.mtime !== mtime) throw new Error('The file changed while it was loading. Open it again to edit.')
+    content += slice.content ?? ''
+    if (!slice.truncated) {
+      return { ...slice, content, offset: 0, nextOffset: slice.size, truncated: false }
+    }
+    if (slice.nextOffset == null || slice.nextOffset <= offset) break
+    offset = slice.nextOffset
+  }
+  throw new Error('The workspace file is too large to load safely.')
+}
+
+export function writeWorkspaceFile(
+  agentId: string,
+  path: string,
+  body: { content: string; ifMatchMtime?: string }
+): Promise<{ path: string; size: number; mtime: string }> {
+  return apiPut<{ path: string; size: number; mtime: string }>(
+    `${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/file?path=${encodeURIComponent(path)}`,
+    body
+  )
 }
 
 // One slice of an agent's memory file (GET /agents/:id/memory) — a single markdown


### PR DESCRIPTION
## Summary

- let agent managers create new UTF-8 files and edit existing files from the scratch Workspace UI
- return a visible conflict while the agent is working; otherwise stop the idle runtime before exclusive creation or atomic replacement
- enforce edit permission, scratch-only access, path containment, `.git` exclusion, UTF-8, and size limits in the control plane and daemon; file bodies remain daemon-local
- use one small editor flow for create and replace, including empty workspaces

## Validation

- all four package typechecks and full Prettier check
- protocol codec tests: 59 passed
- daemon workspace and dispatch tests: 53 passed
- full control-plane integration suite: 626 passed; focused workspace route: 3 passed
- web edit-access regression test: 1 passed
- full ESLint: no errors (2 pre-existing warnings)

Created by Codex . GPT-5
