### PR TITLE
Fix dream memory history diffs

### DIFF
--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -6,22 +6,22 @@ import type { DreamInfo, DreamTrigger, MemoryDreamingPolicy } from '@agentconnec
 import {
   MEMORY_INDEX,
   MEMORY_HISTORY_FILENAME,
-  MAX_HISTORY_VALUE_BYTES,
   MAX_INDEX_INJECT_BYTES,
   MAX_MEMORY_FILE_BYTES,
+  clampMemoryHistoryValue,
   enforceMemoryHistoryRetentionHoldingLock,
   listMemory,
   memoryDir,
   memoryWriteMarks,
   recordExternalMemoryMutation,
   readMemoryFile,
-  snapshotMemoryHistory,
+  snapshotMemoryHistoryHoldingLock,
+  type MemoryHistoryRecord,
   withMemoryDirLock
 } from './memory.js'
 import {
   buildDreamPrompt,
   dreamSystemPrompt,
-  clampToBytesOnBoundary,
   parseDreamProposal,
   storeDigest,
   type DreamProposal,
@@ -520,7 +520,7 @@ export class DreamRunner {
    * Adopt a completed dream (design §6). Serialized per agent (the lock) against
    * concurrent starts, adopts, and discards. The replacement store — including
    * the carried-over `.history` plus one `source:"dream"` provenance row per
-   * file — is built entirely in a sibling temp directory FIRST, so `memory/` is
+   * changed file — is built entirely in a sibling temp directory FIRST, so `memory/` is
    * never a half-written tree: the visible window is a single rename, and a
    * failure rolls the previous store back. Fenced against post-snapshot writes
    * unless `force`.
@@ -551,43 +551,30 @@ export class DreamRunner {
       const live = memoryDir(dir)
       const at = this.nowIso()
 
-      // 1) Build the complete replacement in a temp sibling dir. `memory/` is
-      //    untouched; only its contained history snapshot briefly takes the
-      //    shared lock. Any failure here leaves the live store intact.
+      // 1) Build the proposed files in a temp sibling dir. `memory/` is
+      //    untouched. History is added later under the shared lock so every
+      //    `before` snapshot describes the exact store the swap replaces.
       const replacement = join(dir, `.memory.adopting-${dreamId}`)
       await fsp.rm(replacement, { recursive: true, force: true })
       await fsp.mkdir(replacement, { recursive: true })
-      // Canonicalize BEFORE concatenating dream rows. Otherwise a legacy row
-      // without its final newline (or a torn tail) absorbs the first dream row
-      // into one invalid line that post-swap compaction must discard.
-      let history = await snapshotMemoryHistory(dir)
       for (const name of staged) {
         const content = await fsp.readFile(join(out, name), 'utf8')
         await fsp.writeFile(join(replacement, name), content, 'utf8')
-        history +=
-          JSON.stringify({
-            path: name,
-            event: 'update',
-            after: clampToBytesOnBoundary(content, MAX_HISTORY_VALUE_BYTES),
-            at,
-            scope: 'agent',
-            source: 'dream'
-          }) + '\n'
       }
-      await fsp.writeFile(join(replacement, MEMORY_HISTORY_FILENAME), history, 'utf8')
 
       // 2) Fence + swap under the shared memory-dir lock, so no writeMemoryFile
       //    caller can interleave between the digest re-check and the rename.
       try {
         return await withMemoryDirLock(dir, async () => {
+          const liveFiles = await this.readLiveStore(dir)
           if (!force) {
-            const liveDigest = storeDigest(await this.readLiveStore(dir))
+            const liveDigest = storeDigest(liveFiles)
             if (liveDigest !== dream.snapshotDigest) {
               // §8 distillation rebase: additive per-turn capture may have landed
               // while the dream ran. When EVERY post-snapshot write was
               // distill-sourced, replay those additions onto the replacement and
               // adopt; any tool/console write still hard-fences to review.
-              const rebased = await this.rebaseDistillWrites(dir, dream, replacement, at)
+              const rebased = await this.rebaseDistillWrites(dir, dream, replacement)
               // `0` is a SUCCESSFUL rebase (every addition was already folded in
               // by the dream) — only `null` means the drift wasn't distill-only.
               if (rebased === null) {
@@ -598,6 +585,42 @@ export class DreamRunner {
               this.deps.log.info(`dream ${dreamId}: rebased ${rebased} distilled line(s) onto the staged store`)
             }
           }
+
+          // Canonicalize the exact live history before adding adoption rows. A
+          // legacy final row without a newline (or a torn tail) must not absorb
+          // the first dream row. Build a full add/update/delete change set from
+          // the store that is about to be replaced, skipping unchanged files.
+          let history = await snapshotMemoryHistoryHoldingLock(dir)
+          const beforeByPath = new Map(liveFiles.map((file) => [file.name, file.content]))
+          const afterFiles = (await fsp.readdir(replacement, { withFileTypes: true }))
+            .filter((entry) => entry.isFile() && stagedPathOk(entry.name))
+            .map((entry) => entry.name)
+          const afterByPath = new Map<string, string>()
+          for (const name of afterFiles) {
+            afterByPath.set(name, await fsp.readFile(join(replacement, name), 'utf8'))
+          }
+          const changedPaths = new Set([...beforeByPath.keys(), ...afterByPath.keys()])
+          for (const path of [...changedPaths].sort((a, b) => a.localeCompare(b))) {
+            const before = beforeByPath.get(path)
+            const after = afterByPath.get(path)
+            if (before === after) continue
+
+            const beforeClamped = before === undefined ? undefined : clampMemoryHistoryValue(before)
+            const afterClamped = clampMemoryHistoryValue(after ?? '')
+            const record: MemoryHistoryRecord = {
+              id: randomUUID(),
+              path,
+              event: before === undefined ? 'add' : after === undefined ? 'delete' : 'update',
+              ...(beforeClamped ? { before: beforeClamped.value } : {}),
+              after: afterClamped.value,
+              at,
+              scope: 'agent',
+              source: 'dream',
+              ...(beforeClamped?.truncated || afterClamped.truncated ? { truncated: true } : {})
+            }
+            history += JSON.stringify(record) + '\n'
+          }
+          await fsp.writeFile(join(replacement, MEMORY_HISTORY_FILENAME), history, { encoding: 'utf8', mode: 0o600 })
 
           const backupsRoot = join(dir, BACKUPS_DIRNAME)
           await fsp.mkdir(backupsRoot, { recursive: true })
@@ -704,12 +727,7 @@ export class DreamRunner {
    * The result is re-checked against the store's byte caps: a rebase must never
    * produce a file the ordinary write path would reject.
    */
-  private async rebaseDistillWrites(
-    dir: string,
-    dream: DreamInfo,
-    replacement: string,
-    at: string
-  ): Promise<number | null> {
+  private async rebaseDistillWrites(dir: string, dream: DreamInfo, replacement: string): Promise<number | null> {
     const snapshot = dream.snapshotWrites
     // A dream recorded before this field existed can't be reasoned about.
     if (!snapshot) return null
@@ -777,18 +795,6 @@ export class DreamRunner {
       if (Buffer.byteLength(next) > cap) return null
       await fsp.writeFile(join(replacement, name), next, 'utf8')
       replayed += additions.length
-      await fsp.appendFile(
-        join(replacement, MEMORY_HISTORY_FILENAME),
-        JSON.stringify({
-          path: name,
-          event: 'update',
-          after: clampToBytesOnBoundary(next, MAX_HISTORY_VALUE_BYTES),
-          at,
-          scope: 'agent',
-          source: 'distill'
-        }) + '\n',
-        'utf8'
-      )
     }
     // Zero replayed lines is still a successful rebase — the drift was
     // distill-only and every addition was already represented.

--- a/packages/daemon/src/agents/memory.ts
+++ b/packages/daemon/src/agents/memory.ts
@@ -390,7 +390,7 @@ export async function readMemoryFile(agentDir: string, relPath: string): Promise
 }
 
 /** Truncate a snapshot to the history value cap, on a UTF-8 boundary, flagging it. */
-function clampHistoryValue(text: string): { value: string; truncated: boolean } {
+export function clampMemoryHistoryValue(text: string): { value: string; truncated: boolean } {
   if (Buffer.byteLength(text) <= MAX_HISTORY_VALUE_BYTES) return { value: text, truncated: false }
   const buf = Buffer.from(text, 'utf8').subarray(0, MAX_HISTORY_VALUE_BYTES)
   return { value: buf.toString('utf8') + '…', truncated: true }
@@ -457,16 +457,21 @@ export function canonicalizeMemoryHistory(raw: string): string {
   return retainMemoryHistoryRecords(withIds).map(historyLine).join('')
 }
 
+/** Take a contained/no-follow canonical history snapshot while the caller
+ * already holds the memory-dir lock. Dream adoption uses this in the same
+ * critical section as its final live-store snapshot and directory swap. */
+export async function snapshotMemoryHistoryHoldingLock(agentDir: string): Promise<string> {
+  const dir = memoryDir(agentDir)
+  const path = await containedReadTarget(agentDir, dir, join(dir, MEMORY_HISTORY_FILENAME))
+  if (path === null) return ''
+  const current = await readCurrentMemoryFile(path)
+  return current.existed ? canonicalizeMemoryHistory(current.before) : ''
+}
+
 /** Take a contained/no-follow canonical snapshot for a replacement store. The
  * brief shared lock makes the copied sidecar line up with ordinary appends. */
 export function snapshotMemoryHistory(agentDir: string): Promise<string> {
-  return withMemoryDirLock(agentDir, async () => {
-    const dir = memoryDir(agentDir)
-    const path = await containedReadTarget(agentDir, dir, join(dir, MEMORY_HISTORY_FILENAME))
-    if (path === null) return ''
-    const current = await readCurrentMemoryFile(path)
-    return current.existed ? canonicalizeMemoryHistory(current.before) : ''
-  })
+  return withMemoryDirLock(agentDir, () => snapshotMemoryHistoryHoldingLock(agentDir))
 }
 
 /** Compact one sidecar atomically. Invalid legacy/torn rows are discarded and
@@ -702,8 +707,8 @@ export async function writeMemoryFileHoldingLock(
   // adoption fence authorizes from these counters, never from `.history`.
   bumpWriteMarks(agentDir, source)
 
-  const beforeClamped = existed ? clampHistoryValue(before) : undefined
-  const afterClamped = clampHistoryValue(content)
+  const beforeClamped = existed ? clampMemoryHistoryValue(before) : undefined
+  const afterClamped = clampMemoryHistoryValue(content)
   try {
     await appendHistoryHoldingLock(agentDir, {
       path: relPath,

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -15,7 +15,8 @@ import {
   MEMORY_HISTORY_FILENAME,
   MEMORY_INDEX,
   MAX_MEMORY_FILE_BYTES,
-  memoryDir
+  memoryDir,
+  type MemoryHistoryRecord
 } from '../src/agents/memory.js'
 
 const silent = { info() {}, warn() {} }
@@ -330,6 +331,53 @@ describe('DreamRunner adoption', () => {
     expect(history).toContain('"source":"tool"') // pre-adoption rows preserved
   })
 
+  it('records the exact add, update, and delete set with live before snapshots', async () => {
+    const proposal = JSON.stringify({
+      index: '# Memory\n- [prefs](prefs.md)\n- [fresh](fresh.md)',
+      files: [
+        { path: 'prefs.md', content: '- consolidated preference' },
+        { path: 'fresh.md', content: '- newly learned fact' }
+      ]
+    })
+    const { dir, store, runner } = await setup({ extract: async () => proposal })
+    await writeMemoryFile(dir, 'obsolete.md', '- no longer relevant\n', undefined, 'tool')
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    await runner.adopt('a1', started.dreamId, false)
+
+    const history = (await readFile(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as MemoryHistoryRecord)
+    const adoption = history.filter((event) => event.source === 'dream')
+
+    expect(adoption).toContainEqual(
+      expect.objectContaining({
+        path: 'prefs.md',
+        event: 'update',
+        before: '- uses tabs\n- uses tabs again\n',
+        after: '- consolidated preference\n'
+      })
+    )
+    expect(adoption).toContainEqual(
+      expect.objectContaining({
+        path: 'fresh.md',
+        event: 'add',
+        after: '- newly learned fact\n'
+      })
+    )
+    expect(adoption.find((event) => event.path === 'fresh.md')).not.toHaveProperty('before')
+    expect(adoption).toContainEqual(
+      expect.objectContaining({
+        path: 'obsolete.md',
+        event: 'delete',
+        before: '- no longer relevant\n',
+        after: ''
+      })
+    )
+  })
+
   it.each([
     ['a valid final row without a newline', false],
     ['a torn partial tail', true]
@@ -389,6 +437,17 @@ describe('DreamRunner adoption', () => {
 
     const adopted = await runner.adopt('a1', started.dreamId, true)
     expect(adopted.status).toBe('adopted')
+    const history = (await readFile(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as MemoryHistoryRecord)
+    expect(history.filter((event) => event.source === 'dream' && event.path === 'prefs.md')).toContainEqual(
+      expect.objectContaining({
+        event: 'update',
+        before: '- console edit after snapshot\n',
+        after: '- Uses tabs, not spaces (2026-07-24).\n'
+      })
+    )
   })
 
   it('auto-adopts on a trusted runtime, but leaves an untrusted one for review', async () => {

--- a/packages/web/src/components/console/LineDiff.test.ts
+++ b/packages/web/src/components/console/LineDiff.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { diffLines } from './LineDiff'
+
+describe('diffLines', () => {
+  it('keeps context and marks only the exact removed and added lines', () => {
+    expect(diffLines('alpha\nold value\nomega\n', 'alpha\nnew value\nomega\nextra\n')).toEqual([
+      { kind: 'context', text: 'alpha', oldLine: 1, newLine: 1 },
+      { kind: 'delete', text: 'old value', oldLine: 2 },
+      { kind: 'add', text: 'new value', newLine: 2 },
+      { kind: 'context', text: 'omega', oldLine: 3, newLine: 3 },
+      { kind: 'add', text: 'extra', newLine: 4 }
+    ])
+  })
+
+  it('renders whole-file additions and deletions with the correct side line numbers', () => {
+    expect(diffLines('', 'one\ntwo\n')).toEqual([
+      { kind: 'add', text: 'one', newLine: 1 },
+      { kind: 'add', text: 'two', newLine: 2 }
+    ])
+    expect(diffLines('one\ntwo\n', '')).toEqual([
+      { kind: 'delete', text: 'one', oldLine: 1 },
+      { kind: 'delete', text: 'two', oldLine: 2 }
+    ])
+  })
+})

--- a/packages/web/src/components/console/LineDiff.test.ts
+++ b/packages/web/src/components/console/LineDiff.test.ts
@@ -22,4 +22,29 @@ describe('diffLines', () => {
       { kind: 'delete', text: 'two', oldLine: 2 }
     ])
   })
+
+  it('preserves EOF-newline-only changes with Git-style markers', () => {
+    expect(diffLines('alpha', 'alpha\n')).toEqual([
+      { kind: 'delete', text: 'alpha', oldLine: 1 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'old' },
+      { kind: 'add', text: 'alpha', newLine: 1 }
+    ])
+    expect(diffLines('alpha\n', 'alpha')).toEqual([
+      { kind: 'delete', text: 'alpha', oldLine: 1 },
+      { kind: 'add', text: 'alpha', newLine: 1 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'new' }
+    ])
+  })
+
+  it('handles a newline-heavy 4 KB snapshot without a quadratic matrix', () => {
+    const before = `a${'\n'.repeat(3_998)}x`
+    const after = `b${'\n'.repeat(3_998)}y`
+
+    const rows = diffLines(before, after)
+
+    expect(rows.filter((row) => row.kind === 'context')).toHaveLength(3_997)
+    expect(rows.filter((row) => row.kind === 'delete').map((row) => row.text)).toEqual(['a', 'x'])
+    expect(rows.filter((row) => row.kind === 'add').map((row) => row.text)).toEqual(['b', 'y'])
+    expect(rows.filter((row) => row.kind === 'meta')).toHaveLength(2)
+  })
 })

--- a/packages/web/src/components/console/LineDiff.test.ts
+++ b/packages/web/src/components/console/LineDiff.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { diffLines } from './LineDiff'
+import { diffLines, type LineDiffRow } from './LineDiff'
+
+function rebuild(rows: LineDiffRow[], side: 'old' | 'new'): string {
+  const contentKind = side === 'old' ? 'delete' : 'add'
+  const lines = rows.filter((row) => row.kind === 'context' || row.kind === contentKind).map((row) => row.text)
+  if (lines.length === 0) return ''
+  const missingNewline = rows.some((row) => row.kind === 'meta' && (row.eofSide === side || row.eofSide === 'both'))
+  return lines.join('\n') + (missingNewline ? '' : '\n')
+}
 
 describe('diffLines', () => {
   it('keeps context and marks only the exact removed and added lines', () => {
@@ -34,6 +42,55 @@ describe('diffLines', () => {
       { kind: 'add', text: 'alpha', newLine: 1 },
       { kind: 'meta', text: 'No newline at end of file', eofSide: 'new' }
     ])
+  })
+
+  it('treats an unterminated terminal line as different when it becomes a terminated nonterminal line', () => {
+    expect(diffLines('a', 'a\nb')).toEqual([
+      { kind: 'delete', text: 'a', oldLine: 1 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'old' },
+      { kind: 'add', text: 'a', newLine: 1 },
+      { kind: 'add', text: 'b', newLine: 2 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'new' }
+    ])
+    expect(diffLines('a', 'a\n\n')).toEqual([
+      { kind: 'delete', text: 'a', oldLine: 1 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'old' },
+      { kind: 'add', text: 'a', newLine: 1 },
+      { kind: 'add', text: '', newLine: 2 }
+    ])
+  })
+
+  it('preserves a shared unterminated EOF line when an earlier line changes', () => {
+    expect(diffLines('old\ntail', 'new\ntail')).toEqual([
+      { kind: 'delete', text: 'old', oldLine: 1 },
+      { kind: 'add', text: 'new', newLine: 1 },
+      { kind: 'context', text: 'tail', oldLine: 2, newLine: 2 },
+      { kind: 'meta', text: 'No newline at end of file', eofSide: 'both' }
+    ])
+  })
+
+  it('reconstructs every small before/after line and EOF combination', () => {
+    const values = new Set<string>([''])
+    const atoms = ['a', 'b', '']
+    const addValues = (parts: string[], remaining: number) => {
+      if (remaining === 0) {
+        const value = parts.join('\n')
+        values.add(value)
+        values.add(`${value}\n`)
+        return
+      }
+      for (const atom of atoms) addValues([...parts, atom], remaining - 1)
+    }
+    for (let length = 1; length <= 3; length += 1) addValues([], length)
+
+    for (const before of values) {
+      for (const after of values) {
+        if (before === after) continue
+        const rows = diffLines(before, after)
+        expect(rebuild(rows, 'old'), `${JSON.stringify(before)} → old`).toBe(before)
+        expect(rebuild(rows, 'new'), `${JSON.stringify(after)} → new`).toBe(after)
+      }
+    }
   })
 
   it('handles a newline-heavy 4 KB snapshot without a quadratic matrix', () => {

--- a/packages/web/src/components/console/LineDiff.tsx
+++ b/packages/web/src/components/console/LineDiff.tsx
@@ -1,0 +1,150 @@
+export type LineDiffKind = 'context' | 'add' | 'delete'
+
+export interface LineDiffRow {
+  kind: LineDiffKind
+  text: string
+  oldLine?: number
+  newLine?: number
+}
+
+function splitLines(value: string): string[] {
+  if (!value) return []
+  const lines = value.split('\n')
+  if (value.endsWith('\n')) lines.pop()
+  return lines
+}
+
+/**
+ * Exact line diff for bounded text snapshots. Memory history values are capped
+ * at 4 KB, so a compact LCS matrix is deterministic and comfortably bounded.
+ */
+export function diffLines(before: string, after: string): LineDiffRow[] {
+  const oldLines = splitLines(before)
+  const newLines = splitLines(after)
+  let prefix = 0
+  while (prefix < oldLines.length && prefix < newLines.length && oldLines[prefix] === newLines[prefix]) {
+    prefix += 1
+  }
+  let suffix = 0
+  while (
+    suffix < oldLines.length - prefix &&
+    suffix < newLines.length - prefix &&
+    oldLines[oldLines.length - suffix - 1] === newLines[newLines.length - suffix - 1]
+  ) {
+    suffix += 1
+  }
+
+  const oldMiddle = oldLines.slice(prefix, oldLines.length - suffix)
+  const newMiddle = newLines.slice(prefix, newLines.length - suffix)
+  const columns = newMiddle.length + 1
+  const lcs = new Uint16Array((oldMiddle.length + 1) * columns)
+
+  for (let oldIndex = oldMiddle.length - 1; oldIndex >= 0; oldIndex -= 1) {
+    for (let newIndex = newMiddle.length - 1; newIndex >= 0; newIndex -= 1) {
+      const cell = oldIndex * columns + newIndex
+      lcs[cell] =
+        oldMiddle[oldIndex] === newMiddle[newIndex]
+          ? 1 + lcs[(oldIndex + 1) * columns + newIndex + 1]!
+          : Math.max(lcs[(oldIndex + 1) * columns + newIndex]!, lcs[oldIndex * columns + newIndex + 1]!)
+    }
+  }
+
+  const rows: LineDiffRow[] = oldLines
+    .slice(0, prefix)
+    .map((text, index) => ({ kind: 'context', text, oldLine: index + 1, newLine: index + 1 }))
+  let oldIndex = 0
+  let newIndex = 0
+  let oldLine = prefix + 1
+  let newLine = prefix + 1
+  while (oldIndex < oldMiddle.length && newIndex < newMiddle.length) {
+    if (oldMiddle[oldIndex] === newMiddle[newIndex]) {
+      rows.push({ kind: 'context', text: oldMiddle[oldIndex]!, oldLine, newLine })
+      oldIndex += 1
+      newIndex += 1
+      oldLine += 1
+      newLine += 1
+    } else if (lcs[(oldIndex + 1) * columns + newIndex]! >= lcs[oldIndex * columns + newIndex + 1]!) {
+      rows.push({ kind: 'delete', text: oldMiddle[oldIndex]!, oldLine })
+      oldIndex += 1
+      oldLine += 1
+    } else {
+      rows.push({ kind: 'add', text: newMiddle[newIndex]!, newLine })
+      newIndex += 1
+      newLine += 1
+    }
+  }
+  while (oldIndex < oldMiddle.length) {
+    rows.push({ kind: 'delete', text: oldMiddle[oldIndex]!, oldLine })
+    oldIndex += 1
+    oldLine += 1
+  }
+  while (newIndex < newMiddle.length) {
+    rows.push({ kind: 'add', text: newMiddle[newIndex]!, newLine })
+    newIndex += 1
+    newLine += 1
+  }
+  for (let index = 0; index < suffix; index += 1) {
+    const oldSuffixIndex = oldLines.length - suffix + index
+    const newSuffixIndex = newLines.length - suffix + index
+    rows.push({
+      kind: 'context',
+      text: oldLines[oldSuffixIndex]!,
+      oldLine: oldSuffixIndex + 1,
+      newLine: newSuffixIndex + 1
+    })
+  }
+  return rows
+}
+
+const ROW_STYLE: Record<LineDiffKind, string> = {
+  context: 'bg-(--surface-card) text-(--text-secondary)',
+  add: 'bg-(--status-online-soft) text-(--green-500)',
+  delete: 'bg-(--status-error-soft) text-(--red-600)'
+}
+
+const MARKER: Record<LineDiffKind, string> = {
+  context: ' ',
+  add: '+',
+  delete: '−'
+}
+
+export function LineDiff({ before, after }: { before: string; after: string }) {
+  const rows = diffLines(before, after)
+  const changed = rows.some((row) => row.kind !== 'context')
+
+  return (
+    <div className="min-w-0 overflow-hidden rounded-md border border-(--border-subtle)">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-2 font-sans text-[10.5px] font-semibold leading-normal text-(--text-secondary)">
+        <span>Line changes</span>
+        <span className="font-normal text-(--red-600)">− removed</span>
+        <span className="font-normal text-(--green-500)">+ added</span>
+      </div>
+      {changed ? (
+        <div className="max-h-80 overflow-auto">
+          <table className="mono w-full min-w-max border-collapse text-[11px] leading-[1.55]" aria-label="Line changes">
+            <tbody>
+              {rows.map((row, index) => (
+                <tr
+                  key={`${row.kind}:${row.oldLine ?? ''}:${row.newLine ?? ''}:${index}`}
+                  className={ROW_STYLE[row.kind]}
+                  data-diff-kind={row.kind}
+                >
+                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right text-(--text-tertiary)">
+                    {row.oldLine ?? ''}
+                  </td>
+                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right text-(--text-tertiary)">
+                    {row.newLine ?? ''}
+                  </td>
+                  <td className="w-7 select-none px-2 py-px text-center font-semibold">{MARKER[row.kind]}</td>
+                  <td className="whitespace-pre px-2 py-px pr-4">{row.text || '\u00a0'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="bg-(--surface-card) px-3 py-4 text-[11px] text-(--text-tertiary)">No line changes.</div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/LineDiff.tsx
+++ b/packages/web/src/components/console/LineDiff.tsx
@@ -5,14 +5,27 @@ export interface LineDiffRow {
   text: string
   oldLine?: number
   newLine?: number
-  eofSide?: 'old' | 'new'
+  eofSide?: 'old' | 'new' | 'both'
 }
 
-function splitLines(value: string): string[] {
+interface LineToken {
+  text: string
+  terminated: boolean
+}
+
+function splitLines(value: string): LineToken[] {
   if (!value) return []
   const lines = value.split('\n')
-  if (value.endsWith('\n')) lines.pop()
-  return lines
+  const endsWithNewline = value.endsWith('\n')
+  if (endsWithNewline) lines.pop()
+  return lines.map((text, index) => ({
+    text,
+    terminated: index < lines.length - 1 || endsWithNewline
+  }))
+}
+
+function sameLine(left: LineToken | undefined, right: LineToken | undefined): boolean {
+  return left?.text === right?.text && left?.terminated === right?.terminated
 }
 
 interface LineMatch {
@@ -21,10 +34,10 @@ interface LineMatch {
 }
 
 function prefixLcsLengths(
-  oldLines: string[],
+  oldLines: LineToken[],
   oldStart: number,
   oldEnd: number,
-  newLines: string[],
+  newLines: LineToken[],
   newStart: number,
   newEnd: number
 ): Uint16Array {
@@ -34,10 +47,9 @@ function prefixLcsLengths(
   for (let oldIndex = oldStart; oldIndex < oldEnd; oldIndex += 1) {
     current[0] = 0
     for (let offset = 1; offset <= width; offset += 1) {
-      current[offset] =
-        oldLines[oldIndex] === newLines[newStart + offset - 1]
-          ? previous[offset - 1]! + 1
-          : Math.max(previous[offset]!, current[offset - 1]!)
+      current[offset] = sameLine(oldLines[oldIndex], newLines[newStart + offset - 1])
+        ? previous[offset - 1]! + 1
+        : Math.max(previous[offset]!, current[offset - 1]!)
     }
     ;[previous, current] = [current, previous]
   }
@@ -45,10 +57,10 @@ function prefixLcsLengths(
 }
 
 function suffixLcsLengths(
-  oldLines: string[],
+  oldLines: LineToken[],
   oldStart: number,
   oldEnd: number,
-  newLines: string[],
+  newLines: LineToken[],
   newStart: number,
   newEnd: number
 ): Uint16Array {
@@ -58,10 +70,9 @@ function suffixLcsLengths(
   for (let oldIndex = oldEnd - 1; oldIndex >= oldStart; oldIndex -= 1) {
     current[width] = 0
     for (let offset = width - 1; offset >= 0; offset -= 1) {
-      current[offset] =
-        oldLines[oldIndex] === newLines[newStart + offset]
-          ? previous[offset + 1]! + 1
-          : Math.max(previous[offset]!, current[offset + 1]!)
+      current[offset] = sameLine(oldLines[oldIndex], newLines[newStart + offset])
+        ? previous[offset + 1]! + 1
+        : Math.max(previous[offset]!, current[offset + 1]!)
     }
     ;[previous, current] = [current, previous]
   }
@@ -70,10 +81,10 @@ function suffixLcsLengths(
 
 /** Hirschberg LCS: exact matches with linear working memory. */
 function collectLcsMatches(
-  oldLines: string[],
+  oldLines: LineToken[],
   oldStart: number,
   oldEnd: number,
-  newLines: string[],
+  newLines: LineToken[],
   newStart: number,
   newEnd: number,
   matches: LineMatch[]
@@ -81,7 +92,7 @@ function collectLcsMatches(
   if (oldStart === oldEnd || newStart === newEnd) return
   if (oldEnd - oldStart === 1) {
     for (let newIndex = newStart; newIndex < newEnd; newIndex += 1) {
-      if (oldLines[oldStart] === newLines[newIndex]) {
+      if (sameLine(oldLines[oldStart], newLines[newIndex])) {
         matches.push({ oldIndex: oldStart, newIndex })
         return
       }
@@ -90,7 +101,7 @@ function collectLcsMatches(
   }
   if (newEnd - newStart === 1) {
     for (let oldIndex = oldStart; oldIndex < oldEnd; oldIndex += 1) {
-      if (oldLines[oldIndex] === newLines[newStart]) {
+      if (sameLine(oldLines[oldIndex], newLines[newStart])) {
         matches.push({ oldIndex, newIndex: newStart })
         return
       }
@@ -116,27 +127,12 @@ function collectLcsMatches(
   collectLcsMatches(oldLines, oldMiddle, oldEnd, newLines, newSplit, newEnd, matches)
 }
 
-function addEofMarkers(rows: LineDiffRow[], before: string, after: string, oldCount: number, newCount: number) {
-  const oldMissingNewline = before.length > 0 && !before.endsWith('\n')
-  const newMissingNewline = after.length > 0 && !after.endsWith('\n')
-
-  // A terminal-newline-only change initially appears as one matched content
-  // line. Turn that last context line into the same delete/add pair Git shows.
-  if (oldMissingNewline !== newMissingNewline && oldCount > 0 && newCount > 0) {
-    const lastContext = rows.findIndex(
-      (row) => row.kind === 'context' && row.oldLine === oldCount && row.newLine === newCount
-    )
-    if (lastContext >= 0) {
-      const row = rows[lastContext]!
-      rows.splice(
-        lastContext,
-        1,
-        { kind: 'delete', text: row.text, oldLine: row.oldLine },
-        { kind: 'add', text: row.text, newLine: row.newLine }
-      )
-    }
-  }
-
+function addEofMarkers(rows: LineDiffRow[], oldLines: LineToken[], newLines: LineToken[]) {
+  const oldCount = oldLines.length
+  const newCount = newLines.length
+  const oldMissingNewline = oldLines.at(-1)?.terminated === false
+  const newMissingNewline = newLines.at(-1)?.terminated === false
+  const hasChanges = rows.some((row) => row.kind !== 'context')
   const withMarkers: LineDiffRow[] = []
   for (const row of rows) {
     withMarkers.push(row)
@@ -145,6 +141,16 @@ function addEofMarkers(rows: LineDiffRow[], before: string, after: string, oldCo
     }
     if (row.kind === 'add' && row.newLine === newCount && newMissingNewline) {
       withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'new' })
+    }
+    if (
+      hasChanges &&
+      row.kind === 'context' &&
+      row.oldLine === oldCount &&
+      row.newLine === newCount &&
+      oldMissingNewline &&
+      newMissingNewline
+    ) {
+      withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'both' })
     }
   }
   return withMarkers
@@ -158,14 +164,14 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
   const oldLines = splitLines(before)
   const newLines = splitLines(after)
   let prefix = 0
-  while (prefix < oldLines.length && prefix < newLines.length && oldLines[prefix] === newLines[prefix]) {
+  while (prefix < oldLines.length && prefix < newLines.length && sameLine(oldLines[prefix], newLines[prefix])) {
     prefix += 1
   }
   let suffix = 0
   while (
     suffix < oldLines.length - prefix &&
     suffix < newLines.length - prefix &&
-    oldLines[oldLines.length - suffix - 1] === newLines[newLines.length - suffix - 1]
+    sameLine(oldLines[oldLines.length - suffix - 1], newLines[newLines.length - suffix - 1])
   ) {
     suffix += 1
   }
@@ -184,16 +190,16 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
   let newIndex = 0
   for (const match of matches) {
     while (oldIndex < match.oldIndex) {
-      rows.push({ kind: 'delete', text: oldLines[oldIndex]!, oldLine: oldIndex + 1 })
+      rows.push({ kind: 'delete', text: oldLines[oldIndex]!.text, oldLine: oldIndex + 1 })
       oldIndex += 1
     }
     while (newIndex < match.newIndex) {
-      rows.push({ kind: 'add', text: newLines[newIndex]!, newLine: newIndex + 1 })
+      rows.push({ kind: 'add', text: newLines[newIndex]!.text, newLine: newIndex + 1 })
       newIndex += 1
     }
     rows.push({
       kind: 'context',
-      text: oldLines[match.oldIndex]!,
+      text: oldLines[match.oldIndex]!.text,
       oldLine: match.oldIndex + 1,
       newLine: match.newIndex + 1
     })
@@ -201,14 +207,14 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
     newIndex = match.newIndex + 1
   }
   while (oldIndex < oldLines.length) {
-    rows.push({ kind: 'delete', text: oldLines[oldIndex]!, oldLine: oldIndex + 1 })
+    rows.push({ kind: 'delete', text: oldLines[oldIndex]!.text, oldLine: oldIndex + 1 })
     oldIndex += 1
   }
   while (newIndex < newLines.length) {
-    rows.push({ kind: 'add', text: newLines[newIndex]!, newLine: newIndex + 1 })
+    rows.push({ kind: 'add', text: newLines[newIndex]!.text, newLine: newIndex + 1 })
     newIndex += 1
   }
-  return addEofMarkers(rows, before, after, oldLines.length, newLines.length)
+  return addEofMarkers(rows, oldLines, newLines)
 }
 
 const ROW_STYLE: Record<LineDiffKind, string> = {

--- a/packages/web/src/components/console/LineDiff.tsx
+++ b/packages/web/src/components/console/LineDiff.tsx
@@ -1,10 +1,11 @@
-export type LineDiffKind = 'context' | 'add' | 'delete'
+export type LineDiffKind = 'context' | 'add' | 'delete' | 'meta'
 
 export interface LineDiffRow {
   kind: LineDiffKind
   text: string
   oldLine?: number
   newLine?: number
+  eofSide?: 'old' | 'new'
 }
 
 function splitLines(value: string): string[] {
@@ -14,9 +15,144 @@ function splitLines(value: string): string[] {
   return lines
 }
 
+interface LineMatch {
+  oldIndex: number
+  newIndex: number
+}
+
+function prefixLcsLengths(
+  oldLines: string[],
+  oldStart: number,
+  oldEnd: number,
+  newLines: string[],
+  newStart: number,
+  newEnd: number
+): Uint16Array {
+  const width = newEnd - newStart
+  let previous = new Uint16Array(width + 1)
+  let current = new Uint16Array(width + 1)
+  for (let oldIndex = oldStart; oldIndex < oldEnd; oldIndex += 1) {
+    current[0] = 0
+    for (let offset = 1; offset <= width; offset += 1) {
+      current[offset] =
+        oldLines[oldIndex] === newLines[newStart + offset - 1]
+          ? previous[offset - 1]! + 1
+          : Math.max(previous[offset]!, current[offset - 1]!)
+    }
+    ;[previous, current] = [current, previous]
+  }
+  return previous
+}
+
+function suffixLcsLengths(
+  oldLines: string[],
+  oldStart: number,
+  oldEnd: number,
+  newLines: string[],
+  newStart: number,
+  newEnd: number
+): Uint16Array {
+  const width = newEnd - newStart
+  let previous = new Uint16Array(width + 1)
+  let current = new Uint16Array(width + 1)
+  for (let oldIndex = oldEnd - 1; oldIndex >= oldStart; oldIndex -= 1) {
+    current[width] = 0
+    for (let offset = width - 1; offset >= 0; offset -= 1) {
+      current[offset] =
+        oldLines[oldIndex] === newLines[newStart + offset]
+          ? previous[offset + 1]! + 1
+          : Math.max(previous[offset]!, current[offset + 1]!)
+    }
+    ;[previous, current] = [current, previous]
+  }
+  return previous
+}
+
+/** Hirschberg LCS: exact matches with linear working memory. */
+function collectLcsMatches(
+  oldLines: string[],
+  oldStart: number,
+  oldEnd: number,
+  newLines: string[],
+  newStart: number,
+  newEnd: number,
+  matches: LineMatch[]
+): void {
+  if (oldStart === oldEnd || newStart === newEnd) return
+  if (oldEnd - oldStart === 1) {
+    for (let newIndex = newStart; newIndex < newEnd; newIndex += 1) {
+      if (oldLines[oldStart] === newLines[newIndex]) {
+        matches.push({ oldIndex: oldStart, newIndex })
+        return
+      }
+    }
+    return
+  }
+  if (newEnd - newStart === 1) {
+    for (let oldIndex = oldStart; oldIndex < oldEnd; oldIndex += 1) {
+      if (oldLines[oldIndex] === newLines[newStart]) {
+        matches.push({ oldIndex, newIndex: newStart })
+        return
+      }
+    }
+    return
+  }
+
+  const oldMiddle = oldStart + Math.floor((oldEnd - oldStart) / 2)
+  let newSplit = newStart
+  {
+    const prefix = prefixLcsLengths(oldLines, oldStart, oldMiddle, newLines, newStart, newEnd)
+    const suffix = suffixLcsLengths(oldLines, oldMiddle, oldEnd, newLines, newStart, newEnd)
+    let best = -1
+    for (let offset = 0; offset <= newEnd - newStart; offset += 1) {
+      const score = prefix[offset]! + suffix[offset]!
+      if (score > best) {
+        best = score
+        newSplit = newStart + offset
+      }
+    }
+  }
+  collectLcsMatches(oldLines, oldStart, oldMiddle, newLines, newStart, newSplit, matches)
+  collectLcsMatches(oldLines, oldMiddle, oldEnd, newLines, newSplit, newEnd, matches)
+}
+
+function addEofMarkers(rows: LineDiffRow[], before: string, after: string, oldCount: number, newCount: number) {
+  const oldMissingNewline = before.length > 0 && !before.endsWith('\n')
+  const newMissingNewline = after.length > 0 && !after.endsWith('\n')
+
+  // A terminal-newline-only change initially appears as one matched content
+  // line. Turn that last context line into the same delete/add pair Git shows.
+  if (oldMissingNewline !== newMissingNewline && oldCount > 0 && newCount > 0) {
+    const lastContext = rows.findIndex(
+      (row) => row.kind === 'context' && row.oldLine === oldCount && row.newLine === newCount
+    )
+    if (lastContext >= 0) {
+      const row = rows[lastContext]!
+      rows.splice(
+        lastContext,
+        1,
+        { kind: 'delete', text: row.text, oldLine: row.oldLine },
+        { kind: 'add', text: row.text, newLine: row.newLine }
+      )
+    }
+  }
+
+  const withMarkers: LineDiffRow[] = []
+  for (const row of rows) {
+    withMarkers.push(row)
+    if (row.kind === 'delete' && row.oldLine === oldCount && oldMissingNewline) {
+      withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'old' })
+    }
+    if (row.kind === 'add' && row.newLine === newCount && newMissingNewline) {
+      withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'new' })
+    }
+  }
+  return withMarkers
+}
+
 /**
- * Exact line diff for bounded text snapshots. Memory history values are capped
- * at 4 KB, so a compact LCS matrix is deterministic and comfortably bounded.
+ * Exact line diff for bounded text snapshots. Hirschberg keeps working memory
+ * linear even when a valid 4 KB snapshot contains thousands of tiny lines.
  */
 export function diffLines(before: string, after: string): LineDiffRow[] {
   const oldLines = splitLines(before)
@@ -34,78 +170,59 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
     suffix += 1
   }
 
-  const oldMiddle = oldLines.slice(prefix, oldLines.length - suffix)
-  const newMiddle = newLines.slice(prefix, newLines.length - suffix)
-  const columns = newMiddle.length + 1
-  const lcs = new Uint16Array((oldMiddle.length + 1) * columns)
-
-  for (let oldIndex = oldMiddle.length - 1; oldIndex >= 0; oldIndex -= 1) {
-    for (let newIndex = newMiddle.length - 1; newIndex >= 0; newIndex -= 1) {
-      const cell = oldIndex * columns + newIndex
-      lcs[cell] =
-        oldMiddle[oldIndex] === newMiddle[newIndex]
-          ? 1 + lcs[(oldIndex + 1) * columns + newIndex + 1]!
-          : Math.max(lcs[(oldIndex + 1) * columns + newIndex]!, lcs[oldIndex * columns + newIndex + 1]!)
-    }
-  }
-
-  const rows: LineDiffRow[] = oldLines
-    .slice(0, prefix)
-    .map((text, index) => ({ kind: 'context', text, oldLine: index + 1, newLine: index + 1 }))
-  let oldIndex = 0
-  let newIndex = 0
-  let oldLine = prefix + 1
-  let newLine = prefix + 1
-  while (oldIndex < oldMiddle.length && newIndex < newMiddle.length) {
-    if (oldMiddle[oldIndex] === newMiddle[newIndex]) {
-      rows.push({ kind: 'context', text: oldMiddle[oldIndex]!, oldLine, newLine })
-      oldIndex += 1
-      newIndex += 1
-      oldLine += 1
-      newLine += 1
-    } else if (lcs[(oldIndex + 1) * columns + newIndex]! >= lcs[oldIndex * columns + newIndex + 1]!) {
-      rows.push({ kind: 'delete', text: oldMiddle[oldIndex]!, oldLine })
-      oldIndex += 1
-      oldLine += 1
-    } else {
-      rows.push({ kind: 'add', text: newMiddle[newIndex]!, newLine })
-      newIndex += 1
-      newLine += 1
-    }
-  }
-  while (oldIndex < oldMiddle.length) {
-    rows.push({ kind: 'delete', text: oldMiddle[oldIndex]!, oldLine })
-    oldIndex += 1
-    oldLine += 1
-  }
-  while (newIndex < newMiddle.length) {
-    rows.push({ kind: 'add', text: newMiddle[newIndex]!, newLine })
-    newIndex += 1
-    newLine += 1
-  }
+  const matches: LineMatch[] = oldLines.slice(0, prefix).map((_text, index) => ({ oldIndex: index, newIndex: index }))
+  collectLcsMatches(oldLines, prefix, oldLines.length - suffix, newLines, prefix, newLines.length - suffix, matches)
   for (let index = 0; index < suffix; index += 1) {
-    const oldSuffixIndex = oldLines.length - suffix + index
-    const newSuffixIndex = newLines.length - suffix + index
-    rows.push({
-      kind: 'context',
-      text: oldLines[oldSuffixIndex]!,
-      oldLine: oldSuffixIndex + 1,
-      newLine: newSuffixIndex + 1
+    matches.push({
+      oldIndex: oldLines.length - suffix + index,
+      newIndex: newLines.length - suffix + index
     })
   }
-  return rows
+
+  const rows: LineDiffRow[] = []
+  let oldIndex = 0
+  let newIndex = 0
+  for (const match of matches) {
+    while (oldIndex < match.oldIndex) {
+      rows.push({ kind: 'delete', text: oldLines[oldIndex]!, oldLine: oldIndex + 1 })
+      oldIndex += 1
+    }
+    while (newIndex < match.newIndex) {
+      rows.push({ kind: 'add', text: newLines[newIndex]!, newLine: newIndex + 1 })
+      newIndex += 1
+    }
+    rows.push({
+      kind: 'context',
+      text: oldLines[match.oldIndex]!,
+      oldLine: match.oldIndex + 1,
+      newLine: match.newIndex + 1
+    })
+    oldIndex = match.oldIndex + 1
+    newIndex = match.newIndex + 1
+  }
+  while (oldIndex < oldLines.length) {
+    rows.push({ kind: 'delete', text: oldLines[oldIndex]!, oldLine: oldIndex + 1 })
+    oldIndex += 1
+  }
+  while (newIndex < newLines.length) {
+    rows.push({ kind: 'add', text: newLines[newIndex]!, newLine: newIndex + 1 })
+    newIndex += 1
+  }
+  return addEofMarkers(rows, before, after, oldLines.length, newLines.length)
 }
 
 const ROW_STYLE: Record<LineDiffKind, string> = {
   context: 'bg-(--surface-card) text-(--text-secondary)',
   add: 'bg-(--status-online-soft) text-(--green-500)',
-  delete: 'bg-(--status-error-soft) text-(--red-600)'
+  delete: 'bg-(--status-error-soft) text-(--red-600)',
+  meta: 'bg-(--surface-sunken) italic text-(--text-tertiary)'
 }
 
 const MARKER: Record<LineDiffKind, string> = {
   context: ' ',
   add: '+',
-  delete: '−'
+  delete: '−',
+  meta: '\\'
 }
 
 export function LineDiff({ before, after }: { before: string; after: string }) {
@@ -125,7 +242,7 @@ export function LineDiff({ before, after }: { before: string; after: string }) {
             <tbody>
               {rows.map((row, index) => (
                 <tr
-                  key={`${row.kind}:${row.oldLine ?? ''}:${row.newLine ?? ''}:${index}`}
+                  key={`${row.kind}:${row.oldLine ?? ''}:${row.newLine ?? ''}:${row.eofSide ?? ''}:${index}`}
                   className={ROW_STYLE[row.kind]}
                   data-diff-kind={row.kind}
                 >

--- a/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
@@ -51,11 +51,11 @@ describe('ManagedMemoryHistory', () => {
           {
             path: 'notes.md',
             event: 'update',
-            before: 'version one',
-            after: 'version two',
+            before: 'shared line\nold value\n',
+            after: 'shared line\nnew value\n',
             at: '2026-07-26T10:00:00.000Z',
             scope: 'agent',
-            source: 'console'
+            source: 'dream'
           },
           {
             path: 'notes.md',
@@ -100,11 +100,16 @@ describe('ManagedMemoryHistory', () => {
     expect(disclosure?.getAttribute('aria-expanded')).toBe('true')
     expect(mocks.listMemoryFileHistory).toHaveBeenNthCalledWith(1, 'agent-1', 'notes.md', { limit: 5 })
     expect(container.querySelectorAll('details')).toHaveLength(2)
-    expect(container.textContent).toContain('Before')
-    expect(container.textContent).toContain('version one')
-    expect(container.textContent).toContain('After')
-    expect(container.textContent).toContain('version two')
-    expect(container.textContent).toContain('Console')
+    expect(container.textContent).toContain('Line changes')
+    expect(container.textContent).toContain('Dream adoption')
+    const firstEvent = container.querySelector('details')
+    expect(
+      Array.from(firstEvent?.querySelectorAll('[data-diff-kind]') ?? []).map((row) =>
+        row.getAttribute('data-diff-kind')
+      )
+    ).toEqual(['context', 'delete', 'add'])
+    expect(firstEvent?.textContent).toContain('old value')
+    expect(firstEvent?.textContent).toContain('new value')
 
     await act(async () => button('Load older changes')?.click())
 
@@ -132,5 +137,32 @@ describe('ManagedMemoryHistory', () => {
     await act(async () => disclosure?.click())
     await act(async () => disclosure?.click())
     expect(mocks.listMemoryFileHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains legacy update rows that have no before snapshot', async () => {
+    mocks.listMemoryFileHistory.mockResolvedValue({
+      events: [
+        {
+          path: 'MEMORY.md',
+          event: 'update',
+          after: '# Adopted memory\n',
+          at: '2026-07-26T09:00:00.000Z',
+          scope: 'agent',
+          source: 'dream'
+        }
+      ],
+      nextCursor: null
+    })
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(<ManagedMemoryHistory agentId="agent-1" path="MEMORY.md" />)
+    })
+
+    await act(async () => button('Change history')?.click())
+
+    expect(container.textContent).toContain('The before snapshot was not recorded for this older change.')
+    expect(container.textContent).toContain('# Adopted memory')
   })
 })

--- a/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
@@ -100,9 +100,13 @@ describe('ManagedMemoryHistory', () => {
     expect(disclosure?.getAttribute('aria-expanded')).toBe('true')
     expect(mocks.listMemoryFileHistory).toHaveBeenNthCalledWith(1, 'agent-1', 'notes.md', { limit: 5 })
     expect(container.querySelectorAll('details')).toHaveLength(2)
-    expect(container.textContent).toContain('Line changes')
     expect(container.textContent).toContain('Dream adoption')
-    const firstEvent = container.querySelector('details')
+    const firstEvent = container.querySelector('details') as HTMLDetailsElement
+    expect(firstEvent.querySelector('[data-diff-kind]')).toBeNull()
+
+    await act(async () => firstEvent.querySelector('summary')?.click())
+
+    expect(container.textContent).toContain('Line changes')
     expect(
       Array.from(firstEvent?.querySelectorAll('[data-diff-kind]') ?? []).map((row) =>
         row.getAttribute('data-diff-kind')
@@ -119,6 +123,8 @@ describe('ManagedMemoryHistory', () => {
     })
     expect(container.querySelectorAll('details')).toHaveLength(3)
     expect(container.textContent).toContain('Automatic distillation')
+    const oldestEvent = container.querySelectorAll('details')[2]
+    await act(async () => oldestEvent?.querySelector('summary')?.click())
     expect(container.textContent).toContain('Long snapshots were shortened')
   })
 
@@ -161,6 +167,7 @@ describe('ManagedMemoryHistory', () => {
     })
 
     await act(async () => button('Change history')?.click())
+    await act(async () => container?.querySelector<HTMLElement>('details summary')?.click())
 
     expect(container.textContent).toContain('The before snapshot was not recorded for this older change.')
     expect(container.textContent).toContain('# Adopted memory')

--- a/packages/web/src/components/console/ManagedMemoryHistory.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.tsx
@@ -50,9 +50,13 @@ function Snapshot({ label, value, tone }: { label: string; value: string; tone: 
 function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
   const hasBefore = event.before !== undefined
   const canDiff = hasBefore || event.event === 'add'
+  const [expanded, setExpanded] = useState(false)
 
   return (
-    <details className="group rounded-md border border-(--border-subtle) bg-(--surface-card)">
+    <details
+      className="group rounded-md border border-(--border-subtle) bg-(--surface-card)"
+      onToggle={(toggleEvent) => setExpanded(toggleEvent.currentTarget.open)}
+    >
       <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 px-3 py-[10px] font-sans [&::-webkit-details-marker]:hidden">
         <Icon
           name="chevron-right"
@@ -72,25 +76,27 @@ function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
           {formatHistoryTime(event.at)}
         </time>
       </summary>
-      <div className="border-t border-(--border-subtle) p-3">
-        {canDiff ? (
-          <LineDiff before={event.before ?? ''} after={event.after} />
-        ) : (
-          <>
-            <Snapshot label="After" value={event.after} tone="after" />
+      {expanded ? (
+        <div className="border-t border-(--border-subtle) p-3">
+          {canDiff ? (
+            <LineDiff before={event.before ?? ''} after={event.after} />
+          ) : (
+            <>
+              <Snapshot label="After" value={event.after} tone="after" />
+              <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-[1.45] text-(--text-tertiary)">
+                <Icon name="info" size={12} className="mt-px flex-none" />
+                The before snapshot was not recorded for this older change.
+              </div>
+            </>
+          )}
+          {event.truncated ? (
             <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-[1.45] text-(--text-tertiary)">
               <Icon name="info" size={12} className="mt-px flex-none" />
-              The before snapshot was not recorded for this older change.
+              Long snapshots were shortened when this change was recorded.
             </div>
-          </>
-        )}
-        {event.truncated ? (
-          <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-[1.45] text-(--text-tertiary)">
-            <Icon name="info" size={12} className="mt-px flex-none" />
-            Long snapshots were shortened when this change was recorded.
-          </div>
-        ) : null}
-      </div>
+          ) : null}
+        </div>
+      ) : null}
     </details>
   )
 }

--- a/packages/web/src/components/console/ManagedMemoryHistory.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { ApiError, listMemoryFileHistory, type MemoryFileHistoryEventDto } from '@/lib/api'
 import { Spinner } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
+import { LineDiff } from '@/components/console/LineDiff'
 
 const PAGE_SIZE = 5
 
@@ -48,6 +49,7 @@ function Snapshot({ label, value, tone }: { label: string; value: string; tone: 
 
 function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
   const hasBefore = event.before !== undefined
+  const canDiff = hasBefore || event.event === 'add'
 
   return (
     <details className="group rounded-md border border-(--border-subtle) bg-(--surface-card)">
@@ -71,10 +73,17 @@ function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
         </time>
       </summary>
       <div className="border-t border-(--border-subtle) p-3">
-        <div className={hasBefore ? 'grid grid-cols-1 gap-3 desktop:grid-cols-2' : 'grid grid-cols-1 gap-3'}>
-          {hasBefore ? <Snapshot label="Before" value={event.before ?? ''} tone="before" /> : null}
-          <Snapshot label={event.event === 'delete' ? 'After deletion' : 'After'} value={event.after} tone="after" />
-        </div>
+        {canDiff ? (
+          <LineDiff before={event.before ?? ''} after={event.after} />
+        ) : (
+          <>
+            <Snapshot label="After" value={event.after} tone="after" />
+            <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-[1.45] text-(--text-tertiary)">
+              <Icon name="info" size={12} className="mt-px flex-none" />
+              The before snapshot was not recorded for this older change.
+            </div>
+          </>
+        )}
         {event.truncated ? (
           <div className="mt-2 flex items-start gap-1.5 text-[10.5px] leading-[1.45] text-(--text-tertiary)">
             <Icon name="info" size={12} className="mt-px flex-none" />


### PR DESCRIPTION
## What changed

- Record Dream adoption changes from the exact live store being replaced, including accurate `add`, `update`, and `delete` events with bounded before/after snapshots.
- Render managed-memory history as a Git-style line diff with old/new line numbers and exact added/removed lines.
- Treat EOF termination as part of line identity and render Git-style `No newline at end of file` markers, including mixed edits where an unterminated terminal line becomes a terminated nonterminal line.
- Compute diffs only when a history event is expanded, using an exact linear-memory LCS for newline-heavy snapshots.
- Explain legacy history rows whose before snapshot was never recorded.
- Preserve retention, atomic swap, rebase, and force-adoption behavior while moving history capture into the final memory lock.

## Root cause

Dream adoption hard-coded every staged file as an `update` and only wrote the `after` value. It never read the live file being replaced and did not record files removed by adoption. The history UI could therefore only show the adopted snapshot. Its existing before/after cards also did not compute a line diff.

## Validation

- Full workspace typecheck
- Full repository lint (0 errors; 2 pre-existing duplicate-import warnings)
- Web: 341 tests and production build
- Daemon: 2,094 tests (2 skipped)
- Adversarial coverage for EOF-newline-only and mixed EOF changes, exhaustive small line/EOF reconstruction, a newline-heavy 4 KB snapshot, and lazy collapsed history events
