### PR TITLE
feat(web): show approval requests in sessions

### DIFF
--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -1069,6 +1069,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
         {
           id: requestId,
           agentId,
+          sessionId: 'session-1',
           createdAt: new Date(100).toISOString(),
           requesterId: 'user-1',
           requesterName: 'Ada',
@@ -1091,6 +1092,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
       requests: [
         expect.objectContaining({
           id: requestId,
+          sessionId: 'session-1',
           requesterName: 'Ada',
           command: 'Bash: pnpm test',
           status: 'pending'

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9658,7 +9658,7 @@ export class Daemon {
     })
 
     if (!notifyChat) return
-    const text = '🔒 Permission requested. Ask an Agent editor to allow it from the Agent page.'
+    const text = '🔒 Permission requested. Ask an Agent editor to allow it from the Agent or Session page.'
     try {
       if (p.webchat) {
         p.webchat.sink.output({
@@ -11965,6 +11965,7 @@ export class Daemon {
         requests: this.store.listPermissionRequests(agentId, limit).map((request) => ({
           id: request.id,
           agentId: request.agentId,
+          sessionId: request.sessionId,
           createdAt: new Date(request.createdAt).toISOString(),
           requesterId: request.requesterId,
           requesterName: request.requesterName,

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -352,6 +352,9 @@ export type AgentScopeDenied = z.infer<typeof AgentScopeDenied>
 export const AgentPermissionRequestRecord = z.object({
   id: z.string().uuid(),
   agentId: z.string().uuid(),
+  // Optional for rolling compatibility with daemons that predate session-scoped
+  // approval rendering. Current daemons always report the owning ACP session id.
+  sessionId: z.string().min(1).optional(),
   createdAt: z.string().datetime(),
   requesterId: z.string().nullable(),
   requesterName: z.string().nullable(),

--- a/packages/web/src/components/console/ApprovalRequestsCard.tsx
+++ b/packages/web/src/components/console/ApprovalRequestsCard.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useState } from 'react'
+import useSWR from 'swr'
+import { decideAgentPermissionRequest, fetchAgentPermissionRequests, type AgentPermissionRequestDto } from '@/lib/api'
+import { MOCK_MODE } from '@/lib/data'
+import { useOrgs } from '@/lib/org-context'
+import { consoleKeys } from '@/lib/swr-keys'
+import { Button } from '@/components/ui'
+
+export function ApprovalRequestsCard({
+  agentId,
+  sessionId,
+  hideWhenEmpty = false,
+  className = ''
+}: {
+  agentId: string
+  sessionId?: string
+  hideWhenEmpty?: boolean
+  className?: string
+}) {
+  const { activeOrg } = useOrgs()
+  const requestsKey = MOCK_MODE ? null : consoleKeys.agentPermissionRequests(activeOrg?.id, agentId)
+  const {
+    data: allRequests,
+    error,
+    isLoading,
+    mutate
+  } = useSWR<AgentPermissionRequestDto[]>(requestsKey, ([, , , id]) => fetchAgentPermissionRequests(id as string), {
+    refreshInterval: 3_000,
+    shouldRetryOnError: false
+  })
+  const [busy, setBusy] = useState<string | null>(null)
+  const [decisionError, setDecisionError] = useState<string | null>(null)
+  const requests = sessionId ? allRequests?.filter((request) => request.sessionId === sessionId) : allRequests
+
+  if (hideWhenEmpty && !requests?.length) return null
+
+  const decide = async (request: AgentPermissionRequestDto, decision: 'allow' | 'deny') => {
+    if (busy || request.status !== 'pending') return
+    setBusy(`${request.id}:${decision}`)
+    setDecisionError(null)
+    try {
+      await decideAgentPermissionRequest(agentId, request.id, decision)
+      void mutate(
+        (rows) =>
+          rows?.map((row) =>
+            row.id === request.id
+              ? {
+                  ...row,
+                  status: decision === 'allow' ? ('allowed' as const) : ('denied' as const),
+                  resolvedAt: new Date().toISOString()
+                }
+              : row
+          ),
+        { revalidate: false }
+      )
+    } catch {
+      setDecisionError('This approval request could not be updated. Try again.')
+      void mutate()
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const pendingCount = requests?.filter((request) => request.status === 'pending').length ?? 0
+
+  return (
+    <div className={`card overflow-hidden ${className}`}>
+      <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
+        <span className="font-sans text-[14px] font-semibold leading-normal">Approval requests</span>
+        {pendingCount > 0 && <span className="badge bg-(--amber-50) text-(--amber-600)">{pendingCount} pending</span>}
+      </div>
+      {isLoading ? (
+        <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">Loading requests…</div>
+      ) : error && allRequests === undefined ? (
+        <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">
+          Approval requests are temporarily unavailable.
+        </div>
+      ) : requests?.length ? (
+        <div>
+          {requests.map((request, index) => {
+            const allowBusy = busy === `${request.id}:allow`
+            const denyBusy = busy === `${request.id}:deny`
+            return (
+              <div
+                key={request.id}
+                className={`flex flex-col gap-3 px-4 py-3 desktop:flex-row desktop:items-center ${
+                  index > 0 ? 'border-t border-(--border-subtle)' : ''
+                }`}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                      {request.requesterName ?? request.requesterId ?? 'Unknown user'}
+                    </span>
+                    <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                      {formatApprovalTime(request.createdAt)}
+                    </span>
+                    {request.status !== 'pending' && (
+                      <span className="badge bg-(--surface-active) text-(--text-tertiary)">{request.status}</span>
+                    )}
+                  </div>
+                  <div className="mt-1 break-words font-mono text-[12px] leading-[1.5] text-(--text-secondary)">
+                    {request.command}
+                  </div>
+                </div>
+                {request.status === 'pending' && (
+                  <div className="flex flex-none items-center gap-2">
+                    <Button
+                      variant="secondary"
+                      size="xs"
+                      disabled={busy !== null}
+                      onClick={() => void decide(request, 'deny')}
+                    >
+                      {denyBusy ? 'Denying…' : 'Deny'}
+                    </Button>
+                    <Button size="xs" disabled={busy !== null} onClick={() => void decide(request, 'allow')}>
+                      {allowBusy ? 'Allowing…' : 'Allow'}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      ) : (
+        <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">No approval requests yet.</div>
+      )}
+      {decisionError && (
+        <div className="border-t border-(--border-subtle) px-4 py-3 font-sans text-[12px] text-(--red-600)">
+          {decisionError}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatApprovalTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(date)
+}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -21,16 +21,13 @@ import {
 } from '@/lib/data'
 import {
   creatorLabel,
-  decideAgentPermissionRequest,
   fetchAgentHooks,
-  fetchAgentPermissionRequests,
   fetchAgentRepos,
   fetchGithubInstallations,
   fetchHookRuns,
   updateGithubHook,
   uploadAgentIcon,
   type GithubInstallationDto,
-  type AgentPermissionRequestDto,
   type HookDto,
   type HookRunDto
 } from '@/lib/api'
@@ -45,6 +42,7 @@ import { AgentSecretsCard } from '@/components/console/AgentSecretsCard'
 import { AgentToolsCard } from '@/components/console/AgentToolsCard'
 import { AgentSkillsCard } from '@/components/console/AgentSkillsCard'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
+import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
@@ -123,50 +121,6 @@ export default function AgentDetailView() {
     useConsoleData()
   const { openPlayground } = usePlayground()
   const { openModal } = useModal()
-  const approvalAgent = getAgent(id)
-  const approvalRequestsKey =
-    !MOCK_MODE && approvalAgent?.canManageSharing && !approvalAgent.name.startsWith(MOCK_PREFIX)
-      ? consoleKeys.agentPermissionRequests(activeOrg?.id, id)
-      : null
-  const {
-    data: approvalRequests,
-    error: approvalRequestsError,
-    isLoading: approvalRequestsLoading,
-    mutate: mutateApprovalRequests
-  } = useSWR<AgentPermissionRequestDto[]>(
-    approvalRequestsKey,
-    ([, , , agentId]) => fetchAgentPermissionRequests(agentId as string),
-    { refreshInterval: 3_000, shouldRetryOnError: false }
-  )
-  const [approvalBusy, setApprovalBusy] = useState<string | null>(null)
-  const [approvalError, setApprovalError] = useState<string | null>(null)
-
-  const decideApproval = async (request: AgentPermissionRequestDto, decision: 'allow' | 'deny') => {
-    if (approvalBusy || request.status !== 'pending') return
-    setApprovalBusy(`${request.id}:${decision}`)
-    setApprovalError(null)
-    try {
-      await decideAgentPermissionRequest(id, request.id, decision)
-      void mutateApprovalRequests(
-        (rows) =>
-          rows?.map((row) =>
-            row.id === request.id
-              ? {
-                  ...row,
-                  status: decision === 'allow' ? ('allowed' as const) : ('denied' as const),
-                  resolvedAt: new Date().toISOString()
-                }
-              : row
-          ),
-        { revalidate: false }
-      )
-    } catch {
-      setApprovalError('This approval request could not be updated. Try again.')
-      void mutateApprovalRequests()
-    } finally {
-      setApprovalBusy(null)
-    }
-  }
   // Which webhook row has its recent-deliveries panel expanded (one at a time).
   const [hookRunsFor, setHookRunsFor] = useState<string | null>(null)
   // Hooks are agent-scoped (no org-wide list). Keep a stable resource key so a
@@ -1065,85 +1019,7 @@ export default function AgentDetailView() {
             </div>
 
             {da.canManageSharing && !da.name.startsWith(MOCK_PREFIX) && (
-              <div className="card order-7 overflow-hidden max-desktop:rounded-lg">
-                <div className="flex min-h-[53px] items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:py-[13px]">
-                  <span className="font-sans text-[14px] font-semibold leading-normal">Approval requests</span>
-                  {!!approvalRequests?.filter((request) => request.status === 'pending').length && (
-                    <span className="badge bg-(--amber-50) text-(--amber-600)">
-                      {approvalRequests.filter((request) => request.status === 'pending').length} pending
-                    </span>
-                  )}
-                </div>
-                {approvalRequestsLoading ? (
-                  <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">Loading requests…</div>
-                ) : approvalRequestsError && approvalRequests === undefined ? (
-                  <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">
-                    Approval requests are temporarily unavailable.
-                  </div>
-                ) : approvalRequests?.length ? (
-                  <div>
-                    {approvalRequests.map((request, index) => {
-                      const allowBusy = approvalBusy === `${request.id}:allow`
-                      const denyBusy = approvalBusy === `${request.id}:deny`
-                      return (
-                        <div
-                          key={request.id}
-                          className={`flex flex-col gap-3 px-4 py-3 desktop:flex-row desktop:items-center ${
-                            index > 0 ? 'border-t border-(--border-subtle)' : ''
-                          }`}
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                                {request.requesterName ?? request.requesterId ?? 'Unknown user'}
-                              </span>
-                              <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                                {formatApprovalTime(request.createdAt)}
-                              </span>
-                              {request.status !== 'pending' && (
-                                <span className="badge bg-(--surface-active) text-(--text-tertiary)">
-                                  {request.status}
-                                </span>
-                              )}
-                            </div>
-                            <div className="mt-1 break-words font-mono text-[12px] leading-[1.5] text-(--text-secondary)">
-                              {request.command}
-                            </div>
-                          </div>
-                          {request.status === 'pending' && (
-                            <div className="flex flex-none items-center gap-2">
-                              <Button
-                                variant="secondary"
-                                size="xs"
-                                disabled={approvalBusy !== null}
-                                onClick={() => void decideApproval(request, 'deny')}
-                              >
-                                {denyBusy ? 'Denying…' : 'Deny'}
-                              </Button>
-                              <Button
-                                size="xs"
-                                disabled={approvalBusy !== null}
-                                onClick={() => void decideApproval(request, 'allow')}
-                              >
-                                {allowBusy ? 'Allowing…' : 'Allow'}
-                              </Button>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-                ) : (
-                  <div className="px-4 py-5 font-sans text-[13px] text-(--text-tertiary)">
-                    No approval requests yet.
-                  </div>
-                )}
-                {approvalError && (
-                  <div className="border-t border-(--border-subtle) px-4 py-3 font-sans text-[12px] text-(--red-600)">
-                    {approvalError}
-                  </div>
-                )}
-              </div>
+              <ApprovalRequestsCard agentId={da.id} className="order-7 max-desktop:rounded-lg" />
             )}
           </div>
         </div>
@@ -1846,17 +1722,6 @@ function UnauthorizedWatchBadge() {
       write-back unauthorized
     </span>
   )
-}
-
-function formatApprovalTime(iso: string): string {
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return iso
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  }).format(date)
 }
 
 // "3m ago" for a hook's last-fired stamp and its delivery rows.

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -15,6 +15,7 @@ import {
   lane,
   modelCapability,
   modelLabel,
+  MOCK_PREFIX,
   permissionModeLabel,
   pgPrompts,
   platName,
@@ -53,6 +54,7 @@ import { sessionSenderLabel } from '@/lib/session-trigger'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
+import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import {
   sessionEffortAfterModelChange,
   sessionEffortChoicesForSelection,
@@ -1299,6 +1301,15 @@ export default function SessionDetailView() {
             </span>
           ))}
         </div>
+      )}
+
+      {owner?.canManageSharing && !owner.name.startsWith(MOCK_PREFIX) && session.agentId && (
+        <ApprovalRequestsCard
+          agentId={session.agentId}
+          sessionId={session.realSessionId ?? session.id}
+          hideWhenEmpty
+          className="mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4"
+        />
       )}
 
       {wantTranscript && msgLoading && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2161,6 +2161,7 @@ export async function updateAgent(agentId: string, patch: UpdateAgentInput): Pro
 export interface AgentPermissionRequestDto {
   id: string
   agentId: string
+  sessionId?: string
   createdAt: string
   requesterId: string | null
   requesterName: string | null


### PR DESCRIPTION
## Summary

- forward each approval request's stored session ID through the existing approval response
- reuse the approval card on Agent and Session details, scoped to the current session
- keep the card editor-only and hidden on Session pages that have no matching requests
- update the requester guidance to mention both Agent and Session pages

## Why

Approval requests were stored with a session ID, but that field was omitted from the response consumed by the web app. The Session page therefore could not identify which requests belonged to the session being viewed.

## User impact

Agent editors can allow or deny matching requests directly from the Session page. Existing Agent-page behavior and non-editor access remain unchanged.

## Validation

- Web, protocol, daemon, and control-plane typechecks
- ESLint on all changed files
- 74 focused daemon tests
- control-plane approval-queue integration test
- desktop and 390 px mobile visual checks for Session and Agent detail pages
- pre-push full-repository lint (0 errors; 2 pre-existing warnings)

Created by Codex . GPT-5.6
