### PR TITLE
fix(web): simplify Discord bot setup

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -158,10 +158,9 @@ const GUIDE: Record<
     tokenPlaceholder: '123456789:AAE…'
   },
   discord: {
-    linkHref: 'https://discord.com/developers/applications',
-    linkLabel: 'Open Developer Portal',
-    step1:
-      'Create an application, add a Bot, and enable the Message Content intent (Bot → Privileged Gateway Intents), then copy its token.',
+    linkHref: 'https://discord.com/developers/applications?new_application=true',
+    linkLabel: 'Create Discord app',
+    step1: 'Name and create the application. In Bot, reset and copy the token, then enable Message Content Intent.',
     tokenPlaceholder: 'Bot token from the Developer Portal'
   }
 }


### PR DESCRIPTION
## Summary

- open Discord's New Application dialog directly from integration setup
- remove the obsolete manual Add Bot instruction
- relabel the portal action as `Create Discord app`

## Why

The previous onboarding sent users to the generic application list and included an unnecessary manual Bot-creation step, making setup longer and more confusing.

## Validation

- `pnpm exec prettier --check packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm exec eslint packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm --filter @agentconnect.md/web typecheck`
- pre-push full-repository lint completed with no errors (two existing `import-x/no-duplicates` warnings remain in `packages/control-plane/src/http/routes/icon-upload.ts`)
- visually checked the Discord create flow at 1280x720 and 390x844

Created by Codex . GPT-5
