### PR TITLE
fix(security): bind session reads to their owner

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -545,6 +545,7 @@ const SessionListPage = z.object({ sessions: z.array(SessionListItem) }) // D→
 // ── history: one cursor page of a session's transcript ──
 const SessionHistoryReq = z.object({
   // C→D REQ
+  agentId: z.string().uuid(), // CP-authorized owner; daemon verifies the binding
   sessionId: z.string(), // ACP session id — opaque string, NOT a UUID
   cursor: z.string().optional(), // opaque; omit ⇒ newest page
   limit: z.number().int().positive().max(200).default(50)
@@ -574,7 +575,14 @@ separately.
 scoped to the caller's visible agents; `agentId`/`platform`/`channel` filters
 narrow the set. No daemon is contacted.
 
-**History** (`GET /sessions/:id/messages?agentId=&cursor=&limit=`): the owning daemon is resolved via the row's `agentId`, then `session/history` pulls the page. Cursor-based, newest-first. If the agent is unplaced or its daemon is offline → 503 (the list still works; only that transcript is unavailable). This is an explicit, bounded content-read path: the Control Plane proxies the reply without persisting it. The memory and workspace read families follow the same locality rule.
+**History** (`GET /sessions/:id/messages?cursor=&limit=`): the CP loads the
+`session_meta` row, authorizes its owning agent, and resolves that agent's
+daemon; `session/history` carries the owner `agentId` so the daemon can verify
+the `(agentId, sessionId)` binding before returning content. Cursor-based,
+newest-first. If the agent is unplaced or its daemon is offline → 503 (the list
+still works; only that transcript is unavailable). This is an explicit, bounded
+content-read path: the Control Plane proxies the reply without persisting it.
+The memory and workspace read families follow the same locality rule.
 
 ### 7.7 `channel/agents` (D→C, REQ → REP) — agent collaboration directory
 

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -545,7 +545,7 @@ const SessionListPage = z.object({ sessions: z.array(SessionListItem) }) // D→
 // ── history: one cursor page of a session's transcript ──
 const SessionHistoryReq = z.object({
   // C→D REQ
-  agentId: z.string().uuid(), // CP-authorized owner; daemon verifies the binding
+  agentId: z.string().uuid().optional(), // current CP sends the authorized owner; optional only for rolling upgrades
   sessionId: z.string(), // ACP session id — opaque string, NOT a UUID
   cursor: z.string().optional(), // opaque; omit ⇒ newest page
   limit: z.number().int().positive().max(200).default(50)
@@ -583,6 +583,11 @@ newest-first. If the agent is unplaced or its daemon is offline → 503 (the lis
 still works; only that transcript is unavailable). This is an explicit, bounded
 content-read path: the Control Plane proxies the reply without persisting it.
 The memory and workspace read families follow the same locality rule.
+
+`agentId` remains optional on these two wire requests only so a new daemon can
+still serve an older CP during a rolling upgrade. The daemon logs that legacy
+path and uses the pre-binding lookup. Current CPs always send the owner; once
+present, the daemon fails closed on an `(agentId, sessionId)` mismatch.
 
 ### 7.7 `channel/agents` (D→C, REQ → REP) — agent collaboration directory
 

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -145,6 +145,7 @@ Request:
 
 ```ts
 {
+  agentId: string // CP-authorized owner; daemon verifies the session binding
   sessionId: string
   toolCallId: string
   offset: number // defaults to 0

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -168,6 +168,10 @@ Response:
 offset. It does not select individual fields. Each chunk independently obeys
 the frame budget; absence of `nextOffset` marks the final chunk.
 
+Before reading the row, the daemon verifies the `(agentId, sessionId)` binding
+and requires the tool row's sender to be the same agent. A tool-call id from a
+peer sharing the channel and thread cannot cross this body-read boundary.
+
 The Control Plane exposes the authenticated HTTP proxy for this request, and
 the Console concatenates chunks before parsing and rendering the JSON.
 

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -174,6 +174,11 @@ identity and updates also include that agent because ACP tool-call ids are only
 session-local. A peer sharing the channel and thread can neither overwrite nor
 read another agent's body.
 
+The request's `agentId` is wire-optional only for a rolling upgrade where a new
+daemon still talks to an older CP. That legacy path is logged and uses the
+pre-binding session lookup; current CPs always send their persisted,
+already-authorized session owner.
+
 The Control Plane exposes the authenticated HTTP proxy for this request, and
 the Console concatenates chunks before parsing and rendering the JSON.
 

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -169,8 +169,10 @@ offset. It does not select individual fields. Each chunk independently obeys
 the frame budget; absence of `nextOffset` marks the final chunk.
 
 Before reading the row, the daemon verifies the `(agentId, sessionId)` binding
-and requires the tool row's sender to be the same agent. A tool-call id from a
-peer sharing the channel and thread cannot cross this body-read boundary.
+and requires the tool row's sender to be the same agent. Stored tool-row
+identity and updates also include that agent because ACP tool-call ids are only
+session-local. A peer sharing the channel and thread can neither overwrite nor
+read another agent's body.
 
 The Control Plane exposes the authenticated HTTP proxy for this request, and
 the Console concatenates chunks before parsing and rendering the JSON.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1898,7 +1898,6 @@ export const SessionHistoryDto = z.object({
 
 /** `GET /sessions/:id/tool-body` query — one byte slice of a tool call's full ToolBody JSON. */
 export const SessionToolBodyQueryDto = z.object({
-  agentId: z.string(), // the owning agent (resolves the daemon), mirrors the messages route
   toolCallId: z.string(),
   offset: z.coerce.number().int().nonnegative().optional() // byte offset into the full body JSON
 })

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -258,7 +258,6 @@ function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMeta
 }
 
 const SessionHistoryQueryDto = z.object({
-  agentId: z.string(), // the owning agent (the UI has it from the list row) — resolves the daemon
   cursor: z.string().optional(),
   limit: z.coerce.number().int().positive().max(200).optional()
 })
@@ -274,6 +273,13 @@ export function sessionRoutes(deps: HttpDeps) {
       const agent = await deps.repos.agent.get(AgentId(agentId))
       if (!agent || agent.orgId !== req.orgCtx!.orgId) return null
       return canView(agent, ctxOf(req)) ? agent : null
+    }
+
+    const getOrgViewableSession = async (req: FastifyRequest, sessionId: string) => {
+      const session = await deps.repos.session.get(SessionId(sessionId))
+      if (!session) return null
+      const agent = await getOrgViewableAgent(req, session.agentId)
+      return agent ? { session, agent } : null
     }
 
     r.get(
@@ -392,10 +398,11 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const s = await deps.repos.session.get(SessionId(req.params.id))
-        if (!s || !(await getOrgViewableAgent(req, s.agentId))) {
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
+        const { session: s } = owned
         // Relationships may cross agents (and daemons), so apply the same
         // owning-agent visibility rule to every linked session. A hidden parent
         // is indistinguishable from no parent; hidden children are omitted.
@@ -456,10 +463,11 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const agent = await getOrgViewableAgent(req, req.query.agentId)
-        if (!agent) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
         }
+        const { session, agent } = owned
         if (!agent.daemonId) {
           return reply
             .code(503)
@@ -468,7 +476,8 @@ export function sessionRoutes(deps: HttpDeps) {
 
         try {
           const page = await deps.control.sessionHistory(agent.daemonId, {
-            sessionId: req.params.id,
+            agentId: session.agentId,
+            sessionId: session.id,
             ...(req.query.cursor !== undefined ? { cursor: req.query.cursor } : {}),
             limit: req.query.limit ?? 50
           })
@@ -485,7 +494,7 @@ export function sessionRoutes(deps: HttpDeps) {
     )
 
     // Full-body view: proxy one byte slice of a tool call's untruncated ToolBody
-    // JSON live from the owning daemon (resolved via agentId, same as /messages).
+    // JSON live from the owning daemon (resolved from SessionMeta, same as /messages).
     // The console pages by offset until nextOffset is null. 503 if the agent is
     // unplaced or its daemon is offline.
     r.get(
@@ -503,11 +512,11 @@ export function sessionRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        // Route through the org+visibility gate — this previously did a bare
-        // repo.get with NO org check at all (a cross-tenant tool-body leak), and now
-        // also blocks a non-viewer of a restricted agent.
-        const agent = await getOrgViewableAgent(req, req.query.agentId)
-        if (!agent) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const { session, agent } = owned
         if (!agent.daemonId) {
           return reply
             .code(503)
@@ -516,7 +525,8 @@ export function sessionRoutes(deps: HttpDeps) {
 
         try {
           const chunk = await deps.control.sessionToolBody(agent.daemonId, {
-            sessionId: req.params.id,
+            agentId: session.agentId,
+            sessionId: session.id,
             toolCallId: req.query.toolCallId,
             offset: req.query.offset ?? 0
           })

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -3,8 +3,9 @@
  *
  * - `GET /sessions` reads CP-stored metadata synced from daemon `event/session`
  *   snapshots; transcript bodies remain daemon-local.
- * - `GET /sessions/:id/messages?agentId=` resolves the owning daemon via the
- *   agent and proxies one history page; 404 unknown agent, 503 unplaced/offline.
+ * - `GET /sessions/:id/messages` resolves and authorizes the owning agent from
+ *   SessionMeta, then proxies one history page; 404 unknown/hidden session,
+ *   503 unplaced/offline.
  *
  * Driven with `app.inject`, a spy `ControlSender`, and a liveness override that
  * marks the seeded daemon connected.
@@ -57,6 +58,19 @@ class SpyControl {
 }
 
 const emptyHist: SessionHistoryPage = { sessionId: SESSION, messages: [] }
+
+async function seedSession(agentId = AGENT): Promise<void> {
+  await prisma.sessionMeta.create({
+    data: {
+      id: SESSION,
+      agentId,
+      platform: 'slack',
+      channel: '#deploys',
+      phase: 'start',
+      lastActivityAt: new Date('2026-07-05T08:00:00.000Z')
+    }
+  })
+}
 
 describe('GET /sessions (metadata list from CP DB)', () => {
   it('lists CP-stored session metadata and maps the row shape', async () => {
@@ -531,9 +545,10 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 })
 
 describe('GET /sessions/:id/messages (history pull via the owning agent)', () => {
-  it('resolves the daemon via ?agentId and proxies a page', async () => {
+  it('resolves the owner from SessionMeta and proxies a page', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedSession()
     const spy = new SpyControl(
       { sessions: [] },
       {
@@ -555,7 +570,7 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
 
     const res = await running.app.inject({
       method: 'GET',
-      url: `${ORG}/sessions/${SESSION}/messages?agentId=${AGENT}&cursor=c-100&limit=25`
+      url: `${ORG}/sessions/${SESSION}/messages?cursor=c-100&limit=25`
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as {
@@ -566,34 +581,36 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
     expect(body.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(body.nextCursor).toBe('c-50')
     expect(spy.histCalls[0]!.daemonId).toBe(DAEMON)
-    expect(spy.histCalls[0]!.req).toEqual({ sessionId: SESSION, cursor: 'c-100', limit: 25 })
+    expect(spy.histCalls[0]!.req).toEqual({ agentId: AGENT, sessionId: SESSION, cursor: 'c-100', limit: 25 })
   })
 
-  it('404s for an unknown agent', async () => {
+  it('404s for an unknown session', async () => {
     running = buildHttpApp(prisma)
     const res = await running.app.inject({
       method: 'GET',
-      url: `${ORG}/sessions/${SESSION}/messages?agentId=${randomUUID()}`
+      url: `${ORG}/sessions/${SESSION}/messages`
     })
     expect(res.statusCode).toBe(404)
   })
 
   it('503s when the agent is unplaced (no live daemon)', async () => {
     await seedAgent(prisma, AGENT) // no daemonId
+    await seedSession()
     running = buildHttpApp(prisma)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages?agentId=${AGENT}` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
     expect(res.statusCode).toBe(503)
   })
 
   it('503s when the owning daemon is offline (NoConnection → 503)', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedSession()
     const offline = new ControlSender(
       { get: () => undefined } as unknown as ConstructorParameters<typeof ControlSender>[0],
       { currentLaunch: async () => undefined } as unknown as ConstructorParameters<typeof ControlSender>[1]
     )
     running = buildHttpApp(prisma, undefined, undefined, offline)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages?agentId=${AGENT}` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}/messages` })
     expect(res.statusCode).toBe(503)
   })
 })

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -376,18 +376,34 @@ describe('reference-write cannot target an invisible daemon', () => {
   })
 })
 
