### PR TITLE
feat(slack): prompt for missing bot permissions

### DIFF
--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -554,7 +554,7 @@ export class AgentMoveService {
           botId: String(bot.id),
           shared: isHttp,
           spec: isHttp
-            ? sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated)
+            ? sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
             : integrationToSpec(integration, secret, channels, gated)
         }
       })

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -292,7 +292,8 @@ export function sharedIntegrationToSpec(
   secret: BotSecretMaterial,
   shareable: boolean,
   channels: IntegrationChannelRecord[] = [],
-  gated = false
+  gated = false,
+  slackAppId?: string
 ): IntegrationSpec {
   return {
     integrationId: i.id,
@@ -305,6 +306,7 @@ export function sharedIntegrationToSpec(
       mode: 'shared',
       shareable,
       botToken: secret.botToken,
+      ...(slackAppId ? { appId: slackAppId } : {}),
       allowedUserIds: [],
       bindRules: gated ? gatedBindRules(channels) : [],
       gated
@@ -382,7 +384,7 @@ export class Placement implements ReconcileService {
           // reconciles it send-only (no Socket Mode). Socket bots reconcile as direct.
           const gated = gatedAgentIds.has(i.agentId)
           return bot?.transport === 'http'
-            ? sharedIntegrationToSpec(i, secret, bot.shareable, channels, gated)
+            ? sharedIntegrationToSpec(i, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
             : integrationToSpec(i, secret, channels, gated)
         })
       )

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -96,7 +96,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   let botRow: BotRecord
   let integrations: IntegrationRecord[]
   let channels: IntegrationChannelRecord[]
-  let upserts: { daemonId: string; spec: { platform: string; slack?: { mode?: string } } }[]
+  let upserts: { daemonId: string; spec: { platform: string; slack?: { mode?: string; appId?: string } } }[]
   // Drives the SessionRepo.findThreadOwner fallback in lookupThread (null = no daemon session).
   let threadOwner: { agentId: string; daemonId: string } | null
   let threadOwnerLookup: { botId: BotId; channel: string; thread: string } | null
@@ -302,6 +302,13 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     await makeOrch().syncBot(BOT)
     const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
     expect(assign.routes[0]).toMatchObject({ agentId: ALICE, scope: { channel: 'C9' }, match: { kind: 'auto' } })
+  })
+
+  it('carries the public Slack app id to each daemon for permission-update links', async () => {
+    botRow = bot({ slackAppId: 'A123' })
+    await makeOrch().syncBot(BOT)
+    expect(upserts).toHaveLength(2)
+    expect(upserts.every((upsert) => upsert.spec.slack?.appId === 'A123')).toBe(true)
   })
 
   describe('conversation gating (resource-visibility §14)', () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -138,7 +138,7 @@ export class SharedBotOrchestrator {
       { botId: bot.id, members: compiled.members.length, routes: compiled.routes.length },
       'shared-bot: broadcast assign to relay pool'
     )
-    await this.pushSpecs(compiled, secret, bot.shareable)
+    await this.pushSpecs(compiled, secret, bot)
   }
 
   /**
@@ -167,7 +167,7 @@ export class SharedBotOrchestrator {
       })
     )
     const secret = await this.botSecret.get(bot.id)
-    if (secret) await this.pushSpecs(compiled, secret, bot.shareable)
+    if (secret) await this.pushSpecs(compiled, secret, bot)
   }
 
   /** Release a bot from the relay pool (transport flipped / uninstalled / last
@@ -668,7 +668,11 @@ export class SharedBotOrchestrator {
 
   /** Deliver the shared (send-only) spec to each member agent's daemon (best-effort).
    *  `shareable` rides each spec so the daemon knows whether to expose "Switch agent". */
