### PR TITLE
feat(web): move workspace options into the Workspace tab

### DIFF
--- a/docs/designs/agent-multi-repo-authorization.md
+++ b/docs/designs/agent-multi-repo-authorization.md
@@ -388,19 +388,24 @@ mismatch.
 
 ## Web
 
-1. **Workspace card on agent detail, for GitHub and scratch:**
-   - Make the summary row open the Workspace tab directly; remove a separate
-     "View workspace." Show `read|write` next to a GitHub repository and "From
-     scratch" for scratch.
-   - Provide one Edit action that can switch between scratch and GitHub and
-     choose a covered repository, branch, `agentDir`, and access. Mode,
+1. **Workspace card in the agent's Workspace tab, for GitHub and scratch:**
+   - The card heads the Workspace tab itself, above the file browser; there is no
+     workspace summary row in Configuration to navigate from. Show `read|write`
+     next to a GitHub repository and "Scratch workspace" for scratch.
+   - A `Source` segment switches between scratch and GitHub, and one Edit action
+     chooses a covered repository, branch, `agentDir`, and access. Mode,
      repository, or branch changes show an irreversible warning and "Replace
      workspace." Access-only or directory-only changes retain the checkout.
+   - Because the editor now sits above the live browser, a replacement must
+     remount that browser: its cached tree, preview, and git status may never
+     outlive the workspace they were read from.
    - Every change uses the cold lifecycle to clear daemon credential cache.
      Return 409 when it would remove workspace write authority required by an
      enabled formal review or Check.
-   - Below it, list each additional repository with `repoFullName`, an access
-     badge, and delete.
+   - Beside it, list each additional repository with `repoFullName`, its access
+     tier, and delete. The workspace repository itself appears here only when the
+     workspace is App-backed, where the installation makes it implicit; a manual
+     checkout is represented solely by its explicit grant, if one exists.
    - "Add repository" reuses the installation/repository picker and list
      filtering, offers three access options defaulting to read, describes each
      level, warns on write blast radius, and reuses `/access` preflight.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -218,10 +218,14 @@ does not replace the current review verdict.
 
 ## Workspace navigation and repository access
 
-The workspace summary row is navigation: selecting either its GitHub repository or
-its scratch label opens the agent's Workspace tab. Do not add a second "View
-workspace" action to the row. A single right-aligned `Edit` action owns workspace
-type, repository, branch, working-subdirectory, and repository-access settings.
+The workspace options live in the agent's Workspace tab, above the files they
+configure — not in Configuration, and not behind a summary row that navigates
+there. A `Source` control owns conversion between scratch and GitHub; a single
+`Edit` action owns repository, branch, working-subdirectory, and
+repository-access settings. Replacing a workspace must replace the file browser
+with it: the tree, the open preview, and the git status below the card always
+belong to the workspace the card currently describes, never to the one it
+replaced.
 
 In the Workspace tab, callers who can edit the agent may create or edit one UTF-8
 file at a time when the workspace is scratch. New files use exclusive creation and

