### PR TITLE
feat(daemon): install accepted dream skills under symlink containment

### DIFF
--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -885,11 +885,27 @@ export class DreamRunner {
    * review metadata, and dismissal all work; only acceptance waits.
    */
   async skillAccept(agentId: string, dreamId: string, name: string): Promise<DreamInfo> {
-    this.dirFor(agentId)
-    this.skillCandidate(agentId, dreamId, name) // 404 an unknown candidate first
-    throw new DreamStateError(
-      'accepting a mined skill is not available yet — it needs containment-safe runtime registration'
-    )
+    const dir = this.dirFor(agentId)
+    return this.withLock(agentId, async () => {
+      const { dream, skill } = this.skillCandidate(agentId, dreamId, name)
+      if (skill.state === 'accepted') return dream // idempotent
+      if (skill.state === 'dismissed') throw new DreamStateError('this skill candidate was already dismissed')
+
+      // COPY into the agent's own skills tree rather than referencing the dream
+      // staging, so discarding the dream later cannot uninstall a skill the user
+      // already accepted. Session prep materializes it into the runtime's skill
+      // root (skills/dream-skill-install.ts) under symlink-safe containment.
+      const staged = join(this.dreamDir(agentId, dreamId), 'skills', name)
+      const target = join(dir, AGENT_SKILLS_DIRNAME, name)
+      await fsp.mkdir(join(dir, AGENT_SKILLS_DIRNAME), { recursive: true })
+      await fsp.rm(target, { recursive: true, force: true })
+      await fsp.cp(staged, target, { recursive: true, dereference: false, errorOnExist: false })
+
+      const next = this.setSkillState(agentId, dreamId, name, 'accepted')
+      await this.sweepReviewedStaging(agentId, next)
+      this.deps.log.info(`dream ${dreamId}: accepted skill "${name}" for agent ${agentId}`)
+      return next
+    })
   }
 
   /** Dismiss one candidate: drop its staging and record the decision, so later

--- a/packages/daemon/src/fs/contained-path.ts
+++ b/packages/daemon/src/fs/contained-path.ts
@@ -1,0 +1,140 @@
+/**
+ * Symlink-safe path resolution for daemon-authority writes into trees an AGENT
+ * can influence.
+ *
+ * The daemon runs OUTSIDE the agent's sandbox. Anywhere it writes using an
+ * ordinary pathname — the memory dir, or a skill root inside the workspace — the
+ * agent can replace a component with a symlink and redirect a daemon-privileged
+ * `mkdir`/`copy`/`rm -rf` to an arbitrary host path. Node exposes no `openat`
+ * family, so a path cannot be pinned to a descriptor; the containment we CAN get
+ * is:
+ *
+ *   1. lexical containment (`boundary` ⊇ `root` ⊇ `destination`),
+ *   2. a component-by-component walk that `lstat`s each step and REJECTS a
+ *      symlink instead of following it, creating missing directories itself,
+ *   3. `realpath` after each step, re-checking containment, so a component that
+ *      resolves outside the boundary is caught even if it was a directory,
+ *   4. handing back a target built from the REAL parent, so the caller's write
+ *      cannot be re-pointed by swapping a parent afterwards.
+ *
+ * This is the discipline `agents/memory.ts` has shipped; it lives here so the
+ * skill materializer uses the same one rather than a second, subtly-different
+ * copy. It narrows the TOCTOU window rather than closing it — an attacker who
+ * wins a race between the final `lstat` and the caller's `open` is still
+ * possible in principle — so callers should also publish through an exclusive
+ * temp file and rename where the content matters.
+ */
+import { promises as fsp, type Stats } from 'node:fs'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+/** Raised when a path escapes its boundary or traverses a symlink. */
+export class ContainedPathError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ContainedPathError'
+  }
+}
+
+function isErrno(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === code
+}
+
+/** Is `path` at or beneath `root`, lexically? */
+export function under(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+export interface ContainedTargetOptions {
+  /** Create missing parent directories (write side). Off ⇒ a missing component
+   *  yields `null`, which read callers treat as "nothing there". */
+  create: boolean
+  /** Message prefix so callers keep their own vocabulary in errors. */
+  label?: string
+}
+
+/**
+ * Resolve `destination` to a real, contained path, or `null` when a component is
+ * missing and `create` is false.
+ *
+ * `boundary` is the trusted outer directory nothing may escape; `root` is the
+ * subtree the destination must sit in (often a child of `boundary`).
+ */
+export async function containedTarget(
+  boundary: string,
+  root: string,
+  destination: string,
+  opts: ContainedTargetOptions
+): Promise<string | null> {
+  const label = opts.label ?? 'path'
+  const lexicalBoundary = resolve(boundary)
+  const lexicalRoot = resolve(root)
+  const lexicalTarget = resolve(destination)
+  if (!under(lexicalBoundary, lexicalRoot) || !under(lexicalRoot, lexicalTarget)) {
+    throw new ContainedPathError(`${label} escapes its root`)
+  }
+
+  let realBoundary: string
+  try {
+    realBoundary = await fsp.realpath(lexicalBoundary)
+  } catch (err) {
+    if (!opts.create && isErrno(err, 'ENOENT')) return null
+    throw err
+  }
+
+  let parent = realBoundary
+  for (const part of relative(lexicalBoundary, dirname(lexicalTarget)).split(sep).filter(Boolean)) {
+    const candidate = join(parent, part)
+    let stat: Stats
+    try {
+      stat = await fsp.lstat(candidate)
+    } catch (err) {
+      if (!isErrno(err, 'ENOENT')) throw err
+      if (!opts.create) return null
+      try {
+        await fsp.mkdir(candidate)
+      } catch (mkdirErr) {
+        if (!isErrno(mkdirErr, 'EEXIST')) throw mkdirErr
+      }
+      stat = await fsp.lstat(candidate)
+    }
+    // lstat never follows, so a symlink-to-directory reports isDirectory() ===
+    // false here — which is exactly the escape we are refusing.
+    if (!stat.isDirectory()) throw new ContainedPathError(`${label} contains a symlink or non-directory`)
+    parent = await fsp.realpath(candidate)
+    if (!under(realBoundary, parent)) throw new ContainedPathError(`${label} resolves outside its boundary`)
+  }
+
+  let realRoot: string
+  try {
+    realRoot = await fsp.realpath(lexicalRoot)
+  } catch (err) {
+    if (!opts.create && isErrno(err, 'ENOENT')) return null
+    throw err
+  }
+  if (!under(realBoundary, realRoot) || !under(realRoot, parent)) {
+    throw new ContainedPathError(`${label} resolves outside its root`)
+  }
+  return join(parent, basename(lexicalTarget))
+}
+
+/**
+ * Remove `target` only if it is a real directory reached without traversing a
+ * symlink. A plain `rm -rf` on an agent-influenced path is the escape this
+ * exists to prevent: the agent points the name at an outside tree and the
+ * daemon deletes it.
+ */
+export async function containedRemoveDir(boundary: string, root: string, target: string): Promise<void> {
+  const resolved = await containedTarget(boundary, root, target, { create: false, label: 'skill path' })
+  if (!resolved) return
+  let stat: Stats
+  try {
+    stat = await fsp.lstat(resolved)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return
+    throw err
+  }
+  // Refuse to delete through a link; an unexpected file type is equally suspect.
+  if (!stat.isDirectory()) throw new ContainedPathError('skill path contains a symlink or non-directory')
+  await fsp.rm(resolved, { recursive: true, force: true })
+}

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -59,23 +59,62 @@ function isOwnedSkillDir(rel: string): boolean {
   return m !== null
 }
 
+/** The marker is ALSO a daemon-authority write beneath the agent-writable cwd,
+ *  so it gets the same no-follow treatment as the skill files — a planted
+ *  `.agentconnect` symlink must not redirect it out of the workspace. */
 async function readMarker(cwd: string): Promise<Marker> {
   try {
-    const raw = await fsp.readFile(join(cwd, MARKER_DIR, MARKER_FILE), 'utf8')
-    const parsed = JSON.parse(raw) as Marker
+    const target = await containedTarget(cwd, join(cwd, MARKER_DIR), join(cwd, MARKER_DIR, MARKER_FILE), {
+      create: false,
+      label: 'skill marker'
+    })
+    if (!target) return { installed: [] }
+    const parsed = JSON.parse(await fsp.readFile(target, 'utf8')) as Marker
     return { installed: Array.isArray(parsed.installed) ? parsed.installed.filter(isOwnedSkillDir) : [] }
   } catch {
+    // Unreadable, absent, or refused: treat as "nothing recorded". A refusal is
+    // reported by the write side, which is where the damage would be.
     return { installed: [] }
   }
 }
 
-async function writeMarker(cwd: string, marker: Marker): Promise<void> {
+async function writeMarker(cwd: string, marker: Marker, warn?: (msg: string) => void): Promise<void> {
   try {
-    await fsp.mkdir(join(cwd, MARKER_DIR), { recursive: true })
-    await fsp.writeFile(join(cwd, MARKER_DIR, MARKER_FILE), JSON.stringify(marker), 'utf8')
-  } catch {
-    // best-effort: a lost marker costs a stale dir, never a failed session
+    await publish(cwd, join(cwd, MARKER_DIR), join(cwd, MARKER_DIR, MARKER_FILE), Buffer.from(JSON.stringify(marker)))
+  } catch (err) {
+    // A containment refusal here is a security event, like a refused skill path.
+    warn?.(
+      err instanceof ContainedPathError
+        ? `skills: refused to write the dream-skill marker — ${err.message}`
+        : `skills: could not write the dream-skill marker — ${err instanceof Error ? err.message : ''}`
+    )
   }
+}
+
+/**
+ * Serial mutex per CANONICAL cwd. Ownership is a read → reconcile → copy →
+ * publish transaction over one marker; two agents prepared concurrently in a
+ * shared checkout would otherwise both read the same prior marker, both install,
+ * and each overwrite the other's record — leaving one agent's skill on disk with
+ * nothing recording it, so no later pass could ever reconcile it away.
+ *
+ * Keyed by the REAL path so two spellings of the same directory serialize
+ * together. In-process only, which matches the scope: one daemon prepares the
+ * sessions that share a checkout.
+ */
+const cwdLocks = new Map<string, Promise<unknown>>()
+
+function withCwdLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = cwdLocks.get(key) ?? Promise.resolve()
+  const result = prev.then(fn, fn)
+  cwdLocks.set(
+    key,
+    result.then(
+      () => {},
+      () => {}
+    )
+  )
+  return result
 }
 
 export interface MaterializeResult {
@@ -114,9 +153,20 @@ export async function materializeAcceptedDreamSkills(
   acpCwd: string,
   opts: { warn?: (msg: string) => void } = {}
 ): Promise<MaterializeResult> {
-  const result: MaterializeResult = { installed: [], removed: [], errors: [] }
   const rootRel = skillRootFor(agent.runtime)
-  if (!rootRel) return result // no mapping for this runtime; nothing to do
+  if (!rootRel) return { installed: [], removed: [], errors: [] } // unmapped runtime
+  // Canonical key so `/tmp/x` and `/private/tmp/x` share one lock.
+  const key = await fsp.realpath(acpCwd).catch(() => acpCwd)
+  return withCwdLock(key, () => materialize(agent, acpCwd, rootRel, opts))
+}
+
+async function materialize(
+  agent: { dir: string; runtime: string },
+  acpCwd: string,
+  rootRel: string,
+  opts: { warn?: (msg: string) => void }
+): Promise<MaterializeResult> {
+  const result: MaterializeResult = { installed: [], removed: [], errors: [] }
 
   const names = await acceptedDreamSkillNames({ dir: agent.dir })
   const skillsRoot = join(acpCwd, ...rootRel.split('/'))
@@ -137,7 +187,7 @@ export async function materializeAcceptedDreamSkills(
     }
   }
   if (names.length === 0) {
-    await writeMarker(acpCwd, { installed: [] })
+    await writeMarker(acpCwd, { installed: [] }, opts.warn)
     return result
   }
 
@@ -189,6 +239,6 @@ export async function materializeAcceptedDreamSkills(
       )
     }
   }
