### PR TITLE
test(daemon): synchronize dream backstop cancellation

### DIFF
--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -241,15 +241,20 @@ describe('DreamRunner pipeline', () => {
     // ACP runtime that drops session/cancel. The runner's grace window must still
     // release the reservation so a replacement dream can run.
     let calls = 0
+    let markFirstExtractionReady!: () => void
+    const firstExtractionReady = new Promise<void>((resolve) => {
+      markFirstExtractionReady = resolve
+    })
     const { store, runner } = await setup({
       cancelGraceMs: 20,
       extract: (_a, _s, _p, _signal) => {
         if (calls++ > 0) return Promise.resolve(PROPOSAL)
+        markFirstExtractionReady()
         return new Promise<string>(() => {}) // never resolves, ignores abort
       }
     })
     const first = await runner.start('a1', { trigger: 'manual' })
-    await new Promise((r) => setTimeout(r, 10))
+    await firstExtractionReady
     runner.cancel('a1', first.dreamId)
     const done = await settle(store, first.dreamId)
     expect(done.status).toBe('canceled')


### PR DESCRIPTION
## Summary

- wait for the first dream extraction to enter the ignored-cancel simulation before canceling it
- remove the fixed 10 ms scheduling assumption that could hang the replacement dream under CI load
- keep the production DreamRunner cancellation path unchanged

## Root cause

`runner.start()` performs asynchronous snapshot writes before invoking the extraction callback. Under load, the test could cancel during those writes, leaving the callback's first-call hang for the replacement dream and eventually failing with `dream never settled`.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/dream-runner.test.ts` (49 passed)
- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon test:unit` (2,100 passed)
- `pnpm exec prettier --check packages/daemon/test/dream-runner.test.ts`
- `pnpm exec eslint packages/daemon/test/dream-runner.test.ts`
- pre-push repository lint completed with 0 errors

Created by Codex . GPT-5
