### PR TITLE
fix(slack): enforce shared channel ownership

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -896,7 +896,9 @@ agents.
   rights on its parent agent. A shared bot's channel state is bot-scoped, so the
   route additionally requires edit rights on the effective owner and on a newly
   selected owner; changing a visible sibling cannot enable a hidden restricted
-  owner.
+  owner. Mutations are serialized per bot/channel and fenced to the owner that
+  passed authorization, so a concurrent in-Slack owner move makes the Console
+  request retry instead of applying its trigger to the new owner.
 - `gated` is **derived** from `agent.visibility === 'restricted'` at spec
   assembly; there is no separate stored toggle (see §14.7).
 - Web `IntegrationChannelList`: tri-state segmented control per channel row

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -892,9 +892,11 @@ agents.
   membership report derives the default trigger from gating: `off` when gated,
   `mention` otherwise (today's default).
 - The existing per-channel trigger PATCH route accepts `off` and reuses the
-  existing recompute-bindRules-and-push flow. Authorization is unchanged — the
-  route already requires edit rights on the agent, which for a restricted agent
-  means the private group.
+  existing recompute-bindRules-and-push flow. A direct integration requires edit
+  rights on its parent agent. A shared bot's channel state is bot-scoped, so the
+  route additionally requires edit rights on the effective owner and on a newly
+  selected owner; changing a visible sibling cannot enable a hidden restricted
+  owner.
 - `gated` is **derived** from `agent.visibility === 'restricted'` at spec
   assembly; there is no separate stored toggle (see §14.7).
 - Web `IntegrationChannelList`: tri-state segmented control per channel row

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -184,7 +184,9 @@ Slack HTTP bots require both a bot token and signing secret in the bot secret
 store. Secret reads and writes pass through the configured `SecretCipher`; list
 and metadata APIs do not select secret material.
 
-`IntegrationChannel.agentId` represents a channel-scoped default agent.
+`IntegrationChannel.agentId` represents a channel-scoped default agent. Exactly one
+active integration row carries that owner for each shared channel; sibling rows are
+null because channel membership is repeated per integration.
 `SharedThreadAgent` is the durable fallback for relay-local thread affinity. It
 contains routing metadata only, never message text.
 
@@ -329,6 +331,11 @@ channel settings. The relay applies the shared routing ladder:
 2. existing thread affinity;
 3. agent-slug keyword disambiguation;
 4. the bot's default agent for a bare mention or direct message.
+
+Before compiling routes, CP converges each channel to one canonical owner row. A
+new or ownerless channel uses the earliest active integration, and an owner change
+preserves the channel trigger. This also repairs ownership when an integration is
+removed; `No default` is not an operator state.
 
 Each target contains `agentId`, `daemonId`, and `integrationId`. The relay drops
 messages produced by another managed AgentConnect bot before arbitration so

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -332,9 +332,11 @@ channel settings. The relay applies the shared routing ladder:
 3. agent-slug keyword disambiguation;
 4. the bot's default agent for a bare mention or direct message.
 
-Before compiling routes, CP converges each channel to one canonical owner row. A
-new or ownerless channel uses the earliest active integration, and an owner change
-preserves the channel trigger. This also repairs ownership when an integration is
+Before compiling routes, CP converges each channel to one canonical owner row and
+replicates its effective trigger across the sibling membership rows. A new or
+ownerless channel uses the earliest active integration, and a Console owner change
+preserves the trigger. An in-Slack move or automatic fallback to a restricted agent
+stays Off. This also preserves state and repairs ownership when an integration is
 removed; `No default` is not an operator state.
 
 Each target contains `agentId`, `daemonId`, and `integrationId`. The relay drops

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -333,11 +333,12 @@ channel settings. The relay applies the shared routing ladder:
 4. the bot's default agent for a bare mention or direct message.
 
 Before compiling routes, CP converges each channel to one canonical owner row and
-replicates its effective trigger across the sibling membership rows. A new or
-ownerless channel uses the earliest active integration, and a Console owner change
-preserves the trigger. An in-Slack move or automatic fallback to a restricted agent
-stays Off. This also preserves state and repairs ownership when an integration is
-removed; `No default` is not an operator state.
+replicates its effective trigger across the sibling membership rows, backfilling a
+missing row when a new install has not reported membership yet. A new or ownerless
+channel uses the earliest active integration, and a Console owner change preserves
+the trigger. An in-Slack move or automatic fallback to a restricted agent stays Off.
+This also preserves state and repairs ownership when an integration is removed;
+`No default` is not an operator state.
 
 Each target contains `agentId`, `daemonId`, and `integrationId`. The relay drops
 messages produced by another managed AgentConnect bot before arbitration so

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -69,6 +69,17 @@ best-effort edge: a target on another daemon whose call policy terminally reject
 caller can still leave a visible post, because that policy verdict is only known on the
 target's daemon after the post is made.
 
+## Shared-bot channel ownership
+
+Every active channel served by a shared bot has exactly one default agent. A newly
+observed or ownerless channel converges to the bot's earliest active agent, and removing
+the current owner immediately transfers ownership to the earliest remaining agent.
+Console surfaces must show the same effective owner and trigger from every member
+agent's integration; they must not expose a `No default` state.
+
+Changing the owner preserves the channel's trigger. Direct messages remain separate:
+restricted agents may independently enable or disable their own DM conversation rows.
+
 ## No-response control marker
 
 Every agent session receives the same standing response-choice instruction, independent

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -76,8 +76,8 @@ observed or ownerless channel converges to the bot's earliest active agent, and 
 the current owner immediately transfers ownership to the earliest remaining agent.
 Console surfaces must show the same effective owner and trigger from every member
 agent's integration; they must not expose a `No default` state. The trigger is
-replicated across the channel's membership rows so removing the owner does not
-discard it.
+replicated across every active membership row, backfilling a missing sibling, so
+removing the owner does not discard the channel or its trigger.
 
 A Console owner change preserves the channel's trigger. An in-Slack owner change or
 automatic fallback to a restricted agent instead leaves the channel Off, because only

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -75,9 +75,13 @@ Every active channel served by a shared bot has exactly one default agent. A new
 observed or ownerless channel converges to the bot's earliest active agent, and removing
 the current owner immediately transfers ownership to the earliest remaining agent.
 Console surfaces must show the same effective owner and trigger from every member
-agent's integration; they must not expose a `No default` state.
+agent's integration; they must not expose a `No default` state. The trigger is
+replicated across the channel's membership rows so removing the owner does not
+discard it.
 
-Changing the owner preserves the channel's trigger. Direct messages remain separate:
+A Console owner change preserves the channel's trigger. An in-Slack owner change or
+automatic fallback to a restricted agent instead leaves the channel Off, because only
+an authorized Console editor may enable it. Direct messages remain separate:
 restricted agents may independently enable or disable their own DM conversation rows.
 
 ## No-response control marker

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1411,13 +1411,12 @@ model IntegrationChannel {
   kind          ConversationKind @default(channel)
   trigger       ChannelTrigger   @default(mention)
   // Per-channel default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
-  // channel ownership — the primary disambiguation path). When set, the relay
-  // routes this channel's traffic to this agent (and forwards to its daemon).
-  // Null ⇒ fall through to keyword / the bot's default agent. Irrelevant for a
-  // classic (non-shared) integration, where the owning agent is the only target.
-  agentId       String?        @db.Uuid
-  firstSeenAt   DateTime       @default(now()) @db.Timestamptz(6)
-  updatedAt     DateTime       @updatedAt @db.Timestamptz(6)
+  // channel ownership — the primary disambiguation path). Exactly one active
+  // integration row per shared channel carries the owner; sibling rows are null.
+  // Irrelevant for a classic integration, where its agent is the only target.
+  agentId       String?          @db.Uuid
+  firstSeenAt   DateTime         @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime         @updatedAt @db.Timestamptz(6)
 
   integration Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
 

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1409,6 +1409,9 @@ model IntegrationChannel {
   name          String? // "#deploys" without the hash (or DM counterpart); null if lookup failed
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)
+  // Relay-backed channel rows repeat the effective trigger across each active
+  // integration so deleting the canonical owner does not discard channel state.
+  // DM rows remain independently gated per integration.
   trigger       ChannelTrigger   @default(mention)
   // Per-channel default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
   // channel ownership — the primary disambiguation path). Exactly one active

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -681,7 +681,8 @@ export const IntegrationChannelDto = z.object({
   isPrivate: z.boolean(),
   kind: z.enum(['channel', 'im']),
   trigger: z.enum(['off', 'mention', 'any']),
-  /** Per-channel default/owning agent for a shared bot (§10.1); null ⇒ unset. */
+  /** Effective per-channel owner for a shared bot (§10.1); null before convergence
+   *  or when ownership does not apply. */
   agentId: z.string().nullable()
 })
 
@@ -1117,11 +1118,11 @@ export const SlackAppFinalizeBody = z.object({
 
 /** `PATCH /integrations/:id/channels/:channelId` — per-conversation trigger
  *  ('off' disables the conversation, §14) and/or the shared-bot default agent.
- *  At least one field; `agentId:null` clears the owner. */
+ *  At least one field; an active shared channel always has an owner. */
 export const UpdateIntegrationChannelBody = z
   .object({
     trigger: z.enum(['off', 'mention', 'any']).optional(),
-    agentId: z.string().min(1).nullable().optional()
+    agentId: z.string().min(1).optional()
   })
   .refine((b) => b.trigger !== undefined || b.agentId !== undefined, {
     message: 'provide trigger and/or agentId'

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -527,8 +527,33 @@ export function integrationRoutes(deps: HttpDeps) {
         // Derived visibility: only integrations whose parent agent the caller can
         // see (owner ⇒ all). A restricted agent's integration never leaks here.
         const rows = await deps.repos.integration.listForOrg(orgIdOf(req), ctxOf(req))
-        return Promise.all(
-          rows.map(async (i) => toDto(i, await deps.repos.integrationChannel.listForIntegration(i.id)))
+        const hydrated = await Promise.all(
+          rows.map(async (integration) => ({
+            integration,
+            channels: await deps.repos.integrationChannel.listForIntegration(integration.id)
+          }))
+        )
+        // Membership is repeated per shared-bot integration, while only the
+        // canonical owner row persists agentId. Project that bot-level owner and
+        // trigger onto every visible copy so all agent details agree.
+        const effective = new Map<string, IntegrationChannelRecord>()
+        for (const { integration, channels } of hydrated) {
+          if (integration.status !== 'active') continue
+          for (const channel of channels) {
+            if (channel.kind !== 'channel' || !channel.agentId) continue
+            const key = `${integration.botId}\u0000${channel.channelId}`
+            if (!effective.has(key)) effective.set(key, channel)
+          }
+        }
+        return hydrated.map(({ integration, channels }) =>
+          toDto(
+            integration,
+            channels.map((channel) => {
+              if (channel.kind !== 'channel') return channel
+              const state = effective.get(`${integration.botId}\u0000${channel.channelId}`)
+              return state ? { ...channel, agentId: state.agentId, trigger: state.trigger } : channel
+            })
+          )
         )
       }
     )
@@ -542,12 +567,11 @@ export function integrationRoutes(deps: HttpDeps) {
         schema: {
           tags: [Tag.Integrations],
           summary: 'Update a channel',
-          description:
-            "Set a channel's trigger (@-mention vs any message), then push the integration's recomputed bindRules to the owning daemon.",
+          description: "Set a channel's trigger or default agent, then push the updated routing configuration.",
           operationId: 'updateIntegrationChannel',
           params: IdParam.extend({ channelId: z.string().min(1) }),
           body: UpdateIntegrationChannelBody,
-          response: { 200: IntegrationChannelDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+          response: { 200: IntegrationChannelDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
         }
       },
       async (req, reply) => {
@@ -565,6 +589,16 @@ export function integrationRoutes(deps: HttpDeps) {
         }
         if (!canEdit(agent, ctxOf(req))) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
+        }
+        const existingChannel = (await deps.repos.integrationChannel.listForIntegration(integration.id)).find(
+          (channel) => channel.channelId === req.params.channelId
+        )
+        if (!existingChannel) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
+        }
+        const bot = await deps.repos.bot.get(integration.botId)
+        if (!bot) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
         const observedOwner = req.body.agentId ? await deps.repos.agent.get(AgentId(req.body.agentId)) : null
         const release = deps.agentMutations.tryBeginMutation([
@@ -595,43 +629,48 @@ export function integrationRoutes(deps: HttpDeps) {
               message: 'default agent placement changed; refresh and retry the integration change'
             })
           }
-          // Apply whichever of {trigger, agentId} the body carries (DTO refine
-          // guarantees ≥1). `agentId:null` clears the per-channel owner.
+          // HTTP channel ownership is bot-scoped even though membership rows are
+          // stored per integration. Route the whole patch through the orchestrator
+          // so every agent detail shows the same owner/trigger and exactly one row
+          // remains authoritative.
           let updated: IntegrationChannelRecord | null = null
-          if (req.body.trigger !== undefined) {
+          let routesSynced = false
+          if (bot.transport === 'http' && existingChannel.kind === 'channel') {
+            if (req.body.agentId !== undefined && !bot.agentIds.includes(AgentId(req.body.agentId))) {
+              return reply.code(409).send({
+                error: 'Conflict',
+                statusCode: 409,
+                message: 'default agent must be an agent that uses this bot'
+              })
+            }
+            updated = await deps.sharedBot.updateChannel(bot.id, req.params.channelId, {
+              ...(req.body.agentId !== undefined ? { agentId: req.body.agentId } : {}),
+              ...(req.body.trigger !== undefined ? { trigger: req.body.trigger } : {})
+            })
+            routesSynced = true
+          } else {
+            if (req.body.agentId !== undefined) {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                statusCode: 400,
+                message: 'default agent applies only to shared channels'
+              })
+            }
             updated = await deps.repos.integrationChannel.setTrigger(
               integration.id,
               req.params.channelId,
-              req.body.trigger
+              req.body.trigger!
             )
-            if (!updated)
-              return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
           }
-          if (req.body.agentId !== undefined) {
-            // A named owner must be a placed agent that actually shares this bot.
-            if (req.body.agentId !== null) {
-              const bot = await deps.repos.bot.get(integration.botId)
-              if (!bot || !bot.agentIds.includes(AgentId(req.body.agentId))) {
-                return reply.code(409).send({
-                  error: 'Conflict',
-                  statusCode: 409,
-                  message: 'default agent must be an agent that uses this bot'
-                })
-              }
-            }
-            updated = await deps.repos.integrationChannel.setAgent(
-              integration.id,
-              req.params.channelId,
-              req.body.agentId === null ? null : AgentId(req.body.agentId)
-            )
-            if (!updated)
-              return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
-          }
+          if (!updated)
+            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
           // Push the change: a shared bot's routes hot-update on the relay; a classic
           // bot re-pushes its recomputed bindRules to the owning daemon.
-          const bot = await deps.repos.bot.get(integration.botId)
-          if (bot?.transport === 'http') await deps.sharedBot.syncRoutes(bot.id)
-          else if (agent.daemonId) await replicateUpsert(integration, agent.daemonId)
+          if (bot.transport === 'http') {
+            if (!routesSynced) await deps.sharedBot.syncRoutes(bot.id)
+          } else if (agent.daemonId) {
+            await replicateUpsert(integration, agent.daemonId)
+          }
           return toChannelDto(updated!)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -705,10 +705,25 @@ export function integrationRoutes(deps: HttpDeps) {
           let updated: IntegrationChannelRecord | null = null
           let routesSynced = false
           if (botScopedChannel) {
-            updated = await deps.sharedBot.updateChannel(bot.id, req.params.channelId, {
-              ...(req.body.agentId !== undefined ? { agentId: req.body.agentId } : {}),
-              ...(req.body.trigger !== undefined ? { trigger: req.body.trigger } : {})
-            })
+            updated = await deps.sharedBot.updateChannel(
+              bot.id,
+              req.params.channelId,
+              {
+                ...(req.body.agentId !== undefined ? { agentId: req.body.agentId } : {}),
+                ...(req.body.trigger !== undefined ? { trigger: req.body.trigger } : {})
+              },
+              {
+                expectedOwnerAgentId: effectiveOwner!.id,
+                source: 'console'
+              }
+            )
+            if (!updated) {
+              return reply.code(409).send({
+                error: 'Conflict',
+                statusCode: 409,
+                message: 'channel owner changed; refresh and retry the integration change'
+              })
+            }
             routesSynced = true
           } else {
             if (req.body.agentId !== undefined) {

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -26,6 +26,7 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit } from '../visibility.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
+import { pickChannelOwner } from '../../orchestrator/sharedBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { discordAppIdFromBotToken } from '../discord-identity.js'
@@ -534,15 +535,46 @@ export function integrationRoutes(deps: HttpDeps) {
           }))
         )
         // Membership is repeated per shared-bot integration, while only the
-        // canonical owner row persists agentId. Project that bot-level owner and
-        // trigger onto every visible copy so all agent details agree.
+        // canonical owner row persists agentId. Read effective state from every
+        // active install of each visible bot — not only viewer-visible integrations
+        // — so a sibling never disagrees with the relay's route table.
         const effective = new Map<string, IntegrationChannelRecord>()
-        for (const { integration, channels } of hydrated) {
-          if (integration.status !== 'active') continue
-          for (const channel of channels) {
-            if (channel.kind !== 'channel' || !channel.agentId) continue
-            const key = `${integration.botId}\u0000${channel.channelId}`
-            if (!effective.has(key)) effective.set(key, channel)
+        const bots = new Map((await deps.repos.bot.listForOrg(orgIdOf(req))).map((bot) => [bot.id, bot]))
+        const botStates = await Promise.all(
+          [...new Set(hydrated.map(({ integration }) => integration.botId))].map(async (botId) => {
+            const bot = bots.get(botId)
+            if (bot?.transport !== 'http') return null
+            const [installs, channels] = await Promise.all([
+              deps.repos.integration.listForBot(botId),
+              deps.repos.integrationChannel.listForBot(botId)
+            ])
+            return { botId, installs, channels: channels.filter((channel) => channel.kind === 'channel') }
+          })
+        )
+        for (const state of botStates) {
+          if (!state) continue
+          const byChannel = new Map<string, IntegrationChannelRecord[]>()
+          for (const channel of state.channels) {
+            const channels = byChannel.get(channel.channelId) ?? []
+            channels.push(channel)
+            byChannel.set(channel.channelId, channels)
+          }
+          for (const [channelId, channels] of byChannel) {
+            const owner = pickChannelOwner(state.installs, channels)
+            if (!owner) continue
+            const channel =
+              channels.find((row) => row.agentId === owner.agentId) ??
+              channels.find((row) => row.integrationId === owner.id) ??
+              channels[0]
+            if (channel) {
+              const persistedOwner = channels.some((row) => row.agentId === owner.agentId)
+              const ownerAgent = persistedOwner ? null : await deps.repos.agent.get(owner.agentId)
+              effective.set(`${state.botId}\u0000${channelId}`, {
+                ...channel,
+                agentId: owner.agentId,
+                ...(ownerAgent && isGatedAgent(ownerAgent) ? { trigger: 'off' as const } : {})
+              })
+            }
           }
         }
         return hydrated.map(({ integration, channels }) =>
@@ -600,11 +632,51 @@ export function integrationRoutes(deps: HttpDeps) {
         if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
-        const observedOwner = req.body.agentId ? await deps.repos.agent.get(AgentId(req.body.agentId)) : null
-        const release = deps.agentMutations.tryBeginMutation([
-          agent.id,
-          ...(req.body.agentId ? [req.body.agentId] : [])
-        ])
+        const botScopedChannel = bot.transport === 'http' && existingChannel.kind === 'channel'
+        let effectiveOwner: AgentRecord | null = null
+        let selectedOwner: AgentRecord | null = null
+        if (botScopedChannel) {
+          if (req.body.agentId !== undefined && !bot.agentIds.includes(AgentId(req.body.agentId))) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: 'default agent must be an agent that uses this bot'
+            })
+          }
+          const [installs, channelRows] = await Promise.all([
+            deps.repos.integration.listForBot(bot.id),
+            deps.repos.integrationChannel.listForBot(bot.id)
+          ])
+          const owner = pickChannelOwner(
+            installs,
+            channelRows.filter((channel) => channel.kind === 'channel' && channel.channelId === req.params.channelId)
+          )
+          effectiveOwner = owner ? await deps.repos.agent.get(owner.agentId) : null
+          selectedOwner =
+            req.body.agentId !== undefined ? await deps.repos.agent.get(AgentId(req.body.agentId)) : effectiveOwner
+          if (!effectiveOwner || !selectedOwner) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: 'channel owner changed; refresh and retry the integration change'
+            })
+          }
+          if (!canEdit(effectiveOwner, ctxOf(req)) || !canEdit(selectedOwner, ctxOf(req))) {
+            return reply.code(403).send({
+              error: 'Forbidden',
+              statusCode: 403,
+              message: 'cannot edit the current or selected channel owner'
+            })
+          }
+        }
+        const mutationAgents = [
+          ...new Map(
+            [agent, effectiveOwner, selectedOwner]
+              .filter((candidate): candidate is AgentRecord => candidate !== null)
+              .map((candidate) => [candidate.id, candidate])
+          ).values()
+        ]
+        const release = deps.agentMutations.tryBeginMutation(mutationAgents.map((candidate) => candidate.id))
         if (!release) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -613,36 +685,26 @@ export function integrationRoutes(deps: HttpDeps) {
           })
         }
         try {
-          const current = await refreshMutationAgent(agent)
-          if (!current) {
-            return reply.code(409).send({
-              error: 'Conflict',
-              statusCode: 409,
-              message: 'agent placement changed; refresh and retry the integration change'
-            })
+          const refreshed = new Map<string, AgentRecord>()
+          for (const observed of mutationAgents) {
+            const current = await refreshMutationAgent(observed)
+            if (!current) {
+              return reply.code(409).send({
+                error: 'Conflict',
+                statusCode: 409,
+                message: 'agent placement changed; refresh and retry the integration change'
+              })
+            }
+            refreshed.set(current.id, current)
           }
-          agent = current
-          if (observedOwner && !(await refreshMutationAgent(observedOwner))) {
-            return reply.code(409).send({
-              error: 'Conflict',
-              statusCode: 409,
-              message: 'default agent placement changed; refresh and retry the integration change'
-            })
-          }
+          agent = refreshed.get(agent.id)!
           // HTTP channel ownership is bot-scoped even though membership rows are
           // stored per integration. Route the whole patch through the orchestrator
           // so every agent detail shows the same owner/trigger and exactly one row
           // remains authoritative.
           let updated: IntegrationChannelRecord | null = null
           let routesSynced = false
-          if (bot.transport === 'http' && existingChannel.kind === 'channel') {
-            if (req.body.agentId !== undefined && !bot.agentIds.includes(AgentId(req.body.agentId))) {
-              return reply.code(409).send({
-                error: 'Conflict',
-                statusCode: 409,
-                message: 'default agent must be an agent that uses this bot'
-              })
-            }
+          if (botScopedChannel) {
             updated = await deps.sharedBot.updateChannel(bot.id, req.params.channelId, {
               ...(req.body.agentId !== undefined ? { agentId: req.body.agentId } : {}),
               ...(req.body.trigger !== undefined ? { trigger: req.body.trigger } : {})
@@ -728,6 +790,9 @@ export function integrationRoutes(deps: HttpDeps) {
           }
           agent = current
           const botBefore = await deps.repos.bot.get(existing.botId)
+          if (botBefore?.transport === 'http') {
+            await deps.sharedBot.prepareIntegrationRemoval(existing.botId)
+          }
           await deps.repos.integration.delete(existing.id)
           // "Freed" now means NO active integration remains (a shared bot may still
           // serve other agents — don't stamp it freed while it does, §6).

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -128,7 +128,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     const intRepo: Pick<IntegrationRepo, 'listForBot'> = { listForBot: async () => integrations }
     const chRepo: Pick<
       IntegrationChannelRepo,
-      'listForBot' | 'replaceSnapshot' | 'setAgent' | 'upsertAgent' | 'upsertConversation'
+      'listForBot' | 'replaceSnapshot' | 'setAgent' | 'setTrigger' | 'upsertAgent' | 'upsertConversation'
     > = {
       listForBot: async () => channels,
       replaceSnapshot: async (integrationId, reported, opts) => {
@@ -149,6 +149,12 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
         const row = channels.find((c) => c.integrationId === integrationId && c.channelId === channelId)
         if (!row) return null
         row.agentId = agentId
+        return row
+      },
+      setTrigger: async (integrationId, channelId, trigger) => {
+        const row = channels.find((c) => c.integrationId === integrationId && c.channelId === channelId)
+        if (!row) return null
+        row.trigger = trigger
         return row
       },
       upsertConversation: async (integrationId, conversation, opts) => {
@@ -445,7 +451,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   it('setChannelAgent makes the pick the sole owner of the channel + pushes rc/routes', async () => {
     botRow = bot()
     // Start with C7 owned by alice (on alice's install); no row on bob's install.
-    channels = [channel({ integrationId: INT_A, channelId: 'C7', agentId: ALICE, trigger: 'mention' })]
+    channels = [channel({ integrationId: INT_A, channelId: 'C7', agentId: ALICE, trigger: 'any' })]
     const orch = makeOrch()
     // Operator picks BOB as C7's default in the modal.
     await orch.setChannelAgent(BOT, 'C7', BOB)
@@ -454,7 +460,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'C7')
     const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'C7')
     expect(aliceRow?.agentId).toBeNull()
-    expect(bobRow?.agentId).toBe(BOB)
+    expect(bobRow).toMatchObject({ agentId: BOB, trigger: 'any' })
 
     // and the relay got a hot rc/routes with C7 scoped to bob.
     const routes = ch.sends.filter((s) => s.type === 'rc/routes')
@@ -506,16 +512,29 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     expect(channels.find((c) => c.integrationId === INT_B && c.channelId === 'C1')?.agentId).toBe(BOB)
   })
 
-  it('does not re-seed a known channel the operator cleared to "No default"', async () => {
-    // C1 exists on both installs, un-owned (operator cleared it). A re-reported snapshot
-    // must NOT re-seed it — only genuinely new channels get the creating-agent default.
+  it('repairs a known ownerless channel to the earliest active agent', async () => {
     channels = [
       channel({ integrationId: INT_A, channelId: 'C1', agentId: null }),
       channel({ integrationId: INT_B, channelId: 'C1', agentId: null })
     ]
     await makeOrch().replaceChannels(BOT, [{ id: 'C1', name: 'deploys' }])
-    expect(channels.find((c) => c.integrationId === INT_A && c.channelId === 'C1')?.agentId).toBeNull()
+    expect(channels.find((c) => c.integrationId === INT_A && c.channelId === 'C1')?.agentId).toBe(ALICE)
     expect(channels.find((c) => c.integrationId === INT_B && c.channelId === 'C1')?.agentId).toBeNull()
+  })
+
+  it('transfers an ownerless channel to the earliest remaining integration', async () => {
+    integrations = [integration(INT_B, BOB)]
+    botRow = bot({ agentIds: [BOB] })
+    channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: null })]
+
+    await makeOrch().syncBot(BOT)
+
+    expect(channels).toEqual([expect.objectContaining({ integrationId: INT_B, channelId: 'C1', agentId: BOB })])
+    const assign = ch.sends.find((send) => send.type === 'rc/bot-assign')?.payload as RcBotAssign
+    expect(assign.routes).toEqual([
+      expect.objectContaining({ agentId: BOB, scope: { channel: 'C1' }, match: { kind: 'mention' } }),
+      expect.objectContaining({ agentId: BOB, match: { kind: 'keyword', value: 'bob' } })
+    ])
   })
 
   it('defers placement when no relay is connected', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -104,6 +104,8 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   let gatedAgents: Set<string>
   // Drives ThreadAffinityStore.get (null = affinity miss → SessionMeta fallback).
   let threadBinding: { agentId: AgentId; daemonId: string } | null
+  // One-shot barrier for deterministic channel-mutation concurrency tests.
+  let blockNextChannelList: (() => Promise<void>) | null
 
   function makeOrch(): SharedBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
@@ -130,7 +132,12 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       IntegrationChannelRepo,
       'listForBot' | 'replaceSnapshot' | 'setAgent' | 'setTrigger' | 'upsertAgent' | 'upsertConversation'
     > = {
-      listForBot: async () => channels,
+      listForBot: async () => {
+        const block = blockNextChannelList
+        blockNextChannelList = null
+        if (block) await block()
+        return channels
+      },
       replaceSnapshot: async (integrationId, reported, opts) => {
         channels = channels.filter(
           (row) => row.integrationId !== integrationId || reported.some((candidate) => candidate.id === row.channelId)
@@ -223,6 +230,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     threadOwnerLookup = null
     gatedAgents = new Set()
     threadBinding = null
+    blockNextChannelList = null
   })
 
   describe('lookupThread — SessionMeta fallback on affinity miss (§7.2 case 2a)', () => {
@@ -482,6 +490,55 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     expect(channels.find((row) => row.integrationId === INT_B)).toMatchObject({ agentId: BOB, trigger: 'off' })
     const routes = ch.sends.filter((send) => send.type === 'rc/routes').at(-1)?.payload as RcBotAssign
     expect(routes.routes.some((route) => route.scope?.channel === 'C7')).toBe(false)
+  })
+
+  it('rejects a queued Console update when Slack changes the authorized owner first', async () => {
+    gatedAgents = new Set([BOB])
+    channels = [
+      channel({ integrationId: INT_A, channelId: 'C7', agentId: ALICE, trigger: 'mention' }),
+      channel({ integrationId: INT_B, channelId: 'C7', agentId: null, trigger: 'mention' })
+    ]
+    let releaseChannelList!: () => void
+    let channelListReached!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      releaseChannelList = resolve
+    })
+    const reached = new Promise<void>((resolve) => {
+      channelListReached = resolve
+    })
+    blockNextChannelList = async () => {
+      channelListReached()
+      await blocked
+    }
+    const orch = makeOrch()
+
+    const slackMove = orch.setChannelAgent(BOT, 'C7', BOB)
+    await reached
+    const consoleUpdate = orch.updateChannel(
+      BOT,
+      'C7',
+      { trigger: 'any' },
+      { expectedOwnerAgentId: ALICE, source: 'console' }
+    )
+    releaseChannelList()
+
+    await slackMove
+    expect(await consoleUpdate).toBeNull()
+    expect(channels.find((row) => row.integrationId === INT_A)).toMatchObject({ agentId: null, trigger: 'off' })
+    expect(channels.find((row) => row.integrationId === INT_B)).toMatchObject({ agentId: BOB, trigger: 'off' })
+  })
+
+  it('backfills a missing sibling before the current owner can be removed', async () => {
+    channels = [channel({ integrationId: INT_A, channelId: 'C7', name: 'deploys', agentId: ALICE, trigger: 'any' })]
+
+    await makeOrch().prepareIntegrationRemoval(BOT)
+
+    expect(channels.find((row) => row.integrationId === INT_B)).toMatchObject({
+      channelId: 'C7',
+      name: 'deploys',
+      agentId: null,
+      trigger: 'any'
+    })
   })
 
   it('fans an HTTP Slack channel snapshot across every install and preserves channel ownership', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -353,14 +353,14 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect(bob.slack.bindRules).toEqual([])
     })
 
-    it("replaceChannels defaults a gated install's fresh channels to off (others to mention)", async () => {
+    it("replaceChannels makes a gated default owner's fresh channel Off on every membership row", async () => {
       gatedAgents = new Set([ALICE])
       channels = []
       await makeOrch().replaceChannels(BOT, [{ id: 'C7', name: 'deploys' }])
       const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'C7')
       const bobRow = channels.find((c) => c.integrationId === INT_B && c.channelId === 'C7')
       expect(aliceRow?.trigger).toBe('off')
-      expect(bobRow?.trigger).toBe('mention')
+      expect(bobRow?.trigger).toBe('off')
     })
 
     it('reportConversation fans a kind:im row (Off, agent-owned) to GATED installs only, idempotently', async () => {
@@ -469,6 +469,21 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     expect(last.routes.some((r) => r.scope?.channel === 'C7' && r.agentId === BOB)).toBe(true)
   })
 
+  it('keeps an in-Slack owner move to a gated agent Off', async () => {
+    gatedAgents = new Set([BOB])
+    channels = [
+      channel({ integrationId: INT_A, channelId: 'C7', agentId: ALICE, trigger: 'any' }),
+      channel({ integrationId: INT_B, channelId: 'C7', agentId: null, trigger: 'off' })
+    ]
+
+    await makeOrch().setChannelAgent(BOT, 'C7', BOB)
+
+    expect(channels.find((row) => row.integrationId === INT_A)).toMatchObject({ agentId: null, trigger: 'off' })
+    expect(channels.find((row) => row.integrationId === INT_B)).toMatchObject({ agentId: BOB, trigger: 'off' })
+    const routes = ch.sends.filter((send) => send.type === 'rc/routes').at(-1)?.payload as RcBotAssign
+    expect(routes.routes.some((route) => route.scope?.channel === 'C7')).toBe(false)
+  })
+
   it('fans an HTTP Slack channel snapshot across every install and preserves channel ownership', async () => {
     channels = [
       channel({ integrationId: INT_A, channelId: 'C-old', name: 'old', agentId: null }),
@@ -535,6 +550,21 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect.objectContaining({ agentId: BOB, scope: { channel: 'C1' }, match: { kind: 'mention' } }),
       expect.objectContaining({ agentId: BOB, match: { kind: 'keyword', value: 'bob' } })
     ])
+  })
+
+  it('keeps an automatic ownerless fallback to a gated agent Off', async () => {
+    integrations = [integration(INT_B, BOB)]
+    botRow = bot({ agentIds: [BOB] })
+    gatedAgents = new Set([BOB])
+    channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: null, trigger: 'any' })]
+
+    await makeOrch().syncBot(BOT)
+
+    expect(channels).toEqual([
+      expect.objectContaining({ integrationId: INT_B, channelId: 'C1', agentId: BOB, trigger: 'off' })
+    ])
+    const assign = ch.sends.find((send) => send.type === 'rc/bot-assign')?.payload as RcBotAssign
+    expect(assign.routes).toEqual([])
   })
 
   it('defers placement when no relay is connected', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -80,6 +80,8 @@ export function pickChannelOwner(
 }
 
 export class SharedBotOrchestrator {
+  private readonly channelMutationChains = new Map<string, Promise<unknown>>()
+
   constructor(
     private readonly bots: BotRepo,
     private readonly botSecret: BotSecretStore,
@@ -372,47 +374,55 @@ export class SharedBotOrchestrator {
   async updateChannel(
     botId: string,
     channelId: string,
-    patch: { agentId?: string; trigger?: ChannelTrigger }
+    patch: { agentId?: string; trigger?: ChannelTrigger },
+    options: { expectedOwnerAgentId?: string; source?: 'console' | 'slack' } = {}
   ): Promise<IntegrationChannelRecord | null> {
-    const bot = await this.bots.get(BotId(botId))
-    if (bot?.transport !== 'http') {
-      this.log.warn({ botId }, 'shared-bot: update-channel for a non-http/unknown bot — ignored')
-      return null
-    }
-    const installs = await this.integrations.listForBot(bot.id)
-    if (installs.length === 0) return null
-    const rows = (await this.channels.listForBot(bot.id)).filter(
-      (row) => row.kind === 'channel' && row.channelId === channelId
-    )
-    const currentOwner = pickChannelOwner(installs, rows)
-    const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
-    if (!owner) {
-      this.log.warn({ botId, agentId: patch.agentId }, 'shared-bot: update-channel for a non-member agent — ignored')
-      return null
-    }
+    return this.serializeChannelMutation(botId, channelId, async () => {
+      const bot = await this.bots.get(BotId(botId))
+      if (bot?.transport !== 'http') {
+        this.log.warn({ botId }, 'shared-bot: update-channel for a non-http/unknown bot — ignored')
+        return null
+      }
+      const installs = await this.integrations.listForBot(bot.id)
+      if (installs.length === 0) return null
+      const rows = (await this.channels.listForBot(bot.id)).filter(
+        (row) => row.kind === 'channel' && row.channelId === channelId
+      )
+      const currentOwner = pickChannelOwner(installs, rows)
+      if (options.expectedOwnerAgentId && currentOwner?.agentId !== options.expectedOwnerAgentId) {
+        this.log.warn(
+          { botId, channelId, expectedOwnerAgentId: options.expectedOwnerAgentId },
+          'shared-bot: channel owner changed before update — ignored'
+        )
+        return null
+      }
+      const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
+      if (!owner) {
+        this.log.warn({ botId, agentId: patch.agentId }, 'shared-bot: update-channel for a non-member agent — ignored')
+        return null
+      }
 
-    const currentRow = currentOwner
-      ? (rows.find((row) => row.agentId === currentOwner.agentId) ??
-        rows.find((row) => row.integrationId === currentOwner.id))
-      : undefined
-    const trigger = patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger
-    let updated = await this.persistChannelOwner(installs, channelId, owner)
-    if (trigger !== undefined) {
+      const currentRow = currentOwner
+        ? (rows.find((row) => row.agentId === currentOwner.agentId) ??
+          rows.find((row) => row.integrationId === currentOwner.id))
+        : undefined
+      const targetAgent = options.source === 'slack' ? await this.agents.get(owner.agentId) : null
+      let updated = await this.persistChannelOwner(installs, channelId, owner)
+      const trigger =
+        targetAgent && isGatedAgent(targetAgent)
+          ? ('off' as const)
+          : (patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger ?? updated.trigger)
       await this.syncChannelTrigger(installs, channelId, trigger, rows)
       updated = { ...updated, trigger }
-    }
-    await this.syncRoutes(botId)
-    return updated
+      await this.syncRoutes(botId)
+      return updated
+    })
   }
 
   /** The in-Slack config modal changes only the owner. A workspace user must
    * never enable a restricted agent, so that target always starts Off. */
   async setChannelAgent(botId: string, channelId: string, agentId: string): Promise<void> {
-    const target = await this.agents.get(AgentId(agentId))
-    await this.updateChannel(botId, channelId, {
-      agentId,
-      ...(target && isGatedAgent(target) ? { trigger: 'off' as const } : {})
-    })
+    await this.updateChannel(botId, channelId, { agentId }, { source: 'slack' })
   }
 
   /** Preserve bot-scoped channel state before an owner integration is deleted. */
@@ -424,6 +434,24 @@ export class SharedBotOrchestrator {
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
+
+  /** Serialize the owner check and write per channel. Console authorization
+   * happens before this boundary and supplies the owner it authorized; a queued
+   * Slack move therefore makes that Console mutation fail closed. */
+  private serializeChannelMutation<T>(botId: string, channelId: string, run: () => Promise<T>): Promise<T> {
+    const key = `${botId}\u0000${channelId}`
+    const previous = this.channelMutationChains.get(key) ?? Promise.resolve()
+    const result = previous.then(run, run)
+    const settled = result.then(
+      () => undefined,
+      () => undefined
+    )
+    this.channelMutationChains.set(key, settled)
+    void settled.finally(() => {
+      if (this.channelMutationChains.get(key) === settled) this.channelMutationChains.delete(key)
+    })
+    return result
+  }
 
   /** Store one canonical owner row and clear every sibling install's copy. */
   private async persistChannelOwner(
@@ -448,8 +476,10 @@ export class SharedBotOrchestrator {
     return updated
   }
 
-  /** Keep the effective trigger on every surviving membership row. Ownership is
-   * canonical, but the repeated trigger lets owner deletion preserve channel state. */
+  /** Keep the effective trigger on every active membership row, creating a
+   * missing sibling from the best available channel metadata. Ownership is
+   * canonical, but complete repeated state lets owner deletion preserve the
+   * channel and trigger even before a new install reports its own snapshot. */
   private async syncChannelTrigger(
     installs: IntegrationRecord[],
     channelId: string,
@@ -457,8 +487,23 @@ export class SharedBotOrchestrator {
     knownRows: IntegrationChannelRecord[]
   ): Promise<void> {
     const known = new Map(knownRows.map((row) => [row.integrationId, row]))
+    const template = knownRows.find((row) => row.name !== null) ?? knownRows[0]
     for (const integration of installs) {
-      if (known.get(integration.id)?.trigger === trigger) continue
+      const row = known.get(integration.id)
+      if (row?.trigger === trigger) continue
+      if (!row) {
+        const backfilled = await this.channels.upsertConversation(
+          integration.id,
+          {
+            id: channelId,
+            ...(template?.name ? { name: template.name } : {}),
+            isPrivate: template?.isPrivate ?? false,
+            kind: 'channel'
+          },
+          { defaultTrigger: trigger }
+        )
+        if (backfilled.trigger === trigger) continue
+      }
       await this.channels.setTrigger(integration.id, channelId, trigger)
     }
   }

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -69,6 +69,16 @@ interface Compiled {
   placed: { integration: IntegrationRecord; daemonId: string; gated: boolean }[]
 }
 
+/** Resolve a persisted owner marker to its active integration, falling back to
+ * the earliest active install for new or legacy ownerless channels. */
+export function pickChannelOwner(
+  installs: IntegrationRecord[],
+  rows: IntegrationChannelRecord[]
+): IntegrationRecord | undefined {
+  const assigned = new Set(rows.flatMap((row) => (row.agentId ? [row.agentId] : [])))
+  return installs.find((integration) => assigned.has(integration.agentId)) ?? installs[0]
+}
+
 export class SharedBotOrchestrator {
   constructor(
     private readonly bots: BotRepo,
@@ -374,7 +384,7 @@ export class SharedBotOrchestrator {
     const rows = (await this.channels.listForBot(bot.id)).filter(
       (row) => row.kind === 'channel' && row.channelId === channelId
     )
-    const currentOwner = this.pickChannelOwner(installs, rows)
+    const currentOwner = pickChannelOwner(installs, rows)
     const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
     if (!owner) {
       this.log.warn({ botId, agentId: patch.agentId }, 'shared-bot: update-channel for a non-member agent — ignored')
@@ -387,26 +397,33 @@ export class SharedBotOrchestrator {
       : undefined
     const trigger = patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger
     let updated = await this.persistChannelOwner(installs, channelId, owner)
-    if (trigger !== undefined) updated = (await this.channels.setTrigger(owner.id, channelId, trigger)) ?? updated
+    if (trigger !== undefined) {
+      await this.syncChannelTrigger(installs, channelId, trigger, rows)
+      updated = { ...updated, trigger }
+    }
     await this.syncRoutes(botId)
     return updated
   }
 
-  /** The in-Slack config modal changes only the owner. */
+  /** The in-Slack config modal changes only the owner. A workspace user must
+   * never enable a restricted agent, so that target always starts Off. */
   async setChannelAgent(botId: string, channelId: string, agentId: string): Promise<void> {
-    await this.updateChannel(botId, channelId, { agentId })
+    const target = await this.agents.get(AgentId(agentId))
+    await this.updateChannel(botId, channelId, {
+      agentId,
+      ...(target && isGatedAgent(target) ? { trigger: 'off' as const } : {})
+    })
+  }
+
+  /** Preserve bot-scoped channel state before an owner integration is deleted. */
+  async prepareIntegrationRemoval(botId: string): Promise<void> {
+    const bot = await this.bots.get(BotId(botId))
+    if (bot?.transport !== 'http') return
+    const installs = await this.integrations.listForBot(bot.id)
+    await this.ensureChannelOwners(bot.id, installs)
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
-
-  /** Pick the earliest installed valid owner represented by the channel rows. */
-  private pickChannelOwner(
-    installs: IntegrationRecord[],
-    rows: IntegrationChannelRecord[]
-  ): IntegrationRecord | undefined {
-    const assigned = new Set(rows.flatMap((row) => (row.agentId ? [row.agentId] : [])))
-    return installs.find((integration) => assigned.has(integration.agentId)) ?? installs[0]
-  }
 
   /** Store one canonical owner row and clear every sibling install's copy. */
   private async persistChannelOwner(
@@ -431,6 +448,21 @@ export class SharedBotOrchestrator {
     return updated
   }
 
+  /** Keep the effective trigger on every surviving membership row. Ownership is
+   * canonical, but the repeated trigger lets owner deletion preserve channel state. */
+  private async syncChannelTrigger(
+    installs: IntegrationRecord[],
+    channelId: string,
+    trigger: ChannelTrigger,
+    knownRows: IntegrationChannelRecord[]
+  ): Promise<void> {
+    const known = new Map(knownRows.map((row) => [row.integrationId, row]))
+    for (const integration of installs) {
+      if (known.get(integration.id)?.trigger === trigger) continue
+      await this.channels.setTrigger(integration.id, channelId, trigger)
+    }
+  }
+
   /**
    * Converge every channel to one canonical owner. This repairs owner deletion,
    * legacy ownerless rows, and older Web writes that stored an owner on the wrong
@@ -443,20 +475,23 @@ export class SharedBotOrchestrator {
     const channelIds = [...new Set(rows.map((row) => row.channelId))]
     for (const channelId of channelIds) {
       const channelRows = rows.filter((row) => row.channelId === channelId)
-      const owner = this.pickChannelOwner(installs, channelRows)
+      const owner = pickChannelOwner(installs, channelRows)
       if (!owner) continue
+      const persistedOwner = channelRows.some((row) => row.agentId === owner.agentId)
+      let trigger =
+        channelRows.find((row) => row.agentId === owner.agentId)?.trigger ??
+        channelRows.find((row) => row.integrationId === owner.id)?.trigger ??
+        channelRows[0]?.trigger
+      if (!persistedOwner) {
+        const ownerAgent = await this.agents.get(owner.agentId)
+        if (ownerAgent && isGatedAgent(ownerAgent)) trigger = 'off'
+      }
       const canonical = channelRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
       const conflicting = channelRows.some(
         (row) => row.agentId !== null && (row.integrationId !== owner.id || row.agentId !== owner.agentId)
       )
-      if (!canonical || conflicting) {
-        const trigger =
-          channelRows.find((row) => row.agentId === owner.agentId)?.trigger ??
-          channelRows.find((row) => row.integrationId === owner.id)?.trigger ??
-          channelRows[0]?.trigger
-        await this.persistChannelOwner(installs, channelId, owner)
-        if (trigger !== undefined) await this.channels.setTrigger(owner.id, channelId, trigger)
-      }
+      if (!canonical || conflicting) await this.persistChannelOwner(installs, channelId, owner)
+      if (trigger !== undefined) await this.syncChannelTrigger(installs, channelId, trigger, channelRows)
     }
   }
 

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -31,6 +31,8 @@ import type {
   IntegrationRepo,
   IntegrationRecord,
   IntegrationChannelRepo,
+  IntegrationChannelRecord,
+  ChannelTrigger,
   ReportedChannel,
   AgentRepo,
   AgentRecord,
@@ -270,13 +272,9 @@ export class SharedBotOrchestrator {
    *  app membership, so fan the snapshot across them, preserving per-install
    *  trigger/owner fields in the repository, then hot-refresh relay routes.
    *
-   *  A freshly-invited channel is seeded with the bot's CREATING agent as its
-   *  default owner (§10.1), so it routes out of the box instead of landing on
-   *  "No default" (a bare mention would fall to the group default, but an
-   *  "any message" channel with no owner routes nothing). Only genuinely NEW
-   *  channels are seeded — a channel the operator later clears to "No default"
-   *  stays cleared, never re-seeded. The seed is written on the creating install's
-   *  row alone, preserving the one-owner-per-channel invariant.
+   *  For a shared bot, route compilation converges every reported channel to
+   *  exactly one owner. A new or ownerless channel is assigned to the bot's
+   *  creating (earliest active) agent, while an existing owner is preserved.
    */
   async replaceChannels(botId: string, channels: ReportedChannel[]): Promise<void> {
     const bot = await this.bots.get(BotId(botId))
@@ -285,24 +283,12 @@ export class SharedBotOrchestrator {
       return
     }
     const installs = await this.integrations.listForBot(bot.id)
-    // Channels already known (on ANY install) before this snapshot — the set we must
-    // NOT seed, so an operator's later "No default" clear is honoured, not overwritten.
-    const known = new Set((await this.channels.listForBot(bot.id)).map((c) => c.channelId))
     for (const integration of installs) {
       // Conversation gating (§14): a gated install's fresh channels start Off — an
       // editor must enable them in the console before the compiler emits a route.
       const owner = await this.agents.get(integration.agentId)
       const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
       await this.channels.replaceSnapshot(integration.id, channels, defaultTrigger ? { defaultTrigger } : undefined)
-    }
-    // The creating agent = the earliest install (`listForBot` is createdAt-asc). Own
-    // each new channel on its row so the channel-scoped rule the compiler reads points
-    // at the creating agent (and no other install co-owns it). Operator-overridable.
-    const creating = installs[0]
-    if (creating) {
-      for (const c of channels) {
-        if (!known.has(c.id)) await this.channels.upsertAgent(creating.id, c.id, creating.agentId)
-      }
     }
     await this.syncRoutes(botId)
   }
@@ -369,56 +355,116 @@ export class SharedBotOrchestrator {
   }
 
   /**
-   * Set (or clear) a channel's default/owning agent for a shared bot — the target of
-   * the in-Slack config modal (`rc/set-channel-agent`). Channel ownership is one
-   * agent per channel, but rows are keyed per-install, so this makes the pick the
-   * SOLE owner: it clears the channel's row on every OTHER install of the bot, then
-   * upserts it (with `agentId`) on the chosen agent's own install — which is what the
-   * route compiler reads as the channel-scoped rule. `agentId: null` just clears.
-   * Recompiles + pushes the bot's routes (`rc/routes`). Fire-and-forget safe.
+   * Update a shared channel through its bot-level ownership boundary. The selected
+   * agent becomes the sole owner, and the channel trigger follows the channel when
+   * ownership changes instead of reverting to a stale per-install value.
    */
-  async setChannelAgent(botId: string, channelId: string, agentId: string | null): Promise<void> {
+  async updateChannel(
+    botId: string,
+    channelId: string,
+    patch: { agentId?: string; trigger?: ChannelTrigger }
+  ): Promise<IntegrationChannelRecord | null> {
     const bot = await this.bots.get(BotId(botId))
     if (bot?.transport !== 'http') {
-      this.log.warn({ botId }, 'shared-bot: set-channel-agent for a non-http/unknown bot — ignored')
-      return
+      this.log.warn({ botId }, 'shared-bot: update-channel for a non-http/unknown bot — ignored')
+      return null
     }
     const installs = await this.integrations.listForBot(bot.id)
-    // The chosen owner must actually be an agent installed on this bot.
-    const owner = agentId ? installs.find((i) => i.agentId === agentId) : undefined
-    if (agentId && !owner) {
-      this.log.warn({ botId, agentId }, 'shared-bot: set-channel-agent for a non-member agent — ignored')
-      return
+    if (installs.length === 0) return null
+    const rows = (await this.channels.listForBot(bot.id)).filter(
+      (row) => row.kind === 'channel' && row.channelId === channelId
+    )
+    const currentOwner = this.pickChannelOwner(installs, rows)
+    const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
+    if (!owner) {
+      this.log.warn({ botId, agentId: patch.agentId }, 'shared-bot: update-channel for a non-member agent — ignored')
+      return null
     }
-    // One owner per channel: drop this channel's row on every other install, then set
-    // it (name/isPrivate default in the daemon-report sense are irrelevant here — the
-    // row exists purely to carry the agentId ownership the compiler reads).
-    for (const i of installs) {
-      if (owner && i.id === owner.id) continue
-      await this.channels.setAgent(i.id, channelId, null)
-    }
-    if (owner) {
-      // Conversation gating (§14): the in-Slack config modal is reachable by any
-      // workspace user, so assigning a channel to a GATED agent must not enable it —
-      // a freshly-created row starts Off; only a console editor can flip the trigger.
-      const ownerAgent = await this.agents.get(owner.agentId)
-      const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
-      await this.channels.upsertAgent(
-        owner.id,
-        channelId,
-        AgentId(agentId!),
-        defaultTrigger ? { defaultTrigger } : undefined
-      )
-    }
+
+    const currentRow = currentOwner
+      ? (rows.find((row) => row.agentId === currentOwner.agentId) ??
+        rows.find((row) => row.integrationId === currentOwner.id))
+      : undefined
+    const trigger = patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger
+    let updated = await this.persistChannelOwner(installs, channelId, owner)
+    if (trigger !== undefined) updated = (await this.channels.setTrigger(owner.id, channelId, trigger)) ?? updated
     await this.syncRoutes(botId)
+    return updated
+  }
+
+  /** The in-Slack config modal changes only the owner. */
+  async setChannelAgent(botId: string, channelId: string, agentId: string): Promise<void> {
+    await this.updateChannel(botId, channelId, { agentId })
   }
 
   // ── internals ──────────────────────────────────────────────────────────────
 
-  /** Compile the attributed routing table from the bot's installs + channels. */
+  /** Pick the earliest installed valid owner represented by the channel rows. */
+  private pickChannelOwner(
+    installs: IntegrationRecord[],
+    rows: IntegrationChannelRecord[]
+  ): IntegrationRecord | undefined {
+    const assigned = new Set(rows.flatMap((row) => (row.agentId ? [row.agentId] : [])))
+    return installs.find((integration) => assigned.has(integration.agentId)) ?? installs[0]
+  }
+
+  /** Store one canonical owner row and clear every sibling install's copy. */
+  private async persistChannelOwner(
+    installs: IntegrationRecord[],
+    channelId: string,
+    owner: IntegrationRecord
+  ): Promise<IntegrationChannelRecord> {
+    const ownerAgent = await this.agents.get(owner.agentId)
+    const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
+    const updated = await this.channels.upsertAgent(
+      owner.id,
+      channelId,
+      owner.agentId,
+      defaultTrigger ? { defaultTrigger } : undefined
+    )
+    // Establish the replacement before clearing stale markers: even if a later
+    // cleanup write fails, the channel never regresses to having no owner.
+    for (const integration of installs) {
+      if (integration.id === owner.id) continue
+      await this.channels.setAgent(integration.id, channelId, null)
+    }
+    return updated
+  }
+
+  /**
+   * Converge every channel to one canonical owner. This repairs owner deletion,
+   * legacy ownerless rows, and older Web writes that stored an owner on the wrong
+   * integration. DM rows are intentionally excluded because gated DMs may enable
+   * several agents independently.
+   */
+  private async ensureChannelOwners(botId: BotId, installs: IntegrationRecord[]): Promise<void> {
+    if (installs.length === 0) return
+    const rows = (await this.channels.listForBot(botId)).filter((row) => row.kind === 'channel')
+    const channelIds = [...new Set(rows.map((row) => row.channelId))]
+    for (const channelId of channelIds) {
+      const channelRows = rows.filter((row) => row.channelId === channelId)
+      const owner = this.pickChannelOwner(installs, channelRows)
+      if (!owner) continue
+      const canonical = channelRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
+      const conflicting = channelRows.some(
+        (row) => row.agentId !== null && (row.integrationId !== owner.id || row.agentId !== owner.agentId)
+      )
+      if (!canonical || conflicting) {
+        const trigger =
+          channelRows.find((row) => row.agentId === owner.agentId)?.trigger ??
+          channelRows.find((row) => row.integrationId === owner.id)?.trigger ??
+          channelRows[0]?.trigger
+        await this.persistChannelOwner(installs, channelId, owner)
+        if (trigger !== undefined) await this.channels.setTrigger(owner.id, channelId, trigger)
+      }
+    }
+  }
+
+  /** Compile the attributed routing table after converging channel ownership. */
   private async compile(bot: BotRecord): Promise<Compiled | null> {
     const integrations = await this.integrations.listForBot(bot.id)
     if (integrations.length === 0) return null
+    await this.ensureChannelOwners(bot.id, integrations)
     const agentById = new Map<string, AgentRecord>()
     for (const i of integrations) {
       const a = await this.agents.get(i.agentId)

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2200,7 +2200,7 @@ export interface IntegrationChannelRecord {
   isPrivate: boolean
   kind: ConversationKind
   trigger: ChannelTrigger
-  /** Per-channel default/owning agent for a shared bot (§10.1); null ⇒ unset. */
+  /** Per-channel owner for a shared bot (§10.1); null on sibling non-owner rows. */
   agentId: AgentId | null
 }
 
@@ -2246,8 +2246,8 @@ export interface IntegrationChannelRepo {
     channelId: string,
     trigger: ChannelTrigger
   ): Promise<IntegrationChannelRecord | null>
-  /** Per-channel default/owning agent (shared bot, §10.1); null clears it. Returns
-   *  null when the channel row doesn't exist. */
+  /** Set or clear this integration row's owner marker. The orchestrator keeps
+   *  exactly one row marked per shared channel. Returns null when missing. */
   setAgent(
     integrationId: IntegrationId,
     channelId: string,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2199,6 +2199,7 @@ export interface IntegrationChannelRecord {
   name: string | null
   isPrivate: boolean
   kind: ConversationKind
+  /** Repeated across shared-channel sibling rows; integration-scoped for DMs. */
   trigger: ChannelTrigger
   /** Per-channel owner for a shared bot (§10.1); null on sibling non-owner rows. */
   agentId: AgentId | null

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -17,6 +17,7 @@ import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo, PgDaemonRepo, PgIntegrationRepo, PgIntegrationChannelRepo } from '../../src/persistence/index.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { handleIntegrationChannels } from '../../src/ws/handlers/index.js'
 import { IntegrationId } from '../../src/domain/ids.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
@@ -457,6 +458,130 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
       payload: { agentId: null }
     })
     expect(cleared.statusCode).toBe(400)
+
+    // Simulate a stale legacy sibling, then remove the canonical owner. The
+    // pre-delete convergence must copy the effective trigger to the survivor.
+    await prisma.integrationChannel.update({
+      where: { integrationId_channelId: { integrationId: aliceIntegration, channelId: 'C1' } },
+      data: { trigger: 'mention' }
+    })
+    const removed = await running.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/integrations/${bobIntegration}`
+    })
+    expect(removed.statusCode).toBe(204)
+    expect(
+      await prisma.integrationChannel.findUnique({
+        where: { integrationId_channelId: { integrationId: aliceIntegration, channelId: 'C1' } }
+      })
+    ).toMatchObject({ agentId: alice, trigger: 'any' })
+  })
+
+  it('projects a hidden canonical owner but refuses to mutate it through a visible sibling', async () => {
+    const users = new PgUserRepo(prisma)
+    const subject = `channel-auth-${randomUUID()}`
+    const email = `${subject}@acme.dev`
+    const { userId } = await users.provisionOidcUser({ oidcSubject: subject, email, emailVerified: true })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+
+    await seedDaemon(prisma, DAEMON)
+    const alice = randomUUID()
+    const bob = randomUUID()
+    const botId = randomUUID()
+    const aliceIntegration = randomUUID()
+    const bobIntegration = randomUUID()
+    await seedAgent(prisma, alice, { daemonId: DAEMON })
+    await seedAgent(prisma, bob, { daemonId: DAEMON, visibility: 'restricted' })
+    await prisma.bot.create({
+      data: {
+        id: botId,
+        orgId: DEFAULT_ORG_ID,
+        platform: 'slack',
+        name: 'restricted-owner-bot',
+        shareable: true,
+        transport: 'http'
+      }
+    })
+    await prisma.integration.createMany({
+      data: [
+        {
+          id: aliceIntegration,
+          orgId: DEFAULT_ORG_ID,
+          agentId: alice,
+          botId,
+          platform: 'slack',
+          name: 'restricted-owner-bot'
+        },
+        {
+          id: bobIntegration,
+          orgId: DEFAULT_ORG_ID,
+          agentId: bob,
+          botId,
+          platform: 'slack',
+          name: 'restricted-owner-bot'
+        }
+      ]
+    })
+    await prisma.integrationChannel.createMany({
+      data: [
+        {
+          integrationId: aliceIntegration,
+          channelId: 'C1',
+          name: 'deploys',
+          trigger: 'mention',
+          agentId: null
+        },
+        {
+          integrationId: bobIntegration,
+          channelId: 'C1',
+          name: 'deploys',
+          trigger: 'any',
+          agentId: bob
+        }
+      ]
+    })
+    running = buildHttpApp(prisma, { DEFAULT_OWNER_ID: userId })
+
+    const listed = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const visible = (
+      listed.json() as Array<{
+        agentId: string
+        botId: string
+        channels: Array<{ agentId: string; trigger: string }>
+      }>
+    ).filter((integration) => integration.botId === botId)
+    expect(visible).toHaveLength(1)
+    expect(visible[0]).toMatchObject({
+      agentId: alice,
+      channels: [expect.objectContaining({ agentId: bob, trigger: 'any' })]
+    })
+
+    const denied = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${aliceIntegration}/channels/C1`,
+      payload: { trigger: 'mention' }
+    })
+    expect(denied.statusCode).toBe(403)
+    expect(
+      await prisma.integrationChannel.findUnique({
+        where: { integrationId_channelId: { integrationId: bobIntegration, channelId: 'C1' } }
+      })
+    ).toMatchObject({ agentId: bob, trigger: 'any' })
+
+    await prisma.integrationChannel.update({
+      where: { integrationId_channelId: { integrationId: bobIntegration, channelId: 'C1' } },
+      data: { agentId: null }
+    })
+    await prisma.integrationChannel.update({
+      where: { integrationId_channelId: { integrationId: aliceIntegration, channelId: 'C1' } },
+      data: { agentId: alice, trigger: 'any' }
+    })
+    const deniedTarget = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${aliceIntegration}/channels/C1`,
+      payload: { agentId: bob }
+    })
+    expect(deniedTarget.statusCode).toBe(403)
   })
 
   it("persists the trigger and pushes integration/upsert with the channel-scoped 'auto' rule", async () => {

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -360,6 +360,105 @@ describe('integration/channels EVT → integration_channel convergence', () => {
 })
 
 describe('PATCH /integrations/:id/channels/:channelId', () => {
+  it('projects and updates one shared-channel owner consistently across member integrations', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const alice = randomUUID()
+    const bob = randomUUID()
+    const botId = randomUUID()
+    const aliceIntegration = randomUUID()
+    const bobIntegration = randomUUID()
+    await seedAgent(prisma, alice, { daemonId: DAEMON })
+    await seedAgent(prisma, bob, { daemonId: DAEMON })
+    await prisma.bot.create({
+      data: {
+        id: botId,
+        orgId: DEFAULT_ORG_ID,
+        platform: 'slack',
+        name: 'shared-bot',
+        shareable: true,
+        transport: 'http'
+      }
+    })
+    await prisma.integration.createMany({
+      data: [
+        {
+          id: aliceIntegration,
+          orgId: DEFAULT_ORG_ID,
+          agentId: alice,
+          botId,
+          platform: 'slack',
+          name: 'shared-bot'
+        },
+        {
+          id: bobIntegration,
+          orgId: DEFAULT_ORG_ID,
+          agentId: bob,
+          botId,
+          platform: 'slack',
+          name: 'shared-bot'
+        }
+      ]
+    })
+    await prisma.integrationChannel.createMany({
+      data: [
+        {
+          integrationId: aliceIntegration,
+          channelId: 'C1',
+          name: 'deploys',
+          trigger: 'any',
+          agentId: alice
+        },
+        {
+          integrationId: bobIntegration,
+          channelId: 'C1',
+          name: 'deploys',
+          trigger: 'mention',
+          agentId: null
+        }
+      ]
+    })
+    running = buildHttpApp(prisma)
+
+    let listed = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    let shared = (
+      listed.json() as Array<{ botId: string; channels: Array<{ agentId: string; trigger: string }> }>
+    ).filter((integration) => integration.botId === botId)
+    expect(shared).toHaveLength(2)
+    expect(shared.every((integration) => integration.channels[0]?.agentId === alice)).toBe(true)
+    expect(shared.every((integration) => integration.channels[0]?.trigger === 'any')).toBe(true)
+
+    const changed = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${aliceIntegration}/channels/C1`,
+      payload: { agentId: bob }
+    })
+    expect(changed.statusCode).toBe(200)
+    expect(changed.json()).toMatchObject({ agentId: bob, trigger: 'any' })
+
+    const stored = await prisma.integrationChannel.findMany({
+      where: { integration: { botId }, channelId: 'C1' }
+    })
+    expect(stored.find((channel) => channel.integrationId === aliceIntegration)?.agentId).toBeNull()
+    expect(stored.find((channel) => channel.integrationId === bobIntegration)).toMatchObject({
+      agentId: bob,
+      trigger: 'any'
+    })
+
+    listed = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    shared = (listed.json() as Array<{ botId: string; channels: Array<{ agentId: string; trigger: string }> }>).filter(
+      (integration) => integration.botId === botId
+    )
+    expect(shared.every((integration) => integration.channels[0]?.agentId === bob)).toBe(true)
+    expect(shared.every((integration) => integration.channels[0]?.trigger === 'any')).toBe(true)
+
+    const cleared = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${aliceIntegration}/channels/C1`,
+      payload: { agentId: null }
+    })
+    expect(cleared.statusCode).toBe(400)
+  })
+
   it("persists the trigger and pushes integration/upsert with the channel-scoped 'auto' rule", async () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -459,11 +459,11 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     })
     expect(cleared.statusCode).toBe(400)
 
-    // Simulate a stale legacy sibling, then remove the canonical owner. The
-    // pre-delete convergence must copy the effective trigger to the survivor.
-    await prisma.integrationChannel.update({
-      where: { integrationId_channelId: { integrationId: aliceIntegration, channelId: 'C1' } },
-      data: { trigger: 'mention' }
+    // Simulate a new install whose membership snapshot has not arrived, then
+    // remove the sole-row owner. Pre-delete convergence must backfill the
+    // survivor with both channel metadata and the effective trigger.
+    await prisma.integrationChannel.delete({
+      where: { integrationId_channelId: { integrationId: aliceIntegration, channelId: 'C1' } }
     })
     const removed = await running.app.inject({
       method: 'DELETE',

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -601,12 +601,12 @@ export type RcAssign = z.infer<typeof RcAssign>
 // in-Slack config modal (§10.1). The CP persists it as the channel's owner
 // (IntegrationChannel.agentId on the chosen agent's install for this bot, clearing
 // any other install's row for the same channel) and re-compiles the bot's routes
-// (rc/routes). `agentId: null` clears the channel's default. The relay acks the
-// modal immediately; this rides best-effort like other rc EVTs.
+// (rc/routes). A shared channel always has one owner. The relay acks the modal
+// immediately; this rides best-effort like other rc EVTs.
 export const RcSetChannelAgent = z.object({
   botId: z.string().uuid(),
   channelId: z.string().min(1),
-  agentId: z.string().uuid().nullable()
+  agentId: z.string().uuid()
 })
 export type RcSetChannelAgent = z.infer<typeof RcSetChannelAgent>
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -95,9 +95,8 @@ function TriggerToggle({
   )
 }
 
-/** Per-channel default-agent picker for a SHARED bot (§10.1): which agent this
- *  channel's traffic routes to. "No default" clears it (falls through to keyword /
- *  the bot's group default). */
+/** Per-channel default-agent picker for a SHARED bot (§10.1). Every active
+ *  shared channel has exactly one owner. */
 function DefaultAgentSelect({
   channel,
   options,
@@ -107,22 +106,21 @@ function DefaultAgentSelect({
   channel: IntegrationChannelRow
   options: { id: string; label: string }[]
   disabled: boolean
-  onChange: (agentId: string | null) => void
+  onChange: (agentId: string) => void
 }) {
   const [saving, setSaving] = useState(false)
   return (
     <select
-      value={channel.agentId ?? ''}
+      value={channel.agentId ?? options[0]?.id ?? ''}
       disabled={disabled || saving}
       onChange={(e) => {
         setSaving(true)
-        Promise.resolve(onChange(e.target.value || null)).finally(() => setSaving(false))
+        Promise.resolve(onChange(e.target.value)).finally(() => setSaving(false))
       }}
       className={`rounded-[7px] border border-(--border-subtle) bg-(--surface-card) px-2 py-[5px] font-sans text-[12.5px] leading-normal text-(--text-primary) max-desktop:w-full ${
         disabled ? 'cursor-default opacity-60' : 'cursor-pointer'
       } ${saving ? 'opacity-60' : ''}`}
     >
-      <option value="">No default</option>
       {options.map((o) => (
         <option key={o.id} value={o.id}>
           {o.label}

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -110,17 +110,15 @@ type BotPlatform = (typeof BOT_PLATFORMS)[number]['platform']
 interface BotChannelView {
   channelId: string
   name: string
-  /** Explicit per-channel assignment; null ⇒ the bot's default agent (earliest
-   *  install = agentIds[0], same ordering the route compiler uses, §10.3). */
+  /** Effective per-channel owner; null only before legacy state converges. */
   agentId: string | null
-  /** Integration whose snapshot row backs this channel — the PATCH target when
-   *  the picker switches the active agent. */
+  /** Any integration whose snapshot row backs this channel; ownership PATCHes
+   *  are bot-scoped. */
   integrationId: string | null
 }
 
 // The bot's channel roster, merged across its installs (a shared bot fans out to
-// one integration per agent, each reporting its own membership snapshot). An
-// explicit per-channel assignment wins over rows that carry none.
+// one integration per agent, each reporting its own membership snapshot).
 function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelView[] {
   const merged = new Map<string, BotChannelView>()
   for (const i of integrations) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -536,7 +536,7 @@ export interface IntegrationChannelDto {
   isPrivate: boolean
   kind: 'channel' | 'im'
   trigger: ChannelTrigger
-  agentId: string | null // per-channel default agent for a shared bot; null ⇒ unset
+  agentId: string | null // effective shared-channel owner; null before convergence / when not applicable
 }
 
 // `/integrations` list/create row — control-plane metadata only, NEVER tokens.
@@ -2527,7 +2527,7 @@ export async function fetchHookRuns(id: string, orgId?: string): Promise<HookRun
 export async function updateIntegrationChannel(
   integrationId: string,
   channelId: string,
-  patch: { trigger?: ChannelTrigger; agentId?: string | null }
+  patch: { trigger?: ChannelTrigger; agentId?: string }
 ): Promise<IntegrationChannelDto> {
   return apiPatch<IntegrationChannelDto>(
     `${orgBase()}/integrations/${encodeURIComponent(integrationId)}/channels/${encodeURIComponent(channelId)}`,

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -190,8 +190,8 @@ interface ConsoleData {
   deleteHook: (id: string, agentId?: string | null) => Promise<void>
   /** Per-channel trigger choice (PATCH), applied to the local row on success. */
   setChannelTrigger: (integrationId: string, channelId: string, trigger: ChannelTrigger) => Promise<void>
-  /** Per-channel default agent for a shared bot (PATCH; null clears), applied locally. */
-  setChannelAgent: (integrationId: string, channelId: string, agentId: string | null) => Promise<void>
+  /** Per-channel default agent for a shared bot (PATCH), applied locally. */
+  setChannelAgent: (integrationId: string, channelId: string, agentId: string) => Promise<void>
   /** Flip a bot's shared-bot opt-in (PATCH /bots/:id), then re-pull. */
   setBotShareable: (botId: string, shareable: boolean) => Promise<void>
   /** Create-or-update a cron (PUT upsert; null id ⇒ mint a fresh UUID), then re-pull. */
@@ -1022,45 +1022,64 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     [mutateSkillSources]
   )
 
-  // Flip one channel's trigger (@-mention vs any message). Update the local row
-  // immediately (the PATCH response is authoritative but identical), no full re-pull —
-  // a toggle shouldn't flash every other view.
+  // Flip one conversation's trigger. Shared channels project bot-wide; gated DMs
+  // remain integration-scoped. Avoid a full re-pull so the toggle does not flash.
   const setChannelTrigger = useCallback(
     async (integrationId: string, channelId: string, trigger: ChannelTrigger) => {
       await apiUpdateIntegrationChannel(integrationId, channelId, { trigger })
       settleInBackground(
         mutateIntegrations(
-          (rows) =>
-            rows?.map((r) =>
-              r.id === integrationId
-                ? { ...r, channels: r.channels.map((c) => (c.channelId === channelId ? { ...c, trigger } : c)) }
-                : r
-            ),
+          (rows) => {
+            const source = rows?.find((row) => row.id === integrationId)
+            if (!rows || !source) return rows
+            const channel = source.channels.find((item) => item.channelId === channelId)
+            const botWide =
+              channel?.kind === 'channel' && realBots.some((bot) => bot.id === source.botId && bot.shareable)
+            return rows.map((row) =>
+              (botWide ? row.botId === source.botId : row.id === integrationId)
+                ? {
+                    ...row,
+                    channels: row.channels.map((channel) =>
+                      channel.channelId === channelId ? { ...channel, trigger } : channel
+                    )
+                  }
+                : row
+            )
+          },
           { revalidate: false }
         )
       )
     },
-    [mutateIntegrations]
+    [mutateIntegrations, realBots]
   )
 
-  // Set (or clear, with null) a channel's default agent for a shared bot. Optimistic
-  // local update, no full re-pull — mirrors setChannelTrigger.
+  // Set a shared channel's sole owner. The API projects the effective bot-level
+  // state onto every integration copy, so keep those cached copies in sync.
   const setChannelAgent = useCallback(
-    async (integrationId: string, channelId: string, agentId: string | null) => {
+    async (integrationId: string, channelId: string, agentId: string) => {
       const updated = await apiUpdateIntegrationChannel(integrationId, channelId, { agentId })
       settleInBackground(
         mutateIntegrations(
-          (rows) =>
-            rows?.map((r) =>
-              r.id === integrationId
+          (rows) => {
+            const source = rows?.find((row) => row.id === integrationId)
+            if (!rows || !source) return rows
+            return rows.map((row) =>
+              row.botId === source.botId
                 ? {
-                    ...r,
-                    channels: r.channels.map((c) =>
-                      c.channelId === channelId ? { ...c, agentId: updated.agentId } : c
+                    ...row,
+                    channels: row.channels.map((channel) =>
+                      channel.channelId === channelId
+                        ? {
+                            ...channel,
+                            agentId,
+                            trigger: updated.trigger
+                          }
+                        : channel
                     )
                   }
-                : r
-            ),
+                : row
+            )
+          },
           { revalidate: false }
         )
       )

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1326,7 +1326,7 @@ export interface IntegrationChannelRow {
   /** 'im' = a DM conversation row (gated/restricted agents only); absent = channel. */
   kind?: 'channel' | 'im'
   trigger: 'off' | 'mention' | 'any'
-  /** Per-channel default agent for a shared bot (agentId); null/absent ⇒ unset. */
+  /** Effective per-channel owner for a shared bot. */
   agentId?: string | null
 }
 


### PR DESCRIPTION
## Summary

- enforce one canonical owner for every relay-backed channel and repair legacy ownerless or conflicting rows during route convergence
- mirror the effective trigger across active membership rows and backfill missing siblings so ownership transfer or removal preserves channel state
- keep Slack or automatic moves to restricted agents Off, and require edit access to the current and selected owner for Console changes
- serialize bot/channel mutations and fence Console writes to the owner that passed authorization
- project bot-level owner and trigger consistently into every member-agent view and remove the Console No default option
- keep restricted-agent DM triggers integration-scoped

## Validation

- protocol, Control Plane, Web, and Relay typechecks
- focused ESLint on all changed TypeScript files
- Control Plane unit suite: 650 passed; focused shared-bot suite: 28 passed
- Control Plane integration suite: 635 passed; focused integration-channel suite: 14 passed

Created by Codex . gpt-5.6-sol