### PR TITLE
fix(web): tighten agent form section spacing

### DIFF
--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -1352,7 +1352,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
           <section ref={sectionRef('access')} className="mt-5 border-t border-(--border-subtle) pt-5">
             <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Access</div>
-            <div className="mt-[13px] flex flex-col gap-[14px]">
+            <div className="flex flex-col gap-[14px]">
               <VisibilityField
                 value={sharing}
                 onChange={setSharing}
@@ -1423,17 +1423,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           </section>
 
           <section ref={sectionRef('secrets')} className="mt-5 border-t border-(--border-subtle) pt-5">
-            <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-              Variables and Secrets
-            </div>
-            <div className="mt-[13px]">
-              <EnvSecretsFields
-                envRows={envRows}
-                setEnvRows={setEnvRows}
-                secretRows={secretRows}
-                setSecretRows={setSecretRows}
-              />
-            </div>
+            <EnvSecretsFields
+              envRows={envRows}
+              setEnvRows={setEnvRows}
+              secretRows={secretRows}
+              setSecretRows={setSecretRows}
+            />
           </section>
         </div>
       </div>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -747,7 +747,7 @@ export default function EditAgentModal({
 
             <section ref={sectionRef('access')} className="mt-5 border-t border-(--border-subtle) pt-5">
               <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Access</div>
-              <div className="mt-[13px] flex flex-col gap-[14px]">
+              <div className="flex flex-col gap-[14px]">
                 <VisibilityField
                   value={sharing}
                   onChange={setSharing}
@@ -796,17 +796,12 @@ export default function EditAgentModal({
             </section>
 
             <section ref={sectionRef('secrets')} className="mt-5 border-t border-(--border-subtle) pt-5">
-              <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                Variables and Secrets
-              </div>
-              <div className="mt-[13px]">
-                <EnvSecretsFields
-                  envRows={envRows}
-                  setEnvRows={setEnvRows}
-                  secretRows={secretRows}
-                  setSecretRows={setSecretRows}
-                />
-              </div>
+              <EnvSecretsFields
+                envRows={envRows}
+                setEnvRows={setEnvRows}
+                secretRows={secretRows}
+                setSecretRows={setSecretRows}
+              />
             </section>
 
             {placementRequested && (


### PR DESCRIPTION
## Summary

- remove the redundant `Variables and Secrets` heading from the create and edit agent form content while keeping the navigation label
- tighten the spacing between `Access` and `Team visibility` in both forms

## Why

The access section was applying both the section content margin and `VisibilityField`'s own top margin, which created excessive vertical whitespace. The variables/secrets section also repeated the navigation label as a content heading without adding information.

## Impact

Agent creation and editing now use a more compact, consistent layout on desktop and mobile. Form behavior and data flow are unchanged.

## Validation

- `pnpm exec prettier --check packages/web/src/components/console/modals/AddAgentModal.tsx packages/web/src/components/console/modals/EditAgentModal.tsx`
- `pnpm exec eslint packages/web/src/components/console/modals/AddAgentModal.tsx packages/web/src/components/console/modals/EditAgentModal.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- local visual verification in mock mode at desktop width and 390px mobile width

Created by Codex . gpt-5.6-sol
