### PR TITLE
fix(web): use tools route for Tools & Skills

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -54,7 +54,7 @@ for simplicity.
 
 - **Web:** the "Skills library" on the Tools & Skills page at
   `packages/web/src/app/(app)/[slug]/tools/page.tsx` is entirely mocked.
-  `KnowledgeHubView.tsx:17` uses
+  `ToolsHubView.tsx:17` uses
   `const skills = MOCK_MODE ? SKILLS : []`, and `AddSkillModal` is a placeholder.
 - **Control Plane:** there is no skill-related Prisma model, REST route, or
   protocol frame.
@@ -411,4 +411,4 @@ Replace mock data with the real surface, following `McpServersCard`:
 | protocol      | `frames/agent.ts`, where `AgentSpec.skills` is an inline entry array; new `frames/skill-entry.ts` with the `AgentSkillEntry` schema                                                                                                                                                                                                       | **No** `skillsource/*` frame and **no** `RegisterOk.skillSources`; sources are inline in `AgentSpec.skills`. |
 | control-plane | `prisma/schema.prisma` for the `SkillSource` registry and `Agent.skills`; new `http/routes/skill-sources.ts`; `orchestrator/` to resolve sources into `AgentSpec` and fan out `agent/upsert` after a source change; `github/` for Trees API preview scanning                                                                              | Section 4                                                                                                    |
 | daemon        | New `src/skills/install-skills.ts` and `src/skills/runtime-agent-map.ts`; top-level `skills` in `agents/agent-schema.ts`; `raw.skills=spec.skills` plus `workspace.skills` migration in `agents/write-agent.ts`; trigger in `workspace/workspace-manager.ts` or `session/session-manager.ts`; fingerprint table in `store/local-store.ts` | Section 6                                                                                                    |
-| web           | `KnowledgeHubView.tsx` without mocks; new `modals/ImportSkillSourceModal.tsx` replacing `AddSkillModal`; `lib/api.ts`; `lib/data-context.tsx`; agent editor                                                                                                                                                                               | Section 7                                                                                                    |
+| web           | `ToolsHubView.tsx` without mocks; new `modals/ImportSkillSourceModal.tsx` replacing `AddSkillModal`; `lib/api.ts`; `lib/data-context.tsx`; agent editor                                                                                                                                                                                   | Section 7                                                                                                    |

--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -53,7 +53,7 @@ for simplicity.
 ## 1. Current state and gap
 
 - **Web:** the "Skills library" on the Tools & Skills page at
-  `packages/web/src/app/(app)/[slug]/knowledge/page.tsx` is entirely mocked.
+  `packages/web/src/app/(app)/[slug]/tools/page.tsx` is entirely mocked.
   `KnowledgeHubView.tsx:17` uses
   `const skills = MOCK_MODE ? SKILLS : []`, and `AddSkillModal` is a placeholder.
 - **Control Plane:** there is no skill-related Prisma model, REST route, or

--- a/packages/web/src/app/(app)/[slug]/knowledge/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/knowledge/page.tsx
@@ -1,8 +1,6 @@
-import type { Metadata } from 'next'
-import KnowledgeHubView from '@/components/console/views/KnowledgeHubView'
+import { permanentRedirect } from 'next/navigation'
 
-export const metadata: Metadata = { title: 'Tools & Skills · AgentConnect' }
-
-export default function Page() {
-  return <KnowledgeHubView />
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  permanentRedirect(`/${slug}/tools`)
 }

--- a/packages/web/src/app/(app)/[slug]/knowledge/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/knowledge/page.tsx
@@ -1,6 +1,0 @@
-import { permanentRedirect } from 'next/navigation'
-
-export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params
-  permanentRedirect(`/${slug}/tools`)
-}

--- a/packages/web/src/app/(app)/[slug]/tools/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/tools/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next'
+import KnowledgeHubView from '@/components/console/views/KnowledgeHubView'
+
+export const metadata: Metadata = { title: 'Tools & Skills · AgentConnect' }
+
+export default function Page() {
+  return <KnowledgeHubView />
+}

