### PR TITLE
fix(webchat): enable pre-session runtime controls

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -230,6 +230,7 @@ import type {
   WebchatEvent,
   WebchatOutput,
   WebchatDone,
+  WebchatRuntimeConfig,
   RdMsg,
   RdMsgWebchat,
   WebchatImageAttachment,
@@ -1002,6 +1003,7 @@ interface WebchatTurnContext {
   conversationId: string
   turnId: string
   sink: WebchatSink
+  runtime?: WebchatRuntimeConfig
   doneSent?: boolean
 }
 
@@ -3652,7 +3654,8 @@ export class Daemon {
     user: string,
     sink: WebchatSink,
     requestedTurnId?: string,
-    inlineImages?: WebchatImageAttachment[]
+    inlineImages?: WebchatImageAttachment[],
+    requestedRuntime?: WebchatRuntimeConfig
   ): WebchatAck {
     const turnId = requestedTurnId ?? randomUUID()
     // Route directly to the named agent (bypasses arbitration); null when it isn't a
@@ -3730,7 +3733,9 @@ export class Daemon {
     if (this.webchatStreams.has(turnId)) {
       return { accepted: false, turnId, reason: 'busy' }
     }
-    const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink)
+    const initialRuntime =
+      this.agents.get(result.agentId)?.allowRuntimeChangesInChat === true ? requestedRuntime : undefined
+    const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink, initialRuntime)
     void this.dispatch(result.agentId, msg, undefined, stream).catch((err) =>
       this.log.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
     )
@@ -3757,7 +3762,8 @@ export class Daemon {
     agentId: string,
     conversationId: string,
     turnId: string,
-    transport: WebchatSink
+    transport: WebchatSink,
+    runtime?: WebchatRuntimeConfig
   ): WebchatTurnStream {
     this.pruneWebchatStreams()
     const stream: WebchatTurnStream = {
@@ -3765,6 +3771,7 @@ export class Daemon {
       conversationId,
       turnId,
       transport,
+      ...(runtime ? { runtime } : {}),
       resumeGeneration: 0,
       sink: {
         output: (output) => this.publishWebchatStreamEvent(stream, { kind: 'output', output }),
@@ -5747,7 +5754,8 @@ export class Daemon {
           op.user ?? 'webchat',
           sink,
           op.turnId,
-          op.attachments
+          op.attachments,
+          op.runtime
         )
         return {
           msgId: msg.msgId,
@@ -7629,7 +7637,8 @@ export class Daemon {
         msg,
         entry.initAbort.signal,
         integrationId,
-        callMeta?.originSessionId
+        callMeta?.originSessionId,
+        agent.allowRuntimeChangesInChat ? webchat?.runtime : undefined
       )
     } catch (err) {
       this.finishSessionInitialization(agentId)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3974,10 +3974,9 @@ export class Daemon {
     return true
   }
 
-  /** Removing chat authority also removes its effect from every live session. This
-   *  closes the window where a previously selected full-access mode could otherwise
-   *  survive until the next message restores the Agent-level policy. */
-  private restoreConfiguredRuntimeSettings(agent: LoadedAgent): void {
+  /** Apply the Agent's configured runtime policy to one live session. Callers that
+   *  fence a pending prompt await this; reconciliation fans it out in the background. */
+  private async applyConfiguredRuntimeSettings(agent: LoadedAgent, host: AcpHost, sessionId: string): Promise<void> {
     const catalog = this.runtimeCatalogs.get(agent.runtime)
     // A fresh ACP session may advertise its baseline as the literal `default`.
     // Catalog metadata intentionally keeps defaultModel concrete, so fall back to
@@ -3993,19 +3992,25 @@ export class Daemon {
     // The console treats an unset fast-mode default as off. Explicitly restore
     // that value so disabling chat authority also revokes a live `fast on`.
     const fastMode = agent.fastMode ?? false
+    if (model) await host.setSessionModel(sessionId, model)
+    if (effort) await host.setSessionEffort(sessionId, effort)
+    if (permissionMode && typeof host.setSessionPermissionMode === 'function') {
+      await host.setSessionPermissionMode(sessionId, permissionMode)
+    }
+    await host.setSessionFastMode(sessionId, fastMode)
+  }
+
+  /** Removing chat authority also removes its effect from every live session. This
+   *  closes the window where a previously selected full-access mode could otherwise
+   *  survive until the next message restores the Agent-level policy. */
+  private restoreConfiguredRuntimeSettings(agent: LoadedAgent): void {
     const host = this.hosts.get(agent.id)
     if (!host) return
     for (const session of this.store.listSessions(agent.id)) {
       if (!session.acpSessionId || host.hasSession?.(session.acpSessionId) !== true) continue
       const sessionId = session.acpSessionId
-      void Promise.resolve()
-        .then(async () => {
-          if (model) await host.setSessionModel(sessionId, model)
-          if (effort) await host.setSessionEffort(sessionId, effort)
-          if (permissionMode && typeof host.setSessionPermissionMode === 'function') {
-            await host.setSessionPermissionMode(sessionId, permissionMode)
-          }
-          await host.setSessionFastMode(sessionId, fastMode)
+      void this.applyConfiguredRuntimeSettings(agent, host, sessionId)
+        .then(() => {
           this.refreshStatusBarForKey(session.key)
         })
         .catch((err) =>
@@ -7638,7 +7643,7 @@ export class Daemon {
         entry.initAbort.signal,
         integrationId,
         callMeta?.originSessionId,
-        agent.allowRuntimeChangesInChat ? webchat?.runtime : undefined
+        agent.allowRuntimeChangesInChat ? webchat?.runtime?.effort : undefined
       )
     } catch (err) {
       this.finishSessionInitialization(agentId)
@@ -7725,6 +7730,18 @@ export class Daemon {
       this.log.info(`dispatch: skipped initialized turn ${msg.msgId} (${initializedGate})`)
       return null
     }
+    // A cold session can await workspace/host/session initialization while the Agent is
+    // reconciled. Persist staged first-turn choices only against the current authority,
+    // never the Agent snapshot captured before sessions.handle().
+    const initializedAgent = this.agents.get(agentId)
+    const stagedRuntime =
+      initializedAgent?.allowRuntimeChangesInChat === true && webchat?.runtime ? webchat.runtime : undefined
+    if (stagedRuntime?.model !== undefined) this.store.setModelOverride(key, stagedRuntime.model)
+    if (stagedRuntime?.effort !== undefined) this.store.setEffortOverride(key, stagedRuntime.effort)
+    if (stagedRuntime?.permissionMode !== undefined) {
+      this.store.setPermissionModeOverride(key, stagedRuntime.permissionMode)
+    }
+    if (stagedRuntime?.fastMode !== undefined) this.store.setFastModeOverride(key, stagedRuntime.fastMode)
     // sessions.handle() booted the host — surface any spawn-time config warnings
     // (config-file secret conflicts / write failures) into this session.
     this.flushSpawnNotices(agentId, { replyConn, channel: msg.channel, thread: msg.thread, statusThread })
@@ -7810,7 +7827,8 @@ export class Daemon {
     let finalPhase: EventSession['phase'] = 'end'
     try {
       const host = await this.ensureHostAsync(agentId)
-      const allowRuntimeChangesInChat = agent.allowRuntimeChangesInChat
+      const runtimeAgent = this.agents.get(agentId)
+      const allowRuntimeChangesInChat = runtimeAgent?.allowRuntimeChangesInChat === true
       // Re-apply a sticky session model override (set via the console's in-session model
       // switch) before the turn runs — the agent's default model was applied at
       // session/new, so this layers the per-session choice on top each turn. Best-effort.
@@ -7831,7 +7849,9 @@ export class Daemon {
       }
       const permissionModeOverride = allowRuntimeChangesInChat ? this.store.getPermissionModeOverride(key) : undefined
       const effectivePermissionMode =
-        permissionModeOverride ?? agent.permissionMode ?? this.runtimeCatalogs.get(agent.runtime)?.defaultPermissionMode
+        permissionModeOverride ??
+        runtimeAgent?.permissionMode ??
+        this.runtimeCatalogs.get(runtimeAgent?.runtime ?? agent.runtime)?.defaultPermissionMode
       // AcpHost provides this method; older injected/embedded hosts may not.
       // Treat the selector as an advertised capability, matching the other
       // optional runtime controls, while real hosts still restore the Agent policy.
@@ -7847,6 +7867,14 @@ export class Daemon {
         await host
           .setSessionFastMode(sessionId, fastOverride)
           .catch((err) => this.log.debug(`fast-mode override ${fastOverride} not applied: ${(err as Error).message}`))
+      }
+      // Runtime setters above await the adapter and can race another reconciliation.
+      // Fence immediately before prompt; a revoked permission must be restored
+      // synchronously here, not by reconcile's fire-and-forget live-session sweep.
+      const promptAgent = this.agents.get(agentId)
+      if (webchat?.runtime && promptAgent?.allowRuntimeChangesInChat !== true) {
+        this.store.clearRuntimeConfigOverrides(agentId)
+        await this.applyConfiguredRuntimeSettings(promptAgent ?? agent, host, sessionId)
       }
       // Pause/loop protection may land while a slow host is starting or sticky
       // overrides are being restored. At this point Pending exists but no prompt has

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -1,5 +1,4 @@
 import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
-import type { WebchatRuntimeConfig } from '@agentconnect.md/protocol'
 import { LocalStore, sessionKey } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { prepareWorkspace } from '../workspace/workspace-manager.js'
@@ -238,9 +237,9 @@ export class SessionManager {
      *  THIS turn was woken by another session's `sendMessage`. Surfaced to the agent as the
      *  `Parent session` line of the `# Agent` block — the SessionTarget it replies into. */
     originSessionId?: string,
-    /** Runtime choices staged before a webchat session exists. The daemon has already
-     *  enforced the Agent's allowRuntimeChangesInChat boundary. */
-    initialRuntime?: WebchatRuntimeConfig
+    /** A chat-selected effort needed by session/new metadata before the session row exists.
+     *  The daemon revalidates current Agent authority before persisting or prompting. */
+    initialEffort?: string
   ): Promise<{
     sessionId: string
     blocks: ContentBlock[]
@@ -323,7 +322,7 @@ export class SessionManager {
     // The sticky per-session effort override rides session `_meta` on new/load so the
     // `ultracode` sentinel (rejected by the `thought_level` select) takes effect;
     // select-based effort/model/fast overrides layer on afterward at turn start.
-    const effortOverride = initialRuntime?.effort ?? this.deps.store.getEffortOverride(key)
+    const effortOverride = initialEffort ?? this.deps.store.getEffortOverride(key)
 
     // Agent memory INDEX (agents/memory-provider.ts), read fresh. It's STANDING
     // context (like the system prompt), NOT a user turn — so it rides the system-prompt
@@ -572,15 +571,6 @@ export class SessionManager {
         this.deps.store.upsertSession(rec)
       }
     }
-
-    // The row now exists, so staged first-turn choices can become the same sticky
-    // overrides used by established sessions before Daemon applies them to the prompt.
-    if (initialRuntime?.model !== undefined) this.deps.store.setModelOverride(key, initialRuntime.model)
-    if (initialRuntime?.effort !== undefined) this.deps.store.setEffortOverride(key, initialRuntime.effort)
-    if (initialRuntime?.permissionMode !== undefined) {
-      this.deps.store.setPermissionModeOverride(key, initialRuntime.permissionMode)
-    }
-    if (initialRuntime?.fastMode !== undefined) this.deps.store.setFastModeOverride(key, initialRuntime.fastMode)
 
     // Older anchored cron/hook turns persisted their synthetic UUID as the Slack
     // read cursor. Start one bounded catch-up from scratch instead of passing that

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -342,13 +342,15 @@ export class SessionManager {
       cwd: string,
       mcpServers: McpServer[],
       systemAppend?: string
-    ): Promise<void> => {
-      while (true) {
-        const selected = sessionStartEffort()
-        await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
-        if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return
-        host.discardSession(sessionId)
-      }
+    ): Promise<boolean> => {
+      const selected = sessionStartEffort()
+      await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
+      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return true
+      // The pinned Claude adapter treats a repeated load of the same session/cwd/MCP
+      // fingerprint as idempotent, so another load cannot replace metadata-only effort.
+      // Forget this local attachment and let the caller create a fresh safe session.
+      host.discardSession(sessionId)
+      return false
     }
 
     // Agent memory INDEX (agents/memory-provider.ts), read fresh. It's STANDING
@@ -568,8 +570,12 @@ export class SessionManager {
         // isn't seen as `closed` mid-load, then fall through to `prompting` below.
         this.deps.store.setSessionState(key, 'resuming', Date.now())
         try {
-          await loadRuntimeSession(persistedSessionId, cwd, mcpServers, usesMeta ? resumeSystemContext : undefined)
-          resumed = true
+          resumed = await loadRuntimeSession(
+            persistedSessionId,
+            cwd,
+            mcpServers,
+            usesMeta ? resumeSystemContext : undefined
+          )
         } catch {
           if (signal?.aborted) throw interrupted(signal)
           // agent couldn't load it (GC'd / not durably persisted) — recreate below

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -320,9 +320,37 @@ export class SessionManager {
     const preparedCwd = hostCold ? await abortable(() => prepareWorkspace(agent), signal) : undefined
     const host = await abortable(() => this.deps.hostFor(agentId), signal)
     // The sticky per-session effort override rides session `_meta` on new/load so the
-    // `ultracode` sentinel (rejected by the `thought_level` select) takes effect;
-    // select-based effort/model/fast overrides layer on afterward at turn start.
-    const effortOverride = initialEffort ?? this.deps.store.getEffortOverride(key)
+    // `ultracode` sentinel (rejected by the `thought_level` select) takes effect.
+    // Resolve chat authority immediately before each request, then fence the await:
+    // metadata-only settings cannot be reversed by a later live selector.
+    const sessionStartEffort = (): { value?: string; chatSelected: boolean } => {
+      const allowed = this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true
+      if (!allowed) return { chatSelected: false }
+      const value = initialEffort ?? this.deps.store.getEffortOverride(key)
+      return { value, chatSelected: value !== undefined }
+    }
+    const newRuntimeSession = async (cwd: string, mcpServers: McpServer[], systemAppend?: string): Promise<string> => {
+      const selected = sessionStartEffort()
+      const sessionId = await abortable(() => host.newSession(cwd, mcpServers, selected.value, systemAppend), signal)
+      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return sessionId
+      host.discardSession(sessionId)
+      return abortable(() => host.newSession(cwd, mcpServers, sessionStartEffort().value, systemAppend), signal)
+    }
+    const loadRuntimeSession = async (
+      sessionId: string,
+      cwd: string,
+      mcpServers: McpServer[],
+      systemAppend?: string
+    ): Promise<void> => {
+      const selected = sessionStartEffort()
+      await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
+      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return
+      host.discardSession(sessionId)
+      await abortable(
+        () => host.loadSession(sessionId, cwd, mcpServers, sessionStartEffort().value, systemAppend),
+        signal
+      )
+    }
 
     // Agent memory INDEX (agents/memory-provider.ts), read fresh. It's STANDING
     // context (like the system prompt), NOT a user turn — so it rides the system-prompt
@@ -493,7 +521,7 @@ export class SessionManager {
           ...(integrationId !== undefined ? { integrationId } : {}),
           isDm: msg.isDm
         }) ?? []
-      const acpSessionId = await abortable(() => host.newSession(cwd, mcpServers, effortOverride, metaContext), signal)
+      const acpSessionId = await newRuntimeSession(cwd, mcpServers, metaContext)
       created = true
       rec = {
         key,
@@ -541,17 +569,7 @@ export class SessionManager {
         // isn't seen as `closed` mid-load, then fall through to `prompting` below.
         this.deps.store.setSessionState(key, 'resuming', Date.now())
         try {
-          await abortable(
-            () =>
-              host.loadSession(
-                persistedSessionId,
-                cwd,
-                mcpServers,
-                effortOverride,
-                usesMeta ? resumeSystemContext : undefined
-              ),
-            signal
-          )
+          await loadRuntimeSession(persistedSessionId, cwd, mcpServers, usesMeta ? resumeSystemContext : undefined)
           resumed = true
         } catch {
           if (signal?.aborted) throw interrupted(signal)
@@ -559,10 +577,7 @@ export class SessionManager {
         }
       }
       if (!resumed) {
-        const acpSessionId = await abortable(
-          () => host.newSession(cwd, mcpServers, effortOverride, metaContext),
-          signal
-        )
+        const acpSessionId = await newRuntimeSession(cwd, mcpServers, metaContext)
         // A fresh ACP id the CP has never seen (the persisted one couldn't be resumed),
         // so this counts as a create for `event/session`. A resumed session (loadSession
         // above) keeps its id — the CP already knows it — so `created` stays false there.

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -330,11 +330,12 @@ export class SessionManager {
       return { value, chatSelected: value !== undefined }
     }
     const newRuntimeSession = async (cwd: string, mcpServers: McpServer[], systemAppend?: string): Promise<string> => {
-      const selected = sessionStartEffort()
-      const sessionId = await abortable(() => host.newSession(cwd, mcpServers, selected.value, systemAppend), signal)
-      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return sessionId
-      host.discardSession(sessionId)
-      return abortable(() => host.newSession(cwd, mcpServers, sessionStartEffort().value, systemAppend), signal)
+      while (true) {
+        const selected = sessionStartEffort()
+        const sessionId = await abortable(() => host.newSession(cwd, mcpServers, selected.value, systemAppend), signal)
+        if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return sessionId
+        host.discardSession(sessionId)
+      }
     }
     const loadRuntimeSession = async (
       sessionId: string,
@@ -342,14 +343,12 @@ export class SessionManager {
       mcpServers: McpServer[],
       systemAppend?: string
     ): Promise<void> => {
-      const selected = sessionStartEffort()
-      await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
-      if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return
-      host.discardSession(sessionId)
-      await abortable(
-        () => host.loadSession(sessionId, cwd, mcpServers, sessionStartEffort().value, systemAppend),
-        signal
-      )
+      while (true) {
+        const selected = sessionStartEffort()
+        await abortable(() => host.loadSession(sessionId, cwd, mcpServers, selected.value, systemAppend), signal)
+        if (!selected.chatSelected || this.deps.agentById(agentId)?.allowRuntimeChangesInChat === true) return
+        host.discardSession(sessionId)
+      }
     }
 
     // Agent memory INDEX (agents/memory-provider.ts), read fresh. It's STANDING

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -1,4 +1,5 @@
 import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
+import type { WebchatRuntimeConfig } from '@agentconnect.md/protocol'
 import { LocalStore, sessionKey } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { prepareWorkspace } from '../workspace/workspace-manager.js'
@@ -236,7 +237,10 @@ export class SessionManager {
     /** session-concept §2.3/§5.3: the origin (parent) session's stable id, present only when
      *  THIS turn was woken by another session's `sendMessage`. Surfaced to the agent as the
      *  `Parent session` line of the `# Agent` block — the SessionTarget it replies into. */
-    originSessionId?: string
+    originSessionId?: string,
+    /** Runtime choices staged before a webchat session exists. The daemon has already
+     *  enforced the Agent's allowRuntimeChangesInChat boundary. */
+    initialRuntime?: WebchatRuntimeConfig
   ): Promise<{
     sessionId: string
     blocks: ContentBlock[]
@@ -319,7 +323,7 @@ export class SessionManager {
     // The sticky per-session effort override rides session `_meta` on new/load so the
     // `ultracode` sentinel (rejected by the `thought_level` select) takes effect;
     // select-based effort/model/fast overrides layer on afterward at turn start.
-    const effortOverride = this.deps.store.getEffortOverride(key)
+    const effortOverride = initialRuntime?.effort ?? this.deps.store.getEffortOverride(key)
 
     // Agent memory INDEX (agents/memory-provider.ts), read fresh. It's STANDING
     // context (like the system prompt), NOT a user turn — so it rides the system-prompt
@@ -568,6 +572,15 @@ export class SessionManager {
         this.deps.store.upsertSession(rec)
       }
     }
+
+    // The row now exists, so staged first-turn choices can become the same sticky
+    // overrides used by established sessions before Daemon applies them to the prompt.
+    if (initialRuntime?.model !== undefined) this.deps.store.setModelOverride(key, initialRuntime.model)
+    if (initialRuntime?.effort !== undefined) this.deps.store.setEffortOverride(key, initialRuntime.effort)
+    if (initialRuntime?.permissionMode !== undefined) {
+      this.deps.store.setPermissionModeOverride(key, initialRuntime.permissionMode)
+    }
+    if (initialRuntime?.fastMode !== undefined) this.deps.store.setFastModeOverride(key, initialRuntime.fastMode)
 
     // Older anchored cron/hook turns persisted their synthetic UUID as the Slack
     // read cursor. Start one bounded catch-up from scratch instead of passing that

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -594,12 +594,18 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       fastMode: false
     }
     const root = scaffold(undefined, configured)
+    let newSessionCalls = 0
     const host = {
       start: vi.fn(async () => {}),
       newSession: vi.fn(async () => {
-        await sessionGate
+        newSessionCalls += 1
+        if (newSessionCalls === 1) {
+          await sessionGate
+          return 'acp-wc-staged'
+        }
         return 'acp-wc-1'
       }),
+      discardSession: vi.fn(),
       modelOptions: vi.fn(() => ({ current: 'a', models: ['a', 'b'] })),
       hasSession: vi.fn(() => true),
       setSessionModel: vi.fn(async () => true),
@@ -613,7 +619,7 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     const daemon = new Daemon({ root, hostFactory: () => host as any })
     await daemon.start()
     const cp = fakeCpClient()
-    const runtime = { model: 'b', effort: 'high', permissionMode: 'plan', fastMode: true }
+    const runtime = { model: 'b', effort: 'ultracode', permissionMode: 'plan', fastMode: true }
 
     ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink, undefined, undefined, runtime)
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
@@ -628,7 +634,10 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     expect((daemon as any).store.getEffortOverride(key)).toBeUndefined()
     expect((daemon as any).store.getPermissionModeOverride(key)).toBeUndefined()
     expect((daemon as any).store.getFastModeOverride(key)).toBeUndefined()
-    expect(host.newSession.mock.calls[0]?.[2]).toBe('high')
+    expect(host.newSession).toHaveBeenCalledTimes(2)
+    expect(host.newSession.mock.calls[0]?.[2]).toBe('ultracode')
+    expect(host.newSession.mock.calls[1]?.[2]).toBeUndefined()
+    expect(host.discardSession).toHaveBeenCalledWith('acp-wc-staged')
     expect(host.setSessionModel).toHaveBeenCalledWith('acp-wc-1', 'a')
     expect(host.setSessionEffort).toHaveBeenCalledWith('acp-wc-1', 'low')
     expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-wc-1', 'default')

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -583,6 +583,67 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     15_000
   )
 
+  it('revokes staged first-turn runtime choices when authority changes during session creation', async () => {
+    let releaseSession!: () => void
+    const sessionGate = new Promise<void>((resolve) => (releaseSession = resolve))
+    const configured = {
+      allowRuntimeChangesInChat: true,
+      runtimeOverrides: { model: 'a' },
+      reasoningEffort: 'low',
+      permissionMode: 'default',
+      fastMode: false
+    }
+    const root = scaffold(undefined, configured)
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => {
+        await sessionGate
+        return 'acp-wc-1'
+      }),
+      modelOptions: vi.fn(() => ({ current: 'a', models: ['a', 'b'] })),
+      hasSession: vi.fn(() => true),
+      setSessionModel: vi.fn(async () => true),
+      setSessionEffort: vi.fn(async () => true),
+      setSessionPermissionMode: vi.fn(async () => true),
+      setSessionFastMode: vi.fn(async () => true),
+      prompt: vi.fn(async () => ({ stopReason: 'end_turn' })),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    await daemon.start()
+    const cp = fakeCpClient()
+    const runtime = { model: 'b', effort: 'high', permissionMode: 'plan', fastMode: true }
+
+    ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink, undefined, undefined, runtime)
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(1), WAIT)
+
+    writeAgent(root, { ...configured, allowRuntimeChangesInChat: false })
+    await (daemon as any).reconcile()
+    releaseSession()
+    await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
+
+    const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+    expect((daemon as any).store.getModelOverride(key)).toBeUndefined()
+    expect((daemon as any).store.getEffortOverride(key)).toBeUndefined()
+    expect((daemon as any).store.getPermissionModeOverride(key)).toBeUndefined()
+    expect((daemon as any).store.getFastModeOverride(key)).toBeUndefined()
+    expect(host.newSession.mock.calls[0]?.[2]).toBe('high')
+    expect(host.setSessionModel).toHaveBeenCalledWith('acp-wc-1', 'a')
+    expect(host.setSessionEffort).toHaveBeenCalledWith('acp-wc-1', 'low')
+    expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-wc-1', 'default')
+    expect(host.setSessionFastMode).toHaveBeenCalledWith('acp-wc-1', false)
+    expect(host.setSessionModel).not.toHaveBeenCalledWith('acp-wc-1', 'b')
+    expect(host.setSessionPermissionMode).not.toHaveBeenCalledWith('acp-wc-1', 'plan')
+    expect(host.setSessionFastMode).not.toHaveBeenCalledWith('acp-wc-1', true)
+    const promptOrder = host.prompt.mock.invocationCallOrder[0]!
+    expect(host.setSessionModel.mock.invocationCallOrder.at(-1)).toBeLessThan(promptOrder)
+    expect(host.setSessionEffort.mock.invocationCallOrder.at(-1)).toBeLessThan(promptOrder)
+    expect(host.setSessionPermissionMode.mock.invocationCallOrder.at(-1)).toBeLessThan(promptOrder)
+    expect(host.setSessionFastMode.mock.invocationCallOrder.at(-1)).toBeLessThan(promptOrder)
+    await daemon.stop()
+  }, 15_000)
+
   it('revokes chat-selected runtime settings from an idle warm session', async () => {
     const configured = {
       allowRuntimeChangesInChat: true,

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -546,6 +546,43 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.stop()
   }, 15_000)
 
+  it.each([
+    { allowed: true, expected: { model: 'b', effort: 'high', permissionMode: 'plan', fastMode: true } },
+    { allowed: false, expected: {} }
+  ])(
+    'handles first-turn runtime choices at the Agent authority boundary (allowed=$allowed)',
+    async ({ allowed, expected }) => {
+      const runtime = { model: 'b', effort: 'high', permissionMode: 'plan', fastMode: true }
+      const { factory, host } = streamingHost([text('hi')], { model: 'a', models: ['a', 'b'] })
+      const daemon = new Daemon({
+        root: scaffold(undefined, { allowRuntimeChangesInChat: allowed }),
+        hostFactory: factory
+      })
+      await daemon.start()
+      const cp = fakeCpClient()
+
+      ;(daemon as any).dispatchWebchatTurn(AGENT_ID, CONV, 'go', 'webchat', cp.sink, undefined, undefined, runtime)
+      await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
+
+      const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
+      expect({
+        model: (daemon as any).store.getModelOverride(key),
+        effort: (daemon as any).store.getEffortOverride(key),
+        permissionMode: (daemon as any).store.getPermissionModeOverride(key),
+        fastMode: (daemon as any).store.getFastModeOverride(key)
+      }).toEqual(expected)
+      expect(host.newSession.mock.calls[0]?.[2]).toBe(allowed ? 'high' : undefined)
+      if (allowed) {
+        expect(host.setSessionModel).toHaveBeenCalledWith('acp-wc-1', 'b')
+        expect(host.setSessionEffort).toHaveBeenCalledWith('acp-wc-1', 'high')
+        expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-wc-1', 'plan')
+        expect(host.setSessionFastMode).toHaveBeenCalledWith('acp-wc-1', true)
+      }
+      await daemon.stop()
+    },
+    15_000
+  )
+
   it('revokes chat-selected runtime settings from an idle warm session', async () => {
     const configured = {
       allowRuntimeChangesInChat: true,

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -584,8 +584,10 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
   )
 
   it('revokes staged first-turn runtime choices when authority changes during session creation', async () => {
-    let releaseSession!: () => void
-    const sessionGate = new Promise<void>((resolve) => (releaseSession = resolve))
+    let releaseFirstSession!: () => void
+    let releaseSecondSession!: () => void
+    const firstSessionGate = new Promise<void>((resolve) => (releaseFirstSession = resolve))
+    const secondSessionGate = new Promise<void>((resolve) => (releaseSecondSession = resolve))
     const configured = {
       allowRuntimeChangesInChat: true,
       runtimeOverrides: { model: 'a' },
@@ -595,17 +597,29 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     }
     const root = scaffold(undefined, configured)
     let newSessionCalls = 0
+    let discardCalls = 0
     const host = {
       start: vi.fn(async () => {}),
       newSession: vi.fn(async () => {
         newSessionCalls += 1
         if (newSessionCalls === 1) {
-          await sessionGate
-          return 'acp-wc-staged'
+          await firstSessionGate
+          return 'acp-wc-staged-1'
+        }
+        if (newSessionCalls === 2) {
+          await secondSessionGate
+          return 'acp-wc-staged-2'
         }
         return 'acp-wc-1'
       }),
-      discardSession: vi.fn(),
+      discardSession: vi.fn(() => {
+        discardCalls += 1
+        if (discardCalls !== 1) return
+        // Re-enable in the narrow gap before recreation so the retry itself carries
+        // ultracode; the second disable below must fence that awaited retry too.
+        const current = (daemon as any).agents.get(AGENT_ID)
+        ;(daemon as any).agents.set(AGENT_ID, { ...current, allowRuntimeChangesInChat: true })
+      }),
       modelOptions: vi.fn(() => ({ current: 'a', models: ['a', 'b'] })),
       hasSession: vi.fn(() => true),
       setSessionModel: vi.fn(async () => true),
@@ -626,7 +640,12 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     writeAgent(root, { ...configured, allowRuntimeChangesInChat: false })
     await (daemon as any).reconcile()
-    releaseSession()
+    releaseFirstSession()
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledTimes(2), WAIT)
+
+    writeAgent(root, { ...configured, allowRuntimeChangesInChat: false })
+    await (daemon as any).reconcile()
+    releaseSecondSession()
     await vi.waitFor(() => expect(cp.dones).toHaveLength(1), WAIT)
 
     const key = (daemon as any).webchatSessionKey(CONV, AGENT_ID)
@@ -634,10 +653,12 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     expect((daemon as any).store.getEffortOverride(key)).toBeUndefined()
     expect((daemon as any).store.getPermissionModeOverride(key)).toBeUndefined()
     expect((daemon as any).store.getFastModeOverride(key)).toBeUndefined()
-    expect(host.newSession).toHaveBeenCalledTimes(2)
+    expect(host.newSession).toHaveBeenCalledTimes(3)
     expect(host.newSession.mock.calls[0]?.[2]).toBe('ultracode')
-    expect(host.newSession.mock.calls[1]?.[2]).toBeUndefined()
-    expect(host.discardSession).toHaveBeenCalledWith('acp-wc-staged')
+    expect(host.newSession.mock.calls[1]?.[2]).toBe('ultracode')
+    expect(host.newSession.mock.calls[2]?.[2]).toBeUndefined()
+    expect(host.discardSession).toHaveBeenNthCalledWith(1, 'acp-wc-staged-1')
+    expect(host.discardSession).toHaveBeenNthCalledWith(2, 'acp-wc-staged-2')
     expect(host.setSessionModel).toHaveBeenCalledWith('acp-wc-1', 'a')
     expect(host.setSessionEffort).toHaveBeenCalledWith('acp-wc-1', 'low')
     expect(host.setSessionPermissionMode).toHaveBeenCalledWith('acp-wc-1', 'default')

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -743,6 +743,60 @@ describe('SessionManager', () => {
     store.close()
   })
 
+  it('fences every resumed chat-effort snapshot across repeated authorization changes', async () => {
+    const store = newStore()
+    const host1 = { newSession: vi.fn(async () => 'acp-1'), hasSession: () => true } as any
+    const sm1 = new SessionManager({ store, hostFor: async () => host1, agentById: () => agent, memory })
+    await sm1.handle('bot-a', msg({ ts: '100.1', text: 'first turn' }))
+    store.setEffortOverride(sessionKey('slack', 'C1', '100.1', 'bot-a'), 'ultracode')
+
+    let allowRuntimeChangesInChat = true
+    let releaseFirstLoad!: () => void
+    let releaseSecondLoad!: () => void
+    const firstLoadGate = new Promise<void>((resolve) => (releaseFirstLoad = resolve))
+    const secondLoadGate = new Promise<void>((resolve) => (releaseSecondLoad = resolve))
+    let loadCalls = 0
+    let discardCalls = 0
+    const host2 = {
+      newSession: vi.fn(async () => 'acp-2'),
+      hasSession: () => false,
+      loadSupported: () => true,
+      loadSession: vi.fn(async () => {
+        loadCalls += 1
+        if (loadCalls === 1) await firstLoadGate
+        if (loadCalls === 2) await secondLoadGate
+      }),
+      discardSession: vi.fn(() => {
+        discardCalls += 1
+        if (discardCalls === 1) allowRuntimeChangesInChat = true
+      })
+    } as any
+    const sm2 = new SessionManager({
+      store,
+      hostFor: async () => host2,
+      agentById: () => ({ ...agent, allowRuntimeChangesInChat }),
+      memory
+    })
+
+    const resumed = sm2.handle('bot-a', msg({ ts: '100.2', text: 'second turn' }))
+    await vi.waitFor(() => expect(host2.loadSession).toHaveBeenCalledTimes(1))
+    allowRuntimeChangesInChat = false
+    releaseFirstLoad()
+    await vi.waitFor(() => expect(host2.loadSession).toHaveBeenCalledTimes(2))
+    allowRuntimeChangesInChat = false
+    releaseSecondLoad()
+
+    await expect(resumed).resolves.toMatchObject({ sessionId: 'acp-1', created: false })
+    expect(host2.loadSession).toHaveBeenCalledTimes(3)
+    expect(host2.loadSession.mock.calls[0]?.[3]).toBe('ultracode')
+    expect(host2.loadSession.mock.calls[1]?.[3]).toBe('ultracode')
+    expect(host2.loadSession.mock.calls[2]?.[3]).toBeUndefined()
+    expect(host2.discardSession).toHaveBeenNthCalledWith(1, 'acp-1')
+    expect(host2.discardSession).toHaveBeenNthCalledWith(2, 'acp-1')
+    expect(host2.newSession).not.toHaveBeenCalled()
+    store.close()
+  })
+
   it('builds an inline image block for an attachment when the agent supports images', async () => {
     const store = newStore()
     const host = { newSession: vi.fn(async () => 'acp-1'), promptSupports: (k: string) => k === 'image' } as any

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -743,7 +743,7 @@ describe('SessionManager', () => {
     store.close()
   })
 
-  it('fences every resumed chat-effort snapshot across repeated authorization changes', async () => {
+  it('recreates a resumed session when revoked metadata cannot be replaced by an idempotent reload', async () => {
     const store = newStore()
     const host1 = { newSession: vi.fn(async () => 'acp-1'), hasSession: () => true } as any
     const sm1 = new SessionManager({ store, hostFor: async () => host1, agentById: () => agent, memory })
@@ -751,25 +751,20 @@ describe('SessionManager', () => {
     store.setEffortOverride(sessionKey('slack', 'C1', '100.1', 'bot-a'), 'ultracode')
 
     let allowRuntimeChangesInChat = true
-    let releaseFirstLoad!: () => void
-    let releaseSecondLoad!: () => void
-    const firstLoadGate = new Promise<void>((resolve) => (releaseFirstLoad = resolve))
-    const secondLoadGate = new Promise<void>((resolve) => (releaseSecondLoad = resolve))
-    let loadCalls = 0
-    let discardCalls = 0
+    let releaseLoad!: () => void
+    const loadGate = new Promise<void>((resolve) => (releaseLoad = resolve))
+    let remoteEffort: string | undefined
     const host2 = {
       newSession: vi.fn(async () => 'acp-2'),
       hasSession: () => false,
       loadSupported: () => true,
-      loadSession: vi.fn(async () => {
-        loadCalls += 1
-        if (loadCalls === 1) await firstLoadGate
-        if (loadCalls === 2) await secondLoadGate
+      loadSession: vi.fn(async (_sessionId, _cwd, _mcpServers, effort) => {
+        // Match the pinned adapter: the first load owns the remote query; a repeated
+        // same-fingerprint load would return it without applying replacement metadata.
+        remoteEffort ??= effort
+        await loadGate
       }),
-      discardSession: vi.fn(() => {
-        discardCalls += 1
-        if (discardCalls === 1) allowRuntimeChangesInChat = true
-      })
+      discardSession: vi.fn()
     } as any
     const sm2 = new SessionManager({
       store,
@@ -781,19 +776,14 @@ describe('SessionManager', () => {
     const resumed = sm2.handle('bot-a', msg({ ts: '100.2', text: 'second turn' }))
     await vi.waitFor(() => expect(host2.loadSession).toHaveBeenCalledTimes(1))
     allowRuntimeChangesInChat = false
-    releaseFirstLoad()
-    await vi.waitFor(() => expect(host2.loadSession).toHaveBeenCalledTimes(2))
-    allowRuntimeChangesInChat = false
-    releaseSecondLoad()
+    releaseLoad()
 
-    await expect(resumed).resolves.toMatchObject({ sessionId: 'acp-1', created: false })
-    expect(host2.loadSession).toHaveBeenCalledTimes(3)
+    await expect(resumed).resolves.toMatchObject({ sessionId: 'acp-2', created: true })
+    expect(remoteEffort).toBe('ultracode')
+    expect(host2.loadSession).toHaveBeenCalledTimes(1)
     expect(host2.loadSession.mock.calls[0]?.[3]).toBe('ultracode')
-    expect(host2.loadSession.mock.calls[1]?.[3]).toBe('ultracode')
-    expect(host2.loadSession.mock.calls[2]?.[3]).toBeUndefined()
-    expect(host2.discardSession).toHaveBeenNthCalledWith(1, 'acp-1')
-    expect(host2.discardSession).toHaveBeenNthCalledWith(2, 'acp-1')
-    expect(host2.newSession).not.toHaveBeenCalled()
+    expect(host2.discardSession).toHaveBeenCalledWith('acp-1')
+    expect(host2.newSession).toHaveBeenCalledWith(expect.any(String), [], undefined, undefined)
     store.close()
   })
 

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -94,7 +94,12 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
 
   it('carries every webchat control op and rejects unknown ops', () => {
     const ops = [
-      { op: 'turn', text: 'hello', turnId: TURN_ID },
+      {
+        op: 'turn',
+        text: 'hello',
+        turnId: TURN_ID,
+        runtime: { model: 'gpt-5.6-sol', effort: 'xhigh', permissionMode: 'full-access', fastMode: true }
+      },
       { op: 'resume', turnId: TURN_ID, generation: 2, afterIndex: 3 },
       { op: 'set_model', model: 'opus-4.8' },
       { op: 'set_effort', effort: 'high' },
@@ -110,6 +115,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     expect(RelayWebchatOp.safeParse({ op: 'set_theme', theme: 'dark' }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'turn' }).success).toBe(false) // text required
+    expect(RelayWebchatOp.safeParse({ op: 'turn', text: 'hi', runtime: { fastMode: 'yes' } }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: TURN_ID, generation: 1, afterIndex: -2 }).success).toBe(
       false
     )

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -63,6 +63,14 @@ export type RdHelloOk = z.infer<typeof RdHelloOk>
 // the wire stays at the four designed frames. `turn` is the user message; the
 // rest are the session controls the old daemon↔CP webchat EVTs carried.
 //
+export const WebchatRuntimeConfig = z.object({
+  model: z.string().min(1).optional(),
+  effort: z.string().min(1).optional(),
+  permissionMode: z.string().min(1).optional(),
+  fastMode: z.boolean().optional()
+})
+export type WebchatRuntimeConfig = z.infer<typeof WebchatRuntimeConfig>
+
 export const RelayWebchatOp = z.discriminatedUnion('op', [
   z.object({
     op: z.literal('turn'),
@@ -71,7 +79,10 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
     // New browsers allocate this before sending so a pre-ack reconnect can name
     // the exact turn. Optional for older clients; the daemon allocates a fallback.
     turnId: z.string().uuid().optional(),
-    attachments: z.array(WebchatImageAttachment).max(1).optional()
+    attachments: z.array(WebchatImageAttachment).max(1).optional(),
+    // A fresh Playground has no daemon session to receive standalone `set_*`
+    // operations yet. Carry only the settings the user changed with its first turn.
+    runtime: WebchatRuntimeConfig.optional()
   }),
   // Rebind an in-flight/recent turn to this relay connection and replay every
   // output after the browser's contiguous cursor. The generation monotonically

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -72,6 +72,16 @@ describe('parseBrowserFrame', () => {
       turnId: AGENT
     })
   })
+  it('carries staged runtime choices on the first turn', () => {
+    const runtime = { model: 'gpt-5.6-sol', effort: 'xhigh', permissionMode: 'full-access', fastMode: true }
+    expect(parseBrowserFrame({ text: 'hi', runtime }, USER)).toEqual({
+      op: 'turn',
+      text: 'hi',
+      user: USER,
+      runtime
+    })
+    expect(parseBrowserFrame({ text: 'hi', runtime: { fastMode: 'yes' } }, USER)).toBeNull()
+  })
   it('maps a bounded image attachment while keeping the verified user authoritative', () => {
     const attachment = {
       name: 'screen.webp',

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -3,7 +3,7 @@
  * session (shared-bot-relay.md §7.2 / §10). One socket == one conversation.
  *
  * It speaks the browser-facing, type-tagged webchat envelope. The browser sends
- * `{text, turnId, attachments?}` (a turn with at most one bounded inline image) or
+ * `{text, turnId, attachments?, runtime?}` (a turn with at most one bounded inline image) or
  * `{type:'resume'|'set_model'|'set_effort'|'set_permission_mode'|'set_fast'|'cancel'}`,
  * and the relay sends `{type:'ready'|'output'|'done'|'ack'|'resumed'|'error'}`. Internally each inbound
  * op becomes an `rd/msg(webchat)` bridged onto the target daemon's rd/* socket, and
@@ -43,7 +43,8 @@ export function parseBrowserFrame(msg: unknown, user: string): RelayWebchatOp | 
       text: typeof m.text === 'string' ? m.text : '',
       user,
       ...(m.turnId !== undefined ? { turnId: m.turnId } : {}),
-      ...(m.attachments !== undefined ? { attachments: m.attachments } : {})
+      ...(m.attachments !== undefined ? { attachments: m.attachments } : {}),
+      ...(m.runtime !== undefined ? { runtime: m.runtime } : {})
     })
     return parsed.success && parsed.data.op === 'turn' ? parsed.data : null
   }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -151,6 +151,13 @@ type WebchatDone = {
   error?: string
 }
 
+type WebchatRuntimeConfig = {
+  model?: string
+  effort?: string
+  permissionMode?: string
+  fastMode?: boolean
+}
+
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const [pgSessions, setPgSessions] = useState<Record<string, Session>>({})
   // Live tail for adopted webchat sessions (real CP ids). Kept apart from `pgSessions`
@@ -167,9 +174,17 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const conversationIds = useRef<Map<string, string>>(new Map())
   const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
   const reconnectAttempts = useRef<Map<string, number>>(new Map())
+  // Standalone set_* operations cannot bind until the first daemon session exists.
+  // Keep only fields the user actually touched and attach them atomically to the turn.
+  const stagedRuntime = useRef<Map<string, WebchatRuntimeConfig>>(new Map())
   const busyRef = useRef<Record<string, boolean>>({})
   const closingAll = useRef(false)
   const { activeOrg } = useOrgs()
+
+  const stageRuntimeChange = useCallback((id: string, patch: WebchatRuntimeConfig): void => {
+    if (!id.startsWith(PG_PREFIX)) return
+    stagedRuntime.current.set(id, { ...stagedRuntime.current.get(id), ...patch })
+  }, [])
 
   const setBusy = useCallback((id: string, v: boolean): void => {
     if (v) busyRef.current[id] = true
@@ -599,7 +614,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             JSON.stringify({
               text,
               turnId: requestedTurnId,
-              ...(image ? { attachments: [image] } : {})
+              ...(image ? { attachments: [image] } : {}),
+              ...(stagedRuntime.current.get(id) ? { runtime: stagedRuntime.current.get(id) } : {})
             })
           )
         )
@@ -626,11 +642,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const pgSetModel = useCallback(
     (id: string, agentForId: string, model: string, conversationId?: string) => {
       setPgSessions((cur) => (cur[id] ? { ...cur, [id]: sessionAfterModelSelection(cur[id]!, model) } : cur))
+      stageRuntimeChange(id, { model })
       connect(id, agentForId, conversationId)
         .ready.then((ws) => ws.send(JSON.stringify({ type: 'set_model', model })))
         .catch(() => {})
     },
-    [connect]
+    [connect, stageRuntimeChange]
   )
 
   /** Switch the session's reasoning effort (fire-and-forget). Optimistically updates the
@@ -639,33 +656,36 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const pgSetEffort = useCallback(
     (id: string, agentForId: string, effort: string, conversationId?: string) => {
       setPgSessions((cur) => (cur[id] ? { ...cur, [id]: { ...cur[id]!, effort } } : cur))
+      stageRuntimeChange(id, { effort })
       connect(id, agentForId, conversationId)
         .ready.then((ws) => ws.send(JSON.stringify({ type: 'set_effort', effort })))
         .catch(() => {})
     },
-    [connect]
+    [connect, stageRuntimeChange]
   )
 
   /** Switch the session's permission/approval mode (fire-and-forget), optimistic like pgSetEffort. */
   const pgSetPermissionMode = useCallback(
     (id: string, agentForId: string, permissionMode: string, conversationId?: string) => {
       setPgSessions((cur) => (cur[id] ? { ...cur, [id]: { ...cur[id]!, permissionMode } } : cur))
+      stageRuntimeChange(id, { permissionMode })
       connect(id, agentForId, conversationId)
         .ready.then((ws) => ws.send(JSON.stringify({ type: 'set_permission_mode', permissionMode })))
         .catch(() => {})
     },
-    [connect]
+    [connect, stageRuntimeChange]
   )
 
   /** Toggle the session's fast mode (fire-and-forget), optimistic like pgSetEffort. */
   const pgSetFast = useCallback(
     (id: string, agentForId: string, fastMode: boolean, conversationId?: string) => {
       setPgSessions((cur) => (cur[id] ? { ...cur, [id]: { ...cur[id]!, fastMode } } : cur))
+      stageRuntimeChange(id, { fastMode })
       connect(id, agentForId, conversationId)
         .ready.then((ws) => ws.send(JSON.stringify({ type: 'set_fast', fastMode })))
         .catch(() => {})
     },
-    [connect]
+    [connect, stageRuntimeChange]
   )
 
   /** Interrupt the running turn (fire-and-forget). The daemon ends the turn with a

--- a/packages/web/src/lib/session-runtime-controls.test.ts
+++ b/packages/web/src/lib/session-runtime-controls.test.ts
@@ -41,10 +41,11 @@ const daemon = {
 } satisfies Pick<DaemonRow, 'runtimeModels'>
 
 describe('session runtime controls', () => {
-  it('waits for a daemon-created Playground session before enabling changes', () => {
-    expect(sessionRuntimeChangesEnabled(true, { platform: 'playground' })).toBe(false)
+  it('allows a fresh Playground to stage runtime changes before its first turn', () => {
+    expect(sessionRuntimeChangesEnabled(true, { platform: 'playground' })).toBe(true)
     expect(sessionRuntimeChangesEnabled(true, { platform: 'playground', realSessionId: 'session-1' })).toBe(true)
     expect(sessionRuntimeChangesEnabled(true, { platform: 'webchat' })).toBe(true)
+    expect(sessionRuntimeChangesEnabled(true, { platform: 'slack' })).toBe(false)
     expect(sessionRuntimeChangesEnabled(false, { platform: 'webchat' })).toBe(false)
   })
 

--- a/packages/web/src/lib/session-runtime-controls.ts
+++ b/packages/web/src/lib/session-runtime-controls.ts
@@ -16,12 +16,12 @@ import {
 type RuntimeDaemon = Pick<DaemonRow, 'runtimeModels'> | undefined
 type PermissionChoice = { v: string; l: string; description?: string }
 
-/** Chat-side runtime changes need both Agent authority and a daemon-created session. */
+/** Playground can stage settings for its first turn; other chat surfaces need a live session. */
 export function sessionRuntimeChangesEnabled(
   allowed: boolean,
   session: Pick<Session, 'platform' | 'realSessionId'>
 ): boolean {
-  return allowed && (session.platform === 'webchat' || !!session.realSessionId)
+  return allowed && (session.platform === 'playground' || session.platform === 'webchat' || !!session.realSessionId)
 }
 
 /** A received live list is authoritative, including `[]`; discovery is idle-session fallback only. */


### PR DESCRIPTION
## Summary

- Enable model, effort, permission, and fast-mode selectors before the first Playground turn when the Agent allows chat-side runtime changes.
- Carry only the settings the user actually changed with the first webchat turn.
- Persist and apply those settings before the first prompt while preserving the daemon-side authorization boundary.

## Root cause

A fresh Playground conversation does not have a daemon session row yet. The UI therefore disabled every runtime selector, and standalone runtime-control frames sent before the first turn had nowhere to persist.

## Validation

- `pnpm --filter @agentconnect.md/protocol exec vitest run src/frames/relay-daemon.test.ts`
- `pnpm --filter @agentconnect.md/relay exec vitest run src/relay-browser-connection.test.ts`
- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/session-runtime-controls.test.ts`
- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-webchat.test.ts`
- Type checks for protocol, relay, daemon, and web
- ESLint on all changed files

Created by Codex . GPT-5
