### PR TITLE
feat(agent): private agents' platform ingress is fail-closed

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -790,10 +790,33 @@ editor-configured and keep working regardless of the conversation's state.
 
 ### 14.3 Mechanism
 
-**Enforcement point: the daemon router.** All ingress (direct socket-mode, and
-relay-forwarded shared-bot/http traffic) terminates in the daemon's
-`routeRules` arbitration over the merged rule set. That is the single
-enforcement point; the Console is only a configuration surface.
+**Enforcement points.** The Console is only a configuration surface; where the
+gate executes depends on the transport:
+
+- **Direct (socket) integrations** terminate in the daemon's `routeRules`
+  arbitration over the merged rule set — the scoped-rules mechanism below is the
+  complete gate.
+- **Shared (http) integrations do NOT pass through `routeRules`**: the relay
+  arbitrates from the CP-compiled attributed route table and forwards
+  pre-addressed (`handleRelayIm` dispatches without local routing). The gate is
+  therefore two-layered: (1) **primary — CP route compilation + relay
+  arbitration**: an Off conversation compiles no route, a gated agent is
+  excluded from the unscoped keyword rule and from `defaultAgentId` (the two
+  rungs that make a shared bot fail-open for a bare `@bot` and DMs), the relay's
+  thread-continuity rung honours a binding to a gated agent only while it still
+  has a channel-scoped route in the conversation (`gatedAgentIds` rides
+  `rc/bot-assign`/`rc/routes`), and the CP's `rc/thread-lookup` backstop applies
+  the same check; (2) **backstop — the daemon's `handleRelayIm` admission
+  check**: the shared spec carries the gated install's conversation-scoped
+  bindRules + `gated`, and the last hop refuses (with the one-time notice) any
+  conversation those rules don't cover, so a stale relay route snapshot cannot
+  activate a private agent. The in-Slack config modal (`rc/set-channel-agent`)
+  is reachable by any workspace user, so assigning a channel to a gated agent
+  creates its row **Off** — only a Console editor can enable it.
+
+Control commands (`!stop`, `/status`, …) resolve their target outside
+`routeRules`' scope filter (latest-session fallbacks), so the daemon repeats the
+conversation-admission check in its command authorization.
 
 **Scoped rules instead of unscoped defaults.** Today the CP ships every
 integration `DEFAULT_BIND_RULES` — an **unscoped** `mention` rule and an
@@ -831,10 +854,17 @@ identities.
 **Conversation reporting.** The `integration/channels` D→C EVT and
 `IntegrationChannel` protocol shape gain `kind: 'channel' | 'im'` (absent =
 `'channel'` for wire compatibility). Channel rows keep coming from membership
-events as today. DM rows are reported on first inbound DM to a gated
+events as today; the membership snapshot must never delete `im` rows (they are
+reported incrementally). DM rows are reported on first inbound DM to a gated
 integration, carrying the counterpart's display name; an optional boot-time
 sweep (`conversations.list types=im`) can backfill DMs opened while the daemon
 was down.
+
+_v1 limitation — shared bots:_ the relay's membership snapshot drops IMs and no
+relay-side DM reporting exists yet, so a gated agent behind a **shared** bot has
+no DM rows and thus no DM enablement path — its DMs are simply always off
+(fail-closed). Direct integrations support DM rows fully. Relay-side DM
+reporting is a follow-up.
 
 **Control-plane and web.**
 

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -860,11 +860,18 @@ integration, carrying the counterpart's display name; an optional boot-time
 sweep (`conversations.list types=im`) can backfill DMs opened while the daemon
 was down.
 
-_v1 limitation — shared bots:_ the relay's membership snapshot drops IMs and no
-relay-side DM reporting exists yet, so a gated agent behind a **shared** bot has
-no DM rows and thus no DM enablement path — its DMs are simply always off
-(fail-closed). Direct integrations support DM rows fully. Relay-side DM
-reporting is a follow-up.
+_Shared bots:_ the relay's membership snapshot drops IMs, so DM rows take the
+incremental path there too — an unrouted DM to a bot backing ≥1 gated agent
+makes the relay emit `rc/bot-conversation` (conversation id + best-effort
+`users.info` counterpart name), which the CP fans across the bot's **gated
+installs** as pending Off rows; the relay also posts the one-time
+per-conversation notice (chrome-marked; the unrouted @-mention case included)
+since no daemon is involved before arbitration. Enabling the row compiles a
+conversation-scoped `auto` route plus a conversation-scoped **slug keyword**
+route — arbitration ranks scoped mention → keyword → auto — so a DM enabled
+for several gated agents can be addressed by slug while an unslugged DM falls
+to the first enabled agent. Unscoped keyword remains forbidden for gated
+agents.
 
 **Control-plane and web.**
 

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -3,8 +3,12 @@
 > **Status:** Implemented. The schema, server predicates, Console enforcement,
 > sharing controls, and referenced-resource validation all use the same
 > visibility contract. User-facing labels are **Everyone** and **Selected**.
+> Section 14 (platform conversation gating) is a **proposed** addendum, not yet
+> implemented.
 >
-> **Scope:** control-plane + web. The daemon execution data plane is unaffected.
+> **Scope:** control-plane + web. The daemon execution data plane is unaffected
+> except for §14, which extends restricted visibility to platform ingress via a
+> derived per-conversation gate (protocol + daemon + web).
 >
 > `McpProvider` uses the same `visibility` and `sharedWith` model, including
 > pruning on member removal. Webchat ingress runs through the relay; the
@@ -549,6 +553,13 @@ Visibility is purely a **Console read-model concern**, enforced only on Control
 Plane REST, WebSocket, and SSE read paths. A daemon neither knows nor needs to
 know who can see a resource.
 
+Section 14 introduces one deliberate, **derived-form** exception: for a
+restricted agent the CP assembles different integration bind rules and a
+boolean `gated` flag. The invariant that survives is that **no owner, viewer,
+or `sharedWith` identity ever crosses the wire** — the daemon learns that an
+integration is fail-closed, never who may see the agent — and placement reads
+stay unfiltered exactly as above.
+
 ## 10. Schema Compatibility
 
 The current schema baseline is
@@ -697,3 +708,194 @@ non-creator, non-owner collaborator has `canManageSharing=false`; and
 7. **Drop the entire SSE `/stream` envelope for an invisible agent.** Resolve
    `agentId -> canView` per envelope and send nothing when false. A restricted
    agent remains completely invisible, matching list/get 404 semantics.
