### PR TITLE
fix(web): remove dark backgrounds from integration picker icons

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1343,7 +1343,7 @@ export default function AddIntegrationModal({
                     <GithubMark />
                   </span>
                 ) : (
-                  <span className="imark h-[26px] w-[26px] border-0 bg-transparent">
+                  <span className="flex h-[26px] w-[26px] flex-none items-center justify-center">
                     <PlatformMark platform={candidate.key} fillPct={100} />
                   </span>
                 )}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1458,7 +1458,7 @@ export default function AgentDetailView() {
                             <GithubMark />
                           </span>
                         ) : (
-                          <span className="imark h-[26px] w-[26px] border-0 bg-transparent">
+                          <span className="flex h-[26px] w-[26px] flex-none items-center justify-center">
                             <PlatformMark platform={p.key} fillPct={100} />
                           </span>
                         )}


### PR DESCRIPTION
## Summary

- render platform-picker logos in neutral flex containers instead of the framed integration-mark surface
- fix both the empty Integrations state and the Add integration modal
- preserve the light plate used by connected integration marks in dark mode

## Root cause

The dark-theme .imark selector has higher specificity than the picker bg-transparent utility, so Slack, Telegram, Discord, Feishu, and Webhook logos inherited a bright square background.

## Validation

- pnpm --filter @agentconnect.md/web build
- pnpm --filter @agentconnect.md/web typecheck
- pnpm --filter @agentconnect.md/web test - 52 files, 342 tests passed
- changed-file ESLint and Prettier checks
- visual QA in light and dark themes at desktop and 390px mobile widths, including the Add integration modal

Created by Codex . GPT-5