--- a/packages/web/src/components/console/WorkspaceCard.test.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.test.tsx
@@ -1,0 +1,70 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+const repos = vi.hoisted(() => ({ rows: [] as Array<Record<string, unknown>> }))
+
+vi.mock('swr', () => ({
+  default: () => ({ data: repos.rows, error: undefined, isLoading: false, mutate: vi.fn() })
+}))
+vi.mock('@/lib/api', () => ({
+  creatorLabel: () => 'Dana Reyes',
+  deleteAgentRepo: vi.fn(),
+  fetchAgentRepos: vi.fn()
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org-1' } }) }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ refresh: vi.fn() }) }))
+vi.mock('@/lib/swr-keys', () => ({ consoleKeys: { agentRepos: () => ['repos'] } }))
+vi.mock('@/components/console/modals/AddAgentRepoModal', () => ({ default: () => null }))
+vi.mock('@/components/console/modals/EditWorkspaceModal', () => ({ default: () => null }))
+
+import { WorkspaceCard } from './WorkspaceCard'
+import type { Agent } from '@/lib/data'
+
+const agent = (workspace: Record<string, unknown>) =>
+  ({
+    id: 'agent-a',
+    name: 'deploy-bot',
+    canManageSharing: true,
+    workspace
+  }) as unknown as Agent
+
+const GITHUB = { mode: 'github', repo: 'acme/infra', branch: 'main', agentDir: '/' }
+
+// Only an App-backed workspace has implicit authority over its own repository. A
+// manual checkout's effective access comes from an explicit agent-repo grant (or
+// is none), so an implicit chip there would claim authorization it does not have
+// and duplicate the real explicit row when one exists.
+describe('workspace repository authority', () => {
+  it('shows the workspace repo as an implicit grant when the App backs it', () => {
+    repos.rows = []
+    const html = renderToStaticMarkup(<WorkspaceCard agent={agent({ ...GITHUB, installationId: 'inst-1' })} />)
+    expect(html).toContain('authorized implicitly')
+    expect(html).toContain('acme/infra')
+    expect(html).not.toContain('None explicitly authorized')
+  })
+
+  it('does not claim implicit authority for a manual GitHub checkout', () => {
+    repos.rows = []
+    const html = renderToStaticMarkup(<WorkspaceCard agent={agent(GITHUB)} />)
+    expect(html).not.toContain('authorized implicitly')
+    expect(html).toContain('None explicitly authorized')
+  })
+
+  it('renders a manual checkout through its explicit grant, without duplicating it', () => {
+    repos.rows = [{ id: 'g1', repoFullName: 'acme/infra', access: 'comment', createdBy: 'u1' }]
+    const html = renderToStaticMarkup(<WorkspaceCard agent={agent(GITHUB)} />)
+    expect(html).not.toContain('authorized implicitly')
+    // Exactly one chip for the repo — the explicit, revocable one, carrying its
+    // real tier. A second, non-removable implicit chip would show no Revoke.
+    expect(html.match(/Revoke access/g)).toHaveLength(1)
+    expect(html).toContain('comment access')
+  })
+
+  it('leaves a scratch workspace with no implicit repository', () => {
+    repos.rows = []
+    const html = renderToStaticMarkup(<WorkspaceCard agent={agent({ mode: 'scratch' })} />)
+    expect(html).not.toContain('authorized implicitly')
+    expect(html).toContain('None explicitly authorized')
+  })
+})

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -109,6 +109,10 @@ export function WorkspaceCard({
   const loadError = reposData === undefined && reposError
   const canEdit = agent.canManageSharing
   const branch = header?.branch ?? (ws.mode === 'github' ? ws.branch : null)
+  // A manual checkout has no App installation to mint a write token from, so its
+  // effective workspace access is read regardless of the stored preference.
+  const workspaceAccess =
+    ws.mode === 'github' ? (ws.installationId ? (ws.gitAccess ?? 'write') : ('read' as const)) : null
   const remoteLabel = header?.remoteLabel ?? 'GitHub'
 
   const remove = async (row: AgentRepoAuthDto) => {
@@ -179,6 +183,10 @@ export function WorkspaceCard({
             {branch}
           </span>
         )}
+        {/* Effective workspace access stays visible next to the repository
+            (product-conventions.md §Workspace navigation and repository access) —
+            it is the blast radius of everything the agent pushes. */}
+        {workspaceAccess && <span className={REPO_ACCESS_BADGE[workspaceAccess]}>{workspaceAccess}</span>}
         {header?.status && (
           <span className="badge flex-none" style={{ background: header.status.bg, color: header.status.text }}>
             <span className="dot h-[6px] w-[6px]" style={{ background: header.status.dot }} />
@@ -233,10 +241,14 @@ export function WorkspaceCard({
       <div className="flex flex-wrap items-center gap-2 border-t border-(--border-subtle) px-4 py-[9px]">
         <span className="eyebrow flex-none text-[10.5px]">Authorized repos</span>
 
-        {ws.mode === 'github' && (
+        {/* Only an App-backed workspace carries implicit authority over its own
+            repository. A manual checkout has none: its effective access comes
+            from an explicit grant below (or is `none`), so rendering a chip here
+            would both claim authorization it lacks and duplicate the real row. */}
+        {isGithubApp && (
           <span
             className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-default) bg-(--surface-card) px-2"
-            title="The workspace repository — authorized implicitly"
+            title="The workspace repository — authorized implicitly by the GitHub App installation"
           >
             <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
               <GithubMark />
@@ -274,7 +286,7 @@ export function WorkspaceCard({
                 )}
               </span>
             ))}
-            {repos.length === 0 && ws.mode !== 'github' && (
+            {repos.length === 0 && !isGithubApp && (
               <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
                 None explicitly authorized.
               </span>

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -1,26 +1,34 @@
 'use client'
 
-// Agent detail "Workspace" card (issue #457): the config tab's compact
-// workspace summary. The workspace row itself opens the workspace tab; one Edit
-// action in the card header owns workspace conversion and GitHub repository
-// identity, working-directory, and access changes. Below it, the agent's explicit
-// repository authorizations (agent-multi-repo-authorization.md §web 1). App-backed workspaces already
-// cover their workspace repo implicitly; scratch workspaces have no implicit
-// repo and may authorize any covered repo; manual GitHub workspaces may list
-// only an explicit grant for their own repo so CP-owned effects can run.
+// Agent detail "Workspace" card. Design sync: the workspace options no longer
+// live in the Configuration tab — they sit at the top of the Workspace tab, so
+// the source, its live git state and the files below it read as one surface.
 //
-// Grant rows are visible to anyone who can view the agent; authorize/revoke
-// only for canEdit (canManageSharing — the DTO mirror; viewers see a read-only
-// list). "Authorize repository" opens AddAgentRepoModal (the design's inline
-// add-expander is skipped — established precedent: the modal owns the
-// picker/tier/preflight flow).
+// One compact card, two rows:
+//   1. Source — a segment that owns workspace conversion (scratch ⇄ GitHub),
+//      then the workspace identity (mark, repo/title, branch, status) and, on
+//      the right, the HEAD commit plus the pull / view-on-remote / edit actions.
+//      Everything after the segment is supplied by the caller as
+//      `WorkspaceHeaderInfo` — live git state from <WorkspaceFiles> for real
+//      agents, the static mock fields for demo agents.
+//   2. Authorized repos — the agent's explicit repository authorizations
+//      (agent-multi-repo-authorization.md §web 1). App-backed workspaces already
+//      cover their workspace repo implicitly (rendered as a non-removable chip);
+//      scratch workspaces have no implicit repo and may authorize any covered
+//      repo; manual GitHub workspaces may list only an explicit grant for their
+//      own repo so CP-owned effects can run.
+//
+// Grant rows are visible to anyone who can view the agent; conversion,
+// authorize and revoke only for canEdit (canManageSharing — the DTO mirror;
+// viewers see a read-only card). "Authorize repository" opens AddAgentRepoModal
+// (the design's inline add-expander is skipped — established precedent: the
+// modal owns the picker/tier/preflight flow).
 
 import { useState } from 'react'
 import useSWR from 'swr'
-import Link from 'next/link'
 import { GithubMark, LoadingState } from '@/components/marks'
-import { Button, Icon } from '@/components/ui'
-import type { Agent } from '@/lib/data'
+import { Icon } from '@/components/ui'
+import type { Agent, WorkspaceStatusInfo } from '@/lib/data'
 import { creatorLabel, deleteAgentRepo, fetchAgentRepos, type AgentRepoAuthDto, type RepoAccess } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
@@ -37,25 +45,58 @@ export const REPO_ACCESS_BADGE: Record<RepoAccess, string> = {
   write: 'badge flex-none bg-(--status-paused-soft) text-(--amber-500)'
 }
 
+/**
+ * The live half of the Source row. The card itself only knows the agent's
+ * configured workspace; branch/status/commit and the pull action come from
+ * whoever holds the daemon read model (<WorkspaceFiles>) or, for demo agents,
+ * straight from the mock workspace.
+ */
+export interface WorkspaceHeaderInfo {
+  /** Branch chip. Omit to fall back to the agent's configured branch. */
+  branch?: string | null
+  status?: WorkspaceStatusInfo | null
+  /** HEAD summary, rendered `sha · time` with `title` as its tooltip. */
+  commit?: { sha: string; time: string; title?: string } | null
+  /** Browsable remote URL behind the view-on-remote action. */
+  repoUrl?: string | null
+  /** Remote label for the view action's tooltip ("GitHub", "gitlab.com", …). */
+  remoteLabel?: string | null
+  onPull?: () => void
+  pulling?: boolean
+  /** Transient pull outcome ("Already up to date."), shown after the actions. */
+  pullMsg?: string | null
+}
+
+// Segment buttons — complete literal strings, one per state.
+const SEG_ON =
+  'flex h-5 flex-none cursor-pointer items-center gap-[5px] rounded-[5px] border-0 bg-(--surface-card) px-2 font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-(--shadow-xs)'
+const SEG_OFF =
+  'flex h-5 flex-none cursor-pointer items-center gap-[5px] rounded-[5px] border-0 bg-transparent px-2 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:text-(--text-primary)'
+const SEG_ON_LOCKED =
+  'flex h-5 flex-none cursor-default items-center gap-[5px] rounded-[5px] border-0 bg-(--surface-card) px-2 font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-(--shadow-xs)'
+const SEG_OFF_LOCKED =
+  'flex h-5 flex-none cursor-default items-center gap-[5px] rounded-[5px] border-0 bg-transparent px-2 font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)'
+
 export function WorkspaceCard({
   agent,
-  workspaceHref,
+  header,
   className
 }: {
   agent: Agent
-  /** The agent's workspace-tab href (the detail view's tabHref('workspace')). */
-  workspaceHref: string
+  header?: WorkspaceHeaderInfo
   className?: string
 }) {
   const { activeOrg } = useOrgs()
   const { me } = useProfile()
   const { refresh } = useConsoleData()
   const [addOpen, setAddOpen] = useState(false)
-  const [editOpen, setEditOpen] = useState(false)
+  // Non-null ⇒ the workspace editor is open, preselected on that mode.
+  const [editMode, setEditMode] = useState<'scratch' | 'github' | null>(null)
   const [removing, setRemoving] = useState<string | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
   const ws = agent.workspace
+  const isGithub = ws.mode === 'github'
   const isGithubApp = ws.mode === 'github' && !!ws.installationId
   const reposKey = consoleKeys.agentRepos(activeOrg?.id, agent.id)
   const {
@@ -67,8 +108,8 @@ export function WorkspaceCard({
   const repos = reposData ?? []
   const loadError = reposData === undefined && reposError
   const canEdit = agent.canManageSharing
-  const workspaceAccess =
-    ws.mode === 'github' ? (ws.installationId ? (ws.gitAccess ?? 'write') : ('read' as const)) : null
+  const branch = header?.branch ?? (ws.mode === 'github' ? ws.branch : null)
+  const remoteLabel = header?.remoteLabel ?? 'GitHub'
 
   const remove = async (row: AgentRepoAuthDto) => {
     if (removing) return
@@ -84,112 +125,174 @@ export function WorkspaceCard({
     }
   }
 
+  // The segment is the conversion entry point; picking the mode the agent is
+  // already on is a no-op (the pencil edits the current source's settings).
+  const pickMode = (next: 'scratch' | 'github') => {
+    if (!canEdit || next === ws.mode) return
+    setEditMode(next)
+  }
+  const segClass = (mode: 'scratch' | 'github') =>
+    mode === ws.mode ? (canEdit ? SEG_ON : SEG_ON_LOCKED) : canEdit ? SEG_OFF : SEG_OFF_LOCKED
+
   return (
     <div className={`card overflow-hidden max-desktop:rounded-lg ${className ?? ''}`}>
-      <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
-        <span className="font-sans text-[14px] font-semibold leading-normal">Workspace</span>
+      {/* Source row — conversion segment, then the workspace identity and its
+          live git actions. Wraps on narrow viewports; nothing is truncated away. */}
+      <div className="flex flex-wrap items-center gap-[10px] px-4 py-[9px]">
+        <span className="eyebrow flex-none text-[10.5px]">Source</span>
+        <span className="inline-flex flex-none gap-px rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken) p-px">
+          <button
+            className={segClass('github')}
+            onClick={() => pickMode('github')}
+            title={isGithub ? 'The workspace is a GitHub clone' : 'Convert this workspace to a GitHub repository'}
+          >
+            <Icon name="git-branch" size={12} />
+            GitHub repo
+          </button>
+          <button
+            className={segClass('scratch')}
+            onClick={() => pickMode('scratch')}
+            title={
+              isGithub ? 'Convert this workspace to an empty scratch directory' : 'The workspace is a scratch directory'
+            }
+          >
+            <Icon name="folder" size={12} />
+            Scratch
+          </button>
+        </span>
+
+        <span className="mx-[2px] h-[18px] w-px flex-none bg-(--border-subtle)" />
+
+        {isGithub ? (
+          <span className="flex h-5 w-5 flex-none items-center justify-center">
+            <GithubMark color="var(--text-secondary)" />
+          </span>
+        ) : (
+          <Icon name="folder" size={16} color="var(--text-tertiary)" />
+        )}
+        <span className="mono min-w-0 truncate text-[13px] font-semibold text-(--text-primary)">
+          {ws.mode === 'github' ? ws.repo : 'Scratch workspace'}
+        </span>
+        {isGithub && branch && (
+          <span className="scope inline-flex flex-none items-center gap-1">
+            <Icon name="git-branch" size={12} />
+            {branch}
+          </span>
+        )}
+        {header?.status && (
+          <span className="badge flex-none" style={{ background: header.status.bg, color: header.status.text }}>
+            <span className="dot h-[6px] w-[6px]" style={{ background: header.status.dot }} />
+            {header.status.label}
+          </span>
+        )}
+
+        <div className="min-w-[8px] flex-1" />
+
+        {header?.commit && (
+          <span
+            className="mono flex-none whitespace-nowrap text-[11.5px] text-(--text-tertiary)"
+            title={header.commit.title}
+          >
+            <span className="text-(--brand-soft-text)">{header.commit.sha}</span> · {header.commit.time}
+          </span>
+        )}
+        {isGithub && header?.onPull && (
+          <button
+            className={`iconbtn h-6 w-6 flex-none ${header.pulling ? 'pointer-events-none opacity-50' : ''}`}
+            title="Fast-forward pull from the remote"
+            onClick={header.onPull}
+          >
+            <Icon name="refresh-cw" size={13} />
+          </button>
+        )}
+        {isGithub && header?.repoUrl && (
+          <a
+            className="iconbtn flex h-6 w-6 flex-none items-center justify-center no-underline"
+            title={`View on ${remoteLabel}`}
+            href={header.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Icon name="external-link" size={13} />
+          </a>
+        )}
         {canEdit && (
-          <>
-            <button
-              onClick={() => setEditOpen(true)}
-              className="flex h-7 cursor-pointer items-center gap-[6px] border-0 bg-transparent px-0 py-0 font-sans text-[14px] font-semibold leading-normal text-(--brand-soft-text) desktop:hidden"
-            >
-              <Icon name="pencil" size={14} />
-              Edit
-            </button>
-            <Button
-              variant="secondary"
-              size="xs"
-              className="hidden desktop:inline-flex"
-              onClick={() => setEditOpen(true)}
-            >
-              <Icon name="pencil" size={14} />
-              Edit
-            </Button>
-          </>
+          <button className="iconbtn h-6 w-6 flex-none" title="Edit workspace" onClick={() => setEditMode(ws.mode)}>
+            <Icon name="pencil" size={13} />
+          </button>
+        )}
+        {header?.pullMsg && (
+          <span className="flex-none font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+            {header.pullMsg}
+          </span>
         )}
       </div>
 
-      {/* The whole summary row drills into the workspace; editing is kept in the
-          single header action so the row has no competing click targets. */}
-      <Link
-        className="flex w-full min-w-0 items-center gap-2 px-4 py-[11px] no-underline hover:bg-(--surface-hover)"
-        href={workspaceHref}
-      >
-        {ws.mode === 'github' ? (
-          <>
-            <span className="imark h-4 w-4 border-0 bg-transparent">
-              <GithubMark color="var(--text-tertiary)" />
-            </span>
-            <span className="mono min-w-0 truncate text-[12.5px] text-(--text-secondary)">{ws.repo}</span>
-            {workspaceAccess && <span className={REPO_ACCESS_BADGE[workspaceAccess]}>{workspaceAccess}</span>}
-          </>
-        ) : (
-          <>
-            <Icon name="sparkles" size={14} color="var(--text-tertiary)" />
-            <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-              From scratch
-            </span>
-          </>
-        )}
-      </Link>
+      {/* Authorized repos — chips, since a workspace rarely has more than a
+          handful; the tier lives in each chip's tooltip. */}
+      <div className="flex flex-wrap items-center gap-2 border-t border-(--border-subtle) px-4 py-[9px]">
+        <span className="eyebrow flex-none text-[10.5px]">Authorized repos</span>
 
-      {/* Viewers get no Authorize button, so the section supplies its own
-          bottom breathing room (complete literal strings — never fragments). */}
-      <div className={canEdit ? 'border-t border-(--border-subtle)' : 'border-t border-(--border-subtle) pb-2'}>
-        <div className="eyebrow px-4 pt-[10px] text-[10.5px]">Authorized repositories</div>
+        {ws.mode === 'github' && (
+          <span
+            className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-default) bg-(--surface-card) px-2"
+            title="The workspace repository — authorized implicitly"
+          >
+            <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
+              <GithubMark />
+            </span>
+            <span className="mono text-[11.5px] text-(--text-primary)">{ws.repo}</span>
+          </span>
+        )}
 
         {loadError ? (
-          <div className="px-4 py-2 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+          <span className="font-sans text-[12px] font-normal leading-normal text-(--status-error)">
             Couldn&rsquo;t load repository grants.
-          </div>
+          </span>
         ) : isLoading && reposData === undefined ? (
-          <LoadingState padding={16} />
+          <LoadingState padding={0} />
         ) : (
           <>
             {repos.map((r) => (
-              <div key={r.id} className="flex items-center gap-2 px-4 py-2">
-                <span className="imark h-4 w-4 border-0 bg-transparent">
+              <span
+                key={r.id}
+                className="inline-flex h-6 flex-none items-center gap-[6px] rounded-[5px] border border-(--border-subtle) bg-(--surface-card) py-0 pr-1 pl-2"
+                title={`${r.repoFullName} — ${r.access} access, added by ${creatorLabel(r.createdBy, me)}`}
+              >
+                <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
                   <GithubMark />
                 </span>
-                <span
-                  className="mono min-w-0 flex-1 truncate text-[12px] text-(--text-primary)"
-                  title={`${r.repoFullName} — added by ${creatorLabel(r.createdBy, me)}`}
-                >
-                  {r.repoFullName}
-                </span>
-                <span className={REPO_ACCESS_BADGE[r.access]}>{r.access}</span>
+                <span className="mono text-[11.5px] text-(--text-primary)">{r.repoFullName}</span>
                 {canEdit && (
                   <button
-                    className={`iconbtn h-6 w-6 flex-none ${removing === r.id ? 'pointer-events-none opacity-50' : ''}`}
+                    className={`iconbtn h-[18px] w-[18px] flex-none ${removing === r.id ? 'pointer-events-none opacity-50' : ''}`}
                     title="Revoke access"
                     onClick={() => void remove(r)}
                   >
-                    <Icon name="x" size={12} />
+                    <Icon name="x" size={11} />
                   </button>
                 )}
-              </div>
+              </span>
             ))}
-            {repos.length === 0 && (
-              <div className="px-4 py-2 font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+            {repos.length === 0 && ws.mode !== 'github' && (
+              <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
                 None explicitly authorized.
-              </div>
+              </span>
             )}
           </>
         )}
 
-        {err && (
-          <div className="px-4 py-2 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>
+        {canEdit && (
+          <button
+            className="inline-flex h-6 flex-none cursor-pointer items-center gap-[5px] rounded-[5px] border border-dashed border-(--border-default) bg-transparent px-[9px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:border-(--brand) hover:text-(--brand)"
+            onClick={() => setAddOpen(true)}
+          >
+            <Icon name="plus" size={12} />
+            Authorize repository
+          </button>
         )}
 
-        {canEdit && (
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pt-[2px] pb-[10px]">
-            <button className="lnk text-[12px]" onClick={() => setAddOpen(true)}>
-              <Icon name="plus" size={13} />
-              Authorize repository
-            </button>
-          </div>
-        )}
+        {err && <span className="font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</span>}
       </div>
 
       {addOpen && (
@@ -206,14 +309,15 @@ export function WorkspaceCard({
         />
       )}
 
-      {editOpen && (
+      {editMode && (
         <EditWorkspaceModal
           agent={agent}
           authorized={repos}
-          onClose={() => setEditOpen(false)}
+          initialMode={editMode}
+          onClose={() => setEditMode(null)}
           onChanged={() => {
             void mutate()
-            setEditOpen(false)
+            setEditMode(null)
             refresh()
           }}
         />

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -16,6 +16,8 @@ vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => false }))
 import { WorkspaceFiles } from './WorkspaceFiles'
 
 it('uses configured edit access even before runtime Git status loads', () => {
-  const html = renderToStaticMarkup(<WorkspaceFiles agentId="agent-a" workdir="/workspace" canEdit />)
+  const html = renderToStaticMarkup(
+    <WorkspaceFiles agentId="agent-a" workdir="/workspace" canEdit renderHeader={() => null} />
+  )
   expect(html).toContain('New file')
 })

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('next/dynamic', () => ({ default: () => () => null }))
 vi.mock('@/lib/api', () => ({
@@ -13,11 +13,52 @@ vi.mock('@/lib/api', () => ({
 }))
 vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => false }))
 
-import { WorkspaceFiles } from './WorkspaceFiles'
+import { WorkspaceFiles, workspaceReadModelKey } from './WorkspaceFiles'
+import type { Agent } from '@/lib/data'
 
 it('uses configured edit access even before runtime Git status loads', () => {
   const html = renderToStaticMarkup(
     <WorkspaceFiles agentId="agent-a" workdir="/workspace" canEdit renderHeader={() => null} />
   )
   expect(html).toContain('New file')
+})
+
+// The workspace editor lives in the card this browser renders, so a replacement
+// has to remount the instance — otherwise the previous tree/preview/git state
+// survives underneath a refreshed source card (and GitHub → scratch turns the
+// stale GitHub preview editable).
+describe('workspaceReadModelKey', () => {
+  const github = {
+    id: 'agent-a',
+    workdir: '/ws/agent-a',
+    workspace: { mode: 'github', repo: 'acme/infra', branch: 'main', agentDir: '/' }
+  } as unknown as Pick<Agent, 'id' | 'workspace' | 'workdir'>
+
+  const keyOf = (over: Record<string, unknown> = {}, workspaceOver: Record<string, unknown> = {}) =>
+    workspaceReadModelKey({
+      ...github,
+      ...over,
+      workspace: { ...github.workspace, ...workspaceOver }
+    } as Pick<Agent, 'id' | 'workspace' | 'workdir'>)
+
+  it('is stable while the workspace identity is unchanged', () => {
+    expect(keyOf()).toBe(workspaceReadModelKey(github))
+  })
+
+  it.each([
+    ['repository', { repo: 'acme/web' }],
+    ['branch', { branch: 'next' }],
+    ['working subdirectory', { agentDir: '/services/api' }],
+    ['mode', { mode: 'scratch' }]
+  ])('changes when the %s changes', (_label, workspaceOver) => {
+    expect(keyOf({}, workspaceOver)).not.toBe(workspaceReadModelKey(github))
+  })
+
+  it('changes when the daemon-local working directory moves', () => {
+    expect(keyOf({ workdir: '/ws/agent-a-2' })).not.toBe(workspaceReadModelKey(github))
+  })
+
+  it('separates two agents that share a workspace definition', () => {
+    expect(keyOf({ id: 'agent-b' })).not.toBe(workspaceReadModelKey(github))
+  })
 })

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -1,16 +1,19 @@
 'use client'
 
 // Live workspace file browser for one agent — modelled on GitHub's file explorer:
-// a single repo/status card up top, an expandable directory tree on the left, and
+// a single workspace card up top, an expandable directory tree on the left, and
 // a file preview on the right. Listings and file bytes are proxied through the CP
 // straight from the owning daemon (never stored on the CP — body-locality), so a
 // 503 here just means that daemon is offline / the agent is unplaced — an expected
 // state, rendered as a friendly notice.
 //
-// This component owns the whole workspace surface for a live agent (repo card +
-// Files card); the parent just mounts it. Demo agents use <WorkspaceFilesMock>.
+// This component owns the live git read model (status / pull) but not the card
+// that displays it: it projects that state into a <WorkspaceHeaderInfo> and hands
+// it to `renderHeader`, so the workspace card can also carry the source and
+// repository-authorization controls, which need agent-level data this component
+// has no business fetching. Demo agents use <WorkspaceFilesMock>.
 
-import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { Fragment, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import dynamic from 'next/dynamic'
 import {
   ApiError,
@@ -24,11 +27,12 @@ import {
   type WorkspaceFileDto,
   type WorkspaceGitStatusDto
 } from '@/lib/api'
-import { GithubMark, Spinner } from '@/components/marks'
+import { Spinner } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { escapeHtml, highlight, linkifyHtml, loadHljs } from '@/lib/highlight'
 import { resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
+import type { WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
 import {
   FileBrowserLayout,
@@ -141,17 +145,30 @@ type Viewer = {
   loadingMore: boolean
 }
 
-export function WorkspaceFiles({ agentId, workdir, canEdit }: { agentId: string; workdir?: string; canEdit: boolean }) {
+export function WorkspaceFiles({
+  agentId,
+  workdir,
+  canEdit,
+  renderHeader
+}: {
+  agentId: string
+  workdir?: string
+  canEdit: boolean
+  /** Renders the workspace card above the tree from the live git read model.
+   *  Called on every render — including before the status lands (empty info) and
+   *  for non-repo workspaces — so the card's own controls are never gated on a
+   *  daemon round-trip. */
+  renderHeader: (header: WorkspaceHeaderInfo) => ReactNode
+}) {
   const isMobile = useIsMobile()
   const [dirs, setDirs] = useState<Record<string, DirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [viewer, setViewer] = useState<Viewer | null>(null)
   const [editPath, setEditPath] = useState<string | null>(null) // '' creates; a path replaces
-  // git-repo workspaces: current-checkout status + on-demand pull. `scratch` is set
-  // only on a successful non-repo response — an offline daemon leaves both unset so
-  // we don't mislabel a repo as scratch.
+  // git-repo workspaces: current-checkout status + on-demand pull. Null while
+  // loading, for a non-repo workspace, and when the owning daemon is offline —
+  // the workspace card falls back to the agent's configured source in all three.
   const [git, setGit] = useState<WorkspaceGitStatusDto | null>(null)
-  const [scratch, setScratch] = useState(false)
   const [gitPulling, setGitPulling] = useState(false)
   const [gitMsg, setGitMsg] = useState<string | null>(null)
   // Bumped after a pull to re-fetch both the git status and the tree.
@@ -295,25 +312,17 @@ export function WorkspaceFiles({ agentId, workdir, canEdit }: { agentId: string;
     }
   }, [agentId])
 
-  // git status of the workspace checkout. A thrown request (offline daemon) leaves
-  // both git and scratch unset → no top card; a clean non-repo answer → scratch card.
+  // git status of the workspace checkout. A non-repo answer and a thrown request
+  // (offline daemon) both leave `git` unset — the workspace card then renders the
+  // agent's configured source with no live status half.
   useEffect(() => {
     let active = true
     fetchWorkspaceGitStatus(agentId).then(
       (s) => {
-        if (!active) return
-        if (s.isRepo) {
-          setGit(s)
-          setScratch(false)
-        } else {
-          setGit(null)
-          setScratch(true)
-        }
+        if (active) setGit(s.isRepo ? s : null)
       },
       () => {
-        if (!active) return
-        setGit(null)
-        setScratch(false)
+        if (active) setGit(null)
       }
     )
     return () => {
@@ -488,13 +497,39 @@ export function WorkspaceFiles({ agentId, workdir, canEdit }: { agentId: string;
     )
   }
 
+  // Project the live git read model onto the workspace card. Nothing here is
+  // required: an offline daemon (or a scratch workspace) simply leaves the
+  // status/commit/pull half of the card empty.
+  const remote = git ? parseRemote(git.repo) : null
+  const header: WorkspaceHeaderInfo = {
+    branch: git?.branch ?? null,
+    status: git
+      ? git.clean
+        ? { dot: 'var(--status-online)', bg: 'var(--status-online-soft)', text: '#0f7a48', label: 'clean' }
+        : {
+            dot: 'var(--amber-500)',
+            bg: 'var(--status-paused-soft)',
+            text: '#9a6500',
+            label: `${git.files.length}${git.truncated ? '+' : ''} uncommitted`
+          }
+      : null,
+    commit: git?.lastCommit
+      ? {
+          sha: git.lastCommit.shortSha,
+          time: fmtMtime(git.lastCommit.committedAt),
+          title: git.lastCommit.subject
+        }
+      : null,
+    repoUrl: remote?.url ?? null,
+    remoteLabel: remote ? (/github/i.test(remote.host) ? 'GitHub' : remote.host) : null,
+    ...(git ? { onPull: onGitPull } : {}),
+    pulling: gitPulling,
+    pullMsg: gitMsg
+  }
+
   return (
     <div className="flex flex-col gap-4">
-      {git ? (
-        <RepoCard git={git} pulling={gitPulling} msg={gitMsg} onPull={onGitPull} />
-      ) : scratch ? (
-        <ScratchCard workdir={workdir} />
-      ) : null}
+      {renderHeader(header)}
 
       <FileBrowserShell
         title="Files"
@@ -876,130 +911,6 @@ function WorkspaceFileEditor({
             {saving ? 'Saving…' : 'Save'}
           </Button>
         </div>
-      </div>
-    </div>
-  )
-}
-
-// The git-repo header card: remote / branch / working dir on top, the HEAD commit
-// + last-pull time below, and Pull-latest / View-on-remote actions in a footer.
-function RepoCard({
-  git,
-  pulling,
-  msg,
-  onPull
-}: {
-  git: WorkspaceGitStatusDto
-  pulling: boolean
-  msg: string | null
-  onPull: () => void
-}) {
-  const remote = parseRemote(git.repo)
-  const dirty = !git.clean
-  const uncommitted = git.files.length + (git.truncated ? '+' : '')
-  const onGitHub = remote ? /github/i.test(remote.host) : false
-
-  return (
-    <div className="card">
-      <div className="flex items-start gap-3 px-4 py-[14px]">
-        <div className="imark h-[38px] w-[38px] text-(--text-secondary)" aria-hidden>
-          {onGitHub ? (
-            <span className="inline-flex h-[19px] w-[19px]">
-              <GithubMark color="var(--text-secondary)" />
-            </span>
-          ) : (
-            <Icon name="git-branch" size={19} />
-          )}
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
-              {remote?.label ?? 'workspace'}
-            </span>
-            {git.branch && (
-              <span className="scope inline-flex items-center gap-1">
-                <Icon name="git-branch" size={11} />
-                {git.branch}
-              </span>
-            )}
-            {git.agentDir && <span className="mono text-[12px] text-(--text-tertiary)">{git.agentDir}</span>}
-            <span
-              className={`badge ml-auto ${
-                dirty ? 'bg-(--status-paused-soft) text-(--amber-500)' : 'bg-(--status-online-soft) text-(--green-500)'
-              }`}
-              title={dirty ? 'Working tree has uncommitted changes' : 'Working tree clean'}
-            >
-              <span className="dot h-[6px] w-[6px] bg-current" />
-              {dirty ? `${uncommitted} uncommitted` : 'clean'}
-            </span>
-          </div>
-
-          <div className="mt-1 flex flex-wrap items-center gap-[7px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-            {git.lastFetchAt && <span>pulled {fmtMtime(git.lastFetchAt)}</span>}
-            {git.lastFetchAt && git.lastCommit && <span aria-hidden>·</span>}
-            {git.lastCommit && (
-              <span className="inline-flex min-w-0 items-center gap-[7px]">
-                <span className="mono font-semibold text-(--brand-soft-text)">{git.lastCommit.shortSha}</span>
-                <span className="max-w-[380px] truncate text-(--text-secondary)" title={git.lastCommit.subject}>
-                  {git.lastCommit.subject}
-                </span>
-                <span aria-hidden>·</span>
-                <span>{fmtMtime(git.lastCommit.committedAt)}</span>
-              </span>
-            )}
-            {!git.lastFetchAt && !git.lastCommit && <span>No commits yet.</span>}
-          </div>
-        </div>
-      </div>
-
-      <div className="flex items-center gap-[14px] border-t border-(--border-subtle) px-4 py-[10px]">
-        <button
-          className="iconbtn h-[30px] w-auto gap-[7px] px-3 py-0 text-[13px] font-medium"
-          onClick={onPull}
-          disabled={pulling}
-          title="Fast-forward pull from the remote"
-        >
-          <Icon name="refresh-cw" size={14} />
-          {pulling ? 'Pulling…' : 'Pull latest'}
-        </button>
-        {remote && (
-          <a
-            className="lnk text-[13px] text-(--text-secondary)"
-            href={remote.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Icon name="external-link" size={14} />
-            {onGitHub ? 'View on GitHub' : `View on ${remote.host}`}
-          </a>
-        )}
-        {msg && (
-          <span className="ml-auto font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">{msg}</span>
-        )}
-      </div>
-    </div>
-  )
-}
-
-// Non-git ("scratch") live workspace: files exist only on the daemon's disk.
-function ScratchCard({ workdir }: { workdir?: string }) {
-  return (
-    <div className="card">
-      <div className="flex items-center gap-[11px] px-4 py-[13px]">
-        <span className="imark flex h-[30px] w-[30px] items-center justify-center" aria-hidden>
-          <Icon name="folder" size={16} color="var(--text-tertiary)" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
-            Scratch workspace
-          </div>
-          {workdir && <div className="mono mt-[2px] text-[11.5px] text-(--text-tertiary)">{workdir}</div>}
-        </div>
-      </div>
-      <div className="flex items-center gap-[7px] border-t border-(--border-subtle) px-4 py-[11px] font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
-        <Icon name="info" size={14} />
-        Files here are created by the agent and live only on this machine — not version-controlled.
       </div>
     </div>
   )

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -33,6 +33,7 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { escapeHtml, highlight, linkifyHtml, loadHljs } from '@/lib/highlight'
 import { resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
 import type { WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
+import type { Agent } from '@/lib/data'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
 import {
   FileBrowserLayout,
@@ -55,6 +56,24 @@ const MarkdownView = dynamic(() => import('@/components/console/MarkdownView'), 
 })
 
 const msg = (e: unknown) => (e instanceof Error ? e.message : String(e))
+
+/**
+ * Identity of the daemon-local checkout one <WorkspaceFiles> instance reads.
+ *
+ * The tree, the open preview and the git status are fetched per agent and then
+ * cached in component state keyed only on `agentId`, so a workspace REPLACEMENT
+ * (mode / repo / branch / working subdirectory) has to remount the instance
+ * rather than reuse it. Since the workspace editor now lives in the card above
+ * the browser — same tab, same mounted tree — reuse would leave the refreshed
+ * source card sitting on top of files that belong to the workspace it replaced,
+ * and a GitHub → scratch conversion would additionally flip `canEdit` to true
+ * over that stale GitHub preview. Pass this as the instance's React `key`.
+ */
+export function workspaceReadModelKey(agent: Pick<Agent, 'id' | 'workspace' | 'workdir'>): string {
+  const ws = agent.workspace
+  const at = `${agent.id}:${agent.workdir}`
+  return ws.mode === 'github' ? `${at}:github:${ws.repo}@${ws.branch}:${ws.agentDir}` : `${at}:scratch`
+}
 
 function entryIcon(e: WorkspaceEntryDto): string {
   if (e.type === 'dir') return 'folder'

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -38,19 +38,23 @@ import {
 export default function EditWorkspaceModal({
   agent,
   authorized,
+  initialMode,
   onClose,
   onChanged
 }: {
   agent: Agent
   /** Existing grants — pre-picked and badged, but any covered repo converts. */
   authorized: AgentRepoAuthDto[]
+  /** Preselected mode — the workspace card's Source segment opens the editor
+   *  already switched to the mode the user picked. Defaults to the current one. */
+  initialMode?: 'scratch' | 'github'
   onClose: () => void
   onChanged: () => void
 }) {
   const githubWorkspace = agent.workspace.mode === 'github' ? agent.workspace : null
   const currentWrite = githubWorkspace ? !!githubWorkspace.installationId && githubWorkspace.gitAccess !== 'read' : null
   const currentAgentDir = agentDirInputValue(githubWorkspace?.agentDir)
-  const [mode, setMode] = useState<'scratch' | 'github'>(agent.workspace.mode)
+  const [mode, setMode] = useState<'scratch' | 'github'>(initialMode ?? agent.workspace.mode)
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
   const [repos, setRepos] = useState<Array<GithubRepoDto & { installationId: string }> | null>(null)

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -48,7 +48,7 @@ import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
-import { WorkspaceFiles } from '@/components/console/WorkspaceFiles'
+import { WorkspaceFiles, workspaceReadModelKey } from '@/components/console/WorkspaceFiles'
 import { WorkspaceFilesMock } from '@/components/console/WorkspaceFilesMock'
 import { FileBrowserShell } from '@/components/console/FileBrowser'
 import { MemoryPanel } from '@/components/console/MemoryPanel'
@@ -1603,7 +1603,12 @@ export default function AgentDetailView() {
       {tab === 'workspace' &&
         (!da.name.startsWith(MOCK_PREFIX) ? (
           <div className="p-4 desktop:p-0">
+            {/* Keyed by workspace identity: the editor now lives in the card
+                this instance renders, so a replacement must remount the browser
+                instead of leaving the previous tree/preview/git state beneath a
+                refreshed source card. */}
             <WorkspaceFiles
+              key={workspaceReadModelKey(da)}
               agentId={id}
               workdir={da.workdir}
               canEdit={da.workspace.mode === 'scratch' && da.canManageSharing}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -47,7 +47,7 @@ import { AgentSkillsCard } from '@/components/console/AgentSkillsCard'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
-import { WorkspaceCard } from '@/components/console/WorkspaceCard'
+import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { WorkspaceFiles } from '@/components/console/WorkspaceFiles'
 import { WorkspaceFilesMock } from '@/components/console/WorkspaceFilesMock'
 import { FileBrowserShell } from '@/components/console/FileBrowser'
@@ -405,7 +405,17 @@ export default function AgentDetailView() {
   const modelText = agentModelDisplay(owningDaemon, da.runtime, da.model)
   const ds = status(effectiveAgentStatus(da.status, owningDaemon?.status))
   const ws = da.workspace
-  const wss = workspaceStatus(ws)
+  // Demo agents have no daemon to read git state from, so the workspace card's
+  // live half comes straight from their static mock workspace instead.
+  const mockWorkspaceHeader: WorkspaceHeaderInfo =
+    ws.mode === 'github'
+      ? {
+          branch: ws.branch,
+          status: workspaceStatus(ws),
+          ...(ws.commitMsg ? { commit: { sha: ws.commit, time: ws.commitTime, title: ws.commitMsg } } : {}),
+          repoUrl: ws.repoUrl ?? `https://github.com/${ws.repo}`
+        }
+      : { status: workspaceStatus(ws) }
   // Counts walk the whole mock tree (files are nested under folder children).
   const allFiles = flattenFiles(ws.files)
   const changedFiles = allFiles.filter((f) => f.tag).length
@@ -680,11 +690,12 @@ export default function AgentDetailView() {
         })}
       </div>
 
-      {/* Config tab — one grid: mobile stacks General → Workspace → Description →
-          Visibility → Integrations → Env → Secrets → Approval requests (flex order).
-          Desktop puts General + Workspace + Env + Secrets in the 340px left column
-          and Approval requests at the bottom of the right column (the wrapper is
-          display:contents on mobile so all the cards sit in the same flex column). */}
+      {/* Config tab — one grid: mobile stacks Basics → Runtime → Description →
+          Access → Variables → Secrets → Approval requests (flex order). Desktop
+          puts Basics + Runtime in the 340px left column and the rest in the right
+          column (the wrapper is display:contents on mobile so all the cards sit in
+          the same flex column). Workspace is NOT here — it moved into the
+          Workspace tab, next to the files it configures. */}
       {tab === 'config' && (
         <div className="flex flex-col gap-4 p-4 desktop:grid desktop:grid-cols-[340px_1fr] desktop:items-start desktop:gap-[18px] desktop:p-0">
           <div className="contents desktop:flex desktop:min-w-0 desktop:flex-col desktop:gap-[18px]">
@@ -936,19 +947,15 @@ export default function AgentDetailView() {
                 </div>
               </div>
             </div>
-            {/* Workspace card — the workspace-tab link row (both modes) plus the
-                additional authorized repos for github-app workspaces; last card in the
-                desktop left column, right after Runtime behavior on mobile. */}
-            <WorkspaceCard agent={da} workspaceHref={tabHref('workspace')} className="order-3" />
           </div>
 
           <div className="contents desktop:flex desktop:min-w-0 desktop:flex-col desktop:gap-[18px]">
             {/* Description card (design): its own card at the top of the right column,
                 and the ONE group edited on its own (EditDescriptionModal) rather than
                 through the sectioned Edit-agent modal. Mobile order: Basics 1 → Runtime
-                behavior 2 → Workspace 3 → Description 4 → Access 5 → Variables 6 →
-                Secrets 7 → Approval requests 8. */}
-            <div className="card order-4 overflow-hidden max-desktop:rounded-lg">
+                behavior 2 → Description 3 → Access 4 → Variables 5 → Secrets 6 →
+                Approval requests 7. */}
+            <div className="card order-3 overflow-hidden max-desktop:rounded-lg">
               <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
                 <span className="font-sans text-[14px] font-semibold leading-normal">Description</span>
                 {!da.name.startsWith(MOCK_PREFIX) && (
@@ -979,7 +986,7 @@ export default function AgentDetailView() {
 
             {/* Access card (design) — team visibility + agent-call visibility, read
                 only. Edit opens the sectioned Edit-agent modal at its Access anchor. */}
-            <div className="card order-5 overflow-hidden max-desktop:rounded-lg">
+            <div className="card order-4 overflow-hidden max-desktop:rounded-lg">
               <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
                 <span className="font-sans text-[14px] font-semibold leading-normal">Access</span>
                 {!da.name.startsWith(MOCK_PREFIX) && da.canManageSharing && (
@@ -1050,15 +1057,15 @@ export default function AgentDetailView() {
 
             {/* Variables + Secrets (shared editable cards) — the design keeps these in
                 the right column; each has its own inline add/edit affordances. */}
-            <div className="order-6 min-w-0">
+            <div className="order-5 min-w-0">
               <AgentEnvCard agent={da} />
             </div>
-            <div className="order-7 min-w-0">
+            <div className="order-6 min-w-0">
               <AgentSecretsCard agent={da} />
             </div>
 
             {da.canManageSharing && !da.name.startsWith(MOCK_PREFIX) && (
-              <div className="card order-8 overflow-hidden max-desktop:rounded-lg">
+              <div className="card order-7 overflow-hidden max-desktop:rounded-lg">
                 <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
                   <span className="font-sans text-[14px] font-semibold leading-normal">Approval requests</span>
                   {!!approvalRequests?.filter((request) => request.status === 'pending').length && (
@@ -1588,10 +1595,11 @@ export default function AgentDetailView() {
         </div>
       )}
 
-      {/* Workspace tab. Live agents get the self-contained GitHub-style browser (its
-          own repo card + tree + preview); demo (mocked-) agents keep the static
-          two-card mock. Desktop-only pieces of the mock repo card (branch chip,
-          commit line, actions footer) are CSS-gated. */}
+      {/* Workspace tab — the workspace card (source + authorized repos + live git
+          state) sits above the file browser, so the options and the files they
+          configure read as one surface. Live agents get the self-contained
+          GitHub-style browser, which supplies the card's live half; demo (mocked-)
+          agents fill it from their static workspace fields. */}
       {tab === 'workspace' &&
         (!da.name.startsWith(MOCK_PREFIX) ? (
           <div className="p-4 desktop:p-0">
@@ -1599,81 +1607,12 @@ export default function AgentDetailView() {
               agentId={id}
               workdir={da.workdir}
               canEdit={da.workspace.mode === 'scratch' && da.canManageSharing}
+              renderHeader={(header) => <WorkspaceCard agent={da} header={header} />}
             />
           </div>
         ) : (
           <div className="flex flex-col gap-4 p-4 desktop:p-0">
-            <div className="card overflow-hidden max-desktop:rounded-lg">
-              <div className="flex flex-wrap items-center gap-[11px] px-4 py-[13px]">
-                <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                  {ws.mode === 'github' ? (
-                    <span className="imark h-4 w-4 border-0 bg-transparent">
-                      <GithubMark color="var(--text-secondary)" />
-                    </span>
-                  ) : (
-                    <Icon name="folder" size={16} color="var(--text-tertiary)" />
-                  )}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="mono text-[13.5px] font-semibold text-(--text-primary)">
-                      {ws.mode === 'github' ? ws.repo : 'Scratch workspace'}
-                    </span>
-                    {ws.mode === 'github' && (
-                      <span className="mono hidden items-center gap-1 rounded-[5px] border border-(--border-subtle) bg-(--surface-sunken) px-[7px] py-px text-[11.5px] text-(--text-secondary) desktop:inline-flex">
-                        <Icon name="git-branch" size={12} />
-                        {ws.branch}
-                      </span>
-                    )}
-                    <span className="mono text-[11.5px] text-(--text-tertiary)">{da.workdir}</span>
-                  </div>
-                  <div className="mono mt-1 hidden truncate text-[11.5px] text-(--text-tertiary) desktop:block">
-                    {ws.mode === 'github' ? (
-                      ws.commitMsg ? (
-                        <>
-                          pulled {ws.lastPull} · <span className="text-(--brand-soft-text)">{ws.commit}</span>{' '}
-                          {ws.commitMsg} · {ws.commitTime}
-                        </>
-                      ) : (
-                        <>pulled {ws.lastPull}</>
-                      )
-                    ) : (
-                      <>
-                        created {ws.created} · {ws.size} on disk
-                      </>
-                    )}
-                  </div>
-                </div>
-                <span className="badge flex-none self-start" style={{ background: wss.bg, color: wss.text }}>
-                  <span className="dot h-[6px] w-[6px]" style={{ background: wss.dot }} />
-                  {wss.label}
-                </span>
-              </div>
-              <div className="hidden items-center gap-2 border-t border-(--border-subtle) px-4 py-3 desktop:flex">
-                {ws.mode === 'github' ? (
-                  <>
-                    <Button variant="secondary" size="sm">
-                      <Icon name="refresh-cw" size={14} />
-                      Pull latest
-                    </Button>
-                    <a
-                      className="lnk text-[12px] text-(--text-tertiary)"
-                      href={ws.repoUrl ?? `https://github.com/${ws.repo}`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <Icon name="external-link" size={13} />
-                      View on GitHub
-                    </a>
-                  </>
-                ) : (
-                  <span className="inline-flex items-center gap-[7px] font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
-                    <Icon name="info" size={14} />
-                    Files here are created by the agent and live only on this machine — not version-controlled.
-                  </span>
-                )}
-              </div>
-            </div>
+            <WorkspaceCard agent={da} header={mockWorkspaceHeader} />
 
             <FileBrowserShell
               title="Files"


### PR DESCRIPTION
Design sync with the AgentConnect Console design file.

## What changed

The console design no longer keeps a Workspace card in the **Configuration** tab. The workspace source, its live git state, and the files it configures now read as one surface at the top of the **Workspace** tab:

- **Source row** — a segmented `GitHub repo` / `Scratch` control, then the workspace identity (mark, repo, branch chip, clean/uncommitted badge), the HEAD commit, and the pull / view-on-remote actions.
- **Authorized repos row** — the workspace repo plus the agent's explicit repository grants, as chips with inline revoke and an `Authorize repository` affordance.

## Implementation

- `WorkspaceCard` is rewritten as that compact two-row card. The Source segment is the conversion entry point; `EditWorkspaceModal` gains an `initialMode` prop so picking the other mode opens the editor already switched to it.
- `WorkspaceFiles` keeps owning the live git read model but stops rendering it: `RepoCard`/`ScratchCard` are gone, replaced by a `renderHeader` prop that receives a `WorkspaceHeaderInfo` projection (branch, status, HEAD commit, remote URL, pull action). This keeps the card's agent-level data (repo grants, org, profile) out of the file browser while the design merges both into one row.
- The `scratch` state falls out with it — a non-repo workspace and an offline daemon now both just leave `git` null, and the card falls back to the agent's configured source.
- `AgentDetailView` drops the card from Configuration (mobile flex order renumbered 1–7) and mounts it atop the Workspace tab for both live and demo agents; demo agents fill the live half from their static mock workspace.

## Reviewer notes

Two deliberate deviations from the mock, which has no affordance for either:

1. **A pencil icon button** beside pull / view-on-remote. Without it there would be no way to change branch, working directory, or repository access — the Source segment only handles conversion between scratch and GitHub.
2. **Repo chips carry their access tier in the tooltip** rather than as a visible badge (the design's chips are bare), so the read/comment/write distinction is not lost.

Also dropped, following the design's compact shape: the scratch workspace's "not version-controlled" info line, and the mock card's "pulled X" / "created X · Y on disk" line.

## Verification

Browsed the mock stack: GitHub and scratch workspaces, Configuration tab confirmed clean, desktop + ≤768px, light + dark, and the segment → modal conversion flow opening preselected on the picked mode. `tsc --noEmit`, `eslint`, and `prettier --check` are clean; all 287 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)