### PR TITLE
fix(web): show accurate agent session totals

### DIFF
--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -61,6 +61,7 @@ import { Button, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
+import { useSessionList } from '@/lib/use-session-list'
 import {
   GH_FAMILIES,
   GH_TRIGGER_MODES,
@@ -121,6 +122,7 @@ export default function AgentDetailView() {
     useConsoleData()
   const { openPlayground } = usePlayground()
   const { openModal } = useModal()
+  const { total: agentSessionTotal } = useSessionList(MOCK_MODE ? null : activeOrg?.id, { agentId: id })
   // Which webhook row has its recent-deliveries panel expanded (one at a time).
   const [hookRunsFor, setHookRunsFor] = useState<string | null>(null)
   // Hooks are agent-scoped (no org-wide list). Keep a stable resource key so a
@@ -398,7 +400,7 @@ export default function AgentDetailView() {
       ? (da.hookKinds ?? [])
       : [...new Set(agentHooks.filter((hook) => hook.enabled).map((hook) => hook.kind))]
   const hasIntegrationMarks = agentInts.length > 0 || integrationHookKinds.length > 0
-  const sessionCount = getSessions(da.id).length
+  const sessionCount = MOCK_MODE ? getSessions(da.id).length : agentSessionTotal
   // Icon upload is available only when the object store is configured (org flag) — the
   // picker hides Upload otherwise. On success the CP has persisted the new icon; refetch.
   const onUploadIcon = activeOrg?.iconUploadEnabled


### PR DESCRIPTION
## Summary

- read the agent detail header count from the agent-filtered session query total
- preserve the existing mock-console session count behavior

## Root cause

The agent detail page filtered the organization-wide session page already loaded in memory. Because that page contains at most 50 recent sessions across all agents, the displayed count represented only the matching rows in that partial page rather than the agent's full session total.

## Impact

The count in the agent header now uses the same server-side filter and total as the linked Sessions view, so the two surfaces stay consistent even when the organization has more than one page of session history.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web test` (354 tests)
- `pnpm --filter @agentconnect.md/web exec eslint src/components/console/views/AgentDetailView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/AgentDetailView.tsx`

Created by Codex . gpt-5.6-sol
