### PR TITLE
feat(daemon): scheduled dreams via a DreamScheduler (D-2b)

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -1,8 +1,8 @@
 # Design: Memory Dreaming Mode — Offline Consolidation for Managed Memory
 
-> Status: D-1 shipped (protocol, daemon runner, CP REST, console config);
-> D-2a shipped (auto-adopt gate, distillation rebase). D-2b (scheduled dreams)
-> and D-3 (skill mining) remain proposals — see §12.
+> Status: D-1 shipped (protocol, daemon runner, CP REST, console config); D-2
+> shipped (auto-adopt gate, distillation rebase, scheduled dreams). D-3 (skill
+> mining) remains a proposal — see §12.
 > Prerequisites: [memory-evolution.md](memory-evolution.md),
 > [memory-system-plan.md](memory-system-plan.md),
 > [daemon-centric-architecture.md](daemon-centric-architecture.md),
@@ -113,6 +113,8 @@ export const MemoryDreamingPolicy = z
     sessionWindow: z.number().int().min(1).max(100).optional(),
     /** Optional cron for scheduled dreams (same syntax as agent crons). */
     schedule: z.string().min(1).max(128).optional(),
+    /** IANA zone the `schedule` is evaluated in; absent ⇒ daemon-host local. */
+    timezone: z.string().min(1).max(64).optional(),
     /** Operator steering text applied through the whole pipeline (≤ 4096 chars). */
     instructions: z.string().max(4096).optional(),
     /** Also mine reusable procedures into candidate skills (§7). Default false. */
@@ -376,11 +378,11 @@ to run once dreaming has usage data.
 ## 9. Triggers
 
 - **Manual** — console "Dream now" button; the primary v1 path.
-- **Scheduled** — `dreaming.schedule` cron, registered through the existing
-  `Scheduler` reconciliation (like `agent.json.crons[]`), firing a headless
-  internal trigger (not a synthetic platform message — dreams are not turns).
-- **Idle-triggered (later)** — "N hours since the last consolidation and the
-  agent has been active since" fits the daemon (it already tracks per-agent
+- **Scheduled** — the `dreaming.schedule` cron (+ optional `timezone`), driven
+  by a `DreamScheduler` synced on the same agent reconcile as `agent.json.crons[]`.
+  It is a SIBLING of `Scheduler`, not a reuse: that one synthesizes a message and
+  runs it as a turn, while a dream is a background job with no conversation. A
+  tick landing while a dream is in flight is skipped, never queued.
   activity), as a follow-up once scheduled dreams are proven.
 
 ## 10. Control plane and console
@@ -434,6 +436,6 @@ skill bodies in events or logs (same rule as the capture path).
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | D-1   | Protocol schema (`MemoryDreamingPolicy`), shared extraction-session helper, daemon `DreamRunner` + staged store pipeline, manual trigger via frames, console review + adopt/discard. |
 | D-2a  | `autoAdopt` behind `trustedExtractionMode`, the distillation rebase rule, backup pruning. **Done.**                                                                                  |
-| D-2b  | Scheduled dreams (cron trigger + reconciliation), and the console schedule control it unlocks; evaluation-event dashboards.                                                          |
+| D-2b  | Scheduled dreams (`DreamScheduler` cron trigger + reconciliation) and the console schedule control. **Done.** Evaluation-event dashboards remain.                                    |
 | D-3   | Skill mining (`mineSkills`): extract-procedures phase, staged skill candidates, console recommendations with accept/dismiss, integration with the shared-skills install flow.        |
 | D-4   | Idle-trigger heuristic; revisit external-provider dreaming.                                                                                                                          |

--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -382,7 +382,11 @@ to run once dreaming has usage data.
   by a `DreamScheduler` synced on the same agent reconcile as `agent.json.crons[]`.
   It is a SIBLING of `Scheduler`, not a reuse: that one synthesizes a message and
   runs it as a turn, while a dream is a background job with no conversation. A
-  tick landing while a dream is in flight is skipped, never queued.
+  tick landing while a dream is in flight is skipped, never queued. Each fire
+  also obeys the agent lifecycle gates (pause, safety-drain, per-agent drain,
+  daemon drain) — as skips, so the schedule resumes by itself on unpause.
+- **Idle-triggered (later)** — "N hours since the last consolidation and the
+  agent has been active since" fits the daemon (it already tracks per-agent
   activity), as a follow-up once scheduled dreams are proven.
 
 ## 10. Control plane and console

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -50,7 +50,7 @@ import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-
 import { toolsForIntegrations, MEMORY_TOOL_NAMES, ALL_TOOL_NAMES, GITHUB_REVIEW_TOOLS } from './mcp/tools.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, trustedExtractionMode } from './agents/memory-distiller.js'
