### PR TITLE
fix(web): simplify memory dreaming layout

### DIFF
--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -89,11 +89,18 @@ const button = (host: HTMLElement, label: string) =>
 describe('DreamPanel', () => {
   it('triggers a dream and tells the user it costs a model run', async () => {
     const host = await render()
-    // The cost/latency is stated up front — this is not a free click.
-    expect(host.textContent).toContain('costs tokens')
+    // The cost is stated up front — this is not a free click.
+    expect(host.textContent).toContain('Uses model tokens')
 
     await act(async () => button(host, 'Dream now')?.click())
     expect(api.startDream).toHaveBeenCalledWith(AGENT)
+  })
+
+  it('keeps the detailed explanation collapsed by default', async () => {
+    const host = await render()
+    const explanation = host.querySelector('details')
+    expect(explanation?.open).toBe(false)
+    expect(explanation?.querySelector('summary')?.textContent).toContain('How dreaming works')
   })
 
   it('blocks the trigger for a viewer, with the reason', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -187,14 +187,10 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
   return (
     <div className="flex flex-col gap-3 rounded-(--radius-lg) border border-(--border-subtle) p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-            Dreams — offline consolidation
-          </span>
-          <span className="max-w-[62ch] font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
-            A dream rereads this agent’s whole memory alongside its recent sessions and proposes a tidied-up store —
-            duplicates merged, stale entries replaced, the index rebuilt. It runs a model over all of that, so it takes
-            a few minutes and costs tokens. Nothing changes until you review the result and adopt it.
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Dreams</span>
+          <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
+            Creates a reviewable draft; memory stays unchanged until adoption. Uses model tokens.
           </span>
         </div>
         <span title={startBlocker ?? undefined}>
@@ -207,6 +203,17 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
           </Button>
         </span>
       </div>
+
+      <details className="group">
+        <summary className="inline-flex cursor-pointer list-none items-center gap-1 font-sans text-[11.5px] font-semibold leading-normal text-(--text-tertiary) transition-colors hover:text-(--text-primary) [&::-webkit-details-marker]:hidden">
+          <Icon name="info" size={13} />
+          How dreaming works
+        </summary>
+        <p className="mt-2 mb-0 max-w-[68ch] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+          A dream rereads this agent’s memory and recent sessions, merges duplicates, replaces stale entries, and
+          rebuilds the index. It takes a few minutes. Review the proposed changes before adopting them.
+        </p>
+      </details>
 
       {startBlocker && !inFlight ? (
         <div className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">{startBlocker}</div>

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -41,6 +41,10 @@ vi.mock('@/components/console/RecordMemoryPanel', () => ({
   RecordMemoryPanel: () => <div data-testid="record-memory-view" />
 }))
 
+vi.mock('@/components/console/DreamPanel', () => ({
+  DreamPanel: () => <div data-testid="dream-memory-view" />
+}))
+
 import { MemoryPanel } from './MemoryPanel'
 
 const CONNECTION_ID = '11111111-1111-4111-8111-111111111111'
@@ -257,6 +261,31 @@ describe('MemoryPanel settings draft', () => {
       root?.render(<MemoryPanel {...props} memoryDreaming={{ ...dreaming(), enabled: false }} />)
     })
     expect(dreamingBox()?.checked).toBe(false)
+  })
+
+  it('places dreaming below the live memory browser', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="33333333-3333-4333-8333-333333333333"
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+          memoryDreaming={{ enabled: true }}
+        />
+      )
+    })
+
+    const memory = container.querySelector('[data-testid="file-memory-view"]')
+    const dreaming = container.querySelector('[data-testid="dream-memory-view"]')
+    expect(memory).not.toBeNull()
+    expect(dreaming).not.toBeNull()
+    if (!memory || !dreaming) throw new Error('Expected memory and dreaming panels')
+    expect(memory.compareDocumentPosition(dreaming) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('resyncs on a timezone-only refresh, so a later save cannot restore the stale zone', async () => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -791,11 +791,6 @@ export function MemoryPanel({
         </div>
       ) : (
         <>
-          {/* Dreaming is managed-only; the panel carries its own gates for the
-              in-flight / no-edit / dreaming-off cases. */}
-          {/* Only when dreaming is actually on: with it off the panel could only
-              offer a trigger that does nothing, so the whole section is noise. */}
-          {persistedSettings.dreaming.enabled ? <DreamPanel key={agentId} agentId={agentId} canEdit={canEdit} /> : null}
           <FileBrowserShell
             title="Memory"
             headerEnd={
@@ -818,6 +813,10 @@ export function MemoryPanel({
               preview={renderPreview}
             />
           </FileBrowserShell>
+          {/* Dreaming is managed-only and is secondary to the live memory
+              content, so it sits below the browser. Only render it when the
+              persisted policy is on; otherwise its trigger would be noise. */}
+          {persistedSettings.dreaming.enabled ? <DreamPanel key={agentId} agentId={agentId} canEdit={canEdit} /> : null}
         </>
       )}
       {confirmingBackendChange ? (


### PR DESCRIPTION
## Summary

- move the Dreams panel below the live memory browser so memory content remains the page’s focus
- replace the long always-visible explanation with concise guidance and a collapsed “How dreaming works” disclosure
- add regression coverage for the panel order and collapsed default state

## Why

The dreaming explanation and controls competed with the memory content at the top of the page. The revised hierarchy presents settings, then live memory, then the optional consolidation workflow.

## User impact

The Memory tab is easier to scan on desktop and mobile. Dream execution, review, adoption, permissions, and token-cost disclosure are unchanged.

## Validation

- focused DreamPanel and MemoryPanel tests: 20 passed
- web TypeScript check
- focused ESLint and Prettier checks
- repository pre-push lint (no errors; two existing warnings outside this change)
