### PR TITLE
fix(web): render agent visibility read-only when it isn't editable

### DIFF
--- a/packages/web/src/components/console/AgentCallVisibility.test.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.test.tsx
@@ -135,17 +135,23 @@ describe('AgentCallVisibility', () => {
     expect(el.textContent).not.toContain('No agents selected.')
     expect(el.textContent).not.toContain('No peers selected')
     expect(el.textContent).toContain('1 not visible')
-    // The count reflects the whole grant, not just the resolvable half.
-    expect(el.textContent).toContain('0 of 1')
+    // Nothing was evaluated, so report the unknown rather than a "0 of 1" that
+    // would assert those hidden peers are unreachable.
+    expect(el.textContent).toContain('1 unknown')
+    expect(el.textContent).not.toContain('of 1')
   })
 
-  it('counts hidden peers alongside visible ones', async () => {
+  it('keeps hidden peers out of the reachability fraction', async () => {
     const peers = AGENTS.slice(0, 2)
     const el = await renderReadOnly({ selectedIds: [peers[0]!.id, 'restricted-peer-id'], peers })
 
     expect(el.textContent).toContain(agentLabel(peers[0]!))
     expect(el.textContent).toContain('1 not visible')
-    expect(el.textContent).toContain('0 of 2')
+    // The fraction covers only the peer we could actually evaluate…
+    expect(el.textContent).toContain('0 of 1')
+    // …and the hidden one is reported separately, never folded into it.
+    expect(el.textContent).toContain('1 unknown')
+    expect(el.textContent).not.toContain('0 of 2')
   })
 
   it('still reports a genuinely empty allow-list as empty', async () => {
@@ -154,6 +160,20 @@ describe('AgentCallVisibility', () => {
     expect(el.textContent).toContain('No agents selected.')
     expect(el.textContent).toContain('No peers selected')
     expect(el.textContent).not.toContain('not visible')
+  })
+
+  it('constrains a long peer name instead of overflowing the card', async () => {
+    const peers = AGENTS.slice(0, 1).map((peer) => ({
+      ...peer,
+      displayName: 'an-extremely-long-agent-display-name-that-would-otherwise-run-past-the-card-edge'
+    }))
+    const el = await renderReadOnly({ selectedIds: [peers[0]!.id], peers })
+
+    const label = el.querySelector<HTMLElement>(`span[title="${agentLabel(peers[0]!)}"]`)
+    expect(label).not.toBeNull() // the full name stays reachable on hover
+    expect(label?.classList.contains('truncate')).toBe(true)
+    expect(label?.parentElement?.classList.contains('min-w-0')).toBe(true)
+    expect(label?.parentElement?.classList.contains('max-w-full')).toBe(true)
   })
 
   it('renders no editing affordances when read-only', async () => {

--- a/packages/web/src/components/console/AgentCallVisibility.test.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.test.tsx
@@ -101,4 +101,67 @@ describe('AgentCallVisibility', () => {
 
     expect(input?.parentElement?.nextElementSibling?.classList.contains('absolute')).toBe(true)
   })
+
+  // `/agents` hides restricted peers from non-owners while the CP keeps their
+  // grants (resolvePolicyAgentIds retains hidden ids). Resolving the allow-list
+  // through the viewer's peer list therefore under-reports it, and the read-only
+  // Access card must not claim an active grant is empty.
+  const renderReadOnly = async (props: { selectedIds: string[]; peers: typeof AGENTS }) => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <AgentCallVisibility
+          variant="section"
+          direction="inbound"
+          mode="selected"
+          selectedIds={props.selectedIds}
+          effectivePeerIds={[]}
+          peers={props.peers}
+          daemons={[]}
+          target="review-bot"
+          editable={false}
+          onChange={() => undefined}
+        />
+      )
+    })
+    return container
+  }
+
+  it('reports a selection of only hidden peers as hidden, not empty', async () => {
+    const el = await renderReadOnly({ selectedIds: ['restricted-peer-id'], peers: AGENTS.slice(0, 2) })
+
+    expect(el.textContent).not.toContain('No agents selected.')
+    expect(el.textContent).not.toContain('No peers selected')
+    expect(el.textContent).toContain('1 not visible')
+    // The count reflects the whole grant, not just the resolvable half.
+    expect(el.textContent).toContain('0 of 1')
+  })
+
+  it('counts hidden peers alongside visible ones', async () => {
+    const peers = AGENTS.slice(0, 2)
+    const el = await renderReadOnly({ selectedIds: [peers[0]!.id, 'restricted-peer-id'], peers })
+
+    expect(el.textContent).toContain(agentLabel(peers[0]!))
+    expect(el.textContent).toContain('1 not visible')
+    expect(el.textContent).toContain('0 of 2')
+  })
+
+  it('still reports a genuinely empty allow-list as empty', async () => {
+    const el = await renderReadOnly({ selectedIds: [], peers: AGENTS.slice(0, 2) })
+
+    expect(el.textContent).toContain('No agents selected.')
+    expect(el.textContent).toContain('No peers selected')
+    expect(el.textContent).not.toContain('not visible')
+  })
+
+  it('renders no editing affordances when read-only', async () => {
+    const el = await renderReadOnly({ selectedIds: [AGENTS[0]!.id], peers: AGENTS.slice(0, 2) })
+
+    expect(el.querySelector('input')).toBeNull() // no "Search agents…" field
+    expect(el.querySelector('[role="group"]')).toBeNull() // no All agents/Selected toggle
+    expect(el.querySelectorAll('button')).toHaveLength(0) // no mode or remove buttons
+    expect(el.textContent).toContain('Selected agents') // the read-only state line instead
+  })
 })