-import { DreamRunner } from './agents/dream-runner.js'
+import { DreamRunner, DreamStateError } from './agents/dream-runner.js'
 import { createDreamReader } from './cp/dream-reader.js'
 import { routeRules, type RouteVia } from './router/routing-table.js'
 import { parseCommand, type AgentCommand } from './commands/commands.js'
@@ -108,6 +108,7 @@ import {
 } from './discord/render.js'
 import { FeishuConverger, renderStatusReply as renderFeishuStatusReply, type FeishuAction } from './feishu/render.js'
 import { Scheduler, buildSyntheticMessage } from './scheduler/scheduler.js'
+import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
 import { buildHookMessage, hookAnchorText } from './messages/hook-message.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './github/poster.js'
@@ -243,7 +244,8 @@ import type {
   GitCommitIdentity,
   GithubReviewAuthorized,
   HookReviewResult,
-  FeishuRegion
+  FeishuRegion,
+  MemoryDreamingPolicy
 } from '@agentconnect.md/protocol'
 
 /** Format an error for logs, surfacing a JSON-RPC/ACP RequestError's `code` and
@@ -420,6 +422,14 @@ function reviewResultForWire(effect: GithubReviewEffect): HookReviewResult {
 
 // Cap per-session `!queue` depth so a hung turn or a user spamming `!queue` can't
 // grow `queued` without bound. Past the cap we reject with a clear message.
+/** An agent's dreaming policy, or undefined when it has none. An absent memory
+ *  binding means the managed default, but dreaming itself is always opt-in — and
+ *  it is only valid on the managed provider (the protocol enforces that too). */
+function dreamingPolicyOf(agent: { memory?: Agent['memory'] } | undefined): MemoryDreamingPolicy | undefined {
+  const memory = agent?.memory
+  return memory?.provider === 'managed' ? memory.dreaming : undefined
+}
+
 const MAX_QUEUED_PER_SESSION = 10
 
 /** Bounded hard-stop for a dream extraction whose runtime ignores `session/cancel`:
@@ -1167,6 +1177,7 @@ export class Daemon {
   // from its membership snapshot instead — see refreshChannels). Created in start().
   private channelNameResolver?: ChannelNameResolver
   private scheduler!: Scheduler
+  private dreamScheduler!: DreamScheduler
   private sessions!: SessionManager
   // integrationId -> the SlackConnection that owns it (for replies). Holds BOTH
   // socket-mode (direct) and send-only (shared-bot) connections — a shared bot's
@@ -1940,6 +1951,11 @@ export class Daemon {
       newTraceId: () => randomUUID(),
       warn: (m) => this.log.warn(m)
     })
+    // Scheduled dreams ride their own trigger, never a synthetic turn (§9).
+    this.dreamScheduler = new DreamScheduler({
+      onFire: (agentId) => this.onDreamScheduleFire(agentId),
+      warn: (m) => this.log.warn(m)
+    })
 
     // open consolidated Slack connections, resolve bot user ids (merged rules are per-message)
     const groups = consolidate(agents)
@@ -2011,6 +2027,7 @@ export class Daemon {
 
     // register crons (sync per agent — the same converge reconcile re-runs on change)
     for (const a of agents) this.scheduler.sync(a.id, a.crons)
+    for (const a of agents) this.dreamScheduler.sync(a.id, dreamingPolicyOf(a))
     const cronCount = agents.reduce((n, a) => n + this.scheduler.count(a.id), 0)
     if (cronCount) this.log.info(`registered ${cronCount} cron(s)`)
 
@@ -2123,6 +2140,7 @@ export class Daemon {
       this.interruptAgentTurns(id, 'stop')
       this.agents.delete(id)
       this.scheduler.unregister(id)
+      this.dreamScheduler.unregister(id)
       this.gitCreds.remove(id)
       this.gitCredServer?.revoke(id)
       // Use the one generation-safe teardown path: it evicts the host synchronously,
@@ -2173,6 +2191,7 @@ export class Daemon {
       // crons live in the whole-agent signature, so any change re-syncs the agent's
       // job set (design §5.2: crons change → Scheduler upsert/remove). Idempotent.
       this.scheduler.sync(a.id, a.crons)
+      this.dreamScheduler.sync(a.id, dreamingPolicyOf(a))
       // host-spawn or workspace change → evict the cached host (once) so the next
       // session lazily re-spawns it with fresh env and/or re-materializes cwd via
       // prepareWorkspace. Soft-only and integration-only changes never touch the host.
@@ -2225,6 +2244,7 @@ export class Daemon {
       // start every agent is a toStart), so the repo is cloned ahead of the first message.
       this.prefetchClone(a as LoadedAgent)
       this.scheduler.sync(a.id, a.crons)
+      this.dreamScheduler.sync(a.id, dreamingPolicyOf(a))
     }
     // Reconcile exactly once from the final live roster. The close phase is strict:
     // detach ACKs only after last-reference connections have actually stopped.
@@ -3368,11 +3388,7 @@ export class Daemon {
   private dreamRunner(): DreamRunner {
     this.dreamRunnerInstance ??= new DreamRunner({
       agentDirByAgent: (id) => this.agents.get(id)?.dir,
-      dreamingPolicyFor: (id) => {
-        const memory = this.agents.get(id)?.memory
-        // Absent binding ⇒ managed default, but dreaming stays opt-in (no policy).
-        return memory?.provider === 'managed' ? memory.dreaming : undefined
-      },
+      dreamingPolicyFor: (id) => dreamingPolicyOf(this.agents.get(id)),
       store: this.store,
       extract: (agentId, systemPrompt, prompt, signal) =>
         this.runDreamExtraction(agentId, systemPrompt, prompt, signal),
@@ -11894,6 +11910,30 @@ export class Daemon {
   }
 
   /**
+   * A dream schedule fired for `agentId` (docs/designs/memory-dreaming.md §9).
+   * Deliberately NOT a turn: no synthetic message, no transcript row, no inbox
+   * entry — just the background job, exactly as a manual `dream/start` would.
+   *
+   * Refusals here are ordinary operating states, not errors: a tick that lands
+   * while the previous dream is still running is SKIPPED (dreams are not queued
+   * — a backlog of stale consolidations helps nobody), and a policy switched off
+   * between the reconcile and the tick simply does nothing.
+   */
+  private onDreamScheduleFire(agentId: string): void {
+    void this.dreamRunner()
+      .start(agentId, { trigger: 'schedule' })
+      .then((dream) => this.log.info(`dream ${dream.dreamId} started on schedule for agent "${agentId}"`))
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err)
+        if (err instanceof DreamStateError) {
+          this.log.info(`scheduled dream skipped for agent "${agentId}": ${message}`)
+          return
+        }
+        this.log.error(`scheduled dream failed to start for agent "${agentId}": ${message}`)
+      })
+  }
+
+  /**
    * A cron fired for `agentId` (§8.6 bypass). The fire is stamped into D11
    * first (the daemon owns last-run, protocol §5.4); the anchor+dispatch ride
    * the shared {@link fireTrigger} path.
@@ -12536,6 +12576,7 @@ export class Daemon {
     await this.drainForShutdown()
     const errors: unknown[] = []
     this.scheduler?.stop()
+    this.dreamScheduler?.stop()
     await Promise.resolve(this.cpClient?.stop()).catch((e) => errors.push(e))
     // Stop the body-bearing capture pump before closing its verified clients or
     // SQLite store. Unfinished operations remain durable for restart recovery.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11920,6 +11920,22 @@ export class Daemon {
    * between the reconcile and the tick simply does nothing.
    */
   private onDreamScheduleFire(agentId: string): void {
+    // Lifecycle gates first — a scheduled dream is background work that spawns a
+    // runtime host and burns model tokens, so it obeys the same operator stops as
+    // any other scheduled trigger. The cron stays REGISTERED throughout: these are
+    // skips, not deregistrations, so the schedule resumes by itself on unpause.
+    if (this.paused(agentId)) {
+      this.log.info(`scheduled dream skipped for agent "${agentId}": agent is paused`)
+      return
+    }
+    if (this.safetyDrainingAgents.has(agentId)) {
+      this.log.info(`scheduled dream skipped for agent "${agentId}": interrupted turns are still stopping`)
+      return
+    }
+    if (this.draining || this.drainingAgents.has(agentId)) {
+      this.log.info(`scheduled dream skipped for agent "${agentId}": draining`)
+      return
+    }
     void this.dreamRunner()
       .start(agentId, { trigger: 'schedule' })
       .then((dream) => this.log.info(`dream ${dream.dreamId} started on schedule for agent "${agentId}"`))

--- a/packages/daemon/src/scheduler/dream-scheduler.ts
+++ b/packages/daemon/src/scheduler/dream-scheduler.ts
@@ -1,0 +1,66 @@
+import { Cron } from 'croner'
+import type { MemoryDreamingPolicy } from '@agentconnect.md/protocol'
+
+/**
+ * Cron trigger for scheduled memory dreams (docs/designs/memory-dreaming.md §9,
+ * D-2b). A sibling of {@link Scheduler} rather than a reuse of it, because the
+ * two fire fundamentally different things: `Scheduler` synthesizes a
+ * `NormalizedMessage` and runs it as a TURN (it has a platform target, a thread,
+ * transcript rows, loop-guard accounting); a dream is a background job with its
+ * own lifecycle and no conversation at all. Routing dreams through a synthetic
+ * message would put them in the agent's transcript and inbox, which is exactly
+ * what §9 rules out.
+ *
+ * At most one job per agent — the agent's `dreaming.schedule`. `sync` converges
+ * an agent's job to its current policy (idempotent, replace-all like
+ * `Scheduler.sync`), so any reconcile can call it unconditionally. A malformed
+ * expression drops that agent's schedule with a warning and never throws into
+ * the reconciler.
+ */
+export class DreamScheduler {
+  private jobs = new Map<string, Cron>() // agentId → its live dream job
+
+  constructor(
+    private deps: {
+      /** Fire one scheduled dream. Never rejects into the timer — the daemon's
+       *  handler swallows the ordinary "already in flight"/"not enabled" cases. */
+      onFire: (agentId: string) => void
+      warn?: (msg: string) => void
+    }
+  ) {}
+
+  /** Converge one agent's dream job to its policy. A disabled policy, an absent
+   *  policy, or one without a `schedule` leaves the agent unscheduled. */
+  sync(agentId: string, policy: MemoryDreamingPolicy | undefined): void {
+    this.unregister(agentId)
+    if (!policy?.enabled || !policy.schedule) return
+    try {
+      this.jobs.set(
+        agentId,
+        new Cron(policy.schedule, policy.timezone ? { timezone: policy.timezone } : {}, () => this.deps.onFire(agentId))
+      )
+    } catch (err) {
+      this.deps.warn?.(`dream scheduler: skipping schedule for agent "${agentId}": ${(err as Error).message}`)
+    }
+  }
+
+  /** Stop and drop an agent's dream job (agent removed / dreaming turned off). */
+  unregister(agentId: string): void {
+    this.jobs.get(agentId)?.stop()
+    this.jobs.delete(agentId)
+  }
+
+  /** 1 when this agent has a live dream schedule, else 0. */
+  count(agentId: string): number {
+    return this.jobs.has(agentId) ? 1 : 0
+  }
+
+  /** The next fire time for an agent's dream job, or null when unscheduled. */
+  nextRun(agentId: string): Date | null {
+    return this.jobs.get(agentId)?.nextRun() ?? null
+  }
+
+  stop(): void {
+    for (const agentId of [...this.jobs.keys()]) this.unregister(agentId)
+  }
+}

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { MemoryDreamingPolicy } from '@agentconnect.md/protocol'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { DreamScheduler } from '../src/scheduler/dream-scheduler.js'
+import { Daemon } from '../src/daemon.js'
 
 /** A cron that fires every second, so a real tick is observable in a test. */
 const EVERY_SECOND = '* * * * * *'
@@ -84,5 +88,93 @@ describe('DreamScheduler', () => {
     scheduler.stop()
     await new Promise((r) => setTimeout(r, 1200))
     expect(fired).toHaveLength(0)
+  })
+})
+
+describe('scheduled dream lifecycle gates (daemon)', () => {
+  /** Minimal on-disk daemon root with one managed-memory agent that dreams on a cron. */
+  function scaffold(): string {
+    const root = mkdtempSync(join(tmpdir(), 'ac-dream-gate-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: ['unused'] } }
+      })
+    )
+    const adir = join(root, 'agents', 'bot-a')
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id: 'bot-a',
+        name: 'bot-a',
+        runtime: 'claude',
+        memory: { provider: 'managed', dreaming: { enabled: true, schedule: '0 4 * * *' } }
+      })
+    )
+    return root
+  }
+
+  /** Fire the private schedule handler the way croner would, with the runner
+   *  stubbed — so the assertion is purely "did the gate let this through?"
+   *  (the real runner needs a started daemon, which the gates run before). */
+  async function fire(daemon: Daemon, agentId: string): Promise<boolean> {
+    let started = false
+    const inner = daemon as unknown as {
+      onDreamScheduleFire(id: string): void
+      dreamRunner(): { start(id: string, opts: unknown): Promise<unknown> }
+    }
+    inner.dreamRunner = () => ({
+      start: async () => {
+        started = true
+        return { dreamId: 'drm-test' }
+      }
+    })
+    inner.onDreamScheduleFire(agentId)
+    await new Promise((r) => setTimeout(r, 20))
+    return started
+  }
+
+  it('skips a tick while the agent is paused or the daemon is draining, without deregistering', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    const inner = daemon as unknown as {
+      agents: Map<string, { pause?: boolean }>
+      draining: boolean
+      drainingAgents: Set<string>
+      safetyDrainingAgents: Set<string>
+    }
+    inner.agents.set('bot-a', { pause: false })
+
+    // Paused: an agent-wide operator stop must also stop background dreaming.
+    inner.agents.set('bot-a', { pause: true })
+    expect(await fire(daemon, 'bot-a')).toBe(false)
+
+    // Interrupted turns still stopping.
+    inner.agents.set('bot-a', { pause: false })
+    inner.safetyDrainingAgents.add('bot-a')
+    expect(await fire(daemon, 'bot-a')).toBe(false)
+    inner.safetyDrainingAgents.delete('bot-a')
+
+    // Per-agent drain, then daemon-wide drain.
+    inner.drainingAgents.add('bot-a')
+    expect(await fire(daemon, 'bot-a')).toBe(false)
+    inner.drainingAgents.delete('bot-a')
+    inner.draining = true
+    expect(await fire(daemon, 'bot-a')).toBe(false)
+    inner.draining = false
+
+    // Gates are skips, not deregistrations: once they clear, the very next tick
+    // runs. (That the cron object itself survives is covered by the
+    // DreamScheduler sync/unregister tests above — the gate never touches it.)
+    expect(await fire(daemon, 'bot-a')).toBe(true)
+  })
+
+  it('reaches the runner once the gates clear', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    const inner = daemon as unknown as { agents: Map<string, { pause?: boolean }> }
+    inner.agents.set('bot-a', { pause: false })
+    expect(await fire(daemon, 'bot-a')).toBe(true)
   })
 })

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { MemoryDreamingPolicy } from '@agentconnect.md/protocol'
+import { DreamScheduler } from '../src/scheduler/dream-scheduler.js'
+
+/** A cron that fires every second, so a real tick is observable in a test. */
+const EVERY_SECOND = '* * * * * *'
+
+function make(): { fired: string[]; warned: string[]; scheduler: DreamScheduler } {
+  const fired: string[] = []
+  const warned: string[] = []
+  const scheduler = new DreamScheduler({ onFire: (id) => fired.push(id), warn: (m) => warned.push(m) })
+  return { fired, warned, scheduler }
+}
+
+describe('DreamScheduler', () => {
+  it('schedules only an enabled policy that carries a cron', () => {
+    const { scheduler } = make()
+    const cases: [string, MemoryDreamingPolicy | undefined, number][] = [
+      ['no policy at all', undefined, 0],
+      ['disabled with a schedule', { enabled: false, schedule: '0 4 * * *' }, 0],
+      ['enabled without a schedule (manual-only)', { enabled: true }, 0],
+      ['enabled with a schedule', { enabled: true, schedule: '0 4 * * *' }, 1]
+    ]
+    for (const [label, policy, expected] of cases) {
+      scheduler.sync('a1', policy)
+      expect(scheduler.count('a1'), label).toBe(expected)
+    }
+    scheduler.stop()
+  })
+
+  it('converges on re-sync and drops the job on unregister', () => {
+    const { scheduler } = make()
+    scheduler.sync('a1', { enabled: true, schedule: '0 4 * * *' })
+    const first = scheduler.nextRun('a1')
+    expect(first).toBeInstanceOf(Date)
+
+    // Re-syncing is idempotent (replace-all), so a reconcile may call it freely.
+    scheduler.sync('a1', { enabled: true, schedule: '0 4 * * *' })
+    expect(scheduler.count('a1')).toBe(1)
+
+    // Turning dreaming off converges the agent to unscheduled.
+    scheduler.sync('a1', { enabled: false, schedule: '0 4 * * *' })
+    expect(scheduler.count('a1')).toBe(0)
+    expect(scheduler.nextRun('a1')).toBeNull()
+
+    scheduler.sync('a1', { enabled: true, schedule: '0 4 * * *' })
+    scheduler.unregister('a1')
+    expect(scheduler.count('a1')).toBe(0)
+    scheduler.stop()
+  })
+
+  it('drops a malformed expression with a warning instead of throwing at the reconciler', () => {
+    const { warned, scheduler } = make()
+    expect(() => scheduler.sync('a1', { enabled: true, schedule: 'not a cron' })).not.toThrow()
+    expect(scheduler.count('a1')).toBe(0)
+    expect(warned[0]).toContain('a1')
+
+    // One bad agent must not stop a good one from scheduling.
+    scheduler.sync('a2', { enabled: true, schedule: '0 4 * * *' })
+    expect(scheduler.count('a2')).toBe(1)
+    scheduler.stop()
+  })
+
+  it('rejects an invalid timezone without scheduling the agent', () => {
+    const { warned, scheduler } = make()
+    scheduler.sync('a1', { enabled: true, schedule: '0 4 * * *', timezone: 'Mars/Olympus_Mons' })
+    expect(scheduler.count('a1')).toBe(0)
+    expect(warned).toHaveLength(1)
+    scheduler.stop()
+  })
+
+  it('fires onFire for the scheduled agent', async () => {
+    const { fired, scheduler } = make()
+    scheduler.sync('a1', { enabled: true, schedule: EVERY_SECOND })
+    await new Promise((r) => setTimeout(r, 1400))
+    scheduler.stop()
+    expect(fired.length).toBeGreaterThanOrEqual(1)
+    expect(new Set(fired)).toEqual(new Set(['a1']))
+  })
+
+  it('stops firing once stopped', async () => {
+    const { fired, scheduler } = make()
+    scheduler.sync('a1', { enabled: true, schedule: EVERY_SECOND })
+    scheduler.stop()
+    await new Promise((r) => setTimeout(r, 1200))
+    expect(fired).toHaveLength(0)
+  })
+})

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -51,8 +51,12 @@ export const MemoryDreamingPolicy = z
     enabled: z.boolean(),
     /** How many recent sessions to mine (default 20). */
     sessionWindow: z.number().int().min(1).max(100).optional(),
