### PR TITLE
fix(ci): retry transient Buildx setup failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,6 +110,12 @@ jobs:
         run: bash scripts/component-versions.sh "$VERSION" | tee -a "$GITHUB_OUTPUT"
 
       - name: Set up Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@v4
+
+      - name: Retry Buildx setup
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       # Render the existing Bake definition so image-specific configuration
@@ -224,6 +230,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@v4
+
+      - name: Retry Buildx setup
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       # A target-specific registry cache keeps all intermediate builder layers
@@ -274,6 +286,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
+        id: buildx
+        continue-on-error: true
+        uses: docker/setup-buildx-action@v4
+
+      - name: Retry Buildx setup
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
 
       # Components skipped above still get this release's tag: an alias of the


### PR DESCRIPTION
## Summary

- retry each Buildx setup once when the first attempt fails
- keep the normal successful path to a single setup attempt

## Root cause

Buildx can fail while bootstrapping its builder when Docker Hub has a transient connection timeout. The setup action does not retry that pull.

## Validation

- `pnpm exec prettier --check .github/workflows/build.yaml`
- `git diff --check`
- pre-push `eslint .` (passes with two unrelated existing warnings)

Created by Codex . GPT-5
