### PR TITLE
fix(web): preserve schedule task line breaks

### DIFF
--- a/packages/web/src/components/console/views/ScheduleDetailView.tsx
+++ b/packages/web/src/components/console/views/ScheduleDetailView.tsx
@@ -194,7 +194,7 @@ export default function ScheduleDetailView() {
             <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal">
               Task
             </div>
-            <div className="px-4 py-3 font-sans text-[14px] font-normal leading-[1.55] text-(--text-primary)">
+            <div className="whitespace-pre-wrap px-4 py-3 font-sans text-[14px] font-normal leading-[1.55] text-(--text-primary)">
               {c.trigger}
             </div>
           </div>
@@ -508,7 +508,7 @@ export default function ScheduleDetailView() {
         <div className="cardhead">
           <span className="cardtitle">Task</span>
         </div>
-        <div className="px-4 py-[14px] font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-primary)">
+        <div className="whitespace-pre-wrap px-4 py-[14px] font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-primary)">
           {c.trigger}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- preserve authored line breaks in Schedule task text
- apply the same rendering behavior on desktop and mobile detail layouts

## Root cause

Schedule trigger text was rendered with normal whitespace handling, so browsers collapsed embedded line feeds and blank lines into spaces.

## Impact

Multiline task prompts now remain readable in the Schedule detail view without changing their content or typography.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/ScheduleDetailView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/ScheduleDetailView.tsx`
- `git diff --check`
- visually verified light and dark themes at desktop and 390px mobile widths with multiline task data

Created by Codex . GPT-5
