### PR TITLE
feat(webchat): support image uploads

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -835,10 +835,11 @@ Goal: **channel contains only start / plan / problem / finish + link**, while de
 
 Thread semantics: main progress goes at the thread anchor or, for a subscribed thread, uses `thread_ts`; tool-output messages reply in the same thread. `SlackSendQueue` rate-limits API calls, including the `chat.postMessage` Tier3 limit of 50rpm. The effective output mode is the per-session override when present, otherwise `agent.output.mode`.
 
-### 9.2 Inbound: Slack Event -> ACP `session/prompt` Content
+### 9.2 Inbound Attachments -> ACP `session/prompt` Content
 
 - Extract text from `app_mention` / `message`. For a mid-thread @mention, `SlackConnection.getThreadReplies()` in `packages/daemon/src/slack/connection.ts` fetches the full thread through `conversations.replies`, and `SessionManager` uses that snapshot as prompt context.
 - Download attachment bytes from `files.url_private` with bot token and create ACP `image` / `resource` blocks.
+- Decode a relay-delivered, size-bounded webchat image locally and feed it through the same ACP attachment-block builder; only its name and MIME summary enter the transcript.
 - Normalize to `NormalizedMessage`, then `session/prompt`.
 
 ### 9.3 Telegram / Discord / Feishu Mapping (Implemented)

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -255,8 +255,12 @@ rd/chat { chatId, seq, event }
 
 `rd/msg` already names the destination agent. IM payloads contain normalized
 message data and attachment metadata; attachment bytes are fetched by the
-daemon directly from the platform. `rd/chat` is used only to return webchat
-output to the browser connection held by that relay.
+daemon directly from the platform. A webchat turn may instead carry one inline
+PNG, JPEG, or WebP image: the browser rasterizes and compresses it to at most
+160 KiB before sending, leaving room for base64 expansion under the 256 KiB
+frame ceiling. The relay forwards those bytes without storing them. `rd/chat`
+is used only to return webchat output to the browser connection held by that
+relay.
 
 The same authenticated data plane also carries cross-daemon collaboration
 frames. Their authorization rules are defined in
@@ -380,6 +384,9 @@ the browser rejects frames for any other turn while the daemon rejects stale
 generations, rebinds the live stream, and replays the missing tail. This window
 is volatile, has explicit size and age limits, and does not create a durable
 transcript or offline inbox.
