### PR TITLE
fix(integrations): make Lark the default region

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -469,12 +469,14 @@ single field threaded end to end:
   `FeishuConnection` passes it to the SDK factory, which sets `domain`
   (`Lark.Domain.Feishu` / `Lark.Domain.Lark`) on both the `Lark.Client` and the
   `WSClient` long connection.
-- **Control Plane** — persisted on the `integration` row (`feishuRegion`, NULL ⇒
-  `'feishu'`); `integrationToSpec` reads it into the wire spec, and
+- **Control Plane** — new create requests default an omitted region to `'lark'`;
+  the selection is persisted on the `integration` row, while historical NULL
+  rows still resolve to `'feishu'`. `integrationToSpec` reads it into the wire spec, and
   `verifyFeishuBot` exchanges credentials against the matching gateway (verifying
   a Lark app against the Feishu host would spuriously reject it).
-- **Web** — a region selector in the Add-integration modal; the "Open the
-  console" link and copy switch between the Feishu and Lark developer consoles.
+- **Web** — the Add-integration region selector opens with Lark selected; the
+  operator can switch to Feishu, and the "Open the console" link and copy follow
+  that selection.
 
 ## 11. Current constraints and follow-ups
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -609,12 +609,12 @@ export const CreateIntegrationBody = z
       .optional(),
     /** Register a new Feishu / Lark self-built app from its appId + appSecret pair.
      *  `region` picks the open-platform gateway (feishu.cn vs larksuite.com); it
-     *  defaults to 'feishu' so older clients that omit it keep the China gateway. */
+     *  defaults to international Lark for new create requests. */
     feishu: z
       .object({
         appId: z.string().min(1),
         appSecret: z.string().min(1),
-        region: FeishuRegion.default('feishu')
+        region: FeishuRegion.default('lark')
       })
       .optional()
   })

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -387,7 +387,7 @@ export function integrationRoutes(deps: HttpDeps) {
           // appToken = appId, the identifier — appToken already nullable since Telegram).
           if (req.body.platform === 'feishu') {
             const feishu = req.body.feishu! // superRefine guarantees it when botId is absent
-            const region = feishu.region // zod-defaulted to 'feishu' when omitted
+            const region = feishu.region // zod-defaulted to 'lark' for new installs
             const check = deps.verifyFeishuBot
               ? await deps.verifyFeishuBot(feishu.appId, feishu.appSecret, region)
               : null

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -279,7 +279,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect((unreachable.json() as { name: string }).name).toBe(`agent-${agentId2.slice(0, 4)}`)
   })
 
-  it('POST feishu stores the appId+appSecret pair in the two-slot secret (botToken=appSecret, appToken=appId), pushes a feishu-shaped upsert', async () => {
+  it('POST feishu defaults omitted region to Lark, stores the credential pair, and pushes a feishu-shaped upsert', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
 
@@ -298,7 +298,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const secret = await prisma.botSecret.findUnique({ where: { botId: dto.botId as string } })
     expect(secret).toMatchObject({ botToken: FEISHU.appSecret, appToken: FEISHU.appId })
     const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
-    expect(bot).toMatchObject({ platform: 'feishu' })
+    expect(bot).toMatchObject({ platform: 'feishu', feishuRegion: 'lark' })
 
     // The daemon got a feishu-shaped spec: appId + appSecret, no slack/discord block.
     expect(spy.upserts).toHaveLength(1)
@@ -308,13 +308,13 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       integrationId: dto.id,
       agentId,
       platform: 'feishu',
-      // region defaults to 'feishu' (China gateway) when the install omits it.
-      feishu: { appId: FEISHU.appId, appSecret: FEISHU.appSecret, region: 'feishu' }
+      // New installs default to the international Lark gateway when region is omitted.
+      feishu: { appId: FEISHU.appId, appSecret: FEISHU.appSecret, region: 'lark' }
     })
-    expect(dto.region).toBe('feishu')
+    expect(dto.region).toBe('lark')
   })
 
-  it("POST feishu with region 'lark' verifies against + pushes the international gateway", async () => {
+  it("POST feishu with region 'feishu' verifies against + pushes the China gateway", async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
     const verifierCalls: Array<string | undefined> = []
@@ -323,27 +323,27 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       return { status: 'ok', name: null }
     }
 
-    const FEISHU = { appId: 'cli_lark123', appSecret: 's3cr3t-lark-xyz', region: 'lark' as const }
+    const FEISHU = { appId: 'cli_feishu123', appSecret: 's3cr3t-feishu-xyz', region: 'feishu' as const }
     const res = await app.app.inject({
       method: 'POST',
       url: `${ORG}/integrations`,
-      payload: { name: 'acme-lark', platform: 'feishu', agentId, feishu: FEISHU }
+      payload: { name: 'acme-feishu', platform: 'feishu', agentId, feishu: FEISHU }
     })
     expect(res.statusCode).toBe(201)
     const dto = res.json() as Record<string, unknown>
-    expect(dto.region).toBe('lark')
+    expect(dto.region).toBe('feishu')
 
-    // The verifier was asked to check against the Lark gateway, not the default Feishu one.
-    expect(verifierCalls).toEqual(['lark'])
+    // Explicit Feishu selection overrides the new Lark default.
+    expect(verifierCalls).toEqual(['feishu'])
 
-    // The daemon's spec carries region 'lark' so its SDK dials open.larksuite.com.
+    // The daemon's spec carries region 'feishu' so its SDK dials open.feishu.cn.
     const u = spy.upserts[0]!.u
     if (u.platform !== 'feishu') throw new Error('expected feishu upsert')
-    expect(u.feishu).toMatchObject({ appId: FEISHU.appId, region: 'lark' })
+    expect(u.feishu).toMatchObject({ appId: FEISHU.appId, region: 'feishu' })
 
     // Persisted on the integration row so a reconnect reconstructs the same region.
     const row = await prisma.integration.findUnique({ where: { id: dto.id as string } })
-    expect(row?.feishuRegion).toBe('lark')
+    expect(row?.feishuRegion).toBe('feishu')
   })
 
   it('POST rejects feishu credentials Feishu refuses (400) and stores nothing', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -440,8 +440,8 @@ export default function AddIntegrationModal({
   const [appName, setAppName] = useState(agent.name)
   const [botToken, setBotToken] = useState('')
   const [appToken, setAppToken] = useState('')
-  // Feishu/Lark gateway: 'feishu' (open.feishu.cn, China) vs 'lark' (open.larksuite.com, intl).
-  const [feishuRegion, setFeishuRegion] = useState<'feishu' | 'lark'>('feishu')
+  // Feishu/Lark gateway: new installs default to international Lark.
+  const [feishuRegion, setFeishuRegion] = useState<'feishu' | 'lark'>('lark')
   const [saving, setSaving] = useState(false)
   const [showErrors, setShowErrors] = useState(false)
   const [err, setErr] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

- keep the existing Lark / Feishu selector and open it with Lark selected for new integrations
- default omitted `region` values to Lark in the create-integration API
- preserve the Feishu fallback for historical rows and legacy daemon/protocol configuration

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm exec eslint packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/integrations.route.test.ts` (37 passed)
- pre-push `eslint .` completed with 2 pre-existing duplicate-import warnings

Created by Codex . GPT-5