### PR TITLE
fix(daemon): harden memory writes against symlinks

### DIFF
--- a/packages/daemon/src/agents/memory.ts
+++ b/packages/daemon/src/agents/memory.ts
@@ -10,14 +10,15 @@
  * full-write and str-replace edits); the daemon serves the same directory to the CP
  * for the console (which still lists files via the internal `listMemory` helper).
  *
- * SECURITY: topic paths are agent/console-supplied, so every path is contained to
- * the memory dir — absolute paths and `..` escapes are rejected, and the resolved
- * path is re-checked so a symlink can't smuggle a target out. Flat by design (one
- * level): a topic is a file directly under `memory/`, no nested dirs.
+ * SECURITY: topic paths are agent/console-supplied, so absolute paths and `..`
+ * escapes are rejected. Writes additionally walk and canonicalise every parent,
+ * reject symlinks/non-files, and publish through a random exclusive temp file.
+ * Flat by design (one level): a topic is a file directly under `memory/`, no
+ * nested dirs.
  */
 import { randomUUID } from 'node:crypto'
-import { promises as fsp, mkdirSync, existsSync, writeFileSync } from 'node:fs'
-import { join, resolve, isAbsolute, sep } from 'node:path'
+import { constants, promises as fsp, lstatSync, mkdirSync, realpathSync, writeFileSync, type Stats } from 'node:fs'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { MEMORY_INDEX } from '@agentconnect.md/protocol'
 
 export const MEMORY_DIRNAME = 'memory'
@@ -127,18 +128,152 @@ export function resolveInMemoryDir(agentDir: string, relPath: string): string {
   return abs
 }
 
