### PR TITLE
feat(daemon): prompt for Discord and Feishu permissions

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -111,6 +111,7 @@ const DISCORD_BOT_PERMISSIONS = (
 ).toString()
 
 type DiscordPermissionIssue = 'missing-access' | 'missing-permissions' | 'missing-oauth-scope'
+type DiscordPermissionState = { issue: DiscordPermissionIssue; channel?: string }
 
 type DiscordErrorLike = {
   code?: unknown
@@ -159,7 +160,8 @@ export class DiscordConnection {
   private statusKeys = new Map<string, string>()
   /** Permission failures can repeat for every streamed write. Announce once per bot
    * connection, with a bounded retry if the bot currently cannot send the notice. */
-  private permissionIssues = new Set<DiscordPermissionIssue>()
+  private permissionIssue?: DiscordPermissionState
+  private loggedPermissionIssues = new Set<DiscordPermissionIssue>()
   private permissionNoticeSent = false
   private permissionNoticeInFlight = false
   private permissionNoticeRetryAt = 0
@@ -347,19 +349,30 @@ export class DiscordConnection {
       if (ch && 'send' in ch && typeof (ch as { send?: unknown }).send === 'function') return ch as Sendable
       return null
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channelId)
       this.deps.log?.debug(`discord: channel fetch failed (ch=${channelId}): ${(err as Error).message}`)
       return null
     }
   }
 