+
+## 14. Platform conversation gating (private agents) — proposed
+
+> **Status:** Proposed — product design agreed, implementation not started.
+> Scope: protocol + daemon + control-plane + web. Slack is the driving case;
+> the mechanism is platform-generic (Telegram / Discord / Feishu integrations
+> share the same bind-rule shape).
+
+### 14.1 Problem
+
+The sections above protect a restricted agent in the Console, but the moment it
+gets a platform integration the IM surface is fail-open: **any workspace member
+can invite the bot into any channel, or DM it, and talk to the private agent.**
+
+The platform cannot fix this for us. Slack's app approval governs who may
+_install_ an app, not who may _use_ it; there is no per-user invite ACL. Once
+installed, every member can add the bot to channels they are in and can open a
+DM with it. Native mitigations (private channels, disabling the App Home
+Messages tab) are coarse, app-global, and do not compose with per-agent
+semantics — especially not for a shared (whole-pool) bot serving many agents.
+So authorization must live in AgentConnect's own routing layer.
+
+### 14.2 Product design
+
+**Per-conversation tri-state.** The existing per-channel trigger
+(`mention` | `any`) gains a third state:
+
+| State            | Meaning                                                  |
+| ---------------- | -------------------------------------------------------- |
+| **Off**          | The agent does not activate in this conversation at all. |
+| **Mention**      | Activates on explicit @-mention (today's default).       |
+| **All messages** | Activates on any message (today's `any`).                |
+
+**Gating applies only to restricted agents.**
+
+- **Org-visible agents keep exactly today's behavior.** Unscoped mention
+  default everywhere, DMs open to the whole workspace, per-channel "All
+  messages" opt-in. Nothing changes for them — no new rows, no new UX.
+- **Restricted agents are gated: every conversation defaults to Off.** When
+  the bot is invited to a channel, the channel appears on the integration card
+  in a pending/Off state. An **editor must enable it in the Console**, choosing
+  Mention or All messages. Because the Console is itself protected by this
+  design's predicates, the set of people who can enable a conversation is
+  exactly the private group — the two ACL worlds meet here without any
+  Slack↔AgentConnect identity mapping.
+
+**DMs are conversations too (restricted agents only).** For a gated
+integration, each DM conversation is listed as its own row (platform DM
+conversation id, displayed with the counterpart's name), default **Off**,
+individually enabled by an editor. The integration card groups rows into
+**Channels** and **Direct messages**; DM rows are binary (Off / On — a DM needs
+no mention distinction). Public agents' DMs stay open and produce no rows.
+
+**Behavior of an Off conversation.**
+
+- The bot stays in the channel (no auto-leave) but does not activate: plain
+  messages, keyword/auto triggers, thread follow-ups, and bot-authored
+  activations are all dropped.
+- An **explicitly addressed** message — an @-mention of the bot, or a DM —
+  receives a **one-time per-conversation notice** ("This agent isn't enabled in
+  this conversation. Ask an admin to enable it in the AgentConnect console.")
+  so the bot never appears silently broken, and access pressure is routed to
+  the editors. Subsequent addressed messages in the same conversation are
+  dropped silently.
+- The Console shows a pending indicator on conversations awaiting a decision.
+- Optional (nice-to-have): a "Leave channel" action on a channel row for
+  unwanted invites (`conversations.leave`).
+
+**Trust model — authorize places, not people.** Enabling a channel entrusts
+that channel's **entire current and future membership**. That is a deliberate
+trade-off: the unit of authorization is the conversation, and Slack-native
+membership (especially private channels) governs who is inside it. Per-user
+filtering (the daemon's dormant `allowedUserIds`, or identity mapping that
+would enforce agent visibility directly at ingress) remains a possible future
+overlay — see §14.6.
+
+**Inbound only.** Gating governs **inbound activation** exclusively. Outbound
+deliveries — cron and hook targets posting into a conversation — are already
+editor-configured and keep working regardless of the conversation's state.
+
+### 14.3 Mechanism
+
+**Enforcement point: the daemon router.** All ingress (direct socket-mode, and
+relay-forwarded shared-bot/http traffic) terminates in the daemon's
+`routeRules` arbitration over the merged rule set. That is the single
+enforcement point; the Console is only a configuration surface.
+
+**Scoped rules instead of unscoped defaults.** Today the CP ships every
+integration `DEFAULT_BIND_RULES` — an **unscoped** `mention` rule and an
+**unscoped** `dm` rule — plus one channel-scoped `auto` rule per "All messages"
+channel (`orchestrator/placement.ts`). For a **gated** integration the CP stops
+emitting the unscoped defaults and emits only conversation-scoped rules for
+enabled conversations:
+
+- channel enabled as Mention → `{ channel: C…, match: { kind: 'mention' } }`
+- channel enabled as All → `{ channel: C…, match: { kind: 'auto' } }`
+- DM conversation enabled → `{ channel: D…, match: { kind: 'dm' } }`
+
+An unknown conversation then matches **no rule**, so nothing routes — the
+fail-closed default (including the window between the bot joining a channel and
+the membership report landing) falls out of the existing scope matching in
+`router/routing-table.ts` with zero new enforcement machinery. Thread affinity
+is already scope-filtered (`scopeCandidates`), so follow-ups in an Off
+conversation are blocked by the same mechanism. Non-gated integrations keep
+`DEFAULT_BIND_RULES` verbatim.
+
+_Implementation check:_ confirm the daemon's normalized DM messages carry the
+platform DM conversation id as `msg.channel` on every platform, so a
+channel-scoped `dm` rule matches. (True for Slack `D…` ids; verify Telegram /
+Discord / Feishu DM id shape when extending.)
+
+**Spec flag: `gated`.** `IntegrationSpec` gains a boolean (working name
+`gated`) so the daemon knows this integration is fail-closed. The daemon needs
+it for the two behaviors a rule miss cannot express: (1) send the one-time
+notice when an explicitly addressed message matches no rule; (2) report a
+previously unseen DM conversation so its row appears in the Console's pending
+list. Without the flag (public agents) daemon behavior is byte-for-byte
+unchanged. This is the §9 derived-form exception: the flag carries no
+identities.
+
+**Conversation reporting.** The `integration/channels` D→C EVT and
+`IntegrationChannel` protocol shape gain `kind: 'channel' | 'im'` (absent =
+`'channel'` for wire compatibility). Channel rows keep coming from membership
+events as today. DM rows are reported on first inbound DM to a gated
+integration, carrying the counterpart's display name; an optional boot-time
+sweep (`conversations.list types=im`) can backfill DMs opened while the daemon
+was down.
+
+**Control-plane and web.**
+
+- `IntegrationChannel` (table `integration_channel`): `ChannelTrigger` enum
+  gains `off`; new `kind` column (`channel` | `im`). Row creation from the
+  membership report derives the default trigger from gating: `off` when gated,
+  `mention` otherwise (today's default).
+- The existing per-channel trigger PATCH route accepts `off` and reuses the
+  existing recompute-bindRules-and-push flow. Authorization is unchanged — the
+  route already requires edit rights on the agent, which for a restricted agent
+  means the private group.
+- `gated` is **derived** from `agent.visibility === 'restricted'` at spec
+  assembly; there is no separate stored toggle (see §14.7).
+- Web `IntegrationChannelList`: tri-state segmented control per channel row
+  (Off / Mention / All messages), a Direct-messages section with binary rows,
+  pending badges, and a banner on restricted agents' integration cards
+  explaining the gate.
+
+### 14.4 Visibility transitions
+
+- **org → restricted:** gating turns on. Existing known channel rows keep
+  their current trigger (grandfathered enabled) so running setups are not cut
+  mid-conversation; a Console banner prompts the editor to review them. DM
+  conversations start Off — rows appear as counterparts next write, each
+  receiving the one-time notice.
+- **restricted → org:** gating turns off; unscoped defaults return. Rows and
+  their trigger values persist inert (an `off` row on a non-gated integration
+  is ignored) so flipping back restores the previous decisions — the same
+  preservation principle as Decision 4.
+
+### 14.5 Rollout / migration
+
+Existing integrations already attached to restricted agents follow the same
+grandfathering as the org → restricted transition: known channels keep their
+triggers, DMs close. Closing DMs is the one behavior break for incumbent DM
+users; the one-time notice tells them what happened and the pending row gives
+editors a one-click re-enable. (The strict alternative — everything Off on
+migration — was considered and rejected as needlessly disruptive to channels
+that editors demonstrably already configured.)
+
+### 14.6 Out of scope / future overlays
+
+- **Per-user allowlists.** The daemon already enforces
+  `Integration.<platform>.allowedUserIds` end-to-end (routing filter +
+  control-command authz); the CP simply always sends `[]`. Wiring CP storage +
+  UI to it is a natural finer-grained overlay on top of conversation gating.
+- **Identity mapping.** Resolving platform senders to AgentConnect users
+  (e.g. Slack `users.info` email ↔ OIDC email, with a manual link fallback)
+  would let ingress enforce agent visibility itself, making "private" mean the
+  same set of people on every surface. Conversation gating neither depends on
+  nor conflicts with this.
+- **Auto-leave policy** (bot automatically leaves channels it is not enabled
+  in), **user-group-based grants**, and webchat/GitHub surfaces (already gated
+  by Console auth / repo authorization respectively).
+
+### 14.7 Open questions
+
+1. Does `gated` need a per-integration override (e.g. force-gate a public
+   agent's integration), or is derivation from visibility enough for v1?
+   Current call: derivation only.
+2. Exact notice copy and whether the notice deduplication window should reset
+   (e.g. after 24 h) or be strictly once per conversation per daemon lifetime.
+3. Whether the DM boot-sweep ships in v1 or first-message reporting alone is
+   enough.

--- a/packages/control-plane/prisma/migrations/20260726120000_conversation_gating/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260726120000_conversation_gating/migration.sql
@@ -1,0 +1,10 @@
+-- Conversation gating (resource-visibility.md §14): the per-conversation trigger
+-- gains an 'off' state, and integration_channel rows learn their conversation kind
+-- (member channel vs DM). PG 12+ allows ADD VALUE inside a transaction as long as
+-- the new value is not used in the same transaction (we only add it here).
+ALTER TYPE "ChannelTrigger" ADD VALUE IF NOT EXISTS 'off' BEFORE 'mention';
+
+CREATE TYPE "ConversationKind" AS ENUM ('channel', 'im');
+
+ALTER TABLE "integration_channel"
+  ADD COLUMN "kind" "ConversationKind" NOT NULL DEFAULT 'channel';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1383,21 +1383,33 @@ model Integration {
   @@map("integration")
 }
 
-// How the bot activates in one channel: only when @-mentioned, or on any message.
+// How the bot activates in one conversation: not at all (conversation gating,
+// resource-visibility.md §14), only when @-mentioned, or on any message.
 enum ChannelTrigger {
+  off
   mention
   any
 }
 
-// One channel the integration's bot is a member of (daemon-reported snapshot via
-// `integration/channels`, latest-wins) + the operator's per-channel trigger choice.
-// Channel id/name are control metadata — never message content (§1/§12).
+// Conversation kind (resource-visibility.md §14.3): a member channel vs a DM
+// conversation. DM rows exist only for gated (restricted-agent) integrations.
+enum ConversationKind {
+  channel
+  im
+}
+
+// One conversation the integration's bot participates in (daemon-reported snapshot
+// via `integration/channels`, latest-wins for kind=channel; DM rows are reported on
+// first inbound DM and never dropped by the membership snapshot) + the operator's
+// per-conversation trigger choice. Channel id/name are control metadata — never
+// message content (§1/§12).
 model IntegrationChannel {
-  integrationId String         @db.Uuid
-  channelId     String // platform channel id (Slack "C…")
-  name          String? // "#deploys" without the hash; null if lookup failed
-  isPrivate     Boolean        @default(false)
-  trigger       ChannelTrigger @default(mention)
+  integrationId String           @db.Uuid
+  channelId     String // platform conversation id (Slack "C…" / DM "D…")
+  name          String? // "#deploys" without the hash (or DM counterpart); null if lookup failed
+  isPrivate     Boolean          @default(false)
+  kind          ConversationKind @default(channel)
+  trigger       ChannelTrigger   @default(mention)
   // Per-channel default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
   // channel ownership — the primary disambiguation path). When set, the relay
   // routes this channel's traffic to this agent (and forwards to its daemon).

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1001,6 +1001,15 @@ export function buildContainer(
         http.log.error({ err, botId: m.botId }, 'relay: bot-channels snapshot failed')
       }
     },
+    // Incremental DM-conversation report (§14.3): surface a kind:'im' row (Off) on
+    // the bot's gated installs so console editors can enable the DM. Swallow+log.
+    onBotConversation: async (m) => {
+      try {
+        await sharedBot.reportConversation(m.botId, m.conversation)
+      } catch (err) {
+        http.log.error({ err, botId: m.botId }, 'relay: bot-conversation report failed')
+      }
+    },
     // Durable thread-affinity REPORT leg — persist + broadcast (rc/assign). Swallow+log:
     // a store error must not close the shared relay link.
     onThreadAssign: async (m) => {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -671,12 +671,16 @@ export const CreateIntegrationBody = z
     }
   })
 
-/** One channel the integration's bot is in + how it activates there. */
+/** One conversation the integration's bot is in + how it activates there.
+ *  `off` = conversation gating (resource-visibility.md §14): the agent does not
+ *  activate there — the default for every conversation of a restricted agent.
+ *  `kind: 'im'` rows are DM conversations (gated integrations only). */
 export const IntegrationChannelDto = z.object({
   channelId: z.string(),
-  name: z.string().nullable(), // "#deploys" without the hash; null if lookup failed
+  name: z.string().nullable(), // "#deploys" without the hash (or DM counterpart); null if lookup failed
   isPrivate: z.boolean(),
-  trigger: z.enum(['mention', 'any']),
+  kind: z.enum(['channel', 'im']),
+  trigger: z.enum(['off', 'mention', 'any']),
   /** Per-channel default/owning agent for a shared bot (§10.1); null ⇒ unset. */
   agentId: z.string().nullable()
 })
@@ -1111,11 +1115,12 @@ export const SlackAppFinalizeBody = z.object({
   shareable: z.boolean().optional() // http multi-agent opt-in; coerced off for socket
 })
 
-/** `PATCH /integrations/:id/channels/:channelId` — per-channel trigger and/or the
- *  shared-bot default agent. At least one field; `agentId:null` clears the owner. */
+/** `PATCH /integrations/:id/channels/:channelId` — per-conversation trigger
+ *  ('off' disables the conversation, §14) and/or the shared-bot default agent.
+ *  At least one field; `agentId:null` clears the owner. */
 export const UpdateIntegrationChannelBody = z
   .object({
-    trigger: z.enum(['mention', 'any']).optional(),
+    trigger: z.enum(['off', 'mention', 'any']).optional(),
     agentId: z.string().min(1).nullable().optional()
   })
   .refine((b) => b.trigger !== undefined || b.agentId !== undefined, {

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -15,7 +15,7 @@ import { randomUUID } from 'node:crypto'
 import type { HttpDeps } from './deps.js'
 import type { AgentRecord, IntegrationRecord, SlackTransport } from '../persistence/ports.js'
 import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
-import { integrationToSpec } from '../orchestrator/placement.js'
+import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
 import { NoConnection } from '../orchestrator/outbound.js'
 
 /** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. The id segment
@@ -119,7 +119,10 @@ export async function installNewSlackBot(
   ])
   if (secret) {
     try {
-      await deps.control.integrationUpsert(daemonId, integrationToSpec(integration, secret, channels))
+      await deps.control.integrationUpsert(
+        daemonId,
+        integrationToSpec(integration, secret, channels, isGatedAgent(agent))
+      )
     } catch (err) {
       if (!(err instanceof NoConnection)) throw err
       log.debug({ integrationId: id, daemonId }, 'integration/upsert skipped: daemon offline')

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -345,13 +345,13 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: 'setChannelTrigger',
     description:
-      'Change how an integration behaves in one channel: the trigger mode (mention-only vs any message) and/or the channel’s owning agent (null clears the per-channel override).',
+      'Change how an integration behaves in one conversation: the trigger mode (off / mention-only / any message; off disables the conversation) and/or the channel’s owning agent (null clears the per-channel override).',
     write: true,
     schema: z
       .object({
         integrationId: z.string().min(1).describe('The integration id (from listIntegrations)'),
         channelId: z.string().min(1).describe('The platform channel id (from listIntegrations channels)'),
-        trigger: z.enum(['mention', 'any']).optional(),
+        trigger: z.enum(['off', 'mention', 'any']).optional(),
         agentId: z
           .string()
           .min(1)

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -42,6 +42,7 @@ import { resolveShareSet } from '../sharing.js'
 import { resolveAgentIconUrl, type IconUrlBases } from '../../agents/agent-icon.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { AgentMoveConflict, AgentMoveFailed, AgentMoveService } from '../../orchestrator/agentMove.js'
+import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
 import { ProtocolError } from '../../domain/errors.js'
 import { AGENT_WORKSPACE_INTEGRATION_CONFLICT_MESSAGE } from '../../persistence/errors.js'
 import {
@@ -1672,8 +1673,11 @@ export function agentRoutes(deps: HttpDeps) {
 
     // Set who can see this agent (visibility + share set). Gated exactly like a
     // content edit (canManageSharing === canEdit, §13.3): viewers can't, and a
-    // collaborator who can't even view a restricted agent 404s. Visibility never
-    // rides the wire, so there's nothing to replicate to the daemon.
+    // collaborator who can't even view a restricted agent 404s. Identities never
+    // ride the wire, but the DERIVED conversation-gating flag does (§14/§9): a
+    // visibility flip re-converges every integration of the agent — direct installs
+    // get a fresh spec push, shared bots a route recompile — best-effort, with the
+    // reconcile roster as the durable backstop.
     r.put(
       '/agents/:id/sharing',
       {
@@ -1713,6 +1717,9 @@ export function agentRoutes(deps: HttpDeps) {
             { visibility: req.body.visibility, sharedWith },
             req.principal?.userId
           )
+          if (agent.visibility !== existing.visibility) {
+            await convergeIntegrationGating(deps, agent, req.log)
+          }
           return toDto(
             agent,
             ctxOf(req),

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -25,7 +25,7 @@ import type { AgentRecord, IntegrationRecord, IntegrationChannelRecord } from '.
 import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit } from '../visibility.js'
-import { integrationToSpec } from '../../orchestrator/placement.js'
+import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { discordAppIdFromBotToken } from '../discord-identity.js'
@@ -43,7 +43,14 @@ import {
 } from '../dto/index.js'
 
 function toChannelDto(c: IntegrationChannelRecord): IntegrationChannelDtoT {
-  return { channelId: c.channelId, name: c.name, isPrivate: c.isPrivate, trigger: c.trigger, agentId: c.agentId }
+  return {
+    channelId: c.channelId,
+    name: c.name,
+    isPrivate: c.isPrivate,
+    kind: c.kind,
+    trigger: c.trigger,
+    agentId: c.agentId
+  }
 }
 
 function toDto(i: IntegrationRecord, channels: IntegrationChannelRecord[] = []): IntegrationDtoT {
@@ -81,13 +88,17 @@ export function integrationRoutes(deps: HttpDeps) {
     // daemon. Best-effort: if the daemon is offline the reconcile roster carries it
     // on the next connect. Token-bearing — never log the spec.
     const replicateUpsert = async (i: IntegrationRecord, daemonId: string): Promise<void> => {
-      const [secret, channels] = await Promise.all([
+      const [secret, channels, owner] = await Promise.all([
         deps.repos.botSecret.get(i.botId),
-        deps.repos.integrationChannel.listForIntegration(i.id)
+        deps.repos.integrationChannel.listForIntegration(i.id),
+        deps.repos.agent.get(i.agentId)
       ])
       if (!secret) return
       try {
-        await deps.control.integrationUpsert(daemonId, integrationToSpec(i, secret, channels))
+        await deps.control.integrationUpsert(
+          daemonId,
+          integrationToSpec(i, secret, channels, owner ? isGatedAgent(owner) : false)
+        )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
         app.log.debug({ integrationId: i.id, daemonId }, 'integration/upsert skipped: daemon offline')

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -33,7 +33,7 @@ import type {
 } from '../persistence/ports.js'
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
-import { cronToUpsert, integrationToSpec, sharedIntegrationToSpec } from './placement.js'
+import { cronToUpsert, integrationToSpec, isGatedAgent, sharedIntegrationToSpec } from './placement.js'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { ControlSender } from './outbound.js'
 import type { HookService } from '../hooks/hook.service.js'
@@ -549,12 +549,13 @@ export class AgentMoveService {
         if (!bot) throw new AgentMoveConflict(`integration ${integration.id} has no bot`)
         if (!secret) throw new AgentMoveConflict(`integration ${integration.id} has no credentials`)
         const isHttp = bot.transport === 'http'
+        const gated = isGatedAgent(agent)
         return {
           botId: String(bot.id),
           shared: isHttp,
           spec: isHttp
-            ? sharedIntegrationToSpec(integration, secret, bot.shareable)
-            : integrationToSpec(integration, secret, channels)
+            ? sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated)
+            : integrationToSpec(integration, secret, channels, gated)
         }
       })
     )

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration-gating convergence (resource-visibility.md §14.4): when an agent's
+ * visibility flips, its derived conversation-gating flag changes, so every
+ * integration of the agent must be re-converged — a shared (http) bot recompiles
+ * its relay routes + re-pushes shared specs (`syncBot` covers both), a direct
+ * install gets a fresh token-bearing spec push. Best-effort per integration: a
+ * missed push self-heals from the reconcile roster on the daemon's next connect.
+ */
+import type {
+  AgentRecord,
+  BotRepo,
+  BotSecretStore,
+  IntegrationChannelRepo,
+  IntegrationRepo
+} from '../persistence/ports.js'
+import { NoConnection, type ControlSender } from './outbound.js'
+import { integrationToSpec, isGatedAgent } from './placement.js'
+import { AgentId } from '../domain/ids.js'
+
+export interface GatingPushDeps {
+  repos: {
+    integration: IntegrationRepo
+    bot: BotRepo
+    botSecret: BotSecretStore
+    integrationChannel: IntegrationChannelRepo
+  }
+  control: ControlSender
+  sharedBot: { syncBot(botId: string): Promise<void> }
+}
+
+export async function convergeIntegrationGating(
+  deps: GatingPushDeps,
+  agent: AgentRecord,
+  log?: { warn(obj: unknown, msg?: string): void }
+): Promise<void> {
+  const integrations = await deps.repos.integration.listForAgent(AgentId(agent.id))
+  const syncedBots = new Set<string>()
+  for (const i of integrations) {
+    try {
+      const bot = await deps.repos.bot.get(i.botId)
+      if (bot?.transport === 'http') {
+        if (!syncedBots.has(String(bot.id))) {
+          syncedBots.add(String(bot.id))
+          await deps.sharedBot.syncBot(String(bot.id))
+        }
+        continue
+      }
+      if (!agent.daemonId) continue
+      const [secret, channels] = await Promise.all([
+        deps.repos.botSecret.get(i.botId),
+        deps.repos.integrationChannel.listForIntegration(i.id)
+      ])
+      if (!secret) continue
+      await deps.control.integrationUpsert(agent.daemonId, integrationToSpec(i, secret, channels, isGatedAgent(agent)))
+    } catch (err) {
+      if (err instanceof NoConnection) continue // offline daemon → reconcile roster carries it
+      log?.warn({ integrationId: i.id, err: (err as Error).message }, 'gating converge: integration push failed')
+    }
+  }
+}

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -22,12 +22,18 @@ const INTEGRATION: IntegrationRecord = {
 }
 const SECRET = { botToken: 'xoxb-abc', appToken: 'xapp-def' }
 
-const channel = (channelId: string, trigger: 'mention' | 'any'): IntegrationChannelRecord => ({
+const channel = (
+  channelId: string,
+  trigger: 'off' | 'mention' | 'any',
+  kind: 'channel' | 'im' = 'channel'
+): IntegrationChannelRecord => ({
   integrationId: INTEGRATION.id,
   channelId,
   name: channelId.toLowerCase(),
   isPrivate: false,
-  trigger
+  kind,
+  trigger,
+  agentId: null
 })
 
 describe('integrationToSpec bindRules', () => {
@@ -63,6 +69,39 @@ describe('integrationToSpec bindRules', () => {
       { match: { kind: 'dm' } },
       { channel: '-100', match: { kind: 'auto' } }
     ])
+  })
+})
+
+describe('integrationToSpec conversation gating (§14)', () => {
+  it('gated: emits ONLY conversation-scoped rules — no unscoped defaults', () => {
+    const spec = integrationToSpec(
+      INTEGRATION,
+      SECRET,
+      [channel('C1', 'mention'), channel('C2', 'any'), channel('C3', 'off'), channel('D1', 'any', 'im')],
+      true
+    )
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.gated).toBe(true)
+    expect(spec.slack.bindRules).toEqual([
+      { channel: 'C1', match: { kind: 'mention' } },
+      { channel: 'C2', match: { kind: 'auto' } },
+      { channel: 'D1', match: { kind: 'dm' } }
+    ])
+  })
+
+  it('gated with no enabled conversations ships an EMPTY rule set (fail-closed)', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'off', 'im')], true)
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.bindRules).toEqual([])
+    expect(spec.slack.gated).toBe(true)
+  })
+
+  it("non-gated: 'off' rows stay inert (defaults unchanged) and gated is false", () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'any', 'im')])
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.gated).toBe(false)
+    // The im row adds no auto rule either — DMs are covered by the unscoped dm default.
+    expect(spec.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 })
 

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -39,6 +39,7 @@ import type {
 import { RESERVED_MCP_SERVER_NAME } from '@agentconnect.md/protocol'
 import type {
   AgentRepo,
+  AgentRecord,
   AssignmentRepo,
   AssignmentRecord,
   CronRepo,
@@ -171,6 +172,29 @@ function leaseToGrant(l: LeaseRecord): SecretsGrant {
  */
 const DEFAULT_BIND_RULES: IntegrationBindRule[] = [{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }]
 
+/** Conversation gating (resource-visibility.md §14): derived from restricted
+ *  visibility at spec-assembly time — no stored toggle, no identities on the wire. */
+export const isGatedAgent = (a: { visibility: AgentRecord['visibility'] }): boolean => a.visibility === 'restricted'
+
+/**
+ * Conversation-scoped bind rules for a GATED integration (resource-visibility.md
+ * §14.3): only explicitly enabled conversations produce rules — a Mention channel
+ * gets a channel-scoped mention rule, an "All messages" channel a channel-scoped
+ * auto rule, an enabled DM conversation a conversation-scoped dm rule. An
+ * unknown/Off conversation matches no rule, so nothing routes (fail-closed,
+ * including the window before a fresh channel is reported).
+ */
+function gatedBindRules(channels: IntegrationChannelRecord[]): IntegrationBindRule[] {
+  const out: IntegrationBindRule[] = []
+  for (const c of channels) {
+    if (c.trigger === 'off') continue
+    if (c.kind === 'im') out.push({ channel: c.channelId, match: { kind: 'dm' } })
+    else if (c.trigger === 'any') out.push({ channel: c.channelId, match: { kind: 'auto' } })
+    else out.push({ channel: c.channelId, match: { kind: 'mention' } })
+  }
+  return out
+}
+
 /**
  * Assemble the wire {@link IntegrationSpec} the daemon opens its socket from —
  * metadata from the `integration` row + tokens from the {@link BotSecretStore}
@@ -178,25 +202,28 @@ const DEFAULT_BIND_RULES: IntegrationBindRule[] = [{ match: { kind: 'mention' } 
  * `bindRules`. Shared by the reconcile roster (`register/ok.integrations`) and
  * the live `integration/upsert` REST emit. Token-bearing: NEVER log the result.
  *
- * bindRules = the defaults (@-mention anywhere + DMs) ∪ one channel-scoped `auto`
- * rule per channel the operator switched to "any message". A 'mention' channel
- * needs no extra rule — the unscoped mention default already covers it.
+ * Non-gated: bindRules = the defaults (@-mention anywhere + DMs) ∪ one
+ * channel-scoped `auto` rule per channel the operator switched to "any message".
+ * A 'mention' channel needs no extra rule — the unscoped mention default already
+ * covers it. Gated (`gated`, derived from the owning agent's restricted
+ * visibility): NO unscoped defaults — only {@link gatedBindRules}.
  */
 export function integrationToSpec(
   i: IntegrationRecord,
   secret: BotSecretMaterial,
-  channels: IntegrationChannelRecord[] = []
+  channels: IntegrationChannelRecord[] = [],
+  gated = false
 ): IntegrationSpec {
   const channelRules: IntegrationBindRule[] = channels
-    .filter((c) => c.trigger === 'any')
+    .filter((c) => c.trigger === 'any' && c.kind !== 'im')
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
-  const bindRules = [...DEFAULT_BIND_RULES, ...channelRules]
+  const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
   if (i.platform === 'telegram') {
     return {
       integrationId: i.id,
       agentId: i.agentId,
       platform: 'telegram',
-      telegram: { botToken: secret.botToken, allowedUserIds: [], bindRules }
+      telegram: { botToken: secret.botToken, allowedUserIds: [], bindRules, gated }
     }
   }
   if (i.platform === 'discord') {
@@ -205,7 +232,7 @@ export function integrationToSpec(
       agentId: i.agentId,
       platform: 'discord',
       // Discord authenticates the Gateway with the single bot token (no appToken).
-      discord: { botToken: secret.botToken, allowedUserIds: [], bindRules }
+      discord: { botToken: secret.botToken, allowedUserIds: [], bindRules, gated }
     }
   }
   if (i.platform === 'feishu') {
@@ -221,7 +248,8 @@ export function integrationToSpec(
         appSecret: secret.botToken,
         region: i.feishuRegion ?? 'feishu',
         allowedUserIds: [],
-        bindRules
+        bindRules,
+        gated
       }
     }
   }
@@ -240,7 +268,8 @@ export function integrationToSpec(
       botToken: secret.botToken,
       appToken: secret.appToken ?? '',
       allowedUserIds: [],
-      bindRules
+      bindRules,
+      gated
     }
   }
 }
@@ -251,11 +280,19 @@ export function integrationToSpec(
  * appToken (the relay owns the event stream) and no bindRules (the relay
  * arbitrates inbound and delivers it pre-addressed). Slack-only for now; a
  * shareable Telegram/Discord bot lands in milestone C. Token-bearing — NEVER log.
+ *
+ * GATED exception (resource-visibility.md §14.3): a restricted agent's install
+ * ships its conversation-scoped rules + `gated: true` even in shared mode — the
+ * relay is still the arbiter, but the daemon uses these for its last-hop
+ * admission backstop in `handleRelayIm` (it must not trust a stale relay route
+ * snapshot to keep a private agent fail-closed).
  */
 export function sharedIntegrationToSpec(
   i: IntegrationRecord,
   secret: BotSecretMaterial,
-  shareable: boolean
+  shareable: boolean,
+  channels: IntegrationChannelRecord[] = [],
+  gated = false
 ): IntegrationSpec {
   return {
     integrationId: i.id,
@@ -264,7 +301,14 @@ export function sharedIntegrationToSpec(
     // `shareable` gates the daemon's in-thread "Switch agent" control: a shared bot
     // routes through the relay either way, but only a multi-agent (shareable) bot has
     // something to switch to.
-    slack: { mode: 'shared', shareable, botToken: secret.botToken, allowedUserIds: [], bindRules: [] }
+    slack: {
+      mode: 'shared',
+      shareable,
+      botToken: secret.botToken,
+      allowedUserIds: [],
+      bindRules: gated ? gatedBindRules(channels) : [],
+      gated
+    }
   }
 }
 
@@ -317,6 +361,10 @@ export class Placement implements ReconcileService {
     ])
 
     const quarantinedAgentIds = new Set<string>()
+    // Conversation gating (§14): derived per-agent from restricted visibility. This
+    // is a data-plane read of the DERIVED boolean only — identities never ride the
+    // wire, and the roster itself stays unfiltered (§9 graceful degradation).
+    const gatedAgentIds = new Set(ownedAgents.filter((a) => a.visibility === 'restricted').map((a) => a.id))
     const [desiredAgents, assembledIntegrations] = await Promise.all([
       this.specs.assembleAll(ownedAgents, (agent) => {
         quarantinedAgentIds.add(agent.id)
@@ -332,9 +380,10 @@ export class Placement implements ReconcileService {
           if (!secret) return null
           // An http-transport bot's ingest is on the relay pool — the daemon
           // reconciles it send-only (no Socket Mode). Socket bots reconcile as direct.
+          const gated = gatedAgentIds.has(i.agentId)
           return bot?.transport === 'http'
-            ? sharedIntegrationToSpec(i, secret, bot.shareable)
-            : integrationToSpec(i, secret, channels)
+            ? sharedIntegrationToSpec(i, secret, bot.shareable, channels, gated)
+            : integrationToSpec(i, secret, channels, gated)
         })
       )
     ])

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -126,7 +126,10 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       listForBot: async () => []
     }
     const intRepo: Pick<IntegrationRepo, 'listForBot'> = { listForBot: async () => integrations }
-    const chRepo: Pick<IntegrationChannelRepo, 'listForBot' | 'replaceSnapshot' | 'setAgent' | 'upsertAgent'> = {
+    const chRepo: Pick<
+      IntegrationChannelRepo,
+      'listForBot' | 'replaceSnapshot' | 'setAgent' | 'upsertAgent' | 'upsertConversation'
+    > = {
       listForBot: async () => channels,
       replaceSnapshot: async (integrationId, reported, opts) => {
         channels = channels.filter(
@@ -146,6 +149,21 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
         const row = channels.find((c) => c.integrationId === integrationId && c.channelId === channelId)
         if (!row) return null
         row.agentId = agentId
+        return row
+      },
+      upsertConversation: async (integrationId, conversation, opts) => {
+        let row = channels.find((c) => c.integrationId === integrationId && c.channelId === conversation.id)
+        if (!row) {
+          row = channel({
+            integrationId,
+            channelId: conversation.id,
+            name: conversation.name ?? null,
+            kind: conversation.kind ?? 'channel',
+            trigger: opts?.defaultTrigger ?? 'mention',
+            agentId: opts?.agentId ?? null
+          })
+          channels.push(row)
+        } else if (conversation.name) row.name = conversation.name
         return row
       },
       upsertAgent: async (integrationId, channelId, agentId, opts) => {
@@ -327,6 +345,36 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'C7')
       expect(aliceRow?.trigger).toBe('off')
       expect(bobRow?.trigger).toBe('mention')
+    })
+
+    it('reportConversation fans a kind:im row (Off, agent-owned) to GATED installs only, idempotently', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      const orch = makeOrch()
+      await orch.reportConversation(BOT, { id: 'D42', name: '@Alice' })
+      const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'D42')
+      expect(aliceRow).toMatchObject({ kind: 'im', trigger: 'off', agentId: ALICE, name: '@Alice' })
+      // BOB is org-visible — his DMs already route via defaultAgentId; no row.
+      expect(channels.some((c) => c.integrationId === INT_B && c.channelId === 'D42')).toBe(false)
+
+      // Editor enables it; a re-report must keep the trigger (name refresh only).
+      aliceRow!.trigger = 'any'
+      await orch.reportConversation(BOT, { id: 'D42', name: '@Alice Smith' })
+      expect(aliceRow).toMatchObject({ trigger: 'any', name: '@Alice Smith' })
+    })
+
+    it('an enabled gated DM row compiles a scoped auto route PLUS a scoped slug keyword (§14.3)', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      const d42 = assign.routes.filter((r) => r.scope?.channel === 'D42')
+      expect(d42).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } }),
+          expect.objectContaining({ agentId: ALICE, match: { kind: 'keyword', value: 'alice' } })
+        ])
+      )
     })
 
     it('lookupThread refuses a binding to a gated agent whose conversation is off', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -291,11 +291,21 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   })
 
   describe('conversation gating (resource-visibility §14)', () => {
-    it("an 'off' channel compiles no route (fail-closed until an editor enables it)", async () => {
+    it("a GATED owner's 'off' channel compiles no route (fail-closed until an editor enables it)", async () => {
+      gatedAgents = new Set([ALICE])
       channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
+    })
+
+    it("a NON-gated owner's preserved 'off' row is inert: ownership stays as a mention route (§14.4)", async () => {
+      channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })
+      ])
     })
 
     it('a gated member loses its keyword rung, never becomes the default, and rides gatedAgentIds', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -83,6 +83,7 @@ function channel(over: Partial<IntegrationChannelRecord>): IntegrationChannelRec
     channelId: 'C1',
     name: '#deploys',
     isPrivate: false,
+    kind: 'channel',
     trigger: 'mention',
     agentId: null,
     ...over
@@ -99,6 +100,10 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   // Drives the SessionRepo.findThreadOwner fallback in lookupThread (null = no daemon session).
   let threadOwner: { agentId: string; daemonId: string } | null
   let threadOwnerLookup: { botId: BotId; channel: string; thread: string } | null
+  // §14: agents whose AgentRepo.get returns visibility 'restricted' (⇒ gated).
+  let gatedAgents: Set<string>
+  // Drives ThreadAffinityStore.get (null = affinity miss → SessionMeta fallback).
+  let threadBinding: { agentId: AgentId; daemonId: string } | null
 
   function makeOrch(): SharedBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
@@ -114,20 +119,23 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     }
     const threads: ThreadAffinityStore = {
       upsert: async () => {},
-      get: async () => null,
+      get: async () =>
+        threadBinding
+          ? ({ sessionKey: '', ...threadBinding } as Awaited<ReturnType<ThreadAffinityStore['get']>>)
+          : null,
       listForBot: async () => []
     }
     const intRepo: Pick<IntegrationRepo, 'listForBot'> = { listForBot: async () => integrations }
     const chRepo: Pick<IntegrationChannelRepo, 'listForBot' | 'replaceSnapshot' | 'setAgent' | 'upsertAgent'> = {
       listForBot: async () => channels,
-      replaceSnapshot: async (integrationId, reported) => {
+      replaceSnapshot: async (integrationId, reported, opts) => {
         channels = channels.filter(
           (row) => row.integrationId !== integrationId || reported.some((candidate) => candidate.id === row.channelId)
         )
         for (const candidate of reported) {
           let row = channels.find((item) => item.integrationId === integrationId && item.channelId === candidate.id)
           if (!row) {
-            row = channel({ integrationId, channelId: candidate.id })
+            row = channel({ integrationId, channelId: candidate.id, trigger: opts?.defaultTrigger ?? 'mention' })
             channels.push(row)
           }
           row.name = candidate.name ?? null
@@ -140,16 +148,22 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
         row.agentId = agentId
         return row
       },
-      upsertAgent: async (integrationId, channelId, agentId) => {
+      upsertAgent: async (integrationId, channelId, agentId, opts) => {
         let row = channels.find((c) => c.integrationId === integrationId && c.channelId === channelId)
         if (!row) {
-          row = channel({ integrationId, channelId, agentId })
+          row = channel({ integrationId, channelId, agentId, trigger: opts?.defaultTrigger ?? 'mention' })
           channels.push(row)
         } else row.agentId = agentId
         return row
       }
     }
-    const agentRepo: Pick<AgentRepo, 'get'> = { get: async (id) => agents[id] ?? null }
+    const agentRepo: Pick<AgentRepo, 'get'> = {
+      get: async (id) => {
+        const a = agents[id]
+        if (!a) return null
+        return { ...a, visibility: gatedAgents.has(id) ? 'restricted' : 'org' } as AgentRecord
+      }
+    }
     const control = {
       integrationUpsert: async (daemonId: string, spec: unknown) => void upserts.push({ daemonId, spec: spec as never })
     }
@@ -183,6 +197,8 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     upserts = []
     threadOwner = null
     threadOwnerLookup = null
+    gatedAgents = new Set()
+    threadBinding = null
   })
 
   describe('lookupThread — SessionMeta fallback on affinity miss (§7.2 case 2a)', () => {
@@ -254,6 +270,80 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     await makeOrch().syncBot(BOT)
     const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
     expect(assign.routes[0]).toMatchObject({ agentId: ALICE, scope: { channel: 'C9' }, match: { kind: 'auto' } })
+  })
+
+  describe('conversation gating (resource-visibility §14)', () => {
+    it("an 'off' channel compiles no route (fail-closed until an editor enables it)", async () => {
+      channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
+    })
+
+    it('a gated member loses its keyword rung, never becomes the default, and rides gatedAgentIds', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.some((r) => r.match.kind === 'keyword' && r.agentId === ALICE)).toBe(false)
+      expect(assign.routes.some((r) => r.match.kind === 'keyword' && r.agentId === BOB)).toBe(true)
+      // ALICE's install is the earliest, but a gated agent must not catch bare @bot/DMs.
+      expect(assign.defaultAgentId).toBe(BOB)
+      expect(assign.gatedAgentIds).toEqual([ALICE])
+    })
+
+    it('a group of only gated agents has NO default agent', async () => {
+      gatedAgents = new Set([ALICE, BOB])
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.defaultAgentId).toBeUndefined()
+      expect(assign.gatedAgentIds).toEqual([ALICE, BOB])
+    })
+
+    it("a gated install's shared spec carries its scoped bindRules + gated for the daemon backstop", async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [
+        channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'mention' }),
+        channel({ integrationId: INT_A, channelId: 'C0', agentId: ALICE, trigger: 'off' })
+      ]
+      await makeOrch().syncBot(BOT)
+      const alice = upserts.find((u) => u.daemonId === D1)!.spec as never as {
+        slack: { gated: boolean; bindRules: unknown[] }
+      }
+      expect(alice.slack.gated).toBe(true)
+      expect(alice.slack.bindRules).toEqual([{ channel: 'C9', match: { kind: 'mention' } }])
+      const bob = upserts.find((u) => u.daemonId === D2)!.spec as never as {
+        slack: { gated: boolean; bindRules: unknown[] }
+      }
+      expect(bob.slack.gated).toBe(false)
+      expect(bob.slack.bindRules).toEqual([])
+    })
+
+    it("replaceChannels defaults a gated install's fresh channels to off (others to mention)", async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      await makeOrch().replaceChannels(BOT, [{ id: 'C7', name: 'deploys' }])
+      const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'C7')
+      const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'C7')
+      expect(aliceRow?.trigger).toBe('off')
+      expect(bobRow?.trigger).toBe('mention')
+    })
+
+    it('lookupThread refuses a binding to a gated agent whose conversation is off', async () => {
+      gatedAgents = new Set([ALICE])
+      threadBinding = { agentId: ALICE, daemonId: D1 }
+      channels = [] // no enabled row for ALICE in C1 ⇒ off
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: 'C1/123.456' })
+      expect(res.target).toBeNull()
+    })
+
+    it('lookupThread honours a binding to a gated agent whose conversation is enabled', async () => {
+      gatedAgents = new Set([ALICE])
+      threadBinding = { agentId: ALICE, daemonId: D1 }
+      channels = [channel({ integrationId: INT_A, channelId: 'C1', agentId: ALICE, trigger: 'mention' })]
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: 'C1/123.456' })
+      expect(res.target).toEqual({ agentId: ALICE, daemonId: D1 })
+    })
   })
 
   it('releases the bot (rc/bot-unassign) when transport is socket (no relay ingress)', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -387,6 +387,14 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       )
     })
 
