### PR TITLE
fix(control-plane): guard against unhandled promise rejections

### DIFF
--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -14,6 +14,19 @@ import { startControlPlaneOpenTelemetry } from './observability.js'
 
 const telemetry = startControlPlaneOpenTelemetry()
 
+// One process co-hosts the BFF REST surface, the daemon WS gateway, and the relay
+// WS gateway for EVERY tenant, so a single floating rejection anywhere must not take
+// the whole control plane down (and, under a restart loop, keep taking it down). The
+// WS connections catch their own frame-processing rejections at the transport
+// boundary; this is the last resort for the paths that cannot — mirroring the guards
+// the daemon (index.ts) and relay (index.ts) already install. Node's default here is
+// to crash the process.
+process.on('unhandledRejection', (reason) => {
+  console.error(
+    `control-plane: unhandled rejection (continuing): ${reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)}`
+  )
+})
+
 async function main(): Promise<void> {
   const [
     { loadConfig },


### PR DESCRIPTION
## What

- Install a process-level `unhandledRejection` handler in the control-plane bootstrap, at module scope so it covers boot as well as steady state.

## Why

The control plane runs one process that co-hosts every tenant's BFF REST surface, the daemon WS gateway, and the relay WS gateway — but it was the only service without this guard. The daemon (`packages/daemon/src/index.ts`) and the relay (`packages/relay/src/index.ts`) have both installed one, each with the same reasoning: a shared process must not die because one path let a rejection float. Node's default is to terminate, so any unhandled rejection took the whole control plane down, and under a supervisor kept taking it down on each restart.

This is defense in depth behind the per-connection catches added in #78. Those close a single socket when frame processing rejects; this bounds every path that cannot catch its own rejection.

## Impact

Unhandled rejections are logged and the process keeps serving. Boot failures are unaffected — they still exit non-zero through the existing `main().catch`, since that rejection is handled and never reaches this listener.

## Checks

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 73 files, 627 tests passed
- `npx eslint packages/control-plane/src/index.ts`, `npx prettier --check packages/control-plane/src/index.ts`
- A standalone harness reproducing the bootstrap's shape confirmed both behaviors: a floating rejection is logged and the process survives; a boot failure still exits 1.

Note: no test in the suite covers `index.ts` (control-plane tests call `buildApp` directly), so the harness above is ad-hoc rather than committed coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)