+function isErrno(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === code
+}
+
+function under(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+function sameFileVersion(a: Stats, b: Stats): boolean {
+  return b.isFile() && a.dev === b.dev && a.ino === b.ino && a.size === b.size && a.mtimeMs === b.mtimeMs
+}
+
+/**
+ * Create and canonicalise a destination's parent one component at a time.
+ * `root` is the provider-owned memory tree; `agentDir` is the trusted outer
+ * boundary. Existing symlink components are rejected instead of followed.
+ */
+async function containedWriteTarget(agentDir: string, root: string, destination: string): Promise<string> {
+  const lexicalAgent = resolve(agentDir)
+  const lexicalRoot = resolve(root)
+  const lexicalTarget = resolve(destination)
+  if (!under(lexicalAgent, lexicalRoot) || !under(lexicalRoot, lexicalTarget)) {
+    throw new MemoryPathError('path escapes the memory dir')
+  }
+
+  const realAgent = await fsp.realpath(lexicalAgent)
+  let parent = realAgent
+  for (const part of relative(lexicalAgent, dirname(lexicalTarget)).split(sep).filter(Boolean)) {
+    const candidate = join(parent, part)
+    let stat: Stats
+    try {
+      stat = await fsp.lstat(candidate)
+    } catch (err) {
+      if (!isErrno(err, 'ENOENT')) throw err
+      try {
+        await fsp.mkdir(candidate)
+      } catch (mkdirErr) {
+        if (!isErrno(mkdirErr, 'EEXIST')) throw mkdirErr
+      }
+      stat = await fsp.lstat(candidate)
+    }
+    if (!stat.isDirectory()) throw new MemoryPathError('memory path contains a symlink or non-directory')
+    parent = await fsp.realpath(candidate)
+    if (!under(realAgent, parent)) throw new MemoryPathError('path resolves outside the agent root')
+  }
+
+  const realRoot = await fsp.realpath(lexicalRoot)
+  if (!under(realAgent, realRoot) || !under(realRoot, parent)) {
+    throw new MemoryPathError('path resolves outside the memory dir')
+  }
+  return join(parent, basename(lexicalTarget))
+}
+
+type CurrentMemoryFile =
+  { existed: false; before: ''; stat?: undefined } | { existed: true; before: string; stat: Stats }
+
+async function readCurrentMemoryFile(target: string): Promise<CurrentMemoryFile> {
+  let handle
+  try {
+    handle = await fsp.open(target, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return { existed: false, before: '' }
+    if (isErrno(err, 'ELOOP')) throw new MemoryPathError('memory target is not a regular file')
+    throw err
+  }
+  try {
+    const stat = await handle.stat()
+    if (!stat.isFile()) throw new MemoryPathError('memory target is not a regular file')
+    return { existed: true, before: await handle.readFile('utf8'), stat }
+  } finally {
+    await handle.close()
+  }
+}
+
+/**
+ * Atomically replace one file under a memory provider's tree without following
+ * symlinks. The random `wx` temp defeats pre-planted `<target>.tmp` links; the
+ * canonical parent walk also rejects a symlinked native-memory directory.
+ */
+export async function atomicWriteContainedMemoryFile(
+  agentDir: string,
+  root: string,
+  destination: string,
+  content: string,
+  ifMatchMtime?: string
+): Promise<{ before: string; existed: boolean; stat: Stats }> {
+  const target = await containedWriteTarget(agentDir, root, destination)
+  const current = await readCurrentMemoryFile(target)
+  if (ifMatchMtime && current.stat?.mtime.toISOString() !== ifMatchMtime) {
+    throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
+  }
+
+  const parent = dirname(target)
+  const temp = join(parent, `.agentconnect-memory-${randomUUID()}.tmp`)
+  try {
+    if ((await fsp.realpath(parent)) !== parent) {
+      throw new MemoryPathError('path resolves outside the memory dir')
+    }
+    await fsp.writeFile(temp, content, { encoding: 'utf8', flag: 'wx' })
+
+    if (ifMatchMtime && current.stat) {
+      let latest: Stats
+      try {
+        latest = await fsp.lstat(target)
+      } catch (err) {
+        if (isErrno(err, 'ENOENT')) {
+          throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
+        }
+        throw err
+      }
+      if (!sameFileVersion(current.stat, latest)) {
+        throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
+      }
+    }
+    if ((await fsp.realpath(parent)) !== parent) {
+      throw new MemoryPathError('path resolves outside the memory dir')
+    }
+    await fsp.rename(temp, target)
+  } finally {
+    await fsp.rm(temp, { force: true }).catch(() => {})
+  }
+
+  const stat = await fsp.lstat(target)
+  if (!stat.isFile()) throw new MemoryPathError('memory target is not a regular file')
+  return { before: current.before, existed: current.existed, stat }
+}
+
 /** Seed `<agent-root>/memory/MEMORY.md` with a header if the dir/index is absent
  *  (idempotent). Called at session start so a brand-new agent always has an index. */
 export function ensureMemory(agentDir: string, agentName: string): void {
   const dir = memoryDir(agentDir)
   mkdirSync(dir, { recursive: true })
-  const index = join(dir, MEMORY_INDEX)
-  if (!existsSync(index)) {
+  if (!lstatSync(dir).isDirectory()) throw new MemoryPathError('memory path contains a symlink or non-directory')
+  const realAgent = realpathSync(agentDir)
+  const realDir = realpathSync(dir)
+  if (!under(realAgent, realDir)) throw new MemoryPathError('path resolves outside the agent root')
+  try {
     writeFileSync(
-      index,
+      join(realDir, MEMORY_INDEX),
       `# ${agentName} memory\n\nYour long-term memory index. Keep it short — link out to topic files ` +
-        `(e.g. \`[deploys](deploys.md)\`) for detail and read them on demand with the readMemory tool.\n`
+        `(e.g. \`[deploys](deploys.md)\`) for detail and read them on demand with the readMemory tool.\n`,
+      { encoding: 'utf8', flag: 'wx' }
     )
+  } catch (err) {
+    if (!isErrno(err, 'EEXIST')) throw err
   }
 }
 
@@ -175,8 +310,19 @@ function clampHistoryValue(text: string): { value: string; truncated: boolean } 
  *  a logging failure must never fail the write it describes, so errors are swallowed. */
 export async function appendHistory(agentDir: string, record: MemoryHistoryRecord): Promise<void> {
   try {
-    await fsp.mkdir(memoryDir(agentDir), { recursive: true })
-    await fsp.appendFile(join(memoryDir(agentDir), MEMORY_HISTORY_FILENAME), JSON.stringify(record) + '\n', 'utf8')
+    const dir = memoryDir(agentDir)
+    const target = await containedWriteTarget(agentDir, dir, join(dir, MEMORY_HISTORY_FILENAME))
+    const handle = await fsp.open(
+      target,
+      constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      0o600
+    )
+    try {
+      if (!(await handle.stat()).isFile()) throw new MemoryPathError('memory history is not a regular file')
+      await handle.write(JSON.stringify(record) + '\n')
+    } finally {
+      await handle.close()
+    }
   } catch {
     // provenance is best-effort — never let it break the actual memory write.
   }
@@ -283,32 +429,11 @@ export async function writeMemoryFileHoldingLock(
     throw new MemoryTooLargeError(`memory file exceeds the ${MAX_MEMORY_FILE_BYTES}-byte limit`)
   }
   const abs = resolveInMemoryDir(agentDir, relPath)
-  // Read the prior contents (for the change log's `before` + to decide add vs update)
-  // before we overwrite. '' when absent ⇒ this is an `add`.
-  let before = ''
-  let existed = false
-  try {
-    before = await fsp.readFile(abs, 'utf8')
-    existed = true
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-  }
-  if (ifMatchMtime) {
-    let current: string | null = null
-    try {
-      current = (await fsp.stat(abs)).mtime.toISOString()
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
-    }
-    if (current !== ifMatchMtime) {
-      throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
-    }
-  }
-  await fsp.mkdir(memoryDir(agentDir), { recursive: true })
-  const tmp = `${abs}.tmp`
-  await fsp.writeFile(tmp, content, 'utf8')
-  await fsp.rename(tmp, abs)
-  const st = await fsp.stat(abs)
+  const {
+    before,
+    existed,
+    stat: st
+  } = await atomicWriteContainedMemoryFile(agentDir, memoryDir(agentDir), abs, content, ifMatchMtime)
   // Bump the authoritative ledger the moment the write is durable — BEFORE the
   // best-effort history append, which is allowed to fail silently. The dream
   // adoption fence authorizes from these counters, never from `.history`.

--- a/packages/daemon/src/agents/native-memory.ts
+++ b/packages/daemon/src/agents/native-memory.ts
@@ -13,7 +13,8 @@
  *  2. `nativeMemoryList/Read/Write` — surface the runtime's memory files to the
  *     console from wherever the redirect points. Unlike managed's flat
  *     `<agent-root>/memory/`, the runtime dirs are nested (Claude keys memory by a
- *     sanitized-cwd subpath), so this uses a nested-but-contained walk.
+ *     sanitized-cwd subpath). Writes reject symlinked parents and publish through
+ *     a random exclusive temp file.
  *
  * Levers verified 2026-07-08 (claude docs + binary strings; codex docs; and the
  * daemon's own `runtimes/probe.ts` home-override table):
@@ -26,7 +27,12 @@ import { join, resolve, isAbsolute, sep, relative } from 'node:path'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { MemoryEntry } from '@agentconnect.md/protocol'
 import type { MemoryReadResult, MemoryWriteResult } from './memory-provider.js'
-import { MemoryConflictError, MemoryPathError, MemoryTooLargeError, MAX_MEMORY_FILE_BYTES } from './memory.js'
+import {
+  atomicWriteContainedMemoryFile,
+  MemoryPathError,
+  MemoryTooLargeError,
+  MAX_MEMORY_FILE_BYTES
+} from './memory.js'
 import { nativeRuntimeMemorySpecFor } from './runtime-memory.js'
 
 /** Whether native memory is supported (env levers registered) for this runtime. */
@@ -41,8 +47,8 @@ export function nativeRuntimeEnv(runtime: RuntimeDef, agentRoot: string, runtime
 }
 
 /** Resolve a console-supplied relative path under `root`, allowing nested dirs but
- *  rejecting absolute paths, `..` escapes, and symlink-smuggled escapes. Unlike the
- *  managed dir (flat), native runtime dirs are nested. */
+ *  rejecting absolute paths and lexical `..` escapes. The write path separately
+ *  canonicalises every parent and rejects symlinks. */
 function resolveContained(root: string, relPath: string): string {
   if (isAbsolute(relPath)) throw new MemoryPathError('absolute paths are not allowed')
   const abs = resolve(root, relPath)
@@ -119,23 +125,8 @@ export async function nativeMemoryWrite(
   if (Buffer.byteLength(content) > MAX_MEMORY_FILE_BYTES) {
     throw new MemoryTooLargeError(`memory file exceeds the ${MAX_MEMORY_FILE_BYTES}-byte limit`)
   }
-  const abs = resolveContained(spec.readRoot(agentDir), path)
-  if (ifMatch) {
-    let current: string | null = null
-    try {
-      current = (await fsp.stat(abs)).mtime.toISOString()
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    }
-    if (current !== ifMatch) {
-      throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
-    }
-  }
-  const dir = abs.slice(0, abs.length - (abs.split(sep).pop()?.length ?? 0))
-  await fsp.mkdir(dir, { recursive: true })
-  const tmp = `${abs}.tmp`
-  await fsp.writeFile(tmp, content, 'utf8')
-  await fsp.rename(tmp, abs)
-  const st = await fsp.stat(abs)
+  const root = spec.readRoot(agentDir)
+  const abs = resolveContained(root, path)
+  const { stat: st } = await atomicWriteContainedMemoryFile(agentDir, root, abs, content, ifMatch)
   return { ok: true, path, size: st.size, mtime: st.mtime.toISOString() }
 }

--- a/packages/daemon/test/memory-provider-dispatch.test.ts
+++ b/packages/daemon/test/memory-provider-dispatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { RuntimeDef } from '../src/config/config-schema.js'
@@ -10,7 +10,7 @@ import {
   MemoryProviderUnavailableError,
   type MemoryProviderKind
 } from '../src/agents/memory-provider.js'
-import { MEMORY_INDEX, MemoryConflictError } from '../src/agents/memory.js'
+import { MEMORY_INDEX, MemoryConflictError, MemoryPathError } from '../src/agents/memory.js'
 import { isNativeRuntimeSupported, nativeRuntimeEnv } from '../src/agents/native-memory.js'
 
 function newDir(): string {
@@ -172,6 +172,20 @@ describe('DispatchingMemoryProvider (per-agent routing)', () => {
     await expect(
       p.write({ agentId: 'bot-n' }, nativeFile.name, '# current write', nativeFile.mtime)
     ).resolves.toMatchObject({ ok: true, path: nativeFile.name })
+  })
+
+  it('native write rejects a symlinked parent that leaves the agent root', async () => {
+    const root = newDir()
+    roots['bot-n'] = root
+    const nativeParent = join(root, '.claude', 'projects', 'ws-abc')
+    const outside = newDir()
+    mkdirSync(nativeParent, { recursive: true })
+    symlinkSync(outside, join(nativeParent, 'memory'))
+
+    await expect(provider().write({ agentId: 'bot-n' }, 'ws-abc/memory/MEMORY.md', '# escaped')).rejects.toBeInstanceOf(
+      MemoryPathError
+    )
+    expect(existsSync(join(outside, 'MEMORY.md'))).toBe(false)
   })
 
   it('none: no tools, store, injection, or writes', async () => {

--- a/packages/daemon/test/memory.test.ts
+++ b/packages/daemon/test/memory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, readFileSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -99,6 +99,23 @@ describe('agents/memory (directory model)', () => {
     expect(await readMemoryFile(dir, 'notes.md')).toBe('v2')
     // a precondition on a brand-new (absent) file with a non-empty mtime is a conflict
     await expect(writeMemoryFile(dir, 'fresh.md', 'x', 'some-mtime')).rejects.toBeInstanceOf(MemoryConflictError)
+  })
+
+  it('does not follow a pre-planted predictable temp symlink', async () => {
+    const dir = newDir()
+    const outside = join(newDir(), 'outside.txt')
+    const outsideHistory = join(newDir(), 'history.txt')
+    writeFileSync(outside, 'keep')
+    writeFileSync(outsideHistory, 'keep-history')
+    mkdirSync(memoryDir(dir), { recursive: true })
+    symlinkSync(outside, join(memoryDir(dir), 'notes.md.tmp'))
+    symlinkSync(outsideHistory, join(memoryDir(dir), MEMORY_HISTORY_FILENAME))
+
+    await writeMemoryFile(dir, 'notes.md', 'updated')
+
+    expect(readFileSync(outside, 'utf8')).toBe('keep')
+    expect(readFileSync(outsideHistory, 'utf8')).toBe('keep-history')
+    expect(readFileSync(join(memoryDir(dir), 'notes.md'), 'utf8')).toBe('updated')
   })
 })
 


### PR DESCRIPTION
## Summary

- replace predictable managed and native memory temp paths with randomized exclusive temp files
- canonicalize and validate every write-parent component under the agent root, rejecting symlinks and non-directories
- refuse non-regular final targets and use no-follow, non-blocking file descriptors for existing memory files and history appends
- harden initial `MEMORY.md` creation and the best-effort `.history` sidecar against the same symlink class

## Root cause

Both memory providers performed lexical containment only, then wrote through a predictable `<target>.tmp` path with normal truncate/create semantics. An agent that can write its memory directory could pre-plant a symlink and make the unsandboxed daemon overwrite a file outside the sandbox. Native memory also allowed a symlinked parent inside the runtime-owned home.

## Impact

Managed-agent writes and console-driven native-memory writes now fail closed on symlinked paths and publish atomically through an unpredictable `wx` temp file, preventing the reported F3/F13 arbitrary-write escapes.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- ESLint and Prettier checks on all changed files
- 97 focused managed/native memory and dream tests passed
- Full daemon run completed 2,048 passing assertions (2 skipped); the local Vitest process then hit the existing macOS `EMFILE` watcher limit, including with one worker
- pre-push repository lint: 0 errors (2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