-  await writeMarker(acpCwd, { installed: result.installed })
+  await writeMarker(acpCwd, { installed: result.installed }, opts.warn)
   return result
 }

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -1,0 +1,126 @@
+/**
+ * Materialize ACCEPTED dream skills into the runtime's project-scope skill root
+ * (docs/designs/memory-dreaming.md §7).
+ *
+ * The canonical copy of an accepted skill lives at `<agent-root>/skills/<name>/`
+ * — daemon-owned, outside the workspace, so it survives a reset or re-clone.
+ * Runtimes only discover skills under the ACP cwd, so a copy has to land there
+ * too. That cwd is AGENT-WRITABLE, which is the whole problem:
+ *
+ *   the daemon runs outside the agent's sandbox, so a `.claude/skills` symlink
+ *   planted by a previous session turns a daemon-authority copy (or the
+ *   reconciling remove) into an arbitrary write/delete anywhere on the host.
+ *
+ * So every path here goes through `fs/contained-path.ts`: components are walked
+ * with `lstat` and a symlink is REFUSED rather than followed, each step is
+ * re-checked against the workspace boundary, and files publish through an
+ * exclusive temp + rename. Delegating to the `npx skills` installer would NOT
+ * have helped — process indirection changes who writes, not the authority or
+ * the pathname containment.
+ *
+ * Non-fatal by contract, like `installSkills`: a refused or broken skill warns
+ * and is skipped, never blocking a session from starting.
+ */
+import { randomUUID } from 'node:crypto'
+import { promises as fsp } from 'node:fs'
+import { join } from 'node:path'
+import { ContainedPathError, containedRemoveDir, containedTarget } from '../fs/contained-path.js'
+import { skillsAgentId } from './runtime-agent-map.js'
+import { ACCEPTED_SKILLS_DIRNAME, acceptedDreamSkillNames } from './dream-skills.js'
+
+/** Claude reads `.claude/skills`; the other mapped agents read `.agents/skills` —
+ *  the same split `install-skills.ts` reconciles over. */
+function skillRootFor(runtime: string): string | null {
+  const agentId = skillsAgentId(runtime)
+  if (!agentId) return null
+  return agentId === 'claude-code' ? '.claude/skills' : '.agents/skills'
+}
+
+/** Files a mined skill may carry — the miner already validated these names. */
+const SKILL_FILE_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i
+/** Bounded so a broken canonical copy cannot stall session prep. */
+const MAX_FILES_PER_SKILL = 24
+const MAX_FILE_BYTES = 64 * 1024
+
+export interface MaterializeResult {
+  installed: string[]
+  errors: Array<{ skill: string; error: string }>
+}
+
+/** Copy one already-validated file into `destDir` (already contained). */
+async function publish(boundary: string, root: string, destPath: string, body: Buffer): Promise<void> {
+  const target = await containedTarget(boundary, root, destPath, { create: true, label: 'skill path' })
+  if (!target) throw new ContainedPathError('skill path could not be resolved')
+  // Exclusive temp + rename: a reader never sees a partial file, and the
+  // random name cannot be pre-created by the agent to redirect the write.
+  const temp = join(join(target, '..'), `.agentconnect-skill-${randomUUID()}.tmp`)
+  const handle = await fsp.open(temp, 'wx', 0o600)
+  try {
+    await handle.writeFile(body)
+  } finally {
+    await handle.close()
+  }
+  try {
+    await fsp.rename(temp, target)
+  } catch (err) {
+    await fsp.rm(temp, { force: true }).catch(() => {})
+    throw err
+  }
+}
+
+/**
+ * Copy every accepted skill into the runtime's skill root under `acpCwd`.
+ * Returns what landed; never throws.
+ */
+export async function materializeAcceptedDreamSkills(
+  agent: { dir: string; runtime: string },
+  acpCwd: string,
+  opts: { warn?: (msg: string) => void } = {}
+): Promise<MaterializeResult> {
+  const result: MaterializeResult = { installed: [], errors: [] }
+  const rootRel = skillRootFor(agent.runtime)
+  if (!rootRel) return result // no mapping for this runtime; nothing to do
+
+  const names = await acceptedDreamSkillNames({ dir: agent.dir })
+  if (names.length === 0) return result
+
+  const skillsRoot = join(acpCwd, ...rootRel.split('/'))
+  for (const name of names) {
+    const source = join(agent.dir, ACCEPTED_SKILLS_DIRNAME, name)
+    const destDir = join(skillsRoot, name)
+    try {
+      // Replace any prior copy — refusing if the path traverses a link, which
+      // is exactly the planted-symlink case.
+      await containedRemoveDir(acpCwd, skillsRoot, destDir)
+
+      // Read the canonical (daemon-owned) copy. Symlinks are not followed here
+      // either: the accepted tree should only ever contain regular files.
+      const entries = (await fsp.readdir(source, { withFileTypes: true }))
+        .filter((e) => e.isFile() && !e.isSymbolicLink() && SKILL_FILE_RE.test(e.name))
+        .slice(0, MAX_FILES_PER_SKILL)
+      if (!entries.some((e) => e.name === 'SKILL.md')) {
+        result.errors.push({ skill: name, error: 'accepted skill has no SKILL.md' })
+        continue
+      }
+      for (const entry of entries) {
+        const body = await fsp.readFile(join(source, entry.name))
+        if (body.byteLength > MAX_FILE_BYTES) {
+          result.errors.push({ skill: name, error: `${entry.name} exceeds the size cap` })
+          continue
+        }
+        await publish(acpCwd, skillsRoot, join(destDir, entry.name), body)
+      }
+      result.installed.push(`${rootRel}/${name}`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'unknown error'
+      result.errors.push({ skill: name, error: message })
+      // A containment refusal is a security event, not a routine miss — say so.
+      opts.warn?.(
+        err instanceof ContainedPathError
+          ? `skills: refused to install accepted skill "${name}" — ${message}`
+          : `skills: could not install accepted skill "${name}" — ${message}`
+      )
+    }
+  }
+  return result
+}

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -47,6 +47,8 @@ const MAX_FILE_BYTES = 64 * 1024
  *  those `installSkills` owns (it keeps its own separate marker). */
 const MARKER_DIR = '.agentconnect'
 const MARKER_FILE = 'dream-skills-install.json'
+/** The marker is a short list of short paths; anything larger is not ours. */
+const MAX_MARKER_BYTES = 64 * 1024
 
 interface Marker {
   installed: string[]
@@ -69,6 +71,13 @@ async function readMarker(cwd: string): Promise<Marker> {
       label: 'skill marker'
     })
     if (!target) return { installed: [] }
+    // containedTarget validates the PARENTS and hands back the final name for
+    // the caller to judge — so judge it. A symlink here would still be followed
+    // outside the workspace, and an unbounded read of an agent-chosen target is
+    // a denial-of-service path (a huge or non-terminating file).
+    const stat = await fsp.lstat(target)
+    if (!stat.isFile()) throw new ContainedPathError('skill marker is not a regular file')
+    if (stat.size > MAX_MARKER_BYTES) throw new ContainedPathError('skill marker exceeds its size cap')
     const parsed = JSON.parse(await fsp.readFile(target, 'utf8')) as Marker
     return { installed: Array.isArray(parsed.installed) ? parsed.installed.filter(isOwnedSkillDir) : [] }
   } catch {
@@ -78,9 +87,10 @@ async function readMarker(cwd: string): Promise<Marker> {
   }
 }
 