-describe('derived visibility — sessions tool-body, usage', () => {
-  it('tool-body 404s for a restricted agent the caller can’t see', async () => {
-    const other = await makeUser('tb-other', 'collaborator')
+describe('derived visibility — session bodies, usage', () => {
+  it('caller-supplied agentId cannot authorize another agent’s session bodies', async () => {
+    const other = await makeUser('session-body-other', 'collaborator')
     const daemon = randomUUID()
     await seedDaemon(prisma, daemon)
+    const visible = randomUUID()
     const R = randomUUID()
+    const session = randomUUID()
+    await seedAgent(prisma, visible, { daemonId: daemon })
     await seedAgent(prisma, R, { daemonId: daemon, visibility: 'restricted', sharedWith: [] })
-    const res = await appAs(other).app.inject({
-      method: 'GET',
-      url: `${ORG}/sessions/${randomUUID()}/tool-body?agentId=${R}&toolCallId=t1`
+    await prisma.sessionMeta.create({
+      data: {
+        id: session,
+        agentId: R,
+        platform: 'slack',
+        channel: 'C-HR',
+        phase: 'start',
+        lastActivityAt: new Date()
+      }
     })
-    expect(res.statusCode).toBe(404)
+
+    const app = appAs(other).app
+    for (const path of [
+      `/sessions/${session}/messages?agentId=${visible}`,
+      `/sessions/${session}/tool-body?agentId=${visible}&toolCallId=t1`
+    ]) {
+      expect((await app.inject({ method: 'GET', url: `${ORG}${path}` })).statusCode).toBe(404)
+    }
   })
 
   it('a restricted agent’s usage is absent from a non-viewer’s aggregate but present for an owner', async () => {

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -790,7 +790,10 @@ export class CpClient {
       }
       case 'session/history': {
         try {
-          this.reply(frame, 'session/history/page', this.deps.sessionRead.history(frame.payload as SessionHistoryReq))
+          const req = frame.payload as SessionHistoryReq
+          if (!req.agentId)
+            this.deps.log.warn('cp: legacy session/history request omitted agentId; owner binding is unavailable')
+          this.reply(frame, 'session/history/page', this.deps.sessionRead.history(req))
         } catch (err) {
           this.sendError(frame.id, 'INTERNAL', `session/history failed: ${(err as Error).message}`, false)
         }
@@ -798,11 +801,10 @@ export class CpClient {
       }
       case 'session/tool-body': {
         try {
-          this.reply(
-            frame,
-            'session/tool-body/chunk',
-            this.deps.sessionRead.toolBody(frame.payload as SessionToolBodyReq)
-          )
+          const req = frame.payload as SessionToolBodyReq
+          if (!req.agentId)
+            this.deps.log.warn('cp: legacy session/tool-body request omitted agentId; owner binding is unavailable')
+          this.reply(frame, 'session/tool-body/chunk', this.deps.sessionRead.toolBody(req))
         } catch (err) {
           this.sendError(frame.id, 'INTERNAL', `session/tool-body failed: ${(err as Error).message}`, false)
         }

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -223,7 +223,7 @@ export function createSessionReader(
       return { sessions }
     },
     history(req) {
-      const rec = store.getSessionByAcpId(req.sessionId)
+      const rec = store.getSessionByAcpIdForAgent(req.agentId, req.sessionId)
       if (!rec) return { sessionId: req.sessionId, messages: [] }
       // Slack can append an older platform row during warm-thread backfill, so its
       // authoritative history pages by normalized event time + seq tie-breaker. A
@@ -319,7 +319,7 @@ export function createSessionReader(
       }
     },
     toolBody(req) {
-      const rec = store.getSessionByAcpId(req.sessionId)
+      const rec = store.getSessionByAcpIdForAgent(req.agentId, req.sessionId)
       const empty: SessionToolBodyChunk = {
         sessionId: req.sessionId,
         toolCallId: req.toolCallId,

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -327,7 +327,7 @@ export function createSessionReader(
         totalBytes: 0
       }
       if (!rec) return empty
-      const body = store.getToolBody(rec.channel, rec.thread, req.toolCallId)
+      const body = store.getToolBodyForAgent(rec.channel, rec.thread, rec.agentId, req.toolCallId)
       if (body === undefined) return empty
       const buf = Buffer.from(body, 'utf8')
       const totalBytes = buf.length

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -123,6 +123,12 @@ function parseUsage(raw: string | null): SessionUsage | undefined {
   }
 }
 
+/** Current CPs send the authorized owner. The unscoped branch preserves rolling
+ * compatibility only while a newly upgraded daemon is still connected to an old CP. */
+function sessionForRead(store: LocalStore, agentId: string | undefined, sessionId: string) {
+  return agentId ? store.getSessionByAcpIdForAgent(agentId, sessionId) : store.getSessionByAcpId(sessionId)
+}
+
 /** Rough character budget to trim a free-form value to when shrinking a preview. A
  *  string is truncated to this many chars; a non-string is stringified then truncated
  *  (kept as a string — the preview is still valid JSON, just lossy on that field). */
@@ -223,7 +229,7 @@ export function createSessionReader(
       return { sessions }
     },
     history(req) {
-      const rec = store.getSessionByAcpIdForAgent(req.agentId, req.sessionId)
+      const rec = sessionForRead(store, req.agentId, req.sessionId)
       if (!rec) return { sessionId: req.sessionId, messages: [] }
       // Slack can append an older platform row during warm-thread backfill, so its
       // authoritative history pages by normalized event time + seq tie-breaker. A
@@ -319,7 +325,7 @@ export function createSessionReader(
       }
     },
     toolBody(req) {
-      const rec = store.getSessionByAcpIdForAgent(req.agentId, req.sessionId)
+      const rec = sessionForRead(store, req.agentId, req.sessionId)
       const empty: SessionToolBodyChunk = {
         sessionId: req.sessionId,
         toolCallId: req.toolCallId,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10593,7 +10593,7 @@ export class Daemon {
           body: ev.body
         })
       } else {
-        this.store.updateToolCall(channel, thread, ev.toolCallId, { title: ev.text, body: ev.body })
+        this.store.updateToolCall(channel, thread, agentId, ev.toolCallId, { title: ev.text, body: ev.body })
       }
       return
     }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -415,7 +415,7 @@ export class LocalStore {
         channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT NOT NULL, agentId TEXT NOT NULL,
         PRIMARY KEY (channel, thread, ts, agentId)
       );
-      -- transcript_tool_call (partial unique on tool_call_id) is created in
+      -- transcript_agent_tool_call (partial unique on tool_call_id) is created in
       -- migrateTranscriptToolBody, after the column is guaranteed to exist — a legacy
       -- rebuild in migrateTranscript recreates the table without the new columns.
       CREATE TABLE IF NOT EXISTS cp_routing (
@@ -704,19 +704,19 @@ export class LocalStore {
     else this.db.exec('UPDATE inbox SET loopGuardCounted = 0 WHERE loopGuardCounted IS NULL')
   }
 
-  /** Add the `transcript.tool_call_id` + `transcript.body` columns (and the partial
-   *  unique index) to a pre-existing DB. CREATE TABLE IF NOT EXISTS above adds them for
-   *  fresh DBs but never alters an existing table, so upgrade in place. No-op once the
-   *  columns are present. */
+  /** Add the `transcript.tool_call_id` + `transcript.body` columns and agent-scoped
+   *  partial unique index to a pre-existing DB. ACP tool ids are session-local, so
+   *  same-thread agents may legitimately reuse them. */
   private migrateTranscriptToolBody(): void {
     const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
     if (!cols.some((c) => c.name === 'tool_call_id'))
       this.db.exec('ALTER TABLE transcript ADD COLUMN tool_call_id TEXT')
     if (!cols.some((c) => c.name === 'body')) this.db.exec('ALTER TABLE transcript ADD COLUMN body TEXT')
-    this.db.exec(
-      `CREATE UNIQUE INDEX IF NOT EXISTS transcript_tool_call
-         ON transcript (channel, thread, tool_call_id) WHERE tool_call_id IS NOT NULL`
-    )
+    this.db.exec(`
+      DROP INDEX IF EXISTS transcript_tool_call;
+      CREATE UNIQUE INDEX IF NOT EXISTS transcript_agent_tool_call
+        ON transcript (channel, thread, sender, tool_call_id) WHERE tool_call_id IS NOT NULL;
+    `)
   }
 
   /** Add daemon-local inline webchat image storage to existing transcript tables. */
@@ -1543,8 +1543,8 @@ export class LocalStore {
 
   /** First sight of a tool call: insert its kind='tool' row (title in `text`, the
    *  serialized ToolBody in `body`). INSERT OR IGNORE so a re-fired first update is a
-   *  no-op — the partial unique index on (channel, thread, tool_call_id) dedups. `seq`
-   *  is assigned here and stays stable across later `updateToolCall`s. */
+   *  no-op — the partial unique index on (channel, thread, sender, tool_call_id)
+   *  dedups within one agent. `seq` stays stable across later updates. */
   insertToolCall(e: {
     channel: string
     thread: string
@@ -1572,13 +1572,20 @@ export class LocalStore {
       })
   }
 
-  /** Later update for a tool call: overwrite `text` (title) + `body` on the existing
-   *  row, keyed by (channel, thread, tool_call_id). `seq`/`ts` are untouched so the
-   *  row keeps its first-seen position. No-op if the row is absent. */
-  updateToolCall(channel: string, thread: string, toolCallId: string, patch: { title: string; body: string }): void {
+  /** Later update for one agent's tool call. `seq`/`ts` keep their first-seen
+   *  values; a peer reusing the same session-local tool id cannot overwrite it. */
+  updateToolCall(
+    channel: string,
+    thread: string,
+    agentId: string,
+    toolCallId: string,
+    patch: { title: string; body: string }
+  ): void {
     this.db
-      .prepare('UPDATE transcript SET text = ?, body = ? WHERE channel = ? AND thread = ? AND tool_call_id = ?')
-      .run(patch.title, patch.body, channel, thread, toolCallId)
+      .prepare(
+        'UPDATE transcript SET text = ?, body = ? WHERE channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?'
+      )
+      .run(patch.title, patch.body, channel, thread, agentId, toolCallId)
   }
 
   /** One agent's full stored ToolBody JSON, or undefined if unknown/not owned. */

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1581,11 +1581,11 @@ export class LocalStore {
       .run(patch.title, patch.body, channel, thread, toolCallId)
   }
 
-  /** The full stored ToolBody JSON for one tool call, or undefined if unknown. */
-  getToolBody(channel: string, thread: string, toolCallId: string): string | undefined {
+  /** One agent's full stored ToolBody JSON, or undefined if unknown/not owned. */
+  getToolBodyForAgent(channel: string, thread: string, agentId: string, toolCallId: string): string | undefined {
     const row = this.db
-      .prepare('SELECT body FROM transcript WHERE channel = ? AND thread = ? AND tool_call_id = ?')
-      .get(channel, thread, toolCallId) as { body: string | null } | undefined
+      .prepare('SELECT body FROM transcript WHERE channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?')
+      .get(channel, thread, agentId, toolCallId) as { body: string | null } | undefined
     return row?.body ?? undefined
   }
 

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -646,7 +646,9 @@ describe('CpClient dispatch', () => {
 
   it('answers session/history with a session/history/page reply correlated to the req', async () => {
     const { t } = await readyClient()
-    const f = JSON.parse(frame('session/history', { sessionId: DAEMON_ID, limit: 50 }, { epoch: 5 }))
+    const f = JSON.parse(
+      frame('session/history', { agentId: CRON_AGENT_ID, sessionId: DAEMON_ID, limit: 50 }, { epoch: 5 })
+    )
     t.pushInbound(JSON.stringify(f))
     const rep = JSON.parse(t.sent[0]!)
     expect(rep.type).toBe('session/history/page')

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -481,6 +481,53 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     s.close()
   })
 
+  it('keeps a session-local tool id isolated between agents sharing a thread', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-tool-owner-mig-')), 'local.sqlite')
+    const legacy = new DatabaseSync(path)
+    legacy.exec(`
+      CREATE TABLE transcript (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT,
+        sender TEXT NOT NULL, kind TEXT NOT NULL, text TEXT NOT NULL,
+        tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER,
+        attachmentsJson TEXT
+      );
+      CREATE UNIQUE INDEX transcript_tool_call
+        ON transcript (channel, thread, tool_call_id) WHERE tool_call_id IS NOT NULL;
+    `)
+    legacy.close()
+
+    // Opening the upgraded store replaces the old thread-wide identity.
+    const s = new LocalStore(path)
+    const toolCallId = 'session-local-tc'
+    const aBody = JSON.stringify({ toolCallId, rawOutput: 'agent-a output' })
+    const bInitial = JSON.stringify({ toolCallId, rawOutput: 'agent-b partial' })
+    const bFinal = JSON.stringify({ toolCallId, rawOutput: 'agent-b final' })
+    s.insertToolCall({
+      channel: 'C1',
+      thread: 'T',
+      ts: '1',
+      sender: 'bot-a',
+      toolCallId,
+      title: 'agent-a tool',
+      body: aBody
+    })
+    s.insertToolCall({
+      channel: 'C1',
+      thread: 'T',
+      ts: '2',
+      sender: 'bot-b',
+      toolCallId,
+      title: 'agent-b tool',
+      body: bInitial
+    })
+    s.updateToolCall('C1', 'T', 'bot-b', toolCallId, { title: 'agent-b done', body: bFinal })
+
+    expect(s.getToolBodyForAgent('C1', 'T', 'bot-a', toolCallId)).toBe(aBody)
+    expect(s.getToolBodyForAgent('C1', 'T', 'bot-b', toolCallId)).toBe(bFinal)
+    s.close()
+  })
+
   it('transcriptPageForAgent scopes to what THAT agent received or produced (no peer cross-talk)', () => {
     const s = store()
     // Delivered to bot-a + bot-a's own reply.

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -7,6 +7,7 @@ import { LocalStore, sessionKey } from '../src/store/local-store.js'
 import { createSessionReader } from '../src/cp/session-reader.js'
 
 const AGENT = '11111111-1111-4111-8111-111111111111'
+const OTHER_AGENT = '22222222-2222-4222-8222-222222222222'
 
 function store(): LocalStore {
   return new LocalStore(join(mkdtempSync(join(tmpdir(), 'ac-reader-')), 'local.sqlite'))
@@ -244,7 +245,7 @@ describe('SessionReader', () => {
     s.setDisplayName('U1', 'Dana Reyes', 1)
 
     const reader = createSessionReader(s)
-    const { messages } = reader.history({ sessionId: 'acp-1', limit: 50 })
+    const { messages } = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => [m.sender, m.senderName])).toEqual([
       ['U1', 'Dana Reyes'],
       [AGENT, undefined] // agent-id senders have no display_names entry → omitted
@@ -266,12 +267,33 @@ describe('SessionReader', () => {
       attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
     })
 
-    expect(createSessionReader(s).history({ sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
       expect.objectContaining({
         text: 'Identify this',
         attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
       })
     ])
+    s.close()
+  })
+
+  it('returns no history or tool body when the requested agent does not own the session', () => {
+    const s = store()
+    seedHistorySession(s)
+    const body = JSON.stringify({ toolCallId: 'tc-1', rawOutput: 'restricted output' })
+    s.insertToolCall({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: AGENT,
+      toolCallId: 'tc-1',
+      title: 'restricted tool call',
+      body
+    })
+
+    const reader = createSessionReader(s)
+    expect(reader.history({ agentId: OTHER_AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([])
+    expect(reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe('')
+    expect(reader.toolBody({ agentId: AGENT, sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe(body)
     s.close()
   })
 
@@ -328,7 +350,7 @@ describe('SessionReader', () => {
     })
 
     const reader = createSessionReader(s)
-    const { messages } = reader.history({ sessionId: 'acp-1', limit: 50 })
+    const { messages } = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => m.text)).toEqual(['to-me', 'my-reply'])
     s.close()
   })
@@ -355,7 +377,7 @@ describe('SessionReader', () => {
       })
     }
 
-    const { messages } = createSessionReader(s).history({ sessionId: 'acp-1', limit: 50 })
+    const { messages } = createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
     expect(messages.map((m) => m.text)).toEqual([
       'first request',
       'first backfilled reply',
@@ -388,7 +410,7 @@ describe('SessionReader', () => {
     const all: string[] = []
     let cursor: string | undefined
     for (let pageNo = 0; pageNo < 10; pageNo++) {
-      const page = reader.history({ sessionId: 'acp-1', limit: 2, ...(cursor ? { cursor } : {}) })
+      const page = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 2, ...(cursor ? { cursor } : {}) })
       all.unshift(...page.messages.map((m) => m.text))
       if (!page.nextCursor) break
       cursor = page.nextCursor
@@ -416,7 +438,7 @@ describe('SessionReader', () => {
     const all: string[] = []
     let cursor: string | undefined
     do {
-      const page = reader.history({ sessionId: 'acp-1', limit: 1, ...(cursor ? { cursor } : {}) })
+      const page = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 1, ...(cursor ? { cursor } : {}) })
       all.unshift(...page.messages.map((m) => m.text))
       cursor = page.nextCursor
     } while (cursor)
@@ -442,7 +464,7 @@ describe('SessionReader', () => {
 
     // Cursor "3" means the old client already saw seq >= 3. Do not reinterpret it
     // as an event-time cursor partway through that request's pagination loop.
-    const page = createSessionReader(s).history({ sessionId: 'acp-1', cursor: '3', limit: 50 })
+    const page = createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', cursor: '3', limit: 50 })
     expect(page.messages.map((m) => m.text)).toEqual(['seq-1', 'seq-4'])
     expect(page.nextCursor).toBeUndefined()
     s.close()
@@ -466,7 +488,7 @@ describe('SessionReader', () => {
 
     expect(
       createSessionReader(s)
-        .history({ sessionId: 'acp-1', limit: 50 })
+        .history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
         .messages.map((m) => m.text)
     ).toEqual(['telegram message 100', 'reasoning after 100', 'telegram message 101'])
     s.close()
@@ -496,7 +518,7 @@ describe('SessionReader', () => {
 
     expect(
       createSessionReader(s)
-        .history({ sessionId: 'acp-1', limit: 50 })
+        .history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
         .messages.map((m) => m.text)
     ).toEqual(['first', 'second-backfilled', 'third-trigger'])
     s.close()

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -276,24 +276,44 @@ describe('SessionReader', () => {
     s.close()
   })
 
-  it('returns no history or tool body when the requested agent does not own the session', () => {
+  it('binds session and tool-body reads to the authorized agent in a shared thread', () => {
     const s = store()
     seedHistorySession(s)
-    const body = JSON.stringify({ toolCallId: 'tc-1', rawOutput: 'restricted output' })
+    s.upsertSession({
+      key: sessionKey('slack', 'C1', 'T1', OTHER_AGENT),
+      agentId: OTHER_AGENT,
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      acpSessionId: 'acp-peer',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: 1
+    })
+    const body = JSON.stringify({ toolCallId: 'peer-tc', rawOutput: 'restricted output' })
     s.insertToolCall({
       channel: 'C1',
       thread: 'T1',
       ts: '1',
-      sender: AGENT,
-      toolCallId: 'tc-1',
+      sender: OTHER_AGENT,
+      toolCallId: 'peer-tc',
       title: 'restricted tool call',
       body
     })
 
     const reader = createSessionReader(s)
+    // A peer's private tool row is absent from both the visible agent's history
+    // and its direct full-body lookup, even though the sessions share a thread.
+    expect(reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([])
+    expect(reader.toolBody({ agentId: AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 }).data).toBe('')
+    // The session itself is also bound to its agent, while the peer owner can read its body.
     expect(reader.history({ agentId: OTHER_AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([])
-    expect(reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe('')
-    expect(reader.toolBody({ agentId: AGENT, sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe(body)
+    expect(reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-1', toolCallId: 'peer-tc', offset: 0 }).data).toBe(
+      ''
+    )
+    expect(
+      reader.toolBody({ agentId: OTHER_AGENT, sessionId: 'acp-peer', toolCallId: 'peer-tc', offset: 0 }).data
+    ).toBe(body)
     s.close()
   })
 

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -317,6 +317,26 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('keeps session reads available for a rolling upgrade from a legacy CP', () => {
+    const s = store()
+    seedHistorySession(s)
+    const body = JSON.stringify({ toolCallId: 'tc-1', rawOutput: 'ok' })
+    s.insertToolCall({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: AGENT,
+      toolCallId: 'tc-1',
+      title: 'legacy-compatible tool call',
+      body
+    })
+
+    const reader = createSessionReader(s)
+    expect(reader.history({ sessionId: 'acp-1', limit: 50 }).messages).toHaveLength(1)
+    expect(reader.toolBody({ sessionId: 'acp-1', toolCallId: 'tc-1', offset: 0 }).data).toBe(body)
+    s.close()
+  })
+
   it('history scopes to what THIS agent received or produced (no peer cross-talk)', () => {
     const s = store()
     s.upsertSession({

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -706,11 +706,15 @@ describe('session read-back frames (console history pull)', () => {
   })
 
   it('session/history REQ defaults limit to 50; session/history/page round-trips messages + cursor', () => {
-    const req = decodeEnvelope(envelope('session/history', { sessionId: SESSION_ID, cursor: 'c-100' }))
+    const req = decodeEnvelope(
+      envelope('session/history', { agentId: AGENT_ID, sessionId: SESSION_ID, cursor: 'c-100' })
+    )
     expect(req.ok).toBe(true)
     if (!req.ok || !isFrame('session/history')(req.frame)) throw new Error('expected session/history')
+    expect(req.frame.payload.agentId).toBe(AGENT_ID)
     expect(req.frame.payload.limit).toBe(50) // zod default
     expect(req.frame.payload.cursor).toBe('c-100')
+    expect(decodeEnvelope(envelope('session/history', { sessionId: SESSION_ID })).ok).toBe(false)
 
     const page = decodeEnvelope(
       envelope('session/history/page', {
@@ -778,10 +782,14 @@ describe('session read-back frames (console history pull)', () => {
   })
 
   it('session/tool-body REQ defaults offset to 0; session/tool-body/chunk round-trips with nextOffset', () => {
-    const req = decodeEnvelope(envelope('session/tool-body', { sessionId: SESSION_ID, toolCallId: 'tc-1' }))
+    const req = decodeEnvelope(
+      envelope('session/tool-body', { agentId: AGENT_ID, sessionId: SESSION_ID, toolCallId: 'tc-1' })
+    )
     expect(req.ok).toBe(true)
     if (!req.ok || !isFrame('session/tool-body')(req.frame)) throw new Error('expected session/tool-body')
+    expect(req.frame.payload.agentId).toBe(AGENT_ID)
     expect(req.frame.payload.offset).toBe(0) // zod default
+    expect(decodeEnvelope(envelope('session/tool-body', { sessionId: SESSION_ID, toolCallId: 'tc-1' })).ok).toBe(false)
 
     const chunk = decodeEnvelope(
       envelope(

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -714,7 +714,11 @@ describe('session read-back frames (console history pull)', () => {
     expect(req.frame.payload.agentId).toBe(AGENT_ID)
     expect(req.frame.payload.limit).toBe(50) // zod default
     expect(req.frame.payload.cursor).toBe('c-100')
-    expect(decodeEnvelope(envelope('session/history', { sessionId: SESSION_ID })).ok).toBe(false)
+    const legacyReq = decodeEnvelope(envelope('session/history', { sessionId: SESSION_ID }))
+    expect(legacyReq.ok).toBe(true)
+    if (!legacyReq.ok || !isFrame('session/history')(legacyReq.frame))
+      throw new Error('expected legacy session/history')
+    expect(legacyReq.frame.payload.agentId).toBeUndefined()
 
     const page = decodeEnvelope(
       envelope('session/history/page', {
@@ -789,7 +793,11 @@ describe('session read-back frames (console history pull)', () => {
     if (!req.ok || !isFrame('session/tool-body')(req.frame)) throw new Error('expected session/tool-body')
     expect(req.frame.payload.agentId).toBe(AGENT_ID)
     expect(req.frame.payload.offset).toBe(0) // zod default
-    expect(decodeEnvelope(envelope('session/tool-body', { sessionId: SESSION_ID, toolCallId: 'tc-1' })).ok).toBe(false)
+    const legacyReq = decodeEnvelope(envelope('session/tool-body', { sessionId: SESSION_ID, toolCallId: 'tc-1' }))
+    expect(legacyReq.ok).toBe(true)
+    if (!legacyReq.ok || !isFrame('session/tool-body')(legacyReq.frame))
+      throw new Error('expected legacy session/tool-body')
+    expect(legacyReq.frame.payload.agentId).toBeUndefined()
 
     const chunk = decodeEnvelope(
       envelope(

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -116,6 +116,7 @@ export type SessionMessage = z.infer<typeof SessionMessage>
 
 /** C→D REQ: fetch one page of a session's history from the owning daemon. */
 export const SessionHistoryReq = z.object({
+  agentId: z.string().uuid(), // CP-authorized owner; daemon re-checks the session binding
   sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
   cursor: z.string().optional(), // opaque; omit ⇒ newest page
   limit: z.number().int().positive().max(200).default(50)
@@ -136,6 +137,7 @@ export type SessionHistoryPage = z.infer<typeof SessionHistoryPage>
  * bigger the console pages the whole thing back through this frame by offset.
  */
 export const SessionToolBodyReq = z.object({
+  agentId: z.string().uuid(), // CP-authorized owner; daemon re-checks the session binding
   sessionId: z.string(),
   toolCallId: z.string(),
   offset: z.number().int().nonnegative().default(0)

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -116,7 +116,9 @@ export type SessionMessage = z.infer<typeof SessionMessage>
 
 /** C→D REQ: fetch one page of a session's history from the owning daemon. */
 export const SessionHistoryReq = z.object({
-  agentId: z.string().uuid(), // CP-authorized owner; daemon re-checks the session binding
+  // Optional only for rolling compatibility with an older CP. A current CP always
+  // sends the authorized owner and the daemon re-checks the session binding.
+  agentId: z.string().uuid().optional(),
   sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
   cursor: z.string().optional(), // opaque; omit ⇒ newest page
   limit: z.number().int().positive().max(200).default(50)
@@ -137,7 +139,8 @@ export type SessionHistoryPage = z.infer<typeof SessionHistoryPage>
  * bigger the console pages the whole thing back through this frame by offset.
  */
 export const SessionToolBodyReq = z.object({
-  agentId: z.string().uuid(), // CP-authorized owner; daemon re-checks the session binding
+  // Optional only for rolling compatibility with an older CP; see SessionHistoryReq.
+  agentId: z.string().uuid().optional(),
   sessionId: z.string(),
   toolCallId: z.string(),
   offset: z.number().int().nonnegative().default(0)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -299,7 +299,7 @@ function ContentBlock({ block }: { block: unknown }) {
 
 // The expandable body panel for one tool row: input, output, content blocks,
 // locations, plus a "view full" affordance when only a truncated preview is inline.
-function ToolBodyDetail({ msg, sessionId, agentId }: { msg: SessionMessageDto; sessionId: string; agentId: string }) {
+function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId: string }) {
   const [open, setOpen] = useState(false)
   const [full, setFull] = useState<string | null>(null) // full body JSON, once fetched
   const [loading, setLoading] = useState(false)
@@ -323,10 +323,10 @@ function ToolBodyDetail({ msg, sessionId, agentId }: { msg: SessionMessageDto; s
   const bytes = msg.bodyBytes
 
   const loadFull = () => {
-    if (loading || !agentId) return
+    if (loading) return
     setLoading(true)
     setErr(null)
-    fetchToolBody(sessionId, agentId, msg.toolCallId ?? body?.toolCallId ?? '').then(
+    fetchToolBody(sessionId, msg.toolCallId ?? body?.toolCallId ?? '').then(
       (s) => {
         setFull(s)
         setLoading(false)
@@ -645,7 +645,7 @@ export default function SessionDetailView() {
       let all: SessionMessageDto[] = []
       let cursor: string | undefined
       for (let i = 0; i < MAX_PAGES; i++) {
-        const page = await fetchSessionMessages(sid, aid, cursor)
+        const page = await fetchSessionMessages(sid, cursor)
         if (!active) return
         all = [...page.messages, ...all]
         setMsgs(all)
@@ -1511,7 +1511,7 @@ export default function SessionDetailView() {
                                   ))}
                                 </div>
                               )}
-                              {st.msg && sid && aid && <ToolBodyDetail msg={st.msg} sessionId={sid} agentId={aid} />}
+                              {st.msg && sid && <ToolBodyDetail msg={st.msg} sessionId={sid} />}
                             </div>
                           </div>
                         ))}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1594,15 +1594,10 @@ export function fetchSessionDetail(sessionId: string, orgId?: string): Promise<S
 }
 
 // One page of a session's transcript, proxied live from the owning daemon. The
-// `agentId` (carried by the list row) resolves that daemon on the CP; 503 if it
-// is offline / the agent is unplaced.
-export async function fetchSessionMessages(
-  sessionId: string,
-  agentId: string,
-  cursor?: string,
-  limit = 50
-): Promise<SessionHistoryDto> {
-  const q = new URLSearchParams({ agentId, limit: String(limit) })
+// CP resolves the owner and daemon from its SessionMeta row; 503 if that daemon
+// is offline or the owning agent is unplaced.
+export async function fetchSessionMessages(sessionId: string, cursor?: string, limit = 50): Promise<SessionHistoryDto> {
+  const q = new URLSearchParams({ limit: String(limit) })
   if (cursor) q.set('cursor', cursor)
   return apiGet<SessionHistoryDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`)
 }
@@ -1623,12 +1618,12 @@ export interface SessionToolBodyChunkDto {
 // `GET /sessions/:id/tool-body` by offset, concatenating the byte slices into the
 // complete JSON string (the caller JSON.parse's the result). 503 if the owning
 // daemon is offline / the agent is unplaced (same resolution as the messages route).
-export async function fetchToolBody(sessionId: string, agentId: string, toolCallId: string): Promise<string> {
+export async function fetchToolBody(sessionId: string, toolCallId: string): Promise<string> {
   let out = ''
   let offset = 0
   // Guard against a daemon that never advances `nextOffset` (defensive bound).
   for (;;) {
-    const q = new URLSearchParams({ agentId, toolCallId, offset: String(offset) })
+    const q = new URLSearchParams({ toolCallId, offset: String(offset) })
     const chunk = await apiGet<SessionToolBodyChunkDto>(
       `${orgBase()}/sessions/${encodeURIComponent(sessionId)}/tool-body?${q.toString()}`
     )


### PR DESCRIPTION
## Summary

- resolve transcript and full tool-body authorization from the persisted `SessionMeta` owner instead of a caller-supplied `agentId`
- carry the authorized owner through `session/history` and `session/tool-body` frames, verify the `(agentId, sessionId)` binding, and scope stored tool-row identity, updates, and reads to that agent
- stop the console from sending an authorization-context `agentId` and document the owner-derived flow
- keep the new request field wire-optional for rolling upgrades; a daemon connected to an older CP uses the legacy lookup and emits a warning

## Root cause

The two session-body routes authorized the `agentId` supplied in the query string independently from the session ID in the path. A caller could therefore present a visible agent on the same daemon while requesting a session owned by a restricted agent. The daemon then looked up the session only by ACP session ID.

The fix derives both visibility and daemon placement from the session's persisted owner, then binds tool-row storage and reads to that same owner at the daemon content boundary.

## Rolling upgrade behavior

- A new CP always sends the persisted, authorized owner. This fixes the authorization boundary even while it is connected to an older daemon; the daemon-side binding becomes active after that daemon upgrades.
- A new daemon accepts the owner-less frame shape from an older CP, logs the legacy path, and preserves the prior lookup behavior until the CP upgrades. This avoids breaking transcript and full-body views when daemons are upgraded first.
- Session body routes now require a `session_meta` row. A deep link opened in the short interval before the daemon's metadata snapshot arrives can return 404; normal navigation starts from the same metadata-backed session list and is unaffected.

## Validation

- reproduced the pre-fix regression: the forged-agent request reached the daemon proxy and returned 503 instead of being rejected
- control-plane full integration suite: 628/628 tests passed
- protocol codec: 61/61 tests passed, including the legacy owner-less frame shape
- daemon local store, session reader, and CP dispatch: 85/85 tests passed; the compatibility follow-up's reader/dispatch subset passed 47/47
- protocol, daemon, control-plane, and web typechecks passed
- targeted ESLint passed; pre-push full lint completed with two pre-existing warnings in `icon-upload.ts`

Created by Codex . GPT-5
