### PR TITLE
fix(webchat): refine composer controls

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -839,7 +839,7 @@ Thread semantics: main progress goes at the thread anchor or, for a subscribed t
 
 - Extract text from `app_mention` / `message`. For a mid-thread @mention, `SlackConnection.getThreadReplies()` in `packages/daemon/src/slack/connection.ts` fetches the full thread through `conversations.replies`, and `SessionManager` uses that snapshot as prompt context.
 - Download attachment bytes from `files.url_private` with bot token and create ACP `image` / `resource` blocks.
-- Decode a relay-delivered, size-bounded webchat image locally and feed it through the same ACP attachment-block builder; only its name and MIME summary enter the transcript.
+- Decode a relay-delivered, size-bounded webchat image locally and feed it through the same ACP attachment-block builder. Keep the bounded image only in the daemon-local transcript so an authorized console history read can display it again; the Control Plane proxies that read without persisting the bytes.
 - Normalize to `NormalizedMessage`, then `session/prompt`.
 
 ### 9.3 Telegram / Discord / Feishu Mapping (Implemented)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -16,6 +16,7 @@ import {
   RESERVED_MCP_SERVER_NAME,
   GitCloneUrlError,
   RepoSubdirError,
+  SessionImageAttachment,
   MAX_WORKSPACE_EDIT_BYTES,
   normalizeGitCloneUrl,
   redactGitUrlSecrets,
@@ -1880,6 +1881,7 @@ export const SessionMessageDto = z.object({
   ts: z.string(),
   kind: z.string(),
   text: z.string(),
+  attachments: z.array(SessionImageAttachment).max(1).optional(),
   // ── tool-body enrichment (mirrors protocol SessionMessage; tool rows only) ──
   toolCallId: z.string().optional(),
   toolStatus: z.string().optional(),

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -538,7 +538,16 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
       { sessions: [] },
       {
         sessionId: SESSION,
-        messages: [{ seq: 1, sender: '@dana', ts: '1718000000.000100', kind: 'text', text: 'ship it' }],
+        messages: [
+          {
+            seq: 1,
+            sender: '@dana',
+            ts: '1718000000.000100',
+            kind: 'text',
+            text: 'ship it',
+            attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
+          }
+        ],
         nextCursor: 'c-50'
       }
     )
@@ -549,8 +558,12 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
       url: `${ORG}/sessions/${SESSION}/messages?agentId=${AGENT}&cursor=c-100&limit=25`
     })
     expect(res.statusCode).toBe(200)
-    const body = res.json() as { messages: Array<{ text: string }>; nextCursor: string | null }
+    const body = res.json() as {
+      messages: Array<{ text: string; attachments?: Array<{ name: string }> }>
+      nextCursor: string | null
+    }
     expect(body.messages[0]!.text).toBe('ship it')