+    it('an enabled im row of a NON-gated owner is inert: no scoped route (DMs stay on defaultAgentId)', async () => {
+      // ALICE flipped restricted → org with an enabled DM row left behind (§14.4).
+      channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', agentId: ALICE, trigger: 'any' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'D42')).toEqual([])
+    })
+
     it('lookupThread refuses a binding to a gated agent whose conversation is off', async () => {
       gatedAgents = new Set([ALICE])
       threadBinding = { agentId: ALICE, daemonId: D1 }

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -302,6 +302,31 @@ export class SharedBotOrchestrator {
   }
 
   /**
+   * §14.3: fan an INCREMENTAL DM-conversation report across the bot's GATED installs
+   * as `kind:'im'` rows (default Off, owned by each install's agent) so console
+   * editors can enable the DM. Non-gated installs are untouched — their DMs already
+   * route via `defaultAgentId`. Idempotent, and no route recompile: an Off row
+   * compiles nothing; the recompile happens when an editor enables it.
+   */
+  async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
+    const bot = await this.bots.get(BotId(botId))
+    if (!bot || bot.platform !== 'slack' || bot.transport !== 'http') {
+      this.log.warn({ botId }, 'shared-bot: conversation report for a non-http/unknown Slack bot — ignored')
+      return
+    }
+    const installs = await this.integrations.listForBot(bot.id)
+    for (const install of installs) {
+      const agent = await this.agents.get(install.agentId)
+      if (!agent || !isGatedAgent(agent)) continue
+      await this.channels.upsertConversation(
+        install.id,
+        { ...conversation, kind: 'im' },
+        { agentId: AgentId(install.agentId), defaultTrigger: 'off' }
+      )
+    }
+  }
+
+  /**
    * Set (or clear) a channel's default/owning agent for a shared bot — the target of
    * the in-Slack config modal (`rc/set-channel-agent`). Channel ownership is one
    * agent per channel, but rows are keyed per-install, so this makes the pick the
@@ -402,6 +427,23 @@ export class SharedBotOrchestrator {
         scope: { channel: c.channelId },
         match
       })
+      if (c.kind === 'im' && p.gated) {
+        // Slug disambiguation inside a shared DM enabled for SEVERAL gated agents
+        // (§14.3): a conversation-scoped keyword outranks the scoped auto in the
+        // relay's arbitration, so "<slug> …" names this agent while an unslugged
+        // DM falls to the first enabled auto route. (Unscoped keyword stays
+        // forbidden for gated agents.)
+        const slug = agentById.get(c.agentId)?.name
+        if (slug) {
+          routes.push({
+            agentId: p.integration.agentId,
+            daemonId: p.daemonId,
+            integrationId: p.integration.id,
+            scope: { channel: c.channelId },
+            match: { kind: 'keyword', value: slug }
+          })
+        }
+      }
     }
 
     // 2. keyword disambiguation (§10.2): one keyword rule per agent = its slug, so

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -248,8 +248,8 @@ export class SharedBotOrchestrator {
     const installs = await this.integrations.listForBot(BotId(botId))
     const install = installs.find((i) => i.agentId === agentId)
     if (!install) return false
-    const rows = await this.channels.listForIntegration(install.id)
-    const row = rows.find((c) => c.channelId === channel)
+    const rows = await this.channels.listForBot(BotId(botId))
+    const row = rows.find((c) => c.integrationId === install.id && c.channelId === channel)
     return !!row && row.trigger !== 'off'
   }
 
@@ -449,11 +449,15 @@ export class SharedBotOrchestrator {
   /** Deliver the shared (send-only) spec to each member agent's daemon (best-effort).
    *  `shareable` rides each spec so the daemon knows whether to expose "Switch agent". */
   private async pushSpecs(compiled: Compiled, secret: BotSecretMaterial, shareable: boolean): Promise<void> {
+    // A gated install's spec carries its conversation-scoped rules for the daemon's
+    // last-hop admission backstop (§14.3). One listForBot covers every install; rows
+    // are keyed per install, so filter by integrationId.
+    const anyGated = compiled.placed.some((p) => p.gated)
+    const botChannels =
+      anyGated && compiled.placed[0] ? await this.channels.listForBot(BotId(compiled.placed[0].integration.botId)) : []
     for (const { integration, daemonId, gated } of compiled.placed) {
       try {
-        // A gated install's spec carries its conversation-scoped rules for the
-        // daemon's last-hop admission backstop (§14.3); channels are per-install.
-        const channels = gated ? await this.channels.listForIntegration(integration.id) : []
+        const channels = gated ? botChannels.filter((c) => c.integrationId === integration.id) : []
         await this.control.integrationUpsert(
           daemonId,
           sharedIntegrationToSpec(integration, secret, shareable, channels, gated)

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -412,11 +412,14 @@ export class SharedBotOrchestrator {
     const chans = await this.channels.listForBot(bot.id)
     for (const c of chans) {
       if (!c.agentId) continue
-      // Conversation gating (§14): an Off conversation compiles NO route — for a
-      // gated owner that is the fail-closed default until an editor enables it.
-      if (c.trigger === 'off') continue
       const p = byAgent.get(c.agentId)
       if (!p) continue // channel assigned to an agent not (yet) placed — skip
+      // Conversation gating (§14): an Off conversation compiles NO route for a
+      // GATED owner (fail-closed until an editor enables it). For a non-gated
+      // owner a preserved Off row is inert (§14.4) — the channel keeps its
+      // mention-trigger ownership, matching integrationToSpec(); an inert im row
+      // still compiles nothing (non-gated DMs already route via defaultAgentId).
+      if (c.trigger === 'off' && (p.gated || c.kind === 'im')) continue
       // A DM conversation row activates on any message once enabled (no mention
       // inside a DM); channels follow their trigger.
       const match: BindMatch = c.kind === 'im' || c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -39,7 +39,7 @@ import type {
 } from '../persistence/ports.js'
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
-import { sharedIntegrationToSpec } from './placement.js'
+import { isGatedAgent, sharedIntegrationToSpec } from './placement.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
 export interface SharedBotLog {
@@ -57,8 +57,10 @@ interface Compiled {
   routes: AttributedRoute[]
   defaultAgentId?: string
   defaultDaemonId?: string
+  /** Members whose ingress is conversation-gated (resource-visibility.md §14). */
+  gatedAgentIds: string[]
   /** Placed member integrations (spec push targets: daemonId + integration). */
-  placed: { integration: IntegrationRecord; daemonId: string }[]
+  placed: { integration: IntegrationRecord; daemonId: string; gated: boolean }[]
 }
 
 export class SharedBotOrchestrator {
@@ -140,7 +142,8 @@ export class SharedBotOrchestrator {
         agents: compiled.agents,
         routes: compiled.routes,
         ...(compiled.defaultAgentId ? { defaultAgentId: compiled.defaultAgentId } : {}),
-        ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {})
+        ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
+        gatedAgentIds: compiled.gatedAgentIds
       })
     )
     const secret = await this.botSecret.get(bot.id)
@@ -204,10 +207,17 @@ export class SharedBotOrchestrator {
   }
 
   /** Pull-on-miss BACKSTOP leg (§10): answer a relay's `rc/thread-lookup` from the
-   *  persisted binding (`target: null` ⇒ the CP holds none). */
+   *  persisted binding (`target: null` ⇒ the CP holds none). A binding to a GATED
+   *  agent is honoured only while its conversation is still enabled (§14) — a
+   *  thread bound before the gate was applied must not keep re-seeding relay
+   *  affinity forever. */
   async lookupThread(m: RcThreadLookup): Promise<RcThreadLookupOk> {
+    const channel = m.sessionKey.slice(0, Math.max(m.sessionKey.indexOf('/'), 0)) || m.sessionKey
     const t = await this.threads.get(BotId(m.botId), m.sessionKey)
     if (t) {
+      if (!(await this.threadTargetAllowed(m.botId, channel, t.agentId))) {
+        return { botId: m.botId, sessionKey: m.sessionKey, target: null }
+      }
       return { botId: m.botId, sessionKey: m.sessionKey, target: { agentId: t.agentId, daemonId: t.daemonId } }
     }
     // Affinity miss: fall back to session metadata. A session an agent created directly on the
@@ -221,9 +231,26 @@ export class SharedBotOrchestrator {
       const channel = m.sessionKey.slice(0, slash)
       const thread = m.sessionKey.slice(slash + 1)
       const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
-      if (owner) return { botId: m.botId, sessionKey: m.sessionKey, target: owner }
+      if (owner && (await this.threadTargetAllowed(m.botId, channel, owner.agentId))) {
+        return { botId: m.botId, sessionKey: m.sessionKey, target: owner }
+      }
     }
     return { botId: m.botId, sessionKey: m.sessionKey, target: null }
+  }
+
+  /** §14 conversation-gating check for the thread-lookup backstop: a non-gated
+   *  target is always allowed; a gated target needs its install's row for this
+   *  conversation to be enabled (trigger ≠ off). Fail-closed on missing rows. */
+  private async threadTargetAllowed(botId: string, channel: string, agentId: string): Promise<boolean> {
+    const agent = await this.agents.get(AgentId(agentId))
+    if (!agent) return false
+    if (!isGatedAgent(agent)) return true
+    const installs = await this.integrations.listForBot(BotId(botId))
+    const install = installs.find((i) => i.agentId === agentId)
+    if (!install) return false
+    const rows = await this.channels.listForIntegration(install.id)
+    const row = rows.find((c) => c.channelId === channel)
+    return !!row && row.trigger !== 'off'
   }
 
   /** Is at least one relay connected right now? The install-time gate: a shared
@@ -255,7 +282,13 @@ export class SharedBotOrchestrator {
     // Channels already known (on ANY install) before this snapshot — the set we must
     // NOT seed, so an operator's later "No default" clear is honoured, not overwritten.
     const known = new Set((await this.channels.listForBot(bot.id)).map((c) => c.channelId))
-    for (const integration of installs) await this.channels.replaceSnapshot(integration.id, channels)
+    for (const integration of installs) {
+      // Conversation gating (§14): a gated install's fresh channels start Off — an
+      // editor must enable them in the console before the compiler emits a route.
+      const owner = await this.agents.get(integration.agentId)
+      const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
+      await this.channels.replaceSnapshot(integration.id, channels, defaultTrigger ? { defaultTrigger } : undefined)
+    }
     // The creating agent = the earliest install (`listForBot` is createdAt-asc). Own
     // each new channel on its row so the channel-scoped rule the compiler reads points
     // at the creating agent (and no other install co-owns it). Operator-overridable.
@@ -297,7 +330,19 @@ export class SharedBotOrchestrator {
       if (owner && i.id === owner.id) continue
       await this.channels.setAgent(i.id, channelId, null)
     }
-    if (owner) await this.channels.upsertAgent(owner.id, channelId, AgentId(agentId!))
+    if (owner) {
+      // Conversation gating (§14): the in-Slack config modal is reachable by any
+      // workspace user, so assigning a channel to a GATED agent must not enable it —
+      // a freshly-created row starts Off; only a console editor can flip the trigger.
+      const ownerAgent = await this.agents.get(owner.agentId)
+      const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
+      await this.channels.upsertAgent(
+        owner.id,
+        channelId,
+        AgentId(agentId!),
+        defaultTrigger ? { defaultTrigger } : undefined
+      )
+    }
     await this.syncRoutes(botId)
   }
 
@@ -316,7 +361,12 @@ export class SharedBotOrchestrator {
     const placed = integrations
       .map((integration) => ({ integration, agent: agentById.get(integration.agentId) }))
       .filter((x): x is { integration: IntegrationRecord; agent: AgentRecord } => !!x.agent?.daemonId)
-      .map((x) => ({ integration: x.integration, agent: x.agent, daemonId: x.agent.daemonId! }))
+      .map((x) => ({
+        integration: x.integration,
+        agent: x.agent,
+        daemonId: x.agent.daemonId!,
+        gated: isGatedAgent(x.agent)
+      }))
     if (placed.length === 0) return null
 
     // members: daemonId → agentIds (the daemon connections the relay expects).
@@ -337,9 +387,14 @@ export class SharedBotOrchestrator {
     const chans = await this.channels.listForBot(bot.id)
     for (const c of chans) {
       if (!c.agentId) continue
+      // Conversation gating (§14): an Off conversation compiles NO route — for a
+      // gated owner that is the fail-closed default until an editor enables it.
+      if (c.trigger === 'off') continue
       const p = byAgent.get(c.agentId)
       if (!p) continue // channel assigned to an agent not (yet) placed — skip
-      const match: BindMatch = c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
+      // A DM conversation row activates on any message once enabled (no mention
+      // inside a DM); channels follow their trigger.
+      const match: BindMatch = c.kind === 'im' || c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
       routes.push({
         agentId: p.integration.agentId,
         daemonId: p.daemonId,
@@ -355,6 +410,9 @@ export class SharedBotOrchestrator {
     for (const p of placed) {
       const a = agentById.get(p.integration.agentId)
       if (!a) continue
+      // Conversation gating (§14): no UNSCOPED rung may name a gated agent — the
+      // keyword slug would make "@bot <slug>" fail-open in every conversation.
+      if (isGatedAgent(a)) continue
       routes.push({
         agentId: p.integration.agentId,
         daemonId: p.daemonId,
@@ -363,10 +421,12 @@ export class SharedBotOrchestrator {
       })
     }
 
-    // 3. default agent (§10.3): the earliest install of the group catches a bare
-    //    @bot + DMs. Delivered as `defaultAgentId` (the relay's fallback rung), not
-    //    a route, so it never pre-empts keyword/channel arbitration.
-    const first = placed[0]!
+    // 3. default agent (§10.3): the earliest NON-GATED install of the group catches
+    //    a bare @bot + DMs. Delivered as `defaultAgentId` (the relay's fallback
+    //    rung), not a route, so it never pre-empts keyword/channel arbitration. A
+    //    gated agent must never be the fallback (§14: the bare-@bot/DM rungs are
+    //    what make a shared bot fail-open); a group of only gated agents has none.
+    const first = placed.find((p) => !p.gated)
     const agents = placed.map((p) => {
       const a = agentById.get(p.integration.agentId)
       return {
@@ -380,18 +440,24 @@ export class SharedBotOrchestrator {
       members,
       agents,
       routes,
-      defaultAgentId: first.integration.agentId,
-      defaultDaemonId: first.daemonId,
-      placed: placed.map((p) => ({ integration: p.integration, daemonId: p.daemonId }))
+      ...(first ? { defaultAgentId: first.integration.agentId, defaultDaemonId: first.daemonId } : {}),
+      gatedAgentIds: placed.filter((p) => p.gated).map((p) => p.integration.agentId),
+      placed: placed.map((p) => ({ integration: p.integration, daemonId: p.daemonId, gated: p.gated }))
     }
   }
 
   /** Deliver the shared (send-only) spec to each member agent's daemon (best-effort).
    *  `shareable` rides each spec so the daemon knows whether to expose "Switch agent". */
   private async pushSpecs(compiled: Compiled, secret: BotSecretMaterial, shareable: boolean): Promise<void> {
-    for (const { integration, daemonId } of compiled.placed) {
+    for (const { integration, daemonId, gated } of compiled.placed) {
       try {
-        await this.control.integrationUpsert(daemonId, sharedIntegrationToSpec(integration, secret, shareable))
+        // A gated install's spec carries its conversation-scoped rules for the
+        // daemon's last-hop admission backstop (§14.3); channels are per-install.
+        const channels = gated ? await this.channels.listForIntegration(integration.id) : []
+        await this.control.integrationUpsert(
+          daemonId,
+          sharedIntegrationToSpec(integration, secret, shareable, channels, gated)
+        )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
         this.log.debug?.({ integrationId: integration.id, daemonId }, 'shared-bot: spec push skipped — daemon offline')
@@ -413,7 +479,8 @@ export class SharedBotOrchestrator {
       agents: compiled.agents,
       routes: compiled.routes,
       ...(compiled.defaultAgentId ? { defaultAgentId: compiled.defaultAgentId } : {}),
-      ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {})
+      ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
+      gatedAgentIds: compiled.gatedAgentIds
     }
   }
 

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -416,10 +416,12 @@ export class SharedBotOrchestrator {
       if (!p) continue // channel assigned to an agent not (yet) placed — skip
       // Conversation gating (§14): an Off conversation compiles NO route for a
       // GATED owner (fail-closed until an editor enables it). For a non-gated
-      // owner a preserved Off row is inert (§14.4) — the channel keeps its
-      // mention-trigger ownership, matching integrationToSpec(); an inert im row
-      // still compiles nothing (non-gated DMs already route via defaultAgentId).
-      if (c.trigger === 'off' && (p.gated || c.kind === 'im')) continue
+      // owner a preserved row is inert (§14.4): a channel keeps its
+      // mention-trigger ownership (matching integrationToSpec()), while an im
+      // row compiles nothing at all — §14 DM rows only steer gated members;
+      // non-gated DMs route via defaultAgentId as they always did.
+      if (c.kind === 'im' && (!p.gated || c.trigger === 'off')) continue
+      if (c.trigger === 'off' && p.gated) continue
       // A DM conversation row activates on any message once enabled (no mention
       // inside a DM); channels follow their trigger.
       const match: BindMatch = c.kind === 'im' || c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2221,6 +2221,14 @@ export interface IntegrationChannelRepo {
     opts?: { defaultTrigger?: ChannelTrigger }
   ): Promise<void>
   listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]>
+  /** Incremental conversation upsert (§14.3, DM rows): create the row (kind, name,
+   *  `agentId`, `defaultTrigger`) when absent; when it exists refresh only the name
+   *  — trigger and agentId are operator-owned once created. */
+  upsertConversation(
+    integrationId: IntegrationId,
+    conversation: ReportedChannel,
+    opts?: { agentId?: AgentId | null; defaultTrigger?: ChannelTrigger }
+  ): Promise<IntegrationChannelRecord>
   /** Channels across EVERY integration of a shared bot — the route compiler's
    *  channel-ownership source. */
   listForBot(botId: BotId): Promise<IntegrationChannelRecord[]>

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2174,38 +2174,52 @@ export interface ChannelPlacementRecord {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// IntegrationChannelRepo (C6) — daemon-reported channel membership + the
-// per-channel trigger choice ('@-mention' vs 'any message'). Names/ids are
-// control metadata, never message content.
+// IntegrationChannelRepo (C6) — daemon-reported conversation membership + the
+// per-conversation trigger choice ('off' / '@-mention' / 'any message'). Names
+// and ids are control metadata, never message content.
 // ───────────────────────────────────────────────────────────────────────────
 
-export type ChannelTrigger = 'mention' | 'any'
+export type ChannelTrigger = 'off' | 'mention' | 'any'
 
-/** One channel the integration's bot is a member of, as reported by the daemon. */
+/** Member channel vs DM conversation (resource-visibility.md §14.3). */
+export type ConversationKind = 'channel' | 'im'
+
+/** One conversation the integration's bot participates in, as reported by the daemon. */
 export interface IntegrationChannelRecord {
   integrationId: IntegrationId
   channelId: string
   name: string | null
   isPrivate: boolean
+  kind: ConversationKind
   trigger: ChannelTrigger
   /** Per-channel default/owning agent for a shared bot (§10.1); null ⇒ unset. */
   agentId: AgentId | null
 }
 
-/** Daemon-reported channel (no trigger — that is operator-owned CP state). */
+/** Daemon-reported conversation (no trigger — that is operator-owned CP state). */
 export interface ReportedChannel {
   id: string
   name?: string
   isPrivate?: boolean
+  /** Absent = 'channel' (wire compatibility). */
+  kind?: ConversationKind
 }
 
 export interface IntegrationChannelRepo {
   /**
    * Converge to the daemon's membership snapshot (latest-wins): upsert every
-   * reported channel (refreshing name/isPrivate, PRESERVING the stored trigger),
-   * delete rows the bot is no longer a member of.
+   * reported conversation (refreshing name/isPrivate, PRESERVING the stored
+   * trigger), delete kind='channel' rows the bot is no longer a member of. DM
+   * (kind='im') rows are NEVER deleted by the snapshot — they are reported
+   * incrementally on first inbound DM (§14.3), so a membership-only report must
+   * not wipe them. `defaultTrigger` seeds NEW rows only ('off' for a gated
+   * integration, 'mention' otherwise); existing rows keep their trigger.
    */
-  replaceSnapshot(integrationId: IntegrationId, channels: ReportedChannel[]): Promise<void>
+  replaceSnapshot(
+    integrationId: IntegrationId,
+    channels: ReportedChannel[],
+    opts?: { defaultTrigger?: ChannelTrigger }
+  ): Promise<void>
   listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]>
   /** Channels across EVERY integration of a shared bot — the route compiler's
    *  channel-ownership source. */
@@ -2225,8 +2239,15 @@ export interface IntegrationChannelRepo {
   ): Promise<IntegrationChannelRecord | null>
   /** Set the channel's owning agent, CREATING the row if absent. A shared bot's
    *  ingest is on the relay, so the daemon never reports its channels — the config
-   *  modal must be able to name a channel the CP has never seen. */
-  upsertAgent(integrationId: IntegrationId, channelId: string, agentId: AgentId): Promise<IntegrationChannelRecord>
+   *  modal must be able to name a channel the CP has never seen. `defaultTrigger`
+   *  seeds a CREATED row only ('off' for a gated owner, §14); an existing row
+   *  keeps its trigger. */
+  upsertAgent(
+    integrationId: IntegrationId,
+    channelId: string,
+    agentId: AgentId,
+    opts?: { defaultTrigger?: ChannelTrigger }
+  ): Promise<IntegrationChannelRecord>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -406,6 +406,29 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
     }
   }
 
+  async upsertConversation(
+    integrationId: IntegrationId,
+    conversation: ReportedChannel,
+    opts?: { agentId?: AgentId | null; defaultTrigger?: ChannelTrigger }
+  ): Promise<IntegrationChannelRecord> {
+    const row = await this.db.integrationChannel.upsert({
+      where: { integrationId_channelId: { integrationId, channelId: conversation.id } },
+      create: {
+        integrationId,
+        channelId: conversation.id,
+        name: conversation.name ?? null,
+        isPrivate: conversation.isPrivate ?? false,
+        kind: conversation.kind ?? 'channel',
+        ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {}),
+        ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
+      },
+      // Refresh only a KNOWN name — a nameless re-report must not clobber a
+      // previously resolved counterpart name; trigger/agentId stay operator-owned.
+      update: conversation.name ? { name: conversation.name } : {}
+    })
+    return toChannelRecord(row)
+  }
+
   async listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]> {
     const rows = await this.db.integrationChannel.findMany({
       where: { integrationId },

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -401,7 +401,9 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
           kind: c.kind ?? 'channel',
           ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
         },
-        update: { name: c.name ?? null, isPrivate: c.isPrivate ?? false, kind: c.kind ?? 'channel' }
+        // kind updates only when explicitly reported: a kind-less membership/observed
+        // re-report must never downgrade an established 'im' row (§14.3).
+        update: { name: c.name ?? null, isPrivate: c.isPrivate ?? false, ...(c.kind ? { kind: c.kind } : {}) }
       })
     }
   }

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -28,6 +28,7 @@ import type {
   IntegrationChannelRecord,
   ReportedChannel,
   ChannelTrigger,
+  ConversationKind,
   ViewCtx
 } from '../ports.js'
 import { visibilityWhere } from '../ports.js'
@@ -366,6 +367,7 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     channelId: c.channelId,
     name: c.name,
     isPrivate: c.isPrivate,
+    kind: c.kind as ConversationKind,
     trigger: c.trigger as ChannelTrigger,
     agentId: c.agentId ? AgentId(c.agentId) : null
   }
@@ -375,17 +377,31 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   constructor(private readonly db: PrismaLike) {}
 
   // Converge to the daemon's membership snapshot: refresh name/isPrivate on known
-  // channels (PRESERVING the operator's trigger), insert new ones (trigger defaults
-  // to 'mention'), and drop rows the bot is no longer a member of.
-  async replaceSnapshot(integrationId: IntegrationId, channels: ReportedChannel[]): Promise<void> {
+  // conversations (PRESERVING the operator's trigger), insert new ones (trigger =
+  // `defaultTrigger`, 'mention' unless the integration is gated), and drop
+  // kind='channel' rows the bot is no longer a member of. DM (kind='im') rows are
+  // reported incrementally on first inbound DM (§14.3), so the membership snapshot
+  // must never delete them.
+  async replaceSnapshot(
+    integrationId: IntegrationId,
+    channels: ReportedChannel[],
+    opts?: { defaultTrigger?: ChannelTrigger }
+  ): Promise<void> {
     await this.db.integrationChannel.deleteMany({
-      where: { integrationId, channelId: { notIn: channels.map((c) => c.id) } }
+      where: { integrationId, kind: 'channel', channelId: { notIn: channels.map((c) => c.id) } }
     })
     for (const c of channels) {
       await this.db.integrationChannel.upsert({
         where: { integrationId_channelId: { integrationId, channelId: c.id } },
-        create: { integrationId, channelId: c.id, name: c.name ?? null, isPrivate: c.isPrivate ?? false },
-        update: { name: c.name ?? null, isPrivate: c.isPrivate ?? false }
+        create: {
+          integrationId,
+          channelId: c.id,
+          name: c.name ?? null,
+          isPrivate: c.isPrivate ?? false,
+          kind: c.kind ?? 'channel',
+          ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
+        },
+        update: { name: c.name ?? null, isPrivate: c.isPrivate ?? false, kind: c.kind ?? 'channel' }
       })
     }
   }
@@ -426,11 +442,17 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   async upsertAgent(
     integrationId: IntegrationId,
     channelId: string,
-    agentId: AgentId
+    agentId: AgentId,
+    opts?: { defaultTrigger?: ChannelTrigger }
   ): Promise<IntegrationChannelRecord> {
     const row = await this.db.integrationChannel.upsert({
       where: { integrationId_channelId: { integrationId, channelId } },
-      create: { integrationId, channelId, agentId },
+      create: {
+        integrationId,
+        channelId,
+        agentId,
+        ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
+      },
       update: { agentId }
     })
     return toChannelRecord(row)

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -14,7 +14,8 @@
  * can never write channel rows for another daemon's integration.
  */
 import { isFrame } from '@agentconnect.md/protocol'
-import { DaemonId } from '../../domain/ids.js'
+import { AgentId, DaemonId } from '../../domain/ids.js'
+import { isGatedAgent } from '../../orchestrator/placement.js'
 import type { Handler } from './index.js'
 
 export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
@@ -34,7 +35,16 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     if (!current.some((candidate) => candidate.id === integration.id && candidate.agentId === integration.agentId)) {
       return
     }
-    await deps.integrationChannel.replaceSnapshot(integration.id, p.channels)
+    // Conversation gating (resource-visibility.md §14): a gated (restricted-agent)
+    // integration's fresh conversations start Off — an editor must enable them in
+    // the console. Known rows keep their operator-chosen trigger either way.
+    const owner = await deps.agent.get(AgentId(integration.agentId))
+    const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
+    await deps.integrationChannel.replaceSnapshot(
+      integration.id,
+      p.channels,
+      defaultTrigger ? { defaultTrigger } : undefined
+    )
   } finally {
     release()
   }

--- a/packages/control-plane/src/ws/relay-connection.ts
+++ b/packages/control-plane/src/ws/relay-connection.ts
@@ -23,6 +23,7 @@ import type {
   RcRegister,
   RcRunReport,
   RcBotChannels,
+  RcBotConversation,
   RcSetChannelAgent,
   RcThreadAssign,
   RcThreadLookup,
@@ -57,6 +58,9 @@ export interface RelayConnDeps {
   onSetChannelAgent: (m: RcSetChannelAgent) => Promise<void>
   /** Apply a complete Slack channel-membership snapshot reported by HTTP ingest. */
   onBotChannels: (m: RcBotChannels) => Promise<void>
+  /** Apply an INCREMENTAL DM-conversation report (resource-visibility §14.3): fan a
+   *  kind:'im' row (default Off) across the bot's gated installs. Fire-and-forget. */
+  onBotConversation: (m: RcBotConversation) => Promise<void>
   /** Persist a relay `rc/thread-assign` (durable thread affinity REPORT leg) and
    *  broadcast the binding pool-wide (rc/assign). Fire-and-forget; a store error must
    *  not close the link. */
@@ -144,6 +148,9 @@ export class RelayConnection implements RelayChannel {
         case 'rc/bot-channels':
           await this.deps.onBotChannels(frame.payload)
           return
+        case 'rc/bot-conversation':
+          await this.deps.onBotConversation(frame.payload)
+          return
         case 'rc/thread-assign':
           await this.handleThreadAssign(frame.payload)
           return
@@ -176,6 +183,7 @@ export class RelayConnection implements RelayChannel {
           type === 'rc/run-report' ||
           type === 'rc/set-channel-agent' ||
           type === 'rc/bot-channels' ||
+          type === 'rc/bot-conversation' ||
           type === 'rc/thread-assign' ||
           type === 'rc/thread-lookup' ||
           type === 'rc/github-installation'

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -81,6 +81,7 @@ async function reportChannels(daemonId: string, integrationId: string, channels:
   const deps = {
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
+    agent: new PgAgentRepo(prisma),
     agentMutations: new AgentMutationGate()
   } as unknown as DaemonWsDeps
   await handleIntegrationChannels(frame, { daemonId } as DaemonConnection, deps)

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -136,6 +136,13 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     expect(dto!.channels.map((c) => c.channelId).sort()).toEqual(['C2', 'D1'])
+
+    // A KIND-LESS re-report of the same id (telegram/discord observed-channel
+    // snapshots carry no kind) must not downgrade the established im row.
+    await report(DAEMON, id, [{ id: 'C2', name: 'ops' }, { id: 'D1' }])
+    res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
   })
 
   it('enabling conversations on a GATED integration pushes conversation-scoped rules ONLY (§14)', async () => {

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { PgDaemonRepo, PgIntegrationRepo, PgIntegrationChannelRepo } from '../../src/persistence/index.js'
+import { PgAgentRepo, PgDaemonRepo, PgIntegrationRepo, PgIntegrationChannelRepo } from '../../src/persistence/index.js'
 import { handleIntegrationChannels } from '../../src/ws/handlers/index.js'
 import { IntegrationId } from '../../src/domain/ids.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
@@ -85,6 +85,7 @@ async function report(
   const deps = {
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
+    agent: new PgAgentRepo(prisma),
     agentMutations,
     collabRoutes
   } as unknown as DaemonWsDeps
@@ -106,9 +107,109 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: unknown[] }[]
     expect(dto!.channels).toEqual([
-      { channelId: 'C1', name: 'deploys', isPrivate: false, trigger: 'mention', agentId: null },
-      { channelId: 'C2', name: 'releases', isPrivate: true, trigger: 'mention', agentId: null }
+      { channelId: 'C1', name: 'deploys', isPrivate: false, kind: 'channel', trigger: 'mention', agentId: null },
+      { channelId: 'C2', name: 'releases', isPrivate: true, kind: 'channel', trigger: 'mention', agentId: null }
     ])
+  })
+
+  it("a restricted agent's fresh conversations default to OFF, and DM rows survive a membership re-report (§14)", async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    await prisma.agent.update({ where: { id: integration.agentId }, data: { visibility: 'restricted' } })
+
+    await report(DAEMON, id, [
+      { id: 'C1', name: 'deploys' },
+      { id: 'D1', name: '@alice', kind: 'im' }
+    ])
+    let res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    let [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    const byId = new Map(dto!.channels.map((c) => [c.channelId, c]))
+    expect(byId.get('C1')).toMatchObject({ kind: 'channel', trigger: 'off' })
+    expect(byId.get('D1')).toMatchObject({ kind: 'im', trigger: 'off', name: '@alice' })
+
+    // A later membership-only snapshot (bot left C1; D1 not re-reported) must drop
+    // C1 but KEEP the DM row — the snapshot governs kind='channel' rows only.
+    await report(DAEMON, id, [{ id: 'C2', name: 'ops' }])
+    res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    expect(dto!.channels.map((c) => c.channelId).sort()).toEqual(['C2', 'D1'])
+  })
+
+  it('enabling conversations on a GATED integration pushes conversation-scoped rules ONLY (§14)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    await prisma.agent.update({ where: { id: integration.agentId }, data: { visibility: 'restricted' } })
+    await report(DAEMON, id, [
+      { id: 'C1', name: 'deploys' },
+      { id: 'D1', name: '@alice', kind: 'im' }
+    ])
+    spy.upserts.length = 0
+
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${id}/channels/C1`,
+      payload: { trigger: 'mention' }
+    })
+    expect(res.statusCode).toBe(200)
+    const u0 = spy.upserts[0]!.u
+    if (u0.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u0.slack.gated).toBe(true)
+    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+
+    await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${id}/channels/D1`,
+      payload: { trigger: 'any' }
+    })
+    const u1 = spy.upserts[1]!.u
+    if (u1.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u1.slack.bindRules).toHaveLength(2)
+    expect(u1.slack.bindRules).toEqual(
+      expect.arrayContaining([
+        { channel: 'C1', match: { kind: 'mention' } },
+        { channel: 'D1', match: { kind: 'dm' } }
+      ])
+    )
+  })
+
+  it('flipping agent visibility re-pushes the integration spec with the derived gate (§14.4)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    await report(DAEMON, id, [{ id: 'C1', name: 'deploys' }]) // org agent ⇒ default mention
+    spy.upserts.length = 0
+
+    const put = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${integration.agentId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(put.statusCode).toBe(200)
+    expect(spy.upserts).toHaveLength(1)
+    const u0 = spy.upserts[0]!.u
+    if (u0.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u0.slack.gated).toBe(true)
+    // The pre-flip channel row keeps its 'mention' trigger — grandfathered enabled.
+    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+
+    const back = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${integration.agentId}/sharing`,
+      payload: { visibility: 'org', sharedWith: [] }
+    })
+    expect(back.statusCode).toBe(200)
+    const u1 = spy.upserts[1]!.u
+    if (u1.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u1.slack.gated).toBe(false)
+    expect(u1.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 
   it('a re-report preserves the trigger, refreshes names, and drops left channels', async () => {
@@ -269,7 +370,14 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
       payload: { trigger: 'any' }
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ channelId: 'C2', name: 'releases', isPrivate: false, trigger: 'any', agentId: null })
+    expect(res.json()).toEqual({
+      channelId: 'C2',
+      name: 'releases',
+      isPrivate: false,
+      kind: 'channel',
+      trigger: 'any',
+      agentId: null
+    })
 
     // The daemon got the recomputed rule set: defaults + ONE auto rule for C2.
     expect(spy.upserts).toHaveLength(1)

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -31,7 +31,11 @@ export const SlackConfigSchema = z.object({
   signingSecret: z.string().optional(),
   botUserId: z.string().optional(), // filled at connect via auth.test if absent; provided by CP for shared
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(BindRuleConfigSchema).default([])
+  bindRules: z.array(BindRuleConfigSchema).default([]),
+  // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
+  // ships only conversation-scoped bindRules; explicitly-addressed unrouted
+  // messages get a one-time notice and DM conversations are reported to the CP.
+  gated: z.boolean().default(false)
 })
 export type SlackConfig = z.infer<typeof SlackConfigSchema>
 
@@ -40,7 +44,11 @@ export const TelegramConfigSchema = z.object({
   botUserId: z.string().optional(), // numeric bot id, filled at connect via getMe if absent
   botUsername: z.string().optional(), // @username without the '@', for mention detection; filled via getMe
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(BindRuleConfigSchema).default([])
+  bindRules: z.array(BindRuleConfigSchema).default([]),
+  // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
+  // ships only conversation-scoped bindRules; explicitly-addressed unrouted
+  // messages get a one-time notice and DM conversations are reported to the CP.
+  gated: z.boolean().default(false)
 })
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>
 
@@ -49,7 +57,11 @@ export const DiscordConfigSchema = z.object({
   applicationId: z.string().optional(), // public client id for the invite URL (not used to connect)
   botUserId: z.string().optional(), // numeric bot user id, filled at connect via the ready event if absent
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(BindRuleConfigSchema).default([])
+  bindRules: z.array(BindRuleConfigSchema).default([]),
+  // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
+  // ships only conversation-scoped bindRules; explicitly-addressed unrouted
+  // messages get a one-time notice and DM conversations are reported to the CP.
+  gated: z.boolean().default(false)
 })
 export type DiscordConfig = z.infer<typeof DiscordConfigSchema>
 
@@ -59,7 +71,11 @@ export const FeishuConfigSchema = z.object({
   botOpenId: z.string().optional(), // bot's own open_id for mention detection; filled at connect via bot/info if absent
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn (default) vs larksuite.com
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(BindRuleConfigSchema).default([])
+  bindRules: z.array(BindRuleConfigSchema).default([]),
+  // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
+  // ships only conversation-scoped bindRules; explicitly-addressed unrouted
+  // messages get a one-time notice and DM conversations are reported to the CP.
+  gated: z.boolean().default(false)
 })
 export type FeishuConfig = z.infer<typeof FeishuConfigSchema>
 

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -31,7 +31,8 @@ function toIntegration(spec: IntegrationSpec): Integration {
       telegram: {
         botToken: spec.telegram.botToken,
         allowedUserIds: spec.telegram.allowedUserIds,
-        bindRules: spec.telegram.bindRules
+        bindRules: spec.telegram.bindRules,
+        gated: spec.telegram.gated
       }
     }
   }
@@ -44,7 +45,8 @@ function toIntegration(spec: IntegrationSpec): Integration {
         botToken: spec.discord.botToken,
         ...(spec.discord.applicationId ? { applicationId: spec.discord.applicationId } : {}),
         allowedUserIds: spec.discord.allowedUserIds,
-        bindRules: spec.discord.bindRules
+        bindRules: spec.discord.bindRules,
+        gated: spec.discord.gated
       }
     }
   }
@@ -59,7 +61,8 @@ function toIntegration(spec: IntegrationSpec): Integration {
         ...(spec.feishu.botOpenId ? { botOpenId: spec.feishu.botOpenId } : {}),
         region: spec.feishu.region,
         allowedUserIds: spec.feishu.allowedUserIds,
-        bindRules: spec.feishu.bindRules
+        bindRules: spec.feishu.bindRules,
+        gated: spec.feishu.gated
       }
     }
   }
@@ -77,7 +80,8 @@ function toIntegration(spec: IntegrationSpec): Integration {
       ...(spec.slack.appToken ? { appToken: spec.slack.appToken } : {}),
       ...(spec.slack.botUserId ? { botUserId: spec.slack.botUserId } : {}),
       allowedUserIds: spec.slack.allowedUserIds,
-      bindRules: spec.slack.bindRules
+      bindRules: spec.slack.bindRules,
+      gated: spec.slack.gated
     }
   }
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -54,7 +54,13 @@ import { DreamRunner, DreamStateError } from './agents/dream-runner.js'
 import { createDreamReader } from './cp/dream-reader.js'
 import { routeRules, type RouteVia } from './router/routing-table.js'
 import { parseCommand, type AgentCommand } from './commands/commands.js'
-import { rulesFromAgent, resolveCpRule, resolveAgentIntegration, type RoutingRule } from './router/routing-rule.js'
+import {
+  rulesFromAgent,
+  resolveCpRule,
+  resolveAgentIntegration,
+  integrationRouting,
+  type RoutingRule
+} from './router/routing-rule.js'
 import { CpRoutingLayer } from './router/cp-routing-layer.js'
 import {
   consolidate,
@@ -194,7 +200,7 @@ import type {
   RequestPermissionRequest,
   RequestPermissionResponse
 } from '@agentclientprotocol/sdk'
-import type { Agent, CronDef } from './agents/agent-schema.js'
+import type { Agent, CronDef, Integration } from './agents/agent-schema.js'
 import type { NormalizedMessage } from './messages/normalized.js'
 import type {
   RegisterReq,
@@ -1826,11 +1832,7 @@ export class Daemon {
         return !this.paused(ctx.agentId) && active !== undefined && !active.cancelledReason
       },
       setSessionTitle: (req) => this.setSessionTitleFromTool(req),
-      gatewayFor: (integrationId) =>
-        this.connByIntegration.get(integrationId) ??
-        this.tgConnByIntegration.get(integrationId) ??
-        this.dcConnByIntegration.get(integrationId) ??
-        this.fsConnByIntegration.get(integrationId),
+      gatewayFor: (integrationId) => this.connForIntegration(integrationId),
       // History-backed discovery for platforms whose bot API can't enumerate chats/users
       // (Telegram): the local session store already records every chat + triggering user.
       observedChannels: (agentId, platform) => this.store.observedChannels(agentId, platform),
@@ -2001,7 +2003,7 @@ export class Daemon {
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
           this.nameResolver?.noteMessage(conn, msg)
-          this.onInbound(msg)
+          this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onChannelsChanged: () => void this.refreshChannels(conn),
         onStatusAction: (a) => this.handleStatusAction(a),
@@ -2493,7 +2495,7 @@ export class Daemon {
           newTraceId: () => randomUUID(),
           onMessage: (msg) => {
             this.nameResolver?.noteMessage(conn, msg)
-            this.onInbound(msg)
+            this.onInbound(msg, this.srcIntegrationIds(conn))
           },
           onChannelsChanged: () => void this.refreshChannels(conn),
           onStatusAction: (a) => this.handleStatusAction(a),
@@ -2617,7 +2619,7 @@ export class Daemon {
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
           this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
-          this.onInbound(msg)
+          this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onCallback: (cb) => this.handleTelegramCallback(cb, conn),
         log: this.log
@@ -2680,7 +2682,7 @@ export class Daemon {
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
           this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
-          this.onInbound(msg)
+          this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onStatusAction: (a) => this.handleStatusAction(a),
         onSelectAction: (a) => this.handleDiscordSelect(a),
@@ -2758,7 +2760,7 @@ export class Daemon {
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
           this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
-          this.onInbound(msg)
+          this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         log: this.log
       })
@@ -2880,8 +2882,14 @@ export class Daemon {
       }
       for (const [integrationId, c] of this.connByIntegration) {
         if (c !== conn) continue
-        this.channelSnapshots.set(integrationId, channels)
-        this.cpClient?.emitIntegrationChannels({ integrationId, channels })
+        // Preserve reported DM rows (§14.3): the membership listing carries channels
+        // only, but a gated integration's snapshot also holds DM conversations — a
+        // refresh must not wipe them (the CP protects them too; this keeps the
+        // in-memory snapshot honest for the reconnect re-assert).
+        const ims = (this.channelSnapshots.get(integrationId) ?? []).filter((x) => x.kind === 'im')
+        const merged = [...channels, ...ims]
+        this.channelSnapshots.set(integrationId, merged)
+        this.cpClient?.emitIntegrationChannels({ integrationId, channels: merged })
         this.maybeIntroduceOnJoin(integrationId, channels)
       }
       this.log.debug(`slack: channel snapshot for bot ${conn.botUserId}: ${channels.length} channel(s)`)
@@ -2980,7 +2988,7 @@ export class Daemon {
         // The arrow captures the NEW `conn` ref so nameResolver/onInbound use the
         // successfully-retried connection, not a stale one from an earlier attempt.
         this.nameResolver?.noteMessage(conn, msg)
-        this.onInbound(msg)
+        this.onInbound(msg, this.srcIntegrationIds(conn))
       },
       onChannelsChanged: () => void this.refreshChannels(conn),
       onStatusAction: (a) => this.handleStatusAction(a),
@@ -3514,7 +3522,7 @@ export class Daemon {
     return !!msg.sender.appId && this.cpCollab.isAgentBotApp(msg.platform, msg.channel, msg.sender.appId)
   }
 
-  private onInbound(msg: NormalizedMessage): void {
+  private onInbound(msg: NormalizedMessage, srcIntegrationIds?: string[]): void {
     // Drain gate (§2.5/§5.3): once the daemon is draining (SIGTERM or a scope:daemon
     // drain) it accepts no new turns — in-flight turns finish, new arrivals are
     // dropped (the platform redelivers / the user retries against the new owner).
@@ -3566,6 +3574,10 @@ export class Daemon {
       // coords as SessionManager → INSERT OR IGNORE
       // dedups rather than double-recording.
       this.recordUnrouted(msg)
+      // Conversation gating (§14): if this unrouted message explicitly addressed a
+      // GATED integration's bot (mention or DM), answer once per conversation and
+      // surface DM conversations to the console instead of appearing silently broken.
+      this.maybeGatedNotice(msg, srcIntegrationIds ?? [])
       this.log.debug(
         `routing: dropped message in ch=${msg.channel} (no agent matched — not a mention of a known bot, not a subscribed 'all' channel, not a thread/DM hit)`
       )
@@ -4198,6 +4210,15 @@ export class Daemon {
     // terminal agent-bot suppression here before commands or model admission.
     if (this.isAgentBotMessage(normalized)) {
       this.log.debug(`relay: consumed AgentConnect bot message ${msg.msgId} without waking ${msg.agentId}`)
+      return { msgId: msg.msgId, accepted: true }
+    }
+    // Conversation gating (§14) last-hop backstop: the relay arbitrates shared-bot
+    // routing, but a stale relay route snapshot must not activate a private agent in
+    // an Off conversation. Admission = a bindRule scoped to this conversation (the
+    // CP ships a gated install's enabled set even in shared mode).
+    if (!this.gatedAdmission(msg.integrationId, normalized)) {
+      this.maybeGatedNotice(normalized, [msg.integrationId])
+      this.log.debug(`relay: dropped ${msg.msgId} for gated integration ${msg.integrationId} (conversation off)`)
       return { msgId: msg.msgId, accepted: true }
     }
     // Shared-bot IM bypasses onInbound() because the relay already arbitrated the
@@ -6078,14 +6099,12 @@ export class Daemon {
       .get(agentId)
       ?.integrations.find((candidate) => candidate.id === integrationId && candidate.platform === msg.platform)
     if (!integration) return false
-    const allowed =
-      integration.platform === 'telegram'
-        ? integration.telegram.allowedUserIds
-        : integration.platform === 'discord'
-          ? integration.discord.allowedUserIds
-          : integration.platform === 'feishu'
-            ? integration.feishu.allowedUserIds
-            : integration.slack.allowedUserIds
+    const routing = integrationRouting(integration)
+    // Conversation gating (§14): control commands resolve their target OUTSIDE
+    // routeRules' scope filter (latest-session fallbacks), so they must repeat the
+    // admission check — an Off conversation of a gated integration takes no commands.
+    if (routing.gated && !routing.bindRules.some((r) => r.channel === msg.channel)) return false
+    const allowed = routing.allowedUserIds
     return allowed.length === 0 || allowed.includes(msg.sender.id)
   }
 
@@ -10777,18 +10796,129 @@ export class Daemon {
     })
   }
 
+  // ── Conversation gating (resource-visibility.md §14) ────────────────────────
+
+  /** One-time gating-notice latch, `${integrationId}:${channel}` — per daemon
+   *  lifetime (§14.7 open question 2: a restart re-notices, which is acceptable). */
+  private readonly gatedNoticesSent = new Set<string>()
+
+  /** The integration config backing `integrationId`, across all local agents. */
+  private integrationConfigById(integrationId: string): Integration | undefined {
+    for (const a of this.agents.values()) {
+      const int = a.integrations.find((i) => i.id === integrationId)
+      if (int) return int
+    }
+    return undefined
+  }
+
+  /** Every integrationId served by `conn` — ingress attribution for gating. A Slack
+   *  socket is per app token and may fan out to several integrations. */
+  private srcIntegrationIds(conn: unknown): string[] {
+    const out: string[] = []
+    for (const [id, c] of this.connByIntegration) if (c === conn) out.push(id)
+    for (const [id, c] of this.tgConnByIntegration) if (c === conn) out.push(id)
+    for (const [id, c] of this.dcConnByIntegration) if (c === conn) out.push(id)
+    for (const [id, c] of this.fsConnByIntegration) if (c === conn) out.push(id)
+    return out
+  }
+
+  /** §14 admission for a pre-addressed (relay) message: a gated integration accepts
+   *  a conversation only when its shipped bindRules carry a rule scoped to it. */
+  private gatedAdmission(integrationId: string, msg: NormalizedMessage): boolean {
+    const int = this.integrationConfigById(integrationId)
+    if (!int) return true // unknown here — agent/integration existence is checked separately
+    const routing = integrationRouting(int)
+    return !routing.gated || routing.bindRules.some((r) => r.channel === msg.channel)
+  }
+
+  /**
+   * §14: an explicitly-addressed message (a mention of a gated integration's bot, or
+   * a DM to it) that routed nowhere gets a ONE-TIME per-conversation notice — the
+   * bot must never look silently broken — and a gated DM conversation is reported to
+   * the CP so the console can offer enabling it. Bot senders are never noticed.
+   */
+  private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
+    if (msg.sender.isBot || msg.source !== 'user') return
+    // Slack `app_mention` payloads may omit channel_type, so hedge on the D-prefix.
+    const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
+    for (const integrationId of srcIntegrationIds) {
+      const int = this.integrationConfigById(integrationId)
+      if (!int || int.platform !== msg.platform) continue
+      const routing = integrationRouting(int)
+      if (!routing.gated) continue
+      const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
+      const addressed = isDm || (botUserId !== '' && msg.mentionedBots.includes(botUserId))
+      if (!addressed) continue
+      // Reaching here ⇒ the conversation is Off/unknown for this gated integration
+      // (an enabled conversation would have routed via its scoped rule).
+      if (isDm) this.reportGatedDm(integrationId, msg)
+      const latch = `${integrationId}:${msg.channel}`
+      if (this.gatedNoticesSent.has(latch)) return
+      this.gatedNoticesSent.add(latch)
+      const conn = this.connForIntegration(integrationId)
+      if (!conn) return
+      const text =
+        '🔒 This agent isn’t enabled in this conversation. Ask an admin to enable it in the AgentConnect console.'
+      const thread = isDm ? undefined : msg.thread
+      // Chrome-marked so peer daemons' thread backfill never re-ingests the notice.
+      const post =
+        conn instanceof SlackConnection
+          ? conn.postMessage(msg.channel, text, thread, { chrome: true })
+          : conn.postChrome(msg.channel, text, { threadTs: thread })
+      void post.catch((err: unknown) =>
+        this.log.warn(`gating: notice post failed in ch=${msg.channel}: ${(err as Error).message}`)
+      )
+      return // one notice per message even when several integrations share the socket
+    }
+  }
+
+  /** §14.3: surface a gated DM conversation as a `kind:'im'` row (latest-wins
+   *  snapshot merge) so the console lists it for enablement. Name resolution is
+   *  best-effort: the display-name store first, then a Slack profile lookup that
+   *  re-reports when it lands. */
+  private reportGatedDm(integrationId: string, msg: NormalizedMessage): void {
+    const existing = this.channelSnapshots.get(integrationId) ?? []
+    if (existing.some((c) => c.id === msg.channel)) return
+    const known = this.store.getDisplayNames([msg.channel]).get(msg.channel)
+    const row: IntegrationChannel = { id: msg.channel, ...(known ? { name: known } : {}), kind: 'im' }
+    const next = [...existing, row]
+    this.channelSnapshots.set(integrationId, next)
+    this.cpClient?.emitIntegrationChannels({ integrationId, channels: next })
+    if (known) return
+    const conn = this.connForIntegration(integrationId)
+    if (!(conn instanceof SlackConnection)) return
+    void conn
+      .getUserProfile(msg.sender.id)
+      .then((prof) => {
+        const name = prof.realName || prof.name
+        if (!name) return
+        const snap = this.channelSnapshots.get(integrationId) ?? []
+        const updated = snap.map((c) => (c.id === msg.channel && !c.name ? { ...c, name: `@${name}` } : c))
+        this.channelSnapshots.set(integrationId, updated)
+        this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated })
+      })
+      .catch(() => {})
+  }
+
+  /** The live platform connection serving `integrationId`, any platform. */
+  private connForIntegration(
+    integrationId: string
+  ): SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection | undefined {
+    return (
+      this.connByIntegration.get(integrationId) ??
+      this.tgConnByIntegration.get(integrationId) ??
+      this.dcConnByIntegration.get(integrationId) ??
+      this.fsConnByIntegration.get(integrationId)
+    )
+  }
+
   private replyConnFor(
     agentId: string,
     integrationId?: string
   ): SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection | undefined {
     const intId = integrationId ?? this.agents.get(agentId)?.integrations[0]?.id
     if (!intId) return undefined
-    return (
-      this.connByIntegration.get(intId) ??
-      this.tgConnByIntegration.get(intId) ??
-      this.dcConnByIntegration.get(intId) ??
-      this.fsConnByIntegration.get(intId)
-    )
+    return this.connForIntegration(intId)
   }
 
   /** The CP-owned cron ids currently on disk (register `localState.crons` — the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3563,6 +3563,12 @@ export class Daemon {
     // continues it). No-op on other platforms.
     this.canonicalizeTelegramThread(msg)
 
+    // §14.3: gated-DM discovery must PRECEDE command interception — an Off DM
+    // whose first inbound is a control command is refused by command authz, but
+    // still needs its pending row + one-time notice. Idempotent/latched, and a
+    // no-op for enabled conversations, so the later route-miss call may repeat it.
+    this.maybeGatedNotice(msg, srcIntegrationIds ?? [], { dmOnly: true })
+
     // In-conversation control commands (`!stop` / `!queue …`) act on the running
     // agent and never reach it as a prompt — intercept before routing/dispatch.
     const command = parseCommand(msg.text)
@@ -10851,20 +10857,22 @@ export class Daemon {
    * bot must never look silently broken — and a gated DM conversation is reported to
    * the CP so the console can offer enabling it. Bot senders are never noticed.
    */
-  private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
+  private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[], opts?: { dmOnly?: boolean }): void {
     if (msg.sender.isBot || msg.source !== 'user') return
     // Slack `app_mention` payloads may omit channel_type, so hedge on the D-prefix.
     const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
+    if (opts?.dmOnly && !isDm) return
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue
       const routing = integrationRouting(int)
       if (!routing.gated) continue
+      // An ENABLED conversation never gets a report/notice — this guard makes the
+      // helper safe from the pre-command call site, which sees every DM.
+      if (routing.bindRules.some((r) => r.channel === msg.channel)) continue
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
       const addressed = isDm || (botUserId !== '' && msg.mentionedBots.includes(botUserId))
       if (!addressed) continue
-      // Reaching here ⇒ the conversation is Off/unknown for this gated integration
-      // (an enabled conversation would have routed via its scoped rule).
       if (isDm) this.reportGatedDm(integrationId, msg)
       const latch = `${integrationId}:${msg.channel}`
       if (this.gatedNoticesSent.has(latch)) return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3563,11 +3563,12 @@ export class Daemon {
     // continues it). No-op on other platforms.
     this.canonicalizeTelegramThread(msg)
 
-    // §14.3: gated-DM discovery must PRECEDE command interception — an Off DM
-    // whose first inbound is a control command is refused by command authz, but
-    // still needs its pending row + one-time notice. Idempotent/latched, and a
-    // no-op for enabled conversations, so the later route-miss call may repeat it.
-    this.maybeGatedNotice(msg, srcIntegrationIds ?? [], { dmOnly: true })
+    // §14.3: gated-DM ROW discovery must precede command interception AND routing —
+    // an Off DM whose first inbound is a control command is refused by command
+    // authz but still needs its pending row, and on a consolidated connection
+    // EVERY Off gated integration needs its own row. Report-only: the notice stays
+    // conditional on the message actually resolving to no admitted target.
+    this.discoverGatedDms(msg, srcIntegrationIds ?? [])
 
     // In-conversation control commands (`!stop` / `!queue …`) act on the running
     // agent and never reach it as a prompt — intercept before routing/dispatch.
@@ -3580,7 +3581,9 @@ export class Daemon {
         this.log.warn(`loop guard: ignored unauthenticated resume for ${loopGuardScope(msg)}`)
         return
       }
-      this.handleCommand(command, msg)
+      // §14.3: a command that resolved no admitted target in an Off gated
+      // conversation gets the same one-time notice as an unrouted message.
+      if (!this.handleCommand(command, msg)) this.maybeGatedNotice(msg, srcIntegrationIds ?? [])
       return
     }
 
@@ -6138,7 +6141,7 @@ export class Daemon {
     command: AgentCommand,
     msg: NormalizedMessage,
     explicitTarget?: { agentId: string; integrationId: string; via: RouteVia }
-  ): void {
+  ): boolean {
     let target = explicitTarget ?? routeRules(msg, this.mergedRules(), (c, t) => this.sessions.threadOwner(c, t))
     if (!target) {
       // Routing found no agent — the common group case: a bare `/status@bot` carries no
@@ -6150,11 +6153,11 @@ export class Daemon {
     if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg)
     if (!target) {
       this.log.debug(`command: '${command.kind}' in ch=${msg.channel} — no agent resolved, ignoring`)
-      return
+      return false
     }
     if (!this.commandSenderAllowed(target.agentId, target.integrationId, msg)) {
       this.log.warn(`command: '${command.kind}' rejected for unauthorized sender ${msg.sender.id}`)
-      return
+      return false
     }
     const conn = this.replyConnFor(target.agentId, target.integrationId)
     // Where the command was sent — the reply lands here (Slack thread_ts; Telegram
@@ -6223,7 +6226,7 @@ export class Daemon {
         })
       if (stillStopping) {
         reply('Loop protection is still stopping the previous turn. Try `!resume` again in a moment.')
-        return
+        return true
       }
       const wasOpen = this.store.isLoopGuardOpen(scope)
       this.store.resetLoopGuard(scope)
@@ -6235,7 +6238,7 @@ export class Daemon {
       } else {
         reply('Loop protection is not active in this conversation.')
       }
-      return
+      return true
     }
 
     if (command.kind === 'stop') {
@@ -6246,11 +6249,11 @@ export class Daemon {
       const muteNote = 'Muted in this thread — @mention me to resume.'
       if (!inflight) {
         reply(rec ? `🔇 Nothing is running. ${muteNote}` : 'Nothing is running to stop.')
-        return
+        return true
       }
       this.interruptTurn(target.agentId, key, 'stop', acpSessionId ?? undefined)
       reply(`🛑 Stopped. ${muteNote}`)
-      return
+      return true
     }
 
     if (command.kind === 'cancel') {
@@ -6258,11 +6261,11 @@ export class Daemon {
       // live so a follow-up message dispatches normally. No-op (with a note) when idle.
       if (!inflight) {
         reply('Nothing is running to cancel.')
-        return
+        return true
       }
       this.interruptTurn(target.agentId, key, 'cancel', acpSessionId ?? undefined)
       reply('🛑 Cancelled.')
-      return
+      return true
     }
 
     if (command.kind === 'status') {
@@ -6271,7 +6274,7 @@ export class Daemon {
       // channel, per the resolution above). No-op note when there's none.
       if (!rec) {
         reply('No active session here yet — send me a message to start one.')
-        return
+        return true
       }
       const info = this.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
       const link = acpSessionId ? this.sessionLink(acpSessionId) : undefined
@@ -6297,7 +6300,7 @@ export class Daemon {
         const text = link ? `${renderStatusBar(info)}  ·  <${link}|View session>` : renderStatusBar(info)
         reply(text)
       }
-      return
+      return true
     }
 
     if (
@@ -6308,7 +6311,7 @@ export class Daemon {
       this.agents.get(target.agentId)?.allowRuntimeChangesInChat !== true
     ) {
       reply('Runtime settings can only be changed by an Agent editor from the Agent page.')
-      return
+      return true
     }
 
     if (command.kind === 'fast') {
@@ -6316,15 +6319,15 @@ export class Daemon {
       // Fast button used to offer). Records the sticky override + applies live if warm.
       if (!rec) {
         reply('No active session here to configure.')
-        return
+        return true
       }
       if (command.enable === null) {
         reply('Usage: `/fast on` or `/fast off`.')
-        return
+        return true
       }
       this.setFastByKey(key, command.enable)
       reply(command.enable ? '⚡ Fast mode on.' : '🐢 Fast mode off.')
-      return
+      return true
     }
 
     if (command.kind === 'model' || command.kind === 'effort' || command.kind === 'permission') {
@@ -6334,7 +6337,7 @@ export class Daemon {
       // the sticky per-session override + applies it live when the ACP session is warm.
       if (!rec) {
         reply('No active session here to configure.')
-        return
+        return true
       }
       // Telegram + Discord list via a tappable button card, replied under the command;
       // returns false so handleSelectCommand falls back to a text list (Slack, or when
@@ -6370,7 +6373,7 @@ export class Daemon {
         reply,
         renderCard
       )
-      return
+      return true
     }
 
     // queue — now just admission through the UNIFIED per-sessionKey gate (§6.9 #390): the
@@ -6379,7 +6382,7 @@ export class Daemon {
     // gate (dispatch → QueueFullError), so there is no second FIFO here anymore.
     if (!command.text) {
       reply('Usage: `!queue <message>` — runs when the current turn finishes.')
-      return
+      return true
     }
     // Dispatch/queue into the resolved session's thread (the fallback may have retargeted
     // it from the bare command thread to the channel's latest session).
@@ -6389,7 +6392,7 @@ export class Daemon {
     if (inflight && (this.serialQueue.get(key)?.length ?? 0) >= MAX_QUEUED_PER_SESSION) {
       this.log.warn(`command: queue → agent "${target.agentId}" session ${key} full, rejected`)
       reply(`Queue is full (${MAX_QUEUED_PER_SESSION} pending) — wait for the current turn to finish.`)
-      return
+      return true
     }
     void this.dispatch(target.agentId, payload, target.integrationId, undefined, undefined, { isQueueCmd: true }).catch(
       (err) => {
@@ -6405,6 +6408,7 @@ export class Daemon {
       this.log.info(`command: queue → agent "${target.agentId}" session ${key} (depth ${depth})`)
       reply(`📥 Queued (#${depth}) — will run when the current turn finishes.`)
     }
+    return true
   }
 
   private selectLabel(kind: SelectKind): string {
@@ -10857,11 +10861,30 @@ export class Daemon {
    * bot must never look silently broken — and a gated DM conversation is reported to
    * the CP so the console can offer enabling it. Bot senders are never noticed.
    */
-  private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[], opts?: { dmOnly?: boolean }): void {
+  /** §14.3 DM ROW discovery, report-only: fan the pending-row report across EVERY
+   *  gated src integration whose conversation is Off. Runs before command
+   *  interception and routing for each inbound DM. No notice and no early return —
+   *  on a consolidated connection an Off sibling must not post a misleading lock
+   *  while another integration goes on to handle the DM, and every Off gated
+   *  integration needs its own row. */
+  private discoverGatedDms(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
+    if (msg.sender.isBot || msg.source !== 'user') return
+    const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
+    if (!isDm) return
+    for (const integrationId of srcIntegrationIds) {
+      const int = this.integrationConfigById(integrationId)
+      if (!int || int.platform !== msg.platform) continue
+      const routing = integrationRouting(int)
+      if (!routing.gated) continue
+      if (routing.bindRules.some((r) => r.channel === msg.channel)) continue // enabled
+      this.reportGatedDm(integrationId, msg)
+    }
+  }
+
+  private maybeGatedNotice(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
     if (msg.sender.isBot || msg.source !== 'user') return
     // Slack `app_mention` payloads may omit channel_type, so hedge on the D-prefix.
     const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
-    if (opts?.dmOnly && !isDm) return
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10805,7 +10805,7 @@ export class Daemon {
   /** The integration config backing `integrationId`, across all local agents. */
   private integrationConfigById(integrationId: string): Integration | undefined {
     for (const a of this.agents.values()) {
-      const int = a.integrations.find((i) => i.id === integrationId)
+      const int = a.integrations?.find((i) => i.id === integrationId)
       if (int) return int
     }
     return undefined

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2853,9 +2853,23 @@ export class Daemon {
         // every integration would attribute chats to the wrong bot. Only report when
         // there's exactly one — the common case — and skip the ambiguous multi-bot agent.
         if (!integ || rest.length > 0) continue
-        const channels: IntegrationChannel[] = this.store
-          .observedChannels(agent.id, platform)
-          .map((c) => (c.name ? { id: c.id, name: c.name } : { id: c.id }))
+        // The sessions table can't tell a DM chat from a group, so observed rows are
+        // kind-less. Preserve previously established `im` kinds (§14.3): re-mark
+        // overlapping ids and keep im-only entries, otherwise a refresh would
+        // downgrade a reported DM row back to 'channel' on the CP.
+        const priorIms = new Set(
+          (this.channelSnapshots.get(integ.id) ?? []).filter((x) => x.kind === 'im').map((x) => x.id)
+        )
+        const observed: IntegrationChannel[] = this.store.observedChannels(agent.id, platform).map((c) => ({
+          id: c.id,
+          ...(c.name ? { name: c.name } : {}),
+          ...(priorIms.has(c.id) ? { kind: 'im' as const } : {})
+        }))
+        const observedIds = new Set(observed.map((x) => x.id))
+        const keptIms = (this.channelSnapshots.get(integ.id) ?? []).filter(
+          (x) => x.kind === 'im' && !observedIds.has(x.id)
+        )
+        const channels = [...observed, ...keptIms]
         this.channelSnapshots.set(integ.id, channels)
         this.cpClient?.emitIntegrationChannels({ integrationId: integ.id, channels })
       }
@@ -10878,13 +10892,18 @@ export class Daemon {
    *  re-reports when it lands. */
   private reportGatedDm(integrationId: string, msg: NormalizedMessage): void {
     const existing = this.channelSnapshots.get(integrationId) ?? []
-    if (existing.some((c) => c.id === msg.channel)) return
+    const current = existing.find((c) => c.id === msg.channel)
+    if (current?.kind === 'im') return
     const known = this.store.getDisplayNames([msg.channel]).get(msg.channel)
-    const row: IntegrationChannel = { id: msg.channel, ...(known ? { name: known } : {}), kind: 'im' }
-    const next = [...existing, row]
+    // A previously-observed DM (telegram/discord observed-channel snapshots are
+    // kind-less) is UPGRADED to 'im' rather than skipped — e.g. after an
+    // org→restricted flip the chat already sits in the snapshot as 'channel'.
+    const next = current
+      ? existing.map((c) => (c.id === msg.channel ? { ...c, kind: 'im' as const } : c))
+      : [...existing, { id: msg.channel, ...(known ? { name: known } : {}), kind: 'im' as const }]
     this.channelSnapshots.set(integrationId, next)
     this.cpClient?.emitIntegrationChannels({ integrationId, channels: next })
-    if (known) return
+    if (known || current?.name) return
     const conn = this.connForIntegration(integrationId)
     if (!(conn instanceof SlackConnection)) return
     void conn

--- a/packages/daemon/src/router/routing-rule.ts
+++ b/packages/daemon/src/router/routing-rule.ts
@@ -27,34 +27,40 @@ export interface RoutingRule {
   platform?: string
 }
 
-/** Extract the platform-agnostic routing bits from a (discriminated) Integration. */
-function integrationRouting(int: Integration): {
+/** Extract the platform-agnostic routing bits from a (discriminated) Integration.
+ *  Exported for the daemon's conversation-gating ingress checks (§14). */
+export function integrationRouting(int: Integration): {
   staticBotUserId?: string
   bindRules: BindRuleConfig[]
   allowedUserIds: string[]
+  gated: boolean
 } {
   if (int.platform === 'slack')
     return {
       staticBotUserId: int.slack.botUserId,
       bindRules: int.slack.bindRules,
-      allowedUserIds: int.slack.allowedUserIds
+      allowedUserIds: int.slack.allowedUserIds,
+      gated: int.slack.gated
     }
   if (int.platform === 'discord')
     return {
       staticBotUserId: int.discord.botUserId,
       bindRules: int.discord.bindRules,
-      allowedUserIds: int.discord.allowedUserIds
+      allowedUserIds: int.discord.allowedUserIds,
+      gated: int.discord.gated
     }
   if (int.platform === 'feishu')
     return {
       staticBotUserId: int.feishu.botOpenId,
       bindRules: int.feishu.bindRules,
-      allowedUserIds: int.feishu.allowedUserIds
+      allowedUserIds: int.feishu.allowedUserIds,
+      gated: int.feishu.gated
     }
   return {
     staticBotUserId: int.telegram.botUserId,
     bindRules: int.telegram.bindRules,
-    allowedUserIds: int.telegram.allowedUserIds
+    allowedUserIds: int.telegram.allowedUserIds,
+    gated: int.telegram.gated
   }
 }
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -566,6 +566,19 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.frame.payload.channels[2]).toEqual({ id: 'C789' }) // name optional (lookup may fail)
   })
 
+  it('integration/channels round-trips a DM (kind im) row; kind is optional for wire compat (§14)', () => {
+    const r = decodeEnvelope(
+      envelope('integration/channels', {
+        integrationId: INTEGRATION_ID,
+        channels: [{ id: 'D111', name: '@alice', kind: 'im' }, { id: 'C123' }]
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('integration/channels')(r.frame)) throw new Error('expected integration/channels')
+    expect(r.frame.payload.channels[0]).toEqual({ id: 'D111', name: '@alice', kind: 'im' })
+    expect(r.frame.payload.channels[1]).toEqual({ id: 'C123' }) // absent kind = channel
+  })
+
   it('register/ok defaults integrations[] to [] and round-trips a delivered integration', () => {
     const empty = decodeEnvelope(
       envelope('register/ok', {

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -68,7 +68,13 @@ export const IntegrationSlackConfig = z
     shareable: z.boolean().default(false),
     botUserId: z.string().optional(), // lazily resolved via auth.test; may be seeded by CP
     allowedUserIds: z.array(z.string()).default([]),
-    bindRules: z.array(IntegrationBindRule).default([]) // empty for shared (relay arbitrates)
+    bindRules: z.array(IntegrationBindRule).default([]), // empty for shared (relay arbitrates)
+    // Conversation gating (resource-visibility.md §14): true ⇒ this integration is
+    // fail-closed — the CP ships only conversation-scoped bindRules (no unscoped
+    // defaults), and the daemon answers explicitly-addressed unrouted messages with
+    // a one-time notice + reports DM conversations. Derived from the owning agent's
+    // restricted visibility; carries NO identities. Defaults false (pre-field specs).
+    gated: z.boolean().default(false)
   })
   .superRefine((c, ctx) => {
     if (c.mode === 'direct' && !c.appToken)
@@ -84,7 +90,8 @@ export type IntegrationSlackConfig = z.infer<typeof IntegrationSlackConfig>
 export const IntegrationTelegramConfig = z.object({
   botToken: z.string(), // BotFather "123456:ABC…"  (plaintext — never log)
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(IntegrationBindRule).default([])
+  bindRules: z.array(IntegrationBindRule).default([]),
+  gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationTelegramConfig = z.infer<typeof IntegrationTelegramConfig>
 
@@ -98,7 +105,8 @@ export const IntegrationDiscordConfig = z.object({
   botToken: z.string(), // Bot <token>  (plaintext — never log)
   applicationId: z.string().optional(), // client/application id — public, for the invite URL
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(IntegrationBindRule).default([])
+  bindRules: z.array(IntegrationBindRule).default([]),
+  gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationDiscordConfig = z.infer<typeof IntegrationDiscordConfig>
 
@@ -126,7 +134,8 @@ export const IntegrationFeishuConfig = z.object({
   botOpenId: z.string().optional(), // bot's own open_id; lazily resolved via bot/info
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn vs larksuite.com
   allowedUserIds: z.array(z.string()).default([]),
-  bindRules: z.array(IntegrationBindRule).default([])
+  bindRules: z.array(IntegrationBindRule).default([]),
+  gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationFeishuConfig = z.infer<typeof IntegrationFeishuConfig>
 
@@ -175,11 +184,18 @@ export const IntegrationRemove = z.object({
 })
 export type IntegrationRemove = z.infer<typeof IntegrationRemove>
 
-/** One channel the bot is currently a member of (metadata only — no messages). */
+/**
+ * One conversation the bot participates in (metadata only — no messages).
+ * `kind` distinguishes member channels from DM conversations (resource-
+ * visibility.md §14.3): absent = 'channel' for wire compatibility. DM rows
+ * (`kind: 'im'`, Slack "D…" ids) are reported only for gated integrations, on
+ * first inbound DM; their `name` is the counterpart's display name.
+ */
 export const IntegrationChannel = z.object({
-  id: z.string(), // platform channel id (Slack "C…")
-  name: z.string().optional(), // "#deploys" without the hash; absent if lookup failed
-  isPrivate: z.boolean().optional()
+  id: z.string(), // platform conversation id (Slack "C…" / DM "D…")
+  name: z.string().optional(), // "#deploys" without the hash (or DM counterpart); absent if lookup failed
+  isPrivate: z.boolean().optional(),
+  kind: z.enum(['channel', 'im']).optional() // absent = 'channel'
 })
 export type IntegrationChannel = z.infer<typeof IntegrationChannel>
 

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -575,6 +575,20 @@ export const RcBotChannels = z.object({
 })
 export type RcBotChannels = z.infer<typeof RcBotChannels>
 
+// R→C EVT (fire-and-forget) — INCREMENTAL conversation report (resource-visibility
+// §14.3): the relay saw an inbound DM to a shared bot that backs ≥1 gated
+// (restricted-visibility) agent and arbitration found no route. The CP fans a
+// `kind:'im'` row (default Off) across the bot's GATED installs so console editors
+// can enable it. Incremental on purpose — unlike `rc/bot-channels` this must never
+// carry full-set semantics (DM rows are never dropped by snapshots). Conversation
+// id/name are control metadata; no message content crosses this wire. Loss is
+// self-healing: the counterpart's next DM re-reports.
+export const RcBotConversation = z.object({
+  botId: z.string().uuid(),
+  conversation: IntegrationChannel
+})
+export type RcBotConversation = z.infer<typeof RcBotConversation>
+
 // R→C EVT (fire-and-forget) — durable thread-affinity REPORT leg (§10 step 3, the
 // 3-leg affinity dance). The relay tells the CP which agent now owns a (channel,
 // thread) `sessionKey` the first time it routes that thread, and again on a
@@ -697,6 +711,7 @@ export const RELAY_CP_SCHEMAS = {
   'rc/assign': RcAssign,
   'rc/set-channel-agent': RcSetChannelAgent,
   'rc/bot-channels': RcBotChannels,
+  'rc/bot-conversation': RcBotConversation,
   'rc/thread-assign': RcThreadAssign,
   'rc/thread-lookup': RcThreadLookup,
   'rc/thread-lookup/ok': RcThreadLookupOk,
@@ -738,6 +753,7 @@ export const RelayCpFrame = z.discriminatedUnion('type', [
   frameSchema('rc/assign', RELAY_CP_SCHEMAS['rc/assign']),
   frameSchema('rc/set-channel-agent', RELAY_CP_SCHEMAS['rc/set-channel-agent']),
   frameSchema('rc/bot-channels', RELAY_CP_SCHEMAS['rc/bot-channels']),
+  frameSchema('rc/bot-conversation', RELAY_CP_SCHEMAS['rc/bot-conversation']),
   frameSchema('rc/thread-assign', RELAY_CP_SCHEMAS['rc/thread-assign']),
   frameSchema('rc/thread-lookup', RELAY_CP_SCHEMAS['rc/thread-lookup']),
   frameSchema('rc/thread-lookup/ok', RELAY_CP_SCHEMAS['rc/thread-lookup/ok']),

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -508,7 +508,12 @@ export const RcBotAssign = z.object({
   agents: z.array(RcAgentDirEntry).default([]), // member directory (id→name) for the config modal
   routes: z.array(AttributedRoute),
   defaultAgentId: z.string().uuid().optional(), // bare @bot / DM fallback within the group (§10.3)
-  defaultDaemonId: z.string().uuid().optional()
+  defaultDaemonId: z.string().uuid().optional(),
+  // Conversation gating (resource-visibility.md §14): member agents whose ingress is
+  // fail-closed. The relay's thread-affinity rung honours a binding to a gated agent
+  // only while that agent still has a channel-scoped route in the conversation —
+  // otherwise a thread bound before the gate was applied would keep routing forever.
+  gatedAgentIds: z.array(z.string().uuid()).default([])
 })
 export type RcBotAssign = z.infer<typeof RcBotAssign>
 
@@ -527,7 +532,8 @@ export const RcRoutes = z.object({
   agents: z.array(RcAgentDirEntry).default([]),
   routes: z.array(AttributedRoute),
   defaultAgentId: z.string().uuid().optional(),
-  defaultDaemonId: z.string().uuid().optional()
+  defaultDaemonId: z.string().uuid().optional(),
+  gatedAgentIds: z.array(z.string().uuid()).default([]) // §14 — see RcBotAssign.gatedAgentIds
 })
 export type RcRoutes = z.infer<typeof RcRoutes>
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -47,7 +47,8 @@ function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): Bo
     agents: a.agents.map((x) => ({ agentId: x.agentId, name: x.name })),
     routes: a.routes,
     ...(a.defaultAgentId ? { defaultAgentId: a.defaultAgentId } : {}),
-    ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {})
+    ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {}),
+    gatedAgentIds: a.gatedAgentIds
   }
 }
 
@@ -145,7 +146,8 @@ async function main(): Promise<void> {
         agents: r.agents.map((x) => ({ agentId: x.agentId, name: x.name })),
         routes: r.routes,
         ...(r.defaultAgentId ? { defaultAgentId: r.defaultAgentId } : {}),
-        ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {})
+        ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {}),
+        gatedAgentIds: r.gatedAgentIds
       }),
     onAssign: (a) =>
       held.sharedBot?.setAffinity(a.botId, a.sessionKey, {

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -176,6 +176,7 @@ async function main(): Promise<void> {
     getDaemon: (daemonId) => held.rdServer?.get(daemonId),
     setChannelAgent: (botId, channelId, agentId) => client.emitSetChannelAgent({ botId, channelId, agentId }),
     reportBotChannels: (m) => client.emitBotChannels(m),
+    reportBotConversation: (m) => client.emitBotConversation(m),
     reportThreadAssign: (m) => client.emitThreadAssign(m),
     lookupThread: (m) => client.lookupThread(m),
     isAgentBotApp: (targetAgentId, platform, channelId, appId) =>

--- a/packages/relay/src/relay-cp-client.ts
+++ b/packages/relay/src/relay-cp-client.ts
@@ -34,6 +34,7 @@ import {
   type RcGithubInstallation,
   type RcSetChannelAgent,
   type RcBotChannels,
+  type RcBotConversation,
   type RcThreadAssign,
   type RcThreadLookup,
   type RcThreadLookupOk,
@@ -251,6 +252,17 @@ export class RelayCpClient {
       return false
     }
     this.transport.send(JSON.stringify(buildRelayCpFrame('rc/bot-channels', m)))
+    return true
+  }
+
+  /** Emit one incremental gated-DM conversation report (§14.3). Best-effort: a drop
+   *  self-heals on the counterpart's next DM, so there is no pending-retry queue. */
+  emitBotConversation(m: RcBotConversation): boolean {
+    if (this.state !== 'READY' || !this.transport) {
+      this.deps.log.warn(`relay: dropping rc/bot-conversation for ${m.botId} (link ${this.state})`)
+      return false
+    }
+    this.transport.send(JSON.stringify(buildRelayCpFrame('rc/bot-conversation', m)))
     return true
   }
 

--- a/packages/relay/src/shared-bot-manager.test.ts
+++ b/packages/relay/src/shared-bot-manager.test.ts
@@ -485,10 +485,65 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
     expect(ingest.postText).toHaveBeenCalledTimes(1)
     expect(ingest.postText.mock.calls[0]![0]).toBe('D42')
 
-    // Second DM: re-report (idempotent CP-side) but NO second notice.
+    // Second DM: report is latched per conversation (CP row exists), notice too.
     await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000200' }))
-    expect(reportBotConversation).toHaveBeenCalledTimes(2)
+    expect(reportBotConversation).toHaveBeenCalledTimes(1)
     expect(ingest.postText).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a gated DM even when a non-gated default agent WINS the routing (mixed bot)', async () => {
+    const reportBotConversation = vi.fn(() => true)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    const a = gatedAssignment()
+    // OTHER is org-visible and catches every unslugged DM as the group default.
+    a.members = [
+      { daemonId: DAEMON_ID, agentIds: [AGENT_ID] },
+      { daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] }
+    ]
+    a.agents = [
+      { agentId: AGENT_ID, name: 'Agent' },
+      { agentId: OTHER_AGENT_ID, name: 'Public' }
+    ]
+    a.routes = [
+      {
+        agentId: OTHER_AGENT_ID,
+        daemonId: OTHER_DAEMON_ID,
+        integrationId: OTHER_INTEGRATION_ID,
+        match: { kind: 'keyword', value: 'public' }
+      }
+    ]
+    a.defaultAgentId = OTHER_AGENT_ID
+    a.defaultDaemonId = OTHER_DAEMON_ID
+    internals.router.upsert(a)
+    const ingest = fakeIngest()
+    internals.ingests.set(BOT_ID, ingest)
+
+    await internals.forward(BOT_ID, dm())
+    // The DM routed to the public default — the gated install still needs its
+    // pending Off row, but nothing was unrouted so there is NO notice.
+    expect(reportBotConversation).toHaveBeenCalledWith({
+      botId: BOT_ID,
+      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+    })
+    expect(ingest.postText).not.toHaveBeenCalled()
+  })
+
+  it('retries the DM report on the next DM when the CP link was down', async () => {
+    let ready = false
+    const reportBotConversation = vi.fn(() => ready)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    internals.router.upsert(gatedAssignment())
+    internals.ingests.set(BOT_ID, fakeIngest())
+
+    await internals.forward(BOT_ID, dm())
+    expect(reportBotConversation).toHaveBeenCalledTimes(1) // dropped — not latched
+    ready = true
+    await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000200' }))
+    expect(reportBotConversation).toHaveBeenCalledTimes(2) // delivered — latched
+    await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000300' }))
+    expect(reportBotConversation).toHaveBeenCalledTimes(2)
   })
 
   it('an unrouted @mention in a channel gets the notice but NO conversation report', async () => {

--- a/packages/relay/src/shared-bot-manager.test.ts
+++ b/packages/relay/src/shared-bot-manager.test.ts
@@ -529,6 +529,39 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
     expect(ingest.postText).not.toHaveBeenCalled()
   })
 
+  it('resets the DM-report latch when the gated member set changes (new install needs its row)', async () => {
+    const reportBotConversation = vi.fn(() => true)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    const a = gatedAssignment()
+    internals.router.upsert(a)
+    internals.ingests.set(BOT_ID, fakeIngest())
+
+    await internals.forward(BOT_ID, dm())
+    expect(reportBotConversation).toHaveBeenCalledTimes(1) // latched for this assignment
+
+    // A routes update with a CHANGED gated set (e.g. a newly restricted install)
+    // must invalidate the latch so the next DM fans out the new install's row.
+    manager.updateRoutes(BOT_ID, {
+      members: a.members,
+      agents: a.agents,
+      routes: a.routes,
+      gatedAgentIds: [AGENT_ID, OTHER_AGENT_ID]
+    })
+    await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000200' }))
+    expect(reportBotConversation).toHaveBeenCalledTimes(2)
+
+    // An unchanged gated set keeps the latch.
+    manager.updateRoutes(BOT_ID, {
+      members: a.members,
+      agents: a.agents,
+      routes: a.routes,
+      gatedAgentIds: [AGENT_ID, OTHER_AGENT_ID]
+    })
+    await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000300' }))
+    expect(reportBotConversation).toHaveBeenCalledTimes(2)
+  })
+
   it('retries the DM report on the next DM when the CP link was down', async () => {
     let ready = false
     const reportBotConversation = vi.fn(() => ready)

--- a/packages/relay/src/shared-bot-manager.test.ts
+++ b/packages/relay/src/shared-bot-manager.test.ts
@@ -29,6 +29,7 @@ const deps = (over: Partial<SharedBotManagerDeps> = {}): SharedBotManagerDeps =>
   getDaemon: () => undefined,
   setChannelAgent: vi.fn(),
   reportBotChannels: vi.fn(() => true),
+  reportBotConversation: vi.fn(() => true),
   reportThreadAssign: vi.fn(() => true),
   lookupThread: vi.fn(async () => ({ botId: BOT_ID, sessionKey: '', target: null }) as RcThreadLookupOk),
   isAgentBotApp: vi.fn(() => false),
@@ -64,6 +65,13 @@ const action = (over: Partial<SharedSlackSessionAction> = {}): SharedSlackSessio
 
 interface ManagerInternals {
   router: SharedBotRouter
+  ingests: Map<
+    string,
+    {
+      lookupUserName(u: string): Promise<string | undefined>
+      postText(c: string, t: string, th?: string): Promise<void>
+    }
+  >
   reportChannels(snapshot: RcBotChannels): void
   selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void
   forwardSessionAction(botId: string, action: SharedSlackSessionAction): void
@@ -430,5 +438,88 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
 
     expect(lookupThread).toHaveBeenCalledTimes(1)
     expect(sendMsg).not.toHaveBeenCalled()
+  })
+})
+
+describe('SharedBotManager conversation gating (resource-visibility §14.3)', () => {
+  const fakeIngest = () => ({
+    lookupUserName: vi.fn(async () => '@Alice'),
+    postText: vi.fn(async () => {})
+  })
+  const gatedAssignment = (): BotAssignment => ({
+    botId: BOT_ID,
+    platform: 'slack',
+    secrets: { botToken: 'xoxb', signingSecret: 'ssecret' },
+    botUserId: 'UBOT',
+    members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+    agents: [{ agentId: AGENT_ID, name: 'Agent' }],
+    routes: [], // everything gated ⇒ no keyword rung, no default
+    gatedAgentIds: [AGENT_ID]
+  })
+  const dm = (over: Partial<WireNormalizedMessage> = {}): WireNormalizedMessage => ({
+    msgId: 'slack:D42:1720000000.000100',
+    traceId: 't',
+    source: 'user',
+    platform: 'slack',
+    channel: 'D42',
+    sender: { id: 'U1', isBot: false },
+    text: 'hi there',
+    mentionedBots: [],
+    isDm: true,
+    ...over
+  })
+
+  it('reports an unrouted gated DM as a kind:im conversation and notices once per conversation', async () => {
+    const reportBotConversation = vi.fn(() => true)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    internals.router.upsert(gatedAssignment())
+    const ingest = fakeIngest()
+    internals.ingests.set(BOT_ID, ingest)
+
+    await internals.forward(BOT_ID, dm())
+    expect(reportBotConversation).toHaveBeenCalledWith({
+      botId: BOT_ID,
+      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+    })
+    expect(ingest.postText).toHaveBeenCalledTimes(1)
+    expect(ingest.postText.mock.calls[0]![0]).toBe('D42')
+
+    // Second DM: re-report (idempotent CP-side) but NO second notice.
+    await internals.forward(BOT_ID, dm({ msgId: 'slack:D42:1720000000.000200' }))
+    expect(reportBotConversation).toHaveBeenCalledTimes(2)
+    expect(ingest.postText).toHaveBeenCalledTimes(1)
+  })
+
+  it('an unrouted @mention in a channel gets the notice but NO conversation report', async () => {
+    const reportBotConversation = vi.fn(() => true)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    internals.router.upsert(gatedAssignment())
+    const ingest = fakeIngest()
+    internals.ingests.set(BOT_ID, ingest)
+
+    await internals.forward(
+      BOT_ID,
+      dm({ channel: 'C9', isDm: false, thread: '123.456', text: '<@UBOT> hello', mentionedBots: ['UBOT'] })
+    )
+    expect(reportBotConversation).not.toHaveBeenCalled()
+    expect(ingest.postText).toHaveBeenCalledTimes(1)
+    expect(ingest.postText.mock.calls[0]![2]).toBe('123.456') // threaded, no channel spam
+  })
+
+  it('does nothing gated-related for a bot with no gated members', async () => {
+    const reportBotConversation = vi.fn(() => true)
+    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const internals = manager as unknown as ManagerInternals
+    const a = gatedAssignment()
+    a.gatedAgentIds = []
+    internals.router.upsert(a)
+    const ingest = fakeIngest()
+    internals.ingests.set(BOT_ID, ingest)
+
+    await internals.forward(BOT_ID, dm())
+    expect(reportBotConversation).not.toHaveBeenCalled()
+    expect(ingest.postText).not.toHaveBeenCalled()
   })
 })

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -21,6 +21,8 @@ import type {
   RdMsgIm,
   RdMsgSlackAction,
   RcBotChannels,
+  RcBotConversation,
+  WireNormalizedMessage,
   RcThreadAssign,
   RcThreadLookup
 } from '@agentconnect.md/protocol'
@@ -46,6 +48,9 @@ export interface SharedBotManagerDeps {
   /** Report the authoritative HTTP Slack channel-membership snapshot to the CP.
    *  Returns false when the CP link is down so the latest snapshot can be retried. */
   reportBotChannels: (m: RcBotChannels) => boolean
+  /** Report one gated-DM conversation to the CP (§14.3, → `rc/bot-conversation`).
+   *  Best-effort: loss self-heals on the counterpart's next DM. */
+  reportBotConversation: (m: RcBotConversation) => boolean
   /** Report the thread's now-resolved owner to the CP (→ `rc/thread-assign`). Returns
    *  `false` if the CP link was not READY and the frame was dropped, so the manager can
    *  retry it when the link recovers ({@link SharedBotManager.flushPendingReports}). */
@@ -123,6 +128,8 @@ export class SharedBotManager {
   /** Latest bot-level channel snapshot dropped while the CP link was down. A full
    *  snapshot supersedes any older one for the same bot. */
   private readonly pendingChannelReports = new Map<string, RcBotChannels>()
+  /** §14 one-time gating-notice latch (`botId:channel`) — per relay lifetime. */
+  private readonly gatedNoticesSent = new Set<string>()
 
   constructor(private readonly deps: SharedBotManagerDeps) {}
 
@@ -305,6 +312,18 @@ export class SharedBotManager {
         this.report({ botId, sessionKey, agentId: tgt.agentId, daemonId: tgt.daemonId })
       }
     } else {
+      // Conversation gating (resource-visibility §14.3): an explicitly-addressed
+      // message (DM, or @bot mention) that arbitration could not place, on a bot
+      // that backs ≥1 gated agent, must not look silently dead — surface the DM as
+      // a pending console row and answer once per conversation.
+      const a = this.router.get(botId)
+      if (!msg.sender.isBot && (a?.gatedAgentIds?.length ?? 0) > 0) {
+        const mentioned = a?.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)
+        if (msg.isDm || mentioned) {
+          await this.handleGatedUnrouted(botId, msg)
+          return
+        }
+      }
       // Backstop leg: only a real un-mentioned threaded follow-up is worth a CP lookup.
       if (!this.router.isUnmentionedThreadFollowup(botId, msg)) return
       let target: { agentId: string; daemonId: string } | null
@@ -347,6 +366,37 @@ export class SharedBotManager {
       this.deps.log.warn(
         `shared-bot(${botId}): forward to ${tgt.daemonId} failed: ${(err as Error).message} (dropped ${n})`
       )
+    }
+  }
+
+  /**
+   * §14.3: one explicitly-addressed, unroutable message on a bot with gated members.
+   * A DM is surfaced to the CP as an incremental `kind:'im'` conversation report
+   * (fanned to gated installs as pending Off rows — the console enablement path);
+   * DM or mention alike get a ONE-TIME per-conversation notice so the bot never
+   * looks silently broken. Channel rows need no report here — membership snapshots
+   * already carry them.
+   */
+  private async handleGatedUnrouted(botId: string, msg: WireNormalizedMessage): Promise<void> {
+    const ingest = this.ingests.get(botId)
+    if (msg.isDm) {
+      const name = await ingest?.lookupUserName(msg.sender.id)
+      this.deps.reportBotConversation({
+        botId,
+        conversation: { id: msg.channel, ...(name ? { name } : {}), kind: 'im' }
+      })
+    }
+    const latch = `${botId}:${msg.channel}`
+    if (this.gatedNoticesSent.has(latch)) return
+    this.gatedNoticesSent.add(latch)
+    try {
+      await ingest?.postText(
+        msg.channel,
+        '🔒 This agent isn’t enabled in this conversation. Ask an admin to enable it in the AgentConnect console.',
+        msg.isDm ? undefined : msg.thread
+      )
+    } catch (err) {
+      this.deps.log.warn(`shared-bot(${botId}): gating notice failed in ch=${msg.channel}: ${(err as Error).message}`)
     }
   }
 

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -190,7 +190,7 @@ export class SharedBotManager {
   /** `rc/routes` — hot-update routes/members/default WITHOUT re-opening the ingest. */
   updateRoutes(
     botId: string,
-    patch: Pick<BotAssignment, 'members' | 'agents' | 'routes' | 'defaultAgentId' | 'defaultDaemonId'>
+    patch: Pick<BotAssignment, 'members' | 'agents' | 'routes' | 'defaultAgentId' | 'defaultDaemonId' | 'gatedAgentIds'>
   ): void {
     this.router.updateRoutes(botId, patch)
   }

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -130,8 +130,15 @@ export class SharedBotManager {
   private readonly pendingChannelReports = new Map<string, RcBotChannels>()
   /** §14 one-time gating-notice latch (`botId:channel`) — per relay lifetime. */
   private readonly gatedNoticesSent = new Set<string>()
-  /** §14.3 per-conversation DM-report latch (`botId:channel`) — per relay lifetime. */
+  /** §14.3 per-conversation DM-report latch (`botId:channel`) — scoped to the
+   *  CURRENT bot assignment: cleared on assign/unassign and whenever the gated
+   *  member set changes, since rows belong to the installs of that moment. */
   private readonly gatedDmReported = new Set<string>()
+
+  private clearGatedDmLatches(botId: string): void {
+    const prefix = `${botId}:`
+    for (const k of [...this.gatedDmReported]) if (k.startsWith(prefix)) this.gatedDmReported.delete(k)
+  }
 
   constructor(private readonly deps: SharedBotManagerDeps) {}
 
@@ -167,6 +174,9 @@ export class SharedBotManager {
 
   /** `rc/bot-assign` — (re)load the routing table + (re)build the bot's HTTP ingest. */
   async assign(a: BotAssignment): Promise<void> {
+    // A full (re)assignment can mean new installs / a changed gated set — stale
+    // DM-report latches would starve a later gated install of its pending row.
+    this.clearGatedDmLatches(a.botId)
     this.router.upsert(a)
     if (a.platform !== 'slack') {
       this.deps.log.warn(`shared-bot(${a.botId}): platform '${a.platform}' ingest not yet supported (milestone C)`)
@@ -201,11 +211,17 @@ export class SharedBotManager {
     botId: string,
     patch: Pick<BotAssignment, 'members' | 'agents' | 'routes' | 'defaultAgentId' | 'defaultDaemonId' | 'gatedAgentIds'>
   ): void {
+    // A changed gated member set may require a fresh DM fan-out (§14.3) — e.g. a
+    // newly restricted or newly installed member needs its own pending Off row.
+    const prev = this.router.get(botId)?.gatedAgentIds ?? []
+    const next = patch.gatedAgentIds ?? []
+    if (prev.length !== next.length || !prev.every((id) => next.includes(id))) this.clearGatedDmLatches(botId)
     this.router.updateRoutes(botId, patch)
   }
 
   /** `rc/bot-unassign` — drop the routes + close the ingest. */
   async unassign(botId: string): Promise<void> {
+    this.clearGatedDmLatches(botId)
     this.router.remove(botId)
     await this.stopIngest(botId)
   }

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -130,6 +130,8 @@ export class SharedBotManager {
   private readonly pendingChannelReports = new Map<string, RcBotChannels>()
   /** §14 one-time gating-notice latch (`botId:channel`) — per relay lifetime. */
   private readonly gatedNoticesSent = new Set<string>()
+  /** §14.3 per-conversation DM-report latch (`botId:channel`) — per relay lifetime. */
+  private readonly gatedDmReported = new Set<string>()
 
   constructor(private readonly deps: SharedBotManagerDeps) {}
 
@@ -300,6 +302,12 @@ export class SharedBotManager {
       return
     }
     const sessionKey = sessionKeyOf(msg)
+    const assignment = this.router.get(botId)
+    const hasGatedMembers = (assignment?.gatedAgentIds?.length ?? 0) > 0
+    // §14.3 DM discovery must NOT depend on the arbitration outcome: on a
+    // mixed-visibility bot the public default agent wins every unslugged DM, yet
+    // the gated installs still need their pending Off row to ever be enableable.
+    if (msg.isDm && !msg.sender.isBot && hasGatedMembers) await this.reportGatedDmConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
     let tgt = this.router.route(botId, msg)
     if (tgt) {
@@ -314,13 +322,13 @@ export class SharedBotManager {
     } else {
       // Conversation gating (resource-visibility §14.3): an explicitly-addressed
       // message (DM, or @bot mention) that arbitration could not place, on a bot
-      // that backs ≥1 gated agent, must not look silently dead — surface the DM as
-      // a pending console row and answer once per conversation.
-      const a = this.router.get(botId)
-      if (!msg.sender.isBot && (a?.gatedAgentIds?.length ?? 0) > 0) {
-        const mentioned = a?.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)
+      // that backs ≥1 gated agent, must not look silently dead — answer once per
+      // conversation (the DM row itself was already reported above, un-gated on
+      // the routing outcome).
+      if (!msg.sender.isBot && hasGatedMembers) {
+        const mentioned = assignment?.botUserId !== undefined && msg.mentionedBots.includes(assignment.botUserId)
         if (msg.isDm || mentioned) {
-          await this.handleGatedUnrouted(botId, msg)
+          await this.noticeGatedUnrouted(botId, msg)
           return
         }
       }
@@ -370,31 +378,40 @@ export class SharedBotManager {
   }
 
   /**
-   * §14.3: one explicitly-addressed, unroutable message on a bot with gated members.
-   * A DM is surfaced to the CP as an incremental `kind:'im'` conversation report
-   * (fanned to gated installs as pending Off rows — the console enablement path);
-   * DM or mention alike get a ONE-TIME per-conversation notice so the bot never
-   * looks silently broken. Channel rows need no report here — membership snapshots
-   * already carry them.
+   * §14.3: surface one human DM conversation to the CP as an incremental
+   * `kind:'im'` report (fanned to gated installs as pending Off rows — the console
+   * enablement path). Fires for EVERY human DM on a bot with gated members,
+   * routed or not; latched per conversation per relay lifetime (the CP upsert is
+   * idempotent, this only bounds chatter — a relay restart re-reports harmlessly).
+   * Channel rows need no report here — membership snapshots already carry them.
    */
-  private async handleGatedUnrouted(botId: string, msg: WireNormalizedMessage): Promise<void> {
-    const ingest = this.ingests.get(botId)
-    if (msg.isDm) {
-      const name = await ingest?.lookupUserName(msg.sender.id)
-      this.deps.reportBotConversation({
-        botId,
-        conversation: { id: msg.channel, ...(name ? { name } : {}), kind: 'im' }
-      })
-    }
+  private async reportGatedDmConversation(botId: string, msg: WireNormalizedMessage): Promise<void> {
+    const latch = `${botId}:${msg.channel}`
+    if (this.gatedDmReported.has(latch)) return
+    const name = await this.ingests.get(botId)?.lookupUserName(msg.sender.id)
+    const sent = this.deps.reportBotConversation({
+      botId,
+      conversation: { id: msg.channel, ...(name ? { name } : {}), kind: 'im' }
+    })
+    // Latch only a delivered report — a CP-link-down drop retries on the next DM.
+    if (sent) this.gatedDmReported.add(latch)
+  }
+
+  /** §14.3: the ONE-TIME per-conversation notice for an explicitly-addressed,
+   *  unroutable message on a bot with gated members — the bot must never look
+   *  silently broken. */
+  private async noticeGatedUnrouted(botId: string, msg: WireNormalizedMessage): Promise<void> {
     const latch = `${botId}:${msg.channel}`
     if (this.gatedNoticesSent.has(latch)) return
     this.gatedNoticesSent.add(latch)
     try {
-      await ingest?.postText(
-        msg.channel,
-        '🔒 This agent isn’t enabled in this conversation. Ask an admin to enable it in the AgentConnect console.',
-        msg.isDm ? undefined : msg.thread
-      )
+      await this.ingests
+        .get(botId)
+        ?.postText(
+          msg.channel,
+          '🔒 This agent isn’t enabled in this conversation. Ask an admin to enable it in the AgentConnect console.',
+          msg.isDm ? undefined : msg.thread
+        )
     } catch (err) {
       this.deps.log.warn(`shared-bot(${botId}): gating notice failed in ch=${msg.channel}: ${(err as Error).message}`)
     }

--- a/packages/relay/src/shared-bot-router.test.ts
+++ b/packages/relay/src/shared-bot-router.test.ts
@@ -133,6 +133,34 @@ describe('shared-bot arbitration (§10)', () => {
       expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
     })
 
+    it('a conversation-scoped keyword (DM slug) outranks the scoped auto route', () => {
+      const a = assignment()
+      a.gatedAgentIds = [ALICE, BOB]
+      a.routes = [
+        // Both gated agents enabled the same DM: one auto + one slug route each.
+        { agentId: ALICE, daemonId: D1, integrationId: 'iA', scope: { channel: 'D9' }, match: { kind: 'auto' } },
+        {
+          agentId: ALICE,
+          daemonId: D1,
+          integrationId: 'iA',
+          scope: { channel: 'D9' },
+          match: { kind: 'keyword', value: 'alice' }
+        },
+        { agentId: BOB, daemonId: D2, integrationId: 'iB', scope: { channel: 'D9' }, match: { kind: 'auto' } },
+        {
+          agentId: BOB,
+          daemonId: D2,
+          integrationId: 'iB',
+          scope: { channel: 'D9' },
+          match: { kind: 'keyword', value: 'bob' }
+        }
+      ]
+      const slugged = arbitrate(a, msg({ channel: 'D9', isDm: true, text: 'bob check this please' }), empty())
+      expect(slugged).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
+      const bare = arbitrate(a, msg({ channel: 'D9', isDm: true, text: 'hello' }), empty())
+      expect(bare).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    })
+
     it('thread continuity to a NON-gated agent is unaffected by gatedAgentIds on others', () => {
       const a = { ...assignment(), gatedAgentIds: [ALICE] }
       const aff = new Map<string, RouteTarget>([['CX/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])

--- a/packages/relay/src/shared-bot-router.test.ts
+++ b/packages/relay/src/shared-bot-router.test.ts
@@ -116,6 +116,30 @@ describe('shared-bot arbitration (§10)', () => {
     const t = arbitrate(assignment(), msg({ channel: 'CX', thread: 'ts1', text: 'more' }), aff)
     expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
   })
+
+  describe('conversation gating (resource-visibility §14)', () => {
+    it('thread continuity to a GATED agent is refused when it has no scoped route in the conversation', () => {
+      const a = { ...assignment(), gatedAgentIds: [BOB] }
+      // BOB's only scoped route is C2; a pre-gate binding in CX must not keep routing.
+      const aff = new Map<string, RouteTarget>([['CX/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      const t = arbitrate(a, msg({ channel: 'CX', thread: 'ts1', text: 'and then?' }), aff)
+      expect(t).toBeNull()
+    })
+
+    it('thread continuity to a GATED agent is honoured inside its enabled conversation', () => {
+      const a = { ...assignment(), gatedAgentIds: [BOB] }
+      const aff = new Map<string, RouteTarget>([['C2/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      const t = arbitrate(a, msg({ channel: 'C2', thread: 'ts1', text: 'and then?' }), aff)
+      expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
+    })
+
+    it('thread continuity to a NON-gated agent is unaffected by gatedAgentIds on others', () => {
+      const a = { ...assignment(), gatedAgentIds: [ALICE] }
+      const aff = new Map<string, RouteTarget>([['CX/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      const t = arbitrate(a, msg({ channel: 'CX', thread: 'ts1', text: 'and then?' }), aff)
+      expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
+    })
+  })
 })
 
 describe('SharedBotRouter — table + live affinity', () => {

--- a/packages/relay/src/shared-bot-router.ts
+++ b/packages/relay/src/shared-bot-router.ts
@@ -99,6 +99,11 @@ export function arbitrate(
   //    rule fires on any message — the operator's trigger choice).
   const ownedMention = scoped.find((r) => r.match.kind === 'mention' && kindMatches(r, msg, a.botUserId))
   if (ownedMention) return target(ownedMention)
+  // Conversation-scoped keyword (§14.3): slug disambiguation inside a shared DM
+  // enabled for several gated agents — outranks the scoped auto so "<slug> …"
+  // names its agent; an unslugged message falls through to the first auto route.
+  const ownedKeyword = scoped.find((r) => r.match.kind === 'keyword' && kindMatches(r, msg, a.botUserId))
+  if (ownedKeyword) return target(ownedKeyword)
   const ownedAuto = scoped.find((r) => r.match.kind === 'auto')
   if (ownedAuto) return target(ownedAuto)
 

--- a/packages/relay/src/shared-bot-router.ts
+++ b/packages/relay/src/shared-bot-router.ts
@@ -31,6 +31,11 @@ export interface BotAssignment {
   routes: AttributedRoute[]
   defaultAgentId?: string
   defaultDaemonId?: string
+  /** Conversation-gated members (resource-visibility.md §14): thread continuity to
+   *  one of these agents is honoured only while it still has a channel-scoped route
+   *  in the conversation — a binding made before the gate was applied must not keep
+   *  routing a private agent in a now-Off conversation. */
+  gatedAgentIds?: string[]
 }
 
 /** The arbitration verdict — a target the daemon dispatches to. */
@@ -98,10 +103,13 @@ export function arbitrate(
   if (ownedAuto) return target(ownedAuto)
 
   // 2. Thread continuity: an un-mentioned follow-up in a thread the relay already
-  //    routed continues to that agent, provided it is still a member. A durable
-  //    `rc/assign` seed carries no integrationId — backfill it from the agent's route.
+  //    routed continues to that agent, provided it is still a member — and, for a
+  //    conversation-gated agent (§14), provided the conversation is still enabled
+  //    (a channel-scoped route for that agent exists). The affinity map is not
+  //    scope-filtered, so without this check a pre-gate binding routes forever.
   const cont = affinity.get(sessionKeyOf(msg))
-  if (cont && a.members.some((m) => m.daemonId === cont.daemonId && m.agentIds.includes(cont.agentId))) {
+  const contGateOk = !cont || !a.gatedAgentIds?.includes(cont.agentId) || scoped.some((r) => r.agentId === cont.agentId)
+  if (cont && contGateOk && a.members.some((m) => m.daemonId === cont.daemonId && m.agentIds.includes(cont.agentId))) {
     if (cont.integrationId) return cont
     const route = a.routes.find((r) => r.agentId === cont.agentId)
     if (route) return { ...cont, integrationId: route.integrationId }
@@ -149,7 +157,7 @@ export class SharedBotRouter {
   /** Replace routes/members/agents/default WITHOUT touching secrets or botUserId (rc/routes). */
   updateRoutes(
     botId: string,
-    patch: Pick<BotAssignment, 'members' | 'agents' | 'routes' | 'defaultAgentId' | 'defaultDaemonId'>
+    patch: Pick<BotAssignment, 'members' | 'agents' | 'routes' | 'defaultAgentId' | 'defaultDaemonId' | 'gatedAgentIds'>
   ): void {
     const a = this.bots.get(botId)
     if (!a) return
@@ -158,6 +166,7 @@ export class SharedBotRouter {
     a.routes = patch.routes
     a.defaultAgentId = patch.defaultAgentId
     a.defaultDaemonId = patch.defaultDaemonId
+    a.gatedAgentIds = patch.gatedAgentIds
   }
 
   remove(botId: string): BotAssignment | undefined {

--- a/packages/relay/src/slack-shared-ingest.ts
+++ b/packages/relay/src/slack-shared-ingest.ts
@@ -394,6 +394,8 @@ export class SlackSharedIngest {
   private slackBotId = ''
   private channelRefresh?: Promise<void>
   private channelRefreshQueued = false
+  /** users.info label cache for gated-DM counterpart names (null = lookup failed). */
+  private readonly userNames = new Map<string, string | null>()
 
   constructor(
     readonly botId: string,
@@ -405,6 +407,35 @@ export class SlackSharedIngest {
    *  demux+authenticate a request to this bot. Read-only; NEVER log it. */
   get signingSecret(): string {
     return this.secrets.signingSecret
+  }
+
+  /** Post one plain, chrome-marked text message (the §14 gating notice) — chrome so
+   *  peer daemons' thread backfill never re-ingests it as conversation. */
+  async postText(channel: string, text: string, threadTs?: string): Promise<void> {
+    await this.web?.chat.postMessage({
+      channel,
+      text,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+      metadata: { event_type: 'agentconnect_chrome', event_payload: {} }
+    })
+  }
+
+  /** Cached best-effort users.info lookup → "@Display Name" label for a gated-DM
+   *  conversation row. Undefined when the lookup fails (the row lands nameless). */
+  async lookupUserName(userId: string): Promise<string | undefined> {
+    if (this.userNames.has(userId)) return this.userNames.get(userId) ?? undefined
+    try {
+      const res = await this.web?.users.info({ user: userId })
+      const u = res?.user as
+        { profile?: { display_name?: string; real_name?: string }; real_name?: string; name?: string } | undefined
+      const name = u?.profile?.display_name || u?.profile?.real_name || u?.real_name || u?.name
+      const label = name ? `@${name}` : null
+      this.userNames.set(userId, label)
+      return label ?? undefined
+    } catch {
+      this.userNames.set(userId, null)
+      return undefined
+    }
   }
 
   /** Best-effort setup: resolve the bot user id for arbitration. No socket to open —

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -5,15 +5,20 @@ import type { IntegrationChannelRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 
-/** The per-channel trigger toggle — "@-mention" (default) vs "any message". */
+/** The per-conversation trigger toggle. Channels: "@-mention" (default) vs "any
+ *  message", plus an "off" segment on a gated (restricted-agent) integration —
+ *  resource-visibility.md §14. DM rows are binary off/on. */
 function TriggerToggle({
   channel,
   disabled,
+  gated,
   onChange
 }: {
   channel: IntegrationChannelRow
   /** Demo rows (no live integration id) render the control inert. */
   disabled: boolean
+  /** Restricted-agent integration: conversations are gated, "off" is offered. */
+  gated: boolean
   onChange: (trigger: IntegrationChannelRow['trigger']) => void
 }) {
   const [saving, setSaving] = useState(false)
@@ -41,10 +46,34 @@ function TriggerToggle({
       </button>
     )
   }
+  // A DM conversation activates on any message once enabled — binary off/on. A
+  // channel keeps the mention/any choice; "off" appears when gated (and, so the
+  // state stays visible, on an inert off row of a no-longer-gated integration).
+  const segs: [IntegrationChannelRow['trigger'], string][] =
+    channel.kind === 'im'
+      ? [
+          ['off', 'off'],
+          ['any', 'on']
+        ]
+      : gated || channel.trigger === 'off'
+        ? [
+            ['off', 'off'],
+            ['mention', '@-mention'],
+            ['any', 'any message']
+          ]
+        : [
+            ['mention', '@-mention'],
+            ['any', 'any message']
+          ]
   return (
-    <div className="inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:w-full max-desktop:grid-cols-2">
-      {seg('mention', '@-mention')}
-      {seg('any', 'any message')}
+    <div
+      className={
+        segs.length === 3
+          ? 'inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:w-full max-desktop:grid-cols-3'
+          : 'inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:w-full max-desktop:grid-cols-2'
+      }
+    >
+      {segs.map(([trigger, label]) => seg(trigger, label))}
     </div>
   )
 }
@@ -87,7 +116,8 @@ function DefaultAgentSelect({
 }
 
 /**
- * The channel rows of one integration — one row per channel the bot is in, each
+ * The conversation rows of one integration — one row per channel the bot is in
+ * (plus, on a gated/restricted agent, one row per reported DM conversation), each
  * with its trigger toggle (and, for a SHARED bot, a per-channel default-agent
  * picker), closed by the "invite the bot" hint. Shared by the Integrations page and
  * the agent detail page; render inside a padding-less card whose header row sits
@@ -98,6 +128,7 @@ export function IntegrationChannelList({
   channels,
   botId,
   shareable = false,
+  gated = false,
   padX = 18
 }: {
   integrationId?: string
@@ -106,6 +137,9 @@ export function IntegrationChannelList({
   botId?: string
   /** When true (shared bot), show the per-channel default-agent picker. */
   shareable?: boolean
+  /** Restricted-agent integration (resource-visibility.md §14): conversations are
+   *  gated — new ones start off, DM rows appear, the banner explains the gate. */
+  gated?: boolean
   /** Horizontal row padding, to line up with the host card (18 list / 14 detail). */
   padX?: number
 }) {
@@ -116,33 +150,61 @@ export function IntegrationChannelList({
     const a = agents.find((x) => x.id === id)
     return { id, label: a?.displayName || a?.name || id }
   })
+  const channelRows = channels.filter((c) => c.kind !== 'im')
+  const dmRows = channels.filter((c) => c.kind === 'im')
+  const row = (c: IntegrationChannelRow) => (
+    <div
+      key={c.channelId}
+      className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
+      style={{ padding: `10px ${padX}px` }}
+    >
+      <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
+        {c.kind === 'im' ? '@' : '#'}
+      </span>
+      <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">{c.name}</span>
+      <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-stretch">
+        {c.kind !== 'im' && shareable && agentOptions.length > 0 && (
+          <DefaultAgentSelect
+            channel={c}
+            options={agentOptions}
+            disabled={!integrationId}
+            onChange={(agentId) => setChannelAgent(integrationId!, c.channelId, agentId)}
+          />
+        )}
+        <TriggerToggle
+          channel={c}
+          disabled={!integrationId}
+          gated={gated}
+          onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
+        />
+      </div>
+    </div>
+  )
   return (
     <>
-      {channels.map((c) => (
+      {gated && (
         <div
-          key={c.channelId}
-          className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
-          style={{ padding: `10px ${padX}px` }}
+          role="note"
+          className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)"
+          style={{ padding: `9px ${padX}px` }}
         >
-          <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">#</span>
-          <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">{c.name}</span>
-          <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-stretch">
-            {shareable && agentOptions.length > 0 && (
-              <DefaultAgentSelect
-                channel={c}
-                options={agentOptions}
-                disabled={!integrationId}
-                onChange={(agentId) => setChannelAgent(integrationId!, c.channelId, agentId)}
-              />
-            )}
-            <TriggerToggle
-              channel={c}
-              disabled={!integrationId}
-              onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
-            />
-          </div>
+          <Icon name="lock" size={13} className="mt-[2px] flex-none" />
+          <span>
+            This agent is private: conversations start off. Enable each channel or direct message below before the agent
+            responds there.
+          </span>
         </div>
-      ))}
+      )}
+      {channelRows.map(row)}
+      {dmRows.length > 0 && (
+        <div
+          className="border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[11px] font-semibold leading-normal text-(--text-tertiary) uppercase"
+          style={{ padding: `6px ${padX}px` }}
+        >
+          Direct messages
+        </div>
+      )}
+      {dmRows.map(row)}
       <div
         className="flex items-center gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
         style={{ padding: `10px ${padX}px` }}
@@ -150,7 +212,9 @@ export function IntegrationChannelList({
         <Icon name="info" size={14} className="flex-none" />
         {shareable
           ? 'Channels appear here when the bot is invited. Pick a default agent per channel; trigger is set per channel.'
-          : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}
+          : gated
+            ? 'Channels appear here when the bot is invited; direct messages appear when someone writes to the bot.'
+            : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}
       </div>
     </>
   )

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -161,7 +161,11 @@ export function IntegrationChannelList({
       <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
         {c.kind === 'im' ? '@' : '#'}
       </span>
-      <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">{c.name}</span>
+      {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
+          renders the marker, so strip a leading @ to avoid "@@Alice". */}
+      <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">
+        {c.kind === 'im' ? c.name.replace(/^@+/, '') : c.name}
+      </span>
       <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-stretch">
         {c.kind !== 'im' && shareable && agentOptions.length > 0 && (
           <DefaultAgentSelect

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1090,6 +1090,7 @@ export default function AgentDetailView() {
                         channels={g.channels}
                         botId={g.botId}
                         shareable={g.shareable}
+                        gated={da.visibility === 'restricted'}
                         padX={16}
                       />
                     </div>
@@ -1207,6 +1208,7 @@ export default function AgentDetailView() {
                         channels={g.channels}
                         botId={g.botId}
                         shareable={g.shareable}
+                        gated={da.visibility === 'restricted'}
                         padX={14}
                       />
                     </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -524,14 +524,17 @@ export interface SlackConfigInput {
   refreshToken?: string // xoxe-… — optional; omit to store an access-only (expiring) token
 }
 
-// How the bot activates in one channel: only when @-mentioned, or on any message.
-export type ChannelTrigger = 'mention' | 'any'
+// How the bot activates in one conversation: not at all ('off' — conversation
+// gating for restricted agents), only when @-mentioned, or on any message.
+export type ChannelTrigger = 'off' | 'mention' | 'any'
 
-// One channel the integration's bot is in (daemon-reported) + its trigger choice.
+// One conversation the integration's bot is in (daemon-reported) + its trigger
+// choice. kind 'im' rows are DM conversations (gated/restricted agents only).
 export interface IntegrationChannelDto {
   channelId: string
-  name: string | null // "deploys" without the hash; null if lookup failed
+  name: string | null // "deploys" without the hash (or DM counterpart); null if lookup failed
   isPrivate: boolean
+  kind: 'channel' | 'im'
   trigger: ChannelTrigger
   agentId: string | null // per-channel default agent for a shared bot; null ⇒ unset
 }

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -259,6 +259,7 @@ function integrationRowFromDto(
     channels: d.channels.map((c) => ({
       channelId: c.channelId,
       name: c.name || c.channelId,
+      kind: c.kind,
       trigger: c.trigger,
       agentId: c.agentId
     }))

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1317,12 +1317,15 @@ export function getSessions(agentId: string): Session[] {
   return SESSIONS_BY_AGENT[agentId] ?? []
 }
 
-/** One channel the integration's bot is in + how it activates there. */
+/** One conversation the integration's bot is in + how it activates there. */
 export interface IntegrationChannelRow {
   channelId: string
-  /** Bare channel name, no hash (e.g. "deploys"); the UI renders the leading "#". Falls back to the raw id. */
+  /** Bare channel name, no hash (e.g. "deploys"); the UI renders the leading "#".
+   *  For a DM row (kind 'im') the counterpart's name. Falls back to the raw id. */
   name: string
-  trigger: 'mention' | 'any'
+  /** 'im' = a DM conversation row (gated/restricted agents only); absent = channel. */
+  kind?: 'channel' | 'im'
+  trigger: 'off' | 'mention' | 'any'
   /** Per-channel default agent for a shared bot (agentId); null/absent ⇒ unset. */
   agentId?: string | null
 }


### PR DESCRIPTION
## Problem

A `visibility: restricted` (private) agent is protected in the console, but its platform integration was fail-open: **any workspace member could invite the bot into any channel — or DM it — and talk to the private agent.** Slack has no per-user invite ACL (app approval only governs installation), so authorization must live in AgentConnect's own routing layer.

## Design

`docs/designs/resource-visibility.md` **§14** (added here): per-conversation gating, derived from restricted visibility — no stored toggle, no identities on the wire.

- The per-channel trigger becomes a tri-state: **Off / Mention / All messages**. Gating applies **only to restricted agents**; org-visible agents keep today's behavior byte-for-byte.
- For a gated integration **every conversation defaults to Off**. An invited channel appears on the integration card as a pending Off row; an **editor must enable it in the console** — and since the console is protected by resource visibility, the people who can enable are exactly the private group. No Slack↔AgentConnect identity mapping needed.
- **DMs are conversations too**: each DM gets its own row (counterpart name, binary off/on), reported on first inbound DM.
- An explicitly-addressed message (@-mention / DM) in an Off conversation gets a **one-time per-conversation notice** (chrome-marked) instead of silence; everything else drops.
- Trust model: enabling a channel entrusts its membership ("authorize places, not people"). Per-user allowlists / identity mapping remain future overlays (§14.6).

## Mechanism

**Direct (socket) integrations** — the CP stops shipping the unscoped mention/dm defaults for gated integrations and emits **only conversation-scoped bindRules** for enabled conversations. An unknown conversation matches no rule, so `routeRules` fail-closes with zero new router machinery (thread affinity is already scope-filtered). A `gated` boolean rides each platform config for the two behaviors a rule miss can't express (notice + DM reporting).

**Shared (http) integrations** don't pass through `routeRules` (relay pre-addresses), so the gate is two-layered:
1. **CP compile + relay arbitration**: Off conversations compile no route; gated agents are excluded from the unscoped keyword rule and from `defaultAgentId` (the rungs that made a shared bot fail-open for bare `@bot`/DMs); `gatedAgentIds` rides `rc/bot-assign`/`rc/routes` so the relay's thread-continuity rung honours a binding to a gated agent only while it still has a scoped route in that conversation; the CP `rc/thread-lookup` backstop applies the same check.
2. **Daemon backstop**: the gated shared spec carries its scoped bindRules, and `handleRelayIm` refuses conversations they don't cover — a stale relay snapshot can't activate a private agent.

Also hardened in passing: the in-Slack config modal (`rc/set-channel-agent`) is reachable by any workspace user, so assigning a channel to a gated agent now creates the row **Off**; and control commands (`!stop`, `/status`) repeat the admission check since they resolve targets outside the router's scope filter.

**Shared-bot DMs** get an enablement path too: an unrouted DM to a bot backing gated agents makes the relay emit the new incremental `rc/bot-conversation` (never full-set — DM rows must survive membership snapshots), the CP fans it across the bot's gated installs as pending Off rows, and the relay posts the one-time notice (no daemon sees these messages pre-arbitration). An enabled gated DM compiles a scoped `auto` route plus a scoped **slug keyword** route (arbitration: scoped mention → keyword → auto) so a DM enabled for several agents disambiguates by slug.

## Changes by package

- **protocol**: `gated` on all four platform configs; `IntegrationChannel.kind: 'channel'|'im'`; `gatedAgentIds` on `rc/bot-assign`/`rc/routes`; new `rc/bot-conversation` EVT.
- **control-plane**: `ChannelTrigger` gains `off` + new `ConversationKind` column (migration `20260726120000`); `replaceSnapshot` deletes only `kind='channel'` rows and seeds gated defaults; gated spec assembly (direct + shared); sharedBot compile/lookup gating + `reportConversation`; visibility flips re-converge integration specs (`convergeIntegrationGating`); REST/MCP DTOs expose `kind` + `off`.
- **daemon**: persists `gated`; one-time gating notice; DM rows reported as `kind:'im'` (name via display-name store / Slack profile) and preserved across membership refreshes; command admission check; `handleRelayIm` backstop.
- **relay**: gated thread-continuity check; scoped-keyword arbitration rung; unrouted gated DM/mention → conversation report + notice (`users.info` name cache).
- **web**: restricted agents' integration cards get the tri-state control, a Direct-messages section, and a lock banner; org agents' UI unchanged.

## Migration / compatibility

- All wire fields are optional/defaulted — pre-field specs and frames decode unchanged.
- Existing restricted agents: known channel rows keep their triggers (grandfathered enabled, §14.5); **DMs close** — the one break, mitigated by the notice + one-click re-enable from the pending row. `restricted → org` flips gating off with rows preserved inert, so flipping back restores decisions.
- The enum value is added `BEFORE 'mention'` to match Prisma's declared order.

## Tests

~35 new cases across the stack: gated spec assembly (scoped-only, empty-set fail-closed, inert off rows), sharedBot compile/replaceChannels/lookupThread/reportConversation, relay arbitration (affinity gate, DM slug), manager DM report + notice dedupe, protocol codec round-trips, and CP integration coverage (restricted defaults, DM-row survival, gated PATCH pushes, sharing-flip re-push). Full runs: control-plane unit 639 ✓ / integration 633 ✓ (real Postgres), daemon 2100 ✓, relay 298 ✓, protocol 189 ✓; repo-wide typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)