--- a/packages/web/src/app/(app)/[slug]/tools/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/tools/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next'
-import KnowledgeHubView from '@/components/console/views/KnowledgeHubView'
+import ToolsHubView from '@/components/console/views/ToolsHubView'
 
 export const metadata: Metadata = { title: 'Tools & Skills · AgentConnect' }
 
 export default function Page() {
-  return <KnowledgeHubView />
+  return <ToolsHubView />
 }

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -8,7 +8,7 @@ import { mcpCandidates, mcpCapsFor, mcpServerMeta, mcpServersForRuntime } from '
 import { Icon, Toggle } from '@/components/ui'
 
 /**
- * Leads the agent's Knowledge & Tools tab: the MCP servers the owning daemon's
+ * Leads the agent's Tools & Skills tab: the MCP servers the owning daemon's
  * runtime can attach (via `mcpServersForRuntime`/`mcpServerMeta`), each with an
  * enable/disable toggle. MCP is agent-scoped — this is the surface where it's
  * picked; the daemon detail view no longer lists MCP servers.

--- a/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
+++ b/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
@@ -148,7 +148,7 @@ export function ExternalMemoryBindingFields({
       {!isLoading && connections.length === 0 && (
         <div className="text-[12px] leading-[1.5] text-(--text-secondary)">
           No external-memory connection is configured. An organization owner can add one in{' '}
-          <a className="lnk" href={orgPath('/knowledge')}>
+          <a className="lnk" href={orgPath('/tools')}>
             Tools &amp; Skills → External memory
           </a>
           .

--- a/packages/web/src/components/console/McpServersField.tsx
+++ b/packages/web/src/components/console/McpServersField.tsx
@@ -1,5 +1,5 @@
 // MCP-server helper functions (no component — MCP is agent-scoped and enabled
-// from the agent's Knowledge & Tools card, the sole enablement surface).
+// from the agent's Tools & Skills card, the sole enablement surface).
 
 import type { McpServerInfo } from '@/lib/data'
 
@@ -31,7 +31,7 @@ export function mcpCapsFor(
 
 // ── Shared MCP definition source ────────────────────────────────────────────
 // The "what servers, and what each one is" lives here, once — consumed by the
-// agent's Knowledge & Tools card (the enablement surface), never restated at a
+// agent's Tools & Skills card (the enablement surface), never restated at a
 // call site.
 
 /** The daemon-configured MCP servers a given runtime can actually attach: the

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -38,7 +38,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
   { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
   { href: '/daemons', label: 'Daemons', icon: 'server' },
-  { href: '/knowledge', label: 'Tools & Skills', icon: 'book-open' },
+  { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
   { href: '/usage', label: 'Usage', icon: 'circle-gauge' }
 ]
 
@@ -58,7 +58,7 @@ const MOBILE_NAV: NavItem[] = [
 // prepended separately, in the sheet itself.
 const MORE_ROWS: NavItem[] = [
   { href: '/usage', label: 'Usage', icon: 'circle-gauge' },
-  { href: '/knowledge', label: 'Tools & Skills', icon: 'book-open' },
+  { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
 
@@ -85,7 +85,7 @@ const SECTIONS: { prefix: string; label: string }[] = [
   { prefix: '/sessions', label: 'Sessions' },
   { prefix: '/crons', label: 'Schedules' },
   { prefix: '/daemons', label: 'Daemons' },
-  { prefix: '/knowledge', label: 'Tools & Skills' },
+  { prefix: '/tools', label: 'Tools & Skills' },
   { prefix: '/usage', label: 'Usage' },
   { prefix: '/settings', label: 'Settings' },
   { prefix: '/profile', label: 'Profile' }

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -354,7 +354,7 @@ export default function EditAgentModal({
 
   // Switching runtime invalidates the model and the effort level (both vocabularies
   // are per-runtime), so reset both to the runtime default. (MCP enablement is edited
-  // on the agent's Knowledge & Tools card, not here.)
+  // on the agent's Tools & Skills card, not here.)
   const onRuntimeChange = (nextRuntime: string) => {
     setRuntime(nextRuntime)
     setModel('')

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1580,7 +1580,7 @@ export default function AgentDetailView() {
             <div className="flex items-center gap-2 border-t border-(--border-subtle) px-4 py-[13px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
               <Icon name="info" size={14} />
               Plus everything in{' '}
-              <Link className="lnk text-[12px]" href={orgPath('/knowledge')}>
+              <Link className="lnk text-[12px]" href={orgPath('/tools')}>
                 workspace knowledge &amp; skills
               </Link>
               , shared across all agents.

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -624,7 +624,7 @@ export default function AgentDetailView() {
             ['workspace', 'Workspace'],
             ['memory', 'Memory'],
             ['api', 'API'],
-            ['knowledge', 'Knowledge & Tools']
+            ['knowledge', 'Tools & Skills']
           ] as [DetailTab, string][]
         ).map(([t, label]) => {
           const on = tab === t
@@ -1530,7 +1530,7 @@ export default function AgentDetailView() {
       {/* API tab */}
       {tab === 'api' && <AgentApiPanel agentId={da.id} agentName={da.name} />}
 
