### PR TITLE
feat(web): sync default-dispatch design across integrations and settings

### DIFF
--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -1,5 +1,64 @@
 import { describe, expect, it } from 'vitest'
-import { placePopover } from './IntegrationChannelList'
+import { channelOwners, placePopover } from './IntegrationChannelList'
+import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
+
+// A shared bot fans its membership snapshot out to one integration per member
+// agent, but persists the per-channel owner on a single canonical row. Every
+// member's page must therefore read ownership bot-wide, not off its own row.
+describe('channelOwners', () => {
+  const install = (id: string, agentId: string, channels: IntegrationChannelRow[]): IntegrationRow => ({
+    id,
+    agentId,
+    botId: 'bot_shared',
+    shareable: true,
+    name: 'acme-bridge',
+    platform: 'slack',
+    kind: 'Shared bot',
+    workspace: 'acme.example.test',
+    daemon: 'edge-1',
+    status: 'online',
+    agentCount: '3',
+    channels
+  })
+  const chan = (channelId: string, agentId?: string | null): IntegrationChannelRow => ({
+    channelId,
+    name: channelId,
+    kind: 'channel',
+    trigger: 'mention',
+    ...(agentId !== undefined ? { agentId } : {})
+  })
+
+  it('finds an owner persisted on a different member installation', () => {
+    const owners = channelOwners('bot_shared', [
+      install('int_alice', 'alice', [chan('C-deploys', null)]),
+      install('int_bob', 'bob', [chan('C-deploys', 'bob')])
+    ])
+    // Alice's page renders int_alice's row, whose agentId is null — the owner is bob.
+    expect(owners.get('C-deploys')).toBe('bob')
+  })
+
+  it('ignores installs of other bots and DM rows', () => {
+    const other = { ...install('int_other', 'zoe', [chan('C-deploys', 'zoe')]), botId: 'bot_other' }
+    const dm = install('int_dm', 'bob', [{ ...chan('D-bob', 'bob'), kind: 'im' as const }])
+    const owners = channelOwners('bot_shared', [other, dm, install('int_bob', 'bob', [chan('C-deploys', 'bob')])])
+    expect([...owners]).toEqual([['C-deploys', 'bob']])
+  })
+
+  it('keeps the first explicit owner when installs disagree', () => {
+    // Legacy state can leave two rows claiming a channel; the console must be
+    // deterministic rather than depending on install iteration luck.
+    const owners = channelOwners('bot_shared', [
+      install('int_bob', 'bob', [chan('C-deploys', 'bob')]),
+      install('int_alice', 'alice', [chan('C-deploys', 'alice')])
+    ])
+    expect(owners.get('C-deploys')).toBe('bob')
+  })
+
+  it('reports nothing for a channel no install has claimed', () => {
+    const owners = channelOwners('bot_shared', [install('int_alice', 'alice', [chan('C-deploys', null)])])
+    expect(owners.has('C-deploys')).toBe(false)
+  })
+})
 
 // The default-dispatch popover is portalled to the body at fixed coordinates
 // (its host cards clip), so nothing else keeps it inside the viewport — these

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { placePopover } from './IntegrationChannelList'
+
+// The default-dispatch popover is portalled to the body at fixed coordinates
+// (its host cards clip), so nothing else keeps it inside the viewport — these
+// four corners are that guarantee.
+describe('placePopover', () => {
+  const btn = (left: number, top: number) => ({ left, right: left + 44, top, bottom: top + 28 })
+
+  it('anchors below-left of the button when there is room', () => {
+    expect(placePopover(btn(300, 200), 1280, 720).style).toEqual({ left: 300, top: 234 })
+  })
+
+  it('right-aligns when the menu would run past the right edge', () => {
+    // 1100 + 240 > 1280 - 8 ⇒ pin the menu's right edge to the button's.
+    expect(placePopover(btn(1100, 200), 1280, 720).style).toEqual({ right: 1280 - 1144, top: 234 })
+  })
+
+  it('flips above the button when the bottom edge is too close', () => {
+    expect(placePopover(btn(300, 600), 1280, 720).style).toEqual({ left: 300, bottom: 720 - 600 + 6 })
+  })
+
+  it('stays below when flipping up would clip the top instead', () => {
+    // A short viewport with the button near the top: neither side fits, and
+    // below is the one that keeps the button visible.
+    expect(placePopover(btn(300, 40), 1280, 200).style).toEqual({ left: 300, top: 74 })
+  })
+})

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { agentLabel, type IntegrationChannelRow } from '@/lib/data'
+import { agentLabel, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
@@ -123,6 +123,31 @@ export function placePopover(
   if (btn.bottom + POPOVER_H > vh - 8 && btn.top > POPOVER_H) style.bottom = vh - btn.top + 6
   else style.top = btn.bottom + 6
   return { style }
+}
+
+/**
+ * Explicit per-channel owners of one bot, merged across every install of it.
+ *
+ * A shared bot fans its membership snapshot out to one integration per agent,
+ * while the owner is persisted on a single canonical row — so the row this
+ * agent's page renders may carry no `agentId` even though a sibling install
+ * names the owner. The CP already resolves this bot-wide (GET /integrations
+ * stamps the effective owner onto every install, from ALL installs including
+ * ones the viewer can't see, and PATCH …/channels/:id routes ownership through
+ * `sharedBot.updateChannel`), so this is the client-side safety net for a row
+ * whose owner the CP couldn't resolve — never the only thing keeping the two
+ * pages agreeing. Mirrors `botChannels` in SettingsView.
+ */
+export function channelOwners(botId: string, integrations: IntegrationRow[]): Map<string, string> {
+  const owners = new Map<string, string>()
+  for (const i of integrations) {
+    if (i.botId !== botId) continue
+    for (const c of i.channels) {
+      if (c.kind === 'im' || !c.agentId || owners.has(c.channelId)) continue
+      owners.set(c.channelId, c.agentId)
+    }
+  }
+  return owners
 }
 
 /** Per-channel default dispatch for a SHARED bot (§10.1). Every active shared
@@ -281,20 +306,24 @@ export function IntegrationChannelList({
   /** Horizontal row padding, to line up with the host card (18 list / 14 detail). */
   padX?: number
 }) {
-  const { setChannelTrigger, setChannelAgent, bots, agents } = useConsoleData()
+  const { setChannelTrigger, setChannelAgent, bots, agents, integrations } = useConsoleData()
   // The agents that share this bot — the candidate per-channel defaults.
   const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
   const member = (id: string): MemberAgent => {
     const a = agents.find((x) => x.id === id)
     return { id, label: a ? agentLabel(a) : id, runtime: a?.runtime ?? a?.model ?? '', icon: a?.icon }
   }
-  // The agents that share this bot. The channel's default is its explicit owner,
-  // falling back to the earliest install — the same ordering sharedBot.ts's
-  // compiler uses when a channel has never been claimed.
+  // The agents that share this bot. A channel's default is its explicit owner —
+  // this row's when the CP stamped it, else whichever sibling install of the bot
+  // persists it — falling back to the earliest install, the same ordering
+  // sharedBot.ts's compiler uses for a channel nobody has ever claimed.
   const members = memberIds.map(member)
+  const owners = shareable && botId ? channelOwners(botId, integrations) : undefined
   const viewer = agentId && memberIds.includes(agentId) ? member(agentId) : undefined
-  const defaultAgent = (c: IntegrationChannelRow) =>
-    (c.agentId ? members.find((m) => m.id === c.agentId) : undefined) ?? members[0]
+  const defaultAgent = (c: IntegrationChannelRow) => {
+    const explicit = c.agentId ?? owners?.get(c.channelId)
+    return (explicit ? members.find((m) => m.id === explicit) : undefined) ?? members[0]
+  }
   const channelRows = channels.filter((c) => c.kind !== 'im')
   const dmRows = channels.filter((c) => c.kind === 'im')
   const row = (c: IntegrationChannelRow) => {
@@ -316,6 +345,12 @@ export function IntegrationChannelList({
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
           {def && (
             <>
+              {/* The PATCH goes through THIS agent's integration on purpose:
+                  ownership of a shared (http) channel is bot-scoped server-side —
+                  the route resolves the effective owner across every install,
+                  fences on it (`expectedOwnerAgentId`) and hands the write to
+                  `sharedBot.updateChannel`, so exactly one row stays canonical no
+                  matter which install the console patched. */}
               <DefaultAgentPicker
                 current={def}
                 viewer={viewer}

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useState } from 'react'
-import type { IntegrationChannelRow } from '@/lib/data'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { agentLabel, type IntegrationChannelRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
+import { AgentIconView } from '@/components/marks'
+import type { AgentIcon } from '@/lib/agent-icon'
 
 /** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
  *  bar. Channels: "any message" vs "@-mention" (default; mention sits last),
@@ -95,53 +98,171 @@ function TriggerToggle({
   )
 }
 
-/** Per-channel default-agent picker for a SHARED bot (§10.1). Every active
- *  shared channel has exactly one owner. */
-function DefaultAgentSelect({
-  channel,
-  options,
+/** One agent that shares the bot — the shape the default-dispatch popover renders. */
+type MemberAgent = { id: string; label: string; runtime: string; icon?: AgentIcon | null }
+
+/** Fixed-position placement of the portalled popover, measured off its button. */
+type PopoverBox = { style: { left?: number; right?: number; top?: number; bottom?: number } }
+
+/** Menu width and the room one needs below the button before it flips upward —
+ *  a rough height bound, so nothing has to be measured in a second pass. */
+const POPOVER_W = 240
+const POPOVER_H = 150
+
+/** Anchor the popover under its button, flipping up / right-aligning when the
+ *  viewport edge is too close. Exported for its unit test — the flip corners are
+ *  the whole reason this isn't inline. */
+export function placePopover(
+  btn: { left: number; right: number; top: number; bottom: number },
+  vw: number,
+  vh: number
+): PopoverBox {
+  const style: PopoverBox['style'] = {}
+  if (btn.left + POPOVER_W > vw - 8) style.right = Math.max(8, vw - btn.right)
+  else style.left = btn.left
+  if (btn.bottom + POPOVER_H > vh - 8 && btn.top > POPOVER_H) style.bottom = vh - btn.top + 6
+  else style.top = btn.bottom + 6
+  return { style }
+}
+
+/** Per-channel default dispatch for a SHARED bot (§10.1). Every active shared
+ *  channel has exactly one owner: the agent that answers whatever the channel's
+ *  routing rules don't hand to someone else.
+ *
+ *  The design keeps this strictly apart from the trigger toggle ("切换 default 和
+ *  trigger 是两类控制，不要混一起") — a compact avatar + chevron whose popover
+ *  READS the current default and offers exactly one action, claiming the channel
+ *  for the agent whose page this is. Handing a channel to some third agent stays
+ *  in Settings → Bots, where the whole roster is in view. */
+function DefaultAgentPicker({
+  current,
+  viewer,
   disabled,
-  onChange
+  onClaim
 }: {
-  channel: IntegrationChannelRow
-  options: { id: string; label: string }[]
+  /** The channel's effective default (the bot's earliest member when unset). */
+  current: MemberAgent
+  /** The agent being viewed — the "Make … default" target; absent when it doesn't share this bot. */
+  viewer?: MemberAgent
+  /** Demo rows (no live integration id) render the control read-only. */
   disabled: boolean
-  onChange: (agentId: string) => void
+  onClaim: (agentId: string) => void | Promise<void>
 }) {
+  const [box, setBox] = useState<PopoverBox | null>(null)
   const [saving, setSaving] = useState(false)
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const open = box !== null
+  const isViewer = viewer?.id === current.id
+  const close = useCallback(() => setBox(null), [])
+  // The host cards clip their content (rounded corners over full-bleed rows), so
+  // an absolutely-positioned menu is cut off on the last row. Portal it to the
+  // body at fixed coordinates measured off the button instead — which also means
+  // it can't follow the page, so scrolling and resizing dismiss it.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && close()
+    document.addEventListener('keydown', onKey, true)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      document.removeEventListener('keydown', onKey, true)
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [open, close])
+  const toggle = () => {
+    const el = btnRef.current
+    if (open || !el) return close()
+    setBox(placePopover(el.getBoundingClientRect(), window.innerWidth, window.innerHeight))
+  }
+  const claim = () => {
+    close()
+    if (!viewer || disabled || saving) return
+    setSaving(true)
+    Promise.resolve(onClaim(viewer.id)).finally(() => setSaving(false))
+  }
   return (
-    <select
-      value={channel.agentId ?? options[0]?.id ?? ''}
-      disabled={disabled || saving}
-      onChange={(e) => {
-        setSaving(true)
-        Promise.resolve(onChange(e.target.value)).finally(() => setSaving(false))
-      }}
-      className={`rounded-[7px] border border-(--border-subtle) bg-(--surface-card) px-2 py-[5px] font-sans text-[12.5px] leading-normal text-(--text-primary) max-desktop:w-full ${
-        disabled ? 'cursor-default opacity-60' : 'cursor-pointer'
-      } ${saving ? 'opacity-60' : ''}`}
-    >
-      {options.map((o) => (
-        <option key={o.id} value={o.id}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <span className="flex-none">
+      <button
+        ref={btnRef}
+        onClick={toggle}
+        title={`Default dispatch — ${current.label}`}
+        aria-label={`Default dispatch — ${current.label}`}
+        aria-expanded={open}
+        className={`flex cursor-pointer items-center gap-[3px] rounded-[7px] border-0 bg-transparent p-[3px] hover:bg-(--surface-hover) ${
+          saving ? 'opacity-60' : ''
+        }`}
+      >
+        <span className="av h-[22px] w-[22px] rounded-[6px]">
+          <AgentIconView icon={current.icon} runtime={current.runtime} size={22} />
+        </span>
+        {/* Desktop rows read the avatar in the context of the row it sits on; the
+            mobile row breaks onto its own line, where a bare mark says nothing. */}
+        <span className="mono max-w-[180px] truncate text-[12px] text-(--text-tertiary) desktop:hidden">
+          {current.label}
+        </span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+      </button>
+      {box &&
+        createPortal(
+          <>
+            <span className="fixed inset-0 z-[1090]" onClick={close} />
+            <div
+              className="fixed z-[1100] min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+              style={box.style}
+            >
+              <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                Default dispatch
+              </div>
+              <div className="flex items-center gap-[9px] px-[9px] py-[6px]">
+                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                  <AgentIconView icon={current.icon} runtime={current.runtime} size={22} />
+                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">
+                  {current.label}
+                </span>
+                {isViewer && (
+                  <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">this agent</span>
+                )}
+              </div>
+              {viewer && !isViewer && (
+                <>
+                  <div className="my-1 h-px bg-(--border-subtle)" />
+                  <button
+                    onClick={claim}
+                    disabled={disabled || saving}
+                    className={`flex w-full items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[7px] text-left hover:bg-(--surface-hover) ${
+                      disabled || saving ? 'cursor-default opacity-60' : 'cursor-pointer'
+                    }`}
+                  >
+                    <Icon name="corner-down-left" size={13} color="var(--text-tertiary)" className="flex-none" />
+                    <span className="min-w-0 truncate font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+                      Make <span className="mono">{viewer.label}</span> default
+                    </span>
+                  </button>
+                </>
+              )}
+            </div>
+          </>,
+          document.body
+        )}
+    </span>
   )
 }
 
 /**
  * The conversation rows of one integration — one row per channel the bot is in
  * (plus, on a gated/restricted agent, one row per reported DM conversation), each
- * with its trigger toggle (and, for a SHARED bot, a per-channel default-agent
- * picker), closed by the "invite the bot" hint. Shared by the Integrations page and
- * the agent detail page; render inside a padding-less card whose header row sits
- * above. Demo rows (no `integrationId`) are inert.
+ * with its trigger toggle (and, for a SHARED bot, the per-channel default-dispatch
+ * popover ahead of it), closed by the "invite the bot" hint. Render inside a
+ * padding-less card whose header row sits above. Demo rows (no `integrationId`)
+ * are inert.
  */
 export function IntegrationChannelList({
   integrationId,
   channels,
   botId,
+  agentId,
   shareable = false,
   gated = false,
   padX = 18
@@ -150,6 +271,8 @@ export function IntegrationChannelList({
   channels: IntegrationChannelRow[]
   /** The backing bot id — resolves the member agents offered as per-channel defaults. */
   botId?: string
+  /** The agent whose page this is — the "Make … default" target of the default-dispatch popover. */
+  agentId?: string
   /** When true (shared bot), show the per-channel default-agent picker. */
   shareable?: boolean
   /** Restricted-agent integration (resource-visibility.md §14): conversations are
@@ -161,44 +284,59 @@ export function IntegrationChannelList({
   const { setChannelTrigger, setChannelAgent, bots, agents } = useConsoleData()
   // The agents that share this bot — the candidate per-channel defaults.
   const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
-  const agentOptions = memberIds.map((id) => {
+  const member = (id: string): MemberAgent => {
     const a = agents.find((x) => x.id === id)
-    return { id, label: a?.displayName || a?.name || id }
-  })
+    return { id, label: a ? agentLabel(a) : id, runtime: a?.runtime ?? a?.model ?? '', icon: a?.icon }
+  }
+  // The agents that share this bot. The channel's default is its explicit owner,
+  // falling back to the earliest install — the same ordering sharedBot.ts's
+  // compiler uses when a channel has never been claimed.
+  const members = memberIds.map(member)
+  const viewer = agentId && memberIds.includes(agentId) ? member(agentId) : undefined
+  const defaultAgent = (c: IntegrationChannelRow) =>
+    (c.agentId ? members.find((m) => m.id === c.agentId) : undefined) ?? members[0]
   const channelRows = channels.filter((c) => c.kind !== 'im')
   const dmRows = channels.filter((c) => c.kind === 'im')
-  const row = (c: IntegrationChannelRow) => (
-    <div
-      key={c.channelId}
-      className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
-      style={{ padding: `10px ${padX}px` }}
-    >
-      <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
-        {c.kind === 'im' ? '@' : '#'}
-      </span>
-      {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
-          renders the marker, so strip a leading @ to avoid "@@Alice". */}
-      <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">
-        {c.kind === 'im' ? c.name.replace(/^@+/, '') : c.name}
-      </span>
-      <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-stretch">
-        {c.kind !== 'im' && shareable && agentOptions.length > 0 && (
-          <DefaultAgentSelect
+  const row = (c: IntegrationChannelRow) => {
+    const def = c.kind !== 'im' && shareable ? defaultAgent(c) : undefined
+    return (
+      <div
+        key={c.channelId}
+        className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
+        style={{ padding: `10px ${padX}px` }}
+      >
+        <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
+          {c.kind === 'im' ? '@' : '#'}
+        </span>
+        {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
+            renders the marker, so strip a leading @ to avoid "@@Alice". */}
+        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">
+          {c.kind === 'im' ? c.name.replace(/^@+/, '') : c.name}
+        </span>
+        <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
+          {def && (
+            <>
+              <DefaultAgentPicker
+                current={def}
+                viewer={viewer}
+                disabled={!integrationId}
+                onClaim={(id) => setChannelAgent(integrationId!, c.channelId, id)}
+              />
+              {/* The design separates the two controls with a hairline — default
+                  dispatch and trigger are different decisions, not one bar. */}
+              <span className="hidden h-[18px] w-px flex-none bg-(--border-subtle) desktop:block" />
+            </>
+          )}
+          <TriggerToggle
             channel={c}
-            options={agentOptions}
             disabled={!integrationId}
-            onChange={(agentId) => setChannelAgent(integrationId!, c.channelId, agentId)}
+            gated={gated}
+            onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
-        )}
-        <TriggerToggle
-          channel={c}
-          disabled={!integrationId}
-          gated={gated}
-          onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
-        />
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
   return (
     <>
       {gated && (
@@ -230,7 +368,7 @@ export function IntegrationChannelList({
       >
         <Icon name="info" size={14} className="flex-none" />
         {shareable
-          ? 'Channels appear here when the bot is invited. Pick a default agent per channel; trigger is set per channel.'
+          ? 'Channels appear here when the bot is invited to them. Trigger is set per channel; default dispatch is the agent who handles unmatched messages.'
           : gated
             ? 'Channels appear here when the bot is invited; direct messages appear when someone writes to the bot.'
             : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1084,6 +1084,7 @@ export default function AgentDetailView() {
                         integrationId={g.id}
                         channels={g.channels}
                         botId={g.botId}
+                        agentId={da.id}
                         shareable={g.shareable}
                         gated={da.visibility === 'restricted'}
                         padX={16}
@@ -1169,10 +1170,10 @@ export default function AgentDetailView() {
                             {g.shareable && (
                               <span
                                 className="badge bg-(--surface-app) text-(--text-tertiary)"
-                                title="Shared bot — used by multiple agents, inbound via a relay"
+                                title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
                               >
                                 <Icon name="users" size={11} />
-                                shared
+                                shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
                               </span>
                             )}
                           </div>
@@ -1202,6 +1203,7 @@ export default function AgentDetailView() {
                         integrationId={g.id}
                         channels={g.channels}
                         botId={g.botId}
+                        agentId={da.id}
                         shareable={g.shareable}
                         gated={da.visibility === 'restricted'}
                         padX={14}

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -142,11 +142,13 @@ function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelVie
   return [...merged.values()].sort((a, b) => a.name.localeCompare(b.name))
 }
 
-/** Per-channel active-agent picker for a SHARED bot (design: the Bots card's
- *  expanded channel rows) — a bordered button showing the current agent that
- *  opens a menu of every agent installed on the bot; picking one PATCHes the
- *  channel's explicit owner. */
-function ActiveAgentPicker({
+/** Per-channel default dispatch for a SHARED bot (design: the Bots card's
+ *  expanded channel rows) — the agent a channel's unmatched messages go to.
+ *  Shows the current one and opens a menu of every agent installed on the bot;
+ *  picking one PATCHes the channel's explicit owner. This is the full-roster
+ *  picker: the agent page's own popover (IntegrationChannelList) only claims the
+ *  channel for the agent being viewed. */
+function DefaultDispatchPicker({
   options,
   activeId,
   disabled,
@@ -167,28 +169,29 @@ function ActiveAgentPicker({
     onPick(id).finally(() => setSaving(false))
   }
   return (
-    <span className="relative justify-self-start" onClick={(e) => e.stopPropagation()}>
+    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
       <button
         onClick={() => !disabled && setOpen((v) => !v)}
-        title="Switch active agent"
-        className={`flex items-center gap-2 rounded-[6px] border border-(--border-default) bg-(--surface-card) px-2 py-1 transition-[background-color,border-color] hover:border-(--border-strong) hover:bg-(--surface-hover) ${
+        title="Default dispatch — the agent this channel's unmatched messages go to"
+        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
           disabled ? 'cursor-default' : 'cursor-pointer'
         } ${saving ? 'opacity-60' : ''}`}
       >
         <span className="av h-5 w-5 rounded-[5px]">
           <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
         </span>
-        <span className="font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
-          {active?.name ?? '—'}
-        </span>
-        <Icon name="chevrons-up-down" size={13} color="var(--text-tertiary)" />
+        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
       </button>
       {open && (
         <>
           <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
           {/* right-anchored: the picker sits in the roster's right-most column, so a
               left-anchored menu (wider than its button) would clip past the card edge */}
-          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-lg border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
+          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
+            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+              Default dispatch
+            </div>
             {options.map((o) => (
               <button
                 key={o.id}
@@ -198,12 +201,7 @@ function ActiveAgentPicker({
                 <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
                   <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
                 </span>
-                <span className="flex min-w-0 flex-1 flex-col items-start">
-                  <span className="font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
-                    {o.name}
-                  </span>
-                  <span className="mono text-[10.5px] text-(--text-tertiary)">{o.model}</span>
-                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
                 <Icon
                   name="check"
                   size={13}
@@ -834,7 +832,7 @@ function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | n
                       className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}
                     >
                       <span>Channel</span>
-                      {b.shareable && <span>Active agent</span>}
+                      {b.shareable && <span className="justify-self-end">Default dispatch</span>}
                     </div>
                     <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
                       {channels.map((c) => (
@@ -847,7 +845,7 @@ function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | n
                             <span className="truncate">{c.name}</span>
                           </span>
                           {b.shareable && (
-                            <ActiveAgentPicker
+                            <DefaultDispatchPicker
                               options={agentOptions}
                               activeId={c.agentId ?? b.agentIds[0] ?? null}
                               disabled={!canWrite || !c.integrationId}


### PR DESCRIPTION
## What

Syncs the design's **default dispatch** treatment for shared bots onto both surfaces that expose it.

**Agent detail → Integrations tab**
- The per-channel `<select>` of member agents becomes a compact **avatar + chevron**, separated from the trigger toggle by a hairline. Its popover reads the current default and offers exactly one action — *Make `<this agent>` default* — or shows a `this agent` pill when it already is.
- The shared badge now reports roster size: `shared · 3 agents`.
- Footer hint reworded: "…Trigger is set per channel; default dispatch is the agent who handles unmatched messages."

**Settings → Bots (expanded channel rows)**
- Column header `Active agent` → `Default dispatch`, right-aligned over the picker.
- Picker loses its border/card fill, renders the agent name in mono, `chevrons-up-down` → `chevron-down`; its menu gains the same `DEFAULT DISPATCH` header and single-line mono rows.
- `ActiveAgentPicker` → `DefaultDispatchPicker`.

## Why

Shared-bot channels always had a default agent, but "who answers by default" and "what triggers a reply" rendered as one undifferentiated bar. Per the design discussion, switching the default and setting the trigger are two different kinds of control and should not be mixed into one bar — they are now visibly distinct decisions.

## Notes for reviewers

- **Deliberate scope split.** The agent page's popover only *claims* the channel for the agent you're viewing; picking an arbitrary third agent stays in Settings → Bots, where the whole roster is in view. That's what the design shows, and it's why the two pickers differ.
- **Portalled popover.** The host cards use `overflow-hidden` for their rounded corners, so an absolutely-positioned menu is clipped on the last channel row (reproduced in the browser). The popover is portalled to `document.body` at fixed coordinates measured off the button, flipping up / right-aligning near a viewport edge, and dismisses on scroll, resize and Escape. `placePopover` is a pure helper with 4 unit tests covering those corners.
- **Mobile divergence.** The design has no mobile mock here; on ≤768px the button keeps the agent name beside the avatar, since the row breaks onto its own line where a bare mark says nothing.
- The Settings menu keeps a brand check on the active row (the design crop cuts off that row) — it is the only marker once the menu covers the button. The model subline was dropped to match the design's single-line rows.

## Verification

web-mock, with a temporary shared-bot fixture (mock bots are all `shareable: false`, and `/settings` redirects in no-auth mode — both temporarily relaxed, then reverted):
- both popover states on the agent page, Settings collapsed row + open menu
- light + dark, desktop + mobile

`pnpm typecheck`, eslint, prettier and 350 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)