### PR TITLE
fix(web): align memory history spacing

### DIFF
--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -105,6 +105,14 @@ describe('DreamPanel', () => {
     expect(history?.querySelector('summary')?.textContent).toContain('History')
     expect(history?.querySelector('summary')?.textContent).toContain('2')
     expect(history?.textContent).toContain('Superseded')
+    expect(history?.querySelector('summary')?.classList.contains('border-t')).toBe(false)
+  })
+
+  it('uses one divider when history follows a ready result', async () => {
+    api.listDreams.mockResolvedValue([dream(), dream({ dreamId: 'drm-2', status: 'adopted' })])
+    const host = await render()
+    const history = host.querySelector('details')
+    expect(history?.querySelector('summary')?.classList.contains('border-t')).toBe(true)
   })
 
   it('uses the shared card shell with the action in its header', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -192,6 +192,9 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
     dream.status === 'completed' ? true : !isDreamTerminal(dream.status)
   )
   const pastDreams = (dreams ?? []).filter((dream) => dream.status !== 'completed' && isDreamTerminal(dream.status))
+  const hasContentBeforeHistory = Boolean(
+    (startBlocker && !inFlight) || actionError || actionNotice || listError || activeDreams.length || reviewing
+  )
 
   const discard = (dreamId: string) =>
     void run(async () => {
@@ -303,7 +306,11 @@ export function DreamPanel({ agentId, canEdit }: { agentId: string; canEdit: boo
 
         {pastDreams.length ? (
           <details className="group">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 border-t border-(--border-subtle) pt-3 font-sans text-[12px] font-semibold leading-normal text-(--text-secondary) transition-colors hover:text-(--text-primary) [&::-webkit-details-marker]:hidden">
+            <summary
+              className={`flex cursor-pointer list-none items-center justify-between gap-2 font-sans text-[12px] font-semibold leading-normal text-(--text-secondary) transition-colors hover:text-(--text-primary) [&::-webkit-details-marker]:hidden ${
+                hasContentBeforeHistory ? 'border-t border-(--border-subtle) pt-3' : ''
+              }`}
+            >
               <span className="inline-flex items-center gap-1">
                 <Icon name="chevron-right" size={13} className="transition-transform group-open:rotate-90" />
                 History

--- a/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
@@ -94,6 +94,7 @@ describe('ManagedMemoryHistory', () => {
     expect(mocks.listMemoryFileHistory).not.toHaveBeenCalled()
     const disclosure = button('Change history')
     expect(disclosure?.getAttribute('aria-expanded')).toBe('false')
+    expect(disclosure?.closest('section')?.classList.contains('mt-auto')).toBe(true)
 
     await act(async () => disclosure?.click())
 

--- a/packages/web/src/components/console/ManagedMemoryHistory.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.tsx
@@ -155,7 +155,7 @@ export function ManagedMemoryHistory({ agentId, path }: { agentId: string; path:
   const loadedCount = events?.length ?? 0
 
   return (
-    <section className="border-t border-(--border-subtle)" aria-label={`Change history for ${path}`}>
+    <section className="mt-auto border-t border-(--border-subtle)" aria-label={`Change history for ${path}`}>
       <button
         type="button"
         className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-4 py-3 text-left font-sans transition-colors hover:bg-(--surface-hover) focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-(--brand)"


### PR DESCRIPTION
## Summary

- anchor the collapsed Change history row to the bottom of the memory preview
- omit the Dreams history divider when History is the first item in the card body
- retain a single divider when active or reviewable dream content appears above History

## Why

Short memory files left variable empty space below Change history because the preview column stretched independently of its contents. Dreams history also drew a second separator directly below the card header when no current dream content was present.

## Validation

- focused DreamPanel and ManagedMemoryHistory tests
- web package typecheck
- changed-file ESLint and formatting checks
- full pre-push repository lint
