### PR TITLE
fix(web): simplify Tools & Skills headers

### DIFF
--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -105,9 +105,8 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
 
   return (
     <div className="card overflow-hidden max-desktop:rounded-lg desktop:max-w-[760px]">
-      <div className="flex items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:py-[13px]">
-        <span className="font-sans text-[14px] font-semibold leading-normal">Skills</span>
-        <span className="mono text-[11px] text-(--text-tertiary)">installed via npx skills · before session start</span>
+      <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal desktop:py-[13px]">
+        Skills
       </div>
 
       {skillSources.length === 0 && orphaned.length === 0 ? (

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -117,9 +117,8 @@ export function AgentToolsCard({
 
   return (
     <div className="card overflow-hidden max-desktop:rounded-lg desktop:max-w-[760px]">
-      <div className="flex items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:py-[13px]">
-        <span className="font-sans text-[14px] font-semibold leading-normal">Tools</span>
-        <span className="mono text-[11px] text-(--text-tertiary)">MCP servers · attached at session start</span>
+      <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal desktop:py-[13px]">
+        Tools
       </div>
       {servers.length > 0 || unknown.length > 0 ? (
         <div>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1542,9 +1542,8 @@ export default function AgentDetailView() {
           />
           <AgentSkillsCard agentId={da.id} canEdit={!da.name.startsWith(MOCK_PREFIX)} />
           <div className="card overflow-hidden max-desktop:rounded-lg desktop:max-w-[760px]">
-            <div className="flex items-center justify-between border-b border-(--border-subtle) px-4 py-3 desktop:py-[13px]">
-              <span className="font-sans text-[14px] font-semibold leading-normal">Loaded from workspace</span>
-              <span className="mono text-[11px] text-(--text-tertiary)">on first clone &amp; each pull</span>
+            <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal desktop:py-[13px]">
+              Loaded from workspace
             </div>
             <div className="desktop:py-[6px]">
               {MOCK_MODE ? (


### PR DESCRIPTION
## Summary

- remove the right-side runtime note from the Tools card header
- remove the installation timing note from the Skills card header
- remove the clone and pull timing note from the Loaded from workspace header
- simplify all three headers to the same title-only structure

## Root cause

These implementation and lifecycle notes repeated background details without helping users operate the three sections, adding visual noise to otherwise simple card headers.

## Impact

The Tools & Skills tab keeps the same controls and content while presenting cleaner, more consistent section headers.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web test` (52 files, 341 tests)
- `pnpm --filter @agentconnect.md/web build`
- Prettier and residual-copy scan

Created by Codex . GPT-5