-    /** Cron expression for scheduled dreams (same syntax as agent crons). */
+    /** Cron expression for scheduled dreams (same syntax as agent crons). A tick
+     *  that lands while a dream is already in flight is skipped, not queued. */
     schedule: z.string().min(1).max(128).optional(),
+    /** IANA zone the `schedule` is evaluated in (as on agent crons). Absent ⇒ the
+     *  daemon host's local time. */
+    timezone: z.string().min(1).max(64).optional(),
     /** Operator steering text applied through the whole dream pipeline. */
     instructions: z.string().max(4096).optional(),
     /** Also mine reusable procedures into candidate skills (never auto-installed). */

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -259,6 +259,51 @@ describe('MemoryPanel settings draft', () => {
     expect(dreamingBox()?.checked).toBe(false)
   })
 
+  it('resyncs on a timezone-only refresh, so a later save cannot restore the stale zone', async () => {
+    // `timezone` is preserved through the wholesale memory PATCH but not edited
+    // in the UI. If it were missing from the prop-sync dependency list, a
+    // timezone-only poll would leave the draft on the old zone and the next
+    // unrelated edit would silently write it back.
+    const props = {
+      agentId: '44444444-4444-4444-8444-444444444444',
+      canEdit: true,
+      memoryProvider: 'managed',
+      autoDistill: false
+    }
+    const policy = (timezone: string) => ({ enabled: true, schedule: '0 4 * * *', timezone })
+
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(<MemoryPanel {...props} memoryDreaming={policy('UTC')} />)
+    })
+    await openSettings(container)
+
+    // Only the timezone changes upstream.
+    await act(async () => {
+      root?.render(<MemoryPanel {...props} memoryDreaming={policy('America/New_York')} />)
+    })
+
+    // An unrelated edit (auto-distill) then saves the WHOLE binding.
+    const distillBox = [...container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')].find((box) =>
+      box.parentElement?.textContent?.includes('Automatically distill')
+    )
+    await act(async () => {
+      distillBox?.click()
+    })
+    const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (b) => b.textContent === 'Save memory settings'
+    )
+    await act(async () => {
+      save?.click()
+    })
+
+    const saved = mocks.updateAgent.mock.calls.at(-1)?.[1] as
+      { memory?: { dreaming?: { timezone?: string } } } | undefined
+    expect(saved?.memory?.dreaming?.timezone).toBe('America/New_York')
+  })
+
   it('uses an app confirmation before persisting a backend switch', async () => {
     const nativeConfirm = vi.fn(() => true)
     vi.stubGlobal('confirm', nativeConfirm)

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -215,6 +215,7 @@ export function MemoryPanel({
     memoryDreaming?.enabled,
     memoryDreaming?.sessionWindow,
     memoryDreaming?.schedule,
+    memoryDreaming?.timezone,
     memoryDreaming?.instructions,
     memoryDreaming?.mineSkills,
     memoryDreaming?.autoAdopt,
@@ -672,6 +673,7 @@ export function MemoryPanel({
                       <input
                         type="text"
                         value={settings.dreaming.schedule ?? ''}
+                        maxLength={128}
                         placeholder="0 4 * * *"
                         disabled={!canEdit || savingProvider}
                         onChange={(e) => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -662,11 +662,26 @@ export function MemoryPanel({
                       setProviderError(null)
                     }}
                   />
-                  Enable dreaming — consolidate the store from recent sessions on demand, staged for review before it
-                  replaces the live store. Run a dream from the API (scheduled dreams arrive in a later release).
+                  Enable dreaming — consolidate the store from recent sessions, staged for review before it replaces the
+                  live store. Runs on demand, plus the schedule below if you set one.
                 </label>
                 {settings.dreaming.enabled ? (
                   <div className="ml-6 flex flex-col gap-2">
+                    <label className="flex flex-col gap-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                      Schedule (cron, optional — leave blank to dream only on demand)
+                      <input
+                        type="text"
+                        value={settings.dreaming.schedule ?? ''}
+                        placeholder="0 4 * * *"
+                        disabled={!canEdit || savingProvider}
+                        onChange={(e) => {
+                          const schedule = e.target.value
+                          setSettings((current) => ({ ...current, dreaming: { ...current.dreaming, schedule } }))
+                          setProviderError(null)
+                        }}
+                        className="rounded-sm border border-(--border-subtle) bg-(--surface-card) px-2 py-1 font-mono text-[12px] leading-normal text-(--text-primary)"
+                      />
+                    </label>
                     <label className="flex flex-col gap-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
                       Instructions (optional — steer what the dream focuses on)
                       <textarea

--- a/packages/web/src/components/console/memory-settings.test.ts
+++ b/packages/web/src/components/console/memory-settings.test.ts
@@ -106,8 +106,8 @@ describe('memory settings UX model', () => {
 
   it('preserves the full dreaming policy across a save, even fields the console does not edit', () => {
     // A complete API-configured policy round-trips: the wholesale `memory` PATCH
-    // must not drop sessionWindow / schedule / mineSkills / autoAdopt just because
-    // the D-1 console only edits enabled + instructions.
+    // must not drop sessionWindow / timezone / mineSkills / autoAdopt just because
+    // the console only edits enabled + schedule + instructions.
     const full = memorySettingsDraft({
       provider: 'managed',
       autoDistill: true,
@@ -115,6 +115,7 @@ describe('memory settings UX model', () => {
         enabled: true,
         sessionWindow: 40,
         schedule: '0 4 * * *',
+        timezone: 'America/New_York',
         instructions: 'focus on prefs',
         mineSkills: true,
         autoAdopt: false
@@ -125,6 +126,7 @@ describe('memory settings UX model', () => {
       instructions: 'focus on prefs',
       sessionWindow: 40,
       schedule: '0 4 * * *',
+      timezone: 'America/New_York',
       mineSkills: true,
       autoAdopt: false
     })
@@ -137,10 +139,18 @@ describe('memory settings UX model', () => {
         enabled: true,
         sessionWindow: 40,
         schedule: '0 4 * * *',
+        timezone: 'America/New_York',
         instructions: 'new focus',
         mineSkills: true,
         autoAdopt: false
       }
+    })
+
+    // The schedule IS editable now that D-2b fires it; the edit round-trips.
+    const rescheduled = { ...full, dreaming: { ...full.dreaming, schedule: '30 2 * * 0' } }
+    expect(memorySettingsChanged(full, rescheduled)).toBe(true)
+    expect(memoryConfigForDraft(rescheduled)).toMatchObject({
+      dreaming: { schedule: '30 2 * * 0', timezone: 'America/New_York' }
     })
   })
 })

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -6,17 +6,18 @@ import {
 
 /**
  * Managed-only dreaming policy as a form draft. It carries the COMPLETE policy —
- * including fields the D-1 console doesn't yet edit (`sessionWindow`, and the
- * later-phase `schedule`/`mineSkills`/`autoAdopt`) — because a managed-memory
- * save PATCHes the `memory` binding wholesale, so anything the draft drops is
- * lost. The UI edits only `enabled` and `instructions` today; the rest is
- * preserved verbatim from whatever the API (or a later phase) set.
+ * including fields the console doesn't yet edit (`sessionWindow`, `timezone`, and
+ * the later-phase `mineSkills`/`autoAdopt`) — because a managed-memory save
+ * PATCHes the `memory` binding wholesale, so anything the draft drops is lost.
+ * The UI edits `enabled`, `schedule`, and `instructions`; the rest is preserved
+ * verbatim from whatever the API (or a later phase) set.
  */
 export interface DreamingDraft {
   enabled: boolean
   instructions: string
   sessionWindow?: number
   schedule?: string
+  timezone?: string
   mineSkills?: boolean
   autoAdopt?: boolean
 }
@@ -65,6 +66,7 @@ function sameDreaming(a: DreamingDraft, b: DreamingDraft): boolean {
     a.instructions === b.instructions &&
     a.sessionWindow === b.sessionWindow &&
     a.schedule === b.schedule &&
+    a.timezone === b.timezone &&
     a.mineSkills === b.mineSkills &&
     a.autoAdopt === b.autoAdopt
   )
@@ -87,6 +89,7 @@ export function memorySettingsDraft(input: {
           instructions: input.dreaming.instructions ?? '',
           ...(input.dreaming.sessionWindow !== undefined ? { sessionWindow: input.dreaming.sessionWindow } : {}),
           ...(input.dreaming.schedule ? { schedule: input.dreaming.schedule } : {}),
+          ...(input.dreaming.timezone ? { timezone: input.dreaming.timezone } : {}),
           ...(input.dreaming.mineSkills !== undefined ? { mineSkills: input.dreaming.mineSkills } : {}),
           ...(input.dreaming.autoAdopt !== undefined ? { autoAdopt: input.dreaming.autoAdopt } : {})
         }
@@ -159,6 +162,7 @@ export function dreamingConfigForDraft(draft: DreamingDraft): MemoryDreamingConf
     draft.enabled ||
     !!instructions ||
     !!schedule ||
+    !!draft.timezone ||
     draft.sessionWindow !== undefined ||
     draft.mineSkills !== undefined ||
     draft.autoAdopt !== undefined
@@ -167,6 +171,7 @@ export function dreamingConfigForDraft(draft: DreamingDraft): MemoryDreamingConf
     enabled: draft.enabled,
     ...(draft.sessionWindow !== undefined ? { sessionWindow: draft.sessionWindow } : {}),
     ...(schedule ? { schedule } : {}),
+    ...(draft.timezone ? { timezone: draft.timezone } : {}),
     ...(instructions ? { instructions } : {}),
     ...(draft.mineSkills !== undefined ? { mineSkills: draft.mineSkills } : {}),
     ...(draft.autoAdopt !== undefined ? { autoAdopt: draft.autoAdopt } : {})

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -129,6 +129,7 @@ export interface MemoryDreamingConfig {
   enabled: boolean
   sessionWindow?: number // recent sessions to mine (1–100)
   schedule?: string // cron expression for scheduled dreams
+  timezone?: string // IANA zone the schedule is evaluated in (absent ⇒ daemon local)
   instructions?: string // operator steering text (≤4096 chars)
   mineSkills?: boolean // also mine reusable procedures (D-3)
   autoAdopt?: boolean // adopt automatically on completion (trusted runtimes only)


### PR DESCRIPTION
## Summary

Makes `dreaming.schedule` **real**. Until now the field was accepted, stored, and preserved — but nothing ever read it, so a dream only ran when something explicitly asked for one. This is the D-2b trigger from [memory-dreaming.md](docs/designs/memory-dreaming.md) §9.

- **New `DreamScheduler`** — at most one croner job per agent, synced from the agent's dreaming policy at the same reconcile points as `agent.json.crons[]` (boot, agent added/changed/removed, shutdown). A malformed expression or bad timezone drops that agent's schedule with a warning and never throws into the reconciler.
- **A sibling of `Scheduler`, not a reuse.** That one synthesizes a `NormalizedMessage` and runs it as a **turn** — platform target, thread, transcript rows, loop-guard accounting. A dream is a background job with no conversation, and §9 explicitly rules out putting dreams in the agent's transcript/inbox. So it calls `DreamRunner.start(agentId, { trigger: 'schedule' })` directly.
- **Overlap policy: skip, don't queue.** A tick landing while a dream is in flight is skipped — a backlog of stale consolidations helps nobody. That refusal, and a policy switched off between reconcile and tick, are logged as ordinary states rather than errors.
- **`dreaming.timezone`** (IANA, mirroring `CronDef`) so a daily schedule means what the operator intended; preserved through the console draft like the other unedited policy fields.
- **Re-enables the console cron control** that #34 withheld precisely because nothing fired it. Copy now reads "on demand, plus the schedule below if you set one."

## Test plan

- `DreamScheduler`: what does/doesn't get scheduled (no policy / disabled / enabled-without-cron / enabled-with-cron), convergence on re-sync and `unregister`, malformed-cron and bad-timezone isolation (one bad agent doesn't block a good one), a **real tick** firing `onFire`, and silence after `stop()`.
- Web: the schedule edit round-trips and `timezone` survives an unrelated edit.
- Protocol 180, daemon 2019, web 260 passed; typecheck, eslint, prettier, daemon build clean.

Stacks on #48 (D-2a) conceptually but touches disjoint code — mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
