### PR TITLE
refactor(web): unify the connector, MCP, and skill tiles

### DIFF
--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { fetchAgentDto, fetchSkillSourceSkills, type SkillSourceSkillsDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
+import { MOCK_MODE } from '@/lib/data'
+import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
 import { Icon, Toggle } from '@/components/ui'
 
 /**
@@ -36,7 +38,13 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
   const fetched = useRef(false)
 
   useEffect(() => {
-    if (fetched.current || !canEdit) return
+    if (fetched.current) return
+    // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a selection
+    // so both tile states (whole source vs a picked subset) are visible.
+    if (!canEdit) {
+      if (MOCK_MODE) setEnabled(['example-ai-kit/*', 'internal-runbooks/safe-deploy'])
+      return
+    }
     fetched.current = true
     fetchAgentDto(agentId).then(
       (dto) => setEnabled(dto.skills ?? []),
@@ -115,41 +123,50 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
           No skill sources in your organization yet.
         </div>
       ) : (
-        <div>
+        <ToolTileGrid columns={2}>
           {skillSources.map((s) => {
             const sel = enabled ? selectionFor(enabled, s.name) : { all: false, skills: new Set<string>() }
             const on = sel.all || sel.skills.size > 0
             const manifest = manifests[s.id]
             const isOpen = expanded.has(s.id)
             return (
-              <div key={s.id} className="border-t border-(--border-subtle) first:border-t-0">
-                <div className="flex items-center gap-[11px] px-4 py-[11px] desktop:py-3">
-                  <button
-                    type="button"
-                    className="flex items-center gap-1 text-(--text-tertiary)"
-                    onClick={() => expand(s.id)}
-                    aria-label="Show skills"
-                  >
-                    <Icon name={isOpen ? 'chevron-down' : 'chevron-right'} size={15} />
-                    <Icon name="book-open" size={16} />
-                  </button>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-mono text-[12.5px] font-medium leading-normal text-(--text-primary)">
-                      {s.name}
-                    </div>
-                    <div className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                      {sel.all ? 'all skills' : sel.skills.size > 0 ? `${sel.skills.size} selected` : s.source}
-                    </div>
-                  </div>
-                  <Toggle checked={on} disabled={!interactive} onChange={(next) => toggleSource(s.name, next)} />
-                </div>
-
+              <ToolTile
+                key={s.id}
+                mark={<SkillMark />}
+                name={s.name}
+                // What's selected rides as a badge so the second line can stay the repo,
+                // matching the registry card's tile.
+                badge={
+                  on ? (
+                    <span className="badge flex-none bg-(--status-info-soft) text-[9.5px] text-(--status-info)">
+                      {sel.all ? 'all skills' : `${sel.skills.size} selected`}
+                    </span>
+                  ) : undefined
+                }
+                subtitle={<SkillSourceLine source={s.source} subDir={s.subDir} />}
+                action={
+                  <>
+                    <button
+                      type="button"
+                      className="iconbtn h-6 w-6"
+                      onClick={() => expand(s.id)}
+                      aria-label="Show skills"
+                      title="Show skills"
+                    >
+                      <Icon name={isOpen ? 'chevron-down' : 'chevron-right'} size={13} />
+                    </button>
+                    <span className="ml-[6px]">
+                      <Toggle checked={on} disabled={!interactive} onChange={(next) => toggleSource(s.name, next)} />
+                    </span>
+                  </>
+                }
+              >
                 {isOpen && (
-                  <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-4 py-2 pl-[52px]">
+                  <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-[14px] py-2">
                     {manifest === 'loading' || manifest === undefined ? (
                       <div className="py-1 font-sans text-[12px] text-(--text-tertiary)">Loading skills…</div>
                     ) : !manifest.resolvable || manifest.skills.length === 0 ? (
-                      <div className="py-1 font-sans text-[12px] text-(--text-tertiary)">
+                      <div className="py-1 font-sans text-[12px] leading-[1.5] text-(--text-tertiary)">
                         {manifest.resolvable
                           ? 'No SKILL.md found in this source.'
                           : 'Can’t list individual skills for this source — enable the whole source above.'}
@@ -184,28 +201,21 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
                     )}
                   </div>
                 )}
-              </div>
+              </ToolTile>
             )
           })}
 
           {orphaned.map((name) => (
-            <div
+            <ToolTile
               key={name}
-              className="flex items-center gap-[11px] border-t border-(--border-subtle) px-4 py-[11px] desktop:py-3"
-            >
-              <Icon name="book-open" size={16} color="var(--text-tertiary)" />
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-mono text-[12.5px] font-medium leading-normal text-(--text-primary)">
-                  {name}
-                </div>
-                <div className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                  No longer in the org registry
-                </div>
-              </div>
-              <Toggle checked disabled={!interactive} onChange={() => toggleSource(name, false)} />
-            </div>
+              mark={<SkillMark />}
+              name={name}
+              subtitle="No longer in the org registry"
+              dimmed
+              action={<Toggle checked disabled={!interactive} onChange={() => toggleSource(name, false)} />}
+            />
           ))}
-        </div>
+        </ToolTileGrid>
       )}
 
       {err && (

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { fetchAgentDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
-import type { DaemonRow } from '@/lib/data'
+import { MOCK_MODE, type DaemonRow } from '@/lib/data'
 import { mcpCandidates, mcpCapsFor, mcpServerMeta, mcpServersForRuntime } from '@/components/console/McpServersField'
+import { ProviderMark, ToolTile, ToolTileGrid, useConnectorIcons } from '@/components/console/ToolTile'
 import { Icon, Toggle } from '@/components/ui'
 
 /**
@@ -37,11 +38,28 @@ export function AgentToolsCard({
   daemon: DaemonRow | undefined
   canEdit: boolean
 }) {
-  const { updateAgent, mcpProviders } = useConsoleData()
+  const { updateAgent, mcpProviders, connectorsEnabled } = useConsoleData()
   // Candidate list = daemon-configured servers ∪ org-registry provider names, gated
   // by the runtime's transport support (registry providers are http-proxied).
   const registryNames = useMemo(() => mcpProviders.map((p) => p.name), [mcpProviders])
-  const candidates = daemon ? mcpCandidates(daemon.mcpServers, registryNames) : []
+  // Same catalog icons the registry card's tiles use, keyed here by provider NAME
+  // (that's all a candidate row carries). Names off the registry get the plug glyph.
+  const serviceByName = useMemo(
+    () => new Map(mcpProviders.flatMap((p) => (p.service ? [[p.name, p.service] as const] : []))),
+    [mcpProviders]
+  )
+  const iconByService = useConnectorIcons(connectorsEnabled && serviceByName.size > 0)
+  const iconFor = (name: string) => {
+    const service = serviceByName.get(name)
+    return service ? iconByService.get(service) : undefined
+  }
+  // A demo agent has no live daemon, so mock mode falls back to the org registry
+  // alone — enough to render the tiles with no CP running.
+  const candidates = daemon
+    ? mcpCandidates(daemon.mcpServers, registryNames)
+    : MOCK_MODE
+      ? mcpCandidates([], registryNames)
+      : []
   const caps = daemon ? mcpCapsFor(daemon.runtimeModels, runtime) : null
   const servers = mcpServersForRuntime(candidates, caps)
   // The persisted allow-list, once the raw spec loads; null ⇒ not loaded yet.
@@ -56,7 +74,13 @@ export function AgentToolsCard({
   // Tools card offers no way to clear a stale name. Mock agents (canEdit false)
   // have no spec to fetch.
   useEffect(() => {
-    if (fetched.current || !canEdit) return
+    if (fetched.current) return
+    // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a plausible
+    // saved set instead so the toggles aren't uniformly off.
+    if (!canEdit) {
+      if (MOCK_MODE) setEnabled(['grafana', 'linear'])
+      return
+    }
     fetched.current = true
     fetchAgentDto(agentId).then(
       // The saved allow-list IS the effective set (empty ⇒ no servers), so the
@@ -91,27 +115,22 @@ export function AgentToolsCard({
   const unknownMeta = (n: string) =>
     candidateNames.has(n) ? 'Not supported by this runtime' : 'Not reported by this daemon'
 
-  // One MCP row. Eligible servers toggle freely; an ineligible saved name stays
-  // interactive only while ON, so it can be turned off but not re-enabled here.
-  const row = (name: string, meta: string, eligible: boolean) => {
+  // One MCP tile — the same ToolTile the registry card renders, with the enable toggle
+  // in place of its edit/delete action. Eligible servers toggle freely; an ineligible
+  // saved name stays interactive only while ON, so it can be turned off but not
+  // re-enabled here.
+  const tile = (name: string, meta: string, eligible: boolean) => {
     const on = enabled ? enabled.includes(name) : false // mirror the saved set; off until it loads
     const interactive = canEdit && enabled !== null && !saving && (eligible || on)
     return (
-      <div
+      <ToolTile
         key={name}
-        className="flex items-center gap-[11px] border-t border-(--border-subtle) px-4 py-[11px] first:border-t-0 desktop:py-3"
-      >
-        <Icon name="plug" size={16} color="var(--text-tertiary)" />
-        <div className="min-w-0 flex-1">
-          <div className="truncate font-mono text-[12.5px] font-medium leading-normal text-(--text-primary)">
-            {name}
-          </div>
-          <div className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            {meta}
-          </div>
-        </div>
-        <Toggle checked={on} disabled={!interactive} onChange={(next) => toggle(name, next)} />
-      </div>
+        mark={<ProviderMark iconUrl={iconFor(name)} />}
+        name={name}
+        subtitle={meta}
+        dimmed={!eligible}
+        action={<Toggle checked={on} disabled={!interactive} onChange={(next) => toggle(name, next)} />}
+      />
     )
   }
 
@@ -121,10 +140,10 @@ export function AgentToolsCard({
         Tools
       </div>
       {servers.length > 0 || unknown.length > 0 ? (
-        <div>
-          {servers.map((s) => row(s.name, mcpServerMeta(s), true))}
-          {unknown.map((n) => row(n, unknownMeta(n), false))}
-        </div>
+        <ToolTileGrid columns={2}>
+          {servers.map((s) => tile(s.name, mcpServerMeta(s), true))}
+          {unknown.map((n) => tile(n, unknownMeta(n), false))}
+        </ToolTileGrid>
       ) : (
         <div className="flex items-center gap-2 px-4 py-[13px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:py-3">
           <Icon name="plug" size={14} />

--- a/packages/web/src/components/console/McpServersCard.tsx
+++ b/packages/web/src/components/console/McpServersCard.tsx
@@ -14,7 +14,7 @@
 // create — never retrievable afterward. Self-contained (own create/edit/delete
 // dialogs in a scrim, like the API-keys card).
 
-import { useMemo, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import useSWR from 'swr'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
@@ -25,8 +25,9 @@ import {
   type McpHeaderInput,
   type ConnectorAuthDefinition
 } from '@/lib/api'
-import { credentialFieldsFor, initialAuthType, providerIconUrl, type CredentialField } from '@/lib/connectors'
+import { credentialFieldsFor, initialAuthType, type CredentialField } from '@/lib/connectors'
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
+import { ProviderMark, ToolTile, ToolTileGrid, useConnectorIcons } from '@/components/console/ToolTile'
 import { ConnectorsModal } from '@/components/console/ConnectorsModal'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -44,19 +45,7 @@ export function McpServersCard({ canWrite }: { canWrite: boolean }) {
   // the Add-connectors browser uses). Fetched once, only when there's a connector row
   // to decorate — custom providers keep the generic plug glyph.
   const hasConnectorRows = mcpProviders.some((p) => p.kind === 'open_connector' && p.service)
-  const { data: catalog } = useSWR(
-    connectorsEnabled && hasConnectorRows ? 'connector-catalog' : null,
-    () => fetchConnectorCatalog(),
-    { revalidateOnFocus: false }
-  )
-  const iconByService = useMemo(() => {
-    const m = new Map<string, string>()
-    for (const p of catalog?.providers ?? []) {
-      const url = providerIconUrl(p)
-      if (url) m.set(p.service, url)
-    }
-    return m
-  }, [catalog])
+  const iconByService = useConnectorIcons(connectorsEnabled && hasConnectorRows)
 
   const empty = (
     <div className="px-4 py-7 text-center">
@@ -135,7 +124,7 @@ export function McpServersCard({ canWrite }: { canWrite: boolean }) {
       ) : mcpProviders.length === 0 ? (
         empty
       ) : (
-        <div className="grid grid-cols-1 gap-3 px-4 py-[14px] desktop:grid-cols-[repeat(3,1fr)]">
+        <ToolTileGrid>
           {mcpProviders.map((p) => (
             <ProviderTile
               key={p.id}
@@ -146,7 +135,7 @@ export function McpServersCard({ canWrite }: { canWrite: boolean }) {
               onDelete={() => setDeleting(p)}
             />
           ))}
-        </div>
+        </ToolTileGrid>
       )}
 
       {creating && (
@@ -185,11 +174,10 @@ export function McpServersCard({ canWrite }: { canWrite: boolean }) {
   )
 }
 
-// One provider tile (3-up grid, same card style as the Skills library): mark well +
-// name + kind line with edit/delete icon buttons up top, access scope + added date
-// below. The upstream url, transport, and header names are intentionally not surfaced
-// here — they live in the edit dialog. open_connector tiles show the provider's
-// catalog icon (falls back to the generic plug glyph).
+// One provider tile — the shared ToolTile (see ToolTile.tsx), with edit/delete as its
+// action. The upstream url, transport, and header names are intentionally not surfaced
+// here — they live in the edit dialog. open_connector tiles show the provider's catalog
+// icon (falls back to the generic plug glyph).
 function ProviderTile({
   p,
   iconUrl,
@@ -204,55 +192,31 @@ function ProviderTile({
   onDelete: () => void
 }) {
   return (
-    <div className="flex min-w-0 flex-col gap-[10px] rounded-[9px] border border-(--border-subtle) px-[14px] py-[13px] transition-[border-color,box-shadow] hover:border-(--border-strong) hover:shadow-(--shadow-xs)">
-      <div className="flex min-w-0 items-center gap-[10px]">
-        <ProviderMark iconUrl={iconUrl} />
-        <div className="min-w-0 flex-1">
-          <div className="mono truncate text-[12.5px] font-semibold text-(--text-primary)">{p.name}</div>
-          <div className="mt-px truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-            {p.kind === 'open_connector' ? 'Open connector' : 'Custom MCP server'}
-          </div>
-        </div>
-        {canWrite && (
-          <span className="flex flex-none gap-px">
+    <ToolTile
+      mark={<ProviderMark iconUrl={iconUrl} />}
+      name={p.name}
+      subtitle={p.kind === 'open_connector' ? 'Open connector' : 'Custom MCP server'}
+      action={
+        canWrite ? (
+          <>
             <button className="iconbtn h-6 w-6" title="Edit" onClick={onEdit}>
               <Icon name="pencil" size={12} />
             </button>
             <button className="iconbtn h-6 w-6" title="Remove" onClick={onDelete}>
               <Icon name="trash-2" size={12} />
             </button>
+          </>
+        ) : undefined
+      }
+      footer={
+        <div className="flex min-w-0 items-center gap-2">
+          <VisibilityValue visibility={p.visibility} sharedWith={p.sharedWith} createdBy={p.createdBy} />
+          <span className="mono ml-auto flex-none text-[10.5px] text-(--text-disabled)">
+            added {fmtDate(p.createdAt)}
           </span>
-        )}
-      </div>
-      <div className="flex min-w-0 items-center gap-2">
-        <VisibilityValue visibility={p.visibility} sharedWith={p.sharedWith} createdBy={p.createdBy} />
-        <span className="mono ml-auto flex-none text-[10.5px] text-(--text-disabled)">
-          added {fmtDate(p.createdAt)}
-        </span>
-      </div>
-    </div>
-  )
-}
-
-// The tile's mark well: an open_connector provider's catalog icon when we have one
-// (falls back to the generic plug on a missing/broken image), else the plug glyph.
-function ProviderMark({ iconUrl }: { iconUrl?: string }) {
-  const [broken, setBroken] = useState(false)
-  return (
-    <span className="flex h-[30px] w-[30px] flex-none items-center justify-center overflow-hidden rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
-      {!iconUrl || broken ? (
-        <Icon name="plug" size={15} color="var(--text-tertiary)" />
-      ) : (
-        <img
-          alt=""
-          src={iconUrl}
-          loading="lazy"
-          referrerPolicy="no-referrer"
-          className="h-[15px] w-[15px] object-contain"
-          onError={() => setBroken(true)}
-        />
-      )}
-    </span>
+        </div>
+      }
+    />
   )
 }
 

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -13,9 +13,10 @@
 import { useRef, useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
-import { fmtDate, repoLabel, repoWebUrl, type SkillSourceDto } from '@/lib/api'
+import { fmtDate, type SkillSourceDto } from '@/lib/api'
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
-import { GithubMark, LoadingState } from '@/components/marks'
+import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
+import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 
 /** Split a comma/whitespace-separated skill filter into a clean string[]. */
@@ -54,7 +55,7 @@ export function SkillSourcesCard({ canWrite }: { canWrite: boolean }) {
           No skill sources yet. Import a repo of skills to make them available to your agents.
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-3 px-4 py-[14px] desktop:grid-cols-[repeat(3,minmax(0,1fr))]">
+        <ToolTileGrid>
           {skillSources.map((s) => (
             <SourceTile
               key={s.id}
@@ -64,7 +65,7 @@ export function SkillSourcesCard({ canWrite }: { canWrite: boolean }) {
               onDelete={() => setDeleting(s)}
             />
           ))}
-        </div>
+        </ToolTileGrid>
       )}
 
       {creating && (
@@ -103,73 +104,39 @@ function SourceTile({
   onEdit: () => void
   onDelete: () => void
 }) {
-  const sourceUrl = repoWebUrl(s.source)
-  const fullSourceLabel = repoLabel(s.source)
-  const isGithub = sourceUrl?.startsWith('https://github.com/') ?? false
-  const sourceLabel = isGithub ? fullSourceLabel.split('/').slice(0, 2).join('/') : fullSourceLabel
-  const sourceContent = (
-    <>
-      <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
-        {isGithub ? (
-          <GithubMark color="var(--text-secondary)" />
-        ) : (
-          <Icon name="git-branch" size={13} color="var(--text-tertiary)" />
-        )}
-      </span>
-      <span className="min-w-0 truncate">
-        {sourceLabel}
-        {s.subDir ? <span className="text-(--text-tertiary)"> · {s.subDir}</span> : null}
-      </span>
-    </>
-  )
-
   return (
-    <div className="flex min-w-0 flex-col gap-[10px] overflow-hidden rounded-[9px] border border-(--border-subtle) px-[14px] py-[13px] transition-[border-color,box-shadow] hover:border-(--border-strong) hover:shadow-(--shadow-xs)">
-      <div className="flex min-w-0 items-center gap-[10px]">
-        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
-          <Icon name="book-open" size={16} color="var(--brand)" />
-        </span>
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="mono truncate text-[12.5px] font-semibold text-(--text-primary)">{s.name}</span>
-          {s.ref && (
-            <span className="badge max-w-[92px] flex-none truncate bg-(--status-info-soft) text-[9.5px] text-(--status-info)">
-              {s.ref}
-            </span>
-          )}
-        </div>
-        {canWrite && (
-          <span className="flex flex-none gap-px">
+    <ToolTile
+      mark={<SkillMark />}
+      name={s.name}
+      badge={
+        s.ref ? (
+          <span className="badge max-w-[92px] flex-none truncate bg-(--status-info-soft) text-[9.5px] text-(--status-info)">
+            {s.ref}
+          </span>
+        ) : undefined
+      }
+      subtitle={<SkillSourceLine source={s.source} subDir={s.subDir} />}
+      action={
+        canWrite ? (
+          <>
             <button className="iconbtn h-6 w-6" onClick={onEdit} title="Edit">
               <Icon name="pencil" size={12} />
             </button>
             <button className="iconbtn h-6 w-6" onClick={onDelete} title="Delete">
               <Icon name="trash-2" size={12} />
             </button>
+          </>
+        ) : undefined
+      }
+      footer={
+        <div className="flex min-w-0 items-center gap-2">
+          <VisibilityValue visibility={s.visibility} sharedWith={s.sharedWith} createdBy={s.createdBy} />
+          <span className="mono ml-auto min-w-0 truncate text-right text-[10.5px] text-(--text-disabled)">
+            added {fmtDate(s.createdAt)}
           </span>
-        )}
-      </div>
-      {sourceUrl ? (
-        <a
-          href={sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={`Open ${sourceLabel}`}
-          className="flex min-w-0 items-center gap-[6px] font-mono text-[11.5px] font-normal leading-normal text-(--text-secondary) no-underline hover:text-(--text-primary) hover:underline"
-        >
-          {sourceContent}
-        </a>
-      ) : (
-        <div className="flex min-w-0 items-center gap-[6px] font-mono text-[11.5px] font-normal leading-normal text-(--text-secondary)">
-          {sourceContent}
         </div>
-      )}
-      <div className="flex min-w-0 items-center gap-2">
-        <VisibilityValue visibility={s.visibility} sharedWith={s.sharedWith} createdBy={s.createdBy} />
-        <span className="mono ml-auto min-w-0 truncate text-right text-[10.5px] text-(--text-disabled)">
-          added {fmtDate(s.createdAt)}
-        </span>
-      </div>
-    </div>
+      }
+    />
   )
 }
 

--- a/packages/web/src/components/console/ToolTile.tsx
+++ b/packages/web/src/components/console/ToolTile.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+// The shared tile for connectors / MCP servers and skill sources. Both the org-level
+// registry cards (Tools & Skills page) and the per-agent enable-lists (agent detail →
+// Tools & Skills tab) render the SAME tile — mark well, name line, a muted second line,
+// and an optional footer — and differ only in the top-right ACTION: the registry cards
+// put edit/delete icon buttons there, the agent cards put an enable toggle.
+//
+// Keep the two surfaces rendering through here rather than re-styling a copy, so a tile
+// tweak lands on both at once.
+
+import type { ReactNode } from 'react'
+import { useMemo, useState } from 'react'
+import useSWR from 'swr'
+import { fetchConnectorCatalog, repoLabel, repoWebUrl } from '@/lib/api'
+import { providerIconUrl } from '@/lib/connectors'
+import { GithubMark } from '@/components/marks'
+import { Icon } from '@/components/ui'
+
+export function ToolTile({
+  mark,
+  name,
+  badge,
+  subtitle,
+  action,
+  footer,
+  children,
+  dimmed
+}: {
+  mark: ReactNode
+  name: string
+  /** Rendered right after the name (e.g. a skill source's pinned ref). */
+  badge?: ReactNode
+  /** The muted second line — an MCP server's kind, a skill source's repo. */
+  subtitle: ReactNode
+  /** Top-right: edit/delete on the registry cards, a Toggle on the agent cards. */
+  action?: ReactNode
+  /** Optional third line (access scope + added date on the registry cards). */
+  footer?: ReactNode
+  /** Full-bleed panel below the tile body (the agent skills card's per-skill list). */
+  children?: ReactNode
+  dimmed?: boolean
+}) {
+  return (
+    <div
+      className={`flex min-w-0 flex-col overflow-hidden rounded-[9px] border border-(--border-subtle) transition-[border-color,box-shadow] hover:border-(--border-strong) hover:shadow-(--shadow-xs) ${dimmed ? 'opacity-60' : ''}`}
+    >
+      <div className="flex min-w-0 flex-col gap-[10px] px-[14px] py-[13px]">
+        <div className="flex min-w-0 items-center gap-[10px]">
+          {mark}
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="mono truncate text-[12.5px] font-semibold text-(--text-primary)">{name}</span>
+              {badge}
+            </div>
+            <div className="mt-px min-w-0 truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+              {subtitle}
+            </div>
+          </div>
+          {action && <span className="flex flex-none items-center gap-px">{action}</span>}
+        </div>
+        {footer}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/** The 3-up tile grid both pages lay tiles out in (the agent cards are narrower ⇒ 2-up). */
+export function ToolTileGrid({ columns = 3, children }: { columns?: 2 | 3; children: ReactNode }) {
+  return (
+    <div
+      className={`grid grid-cols-1 gap-3 px-4 py-[14px] ${columns === 2 ? 'desktop:grid-cols-2' : 'desktop:grid-cols-[repeat(3,minmax(0,1fr))]'}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** The skill-source mark: a brand-tinted book well. */
+export function SkillMark() {
+  return (
+    <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+      <Icon name="book-open" size={16} color="var(--brand)" />
+    </span>
+  )
+}
+
+/**
+ * The MCP mark well: an open_connector provider's catalog icon when we have one
+ * (falls back to the generic plug on a missing/broken image), else the plug glyph.
+ */
+export function ProviderMark({ iconUrl }: { iconUrl?: string }) {
+  const [broken, setBroken] = useState(false)
+  return (
+    <span className="flex h-[30px] w-[30px] flex-none items-center justify-center overflow-hidden rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
+      {!iconUrl || broken ? (
+        <Icon name="plug" size={15} color="var(--text-tertiary)" />
+      ) : (
+        <img
+          alt=""
+          src={iconUrl}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="h-[15px] w-[15px] object-contain"
+          onError={() => setBroken(true)}
+        />
+      )}
+    </span>
+  )
+}
+
+/**
+ * service → catalog icon URL, for decorating open_connector tiles. Fetched once per
+ * page (SWR dedupes across the registry and agent cards) and only when `enabled`.
+ */
+export function useConnectorIcons(enabled: boolean): Map<string, string> {
+  const { data: catalog } = useSWR(enabled ? 'connector-catalog' : null, () => fetchConnectorCatalog(), {
+    revalidateOnFocus: false
+  })
+  return useMemo(() => {
+    const m = new Map<string, string>()
+    for (const p of catalog?.providers ?? []) {
+      const url = providerIconUrl(p)
+      if (url) m.set(p.service, url)
+    }
+    return m
+  }, [catalog])
+}
+
+/**
+ * A skill source's second line: the repo it installs from, linked out when we can
+ * resolve a web URL for it. Mirrors the MCP tile's kind line in weight and color.
+ */
+export function SkillSourceLine({ source, subDir }: { source: string; subDir?: string | null }) {
+  const url = repoWebUrl(source)
+  const full = repoLabel(source)
+  const isGithub = url?.startsWith('https://github.com/') ?? false
+  // A GitHub repo reads as owner/repo — drop any deeper path the source string carries.
+  const label = isGithub ? full.split('/').slice(0, 2).join('/') : full
+  const body = (
+    <>
+      <span className="imark h-[13px] w-[13px] flex-none border-0 bg-transparent">
+        {isGithub ? <GithubMark color="var(--text-tertiary)" /> : <Icon name="git-branch" size={11} />}
+      </span>
+      <span className="min-w-0 truncate">
+        {label}
+        {subDir ? <span> · {subDir}</span> : null}
+      </span>
+    </>
+  )
+  return url ? (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`Open ${label}`}
+      className="flex min-w-0 items-center gap-[5px] font-mono text-[11px] font-normal leading-normal text-(--text-tertiary) no-underline hover:text-(--text-secondary) hover:underline"
+    >
+      {body}
+    </a>
+  ) : (
+    <span className="flex min-w-0 items-center gap-[5px] font-mono text-[11px] font-normal leading-normal">{body}</span>
+  )
+}

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -451,6 +451,116 @@ const MOCK_BOTS: BotDto[] = [
   }
 ]
 
+// Demo MCP-provider registry (MOCK_MODE only) — covers both kinds so the Tools &
+// Skills tiles show the connector icon path and the plain plug, and both access
+// scopes (org-wide vs restricted, which renders the avatar stack). `service` slugs
+// are real catalog names so the icons resolve when the CP serves a catalog; with no
+// CP they fall back to the plug glyph. No urls/secrets here — headerNames only.
+const MOCK_MCP_PROVIDERS: McpProviderDto[] = [
+  {
+    id: 'mcp_grafana',
+    name: 'grafana',
+    kind: 'custom',
+    transport: 'http',
+    visibility: 'org',
+    sharedWith: [],
+    createdBy: 'u_dana',
+    canManageSharing: true,
+    url: 'https://mcp.example.test/grafana/sse',
+    headerNames: ['Authorization'],
+    createdAt: '2026-07-14T00:00:00Z'
+  },
+  {
+    id: 'mcp_linear',
+    name: 'linear',
+    kind: 'open_connector',
+    transport: 'http',
+    service: 'linear',
+    visibility: 'org',
+    sharedWith: [],
+    createdBy: 'u_sam',
+    canManageSharing: true,
+    url: 'https://connectors.example.test/mcp',
+    headerNames: ['x-oomol-connector-id'],
+    createdAt: '2026-07-16T00:00:00Z'
+  },
+  {
+    id: 'mcp_notion',
+    name: 'team-notion',
+    kind: 'open_connector',
+    transport: 'http',
+    service: 'notion',
+    visibility: 'restricted',
+    sharedWith: ['u_sam', 'u_ana'],
+    createdBy: 'u_dana',
+    canManageSharing: true,
+    url: 'https://connectors.example.test/mcp',
+    headerNames: ['x-oomol-connector-id'],
+    createdAt: '2026-07-18T00:00:00Z'
+  },
+  {
+    id: 'mcp_deepseek',
+    name: 'my-deepseek',
+    kind: 'custom',
+    transport: 'http',
+    visibility: 'restricted',
+    sharedWith: ['u_noah'],
+    createdBy: 'u_leo',
+    canManageSharing: true,
+    url: 'https://mcp.example.test/deepseek',
+    headerNames: [],
+    createdAt: '2026-07-16T00:00:00Z'
+  }
+]
+
+// Demo skill-source registry (MOCK_MODE only) — one plain GitHub repo, one pinned
+// to a ref with a subdir, one non-GitHub git URL (exercises the branch glyph and the
+// unlinked source line), one restricted. Names double as the agent enable-list keys.
+const MOCK_SKILL_SOURCES: SkillSourceDto[] = [
+  {
+    id: 'skill_ai_kit',
+    name: 'example-ai-kit',
+    source: 'example-org/example-ai-kit',
+    githubRepoId: null,
+    ref: null,
+    subDir: null,
+    skills: [],
+    visibility: 'org',
+    sharedWith: [],
+    createdBy: 'u_dana',
+    canManageSharing: true,
+    createdAt: '2026-07-24T00:00:00Z'
+  },
+  {
+    id: 'skill_platform',
+    name: 'platform-skills',
+    source: 'https://github.com/example-org/example-platform',
+    githubRepoId: null,
+    ref: 'v1.2.0',
+    subDir: 'skills',
+    skills: [],
+    visibility: 'org',
+    sharedWith: [],
+    createdBy: 'u_sam',
+    canManageSharing: true,
+    createdAt: '2026-06-30T00:00:00Z'
+  },
+  {
+    id: 'skill_internal',
+    name: 'internal-runbooks',
+    source: 'git@git.example.test:ops/runbooks.git',
+    githubRepoId: null,
+    ref: 'main',
+    subDir: null,
+    skills: ['safe-deploy', 'rollback'],
+    visibility: 'restricted',
+    sharedWith: ['u_noah', 'u_priya'],
+    createdBy: 'u_leo',
+    canManageSharing: true,
+    createdAt: '2026-05-11T00:00:00Z'
+  }
+]
+
 export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const { activeOrg, orgs, loading: orgLoading, error: orgError } = useOrgs()
   const { mutate: mutateCache } = useSWRConfig()
@@ -505,12 +615,12 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     mutate: mutateBots
   } = useSWR<BotDto[]>(consoleKeys.bots(orgKey), ([, orgId]) => fetchBots(orgId as string))
   const {
-    data: mcpProviders = [],
+    data: realMcpProviders = [],
     isLoading: mcpProvidersIsLoading,
     mutate: mutateMcpProviders
   } = useSWR<McpProviderDto[]>(consoleKeys.mcpProviders(orgKey), ([, orgId]) => fetchMcpProviders(orgId as string))
   const {
-    data: skillSources = [],
+    data: realSkillSources = [],
     isLoading: skillSourcesIsLoading,
     mutate: mutateSkillSources
   } = useSWR<SkillSourceDto[]>(consoleKeys.skillSources(orgKey), ([, orgId]) => fetchSkillSources(orgId as string))
@@ -680,6 +790,18 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   // bots: live rows, plus the demo roster in mock mode — so the Settings platform
   // cards + the Add-integration reuse picker are populated with no CP running.
   const bots = useMemo(() => (MOCK_MODE ? [...realBots, ...MOCK_BOTS] : realBots), [realBots])
+
+  // mcp providers / skill sources: live rows, plus the demo registries in mock mode —
+  // so the Tools & Skills tiles (and the per-agent enable-lists that read the same
+  // candidate set) render populated with no CP running.
+  const mcpProviders = useMemo(
+    () => (MOCK_MODE ? [...realMcpProviders, ...MOCK_MCP_PROVIDERS] : realMcpProviders),
+    [realMcpProviders]
+  )
+  const skillSources = useMemo(
+    () => (MOCK_MODE ? [...realSkillSources, ...MOCK_SKILL_SOURCES] : realSkillSources),
+    [realSkillSources]
+  )
 
   // integrations: live rows (daemon resolved via the owning agent), plus the demo
   // rows in mock mode — so the view is populated even with no CP running (as with agents).
@@ -1029,8 +1151,10 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const sessionsLoading = waitingForOrg || sessionsIsLoading || sessionFacetsIsLoading
   const daemonsLoading = waitingForOrg || daemonsIsLoading
   const cronsLoading = waitingForOrg || cronsIsLoading
-  const mcpProvidersLoading = waitingForOrg || mcpProvidersIsLoading
-  const skillSourcesLoading = waitingForOrg || skillSourcesIsLoading
+  // Mock mode never waits: the demo registries are always there, so the tiles render
+  // immediately instead of sitting on a spinner while a CP that isn't running fails.
+  const mcpProvidersLoading = !MOCK_MODE && (waitingForOrg || mcpProvidersIsLoading)
+  const skillSourcesLoading = !MOCK_MODE && (waitingForOrg || skillSourcesIsLoading)
   const connectorsEnabled = connectorsConfig?.enabled ?? false
   const loading =
     waitingForOrg ||


### PR DESCRIPTION
## What

The Skills library rendered its sources as three-line tiles while the Connectors & MCP servers card used a two-line one, and the agent's Tools & Skills tab used neither — it listed plain full-width rows.

This extracts a shared `ToolTile` (mark well, name line, muted second line, optional footer, full-bleed expansion panel) and renders all four surfaces through it. The only difference between them is the top-right action:

| Surface | Action |
| --- | --- |
| `McpServersCard` (Tools & Skills page) | edit / delete |
| `SkillSourcesCard` (Tools & Skills page) | edit / delete |
| `AgentToolsCard` (agent detail) | enable toggle |
| `AgentSkillsCard` (agent detail) | expand chevron + enable toggle |

## Behavior changes that fall out of the unification

- A skill source's second line is now its **repo**, matching the MCP tile's kind line (linked out when a web URL resolves; GitHub mark vs branch glyph). The agent's skill tiles gain that line, and the `all skills` / `N selected` state moves to a badge beside the name.
- The agent's MCP tiles gain the **connector catalog icon**, sharing one SWR fetch with the registry card through `useConnectorIcons()`.
- The agent cards move from a full-width row list to a 2-up tile grid (they render in a 760px card; the registry cards stay 3-up).
- Ineligible / de-registered entries render dimmed and stay toggle-off-able, as before.

## Mock data

Mock mode (`NEXT_PUBLIC_MOCK=1`) grows demo MCP-provider and skill-source registries plus seeded per-agent selections, so all four surfaces can be reviewed with no control plane running — the demo rows cover both provider kinds, both visibility scopes, and pinned-ref / non-GitHub sources.

## Verification

`pnpm --filter @agentconnect.md/web typecheck`, `lint`, and `test` (342 tests) pass. Reviewed visually in mock mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)