### PR TITLE
fix(webchat): resume interrupted response streams

### DIFF
--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -376,9 +376,10 @@ Conversation bodies remain daemon-local. While a turn is active or recently
 completed, the daemon retains a bounded, short-lived output window keyed by the
 browser-allocated turn id. A reconnecting browser reports its last contiguous
 output index and an increasing connection generation through any healthy relay;
-the daemon rejects stale generations, rebinds the live stream, and replays the
-missing tail. This window is volatile, has explicit size and age limits, and
-does not create a durable transcript or offline inbox.
+the browser rejects frames for any other turn while the daemon rejects stale
+generations, rebinds the live stream, and replays the missing tail. This window
+is volatile, has explicit size and age limits, and does not create a durable
+transcript or offline inbox.
 
 ## 11. Daemon Responsibilities
 

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -372,7 +372,12 @@ the agent's current daemon placement and bridges browser turns and daemon
 output without routing arbitration. Webchat verification carries a
 `conversationBinding: 'v1'` fence and uses a v2 token-signing domain so mixed
 old/new CP and relay instances fail closed instead of silently downgrading.
-Conversation bodies remain daemon-local.
+Conversation bodies remain daemon-local. While a turn is active or recently
+completed, the daemon retains a bounded, short-lived output window keyed by the
+turn id. A reconnecting browser reports its last contiguous output index
+through any healthy relay; the daemon rebinds the live stream and replays the
+missing tail. This window is volatile, has explicit size and age limits, and
+does not create a durable transcript or offline inbox.
 
 ## 11. Daemon Responsibilities
 
@@ -386,7 +391,9 @@ Conversation bodies remain daemon-local.
   the normal daemon path.
 - Direct Slack integrations retain their daemon-owned socket transport.
 - Webchat output is returned through `rd/chat` to the relay holding the browser
-  session.
+  session. The daemon assigns monotonically increasing output indexes, retains
+  the bounded replay window, and can rebind an accepted turn to a replacement
+  relay connection.
 
 Slack rate limits are global to a bot while send queues are local to member
 daemons. Each daemon respects `429` and `Retry-After`; channel ownership reduces
@@ -422,8 +429,14 @@ Hook ingress responds quickly after verification and admission. Stable
 provider retry behavior is not treated as a durable queue.
 
 Webchat uses connection semantics: `rd/ack` reports whether the daemon accepted
