### PR TITLE
fix(daemon): label Discord thread sessions with their parent channel

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -433,18 +433,37 @@ export class DiscordConnection {
 
   // ── MCP MessageGateway: read helpers backing the injected channel tools ──
 
-  async getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }> {
+  async getChannelInfo(channel: string): Promise<{
+    id: string
+    name?: string
+    isIm?: boolean
+    isPrivate?: boolean
+    parentName?: string
+  }> {
     const ch = await this.client.channels.fetch(channel).catch(() => null)
-    const c = ch as (Channel & { name?: string; isDMBased?: () => boolean }) | null
+    const c = ch as
+      | (Channel & { name?: string; isDMBased?: () => boolean; isThread?: () => boolean; parentId?: string | null })
+      | null
     const isIm = typeof c?.isDMBased === 'function' ? c.isDMBased() : false
+    // A thread's own name is the turn title the bot generated; readers that want the
+    // enclosing channel ("#general") get it as `parentName`.
+    const parentName =
+      typeof c?.isThread === 'function' && c.isThread() && c.parentId ? await this.channelName(c.parentId) : undefined
     return {
       id: channel,
       ...(c?.name ? { name: c.name } : {}),
+      ...(parentName ? { parentName } : {}),
       isIm,
       // A guild channel's visibility depends on role overwrites we don't resolve here;
       // treat non-DM guild channels as non-private best-effort.
       isPrivate: false
     }
+  }
+
+  /** Name of one channel id (cache-first via channels.fetch), undefined if unreachable. */
+  private async channelName(channel: string): Promise<string | undefined> {
+    const ch = await this.client.channels.fetch(channel).catch(() => null)
+    return (ch as (Channel & { name?: string }) | null)?.name
   }
 
   /** Discord bots cannot cheaply enumerate a channel's full member list — return []

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -7,7 +7,14 @@ import type { Logger } from '../log.js'
  * no name of its own.
  */
 export interface ChannelInfoSource {
-  getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }>
+  getChannelInfo(channel: string): Promise<{
+    id: string
+    name?: string
+    isIm?: boolean
+    isPrivate?: boolean
+    /** Enclosing channel name when `channel` is itself a thread (Discord). */
+    parentName?: string
+  }>
   getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
 }
 
@@ -75,8 +82,12 @@ export class ChannelNameResolver {
       const info = await src.getChannelInfo(channel)
       // A named channel/group is saved bare (the console prefixes "#"); a DM that carries
       // its own handle (a Telegram @username) is saved "@name" so readers can tell it apart.
-      if (info.name) {
-        this.save(channel, info.isIm ? `@${info.name}` : info.name)
+      // A Discord session keys on the THREAD id, whose own name is the turn's title — label
+      // it with the enclosing channel instead, so the console reads "#general" the way a
+      // threaded Slack session does.
+      const name = info.parentName ?? info.name
+      if (name) {
+        this.save(channel, info.isIm ? `@${name}` : name)
         return
       }
       // A DM with no name of its own (a Discord DM channel) — label it by the human on the

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { SlackNameResolver } from '../src/slack/name-resolver.js'
 import type { SlackConnection } from '../src/slack/connection.js'
+import { ChannelNameResolver, type ChannelInfoSource } from '../src/messages/channel-name-resolver.js'
 
 // The resolver only touches getChannelInfo/getUserProfile.
 function fakeConn(over: Partial<Pick<SlackConnection, 'getChannelInfo' | 'getUserProfile'>> = {}) {
@@ -85,5 +86,28 @@ describe('SlackNameResolver', () => {
     r.noteMessage(conn, msg('C1', 'U1', true))
     await flush()
     expect(conn.getChannelInfo).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ChannelNameResolver', () => {
+  const source = (info: Awaited<ReturnType<ChannelInfoSource['getChannelInfo']>>): ChannelInfoSource => ({
+    getChannelInfo: vi.fn(async () => info),
+    getUserProfile: vi.fn(async (id: string) => ({ id, name: 'dana', realName: 'Dana Reyes' }))
+  })
+
+  it('labels a Discord thread with its enclosing channel, not the thread title', async () => {
+    const saved = new Map<string, string>()
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    r.noteChannel(source({ id: 'T1', name: '@bot deploy the docs', parentName: 'general' }), 'T1')
+    await flush()
+    expect(saved.get('T1')).toBe('general')
+  })
+
+  it('keeps the channel name when there is no parent', async () => {
+    const saved = new Map<string, string>()
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    r.noteChannel(source({ id: 'C1', name: 'general' }), 'C1')
+    await flush()
+    expect(saved.get('C1')).toBe('general')
   })
 })


### PR DESCRIPTION
## Problem

A Discord top-level `@mention` opens a thread and re-keys the turn onto the thread id (`dispatchDiscordTopLevel`), so a session's `channel` **is** the thread. `ChannelNameResolver` then resolved that id and got the thread's own name — the bot-generated turn title (`@<bot id> hello`) — and the console showed that as the channel. Slack, where a thread is not its own channel, shows `#general`; Discord was inconsistent.

## Fix

- `discord/connection.ts` — `getChannelInfo` now also returns `parentName` for a thread channel (cache-first `channels.fetch` on `parentId`).
- `messages/channel-name-resolver.ts` — `ChannelInfoSource` gains the optional `parentName`; the saved display name prefers it over the channel's own name. Telegram/Feishu don't set it, so their behavior is unchanged.

Sessions already carrying a stale thread-title name get re-resolved by `backfillChannelNames()` on the next daemon start (the attempt cache is in-memory) or after the 6h OK TTL.

## Tests

Two new `ChannelNameResolver` cases in `test/name-resolver.test.ts` (thread → parent channel; no parent → unchanged). `pnpm --filter @agentconnect.md/daemon typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)