### PR TITLE
fix(protocol): bound git-repo normalization instead of backtracking on it

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -19,6 +19,7 @@ import {
   RepoSubdirError,
   SessionImageAttachment,
   MAX_WORKSPACE_EDIT_BYTES,
+  MAX_GIT_REPO_LENGTH,
   normalizeGitCloneUrl,
   redactGitUrlSecrets,
   normalizeRepoSubdir
@@ -292,7 +293,9 @@ function normalizeAgentGitRepo(value: string, ctx: z.RefinementCtx): string {
   }
 }
 
-const GitRepoInput = z.string().min(1).transform(normalizeAgentGitRepo)
+// `.max` before the transform: zod runs checks in order, so an oversized value is
+// rejected without normalization ever scanning it.
+const GitRepoInput = z.string().min(1).max(MAX_GIT_REPO_LENGTH).transform(normalizeAgentGitRepo)
 const AgentDirCreateInput = z.string().transform(normalizeAgentDir)
 const AgentDirPatchInput = z
   .union([z.string(), z.null()])

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  MAX_GIT_REPO_LENGTH,
   GitCloneUrlError,
   normalizeAllowedWorkspaceGitUrl,
   normalizeGitCloneUrl,
@@ -223,5 +224,36 @@ describe('gitRepoLabel', () => {
 
   it('round-trips normalize → label back to the short form', () => {
     expect(gitRepoLabel(normalizeGitUrl('acme/infra'))).toBe('acme/infra')
+  })
+})
+
+describe('bounded normalization (no quadratic scan on untrusted text)', () => {
+  // A run of slashes NOT at end-of-string is the shape that made `/\/+$/` retry
+  // from every offset. These run inside CP request validation, on the single
+  // event loop shared by every tenant — so the cost has to stay linear.
+  const slashRun = (n: number) => '/'.repeat(n) + 'x'
+
+  it('rejects an oversized clone url before scanning it', () => {
+    expect(() => normalizeGitCloneUrl(slashRun(MAX_GIT_REPO_LENGTH))).toThrow(GitCloneUrlError)
+    expect(() => normalizeGitCloneUrl('a'.repeat(MAX_GIT_REPO_LENGTH + 1))).toThrow(/too long/)
+    // At the cap it is still processed normally (rejected on its own merits here).
+    expect(() => normalizeGitCloneUrl('/'.repeat(MAX_GIT_REPO_LENGTH))).toThrow(GitCloneUrlError)
+  })
+
+  it('normalizes a huge slash run in linear time', () => {
+    // gitRepoLabel and normalizeGitUrl take unbounded text from stored values, so
+    // they cannot lean on the clone-url cap. 1e6 chars is ~10^12 steps quadratic.
+    const huge = slashRun(1_000_000)
+    const started = process.hrtime.bigint()
+    expect(normalizeGitUrl(huge)).toBe(huge)
+    expect(gitRepoLabel(huge)).toBe(huge)
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6
+    expect(elapsedMs).toBeLessThan(1000)
+  })
+
+  it('still strips real trailing slashes', () => {
+    expect(normalizeGitUrl('acme/infra///')).toBe('https://github.com/acme/infra')
+    expect(normalizeGitCloneUrl('https://github.com/acme/infra/')).toBe('https://github.com/acme/infra')
+    expect(gitRepoLabel('https://github.com/acme/infra//')).toBe('acme/infra')
   })
 })

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -21,11 +21,33 @@ const CONTROL_RE = /[\u0000-\u001f\u007f]/
  * for GitLab, Bitbucket, or self-managed Git services. */
 export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = ['https://github.com', 'ssh://github.com'] as const
 
+/**
+ * Hard cap on an untrusted repo reference. Real clone addresses are far under
+ * this; the bound exists so no amount of caller-supplied text can turn
+ * normalization into a long synchronous scan on the CP's single event loop.
+ */
+export const MAX_GIT_REPO_LENGTH = 512
+
 export class GitCloneUrlError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'GitCloneUrlError'
   }
