### PR TITLE
feat(daemon,cli): rename startup flags to API

### DIFF
--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -57,8 +57,9 @@ service or foreground startup. It:
 
 1. performs an auth-only daemon WebSocket exchange;
 2. writes the accepted Control Plane URL and key to local config;
-3. in interactive mode, either installs and starts the OS service or enters the
-   foreground `run` shell.
+3. in interactive mode, ensures the selected daemon channel is installed when
+   the root has no active version, then either installs and starts the OS service
+   or enters the foreground `run` shell.
 
 The login probe uses `@agentconnect.md/protocol`,
 `@agentconnect.md/connection`, and `ws`. It does not import daemon config or
@@ -205,6 +206,10 @@ versions does not require rewriting the service definition.
 `agentconnect up` starts it. `uninstall-service` stops and removes it. The
 service definition retains the Node executable used during installation, so a
 Node runtime change requires reinstalling the service.
+
+Interactive `agentconnect login` ensures an active daemon version exists before
+installing and starting the service, so first-time onboarding does not require a
+separate `agentconnect install`.
 
 ## 5. Stable helper entry
 

--- a/docs/designs/daemon-api-key-auth.md
+++ b/docs/designs/daemon-api-key-auth.md
@@ -137,10 +137,10 @@ key is valid:
 The generated command uses:
 
 ```text
-npx -y @agentconnect.md/daemon run --cp-url <control-plane-websocket-url> --cp-key <generated-key>
+npx -y @agentconnect.md/daemon run --api-url <control-plane-websocket-url> --api-key <generated-key>
 ```
 
-The daemon stores the key in `controlPlane.key`; `--cp-key` is the connect
+The daemon stores the key in `controlPlane.key`; `--api-key` is the connect
 override. `AuthReq.apiKey` is the only daemon credential field.
 
 Daemon keys currently have no fixed expiry or idle reaper. They remain valid

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -126,8 +126,8 @@ The daemon does not implement these, but interacts with them through the section
 | ----------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--config <path>`       | Locates the file itself        | Specify config.json, default `~/.agentconnect/config.json`.                                                                                        |
 | `--root <dir>`          | Locates the root               | Override `~/.agentconnect`; maps to `AGENTCONNECT_ROOT`.                                                                                           |
-| `--cp-url <wss://...>`  | `controlPlane.url`             | Override the CP endpoint; this is the most common override.                                                                                        |
-| `--cp-key <key>`        | `controlPlane.key`             | Override the opaque, long-lived, revocable CP **API key**; see [daemon-api-key-auth.md](daemon-api-key-auth.md).                                   |
+| `--api-url <wss://...>` | `controlPlane.url`             | Override the API endpoint; this is the most common override.                                                                                       |
+| `--api-key <key>`       | `controlPlane.key`             | Override the opaque, long-lived, revocable daemon **API key**; see [daemon-api-key-auth.md](daemon-api-key-auth.md).                               |
 | `--no-cp` / `--offline` | `controlPlane.enabled=false`   | Force local-only mode with no CP connection.                                                                                                       |
 | `--daemon-id <id>`      | `daemonId`                     | Override/specify daemon identity.                                                                                                                  |
 | `--log-level <lvl>`     | `logging.level`                | trace/debug/info/warn/error.                                                                                                                       |
@@ -159,7 +159,7 @@ isInstalled()   Whether the unit file exists.
 - **macOS (launchd):** `~/Library/LaunchAgents/md.agentconnect.daemon.plist`, label `md.agentconnect.daemon`, reference `packages/cli/src/service/launchd.ts`. `ProgramArguments = [execPath, cliEntry, "run"]`; `RunAtLoad=true`; `KeepAlive.SuccessfulExit=false`; `StandardOutPath` / `StandardErrorPath` point to `~/.agentconnect/logs/daemon.log`. `up` uses `launchctl bootstrap gui/$UID <plist>` with `load -w` fallback; `down` uses `launchctl bootout gui/$UID/<label>` with `unload -w` fallback; status uses `launchctl print` / `list`.
 - **Linux (systemd `--user`):** `~/.config/systemd/user/agentconnect.service`, with `[Service] ExecStart=execPath cliEntry run`, `Restart=always`, `Environment=AGENTCONNECT_ROOT=<root>`, and `[Install] WantedBy=default.target`. Run `systemctl --user daemon-reload` after writing. `up = enable --now`; `down = disable --now`; status uses `is-active`, `is-enabled`, and `show -p MainPID`.
 - **Testability:** Pure builders `buildPlist` / `buildSystemdUnit` generate unit contents for direct assertions. Every `launchctl` / `systemctl` call uses an injectable `exec(cmd,args)` dependency, replaced by test stubs with no real side effects.
-- **Credentials:** Unit files include only nonsensitive `AGENTCONNECT_ROOT`, and only when nondefault. The opaque CP API key and platform tokens currently live directly in `config.json` / `agent.json`, never the plist/unit. The key has no prefix and cannot be redacted by a content pattern; logs, telemetry, and error frames must structurally redact values of `--cp-key`, `apiKey`, and `Bearer ...` before leaving the edge.
+- **Credentials:** Unit files include only nonsensitive `AGENTCONNECT_ROOT`, and only when nondefault. The opaque CP API key and platform tokens currently live directly in `config.json` / `agent.json`, never the plist/unit. The key has no prefix and cannot be redacted by a content pattern; logs, telemetry, and error frames must structurally redact values of `--api-key`, `apiKey`, and `Bearer ...` before leaving the edge.
 - The `run` process handles `SIGTERM` / `SIGINT`: stop accepting new messages, drain active turns to a deadline, close platform connections, close ACP adapter children, then exit.
 
 > The service-install branch of `login` invokes this controller. After successful auth probing and persistence, yes -> `install()` + `up()` and exit; no -> start foreground `run` using the same Daemon construction and signal handling.
