### PR TITLE
feat(daemon): increase default max agents

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -290,7 +290,7 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
 
   // ---------- Local capacity/limits ----------
   "limits": {
-    "maxAgents": 8,
+    "maxAgents": 32,
     "maxConcurrentSessions": 32,
     "agentIdleTimeoutMs": 900000 // Reclaim ACP adapter after 15m idle; background-aware reclaim: background-task-aware-reclaim.md.
   }
@@ -956,7 +956,7 @@ control channel.
     "acp": true,
     "features": [] // Capability flags
   },
-  "maxAgents": 8,
+  "maxAgents": 32,
   "localState": {
     // What the daemon currently believes it holds, used for reconciliation
     "assignments": ["slack:C0TEAM:-"], // Session keys currently being served

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -151,7 +151,7 @@ export const ConfigSchema = z.object({
     .default({ level: 'info' }),
   limits: z
     .object({
-      maxAgents: z.number().int().default(8),
+      maxAgents: z.number().int().default(32),
       maxConcurrentSessions: z.number().int().default(32),
       // Idle window before the sweep TTL-closes a session (§7.3) AND reaps its
       // agent's ACP host back to `provisioned` (§7.2). Background work is protected
@@ -202,7 +202,7 @@ export const ConfigSchema = z.object({
         .default(8 * 1024 * 1024)
     })
     .default({
-      maxAgents: 8,
+      maxAgents: 32,
       maxConcurrentSessions: 32,
       agentIdleTimeoutMs: 900_000,
       agentMaxLifetimeMs: 21_600_000,

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -24,7 +24,7 @@ describe('loadConfig', () => {
     expect(cfg.runtimes.claude.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
     expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['https://github.com', 'ssh://github.com'])
-    expect(cfg.limits.maxAgents).toBeGreaterThan(0) // default applied
+    expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
   })
 
@@ -53,7 +53,7 @@ describe('loadConfig', () => {
     const cfg = loadConfig({ root, optional: true })
     expect(cfg.version).toBe(1)
     expect(cfg.runtimes).toBeUndefined() // none from file → resolveRuntimes fills from registry
-    expect(cfg.limits.maxAgents).toBeGreaterThan(0) // defaults still applied
+    expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
   })
 
@@ -66,7 +66,7 @@ describe('loadConfig', () => {
     expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({ version: 1 })
     if (process.platform !== 'win32') expect(statSync(file).mode & 0o777).toBe(0o600)
     expect(cfg.controlPlane?.enabled).toBe(false) // fully local, no CP
-    expect(cfg.limits.maxAgents).toBeGreaterThan(0) // defaults applied
+    expect(cfg.limits.maxAgents).toBe(32)
   })
 
   it('applies CLI/env overrides over file values', () => {


### PR DESCRIPTION
## Summary

- increase the daemon's built-in `limits.maxAgents` default from 8 to 32
- keep the default consistent when the whole `limits` block is omitted
- update the exact config assertions and daemon design examples

## Impact

Fresh and minimal daemon configurations now advertise and enforce capacity for 32 agents. Existing `config.json` values and `--max-agents` overrides remain unchanged. The separate `maxConcurrentSessions` default stays at 32 because it is not coupled to agent placement capacity.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/config.test.ts` (19 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- changed-file ESLint and Prettier checks
- `git diff --check`
- pre-push full ESLint (0 errors; 2 unrelated existing duplicate-import warnings)

Created by Codex . GPT-5