-  private rememberPermissionIssue(err: unknown): boolean {
+  private rememberPermissionIssue(err: unknown, channel?: string): boolean {
     const issue = discordPermissionIssueFrom(err)
     if (!issue) return false
-    if (!this.permissionIssues.has(issue)) {
-      this.permissionIssues.add(issue)
+    if (!this.loggedPermissionIssues.has(issue)) {
+      this.loggedPermissionIssues.add(issue)
       this.deps.log?.warn(`discord: bot permission update required (${issue})`)
     }
+    const next: DiscordPermissionState = {
+      issue,
+      // OAuth scope is application-wide. Access/permission errors discovered during a
+      // channel operation must stay on that channel so a healthy guild cannot consume
+      // a stale retry. Calls without a channel (command registration) remain global.
+      ...(issue !== 'missing-oauth-scope' && channel ? { channel } : {})
+    }
+    if (this.permissionIssue?.issue !== next.issue || this.permissionIssue.channel !== next.channel) {
+      this.permissionNoticeRetryAt = 0
+    }
+    this.permissionIssue = next
     return true
   }
 
@@ -379,8 +392,10 @@ export class DiscordConnection {
    * (`undefined`). The in-flight claim is set before any await so concurrent thread or
    * chrome failures cannot race into duplicate notices. */
   private async postPermissionUpdateNotice(channel: string, target?: Sendable | null): Promise<void> {
+    const permission = this.permissionIssue
     if (
-      this.permissionIssues.size === 0 ||
+      !permission ||
+      (permission.channel !== undefined && permission.channel !== channel) ||
       this.permissionNoticeSent ||
       this.permissionNoticeInFlight ||
       Date.now() < this.permissionNoticeRetryAt
@@ -399,7 +414,7 @@ export class DiscordConnection {
       await ch.send(buildPermissionUpdateNotice(updateUrl))
       this.permissionNoticeSent = true
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channel)
       this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
       this.deps.log?.debug(`discord: permission update notice failed (ch=${channel}): ${(err as Error).message}`)
     } finally {
@@ -425,7 +440,7 @@ export class DiscordConnection {
       const thread = await message.startThread({ name: name.slice(0, 100) || 'Agent thread' })
       return thread.id
     } catch (err) {
-      if (this.rememberPermissionIssue(err)) await this.postPermissionUpdateNotice(channelId, ch)
+      if (this.rememberPermissionIssue(err, channelId)) await this.postPermissionUpdateNotice(channelId, ch)
       this.deps.log?.debug(`discord: createThread failed (ch=${channelId} msg=${messageId}): ${(err as Error).message}`)
       return undefined
     }
@@ -447,7 +462,7 @@ export class DiscordConnection {
       let firstId: string | undefined
       for (const chunk of chunkForDiscord(text)) {
         const sent = await ch.send({ content: chunk }).catch((err: Error) => {
-          this.rememberPermissionIssue(err)
+          this.rememberPermissionIssue(err, channel)
           this.deps.log?.debug(`discord: send failed (ch=${channel}): ${err.message}`)
           return null
         })
@@ -486,7 +501,7 @@ export class DiscordConnection {
         await this.postPermissionUpdateNotice(channel, ch)
         return sent?.id
       } catch (err) {
-        this.rememberPermissionIssue(err)
+        this.rememberPermissionIssue(err, channel)
         await this.postPermissionUpdateNotice(channel, ch)
         this.deps.log?.debug(`discord: send (chrome) failed (ch=${channel}): ${(err as Error).message}`)
         return undefined
@@ -515,7 +530,7 @@ export class DiscordConnection {
         if (opts.keyboard) payload.components = opts.keyboard
         await msg.edit(payload)
       } catch (err) {
-        this.rememberPermissionIssue(err)
+        this.rememberPermissionIssue(err, channel)
         this.deps.log?.debug(`discord: edit failed (ch=${channel} id=${messageId}): ${(err as Error).message}`)
       }
       await this.postPermissionUpdateNotice(channel, ch)
@@ -530,7 +545,7 @@ export class DiscordConnection {
       ch = await this.sendableChannel(channel)
       if (ch?.sendTyping) await ch.sendTyping()
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channel)
       this.deps.log?.debug(`discord: sendTyping failed (ch=${channel}): ${(err as Error).message}`)
     }
     await this.postPermissionUpdateNotice(channel, ch)

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -15,6 +15,7 @@ import type { InteractionActor } from '../slack/connection.js'
 import { normalizeDiscordMessage, type DiscordMessageLike } from './normalize.js'
 import { DISCORD_APP_COMMANDS } from './app-commands.js'
 import {
+  buildPermissionUpdateNotice,
   parseDiscordCallback,
   parseDiscordSelect,
   chunkForDiscord,
@@ -93,9 +94,53 @@ export interface DiscordDeps {
 const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 /** Cap on channels enumerated per listChannels call (bounds the response). */
 const CHANNEL_CAP = 200
+const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
+
+// Keep this permission set in lock-step with packages/web/src/lib/discord-invite.ts.
+// It covers reactions, channel visibility, messages, embeds/files/history, and public
+// thread creation + replies. Discord permission bitfields exceed 32 bits.
+const DISCORD_BOT_PERMISSIONS = (
+  (1n << 6n) |
+  (1n << 10n) |
+  (1n << 11n) |
+  (1n << 14n) |
+  (1n << 15n) |
+  (1n << 16n) |
+  (1n << 34n) |
+  (1n << 38n)
+).toString()
+
+type DiscordPermissionIssue = 'missing-access' | 'missing-permissions' | 'missing-oauth-scope'
+
+type DiscordErrorLike = {
+  code?: unknown
+  data?: { code?: unknown }
+  rawError?: { code?: unknown }
+}
+
+/** Discord API errors use stable numeric codes even though discord.js may expose the
+ * code on either the wrapper or raw payload. Exact message matching keeps test doubles
+ * and older library shapes compatible without treating every HTTP 403 as reparable. */
+function discordPermissionIssueFrom(err: unknown): DiscordPermissionIssue | null {
+  const e = err && typeof err === 'object' ? (err as DiscordErrorLike) : undefined
+  const candidate = e?.code ?? e?.rawError?.code ?? e?.data?.code
+  const code = typeof candidate === 'number' ? candidate : Number(candidate)
+  if (code === 50001) return 'missing-access'
+  if (code === 50013) return 'missing-permissions'
+  if (code === 50026) return 'missing-oauth-scope'
+
+  const message = err instanceof Error ? err.message : ''
+  if (/\bmissing access\b/i.test(message)) return 'missing-access'
+  if (/\bmissing permissions?\b/i.test(message)) return 'missing-permissions'
+  if (/\bmissing required oauth2 scope\b/i.test(message)) return 'missing-oauth-scope'
+  return null
+}
 
 /** The discord.js message-send payload we use (content + optional components). */
-type SendPayload = { content: string; components?: DiscordComponents }
+type SendPayload = {
+  content?: string
+  components?: DiscordComponents
+}
 type Sendable = Channel & {
   send: (payload: SendPayload) => Promise<Message>
   sendTyping?: () => Promise<void>
@@ -112,6 +157,12 @@ export class DiscordConnection {
   // only channel+message id, not the session key) resolves back to its session.
   // Keyed `${channelId}:${messageId}`.
   private statusKeys = new Map<string, string>()
+  /** Permission failures can repeat for every streamed write. Announce once per bot
+   * connection, with a bounded retry if the bot currently cannot send the notice. */
+  private permissionIssues = new Set<DiscordPermissionIssue>()
+  private permissionNoticeSent = false
+  private permissionNoticeInFlight = false
+  private permissionNoticeRetryAt = 0
   /** The bot token this gateway authenticated with (used to detect a swap). */
   readonly botToken: string
   /** The bot's user id (a numeric snowflake, as string). Discord routes mentions on
@@ -214,6 +265,7 @@ export class DiscordConnection {
         `discord: registered ${DISCORD_APP_COMMANDS.length} slash commands (global) for @${this.botUsername}`
       )
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.error(
         `discord: slash-command registration failed — is the bot invited with the ` +
           `applications.commands scope? (${(err as Error).message})`
@@ -290,9 +342,69 @@ export class DiscordConnection {
 
   /** Fetch a channel and confirm it can send messages. */
   private async sendableChannel(channelId: string): Promise<Sendable | null> {
-    const ch = await this.client.channels.fetch(channelId).catch(() => null)
-    if (ch && 'send' in ch && typeof (ch as { send?: unknown }).send === 'function') return ch as Sendable
-    return null
+    try {
+      const ch = await this.client.channels.fetch(channelId)
+      if (ch && 'send' in ch && typeof (ch as { send?: unknown }).send === 'function') return ch as Sendable
+      return null
+    } catch (err) {
+      this.rememberPermissionIssue(err)
+      this.deps.log?.debug(`discord: channel fetch failed (ch=${channelId}): ${(err as Error).message}`)
+      return null
+    }
+  }
+
+  private rememberPermissionIssue(err: unknown): boolean {
+    const issue = discordPermissionIssueFrom(err)
+    if (!issue) return false
+    if (!this.permissionIssues.has(issue)) {
+      this.permissionIssues.add(issue)
+      this.deps.log?.warn(`discord: bot permission update required (${issue})`)
+    }
+    return true
+  }
+
+  private permissionUpdateUrl(): string | undefined {
+    const applicationId = this.client.application?.id ?? this.botUserId
+    if (!/^\d{17,20}$/.test(applicationId)) return undefined
+    const params = new URLSearchParams({
+      client_id: applicationId,
+      scope: 'bot applications.commands',
+      permissions: DISCORD_BOT_PERMISSIONS
+    })
+    return `https://discord.com/oauth2/authorize?${params.toString()}`
+  }
+
+  /** Post one Devin-style permission notice. `target` distinguishes an already-failed
+   * channel lookup (`null`) from a caller that has not fetched the channel yet
+   * (`undefined`). The in-flight claim is set before any await so concurrent thread or
+   * chrome failures cannot race into duplicate notices. */
+  private async postPermissionUpdateNotice(channel: string, target?: Sendable | null): Promise<void> {
+    if (
+      this.permissionIssues.size === 0 ||
+      this.permissionNoticeSent ||
+      this.permissionNoticeInFlight ||
+      Date.now() < this.permissionNoticeRetryAt
+    )
+      return
+    const updateUrl = this.permissionUpdateUrl()
+    if (!updateUrl) return
+
+    this.permissionNoticeInFlight = true
+    try {
+      const ch = target === undefined ? await this.sendableChannel(channel) : target
+      if (!ch) {
+        this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+        return
+      }
+      await ch.send(buildPermissionUpdateNotice(updateUrl))
+      this.permissionNoticeSent = true
+    } catch (err) {
+      this.rememberPermissionIssue(err)
+      this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+      this.deps.log?.debug(`discord: permission update notice failed (ch=${channel}): ${(err as Error).message}`)
+    } finally {
+      this.permissionNoticeInFlight = false
+    }
   }
 
   /**
@@ -305,13 +417,15 @@ export class DiscordConnection {
    * the bot lacks the Create Public Threads permission (caller then replies in-channel).
    */
   async createThread(channelId: string, messageId: string, name: string): Promise<string | undefined> {
+    let ch: Sendable | null = null
     try {
-      const ch = await this.sendableChannel(channelId)
+      ch = await this.sendableChannel(channelId)
       if (!ch?.messages) return undefined
       const message = await ch.messages.fetch(messageId)
       const thread = await message.startThread({ name: name.slice(0, 100) || 'Agent thread' })
       return thread.id
     } catch (err) {
+      if (this.rememberPermissionIssue(err)) await this.postPermissionUpdateNotice(channelId, ch)
       this.deps.log?.debug(`discord: createThread failed (ch=${channelId} msg=${messageId}): ${(err as Error).message}`)
       return undefined
     }
@@ -326,15 +440,20 @@ export class DiscordConnection {
   async postMessage(channel: string, text: string, _threadTs?: string): Promise<string | undefined> {
     return this.queue.enqueue(async () => {
       const ch = await this.sendableChannel(channel)
-      if (!ch) return undefined
+      if (!ch) {
+        await this.postPermissionUpdateNotice(channel, ch)
+        return undefined
+      }
       let firstId: string | undefined
       for (const chunk of chunkForDiscord(text)) {
         const sent = await ch.send({ content: chunk }).catch((err: Error) => {
+          this.rememberPermissionIssue(err)
           this.deps.log?.debug(`discord: send failed (ch=${channel}): ${err.message}`)
           return null
         })
         if (sent && firstId === undefined) firstId = sent.id
       }
+      await this.postPermissionUpdateNotice(channel, ch)
       return firstId
     })
   }
@@ -353,15 +472,22 @@ export class DiscordConnection {
     opts: { threadTs?: string; keyboard?: DiscordComponents; sessionKey?: string } = {}
   ): Promise<string | undefined> {
     return this.queue.enqueue(async () => {
+      let ch: Sendable | null = null
       try {
-        const ch = await this.sendableChannel(channel)
-        if (!ch) return undefined
+        ch = await this.sendableChannel(channel)
+        if (!ch) {
+          await this.postPermissionUpdateNotice(channel, ch)
+          return undefined
+        }
         const payload: SendPayload = { content: chunkForDiscord(text)[0] ?? '' }
         if (opts.keyboard) payload.components = opts.keyboard
         const sent = await ch.send(payload)
         if (sent && opts.sessionKey) this.statusKeys.set(`${channel}:${sent.id}`, opts.sessionKey)
+        await this.postPermissionUpdateNotice(channel, ch)
         return sent?.id
       } catch (err) {
+        this.rememberPermissionIssue(err)
+        await this.postPermissionUpdateNotice(channel, ch)
         this.deps.log?.debug(`discord: send (chrome) failed (ch=${channel}): ${(err as Error).message}`)
         return undefined
       }
@@ -377,28 +503,37 @@ export class DiscordConnection {
     opts: { keyboard?: DiscordComponents } = {}
   ): Promise<void> {
     await this.queue.enqueue(async () => {
+      let ch: Sendable | null = null
       try {
-        const ch = await this.sendableChannel(channel)
-        if (!ch?.messages) return
+        ch = await this.sendableChannel(channel)
+        if (!ch?.messages) {
+          await this.postPermissionUpdateNotice(channel, ch)
+          return
+        }
         const msg = await ch.messages.fetch(messageId)
         const payload: SendPayload = { content: chunkForDiscord(text)[0] ?? '' }
         if (opts.keyboard) payload.components = opts.keyboard
         await msg.edit(payload)
       } catch (err) {
+        this.rememberPermissionIssue(err)
         this.deps.log?.debug(`discord: edit failed (ch=${channel} id=${messageId}): ${(err as Error).message}`)
       }
+      await this.postPermissionUpdateNotice(channel, ch)
     })
   }
 
   /** Best-effort transient "typing…" indicator (Discord's analog of a status bar).
    *  Not queued — a fire-and-forget hint that expires on its own (~10s). */
   async sendChatAction(channel: string): Promise<void> {
+    let ch: Sendable | null = null
     try {
-      const ch = await this.sendableChannel(channel)
+      ch = await this.sendableChannel(channel)
       if (ch?.sendTyping) await ch.sendTyping()
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.debug(`discord: sendTyping failed (ch=${channel}): ${(err as Error).message}`)
     }
+    await this.postPermissionUpdateNotice(channel, ch)
   }
 
   /**

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -111,7 +111,6 @@ const DISCORD_BOT_PERMISSIONS = (
 ).toString()
 
 type DiscordPermissionIssue = 'missing-access' | 'missing-permissions' | 'missing-oauth-scope'
-type DiscordPermissionState = { issue: DiscordPermissionIssue; channel?: string }
 
 type DiscordErrorLike = {
   code?: unknown
@@ -160,11 +159,12 @@ export class DiscordConnection {
   private statusKeys = new Map<string, string>()
   /** Permission failures can repeat for every streamed write. Announce once per bot
    * connection, with a bounded retry if the bot currently cannot send the notice. */
-  private permissionIssue?: DiscordPermissionState
+  private hasGlobalPermissionIssue = false
+  private permissionIssueChannels = new Set<string>()
   private loggedPermissionIssues = new Set<DiscordPermissionIssue>()
   private permissionNoticeSent = false
   private permissionNoticeInFlight = false
-  private permissionNoticeRetryAt = 0
+  private permissionNoticeRetryAt = new Map<string, number>()
   /** The bot token this gateway authenticated with (used to detect a swap). */
   readonly botToken: string
   /** The bot's user id (a numeric snowflake, as string). Discord routes mentions on
@@ -362,18 +362,22 @@ export class DiscordConnection {
       this.loggedPermissionIssues.add(issue)
       this.deps.log?.warn(`discord: bot permission update required (${issue})`)
     }
-    const next: DiscordPermissionState = {
-      issue,
-      // OAuth scope is application-wide. Access/permission errors discovered during a
-      // channel operation must stay on that channel so a healthy guild cannot consume
-      // a stale retry. Calls without a channel (command registration) remain global.
-      ...(issue !== 'missing-oauth-scope' && channel ? { channel } : {})
+    // OAuth scope is application-wide. Access/permission errors discovered during a
+    // channel operation stay on that channel; calls without a channel (command
+    // registration) remain global. Keep both layers so a failed channel notice cannot
+    // replace an earlier unsent global repair.
+    if (issue === 'missing-oauth-scope' || !channel) {
+      this.hasGlobalPermissionIssue = true
+    } else if (!this.permissionIssueChannels.has(channel)) {
+      this.permissionIssueChannels.add(channel)
+      this.permissionNoticeRetryAt.delete(`channel:${channel}`)
     }
-    if (this.permissionIssue?.issue !== next.issue || this.permissionIssue.channel !== next.channel) {
-      this.permissionNoticeRetryAt = 0
-    }
-    this.permissionIssue = next
     return true
+  }
+
+  private pendingPermissionKey(channel: string): string | undefined {
+    if (this.hasGlobalPermissionIssue) return `global:${channel}`
+    return this.permissionIssueChannels.has(channel) ? `channel:${channel}` : undefined
   }
 
   private permissionUpdateUrl(): string | undefined {
@@ -392,13 +396,12 @@ export class DiscordConnection {
    * (`undefined`). The in-flight claim is set before any await so concurrent thread or
    * chrome failures cannot race into duplicate notices. */
   private async postPermissionUpdateNotice(channel: string, target?: Sendable | null): Promise<void> {
-    const permission = this.permissionIssue
+    const pendingKey = this.pendingPermissionKey(channel)
     if (
-      !permission ||
-      (permission.channel !== undefined && permission.channel !== channel) ||
+      !pendingKey ||
       this.permissionNoticeSent ||
       this.permissionNoticeInFlight ||
-      Date.now() < this.permissionNoticeRetryAt
+      Date.now() < (this.permissionNoticeRetryAt.get(pendingKey) ?? 0)
     )
       return
     const updateUrl = this.permissionUpdateUrl()
@@ -408,14 +411,20 @@ export class DiscordConnection {
     try {
       const ch = target === undefined ? await this.sendableChannel(channel) : target
       if (!ch) {
-        this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+        this.permissionNoticeRetryAt.set(
+          this.pendingPermissionKey(channel) ?? pendingKey,
+          Date.now() + PERMISSION_NOTICE_RETRY_MS
+        )
         return
       }
       await ch.send(buildPermissionUpdateNotice(updateUrl))
       this.permissionNoticeSent = true
     } catch (err) {
       this.rememberPermissionIssue(err, channel)
-      this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+      this.permissionNoticeRetryAt.set(
+        this.pendingPermissionKey(channel) ?? pendingKey,
+        Date.now() + PERMISSION_NOTICE_RETRY_MS
+      )
       this.deps.log?.debug(`discord: permission update notice failed (ch=${channel}): ${(err as Error).message}`)
     } finally {
       this.permissionNoticeInFlight = false

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -376,7 +376,7 @@ export class DiscordConnection {
   }
 
   private pendingPermissionKey(channel: string): string | undefined {
-    if (this.hasGlobalPermissionIssue) return `global:${channel}`
+    if (this.hasGlobalPermissionIssue) return 'global'
     return this.permissionIssueChannels.has(channel) ? `channel:${channel}` : undefined
   }
 

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -273,6 +273,22 @@ export function buildLinkComponents(link: string, label = '🔗 View session'): 
   return [{ type: 1, components: [{ type: 2, style: 5, label, url: link }] }]
 }
 
+/** A bot-install warning shown after Discord rejects an API call for missing access,
+ * permissions, or OAuth scope. Link buttons open directly and need no interaction
+ * callback. Keep the body as plain content (not an embed) so the warning can still
+ * send when the missing permission is Embed Links. */
+export function buildPermissionUpdateNotice(updateUrl: string): {
+  content: string
+  components: DiscordComponents
+} {
+  return {
+    content:
+      '⚠️ **Permissions update required.** Please re-authorize this Discord app to grant the required server ' +
+      "permissions. If the bot is restricted only in this channel, update the channel's permission overrides instead.",
+    components: buildLinkComponents(updateUrl, 'Update permissions')
+  }
+}
+
 /**
  * Build the per-turn status button row: a Cancel button, an optional Fast on/off
  * toggle (when the model advertises one), and a View-session Link button when a

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -565,9 +565,7 @@ export class FeishuConnection {
     const oldScopeCount = this.permissionScopes.size
     for (const scope of scopes) this.permissionScopes.add(scope)
     if (wasNewIssue || this.permissionScopes.size !== oldScopeCount) {
-      for (const key of this.permissionNoticeRetryAt.keys()) {
-        if (key.startsWith('global:')) this.permissionNoticeRetryAt.delete(key)
-      }
+      this.permissionNoticeRetryAt.delete('global')
     }
     return true
   }
@@ -583,7 +581,7 @@ export class FeishuConnection {
 
   private pendingPermission(channel: string): { permission: FeishuPermissionState; key: string } | undefined {
     const global = this.pendingGlobalPermission()
-    if (global) return { permission: global, key: `global:${channel}` }
+    if (global) return { permission: global, key: 'global' }
     return this.permissionIssueChannels.has(channel)
       ? { permission: { issue: 'chat-access', scopes: [] }, key: `channel:${channel}` }
       : undefined

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -262,6 +262,7 @@ const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 type FeishuPermissionIssue = 'app-permissions' | 'bot-capability' | 'app-availability' | 'chat-access'
 
 type UnknownRecord = Record<string, unknown>
+type FeishuPermissionState = { issue: FeishuPermissionIssue; scopes: string[] }
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === 'object' ? (value as UnknownRecord) : undefined
@@ -292,6 +293,52 @@ function feishuErrorCode(err: unknown): number | undefined {
   const candidate = body?.code ?? asRecord(body?.error)?.code
   const code = typeof candidate === 'number' ? candidate : Number(candidate)
   return Number.isFinite(code) ? code : undefined
+}
+
+const FEISHU_SCOPE_RE = /^[a-z0-9][a-z0-9._-]*(?::[a-z0-9][a-z0-9._-]*)+$/
+
+function validatedFeishuScopes(values: unknown[]): string[] {
+  const scopes = new Set<string>()
+  for (const value of values) {
+    if (typeof value !== 'string' || value.length > 128 || !FEISHU_SCOPE_RE.test(value)) continue
+    scopes.add(value)
+    if (scopes.size >= 20) break
+  }
+  return [...scopes]
+}
+
+/** Retain the exact missing scopes reported by Feishu/Lark instead of guessing from
+ * the error code. `99991672` is shared by every API family (including contact reads),
+ * so a fixed IM scope list can produce a successful but useless repair card. */
+function feishuRequiredScopes(err: unknown, appId: string, region: FeishuRegion): string[] {
+  const body = feishuErrorBody(err)
+  const nested = asRecord(body?.error)
+  const violations = Array.isArray(nested?.permission_violations)
+    ? nested.permission_violations
+    : Array.isArray(body?.permission_violations)
+      ? body.permission_violations
+      : []
+  const subjects = validatedFeishuScopes(violations.map((item) => asRecord(item)?.subject))
+  if (subjects.length) return subjects
+
+  // Some API versions expose only `error.helps[].url`. Accept its q scopes only when
+  // the link points to this exact app on the configured regional developer domain.
+  const helps = Array.isArray(nested?.helps) ? nested.helps : Array.isArray(body?.helps) ? body.helps : []
+  const expectedOrigin = region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
+  const expectedPath = `/app/${appId}/auth`
+  for (const help of helps) {
+    const candidate = asRecord(help)?.url
+    if (typeof candidate !== 'string') continue
+    try {
+      const url = new URL(candidate)
+      if (url.origin !== expectedOrigin || url.pathname !== expectedPath) continue
+      const scopes = validatedFeishuScopes((url.searchParams.get('q') ?? '').split(','))
+      if (scopes.length) return scopes
+    } catch {
+      // Ignore malformed platform help data and fall back to the app settings page.
+    }
+  }
+  return []
 }
 
 const FEISHU_PERMISSION_NOTICE: Record<
@@ -347,7 +394,7 @@ export class FeishuConnection {
   private queue: SlackSendQueue
   /** App-level permission failures repeat across streamed writes. Announce once per
    * connection, with a bounded retry when the bot currently cannot send the card. */
-  private permissionIssue?: FeishuPermissionIssue
+  private permissionIssue?: FeishuPermissionState
   private permissionNoticeSent = false
   private permissionNoticeInFlight = false
   private permissionNoticeRetryAt = 0
@@ -490,8 +537,9 @@ export class FeishuConnection {
   private rememberPermissionIssue(err: unknown): boolean {
     const issue = feishuPermissionIssueFrom(err)
     if (!issue) return false
-    const changed = this.permissionIssue !== issue
-    this.permissionIssue = issue
+    const scopes = issue === 'app-permissions' ? feishuRequiredScopes(err, this.appId, this.region) : []
+    const changed = this.permissionIssue?.issue !== issue || this.permissionIssue.scopes.join(',') !== scopes.join(',')
+    this.permissionIssue = { issue, scopes }
     if (changed) {
       const code = feishuErrorCode(err)
       this.deps.log?.warn(
@@ -502,13 +550,13 @@ export class FeishuConnection {
     return true
   }
 
-  private permissionUpdateUrl(issue: FeishuPermissionIssue): string | undefined {
+  private permissionUpdateUrl({ issue, scopes }: FeishuPermissionState): string | undefined {
     if (!/^cli_[A-Za-z0-9]+$/.test(this.appId)) return undefined
     const host = this.region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
     const appRoot = `${host}/app/${encodeURIComponent(this.appId)}`
-    if (issue !== 'app-permissions') return appRoot
+    if (issue !== 'app-permissions' || scopes.length === 0) return appRoot
     const params = new URLSearchParams({
-      q: 'im:message,im:message:send_as_bot,im:resource,im:chat',
+      q: scopes.join(','),
       op_from: 'openapi',
       token_type: 'tenant'
     })
@@ -520,19 +568,19 @@ export class FeishuConnection {
    * retried only after a cooldown because missing send/chat access also blocks the
    * warning itself. */
   private async postPermissionUpdateCard(channel: string, anchor?: string): Promise<void> {
-    const issue = this.permissionIssue
+    const permission = this.permissionIssue
     if (
-      !issue ||
+      !permission ||
       this.permissionNoticeSent ||
       this.permissionNoticeInFlight ||
       Date.now() < this.permissionNoticeRetryAt
     )
       return
-    const updateUrl = this.permissionUpdateUrl(issue)
+    const updateUrl = this.permissionUpdateUrl(permission)
     if (!updateUrl) return
 
     this.permissionNoticeInFlight = true
-    const notice = FEISHU_PERMISSION_NOTICE[issue]
+    const notice = FEISHU_PERMISSION_NOTICE[permission.issue]
     try {
       await this.sendPermissionCard(
         channel,

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -9,7 +9,7 @@ import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { SlackSendQueue } from '../slack/send-queue.js'
 import { normalizeFeishuMessage, type FeishuAttachmentLike, type FeishuMessageLike } from './normalize.js'
-import { chunkForFeishu } from './render.js'
+import { buildPermissionUpdateCard, chunkForFeishu } from './render.js'
 
 /**
  * §Feishu / Lark edge unit. Mirrors discord/connection.ts but over the official
@@ -17,11 +17,12 @@ import { chunkForFeishu } from './render.js'
  * NAT like Slack Socket Mode / Telegram long-polling / Discord Gateway). One WSClient
  * per unique appId (one self-built app = one bot).
  *
- * v1 is TEXT-ONLY: `postMessage`/`postChrome` send `msg_type:'text'` (content is the
- * Feishu JSON wrapper `{"text":…}`) chunked to a safe cap, `sendChatAction` is a no-op
- * (Feishu has no typing API), and control actions (`/status`, `/models`, …) are TYPED
- * TEXT COMMANDS routed through the normal onMessage path — there is NO native slash
- * registration and NO interactive card in v1 (that's a v2 enhancement).
+ * Ordinary v1 output is TEXT-ONLY: `postMessage`/`postChrome` send `msg_type:'text'`
+ * (content is the Feishu JSON wrapper `{"text":…}`) chunked to a safe cap,
+ * `sendChatAction` is a no-op (Feishu has no typing API), and control actions
+ * (`/status`, `/models`, …) are TYPED TEXT COMMANDS routed through the normal
+ * onMessage path. The one static interactive surface is a platform-permission notice
+ * with an open-URL button; it needs no callback endpoint.
  *
  * Attachments need AUTH to download (like Slack, unlike Discord): the inbound event
  * carries an opaque `image_key`/`file_key`, fetched via `im.messageResource.get` with a
@@ -71,7 +72,8 @@ export interface FeishuDeps {
   log?: Logger
   /** Min spacing (ms) between outbound writes (serialized send-queue). Tests pass 0. */
   sendIntervalMs?: number
-  // NOTE: no onCallback/onStatusAction/onSelectAction in v1 (no interactive cards).
+  // NOTE: no onCallback/onStatusAction/onSelectAction in v1; the permission card's
+  // button is an open-URL behavior and sends no callback.
 }
 
 /** The raw `im.message.receive_v1` event body the WSClient dispatches. `data` IS the
@@ -105,9 +107,13 @@ export interface FeishuRawEvent {
 export interface FeishuApi {
   /** im.message.create (msg_type 'text'). Returns the new message_id when known. */
   createText(chatId: string, text: string): Promise<{ messageId?: string }>
+  /** im.message.create (msg_type 'interactive') for a static open-URL card. */
+  createCard(chatId: string, card: Record<string, unknown>): Promise<{ messageId?: string }>
   /** im.message.reply (msg_type 'text', reply_in_thread) — the agent's reply lands in the
    *  topic thread rooted at `messageId`. Returns the new message_id when known. */
   replyText(messageId: string, text: string): Promise<{ messageId?: string }>
+  /** im.message.reply (msg_type 'interactive', reply_in_thread). */
+  replyCard(messageId: string, card: Record<string, unknown>): Promise<{ messageId?: string }>
   /** im.message.patch (in-place text edit). */
   patchText(messageId: string, text: string): Promise<void>
   /** im.messageResource.get(...).writeFile(destPath) — auth'd resource download. */
@@ -147,21 +153,35 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
   const client = new Lark.Client({ appId, appSecret, domain, loggerLevel: Lark.LoggerLevel.error })
   let ws: Lark.WSClient | undefined
 
+  const createMessage = async (
+    chatId: string,
+    msgType: 'text' | 'interactive',
+    content: Record<string, unknown>
+  ): Promise<{ messageId?: string }> => {
+    const res = (await client.im.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: { receive_id: chatId, msg_type: msgType, content: JSON.stringify(content) }
+    })) as { data?: { message_id?: string } }
+    return { messageId: res?.data?.message_id }
+  }
+
+  const replyMessage = async (
+    messageId: string,
+    msgType: 'text' | 'interactive',
+    content: Record<string, unknown>
+  ): Promise<{ messageId?: string }> => {
+    const res = (await client.im.message.reply({
+      path: { message_id: messageId },
+      data: { content: JSON.stringify(content), msg_type: msgType, reply_in_thread: true }
+    })) as { data?: { message_id?: string } }
+    return { messageId: res?.data?.message_id }
+  }
+
   const api: FeishuApi = {
-    async createText(chatId, text) {
-      const res = (await client.im.message.create({
-        params: { receive_id_type: 'chat_id' },
-        data: { receive_id: chatId, msg_type: 'text', content: JSON.stringify({ text }) }
-      })) as { data?: { message_id?: string } }
-      return { messageId: res?.data?.message_id }
-    },
-    async replyText(messageId, text) {
-      const res = (await client.im.message.reply({
-        path: { message_id: messageId },
-        data: { content: JSON.stringify({ text }), msg_type: 'text', reply_in_thread: true }
-      })) as { data?: { message_id?: string } }
-      return { messageId: res?.data?.message_id }
-    },
+    createText: (chatId, text) => createMessage(chatId, 'text', { text }),
+    createCard: (chatId, card) => createMessage(chatId, 'interactive', card),
+    replyText: (messageId, text) => replyMessage(messageId, 'text', { text }),
+    replyCard: (messageId, card) => replyMessage(messageId, 'interactive', card),
     async patchText(messageId, text) {
       await client.im.message.patch({
         path: { message_id: messageId },
@@ -237,6 +257,69 @@ const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 /** Cap on channels/members enumerated per read call (bounds the response). */
 const CHANNEL_CAP = 200
 const MEMBER_CAP = 50
+const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
+
+type FeishuPermissionIssue = 'app-permissions' | 'bot-capability' | 'app-availability' | 'chat-access'
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === 'object' ? (value as UnknownRecord) : undefined
+}
+
+function feishuErrorBody(err: unknown): UnknownRecord | undefined {
+  const outer = asRecord(err)
+  return asRecord(asRecord(outer?.response)?.data) ?? asRecord(outer?.data) ?? outer
+}
+
+/** Feishu/Lark returns stable business codes inside the SDK's HTTP error payload.
+ * Classify only documented authorization/configuration failures; rate limits,
+ * malformed requests, and transient network failures must not produce a misleading
+ * permission card. */
+function feishuPermissionIssueFrom(err: unknown): FeishuPermissionIssue | null {
+  const body = feishuErrorBody(err)
+  const candidate = body?.code ?? asRecord(body?.error)?.code
+  const code = typeof candidate === 'number' ? candidate : Number(candidate)
+  if (code === 99991672 || code === 230027) return 'app-permissions'
+  if (code === 230006 || code === 232025) return 'bot-capability'
+  if (code === 230013 || code === 232034) return 'app-availability'
+  if (code === 230002 || code === 230035) return 'chat-access'
+  return null
+}
+
+function feishuErrorCode(err: unknown): number | undefined {
+  const body = feishuErrorBody(err)
+  const candidate = body?.code ?? asRecord(body?.error)?.code
+  const code = typeof candidate === 'number' ? candidate : Number(candidate)
+  return Number.isFinite(code) ? code : undefined
+}
+
+const FEISHU_PERMISSION_NOTICE: Record<
+  FeishuPermissionIssue,
+  { hint: string; description: string; buttonLabel: string }
+> = {
+  'app-permissions': {
+    hint: 'add the required API permissions, publish a new app version, and complete approval if required',
+    description:
+      'Add the required API permissions, publish a new app version, and complete administrator approval if required.',
+    buttonLabel: 'Update permissions'
+  },
+  'bot-capability': {
+    hint: 'enable the Bot capability and publish a new app version',
+    description: 'Enable the Bot capability, then publish a new app version.',
+    buttonLabel: 'Review app settings'
+  },
+  'app-availability': {
+    hint: 'update the app availability, publish a new version, and verify tenant administrator settings',
+    description: "Update the app's availability, publish a new version, and verify the tenant administrator settings.",
+    buttonLabel: 'Review app settings'
+  },
+  'chat-access': {
+    hint: 'add the bot to the chat or restore its posting permission',
+    description: 'Add the bot to this chat or restore its posting permission, then try again.',
+    buttonLabel: 'Review app settings'
+  }
+}
 
 /** The `sourceUrl` separator normalize.ts encodes the compound download key with. */
 const DOWNLOAD_KEY_SEP = ':'
@@ -262,6 +345,12 @@ export class FeishuConnection {
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (keeps a post-then-edit pair from racing on the same progress msg).
   private queue: SlackSendQueue
+  /** App-level permission failures repeat across streamed writes. Announce once per
+   * connection, with a bounded retry when the bot currently cannot send the card. */
+  private permissionIssue?: FeishuPermissionIssue
+  private permissionNoticeSent = false
+  private permissionNoticeInFlight = false
+  private permissionNoticeRetryAt = 0
   /** The appId this connection authenticated with (used to detect a swap). */
   readonly appId: string
   /** The gateway region this connection dialed (feishu.cn vs larksuite.com). Reconcile
@@ -301,6 +390,7 @@ export class FeishuConnection {
         if (info.openId) this.botOpenId = info.openId
         if (info.name) this.botName = info.name
       } catch (err) {
+        this.rememberPermissionIssue(err)
         log?.debug(`feishu: bot/info lookup failed: ${(err as Error).message}`)
       }
     }
@@ -387,6 +477,78 @@ export class FeishuConnection {
       : this.handle.api.createText(channel, text)
   }
 
+  private sendPermissionCard(
+    channel: string,
+    anchor: string | undefined,
+    card: Record<string, unknown>
+  ): Promise<{ messageId?: string }> {
+    return anchor && anchor.startsWith('om_')
+      ? this.handle.api.replyCard(anchor, card)
+      : this.handle.api.createCard(channel, card)
+  }
+
+  private rememberPermissionIssue(err: unknown): boolean {
+    const issue = feishuPermissionIssueFrom(err)
+    if (!issue) return false
+    const changed = this.permissionIssue !== issue
+    this.permissionIssue = issue
+    if (changed) {
+      const code = feishuErrorCode(err)
+      this.deps.log?.warn(
+        `feishu: bot permission update required${code === undefined ? '' : ` (code ${code})`}; ` +
+          FEISHU_PERMISSION_NOTICE[issue].hint
+      )
+    }
+    return true
+  }
+
+  private permissionUpdateUrl(issue: FeishuPermissionIssue): string | undefined {
+    if (!/^cli_[A-Za-z0-9]+$/.test(this.appId)) return undefined
+    const host = this.region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
+    const appRoot = `${host}/app/${encodeURIComponent(this.appId)}`
+    if (issue !== 'app-permissions') return appRoot
+    const params = new URLSearchParams({
+      q: 'im:message,im:message:send_as_bot,im:resource,im:chat',
+      op_from: 'openapi',
+      token_type: 'tenant'
+    })
+    return `${appRoot}/auth?${params.toString()}`
+  }
+
+  /** Post one static permission card. Claim before the first await so concurrent
+   * progress/reply failures cannot race into duplicate cards. A failed attempt is
+   * retried only after a cooldown because missing send/chat access also blocks the
+   * warning itself. */
+  private async postPermissionUpdateCard(channel: string, anchor?: string): Promise<void> {
+    const issue = this.permissionIssue
+    if (
+      !issue ||
+      this.permissionNoticeSent ||
+      this.permissionNoticeInFlight ||
+      Date.now() < this.permissionNoticeRetryAt
+    )
+      return
+    const updateUrl = this.permissionUpdateUrl(issue)
+    if (!updateUrl) return
+
+    this.permissionNoticeInFlight = true
+    const notice = FEISHU_PERMISSION_NOTICE[issue]
+    try {
+      await this.sendPermissionCard(
+        channel,
+        anchor,
+        buildPermissionUpdateCard(updateUrl, notice.description, notice.buttonLabel)
+      )
+      this.permissionNoticeSent = true
+    } catch (err) {
+      this.rememberPermissionIssue(err)
+      this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+      this.deps.log?.debug(`feishu: permission update card failed (ch=${channel}): ${(err as Error).message}`)
+    } finally {
+      this.permissionNoticeInFlight = false
+    }
+  }
+
   /**
    * Post a message. `channel` is the chat_id; `threadAnchor` is the session thread root —
    * a message id (`om_…`) for a group turn, so the reply lands in the topic thread rooted
@@ -398,11 +560,13 @@ export class FeishuConnection {
       let firstId: string | undefined
       for (const chunk of chunkForFeishu(text)) {
         const res = await this.sendChunk(channel, threadAnchor, chunk).catch((err: Error) => {
+          this.rememberPermissionIssue(err)
           this.deps.log?.debug(`feishu: send failed (ch=${channel}): ${err.message}`)
           return null
         })
         if (res && firstId === undefined) firstId = res.messageId
       }
+      await this.postPermissionUpdateCard(channel, threadAnchor)
       return firstId
     })
   }
@@ -417,8 +581,11 @@ export class FeishuConnection {
     return this.queue.enqueue(async () => {
       try {
         const res = await this.sendChunk(channel, opts.threadTs, chunkForFeishu(text)[0] ?? '')
+        await this.postPermissionUpdateCard(channel, opts.threadTs)
         return res.messageId
       } catch (err) {
+        this.rememberPermissionIssue(err)
+        await this.postPermissionUpdateCard(channel, opts.threadTs)
         this.deps.log?.debug(`feishu: send (chrome) failed (ch=${channel}): ${(err as Error).message}`)
         return undefined
       }
@@ -427,17 +594,20 @@ export class FeishuConnection {
 
   /**
    * Edit a previously-posted message in place (im.message.patch, text). `channel` is
-   * accepted for parity (Feishu edits by message_id only). Best-effort: a patch failure
-   * degrades harmlessly (the streamed progress just doesn't refresh). Only the first
-   * chunk is shown (progress messages are short).
+   * used only as the fallback target for a permission notice (Feishu edits by
+   * message_id). Best-effort: a patch failure degrades harmlessly (the streamed
+   * progress just doesn't refresh). Only the first chunk is shown (progress messages
+   * are short).
    */
-  async updateMessage(_channel: string, messageId: string, text: string, _opts: object = {}): Promise<void> {
+  async updateMessage(channel: string, messageId: string, text: string, _opts: object = {}): Promise<void> {
     await this.queue.enqueue(async () => {
       try {
         await this.handle.api.patchText(messageId, chunkForFeishu(text)[0] ?? '')
       } catch (err) {
+        this.rememberPermissionIssue(err)
         this.deps.log?.debug(`feishu: patch failed (id=${messageId}): ${(err as Error).message}`)
       }
+      await this.postPermissionUpdateCard(channel)
     })
   }
 
@@ -476,6 +646,7 @@ export class FeishuConnection {
       }
       return buf
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.debug(`feishu: downloadFile failed: ${(err as Error).message}`)
       return null
     } finally {
@@ -496,6 +667,7 @@ export class FeishuConnection {
         isPrivate: false
       }
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.debug(`feishu: getChat failed (ch=${channel}): ${(err as Error).message}`)
       return { id: channel }
     }
@@ -505,6 +677,7 @@ export class FeishuConnection {
     try {
       return await this.handle.api.listChatMembers(channel, MEMBER_CAP)
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.debug(`feishu: listMembers failed (ch=${channel}): ${(err as Error).message}`)
       return []
     }
@@ -518,6 +691,7 @@ export class FeishuConnection {
         isPrivate: false
       }))
     } catch (err) {
+      this.rememberPermissionIssue(err)
       this.deps.log?.debug(`feishu: listChannels failed: ${(err as Error).message}`)
       return []
     }
@@ -526,7 +700,8 @@ export class FeishuConnection {
   async getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }> {
     try {
       return await this.handle.api.getUser(user)
-    } catch {
+    } catch (err) {
+      this.rememberPermissionIssue(err)
       return { id: user }
     }
   }

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -262,7 +262,7 @@ const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 type FeishuPermissionIssue = 'app-permissions' | 'bot-capability' | 'app-availability' | 'chat-access'
 
 type UnknownRecord = Record<string, unknown>
-type FeishuPermissionState = { issue: FeishuPermissionIssue; scopes: string[]; channel?: string }
+type FeishuPermissionState = { issue: FeishuPermissionIssue; scopes: string[] }
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === 'object' ? (value as UnknownRecord) : undefined
@@ -394,11 +394,13 @@ export class FeishuConnection {
   private queue: SlackSendQueue
   /** App-level permission failures repeat across streamed writes. Announce once per
    * connection, with a bounded retry when the bot currently cannot send the card. */
-  private permissionIssue?: FeishuPermissionState
+  private globalPermissionIssues = new Set<Exclude<FeishuPermissionIssue, 'chat-access'>>()
+  private permissionScopes = new Set<string>()
+  private permissionIssueChannels = new Set<string>()
   private loggedPermissionIssues = new Set<string>()
   private permissionNoticeSent = false
   private permissionNoticeInFlight = false
-  private permissionNoticeRetryAt = 0
+  private permissionNoticeRetryAt = new Map<string, number>()
   /** The appId this connection authenticated with (used to detect a swap). */
   readonly appId: string
   /** The gateway region this connection dialed (feishu.cn vs larksuite.com). Reconcile
@@ -550,18 +552,41 @@ export class FeishuConnection {
     }
     // Chat access is target-specific. Without a concrete chat there is nowhere
     // accurate to display "add the bot to this chat", so keep only the diagnostic log.
-    if (issue === 'chat-access' && !channel) return true
-
-    const next: FeishuPermissionState = { issue, scopes, ...(issue === 'chat-access' ? { channel } : {}) }
-    if (
-      this.permissionIssue?.issue !== next.issue ||
-      this.permissionIssue.scopes.join(',') !== next.scopes.join(',') ||
-      this.permissionIssue.channel !== next.channel
-    ) {
-      this.permissionNoticeRetryAt = 0
+    if (issue === 'chat-access') {
+      if (channel && !this.permissionIssueChannels.has(channel)) {
+        this.permissionIssueChannels.add(channel)
+        this.permissionNoticeRetryAt.delete(`channel:${channel}`)
+      }
+      return true
     }
-    this.permissionIssue = next
+
+    const wasNewIssue = !this.globalPermissionIssues.has(issue)
+    this.globalPermissionIssues.add(issue)
+    const oldScopeCount = this.permissionScopes.size
+    for (const scope of scopes) this.permissionScopes.add(scope)
+    if (wasNewIssue || this.permissionScopes.size !== oldScopeCount) {
+      for (const key of this.permissionNoticeRetryAt.keys()) {
+        if (key.startsWith('global:')) this.permissionNoticeRetryAt.delete(key)
+      }
+    }
     return true
+  }
+
+  private pendingGlobalPermission(): FeishuPermissionState | undefined {
+    if (this.globalPermissionIssues.has('app-permissions')) {
+      return { issue: 'app-permissions', scopes: [...this.permissionScopes] }
+    }
+    if (this.globalPermissionIssues.has('bot-capability')) return { issue: 'bot-capability', scopes: [] }
+    if (this.globalPermissionIssues.has('app-availability')) return { issue: 'app-availability', scopes: [] }
+    return undefined
+  }
+
+  private pendingPermission(channel: string): { permission: FeishuPermissionState; key: string } | undefined {
+    const global = this.pendingGlobalPermission()
+    if (global) return { permission: global, key: `global:${channel}` }
+    return this.permissionIssueChannels.has(channel)
+      ? { permission: { issue: 'chat-access', scopes: [] }, key: `channel:${channel}` }
+      : undefined
   }
 
   private permissionUpdateUrl({ issue, scopes }: FeishuPermissionState): string | undefined {
@@ -582,20 +607,19 @@ export class FeishuConnection {
    * retried only after a cooldown because missing send/chat access also blocks the
    * warning itself. */
   private async postPermissionUpdateCard(channel: string, anchor?: string): Promise<void> {
-    const permission = this.permissionIssue
+    const pending = this.pendingPermission(channel)
     if (
-      !permission ||
-      (permission.channel !== undefined && permission.channel !== channel) ||
+      !pending ||
       this.permissionNoticeSent ||
       this.permissionNoticeInFlight ||
-      Date.now() < this.permissionNoticeRetryAt
+      Date.now() < (this.permissionNoticeRetryAt.get(pending.key) ?? 0)
     )
       return
-    const updateUrl = this.permissionUpdateUrl(permission)
+    const updateUrl = this.permissionUpdateUrl(pending.permission)
     if (!updateUrl) return
 
     this.permissionNoticeInFlight = true
-    const notice = FEISHU_PERMISSION_NOTICE[permission.issue]
+    const notice = FEISHU_PERMISSION_NOTICE[pending.permission.issue]
     try {
       await this.sendPermissionCard(
         channel,
@@ -605,7 +629,10 @@ export class FeishuConnection {
       this.permissionNoticeSent = true
     } catch (err) {
       this.rememberPermissionIssue(err, channel)
-      this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
+      this.permissionNoticeRetryAt.set(
+        this.pendingPermission(channel)?.key ?? pending.key,
+        Date.now() + PERMISSION_NOTICE_RETRY_MS
+      )
       this.deps.log?.debug(`feishu: permission update card failed (ch=${channel}): ${(err as Error).message}`)
     } finally {
       this.permissionNoticeInFlight = false

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -262,7 +262,7 @@ const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 type FeishuPermissionIssue = 'app-permissions' | 'bot-capability' | 'app-availability' | 'chat-access'
 
 type UnknownRecord = Record<string, unknown>
-type FeishuPermissionState = { issue: FeishuPermissionIssue; scopes: string[] }
+type FeishuPermissionState = { issue: FeishuPermissionIssue; scopes: string[]; channel?: string }
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === 'object' ? (value as UnknownRecord) : undefined
@@ -395,6 +395,7 @@ export class FeishuConnection {
   /** App-level permission failures repeat across streamed writes. Announce once per
    * connection, with a bounded retry when the bot currently cannot send the card. */
   private permissionIssue?: FeishuPermissionState
+  private loggedPermissionIssues = new Set<string>()
   private permissionNoticeSent = false
   private permissionNoticeInFlight = false
   private permissionNoticeRetryAt = 0
@@ -534,19 +535,32 @@ export class FeishuConnection {
       : this.handle.api.createCard(channel, card)
   }
 
-  private rememberPermissionIssue(err: unknown): boolean {
+  private rememberPermissionIssue(err: unknown, channel?: string): boolean {
     const issue = feishuPermissionIssueFrom(err)
     if (!issue) return false
     const scopes = issue === 'app-permissions' ? feishuRequiredScopes(err, this.appId, this.region) : []
-    const changed = this.permissionIssue?.issue !== issue || this.permissionIssue.scopes.join(',') !== scopes.join(',')
-    this.permissionIssue = { issue, scopes }
-    if (changed) {
+    const logKey = `${issue}:${scopes.join(',')}`
+    if (!this.loggedPermissionIssues.has(logKey)) {
+      this.loggedPermissionIssues.add(logKey)
       const code = feishuErrorCode(err)
       this.deps.log?.warn(
         `feishu: bot permission update required${code === undefined ? '' : ` (code ${code})`}; ` +
           FEISHU_PERMISSION_NOTICE[issue].hint
       )
     }
+    // Chat access is target-specific. Without a concrete chat there is nowhere
+    // accurate to display "add the bot to this chat", so keep only the diagnostic log.
+    if (issue === 'chat-access' && !channel) return true
+
+    const next: FeishuPermissionState = { issue, scopes, ...(issue === 'chat-access' ? { channel } : {}) }
+    if (
+      this.permissionIssue?.issue !== next.issue ||
+      this.permissionIssue.scopes.join(',') !== next.scopes.join(',') ||
+      this.permissionIssue.channel !== next.channel
+    ) {
+      this.permissionNoticeRetryAt = 0
+    }
+    this.permissionIssue = next
     return true
   }
 
@@ -571,6 +585,7 @@ export class FeishuConnection {
     const permission = this.permissionIssue
     if (
       !permission ||
+      (permission.channel !== undefined && permission.channel !== channel) ||
       this.permissionNoticeSent ||
       this.permissionNoticeInFlight ||
       Date.now() < this.permissionNoticeRetryAt
@@ -589,7 +604,7 @@ export class FeishuConnection {
       )
       this.permissionNoticeSent = true
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channel)
       this.permissionNoticeRetryAt = Date.now() + PERMISSION_NOTICE_RETRY_MS
       this.deps.log?.debug(`feishu: permission update card failed (ch=${channel}): ${(err as Error).message}`)
     } finally {
@@ -608,7 +623,7 @@ export class FeishuConnection {
       let firstId: string | undefined
       for (const chunk of chunkForFeishu(text)) {
         const res = await this.sendChunk(channel, threadAnchor, chunk).catch((err: Error) => {
-          this.rememberPermissionIssue(err)
+          this.rememberPermissionIssue(err, channel)
           this.deps.log?.debug(`feishu: send failed (ch=${channel}): ${err.message}`)
           return null
         })
@@ -632,7 +647,7 @@ export class FeishuConnection {
         await this.postPermissionUpdateCard(channel, opts.threadTs)
         return res.messageId
       } catch (err) {
-        this.rememberPermissionIssue(err)
+        this.rememberPermissionIssue(err, channel)
         await this.postPermissionUpdateCard(channel, opts.threadTs)
         this.deps.log?.debug(`feishu: send (chrome) failed (ch=${channel}): ${(err as Error).message}`)
         return undefined
@@ -652,7 +667,7 @@ export class FeishuConnection {
       try {
         await this.handle.api.patchText(messageId, chunkForFeishu(text)[0] ?? '')
       } catch (err) {
-        this.rememberPermissionIssue(err)
+        this.rememberPermissionIssue(err, channel)
         this.deps.log?.debug(`feishu: patch failed (id=${messageId}): ${(err as Error).message}`)
       }
       await this.postPermissionUpdateCard(channel)
@@ -715,7 +730,7 @@ export class FeishuConnection {
         isPrivate: false
       }
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channel)
       this.deps.log?.debug(`feishu: getChat failed (ch=${channel}): ${(err as Error).message}`)
       return { id: channel }
     }
@@ -725,7 +740,7 @@ export class FeishuConnection {
     try {
       return await this.handle.api.listChatMembers(channel, MEMBER_CAP)
     } catch (err) {
-      this.rememberPermissionIssue(err)
+      this.rememberPermissionIssue(err, channel)
       this.deps.log?.debug(`feishu: listMembers failed (ch=${channel}): ${(err as Error).message}`)
       return []
     }

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -396,6 +396,7 @@ export class FeishuConnection {
    * connection, with a bounded retry when the bot currently cannot send the card. */
   private globalPermissionIssues = new Set<Exclude<FeishuPermissionIssue, 'chat-access'>>()
   private permissionScopes = new Set<string>()
+  private globalPermissionRevision = 0
   private permissionIssueChannels = new Set<string>()
   private loggedPermissionIssues = new Set<string>()
   private permissionNoticeSent = false
@@ -565,6 +566,7 @@ export class FeishuConnection {
     const oldScopeCount = this.permissionScopes.size
     for (const scope of scopes) this.permissionScopes.add(scope)
     if (wasNewIssue || this.permissionScopes.size !== oldScopeCount) {
+      this.globalPermissionRevision += 1
       this.permissionNoticeRetryAt.delete('global')
     }
     return true
@@ -616,6 +618,7 @@ export class FeishuConnection {
     const updateUrl = this.permissionUpdateUrl(pending.permission)
     if (!updateUrl) return
 
+    const globalPermissionRevision = this.globalPermissionRevision
     this.permissionNoticeInFlight = true
     const notice = FEISHU_PERMISSION_NOTICE[pending.permission.issue]
     try {
@@ -624,7 +627,7 @@ export class FeishuConnection {
         anchor,
         buildPermissionUpdateCard(updateUrl, notice.description, notice.buttonLabel)
       )
-      this.permissionNoticeSent = true
+      if (this.globalPermissionRevision === globalPermissionRevision) this.permissionNoticeSent = true
     } catch (err) {
       this.rememberPermissionIssue(err, channel)
       this.permissionNoticeRetryAt.set(

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -7,13 +7,15 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
  * DiscordAction). The daemon's applyAction resolves these against a live
  * FeishuConnection.
  *
- * FORMATTING: Feishu v1 is TEXT-ONLY. A text message (`msg_type:'text'`) has no
- * HTML/MarkdownV2 parse mode and no interactive cards or buttons — markup renders
- * literally — so BOTH the agent's reply (`post`) and daemon "chrome" (progress /
- * reasoning / plan / tool-output) are emitted as PLAIN text with no escaping and no
- * parse_mode (unlike Telegram's HTML). The only hard constraint is a per-message
- * length cap, so long output is chunked (see chunkForFeishu). Fenced code blocks
- * (```) are kept for tool output — they render harmlessly as literal fences.
+ * FORMATTING: ordinary Feishu v1 output is TEXT-ONLY. A text message
+ * (`msg_type:'text'`) has no HTML/MarkdownV2 parse mode — markup renders literally —
+ * so BOTH the agent's reply (`post`) and daemon "chrome" (progress / reasoning / plan /
+ * tool-output) are emitted as PLAIN text with no escaping and no parse_mode (unlike
+ * Telegram's HTML). The only card is the static platform-permission notice built below;
+ * it has an open-URL button and does not enter this action model. The text-message hard
+ * constraint is a per-message length cap, so long output is chunked (see
+ * chunkForFeishu). Fenced code blocks (```) are kept for tool output — they render
+ * harmlessly as literal fences.
  *
  * Kinds mirror TelegramAction/DiscordAction so the daemon's dispatch stays parallel:
  *  - `post`        the agent's reply (recorded into the transcript).
@@ -26,10 +28,10 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
  *  - `tool-output` a finished tool's output as a fenced code block (high only), not recorded.
  *
  * There is deliberately NO per-turn `status-bar` action (unlike Slack/Discord):
- * Feishu v1 has no interactive cards, so session state and controls are exposed on
- * demand via typed /commands instead (`/status`, `/stop`, `/cancel`, `/fast` — see
- * commands/commands.ts + daemon.handleCommand). The `/status` reply reuses
- * {@link renderStatusReply}.
+ * Feishu v1 has no interactive session controls, so session state and controls are
+ * exposed on demand via typed /commands instead (`/status`, `/stop`, `/cancel`,
+ * `/fast` — see commands/commands.ts + daemon.handleCommand). The `/status` reply
+ * reuses {@link renderStatusReply}.
  */
 export type FeishuAction =
   // `recordOnly: true` writes to the transcript without sending — minimal mode keeps the
@@ -48,6 +50,41 @@ export type FeishuAction =
 /** Feishu single-text-message chunk cap. Feishu's real limit is generous; we chunk
  *  to a safe cap like Telegram (4096) / Discord (2000). */
 export const FEISHU_MESSAGE_LIMIT = 4000
+
+/** Static JSON 2.0 card used only for platform permission/configuration failures.
+ * The button opens app settings directly, so no card callback or public endpoint is
+ * required. Ordinary agent output remains plain text. */
+export function buildPermissionUpdateCard(
+  updateUrl: string,
+  description: string,
+  buttonLabel = 'Update permissions'
+): Record<string, unknown> {
+  return {
+    schema: '2.0',
+    config: { update_multi: true },
+    body: {
+      direction: 'vertical',
+      padding: '12px 12px 12px 12px',
+      elements: [
+        { tag: 'markdown', content: description },
+        {
+          tag: 'button',
+          text: { tag: 'plain_text', content: buttonLabel },
+          type: 'primary',
+          width: 'default',
+          size: 'medium',
+          behaviors: [{ type: 'open_url', default_url: updateUrl }],
+          margin: '8px 0px 0px 0px'
+        }
+      ]
+    },
+    header: {
+      title: { tag: 'plain_text', content: '⚠️ Permissions update required' },
+      template: 'orange',
+      padding: '12px 12px 12px 12px'
+    }
+  }
+}
 
 const MAX_LABEL = 100
 const MAX_REASONING = 2800

--- a/packages/daemon/test/discord-permission-notice.test.ts
+++ b/packages/daemon/test/discord-permission-notice.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DiscordConnection } from '../src/discord/connection.js'
+
+function connectionWith(channel: unknown): DiscordConnection {
+  const conn = new DiscordConnection({
+    group: { botToken: 'token', integrations: [] },
+    onMessage: () => {},
+    newTraceId: () => 'trace',
+    sendIntervalMs: 0
+  })
+  conn.botUserId = '123456789012345678'
+  ;(conn as unknown as { client: unknown }).client = {
+    application: null,
+    channels: { fetch: vi.fn(async () => channel) }
+  }
+  return conn
+}
+
+describe('Discord permission update notice', () => {
+  it('posts one OAuth permission card after concurrent missing-permission failures', async () => {
+    const missingPermission = Object.assign(new Error('Missing Permissions'), { code: 50013 })
+    const startThread = vi.fn(async () => {
+      throw missingPermission
+    })
+    let resolveNotice!: (message: { id: string }) => void
+    const send = vi.fn(
+      (_payload: unknown) =>
+        new Promise<{ id: string }>((resolve) => {
+          resolveNotice = resolve
+        })
+    )
+    const channel = {
+      send,
+      messages: { fetch: vi.fn(async () => ({ startThread })) }
+    }
+    const conn = connectionWith(channel)
+
+    const first = conn.createThread('channel-1', 'message-1', 'First')
+    await vi.waitFor(() => expect(send).toHaveBeenCalledOnce())
+    const second = conn.createThread('channel-1', 'message-2', 'Second')
+    await vi.waitFor(() => expect(startThread).toHaveBeenCalledTimes(2))
+    expect(send).toHaveBeenCalledOnce()
+
+    const payload = send.mock.calls[0]![0] as {
+      content: string
+      components: { components: { url?: string; label: string; style: number }[] }[]
+    }
+    expect(payload.content).toContain('⚠️ **Permissions update required.**')
+    expect(payload.content).toContain("channel's permission overrides")
+    const button = payload.components[0]!.components[0]!
+    expect(button).toEqual(expect.objectContaining({ label: 'Update permissions', style: 5 }))
+    const url = new URL(button.url!)
+    expect(url.origin).toBe('https://discord.com')
+    expect(url.pathname).toBe('/oauth2/authorize')
+    expect(url.searchParams.get('client_id')).toBe('123456789012345678')
+    expect(url.searchParams.get('scope')).toBe('bot applications.commands')
+    expect(url.searchParams.get('permissions')).toBe('292057893952')
+
+    resolveNotice({ id: 'notice-1' })
+    await Promise.all([first, second])
+  })
+
+  it('does not label unrelated Discord API failures as permission problems', async () => {
+    const startThread = vi.fn(async () => {
+      throw Object.assign(new Error('Thread is archived'), { code: 50083 })
+    })
+    const send = vi.fn(async (_payload: unknown) => ({ id: 'unexpected' }))
+    const conn = connectionWith({
+      send,
+      messages: { fetch: vi.fn(async () => ({ startThread })) }
+    })
+
+    await expect(conn.createThread('channel-1', 'message-1', 'Archived')).resolves.toBeUndefined()
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/discord-permission-notice.test.ts
+++ b/packages/daemon/test/discord-permission-notice.test.ts
@@ -99,9 +99,45 @@ describe('Discord permission update notice', () => {
 
     await conn.createThread('A', 'message-1', 'Thread')
     expect(sendA).toHaveBeenCalledOnce()
-    ;(conn as unknown as { permissionNoticeRetryAt: number }).permissionNoticeRetryAt = 0
+    ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
 
     await conn.sendChatAction('B')
     expect(sendB).not.toHaveBeenCalled()
+  })
+
+  it('preserves a global OAuth repair when a channel-specific notice fails', async () => {
+    const missingScope = Object.assign(new Error('Missing required OAuth2 scope'), { code: 50026 })
+    const missingPermission = Object.assign(new Error('Missing Permissions'), { code: 50013 })
+    const sendA = vi.fn(async () => {
+      throw missingPermission
+    })
+    const sendB = vi.fn(async () => ({ id: 'notice-B' }))
+    const conn = connectionWith((id) =>
+      id === 'A'
+        ? {
+            send: sendA,
+            messages: {
+              fetch: vi.fn(async () => ({
+                startThread: async () => {
+                  throw missingPermission
+                }
+              }))
+            }
+          }
+        : { send: sendB, sendTyping: vi.fn(async () => {}) }
+    )
+    ;(
+      conn as unknown as {
+        rememberPermissionIssue: (err: unknown, channel?: string) => boolean
+      }
+    ).rememberPermissionIssue(missingScope)
+
+    await conn.createThread('A', 'message-1', 'Thread')
+    expect(sendA).toHaveBeenCalledOnce()
+    ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
+
+    await conn.sendChatAction('B')
+    expect(sendB).toHaveBeenCalledOnce()
+    expect((sendB.mock.calls[0]![0] as { content: string }).content).toContain('Permissions update required')
   })
 })

--- a/packages/daemon/test/discord-permission-notice.test.ts
+++ b/packages/daemon/test/discord-permission-notice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DiscordConnection } from '../src/discord/connection.js'
 
-function connectionWith(channel: unknown): DiscordConnection {
+function connectionWith(channel: unknown | ((id: string) => unknown | Promise<unknown>)): DiscordConnection {
   const conn = new DiscordConnection({
     group: { botToken: 'token', integrations: [] },
     onMessage: () => {},
@@ -11,7 +11,9 @@ function connectionWith(channel: unknown): DiscordConnection {
   conn.botUserId = '123456789012345678'
   ;(conn as unknown as { client: unknown }).client = {
     application: null,
-    channels: { fetch: vi.fn(async () => channel) }
+    channels: {
+      fetch: vi.fn(async (id: string) => (typeof channel === 'function' ? await channel(id) : channel))
+    }
   }
   return conn
 }
@@ -72,5 +74,34 @@ describe('Discord permission update notice', () => {
 
     await expect(conn.createThread('channel-1', 'message-1', 'Archived')).resolves.toBeUndefined()
     expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not deliver a failed channel-specific notice in another channel', async () => {
+    const missingPermission = Object.assign(new Error('Missing Permissions'), { code: 50013 })
+    const sendA = vi.fn(async () => {
+      throw missingPermission
+    })
+    const sendB = vi.fn(async () => ({ id: 'unexpected-notice' }))
+    const conn = connectionWith((id) =>
+      id === 'A'
+        ? {
+            send: sendA,
+            messages: {
+              fetch: vi.fn(async () => ({
+                startThread: async () => {
+                  throw missingPermission
+                }
+              }))
+            }
+          }
+        : { send: sendB, sendTyping: vi.fn(async () => {}) }
+    )
+
+    await conn.createThread('A', 'message-1', 'Thread')
+    expect(sendA).toHaveBeenCalledOnce()
+    ;(conn as unknown as { permissionNoticeRetryAt: number }).permissionNoticeRetryAt = 0
+
+    await conn.sendChatAction('B')
+    expect(sendB).not.toHaveBeenCalled()
   })
 })

--- a/packages/daemon/test/discord-permission-notice.test.ts
+++ b/packages/daemon/test/discord-permission-notice.test.ts
@@ -105,7 +105,7 @@ describe('Discord permission update notice', () => {
     expect(sendB).not.toHaveBeenCalled()
   })
 
-  it('preserves a global OAuth repair when a channel-specific notice fails', async () => {
+  it('rate-limits a global OAuth repair across channels without losing it', async () => {
     const missingScope = Object.assign(new Error('Missing required OAuth2 scope'), { code: 50026 })
     const missingPermission = Object.assign(new Error('Missing Permissions'), { code: 50013 })
     const sendA = vi.fn(async () => {
@@ -134,6 +134,10 @@ describe('Discord permission update notice', () => {
 
     await conn.createThread('A', 'message-1', 'Thread')
     expect(sendA).toHaveBeenCalledOnce()
+
+    await conn.sendChatAction('B')
+    expect(sendB).not.toHaveBeenCalled()
+
     ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
 
     await conn.sendChatAction('B')

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -109,6 +109,24 @@ describe('Feishu/Lark permission update notice', () => {
     expect(url.searchParams.get('q')).not.toContain('im:message')
   })
 
+  it('does not deliver a failed chat-specific card in another chat', async () => {
+    const chatAccessError = permissionError(230002)
+    const { conn, createCard } = connectionFor('feishu', async () => {
+      throw chatAccessError
+    })
+    createCard.mockImplementation(async (chatId) => {
+      if (chatId === 'A') throw chatAccessError
+      return { messageId: 'unexpected-notice' }
+    })
+
+    await conn.updateMessage('A', 'om_progress', 'first')
+    expect(createCard.mock.calls.map(([chatId]) => chatId)).toEqual(['A'])
+    ;(conn as unknown as { permissionNoticeRetryAt: number }).permissionNoticeRetryAt = 0
+
+    await conn.postMessage('B', 'healthy')
+    expect(createCard.mock.calls.map(([chatId]) => chatId)).toEqual(['A'])
+  })
+
   it('does not post a permission card for an unrelated request error', async () => {
     const { conn, createCard } = connectionFor('lark', async () => {
       throw permissionError(230001)

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FeishuConnection, type ConsolidatedFeishuGroup, type FeishuClientHandle } from '../src/feishu/connection.js'
+
+function permissionError(code = 99991672): Error {
+  return Object.assign(new Error('Request failed with status code 400'), {
+    response: { data: { code, msg: 'Access denied. Required scopes are missing.' } }
+  })
+}
+
+function connectionFor(region: 'feishu' | 'lark', patchText: () => Promise<void>) {
+  const createCard = vi.fn(async (_chatId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-1' }))
+  const replyCard = vi.fn(async (_messageId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-2' }))
+  const handle: FeishuClientHandle = {
+    api: {
+      createText: async () => ({}),
+      createCard,
+      replyText: async () => ({}),
+      replyCard,
+      patchText,
+      downloadResource: async () => {},
+      getChat: async (id) => ({ id }),
+      listChatMembers: async () => [],
+      listChats: async () => [],
+      getUser: async (id) => ({ id }),
+      getBotInfo: async () => ({})
+    },
+    startWs: async () => {},
+    close: () => {}
+  }
+  const group: ConsolidatedFeishuGroup = {
+    appId: 'cli_permissiontest',
+    appSecret: 'secret',
+    region,
+    integrations: []
+  }
+  const conn = new FeishuConnection(
+    { group, onMessage: () => {}, newTraceId: () => 'trace', sendIntervalMs: 0 },
+    () => handle
+  )
+  return { conn, createCard, replyCard }
+}
+
+describe('Feishu/Lark permission update notice', () => {
+  it.each([
+    ['feishu', 'https://open.feishu.cn'],
+    ['lark', 'https://open.larksuite.com']
+  ] as const)('posts one region-specific app-permission card for %s', async (region, origin) => {
+    const patchText = vi.fn(async () => {
+      throw permissionError()
+    })
+    const { conn, createCard, replyCard } = connectionFor(region, patchText)
+
+    await conn.updateMessage('oc_chat', 'om_progress', 'first')
+    await conn.updateMessage('oc_chat', 'om_progress', 'second')
+
+    expect(patchText).toHaveBeenCalledTimes(2)
+    expect(createCard).toHaveBeenCalledOnce()
+    expect(replyCard).not.toHaveBeenCalled()
+    const [chatId, card] = createCard.mock.calls[0]!
+    expect(chatId).toBe('oc_chat')
+    const c = card as {
+      header: { title: { content: string } }
+      body: { elements: { tag: string; content?: string; behaviors?: { default_url: string }[] }[] }
+    }
+    expect(c.header.title.content).toBe('⚠️ Permissions update required')
+    expect(c.body.elements[0]?.content).toContain('publish a new app version')
+    const url = new URL(c.body.elements[1]!.behaviors![0]!.default_url)
+    expect(url.origin).toBe(origin)
+    expect(url.pathname).toBe('/app/cli_permissiontest/auth')
+    expect(url.searchParams.get('q')).toBe('im:message,im:message:send_as_bot,im:resource,im:chat')
+    expect(url.searchParams.get('op_from')).toBe('openapi')
+    expect(url.searchParams.get('token_type')).toBe('tenant')
+  })
+
+  it('does not post a permission card for an unrelated request error', async () => {
+    const { conn, createCard } = connectionFor('lark', async () => {
+      throw permissionError(230001)
+    })
+
+    await conn.updateMessage('oc_chat', 'om_progress', 'text')
+    expect(createCard).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -144,9 +144,13 @@ describe('Feishu/Lark permission update notice', () => {
     await conn.getUserProfile('ou_user')
     await conn.postMessage('A', 'blocked')
     expect(createCard).toHaveBeenCalledOnce()
+
+    await conn.postMessage('B', 'still cooling down')
+    expect(createCard).toHaveBeenCalledOnce()
+
     ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
 
-    await conn.postMessage('B', 'repaired')
+    await conn.postMessage('C', 'repaired')
     expect(createCard).toHaveBeenCalledTimes(2)
     const card = createCard.mock.calls[1]![1] as {
       body: { elements: { behaviors?: { default_url: string }[] }[] }

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -159,6 +159,42 @@ describe('Feishu/Lark permission update notice', () => {
     expect(url.searchParams.get('q')).toBe(`${contactScope},${sendScope}`)
   })
 
+  it('keeps scopes learned while a permission card is in flight', async () => {
+    const contactScope = 'contact:contact.base:readonly'
+    const sendScope = 'im:message:send_as_bot'
+    let profileCall = 0
+    let resolveFirstCard!: (value: { messageId: string }) => void
+    const { conn, createCard } = connectionFor(
+      'feishu',
+      async () => {},
+      async () => {
+        profileCall += 1
+        throw permissionError(99991672, [profileCall === 1 ? contactScope : sendScope])
+      }
+    )
+    createCard.mockImplementationOnce(
+      async () =>
+        await new Promise<{ messageId: string }>((resolve) => {
+          resolveFirstCard = resolve
+        })
+    )
+
+    await conn.getUserProfile('ou_contact')
+    const firstPost = conn.postMessage('A', 'first')
+    await vi.waitFor(() => expect(createCard).toHaveBeenCalledOnce())
+    await conn.getUserProfile('ou_message')
+    resolveFirstCard({ messageId: 'notice-1' })
+    await firstPost
+
+    await conn.postMessage('B', 'follow-up')
+    expect(createCard).toHaveBeenCalledTimes(2)
+    const card = createCard.mock.calls[1]![1] as {
+      body: { elements: { behaviors?: { default_url: string }[] }[] }
+    }
+    const url = new URL(card.body.elements[1]!.behaviors![0]!.default_url)
+    expect(url.searchParams.get('q')).toBe(`${contactScope},${sendScope}`)
+  })
+
   it('does not post a permission card for an unrelated request error', async () => {
     const { conn, createCard } = connectionFor('lark', async () => {
       throw permissionError(230001)

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -23,11 +23,12 @@ function connectionFor(
   patchText: () => Promise<void>,
   getUser: (id: string) => Promise<{ id: string }> = async (id) => ({ id })
 ) {
+  const createText = vi.fn(async (_chatId: string, _text: string) => ({}))
   const createCard = vi.fn(async (_chatId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-1' }))
   const replyCard = vi.fn(async (_messageId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-2' }))
   const handle: FeishuClientHandle = {
     api: {
-      createText: async () => ({}),
+      createText,
       createCard,
       replyText: async () => ({}),
       replyCard,
@@ -52,7 +53,7 @@ function connectionFor(
     { group, onMessage: () => {}, newTraceId: () => 'trace', sendIntervalMs: 0 },
     () => handle
   )
-  return { conn, createCard, replyCard }
+  return { conn, createText, createCard, replyCard }
 }
 
 describe('Feishu/Lark permission update notice', () => {
@@ -121,10 +122,37 @@ describe('Feishu/Lark permission update notice', () => {
 
     await conn.updateMessage('A', 'om_progress', 'first')
     expect(createCard.mock.calls.map(([chatId]) => chatId)).toEqual(['A'])
-    ;(conn as unknown as { permissionNoticeRetryAt: number }).permissionNoticeRetryAt = 0
+    ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
 
     await conn.postMessage('B', 'healthy')
     expect(createCard.mock.calls.map(([chatId]) => chatId)).toEqual(['A'])
+  })
+
+  it('merges application scopes until a permission card succeeds', async () => {
+    const contactScope = 'contact:contact.base:readonly'
+    const sendScope = 'im:message:send_as_bot'
+    const { conn, createText, createCard } = connectionFor(
+      'lark',
+      async () => {},
+      async () => {
+        throw permissionError(99991672, [contactScope])
+      }
+    )
+    createText.mockRejectedValueOnce(permissionError(99991672, [sendScope]))
+    createCard.mockRejectedValueOnce(permissionError(99991672, [sendScope]))
+
+    await conn.getUserProfile('ou_user')
+    await conn.postMessage('A', 'blocked')
+    expect(createCard).toHaveBeenCalledOnce()
+    ;(conn as unknown as { permissionNoticeRetryAt: Map<string, number> }).permissionNoticeRetryAt.clear()
+
+    await conn.postMessage('B', 'repaired')
+    expect(createCard).toHaveBeenCalledTimes(2)
+    const card = createCard.mock.calls[1]![1] as {
+      body: { elements: { behaviors?: { default_url: string }[] }[] }
+    }
+    const url = new URL(card.body.elements[1]!.behaviors![0]!.default_url)
+    expect(url.searchParams.get('q')).toBe(`${contactScope},${sendScope}`)
   })
 
   it('does not post a permission card for an unrelated request error', async () => {

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -1,13 +1,28 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FeishuConnection, type ConsolidatedFeishuGroup, type FeishuClientHandle } from '../src/feishu/connection.js'
 
-function permissionError(code = 99991672): Error {
+function permissionError(
+  code = 99991672,
+  scopes = ['im:message', 'im:message:send_as_bot', 'im:resource', 'im:chat']
+): Error {
   return Object.assign(new Error('Request failed with status code 400'), {
-    response: { data: { code, msg: 'Access denied. Required scopes are missing.' } }
+    response: {
+      data: {
+        code,
+        msg: 'Access denied. Required scopes are missing.',
+        error: {
+          permission_violations: scopes.map((subject) => ({ type: 'action_scope_required', subject }))
+        }
+      }
+    }
   })
 }
 
-function connectionFor(region: 'feishu' | 'lark', patchText: () => Promise<void>) {
+function connectionFor(
+  region: 'feishu' | 'lark',
+  patchText: () => Promise<void>,
+  getUser: (id: string) => Promise<{ id: string }> = async (id) => ({ id })
+) {
   const createCard = vi.fn(async (_chatId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-1' }))
   const replyCard = vi.fn(async (_messageId: string, _card: Record<string, unknown>) => ({ messageId: 'notice-2' }))
   const handle: FeishuClientHandle = {
@@ -21,7 +36,7 @@ function connectionFor(region: 'feishu' | 'lark', patchText: () => Promise<void>
       getChat: async (id) => ({ id }),
       listChatMembers: async () => [],
       listChats: async () => [],
-      getUser: async (id) => ({ id }),
+      getUser,
       getBotInfo: async () => ({})
     },
     startWs: async () => {},
@@ -70,6 +85,28 @@ describe('Feishu/Lark permission update notice', () => {
     expect(url.searchParams.get('q')).toBe('im:message,im:message:send_as_bot,im:resource,im:chat')
     expect(url.searchParams.get('op_from')).toBe('openapi')
     expect(url.searchParams.get('token_type')).toBe('tenant')
+  })
+
+  it('uses the platform-reported contact scopes for a profile permission failure', async () => {
+    const contactScopes = ['contact:contact.base:readonly', 'contact:contact:readonly_as_app']
+    const { conn, createCard } = connectionFor(
+      'feishu',
+      async () => {},
+      async () => {
+        throw permissionError(99991672, contactScopes)
+      }
+    )
+
+    await conn.getUserProfile('ou_user')
+    await conn.postMessage('oc_chat', 'reply')
+
+    expect(createCard).toHaveBeenCalledOnce()
+    const card = createCard.mock.calls[0]![1] as {
+      body: { elements: { behaviors?: { default_url: string }[] }[] }
+    }
+    const url = new URL(card.body.elements[1]!.behaviors![0]!.default_url)
+    expect(url.searchParams.get('q')).toBe(contactScopes.join(','))
+    expect(url.searchParams.get('q')).not.toContain('im:message')
   })
 
   it('does not post a permission card for an unrelated request error', async () => {

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -26,7 +26,9 @@ function fakeFeishuConn(appId: string, region: 'feishu' | 'lark', botOpenId: str
   const handle: FeishuClientHandle = {
     api: {
       createText: async () => ({}),
+      createCard: async () => ({}),
       replyText: async () => ({}),
+      replyCard: async () => ({}),
       patchText: async () => {},
       downloadResource: async () => {},
       getChat: async (id: string) => ({ id }),

--- a/packages/daemon/test/feishu-region.test.ts
+++ b/packages/daemon/test/feishu-region.test.ts
@@ -26,7 +26,9 @@ function feishuAgent(id: string, appId: string, region: FeishuRegion): Agent {
 function fakeHandle(): FeishuClientHandle {
   const api = {
     createText: async () => ({}),
+    createCard: async () => ({}),
     replyText: async () => ({}),
+    replyCard: async () => ({}),
     patchText: async () => {},
     downloadResource: async () => {},
     getChat: async (id: string) => ({ id }),


### PR DESCRIPTION
## Summary

- detect exact Discord missing-access, missing-permission, and missing-OAuth-scope errors and post an in-chat reauthorization prompt
- detect documented Feishu/Lark permission and app-configuration errors, then post a region-correct interactive settings card
- deduplicate notices per bot connection and rate-limit failed notice attempts when the bot cannot send
- keep unrelated API failures on the existing best-effort path

## Validation

- `pnpm exec eslint` on all changed files
- `pnpm --filter @agentconnect.md/daemon typecheck`
- 14 focused Discord/Feishu tests
- GitHub Build, Check, Unit Test, and both Integration shards passed on the final head

Created by Codex . GPT-5.6 Sol