### PR TITLE
fix(webchat): add composer setting tooltips

### DIFF
--- a/packages/web/src/components/console/ComposerMenu.test.tsx
+++ b/packages/web/src/components/console/ComposerMenu.test.tsx
@@ -18,7 +18,7 @@ function Harness() {
       title="Effort"
       value={value}
       options={[
-        { value: 'low', label: 'Low' },
+        { value: 'low', label: 'Low', description: 'Faster, lighter reasoning' },
         { value: 'high', label: 'High' }
       ]}
       open={open}
@@ -43,17 +43,21 @@ describe('ComposerMenu', () => {
     await act(async () => root?.render(<Harness />))
 
     const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!
+    expect(trigger.title).toBe('Faster, lighter reasoning')
     await act(async () => trigger.click())
 
     const menu = container.querySelector<HTMLElement>('[role="menu"]')
     expect(menu?.textContent).toContain('Effort')
+    expect(menu?.querySelector<HTMLButtonElement>('[role="menuitemradio"]')?.title).toBe('Faster, lighter reasoning')
     const high = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? []).find(
       (option) => option.textContent === 'High'
     )!
+    expect(high.title).toBe('Effort: High')
 
     await act(async () => high.click())
 
     expect(trigger.textContent).toContain('High')
+    expect(trigger.title).toBe('Effort: High')
     expect(container.querySelector('[role="menu"]')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -3,7 +3,7 @@
 import { useId, useRef, type KeyboardEvent } from 'react'
 import { Icon } from '@/components/ui'
 
-type ComposerMenuChoice = { value: string; label: string }
+type ComposerMenuChoice = { value: string; label: string; description?: string }
 
 export function ComposerMenu({
   title,
@@ -26,6 +26,8 @@ export function ComposerMenu({
   const menuId = useId()
   const headingId = useId()
   const selected = options.find((choice) => choice.value === value) ?? options[0]
+  const tooltipFor = (choice: ComposerMenuChoice | undefined) =>
+    choice?.description ?? (choice ? `${title}: ${choice.label}` : title)
 
   const closeAndFocus = () => {
     onOpenChange(false)
@@ -68,6 +70,7 @@ export function ComposerMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
+        title={tooltipFor(selected)}
         onClick={() => onOpenChange(!open)}
         onKeyDown={(event) => {
           if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
@@ -105,6 +108,7 @@ export function ComposerMenu({
                   role="menuitemradio"
                   aria-checked={selectedChoice}
                   autoFocus={selectedChoice}
+                  title={tooltipFor(choice)}
                   className={`fopt min-h-8 gap-2 rounded-md px-2 py-[5px] text-[12px] ${
                     selectedChoice ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
                   }`}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1000,7 +1000,11 @@ export default function SessionDetailView() {
         <ComposerMenu
           title="Permission"
           value={pgPermissionMode}
-          options={pgPermissionModes.map((mode) => ({ value: mode.v, label: mode.l }))}
+          options={pgPermissionModes.map((mode) => ({
+            value: mode.v,
+            label: mode.l,
+            description: mode.description
+          }))}
           open={composerMenuOpen === 'permission'}
           align="left"
           onOpenChange={(open) => {
@@ -1013,7 +1017,9 @@ export default function SessionDetailView() {
           }}
         />
       ) : (
-        pgPermissionMode && <span>{agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionMode)}</span>
+        pgPermissionMode && (
+          <span title="Permission">{agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionMode)}</span>
+        )
       )}
       <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
         <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
@@ -1046,14 +1052,18 @@ export default function SessionDetailView() {
               }}
             />
           ) : (
-            modelLabel(pgModel)
+            <span title="Model">{modelLabel(pgModel)}</span>
           )}
         </span>
         {runtimeChangesEnabled && pgEffortOptions.length > 0 && (
           <ComposerMenu
             title="Effort"
             value={pgEffort}
-            options={pgEffortOptions.map((effort) => ({ value: effort.value, label: effort.label }))}
+            options={pgEffortOptions.map((effort) => ({
+              value: effort.value,
+              label: effort.label,
+              description: effort.description
+            }))}
             open={composerMenuOpen === 'effort'}
             onOpenChange={(open) => {
               setAttachMenuOpen(false)
@@ -1066,7 +1076,7 @@ export default function SessionDetailView() {
           />
         )}
         {!runtimeChangesEnabled && pgEffort && (
-          <span>
+          <span title="Effort">
             effort:{' '}
             {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ?? effortLabel(agentRuntime, pgEffort)}
           </span>
@@ -1087,7 +1097,9 @@ export default function SessionDetailView() {
             onChange={(fast) => pgSetFast(session.id, session.agentId ?? '', fast === 'on', webchatConversationId)}
           />
         )}
-        {!runtimeChangesEnabled && pgFastModeAvailable && <span>fast: {pgFastMode ? 'on' : 'off'}</span>}
+        {!runtimeChangesEnabled && pgFastModeAvailable && (
+          <span title="Fast mode">fast: {pgFastMode ? 'on' : 'off'}</span>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- add hover and keyboard-focus tooltips to the Permission, Model, Effort, and Fast mode composer controls
- preserve runtime-provided effort and permission descriptions in the compact menus
- give every menu option a useful fallback tooltip such as `Model: gpt-5.6-terra` when the runtime has no description
- keep read-only runtime values labeled through the same delegated tooltip layer

## Root cause

`ComposerMenu` accepted only `value` and `label`, so descriptions discovered from the runtime catalog were discarded before rendering. Its trigger also used the `title` prop only as the popover heading and never forwarded it to the console's delegated tooltip API.

## Impact

Hovering or keyboard-focusing composer runtime controls now explains what they represent. Menu options surface the runtime's own descriptions when available and remain informative when metadata is absent.

## Validation

- focused ComposerMenu and delegated-tooltip tests: 2 files, 9 tests
- full Web suite: 49 files, 308 tests
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @agentconnect.md/web build`
- changed-file ESLint and Prettier
- `git diff --check`

Created by Codex . GPT-5
