### PR TITLE
fix(memory): supersede stale dream proposals

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -155,7 +155,7 @@ recoverable and history is listable):
 interface DreamRecord {
   dreamId: string
   agentId: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'canceled' | 'adopted' | 'discarded'
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'canceled' | 'adopted' | 'discarded' | 'superseded'
   trigger: 'manual' | 'schedule' | 'auto'
   sessionIds: string[] // transcripts mined
   snapshotDigest: string // digest of the live store at snapshot time (adoption fence)
@@ -253,7 +253,11 @@ unattended path never runs on an untrusted channel.
 3. Atomically: rename `memory/` → `memory-backups/<ts>-pre-<dreamId>/`; move
    staged `output/` into place as `memory/`; carry `.history` over and append
    one `dream-adopt` line (`source: 'dream'`, dreamId, backup path).
-4. Mark the record `adopted`.
+4. Mark the record `adopted`. Every other `completed` store proposal for the
+   agent is no longer based on the live store, so remove its store staging and
+   mark it `superseded`; independently staged skill candidates remain
+   reviewable. Existing completed proposals that predate the latest adoption
+   are reconciled the same way when an older daemon store is upgraded.
 
 `discardDream` deletes the staging directory and marks `discarded`. Backups
 are pruned to the most recent one on each successful adoption.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2114,7 +2114,7 @@ export const DreamSkillDto = z.object({
 export const DreamDto = z.object({
   dreamId: z.string(),
   agentId: z.string(),
-  status: z.enum(['pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded']),
+  status: z.enum(['pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded', 'superseded']),
   trigger: z.enum(['manual', 'schedule', 'auto']),
   sessionIds: z.array(z.string()),
   snapshotDigest: z.string(),

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -65,6 +65,10 @@ export interface DreamStorePort {
   listDreams(agentId: string, limit: number): DreamInfo[]
   /** Non-terminal dreams (pending|running) for crash recovery at boot. */
   openDreams(): DreamInfo[]
+  /** Every completed store proposal for one agent, without the public list cap. */
+  completedDreams(agentId: string): DreamInfo[]
+  /** Proposals reconciled as superseded during a store upgrade. */
+  supersededDreams(): DreamInfo[]
   /** Newest-first addressable sessions for the agent (transcript sources). */
   dreamSessionSources(agentId: string, limit: number): { sessionId: string; channel: string; thread: string }[]
   /** Chronological text rows of one session thread, scoped to the agent. */
@@ -181,6 +185,18 @@ export class DreamRunner {
         status: 'failed',
         error: { type: 'daemon_restart', message: 'the daemon restarted while this dream was in flight' },
         endedAt: this.nowIso()
+      })
+    }
+    // The LocalStore migration marks proposals stranded by adoptions made on an
+    // older daemon. Their metadata is already safe; sweep the corresponding
+    // store staging now that the runner can resolve agent directories. Proposed
+    // skills keep their independent review lifecycle.
+    for (const dream of this.deps.store.supersededDreams()) {
+      if (!this.deps.agentDirByAgent(dream.agentId)) continue
+      void this.removeStoreStaging(dream.agentId, dream).catch((err) => {
+        this.deps.log.warn(
+          `dream ${dream.dreamId}: could not remove superseded store staging (${err instanceof Error ? err.message : 'unknown'})`
+        )
       })
     }
   }
@@ -637,9 +653,13 @@ export class DreamRunner {
             }
           }
 
-          const adopted: DreamInfo = { ...this.getDream(agentId, dreamId), status: 'adopted', endedAt: this.nowIso() }
+          const adoptedAt = this.nowIso()
+          const adopted: DreamInfo = { ...this.getDream(agentId, dreamId), status: 'adopted', endedAt: adoptedAt }
           this.deps.store.updateDream(adopted)
-          this.deps.log.info(`dream ${dreamId} adopted for agent ${agentId} (${staged.length} files)`)
+          const superseded = await this.supersedeCompletedDreams(agentId, dreamId, adoptedAt)
+          this.deps.log.info(
+            `dream ${dreamId} adopted for agent ${agentId} (${staged.length} files, ${superseded} competing proposal(s) superseded)`
+          )
           return adopted
         })
       } finally {
@@ -805,24 +825,43 @@ export class DreamRunner {
       if (dream.status !== 'completed' && dream.status !== 'failed' && dream.status !== 'canceled') {
         throw new DreamStateError(`cannot discard a ${dream.status} dream`)
       }
-      // Skills have an INDEPENDENT review lifecycle (design §7): discarding the
-      // consolidated store must not destroy a candidate the user hasn't ruled on,
-      // or its metadata would say `proposed` while accepting it fails. Drop the
-      // store staging and the input snapshot; keep `skills/` when any candidate
-      // is still proposed.
-      const base = this.dreamDir(agentId, dreamId)
-      const pending = (dream.skills ?? []).some((skill) => skill.state === 'proposed')
-      if (pending) {
-        for (const part of ['input', 'output']) {
-          await fsp.rm(join(base, part), { recursive: true, force: true })
-        }
-      } else {
-        await fsp.rm(base, { recursive: true, force: true })
-      }
+      await this.removeStoreStaging(agentId, dream)
       const discarded: DreamInfo = { ...dream, status: 'discarded', endedAt: this.nowIso() }
       this.deps.store.updateDream(discarded)
       return discarded
     })