-  private async pushSpecs(compiled: Compiled, secret: BotSecretMaterial, shareable: boolean): Promise<void> {
+  private async pushSpecs(
+    compiled: Compiled,
+    secret: BotSecretMaterial,
+    bot: Pick<BotRecord, 'shareable' | 'slackAppId'>
+  ): Promise<void> {
     // A gated install's spec carries its conversation-scoped rules for the daemon's
     // last-hop admission backstop (§14.3). One listForBot covers every install; rows
     // are keyed per install, so filter by integrationId.
@@ -680,7 +684,7 @@ export class SharedBotOrchestrator {
         const channels = gated ? botChannels.filter((c) => c.integrationId === integration.id) : []
         await this.control.integrationUpsert(
           daemonId,
-          sharedIntegrationToSpec(integration, secret, shareable, channels, gated)
+          sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
         )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -28,6 +28,7 @@ export const SlackConfigSchema = z.object({
   shareable: z.boolean().default(false),
   botToken: z.string(),
   appToken: z.string().optional(), // direct only (Socket Mode); absent for shared
+  appId: z.string().optional(), // public A… app id used for Slack permission-update links
   signingSecret: z.string().optional(),
   botUserId: z.string().optional(), // filled at connect via auth.test if absent; provided by CP for shared
   allowedUserIds: z.array(z.string()).default([]),

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -78,6 +78,7 @@ function toIntegration(spec: IntegrationSpec): Integration {
       // Shared mode carries no appToken (the relay owns the event stream) but does
       // carry the CP-resolved botUserId; direct mode is the reverse.
       ...(spec.slack.appToken ? { appToken: spec.slack.appToken } : {}),
+      ...(spec.slack.appId ? { appId: spec.slack.appId } : {}),
       ...(spec.slack.botUserId ? { botUserId: spec.slack.botUserId } : {}),
       allowedUserIds: spec.slack.allowedUserIds,
       bindRules: spec.slack.bindRules,

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -684,6 +684,9 @@ export class SlackConnection {
     if (this.permissionUpdateAnnounced || this.missingScopes.size === 0) return
     const updateUrl = this.permissionUpdateUrl()
     if (!updateUrl) return
+    // Claim before the first await so overlapping status/title failures cannot
+    // race into duplicate cards. A failed post releases the claim for a later retry.
+    this.permissionUpdateAnnounced = true
     const text =
       'Permissions update required. Please update and re-authorize this Slack app to ensure all features work correctly.'
     try {
@@ -696,8 +699,8 @@ export class SlackConnection {
         unfurl_media: false,
         metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} }
       })
-      this.permissionUpdateAnnounced = true
     } catch (err) {
+      this.permissionUpdateAnnounced = false
       this.rememberMissingScopes(err)
       this.deps.log?.debug(`slack: permission update card failed (ch=${channel}): ${(err as Error).message}`)
     }

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -16,6 +16,8 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_DISMISS_ACTION,
   PERMISSION_ACTION_PREFIX,
+  PERMISSION_UPDATE_ACTION,
+  buildPermissionUpdateCard,
   buildStatusModal,
   decodePermValue,
   type StatusBarInfo,
@@ -25,6 +27,8 @@ import {
 export interface ConsolidatedGroup {
   appToken: string
   botToken: string
+  /** Public Slack app id (A…) used only to build the OAuth permission-update URL. */
+  appId?: string
   integrations: { agentId: string; integrationId: string }[]
 }
 
@@ -61,6 +65,14 @@ export interface SlackStatusOptions {
  *  `SlackPostOptions.chrome`). Exported so the backfill can recognize it. */
 export const SLACK_CHROME_EVENT_TYPE = 'agentconnect_chrome'
 
+/** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. Keep this
+ * local fallback for hand-authored direct integrations; CP-pushed shared specs
+ * carry the same public id explicitly because they intentionally omit xapp. */
+function slackAppIdFromAppToken(appToken: string): string | undefined {
+  const segment = appToken.split('-')[2]
+  return segment && /^A[A-Z0-9]+$/.test(segment) ? segment : undefined
+}
+
 /** §6.1: one Slack Socket Mode connection per unique appToken.
  *  Shared-mode integrations are SKIPPED here — their inbound lives on a relay, so
  *  the daemon opens no socket for them (it reaches them send-only via RelayClient;
@@ -73,7 +85,14 @@ export function consolidate(agents: Agent[]): Map<string, ConsolidatedGroup> {
       if (int.platform !== 'slack') continue
       if (int.slack.mode === 'shared' || !int.slack.appToken) continue
       const k = int.slack.appToken
-      const g = groups.get(k) ?? { appToken: k, botToken: int.slack.botToken, integrations: [] }
+      const appId = int.slack.appId ?? slackAppIdFromAppToken(k)
+      const g = groups.get(k) ?? {
+        appToken: k,
+        botToken: int.slack.botToken,
+        ...(appId ? { appId } : {}),
+        integrations: []
+      }
+      if (!g.appId && appId) g.appId = appId
       g.integrations.push({ agentId: a.id, integrationId: int.id })
       groups.set(k, g)
     }
@@ -90,7 +109,13 @@ export function consolidateShared(agents: Agent[]): Map<string, ConsolidatedGrou
     for (const int of a.integrations) {
       if (int.platform !== 'slack' || int.slack.mode !== 'shared') continue
       const k = int.slack.botToken
-      const g = groups.get(k) ?? { appToken: '', botToken: k, integrations: [] }
+      const g = groups.get(k) ?? {
+        appToken: '',
+        botToken: k,
+        ...(int.slack.appId ? { appId: int.slack.appId } : {}),
+        integrations: []
+      }
+      if (!g.appId && int.slack.appId) g.appId = int.slack.appId
       g.integrations.push({ agentId: a.id, integrationId: int.id })
       groups.set(k, g)
     }
@@ -197,9 +222,16 @@ type AppLike = {
       open: (a: unknown) => Promise<unknown>
       update: (a: unknown) => Promise<unknown>
     }
-    // auth.test also returns `url` — the workspace's base Slack URL
-    // (e.g. "https://acme.slack.com/"), the root for thread permalinks.
-    auth: { test: () => Promise<{ user_id?: string; bot_id?: string; url?: string }> }
+    // auth.test also returns the team id and `url`, the workspace's base Slack
+    // URL (e.g. "https://acme.slack.com/").
+    auth: {
+      test: () => Promise<{
+        user_id?: string
+        bot_id?: string
+        team_id?: string
+        url?: string
+      }>
+    }
     chat: {
       postMessage: (a: unknown) => Promise<{ ts?: string }>
       update: (a: unknown) => Promise<{ ts?: string }>
@@ -300,17 +332,24 @@ function markdownBlock(text: string): { text: string; blocks: { type: 'markdown'
   return { text, blocks: [{ type: 'markdown', text }] }
 }
 
-/** Slack Web API platform errors carry the rejected scope in `data.needed`.
- *  Match that exact capability so a real chat:write/network failure is never
- *  retried and cannot duplicate a message whose first result was ambiguous. */
-function isMissingCustomizeScope(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false
+/** Slack Web API platform errors carry rejected OAuth scopes in `data.needed`.
+ * Preserve an `unknown` marker when a test/adapter exposes only the error name:
+ * the user-facing card does not print scope names, but should still appear. */
+function missingScopesFrom(err: unknown): string[] {
+  if (!err || typeof err !== 'object') return []
   const data = (err as { data?: unknown }).data
-  if (!data || typeof data !== 'object') return false
-  const record = data as { error?: unknown; needed?: unknown }
-  if (record.error !== 'missing_scope') return false
-  const needed = Array.isArray(record.needed) ? record.needed : String(record.needed ?? '').split(',')
-  return needed.some((scope) => String(scope).trim() === 'chat:write.customize')
+  const record = data && typeof data === 'object' ? (data as { error?: unknown; needed?: unknown }) : undefined
+  const message = err instanceof Error ? err.message : ''
+  if (record?.error !== 'missing_scope' && !/\bmissing_scope\b/.test(message)) return []
+  const needed = Array.isArray(record?.needed) ? record.needed : String(record?.needed ?? '').split(',')
+  const scopes = needed.map((scope) => String(scope).trim()).filter((scope) => /^[a-z0-9._:-]+$/i.test(scope))
+  return scopes.length > 0 ? [...new Set(scopes)] : ['unknown']
+}
+
+/** Match that exact capability so a real chat:write/network failure is never
+ * retried and cannot duplicate a message whose first result was ambiguous. */
+function isMissingCustomizeScope(err: unknown): boolean {
+  return missingScopesFrom(err).includes('chat:write.customize')
 }
 
 // Re-probe periodically so granting chat:write.customize to an existing Slack app
@@ -354,6 +393,12 @@ export class SlackConnection {
   private queue: SlackSendQueue
   /** Cooldown after Slack proves this installation lacks chat:write.customize. */
   private customUsernameRetryAt = 0
+  /** Slack app/workspace ids are public metadata used only for the OAuth settings link. */
+  private appId = ''
+  private teamId = ''
+  /** A workspace-wide missing scope should create one card, not one per streamed write. */
+  private missingScopes = new Set<string>()
+  private permissionUpdateAnnounced = false
   // Slack's Agent/assistant DM surface can announce the real app-thread root via
   // assistant_thread_started, while later message.im payloads may arrive without
   // thread_ts. Keep the active DM thread root so replies stay inside that thread.
@@ -407,6 +452,7 @@ export class SlackConnection {
   ) {
     this.appToken = deps.group.appToken
     this.botToken = deps.group.botToken
+    this.appId = deps.group.appId ?? slackAppIdFromAppToken(deps.group.appToken) ?? ''
     // Send-only: a bare Web-API client (no Socket Mode, no appToken) wrapped in the
     // AppLike send surface. The event/action/start/stop members are inert — nothing
     // ever registers a handler or opens a socket in this mode.
@@ -425,6 +471,7 @@ export class SlackConnection {
     this.botUserId = auth.user_id ?? ''
     this.botId = auth.bot_id ?? ''
     this.workspaceUrl = auth.url ?? ''
+    this.teamId = auth.team_id && /^T[A-Z0-9]+$/.test(auth.team_id) ? auth.team_id : ''
     log?.debug(`slack: auth.test ok → bot user ${this.botUserId} (bot_id ${this.botId || 'n/a'})`)
     // Send-only (shared bot): no Socket Mode socket, no event/action handlers, no
     // app.start(). Identity is resolved above (for mention rendering / echo id); the
@@ -553,6 +600,9 @@ export class SlackConnection {
     this.app.action(STATUS_ACTION.view, async ({ ack }) => {
       await ack() // URL button — the browser follows the link; nothing to do here.
     })
+    this.app.action(PERMISSION_UPDATE_ACTION, async ({ ack }) => {
+      await ack() // URL button — Slack still sends an interaction payload.
+    })
     // Interactive permission card (buildPermissionCard): every option button shares the
     // `ac_perm:<index>` prefix, matched here by RegExp. The chosen requestId+optionId ride
     // the button `value`; the daemon resolves the pending ACP request from them.
@@ -610,12 +660,57 @@ export class SlackConnection {
     return threadTs ? { ...ev, thread_ts: threadTs } : ev
   }
 
+  private rememberMissingScopes(err: unknown): void {
+    const added = missingScopesFrom(err).filter((scope) => {
+      if (this.missingScopes.has(scope)) return false
+      this.missingScopes.add(scope)
+      return true
+    })
+    if (added.length > 0) this.deps.log?.warn(`slack: bot token missing OAuth scope(s): ${added.join(', ')}`)
+  }
+
+  private permissionUpdateUrl(): string | undefined {
+    if (!/^A[A-Z0-9]+$/.test(this.appId)) return undefined
+    const appId = encodeURIComponent(this.appId)
+    return this.teamId
+      ? `https://app.slack.com/app-settings/${encodeURIComponent(this.teamId)}/${appId}/oauth`
+      : `https://api.slack.com/apps/${appId}/install-on-team?`
+  }
+
+  /** Post the Devin-style reauthorization notice once for this connection.
+   * This bypasses `postChatMessage` deliberately: the card must use the Slack App
+   * identity and must not recursively trigger itself. */
+  private async postPermissionUpdateCard(channel: string, threadTs?: string): Promise<void> {
+    if (this.permissionUpdateAnnounced || this.missingScopes.size === 0) return
+    const updateUrl = this.permissionUpdateUrl()
+    if (!updateUrl) return
+    const text =
+      'Permissions update required. Please update and re-authorize this Slack app to ensure all features work correctly.'
+    try {
+      await this.app.client.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text,
+        blocks: buildPermissionUpdateCard(updateUrl),
+        unfurl_links: false,
+        unfurl_media: false,
+        metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} }
+      })
+      this.permissionUpdateAnnounced = true
+    } catch (err) {
+      this.rememberMissingScopes(err)
+      this.deps.log?.debug(`slack: permission update card failed (ch=${channel}): ${(err as Error).message}`)
+    }
+  }
+
   /** Shared chat.postMessage boundary for plain/markdown and Block Kit messages.
    *  `username` + `icon_url` are the per-message identity overrides — both gated by
    *  the same `chat:write.customize` scope, so they share one probe/cooldown. A
    *  missing customize scope is safe to retry because Slack rejected the first
    *  request before creating a message; every other error is propagated. */
   private async postChatMessage(
+    channel: string,
+    threadTs: string | undefined,
     payload: Record<string, unknown>,
     options?: SlackPostOptions
   ): Promise<{ ts?: string }> {
@@ -624,17 +719,28 @@ export class SlackConnection {
     const iconUrl = options?.icon_url?.trim()
     if (username) customize.username = username
     if (iconUrl) customize.icon_url = iconUrl
-    if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt)
-      return this.app.client.chat.postMessage(payload)
     try {
-      const result = await this.app.client.chat.postMessage({ ...payload, ...customize })
-      this.customUsernameRetryAt = 0
+      let result: { ts?: string }
+      if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt) {
+        result = await this.app.client.chat.postMessage(payload)
+      } else {
+        try {
+          result = await this.app.client.chat.postMessage({ ...payload, ...customize })
+          this.customUsernameRetryAt = 0
+        } catch (err) {
+          this.rememberMissingScopes(err)
+          if (!isMissingCustomizeScope(err)) throw err
+          this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
+          this.deps.log?.debug('slack: chat:write.customize missing — retrying with the app default identity')
+          result = await this.app.client.chat.postMessage(payload)
+        }
+      }
+      await this.postPermissionUpdateCard(channel, threadTs)
       return result
     } catch (err) {
-      if (!isMissingCustomizeScope(err)) throw err
-      this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
-      this.deps.log?.debug('slack: chat:write.customize missing — retrying with the app default identity')
-      return this.app.client.chat.postMessage(payload)
+      this.rememberMissingScopes(err)
+      await this.postPermissionUpdateCard(channel, threadTs)
+      throw err
     }
   }
 
@@ -649,6 +755,8 @@ export class SlackConnection {
       const trailing = options?.trailingBlocks
       const agentAuthorId = options?.agentAuthorId?.trim()
       const res = await this.postChatMessage(
+        channel,
+        threadTs,
         {
           channel,
           thread_ts: threadTs,
@@ -711,6 +819,8 @@ export class SlackConnection {
   ): Promise<string | undefined> {
     return this.queue.enqueue(async () => {
       const res = await this.postChatMessage(
+        channel,
+        threadTs,
         {
           channel,
           thread_ts: threadTs,
@@ -988,8 +1098,10 @@ export class SlackConnection {
           ...(iconUrl ? { icon_url: iconUrl } : {})
         })
       } catch (err) {
+        this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: setStatus failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
       }
+      await this.postPermissionUpdateCard(channel, threadTs)
     })
   }
 
@@ -1009,6 +1121,8 @@ export class SlackConnection {
         })
       )
     } catch (err) {
+      this.rememberMissingScopes(err)
+      await this.postPermissionUpdateCard(channel, threadTs)
       this.deps.log?.debug(`slack: setTitle failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
     }
   }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -317,6 +317,10 @@ export function renderStatusBar(info: StatusBarInfo): string {
  *  values because a shared bot receives the same actions on the relay first. */
 export const STATUS_ACTION = SLACK_STATUS_ACTION
 
+/** URL-only OAuth button. Direct Socket Mode bots still receive its interaction
+ * payload and must ACK it; shared HTTP bots are ACKed by the relay ingress. */
+export const PERMISSION_UPDATE_ACTION = 'ac_update_permissions'
+
 /** The modal view's callback_id — used if we ever handle a submit (controls apply on
  *  interaction today, so there's no submit). */
 export const STATUS_MODAL_CALLBACK = 'ac_status_modal'
@@ -383,6 +387,33 @@ export function buildPermissionResolvedCard(
     {
       type: 'section',
       text: { type: 'mrkdwn', text: `:lock: *Permission* — ${permToolLabel(params)}\n${icon} ${decision}` }
+    }
+  ]
+}
+
+/** A workspace-level OAuth warning shown when Slack rejects an API call with
+ * `missing_scope`. The URL button needs no daemon-side action handling: Slack opens
+ * the app's OAuth & Permissions page directly so an owner can update/reinstall it. */
+export function buildPermissionUpdateCard(updateUrl: string): unknown[] {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: ':warning: *Permissions update required.* Please update and re-authorize this Slack app to ensure all features work correctly.'
+      }
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Update permissions', emoji: true },
+          style: 'primary',
+          url: updateUrl,
+          action_id: PERMISSION_UPDATE_ACTION
+        }
+      ]
     }
   ]
 }

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -833,6 +833,35 @@ describe('SlackConnection.setTitle', () => {
     )
     await expect(conn.setTitle('D1', '123.45', 'Runtime summary')).resolves.toBeUndefined()
   })
+
+  it('coalesces concurrent missing-scope notices into one card', async () => {
+    const missingScope = Object.assign(new Error('An API error occurred: missing_scope'), {
+      data: { error: 'missing_scope', needed: 'assistant:write', provided: 'chat:write' }
+    })
+    let resolveCard!: (value: { ts: string }) => void
+    const postMessage = vi.fn(
+      () =>
+        new Promise<{ ts: string }>((resolve) => {
+          resolveCard = resolve
+        })
+    )
+    const setTitle = vi.fn(async () => {
+      throw missingScope
+    })
+    const conn = new SlackConnection(
+      { ...deps(), group: { ...deps().group, appId: 'A123' }, sendIntervalMs: 0 } as any,
+      () => fakeAppWith(async () => undefined, setTitle, postMessage) as any
+    )
+
+    const first = conn.setTitle('D1', '123.45', 'First title')
+    await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+    const second = conn.setTitle('D1', '123.45', 'Second title')
+    await vi.waitFor(() => expect(setTitle).toHaveBeenCalledTimes(2))
+    expect(postMessage).toHaveBeenCalledOnce()
+
+    resolveCard({ ts: 'card-1' })
+    await Promise.all([first, second])
+  })
 })
 
 describe('SlackConnection.updateBlocks', () => {

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -29,24 +29,27 @@ const mk = (id: string, appToken: string, botToken: string): Agent =>
 
 describe('consolidate', () => {
   it('opens one connection per unique appToken and groups integrations', () => {
-    const groups = consolidate([mk('a', 'xapp-1', 'xoxb-a'), mk('b', 'xapp-1', 'xoxb-a'), mk('c', 'xapp-2', 'xoxb-c')])
+    const appToken = 'xapp-1-A123-456-secret'
+    const groups = consolidate([mk('a', appToken, 'xoxb-a'), mk('b', appToken, 'xoxb-a'), mk('c', 'xapp-2', 'xoxb-c')])
     expect(groups.size).toBe(2)
-    expect(groups.get('xapp-1')!.integrations).toHaveLength(2)
+    expect(groups.get(appToken)).toMatchObject({ appId: 'A123', integrations: expect.any(Array) })
+    expect(groups.get(appToken)!.integrations).toHaveLength(2)
     expect(groups.get('xapp-2')!.integrations).toHaveLength(1)
   })
 })
 
 function fakeAppWith(
   setStatus: (a: any) => Promise<unknown>,
-  setTitle: (a: any) => Promise<unknown> = async () => undefined
+  setTitle: (a: any) => Promise<unknown> = async () => undefined,
+  postMessage: (a: any) => Promise<unknown> = async () => ({})
 ) {
   return {
     message() {},
     event() {},
     action() {},
     client: {
-      auth: { test: async () => ({ user_id: 'U1' }) },
-      chat: { postMessage: async () => ({}) },
+      auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
+      chat: { postMessage },
       assistant: { threads: { setStatus, setTitle } }
     },
     start: async () => {},
@@ -391,6 +394,15 @@ describe('SlackConnection membership events', () => {
     await handlers.get('channel_left')!({ event: { channel: 'C1' } })
     await handlers.get('group_left')!({ event: { channel: 'G1' } })
     expect(changed).toBe(3)
+  })
+
+  it('acknowledges the permission-update URL button', async () => {
+    const actions = new Map<string, (a: any) => unknown>()
+    const conn = new SlackConnection(deps() as any, () => fakeAppWithEvents(new Map(), actions) as any)
+    await conn.start()
+    const ack = vi.fn(async () => {})
+    await actions.get('ac_update_permissions')!({ ack, action: {} })
+    expect(ack).toHaveBeenCalledOnce()
   })
 
   it('opens the controls modal on Configure and routes status actions by session key', async () => {
@@ -746,6 +758,50 @@ describe('SlackConnection.setStatus', () => {
         }) as any
     )
     await expect(conn.setStatus('C1', '123.45', 'is thinking…')).resolves.toBeUndefined()
+  })
+
+  it('posts one permission-update card when Slack reports a missing scope', async () => {
+    const missingScope = Object.assign(new Error('An API error occurred: missing_scope'), {
+      data: { error: 'missing_scope', needed: 'assistant:write', provided: 'chat:write' }
+    })
+    const postMessage = vi.fn(async () => ({ ts: 'card-1' }))
+    const conn = new SlackConnection(
+      { ...deps(), group: { ...deps().group, appId: 'A123' }, sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(
+          async () => {
+            throw missingScope
+          },
+          undefined,
+          postMessage
+        ) as any
+    )
+    await conn.start()
+
+    await conn.setStatus('C1', '123.45', 'is thinking…')
+    await conn.setStatus('C1', '123.45', 'is still thinking…')
+
+    expect(postMessage).toHaveBeenCalledOnce()
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C1',
+        thread_ts: '123.45',
+        text: expect.stringContaining('Permissions update required'),
+        blocks: expect.arrayContaining([
+          expect.objectContaining({ type: 'section' }),
+          expect.objectContaining({
+            type: 'actions',
+            elements: [
+              expect.objectContaining({
+                style: 'primary',
+                url: 'https://app.slack.com/app-settings/T123/A123/oauth'
+              })
+            ]
+          })
+        ]),
+        metadata: { event_type: 'agentconnect_chrome', event_payload: {} }
+      })
+    )
   })
 })
 

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -8,6 +8,7 @@ import {
   buildStatusModal,
   buildPermissionCard,
   buildPermissionResolvedCard,
+  buildPermissionUpdateCard,
   buildElicitationCard,
   buildElicitationResolvedCard,
   buildAttributionBlocks,
@@ -1178,6 +1179,21 @@ describe('permission card', () => {
     expect((allow[0] as any).text.text).toContain(':white_check_mark:')
     expect((buildPermissionResolvedCard(req(), 'Reject', false)[0] as any).text.text).toContain(':no_entry_sign:')
     expect((buildPermissionResolvedCard(req(), 'Cancelled')[0] as any).text.text).toContain(':hourglass:')
+  })
+
+  it('renders a primary URL button for updating Slack permissions', () => {
+    const updateUrl = 'https://app.slack.com/app-settings/T123/A123/oauth'
+    const [message, actions] = buildPermissionUpdateCard(updateUrl) as any[]
+    expect(message.text.text).toContain('Permissions update required')
+    expect(actions.elements).toEqual([
+      expect.objectContaining({
+        type: 'button',
+        style: 'primary',
+        url: updateUrl,
+        action_id: 'ac_update_permissions',
+        text: expect.objectContaining({ text: 'Update permissions' })
+      })
+    ])
   })
 
   it('encode/decode round-trips and splits on the first | (optionId may contain |)', () => {

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -692,6 +692,7 @@ describe('cold-move archive', () => {
         mode: 'direct',
         botToken: 'new-secret',
         appToken: 'new-app',
+        appId: 'A123',
         allowedUserIds: [],
         bindRules: []
       }
@@ -739,6 +740,7 @@ describe('cold-move archive', () => {
           mode: 'direct',
           botToken: 'new-secret',
           appToken: 'new-app',
+          appId: 'A123',
           allowedUserIds: [],
           bindRules: []
         }

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -430,7 +430,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
         integrationId: INTEGRATION_ID,
         agentId: AGENT_ID,
         platform: 'slack',
-        slack: { botToken: 'xoxb-abc', appToken: 'xapp-1-def' }
+        slack: { botToken: 'xoxb-abc', appToken: 'xapp-1-def', appId: 'A123' }
       })
     )
     expect(r.ok).toBe(true)
@@ -438,6 +438,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     if (r.frame.payload.platform !== 'slack') throw new Error('expected slack integration')
     expect(r.frame.payload.slack.botToken).toBe('xoxb-abc')
     expect(r.frame.payload.slack.appToken).toBe('xapp-1-def')
+    expect(r.frame.payload.slack.appId).toBe('A123')
     expect(r.frame.payload.slack.allowedUserIds).toEqual([]) // zod default
     expect(r.frame.payload.slack.bindRules).toEqual([]) // zod default
   })

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -60,6 +60,7 @@ export const IntegrationSlackConfig = z
     mode: z.enum(['direct', 'shared']).default('direct'),
     botToken: z.string(), // xoxb-…  (plaintext — never log) — always present (send path)
     appToken: z.string().optional(), // xapp-… (plaintext — never log) — direct only (Socket Mode)
+    appId: z.string().optional(), // A… public metadata — permission-update deep link (especially shared mode)
     // Multi-agent opt-in — the bot backs MANY agents, so an in-thread "Switch agent"
     // control is meaningful. ONLY ever true in `shared` mode (an http/relay bot); a
     // non-shareable http bot is still `shared` for routing but has one agent, so the


### PR DESCRIPTION
## Summary

- detect Slack `missing_scope` failures on message delivery and assistant thread chrome
- post one Devin-style Block Kit warning per connection with a primary **Update permissions** URL button
- carry the public Slack app ID through shared-bot specs and acknowledge URL-button interactions on both ingress paths

## Testing

- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon test` (2104 passed, 2 skipped)
- `pnpm --filter @agentconnect.md/control-plane test:unit` (651 passed)
- focused daemon, protocol, and orchestrator tests (283 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 2 pre-existing warnings)
- `pnpm format:check`

Created by Codex . GPT-5.6