@@ -337,7 +337,7 @@ separate trust boundaries.
 
 ### 3.4 Field Precedence and Merge
 
-Apply, later overriding earlier: built-in defaults including **ACP-registry runtime defaults** -> `config.json` -> `AGENTCONNECT_*` environment -> CLI flags. `controlPlane.url` is overridden most often through `--cp-url` because one image connects to different CP environments.
+Apply, later overriding earlier: built-in defaults including **ACP-registry runtime defaults** -> `config.json` -> `AGENTCONNECT_*` environment -> CLI flags. `controlPlane.url` is overridden most often through `--api-url` because one image connects to different CP environments.
 
 ### 3.5 Validation and Live Reload
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,14 +34,14 @@ async function main(): Promise<void> {
     .description('AgentConnect CLI — daemon lifecycle, version management, upgrade')
     .version(CLI_VERSION)
 
-  // Global options. The CLI itself only reads --root/--config/--cp-*/--daemon-id;
+  // Global options. The CLI itself only reads --root/--config/--api-*/--daemon-id;
   // the rest are declared so they pass validation on CLI-owned commands and are
   // forwarded verbatim to the daemon on delegated ones.
   program
     .option('--config <path>', 'path to config.json (default ~/.agentconnect/config.json)')
     .option('--root <dir>', 'override ~/.agentconnect root directory')
-    .option('--cp-url <url>', 'override controlPlane.url')
-    .option('--cp-key <key>', 'override controlPlane.key (the CP API key)')
+    .option('--api-url <url>', 'override AgentConnect API WebSocket URL')
+    .option('--api-key <key>', 'override daemon API key')
     .option('--no-cp', 'run fully local, do not connect to the Control Plane')
     .option('--daemon-id <id>', 'override daemon identity')
     .option('--log-level <level>', 'trace|debug|info|warn|error')
@@ -159,14 +159,14 @@ async function main(): Promise<void> {
   program
     .command('login')
     .description(
-      'Interactive onboarding: test the Control Plane auth, save credentials, then install+start the service or run in the foreground'
+      'Interactive onboarding: test API credentials, save them, then install+start the service or run in the foreground'
     )
     .action(async () => {
       const opts = program.opts()
       try {
         await runLogin({
-          cpUrl: opts.cpUrl,
-          cpKey: opts.cpKey,
+          apiUrl: opts.apiUrl,
+          apiKey: opts.apiKey,
           daemonId: opts.daemonId,
           root: opts.root,
           configPath: opts.config

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -224,9 +224,9 @@ async function main(): Promise<void> {
         fail('version prune', err)
       }
     })
-  // Top-level `install` — the onboarding-friendly alias of `version install`.
-  // First install on a fresh root also activates it (versionInstall), so the
-  // onboarding two-step (`install` → `run`/`login`) works without `version use`.
+  // Top-level `install` — the convenient alias of `version install`. First
+  // install on a fresh root also activates it (versionInstall), so manual
+  // installs do not need a follow-up `version use`.
   program
     .command('install [version]')
     .description('Download, unpack, and (on a fresh host) activate a daemon version')

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -19,8 +19,8 @@ import { resolveController, type InstallOpts } from './service/index.js'
 import { runShell } from './run-shell.js'
 
 export interface PersistCredsOpts {
-  cpUrl: string
-  cpKey: string
+  apiUrl: string
+  apiKey: string
   daemonId?: string
   root?: string
   configPath?: string
@@ -74,7 +74,7 @@ export function persistCredentials(opts: PersistCredsOpts): string {
   const raw: Record<string, unknown> = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : { version: 1 }
 
   const cp = (raw.controlPlane as Record<string, unknown> | undefined) ?? {}
-  raw.controlPlane = { ...cp, url: opts.cpUrl, key: opts.cpKey, enabled: true }
+  raw.controlPlane = { ...cp, url: opts.apiUrl, key: opts.apiKey, enabled: true }
   if (opts.daemonId) raw.daemonId = opts.daemonId
 
   assertValidControlPlane(raw) // fail before writing if the merge is invalid
@@ -84,8 +84,8 @@ export function persistCredentials(opts: PersistCredsOpts): string {
 }
 
 export interface RunLoginOpts {
-  cpUrl?: string
-  cpKey?: string
+  apiUrl?: string
+  apiKey?: string
   daemonId?: string
   root?: string
   configPath?: string
@@ -105,12 +105,12 @@ export function buildInstallOpts(opts: { root?: string }): InstallOpts {
 }
 
 /** Foreground args for the daemon `run`, threading through the resolved root and
- *  any CP overrides so the spawned daemon matches what login just configured. */
+ *  any API overrides so the spawned daemon matches what login just configured. */
 function foregroundArgv(opts: RunLoginOpts): string[] {
   const argv = ['run']
   if (opts.root) argv.push('--root', opts.root)
-  if (opts.cpUrl) argv.push('--cp-url', opts.cpUrl)
-  if (opts.cpKey) argv.push('--cp-key', opts.cpKey)
+  if (opts.apiUrl) argv.push('--api-url', opts.apiUrl)
+  if (opts.apiKey) argv.push('--api-key', opts.apiKey)
   if (opts.daemonId) argv.push('--daemon-id', opts.daemonId)
   return argv
 }
@@ -161,11 +161,11 @@ export async function runLogin(opts: RunLoginOpts, partial: Partial<LoginDeps> =
 
   // ── Non-interactive: flags required; probe; persist. No prompts, no handoff. ──
   if (!deps.isTTY) {
-    if (!opts.cpUrl) throw new Error('login requires --cp-url <url>')
-    if (!opts.cpKey) throw new Error('login requires --cp-key <key>')
-    const r = await deps.probe({ url: opts.cpUrl, token: opts.cpKey })
+    if (!opts.apiUrl) throw new Error('login requires --api-url <url>')
+    if (!opts.apiKey) throw new Error('login requires --api-key <key>')
+    const r = await deps.probe({ url: opts.apiUrl, token: opts.apiKey })
     if (!r.ok) throw new Error(`authentication failed: ${r.reason}`)
-    persistCredentials({ ...opts, cpUrl: opts.cpUrl, cpKey: opts.cpKey })
+    persistCredentials({ ...opts, apiUrl: opts.apiUrl, apiKey: opts.apiKey })
     out.write(`✓ authenticated${r.daemonId ? ` (daemon ${r.daemonId})` : ''} — credentials saved\n`)
     return
   }
@@ -184,10 +184,10 @@ export async function runLogin(opts: RunLoginOpts, partial: Partial<LoginDeps> =
   // ── Interactive ──
   const rl = createInterface({ input: deps.input, output: out })
   const iter = rl[Symbol.asyncIterator]()
-  let url = opts.cpUrl
-  let token = opts.cpKey
+  let url = opts.apiUrl
+  let token = opts.apiKey
   try {
-    if (!url) url = await nextLine(iter, 'Control Plane URL: ', out)
+    if (!url) url = await nextLine(iter, 'AgentConnect API URL: ', out)
 
     for (let attempt = 0; ; attempt++) {
       if (!token) token = await nextLine(iter, 'Daemon API key: ', out)
@@ -202,7 +202,7 @@ export async function runLogin(opts: RunLoginOpts, partial: Partial<LoginDeps> =
       token = undefined // re-prompt on retry
     }
 
-    persistCredentials({ ...opts, cpUrl: url!, cpKey: token! })
+    persistCredentials({ ...opts, apiUrl: url!, apiKey: token! })
 
     const ans = (await nextLine(iter, 'Install AgentConnect as a background service? (y/N) ', out)).toLowerCase()
     if (ans === 'y' || ans === 'yes') {

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -16,7 +16,7 @@ import { resolveRoot, configPath } from './paths.js'
 import { CLI_VERSION } from './version.js'
 import { probeAuth, type ProbeResult } from './cp/auth-probe.js'
 import { resolveController, type InstallOpts } from './service/index.js'
-import { runShell } from './run-shell.js'
+import { ensureDaemonInstalled, runShell } from './run-shell.js'
 
 export interface PersistCredsOpts {
   apiUrl: string
@@ -128,14 +128,16 @@ function realDeps(opts: RunLoginOpts): LoginDeps {
   return {
     probe: (o) => probeAuth({ url: o.url, token: o.token, agentVersion: CLI_VERSION }),
     installService: async () => {
-      const controller = resolveController({ root: opts.root })
+      const root = resolveRoot(opts.root)
+      await ensureDaemonInstalled(root)
+      const controller = resolveController({ root })
       await controller.install(buildInstallOpts(opts))
       await controller.up()
     },
     // Foreground onboarding runs the daemon via the same respawn shell as
     // `agentconnect run` (§6.1) — it delegates to <root>/current and never
-    // returns. Requires an installed daemon version (P2), or a manually seeded
-    // `current` in P1.
+    // returns. The shell bootstraps the selected daemon channel when `current`
+    // does not exist yet.
     runForeground: () => runShell(resolveRoot(opts.root), foregroundArgv(opts)),
     out: process.stdout,
     input: process.stdin,

--- a/packages/cli/src/route.ts
+++ b/packages/cli/src/route.ts
@@ -31,8 +31,8 @@ export const CLI_OWNED_COMMANDS = new Set([
 const VALUE_OPTS = new Set([
   '--config',
   '--root',
-  '--cp-url',
-  '--cp-key',
+  '--api-url',
+  '--api-key',
   '--daemon-id',
   '--log-level',
   '--agents-dir',

--- a/packages/cli/test/login.test.ts
+++ b/packages/cli/test/login.test.ts
@@ -41,7 +41,7 @@ describe('buildInstallOpts', () => {
 describe('persistCredentials', () => {
   it('writes controlPlane url/token and enables the control plane', () => {
     const root = emptyRoot()
-    persistCredentials({ root, cpUrl: 'wss://cp.example/daemon/ws', cpKey: 'tok-123' })
+    persistCredentials({ root, apiUrl: 'wss://cp.example/daemon/ws', apiKey: 'tok-123' })
     const raw = readConfig(root)
     expect(raw.controlPlane.url).toBe('wss://cp.example/daemon/ws')
     expect(raw.controlPlane.key).toBe('tok-123')
@@ -51,10 +51,10 @@ describe('persistCredentials', () => {
 
   it('persists daemonId only when explicitly provided', () => {
     const root = emptyRoot()
-    persistCredentials({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' })
+    persistCredentials({ root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' })
     expect(readConfig(root).daemonId).toBeUndefined()
     const root2 = emptyRoot()
-    persistCredentials({ root: root2, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok', daemonId: 'fixed-id' })
+    persistCredentials({ root: root2, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok', daemonId: 'fixed-id' })
     expect(readConfig(root2).daemonId).toBe('fixed-id')
   })
 
@@ -65,7 +65,7 @@ describe('persistCredentials', () => {
       join(root, 'config.json'),
       JSON.stringify({ version: 1, logging: { level: 'debug' }, runtimes: { claude: { command: 'npx', args: [] } } })
     )
-    persistCredentials({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' })
+    persistCredentials({ root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' })
     const raw = readConfig(root)
     expect(raw.logging.level).toBe('debug')
     expect(raw.runtimes.claude.command).toBe('npx')
@@ -78,26 +78,26 @@ describe('persistCredentials', () => {
     writeFileSync(file, JSON.stringify({ version: 1 }), { mode: 0o644 })
     chmodSync(file, 0o644)
 
-    persistCredentials({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' })
+    persistCredentials({ root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' })
 
     expect(statSync(file).mode & 0o777).toBe(0o600)
   })
 })
 
 describe('runLogin — non-interactive (no TTY)', () => {
-  it('throws a clear error when the cp-url is missing', async () => {
+  it('throws a clear error when the api-url is missing', async () => {
     const { out } = sink()
-    await expect(runLogin({ cpKey: 'tok' }, { isTTY: false, out })).rejects.toThrow(/--cp-url/)
+    await expect(runLogin({ apiKey: 'tok' }, { isTTY: false, out })).rejects.toThrow(/--api-url/)
   })
-  it('throws a clear error when the cp-key is missing', async () => {
+  it('throws a clear error when the api-key is missing', async () => {
     const { out } = sink()
-    await expect(runLogin({ cpUrl: 'wss://cp/daemon/ws' }, { isTTY: false, out })).rejects.toThrow(/--cp-key/)
+    await expect(runLogin({ apiUrl: 'wss://cp/daemon/ws' }, { isTTY: false, out })).rejects.toThrow(/--api-key/)
   })
   it('probes then persists on success', async () => {
     const root = emptyRoot()
     const { out } = sink()
     const probe = vi.fn(async () => ({ ok: true, daemonId: 'd1' }))
-    await runLogin({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' }, { isTTY: false, out, probe })
+    await runLogin({ root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' }, { isTTY: false, out, probe })
     expect(probe).toHaveBeenCalledOnce()
     expect(readConfig(root).controlPlane.key).toBe('tok')
   })
@@ -106,7 +106,7 @@ describe('runLogin — non-interactive (no TTY)', () => {
     const { out } = sink()
     const probe = vi.fn(async () => ({ ok: false, reason: 'bad token' }))
     await expect(
-      runLogin({ root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'bad' }, { isTTY: false, out, probe })
+      runLogin({ root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'bad' }, { isTTY: false, out, probe })
     ).rejects.toThrow(/bad token/)
     expect(existsSync(join(root, 'config.json'))).toBe(false)
   })
@@ -119,7 +119,7 @@ describe('runLogin — interactive', () => {
     const installService = vi.fn(async () => {})
     const runForeground = vi.fn(async () => {})
     await runLogin(
-      { root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' },
+      { root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' },
       {
         isTTY: true,
         out,
@@ -140,7 +140,7 @@ describe('runLogin — interactive', () => {
     const installService = vi.fn(async () => {})
     const runForeground = vi.fn(async () => {})
     await runLogin(
-      { root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' },
+      { root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' },
       {
         isTTY: true,
         out,
@@ -162,7 +162,7 @@ describe('runLogin — interactive', () => {
     const runForeground = vi.fn(async () => {})
     await expect(
       runLogin(
-        { root, configPath: join(root, 'custom.json'), cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' },
+        { root, configPath: join(root, 'custom.json'), apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' },
         { isTTY: true, out, input: tty(['y']), probe, installService, runForeground }
       )
     ).rejects.toThrow(/--config/)
@@ -179,7 +179,7 @@ describe('runLogin — interactive', () => {
     const installService = vi.fn(async () => {})
     const runForeground = vi.fn(async () => {})
     await runLogin(
-      { root, cpUrl: 'wss://cp/daemon/ws', cpKey: 'tok' },
+      { root, apiUrl: 'wss://cp/daemon/ws', apiKey: 'tok' },
       {
         isTTY: true,
         out,
@@ -210,7 +210,7 @@ describe('runLogin — interactive', () => {
     )
     expect(probe).toHaveBeenCalledWith({ url: 'wss://typed/daemon/ws', token: 'typed-tok' })
     expect(readConfig(root).controlPlane.url).toBe('wss://typed/daemon/ws')
-    expect(lines.join('')).toContain('Control Plane URL:')
+    expect(lines.join('')).toContain('AgentConnect API URL:')
     expect(lines.join('')).toContain('Daemon API key:')
   })
 
@@ -222,7 +222,7 @@ describe('runLogin — interactive', () => {
       .mockResolvedValueOnce({ ok: false, reason: 'bad token' })
       .mockResolvedValueOnce({ ok: true, daemonId: 'd1' })
     await runLogin(
-      { root, cpUrl: 'wss://cp/daemon/ws' },
+      { root, apiUrl: 'wss://cp/daemon/ws' },
       {
         isTTY: true,
         out,
@@ -242,7 +242,7 @@ describe('runLogin — interactive', () => {
     const probe = vi.fn(async () => ({ ok: false, reason: 'bad token' }))
     await expect(
       runLogin(
-        { root, cpUrl: 'wss://cp/daemon/ws' },
+        { root, apiUrl: 'wss://cp/daemon/ws' },
         {
           isTTY: true,
           out,

--- a/packages/cli/test/route.test.ts
+++ b/packages/cli/test/route.test.ts
@@ -7,6 +7,7 @@ describe('firstPositional', () => {
   })
   it('skips a value-taking global option and its value', () => {
     expect(firstPositional(['--root', '/tmp/ac', 'chat'])).toBe('chat')
+    expect(firstPositional(['--api-url', 'wss://api.example/daemon/ws', 'run'])).toBe('run')
   })
   it('handles the --opt=value form (no separate value token)', () => {
     expect(firstPositional(['--root=/tmp/ac', 'chat'])).toBe('chat')

--- a/packages/control-plane/src/http/onboarding.test.ts
+++ b/packages/control-plane/src/http/onboarding.test.ts
@@ -78,7 +78,7 @@ describe('daemonStartCommand', () => {
   it('renders a copy-pasteable npx command with url + key (no --daemon-id)', () => {
     const cmd = daemonStartCommand('wss://cp.example.com/cp/daemon/ws', 'test-api-key')
     expect(cmd).toBe(
-      'npx -y @agentconnect.md/daemon run --cp-url wss://cp.example.com/cp/daemon/ws --cp-key test-api-key'
+      'npx -y @agentconnect.md/daemon run --api-url wss://cp.example.com/cp/daemon/ws --api-key test-api-key'
     )
     expect(cmd).not.toContain('--daemon-id')
   })
@@ -86,7 +86,7 @@ describe('daemonStartCommand', () => {
   it('pins the configured dist-tag on the package (e.g. @rc on the test CP)', () => {
     const cmd = daemonStartCommand('wss://cp.example.com/cp/daemon/ws', 'test-api-key', 'rc')
     expect(cmd).toBe(
-      'npx -y @agentconnect.md/daemon@rc run --cp-url wss://cp.example.com/cp/daemon/ws --cp-key test-api-key'
+      'npx -y @agentconnect.md/daemon@rc run --api-url wss://cp.example.com/cp/daemon/ws --api-key test-api-key'
     )
   })
 })

--- a/packages/control-plane/src/http/onboarding.ts
+++ b/packages/control-plane/src/http/onboarding.ts
@@ -65,12 +65,12 @@ export function daemonWsUrl(config: HttpServerConfig): string {
 
 /** Render the copy-paste daemon start command for a freshly-minted API key.
  *  The key's row carries the daemonId, so no `--daemon-id` is needed — the daemon
- *  adopts its identity from `auth/ok` (a minimal `--server-url --api-key` shape).
+ *  adopts its identity from `auth/ok` (a minimal `--api-url --api-key` shape).
  *  `distTag` pins the npm dist-tag/version `npx` installs (see `daemonPkgSpec`). */
 export function daemonStartCommand(wsUrl: string, apiKey: string, distTag?: string): string {
   // `-y` so npx installs the package non-interactively (a copy-pasted command
   // shouldn't stall on the "Ok to proceed?" prompt on a fresh host).
-  return `npx -y ${daemonPkgSpec(distTag)} run --cp-url ${wsUrl} --cp-key ${apiKey}`
+  return `npx -y ${daemonPkgSpec(distTag)} run --api-url ${wsUrl} --api-key ${apiKey}`
 }
 
 /**

--- a/packages/control-plane/test/integration/daemon-onboarding.route.test.ts
+++ b/packages/control-plane/test/integration/daemon-onboarding.route.test.ts
@@ -55,10 +55,10 @@ describe('Daemon onboarding — POST /daemons/token', () => {
 
     // The command is copy-pasteable and carries just url + key —
     // the daemon derives its id from `auth/ok`, so NO --daemon-id is needed.
-    expect(body.command).toContain('--cp-url wss://cp.example.com/daemon/ws')
-    expect(body.command).toContain(`--cp-key ${body.apiKey}`)
+    expect(body.command).toContain('--api-url wss://cp.example.com/daemon/ws')
+    expect(body.command).toContain(`--api-key ${body.apiKey}`)
     expect(body.command).not.toContain('--daemon-id')
-    expect(body.command).not.toContain('--cp-token')
+    expect(body.command).not.toContain('--api-token')
 
     // Onboarding WROTE rows: a provisioned daemon (epoch 0) + a hash-only api_key.
     const daemon = await prisma.daemon.findUnique({ where: { id: body.daemonId } })
@@ -97,7 +97,7 @@ describe('Daemon onboarding — POST /daemons/token', () => {
     const app = build() // no PUBLIC_CP_URL
     const body = (await app.app.inject({ method: 'POST', url: `${ORG}/daemons/token` })).json() as { command: string }
     // Falls back to a host:port ws URL (default 0.0.0.0:8080 unless configured).
-    expect(body.command).toMatch(/--cp-url wss?:\/\/[^ ]+\/daemon\/ws/)
+    expect(body.command).toMatch(/--api-url wss?:\/\/[^ ]+\/daemon\/ws/)
   })
 })
 
@@ -118,7 +118,7 @@ describe('Agent create — connect block tie-in', () => {
     expect(body.name).toBe('router-bot')
     expect(body.connect).toBeDefined()
     expect(body.connect!.apiKey).toMatch(/^[0-9A-Za-z]+$/)
-    expect(body.connect!.command).toContain('--cp-key ')
+    expect(body.connect!.command).toContain('--api-key ')
     expect(body.connect!.command).not.toContain('--daemon-id')
   })
 

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -5,8 +5,8 @@ import { ConfigSchema, type Config } from './config-schema.js'
 import { resolveRoot, configPath, defaultAgentsDir } from '../paths.js'
 
 export interface FlatOverrides {
-  cpUrl?: string
-  cpKey?: string
+  apiUrl?: string
+  apiKey?: string
   noCp?: boolean
   daemonId?: string
   logLevel?: Config['logging']['level']
@@ -67,11 +67,11 @@ export function loadConfig(
   if (o.logLevel) cfg.logging.level = o.logLevel
   if (o.maxAgents !== undefined) cfg.limits.maxAgents = o.maxAgents
   if (o.requireSandbox) cfg.security.requireSandbox = true
-  if (o.cpUrl) cfg.controlPlane.url = o.cpUrl
-  if (o.cpKey) cfg.controlPlane.key = o.cpKey
-  // Passing --cp-url/--cp-key implies "connect to the CP" (it defaults off),
+  if (o.apiUrl) cfg.controlPlane.url = o.apiUrl
+  if (o.apiKey) cfg.controlPlane.key = o.apiKey
+  // Passing --api-url/--api-key implies "connect to the CP" (it defaults off),
   // so the one-line onboarding command works without a config edit. --no-cp wins.
-  if (o.cpUrl || o.cpKey) cfg.controlPlane.enabled = true
+  if (o.apiUrl || o.apiKey) cfg.controlPlane.enabled = true
   if (o.noCp) cfg.controlPlane.enabled = false
 
   cfg.agentsDir = o.agentsDir ?? cfg.agentsDir ?? defaultAgentsDir(root)

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -32,8 +32,8 @@ program
 program
   .option('--config <path>', 'path to config.json (default ~/.agentconnect/config.json)')
   .option('--root <dir>', 'override ~/.agentconnect root directory')
-  .option('--cp-url <url>', 'override controlPlane.url')
-  .option('--cp-key <key>', 'override controlPlane.key (the CP API key)')
+  .option('--api-url <url>', 'override AgentConnect API WebSocket URL')
+  .option('--api-key <key>', 'override daemon API key')
   .option('--no-cp', 'run fully local, do not connect to the Control Plane')
   .option('--daemon-id <id>', 'override daemon identity')
   .option('--log-level <level>', 'trace|debug|info|warn|error')
@@ -79,8 +79,8 @@ program
         // that the service layer lives in the CLI (cli-daemon-split.md §7.1).
         supervisor: process.env.AGENTCONNECT_SUPERVISOR,
         overrides: {
-          cpUrl: opts.cpUrl,
-          cpKey: opts.cpKey,
+          apiUrl: opts.apiUrl,
+          apiKey: opts.apiKey,
           noCp: opts.cp === false,
           daemonId: opts.daemonId,
           logLevel: opts.logLevel,

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -77,7 +77,7 @@ describe('loadConfig', () => {
     })
     const cfg = loadConfig({
       root,
-      overrides: { cpUrl: 'wss://override.example/daemon', logLevel: 'debug', requireSandbox: true }
+      overrides: { apiUrl: 'wss://override.example/daemon', logLevel: 'debug', requireSandbox: true }
     })
     expect(cfg.controlPlane?.url).toBe('wss://override.example/daemon')
     expect(cfg.logging.level).toBe('debug')
@@ -113,17 +113,17 @@ describe('loadConfig', () => {
     expect(() => loadConfig({ root })).toThrow(/workspace Git origins/)
   })
 
-  it('passing --cp-url/--cp-key enables the control plane (defaults off)', () => {
+  it('passing --api-url/--api-key enables the control plane (defaults off)', () => {
     const root = tmpRoot({ version: 1 }) // no controlPlane block → enabled defaults false
-    const cfg = loadConfig({ root, overrides: { cpUrl: 'ws://cp/daemon/ws', cpKey: 'tok' } })
+    const cfg = loadConfig({ root, overrides: { apiUrl: 'ws://cp/daemon/ws', apiKey: 'tok' } })
     expect(cfg.controlPlane.enabled).toBe(true)
     expect(cfg.controlPlane.url).toBe('ws://cp/daemon/ws')
     expect(cfg.controlPlane.key).toBe('tok')
   })
 
-  it('--no-cp wins even when --cp-url is also passed', () => {
+  it('--no-cp wins even when --api-url is also passed', () => {
     const root = tmpRoot({ version: 1 })
-    const cfg = loadConfig({ root, overrides: { cpUrl: 'ws://cp/daemon/ws', noCp: true } })
+    const cfg = loadConfig({ root, overrides: { apiUrl: 'ws://cp/daemon/ws', noCp: true } })
     expect(cfg.controlPlane.enabled).toBe(false)
   })
 

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -135,25 +135,10 @@ export default function AddDaemonModal({ onClose }: { onClose: () => void }) {
       </div>
       <div className="modalbody">
         <p className="mb-[14px] font-sans text-[13px] font-normal leading-[1.55] text-(--text-secondary)">
-          Run these on the machine where agents should run — first install the daemon, then connect it to the control
-          plane.
+          Run one of these commands on the machine where agents should run. AgentConnect installs the daemon
+          automatically before connecting it.
         </p>
-        <p className="mb-[8px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">
-          1 · Install the daemon
-        </p>
-        <CommandBox
-          tabs={[{ key: 'install', label: 'install', command: cmds?.install ?? null }]}
-          placeholder={
-            err ? (
-              <div className="text-(--status-error)">Could not provision a key — {err}</div>
-            ) : (
-              <div className="text-(--text-inverse-dim)">Minting key…</div>
-            )
-          }
-        />
-        <p className="mb-[8px] mt-[16px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">
-          2 · Connect
-        </p>
+        <p className="mb-[8px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">Connect</p>
         <CommandBox
           tabs={[
             { key: 'run', label: 'Run', command: cmds?.run ?? null },

--- a/packages/web/src/lib/daemon-commands.test.ts
+++ b/packages/web/src/lib/daemon-commands.test.ts
@@ -5,39 +5,32 @@ const RUN = 'run --api-url wss://cp.example.com/cp/daemon/ws --api-key test-api-
 const LOGIN = RUN.replace(/^run\b/, 'login')
 
 describe('daemonCommands', () => {
-  it('rewrites the default (untagged) command to latest-CLI install + run/login', () => {
+  it('rewrites the default command to single-step latest-CLI run/login', () => {
     const c = daemonCommands(`npx -y @agentconnect.md/daemon ${RUN}`)
-    expect(c.install).toBe('npx -y @agentconnect.md/cli install --channel stable')
     expect(c.run).toBe(`npx -y @agentconnect.md/cli ${RUN}`)
     expect(c.login).toBe(`npx -y @agentconnect.md/cli ${LOGIN}`)
   })
 
-  it('pins the CLI package to @rc AND the daemon install to the rc channel', () => {
+  it('pins the CLI package to @rc so its first run bootstraps the rc daemon channel', () => {
     const c = daemonCommands(`npx -y @agentconnect.md/daemon@rc ${RUN}`)
-    // Every command must run the rc CLI so it contains rc-only behavior (install).
-    expect(c.install).toBe('npx -y @agentconnect.md/cli@rc install --channel rc')
     expect(c.run).toBe(`npx -y @agentconnect.md/cli@rc ${RUN}`)
     expect(c.login).toBe(`npx -y @agentconnect.md/cli@rc ${LOGIN}`)
   })
 
   it('maps stable dist-tag to the latest CLI + stable channel', () => {
     const c = daemonCommands(`npx -y @agentconnect.md/daemon@stable ${RUN}`)
-    expect(c.install).toBe('npx -y @agentconnect.md/cli install --channel stable')
     expect(c.run).toBe(`npx -y @agentconnect.md/cli ${RUN}`)
   })
 
-  it('treats an exact version pin as `install <version>` and never pins the CLI to it', () => {
+  it('keeps an exact daemon version as an inline install before connecting', () => {
     const c = daemonCommands(`npx -y @agentconnect.md/daemon@1.4.2 ${RUN}`)
-    expect(c.install).toBe('npx -y @agentconnect.md/cli install 1.4.2')
-    // CLI resolves from latest — it is never pinned to a daemon version.
-    expect(c.run).toBe(`npx -y @agentconnect.md/cli ${RUN}`)
-    expect(c.run).not.toContain('1.4.2')
+    const install = 'npx -y @agentconnect.md/cli install 1.4.2'
+    expect(c.run).toBe(`${install} && npx -y @agentconnect.md/cli ${RUN}`)
+    expect(c.login).toBe(`${install} && npx -y @agentconnect.md/cli ${LOGIN}`)
   })
 
   it('degrades gracefully on an unexpected command shape', () => {
     const c = daemonCommands('weird command without the daemon pkg')
-    // Falls back to a stable install and does not throw.
-    expect(c.install).toBe('npx -y @agentconnect.md/cli install --channel stable')
     expect(c.run.startsWith('npx -y @agentconnect.md/cli ')).toBe(true)
   })
 })

--- a/packages/web/src/lib/daemon-commands.test.ts
+++ b/packages/web/src/lib/daemon-commands.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { daemonCommands } from './daemon-commands'
 
-const RUN = 'run --cp-url wss://cp.example.com/cp/daemon/ws --cp-key test-api-key'
+const RUN = 'run --api-url wss://cp.example.com/cp/daemon/ws --api-key test-api-key'
 const LOGIN = RUN.replace(/^run\b/, 'login')
 
 describe('daemonCommands', () => {

--- a/packages/web/src/lib/daemon-commands.ts
+++ b/packages/web/src/lib/daemon-commands.ts
@@ -4,21 +4,17 @@
  *
  * The CP mints `npx -y @agentconnect.md/daemon[@<tag>] run --api-url … --api-key …`
  * (`onboarding.ts`), where `<tag>` is the pinned daemon dist-tag/version
- * (`DAEMON_DIST_TAG`, e.g. `rc` on a test CP). The CLI is a version manager that
- * ships WITHOUT a daemon bundle, so onboarding is two steps: install a daemon
- * version, then run/login.
+ * (`DAEMON_DIST_TAG`, e.g. `rc` on a test CP). The CLI's first run automatically
+ * installs and activates its release channel, so onboarding needs only one
+ * run/login command.
  *
- * Two distinct selectors come out of that one `<tag>`:
- *  - The **daemon** release goes on the INSTALL command's args
- *    (`install --channel <ch>` / `install <version>`) — that's what the CLI
- *    fetches and activates.
- *  - The **CLI** release channel goes on the npx package spec
- *    (`@agentconnect.md/cli@rc`). The CLI is published to npm on the SAME
- *    `rc`/`latest` dist-tags as the daemon (`scripts/publish-cli-if-changed.sh`),
- *    so an rc environment must pull the rc CLI or it won't contain rc-only
- *    behavior (e.g. this feature's top-level `install`). We mirror the *channel*
- *    only — never an exact daemon version, since CLI and daemon publishes are
- *    independent and a matching CLI version needn't exist.
+ * The **CLI** release channel goes on the npx package spec
+ * (`@agentconnect.md/cli@rc`). The CLI is published to npm on the SAME
+ * `rc`/`latest` dist-tags as the daemon (`scripts/publish-cli-if-changed.sh`),
+ * so an rc environment must pull the rc CLI and therefore bootstrap an rc
+ * daemon. Exact daemon versions cannot be applied to the independently
+ * versioned CLI package, so their single command retains an explicit install
+ * prefix before run/login.
  */
 const DAEMON_PKG = '@agentconnect.md/daemon'
 const CLI_PKG = '@agentconnect.md/cli'
@@ -34,15 +30,13 @@ function parse(command: string): { tag?: string; rest: string } | null {
 }
 
 export interface DaemonCommands {
-  /** `npx -y @agentconnect.md/cli[@rc] install …` — step 1 on a fresh host. */
-  install: string
   /** `npx -y @agentconnect.md/cli[@rc] run …` — foreground. */
   run: string
   /** `npx -y @agentconnect.md/cli[@rc] login …` — probe + save creds + install service. */
   login: string
 }
 
-/** Build the install/run/login CLI commands from the CP's minted command. */
+/** Build the single-step run/login CLI commands from the CP's minted command. */
 export function daemonCommands(command: string): DaemonCommands {
   const parsed = parse(command)
   // Fall back to a name-only rewrite if the shape is unexpected, so we never show
@@ -50,11 +44,13 @@ export function daemonCommands(command: string): DaemonCommands {
   const rest = parsed?.rest ?? command.replace(new RegExp(`\\b${DAEMON_PKG.replace(/[.]/g, '\\.')}(@\\S+)?`), 'run')
   const tag = parsed?.tag
   const cli = cliPkgSpec(tag)
+  const run = `npx -y ${cli} ${rest}`
+  const login = `npx -y ${cli} ${rest.replace(/^run\b/, 'login')}`
+  const install = exactInstallPrefix(cli, tag)
 
   return {
-    install: `npx -y ${cli} ${installArgs(tag)}`,
-    run: `npx -y ${cli} ${rest}`,
-    login: `npx -y ${cli} ${rest.replace(/^run\b/, 'login')}`
+    run: install ? `${install} && ${run}` : run,
+    login: install ? `${install} && ${login}` : login
   }
 }
 
@@ -66,10 +62,9 @@ function cliPkgSpec(tag?: string): string {
   return tag === 'rc' ? `${CLI_PKG}@rc` : CLI_PKG
 }
 
-/** Map the pinned daemon tag to `install` args. `stable`/absent and `rc` are
- *  channels; anything else is treated as an exact version/dist-tag. */
-function installArgs(tag?: string): string {
-  if (!tag || tag === 'stable') return 'install --channel stable'
-  if (tag === 'rc') return 'install --channel rc'
-  return `install ${tag}`
+/** Stable/rc are inferred by the selected CLI channel. An exact daemon version
+ *  still needs one explicit install before the connect command. */
+function exactInstallPrefix(cli: string, tag?: string): string | null {
+  if (!tag || tag === 'stable' || tag === 'rc') return null
+  return `npx -y ${cli} install ${tag}`
 }

--- a/packages/web/src/lib/daemon-commands.ts
+++ b/packages/web/src/lib/daemon-commands.ts
@@ -2,7 +2,7 @@
  * Translate the Control-Plane-minted onboarding command into the unified-CLI
  * (`@agentconnect.md/cli`) commands the console shows.
  *
- * The CP mints `npx -y @agentconnect.md/daemon[@<tag>] run --cp-url … --cp-key …`
+ * The CP mints `npx -y @agentconnect.md/daemon[@<tag>] run --api-url … --api-key …`
  * (`onboarding.ts`), where `<tag>` is the pinned daemon dist-tag/version
  * (`DAEMON_DIST_TAG`, e.g. `rc` on a test CP). The CLI is a version manager that
  * ships WITHOUT a daemon bundle, so onboarding is two steps: install a daemon
@@ -24,7 +24,7 @@ const DAEMON_PKG = '@agentconnect.md/daemon'
 const CLI_PKG = '@agentconnect.md/cli'
 
 /** Parse `npx -y @agentconnect.md/daemon[@<tag>] <rest…>` into its pinned daemon
- *  tag (if any) and the remainder (`run --cp-url … --cp-key …`). Returns null if
+ *  tag (if any) and the remainder (`run --api-url … --api-key …`). Returns null if
  *  the command isn't in the expected shape (defensive — callers fall back). */
 function parse(command: string): { tag?: string; rest: string } | null {
   const esc = DAEMON_PKG.replace(/[.]/g, '\\.')


### PR DESCRIPTION
## Summary

- rename the public daemon and unified CLI flags from `--cp-url` / `--cp-key` to `--api-url` / `--api-key`
- carry the API names through login handoff and daemon config overrides while keeping the persisted `controlPlane` schema unchanged
- simplify Add daemon onboarding to one `run` or `login` command because the CLI now installs the selected daemon channel automatically
- bootstrap a daemon before the interactive `login` service handoff, while preserving exact daemon-version pins inside the single generated command
- update generated onboarding commands, Web command conversion, tests, and design documentation

## Impact

Existing command-line invocations must use the new `--api-*` flags. Newly generated onboarding commands already use them, stored configuration remains compatible, and first-time users no longer need a separate install step.

## Validation

- CLI flag and routing tests: 33 passed
- CLI login/bootstrap tests: 21 passed
- daemon config tests: 19 passed
- control-plane onboarding unit tests: 13 passed
- Web command conversion tests: 5 passed
- typecheck: CLI, daemon, control-plane, Web
- build: CLI and daemon self-contained bundles; Web production build
- browser QA: Add daemon modal on desktop and 390px mobile, including both command tabs
- Prettier and ESLint on changed files; pre-push full ESLint completed with no errors

Created by Codex . gpt-5.6-sol