+  }
+
+  /** Adoption changes the live store, so every other completed proposal is now
+   *  fenced by definition. Make that invalidation explicit and remove only its
+   *  memory-store staging; proposed skills remain independently reviewable. */
+  private async supersedeCompletedDreams(agentId: string, adoptedDreamId: string, adoptedAt: string): Promise<number> {
+    const candidates = this.deps.store.completedDreams(agentId).filter((dream) => dream.dreamId !== adoptedDreamId)
+    for (const dream of candidates) {
+      this.deps.store.updateDream({ ...dream, status: 'superseded', endedAt: adoptedAt })
+    }
+    for (const dream of candidates) {
+      await this.removeStoreStaging(agentId, dream).catch((err) => {
+        this.deps.log.warn(
+          `dream ${dream.dreamId}: could not remove superseded store staging (${err instanceof Error ? err.message : 'unknown'})`
+        )
+      })
+    }
+    return candidates.length
+  }
+
+  /** Skills have an INDEPENDENT review lifecycle (design §7): removing a store
+   *  proposal must not destroy a candidate the user has not ruled on. */
+  private async removeStoreStaging(agentId: string, dream: DreamInfo): Promise<void> {
+    const base = this.dreamDir(agentId, dream.dreamId)
+    const pending = (dream.skills ?? []).some((skill) => skill.state === 'proposed')
+    if (pending) {
+      for (const part of ['input', 'output']) {
+        await fsp.rm(join(base, part), { recursive: true, force: true })
+      }
+    } else {
+      await fsp.rm(base, { recursive: true, force: true })
+    }
   }
 
   /**
@@ -874,10 +913,10 @@ export class DreamRunner {
     return [...names]
   }
 
-  /** A discarded dream keeps its `skills/` only while a candidate is unreviewed;
-   *  once the last one is decided there is nothing left to review. */
+  /** A discarded or superseded dream keeps its `skills/` only while a candidate
+   *  is unreviewed; once the last one is decided there is nothing left to review. */
   private async sweepReviewedStaging(agentId: string, dream: DreamInfo): Promise<void> {
-    if (dream.status !== 'discarded') return
+    if (dream.status !== 'discarded' && dream.status !== 'superseded') return
     if ((dream.skills ?? []).some((skill) => skill.state === 'proposed')) return
     await fsp.rm(this.dreamDir(agentId, dream.dreamId), { recursive: true, force: true }).catch(() => {})
   }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -590,7 +590,7 @@ export class LocalStore {
         dreamId TEXT PRIMARY KEY,
         agentId TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN
-          ('pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded')),
+          ('pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded', 'superseded')),
         triggerKind TEXT NOT NULL,
         sessionIds TEXT NOT NULL,         -- JSON string[]
         snapshotDigest TEXT NOT NULL,