+}
+
+/**
+ * Strip trailing `/` without a backtracking regex.
+ *
+ * `s.replace(/\/+$/, '')` looks anchored but is not: the engine retries the
+ * greedy `+` from every offset, so a long run of slashes that does NOT end the
+ * string costs O(n²). These helpers run inside request validation on the
+ * control plane's single-threaded event loop, where that is a stall for every
+ * tenant, not just the caller.
+ */
+function trimTrailingSlashes(s: string): string {
+  let end = s.length
+  while (end > 0 && s.charCodeAt(end - 1) === 0x2f /* '/' */) end--
+  return end === s.length ? s : s.slice(0, end)
 }
 
 /**
@@ -38,7 +60,7 @@ export class GitCloneUrlError extends Error {
  * - anything else (e.g. a local path) → as-is
  */
 export function normalizeGitUrl(input: string): string {
-  const s = input.trim().replace(/\/+$/, '')
+  const s = trimTrailingSlashes(input.trim())
   if (!s || SCHEME_RE.test(s) || SCP_RE.test(s)) return s
   const segments = s.split('/')
   // host-prefixed shorthand: first segment looks like a hostname (has a dot)
@@ -72,9 +94,12 @@ function hasLocalPathPrefix(value: string): boolean {
  * the execution boundary.
  */
 export function normalizeGitCloneUrl(input: string): string {
+  // Bound FIRST: every check below scans the value, and this is the one entry
+  // point untrusted repo text reaches. A real address is nowhere near the cap.
+  if (input.length > MAX_GIT_REPO_LENGTH) invalidCloneUrl('git clone url is too long')
   if (CONTROL_RE.test(input)) invalidCloneUrl('git clone url must not contain control characters')
 
-  const s = input.trim().replace(/\/+$/, '')
+  const s = trimTrailingSlashes(input.trim())
   if (!s) invalidCloneUrl('git clone url must not be empty')
   if (s.startsWith('-')) invalidCloneUrl('git clone url must not start with "-"')
   if (/\s/.test(s)) invalidCloneUrl('git clone url must not contain whitespace')
@@ -289,10 +314,7 @@ export function normalizeGithubRepoUrl(input: string): string {
  * Unrecognized inputs come back unchanged (minus a trailing `.git`).
  */
 export function gitRepoLabel(gitRepo: string): string {
-  const s = gitRepo
-    .trim()
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '')
+  const s = trimTrailingSlashes(gitRepo.trim()).replace(/\.git$/, '')
   const scp = SCP_RE.exec(s)
   if (scp) return scp[1]!.replace(/^\/+/, '')
   const url = /^[a-z][a-z0-9+.-]*:\/\/[^/]+\/(.+)$/i.exec(s)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -68,6 +68,7 @@ export type { DecodeResultOf } from './wire.js'
 // ── git repo address helpers (normalize on write, shorten for display) ──
 export {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  MAX_GIT_REPO_LENGTH,
   GitCloneUrlError,
   normalizeAllowedWorkspaceGitUrl,
   normalizeGitCloneUrl,


### PR DESCRIPTION
Closes finding **F11** from the security scan.

## What

- Strip trailing slashes with a linear scan instead of `/\/+$/` (three call sites).
- Reject an oversized value in `normalizeGitCloneUrl` before any check reads it.
- Cap `GitRepoInput` ahead of its transform, so an oversized body never reaches normalization.

## Why

`s.replace(/\/+$/, '')` reads as anchored but is not — the engine retries the greedy `+` from every start offset, so a long run of slashes that does **not** end the string costs O(n²).

`normalizeGitCloneUrl` runs inside CP request validation. A `gitRepo` of ~1 MB of slashes plus one trailing character therefore stalled the single event loop the whole deployment shares: every other tenant's REST request, daemon heartbeat and relay frame waits it out, and the request repeats freely. `GitRepoInput` was `z.string().min(1)` with no maximum, and every check that would have rejected the value ran *after* the strip.

## Why both a linear scan and a bound

The cap alone would not be enough: `normalizeGitUrl` and `gitRepoLabel` also run over **stored** values that never passed through the clone-url cap (the latter from response serialization), so the strip itself had to stop backtracking. The bound alone would not be enough either — it only guards the one entry point. Neither layer depends on the other.

`.max()` sits before `.transform()` deliberately: zod runs checks in order, so an oversized body is rejected without normalization scanning it at all.

## Checks

- typecheck: protocol + control-plane + daemon
- protocol 188, daemon 2071, control-plane 627 unit + 630 integration — all passed
- New regression asserts a 1M-character slash run normalizes in well under a second; the previous implementation is ~10^12 steps there
- `npx eslint` and `npx prettier --check` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)