--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -262,14 +262,20 @@ export function AgentCallVisibility({
         ) : (
           <div className="flex flex-wrap items-center gap-[6px]">
             {selectedPeers.map((peer) => (
+              // `displayName` is unbounded, so the chip must be able to shrink and
+              // clip inside this wrapping row — otherwise one long name paints over
+              // the neighbouring direction card (desktop) or past the card edge.
               <span
                 key={peer.id}
-                className="flex h-6 flex-none items-center gap-[5px] rounded-full bg-(--surface-active) pr-[9px] pl-[5px]"
+                className="flex h-6 max-w-full min-w-0 items-center gap-[5px] rounded-full bg-(--surface-active) pr-[9px] pl-[5px]"
               >
                 <span className="flex h-4 w-4 flex-none items-center justify-center rounded-xs border border-(--border-subtle) bg-(--surface-card) [&>svg]:h-full [&>svg]:w-full">
                   <AgentIconView icon={peer.icon} runtime={peer.runtime} size={16} />
                 </span>
-                <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-primary)">
+                <span
+                  title={agentLabel(peer)}
+                  className="truncate font-sans text-[12.5px] font-medium leading-normal text-(--text-primary)"
+                >
                   {agentLabel(peer)}
                 </span>
               </span>
@@ -373,9 +379,15 @@ export function AgentCallVisibility({
     </div>
   ) : null
 
-  // Count the whole grant, including peers hidden from this viewer — otherwise a
-  // restricted-but-invisible selection reads as "No peers selected".
-  const policyPeerCount = mode === 'all' ? policyPeers.length : selectedTotal
+  // Whether ANYTHING is granted counts hidden peers (else a restricted-but-
+  // invisible selection reads as "No peers selected"), but the reachability
+  // FRACTION must not: `effectivePeerIds` is computed over the viewer-filtered
+  // roster, so no reciprocal policy was ever evaluated for a hidden peer. Mixing
+  // a visible-only numerator into a visible+hidden denominator would state an
+  // exact negative about something unknown, so the unknown part is reported
+  // separately rather than folded into the fraction.
+  const hasSelection = mode === 'all' ? policyPeers.length > 0 : selectedTotal > 0
+  const evaluatedCount = policyPeers.length
   const relationshipLabel = direction === 'inbound' ? 'Can call this agent' : 'This agent can call'
   const effectiveSummary =
     effectivePeerIds !== undefined && mode === 'selected' ? (
@@ -386,22 +398,25 @@ export function AgentCallVisibility({
       >
         <span className="flex min-w-0 items-center gap-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)">
           <Icon
-            name={policyPeerCount === 0 ? 'users' : 'arrow-left-right'}
+            name={hasSelection ? 'arrow-left-right' : 'users'}
             size={13}
             color="var(--text-tertiary)"
             className="flex-none"
           />
-          {policyPeerCount === 0 ? 'No peers selected' : relationshipLabel}
+          {hasSelection ? relationshipLabel : 'No peers selected'}
         </span>
-        {policyPeerCount > 0 && (
-          <span
-            // Reachability can only be computed for peers this viewer can see, so
-            // say so rather than letting a hidden grant read as unreachable.
-            title={hiddenSelectedNote}
-            className="flex-none font-mono text-[11px] font-semibold leading-normal text-(--text-primary)"
-          >
-            {effectivePeers.length} of {policyPeerCount}
-            {hiddenSelectedCount > 0 ? '*' : ''}
+        {hasSelection && (
+          <span className="flex flex-none items-center gap-[6px] font-mono text-[11px] font-semibold leading-normal text-(--text-primary)">
+            {evaluatedCount > 0 && (
+              <span>
+                {effectivePeers.length} of {evaluatedCount}
+              </span>
+            )}
+            {hiddenSelectedCount > 0 && (
+              <span title={hiddenSelectedNote} className="font-medium text-(--text-tertiary)">
+                {hiddenSelectedCount} unknown
+              </span>
+            )}
           </span>
         )}
       </div>

--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -43,6 +43,23 @@ function daemonLabel(agent: Agent): string {
   return !agent.daemon || agent.daemon === '—' ? 'unplaced' : agent.daemon
 }
 
+/** Stands in for granted peers this viewer can't resolve (restricted agents are
+ *  filtered out of `/agents`, yet their grants remain active and are preserved
+ *  by the CP on save). Without it the allow-list would under-report itself. */
+function HiddenSelectionChip({ count, note }: { count: number; note?: string }) {
+  return (
+    <span
+      title={note}
+      className="flex h-6 flex-none items-center gap-[5px] rounded-full border border-dashed border-(--border-default) pr-[9px] pl-[7px]"
+    >
+      <Icon name="eye-off" size={12} color="var(--text-tertiary)" className="flex-none" />
+      <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+        {count} not visible
+      </span>
+    </span>
+  )
+}
+
 function plural(count: number, word: string): string {
   return count === 1 ? word : `${word}s`
 }
@@ -77,6 +94,23 @@ export function AgentCallVisibility({
     () => visibleSelected.flatMap((id) => peers.find((p) => p.id === id) ?? []),
     [peers, visibleSelected]
   )
+  // Grants can point at peers this viewer cannot see: `/agents` hides restricted
+  // agents from non-owners, and the CP's resolvePolicyAgentIds deliberately
+  // RETAINS those existing grants when a collaborator edits the policy. So an
+  // unresolvable id is an active grant we must still account for — never treat
+  // `selectedPeers.length === 0` as "nothing is selected".
+  const uniqueSelectedIds = useMemo(() => [...new Set(selectedIds)], [selectedIds])
+  const hiddenSelectedCount = useMemo(
+    () => uniqueSelectedIds.filter((id) => !peerIds.has(id)).length,
+    [uniqueSelectedIds, peerIds]
+  )
+  const selectedTotal = selectedPeers.length + hiddenSelectedCount
+  const hiddenSelectedNote =
+    hiddenSelectedCount > 0
+      ? `${hiddenSelectedCount} selected ${plural(hiddenSelectedCount, 'agent')} ${
+          hiddenSelectedCount === 1 ? 'is' : 'are'
+        } restricted and not visible to you.`
+      : undefined
   const policyPeers = mode === 'all' ? peers : selectedPeers
   const effectivePeerIdSet = useMemo(() => new Set(effectivePeerIds ?? []), [effectivePeerIds])
   const effectivePeers = useMemo(
@@ -221,12 +255,12 @@ export function AgentCallVisibility({
       // Read-only `selected`: the chosen peers as plain chips — no search field,
       // no remove buttons, nothing that invites an edit this surface can't make.
       <div className="min-h-[60px] px-4 py-[14px]">
-        {selectedPeers.length === 0 ? (
+        {selectedTotal === 0 ? (
           <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
             No agents selected.
           </span>
         ) : (
-          <div className="flex flex-wrap gap-[6px]">
+          <div className="flex flex-wrap items-center gap-[6px]">
             {selectedPeers.map((peer) => (
               <span
                 key={peer.id}
@@ -240,6 +274,7 @@ export function AgentCallVisibility({
                 </span>
               </span>
             ))}
+            {hiddenSelectedCount > 0 && <HiddenSelectionChip count={hiddenSelectedCount} note={hiddenSelectedNote} />}
           </div>
         )}
       </div>
@@ -272,6 +307,10 @@ export function AgentCallVisibility({
               </button>
             </span>
           ))}
+          {/* Grants to peers this editor can't see are preserved by the CP on
+              save — surface them so the row never reads as a smaller allow-list
+              than the one actually stored. */}
+          {hiddenSelectedCount > 0 && <HiddenSelectionChip count={hiddenSelectedCount} note={hiddenSelectedNote} />}
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
@@ -334,7 +373,9 @@ export function AgentCallVisibility({
     </div>
   ) : null
 
-  const policyPeerCount = policyPeers.length
+  // Count the whole grant, including peers hidden from this viewer — otherwise a
+  // restricted-but-invisible selection reads as "No peers selected".
+  const policyPeerCount = mode === 'all' ? policyPeers.length : selectedTotal
   const relationshipLabel = direction === 'inbound' ? 'Can call this agent' : 'This agent can call'
   const effectiveSummary =
     effectivePeerIds !== undefined && mode === 'selected' ? (
@@ -353,8 +394,14 @@ export function AgentCallVisibility({
           {policyPeerCount === 0 ? 'No peers selected' : relationshipLabel}
         </span>
         {policyPeerCount > 0 && (
-          <span className="flex-none font-mono text-[11px] font-semibold leading-normal text-(--text-primary)">
+          <span
+            // Reachability can only be computed for peers this viewer can see, so
+            // say so rather than letting a hidden grant read as unreachable.
+            title={hiddenSelectedNote}
+            className="flex-none font-mono text-[11px] font-semibold leading-normal text-(--text-primary)"
+          >
             {effectivePeers.length} of {policyPeerCount}
+            {hiddenSelectedCount > 0 ? '*' : ''}
           </span>
         )}
       </div>

--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -123,7 +123,18 @@ export function AgentCallVisibility({
     onChange('selected', next)
   }
 
-  const toggle = (
+  // Read-only surfaces (the agent page's Access card, or a viewer without
+  // sharing rights) must not render a segmented toggle and a search box that
+  // look editable but silently do nothing. They get the state as a plain line
+  // plus a non-interactive peer list instead — same card, honest affordances.
+  const toggle = !editable ? (
+    <div className="flex items-center gap-2">
+      <Icon name={mode === 'all' ? 'globe' : 'lock'} size={13} color="var(--text-tertiary)" className="flex-none" />
+      <span className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+        {mode === 'all' ? 'All agents' : 'Selected agents'}
+      </span>
+    </div>
+  ) : (
     <div
       className={
         variant === 'section'
@@ -204,6 +215,32 @@ export function AgentCallVisibility({
           <span className="col-start-2 w-fit rounded-full bg-(--surface-active) px-[9px] py-[2px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-tertiary) desktop:col-auto desktop:flex-none">
             default
           </span>
+        )}
+      </div>
+    ) : !editable ? (
+      // Read-only `selected`: the chosen peers as plain chips — no search field,
+      // no remove buttons, nothing that invites an edit this surface can't make.
+      <div className="min-h-[60px] px-4 py-[14px]">
+        {selectedPeers.length === 0 ? (
+          <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
+            No agents selected.
+          </span>
+        ) : (
+          <div className="flex flex-wrap gap-[6px]">
+            {selectedPeers.map((peer) => (
+              <span
+                key={peer.id}
+                className="flex h-6 flex-none items-center gap-[5px] rounded-full bg-(--surface-active) pr-[9px] pl-[5px]"
+              >
+                <span className="flex h-4 w-4 flex-none items-center justify-center rounded-xs border border-(--border-subtle) bg-(--surface-card) [&>svg]:h-full [&>svg]:w-full">
+                  <AgentIconView icon={peer.icon} runtime={peer.runtime} size={16} />
+                </span>
+                <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-primary)">
+                  {agentLabel(peer)}
+                </span>
+              </span>
+            ))}
+          </div>
         )}
       </div>
     ) : (


### PR DESCRIPTION
## What & why

Follow-up to #46. The agent page's Access card shares `AgentCallVisibility` with the Add/Edit modals so the two surfaces stay visually identical — but read-only mode still drew a segmented **All agents / Selected** toggle, a **"Search agents…"** field and **removable chips**.

They were only `disabled`, so the card *looked* editable and silently did nothing when clicked. That's a worse problem than the style mismatch that motivated sharing the component in the first place.

## Changes

### Honest read-only affordances
`editable={false}` now renders a genuinely read-only body:
- the policy as a **globe / lock state line** ("All agents" / "Selected agents") instead of the segmented toggle;
- for `selected`, the chosen peers as **plain chips** — no remove buttons, no search field;
- an explicit "No agents selected." when the allow-list is genuinely empty.

The card chrome, the INBOUND/OUTBOUND header and the reachability footer are untouched, so both surfaces still read as one design. This also covers a **viewer without sharing rights** opening the Edit modal (`editable` is already false there).

### Hidden grants are not an empty allow-list
`selectedPeers` resolves ids through `peers`, but `/agents` filters restricted agents out for non-owners while the CP's `resolvePolicyAgentIds` deliberately **retains** those grants. A viewer can therefore hold a non-empty `selectedIds` whose entries are all unresolvable — which would have announced "No agents selected" over an active grant.

An unresolvable id is now treated as a *hidden* peer, not a missing one: resolvable peers render as chips plus a **"N not visible"** chip, and "No agents selected." is reserved for a genuinely empty list.

### Known vs unknown reachability
`effectivePeerIds` is computed over the viewer-filtered roster, so no reciprocal policy is ever evaluated for a hidden peer. The footer therefore keeps the fraction to peers actually evaluated and reports the rest separately — `0 of 1 · 1 unknown`, never a `0 of 2` that would assert an exact negative about an unevaluated relationship. Whether *anything* is granted still counts hidden peers, so an invisible selection never reads as "No peers selected".

### Overflow
`displayName` is unbounded, so the read-only chip shrinks and clips (`min-w-0 max-w-full` + `truncate`, full name on a `title`) instead of painting across the adjacent direction card.

**Editable path:** unchanged except that the chip row now shows the same "N not visible" marker — a collaborator's save silently preserves those grants, so the row should not under-report the stored allow-list.

## Verification

- `typecheck`, `lint`, `prettier`, **316 web tests** green against current `main`.
- Five new component tests: hidden-only, mixed visible+hidden, genuinely empty, long-name truncation, and the read-only affordance check. Verified the hidden-selection tests fail without the fix (the reverted build reproduces "No agents selected.No peers selected" over an active grant).
- Checked live against a local control plane with the agent set to `selected` in both directions: the Access card shows the lock line plus non-removable peer chips, while the Edit modal still shows the full editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)