### PR TITLE
fix(web): align agent Tools & Skills tiles with the org registry

### DIFF
--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -5,6 +5,7 @@ import { fetchAgentDto, fetchSkillSourceSkills, type SkillSourceSkillsDto } from
 import { useConsoleData } from '@/lib/data-context'
 import { MOCK_MODE } from '@/lib/data'
 import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
+import { VisibilityValue } from '@/components/console/VisibilityField'
 import { Icon, Toggle } from '@/components/ui'
 
 /**
@@ -144,13 +145,20 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
                   ) : undefined
                 }
                 subtitle={<SkillSourceLine source={s.source} subDir={s.subDir} />}
+                // Who the source belongs to, worded exactly as its registry tile words it.
+                footer={<VisibilityValue visibility={s.visibility} sharedWith={s.sharedWith} createdBy={s.createdBy} />}
                 action={
                   <>
+                    {/* Expanding is a secondary move, so the chevron only surfaces on
+                        hover/keyboard focus (and stays put once open). Its box is always
+                        reserved, so revealing it never shifts the toggle. Touch has no
+                        hover, so below the desktop breakpoint it stays visible. */}
                     <button
                       type="button"
-                      className="iconbtn h-6 w-6"
+                      className={`iconbtn h-6 w-6 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 max-desktop:opacity-100 ${isOpen ? 'opacity-100' : 'opacity-0'}`}
                       onClick={() => expand(s.id)}
                       aria-label="Show skills"