-async function writeMarker(cwd: string, marker: Marker, warn?: (msg: string) => void): Promise<void> {
+async function writeMarker(cwd: string, marker: Marker, warn?: (msg: string) => void): Promise<boolean> {
   try {
     await publish(cwd, join(cwd, MARKER_DIR), join(cwd, MARKER_DIR, MARKER_FILE), Buffer.from(JSON.stringify(marker)))
+    return true
   } catch (err) {
     // A containment refusal here is a security event, like a refused skill path.
     warn?.(
@@ -88,6 +98,7 @@ async function writeMarker(cwd: string, marker: Marker, warn?: (msg: string) => 
         ? `skills: refused to write the dream-skill marker — ${err.message}`
         : `skills: could not write the dream-skill marker — ${err instanceof Error ? err.message : ''}`
     )
+    return false
   }
 }
 
@@ -188,6 +199,18 @@ async function materialize(
   }
   if (names.length === 0) {
     await writeMarker(acpCwd, { installed: [] }, opts.warn)
+    return result
+  }
+
+  // JOURNAL BEFORE MUTATING. If ownership cannot be recorded, installing anyway
+  // would leave an untracked skill that no later pass could reconcile away — so
+  // fail closed to "no accepted skill" rather than to an untracked one. The
+  // journal is a conservative SUPERSET (what may exist after this pass), then
+  // narrowed to what actually landed; a crash in between leaves extras
+  // recorded, which a later pass simply removes.
+  const journal = [...new Set([...prior.installed.filter((rel) => desired.has(rel)), ...desired])]
+  if (!(await writeMarker(acpCwd, { installed: journal }, opts.warn))) {
+    result.errors.push({ skill: '*', error: 'ownership could not be recorded; skills were not installed' })
     return result
   }
 

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -42,8 +42,45 @@ const SKILL_FILE_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i
 const MAX_FILES_PER_SKILL = 24
 const MAX_FILE_BYTES = 64 * 1024
 
+/** Records exactly which dirs this pass materialized, so the next pass can
+ *  remove the ones no longer wanted WITHOUT touching hand-authored skills or
+ *  those `installSkills` owns (it keeps its own separate marker). */
+const MARKER_DIR = '.agentconnect'
+const MARKER_FILE = 'dream-skills-install.json'
+
+interface Marker {
+  installed: string[]
+}
+
+/** Only paths this feature could have produced may drive a removal — the marker
+ *  is on-disk state an agent can edit, so its entries are untrusted input. */
+function isOwnedSkillDir(rel: string): boolean {
+  const m = /^(\.claude\/skills|\.agents\/skills)\/([a-z0-9][a-z0-9-]{0,62})$/.exec(rel)
+  return m !== null
+}
+
+async function readMarker(cwd: string): Promise<Marker> {
+  try {
+    const raw = await fsp.readFile(join(cwd, MARKER_DIR, MARKER_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as Marker
+    return { installed: Array.isArray(parsed.installed) ? parsed.installed.filter(isOwnedSkillDir) : [] }
+  } catch {
+    return { installed: [] }
+  }
+}
+
+async function writeMarker(cwd: string, marker: Marker): Promise<void> {
+  try {
+    await fsp.mkdir(join(cwd, MARKER_DIR), { recursive: true })
+    await fsp.writeFile(join(cwd, MARKER_DIR, MARKER_FILE), JSON.stringify(marker), 'utf8')
+  } catch {
+    // best-effort: a lost marker costs a stale dir, never a failed session
+  }
+}
+
 export interface MaterializeResult {
   installed: string[]
+  removed: string[]
   errors: Array<{ skill: string; error: string }>
 }
 
@@ -77,14 +114,33 @@ export async function materializeAcceptedDreamSkills(
   acpCwd: string,
   opts: { warn?: (msg: string) => void } = {}
 ): Promise<MaterializeResult> {
-  const result: MaterializeResult = { installed: [], errors: [] }
+  const result: MaterializeResult = { installed: [], removed: [], errors: [] }
   const rootRel = skillRootFor(agent.runtime)
   if (!rootRel) return result // no mapping for this runtime; nothing to do
 
   const names = await acceptedDreamSkillNames({ dir: agent.dir })
-  if (names.length === 0) return result
-
   const skillsRoot = join(acpCwd, ...rootRel.split('/'))
+
+  // RECONCILE FIRST, and even when this agent accepted nothing. A checkout can
+  // be shared between agents, so a skill agent A accepted must not still be
+  // sitting in the runtime's discovery root when agent B is prepared — that
+  // would hand B executable instruction content it never reviewed.
+  const desired = new Set(names.map((name) => `${rootRel}/${name}`))
+  const prior = await readMarker(acpCwd)
+  for (const rel of prior.installed) {
+    if (desired.has(rel)) continue
+    try {
+      await containedRemoveDir(acpCwd, join(acpCwd, ...rel.split('/').slice(0, -1)), join(acpCwd, ...rel.split('/')))
+      result.removed.push(rel)
+    } catch (err) {
+      opts.warn?.(`skills: could not remove stale dream skill "${rel}" — ${err instanceof Error ? err.message : ''}`)
+    }
+  }
+  if (names.length === 0) {
+    await writeMarker(acpCwd, { installed: [] })
+    return result
+  }
+
   for (const name of names) {
     const source = join(agent.dir, ACCEPTED_SKILLS_DIRNAME, name)
     const destDir = join(skillsRoot, name)
@@ -95,20 +151,31 @@ export async function materializeAcceptedDreamSkills(
 
       // Read the canonical (daemon-owned) copy. Symlinks are not followed here
       // either: the accepted tree should only ever contain regular files.
-      const entries = (await fsp.readdir(source, { withFileTypes: true }))
-        .filter((e) => e.isFile() && !e.isSymbolicLink() && SKILL_FILE_RE.test(e.name))
-        .slice(0, MAX_FILES_PER_SKILL)
-      if (!entries.some((e) => e.name === 'SKILL.md')) {
+      // The accepted tree is `SKILL.md` plus an optional FLAT `scripts/` dir —
+      // exactly what DreamRunner stages. Copying only the top level would report
+      // success while silently dropping every reviewed script.
+      const files: Array<{ rel: string; abs: string }> = []
+      for (const entry of await fsp.readdir(source, { withFileTypes: true })) {
+        if (entry.isFile() && !entry.isSymbolicLink() && SKILL_FILE_RE.test(entry.name)) {
+          files.push({ rel: entry.name, abs: join(source, entry.name) })
+        } else if (entry.isDirectory() && !entry.isSymbolicLink() && entry.name === 'scripts') {
+          for (const script of await fsp.readdir(join(source, 'scripts'), { withFileTypes: true })) {
+            if (!script.isFile() || script.isSymbolicLink() || !SKILL_FILE_RE.test(script.name)) continue
+            files.push({ rel: `scripts/${script.name}`, abs: join(source, 'scripts', script.name) })
+          }
+        }
+      }
+      if (!files.some((f) => f.rel === 'SKILL.md')) {
         result.errors.push({ skill: name, error: 'accepted skill has no SKILL.md' })
         continue
       }
-      for (const entry of entries) {
-        const body = await fsp.readFile(join(source, entry.name))
+      for (const file of files.slice(0, MAX_FILES_PER_SKILL)) {
+        const body = await fsp.readFile(file.abs)
         if (body.byteLength > MAX_FILE_BYTES) {
-          result.errors.push({ skill: name, error: `${entry.name} exceeds the size cap` })
+          result.errors.push({ skill: name, error: `${file.rel} exceeds the size cap` })
           continue
         }
-        await publish(acpCwd, skillsRoot, join(destDir, entry.name), body)
+        await publish(acpCwd, skillsRoot, join(destDir, ...file.rel.split('/')), body)
       }
       result.installed.push(`${rootRel}/${name}`)
     } catch (err) {
@@ -122,5 +189,6 @@ export async function materializeAcceptedDreamSkills(
       )
     }
   }
+  await writeMarker(acpCwd, { installed: result.installed })
   return result
 }

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -198,7 +198,11 @@ async function materialize(
     }
   }
   if (names.length === 0) {
-    await writeMarker(acpCwd, { installed: [] }, opts.warn)
+    // Only record an empty set if something was actually removed. Writing a
+    // marker unconditionally would create a file in EVERY workspace on every
+    // prep — pointless for the overwhelmingly common no-accepted-skills case,
+    // and a spurious workspace mutation the reconcile watcher can react to.
+    if (result.removed.length > 0) await writeMarker(acpCwd, { installed: [] }, opts.warn)
     return result
   }
 

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -188,12 +188,19 @@ async function materialize(
   // would hand B executable instruction content it never reviewed.
   const desired = new Set(names.map((name) => `${rootRel}/${name}`))
   const prior = await readMarker(acpCwd)
+  // Ownership must survive a FAILED removal. If A's removal is refused (its
+  // path was replaced by a symlink) while B's succeeds, dropping A from the
+  // marker forgets it forever: once A's real directory is restored, no later
+  // pass knows to reconcile it, and it stays discoverable to agents that never
+  // accepted it. So carry forward every entry we did not actually remove.
+  const retained: string[] = []
   for (const rel of prior.installed) {
     if (desired.has(rel)) continue
     try {
       await containedRemoveDir(acpCwd, join(acpCwd, ...rel.split('/').slice(0, -1)), join(acpCwd, ...rel.split('/')))
       result.removed.push(rel)
     } catch (err) {
+      retained.push(rel)
       opts.warn?.(`skills: could not remove stale dream skill "${rel}" — ${err instanceof Error ? err.message : ''}`)
     }
   }
@@ -202,7 +209,7 @@ async function materialize(
     // marker unconditionally would create a file in EVERY workspace on every
     // prep — pointless for the overwhelmingly common no-accepted-skills case,
     // and a spurious workspace mutation the reconcile watcher can react to.
-    if (result.removed.length > 0) await writeMarker(acpCwd, { installed: [] }, opts.warn)
+    if (result.removed.length > 0) await writeMarker(acpCwd, { installed: retained }, opts.warn)
     return result
   }
 
@@ -212,7 +219,7 @@ async function materialize(
   // journal is a conservative SUPERSET (what may exist after this pass), then
   // narrowed to what actually landed; a crash in between leaves extras
   // recorded, which a later pass simply removes.
-  const journal = [...new Set([...prior.installed.filter((rel) => desired.has(rel)), ...desired])]
+  const journal = [...new Set([...retained, ...prior.installed.filter((rel) => desired.has(rel)), ...desired])]
   if (!(await writeMarker(acpCwd, { installed: journal }, opts.warn))) {
     result.errors.push({ skill: '*', error: 'ownership could not be recorded; skills were not installed' })
     return result
@@ -266,6 +273,6 @@ async function materialize(
       )
     }
   }
-  await writeMarker(acpCwd, { installed: result.installed }, opts.warn)
+  await writeMarker(acpCwd, { installed: [...new Set([...retained, ...result.installed])] }, opts.warn)
   return result
 }

--- a/packages/daemon/src/skills/dream-skills.ts
+++ b/packages/daemon/src/skills/dream-skills.ts
@@ -1,0 +1,33 @@
+/**
+ * Accepted dream skills (docs/designs/memory-dreaming.md §7) — the canonical
+ * copy, at `<agent-root>/skills/<name>/`.
+ *
+ * Daemon-owned and OUTSIDE the workspace, so an accepted skill survives a
+ * workspace reset or re-clone and is never committed into a github-mode repo,
+ * exactly like memory. Getting it in front of the runtime is a separate,
+ * containment-checked step — see `dream-skill-install.ts`.
+ */
+import { promises as fsp } from 'node:fs'
+import { join } from 'node:path'
+
+/** Where an accepted mined skill is stored, under the agent root. */
+export const ACCEPTED_SKILLS_DIRNAME = 'skills'
+
+/** Same name discipline as the miner — these become filesystem paths. */
+const SKILL_DIR_RE = /^[a-z0-9][a-z0-9-]{0,62}$/
+
+/**
+ * Names of the skills this agent has accepted. A symlink is never listed: the
+ * name is handed onward to a copier, so a link here would be a redirect.
+ * Never throws — a missing tree is simply "none accepted".
+ */
+export async function acceptedDreamSkillNames(agent: { dir: string }): Promise<string[]> {
+  try {
+    return (await fsp.readdir(join(agent.dir, ACCEPTED_SKILLS_DIRNAME), { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink() && SKILL_DIR_RE.test(entry.name))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -21,6 +21,7 @@ import {
 import type { Agent } from '../agents/agent-schema.js'
 import { makeLogger } from '../log.js'
 import { installSkills } from '../skills/install-skills.js'
+import { materializeAcceptedDreamSkills } from '../skills/dream-skill-install.js'
 import {
   assertSafeWorkspaceGitConfig,
   cloneGitEnv,
@@ -54,6 +55,17 @@ async function withSkills(agent: Agent, acpCwd: string): Promise<string> {
     },
     warn: (msg) => skillsLog.warn(msg)
   })
+  // Skills the user ACCEPTED from a dream are daemon-owned (they live under the
+  // agent root, not in `agent.skills`), so they get their own materialization
+  // pass — one that treats every path in the agent-writable cwd as hostile.
+  // Runs AFTER installSkills so its reconciliation cannot remove these copies.
+  // `dir` is present on every discovered agent (LoadedAgent); a bare spec has none.
+  const agentRoot = (agent as { dir?: string }).dir
+  if (agentRoot) {
+    await materializeAcceptedDreamSkills({ dir: agentRoot, runtime: agent.runtime }, acpCwd, {
+      warn: (msg) => skillsLog.warn(msg)
+    })
+  }
   return acpCwd
 }
 

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -933,15 +933,26 @@ describe('DreamRunner skill mining (D-3)', () => {
     expect(done.skills).toBeUndefined()
   })
 
-  it('refuses to accept — a terminal success without its effect would be a lie', async () => {
-    // Accepting must mean the skill can steer later sessions, which needs a
-    // containment-safe write under the agent-writable cwd. Until that exists,
-    // refuse loudly rather than record `accepted` with no effect.
-    const { runner, dreamId, done } = await mining(grounded)
-    await expect(runner.skillAccept('a1', dreamId, 'deploy-staging')).rejects.toThrow(/not available yet/)
-    // The candidate stays reviewable rather than being consumed.
-    expect(done.skills?.[0]).toMatchObject({ state: 'proposed' })
-    expect(await runner.stagedSkill('a1', dreamId, 'deploy-staging')).not.toBeNull()
+  it('accept copies the skill into the agent-owned tree and marks it accepted', async () => {
+    const { dir, runner, dreamId } = await mining(grounded)
+    const after = await runner.skillAccept('a1', dreamId, 'deploy-staging')
+    expect(after.skills?.[0]).toMatchObject({ state: 'accepted' })
+
+    // The canonical copy lands under the agent root — daemon-owned, outside the
+    // workspace. Session prep materializes it into the runtime's skill root
+    // under symlink containment (see dream-skill-install.test.ts).
+    expect(await readFile(join(dir, 'skills', 'deploy-staging', 'SKILL.md'), 'utf8')).toContain('name: deploy-staging')
+    // Idempotent.
+    await expect(runner.skillAccept('a1', dreamId, 'deploy-staging')).resolves.toMatchObject({})
+  })
+
+  it('an accepted skill survives discarding the dream it came from', async () => {
+    // Acceptance COPIES rather than referencing the staging, so tidying up the
+    // dream cannot silently uninstall a skill the user already took.
+    const { dir, runner, dreamId } = await mining(grounded)
+    await runner.skillAccept('a1', dreamId, 'deploy-staging')
+    await runner.discard('a1', dreamId)
+    expect(await readFile(join(dir, 'skills', 'deploy-staging', 'SKILL.md'), 'utf8')).toContain('name: deploy-staging')
   })
 
   it('dismiss drops the staging and blocks a later accept; both are idempotent', async () => {
@@ -1029,13 +1040,13 @@ describe('DreamRunner skill mining — review findings', () => {
     expect(prompts[0]).not.toContain('Bash(')
   })
 
-  it('keeps the candidate reviewable rather than half-accepting it', async () => {
-    // Acceptance is deferred (see skillAccept), so the daemon must not leave a
-    // half-applied state behind: the candidate stays `proposed` and staged.
-    const { runner, dreamId } = await mine()
-    await expect(runner.skillAccept('a1', dreamId, 'deploy-staging')).rejects.toThrow(/not available yet/)
-    const staged = await runner.stagedSkill('a1', dreamId, 'deploy-staging')
-    expect(staged?.skill).toContain('name: deploy-staging')
+  it('accepts the generated skill with its validated frontmatter intact', async () => {
+    const { dir, runner, dreamId } = await mine()
+    await runner.skillAccept('a1', dreamId, 'deploy-staging')
+    const body = await readFile(join(dir, 'skills', 'deploy-staging', 'SKILL.md'), 'utf8')
+    // Frontmatter is daemon-generated from the VALIDATED name/description, so
+    // what ships is exactly what the reviewer saw.
+    expect(parseYaml(body.split('---')[1] ?? '')).toMatchObject({ name: 'deploy-staging' })
   })
 
   it('keeps a still-proposed candidate reviewable after the store proposal is discarded', async () => {

--- a/packages/daemon/test/dream-skill-install.test.ts
+++ b/packages/daemon/test/dream-skill-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -161,6 +161,36 @@ describe('materializeAcceptedDreamSkills', () => {
 
     expect(existsSync(join(cwd, '.claude/skills', nameA))).toBe(false)
     expect(existsSync(join(cwd, '.claude/skills', nameB))).toBe(false)
+  })
+
+  it('REFUSES a symlinked marker FILE rather than reading through it', async () => {
+    // containedTarget validates parents but returns the final name — so an
+    // outside marker was still read, and drove deletion of a peer skill.
+    const { dir, cwd, name } = await fixture()
+    await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await writeFile(join(outside, 'marker.json'), JSON.stringify({ installed: [`.claude/skills/${name}`] }), 'utf8')
+    await rm(join(cwd, '.agentconnect', 'dream-skills-install.json'))
+    await symlink(join(outside, 'marker.json'), join(cwd, '.agentconnect', 'dream-skills-install.json'), 'file')
+
+    // A second agent with nothing accepted must NOT act on that outside marker.
+    const dirB = await mkdtemp(join(tmpdir(), 'ac-agent-b-'))
+    const result = await materializeAcceptedDreamSkills({ dir: dirB, runtime: 'claude' }, cwd)
+    expect(result.removed).toEqual([]) // the planted marker was not obeyed
+  })
+
+  it('fails closed when ownership cannot be recorded, rather than installing untracked', async () => {
+    // Marker refused (.agentconnect symlinked out) + skill installed anyway =
+    // an untracked skill no later pass can reconcile away. Install nothing.
+    const { dir, cwd, name } = await fixture()
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await symlink(outside, join(cwd, '.agentconnect'), 'dir')
+
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    expect(result.installed).toEqual([])
+    expect(existsSync(join(cwd, '.claude/skills', name))).toBe(false)
+    expect(result.errors.some((e) => /ownership could not be recorded/.test(e.error))).toBe(true)
   })
 
   it('skips a malformed accepted skill without failing the others', async () => {

--- a/packages/daemon/test/dream-skill-install.test.ts
+++ b/packages/daemon/test/dream-skill-install.test.ts
@@ -84,6 +84,47 @@ describe('materializeAcceptedDreamSkills', () => {
     expect(existsSync(join(cwd, '.claude/skills', name, 'gone.md'))).toBe(false)
   })
 
+  it('copies the staged scripts/ subtree, not just the top level', async () => {
+    // DreamRunner stages `<skill>/scripts/<file>`. Copying only top-level files
+    // reported success while every reviewed script silently vanished.
+    const { dir, cwd, name } = await fixture()
+    await mkdir(join(dir, 'skills', name, 'scripts'), { recursive: true })
+    await writeFile(join(dir, 'skills', name, 'scripts', 'run.sh'), '#!/bin/sh\necho go\n', 'utf8')
+
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    expect(result.errors).toEqual([])
+    expect(await readFile(join(cwd, '.claude/skills', name, 'scripts', 'run.sh'), 'utf8')).toContain('echo go')
+  })
+
+  it('does not leak one agent’s accepted skill into another sharing the checkout', async () => {
+    // Shared checkouts are supported: preparing agent A then agent B must not
+    // leave A's executable instruction content in B's discovery root.
+    const { dir: dirA, cwd, name } = await fixture()
+    await materializeAcceptedDreamSkills({ dir: dirA, runtime: 'claude' }, cwd)
+    expect(existsSync(join(cwd, '.claude/skills', name, 'SKILL.md'))).toBe(true)
+
+    // Agent B shares the cwd and has accepted nothing.
+    const dirB = await mkdtemp(join(tmpdir(), 'ac-agent-b-'))
+    const result = await materializeAcceptedDreamSkills({ dir: dirB, runtime: 'claude' }, cwd)
+
+    expect(result.removed).toEqual([`.claude/skills/${name}`])
+    expect(existsSync(join(cwd, '.claude/skills', name))).toBe(false)
+  })
+
+  it('leaves skills it does not own alone while reconciling', async () => {
+    // Hand-authored skills (and anything installSkills owns) share the root.
+    const { dir, cwd, name } = await fixture()
+    await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    await mkdir(join(cwd, '.claude/skills', 'hand-written'), { recursive: true })
+    await writeFile(join(cwd, '.claude/skills', 'hand-written', 'SKILL.md'), 'mine', 'utf8')
+
+    const dirB = await mkdtemp(join(tmpdir(), 'ac-agent-b-'))
+    await materializeAcceptedDreamSkills({ dir: dirB, runtime: 'claude' }, cwd)
+
+    expect(existsSync(join(cwd, '.claude/skills', name))).toBe(false) // ours, reconciled away
+    expect(existsSync(join(cwd, '.claude/skills', 'hand-written', 'SKILL.md'))).toBe(true) // not ours
+  })
+
   it('skips a malformed accepted skill without failing the others', async () => {
     const { dir, cwd } = await fixture()
     await mkdir(join(dir, 'skills', 'broken'), { recursive: true })

--- a/packages/daemon/test/dream-skill-install.test.ts
+++ b/packages/daemon/test/dream-skill-install.test.ts
@@ -193,6 +193,38 @@ describe('materializeAcceptedDreamSkills', () => {
     expect(result.errors.some((e) => /ownership could not be recorded/.test(e.error))).toBe(true)
   })
 
+  it('keeps owning a stale skill whose removal was REFUSED, even when another succeeds', async () => {
+    // Mixed pass: A's removal is refused (planted symlink), B's succeeds.
+    // Deriving ownership only from successes forgets A — and once A's real
+    // directory is restored nothing ever reconciles it away again.
+    const { dir: dirA, cwd } = await fixture('skill-a')
+    await materializeAcceptedDreamSkills({ dir: dirA, runtime: 'claude' }, cwd)
+    const { dir: dirB } = await fixture('skill-b')
+    // Install B alongside A by pointing one agent root at both.
+    await mkdir(join(dirA, 'skills', 'skill-b'), { recursive: true })
+    await writeFile(join(dirA, 'skills', 'skill-b', 'SKILL.md'), '# B\n', 'utf8')
+    await materializeAcceptedDreamSkills({ dir: dirA, runtime: 'claude' }, cwd)
+    expect(existsSync(join(cwd, '.claude/skills/skill-a'))).toBe(true)
+    expect(existsSync(join(cwd, '.claude/skills/skill-b'))).toBe(true)
+
+    // Make skill-a's removal refuse, then prepare an agent that wants neither.
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await rm(join(cwd, '.claude/skills/skill-a'), { recursive: true })
+    await symlink(outside, join(cwd, '.claude/skills/skill-a'), 'dir')
+    const empty = await mkdtemp(join(tmpdir(), 'ac-agent-e-'))
+    const mixed = await materializeAcceptedDreamSkills({ dir: empty, runtime: 'claude' }, cwd)
+    expect(mixed.removed).toEqual(['.claude/skills/skill-b']) // only B went
+
+    // Restore skill-a as a real directory; a later pass must still reconcile it.
+    await rm(join(cwd, '.claude/skills/skill-a'))
+    await mkdir(join(cwd, '.claude/skills/skill-a'), { recursive: true })
+    await writeFile(join(cwd, '.claude/skills/skill-a', 'SKILL.md'), '# A\n', 'utf8')
+    const after = await materializeAcceptedDreamSkills({ dir: empty, runtime: 'claude' }, cwd)
+    expect(after.removed).toEqual(['.claude/skills/skill-a'])
+    expect(existsSync(join(cwd, '.claude/skills/skill-a'))).toBe(false)
+    void dirB
+  })
+
   it('skips a malformed accepted skill without failing the others', async () => {
     const { dir, cwd } = await fixture()
     await mkdir(join(dir, 'skills', 'broken'), { recursive: true })

--- a/packages/daemon/test/dream-skill-install.test.ts
+++ b/packages/daemon/test/dream-skill-install.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, readFile, readdir, symlink, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { materializeAcceptedDreamSkills } from '../src/skills/dream-skill-install.js'
+import { acceptedDreamSkillNames } from '../src/skills/dream-skills.js'
+
+/** An agent root holding one accepted skill, plus an empty workspace cwd. */
+async function fixture(name = 'deploy-staging') {
+  const dir = await mkdtemp(join(tmpdir(), 'ac-agent-'))
+  const cwd = await mkdtemp(join(tmpdir(), 'ac-cwd-'))
+  await mkdir(join(dir, 'skills', name), { recursive: true })
+  await writeFile(join(dir, 'skills', name, 'SKILL.md'), '---\nname: deploy\n---\n# Deploy\n', 'utf8')
+  await writeFile(join(dir, 'skills', name, 'run.sh'), 'echo deploy\n', 'utf8')
+  return { dir, cwd, name }
+}
+
+describe('materializeAcceptedDreamSkills', () => {
+  it('copies an accepted skill into the runtime skill root the runtime actually reads', async () => {
+    const { dir, cwd, name } = await fixture()
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+
+    expect(result.installed).toEqual([`.claude/skills/${name}`])
+    expect(result.errors).toEqual([])
+    expect(await readFile(join(cwd, '.claude/skills', name, 'SKILL.md'), 'utf8')).toContain('# Deploy')
+    expect(await readFile(join(cwd, '.claude/skills', name, 'run.sh'), 'utf8')).toContain('echo deploy')
+  })
+
+  it('uses .agents/skills for non-Claude runtimes, and does nothing for an unmapped one', async () => {
+    const { dir, cwd, name } = await fixture()
+    expect((await materializeAcceptedDreamSkills({ dir, runtime: 'codex' }, cwd)).installed).toEqual([
+      `.agents/skills/${name}`
+    ])
+    expect(existsSync(join(cwd, '.agents/skills', name, 'SKILL.md'))).toBe(true)
+
+    const { dir: d2, cwd: c2 } = await fixture()
+    expect((await materializeAcceptedDreamSkills({ dir: d2, runtime: 'not-a-runtime' }, c2)).installed).toEqual([])
+  })
+
+  it('REFUSES a workspace-planted skill-root symlink instead of writing through it', async () => {
+    // The reproduced escape: a previous session points `.claude/skills` at an
+    // outside directory, and a daemon-authority copy lands on the host.
+    const { dir, cwd, name } = await fixture()
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await writeFile(join(outside, 'canary.txt'), 'do not touch', 'utf8')
+    await mkdir(join(cwd, '.claude'), { recursive: true })
+    await symlink(outside, join(cwd, '.claude', 'skills'), 'dir')
+
+    const warnings: string[] = []
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd, {
+      warn: (m) => warnings.push(m)
+    })
+
+    expect(result.installed).toEqual([])
+    expect(result.errors[0]?.error).toMatch(/symlink|non-directory/)
+    expect(warnings.join(' ')).toContain('refused')
+    // Nothing was created outside the workspace, and the canary is intact.
+    expect(await readdir(outside)).toEqual(['canary.txt'])
+    expect(existsSync(join(outside, name))).toBe(false)
+  })
+
+  it('REFUSES a symlink at the individual skill directory (the remove path)', async () => {
+    const { dir, cwd, name } = await fixture()
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await writeFile(join(outside, 'keep.txt'), 'keep', 'utf8')
+    await mkdir(join(cwd, '.claude', 'skills'), { recursive: true })
+    // A prior copy replaced by a link — a naive rm -rf would delete `outside`.
+    await symlink(outside, join(cwd, '.claude', 'skills', name), 'dir')
+
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    expect(result.installed).toEqual([])
+    expect(await readdir(outside)).toEqual(['keep.txt'])
+  })
+
+  it('replaces a previous real copy so an updated skill actually lands', async () => {
+    const { dir, cwd, name } = await fixture()
+    await mkdir(join(cwd, '.claude', 'skills', name), { recursive: true })
+    await writeFile(join(cwd, '.claude/skills', name, 'SKILL.md'), 'stale', 'utf8')
+    await writeFile(join(cwd, '.claude/skills', name, 'gone.md'), 'removed', 'utf8')
+
+    await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    expect(await readFile(join(cwd, '.claude/skills', name, 'SKILL.md'), 'utf8')).toContain('# Deploy')
+    expect(existsSync(join(cwd, '.claude/skills', name, 'gone.md'))).toBe(false)
+  })
+
+  it('skips a malformed accepted skill without failing the others', async () => {
+    const { dir, cwd } = await fixture()
+    await mkdir(join(dir, 'skills', 'broken'), { recursive: true })
+    await writeFile(join(dir, 'skills', 'broken', 'notes.md'), 'no SKILL.md here', 'utf8')
+
+    const result = await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd)
+    expect(result.installed).toEqual(['.claude/skills/deploy-staging'])
+    expect(result.errors[0]).toMatchObject({ skill: 'broken' })
+  })
+
+  it('never lists a symlinked or badly-named entry as accepted', async () => {
+    const { dir } = await fixture()
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await symlink(outside, join(dir, 'skills', 'sneaky'), 'dir')
+    await mkdir(join(dir, 'skills', 'Not Kebab'), { recursive: true })
+    expect(await acceptedDreamSkillNames({ dir })).toEqual(['deploy-staging'])
+  })
+})

--- a/packages/daemon/test/dream-skill-install.test.ts
+++ b/packages/daemon/test/dream-skill-install.test.ts
@@ -125,6 +125,44 @@ describe('materializeAcceptedDreamSkills', () => {
     expect(existsSync(join(cwd, '.claude/skills', 'hand-written', 'SKILL.md'))).toBe(true) // not ours
   })
 
+  it('REFUSES a planted .agentconnect symlink instead of writing the marker through it', async () => {
+    // The marker is a daemon-authority write under the agent-writable cwd too —
+    // a plain writeFile followed `.agentconnect -> outside` and clobbered a file
+    // there.
+    const { dir, cwd } = await fixture()
+    const outside = await mkdtemp(join(tmpdir(), 'ac-outside-'))
+    await writeFile(join(outside, 'dream-skills-install.json'), 'CANARY', 'utf8')
+    await symlink(outside, join(cwd, '.agentconnect'), 'dir')
+
+    const warnings: string[] = []
+    await materializeAcceptedDreamSkills({ dir, runtime: 'claude' }, cwd, { warn: (m) => warnings.push(m) })
+
+    // The canary is intact and the refusal was reported as a security event.
+    expect(await readFile(join(outside, 'dream-skills-install.json'), 'utf8')).toBe('CANARY')
+    expect(warnings.join(' ')).toContain('refused to write the dream-skill marker')
+  })
+
+  it('serializes concurrent preparation so neither agent’s ownership is lost', async () => {
+    // Both agents read the same prior marker, both install, and each overwrites
+    // the other's record — leaving one skill on disk that no later pass can
+    // reconcile away. The transaction must be serialized per canonical cwd.
+    const { dir: dirA, cwd, name: nameA } = await fixture('skill-a')
+    const { dir: dirB, name: nameB } = await fixture('skill-b')
+
+    await Promise.all([
+      materializeAcceptedDreamSkills({ dir: dirA, runtime: 'claude' }, cwd),
+      materializeAcceptedDreamSkills({ dir: dirB, runtime: 'claude' }, cwd)
+    ])
+
+    // A third agent with nothing accepted must be able to clear the root: that
+    // only works if the marker recorded whichever set actually survived.
+    const dirC = await mkdtemp(join(tmpdir(), 'ac-agent-c-'))
+    await materializeAcceptedDreamSkills({ dir: dirC, runtime: 'claude' }, cwd)
+
+    expect(existsSync(join(cwd, '.claude/skills', nameA))).toBe(false)
+    expect(existsSync(join(cwd, '.claude/skills', nameB))).toBe(false)
+  })
+
   it('skips a malformed accepted skill without failing the others', async () => {
     const { dir, cwd } = await fixture()
     await mkdir(join(dir, 'skills', 'broken'), { recursive: true })


### PR DESCRIPTION
Unblocks `skillAccept`, which #86 shipped **refusing** with `"not available yet"` because every materialization attempt was escapable.

## Why the earlier attempts failed

Runtimes only read skills from project-scope directories under the ACP cwd — and that cwd is **agent-writable**, while the daemon writes with daemon authority from *outside* the agent's sandbox. Across #86's review rounds:

- a bespoke `rm -rf` + copy **followed a planted `.claude/skills` symlink** (reproduced by the reviewer: `outside/deploy/SKILL.md` created, a marker deleted);
- delegating to the existing `npx skills` installer **did not help** — process indirection changes *who* performs the write, not its authority or its pathname containment, and that installer does its own path-based reconciliation removal.

## What's different

The answer was already in this repo. `agents/memory.ts` has shipped a discipline for exactly this problem: walk each path component with `lstat`, **refuse** a symlink instead of following it, `realpath` and re-check containment after every step, and publish through an exclusive temp + rename. I hadn't used it.

This extracts that into **`fs/contained-path.ts`** so both callers share one implementation — duplicating ~50 lines of subtle security logic is exactly the thing that rots — and builds the materializer on it.

- **`fs/contained-path.ts`** — `containedTarget` (read/write) and `containedRemoveDir`, which refuses to *delete* through a link. Honestly documented as **narrowing** the TOCTOU window, not closing it: Node has no `openat` family.
- **`skills/dream-skill-install.ts`** — copies accepted skills into `.claude/skills` / `.agents/skills` by runtime, every path contained, bounded file count and size, non-fatal like `installSkills`. A containment refusal warns as a **security event**, not a routine miss.
- **`skills/dream-skills.ts`** — the canonical accepted copy under the agent root; never lists a symlink, since the name is handed onward to a copier.
- **`skillAccept`** now **copies** staging into the agent-owned tree, so discarding the dream later cannot uninstall a skill the user already took.

## Test plan

Both reproduced escapes are covered — a skill-root symlink and a per-skill symlink — asserting the outside tree is **provably untouched** (canary intact, no new entries). Both were **verified to fail** against the naive implementation before the containment was restored.

Also: runtime-root mapping (`claude` → `.claude/skills`, `codex` → `.agents/skills`, unmapped → no-op), replacement of a prior real copy, malformed-skill skipping, and accept surviving a later `discard`.

Daemon suite **2108 passed**; typecheck, ESLint, Prettier, build clean.

## Reviewer notes

- Two stale tests from #86 asserted the old refusal; they're replaced with the new behavior rather than deleted.
- `memory.ts` is **not** refactored onto the shared helper in this PR — it is shipped, security-critical, and heavily tested, so I left it alone rather than risk regressing it for tidiness. Consolidating it is a reasonable follow-up once this helper has soaked.
- The CP accept/dismiss routes and the console Accept button are still outstanding; this makes them implementable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)