### PR TITLE
test(daemon): synchronize dream cancellation test

### DIFF
--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -258,6 +258,10 @@ describe('DreamRunner pipeline', () => {
     // never resolves and the one-in-flight reservation is pinned forever.
     let sawAbort = false
     let calls = 0
+    let markFirstExtractionReady!: () => void
+    const firstExtractionReady = new Promise<void>((resolve) => {
+      markFirstExtractionReady = resolve
+    })
     const { store, runner } = await setup({
       extract: (_a, _s, _p, signal) => {
         // First extraction hangs until aborted; the replacement completes normally.
@@ -267,11 +271,12 @@ describe('DreamRunner pipeline', () => {
             sawAbort = true
             reject(new Error('aborted'))
           })
+          markFirstExtractionReady()
         })
       }
     })
     const first = await runner.start('a1', { trigger: 'manual' })
-    await new Promise((r) => setTimeout(r, 10))
+    await firstExtractionReady
     runner.cancel('a1', first.dreamId)
     const done = await settle(store, first.dreamId)
     expect(sawAbort).toBe(true)


### PR DESCRIPTION
## Summary

- wait until the first dream extraction has installed its abort listener before canceling it
- remove the fixed 10 ms delay that raced with snapshot I/O on busy CI runners
- keep production behavior unchanged

## Root cause

`DreamRunner.start()` schedules the pipeline while it is still writing the snapshot input. The test assumed 10 ms was always enough for extraction to begin. Under load, cancellation could land while the dream was still pending, correctly skip extraction, and leave the test-only `sawAbort` flag false.

## Validation

- focused cancellation test passed in 30 independent Vitest runs
- `pnpm exec prettier --check packages/daemon/test/dream-runner.test.ts`
- `env CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon test:unit` (127 files passed, 1 skipped; 2038 tests passed, 2 skipped)
- pre-push `eslint .` (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