+                      aria-expanded={isOpen}
                       title="Show skills"
                     >
                       <Icon name={isOpen ? 'chevron-down' : 'chevron-right'} size={13} />

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -4,13 +4,14 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { fetchAgentDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { MOCK_MODE, type DaemonRow } from '@/lib/data'
-import { mcpCandidates, mcpCapsFor, mcpServerMeta, mcpServersForRuntime } from '@/components/console/McpServersField'
+import { mcpCandidates, mcpCapsFor, mcpKindLabel, mcpServersForRuntime } from '@/components/console/McpServersField'
 import { ProviderMark, ToolTile, ToolTileGrid, useConnectorIcons } from '@/components/console/ToolTile'
+import { VisibilityValue } from '@/components/console/VisibilityField'
 import { Icon, Toggle } from '@/components/ui'
 
 /**
  * Leads the agent's Tools & Skills tab: the MCP servers the owning daemon's
- * runtime can attach (via `mcpServersForRuntime`/`mcpServerMeta`), each with an
+ * runtime can attach (via `mcpServersForRuntime`/`mcpKindLabel`), each with an
  * enable/disable toggle. MCP is agent-scoped — this is the surface where it's
  * picked; the daemon detail view no longer lists MCP servers.
  *
@@ -48,6 +49,10 @@ export function AgentToolsCard({
     () => new Map(mcpProviders.flatMap((p) => (p.service ? [[p.name, p.service] as const] : []))),
     [mcpProviders]
   )
+  // The registry row behind a candidate name (when there is one) — it carries both the
+  // kind wording and the access footer, so an agent tile says the same thing about a
+  // server as its registry tile does.
+  const providerByName = useMemo(() => new Map(mcpProviders.map((p) => [p.name, p] as const)), [mcpProviders])
   const iconByService = useConnectorIcons(connectorsEnabled && serviceByName.size > 0)
   const iconFor = (name: string) => {
     const service = serviceByName.get(name)
@@ -122,6 +127,7 @@ export function AgentToolsCard({
   const tile = (name: string, meta: string, eligible: boolean) => {
     const on = enabled ? enabled.includes(name) : false // mirror the saved set; off until it loads
     const interactive = canEdit && enabled !== null && !saving && (eligible || on)
+    const provider = providerByName.get(name)
     return (
       <ToolTile
         key={name}
@@ -130,6 +136,17 @@ export function AgentToolsCard({
         subtitle={meta}
         dimmed={!eligible}
         action={<Toggle checked={on} disabled={!interactive} onChange={(next) => toggle(name, next)} />}
+        // Who the server belongs to, same as its registry tile. A daemon-local server
+        // has no registry row, so it has no access line to show.
+        footer={
+          provider ? (
+            <VisibilityValue
+              visibility={provider.visibility}
+              sharedWith={provider.sharedWith}
+              createdBy={provider.createdBy}
+            />
+          ) : undefined
+        }
       />
     )
   }
@@ -141,7 +158,7 @@ export function AgentToolsCard({
       </div>
       {servers.length > 0 || unknown.length > 0 ? (
         <ToolTileGrid columns={2}>
-          {servers.map((s) => tile(s.name, mcpServerMeta(s), true))}
+          {servers.map((s) => tile(s.name, mcpKindLabel(providerByName.get(s.name)?.kind), true))}
           {unknown.map((n) => tile(n, unknownMeta(n), false))}
         </ToolTileGrid>
       ) : (

--- a/packages/web/src/components/console/McpServersField.tsx
+++ b/packages/web/src/components/console/McpServersField.tsx
@@ -45,11 +45,13 @@ export function mcpServersForRuntime(
   return servers.filter((s) => mcpTransportSupported(s.transport, caps))
 }
 
-/** One MCP server's definition line — its transport. Shared so every surface
- *  labels a server identically. A registry-only candidate the daemon hasn't
- *  reported yet is labelled by origin. */
-export function mcpServerMeta(s: McpServerInfo): string {
-  return s.registry ? `${s.transport} · org registry` : s.transport
+/** One MCP server's definition line — what KIND of server it is, worded exactly
+ *  as the org registry tiles word it (Tools & Skills page) so the same server
+ *  reads identically on both surfaces. Transport is an implementation detail and
+ *  lives in the edit dialog. A server the org registry doesn't know (daemon-local
+ *  definition) is a custom server by definition. */
+export function mcpKindLabel(kind: string | undefined): string {
+  return kind === 'open_connector' ? 'Open connector' : 'Custom MCP server'
 }
 
 /** Candidate MCP servers an agent can enable: the daemon-configured servers plus

--- a/packages/web/src/components/console/ToolTile.tsx
+++ b/packages/web/src/components/console/ToolTile.tsx
@@ -43,7 +43,9 @@ export function ToolTile({
 }) {
   return (
     <div
-      className={`flex min-w-0 flex-col overflow-hidden rounded-[9px] border border-(--border-subtle) transition-[border-color,box-shadow] hover:border-(--border-strong) hover:shadow-(--shadow-xs) ${dimmed ? 'opacity-60' : ''}`}
+      // `group` so an action can reveal itself on tile hover (see the skills card's
+      // expand chevron) rather than sitting there permanently.
+      className={`group flex min-w-0 flex-col overflow-hidden rounded-[9px] border border-(--border-subtle) transition-[border-color,box-shadow] hover:border-(--border-strong) hover:shadow-(--shadow-xs) ${dimmed ? 'opacity-60' : ''}`}
     >
       <div className="flex min-w-0 flex-col gap-[10px] px-[14px] py-[13px]">
         <div className="flex min-w-0 items-center gap-[10px]">


### PR DESCRIPTION
The agent detail → Tools & Skills tab described MCP servers by transport (`http`, `http · org registry`) while the org Tools & Skills page describes the same servers by kind, and neither section showed who a server or skill source belongs to.

## Changes

- **MCP subtitle matches the registry card** — tiles now read **Open connector** / **Custom MCP server**, taken from the registry provider's `kind` (`mcpServerMeta` → `mcpKindLabel`). Transport is an implementation detail and stays in the edit dialog, as on the registry card. A daemon-local server with no registry row reads as custom; ineligible/stale rows keep their reason line.
- **Owner/access footer on both sections** — the shared `VisibilityValue` footer ("Everyone" or the access avatars) now renders under MCP tiles and skill-source tiles, same as the registry tiles. Added to both halves rather than just Skills so the page doesn't show owners on one half only. Daemon-local servers have no registry row and render without it.
- **Skill source's expand chevron is hover-revealed** — `ToolTile`'s root gained `group`; the chevron is `opacity-0` → `group-hover:opacity-100`, and also visible on `focus-visible`, while expanded, and always below the desktop breakpoint (touch has no hover). Its box stays reserved, so revealing it never shifts the toggle. Added `aria-expanded`.

## Verification

`pnpm --filter @agentconnect.md/web typecheck`, `eslint`, and `pnpm --filter @agentconnect.md/web test` (346 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)