@@ -605,6 +605,7 @@ export class LocalStore {
       CREATE INDEX IF NOT EXISTS dreams_agent_created ON dreams (agentId, createdAt DESC);
     `)
     this.migrateDreamSnapshotWrites()
+    this.migrateDreamSupersededStatus()
     this.migrateSessionUsage()
     this.migrateSessionMutes()
     this.migrateInboxLoopGuardCounted()
@@ -689,6 +690,71 @@ export class LocalStore {
     const cols = this.db.prepare('PRAGMA table_info(dreams)').all() as { name: string }[]
     if (!cols.some((c) => c.name === 'snapshotWrites'))
       this.db.exec('ALTER TABLE dreams ADD COLUMN snapshotWrites TEXT')
+  }
+
+  /** Extend the dream lifecycle without stranding proposals created before the
+   *  state existed. SQLite cannot alter a CHECK constraint in place, so rebuild
+   *  this metadata-only table and reconcile every completed proposal that
+   *  predates a successful adoption for the same agent. */
+  private migrateDreamSupersededStatus(): void {
+    const table = this.db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'dreams'").get() as
+      { sql: string } | undefined
+    if (!table || table.sql.includes("'superseded'")) return
+
+    this.db.exec('BEGIN')
+    try {
+      this.db.exec(`
+        ALTER TABLE dreams RENAME TO dreams_before_superseded;
+        CREATE TABLE dreams (
+          dreamId TEXT PRIMARY KEY,
+          agentId TEXT NOT NULL,
+          status TEXT NOT NULL CHECK (status IN
+            ('pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded', 'superseded')),
+          triggerKind TEXT NOT NULL,
+          sessionIds TEXT NOT NULL,
+          snapshotDigest TEXT NOT NULL,
+          snapshotWrites TEXT,
+          instructions TEXT,
+          skills TEXT,
+          usage TEXT,
+          error TEXT,
+          createdAt TEXT NOT NULL,
+          endedAt TEXT
+        );
+        INSERT INTO dreams (
+          dreamId, agentId, status, triggerKind, sessionIds, snapshotDigest,
+          snapshotWrites, instructions, skills, usage, error, createdAt, endedAt
+        ) SELECT
+          dreamId, agentId, status, triggerKind, sessionIds, snapshotDigest,
+          snapshotWrites, instructions, skills, usage, error, createdAt, endedAt
+        FROM dreams_before_superseded;
+        DROP TABLE dreams_before_superseded;
+        CREATE INDEX dreams_agent_created ON dreams (agentId, createdAt DESC);
+
+        UPDATE dreams AS candidate
+        SET status = 'superseded', endedAt = (
+          SELECT MIN(adopted.endedAt)
+          FROM dreams AS adopted
+          WHERE adopted.agentId = candidate.agentId
+            AND adopted.status = 'adopted'
+            AND adopted.endedAt IS NOT NULL
+            AND adopted.endedAt > candidate.createdAt
+        )
+        WHERE candidate.status = 'completed'
+          AND EXISTS (
+            SELECT 1
+            FROM dreams AS adopted
+            WHERE adopted.agentId = candidate.agentId
+              AND adopted.status = 'adopted'
+              AND adopted.endedAt IS NOT NULL
+              AND adopted.endedAt > candidate.createdAt
+          );
+      `)
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
   }
 
   private migrateSessionMutes(): void {
@@ -1486,6 +1552,23 @@ export class LocalStore {
     return (
       this.db.prepare("SELECT * FROM dreams WHERE status IN ('pending', 'running')").all() as Record<string, unknown>[]
     ).map((row) => this.dreamFromRow(row))
+  }
+
+  completedDreams(agentId: string): DreamInfo[] {
+    return (
+      this.db.prepare("SELECT * FROM dreams WHERE agentId = ? AND status = 'completed'").all(agentId) as Record<
+        string,
+        unknown
+      >[]
+    ).map((row) => this.dreamFromRow(row))
+  }
+
+  /** Store proposals reconciled as stale during upgrade. The runner removes
+   *  their daemon-local staging once agent directories are available. */
+  supersededDreams(): DreamInfo[] {
+    return (this.db.prepare("SELECT * FROM dreams WHERE status = 'superseded'").all() as Record<string, unknown>[]).map(
+      (row) => this.dreamFromRow(row)
+    )
   }
 
   /** Newest-first addressable sessions to mine as dream transcript sources. */

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -41,6 +41,12 @@ class FakeStore implements DreamStorePort {
   }
   openDreams(): DreamInfo[] {
     return [...this.dreams.values()].filter((d) => d.status === 'pending' || d.status === 'running')
+  }
+  completedDreams(agentId: string): DreamInfo[] {
+    return [...this.dreams.values()].filter((d) => d.agentId === agentId && d.status === 'completed')
+  }
+  supersededDreams(): DreamInfo[] {
+    return [...this.dreams.values()].filter((d) => d.status === 'superseded')
   }
   dreamSessionSources(): { sessionId: string; channel: string; thread: string }[] {
     return this.sources
@@ -459,10 +465,9 @@ describe('DreamRunner adoption', () => {
     await expect(runner.adopt('a1', started.dreamId, false)).rejects.toThrow(/changed since/)
   })
 
-  it('fences a second dream staged from the same snapshot as an already-adopted one', async () => {
-    // Adoption rewrites the store by rename, bypassing writeMemoryFile. Unless
-    // that swap is counted, dream B (same snapshot as A) sees only the later
-    // distill write, calls the drift distill-only, and rolls over A's adoption.
+  it('keeps a superseded proposal unadoptable after later distillation', async () => {
+    // Adoption makes B explicitly superseded. A later distill write must not
+    // make that stale proposal look rebaseable or restore it to review.
     const { dir, store, runner } = await setup({})
     const a = await runner.start('a1', { trigger: 'manual' })
     await settle(store, a.dreamId)
@@ -479,7 +484,8 @@ describe('DreamRunner adoption', () => {
       'distill'
     )
 
-    await expect(runner.adopt('a1', b.dreamId, false)).rejects.toThrow(/changed since/)
+    expect(store.dreams.get(b.dreamId)?.status).toBe('superseded')
+    await expect(runner.adopt('a1', b.dreamId, false)).rejects.toThrow(/superseded/)
   })
 
   it('refuses to rebase over a write whose history append was lost (ledger is authoritative)', async () => {
@@ -584,6 +590,23 @@ describe('DreamRunner adoption', () => {
     expect(await runner.stagedFiles('a1', started.dreamId)).toBeNull()
     expect(store.dreams.get(started.dreamId)?.status).toBe('discarded')
   })
+
+  it('supersedes every competing completed proposal after an adoption', async () => {
+    const { store, runner } = await setup({})
+    const older = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, older.dreamId)
+    const chosen = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, chosen.dreamId)
+
+    await runner.adopt('a1', chosen.dreamId, false)
+
+    expect(store.dreams.get(chosen.dreamId)?.status).toBe('adopted')
+    expect(store.dreams.get(older.dreamId)).toMatchObject({
+      status: 'superseded',
+      endedAt: store.dreams.get(chosen.dreamId)?.endedAt
+    })
+    expect(await runner.stagedFiles('a1', older.dreamId)).toBeNull()
+  })
 })
 
 describe('DreamRunner crash recovery', () => {
@@ -609,6 +632,43 @@ describe('DreamRunner crash recovery', () => {
       status: 'failed',
       error: { type: 'daemon_restart' }
     })
+  })
+
+  it('sweeps reconciled superseded staging while preserving proposed skills', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ac-dream-reconcile-'))
+    const base = join(dir, 'memory-dreams', 'drm-superseded')
+    await mkdir(join(base, 'input'), { recursive: true })
+    await mkdir(join(base, 'output'), { recursive: true })
+    await mkdir(join(base, 'skills', 'keep-me'), { recursive: true })
+    await writeFile(join(base, 'output', 'MEMORY.md'), '# stale')
+    await writeFile(join(base, 'skills', 'keep-me', 'SKILL.md'), '# keep')
+    const store = new FakeStore()
+    store.insertDream({
+      dreamId: 'drm-superseded',
+      agentId: 'a1',
+      status: 'superseded',
+      trigger: 'manual',
+      sessionIds: [],
+      snapshotDigest: 'sha256:x',
+      skills: [{ name: 'keep-me', description: 'Keep me', state: 'proposed' }],
+      createdAt: '2026-07-24T00:00:00.000Z',
+      endedAt: '2026-07-24T01:00:00.000Z'
+    })
+
+    new DreamRunner({
+      agentDirByAgent: (agentId) => (agentId === 'a1' ? dir : undefined),
+      dreamingPolicyFor: () => undefined,
+      store,
+      extract: async () => ({ output: '', trustedChannel: false }),
+      log: silent
+    })
+    for (let i = 0; i < 20; i++) {
+      if (!(await readdir(base)).includes('output')) break
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+
+    expect(await readdir(base)).toEqual(['skills'])
+    expect(await readFile(join(base, 'skills', 'keep-me', 'SKILL.md'), 'utf8')).toBe('# keep')
   })
 })
 
@@ -931,6 +991,20 @@ describe('DreamRunner skill mining — review findings', () => {
     expect(after.skills?.[0]).toMatchObject({ state: 'dismissed' })
     // Once nothing is left to review, the staging is finally swept.
     expect(await runner.stagedSkill('a1', dreamId, 'deploy-staging')).toBeNull()
+  })
+
+  it('keeps a still-proposed candidate reviewable when its store proposal is superseded', async () => {
+    const first = await mine()
+    const chosen = await first.runner.start('a1', { trigger: 'manual' })
+    await settle(first.store, chosen.dreamId)
+
+    await first.runner.adopt('a1', chosen.dreamId, false)
+
+    expect(first.store.dreams.get(first.dreamId)?.status).toBe('superseded')
+    expect(await first.runner.stagedFiles('a1', first.dreamId)).toBeNull()
+    expect(await first.runner.stagedSkill('a1', first.dreamId, 'deploy-staging')).not.toBeNull()
+    await first.runner.skillDismiss('a1', first.dreamId, 'deploy-staging')
+    expect(await first.runner.stagedSkill('a1', first.dreamId, 'deploy-staging')).toBeNull()
   })
 
   it('encodes a punctuation-heavy description as a YAML scalar, not raw text', async () => {

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -85,6 +85,48 @@ describe('LocalStore', () => {
     s.close()
   })
 
+  it('adds the superseded dream state and reconciles proposals stranded by an adoption', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-dream-status-mig-')), 'local.sqlite')
+    const legacy = new DatabaseSync(path)
+    legacy.exec(`
+      CREATE TABLE dreams (
+        dreamId TEXT PRIMARY KEY,
+        agentId TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN
+          ('pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded')),
+        triggerKind TEXT NOT NULL,
+        sessionIds TEXT NOT NULL,
+        snapshotDigest TEXT NOT NULL,
+        snapshotWrites TEXT,
+        instructions TEXT,
+        skills TEXT,
+        usage TEXT,
+        error TEXT,
+        createdAt TEXT NOT NULL,
+        endedAt TEXT
+      )
+    `)
+    const insert = legacy.prepare(`
+      INSERT INTO dreams (
+        dreamId, agentId, status, triggerKind, sessionIds, snapshotDigest,
+        snapshotWrites, instructions, skills, usage, error, createdAt, endedAt
+      ) VALUES (?, 'a1', ?, 'manual', '[]', 'sha256:x', NULL, NULL, NULL, NULL, NULL, ?, ?)
+    `)
+    insert.run('older-ready', 'completed', '2026-07-24T00:00:00.000Z', '2026-07-24T00:05:00.000Z')
+    insert.run('chosen', 'adopted', '2026-07-24T00:01:00.000Z', '2026-07-24T00:06:00.000Z')
+    insert.run('new-ready', 'completed', '2026-07-24T00:07:00.000Z', '2026-07-24T00:08:00.000Z')
+    legacy.close()
+
+    const migrated = new LocalStore(path)
+    expect(migrated.getDream('a1', 'older-ready')).toMatchObject({
+      status: 'superseded',
+      endedAt: '2026-07-24T00:06:00.000Z'
+    })
+    expect(migrated.getDream('a1', 'new-ready')?.status).toBe('completed')
+    expect(migrated.supersededDreams().map((dream) => dream.dreamId)).toEqual(['older-ready'])
+    migrated.close()
+  })
+
   it('round-trips per-cron last-run stamps (latest-wins)', () => {
     const s = store()
     expect(s.getCronLastRun('bot-a:daily')).toBeUndefined()

--- a/packages/protocol/src/frames/memory-dream.test.ts
+++ b/packages/protocol/src/frames/memory-dream.test.ts
@@ -70,6 +70,7 @@ describe('memory dreaming frames', () => {
 
   it('rejects unbounded or malformed dream metadata', () => {
     expect(DreamInfo.parse(dream)).toMatchObject({ status: 'completed' })
+    expect(DreamInfo.parse({ ...dream, status: 'superseded' })).toMatchObject({ status: 'superseded' })
     expect(() => DreamInfo.parse({ ...dream, status: 'dreaming' })).toThrow()
     expect(() =>
       DreamInfo.parse({ ...dream, skills: [{ name: 'Bad Name', description: '', state: 'proposed' }] })

--- a/packages/protocol/src/frames/memory.ts
+++ b/packages/protocol/src/frames/memory.ts
@@ -298,7 +298,16 @@ export type MemoryRecordHistoryPage = z.infer<typeof MemoryRecordHistoryPage>
  *   candidates (skills are never auto-adopted; see the design §7).
  */
 
-export const DreamStatus = z.enum(['pending', 'running', 'completed', 'failed', 'canceled', 'adopted', 'discarded'])
+export const DreamStatus = z.enum([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'canceled',
+  'adopted',
+  'discarded',
+  'superseded'
+])
 export type DreamStatus = z.infer<typeof DreamStatus>
 
 export const DreamTrigger = z.enum(['manual', 'schedule', 'auto'])

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -98,12 +98,13 @@ describe('DreamPanel', () => {
   })
 
   it('keeps terminal history collapsed by default', async () => {
-    api.listDreams.mockResolvedValue([dream({ status: 'adopted' })])
+    api.listDreams.mockResolvedValue([dream({ status: 'adopted' }), dream({ dreamId: 'drm-2', status: 'superseded' })])
     const host = await render()
     const history = host.querySelector('details')
     expect(history?.open).toBe(false)
     expect(history?.querySelector('summary')?.textContent).toContain('History')
-    expect(history?.querySelector('summary')?.textContent).toContain('1')
+    expect(history?.querySelector('summary')?.textContent).toContain('2')
+    expect(history?.textContent).toContain('Superseded')
   })
 
   it('uses the shared card shell with the action in its header', async () => {
@@ -167,15 +168,17 @@ describe('DreamPanel', () => {
     )
     await act(async () => confirm.at(-1)?.click())
     expect(api.adoptDream).toHaveBeenCalledWith(AGENT, 'drm-1')
+    expect(host.textContent).toContain('Outdated proposals were moved to History')
   })
 
-  it('discards a staged dream without touching live memory', async () => {
+  it('discards a ready dream from its row without making the user open review', async () => {
     api.listDreams.mockResolvedValue([dream()])
     const host = await render()
-    await act(async () => button(host, 'Review')?.click())
     await act(async () => button(host, 'Discard')?.click())
     expect(api.discardDream).toHaveBeenCalledWith(AGENT, 'drm-1')
     expect(api.adoptDream).not.toHaveBeenCalled()
+    expect(api.listDreamFiles).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Dream discarded')
   })
 
   it('reads an offline daemon as an expected state, not an error', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -49,7 +49,8 @@ const STATUS_LABEL: Record<DreamDto['status'], string> = {
   failed: 'Failed',
   canceled: 'Canceled',
   adopted: 'Adopted',
-  discarded: 'Discarded'
+  discarded: 'Discarded',
+  superseded: 'Superseded'
 }
 
 /** Status dot colour per lifecycle state — the same visual language the
@@ -62,7 +63,8 @@ const STATUS_DOT: Record<DreamDto['status'], string> = {
   failed: 'var(--status-error)',
   canceled: 'var(--text-disabled)',
   adopted: 'var(--status-online)',
-  discarded: 'var(--text-disabled)'
+  discarded: 'var(--text-disabled)',
+  superseded: 'var(--text-disabled)'
 }
 
 function statusTone(status: DreamDto['status']): string {
@@ -84,6 +86,7 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
   const [unsupported, setUnsupported] = useState(false)
   const [busy, setBusy] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [reviewing, setReviewing] = useState<string | null>(null)
   const [confirmStart, setConfirmStart] = useState(false)
   const [confirmAdopt, setConfirmAdopt] = useState<string | null>(null)
@@ -133,6 +136,7 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
   const run = async (fn: () => Promise<unknown>, action: 'start' | 'other' = 'other') => {
     setBusy(true)
     setActionError(null)
+    setActionNotice(null)
     try {
       await fn()
       await refresh()
@@ -189,6 +193,13 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
   )
   const pastDreams = (dreams ?? []).filter((dream) => dream.status !== 'completed' && isDreamTerminal(dream.status))
 
+  const discard = (dreamId: string) =>
+    void run(async () => {
+      await discardDream(agentId, dreamId)
+      setReviewing((current) => (current === dreamId ? null : current))
+      setActionNotice('Dream discarded.')
+    })
+
   const renderDreamRows = (rows: DreamDto[]) => (
     <ul className="flex list-none flex-col gap-0 p-0">
       {rows.map((dream) => (
@@ -219,6 +230,11 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
                 onClick={() => setReviewing(reviewing === dream.dreamId ? null : dream.dreamId)}
               >
                 {reviewing === dream.dreamId ? 'Hide' : 'Review'}
+              </Button>
+            ) : null}
+            {dream.status === 'completed' && canEdit ? (
+              <Button variant="secondary" size="xs" disabled={busy} onClick={() => discard(dream.dreamId)}>
+                Discard
               </Button>
             ) : null}
             {!isDreamTerminal(dream.status) && canEdit ? (
@@ -257,6 +273,9 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
         {actionError ? (
           <div className="font-sans text-[12px] font-normal leading-normal text-(--status-error)">{actionError}</div>
         ) : null}
+        {actionNotice ? (
+          <div className="font-sans text-[12px] font-normal leading-normal text-(--status-online)">{actionNotice}</div>
+        ) : null}
         {listError ? (
           <div className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">{listError}</div>
         ) : null}
@@ -278,12 +297,7 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
             canEdit={canEdit}
             busy={busy}
             onAdopt={() => setConfirmAdopt(reviewing)}
-            onDiscard={() =>
-              void run(async () => {
-                await discardDream(agentId, reviewing)
-                setReviewing(null)
-              })
-            }
+            onDiscard={() => discard(reviewing)}
           />
         ) : null}
 
@@ -328,6 +342,7 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
               void run(async () => {
                 await adoptDream(agentId, dreamId)
                 setReviewing(null)
+                setActionNotice('Memory adopted. Outdated proposals were moved to History.')
               })
             }}
           >

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1866,7 +1866,8 @@ export async function listMemoryFileHistory(
 
 // ── memory dreaming (docs/designs/memory-dreaming.md §10) — offline consolidation jobs ──
 
-export type DreamStatus = 'pending' | 'running' | 'completed' | 'failed' | 'canceled' | 'adopted' | 'discarded'
+export type DreamStatus =
+  'pending' | 'running' | 'completed' | 'failed' | 'canceled' | 'adopted' | 'discarded' | 'superseded'
 
 export interface DreamDto {
   dreamId: string


### PR DESCRIPTION
## Summary

- mark competing completed dream proposals as superseded after memory adoption
- reconcile proposals stranded by earlier adoptions and remove only their store staging
- preserve independently reviewable skill candidates
- show superseded proposals in collapsed History and expose Discard on ready-result rows

## Why

An adopted dream changes the live memory store, so other completed proposals no longer match the current snapshot. Leaving them labeled “Ready to review” made stale, non-adoptable results look actionable.

## Validation

- focused protocol, daemon, control-plane, and web tests
- type checks for all four affected packages
- targeted ESLint and formatting checks
- full pre-push repository lint
