### PR TITLE
fix(daemon,cli): create the state store and CLI root with restrictive modes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
-import { cliEntryPath, resolveRoot } from './paths.js'
+import { resolveRoot } from './paths.js'
+import { selfHealCliEntry } from './self-heal.js'
 import { delegate } from './delegate.js'
 import { runShell } from './run-shell.js'
 import { classifyInvocation, parseRootFlag } from './route.js'
@@ -11,18 +10,6 @@ import { runLogin } from './login.js'
 import { resolveController } from './service/index.js'
 import { runUpgrade, versionInstall, versionList, versionPrune, versionUse } from './version-commands.js'
 import { CLI_VERSION } from './version.js'
-
-/** Write <root>/cli-entry so a service/foreground daemon can locate this CLI to
- *  run an upgrade even when its PATH omits npm's global bin (§3). Best-effort. */
-function selfHealCliEntry(root: string): void {
-  try {
-    const p = cliEntryPath(root)
-    mkdirSync(dirname(p), { recursive: true })
-    writeFileSync(p, fileURLToPath(import.meta.url) + '\n')
-  } catch {
-    // non-fatal: the pointer is a convenience for daemon→CLI handoff
-  }
-}
 
 const fail = (cmd: string, err: unknown): never => {
   console.error(`agentconnect ${cmd}: ${(err as Error).message}`)
@@ -32,7 +19,7 @@ const fail = (cmd: string, err: unknown): never => {
 async function main(): Promise<void> {
   const argv = process.argv.slice(2)
   const root = resolveRoot(parseRootFlag(argv))
-  selfHealCliEntry(root)
+  selfHealCliEntry(root, fileURLToPath(import.meta.url))
 
   // ── Route by the first positional command (honoring global options before it),
   //    reserving only CLI-owned commands; everything else delegates verbatim (§4.2).

--- a/packages/cli/src/self-heal.ts
+++ b/packages/cli/src/self-heal.ts
@@ -1,0 +1,49 @@
+/**
+ * `<root>/cli-entry` self-heal — written on EVERY invocation so a service or
+ * foreground daemon can locate this CLI to run an upgrade even when its PATH omits
+ * npm's global bin (cli-daemon-split.md §3).
+ *
+ * Lives outside `index.ts` because that module executes `main()` on import; keeping
+ * it here makes the root's permission handling directly testable.
+ */
+import { chmodSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { cliEntryPath } from './paths.js'
+
+/**
+ * Narrow an ALREADY-EXISTING root to 0700. `mkdirSync`'s `mode` applies only on
+ * creation, so a root laid down earlier at 0755 — by an older CLI, a container image
+ * build, or systemd `StateDirectory=` — has to be repaired rather than merely created
+ * correctly. Mirrors `login.ts:protectCredentialsFile`, including leaving win32 alone
+ * (no enforceable POSIX mode semantics there).
+ */
+export function protectRootDir(dir: string): void {
+  if (process.platform === 'win32') return
+  try {
+    if ((statSync(dir).mode & 0o777) !== 0o700) chmodSync(dir, 0o700)
+  } catch {
+    // best-effort: a root we cannot stat/chmod is not a reason to fail the command
+  }
+}
+
+/**
+ * Write `<root>/cli-entry` pointing at `entryPath`. Best-effort — the pointer is a
+ * convenience for the daemon→CLI handoff, not a precondition for the command.
+ *
+ * This normally CREATES `<root>`, since it runs before anything else. With the
+ * default umask that landed at 0755, while every other creator of the same directory
+ * passes 0o700 (`login.ts`, the daemon's `config/load-config.ts`) — so the loose mode
+ * is the one that persisted, leaving the transcript store and daemon logs beneath it
+ * traversable by any other local user.
+ */
+export function selfHealCliEntry(root: string, entryPath: string): void {
+  try {
+    const p = cliEntryPath(root)
+    const dir = dirname(p)
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    protectRootDir(dir)
+    writeFileSync(p, entryPath + '\n')
+  } catch {
+    // non-fatal: the pointer is a convenience for daemon→CLI handoff
+  }
+}

--- a/packages/cli/test/self-heal.test.ts
+++ b/packages/cli/test/self-heal.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `selfHealCliEntry` runs before anything else on every CLI invocation, so it is
+ * normally the code that CREATES `<root>`. With the default umask that landed at
+ * 0755, while every other creator of the same directory passes 0o700 — leaving the
+ * transcript store and daemon logs beneath it traversable by other local users.
+ */
+import { describe, it, expect } from 'vitest'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { cliEntryPath } from '../src/paths.js'
+import { selfHealCliEntry } from '../src/self-heal.js'
+
+const mode = (p: string) => statSync(p).mode & 0o777
+const newRoot = () => join(mkdtempSync(join(tmpdir(), 'ac-selfheal-')), 'root')
+
+describe.skipIf(process.platform === 'win32')('selfHealCliEntry', () => {
+  it('creates the root 0700 and writes the entry pointer', () => {
+    const root = newRoot()
+    selfHealCliEntry(root, '/opt/agentconnect/cli.js')
+
+    const entry = cliEntryPath(root)
+    expect(existsSync(entry)).toBe(true)
+    expect(readFileSync(entry, 'utf8')).toBe('/opt/agentconnect/cli.js\n')
+    expect(mode(root)).toBe(0o700)
+  })
+
+  it('repairs a root that already exists group/other-readable', () => {
+    // `mkdirSync`'s mode does not apply to an existing directory, so a root created
+    // by an older CLI, a container image, or systemd `StateDirectory=` keeps 0755
+    // unless it is explicitly narrowed.
+    const root = newRoot()
+    mkdirSync(root, { recursive: true })
+    chmodSync(root, 0o755)
+
+    selfHealCliEntry(root, '/opt/agentconnect/cli.js')
+    expect(mode(root)).toBe(0o700)
+  })
+
+  it('stays best-effort when the root cannot be created', () => {
+    // A pre-existing FILE where the root should be: the write fails, and the CLI must
+    // still run — the pointer is a convenience for the daemon handoff, not a gate.
+    const base = mkdtempSync(join(tmpdir(), 'ac-selfheal-'))
+    const asFile = join(base, 'root')
+    writeFileSync(asFile, 'not a directory')
+    expect(() => selfHealCliEntry(asFile, '/opt/agentconnect/cli.js')).not.toThrow()
+  })
+})

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync, type SQLInputValue } from 'node:sqlite'
-import { mkdirSync } from 'node:fs'
+import { chmodSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import type { DreamInfo, SessionImageAttachment } from '@agentconnect.md/protocol'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
@@ -358,13 +358,41 @@ export interface RuntimeModelCapRecord {
   observedAt: number
 }
 
+/**
+ * Narrow an existing path's mode, mirroring `cli/login.ts:protectCredentialsFile`.
+ * Best-effort by design: Windows has no enforceable POSIX mode semantics, and a
+ * path that vanished (WAL siblings appear lazily) is not an error worth failing a
+ * daemon boot over.
+ */
+function restrictPath(path: string, mode: number): void {
+  try {
+    if ((statSync(path).mode & 0o777) !== mode) chmodSync(path, mode)
+  } catch {
+    // absent, or a platform without POSIX modes — nothing to narrow
+  }
+}
+
 export class LocalStore {
   private db: DatabaseSync
 
   constructor(dbPath: string) {
-    mkdirSync(dirname(dbPath), { recursive: true })
+    // This database holds every platform message body, agent reply, tool payload and
+    // durable inbox blob the daemon has seen — the same material the console serves
+    // behind authorization. Every other secret-bearing artifact the daemon writes is
+    // explicitly 0600/0700 (config.json, agent.json, materialized config-file secrets,
+    // runtime homes, evaluation artifacts); this one inherited the umask, so on a host
+    // where the root pre-exists group/other-readable — a container image `mkdir -p`, a
+    // systemd `StateDirectory=` (0755), an operator-created path — a second local
+    // account could read the lot. Restrict the directory and the database explicitly,
+    // and chmod after creation so a loose umask cannot widen either.
+    const dir = dirname(dbPath)
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    restrictPath(dir, 0o700)
     this.db = new DatabaseSync(dbPath)
     this.db.exec('PRAGMA journal_mode = WAL')
+    // WAL mode publishes two siblings alongside the database; they carry the same
+    // rows, so restricting only the main file would leave the content readable.
+    for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) restrictPath(p, 0o600)
     this.migrateTranscript()
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS sessions (

--- a/packages/daemon/test/local-store-permissions.test.ts
+++ b/packages/daemon/test/local-store-permissions.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The transcript store holds every message body, agent reply and tool payload the
+ * daemon has seen. Every other secret-bearing artifact it writes is explicitly
+ * 0600/0700; this one used to inherit the umask, so on a host whose root pre-exists
+ * group/other-readable a second local account could read the lot.
+ */
+import { describe, it, expect } from 'vitest'
+import { chmodSync, mkdirSync, mkdtempSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LocalStore } from '../src/store/local-store.js'
+
+const mode = (p: string) => statSync(p).mode & 0o777
+
+describe.skipIf(process.platform === 'win32')('local store file permissions', () => {
+  it('creates the state dir 0700 and the database (with its WAL siblings) 0600', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-store-perm-'))
+    const dbPath = join(root, 'state', 'local.sqlite')
+    const store = new LocalStore(dbPath)
+    // A write forces the WAL siblings into existence.
+    store.insertToolCall({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: 'agent-1',
+      toolCallId: 'tc-1',
+      title: 't',
+      body: '{}'
+    })
+
+    expect(mode(join(root, 'state'))).toBe(0o700)
+    expect(mode(dbPath)).toBe(0o600)
+    for (const sibling of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+      // Present in WAL mode; they carry the same rows, so they must be narrowed too.
+      expect(mode(sibling)).toBe(0o600)
+    }
+    store.close()
+  })
+
+  it('repairs a state dir that already exists group/other-readable', () => {
+    // The container-image / `StateDirectory=` case: the path is laid down before the
+    // daemon runs, so `mkdirSync`'s mode never applies.
+    const root = mkdtempSync(join(tmpdir(), 'ac-store-perm-'))
+    const dir = join(root, 'state')
+    mkdirSync(dir, { recursive: true })
+    chmodSync(dir, 0o755)
+
+    const store = new LocalStore(join(dir, 'local.sqlite'))
+    expect(mode(dir)).toBe(0o700)
+    store.close()
+  })
+})


### PR DESCRIPTION
Closes findings **F14** and **F16** from the security scan — same class, so one PR.

## What

- `<root>/state/` is created 0700 and the SQLite database (plus its `-wal`/`-shm` siblings) 0600, each chmod'ed after creation.
- `selfHealCliEntry` creates `<root>` 0700 and repairs an existing looser one.
- It moves to `src/self-heal.ts` so it is testable at all — see below.

## Why

Both inherited the umask while everything around them is explicit.

**F14.** `state/local.sqlite` holds every platform message body, agent reply, tool payload and durable inbox blob the daemon has seen — the same material the console serves behind authorization. `config.json` (0600), `agent.json` (0600), materialized config-file secrets (0600), runtime homes (0700) and evaluation artifacts (0600) all pass an explicit mode; the transcript store did not, landing 0644 in a 0755 directory.

**F16.** `selfHealCliEntry` runs before anything else on every invocation, so it is normally the first code to create `<root>` — at 0755, while `cli/login.ts` and the daemon's `config/load-config.ts` both pass `0o700`. The loose mode is the one that persisted.

Neither is reachable by a chat user; the exposure is **another local account on the daemon host**, so it matters on a shared build box, a jump host, or a container with a second service account, and not on a single-user laptop.

## Details worth a look

- **chmod after create, not just `mode` on create.** `mkdirSync`'s `mode` is ignored when the path already exists, which is precisely the case that bites: a container image `mkdir -p`, a systemd `StateDirectory=` (0755), or an operator-created path. Both fixes therefore narrow an existing directory rather than assuming they created it.
- **The WAL siblings are narrowed too** — they carry the same rows, so restricting only the main file would leave the content readable.
- **win32 is skipped** in the CLI path, matching the existing carve-out in `protectCredentialsFile` (no enforceable POSIX mode semantics).
- **The extraction is not cosmetic:** `index.ts` executes `main()` at module scope, so nothing in it can be imported by a test. Moving `selfHealCliEntry` into `src/self-heal.ts` is what makes the permission behaviour assertable; `import.meta.url` is now passed in rather than read inside, so the pointer still names the CLI entry and not the new module.

## Note on merge order

This touches the same import block in `packages/cli/src/index.ts` as #91. Whichever lands second needs a trivial rebase; the changes are independent.

## Checks

- typecheck: cli + daemon
- CLI 102 tests, daemon 2073 tests — all passed (5 new, skipped on win32)
- `npx eslint` and `npx prettier --check` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)