+    expect(body.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(body.nextCursor).toBe('c-50')
     expect(spy.histCalls[0]!.daemonId).toBe(DAEMON)
     expect(spy.histCalls[0]!.req).toEqual({ sessionId: SESSION, cursor: 'c-100', limit: 25 })

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -10,7 +10,7 @@
  * preview and assembles a page under the per-frame budget (newest rows that fit);
  * the FULL body is pulled on demand via `toolBody`, chunked by offset.
  */
-import { MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { MAX_FRAME_BYTES, SessionImageAttachment as SessionImageAttachmentSchema } from '@agentconnect.md/protocol'
 import type {
   SessionListReq,
   SessionListPage,
@@ -58,6 +58,26 @@ function decodeEventCursor(raw: string | undefined): TranscriptEventCursor | nul
  *  codec's `encode`), measured in bytes. */
 function encodedBytes(payload: unknown): number {
   return Buffer.byteLength(JSON.stringify(payload))
+}
+
+function transcriptAttachments(raw: string | null | undefined): NonNullable<SessionMessage['attachments']> {
+  if (!raw) return []
+  try {
+    const parsed = SessionImageAttachmentSchema.array().max(1).safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : []
+  } catch {
+    return []
+  }
+}
+
+/** The persisted text keeps this synthetic suffix for prompt replay; the console
+ * receives the real image instead, matching the live turn. */
+function withoutAttachmentMention(text: string, attachments: NonNullable<SessionMessage['attachments']>): string {
+  if (attachments.length === 0) return text
+  const mention = `[attached: ${attachments.map((attachment) => `${attachment.name} (${attachment.mimeType})`).join(', ')}]`
+  if (text === mention) return ''
+  const suffix = `\n${mention}`
+  return text.endsWith(suffix) ? text.slice(0, -suffix.length) : text
 }
 
 /** Largest index ≤ `len` that lands on a UTF-8 character boundary — never cuts a
@@ -228,13 +248,15 @@ export function createSessionReader(
       const names = store.getDisplayNames(ordered.flatMap((r) => [r.sender, ...mentionedUserIds(r.text)]))
       const built = ordered.map<SessionMessage>((r) => {
         const senderName = names.get(r.sender)
+        const attachments = transcriptAttachments(r.attachmentsJson)
         const base: SessionMessage = {
           seq: r.seq,
           sender: r.sender,
           ...(senderName ? { senderName } : {}),
           ts: r.ts,
           kind: r.kind,
-          text: substituteUserMentions(r.text, names)
+          text: substituteUserMentions(withoutAttachmentMention(r.text, attachments), names),
+          ...(attachments.length ? { attachments } : {})
         }
         if (r.kind !== 'tool' || !r.body) return base
         // Enrich a tool row: surface toolCallId/status/kind + an inline body (verbatim

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -3,7 +3,7 @@
  * fetch URL and download the bytes daemon-locally with the provider token.
  * Webchat may instead arrive with bounded inline bytes from the relay content
  * plane. Both forms become ACP image/resource blocks at prompt assembly; the
- * bytes never traverse the daemon↔CP control WS.
+ * daemon also retains bounded webchat images for authorized transcript replay.
  */
 export interface Attachment {
   /** Stable source id (Slack file.id). */

--- a/packages/daemon/src/session/attachment-block.ts
+++ b/packages/daemon/src/session/attachment-block.ts
@@ -1,4 +1,8 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
+import {
+  SessionImageAttachment as SessionImageAttachmentSchema,
+  type SessionImageAttachment
+} from '@agentconnect.md/protocol'
 import type { Attachment } from '../messages/normalized.js'
 
 /** Capability + byte-fetch surface the block builder needs (satisfied by the
@@ -78,8 +82,22 @@ export async function buildAttachmentBlocks(attachments: Attachment[], deps: Att
   )
 }
 
-/** One-line human summary of attachments for the transcript text (so §8.5
- *  catch-up replay at least notes a file was shared, since bytes aren't stored). */
+/** Keep a validated bounded inline image beside its daemon-local transcript row. */
+export function transcriptImageAttachments(attachments: Attachment[] | undefined): SessionImageAttachment[] {
+  return (attachments ?? [])
+    .flatMap((attachment) => {
+      if (!attachment.inlineData) return []
+      const parsed = SessionImageAttachmentSchema.safeParse({
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        data: attachment.inlineData.toString('base64')
+      })
+      return parsed.success ? [parsed.data] : []
+    })
+    .slice(0, 1)
+}
+
+/** One-line human summary of attachments for transcript prompt replay. */
 export function attachmentMention(attachments: Attachment[] | undefined): string {
   if (!attachments?.length) return ''
   const list = attachments.map((a) => `${a.name} (${a.mimeType})`).join(', ')

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -10,7 +10,7 @@ import type { AcpHost } from '../acp/acp-host.js'
 import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { Attachment, NormalizedMessage } from '../messages/normalized.js'
-import { buildAttachmentBlocks, attachmentMention } from './attachment-block.js'
+import { buildAttachmentBlocks, attachmentMention, transcriptImageAttachments } from './attachment-block.js'
 import { EXPLICIT_MENTION_REMINDER, NO_RESPONSE_RULE, NO_RESPONSE_REMINDER } from './no-response.js'
 
 /** Metadata-only semantic lifecycle for one provider-neutral recall attempt. Query
@@ -266,8 +266,9 @@ export class SessionManager {
     const key = sessionKey(msg.platform, msg.channel, thread, agentId)
 
     // record the triggering message in the transcript (with an attachment mention
-    // so later catch-up replay notes shared files even though bytes aren't stored)
+    // for prompt replay; bounded inline webchat images remain daemon-local for UI replay)
     const mention = attachmentMention(msg.attachments)
+    const transcriptAttachments = transcriptImageAttachments(msg.attachments)
     this.deps.store.appendTranscript({
       channel: msg.channel,
       thread,
@@ -277,7 +278,8 @@ export class SessionManager {
       // recipient — the console session view scopes to what THIS agent received + produced.
       recipient: agentId,
       kind: 'text',
-      text: mention ? `${msg.text}\n${mention}`.trim() : msg.text
+      text: mention ? `${msg.text}\n${mention}`.trim() : msg.text,
+      ...(transcriptAttachments.length ? { attachments: transcriptAttachments } : {})
     })
 
     let rec = this.deps.store.getSession(key)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync, type SQLInputValue } from 'node:sqlite'
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
-import type { DreamInfo } from '@agentconnect.md/protocol'
+import type { DreamInfo, SessionImageAttachment } from '@agentconnect.md/protocol'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
 
 // node:sqlite binds named params as a generic Record and returns rows as
@@ -159,6 +159,8 @@ export interface TranscriptEntry {
   sender: string
   kind: TranscriptKind
   text: string
+  /** Bounded inline webchat images. Persisted daemon-side; never provider-backed files. */
+  attachments?: SessionImageAttachment[]
   /** The agent this row was delivered TO (an inbound trigger / replayed context), when
    *  known. Absent for an agent's own output rows (those attribute via `sender`) and for
    *  unrouted messages. Lets the console session view show what one agent actually
@@ -174,6 +176,7 @@ export interface TranscriptRow extends TranscriptEntry {
   eventTimeUs: number
   toolCallId?: string | null
   body?: string | null // JSON.stringify(ToolBody); NULL for text/reasoning rows
+  attachmentsJson?: string | null // JSON.stringify(SessionImageAttachment[]); inline webchat only
 }
 
 export interface TranscriptEventCursor {
@@ -395,7 +398,8 @@ export class LocalStore {
         seq INTEGER PRIMARY KEY AUTOINCREMENT,
         channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT,
         sender TEXT NOT NULL, kind TEXT NOT NULL, text TEXT NOT NULL,
-        tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER
+        tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER,
+        attachmentsJson TEXT
       );
       CREATE INDEX IF NOT EXISTS transcript_thread_seq ON transcript (channel, thread, seq);
       -- Dedup conversational rows by platform ts (double-fired inbound / redelivery);
@@ -601,6 +605,7 @@ export class LocalStore {
     this.migrateSessionMutes()
     this.migrateInboxLoopGuardCounted()
     this.migrateTranscriptToolBody()
+    this.migrateTranscriptAttachments()
     this.migrateTranscriptRecipient()
     this.migrateTranscriptEventTime()
     this.migrateInboxHookContext()
@@ -712,6 +717,13 @@ export class LocalStore {
       `CREATE UNIQUE INDEX IF NOT EXISTS transcript_tool_call
          ON transcript (channel, thread, tool_call_id) WHERE tool_call_id IS NOT NULL`
     )
+  }
+
+  /** Add daemon-local inline webchat image storage to existing transcript tables. */
+  private migrateTranscriptAttachments(): void {
+    const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
+    if (!cols.some((c) => c.name === 'attachmentsJson'))
+      this.db.exec('ALTER TABLE transcript ADD COLUMN attachmentsJson TEXT')
   }
 
   /** Add the defaultPermissionMode column to runtime_catalog_meta for DBs that
@@ -1506,14 +1518,19 @@ export class LocalStore {
   }
 
   appendTranscript(e: TranscriptEntry): void {
+    const { attachments, ...entry } = e
     this.db
       .prepare(
-        'INSERT OR IGNORE INTO transcript (channel, thread, ts, sender, kind, text, recipient, eventTimeUs) VALUES (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs)'
+        `INSERT OR IGNORE INTO transcript
+           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson)
+         VALUES
+           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson)`
       )
       .run({
-        ...e,
+        ...entry,
         recipient: e.recipient ?? null,
-        eventTimeUs: transcriptEventTimeUs(e.ts)
+        eventTimeUs: transcriptEventTimeUs(e.ts),
+        attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null
       } as unknown as SqlParams)
     // Record the delivery separately so it survives the text-row dedup above: if this same
     // (channel, thread, ts) was already recorded by another agent, the INSERT OR IGNORE

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1175,7 +1175,7 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   })
 
-  it('delivers an inline webchat image as an ACP image block and records only its summary', async () => {
+  it('delivers an inline webchat image and retains it for transcript replay', async () => {
     const { factory, host } = streamingHost([text('I can see it')])
     ;(host as any).promptSupports = (kind: string) => kind === 'image'
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
@@ -1205,8 +1205,13 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     const rows = (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`) as Array<{
       sender: string
       text: string
+      attachmentsJson?: string
     }>
-    expect(rows.find((row) => row.sender === 'ada')?.text).toBe('What is shown?\n[attached: screen.webp (image/webp)]')
+    const userRow = rows.find((row) => row.sender === 'ada')
+    expect(userRow?.text).toBe('What is shown?\n[attached: screen.webp (image/webp)]')
+    expect(JSON.parse(userRow?.attachmentsJson ?? '[]')).toEqual([
+      { name: 'screen.webp', mimeType: 'image/webp', data: bytes.toString('base64') }
+    ])
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -252,6 +252,29 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('history restores a daemon-local webchat image without the synthetic attachment suffix', () => {
+    const s = store()
+    seedHistorySession(s, { platform: 'webchat', channel: 'conv-1', thread: 'webchat:conv-1' })
+    s.appendTranscript({
+      channel: 'conv-1',
+      thread: 'webchat:conv-1',
+      ts: '1',
+      sender: 'alice',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'Identify this\n[attached: screen.webp (image/webp)]',
+      attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
+    })
+
+    expect(createSessionReader(s).history({ sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+      expect.objectContaining({
+        text: 'Identify this',
+        attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
+      })
+    ])
+    s.close()
+  })
+
   it('history scopes to what THIS agent received or produced (no peer cross-talk)', () => {
     const s = store()
     s.upsertSession({

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -709,13 +709,23 @@ describe('session read-back frames (console history pull)', () => {
     const page = decodeEnvelope(
       envelope('session/history/page', {
         sessionId: SESSION_ID,
-        messages: [{ seq: 1, sender: '@dana', ts: '1718000000.000100', kind: 'text', text: 'ship it' }],
+        messages: [
+          {
+            seq: 1,
+            sender: '@dana',
+            ts: '1718000000.000100',
+            kind: 'text',
+            text: 'ship it',
+            attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
+          }
+        ],
         nextCursor: 'c-50'
       })
     )
     expect(page.ok).toBe(true)
     if (!page.ok || !isFrame('session/history/page')(page.frame)) throw new Error('expected page')
     expect(page.frame.payload.messages[0]!.text).toBe('ship it')
+    expect(page.frame.payload.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(page.frame.payload.nextCursor).toBe('c-50')
   })
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
-import { WebchatDone, WebchatOutput } from './webchat.js'
+import { WebchatDone, WebchatImageAttachment, WebchatOutput } from './webchat.js'
 import { GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
 import { CronTarget } from './cron.js'
 import { buildEnvelopeRaw, decodeEnvelopeWith, type BuildOpts, type DecodeResultOf } from '../wire.js'
@@ -63,38 +63,6 @@ export type RdHelloOk = z.infer<typeof RdHelloOk>
 // the wire stays at the four designed frames. `turn` is the user message; the
 // rest are the session controls the old daemon↔CP webchat EVTs carried.
 //
-// Image bytes stay on the content plane: the browser rasterizes/compresses one
-// selected image below this cap, the relay forwards it inline, and the daemon
-// converts it into an ACP image block. The headroom below MAX_FRAME_BYTES leaves
-// room for base64 expansion plus the rd/msg envelope.
-export const WEBCHAT_IMAGE_MAX_BYTES = 160 * 1024
-export const WEBCHAT_IMAGE_MAX_BASE64_CHARS = Math.ceil(WEBCHAT_IMAGE_MAX_BYTES / 3) * 4
-
-const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
-
-function decodedBase64Bytes(value: string): number {
-  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
-  return (value.length / 4) * 3 - padding
-}
-
-export const WebchatImageAttachment = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1)
-    .max(255)
-    .regex(/^[^\u0000-\u001f\u007f]+$/, 'webchat image name must not contain control characters'),
-  mimeType: z.enum(['image/png', 'image/jpeg', 'image/webp']),
-  data: z
-    .string()
-    .min(4)
-    .max(WEBCHAT_IMAGE_MAX_BASE64_CHARS)
-    .refine((value) => CANONICAL_BASE64.test(value) && decodedBase64Bytes(value) <= WEBCHAT_IMAGE_MAX_BYTES, {
-      message: `webchat image must be canonical base64 encoding at most ${WEBCHAT_IMAGE_MAX_BYTES} bytes`
-    })
-})
-export type WebchatImageAttachment = z.infer<typeof WebchatImageAttachment>
-
 export const RelayWebchatOp = z.discriminatedUnion('op', [
   z.object({
     op: z.literal('turn'),

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { SessionKey } from './route.js'
+import { WebchatImageAttachment } from './webchat.js'
 
 /**
  * Session read-back (C→D REQ → REP) — the console's on-demand pulls.
@@ -90,6 +91,10 @@ export const ToolBody = z.object({
 })
 export type ToolBody = z.infer<typeof ToolBody>
 
+/** One bounded webchat image persisted only in the daemon-local transcript. */
+export const SessionImageAttachment = WebchatImageAttachment
+export type SessionImageAttachment = z.infer<typeof SessionImageAttachment>
+
 /** One message in a session transcript page (a body — returned only for display). */
 export const SessionMessage = z.object({
   seq: z.number().int(), // daemon-local insertion order within the session
@@ -98,6 +103,7 @@ export const SessionMessage = z.object({
   ts: z.string(), // platform timestamp (daemon-local string form)
   kind: z.string(), // "text" / tool / … (daemon transcript kind)
   text: z.string(),
+  attachments: z.array(SessionImageAttachment).max(1).optional(),
   // ── tool-body enrichment (optional ⇒ text/reasoning rows and old daemons omit these) ──
   toolCallId: z.string().optional(), // parsed from the ToolBody (tool rows only)
   toolStatus: z.string().optional(), // ACP ToolCallStatus, surfaced for the console badge

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -4,7 +4,38 @@ import { z } from 'zod'
 // a browser dials the relay pool with a CP-minted token and the relay bridges the
 // conversation onto the target daemon's rd/* socket. These payloads describe the reply
 // stream + the turn verdict; the relay's `rd/chat` / `rd/ack` frames REUSE them verbatim
-// (packages/protocol/src/frames/relay-daemon.ts). Content never touches the CP.
+// (packages/protocol/src/frames/relay-daemon.ts). Live content never touches the CP;
+// an authorized session-history read may later proxy a daemon-local image for display.
+
+// The browser rasterizes/compresses one selected image below this cap. It fits the
+// relay ingress frame and, later, one daemon→CP history frame with base64 expansion.
+export const WEBCHAT_IMAGE_MAX_BYTES = 160 * 1024
+export const WEBCHAT_IMAGE_MAX_BASE64_CHARS = Math.ceil(WEBCHAT_IMAGE_MAX_BYTES / 3) * 4
+
+const CANONICAL_BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+function decodedBase64Bytes(value: string): number {
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+  return (value.length / 4) * 3 - padding
+}
+
+export const WebchatImageAttachment = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .regex(/^[^\u0000-\u001f\u007f]+$/, 'webchat image name must not contain control characters'),
+  mimeType: z.enum(['image/png', 'image/jpeg', 'image/webp']),
+  data: z
+    .string()
+    .min(4)
+    .max(WEBCHAT_IMAGE_MAX_BASE64_CHARS)
+    .refine((value) => CANONICAL_BASE64.test(value) && decodedBase64Bytes(value) <= WEBCHAT_IMAGE_MAX_BYTES, {
+      message: `webchat image must be canonical base64 encoding at most ${WEBCHAT_IMAGE_MAX_BYTES} bytes`
+    })
+})
+export type WebchatImageAttachment = z.infer<typeof WebchatImageAttachment>
 
 // The webchat turn verdict — `dispatchWebchatTurn` returns this and the relay path folds
 // it into `rd/ack` (accepted + the turnId that correlates the reply stream; `reason`

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -12,6 +12,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { agentLabel, type Agent, type Session, type SessionImage, type SessionStep } from '@/lib/data'
 import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
+import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import {
   acceptWebchatDone,
   acceptWebchatOutput,
@@ -624,7 +625,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  daemon confirms via the next status frame. */
   const pgSetModel = useCallback(
     (id: string, agentForId: string, model: string, conversationId?: string) => {
-      setPgSessions((cur) => (cur[id] ? { ...cur, [id]: { ...cur[id]!, model } } : cur))
+      setPgSessions((cur) => (cur[id] ? { ...cur, [id]: sessionAfterModelSelection(cur[id]!, model) } : cur))
       connect(id, agentForId, conversationId)
         .ready.then((ws) => ws.send(JSON.stringify({ type: 'set_model', model })))
         .catch(() => {})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -6,13 +6,18 @@ import { useParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import {
   agentLabel,
+  displayedEffort,
+  effortLabel,
   fileColor,
   isSelfSender,
   lane,
+  modelCapability,
   modelLabel,
+  permissionModeDefault,
   permissionModeLabel,
   pgPrompts,
   platName,
+  preferredModelFor,
   runtimeLabel,
   sessionPlatform,
   speaker,
@@ -46,6 +51,13 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { sessionSenderLabel } from '@/lib/session-trigger'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
+import {
+  sessionEffortAfterModelChange,
+  sessionEffortChoicesForSelection,
+  sessionPermissionChoices,
+  sessionPermissionSelection,
+  sessionRuntimeChangesEnabled
+} from '@/lib/session-runtime-controls'
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
 // transcript kind (text | tool | reasoning) onto the existing lane styling.
@@ -538,6 +550,9 @@ export default function SessionDetailView() {
   const [imagePreparing, setImagePreparing] = useState(false)
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
+  const [runtimeSelections, setRuntimeSelections] = useState<
+    Record<string, { model?: string; effort?: string; permissionMode?: string }>
+  >({})
   const imageInputRef = useRef<HTMLInputElement>(null)
 
   const localSession = getPgSession(id) ?? allSessions.find((s) => s.id === id) ?? null
@@ -773,6 +788,7 @@ export default function SessionDetailView() {
           sourceLabel: platName(sessionIntegration),
           time: formatTranscriptTime(m.ts),
           text: m.text,
+          image: m.attachments?.[0],
           isCron: !!cron,
           cronId: cron?.id ?? null
         })
@@ -864,10 +880,12 @@ export default function SessionDetailView() {
   // The session's `daemon` is the owning agent's daemonId (or '—' when unplaced);
   // resolve it to the daemon's display name — never surface the raw id/host
   // (short-id fallback when it isn't in the fleet), matching the Agents list.
+  const owningDaemonId = session.daemon && session.daemon !== '—' ? session.daemon : owner?.daemon
+  const owningDaemon =
+    owningDaemonId && owningDaemonId !== '—' ? daemons.find((d) => d.daemonId === owningDaemonId) : undefined
   const daemonName =
-    session.daemon && session.daemon !== '—'
-      ? (daemons.find((d) => d.daemonId === session.daemon)?.name ??
-        (session.daemon.length > 12 ? session.daemon.slice(0, 8) : session.daemon))
+    owningDaemonId && owningDaemonId !== '—'
+      ? (owningDaemon?.name ?? (owningDaemonId.length > 12 ? owningDaemonId.slice(0, 8) : owningDaemonId))
       : ''
   // A cron-triggered session carries `user === "cron:<scheduleId>"`. When that's the
   // shown participant, render the chip as a link back to the owning schedule
@@ -919,11 +937,54 @@ export default function SessionDetailView() {
   }
 
   // Live controls and status folded into the composer toolbar. Webchat `status`
-  // frames update model/context/cost during the turn and tokens at turn end.
+  // frames are authoritative when they include choices. An idle or restored session
+  // may not have a live frame, so fall back to the owning daemon's discovered catalog.
   const allowRuntimeChangesInChat = owner?.allowRuntimeChangesInChat === true
-  const pgModels = allowRuntimeChangesInChat ? (session.availableModels ?? []) : []
-  const pgEfforts = allowRuntimeChangesInChat ? (session.availableEfforts ?? []) : []
-  const pgPermissionModes = allowRuntimeChangesInChat ? (session.availablePermissionModes ?? []) : []
+  const runtimeChangesEnabled = sessionRuntimeChangesEnabled(allowRuntimeChangesInChat, session)
+  const runtimeSelection = runtimeSelections[session.id]
+  const setRuntimeSelection = (patch: { model?: string; effort?: string; permissionMode?: string }) =>
+    setRuntimeSelections((current) => ({
+      ...current,
+      [session.id]: { ...current[session.id], ...patch }
+    }))
+  const runtimeProfile = owningDaemon?.runtimeModels.find((profile) => profile.runtime === agentRuntime)
+  const runtimeCatalog = runtimeProfile?.modelCatalog ?? undefined
+  const pgModel =
+    runtimeSelection?.model ?? (session.model || owner?.model || preferredModelFor(owningDaemon, agentRuntime))
+  const pgModels = runtimeChangesEnabled ? (session.availableModels ?? runtimeProfile?.models ?? []) : []
+  const pgModelOptions =
+    pgModels.length > 0 && pgModel && !pgModels.includes(pgModel) ? [pgModel, ...pgModels] : pgModels
+  const selectedModelCapability = modelCapability(owningDaemon, agentRuntime, pgModel)
+  const pgEffortChoices = runtimeChangesEnabled
+    ? sessionEffortChoicesForSelection(agentRuntime, owningDaemon, pgModel, session.model, session.availableEfforts)
+    : []
+  const pgEffort = displayedEffort(
+    runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? '',
+    pgEffortChoices,
+    selectedModelCapability?.defaultEffort
+  )
+  const pgEffortOptions =
+    runtimeChangesEnabled && pgEffort && !pgEffortChoices.some((choice) => choice.value === pgEffort)
+      ? [{ value: pgEffort, label: effortLabel(agentRuntime, pgEffort) }, ...pgEffortChoices]
+      : pgEffortChoices
+  const livePermissionModes = session.availablePermissionModes
+  const selectablePermissionModes = sessionPermissionChoices(agentRuntime, runtimeCatalog, livePermissionModes)
+  const pgPermissionMode = sessionPermissionSelection(
+    agentRuntime,
+    runtimeCatalog,
+    livePermissionModes,
+    runtimeSelection?.permissionMode ??
+      session.permissionMode ??
+      owner?.permissionMode ??
+      permissionModeDefault(agentRuntime)
+  )
+  const pgPermissionModes = runtimeChangesEnabled
+    ? livePermissionModes === undefined &&
+      pgPermissionMode &&
+      !selectablePermissionModes.some((choice) => choice.v === pgPermissionMode)
+      ? [{ v: pgPermissionMode, l: permissionModeLabel(agentRuntime, pgPermissionMode) }, ...selectablePermissionModes]
+      : selectablePermissionModes
+    : []
   // Shared style for the inline composer selectors.
   const pgSelectClass =
     'cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)'
@@ -932,18 +993,17 @@ export default function SessionDetailView() {
       {pgPermissionModes.length > 0 ? (
         <select
           aria-label="Session permission mode"
-          value={session.permissionMode ?? ''}
-          onChange={(event) =>
-            pgSetPermissionMode(session.id, session.agentId ?? '', event.target.value, webchatConversationId)
-          }
+          value={pgPermissionMode}
+          onChange={(event) => {
+            const permissionMode = event.target.value
+            setRuntimeSelection({ permissionMode })
+            pgSetPermissionMode(session.id, session.agentId ?? '', permissionMode, webchatConversationId)
+          }}
           className={pgSelectClass}
         >
-          {(session.permissionMode && !pgPermissionModes.includes(session.permissionMode)
-            ? [session.permissionMode, ...pgPermissionModes]
-            : pgPermissionModes
-          ).map((mode) => (
-            <option key={mode} value={mode}>
-              {permissionModeLabel(session.runtime ?? '', mode)}
+          {pgPermissionModes.map((mode) => (
+            <option key={mode.v} value={mode.v}>
+              {mode.l}
             </option>
           ))}
         </select>
@@ -960,43 +1020,54 @@ export default function SessionDetailView() {
           <span className="av h-4 w-4 flex-none rounded-xs">
             <AgentMark model={agentRuntime} />
           </span>
-          {pgModels.length > 0 ? (
+          {pgModelOptions.length > 0 ? (
             <select
               aria-label="Session model"
-              value={session.model ?? ''}
-              onChange={(e) => pgSetModel(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
+              value={pgModel}
+              onChange={(event) => {
+                const model = event.target.value
+                const currentEffort = runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
+                const effort = sessionEffortAfterModelChange(agentRuntime, owningDaemon, model, currentEffort)
+                setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
+                pgSetModel(session.id, session.agentId ?? '', model, webchatConversationId)
+                if (effort !== currentEffort) {
+                  pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                }
+              }}
               className={pgSelectClass}
             >
-              {(session.model && !pgModels.includes(session.model) ? [session.model, ...pgModels] : pgModels).map(
-                (model) => (
-                  <option key={model} value={model}>
-                    {modelLabel(model)}
-                  </option>
-                )
-              )}
+              {pgModelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {modelLabel(model)}
+                </option>
+              ))}
             </select>
           ) : (
             modelLabel(session.model ?? '')
           )}
         </span>
-        {pgEfforts.length > 0 && (
+        {pgEffortOptions.length > 0 && (
           <select
             aria-label="Session reasoning effort"
-            value={session.effort ?? ''}
-            onChange={(e) => pgSetEffort(session.id, session.agentId ?? '', e.target.value, webchatConversationId)}
+            value={pgEffort}
+            onChange={(event) => {
+              const effort = event.target.value
+              setRuntimeSelection({ effort })
+              pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+            }}
             className={pgSelectClass}
           >
-            {(session.effort && !pgEfforts.includes(session.effort) ? [session.effort, ...pgEfforts] : pgEfforts).map(
-              (effort) => (
-                <option key={effort} value={effort}>
-                  {effort}
-                </option>
-              )
-            )}
+            {pgEffortOptions.map((effort) => (
+              <option key={effort.value} value={effort.value}>
+                {effort.label}
+              </option>
+            ))}
           </select>
         )}
-        {!allowRuntimeChangesInChat && session.effort && <span>effort: {session.effort}</span>}
-        {allowRuntimeChangesInChat && session.fastModeAvailable && (
+        {!runtimeChangesEnabled && (session.effort ?? owner?.reasoning) && (
+          <span>effort: {session.effort ?? owner?.reasoning}</span>
+        )}
+        {runtimeChangesEnabled && session.fastModeAvailable && (
           <select
             aria-label="Session fast mode"
             value={session.fastMode ? 'on' : 'off'}
@@ -1009,7 +1080,7 @@ export default function SessionDetailView() {
             <option value="off">fast: off</option>
           </select>
         )}
-        {!allowRuntimeChangesInChat && session.fastMode !== undefined && (
+        {!runtimeChangesEnabled && session.fastMode !== undefined && (
           <span>fast: {session.fastMode ? 'on' : 'off'}</span>
         )}
       </div>
@@ -1484,7 +1555,7 @@ export default function SessionDetailView() {
               <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
             )}
             <div
-              className="pgcomposer relative flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default) desktop:mt-4"
+              className="pgcomposer relative flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default) desktop:ml-[41px] desktop:mt-4"
               onKeyDown={(event) => {
                 if (event.key === 'Escape') setAttachMenuOpen(false)
               }}
@@ -1539,7 +1610,7 @@ export default function SessionDetailView() {
                 <div className="relative flex-none">
                   <button
                     type="button"
-                    className="iconbtn h-10 w-10 rounded-[9px]"
+                    className="iconbtn"
                     aria-label="Add"
                     aria-haspopup="menu"
                     aria-expanded={attachMenuOpen}
@@ -1577,14 +1648,14 @@ export default function SessionDetailView() {
                 </div>
                 {pgStatusBar}
                 <button
-                  className="sendbtn"
+                  className="sendbtn h-8 w-8 rounded-md"
                   aria-label={pgBusy ? 'Stop response' : 'Send message'}
                   onClick={() =>
                     pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
                   }
                   disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
                 >
-                  <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 14 : 18} />
+                  <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 12 : 16} />
                 </button>
               </div>
             </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4,7 +4,16 @@
 // mappers translate the lean wire DTOs into the richer UI shapes from `./data`,
 // filling fields the API does not (yet) expose with placeholders.
 
-import type { Agent, AgentCallPolicy, DaemonRow, ResourceVisibility, Session, StatusKey, Workspace } from '@/lib/data'
+import type {
+  Agent,
+  AgentCallPolicy,
+  DaemonRow,
+  ResourceVisibility,
+  Session,
+  SessionImage,
+  StatusKey,
+  Workspace
+} from '@/lib/data'
 import { isSelfSender, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
@@ -361,6 +370,7 @@ export interface SessionMessageDto {
   ts: string
   kind: string
   text: string
+  attachments?: SessionImage[]
   toolCallId?: string // ties the row to its full body (session/tool-body key)
   toolStatus?: string // ACP ToolCallStatus — drives the console status badge
   toolKind?: string // ACP ToolKind — drives the console icon

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -685,9 +685,7 @@ export interface SessionFile {
   path: string
 }
 
-/** Ephemeral image on a live Playground/WebChat user turn. The daemon persists
- * only its name/MIME summary, so bytes disappear when authoritative history is
- * reloaded. */
+/** Bounded image on a live or daemon-backed Playground/WebChat user turn. */
 export interface SessionImage {
   name: string
   mimeType: 'image/png' | 'image/jpeg' | 'image/webp'

--- a/packages/web/src/lib/session-runtime-controls.test.ts
+++ b/packages/web/src/lib/session-runtime-controls.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sessionAfterModelSelection,
+  sessionEffortAfterModelChange,
+  sessionEffortChoices,
+  sessionEffortChoicesForSelection,
+  sessionPermissionChoices,
+  sessionPermissionSelection,
+  sessionRuntimeChangesEnabled
+} from '@/lib/session-runtime-controls'
+import type { DaemonRow, RuntimeModelCatalog } from '@/lib/data'
+
+const catalog: RuntimeModelCatalog = {
+  models: [
+    {
+      id: 'sol',
+      efforts: [
+        { value: 'high', name: 'High' },
+        { value: 'max', name: 'Max' }
+      ],
+      defaultEffort: 'max'
+    },
+    {
+      id: 'terra',
+      efforts: [{ value: 'high', name: 'High' }],
+      defaultEffort: 'high'
+    }
+  ],
+  defaultModel: 'sol',
+  permissionModes: [
+    { value: 'default', name: 'Ask' },
+    { value: 'full-access', name: 'Full Access' }
+  ],
+  defaultPermissionMode: 'default',
+  source: 'acp',
+  observedAt: '2026-07-25T00:00:00.000Z'
+}
+
+const daemon = {
+  runtimeModels: [{ runtime: 'codex', version: '1.0.0', models: ['sol', 'terra'], modelCatalog: catalog }]
+} satisfies Pick<DaemonRow, 'runtimeModels'>
+
+describe('session runtime controls', () => {
+  it('waits for a daemon-created Playground session before enabling changes', () => {
+    expect(sessionRuntimeChangesEnabled(true, { platform: 'playground' })).toBe(false)
+    expect(sessionRuntimeChangesEnabled(true, { platform: 'playground', realSessionId: 'session-1' })).toBe(true)
+    expect(sessionRuntimeChangesEnabled(true, { platform: 'webchat' })).toBe(true)
+    expect(sessionRuntimeChangesEnabled(false, { platform: 'webchat' })).toBe(false)
+  })
+
+  it('preserves a live permission list, including an explicit empty list', () => {
+    expect(sessionPermissionChoices('codex', catalog, [])).toEqual([])
+    expect(sessionPermissionChoices('codex', catalog, ['full-access'])).toEqual([
+      { v: 'full-access', l: 'Full Access' }
+    ])
+    expect(sessionPermissionChoices('codex', catalog, undefined)).toHaveLength(2)
+  })
+
+  it('resolves the selected permission from a narrowed live list', () => {
+    expect(sessionPermissionSelection('codex', catalog, ['default'], 'full-access')).toBe('default')
+    expect(sessionPermissionSelection('codex', catalog, [], 'full-access')).toBe('')
+  })
+
+  it('moves an unavailable effort to the selected model default', () => {
+    expect(sessionEffortAfterModelChange('codex', daemon, 'terra', 'max')).toBe('high')
+  })
+
+  it('drops the previous model live efforts while a model change is pending', () => {
+    const next = sessionAfterModelSelection({ model: 'sol', availableEfforts: ['high', 'max'] }, 'terra')
+
+    expect(next).toEqual({ model: 'terra', availableEfforts: undefined })
+    expect(sessionEffortChoices('codex', daemon, next.model, next.availableEfforts)).toEqual([
+      { value: 'high', label: 'High' }
+    ])
+    expect(sessionEffortChoicesForSelection('codex', daemon, 'terra', 'sol', ['high', 'max'])).toEqual([
+      { value: 'high', label: 'High' }
+    ])
+  })
+})

--- a/packages/web/src/lib/session-runtime-controls.ts
+++ b/packages/web/src/lib/session-runtime-controls.ts
@@ -1,0 +1,95 @@
+import {
+  effortChoicesFor,
+  effortLabel,
+  modelCapability,
+  permissionModeChoicesFor,
+  permissionModeLabel,
+  resolvedPermissionMode,
+  resolveEffortForModel,
+  type DaemonRow,
+  type EffortChoice,
+  type RuntimeModelCatalog,
+  type Session
+} from '@/lib/data'
+
+type RuntimeDaemon = Pick<DaemonRow, 'runtimeModels'> | undefined
+type PermissionChoice = { v: string; l: string; description?: string }
+
+/** Chat-side runtime changes need both Agent authority and a daemon-created session. */
+export function sessionRuntimeChangesEnabled(
+  allowed: boolean,
+  session: Pick<Session, 'platform' | 'realSessionId'>
+): boolean {
+  return allowed && (session.platform === 'webchat' || !!session.realSessionId)
+}
+
+/** A received live list is authoritative, including `[]`; discovery is idle-session fallback only. */
+export function sessionEffortChoices(
+  runtime: string,
+  daemon: RuntimeDaemon,
+  model: string,
+  liveValues: string[] | undefined
+): EffortChoice[] {
+  const discovered = effortChoicesFor(runtime, modelCapability(daemon, runtime, model))
+  if (liveValues === undefined) return discovered
+  return liveValues.map(
+    (value) => discovered.find((choice) => choice.value === value) ?? { value, label: effortLabel(runtime, value) }
+  )
+}
+
+/** Live efforts belong to the reported model, not an optimistic local selection. */
+export function sessionEffortChoicesForSelection(
+  runtime: string,
+  daemon: RuntimeDaemon,
+  selectedModel: string,
+  reportedModel: string | undefined,
+  liveValues: string[] | undefined
+): EffortChoice[] {
+  return sessionEffortChoices(runtime, daemon, selectedModel, selectedModel === reportedModel ? liveValues : undefined)
+}
+
+/** Permission capabilities follow the same live-first rule as model and effort selectors. */
+export function sessionPermissionChoices(
+  runtime: string,
+  catalog: RuntimeModelCatalog | undefined,
+  liveValues: string[] | undefined
+): PermissionChoice[] {
+  const discovered = permissionModeChoicesFor(runtime, catalog)
+  if (liveValues === undefined) return discovered
+  return liveValues.map(
+    (value) => discovered.find((choice) => choice.v === value) ?? { v: value, l: permissionModeLabel(runtime, value) }
+  )
+}
+
+/** Resolve the displayed permission from the same vocabulary rendered by the select. */
+export function sessionPermissionSelection(
+  runtime: string,
+  catalog: RuntimeModelCatalog | undefined,
+  liveValues: string[] | undefined,
+  current: string
+): string {
+  const choices = sessionPermissionChoices(runtime, catalog, liveValues)
+  if (liveValues === undefined) return resolvedPermissionMode(current, choices, catalog)
+  if (choices.some((choice) => choice.v === current)) return current
+  const defaultMode = catalog?.defaultPermissionMode
+  if (defaultMode && choices.some((choice) => choice.v === defaultMode)) return defaultMode
+  return choices[0]?.v ?? ''
+}
+
+/** Keep the sticky effort compatible with a user-selected model. */
+export function sessionEffortAfterModelChange(
+  runtime: string,
+  daemon: RuntimeDaemon,
+  model: string,
+  currentEffort: string
+): string {
+  return resolveEffortForModel(runtime, modelCapability(daemon, runtime, model), currentEffort)
+}
+
+/** A live effort list describes the previous model until a new status frame arrives. */
+export function sessionAfterModelSelection<T extends { availableEfforts?: string[] }>(
+  session: T,
+  model: string
+): T & { model: string } {
+  return { ...session, model, availableEfforts: undefined }
+}


### PR DESCRIPTION
## Summary

- align the desktop WebChat composer with the message bubble column
- shrink the Add and Send controls to the compact toolbar sizes
- expose model, reasoning effort, and permission selectors whenever chat-side runtime changes are allowed
- preserve authoritative live runtime choices while falling back to the owning daemon's discovered catalog for restored sessions
- persist the bounded WebChat image attachment in the daemon transcript so reopening a session renders the image instead of only its attachment marker

## Root cause

The composer occupied the full transcript row, including the avatar gutter, while message bubbles started after that gutter. Runtime selectors also depended only on live status frames, so idle or restored sessions rendered static values despite the daemon having a runtime catalog. Image bytes were kept only in browser state; the persisted transcript stored just a synthetic attachment line.

## Impact

Allowed WebChat sessions now present compact, editable runtime controls while the daemon-side `allowRuntimeChangesInChat` guard remains authoritative. A newly uploaded image stays daemon-local, is proxied only through the authorized session-history route, and is restored when the same session is reopened. Images sent before this change cannot be reconstructed because their bytes were never persisted.

## Validation

- protocol codec: 59 tests
- daemon session history and WebChat image flow: 44 tests
- control-plane session-history route: 13 tests
- full Web suite: 48 files, 303 tests
- protocol, daemon, control-plane, and Web typechecks
- Web production build
- changed-file ESLint, Prettier, and cumulative diff-check
- browser QA in light and dark themes for composer alignment, compact controls, selectors, and Add photos anchoring

Created by Codex . GPT-5
