### PR TITLE
feat(control-plane): optional-email activation links (bound or one-time bearer)

### DIFF
--- a/packages/control-plane/prisma/migrations/20260727120000_activation_link_optional_email/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260727120000_activation_link_optional_email/migration.sql
@@ -1,0 +1,31 @@
+-- Activation-link redesign (waitlist-and-login.md §6) — make `waitlist_entry` carry
+-- BOTH kinds of activation link in one table, keyed by whether `email` is set:
+--   • email SET  → strong binding: only that verified email may redeem (unchanged);
+--   • email NULL → one-time BEARER link: any verified identity may redeem it once,
+--     and the redeemer's verified email is recorded in `redeemedEmail`.
+--
+-- Changes:
+--   1. `email` becomes NULLABLE. The existing UNIQUE index is kept as-is — Postgres
+--      treats NULLs as DISTINCT, so unlimited bearer rows (email NULL) coexist while
+--      real emails still cannot collide (self-signup upserts keep working).
+--   2. `name` — display name for the applicant/invitee, writable by the admin app.
+--   3. `redeemedEmail` — the redeemer's verified email; CP-only (audit for bearer links).
+
+ALTER TABLE "waitlist_entry" ALTER COLUMN "email" DROP NOT NULL;
+ALTER TABLE "waitlist_entry" ADD COLUMN "name" TEXT;
+ALTER TABLE "waitlist_entry" ADD COLUMN "redeemedEmail" TEXT;
+
+-- Extend the least-privilege admin-app role (see 20260723120100_waitlist_admin_grants):
+--   • `name` is grantable on INSERT and UPDATE (admin display metadata);
+--   • `email` stays INSERT-only (identity key, never updated by the admin app);
+--   • `redeemedEmail` is NOT granted — like the other redeemed* columns it is the
+--     CP's alone, so a compromised admin app still cannot forge a redemption.
+-- Guarded by a role-existence check so OSS / single-app deploys are a safe no-op.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'waitlist_admin') THEN
+    GRANT INSERT ("name") ON "waitlist_entry" TO "waitlist_admin";
+    GRANT UPDATE ("name") ON "waitlist_entry" TO "waitlist_admin";
+  END IF;
+END
+$$;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -182,12 +182,18 @@ model OrgInviteRedemption {
 
 // ───────────────────────────────────────────────────────────────────────────
 // WaitlistEntry — closed-beta admission
-//   One row per verified email. TWO write sides share this table (§7):
-//     • the EXTERNAL admin app writes approval/mint fields (status, note, source,
-//       tokenHash, displayTail, joinExpiresAt, revokedAt, approved*) — enforced by
-//       a column-level least-privilege DB role granted in the migration;
+//   One row per activation link. TWO write sides share this table (§7):
+//     • the EXTERNAL admin app writes approval/mint fields (name, email, status,
+//       note, source, tokenHash, displayTail, joinExpiresAt, revokedAt, approved*)
+//       — enforced by a column-level least-privilege DB role granted in the migration;
 //     • the CP writes ONLY the redemption fields (redeemed*), in the same
 //       transaction that sets User.activatedAt.
+//   `email` is OPTIONAL and drives the ONE redemption rule (§6): a row WITH an email
+//   may be redeemed ONLY by that verified email (strong binding); a row with NO email
+//   is a one-time BEARER link — any verified identity may redeem it once, and the
+//   redeemer's email is recorded in `redeemedEmail`. `email` stays `@unique` so real
+//   emails don't collide and self-signup upserts still work; Postgres treats NULLs as
+//   distinct, so any number of bearer rows (email null) coexist.
 //   The join link reuses OrgInviteLink's peppered-hash + tail + expiry/revoke
 //   shape, but the token is minted by the admin app and only VERIFIED (hashed &
 //   compared) by the CP on redeem. Minting/approval/admin-auth are out of this
@@ -202,7 +208,8 @@ enum WaitlistStatus {
 
 model WaitlistEntry {
   id     String         @id @default(cuid())
-  email  String         @unique // normalized lowercase, matching auth.ts
+  name   String? // display name for the applicant / invitee (admin- or intake-supplied)
+  email  String?        @unique // normalized lowercase (auth.ts); NULL ⇒ bearer link
   status WaitlistStatus @default(pending)
   note   String? // applicant message / admin note
   source String? // 'self' | 'admin' | …
@@ -218,6 +225,7 @@ model WaitlistEntry {
   approvedAt       DateTime? @db.Timestamptz(6)
   redeemedByUserId String? // written ONLY by the CP redeem path
   redeemedAt       DateTime? @db.Timestamptz(6) // written ONLY by the CP redeem path
+  redeemedEmail    String? // the redeemer's verified email; written ONLY by the CP redeem path
 
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)

--- a/packages/control-plane/src/http/routes/waitlist.ts
+++ b/packages/control-plane/src/http/routes/waitlist.ts
@@ -107,7 +107,7 @@ export function waitlistRoutes(deps: HttpDeps) {
           tags: [Tag.Profile],
           summary: 'Redeem a waitlist activation link',
           description:
-            'Redeem the join link minted for the signed-in user, making them a formal (activated) user with a personal org. The link’s email must match the caller’s verified email. Idempotent on repeat by the same user. Requires OIDC sign-in with a verified email.',
+            'Redeem an activation link, making the signed-in user a formal (activated) user with a personal org. A link minted for a specific email must be redeemed by that verified email; an email-less bearer link may be redeemed by any verified identity and binds to the first redeemer (one use). Idempotent on repeat by the same user. Requires OIDC sign-in with a verified email.',
           operationId: 'redeemWaitlistLink',
           body: WaitlistRedeemBody,
           response: {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2603,14 +2603,17 @@ export interface WaitlistRepo {
    * and an approved/pending one is not disturbed); returns the resulting status.
    * `note` is the applicant's self-submitted intake (opaque JSON string, written
    * only on the CREATE path) — context for the admin app, never the email source.
+   * `name` is the intake display name, mirrored into the `name` column on CREATE.
    */
-  addSelf(email: string, note?: string): Promise<WaitlistEntryStatus>
+  addSelf(email: string, note?: string, name?: string): Promise<WaitlistEntryStatus>
   /**
    * Redeem an admin-minted join link for a signed-in user (single transaction,
    * row-level `FOR UPDATE`, waitlist-and-login.md §6). On success sets
-   * `User.activatedAt`, creates the personal org, and stamps `redeemed*`. The
-   * `verifiedEmail` (already normalized) must equal the entry's email or the redeem
-   * fails `email_mismatch`. Idempotent: a repeat by the SAME user returns `activated`.
+   * `User.activatedAt`, creates the personal org, and stamps `redeemed*` (including
+   * `redeemedEmail`). Conditional email binding: a BOUND entry (email set) must match
+   * `verifiedEmail` (already normalized) or the redeem fails `email_mismatch`; a
+   * BEARER entry (email null) skips the match and any verified identity may redeem it
+   * once. Idempotent: a repeat by the SAME user returns `activated`.
    */
   redeem(tokenHash: string, userId: string, verifiedEmail: string, now: Date): Promise<WaitlistRedeemResult>
 }

--- a/packages/control-plane/src/persistence/repositories/waitlist.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/waitlist.repo.ts
@@ -80,12 +80,19 @@ export class PgWaitlistRepo implements WaitlistRepo {
       await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "waitlist_entry" WHERE "tokenHash" = ${tokenHash} FOR UPDATE`)
 
       const entry = await tx.waitlistEntry.findUnique({ where: { tokenHash } })
-      // Unknown / not-approved / revoked / expired → indistinguishable "invalid" to
-      // avoid leaking which condition failed.
-      if (!entry || entry.status !== 'approved' || entry.revokedAt) return { status: 'invalid' }
+      if (!entry) return { status: 'invalid' }
+      // Idempotency FIRST (§6): once THIS user has redeemed the link, a repeat always
+      // succeeds — even if the link was later revoked or expired. Their account is
+      // already activated, so a retry must not be punished. This must precede the
+      // approval/revoke/expiry gates below (a DIFFERENT user still fails there).
+      if (entry.redeemedByUserId === userId) return { status: 'activated' }
+
+      // From here the link is unredeemed or was taken by someone else. Unknown /
+      // not-approved / revoked / expired / already-taken all collapse to an
+      // indistinguishable "invalid" so we don't leak which condition failed.
+      if (entry.status !== 'approved' || entry.revokedAt) return { status: 'invalid' }
       if (entry.joinExpiresAt && entry.joinExpiresAt.getTime() < now.getTime()) return { status: 'invalid' }
-      // Already redeemed by a DIFFERENT user — every link is one-use/one-user.
-      if (entry.redeemedByUserId && entry.redeemedByUserId !== userId) return { status: 'invalid' }
+      if (entry.redeemedByUserId) return { status: 'invalid' } // redeemed by a DIFFERENT user
 
       // Conditional email binding (§6). A row WITH an email is bound: the signed-in
       // user's verified email must match the one the link was minted for (surfaced so
@@ -103,16 +110,15 @@ export class PgWaitlistRepo implements WaitlistRepo {
       if (!user) return { status: 'invalid' }
 
       // Activate (idempotent) + create the personal org (idempotent) + stamp the
-      // redemption. All within this locked transaction.
+      // redemption. All within this locked transaction. `redeemedByUserId` is null
+      // here (the same-user short-circuit and different-user reject are both above).
       if (!user.activatedAt) await tx.user.update({ where: { id: userId }, data: { activatedAt: now } })
       const realEmail = isSyntheticEmail(user.email) ? normalizedEmail : user.email
       await ensurePersonalOrg(tx, userId, user.displayName, realEmail)
-      if (!entry.redeemedByUserId) {
-        await tx.waitlistEntry.update({
-          where: { tokenHash },
-          data: { redeemedByUserId: userId, redeemedAt: now, redeemedEmail: normalizedEmail }
-        })
-      }
+      await tx.waitlistEntry.update({
+        where: { tokenHash },
+        data: { redeemedByUserId: userId, redeemedAt: now, redeemedEmail: normalizedEmail }
+      })
       return { status: 'activated' }
     })
   }

--- a/packages/control-plane/src/persistence/repositories/waitlist.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/waitlist.repo.ts
@@ -45,13 +45,19 @@ export class PgWaitlistRepo implements WaitlistRepo {
     return { activated: user.activatedAt != null, orgCount, email, entryStatus }
   }
 
-  async addSelf(email: string, note?: string): Promise<WaitlistEntryStatus> {
+  async addSelf(email: string, note?: string, name?: string): Promise<WaitlistEntryStatus> {
     const normalized = email.trim().toLowerCase()
     const existing = await this.db.waitlistEntry.findUnique({ where: { email: normalized }, select: { status: true } })
     if (existing) return existing.status // leave pending/approved/rejected untouched (§11)
     try {
       const created = await this.db.waitlistEntry.create({
-        data: { email: normalized, status: 'pending', source: 'self', ...(note ? { note } : {}) },
+        data: {
+          email: normalized,
+          status: 'pending',
+          source: 'self',
+          ...(note ? { note } : {}),
+          ...(name ? { name } : {})
+        },
         select: { status: true }
       })
       return created.status
@@ -78,13 +84,17 @@ export class PgWaitlistRepo implements WaitlistRepo {
       // avoid leaking which condition failed.
       if (!entry || entry.status !== 'approved' || entry.revokedAt) return { status: 'invalid' }
       if (entry.joinExpiresAt && entry.joinExpiresAt.getTime() < now.getTime()) return { status: 'invalid' }
-      // Already redeemed by a DIFFERENT user — the link is one-email/one-user.
+      // Already redeemed by a DIFFERENT user — every link is one-use/one-user.
       if (entry.redeemedByUserId && entry.redeemedByUserId !== userId) return { status: 'invalid' }
 
-      // Strong email binding: the signed-in user's verified email must match the
-      // email the link was minted for (§6 step 3). Surfaced so the UI can tell the
-      // user which account to sign in with.
-      if (entry.email !== normalizedEmail) return { status: 'email_mismatch', expectedEmail: entry.email }
+      // Conditional email binding (§6). A row WITH an email is bound: the signed-in
+      // user's verified email must match the one the link was minted for (surfaced so
+      // the UI can say which account to use). A BEARER row (email null) skips the
+      // check — any verified identity may redeem it once (the one-use guard above
+      // still applies); the redeemer's email is recorded below in `redeemedEmail`.
+      if (entry.email !== null && entry.email !== normalizedEmail) {
+        return { status: 'email_mismatch', expectedEmail: entry.email }
+      }
 
       const user = await tx.user.findUnique({
         where: { id: userId },
@@ -100,7 +110,7 @@ export class PgWaitlistRepo implements WaitlistRepo {
       if (!entry.redeemedByUserId) {
         await tx.waitlistEntry.update({
           where: { tokenHash },
-          data: { redeemedByUserId: userId, redeemedAt: now }
+          data: { redeemedByUserId: userId, redeemedAt: now, redeemedEmail: normalizedEmail }
         })
       }
       return { status: 'activated' }

--- a/packages/control-plane/src/registry/waitlistService.ts
+++ b/packages/control-plane/src/registry/waitlistService.ts
@@ -59,7 +59,7 @@ export class WaitlistService {
    *  edge and stored as a JSON note on the CREATE path — applicant context for the
    *  admin app; the email is never taken from it. */
   addSelf(email: string, intake: WaitlistIntake): Promise<WaitlistEntryStatus> {
-    return this.repo.addSelf(email, JSON.stringify(intake))
+    return this.repo.addSelf(email, JSON.stringify(intake), intake.name)
   }
 
   /** Redeem a join link for the signed-in user. A token failing codec validation

--- a/packages/control-plane/test/integration/waitlist.route.test.ts
+++ b/packages/control-plane/test/integration/waitlist.route.test.ts
@@ -341,6 +341,44 @@ describe('waitlist admission — POST /waitlist/redeem', () => {
     }
   })
 
+  it('same-user retry stays 200 even after the link later expires or is revoked (bound + bearer)', async () => {
+    const boundToken = await approveAndMint('wl-retry@acme.dev')
+    const { app, close } = buildApp()
+    try {
+      // ── bound link ──
+      const h = await headers('wl-retry', 'wl-retry@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: h })
+      const redeem = (token: string, hdrs: Record<string, string>) =>
+        app.inject({ method: 'POST', url: '/api/v1/waitlist/redeem', headers: hdrs, payload: { token } })
+
+      expect((await redeem(boundToken, h)).statusCode).toBe(200)
+      // Expiring the link AFTER redemption must not break the same user's retry.
+      await prisma.waitlistEntry.update({
+        where: { email: 'wl-retry@acme.dev' },
+        data: { joinExpiresAt: new Date(Date.now() - 1000) }
+      })
+      expect((await redeem(boundToken, h)).statusCode).toBe(200)
+      // Nor must a post-redemption revoke.
+      await prisma.waitlistEntry.update({ where: { email: 'wl-retry@acme.dev' }, data: { revokedAt: new Date() } })
+      expect((await redeem(boundToken, h)).statusCode).toBe(200)
+
+      // ── bearer link ──
+      const { token: bearerToken, tokenHash } = await mintOpenLink()
+      const hb = await headers('wl-retry-bearer', 'rb@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: hb })
+      expect((await redeem(bearerToken, hb)).statusCode).toBe(200)
+      await prisma.waitlistEntry.update({ where: { tokenHash }, data: { revokedAt: new Date() } })
+      expect((await redeem(bearerToken, hb)).statusCode).toBe(200) // same user, still ok
+
+      // A DIFFERENT user hitting the now-revoked bearer link is refused.
+      const other = await headers('wl-retry-other', 'other@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: other })
+      expect((await redeem(bearerToken, other)).statusCode).toBe(410)
+    } finally {
+      await close()
+    }
+  })
+
   it('refuses when the signed-in email differs from the link email', async () => {
     const token = await approveAndMint('wl-owner@acme.dev')
     const { app, close } = buildApp()

--- a/packages/control-plane/test/integration/waitlist.route.test.ts
+++ b/packages/control-plane/test/integration/waitlist.route.test.ts
@@ -90,6 +90,25 @@ async function approveAndMint(email: string, opts: { expiresInMs?: number; revok
   return minted.token
 }
 
+/** Simulate the admin app minting a BEARER link — an approved entry with NO email,
+ *  redeemable once by any verified identity. Returns the plaintext token + its hash
+ *  (the row has no email to look it up by). */
+async function mintOpenLink(opts: { expiresInMs?: number; revoked?: boolean } = {}) {
+  const minted = codec.mint()
+  const now = Date.now()
+  await prisma.waitlistEntry.create({
+    data: {
+      status: 'approved',
+      source: 'admin',
+      tokenHash: minted.hash,
+      displayTail: minted.displayTail,
+      joinExpiresAt: new Date(now + (opts.expiresInMs ?? 30 * 24 * 3600 * 1000)),
+      revokedAt: opts.revoked ? new Date(now - 1) : null
+    }
+  })
+  return { token: minted.token, tokenHash: minted.hash }
+}
+
 describe('waitlist admission — GET /me/access', () => {
   it('always reports active when waitlist mode is off', async () => {
     const { app, close } = buildHttpApp(prisma, { OIDC_ISSUER: oidcIssuer, OIDC_AUDIENCE })
@@ -258,6 +277,65 @@ describe('waitlist admission — POST /waitlist/redeem', () => {
       // Repeat redeem is idempotent.
       const again = await app.inject({ method: 'POST', url: '/api/v1/waitlist/redeem', headers: h, payload: { token } })
       expect(again.statusCode).toBe(200)
+    } finally {
+      await close()
+    }
+  })
+
+  it('a bearer link (no email) activates any verified identity and records the redeemer', async () => {
+    const { token, tokenHash } = await mintOpenLink()
+    const { app, close } = buildApp()
+    try {
+      // Any verified email — the link was minted with no email to bind.
+      const h = await headers('wl-bearer', 'whoever@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: h })
+
+      const redeem = await app.inject({
+        method: 'POST',
+        url: '/api/v1/waitlist/redeem',
+        headers: h,
+        payload: { token }
+      })
+      expect(redeem.statusCode).toBe(200)
+      expect(redeem.json()).toEqual({ activated: true })
+
+      const user = await prisma.user.findUnique({ where: { oidcSubject: 'wl-bearer' } })
+      expect(user!.activatedAt).not.toBeNull()
+      const entry = await prisma.waitlistEntry.findUnique({ where: { tokenHash } })
+      expect(entry!.email).toBeNull() // stays a bearer row
+      expect(entry!.redeemedByUserId).toBe(user!.id)
+      expect(entry!.redeemedEmail).toBe('whoever@acme.dev') // redeemer recorded for audit
+
+      // Idempotent for the SAME user.
+      const again = await app.inject({ method: 'POST', url: '/api/v1/waitlist/redeem', headers: h, payload: { token } })
+      expect(again.statusCode).toBe(200)
+    } finally {
+      await close()
+    }
+  })
+
+  it('a bearer link is one-use — a second, different user is refused', async () => {
+    const { token } = await mintOpenLink()
+    const { app, close } = buildApp()
+    try {
+      const first = await headers('wl-bearer-first', 'first@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: first })
+      expect(
+        (await app.inject({ method: 'POST', url: '/api/v1/waitlist/redeem', headers: first, payload: { token } }))
+          .statusCode
+      ).toBe(200)
+
+      // A different identity now finds the link already consumed → 410.
+      const second = await headers('wl-bearer-second', 'second@acme.dev')
+      await app.inject({ method: 'GET', url: '/api/v1/me/access', headers: second })
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/waitlist/redeem',
+        headers: second,
+        payload: { token }
+      })
+      expect(res.statusCode).toBe(410)
+      expect(res.json()).toMatchObject({ code: 'WAITLIST_LINK_UNAVAILABLE' })
     } finally {
       await close()
     }


### PR DESCRIPTION
## What

Make `waitlist_entry` carry **both kinds of activation link in one table**, keyed by whether `email` is set:

- **email SET** → strong binding: only that verified email may redeem it (unchanged behavior).
- **email NULL** → a one-time **bearer** link: any verified identity may redeem it once, and the redeemer's verified email is recorded in the new `redeemedEmail` column.

This replaces the abandoned two-table `activation_link` design (branch `feat/open-activation-link`, now deleted) with a smaller single-table shape.

## Changes

- **Migration** `20260727120000_activation_link_optional_email`: `email` becomes nullable (the existing `@unique` is kept — Postgres treats NULLs as distinct, so unlimited bearer rows coexist while real emails still can't collide and self-signup upserts keep working); adds `name` and `redeemedEmail`; extends the least-privilege `waitlist_admin` grants so the admin app may write `name` (INSERT+UPDATE) but never `redeemedEmail`.
- **Redeem**: the email match is now conditional — bound rows still require a match (`email_mismatch` → 403); bearer rows skip it. The one-use guard (`redeemedByUserId`) applies to every link. `redeemedEmail` is stamped on redeem.
- **`addSelf`** mirrors the intake `name` into the new column.

## Tests

- Existing bound-link + email-mismatch + revoked/expired tests unchanged and passing.
- New integration tests: a bearer link activates any verified identity + records the redeemer; a bearer link is one-use (second user → 410).
- `test:unit` green (651). Integration tests run in CI (Testcontainers Postgres — no Docker locally).

## Coordinated with

admin-server (extensions repo) PR that mints name + optional-email links and adds revoke — mirrors this schema/redeem contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)