-a turn, and `rd/chat` streams output until completion. Browser reconnect
-behavior is separate from IM delivery.
+a turn, and `rd/chat` streams indexed output until completion. After a browser
+reconnect, the browser sends the last contiguous index it assembled. The daemon
+either replays the missing tail and continues the same turn or returns an
+explicit resume failure when the turn is unknown, the cursor is invalid, or
+the bounded replay window has overflowed. Completion includes the final output
+index so the browser does not render a response as complete while an earlier
+frame is still missing. Browser reconnect behavior is separate from IM
+delivery, and replay is not guaranteed after the bounded window expires.
 
 All writers and retry caches must comply with
 [high-availability.md](high-availability.md#backpressure-and-delivery):
@@ -435,7 +448,7 @@ delivery.
 | Failure                             | Shared Slack ingress                                                                                           | Hook ingress                                                     | Webchat                                                            | Agent API egress                              |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
 | CP unavailable                      | Cached assignments and existing daemon sockets continue; affinity misses and new authentication fail closed    | Cached rules continue; metadata reports may wait or fail visibly | Established sessions continue; new verification is unavailable     | Continues directly from online daemons        |
-| Relay instance unavailable          | Other healthy instances continue receiving public callbacks; daemons reconnect according to the updated roster | Other healthy instances continue                                 | Browser reconnects through the public origin                       | Unaffected                                    |
+| Relay instance unavailable          | Other healthy instances continue receiving public callbacks; daemons reconnect according to the updated roster | Other healthy instances continue                                 | Browser reconnects and resumes from the daemon replay window       | Unaffected                                    |
 | Entire relay pool unavailable       | HTTP bot callbacks cannot be processed                                                                         | Public hook ingress is unavailable                               | Browser sessions are unavailable                                   | Existing daemons can still call platform APIs |
 | Target daemon unavailable           | Selected messages are dropped and counted; unrelated daemons continue                                          | Target delivery fails visibly                                    | Target session cannot start or continue                            | That daemon cannot send                       |
 | Partial daemon-to-pool connectivity | A callback landing without its target socket is dropped and counted                                            | Same bounded-loss outcome                                        | A browser must reconnect to an instance with the target connection | Unaffected                                    |
@@ -500,6 +513,8 @@ The smallest useful evidence for this design includes:
 - relay-daemon tests for identity verification, relay identity mismatch,
   revocation, typed acknowledgement, offline-target drops, and daemon-side
   deduplication;
+- webchat tests for ordered output assembly, reconnect replay, terminal-frame
+  gaps, and explicit replay-window overflow;
 - end-to-end tests that confirm Slack ingress reaches the selected daemon while
   normal agent replies bypass the relay;
 - security assertions that logs contain no credentials, signatures, message

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -437,8 +437,10 @@ and continues the same turn or returns an explicit resume failure when the turn
 is unknown, the reconnect is stale, the cursor is invalid, or the bounded replay
 window has overflowed. Completion includes the final output index so the browser
 does not render a response as complete while an earlier frame is still missing.
-Browser reconnect behavior is separate from IM delivery, and replay is not
-guaranteed after the bounded window expires.
+A not-found result is retried only through the original turn-admission window,
+covering a resume that reaches the daemon before its delayed turn. Browser
+reconnect behavior is separate from IM delivery, and replay is not guaranteed
+after the bounded window expires.
 
 All writers and retry caches must comply with
 [high-availability.md](high-availability.md#backpressure-and-delivery):
@@ -515,8 +517,9 @@ The smallest useful evidence for this design includes:
 - relay-daemon tests for identity verification, relay identity mismatch,
   revocation, typed acknowledgement, offline-target drops, and daemon-side
   deduplication;
-- webchat tests for ordered output assembly, reconnect replay, terminal-frame
-  gaps, and explicit replay-window overflow;
+- webchat tests for ordered output assembly, reconnect replay in both
+  turn/resume arrival orders, stale-generation fencing, terminal-frame gaps, and
+  explicit replay-window overflow;
 - end-to-end tests that confirm Slack ingress reaches the selected daemon while
   normal agent replies bypass the relay;
 - security assertions that logs contain no credentials, signatures, message

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -374,8 +374,9 @@ output without routing arbitration. Webchat verification carries a
 old/new CP and relay instances fail closed instead of silently downgrading.
 Conversation bodies remain daemon-local. While a turn is active or recently
 completed, the daemon retains a bounded, short-lived output window keyed by the
-turn id. A reconnecting browser reports its last contiguous output index
-through any healthy relay; the daemon rebinds the live stream and replays the
+browser-allocated turn id. A reconnecting browser reports its last contiguous
+output index and an increasing connection generation through any healthy relay;
+the daemon rejects stale generations, rebinds the live stream, and replays the
 missing tail. This window is volatile, has explicit size and age limits, and
 does not create a durable transcript or offline inbox.
 
@@ -431,12 +432,13 @@ provider retry behavior is not treated as a durable queue.
 Webchat uses connection semantics: `rd/ack` reports whether the daemon accepted
 a turn, and `rd/chat` streams indexed output until completion. After a browser
 reconnect, the browser sends the last contiguous index it assembled. The daemon
-either replays the missing tail and continues the same turn or returns an
-explicit resume failure when the turn is unknown, the cursor is invalid, or
-the bounded replay window has overflowed. Completion includes the final output
-index so the browser does not render a response as complete while an earlier
-frame is still missing. Browser reconnect behavior is separate from IM
-delivery, and replay is not guaranteed after the bounded window expires.
+accepts only a newer reconnect generation, then either replays the missing tail
+and continues the same turn or returns an explicit resume failure when the turn
+is unknown, the reconnect is stale, the cursor is invalid, or the bounded replay
+window has overflowed. Completion includes the final output index so the browser
+does not render a response as complete while an earlier frame is still missing.
+Browser reconnect behavior is separate from IM delivery, and replay is not
+guaranteed after the bounded window expires.
 
 All writers and retry caches must comply with
 [high-availability.md](high-availability.md#backpressure-and-delivery):

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -485,6 +485,13 @@ const SELECT_CODE_KIND = { m: 'model', e: 'effort', p: 'permission' } as const s
 // kind + JSON escaping of control chars, up to a 6× blowup) can never push a chunk
 // over the wire limit. Long agent output is split across several chunks at this size.
 const WEBCHAT_CHUNK_BYTES = 32 * 1024
+// A reconnectable turn keeps a bounded in-memory output window on the daemon,
+// where the stream originates. This survives a browser moving between relay
+// instances without putting message bodies on the Control Plane or disk.
+const WEBCHAT_REPLAY_MAX_EVENTS = 256
+const WEBCHAT_REPLAY_MAX_BYTES = 1024 * 1024
+const WEBCHAT_REPLAY_MAX_STREAMS = 64
+const WEBCHAT_REPLAY_TTL_MS = 5 * 60_000
 
 /** Split `text` into pieces whose UTF-8 byte length each stays under WEBCHAT_CHUNK_BYTES
  *  so no single relay `rd/chat` payload exceeds the 256 KiB cap. Splits on byte budget
@@ -768,7 +775,7 @@ interface QueueEntry {
    *  host-stop backstop, including non-host awaits such as workspace/history I/O. */
   initAbort: AbortController
   integrationId?: string
-  webchat?: { conversationId: string; turnId: string; sink: WebchatSink; doneSent?: boolean }
+  webchat?: WebchatTurnContext
   callMeta?: CallMeta
   hookContext?: HookDispatchContext
   /** Best-effort lifecycle notification after ACP session initialization but
@@ -957,14 +964,7 @@ interface Pending {
    * accumulates the agent's message chunks so the finished reply is recorded to the
    * transcript once (webchat has no Slack post boundary where text is otherwise saved).
    */
-  webchat?: {
-    conversationId: string
-    turnId: string
-    index: number
-    replyText: string
-    sink: WebchatSink
-    doneSent?: boolean
-  }
+  webchat?: WebchatTurnContext & { index: number; replyText: string }
 }
 
 /** Visible Slack thread messages that establish a new chronological boundary. Any live
@@ -990,6 +990,32 @@ interface SessionDeliveryBinding {
 export interface WebchatSink {
   output(o: WebchatOutput): void
   done(d: WebchatDone): void
+}
+
+interface BufferedWebchatEvent {
+  event: RdChatEvent
+  bytes: number
+}
+
+interface WebchatTurnContext {
+  conversationId: string
+  turnId: string
+  sink: WebchatSink
+  doneSent?: boolean
+}
+
+/** One daemon-owned turn stream. `sink` is stable for the turn engine; `transport`
+ * is rebound when a browser resumes through any relay. The replay window is
+ * ephemeral, bounded, and never written to disk. */
+interface WebchatTurnStream extends WebchatTurnContext {
+  agentId: string
+  transport: WebchatSink
+  replay: BufferedWebchatEvent[]
+  replayBytes: number
+  replayFloor: number
+  replayDisabled: boolean
+  lastOutputIndex: number
+  completedAt?: number
 }
 
 export interface DaemonEvaluationOptions {
@@ -3680,7 +3706,8 @@ export class Daemon {
       this.log.warn(`webchat: queue full for session ${key} — rejecting turn`)
       return { accepted: false, turnId, reason: 'busy' }
     }
-    void this.dispatch(result.agentId, msg, undefined, { conversationId: chatId, turnId, sink }).catch((err) =>
+    const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink)
+    void this.dispatch(result.agentId, msg, undefined, stream).catch((err) =>
       this.log.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
     )
     return { accepted: true, turnId }
@@ -3697,6 +3724,136 @@ export class Daemon {
    *  (channel = conversationId, statusThread = the stable `webchat:<id>` msgId, no thread). */
   private webchatSessionKey(conversationId: string, agentId: string): string {
     return sessionKey('webchat', conversationId, `webchat:${conversationId}`, agentId)
+  }
+
+  /** Wrap the turn's relay-bound transport with daemon-owned bounded replay. The
+   * turn engine keeps calling the stable wrapper while resume swaps only the raw
+   * transport underneath it. */
+  private createWebchatTurnStream(
+    agentId: string,
+    conversationId: string,
+    turnId: string,
+    transport: WebchatSink
+  ): WebchatTurnStream {
+    this.pruneWebchatStreams()
+    const stream: WebchatTurnStream = {
+      agentId,
+      conversationId,
+      turnId,
+      transport,
+      sink: {
+        output: (output) => this.publishWebchatStreamEvent(stream, { kind: 'output', output }),
+        done: (done) => this.publishWebchatStreamEvent(stream, { kind: 'done', done })
+      },
+      replay: [],
+      replayBytes: 0,
+      replayFloor: 0,
+      replayDisabled: false,
+      lastOutputIndex: -1
+    }
+    this.webchatStreams.set(turnId, stream)
+    this.latestWebchatTurn.set(this.webchatSessionKey(conversationId, agentId), turnId)
+    this.pruneWebchatStreams()
+    return stream
+  }
+
+  /** Buffer before sending so a transport gap is recoverable even when the live
+   * write is lost. The terminal frame carries the final output index for browser
+   * gap detection. */
+  private publishWebchatStreamEvent(stream: WebchatTurnStream, event: RdChatEvent): void {
+    const normalized: RdChatEvent =
+      event.kind === 'output' ? event : { kind: 'done', done: { ...event.done, lastIndex: stream.lastOutputIndex } }
+    if (normalized.kind === 'output') {
+      stream.lastOutputIndex = Math.max(stream.lastOutputIndex, normalized.output.index)
+    }
+    if (!stream.replayDisabled) this.bufferWebchatStreamEvent(stream, normalized)
+    this.deliverWebchatStreamEvent(stream.transport, normalized)
+    if (normalized.kind === 'done') {
+      stream.completedAt = this.clock.now()
+      this.pruneWebchatStreams()
+    }
+  }
+
+  private bufferWebchatStreamEvent(stream: WebchatTurnStream, event: RdChatEvent): void {
+    const bytes = Buffer.byteLength(JSON.stringify(event))
+    stream.replay.push({ event, bytes })
+    stream.replayBytes += bytes
+    while (stream.replay.length > WEBCHAT_REPLAY_MAX_EVENTS || stream.replayBytes > WEBCHAT_REPLAY_MAX_BYTES) {
+      const dropped = stream.replay.shift()
+      if (!dropped) break
+      stream.replayBytes -= dropped.bytes
+      if (dropped.event.kind === 'output') {
+        stream.replayFloor = Math.max(stream.replayFloor, dropped.event.output.index + 1)
+      } else {
+        // A terminal frame is tiny and should never be the overflow victim. Fail
+        // closed if a future payload shape violates that assumption.
+        stream.replayDisabled = true
+        stream.replay = []
+        stream.replayBytes = 0
+        break
+      }
+    }
+  }
+
+  private deliverWebchatStreamEvent(sink: WebchatSink, event: RdChatEvent): void {
+    if (event.kind === 'output') sink.output(event.output)
+    else sink.done(event.done)
+  }
+
+  private resumeWebchatStream(
+    agentId: string,
+    conversationId: string,
+    turnId: string | undefined,
+    afterIndex: number,
+    transport: WebchatSink
+  ): { accepted: boolean; turnId?: string; reason?: string } {
+    this.pruneWebchatStreams()
+    const resolvedTurnId = turnId ?? this.latestWebchatTurn.get(this.webchatSessionKey(conversationId, agentId))
+    const stream = resolvedTurnId ? this.webchatStreams.get(resolvedTurnId) : undefined
+    if (!stream || stream.agentId !== agentId || stream.conversationId !== conversationId) {
+      return { accepted: false, reason: 'stream_not_found' }
+    }
+    if (stream.replayDisabled || afterIndex < stream.replayFloor - 1) {
+      return { accepted: false, turnId: stream.turnId, reason: 'stream_gap' }
+    }
+    if (afterIndex > stream.lastOutputIndex) {
+      return { accepted: false, turnId: stream.turnId, reason: 'stream_cursor_invalid' }
+    }
+
+    // Rebind first: outputs produced after this synchronous replay leave through
+    // the same new relay connection. Replay bypasses the stable buffering wrapper
+    // so retained frames are not inserted twice.
+    stream.transport = transport
+    for (const buffered of stream.replay) {
+      if (buffered.event.kind === 'output' && buffered.event.output.index <= afterIndex) continue
+      this.deliverWebchatStreamEvent(transport, buffered.event)
+    }
+    return { accepted: true, turnId: stream.turnId }
+  }
+
+  private removeWebchatStream(turnId: string, stream: WebchatTurnStream): void {
+    this.webchatStreams.delete(turnId)
+    const key = this.webchatSessionKey(stream.conversationId, stream.agentId)
+    if (this.latestWebchatTurn.get(key) === turnId) this.latestWebchatTurn.delete(key)
+    stream.replayDisabled = true
+    stream.replay = []
+    stream.replayBytes = 0
+  }
+
+  private pruneWebchatStreams(): void {
+    const now = this.clock.now()
+    for (const [turnId, stream] of this.webchatStreams) {
+      if (stream.completedAt !== undefined && now - stream.completedAt > WEBCHAT_REPLAY_TTL_MS) {
+        this.removeWebchatStream(turnId, stream)
+      }
+    }
+    while (this.webchatStreams.size > WEBCHAT_REPLAY_MAX_STREAMS) {
+      const completed =
+        [...this.webchatStreams].find(([, stream]) => stream.completedAt !== undefined) ??
+        this.webchatStreams.entries().next().value
+      if (!completed) break
+      this.removeWebchatStream(completed[0], completed[1])
+    }
   }
 
   /** Resolve a session only while its Agent explicitly permits chat-side runtime changes. */
@@ -3890,6 +4047,11 @@ export class Daemon {
     this.log.debug(`webchat cancel: no in-flight turn for conversation ${conversationId}`)
   }
 
+  // Bounded, ephemeral reconnect state. The exact turn map authorizes cursored
+  // resume; the session map covers the pre-ack disconnect case where the browser
+  // does not know its turnId yet.
+  private readonly webchatStreams = new Map<string, WebchatTurnStream>()
+  private readonly latestWebchatTurn = new Map<string, string>()
   // Idempotency cache for the at-least-once rd/* wire: (sessionKey:msgId) → the ack we
   // already returned. Bounded like `seenMsgIds`. A relay retransmit replays this instead
   // of re-dispatching. (design §7.2 RdMsgWebchat: "the daemon drops an already-seen
@@ -5561,6 +5723,15 @@ export class Daemon {
           ...(ack.reason ? { reason: ack.reason } : {})
         }
       }
+      case 'resume': {
+        const resumed = this.resumeWebchatStream(msg.agentId, msg.chatId, op.turnId, op.afterIndex, sink)
+        return {
+          msgId: msg.msgId,
+          accepted: resumed.accepted,
+          ...(resumed.turnId ? { turnId: resumed.turnId } : {}),
+          ...(resumed.reason ? { reason: resumed.reason } : {})
+        }
+      }
       case 'set_model':
         return this.setModelByKey(key(), op.model)
           ? { msgId: msg.msgId, accepted: true }
@@ -6342,7 +6513,7 @@ export class Daemon {
       iconUrl?: string
       platform: string
       isDm: boolean
-      webchat?: { conversationId: string; turnId: string; sink: WebchatSink }
+      webchat?: WebchatTurnContext
       replyConn?: SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection
       channel: string
       thread?: string
@@ -6799,7 +6970,7 @@ export class Daemon {
     agentId: string,
     msg: NormalizedMessage,
     integrationId?: string,
-    webchat?: { conversationId: string; turnId: string; sink: WebchatSink },
+    webchat?: WebchatTurnContext,
     callMeta?: CallMeta,
     opts?: {
       isQueueCmd?: boolean

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1010,6 +1010,7 @@ interface WebchatTurnContext {
 interface WebchatTurnStream extends WebchatTurnContext {
   agentId: string
   transport: WebchatSink
+  resumeGeneration: number
   replay: BufferedWebchatEvent[]
   replayBytes: number
   replayFloor: number
@@ -3646,9 +3647,10 @@ export class Daemon {
     chatId: string,
     text: string,
     user: string,
-    sink: WebchatSink
+    sink: WebchatSink,
+    requestedTurnId?: string
   ): WebchatAck {
-    const turnId = randomUUID()
+    const turnId = requestedTurnId ?? randomUUID()
     // Route directly to the named agent (bypasses arbitration); null when it isn't a
     // servable agent on this daemon.
     const result = routeRules(
@@ -3706,6 +3708,10 @@ export class Daemon {
       this.log.warn(`webchat: queue full for session ${key} — rejecting turn`)
       return { accepted: false, turnId, reason: 'busy' }
     }
+    this.pruneWebchatStreams()
+    if (this.webchatStreams.has(turnId)) {
+      return { accepted: false, turnId, reason: 'busy' }
+    }
     const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink)
     void this.dispatch(result.agentId, msg, undefined, stream).catch((err) =>
       this.log.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
@@ -3741,6 +3747,7 @@ export class Daemon {
       conversationId,
       turnId,
       transport,
+      resumeGeneration: 0,
       sink: {
         output: (output) => this.publishWebchatStreamEvent(stream, { kind: 'output', output }),
         done: (done) => this.publishWebchatStreamEvent(stream, { kind: 'done', done })
@@ -3752,7 +3759,6 @@ export class Daemon {
       lastOutputIndex: -1
     }
     this.webchatStreams.set(turnId, stream)
-    this.latestWebchatTurn.set(this.webchatSessionKey(conversationId, agentId), turnId)
     this.pruneWebchatStreams()
     return stream
   }
@@ -3803,16 +3809,22 @@ export class Daemon {
   private resumeWebchatStream(
     agentId: string,
     conversationId: string,
-    turnId: string | undefined,
+    turnId: string,
+    generation: number,
     afterIndex: number,
     transport: WebchatSink
   ): { accepted: boolean; turnId?: string; reason?: string } {
     this.pruneWebchatStreams()
-    const resolvedTurnId = turnId ?? this.latestWebchatTurn.get(this.webchatSessionKey(conversationId, agentId))
-    const stream = resolvedTurnId ? this.webchatStreams.get(resolvedTurnId) : undefined
+    const stream = this.webchatStreams.get(turnId)
     if (!stream || stream.agentId !== agentId || stream.conversationId !== conversationId) {
       return { accepted: false, reason: 'stream_not_found' }
     }
+    if (generation <= stream.resumeGeneration) {
+      return { accepted: false, turnId: stream.turnId, reason: 'stream_stale' }
+    }
+    // Claim the newer connection generation before validating its cursor. Even a
+    // failed newer resume must fence an older request that is still in flight.
+    stream.resumeGeneration = generation
     if (stream.replayDisabled || afterIndex < stream.replayFloor - 1) {
       return { accepted: false, turnId: stream.turnId, reason: 'stream_gap' }
     }
@@ -3833,8 +3845,6 @@ export class Daemon {
 
   private removeWebchatStream(turnId: string, stream: WebchatTurnStream): void {
     this.webchatStreams.delete(turnId)
-    const key = this.webchatSessionKey(stream.conversationId, stream.agentId)
-    if (this.latestWebchatTurn.get(key) === turnId) this.latestWebchatTurn.delete(key)
     stream.replayDisabled = true
     stream.replay = []
     stream.replayBytes = 0
@@ -4047,11 +4057,8 @@ export class Daemon {
     this.log.debug(`webchat cancel: no in-flight turn for conversation ${conversationId}`)
   }
 
-  // Bounded, ephemeral reconnect state. The exact turn map authorizes cursored
-  // resume; the session map covers the pre-ack disconnect case where the browser
-  // does not know its turnId yet.
+  // Bounded, ephemeral reconnect state keyed by the browser-known turn id.
   private readonly webchatStreams = new Map<string, WebchatTurnStream>()
-  private readonly latestWebchatTurn = new Map<string, string>()
   // Idempotency cache for the at-least-once rd/* wire: (sessionKey:msgId) → the ack we
   // already returned. Bounded like `seenMsgIds`. A relay retransmit replays this instead
   // of re-dispatching. (design §7.2 RdMsgWebchat: "the daemon drops an already-seen
@@ -5715,7 +5722,7 @@ export class Daemon {
     const key = (): string => this.webchatSessionKey(msg.chatId, msg.agentId)
     switch (op.op) {
       case 'turn': {
-        const ack = this.dispatchWebchatTurn(msg.agentId, msg.chatId, op.text, op.user ?? 'webchat', sink)
+        const ack = this.dispatchWebchatTurn(msg.agentId, msg.chatId, op.text, op.user ?? 'webchat', sink, op.turnId)
         return {
           msgId: msg.msgId,
           accepted: ack.accepted,
@@ -5724,7 +5731,7 @@ export class Daemon {
         }
       }
       case 'resume': {
-        const resumed = this.resumeWebchatStream(msg.agentId, msg.chatId, op.turnId, op.afterIndex, sink)
+        const resumed = this.resumeWebchatStream(msg.agentId, msg.chatId, op.turnId, op.generation, op.afterIndex, sink)
         return {
           msgId: msg.msgId,
           accepted: resumed.accepted,

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1045,6 +1045,83 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   }, 15_000)
 
+  it('rebinds an active turn to a new relay sink and replays a missed terminal tail', async () => {
+    const { factory } = streamingHost([])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const first: RdChatEvent[] = []
+    const second: RdChatEvent[] = []
+    const third: RdChatEvent[] = []
+    const sink = (events: RdChatEvent[]) => ({
+      output: (output: WebchatOutput) => events.push({ kind: 'output', output }),
+      done: (done: WebchatDone) => events.push({ kind: 'done', done })
+    })
+    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, sink(first))
+
+    stream.sink.output({ conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'first' } })
+    const activeResume = (daemon as any).handleRelayMsg(
+      rd({ op: 'resume', turnId, afterIndex: -1 }, { msgId: 'resume-active' }),
+      (event: RdChatEvent) => second.push(event)
+    )
+    expect(activeResume).toMatchObject({ accepted: true, turnId })
+    expect(second.filter((event) => event.kind === 'output')).toHaveLength(1)
+
+    stream.sink.output({ conversationId: CONV, turnId, index: 1, event: { kind: 'message', text: 'second' } })
+    stream.sink.done({ conversationId: CONV, turnId, stopReason: 'end_turn' })
+    expect(first).toHaveLength(1) // future output moved to the resumed relay sink
+    expect(second.at(-1)).toEqual({
+      kind: 'done',
+      done: { conversationId: CONV, turnId, lastIndex: 1, stopReason: 'end_turn' }
+    })
+
+    const terminalResume = (daemon as any).handleRelayMsg(
+      rd({ op: 'resume', turnId, afterIndex: 0 }, { msgId: 'resume-terminal' }),
+      (event: RdChatEvent) => third.push(event)
+    )
+    expect(terminalResume).toMatchObject({ accepted: true, turnId })
+    expect(third).toEqual([
+      {
+        kind: 'output',
+        output: { conversationId: CONV, turnId, index: 1, event: { kind: 'message', text: 'second' } }
+      },
+      {
+        kind: 'done',
+        done: { conversationId: CONV, turnId, lastIndex: 1, stopReason: 'end_turn' }
+      }
+    ])
+    await daemon.stop()
+  })
+
+  it('rejects resume explicitly when the bounded replay window no longer covers the cursor', async () => {
+    const { factory } = streamingHost([])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, {
+      output: () => {},
+      done: () => {}
+    })
+    for (let index = 0; index <= 256; index++) {
+      stream.sink.output({
+        conversationId: CONV,
+        turnId,
+        index,
+        event: { kind: 'message', text: String(index) }
+      })
+    }
+
+    expect(
+      (daemon as any).handleRelayMsg(
+        rd({ op: 'resume', turnId, afterIndex: -1 }, { msgId: 'resume-overflow' }),
+        () => {}
+      )
+    ).toMatchObject({ accepted: false, turnId, reason: 'stream_gap' })
+    await daemon.stop()
+  })
+
   it('rejects a turn for an agent not on this daemon (accepted:false, reason no_agent)', async () => {
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1102,6 +1102,51 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   })
 
+  it('accepts a retry after resume arrives before the delayed original turn', async () => {
+    const { factory } = streamingHost([])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const original: RdChatEvent[] = []
+    const resumed: RdChatEvent[] = []
+    const beforeTurn = (daemon as any).handleRelayMsg(
+      rd({ op: 'resume', turnId, generation: 1, afterIndex: -1 }, { msgId: 'resume-before-turn' }),
+      (event: RdChatEvent) => resumed.push(event)
+    )
+    expect(beforeTurn).toMatchObject({ accepted: false, reason: 'stream_not_found' })
+
+    const stream = (daemon as any).createWebchatTurnStream(AGENT_ID, CONV, turnId, {
+      output: (output: WebchatOutput) => original.push({ kind: 'output', output }),
+      done: (done: WebchatDone) => original.push({ kind: 'done', done })
+    })
+    stream.sink.output({ conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'missed' } })
+    const retry = (daemon as any).handleRelayMsg(
+      rd({ op: 'resume', turnId, generation: 2, afterIndex: -1 }, { msgId: 'resume-retry' }),
+      (event: RdChatEvent) => resumed.push(event)
+    )
+    expect(retry).toMatchObject({ accepted: true, turnId })
+
+    stream.sink.output({ conversationId: CONV, turnId, index: 1, event: { kind: 'message', text: 'continued' } })
+    expect(original).toEqual([
+      {
+        kind: 'output',
+        output: { conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'missed' } }
+      }
+    ])
+    expect(resumed).toEqual([
+      {
+        kind: 'output',
+        output: { conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'missed' } }
+      },
+      {
+        kind: 'output',
+        output: { conversationId: CONV, turnId, index: 1, event: { kind: 'message', text: 'continued' } }
+      }
+    ])
+    await daemon.stop()
+  })
+
   it('rejects resume explicitly when the bounded replay window no longer covers the cursor', async () => {
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1023,18 +1023,18 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     ...over
   })
 
-  it('a turn op dispatches and streams rd/chat output→done, acking accepted+turnId', async () => {
+  it('a turn op preserves the browser turnId and streams rd/chat output→done', async () => {
     const { factory } = streamingHost([text('hi from agent')])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
     ;(daemon as any).cpClient = fakeCpClient()
 
+    const turnId = '77777777-7777-4777-8777-777777777777'
     const events: RdChatEvent[] = []
-    const ack = (daemon as any).handleRelayMsg(rd({ op: 'turn', text: 'go', user: 'ada' }), (e: RdChatEvent) =>
+    const ack = (daemon as any).handleRelayMsg(rd({ op: 'turn', text: 'go', user: 'ada', turnId }), (e: RdChatEvent) =>
       events.push(e)
     )
-    expect(ack).toMatchObject({ msgId: 'm-1', accepted: true })
-    expect(ack.turnId).toBeDefined()
+    expect(ack).toMatchObject({ msgId: 'm-1', accepted: true, turnId })
 
     // The reply streams asynchronously through the same engine as the CP path, but now
     // over the `chat` callback (→ rd/chat) instead of the cp client.
@@ -1045,7 +1045,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   }, 15_000)
 
-  it('rebinds an active turn to a new relay sink and replays a missed terminal tail', async () => {
+  it('keeps a newer resume bound when a delayed older generation arrives afterward', async () => {
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
     await daemon.start()
@@ -1054,6 +1054,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const first: RdChatEvent[] = []
     const second: RdChatEvent[] = []
     const third: RdChatEvent[] = []
+    const stale: RdChatEvent[] = []
     const sink = (events: RdChatEvent[]) => ({
       output: (output: WebchatOutput) => events.push({ kind: 'output', output }),
       done: (done: WebchatDone) => events.push({ kind: 'done', done })
@@ -1062,22 +1063,29 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
 
     stream.sink.output({ conversationId: CONV, turnId, index: 0, event: { kind: 'message', text: 'first' } })
     const activeResume = (daemon as any).handleRelayMsg(
-      rd({ op: 'resume', turnId, afterIndex: -1 }, { msgId: 'resume-active' }),
+      rd({ op: 'resume', turnId, generation: 2, afterIndex: -1 }, { msgId: 'resume-active' }),
       (event: RdChatEvent) => second.push(event)
     )
     expect(activeResume).toMatchObject({ accepted: true, turnId })
     expect(second.filter((event) => event.kind === 'output')).toHaveLength(1)
 
+    const delayedResume = (daemon as any).handleRelayMsg(
+      rd({ op: 'resume', turnId, generation: 1, afterIndex: -1 }, { msgId: 'resume-delayed' }),
+      (event: RdChatEvent) => stale.push(event)
+    )
+    expect(delayedResume).toMatchObject({ accepted: false, turnId, reason: 'stream_stale' })
+
     stream.sink.output({ conversationId: CONV, turnId, index: 1, event: { kind: 'message', text: 'second' } })
     stream.sink.done({ conversationId: CONV, turnId, stopReason: 'end_turn' })
     expect(first).toHaveLength(1) // future output moved to the resumed relay sink
+    expect(stale).toEqual([]) // delayed generation never steals the stream transport
     expect(second.at(-1)).toEqual({
       kind: 'done',
       done: { conversationId: CONV, turnId, lastIndex: 1, stopReason: 'end_turn' }
     })
 
     const terminalResume = (daemon as any).handleRelayMsg(
-      rd({ op: 'resume', turnId, afterIndex: 0 }, { msgId: 'resume-terminal' }),
+      rd({ op: 'resume', turnId, generation: 3, afterIndex: 0 }, { msgId: 'resume-terminal' }),
       (event: RdChatEvent) => third.push(event)
     )
     expect(terminalResume).toMatchObject({ accepted: true, turnId })
@@ -1115,7 +1123,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
 
     expect(
       (daemon as any).handleRelayMsg(
-        rd({ op: 'resume', turnId, afterIndex: -1 }, { msgId: 'resume-overflow' }),
+        rd({ op: 'resume', turnId, generation: 1, afterIndex: -1 }, { msgId: 'resume-overflow' }),
         () => {}
       )
     ).toMatchObject({ accepted: false, turnId, reason: 'stream_gap' })

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -93,8 +93,8 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
 
   it('carries every webchat control op and rejects unknown ops', () => {
     const ops = [
-      { op: 'resume', turnId: TURN_ID, afterIndex: 3 },
-      { op: 'resume', afterIndex: -1 },
+      { op: 'turn', text: 'hello', turnId: TURN_ID },
+      { op: 'resume', turnId: TURN_ID, generation: 2, afterIndex: 3 },
       { op: 'set_model', model: 'opus-4.8' },
       { op: 'set_effort', effort: 'high' },
       { op: 'set_permission_mode', permissionMode: 'plan' },
@@ -109,8 +109,15 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     expect(RelayWebchatOp.safeParse({ op: 'set_theme', theme: 'dark' }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'turn' }).success).toBe(false) // text required
-    expect(RelayWebchatOp.safeParse({ op: 'resume', afterIndex: -2 }).success).toBe(false)
-    expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: 'not-a-uuid', afterIndex: 0 }).success).toBe(false)
+    expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: TURN_ID, generation: 1, afterIndex: -2 }).success).toBe(
+      false
+    )
+    expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: 'not-a-uuid', generation: 1, afterIndex: 0 }).success).toBe(
+      false
+    )
+    expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: TURN_ID, generation: 0, afterIndex: 0 }).success).toBe(
+      false
+    )
   })
 
   it('decodes an rd/msg im (shared bot) inbound, pre-addressed to an agent', () => {

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -93,6 +93,8 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
 
   it('carries every webchat control op and rejects unknown ops', () => {
     const ops = [
+      { op: 'resume', turnId: TURN_ID, afterIndex: 3 },
+      { op: 'resume', afterIndex: -1 },
       { op: 'set_model', model: 'opus-4.8' },
       { op: 'set_effort', effort: 'high' },
       { op: 'set_permission_mode', permissionMode: 'plan' },
@@ -107,6 +109,8 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     expect(RelayWebchatOp.safeParse({ op: 'set_theme', theme: 'dark' }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'turn' }).success).toBe(false) // text required
+    expect(RelayWebchatOp.safeParse({ op: 'resume', afterIndex: -2 }).success).toBe(false)
+    expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: 'not-a-uuid', afterIndex: 0 }).success).toBe(false)
   })
 
   it('decodes an rd/msg im (shared bot) inbound, pre-addressed to an agent', () => {
@@ -277,7 +281,10 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     const done = {
       chatId: CONV_ID,
       seq: 2,
-      event: { kind: 'done', done: { conversationId: CONV_ID, turnId: TURN_ID, stopReason: 'end_turn' } }
+      event: {
+        kind: 'done',
+        done: { conversationId: CONV_ID, turnId: TURN_ID, lastIndex: 1, stopReason: 'end_turn' }
+      }
     }
     expect(RdChat.safeParse(done).success).toBe(true)
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -64,6 +64,14 @@ export type RdHelloOk = z.infer<typeof RdHelloOk>
 // rest are the session controls the old daemon↔CP webchat EVTs carried.
 export const RelayWebchatOp = z.discriminatedUnion('op', [
   z.object({ op: z.literal('turn'), text: z.string(), user: z.string().optional() }),
+  // Rebind an in-flight/recent turn to this relay connection and replay every
+  // output after the browser's contiguous cursor. `turnId` can be absent only
+  // when the socket dropped before the initial turn ack arrived.
+  z.object({
+    op: z.literal('resume'),
+    turnId: z.string().uuid().optional(),
+    afterIndex: z.number().int().min(-1)
+  }),
   z.object({ op: z.literal('set_model'), model: z.string() }),
   z.object({ op: z.literal('set_effort'), effort: z.string() }),
   z.object({ op: z.literal('set_permission_mode'), permissionMode: z.string() }),

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -63,13 +63,21 @@ export type RdHelloOk = z.infer<typeof RdHelloOk>
 // the wire stays at the four designed frames. `turn` is the user message; the
 // rest are the session controls the old daemon↔CP webchat EVTs carried.
 export const RelayWebchatOp = z.discriminatedUnion('op', [
-  z.object({ op: z.literal('turn'), text: z.string(), user: z.string().optional() }),
+  z.object({
+    op: z.literal('turn'),
+    text: z.string(),
+    user: z.string().optional(),
+    // New browsers allocate this before sending so a pre-ack reconnect can name
+    // the exact turn. Optional for older clients; the daemon allocates a fallback.
+    turnId: z.string().uuid().optional()
+  }),
   // Rebind an in-flight/recent turn to this relay connection and replay every
-  // output after the browser's contiguous cursor. `turnId` can be absent only
-  // when the socket dropped before the initial turn ack arrived.
+  // output after the browser's contiguous cursor. The generation monotonically
+  // fences delayed resume requests from older browser connections.
   z.object({
     op: z.literal('resume'),
-    turnId: z.string().uuid().optional(),
+    turnId: z.string().uuid(),
+    generation: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
     afterIndex: z.number().int().min(-1)
   }),
   z.object({ op: z.literal('set_model'), model: z.string() }),

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -93,6 +93,10 @@ export type WebchatOutput = z.infer<typeof WebchatOutput>
 export const WebchatDone = z.object({
   conversationId: z.string().uuid(),
   turnId: z.string().uuid(),
+  // Last output index emitted before this terminal marker. A reconnecting browser
+  // holds `done` until it has assembled every output through this index, so an
+  // early terminal frame cannot hide a gap. Optional for rolling compatibility.
+  lastIndex: z.number().int().min(-1).optional(),
   stopReason: z.string().optional(),
   usage: z.object({ used: z.number().int().optional(), cost: z.number().optional() }).optional(),
   error: z.string().optional()

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 // (packages/protocol/src/frames/relay-daemon.ts). Content never touches the CP.
 
 // The webchat turn verdict — `dispatchWebchatTurn` returns this and the relay path folds
-// it into `rd/ack` (accepted + a fresh turnId that correlates the reply stream; `reason`
+// it into `rd/ack` (accepted + the turnId that correlates the reply stream; `reason`
 // explains a rejection). Not a wire frame of its own anymore.
 export const WebchatAck = z.object({
   accepted: z.boolean(),

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -65,15 +65,20 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 describe('parseBrowserFrame', () => {
   it('maps a bare {text} and {type:"message",text} to a turn op carrying the user', () => {
     expect(parseBrowserFrame({ text: 'hi' }, USER)).toEqual({ op: 'turn', text: 'hi', user: USER })
-    expect(parseBrowserFrame({ type: 'message', text: 'hi' }, USER)).toEqual({ op: 'turn', text: 'hi', user: USER })
+    expect(parseBrowserFrame({ type: 'message', text: 'hi', turnId: AGENT }, USER)).toEqual({
+      op: 'turn',
+      text: 'hi',
+      user: USER,
+      turnId: AGENT
+    })
   })
   it('maps the session-control envelopes', () => {
-    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, afterIndex: 4 }, USER)).toEqual({
+    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 3, afterIndex: 4 }, USER)).toEqual({
       op: 'resume',
       turnId: AGENT,
+      generation: 3,
       afterIndex: 4
     })
-    expect(parseBrowserFrame({ type: 'resume', afterIndex: -1 }, USER)).toEqual({ op: 'resume', afterIndex: -1 })
     expect(parseBrowserFrame({ type: 'set_model', model: 'claude' }, USER)).toEqual({
       op: 'set_model',
       model: 'claude'
@@ -92,8 +97,10 @@ describe('parseBrowserFrame', () => {
   it('rejects malformed / unknown envelopes', () => {
     expect(parseBrowserFrame({ type: 'set_model' }, USER)).toBeNull() // no model
     expect(parseBrowserFrame({ type: 'set_fast', fastMode: 'yes' }, USER)).toBeNull() // wrong type
-    expect(parseBrowserFrame({ type: 'resume', afterIndex: -2 }, USER)).toBeNull()
-    expect(parseBrowserFrame({ type: 'resume', afterIndex: 1.5 }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 1, afterIndex: -2 }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 1, afterIndex: 1.5 }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, generation: 0, afterIndex: 0 }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'resume', generation: 1, afterIndex: 0 }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'nope' }, USER)).toBeNull()
     expect(parseBrowserFrame(null, USER)).toBeNull()
     expect(parseBrowserFrame(42, USER)).toBeNull()
@@ -132,9 +139,9 @@ describe('RelayBrowserConnection', () => {
   it('forwards a resume cursor and surfaces its replay verdict', async () => {
     const turnId = '22222222-2222-4222-8222-222222222222'
     const { transport, sent } = build({ ack: { msgId: 'resume-1', accepted: true, turnId } })
-    transport.feed({ type: 'resume', turnId, afterIndex: 7 })
+    transport.feed({ type: 'resume', turnId, generation: 4, afterIndex: 7 })
     await tick()
-    expect(sent[0]).toMatchObject({ payload: { op: 'resume', turnId, afterIndex: 7 } })
+    expect(sent[0]).toMatchObject({ payload: { op: 'resume', turnId, generation: 4, afterIndex: 7 } })
     expect(transport.last('resumed')).toEqual({
       type: 'resumed',
       ack: { accepted: true, turnId }

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -68,6 +68,12 @@ describe('parseBrowserFrame', () => {
     expect(parseBrowserFrame({ type: 'message', text: 'hi' }, USER)).toEqual({ op: 'turn', text: 'hi', user: USER })
   })
   it('maps the session-control envelopes', () => {
+    expect(parseBrowserFrame({ type: 'resume', turnId: AGENT, afterIndex: 4 }, USER)).toEqual({
+      op: 'resume',
+      turnId: AGENT,
+      afterIndex: 4
+    })
+    expect(parseBrowserFrame({ type: 'resume', afterIndex: -1 }, USER)).toEqual({ op: 'resume', afterIndex: -1 })
     expect(parseBrowserFrame({ type: 'set_model', model: 'claude' }, USER)).toEqual({
       op: 'set_model',
       model: 'claude'
@@ -86,6 +92,8 @@ describe('parseBrowserFrame', () => {
   it('rejects malformed / unknown envelopes', () => {
     expect(parseBrowserFrame({ type: 'set_model' }, USER)).toBeNull() // no model
     expect(parseBrowserFrame({ type: 'set_fast', fastMode: 'yes' }, USER)).toBeNull() // wrong type
+    expect(parseBrowserFrame({ type: 'resume', afterIndex: -2 }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'resume', afterIndex: 1.5 }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'nope' }, USER)).toBeNull()
     expect(parseBrowserFrame(null, USER)).toBeNull()
     expect(parseBrowserFrame(42, USER)).toBeNull()
@@ -119,6 +127,18 @@ describe('RelayBrowserConnection', () => {
     transport.feed({ text: 'hi' })
     await tick()
     expect(transport.last('ack')).toEqual({ type: 'ack', ack: { accepted: false, reason: 'paused' } })
+  })
+
+  it('forwards a resume cursor and surfaces its replay verdict', async () => {
+    const turnId = '22222222-2222-4222-8222-222222222222'
+    const { transport, sent } = build({ ack: { msgId: 'resume-1', accepted: true, turnId } })
+    transport.feed({ type: 'resume', turnId, afterIndex: 7 })
+    await tick()
+    expect(sent[0]).toMatchObject({ payload: { op: 'resume', turnId, afterIndex: 7 } })
+    expect(transport.last('resumed')).toEqual({
+      type: 'resumed',
+      ack: { accepted: true, turnId }
+    })
   })
 
   it('translates an rd/chat output/done back to {type:output}/{type:done}', () => {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -4,8 +4,8 @@
  *
  * It speaks the browser-facing, type-tagged webchat envelope. The browser sends
  * `{text}` (a turn) or
- * `{type:'set_model'|'set_effort'|'set_permission_mode'|'set_fast'|'cancel'}`, and the
- * relay sends `{type:'ready'|'output'|'done'|'ack'|'error'}`. Internally each inbound
+ * `{type:'resume'|'set_model'|'set_effort'|'set_permission_mode'|'set_fast'|'cancel'}`,
+ * and the relay sends `{type:'ready'|'output'|'done'|'ack'|'resumed'|'error'}`. Internally each inbound
  * op becomes an `rd/msg(webchat)` bridged onto the target daemon's rd/* socket, and
  * each `rd/chat` chunk the daemon streams back is translated to `{type:'output'|'done'}`.
  *
@@ -41,6 +41,16 @@ export function parseBrowserFrame(msg: unknown, user: string): RelayWebchatOp | 
     return { op: 'turn', text: m.text, user }
   }
   switch (m.type) {
+    case 'resume':
+      return Number.isInteger(m.afterIndex) &&
+        (m.afterIndex as number) >= -1 &&
+        (m.turnId === undefined || typeof m.turnId === 'string')
+        ? {
+            op: 'resume',
+            afterIndex: m.afterIndex as number,
+            ...(typeof m.turnId === 'string' ? { turnId: m.turnId } : {})
+          }
+        : null
     case 'set_model':
       return typeof m.model === 'string' ? { op: 'set_model', model: m.model } : null
     case 'set_effort':
@@ -112,9 +122,15 @@ export class RelayBrowserConnection implements ChatSink {
     }
     try {
       const ack = await daemon.sendMsg(rdMsg)
-      // Only a turn's verdict is surfaced (accepted:false ⇒ paused / no daemon).
+      const browserAck = {
+        accepted: ack.accepted,
+        ...(ack.turnId ? { turnId: ack.turnId } : {}),
+        ...(ack.reason ? { reason: ack.reason } : {})
+      }
       if (op.op === 'turn') {
-        this.send({ type: 'ack', ack: { accepted: ack.accepted, ...(ack.reason ? { reason: ack.reason } : {}) } })
+        this.send({ type: 'ack', ack: browserAck })
+      } else if (op.op === 'resume') {
+        this.send({ type: 'resumed', ack: browserAck })
       }
     } catch (err) {
       this.deps.log.warn(`relay: webchat op delivery failed: ${(err as Error).message}`)

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -38,17 +38,22 @@ export function parseBrowserFrame(msg: unknown, user: string): RelayWebchatOp | 
   const m = msg as Record<string, unknown>
   // A bare {text} (no type) OR {type:'message', text} is a turn.
   if ((m.type === undefined || m.type === 'message') && typeof m.text === 'string') {
-    return { op: 'turn', text: m.text, user }
+    return m.turnId === undefined || typeof m.turnId === 'string'
+      ? { op: 'turn', text: m.text, user, ...(typeof m.turnId === 'string' ? { turnId: m.turnId } : {}) }
+      : null
   }
   switch (m.type) {
     case 'resume':
       return Number.isInteger(m.afterIndex) &&
         (m.afterIndex as number) >= -1 &&
-        (m.turnId === undefined || typeof m.turnId === 'string')
+        typeof m.turnId === 'string' &&
+        Number.isSafeInteger(m.generation) &&
+        (m.generation as number) >= 1
         ? {
             op: 'resume',
-            afterIndex: m.afterIndex as number,
-            ...(typeof m.turnId === 'string' ? { turnId: m.turnId } : {})
+            turnId: m.turnId,
+            generation: m.generation as number,
+            afterIndex: m.afterIndex as number
           }
         : null
     case 'set_model':

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -436,11 +436,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 }
                 if (resumeStream && busyRef.current[id]) {
                   const cursor = streamCursors.current.get(id)
-                  if (cursor) {
+                  const turnId = cursor?.turnId ?? cursor?.requestedTurnId
+                  if (cursor && turnId) {
+                    cursor.resumeGeneration += 1
                     ws.send(
                       JSON.stringify({
                         type: 'resume',
-                        ...(cursor.turnId ? { turnId: cursor.turnId } : {}),
+                        turnId,
+                        generation: cursor.resumeGeneration,
                         afterIndex: cursor.nextIndex - 1
                       })
                     )
@@ -538,12 +541,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       pushStep(id, { kind: 'msg', who: '@you', text })
       setPgInput(id, '')
       setBusy(id, true)
-      streamCursors.current.set(id, createWebchatCursor<WebchatOutput, WebchatDone>())
+      const requestedTurnId = crypto.randomUUID()
+      streamCursors.current.set(id, createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
       if (conversationId) conversationIds.current.set(id, conversationId)
       reconnectAttempts.current.delete(id)
       const conn = connect(id, agentForId, conversationId)
       conn.ready
-        .then((ws) => ws.send(JSON.stringify({ text })))
+        .then((ws) => ws.send(JSON.stringify({ text, turnId: requestedTurnId })))
         .catch((err) => {
           // A 503 from the token mint means the CP has no relay pool configured — the
           // agent may be perfectly healthy, so name the real cause instead of "unreachable".

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -12,6 +12,14 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { agentLabel, type Agent, type Session, type SessionStep } from '@/lib/data'
 import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
+import {
+  acceptWebchatDone,
+  acceptWebchatOutput,
+  bindWebchatTurn,
+  createWebchatCursor,
+  type OrderedWebchatCursor,
+  type OrderedWebchatResult
+} from '@/lib/webchat-stream'
 
 interface PlaygroundData {
   /** Composer buffer for one session id (each live conversation has its own). */
@@ -126,6 +134,19 @@ type WebchatStatus = {
   sessionId?: string
 }
 
+type WebchatOutput = {
+  turnId: string
+  index: number
+  event?: WebchatEvent
+  status?: WebchatStatus
+}
+
+type WebchatDone = {
+  turnId: string
+  lastIndex?: number
+  error?: string
+}
+
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const [pgSessions, setPgSessions] = useState<Record<string, Session>>({})
   // Live tail for adopted webchat sessions (real CP ids). Kept apart from `pgSessions`
@@ -139,6 +160,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const [pgBusyBy, setPgBusyBy] = useState<Record<string, boolean>>({})
   const conns = useRef<Map<string, Conn>>(new Map())
   const conversationIds = useRef<Map<string, string>>(new Map())
+  const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
   const reconnectAttempts = useRef<Map<string, number>>(new Map())
   const busyRef = useRef<Record<string, boolean>>({})
   const closingAll = useRef(false)
@@ -280,11 +302,63 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
+  const failStream = useCallback(
+    (id: string, message: string): void => {
+      streamCursors.current.delete(id)
+      reconnectAttempts.current.delete(id)
+      pushStep(id, { kind: 'done', text: `⚠️ ${message}` })
+      setBusy(id, false)
+    },
+    [pushStep, setBusy]
+  )
+
+  const applyStreamResult = useCallback(
+    (id: string, result: OrderedWebchatResult<WebchatOutput, WebchatDone>): void => {
+      if (result.overflow) {
+        failStream(id, 'Connection interrupted — refresh to load the complete response.')
+        return
+      }
+      for (const output of result.outputs) {
+        if (output.status) applyStatus(id, output.status)
+        const event = output.event
+        if (event) {
+          if (event.kind === 'session_info') applyTitle(id, event.title)
+          else applyEvent(id, event)
+        }
+      }
+      if (!result.done) return
+      reconnectAttempts.current.delete(id)
+      streamCursors.current.delete(id)
+      if (result.done.error) pushStep(id, { kind: 'done', text: `⚠️ ${result.done.error}` })
+      setBusy(id, false)
+    },
+    [applyEvent, applyStatus, applyTitle, failStream, pushStep, setBusy]
+  )
+
+  const receiveOutput = useCallback(
+    (id: string, output: WebchatOutput): void => {
+      const cursor = streamCursors.current.get(id)
+      if (!cursor) return
+      reconnectAttempts.current.delete(id)
+      applyStreamResult(id, acceptWebchatOutput(cursor, output))
+    },
+    [applyStreamResult]
+  )
+
+  const receiveDone = useCallback(
+    (id: string, done: WebchatDone): void => {
+      const cursor = streamCursors.current.get(id)
+      if (!cursor) return
+      applyStreamResult(id, acceptWebchatDone(cursor, done))
+    },
+    [applyStreamResult]
+  )
+
   /** Open (or reuse) the webchat socket for a session. `conversationId` RESUMES an
    *  existing conversation (adopted webchat sessions); omit it for a fresh playground
    *  turn (the CP mints the id). */
   const connect = useCallback(
-    (id: string, agentId: string, conversationId?: string): Conn => {
+    (id: string, agentId: string, conversationId?: string, resumeStream = false): Conn => {
       const resumeId = conversationId ?? conversationIds.current.get(id)
       if (resumeId) conversationIds.current.set(id, resumeId)
       const existing = conns.current.get(id)
@@ -317,9 +391,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
         const attempt = reconnectAttempts.current.get(id) ?? 0
         if (attempt >= WEBCHAT_RECONNECT_MAX_ATTEMPTS) {
-          reconnectAttempts.current.delete(id)
-          pushStep(id, { kind: 'done', text: '⚠️ Connection interrupted.' })
-          setBusy(id, false)
+          failStream(id, 'Connection interrupted.')
           return
         }
         reconnectAttempts.current.set(id, attempt + 1)
@@ -327,7 +399,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         conn.reconnectTimer = window.setTimeout(() => {
           conn.reconnectTimer = undefined
           if (!busyRef.current[id] || conns.current.has(id)) return
-          void connect(id, agentId, reconnectId).ready.catch(() => {})
+          void connect(id, agentId, reconnectId, true).ready.catch(() => {})
         }, delay)
       }
 
@@ -348,9 +420,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               let m: {
                 type?: string
                 conversationId?: string
-                output?: { event?: WebchatEvent; status?: WebchatStatus }
-                done?: { error?: string }
-                ack?: { accepted?: boolean; reason?: string }
+                output?: WebchatOutput
+                done?: WebchatDone
+                ack?: { accepted?: boolean; reason?: string; turnId?: string }
               }
               try {
                 m = JSON.parse(String(e.data))
@@ -362,22 +434,34 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                   conn.conversationId = m.conversationId
                   conversationIds.current.set(id, m.conversationId)
                 }
-              } else if (m.type === 'output') {
-                reconnectAttempts.current.delete(id)
-                // A frame may carry a status snapshot, a reply event, or (rarely) both.
-                if (m.output?.status) applyStatus(id, m.output.status)
-                const ev = m.output?.event
-                if (ev) {
-                  if (ev.kind === 'session_info') applyTitle(id, ev.title)
-                  else applyEvent(id, ev)
+                if (resumeStream && busyRef.current[id]) {
+                  const cursor = streamCursors.current.get(id)
+                  if (cursor) {
+                    ws.send(
+                      JSON.stringify({
+                        type: 'resume',
+                        ...(cursor.turnId ? { turnId: cursor.turnId } : {}),
+                        afterIndex: cursor.nextIndex - 1
+                      })
+                    )
+                  }
                 }
+              } else if (m.type === 'output') {
+                if (m.output) receiveOutput(id, m.output)
               } else if (m.type === 'done') {
-                reconnectAttempts.current.delete(id)
-                // A turn that failed to start / errored ends with `done.error` instead
-                // of a reply — show it so the transcript doesn't just fall silent.
-                if (m.done?.error) pushStep(id, { kind: 'done', text: `⚠️ ${m.done.error}` })
-                setBusy(id, false)
+                if (m.done) receiveDone(id, m.done)
+              } else if (m.type === 'ack' && m.ack?.accepted !== false) {
+                const cursor = streamCursors.current.get(id)
+                if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
+              } else if (m.type === 'resumed' && m.ack?.accepted === false) {
+                failStream(
+                  id,
+                  m.ack.reason === 'stream_gap'
+                    ? 'Some response updates could not be recovered — refresh to load the complete response.'
+                    : 'The response could not be resumed — refresh to load its latest state.'
+                )
               } else if (m.type === 'ack' && m.ack?.accepted === false) {
+                streamCursors.current.delete(id)
                 reconnectAttempts.current.delete(id)
                 pushStep(id, {
                   kind: 'done',
@@ -388,9 +472,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 })
                 setBusy(id, false)
               } else if (m.type === 'error') {
-                reconnectAttempts.current.delete(id)
-                pushStep(id, { kind: 'done', text: '⚠️ Connection error.' })
-                setBusy(id, false)
+                failStream(id, 'Connection error.')
               }
             }
             if (conns.current.get(id) === conn) conn.ws = ws
@@ -407,7 +489,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       conns.current.set(id, conn)
       return conn
     },
-    [activeOrg, applyEvent, applyStatus, applyTitle, pushStep, setBusy]
+    [activeOrg, failStream, receiveDone, receiveOutput, pushStep, setBusy]
   )
 
   const openPlayground = useCallback(
@@ -456,6 +538,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       pushStep(id, { kind: 'msg', who: '@you', text })
       setPgInput(id, '')
       setBusy(id, true)
+      streamCursors.current.set(id, createWebchatCursor<WebchatOutput, WebchatDone>())
       if (conversationId) conversationIds.current.set(id, conversationId)
       reconnectAttempts.current.delete(id)
       const conn = connect(id, agentForId, conversationId)
@@ -471,6 +554,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               ? '⚠️ Webchat relay not configured — set PUBLIC_RELAY_URL on the control plane.'
               : '⚠️ Could not reach the agent.'
           })
+          streamCursors.current.delete(id)
           setBusy(id, false)
         })
     },

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -338,7 +338,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const receiveOutput = useCallback(
     (id: string, output: WebchatOutput): void => {
       const cursor = streamCursors.current.get(id)
-      if (!cursor) return
+      if (!cursor || !bindWebchatTurn(cursor, output.turnId)) return
       reconnectAttempts.current.delete(id)
       applyStreamResult(id, acceptWebchatOutput(cursor, output))
     },

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -383,6 +383,39 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         if (conns.current.get(id) === conn) conns.current.delete(id)
       }
 
+      const sendResume = (ws: WebSocket): void => {
+        const cursor = streamCursors.current.get(id)
+        const turnId = cursor?.turnId ?? cursor?.requestedTurnId
+        if (!cursor || !turnId || ws.readyState !== WebSocket.OPEN) return
+        cursor.resumeGeneration += 1
+        ws.send(
+          JSON.stringify({
+            type: 'resume',
+            turnId,
+            generation: cursor.resumeGeneration,
+            afterIndex: cursor.nextIndex - 1
+          })
+        )
+      }
+
+      /** A reconnect can beat the original turn across different relay links.
+       * Retry only inside the same bounded admission window; once the delayed
+       * turn exists, daemon replay recovers everything emitted in the meantime. */
+      const scheduleResumeRetry = (ws: WebSocket): void => {
+        const attempt = reconnectAttempts.current.get(id) ?? 0
+        if (attempt >= WEBCHAT_RECONNECT_MAX_ATTEMPTS) {
+          failStream(id, 'The response could not be resumed — refresh to load its latest state.')
+          return
+        }
+        reconnectAttempts.current.set(id, attempt + 1)
+        const delay = Math.min(WEBCHAT_RECONNECT_MAX_MS, WEBCHAT_RECONNECT_BASE_MS * 2 ** attempt)
+        conn.reconnectTimer = window.setTimeout(() => {
+          conn.reconnectTimer = undefined
+          if (!busyRef.current[id] || conns.current.get(id) !== conn) return
+          sendResume(ws)
+        }, delay)
+      }
+
       const scheduleReconnect = (): void => {
         const reconnectId = conn.conversationId ?? resumeId ?? conversationIds.current.get(id)
         if (closingAll.current || conn.closing || !busyRef.current[id] || !reconnectId) {
@@ -412,6 +445,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             ws.onopen = () => resolve(ws)
             ws.onerror = () => reject(new Error('webchat connection failed'))
             ws.onclose = () => {
+              if (conn.reconnectTimer) window.clearTimeout(conn.reconnectTimer)
+              conn.reconnectTimer = undefined
               dropSelf()
               if (busyRef.current[id]) scheduleReconnect()
               else setBusy(id, false)
@@ -435,19 +470,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                   conversationIds.current.set(id, m.conversationId)
                 }
                 if (resumeStream && busyRef.current[id]) {
-                  const cursor = streamCursors.current.get(id)
-                  const turnId = cursor?.turnId ?? cursor?.requestedTurnId
-                  if (cursor && turnId) {
-                    cursor.resumeGeneration += 1
-                    ws.send(
-                      JSON.stringify({
-                        type: 'resume',
-                        turnId,
-                        generation: cursor.resumeGeneration,
-                        afterIndex: cursor.nextIndex - 1
-                      })
-                    )
-                  }
+                  sendResume(ws)
                 }
               } else if (m.type === 'output') {
                 if (m.output) receiveOutput(id, m.output)
@@ -456,13 +479,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
                 const cursor = streamCursors.current.get(id)
                 if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
+              } else if (m.type === 'resumed' && m.ack?.accepted !== false) {
+                const cursor = streamCursors.current.get(id)
+                if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
+                reconnectAttempts.current.delete(id)
               } else if (m.type === 'resumed' && m.ack?.accepted === false) {
-                failStream(
-                  id,
-                  m.ack.reason === 'stream_gap'
-                    ? 'Some response updates could not be recovered — refresh to load the complete response.'
-                    : 'The response could not be resumed — refresh to load its latest state.'
-                )
+                const awaitingAdmission = m.ack.reason === 'stream_not_found' && !streamCursors.current.get(id)?.turnId
+                if (awaitingAdmission) scheduleResumeRetry(ws)
+                else
+                  failStream(
+                    id,
+                    m.ack.reason === 'stream_gap'
+                      ? 'Some response updates could not be recovered — refresh to load the complete response.'
+                      : 'The response could not be resumed — refresh to load its latest state.'
+                  )
               } else if (m.type === 'ack' && m.ack?.accepted === false) {
                 streamCursors.current.delete(id)
                 reconnectAttempts.current.delete(id)

--- a/packages/web/src/lib/webchat-stream.test.ts
+++ b/packages/web/src/lib/webchat-stream.test.ts
@@ -17,8 +17,8 @@ interface Done extends OrderedWebchatDone {
 
 describe('ordered webchat stream', () => {
   it('holds out-of-order frames, drains them contiguously, and ignores duplicates', () => {
-    const cursor = createWebchatCursor<Output, Done>('requested-turn')
-    expect(cursor).toMatchObject({ requestedTurnId: 'requested-turn', resumeGeneration: 0 })
+    const cursor = createWebchatCursor<Output, Done>('t1')
+    expect(cursor).toMatchObject({ requestedTurnId: 't1', resumeGeneration: 0 })
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 2, text: 'c' }).outputs).toEqual([])
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 0, text: 'a' }).outputs.map((o) => o.text)).toEqual(['a'])
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'b' }).outputs.map((o) => o.text)).toEqual([
@@ -27,6 +27,17 @@ describe('ordered webchat stream', () => {
     ])
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'duplicate' }).outputs).toEqual([])
     expect(cursor.nextIndex).toBe(3)
+  })
+
+  it('rejects output and done from a turn other than the browser-requested one', () => {
+    const cursor = createWebchatCursor<Output, Done>('current')
+    expect(acceptWebchatOutput(cursor, { turnId: 'abandoned', index: 0, text: 'stale' }).outputs).toEqual([])
+    expect(acceptWebchatDone(cursor, { turnId: 'abandoned', lastIndex: -1, result: 'stale' }).done).toBeUndefined()
+    expect(cursor).toMatchObject({ requestedTurnId: 'current', nextIndex: 0 })
+    expect(cursor.turnId).toBeUndefined()
+
+    expect(acceptWebchatOutput(cursor, { turnId: 'current', index: 0, text: 'fresh' }).outputs).toHaveLength(1)
+    expect(cursor.turnId).toBe('current')
   })
 
   it('holds done until every output through its lastIndex has arrived', () => {

--- a/packages/web/src/lib/webchat-stream.test.ts
+++ b/packages/web/src/lib/webchat-stream.test.ts
@@ -17,7 +17,8 @@ interface Done extends OrderedWebchatDone {
 
 describe('ordered webchat stream', () => {
   it('holds out-of-order frames, drains them contiguously, and ignores duplicates', () => {
-    const cursor = createWebchatCursor<Output, Done>()
+    const cursor = createWebchatCursor<Output, Done>('requested-turn')
+    expect(cursor).toMatchObject({ requestedTurnId: 'requested-turn', resumeGeneration: 0 })
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 2, text: 'c' }).outputs).toEqual([])
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 0, text: 'a' }).outputs.map((o) => o.text)).toEqual(['a'])
     expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'b' }).outputs.map((o) => o.text)).toEqual([

--- a/packages/web/src/lib/webchat-stream.test.ts
+++ b/packages/web/src/lib/webchat-stream.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  acceptWebchatDone,
+  acceptWebchatOutput,
+  createWebchatCursor,
+  type OrderedWebchatDone,
+  type OrderedWebchatOutput
+} from './webchat-stream'
+
+interface Output extends OrderedWebchatOutput {
+  text: string
+}
+
+interface Done extends OrderedWebchatDone {
+  result: string
+}
+
+describe('ordered webchat stream', () => {
+  it('holds out-of-order frames, drains them contiguously, and ignores duplicates', () => {
+    const cursor = createWebchatCursor<Output, Done>()
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 2, text: 'c' }).outputs).toEqual([])
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 0, text: 'a' }).outputs.map((o) => o.text)).toEqual(['a'])
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'b' }).outputs.map((o) => o.text)).toEqual([
+      'b',
+      'c'
+    ])
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'duplicate' }).outputs).toEqual([])
+    expect(cursor.nextIndex).toBe(3)
+  })
+
+  it('holds done until every output through its lastIndex has arrived', () => {
+    const cursor = createWebchatCursor<Output, Done>()
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 0, text: 'a' }).outputs).toHaveLength(1)
+    expect(acceptWebchatDone(cursor, { turnId: 't1', lastIndex: 2, result: 'ok' }).done).toBeUndefined()
+    expect(acceptWebchatOutput(cursor, { turnId: 't1', index: 2, text: 'c' }).done).toBeUndefined()
+    const final = acceptWebchatOutput(cursor, { turnId: 't1', index: 1, text: 'b' })
+    expect(final.outputs.map((o) => o.text)).toEqual(['b', 'c'])
+    expect(final.done?.result).toBe('ok')
+  })
+})

--- a/packages/web/src/lib/webchat-stream.ts
+++ b/packages/web/src/lib/webchat-stream.ts
@@ -1,0 +1,84 @@
+export interface OrderedWebchatOutput {
+  turnId: string
+  index: number
+}
+
+export interface OrderedWebchatDone {
+  turnId: string
+  lastIndex?: number
+}
+
+export interface OrderedWebchatCursor<
+  Output extends OrderedWebchatOutput = OrderedWebchatOutput,
+  Done extends OrderedWebchatDone = OrderedWebchatDone
+> {
+  turnId?: string
+  nextIndex: number
+  pending: Map<number, Output>
+  done?: Done
+}
+
+export interface OrderedWebchatResult<Output, Done> {
+  outputs: Output[]
+  done?: Done
+  overflow?: true
+}
+
+const MAX_PENDING_OUTPUTS = 512
+
+export function createWebchatCursor<
+  Output extends OrderedWebchatOutput,
+  Done extends OrderedWebchatDone
+>(): OrderedWebchatCursor<Output, Done> {
+  return { nextIndex: 0, pending: new Map() }
+}
+
+/** Bind a pre-ack cursor to the daemon-issued turn id. A different id is stale
+ * traffic from another turn and must not alter the current transcript. */
+export function bindWebchatTurn(cursor: OrderedWebchatCursor, turnId: string): boolean {
+  if (!turnId) return false
+  if (!cursor.turnId) cursor.turnId = turnId
+  return cursor.turnId === turnId
+}
+
+function drainWebchatCursor<Output extends OrderedWebchatOutput, Done extends OrderedWebchatDone>(
+  cursor: OrderedWebchatCursor<Output, Done>
+): OrderedWebchatResult<Output, Done> {
+  const outputs: Output[] = []
+  for (;;) {
+    const output = cursor.pending.get(cursor.nextIndex)
+    if (!output) break
+    cursor.pending.delete(cursor.nextIndex)
+    outputs.push(output)
+    cursor.nextIndex += 1
+  }
+  const done =
+    cursor.done && (cursor.done.lastIndex === undefined || cursor.nextIndex > cursor.done.lastIndex)
+      ? cursor.done
+      : undefined
+  if (done) delete cursor.done
+  return { outputs, ...(done ? { done } : {}) }
+}
+
+export function acceptWebchatOutput<Output extends OrderedWebchatOutput, Done extends OrderedWebchatDone>(
+  cursor: OrderedWebchatCursor<Output, Done>,
+  output: Output
+): OrderedWebchatResult<Output, Done> {
+  if (!bindWebchatTurn(cursor, output.turnId)) return { outputs: [] }
+  if (!Number.isInteger(output.index) || output.index < 0) return { outputs: [], overflow: true }
+  if (output.index < cursor.nextIndex || cursor.pending.has(output.index)) return { outputs: [] }
+  if (output.index - cursor.nextIndex >= MAX_PENDING_OUTPUTS || cursor.pending.size >= MAX_PENDING_OUTPUTS) {
+    return { outputs: [], overflow: true }
+  }
+  cursor.pending.set(output.index, output)
+  return drainWebchatCursor(cursor)
+}
+
+export function acceptWebchatDone<Output extends OrderedWebchatOutput, Done extends OrderedWebchatDone>(
+  cursor: OrderedWebchatCursor<Output, Done>,
+  done: Done
+): OrderedWebchatResult<Output, Done> {
+  if (!bindWebchatTurn(cursor, done.turnId)) return { outputs: [] }
+  cursor.done = done
+  return drainWebchatCursor(cursor)
+}

--- a/packages/web/src/lib/webchat-stream.ts
+++ b/packages/web/src/lib/webchat-stream.ts
@@ -34,10 +34,11 @@ export function createWebchatCursor<Output extends OrderedWebchatOutput, Done ex
   return { ...(requestedTurnId ? { requestedTurnId } : {}), resumeGeneration: 0, nextIndex: 0, pending: new Map() }
 }
 
-/** Bind a pre-ack cursor to the daemon-issued turn id. A different id is stale
- * traffic from another turn and must not alter the current transcript. */
+/** Bind a pre-ack cursor to its turn id. A browser-requested id is an immediate
+ * fence: late traffic from another turn must never claim the new cursor. */
 export function bindWebchatTurn(cursor: OrderedWebchatCursor, turnId: string): boolean {
   if (!turnId) return false
+  if (cursor.requestedTurnId && cursor.requestedTurnId !== turnId) return false
   if (!cursor.turnId) cursor.turnId = turnId
   return cursor.turnId === turnId
 }

--- a/packages/web/src/lib/webchat-stream.ts
+++ b/packages/web/src/lib/webchat-stream.ts
@@ -12,7 +12,9 @@ export interface OrderedWebchatCursor<
   Output extends OrderedWebchatOutput = OrderedWebchatOutput,
   Done extends OrderedWebchatDone = OrderedWebchatDone
 > {
+  requestedTurnId?: string
   turnId?: string
+  resumeGeneration: number
   nextIndex: number
   pending: Map<number, Output>
   done?: Done
@@ -26,11 +28,10 @@ export interface OrderedWebchatResult<Output, Done> {
 
 const MAX_PENDING_OUTPUTS = 512
 
-export function createWebchatCursor<
-  Output extends OrderedWebchatOutput,
-  Done extends OrderedWebchatDone
->(): OrderedWebchatCursor<Output, Done> {
-  return { nextIndex: 0, pending: new Map() }
+export function createWebchatCursor<Output extends OrderedWebchatOutput, Done extends OrderedWebchatDone>(
+  requestedTurnId?: string
+): OrderedWebchatCursor<Output, Done> {
+  return { ...(requestedTurnId ? { requestedTurnId } : {}), resumeGeneration: 0, nextIndex: 0, pending: new Map() }
 }
 
 /** Bind a pre-ack cursor to the daemon-issued turn id. A different id is stale


### PR DESCRIPTION
## Summary

- retain a bounded, short-lived WebChat replay window at the daemon where response streams originate
- let reconnecting browsers resume an accepted turn from their last contiguous output index through any healthy relay
- allocate turn ids before send and fence reconnects by generation so a delayed older relay request cannot steal the live stream
- retry bounded pre-ack resume misses and reject frames whose turn id does not match the browser's requested turn
- assemble indexed output in order, deduplicate replayed frames, and wait for the declared final index before completing the response
- return explicit recovery failures when the replay window expired or overflowed, and document the volatile delivery semantics

## Root cause

WebChat streamed live output, but a relay/browser disconnect discarded any frames emitted while no browser was attached. The browser reconnected to the conversation without sending a turn cursor, so it could not recover the missing tail or distinguish an incomplete response from a completed one. Concurrent reconnect requests also had no ordering fence, allowing a delayed request from an older connection to replace a newer live transport.

## Validation

- protocol codec: 16 tests passed
- relay browser bridge: 14 tests passed
- browser ordered-stream helper: 3 tests passed
- daemon WebChat suite: 30 tests passed with polling enabled for macOS watcher limits
- protocol, relay, daemon, and web typechecks passed
- ESLint, Prettier, `git diff --check`, and the full pre-push lint completed (two existing control-plane duplicate-import warnings remain)

Created by Codex . GPT-5