+An optional image upload follows the same browser-to-relay-to-daemon content
+path, is bounded to one compressed image per turn, becomes an ACP image prompt
+block at the daemon, and is never persisted by the relay or Control Plane.
 
 ## 11. Daemon Responsibilities
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -232,6 +232,7 @@ import type {
   WebchatDone,
   RdMsg,
   RdMsgWebchat,
+  WebchatImageAttachment,
   RdMsgIm,
   RdMsgSlackAction,
   RdMsgHook,
@@ -1962,8 +1963,10 @@ export class Daemon {
       // §9.2: download inbound attachment bytes via the agent's Slack connection
       // (bot-token auth). Returns null (→ baseline resource_link) if no connection.
       downloadAttachment: (agentId, att) =>
-        this.replyConnFor(agentId)?.downloadFile?.(att.sourceUrl, this.cfg.limits.maxAttachmentBytes) ??
-        Promise.resolve(null),
+        att.sourceUrl
+          ? (this.replyConnFor(agentId)?.downloadFile?.(att.sourceUrl, this.cfg.limits.maxAttachmentBytes) ??
+            Promise.resolve(null))
+          : Promise.resolve(null),
       attachmentMaxBytes: cfg.limits.maxAttachmentBytes,
       // §8.4/§8.5/§9.2: snapshot real Slack thread history for cold backfill and
       // warm-turn unread reconciliation (#649).
@@ -3648,7 +3651,8 @@ export class Daemon {
     text: string,
     user: string,
     sink: WebchatSink,
-    requestedTurnId?: string
+    requestedTurnId?: string,
+    inlineImages?: WebchatImageAttachment[]
   ): WebchatAck {
     const turnId = requestedTurnId ?? randomUUID()
     // Route directly to the named agent (bypasses arbitration); null when it isn't a
@@ -3696,6 +3700,20 @@ export class Daemon {
       sender: { id: user, isBot: false },
       text,
       mentionedBots: [],
+      ...(inlineImages?.length
+        ? {
+            attachments: inlineImages.map((image, index) => {
+              const inlineData = Buffer.from(image.data, 'base64')
+              return {
+                id: `webchat:${turnId}:${index}`,
+                name: image.name,
+                mimeType: image.mimeType,
+                size: inlineData.byteLength,
+                inlineData
+              }
+            })
+          }
+        : {}),
       isDm: true,
       trigger: 'dm'
     }
@@ -5722,7 +5740,15 @@ export class Daemon {
     const key = (): string => this.webchatSessionKey(msg.chatId, msg.agentId)
     switch (op.op) {
       case 'turn': {
-        const ack = this.dispatchWebchatTurn(msg.agentId, msg.chatId, op.text, op.user ?? 'webchat', sink, op.turnId)
+        const ack = this.dispatchWebchatTurn(
+          msg.agentId,
+          msg.chatId,
+          op.text,
+          op.user ?? 'webchat',
+          sink,
+          op.turnId,
+          op.attachments
+        )
         return {
           msgId: msg.msgId,
           accepted: ack.accepted,

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -1,8 +1,9 @@
 /**
- * A file shared alongside a message. Carries only metadata + a fetch URL — the
- * bytes are downloaded daemon-locally (with the bot token) at prompt-assembly
- * time and turned into an ACP image/resource content block. Attachment bytes
- * never traverse the daemon↔CP WS (they stay edge-local; see §9.2 / §3.2).
+ * A file shared alongside a message. Platform ingresses carry metadata + a
+ * fetch URL and download the bytes daemon-locally with the provider token.
+ * Webchat may instead arrive with bounded inline bytes from the relay content
+ * plane. Both forms become ACP image/resource blocks at prompt assembly; the
+ * bytes never traverse the daemon↔CP control WS.
  */
 export interface Attachment {
   /** Stable source id (Slack file.id). */
@@ -13,11 +14,10 @@ export interface Attachment {
   mimeType: string
   /** Bytes, when the platform reports it. */
   size?: number
-  /**
-   * Auth-gated source URL (Slack `url_private_download`). Fetching it requires
-   * `Authorization: Bearer <botToken>`; resolved by the owning SlackConnection.
-   */
-  sourceUrl: string
+  /** Auth-gated provider URL/key, absent for an inline webchat upload. */
+  sourceUrl?: string
+  /** Already-bounded bytes from webchat, absent for provider-backed attachments. */
+  inlineData?: Buffer
 }
 
 export interface NormalizedMessage {

--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -34,15 +34,22 @@ export function attachmentToBlock(
     return { type: 'image', data: bytes.toString('base64'), mimeType: att.mimeType }
   }
   if (bytes && supports('embeddedContext')) {
+    const uri = att.sourceUrl ?? `attachment://webchat/${encodeURIComponent(att.id)}`
     if (att.mimeType.startsWith('text/')) {
       return {
         type: 'resource',
-        resource: { text: bytes.toString('utf8'), uri: att.sourceUrl, mimeType: att.mimeType }
+        resource: { text: bytes.toString('utf8'), uri, mimeType: att.mimeType }
       }
     }
     return {
       type: 'resource',
-      resource: { blob: bytes.toString('base64'), uri: att.sourceUrl, mimeType: att.mimeType }
+      resource: { blob: bytes.toString('base64'), uri, mimeType: att.mimeType }
+    }
+  }
+  if (!att.sourceUrl) {
+    return {
+      type: 'text',
+      text: `[attached image: ${att.name} (${att.mimeType}); image input is unavailable for this agent]`
     }
   }
   // Baseline: a pointer the agent can't fetch directly (the URL is auth-gated) —
@@ -65,7 +72,7 @@ export async function buildAttachmentBlocks(attachments: Attachment[], deps: Att
   return Promise.all(
     attachments.map(async (att) => {
       const overCap = typeof att.size === 'number' && att.size > cap
-      const bytes = overCap ? null : await deps.download(att).catch(() => null)
+      const bytes = overCap ? null : (att.inlineData ?? (await deps.download(att).catch(() => null)))
       return attachmentToBlock(att, bytes, deps.supports)
     })
   )

--- a/packages/daemon/test/attachment-block.test.ts
+++ b/packages/daemon/test/attachment-block.test.ts
@@ -83,6 +83,18 @@ describe('buildAttachmentBlocks', () => {
     expect(blocks[0]).toMatchObject({ type: 'image', data: bytes.toString('base64') })
   })
 
+  it('uses inline webchat bytes without calling a platform downloader', async () => {
+    const bytes = Buffer.from('IMG')
+    const download = vi.fn(async () => null)
+    const blocks = await buildAttachmentBlocks([att({ sourceUrl: undefined, inlineData: bytes, size: bytes.length })], {
+      download,
+      supports: supportsAll,
+      maxBytes: 1024
+    })
+    expect(download).not.toHaveBeenCalled()
+    expect(blocks[0]).toEqual({ type: 'image', data: bytes.toString('base64'), mimeType: 'image/png' })
+  })
+
   it('degrades to resource_link (not dropped) when a download throws', async () => {
     const blocks = await buildAttachmentBlocks([att()], {
       download: async () => {

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1175,6 +1175,41 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   })
 
+  it('delivers an inline webchat image as an ACP image block and records only its summary', async () => {
+    const { factory, host } = streamingHost([text('I can see it')])
+    ;(host as any).promptSupports = (kind: string) => kind === 'image'
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const bytes = Buffer.from('image bytes')
+    const events: RdChatEvent[] = []
+    const ack = (daemon as any).handleRelayMsg(
+      rd({
+        op: 'turn',
+        text: 'What is shown?',
+        user: 'ada',
+        attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: bytes.toString('base64') }]
+      }),
+      (event: RdChatEvent) => events.push(event)
+    )
+    expect(ack).toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(events.some((event) => event.kind === 'done')).toBe(true), WAIT)
+
+    expect(host.prompt.mock.calls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        { type: 'text', text: 'What is shown?' },
+        { type: 'image', data: bytes.toString('base64'), mimeType: 'image/webp' }
+      ])
+    )
+    const rows = (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`) as Array<{
+      sender: string
+      text: string
+    }>
+    expect(rows.find((row) => row.sender === 'ada')?.text).toBe('What is shown?\n[attached: screen.webp (image/webp)]')
+    await daemon.stop()
+  }, 15_000)
+
   it('rejects a turn for an agent not on this daemon (accepted:false, reason no_agent)', async () => {
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -6,6 +6,7 @@ import {
   RdAgentMsgFwd,
   RdSlackAction,
   RelayWebchatOp,
+  WEBCHAT_IMAGE_MAX_BYTES,
   RELAY_DAEMON_FRAME_TYPES,
   buildRelayDaemonFrame,
   decodeRelayDaemonFrame,
@@ -118,6 +119,42 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: TURN_ID, generation: 0, afterIndex: 0 }).success).toBe(
       false
     )
+  })
+
+  it('carries one bounded inline image on a webchat turn', () => {
+    const image = {
+      name: 'screenshot.webp',
+      mimeType: 'image/webp' as const,
+      data: Buffer.from('small image').toString('base64')
+    }
+    expect(RelayWebchatOp.safeParse({ op: 'turn', text: '', attachments: [image] }).success).toBe(true)
+    expect(
+      decodeRelayDaemonFrame(
+        envelope('rd/msg', { ...turnMsg, payload: { op: 'turn', text: '', attachments: [image] } })
+      ).ok
+    ).toBe(true)
+    expect(
+      RelayWebchatOp.safeParse({
+        op: 'turn',
+        text: 'look',
+        attachments: [{ ...image, mimeType: 'image/svg+xml' }]
+      }).success
+    ).toBe(false)
+    expect(RelayWebchatOp.safeParse({ op: 'turn', text: 'look', attachments: [image, image] }).success).toBe(false)
+    expect(
+      RelayWebchatOp.safeParse({
+        op: 'turn',
+        text: 'look',
+        attachments: [{ ...image, data: 'not base64' }]
+      }).success
+    ).toBe(false)
+    expect(
+      RelayWebchatOp.safeParse({
+        op: 'turn',
+        text: 'look',
+        attachments: [{ ...image, data: Buffer.alloc(WEBCHAT_IMAGE_MAX_BYTES + 1).toString('base64') }]
+      }).success
+    ).toBe(false)
   })
 
   it('decodes an rd/msg im (shared bot) inbound, pre-addressed to an agent', () => {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -62,6 +62,39 @@ export type RdHelloOk = z.infer<typeof RdHelloOk>
 // The webchat operations a browser can issue, folded into one payload union so
 // the wire stays at the four designed frames. `turn` is the user message; the
 // rest are the session controls the old daemon↔CP webchat EVTs carried.
+//
+// Image bytes stay on the content plane: the browser rasterizes/compresses one
+// selected image below this cap, the relay forwards it inline, and the daemon
+// converts it into an ACP image block. The headroom below MAX_FRAME_BYTES leaves
+// room for base64 expansion plus the rd/msg envelope.
+export const WEBCHAT_IMAGE_MAX_BYTES = 160 * 1024
+export const WEBCHAT_IMAGE_MAX_BASE64_CHARS = Math.ceil(WEBCHAT_IMAGE_MAX_BYTES / 3) * 4
+
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+function decodedBase64Bytes(value: string): number {
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+  return (value.length / 4) * 3 - padding
+}
+
+export const WebchatImageAttachment = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .regex(/^[^\u0000-\u001f\u007f]+$/, 'webchat image name must not contain control characters'),
+  mimeType: z.enum(['image/png', 'image/jpeg', 'image/webp']),
+  data: z
+    .string()
+    .min(4)
+    .max(WEBCHAT_IMAGE_MAX_BASE64_CHARS)
+    .refine((value) => CANONICAL_BASE64.test(value) && decodedBase64Bytes(value) <= WEBCHAT_IMAGE_MAX_BYTES, {
+      message: `webchat image must be canonical base64 encoding at most ${WEBCHAT_IMAGE_MAX_BYTES} bytes`
+    })
+})
+export type WebchatImageAttachment = z.infer<typeof WebchatImageAttachment>
+
 export const RelayWebchatOp = z.discriminatedUnion('op', [
   z.object({
     op: z.literal('turn'),
@@ -69,7 +102,8 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
     user: z.string().optional(),
     // New browsers allocate this before sending so a pre-ack reconnect can name
     // the exact turn. Optional for older clients; the daemon allocates a fallback.
-    turnId: z.string().uuid().optional()
+    turnId: z.string().uuid().optional(),
+    attachments: z.array(WebchatImageAttachment).max(1).optional()
   }),
   // Rebind an in-flight/recent turn to this relay connection and replay every
   // output after the browser's contiguous cursor. The generation monotonically

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -72,6 +72,20 @@ describe('parseBrowserFrame', () => {
       turnId: AGENT
     })
   })
+  it('maps a bounded image attachment while keeping the verified user authoritative', () => {
+    const attachment = {
+      name: 'screen.webp',
+      mimeType: 'image/webp',
+      data: Buffer.from('image').toString('base64')
+    }
+    expect(parseBrowserFrame({ text: '', user: 'spoofed', attachments: [attachment] }, USER)).toEqual({
+      op: 'turn',
+      text: '',
+      user: USER,
+      attachments: [attachment]
+    })
+    expect(parseBrowserFrame({ text: '', attachments: [{ ...attachment, data: 'invalid' }] }, USER)).toBeNull()
+  })
   it('maps the session-control envelopes', () => {
     expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 3, afterIndex: 4 }, USER)).toEqual({
       op: 'resume',
@@ -127,6 +141,21 @@ describe('RelayBrowserConnection', () => {
       payload: { op: 'turn', text: 'hello there', user: USER }
     })
     expect(transport.last('ack')).toEqual({ type: 'ack', ack: { accepted: true } })
+  })
+
+  it('bridges an image-only turn without putting the bytes on any control-plane path', async () => {
+    const { transport, sent } = build()
+    const attachment = {
+      name: 'screen.webp',
+      mimeType: 'image/webp',
+      data: Buffer.from('image').toString('base64')
+    }
+    transport.feed({ attachments: [attachment] })
+    await tick()
+    expect(sent[0]).toMatchObject({
+      source: 'webchat',
+      payload: { op: 'turn', text: '', user: USER, attachments: [attachment] }
+    })
   })
 
   it('surfaces a rejected turn ack with its reason', async () => {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -3,7 +3,7 @@
  * session (shared-bot-relay.md §7.2 / §10). One socket == one conversation.
  *
  * It speaks the browser-facing, type-tagged webchat envelope. The browser sends
- * `{text}` (a turn) or
+ * `{text, turnId, attachments?}` (a turn with at most one bounded inline image) or
  * `{type:'resume'|'set_model'|'set_effort'|'set_permission_mode'|'set_fast'|'cancel'}`,
  * and the relay sends `{type:'ready'|'output'|'done'|'ack'|'resumed'|'error'}`. Internally each inbound
  * op becomes an `rd/msg(webchat)` bridged onto the target daemon's rd/* socket, and
@@ -13,7 +13,7 @@
  * daemon has no live rd/* socket on THIS relay the op fails with an error frame.
  */
 import { randomUUID } from 'node:crypto'
-import type { RdChat, RdMsgWebchat, RelayWebchatOp } from '@agentconnect.md/protocol'
+import { RelayWebchatOp, type RdChat, type RdMsgWebchat } from '@agentconnect.md/protocol'
 import type { ServerTransport } from '@agentconnect.md/connection'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 import type { ChatSink } from './webchat-router.js'
@@ -36,11 +36,16 @@ export interface RelayBrowserConnDeps {
 export function parseBrowserFrame(msg: unknown, user: string): RelayWebchatOp | null {
   if (typeof msg !== 'object' || msg === null) return null
   const m = msg as Record<string, unknown>
-  // A bare {text} (no type) OR {type:'message', text} is a turn.
-  if ((m.type === undefined || m.type === 'message') && typeof m.text === 'string') {
-    return m.turnId === undefined || typeof m.turnId === 'string'
-      ? { op: 'turn', text: m.text, user, ...(typeof m.turnId === 'string' ? { turnId: m.turnId } : {}) }
-      : null
+  // A bare message envelope (no type) or {type:'message', ...} is a turn.
+  if ((m.type === undefined || m.type === 'message') && (typeof m.text === 'string' || Array.isArray(m.attachments))) {
+    const parsed = RelayWebchatOp.safeParse({
+      op: 'turn',
+      text: typeof m.text === 'string' ? m.text : '',
+      user,
+      ...(m.turnId !== undefined ? { turnId: m.turnId } : {}),
+      ...(m.attachments !== undefined ? { attachments: m.attachments } : {})
+    })
+    return parsed.success && parsed.data.op === 'turn' ? parsed.data : null
   }
   switch (m.type) {
     case 'resume':

--- a/packages/web/src/components/console/ContextWindowIndicator.test.tsx
+++ b/packages/web/src/components/console/ContextWindowIndicator.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ContextWindowIndicator } from './ContextWindowIndicator'
+
+describe('ContextWindowIndicator', () => {
+  it('shows compact context usage with hover and focus detail', () => {
+    const html = renderToStaticMarkup(<ContextWindowIndicator used={69_000} size={258_000} />)
+
+    expect(html).toContain('aria-label="Context window"')
+    expect(html).toContain('aria-describedby=')
+    expect(html).toContain('role="tooltip"')
+    expect(html).toContain('27% used (73% left)')
+    expect(html).toContain('69K / 258K tokens used')
+    expect(html).toContain('group-hover:visible')
+    expect(html).toContain('group-focus-within:visible')
+  })
+})

--- a/packages/web/src/components/console/ContextWindowIndicator.tsx
+++ b/packages/web/src/components/console/ContextWindowIndicator.tsx
@@ -1,0 +1,58 @@
+import { useId } from 'react'
+import { fmtCountCompact } from '@/lib/api'
+
+export function ContextWindowIndicator({ used, size }: { used?: number; size?: number }) {
+  const tooltipId = useId()
+  const percentage =
+    used != null && size != null && size > 0 ? Math.min(100, Math.max(0, Math.round((used / size) * 100))) : null
+  const usedText = used != null ? fmtCountCompact(used) : null
+  const sizeText = size != null ? fmtCountCompact(size) : null
+
+  return (
+    <span className="group relative inline-flex flex-none">
+      <button
+        type="button"
+        aria-label="Context window"
+        aria-describedby={tooltipId}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault()
+            event.stopPropagation()
+            event.currentTarget.blur()
+          }
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="flex h-[18px] w-[18px] items-center justify-center rounded-full"
+          style={{
+            background:
+              percentage == null
+                ? 'var(--border-default)'
+                : `conic-gradient(var(--text-secondary) ${percentage}%, var(--border-default) 0)`
+          }}
+        >
+          <span className="h-3 w-3 rounded-full bg-(--surface-card)" />
+        </span>
+      </button>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className="pointer-events-none invisible absolute right-0 bottom-full z-30 mb-2 min-w-[210px] max-w-[calc(100vw-40px)] translate-y-1 rounded-md border border-(--border-default) bg-(--surface-card) px-3 py-[9px] text-center opacity-0 shadow-(--shadow-lg) transition-[opacity,transform,visibility] group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 desktop:right-auto desktop:left-1/2 desktop:-translate-x-1/2"
+      >
+        <span className="block font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
+          Context window:
+        </span>
+        <span className="mt-[5px] block font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+          {percentage == null ? 'Usage unavailable' : `${percentage}% used (${100 - percentage}% left)`}
+        </span>
+        {usedText && (
+          <span className="mt-[5px] block font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+            {sizeText ? `${usedText} / ${sizeText} tokens used` : `${usedText} tokens used`}
+          </span>
+        )}
+      </span>
+    </span>
+  )
+}

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -9,7 +9,7 @@
 // view.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { agentLabel, type Agent, type Session, type SessionStep } from '@/lib/data'
+import { agentLabel, type Agent, type Session, type SessionImage, type SessionStep } from '@/lib/data'
 import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import {
@@ -25,6 +25,9 @@ interface PlaygroundData {
   /** Composer buffer for one session id (each live conversation has its own). */
   getPgInput: (id: string) => string
   setPgInput: (id: string, v: string) => void
+  /** One prepared image waiting in this session's composer. */
+  getPgImage: (id: string) => SessionImage | undefined
+  setPgImage: (id: string, image?: SessionImage) => void
   /** Is a turn in flight for this session id? Drives its typing indicator + send-disable. */
   isPgBusy: (id: string) => boolean
   /** Create a new sandbox session for an agent and return its id. Does not navigate. */
@@ -157,6 +160,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // conversations live at once (each streams in the background across route changes),
   // so a single global would let one session disable/clear another's composer.
   const [pgInputBy, setPgInputBy] = useState<Record<string, string>>({})
+  const [pgImageBy, setPgImageBy] = useState<Record<string, SessionImage>>({})
   const [pgBusyBy, setPgBusyBy] = useState<Record<string, boolean>>({})
   const conns = useRef<Map<string, Conn>>(new Map())
   const conversationIds = useRef<Map<string, string>>(new Map())
@@ -173,6 +177,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }, [])
   const setPgInput = useCallback((id: string, v: string): void => {
     setPgInputBy((cur) => ({ ...cur, [id]: v }))
+  }, [])
+  const setPgImage = useCallback((id: string, image?: SessionImage): void => {
+    setPgImageBy((cur) => {
+      if (image) return { ...cur, [id]: image }
+      if (!(id in cur)) return cur
+      const next = { ...cur }
+      delete next[id]
+      return next
+    })
   }, [])
 
   // Close every socket when the provider unmounts (console teardown).
@@ -554,6 +567,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
       })
       setPgInput(id, '')
+      setPgImage(id)
       setBusy(id, false)
       // Warm the socket so the first turn is snappy. Swallow its ready rejection here —
       // a token-mint failure (e.g. no relay pool configured → 503) is surfaced on the
@@ -561,15 +575,17 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       connect(id, da.id).ready.catch(() => {})
       return id
     },
-    [connect, setPgInput, setBusy]
+    [connect, setPgImage, setPgInput, setBusy]
   )
 
   const pgSend = useCallback(
     (id: string, agentForId: string, textArg?: string, conversationId?: string) => {
       const text = String(textArg ?? pgInputBy[id] ?? '').trim()
-      if (!text || pgBusyBy[id]) return
-      pushStep(id, { kind: 'msg', who: '@you', text })
+      const image = pgImageBy[id]
+      if ((!text && !image) || pgBusyBy[id]) return
+      pushStep(id, { kind: 'msg', who: '@you', text, ...(image ? { image } : {}) })
       setPgInput(id, '')
+      setPgImage(id)
       setBusy(id, true)
       const requestedTurnId = crypto.randomUUID()
       streamCursors.current.set(id, createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
@@ -577,7 +593,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       reconnectAttempts.current.delete(id)
       const conn = connect(id, agentForId, conversationId)
       conn.ready
-        .then((ws) => ws.send(JSON.stringify({ text, turnId: requestedTurnId })))
+        .then((ws) =>
+          ws.send(
+            JSON.stringify({
+              text,
+              turnId: requestedTurnId,
+              ...(image ? { attachments: [image] } : {})
+            })
+          )
+        )
         .catch((err) => {
           // A 503 from the token mint means the CP has no relay pool configured — the
           // agent may be perfectly healthy, so name the real cause instead of "unreachable".
@@ -592,7 +616,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           setBusy(id, false)
         })
     },
-    [pgBusyBy, pgInputBy, connect, pushStep, setPgInput, setBusy]
+    [pgBusyBy, pgImageBy, pgInputBy, connect, pushStep, setPgImage, setPgInput, setBusy]
   )
 
   /** Switch the session's model (fire-and-forget over the conversation socket). Updates
@@ -662,6 +686,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [pgSessions]
   )
   const getPgInput = useCallback((id: string) => pgInputBy[id] ?? '', [pgInputBy])
+  const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
   const clearLiveSteps = useCallback((id: string): void => {
@@ -678,6 +703,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     () => ({
       getPgInput,
       setPgInput,
+      getPgImage,
+      setPgImage,
       isPgBusy,
       openPlayground,
       pgSend,
@@ -694,6 +721,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [
       getPgInput,
       setPgInput,
+      getPgImage,
+      setPgImage,
       isPgBusy,
       openPlayground,
       pgSend,

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
@@ -17,6 +17,7 @@ import {
   sessionPlatform,
   speaker,
   status,
+  type SessionImage,
   type SessionStep
 } from '@/lib/data'
 import {
@@ -43,6 +44,8 @@ import { formatTranscriptTime, parseTranscriptTime } from '@/lib/transcript-time
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionSenderLabel } from '@/lib/session-trigger'
+import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
+import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
 // transcript kind (text | tool | reasoning) onto the existing lane styling.
@@ -425,6 +428,7 @@ type Turn =
       sourceLabel: string
       time: string
       text: string
+      image?: SessionImage
       isCron: boolean
       cronId: string | null
     }
@@ -511,8 +515,10 @@ export default function SessionDetailView() {
     getLiveSteps,
     clearLiveSteps,
     getPgInput,
+    getPgImage,
     isPgBusy,
     setPgInput: setPgInputById,
+    setPgImage,
     pgSend,
     pgSetModel,
     pgSetEffort,
@@ -529,6 +535,10 @@ export default function SessionDetailView() {
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [showThinking, setShowThinking] = useState(true)
   const [showTools, setShowTools] = useState(true)
+  const [imagePreparing, setImagePreparing] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false)
+  const imageInputRef = useRef<HTMLInputElement>(null)
 
   const localSession = getPgSession(id) ?? allSessions.find((s) => s.id === id) ?? null
   // Relationship links can point outside the cursor pages loaded by SessionsView.
@@ -683,14 +693,32 @@ export default function SessionDetailView() {
   // different live conversation streaming in the background can't disable or clear it.
   const pgBusy = sessionBusy
   const pgInput = getPgInput(session.id)
+  const pgImage = getPgImage(session.id)
   const setPgInput = (v: string) => setPgInputById(session.id, v)
   const agentHref = session.agentId ? `/agents/${session.agentId}` : null
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
   // Resume the webchat conversation by its id (session.channelId == the conversationId);
   // a synthetic playground turn omits it (the CP mints a fresh id).
-  const onPgSend = (text?: string) =>
+  const onPgSend = (text?: string) => {
+    if (imagePreparing) return
+    setImageError(null)
     pgSend(session.id, session.agentId ?? '', text, isWebchat ? session.channelId : undefined)
+  }
+  const onImageFile = async (file: File | undefined): Promise<void> => {
+    if (!file || imagePreparing) return
+    setAttachMenuOpen(false)
+    setImagePreparing(true)
+    setImageError(null)
+    try {
+      setPgImage(session.id, await prepareWebchatImage(file))
+    } catch (error) {
+      setImageError(error instanceof Error ? error.message : 'Couldn’t prepare that image.')
+    } finally {
+      setImagePreparing(false)
+      if (imageInputRef.current) imageInputRef.current.value = ''
+    }
+  }
   const webchatConversationId = isWebchat ? session.channelId : undefined
   const onCopyLink = () => {
     try {
@@ -764,6 +792,7 @@ export default function SessionDetailView() {
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? (firstMsg ? session.time : ''),
           text: stp.text,
+          image: stp.image,
           isCron: !!cron,
           cronId: cron?.id ?? null
         })
@@ -795,6 +824,7 @@ export default function SessionDetailView() {
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? '',
           text: stp.text,
+          image: stp.image,
           isCron: false,
           cronId: null
         })
@@ -888,69 +918,17 @@ export default function SessionDetailView() {
       })
   }
 
-  // The live playground status bar (model · context · tokens · cost), rendered directly
-  // above the composer. Fed by the webchat `status` frames the PlaygroundProvider folds
-  // into the session — model appears at turn start, context/cost stream live, tokens
-  // land at turn end. Unknown fields fall back to a muted em dash.
-  const ctxText =
-    u?.contextUsed != null
-      ? u.contextSize != null
-        ? `${fmtN(u.contextUsed)} / ${fmtN(u.contextSize)} (${Math.round((u.contextUsed / u.contextSize) * 100)}%)`
-        : fmtN(u.contextUsed)
-      : null
+  // Live controls and status folded into the composer toolbar. Webchat `status`
+  // frames update model/context/cost during the turn and tokens at turn end.
   const allowRuntimeChangesInChat = owner?.allowRuntimeChangesInChat === true
   const pgModels = allowRuntimeChangesInChat ? (session.availableModels ?? []) : []
   const pgEfforts = allowRuntimeChangesInChat ? (session.availableEfforts ?? []) : []
   const pgPermissionModes = allowRuntimeChangesInChat ? (session.availablePermissionModes ?? []) : []
-  // Shared style for the inline status-bar selectors.
+  // Shared style for the inline composer selectors.
   const pgSelectClass =
     'cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)'
   const pgStatusBar = (
-    <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-[11px] py-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)">
-      <span className="inline-flex items-center gap-[6px] text-(--text-secondary)">
-        <span className="av h-4 w-4 flex-none rounded-xs">
-          <AgentMark model={agentRuntime} />
-        </span>
-        {/* Model selector — switch the model for THIS session. Only a real dropdown when
-            the runtime advertised selectable models; otherwise the static label. */}
-        {pgModels.length > 0 ? (
-          <select
-            aria-label="Session model"
-            value={session.model ?? ''}
-            onChange={(e) => pgSetModel(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
-            className="cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)"
-          >
-            {(session.model && !pgModels.includes(session.model) ? [session.model, ...pgModels] : pgModels).map((m) => (
-              <option key={m} value={m}>
-                {modelLabel(m)}
-              </option>
-            ))}
-          </select>
-        ) : (
-          modelLabel(session.model ?? '')
-        )}
-      </span>
-      {/* Effort selector — switch reasoning effort for THIS session. Only shown when the
-          runtime advertised effort levels (incl. synthetic ultracode/max on Claude). */}
-      {pgEfforts.length > 0 && (
-        <select
-          aria-label="Session reasoning effort"
-          value={session.effort ?? ''}
-          onChange={(e) => pgSetEffort(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
-          className={pgSelectClass}
-        >
-          {(session.effort && !pgEfforts.includes(session.effort) ? [session.effort, ...pgEfforts] : pgEfforts).map(
-            (e) => (
-              <option key={e} value={e}>
-                {e}
-              </option>
-            )
-          )}
-        </select>
-      )}
-      {!allowRuntimeChangesInChat && session.effort && <span>effort: {session.effort}</span>}
-      {/* Permission-mode selector — switch approval mode for THIS session. Only shown
-          when both the Agent setting and runtime capabilities permit it. */}
+    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1 font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)">
       {pgPermissionModes.length > 0 ? (
         <select
           aria-label="Session permission mode"
@@ -970,44 +948,71 @@ export default function SessionDetailView() {
           ))}
         </select>
       ) : (
-        session.permissionMode && (
-          <span>permission: {permissionModeLabel(session.runtime ?? '', session.permissionMode)}</span>
-        )
+        session.permissionMode && <span>{permissionModeLabel(session.runtime ?? '', session.permissionMode)}</span>
       )}
-      {/* Fast-mode toggle — only when the selected model advertises a fast toggle. */}
-      {allowRuntimeChangesInChat && session.fastModeAvailable && (
-        <select
-          aria-label="Session fast mode"
-          value={session.fastMode ? 'on' : 'off'}
-          onChange={(e) => pgSetFast(session.id, session.agentId ?? '', e.target.value === 'on', webchatConversationId)}
-          className={pgSelectClass}
-        >
-          <option value="on">fast: on</option>
-          <option value="off">fast: off</option>
-        </select>
-      )}
-      {!allowRuntimeChangesInChat && session.fastMode !== undefined && (
-        <span>fast: {session.fastMode ? 'on' : 'off'}</span>
-      )}
-      <span>
-        ctx&nbsp;<span className="font-mono text-[11.5px] font-medium leading-normal">{ctxText ?? '—'}</span>
-      </span>
-      <span>
-        <span className="font-mono text-[11.5px] font-medium leading-normal">{session.tokens}</span>&nbsp;tok
-      </span>
-      <span className="font-mono text-[11.5px] font-medium leading-normal">{session.cost}</span>
-      {/* Right-aligned action: cancel the running turn. (No "View session" link — in the
-          playground you're already on the session; the deep link was redundant.) */}
-      {pgBusy && (
-        <span className="ml-auto inline-flex items-center">
-          <button
-            onClick={() => pgCancel(session.id, session.agentId ?? '', webchatConversationId)}
-            className="cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold leading-normal text-(--red-600)"
-          >
-            Cancel
-          </button>
+      <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
+        <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
+        <span>
+          <span className="font-mono text-[11.5px] font-medium leading-normal">{session.tokens}</span>&nbsp;tok
         </span>
-      )}
+        <span className="font-mono text-[11.5px] font-medium leading-normal">{session.cost}</span>
+        <span className="inline-flex items-center gap-[6px] text-(--text-secondary)">
+          <span className="av h-4 w-4 flex-none rounded-xs">
+            <AgentMark model={agentRuntime} />
+          </span>
+          {pgModels.length > 0 ? (
+            <select
+              aria-label="Session model"
+              value={session.model ?? ''}
+              onChange={(e) => pgSetModel(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
+              className={pgSelectClass}
+            >
+              {(session.model && !pgModels.includes(session.model) ? [session.model, ...pgModels] : pgModels).map(
+                (model) => (
+                  <option key={model} value={model}>
+                    {modelLabel(model)}
+                  </option>
+                )
+              )}
+            </select>
+          ) : (
+            modelLabel(session.model ?? '')
+          )}
+        </span>
+        {pgEfforts.length > 0 && (
+          <select
+            aria-label="Session reasoning effort"
+            value={session.effort ?? ''}
+            onChange={(e) => pgSetEffort(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
+            className={pgSelectClass}
+          >
+            {(session.effort && !pgEfforts.includes(session.effort) ? [session.effort, ...pgEfforts] : pgEfforts).map(
+              (effort) => (
+                <option key={effort} value={effort}>
+                  {effort}
+                </option>
+              )
+            )}
+          </select>
+        )}
+        {!allowRuntimeChangesInChat && session.effort && <span>effort: {session.effort}</span>}
+        {allowRuntimeChangesInChat && session.fastModeAvailable && (
+          <select
+            aria-label="Session fast mode"
+            value={session.fastMode ? 'on' : 'off'}
+            onChange={(e) =>
+              pgSetFast(session.id, session.agentId ?? '', e.target.value === 'on', webchatConversationId)
+            }
+            className={pgSelectClass}
+          >
+            <option value="on">fast: on</option>
+            <option value="off">fast: off</option>
+          </select>
+        )}
+        {!allowRuntimeChangesInChat && session.fastMode !== undefined && (
+          <span>fast: {session.fastMode ? 'on' : 'off'}</span>
+        )}
+      </div>
     </div>
   )
 
@@ -1325,7 +1330,16 @@ export default function SessionDetailView() {
                       )}
                     </div>
                     <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-card) px-[13px] py-[10px] font-sans text-[13.5px] font-normal leading-[1.5] text-(--text-primary) desktop:px-[14px] desktop:py-[11px] desktop:leading-[1.55]">
-                      <MessageText text={turn.text} />
+                      {turn.image && (
+                        <img
+                          src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                          alt={turn.image.name}
+                          className={`max-h-[360px] max-w-full rounded-md object-contain ${
+                            turn.text ? 'mb-[10px]' : ''
+                          }`}
+                        />
+                      )}
+                      {turn.text && <MessageText text={turn.text} />}
                     </div>
                   </div>
                 </div>
@@ -1455,23 +1469,113 @@ export default function SessionDetailView() {
                 ))}
               </div>
             )}
-            <div className="desktop:mt-4">{pgStatusBar}</div>
-            <div className="pgcomposer rounded-[11px] border border-(--border-default)">
-              <textarea
-                className="pgin border-0"
-                placeholder={`Message ${session.agentName}…`}
-                value={pgInput}
-                onChange={(e) => setPgInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault()
-                    onPgSend()
-                  }
-                }}
+            {imageError && (
+              <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
+            )}
+            <div
+              className="pgcomposer relative flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default) desktop:mt-4"
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') setAttachMenuOpen(false)
+              }}
+            >
+              <input
+                ref={imageInputRef}
+                type="file"
+                accept="image/*"
+                hidden
+                onChange={(event) => void onImageFile(event.target.files?.[0])}
               />
-              <button className="sendbtn" onClick={() => onPgSend()} disabled={pgBusy || !pgInput.trim()}>
-                <Icon name="arrow-up" size={18} />
-              </button>
+              <div className="flex min-w-0 flex-col">
+                {pgImage && (
+                  <div className="relative mb-2 w-fit">
+                    <img
+                      src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
+                      alt={pgImage.name}
+                      title={pgImage.name}
+                      className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                    />
+                    <button
+                      type="button"
+                      className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+                      title="Remove image"
+                      aria-label="Remove image"
+                      onClick={() => setPgImage(session.id)}
+                    >
+                      <Icon name="x" size={14} />
+                    </button>
+                  </div>
+                )}
+                <textarea
+                  className="pgin w-full border-0 px-1 py-2 focus:shadow-none"
+                  placeholder={`Message ${session.agentName}…`}
+                  value={pgInput}
+                  onChange={(e) => setPgInput(e.target.value)}
+                  onPaste={(event) => {
+                    const image = clipboardImageFile(event.clipboardData)
+                    if (!image) return
+                    event.preventDefault()
+                    void onImageFile(image)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      onPgSend()
+                    }
+                  }}
+                />
+              </div>
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="relative flex-none">
+                  <button
+                    type="button"
+                    className="iconbtn h-10 w-10 rounded-[9px]"
+                    aria-label="Add"
+                    aria-haspopup="menu"
+                    aria-expanded={attachMenuOpen}
+                    disabled={imagePreparing}
+                    onClick={() => setAttachMenuOpen((open) => !open)}
+                  >
+                    {imagePreparing ? <Spinner size={16} /> : <Icon name="plus" size={19} />}
+                  </button>
+                  {attachMenuOpen && (
+                    <>
+                      <div
+                        aria-hidden="true"
+                        className="fixed inset-0 z-40"
+                        onClick={() => setAttachMenuOpen(false)}
+                      ></div>
+                      <div
+                        role="menu"
+                        className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+                      >
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="fopt"
+                          onClick={() => {
+                            setAttachMenuOpen(false)
+                            imageInputRef.current?.click()
+                          }}
+                        >
+                          <Icon name="image" size={16} color="var(--text-secondary)" />
+                          Add photos
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+                {pgStatusBar}
+                <button
+                  className="sendbtn"
+                  aria-label={pgBusy ? 'Stop response' : 'Send message'}
+                  onClick={() =>
+                    pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
+                  }
+                  disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
+                >
+                  <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 14 : 18} />
+                </button>
+              </div>
             </div>
           </>
         )}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -685,6 +685,15 @@ export interface SessionFile {
   path: string
 }
 
+/** Ephemeral image on a live Playground/WebChat user turn. The daemon persists
+ * only its name/MIME summary, so bytes disappear when authoritative history is
+ * reloaded. */
+export interface SessionImage {
+  name: string
+  mimeType: 'image/png' | 'image/jpeg' | 'image/webp'
+  data: string
+}
+
 export interface SessionStep {
   kind: LaneKind
   who?: string
@@ -693,6 +702,7 @@ export interface SessionStep {
   text: string
   code?: string
   files?: SessionFile[]
+  image?: SessionImage
   /** Client-side timestamp for live playground/webchat steps. Persisted transcripts
    *  carry their own message `ts`; this only keeps in-memory live stats moving. */
   observedAtMs?: number

--- a/packages/web/src/lib/webchat-image.test.ts
+++ b/packages/web/src/lib/webchat-image.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { clipboardImageFile } from './webchat-image'
+
+function clipboardData(
+  items: Array<Pick<DataTransferItem, 'kind' | 'type' | 'getAsFile'>>,
+  files: File[] = []
+): Pick<DataTransfer, 'items' | 'files'> {
+  return {
+    items: items as unknown as DataTransferItemList,
+    files: files as unknown as FileList
+  }
+}
+
+describe('clipboardImageFile', () => {
+  it('returns a pasted image without treating ordinary clipboard content as an attachment', () => {
+    const image = { name: 'pasted.png', type: 'image/png' } as File
+    expect(
+      clipboardImageFile(
+        clipboardData([
+          { kind: 'string', type: 'text/plain', getAsFile: () => null },
+          { kind: 'file', type: image.type, getAsFile: () => image }
+        ])
+      )
+    ).toBe(image)
+    expect(clipboardImageFile(clipboardData([{ kind: 'string', type: 'text/plain', getAsFile: () => null }]))).toBe(
+      undefined
+    )
+  })
+})

--- a/packages/web/src/lib/webchat-image.ts
+++ b/packages/web/src/lib/webchat-image.ts
@@ -1,0 +1,102 @@
+import type { SessionImage } from '@/lib/data'
+
+// The relay/daemon wire allows 160 KiB of decoded image bytes. Keeping the
+// browser target identical leaves enough room for base64 expansion and the
+// surrounding rd/msg envelope under the protocol's 256 KiB frame ceiling.
+export const WEBCHAT_IMAGE_MAX_BYTES = 160 * 1024
+const WEBCHAT_IMAGE_MAX_SOURCE_BYTES = 20 * 1024 * 1024
+const WEBCHAT_IMAGE_MAX_EDGE = 1600
+
+/** Read the first pasted image without intercepting ordinary text paste. */
+export function clipboardImageFile(data: Pick<DataTransfer, 'items' | 'files'>): File | undefined {
+  for (const item of Array.from(data.items)) {
+    if (item.kind !== 'file' || !item.type.startsWith('image/')) continue
+    const file = item.getAsFile()
+    if (file) return file
+  }
+  return Array.from(data.files).find((file) => file.type.startsWith('image/'))
+}
+
+function canvasBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('Could not encode this image.'))),
+      'image/webp',
+      quality
+    )
+  })
+}
+
+function blobBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(new Error('Could not read this image.'))
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : ''
+      const comma = result.indexOf(',')
+      if (comma < 0) reject(new Error('Could not read this image.'))
+      else resolve(result.slice(comma + 1))
+    }
+    reader.readAsDataURL(blob)
+  })
+}
+
+function webpName(name: string): string {
+  const clean = name.replace(/[\u0000-\u001f\u007f]/g, ' ').trim()
+  const dot = clean.lastIndexOf('.')
+  const stem = (dot > 0 ? clean.slice(0, dot) : clean).trim().slice(0, 245) || 'image'
+  return `${stem}.webp`
+}
+
+/** Rasterize a browser-readable image into one bounded WebP attachment. */
+export async function prepareWebchatImage(file: File): Promise<SessionImage> {
+  if (file.size > WEBCHAT_IMAGE_MAX_SOURCE_BYTES) {
+    throw new Error('Choose an image smaller than 20 MB.')
+  }
+  if (file.type && !file.type.startsWith('image/')) {
+    throw new Error('Choose an image file.')
+  }
+
+  let bitmap: ImageBitmap
+  try {
+    bitmap = await createImageBitmap(file)
+  } catch {
+    throw new Error('Couldn’t read that image. Try PNG, JPEG, or WebP.')
+  }
+
+  try {
+    const sourceEdge = Math.max(bitmap.width, bitmap.height)
+    let scale = sourceEdge > WEBCHAT_IMAGE_MAX_EDGE ? WEBCHAT_IMAGE_MAX_EDGE / sourceEdge : 1
+    let quality = 0.86
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Couldn’t prepare that image.')
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale))
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale))
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
+
+      const blob = await canvasBlob(canvas, quality)
+      if (blob.size <= WEBCHAT_IMAGE_MAX_BYTES) {
+        return {
+          name: webpName(file.name),
+          mimeType: 'image/webp',
+          data: await blobBase64(blob)
+        }
+      }
+
+      if (quality > 0.5) {
+        quality = Math.max(0.5, quality - 0.12)
+      } else {
+        const shrink = Math.max(0.5, Math.min(0.88, Math.sqrt(WEBCHAT_IMAGE_MAX_BYTES / blob.size) * 0.92))
+        scale *= shrink
+      }
+    }
+  } finally {
+    bitmap.close()
+  }
+
+  throw new Error('Couldn’t make that image small enough to send.')
+}


### PR DESCRIPTION
## Summary

- add a bounded inline image attachment to the browser → relay → daemon WebChat path
- rasterize and compress uploads in the browser, then deliver them as ACP image prompt blocks while persisting only filename/MIME summaries
- support direct image paste plus a one-item `Add` → `Add photos` picker, thumbnail preview/removal, image-only sends, and live transcript rendering
- fold permission, usage, model, effort, fast mode, and send/stop controls into the composer toolbar
- present context-window usage as a compact progress ring with used/remaining percentages and token detail on hover or focus
- anchor the `Add photos` menu directly above the `+` button inside the composer

## User impact

WebChat users can paste an image directly into the message box or choose `Add photos`. Browser-readable images are converted to WebP and compressed below the wire limit before sending. Image bytes stay off the Control Plane path. Context usage remains compact until the user asks for detail.

## Validation

- protocol: 181 tests passed
- relay: 283 tests passed
- daemon: 41 focused attachment/WebChat tests passed
- web: 287 tests passed
- protocol, relay, daemon, and web typechecks passed
- changed-file ESLint, Prettier, and `git diff --check` passed
- Next.js production build passed
- browser QA covered the anchored `Add photos` menu plus light/dark context-window hover and keyboard-focus presentation

Created by Codex . GPT-5
