### PR TITLE
fix(security): harden frame and release note handling

### DIFF
--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -47,7 +47,9 @@ export class DaemonConnection implements ConnChannel {
   start(): void {
     this.state = 'AUTHENTICATING'
     this.transport.onMessage((t) => {
-      void this.onText(t)
+      void this.onText(t).catch(() => {
+        if (this.state !== 'CLOSED') this.close(1011, 'SERVER_INTERNAL')
+      })
     })
     this.transport.onClose((c, r) => this.onClose(c, r))
   }

--- a/packages/control-plane/src/ws/relay-connection.ts
+++ b/packages/control-plane/src/ws/relay-connection.ts
@@ -94,7 +94,11 @@ export class RelayConnection implements RelayChannel {
 
   /** Begin: wire transport callbacks (the gate opens at AUTHENTICATING). */
   start(): void {
-    this.transport.onMessage((t) => void this.onText(t))
+    this.transport.onMessage((t) => {
+      void this.onText(t).catch(() => {
+        if (this.state !== 'CLOSED') this.close(1011, 'SERVER_INTERNAL')
+      })
+    })
     this.transport.onClose(() => this.onClose())
   }
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -80,6 +80,12 @@ describe('decodeEnvelope — first failing test (design §6 Phase 0)', () => {
     expect(r).toEqual({ ok: false, id: ID, msg: 'UNKNOWN_FRAME' })
   })
 
+  it('rejects inherited schema-map keys with UNKNOWN_FRAME', () => {
+    for (const type of ['__proto__', 'constructor', 'toString']) {
+      expect(decodeEnvelope(envelope(type, {}))).toEqual({ ok: false, id: ID, msg: 'UNKNOWN_FRAME' })
+    }
+  })
+
   it('rejects a frame larger than 256 KiB with FRAME_TOO_LARGE', () => {
     const big = 'x'.repeat(MAX_FRAME_BYTES + 1)
     const r = decodeEnvelope(envelope('auth', { ...validAuthPayload, agentVersion: big }))

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -72,7 +72,7 @@ export function decodeEnvelopeWith<TFrame>(
         : NIL_UUID
     return { ok: false, id, msg: env.error.message }
   }
-  const schema = schemas[env.data.type]
+  const schema = Object.hasOwn(schemas, env.data.type) ? schemas[env.data.type] : undefined
   if (!schema) {
     return {
       ok: false,

--- a/release.config.js
+++ b/release.config.js
@@ -58,14 +58,7 @@ export default {
         // `npm i @agentconnect.md/daemon` never grabs an rc. The script restores
         // the manifest changed by prepareCmd before any later release step runs.
         publishCmd:
-          'sh scripts/publish-daemon-if-changed.sh "${lastRelease.gitTag}" "${nextRelease.version.includes("-") ? "rc" : "latest"}"',
-        // Expose the published tag to release.yaml so image publication can run
-        // next in the same workflow. Also write the version + notes to the job
-        // summary. Both happen only when a release is actually published. Notes
-        // come straight from semantic-release's release context; the quoted
-        // heredoc keeps markdown/backticks/$ literal under /bin/sh.
-        successCmd:
-          '[ -n "$GITHUB_OUTPUT" ] && echo \'version=${nextRelease.gitTag}\' >> "$GITHUB_OUTPUT"; [ -n "$GITHUB_STEP_SUMMARY" ] && cat >> "$GITHUB_STEP_SUMMARY" <<\'__ACP_NOTES__\'\n### 🚀 Released ${nextRelease.gitTag}\n\n${nextRelease.notes}\n__ACP_NOTES__\n'
+          'sh scripts/publish-daemon-if-changed.sh "${lastRelease.gitTag}" "${nextRelease.version.includes("-") ? "rc" : "latest"}"'
       }
     ],
     [
@@ -83,6 +76,11 @@ export default {
           'sh scripts/publish-cli-if-changed.sh "${lastRelease.gitTag}" "${nextRelease.version.includes("-") ? "rc" : "latest"}"'
       }
     ],
+    // Expose the published tag to release.yaml so image publication can run
+    // next in the same workflow, and add the version + notes to the job summary.
+    // Write through Node's file API so commit-derived notes are never evaluated
+    // by the shell.
+    './scripts/semantic-release-summary.js',
     [
       // semantic-release creates and pushes the git tag before publish plugins
       // run. Keep that behavior for rc builds, but let this adapter skip the

--- a/scripts/semantic-release-summary.js
+++ b/scripts/semantic-release-summary.js
@@ -1,0 +1,10 @@
+import { appendFile } from 'node:fs/promises'
+
+export async function success(_pluginConfig, { env, nextRelease }) {
+  if (env.GITHUB_OUTPUT) {
+    await appendFile(env.GITHUB_OUTPUT, `version=${nextRelease.gitTag}\n`)
+  }
+  if (env.GITHUB_STEP_SUMMARY) {
+    await appendFile(env.GITHUB_STEP_SUMMARY, `### 🚀 Released ${nextRelease.gitTag}\n\n${nextRelease.notes}\n`)
+  }
+}

--- a/scripts/semantic-release-summary.test.mjs
+++ b/scripts/semantic-release-summary.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+import releaseConfig from '../release.config.js'
+import { success } from './semantic-release-summary.js'
+
+test('release summary writes commit-derived notes literally', async (t) => {
+  assert.ok(releaseConfig.plugins.includes('./scripts/semantic-release-summary.js'))
+  const daemonPublisher = releaseConfig.plugins.find(
+    (plugin) => Array.isArray(plugin) && plugin[1]?.prepareCmd?.includes('publish-daemon-if-changed')
+  )
+  assert.ok(daemonPublisher)
+  assert.equal(daemonPublisher[1].successCmd, undefined)
+
+  const dir = await mkdtemp(join(tmpdir(), 'agentconnect-release-summary-'))
+  t.after(() => rm(dir, { recursive: true, force: true }))
+
+  const outputPath = join(dir, 'output')
+  const summaryPath = join(dir, 'summary')
+  const markerPath = join(dir, 'should-not-run')
+  const notes = `__ACP_NOTES__\ntouch "${markerPath}"\n\`echo should-not-run\``
+
+  await success(
+    {},
+    {
+      env: {
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: summaryPath
+      },
+      nextRelease: {
+        gitTag: 'v1.2.3',
+        notes
+      }
+    }
+  )
+
+  assert.equal(await readFile(outputPath, 'utf8'), 'version=v1.2.3\n')
+  assert.equal(await readFile(summaryPath, 'utf8'), `### 🚀 Released v1.2.3\n\n${notes}\n`)
+  await assert.rejects(readFile(markerPath), { code: 'ENOENT' })
+})


### PR DESCRIPTION
## What

- Reject inherited schema-map keys in the shared WebSocket frame decoder and return `UNKNOWN_FRAME`.
- Catch unexpected frame-processing rejections at both control-plane WebSocket connection boundaries so one socket cannot create an unhandled rejection.
- Replace the semantic-release shell heredoc with a local success plugin that appends the release tag and notes through Node's file API.
- Add focused regressions for prototype-key frame types and heredoc/command-shaped release notes.

## Why

F1 allowed an unauthenticated frame type such as an inherited `Object.prototype` key to bypass the unknown-frame guard and throw before authentication. F2 interpolated commit-derived release notes into a fixed shell heredoc, allowing a crafted note to terminate the heredoc and become shell input in the release job.

## Impact

Unknown or inherited frame types now remain typed protocol failures, and release notes are handled strictly as file content while preserving the existing GitHub output and job-summary behavior.

## Checks

- `pnpm --filter @agentconnect.md/protocol exec vitest run src/codec.test.ts`
- `node --test scripts/release-notes.test.mjs scripts/semantic-release-summary.test.mjs`
- `pnpm --filter @agentconnect.md/protocol --filter @agentconnect.md/control-plane -r typecheck`
- Targeted ESLint and Prettier checks
- Control-plane unit tests: 627 passed
- Relay unit tests: 284 passed

Created by Codex . GPT-5
