### PR TITLE
feat(web): unify IM and GitHub trigger bars

### DIFF
--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -5,9 +5,11 @@ import type { IntegrationChannelRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 
-/** The per-conversation trigger toggle. Channels: "@-mention" (default) vs "any
- *  message", plus an "off" segment on a gated (restricted-agent) integration —
- *  resource-visibility.md §14. DM rows are binary off/on. */
+/** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
+ *  bar. Channels: "any message" vs "@-mention" (default; mention sits last),
+ *  plus an "off" segment on a gated (restricted-agent) integration —
+ *  resource-visibility.md §14. DM rows are binary off/on. Every segment
+ *  carries hover copy. */
 function TriggerToggle({
   channel,
   disabled,
@@ -27,13 +29,14 @@ function TriggerToggle({
     setSaving(true)
     Promise.resolve(onChange(trigger)).finally(() => setSaving(false))
   }
-  const seg = (trigger: IntegrationChannelRow['trigger'], label: string) => {
+  const seg = (trigger: IntegrationChannelRow['trigger'], label: string, hint: string) => {
     const active = channel.trigger === trigger
     return (
       <button
         key={trigger}
         onClick={() => pick(trigger)}
         disabled={disabled || saving}
+        title={hint}
         className={`rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal max-desktop:w-full ${
           disabled ? 'cursor-default' : 'cursor-pointer'
         } ${
@@ -47,34 +50,40 @@ function TriggerToggle({
     )
   }
   // A DM conversation activates on any message once enabled — binary off/on. A
-  // channel keeps the mention/any choice; "off" appears when gated (and, so the
-  // state stays visible, on an inert off row of a no-longer-gated integration).
-  const segs: [IntegrationChannelRow['trigger'], string][] =
+  // channel keeps the any/mention choice (mention last); "off" appears when
+  // gated (and, so the state stays visible, on an inert off row of a
+  // no-longer-gated integration).
+  const segs: [IntegrationChannelRow['trigger'], string, string][] =
     channel.kind === 'im'
       ? [
-          ['off', 'off'],
-          ['any', 'on']
+          ['off', 'off', "The agent doesn't respond in this conversation."],
+          ['any', 'on', 'The agent responds to messages in this conversation.']
         ]
       : gated || channel.trigger === 'off'
         ? [
-            ['off', 'off'],
-            ['mention', '@-mention'],
-            ['any', 'any message']
+            ['off', 'off', "The agent doesn't respond in this channel."],
+            ['any', 'any message', 'The agent responds to every message in this channel.'],
+            ['mention', '@-mention', 'The agent responds only when @-mentioned.']
           ]
         : [
-            ['mention', '@-mention'],
-            ['any', 'any message']
+            ['any', 'any message', 'The agent responds to every message in this channel.'],
+            ['mention', '@-mention', 'The agent responds only when @-mentioned.']
           ]
   return (
-    <div
-      className={
-        segs.length === 3
-          ? 'inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:w-full max-desktop:grid-cols-3'
-          : 'inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:w-full max-desktop:grid-cols-2'
-      }
-    >
-      {segs.map(([trigger, label]) => seg(trigger, label))}
-    </div>
+    <span className="inline-flex items-center gap-[7px] max-desktop:w-full">
+      <span title="Trigger — when the agent responds here" className="flex-none leading-none">
+        <Icon name="zap" size={14} color="var(--text-tertiary)" />
+      </span>
+      <div
+        className={
+          segs.length === 3
+            ? 'inline-flex flex-1 gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:grid-cols-3'
+            : 'inline-flex flex-1 gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:grid-cols-2'
+        }
+      >
+        {segs.map(([trigger, label, hint]) => seg(trigger, label, hint))}
+      </div>
+    </span>
   )
 }
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -63,11 +63,19 @@ function TriggerToggle({
         ? [
             ['off', 'off', "The agent doesn't respond in this channel."],
             ['any', 'any message', 'The agent responds to every message in this channel.'],
-            ['mention', '@-mention', 'The agent responds only when @-mentioned.']
+            [
+              'mention',
+              '@-mention',
+              "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
+            ]
           ]
         : [
             ['any', 'any message', 'The agent responds to every message in this channel.'],
-            ['mention', '@-mention', 'The agent responds only when @-mentioned.']
+            [
+              'mention',
+              '@-mention',
+              "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
+            ]
           ]
   return (
     <span className="inline-flex items-center gap-[7px] max-desktop:w-full">

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -63,13 +63,13 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import {
   GH_FAMILIES,
-  GH_TRIGGER_LABEL,
   GH_TRIGGER_MODES,
+  GH_TRIGGER_PILL,
   commentFamiliesForFamilies,
   eventsForFamilies,
   famCovered,
   githubHookNeedsNormalization,
-  githubMentionUsage,
+  githubTriggerTooltip,
   triggerModeOf,
   type GhFamily,
   type GhTriggerMode
@@ -250,13 +250,9 @@ export default function AgentDetailView() {
   }
 
   // Edit one github subscription in place (PUT re-sends the whole block); the
-  // SWR row is patched — no full revalidation. Families and the "when
-  // created/updated" cadence both ride the stored event patterns.
+  // SWR row is patched — no full revalidation. Families and the
+  // create/update/@-mention trigger both ride the stored event patterns.
   const [hookBusy, setHookBusy] = useState<string | null>(null)
-  const [hookCadenceFor, setHookCadenceFor] = useState<string | null>(null)
-  // Viewport anchor for the cadence menu: it renders position:fixed so no
-  // ancestor overflow-hidden (the group card, the Integrations card) clips it.
-  const [cadenceAnchor, setCadenceAnchor] = useState<{ top: number; right: number } | null>(null)
   const saveHookEvents = async (h: HookDto, fams: GhFamily[], mode: GhTriggerMode) => {
     if (hookBusy || !h.agentId || !h.repoFullName) return
     setHookBusy(h.id)
@@ -290,7 +286,6 @@ export default function AgentDetailView() {
     await saveHookEvents(h, fams, mode)
   }
   const setHookCadence = async (h: HookDto, mode: GhTriggerMode) => {
-    setHookCadenceFor(null)
     if (mode === triggerModeOf(h) && !githubHookNeedsNormalization(h)) return
     const fams = GH_FAMILIES.map((f) => f.fam).filter((f) => famCovered(h.events, f))
     await saveHookEvents(h, fams, mode)
@@ -1309,65 +1304,31 @@ export default function AgentDetailView() {
                                   )
                                 })}
                               </div>
-                              <span className="inline-flex flex-none items-center gap-[5px]">
-                                <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                                  when
+                              {/* Trigger bar — same ⚡ + segmented control as the IM
+                                    channel rows, mention last, hover copy per segment. */}
+                              <span className="inline-flex flex-none items-center gap-[7px]">
+                                <span title="Trigger — when this agent runs" className="flex-none leading-none">
+                                  <Icon name="zap" size={14} color="var(--text-tertiary)" />
                                 </span>
-                                <div className="relative">
-                                  <button
-                                    title={
-                                      triggerModeOf(h) === 'mention'
-                                        ? githubMentionUsage(da.name)
-                                        : `Choose when this agent runs: when created (plus later @${da.name} mentions), on updates, or only when @${da.name} is mentioned.`
-                                    }
-                                    className={`flex h-[26px] cursor-pointer items-center gap-[5px] rounded-[7px] border bg-(--surface-card) px-[9px] font-sans text-[11.5px] font-medium leading-normal text-(--text-primary) transition-[background-color,border-color] hover:bg-(--surface-hover) ${
-                                      hookCadenceFor === h.id
-                                        ? 'border-(--brand)'
-                                        : 'border-(--border-default) hover:border-(--border-strong)'
-                                    } ${hookBusy === h.id ? 'pointer-events-none opacity-60' : ''}`}
-                                    onClick={(e) => {
-                                      if (hookCadenceFor === h.id) {
-                                        setHookCadenceFor(null)
-                                        return
-                                      }
-                                      const r = e.currentTarget.getBoundingClientRect()
-                                      setCadenceAnchor({ top: r.bottom + 5, right: window.innerWidth - r.right })
-                                      setHookCadenceFor(h.id)
-                                    }}
-                                  >
-                                    {GH_TRIGGER_LABEL[triggerModeOf(h)]}
-                                    <Icon name="chevron-down" size={12} color="var(--text-tertiary)" />
-                                  </button>
-                                  {hookCadenceFor === h.id && (
-                                    <>
-                                      <div className="fscrim" onClick={() => setHookCadenceFor(null)} />
-                                      <div
-                                        className="fmenu z-40 min-w-[130px] rounded-lg p-1 shadow-(--shadow-xl)"
-                                        style={{
-                                          position: 'fixed',
-                                          left: 'auto',
-                                          top: cadenceAnchor?.top,
-                                          right: cadenceAnchor?.right
-                                        }}
+                                <div className="inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px]">
+                                  {GH_TRIGGER_MODES.map((mode) => {
+                                    const active = triggerModeOf(h) === mode
+                                    return (
+                                      <button
+                                        key={mode}
+                                        onClick={() => void setHookCadence(h, mode)}
+                                        disabled={hookBusy === h.id}
+                                        title={githubTriggerTooltip(mode, da.name)}
+                                        className={`cursor-pointer rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal ${
+                                          active
+                                            ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
+                                            : 'bg-transparent font-normal text-(--text-tertiary)'
+                                        } ${hookBusy === h.id ? 'opacity-60' : ''}`}
                                       >
-                                        {GH_TRIGGER_MODES.map((mode) => (
-                                          <button
-                                            key={mode}
-                                            title={mode === 'mention' ? githubMentionUsage(da.name) : undefined}
-                                            className="fopt items-center gap-2 px-2 py-[7px]"
-                                            onClick={() => void setHookCadence(h, mode)}
-                                          >
-                                            <span className="flex-1 text-left font-sans text-[12.5px] font-medium leading-normal">
-                                              {GH_TRIGGER_LABEL[mode]}
-                                            </span>
-                                            {triggerModeOf(h) === mode && (
-                                              <Icon name="check" size={14} color="var(--brand)" />
-                                            )}
-                                          </button>
-                                        ))}
-                                      </div>
-                                    </>
-                                  )}
+                                        {GH_TRIGGER_PILL[mode]}
+                                      </button>
+                                    )
+                                  })}
                                 </div>
                               </span>
                               <span className="inline-flex flex-none gap-[2px]">

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -36,6 +36,13 @@ describe('GH_TRIGGER_PILL', () => {
       'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and edits are ignored).'
     )
   })
+
+  it('mention-mode copy admits the App broadcast and explicit App review requests, without an absolute "only"', () => {
+    const copy = githubTriggerTooltip('mention', 'reviewer')
+    expect(copy).toContain('GitHub App')
+    expect(copy).toContain('review request')
+    expect(copy).not.toMatch(/\bonly\b/)
+  })
 })
 
 describe('GH_FAMILIES', () => {

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -5,7 +5,10 @@ import {
   GH_DEFAULT_TRIGGER_MODE,
   GH_FAMILIES,
   GH_TRIGGER_LABEL,
+  GH_TRIGGER_MODES,
+  GH_TRIGGER_PILL,
   githubHookNeedsNormalization,
+  githubTriggerTooltip,
   THREAD_COMMENT_EVENT
 } from './github-events'
 
@@ -17,6 +20,19 @@ describe('GH_TRIGGER_LABEL', () => {
 
   it('makes the restrictive mention mode explicit', () => {
     expect(GH_TRIGGER_LABEL.mention).toBe('mention only')
+  })
+})
+
+describe('GH_TRIGGER_PILL', () => {
+  it('keeps mention as the last segment, worded like the IM bar', () => {
+    expect(GH_TRIGGER_MODES[GH_TRIGGER_MODES.length - 1]).toBe('mention')
+    expect(GH_TRIGGER_PILL.mention).toBe('@-mention')
+  })
+
+  it('names the agent in the per-segment hover copy', () => {
+    expect(githubTriggerTooltip('first', 'reviewer')).toContain('@reviewer')
+    expect(githubTriggerTooltip('mention', 'reviewer')).toContain('@reviewer')
+    expect(githubTriggerTooltip('every', 'reviewer')).toBe('Runs on every update and reply.')
   })
 })
 

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -32,7 +32,9 @@ describe('GH_TRIGGER_PILL', () => {
   it('names the agent in the per-segment hover copy', () => {
     expect(githubTriggerTooltip('first', 'reviewer')).toContain('@reviewer')
     expect(githubTriggerTooltip('mention', 'reviewer')).toContain('@reviewer')
-    expect(githubTriggerTooltip('every', 'reviewer')).toBe('Runs on every update and reply.')
+    expect(githubTriggerTooltip('every', 'reviewer')).toBe(
+      'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and edits are ignored).'
+    )
   })
 })
 

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -74,7 +74,9 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
     case 'every':
       return 'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and edits are ignored).'
     case 'mention':
-      return `Runs only when @${agentName} is mentioned.`
+      // Not "only @agent": the App handle is the repository-wide broadcast, and
+      // an authorized native App review request bypasses cadence/mention/label.
+      return `Runs when @${agentName} or the GitHub App is mentioned, and on explicit App review requests.`
   }
 }
 

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -72,7 +72,7 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
     case 'first':
       return `Runs when an issue or PR is opened, plus on later @${agentName} mentions.`
     case 'every':
-      return 'Runs on every update and reply.'
+      return 'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and edits are ignored).'
     case 'mention':
       return `Runs only when @${agentName} is mentioned.`
   }

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -50,12 +50,32 @@ export const GH_FAMILIES: { fam: GhFamily; pill: string; icon: string; label: st
   }
 ]
 
-/** The "when" dropdown's vocabulary, in menu order. */
+/** The trigger modes in display order — mention deliberately last. */
 export const GH_TRIGGER_MODES: readonly GhTriggerMode[] = ['first', 'every', 'mention']
+/** The Add-integration cadence tiles' vocabulary ("Trigger when …"). */
 export const GH_TRIGGER_LABEL: Record<GhTriggerMode, string> = {
   first: 'created',
   every: 'updated',
   mention: 'mention only'
+}
+/** The agent-detail trigger bar's segment vocabulary (shared with the IM bar's
+ *  "@-mention" wording; mention sits last there too). */
+export const GH_TRIGGER_PILL: Record<GhTriggerMode, string> = {
+  first: 'create',
+  every: 'update',
+  mention: '@-mention'
+}
+
+/** Per-segment hover copy for the trigger bar. */
+export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): string {
+  switch (mode) {
+    case 'first':
+      return `Runs when an issue or PR is opened, plus on later @${agentName} mentions.`
+    case 'every':
+      return 'Runs on every update and reply.'
+    case 'mention':
+      return `Runs only when @${agentName} is mentioned.`
+  }
 }
 
 /** Concrete hover copy for the agent-targeted GitHub mention form. */


### PR DESCRIPTION
## What

Design adjustments to the per-conversation trigger controls on the agent detail page:

- **⚡ marker** — both the IM channel rows and the GitHub repo rows now lead their trigger control with a small lightning glyph.
- **GitHub uses the IM segmented bar** — the GitHub rows' "when …" dropdown is replaced with the same segmented control the IM rows use (`create | update | @-mention`), and the now-unused dropdown state/menu is removed.
- **Mention sits last** — the IM bar reorders to `any message | @-mention` (with `off` first on gated integrations); the GitHub bar keeps mention last, now pinned by a test.
- **Tooltips** — every segment carries short hover copy (the GitHub ones name the agent, e.g. "Runs only when @<agent> is mentioned."), replacing the previous long combined GitHub tooltip. The ⚡ markers get hover copy too.

## Notes for review

- New `GH_TRIGGER_PILL` vocabulary + `githubTriggerTooltip` live in `github-events.ts`; the existing `GH_TRIGGER_LABEL` map is untouched and still drives the Add-integration modal's "Trigger when" tiles (its test pins stand).
- GitHub event-family pills (`PRs | Issues`) are unchanged.
- Verified in the mock console (desktop light + mobile): segment order, active states, and all title attributes; `typecheck`, `eslint`, and the 344 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)