### PR TITLE
fix(daemon): inline downloaded ACP images

### DIFF
--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -29,7 +29,9 @@ export function attachmentToBlock(
 ): ContentBlock {
   const isImage = att.mimeType.startsWith('image/')
   if (bytes && isImage && supports('image')) {
-    return { type: 'image', data: bytes.toString('base64'), mimeType: att.mimeType, uri: att.sourceUrl }
+    // Keep downloaded images self-contained. Some ACP adapters prefer `uri`
+    // over `data`, breaking auth-gated URLs despite having bytes. Remove via #52.
+    return { type: 'image', data: bytes.toString('base64'), mimeType: att.mimeType }
   }
   if (bytes && supports('embeddedContext')) {
     if (att.mimeType.startsWith('text/')) {

--- a/packages/daemon/test/attachment-block.test.ts
+++ b/packages/daemon/test/attachment-block.test.ts
@@ -14,13 +14,12 @@ const supportsAll = () => true
 const supportsNone = () => false
 
 describe('attachmentToBlock', () => {
-  it('builds an inline image block for image/* when the agent supports images', () => {
+  it('builds a self-contained inline image block when the agent supports images', () => {
     const bytes = Buffer.from('IMG')
     expect(attachmentToBlock(att(), bytes, supportsAll)).toEqual({
       type: 'image',
       data: bytes.toString('base64'),
-      mimeType: 'image/png',
-      uri: 'https://files/F1'
+      mimeType: 'image/png'
     })
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -764,6 +764,7 @@ describe('SessionManager', () => {
     )
     const img = blocks.find((b: any) => b.type === 'image') as any
     expect(img).toMatchObject({ type: 'image', mimeType: 'image/png', data: png.toString('base64') })
+    expect(img).not.toHaveProperty('uri')
     store.close()
   })
 


### PR DESCRIPTION
## Summary

- send downloaded image attachments as self-contained ACP `image` blocks
- omit the source `uri` so adapters cannot override valid inline bytes with an auth-gated URL
- preserve the existing `resource_link` fallback when download fails, the file exceeds the cap, or the runtime lacks image support
- tighten the attachment and session-manager regression expectations

## Root cause

AgentConnect supplied both base64 `data` and the original URL. Current `codex-acp` releases prefer an HTTP(S) `uri` over the available data, while Codex app-server rejects remote image URLs. Slack file URLs are also auth-gated, so the turn surfaced only as `Agent failed to respond: Internal error` despite a successful daemon-side download.

## Impact

Slack images now reach Codex through inline data. Claude and other image-capable ACP runtimes continue to receive valid self-contained image blocks, while unavailable attachments retain the existing tool-assisted link fallback.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/attachment-block.test.ts test/session-manager.test.ts` — 68 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- Prettier check on all changed files
- ESLint on all changed files
- pre-push full-repository ESLint — 0 errors; two unrelated existing warnings

## Follow-up

Issue #52 tracks restoring URI metadata and removing this workaround after the minimum supported `codex-acp` version prefers inline data when both fields are present.

Upstream:

- https://github.com/agentclientprotocol/codex-acp/issues/313
- https://github.com/openai/codex/issues/33788

Created by Codex . GPT-5
