### PR TITLE
fix(webchat): polish composer controls

### DIFF
--- a/packages/web/src/components/console/ComposerMenu.test.tsx
+++ b/packages/web/src/components/console/ComposerMenu.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ComposerMenu } from './ComposerMenu'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function Harness() {
+  const [open, setOpen] = useState(false)
+  const [value, setValue] = useState('low')
+  return (
+    <ComposerMenu
+      title="Effort"
+      value={value}
+      options={[
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' }
+      ]}
+      open={open}
+      onOpenChange={setOpen}
+      onChange={setValue}
+    />
+  )
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+describe('ComposerMenu', () => {
+  it('opens a titled popover and applies the selected option', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root?.render(<Harness />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!
+    await act(async () => trigger.click())
+
+    const menu = container.querySelector<HTMLElement>('[role="menu"]')
+    expect(menu?.textContent).toContain('Effort')
+    const high = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? []).find(
+      (option) => option.textContent === 'High'
+    )!
+
+    await act(async () => high.click())
+
+    expect(trigger.textContent).toContain('High')
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useId, useRef, type KeyboardEvent } from 'react'
+import { Icon } from '@/components/ui'
+
+type ComposerMenuChoice = { value: string; label: string }
+
+export function ComposerMenu({
+  title,
+  value,
+  options,
+  open,
+  align = 'right',
+  onOpenChange,
+  onChange
+}: {
+  title: string
+  value: string
+  options: ComposerMenuChoice[]
+  open: boolean
+  align?: 'left' | 'right'
+  onOpenChange: (open: boolean) => void
+  onChange: (value: string) => void
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuId = useId()
+  const headingId = useId()
+  const selected = options.find((choice) => choice.value === value) ?? options[0]
+
+  const closeAndFocus = () => {
+    onOpenChange(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const pick = (next: string) => {
+    onChange(next)
+    closeAndFocus()
+  }
+
+  const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    const options = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'))
+    if (options.length === 0) return
+    const current = Math.max(0, options.indexOf(document.activeElement as HTMLButtonElement))
+    const next =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? options.length - 1
+          : (current + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length
+    options[next]?.focus()
+  }
+
+  return (
+    <div className="relative flex-none">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="inline-flex h-6 items-center gap-1 rounded-sm px-1 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover)"
+        aria-label={`${title}: ${selected?.label ?? value}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => onOpenChange(!open)}
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+          event.preventDefault()
+          onOpenChange(true)
+        }}
+      >
+        <span>{selected?.label ?? value}</span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => onOpenChange(false)} />
+          <div
+            id={menuId}
+            role="menu"
+            aria-labelledby={headingId}
+            className={`absolute bottom-[calc(100%+8px)] z-50 min-w-[148px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
+              align === 'left' ? 'left-0' : 'right-0'
+            }`}
+            onKeyDown={moveFocus}
+          >
+            <div
+              id={headingId}
+              className="px-2 pt-[5px] pb-1 font-sans text-[10.5px] font-semibold leading-normal text-(--text-tertiary)"
+            >
+              {title}
+            </div>
+            {options.map((choice) => {
+              const selectedChoice = choice.value === selected?.value
+              return (
+                <button
+                  key={choice.value}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selectedChoice}
+                  autoFocus={selectedChoice}
+                  className={`fopt min-h-8 gap-2 rounded-md px-2 py-[5px] text-[12px] ${
+                    selectedChoice ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
+                  }`}
+                  onClick={() => pick(choice.value)}
+                >
+                  <span className="min-w-0 flex-1 truncate text-left">{choice.label}</span>
+                  {selectedChoice && <Icon name="check" size={14} color="var(--brand)" className="flex-none" />}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/ContextWindowIndicator.tsx
+++ b/packages/web/src/components/console/ContextWindowIndicator.tsx
@@ -39,16 +39,16 @@ export function ContextWindowIndicator({ used, size }: { used?: number; size?: n
       <span
         id={tooltipId}
         role="tooltip"
-        className="pointer-events-none invisible absolute right-0 bottom-full z-30 mb-2 min-w-[210px] max-w-[calc(100vw-40px)] translate-y-1 rounded-md border border-(--border-default) bg-(--surface-card) px-3 py-[9px] text-center opacity-0 shadow-(--shadow-lg) transition-[opacity,transform,visibility] group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 desktop:right-auto desktop:left-1/2 desktop:-translate-x-1/2"
+        className="pointer-events-none invisible absolute right-0 bottom-full z-30 mb-2 min-w-[174px] max-w-[calc(100vw-40px)] translate-y-1 rounded-[7px] border border-(--border-default) bg-(--surface-card) px-[10px] py-2 text-center opacity-0 shadow-(--shadow-lg) transition-[opacity,transform,visibility] group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 desktop:right-auto desktop:left-1/2 desktop:-translate-x-1/2"
       >
-        <span className="block font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
+        <span className="block font-sans text-[10.5px] font-medium leading-normal text-(--text-tertiary)">
           Context window:
         </span>
-        <span className="mt-[5px] block font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+        <span className="mt-[3px] block font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
           {percentage == null ? 'Usage unavailable' : `${percentage}% used (${100 - percentage}% left)`}
         </span>
         {usedText && (
-          <span className="mt-[5px] block font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+          <span className="mt-[3px] block font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
             {sizeText ? `${usedText} / ${sizeText} tokens used` : `${usedText} tokens used`}
           </span>
         )}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -6,14 +6,15 @@ import { useParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import {
   agentLabel,
+  agentPermissionDisplay,
   displayedEffort,
   effortLabel,
+  fastModeAvailableFor,
   fileColor,
   isSelfSender,
   lane,
   modelCapability,
   modelLabel,
-  permissionModeDefault,
   permissionModeLabel,
   pgPrompts,
   platName,
@@ -51,6 +52,7 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { sessionSenderLabel } from '@/lib/session-trigger'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
+import { ComposerMenu } from '@/components/console/ComposerMenu'
 import {
   sessionEffortAfterModelChange,
   sessionEffortChoicesForSelection,
@@ -58,6 +60,8 @@ import {
   sessionPermissionSelection,
   sessionRuntimeChangesEnabled
 } from '@/lib/session-runtime-controls'
+
+type ComposerMenuKey = 'permission' | 'model' | 'effort' | 'fast'
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
 // transcript kind (text | tool | reasoning) onto the existing lane styling.
@@ -550,6 +554,7 @@ export default function SessionDetailView() {
   const [imagePreparing, setImagePreparing] = useState(false)
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
+  const [composerMenuOpen, setComposerMenuOpen] = useState<ComposerMenuKey | null>(null)
   const [runtimeSelections, setRuntimeSelections] = useState<
     Record<string, { model?: string; effort?: string; permissionMode?: string }>
   >({})
@@ -951,13 +956,17 @@ export default function SessionDetailView() {
   const runtimeCatalog = runtimeProfile?.modelCatalog ?? undefined
   const pgModel =
     runtimeSelection?.model ?? (session.model || owner?.model || preferredModelFor(owningDaemon, agentRuntime))
-  const pgModels = runtimeChangesEnabled ? (session.availableModels ?? runtimeProfile?.models ?? []) : []
+  const pgModels = session.availableModels ?? runtimeProfile?.models ?? []
   const pgModelOptions =
     pgModels.length > 0 && pgModel && !pgModels.includes(pgModel) ? [pgModel, ...pgModels] : pgModels
   const selectedModelCapability = modelCapability(owningDaemon, agentRuntime, pgModel)
-  const pgEffortChoices = runtimeChangesEnabled
-    ? sessionEffortChoicesForSelection(agentRuntime, owningDaemon, pgModel, session.model, session.availableEfforts)
-    : []
+  const pgEffortChoices = sessionEffortChoicesForSelection(
+    agentRuntime,
+    owningDaemon,
+    pgModel,
+    session.model,
+    session.availableEfforts
+  )
   const pgEffort = displayedEffort(
     runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? '',
     pgEffortChoices,
@@ -973,42 +982,38 @@ export default function SessionDetailView() {
     agentRuntime,
     runtimeCatalog,
     livePermissionModes,
-    runtimeSelection?.permissionMode ??
-      session.permissionMode ??
-      owner?.permissionMode ??
-      permissionModeDefault(agentRuntime)
+    runtimeSelection?.permissionMode ?? session.permissionMode ?? owner?.permissionMode ?? ''
   )
-  const pgPermissionModes = runtimeChangesEnabled
-    ? livePermissionModes === undefined &&
-      pgPermissionMode &&
-      !selectablePermissionModes.some((choice) => choice.v === pgPermissionMode)
+  const pgPermissionModes =
+    livePermissionModes === undefined &&
+    pgPermissionMode &&
+    !selectablePermissionModes.some((choice) => choice.v === pgPermissionMode)
       ? [{ v: pgPermissionMode, l: permissionModeLabel(agentRuntime, pgPermissionMode) }, ...selectablePermissionModes]
       : selectablePermissionModes
-    : []
-  // Shared style for the inline composer selectors.
-  const pgSelectClass =
-    'cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)'
+  const pgFastMode = session.fastMode ?? owner?.fastMode ?? false
+  const pgFastModeAvailable =
+    (pgModel === session.model ? session.fastModeAvailable : undefined) ??
+    fastModeAvailableFor(agentRuntime, selectedModelCapability)
   const pgStatusBar = (
     <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1 font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary)">
-      {pgPermissionModes.length > 0 ? (
-        <select
-          aria-label="Session permission mode"
+      {runtimeChangesEnabled && pgPermissionModes.length > 0 ? (
+        <ComposerMenu
+          title="Permission"
           value={pgPermissionMode}
-          onChange={(event) => {
-            const permissionMode = event.target.value
+          options={pgPermissionModes.map((mode) => ({ value: mode.v, label: mode.l }))}
+          open={composerMenuOpen === 'permission'}
+          align="left"
+          onOpenChange={(open) => {
+            setAttachMenuOpen(false)
+            setComposerMenuOpen(open ? 'permission' : null)
+          }}
+          onChange={(permissionMode) => {
             setRuntimeSelection({ permissionMode })
             pgSetPermissionMode(session.id, session.agentId ?? '', permissionMode, webchatConversationId)
           }}
-          className={pgSelectClass}
-        >
-          {pgPermissionModes.map((mode) => (
-            <option key={mode.v} value={mode.v}>
-              {mode.l}
-            </option>
-          ))}
-        </select>
+        />
       ) : (
-        session.permissionMode && <span>{permissionModeLabel(session.runtime ?? '', session.permissionMode)}</span>
+        pgPermissionMode && <span>{agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionMode)}</span>
       )}
       <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
         <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
@@ -1017,15 +1022,20 @@ export default function SessionDetailView() {
         </span>
         <span className="font-mono text-[11.5px] font-medium leading-normal">{session.cost}</span>
         <span className="inline-flex items-center gap-[6px] text-(--text-secondary)">
-          <span className="av h-4 w-4 flex-none rounded-xs">
+          <span className="inline-flex h-4 w-4 flex-none items-center justify-center">
             <AgentMark model={agentRuntime} />
           </span>
-          {pgModelOptions.length > 0 ? (
-            <select
-              aria-label="Session model"
+          {runtimeChangesEnabled && pgModelOptions.length > 0 ? (
+            <ComposerMenu
+              title="Model"
               value={pgModel}
-              onChange={(event) => {
-                const model = event.target.value
+              options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
+              open={composerMenuOpen === 'model'}
+              onOpenChange={(open) => {
+                setAttachMenuOpen(false)
+                setComposerMenuOpen(open ? 'model' : null)
+              }}
+              onChange={(model) => {
                 const currentEffort = runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
                 const effort = sessionEffortAfterModelChange(agentRuntime, owningDaemon, model, currentEffort)
                 setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
@@ -1034,55 +1044,50 @@ export default function SessionDetailView() {
                   pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
                 }
               }}
-              className={pgSelectClass}
-            >
-              {pgModelOptions.map((model) => (
-                <option key={model} value={model}>
-                  {modelLabel(model)}
-                </option>
-              ))}
-            </select>
+            />
           ) : (
-            modelLabel(session.model ?? '')
+            modelLabel(pgModel)
           )}
         </span>
-        {pgEffortOptions.length > 0 && (
-          <select
-            aria-label="Session reasoning effort"
+        {runtimeChangesEnabled && pgEffortOptions.length > 0 && (
+          <ComposerMenu
+            title="Effort"
             value={pgEffort}
-            onChange={(event) => {
-              const effort = event.target.value
+            options={pgEffortOptions.map((effort) => ({ value: effort.value, label: effort.label }))}
+            open={composerMenuOpen === 'effort'}
+            onOpenChange={(open) => {
+              setAttachMenuOpen(false)
+              setComposerMenuOpen(open ? 'effort' : null)
+            }}
+            onChange={(effort) => {
               setRuntimeSelection({ effort })
               pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
             }}
-            className={pgSelectClass}
-          >
-            {pgEffortOptions.map((effort) => (
-              <option key={effort.value} value={effort.value}>
-                {effort.label}
-              </option>
-            ))}
-          </select>
+          />
         )}
-        {!runtimeChangesEnabled && (session.effort ?? owner?.reasoning) && (
-          <span>effort: {session.effort ?? owner?.reasoning}</span>
+        {!runtimeChangesEnabled && pgEffort && (
+          <span>
+            effort:{' '}
+            {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ?? effortLabel(agentRuntime, pgEffort)}
+          </span>
         )}
-        {runtimeChangesEnabled && session.fastModeAvailable && (
-          <select
-            aria-label="Session fast mode"
-            value={session.fastMode ? 'on' : 'off'}
-            onChange={(e) =>
-              pgSetFast(session.id, session.agentId ?? '', e.target.value === 'on', webchatConversationId)
-            }
-            className={pgSelectClass}
-          >
-            <option value="on">fast: on</option>
-            <option value="off">fast: off</option>
-          </select>
+        {runtimeChangesEnabled && pgFastModeAvailable && (
+          <ComposerMenu
+            title="Fast mode"
+            value={pgFastMode ? 'on' : 'off'}
+            options={[
+              { value: 'on', label: 'fast: on' },
+              { value: 'off', label: 'fast: off' }
+            ]}
+            open={composerMenuOpen === 'fast'}
+            onOpenChange={(open) => {
+              setAttachMenuOpen(false)
+              setComposerMenuOpen(open ? 'fast' : null)
+            }}
+            onChange={(fast) => pgSetFast(session.id, session.agentId ?? '', fast === 'on', webchatConversationId)}
+          />
         )}
-        {!runtimeChangesEnabled && session.fastMode !== undefined && (
-          <span>fast: {session.fastMode ? 'on' : 'off'}</span>
-        )}
+        {!runtimeChangesEnabled && pgFastModeAvailable && <span>fast: {pgFastMode ? 'on' : 'off'}</span>}
       </div>
     </div>
   )
@@ -1554,109 +1559,117 @@ export default function SessionDetailView() {
             {imageError && (
               <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
             )}
-            <div
-              className="pgcomposer relative flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default) desktop:ml-[41px] desktop:mt-4"
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') setAttachMenuOpen(false)
-              }}
-            >
-              <input
-                ref={imageInputRef}
-                type="file"
-                accept="image/*"
-                hidden
-                onChange={(event) => void onImageFile(event.target.files?.[0])}
-              />
-              <div className="flex min-w-0 flex-col">
-                {pgImage && (
-                  <div className="relative mb-2 w-fit">
-                    <img
-                      src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
-                      alt={pgImage.name}
-                      title={pgImage.name}
-                      className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
-                    />
+            <div className="flex items-start gap-[10px] desktop:mt-4 desktop:gap-[11px]">
+              <Avatar src={user.picture} initials={user.initials} size={30} fontSize={11} />
+              <div
+                className="pgcomposer relative min-w-0 flex-1 flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default)"
+                onKeyDown={(event) => {
+                  if (event.key !== 'Escape') return
+                  setAttachMenuOpen(false)
+                  setComposerMenuOpen(null)
+                }}
+              >
+                <input
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(event) => void onImageFile(event.target.files?.[0])}
+                />
+                <div className="flex min-w-0 flex-col">
+                  {pgImage && (
+                    <div className="relative mb-2 w-fit">
+                      <img
+                        src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
+                        alt={pgImage.name}
+                        title={pgImage.name}
+                        className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                      />
+                      <button
+                        type="button"
+                        className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+                        title="Remove image"
+                        aria-label="Remove image"
+                        onClick={() => setPgImage(session.id)}
+                      >
+                        <Icon name="x" size={14} />
+                      </button>
+                    </div>
+                  )}
+                  <textarea
+                    className="pgin w-full border-0 px-1 py-2 focus:shadow-none"
+                    placeholder={`Message ${session.agentName}…`}
+                    value={pgInput}
+                    onChange={(e) => setPgInput(e.target.value)}
+                    onPaste={(event) => {
+                      const image = clipboardImageFile(event.clipboardData)
+                      if (!image) return
+                      event.preventDefault()
+                      void onImageFile(image)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault()
+                        onPgSend()
+                      }
+                    }}
+                  />
+                </div>
+                <div className="flex min-w-0 items-center gap-2">
+                  <div className="relative flex-none">
                     <button
                       type="button"
-                      className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
-                      title="Remove image"
-                      aria-label="Remove image"
-                      onClick={() => setPgImage(session.id)}
+                      className="iconbtn h-7 w-7 rounded-sm"
+                      aria-label="Add"
+                      aria-haspopup="menu"
+                      aria-expanded={attachMenuOpen}
+                      disabled={imagePreparing}
+                      onClick={() => {
+                        setComposerMenuOpen(null)
+                        setAttachMenuOpen((open) => !open)
+                      }}
                     >
-                      <Icon name="x" size={14} />
+                      {imagePreparing ? <Spinner size={14} /> : <Icon name="plus" size={17} />}
                     </button>
-                  </div>
-                )}
-                <textarea
-                  className="pgin w-full border-0 px-1 py-2 focus:shadow-none"
-                  placeholder={`Message ${session.agentName}…`}
-                  value={pgInput}
-                  onChange={(e) => setPgInput(e.target.value)}
-                  onPaste={(event) => {
-                    const image = clipboardImageFile(event.clipboardData)
-                    if (!image) return
-                    event.preventDefault()
-                    void onImageFile(image)
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault()
-                      onPgSend()
-                    }
-                  }}
-                />
-              </div>
-              <div className="flex min-w-0 items-center gap-2">
-                <div className="relative flex-none">
-                  <button
-                    type="button"
-                    className="iconbtn"
-                    aria-label="Add"
-                    aria-haspopup="menu"
-                    aria-expanded={attachMenuOpen}
-                    disabled={imagePreparing}
-                    onClick={() => setAttachMenuOpen((open) => !open)}
-                  >
-                    {imagePreparing ? <Spinner size={16} /> : <Icon name="plus" size={19} />}
-                  </button>
-                  {attachMenuOpen && (
-                    <>
-                      <div
-                        aria-hidden="true"
-                        className="fixed inset-0 z-40"
-                        onClick={() => setAttachMenuOpen(false)}
-                      ></div>
-                      <div
-                        role="menu"
-                        className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-                      >
-                        <button
-                          type="button"
-                          role="menuitem"
-                          className="fopt"
-                          onClick={() => {
-                            setAttachMenuOpen(false)
-                            imageInputRef.current?.click()
-                          }}
+                    {attachMenuOpen && (
+                      <>
+                        <div
+                          aria-hidden="true"
+                          className="fixed inset-0 z-40"
+                          onClick={() => setAttachMenuOpen(false)}
+                        ></div>
+                        <div
+                          role="menu"
+                          className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
                         >
-                          <Icon name="image" size={16} color="var(--text-secondary)" />
-                          Add photos
-                        </button>
-                      </div>
-                    </>
-                  )}
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="fopt"
+                            onClick={() => {
+                              setAttachMenuOpen(false)
+                              imageInputRef.current?.click()
+                            }}
+                          >
+                            <Icon name="image" size={16} color="var(--text-secondary)" />
+                            Add photos
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                  {pgStatusBar}
+                  <button
+                    className="sendbtn h-7 w-7 rounded-sm"
+                    aria-label={pgBusy ? 'Stop response' : 'Send message'}
+                    onClick={() =>
+                      pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
+                    }
+                    disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
+                  >
+                    <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
+                  </button>
                 </div>
-                {pgStatusBar}
-                <button
-                  className="sendbtn h-8 w-8 rounded-md"
-                  aria-label={pgBusy ? 'Stop response' : 'Send message'}
-                  onClick={() =>
-                    pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
-                  }
-                  disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
-                >
-                  <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 12 : 16} />
-                </button>
               </div>
             </div>
           </>

--- a/packages/web/src/lib/session-runtime-controls.test.ts
+++ b/packages/web/src/lib/session-runtime-controls.test.ts
@@ -58,7 +58,13 @@ describe('session runtime controls', () => {
 
   it('resolves the selected permission from a narrowed live list', () => {
     expect(sessionPermissionSelection('codex', catalog, ['default'], 'full-access')).toBe('default')
-    expect(sessionPermissionSelection('codex', catalog, [], 'full-access')).toBe('')
+    expect(sessionPermissionSelection('codex', catalog, [], 'full-access')).toBe('full-access')
+    expect(sessionPermissionSelection('codex', catalog, [], '')).toBe('default')
+  })
+
+  it('shows the runtime permission default when no override is stored', () => {
+    expect(sessionPermissionSelection('codex', catalog, undefined, '')).toBe('default')
+    expect(sessionPermissionSelection('codex', undefined, undefined, '')).toBe('agent')
   })
 
   it('moves an unavailable effort to the selected model default', () => {

--- a/packages/web/src/lib/session-runtime-controls.ts
+++ b/packages/web/src/lib/session-runtime-controls.ts
@@ -3,6 +3,7 @@ import {
   effortLabel,
   modelCapability,
   permissionModeChoicesFor,
+  permissionModeDefault,
   permissionModeLabel,
   resolvedPermissionMode,
   resolveEffortForModel,
@@ -61,7 +62,7 @@ export function sessionPermissionChoices(
   )
 }
 
-/** Resolve the displayed permission from the same vocabulary rendered by the select. */
+/** Resolve the displayed permission while keeping an empty live list authoritative for menu availability. */
 export function sessionPermissionSelection(
   runtime: string,
   catalog: RuntimeModelCatalog | undefined,
@@ -69,7 +70,11 @@ export function sessionPermissionSelection(
   current: string
 ): string {
   const choices = sessionPermissionChoices(runtime, catalog, liveValues)
-  if (liveValues === undefined) return resolvedPermissionMode(current, choices, catalog)
+  const resolvedCurrent = current || catalog?.defaultPermissionMode || permissionModeDefault(runtime)
+  if (liveValues === undefined) {
+    return resolvedPermissionMode(resolvedCurrent, choices, catalog)
+  }
+  if (choices.length === 0) return resolvedCurrent
   if (choices.some((choice) => choice.v === current)) return current
   const defaultMode = catalog?.defaultPermissionMode
   if (defaultMode && choices.some((choice) => choice.v === defaultMode)) return defaultMode


### PR DESCRIPTION
## Summary

- keep the signed-in user's avatar in the composer gutter while the input stays aligned with transcript bubbles
- reduce the Add and Send controls to 28px
- resolve model, effort, permission, and fast-mode display values from the runtime catalog before the first daemon session exists
- replace native runtime selectors with compact titled popovers for Permission, Model, Effort, and Fast mode
- keep the official codex-acp registry mark while removing the unrelated agent-avatar plate behind it
- tighten the Context window tooltip typography and spacing to match the Codex composer

## Root cause

The composer reserved the transcript avatar gutter with margin alone, so a fresh Playground left that space visibly empty. Its pre-session read-only state also rendered raw session overrides instead of the same daemon-catalog defaults used by editable controls. Native selects could not present setting titles, and the runtime mark inherited the dark agent-avatar plate rather than rendering as a standalone ACP mark.

## Impact

A new Playground now looks complete before the first message: the user's avatar is present, runtime defaults are visible but remain read-only until the daemon creates the session, and the controls stay compact. Once changes are allowed, every runtime menu has a labeled, keyboard-navigable popover.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- focused ComposerMenu and runtime-default regressions: 2 files, 7 tests
- full Web suite: 49 files, 308 tests
- `pnpm --filter @agentconnect.md/web build`
- changed-file ESLint and Prettier
- cumulative diff-check
- verified generated CSS places the 28px size utilities after the legacy 30px/40px semantic button rules

Created by Codex . GPT-5