-      {/* Knowledge & Tools tab — leads with the daemon runtime's MCP servers (Tools),
+      {/* Tools & Skills tab — leads with the daemon runtime's MCP servers (Tools),
           then the workspace-indexed knowledge below it. */}
       {tab === 'knowledge' && (
         <div className="flex flex-col gap-4 p-4 desktop:gap-[18px] desktop:p-0">

--- a/packages/web/src/components/console/views/ToolsHubView.tsx
+++ b/packages/web/src/components/console/views/ToolsHubView.tsx
@@ -10,7 +10,7 @@ import { McpServersCard } from '@/components/console/McpServersCard'
 import { SkillSourcesCard } from '@/components/console/SkillSourcesCard'
 import { MemoryConnectionsCard } from '@/components/console/MemoryConnectionsCard'
 
-export default function KnowledgeHubView() {
+export default function ToolsHubView() {
   const { mcpProviders, skillSources } = useConsoleData()
   const { activeOrg, myRole } = useOrgs()
   const memoryConnectionKey = consoleKeys.externalMemoryConnections(activeOrg?.id)

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -15,7 +15,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 //     org and replaces it in one step.
 // A stale cookie (renamed/removed org) is fine: the org context's
 // reconciliation replaces an unknown slug with the caller's real org.
-const CONSOLE_ROOTS = ['agents', 'sessions', 'daemons', 'crons', 'knowledge', 'usage', 'settings', 'profile']
+const CONSOLE_ROOTS = ['agents', 'sessions', 'daemons', 'crons', 'tools', 'knowledge', 'usage', 'settings', 'profile']
 
 // A real slug or the reserved `-` — anything else in the cookie is ignored
 // (it goes straight into a redirect path, so validate strictly).

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -15,7 +15,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 //     org and replaces it in one step.
 // A stale cookie (renamed/removed org) is fine: the org context's
 // reconciliation replaces an unknown slug with the caller's real org.
-const CONSOLE_ROOTS = ['agents', 'sessions', 'daemons', 'crons', 'tools', 'knowledge', 'usage', 'settings', 'profile']
+const CONSOLE_ROOTS = ['agents', 'sessions', 'daemons', 'crons', 'tools', 'usage', 'settings', 'profile']
 
 // A real slug or the reserved `-` — anything else in the cookie is ignored
 // (it goes straight into a redirect path, so validate strictly).


### PR DESCRIPTION
## Summary

- make `/[slug]/tools` the canonical Tools & Skills route
- update desktop, mobile, in-product links, and the agent detail tab to use the Tools & Skills name
- remove the old `/[slug]/knowledge` page and bare console entry so that namespace stays available for a future feature
- align the hub component and shared-skills design pointer with the canonical name

## Root cause

The feature had been renamed to Tools & Skills in parts of the UI, but its page, navigation, agent tab, and internal hub name still used the legacy Knowledge wording.

## Impact

Tools & Skills navigation now lands on the matching `/tools` URL, the agent tab uses the same product name, and `/knowledge` no longer redirects to or renders the Tools & Skills page.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web test` (52 files, 341 tests)
- `pnpm --filter @agentconnect.md/web build`
- local production HTTP check: `/acme/tools` returned 200, `/acme/knowledge` rendered Not found without redirecting, and bare `/knowledge` returned 404

Created by Codex . GPT-5
