### PR TITLE
feat(sessions): stream live transcript updates

### DIFF
--- a/packages/control-plane/src/events/sink.ts
+++ b/packages/control-plane/src/events/sink.ts
@@ -1,24 +1,24 @@
 /**
  * `events/sink.ts` — the dashboard feed seam (design §2.3 `SessionEventSink`).
  *
- * The WS `event/session` handler `publish()`es converged session milestones
- * (NO bodies — metadata only); the C2 SSE route (`/stream`) `subscribe()`s and
- * relays them to the WebUI. An in-process pub/sub for the co-process MVP; the Go
- * split replaces the implementation behind this port (e.g. a broker) without
- * touching either edge.
+ * The WS handlers publish converged session milestones plus body-free transcript
+ * invalidations; the C2 SSE route (`/stream`) relays them to the WebUI. An
+ * in-process pub/sub for the co-process MVP; the Go split replaces the
+ * implementation behind this port (e.g. a broker) without touching either edge.
  */
-import type { EventSession } from '@agentconnect.md/protocol'
+import type { EventSession, SessionActivity } from '@agentconnect.md/protocol'
 import type { DaemonId } from '../domain/ids.js'
 
-/** A milestone as relayed to subscribers: the daemon that reported it + the event. */
-export interface SessionEventEnvelope {
-  daemonId: DaemonId
-  event: EventSession
-}
+/** A metadata event as relayed to subscribers, stamped with its reporting daemon. */
+export type SessionEventEnvelope =
+  | { daemonId: DaemonId; event: EventSession; activity?: never }
+  | { daemonId: DaemonId; activity: SessionActivity; event?: never }
 
 export interface SessionEventSink {
   /** Fan a converged milestone out to all current subscribers. */
   publish(daemonId: DaemonId, ev: EventSession): void
+  /** Fan a body-free transcript invalidation out to current subscribers. */
+  publishActivity(daemonId: DaemonId, activity: SessionActivity): void
   /** Subscribe; returns an unsubscribe fn. */
   subscribe(cb: (e: SessionEventEnvelope) => void): () => void
 }
@@ -29,6 +29,14 @@ export class InMemorySessionEventSink implements SessionEventSink {
 
   publish(daemonId: DaemonId, ev: EventSession): void {
     const envelope: SessionEventEnvelope = { daemonId, event: ev }
+    this.fanOut(envelope)
+  }
+
+  publishActivity(daemonId: DaemonId, activity: SessionActivity): void {
+    this.fanOut({ daemonId, activity })
+  }
+
+  private fanOut(envelope: SessionEventEnvelope): void {
     for (const cb of this.subscribers) {
       try {
         cb(envelope)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1955,7 +1955,9 @@ export const SessionMessageDto = z.object({
 export const SessionHistoryDto = z.object({
   sessionId: z.string(),
   messages: z.array(SessionMessageDto),
-  nextCursor: z.string().nullable()
+  nextCursor: z.string().nullable(),
+  liveCursor: z.string().nullable(),
+  liveMore: z.boolean()
 })
 
 /** `GET /sessions/:id/tool-body` query — one byte slice of a tool call's full ToolBody JSON. */

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -257,10 +257,19 @@ function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMeta
   }
 }
 
-const SessionHistoryQueryDto = z.object({
-  cursor: z.string().optional(),
-  limit: z.coerce.number().int().positive().max(200).optional()
-})
+const SessionHistoryQueryDto = z
+  .object({
+    cursor: z.string().optional(),
+    after: z
+      .string()
+      .regex(/^\d+$/)
+      .refine((value) => Number.isSafeInteger(Number(value)))
+      .optional(),
+    limit: z.coerce.number().int().positive().max(200).optional()
+  })
+  .refine(({ cursor, after }) => cursor === undefined || after === undefined, {
+    message: 'cursor and after are mutually exclusive'
+  })
 
 export function sessionRoutes(deps: HttpDeps) {
   return async function sessionRoutesPlugin(app: FastifyInstance): Promise<void> {
@@ -479,9 +488,16 @@ export function sessionRoutes(deps: HttpDeps) {
             agentId: session.agentId,
             sessionId: session.id,
             ...(req.query.cursor !== undefined ? { cursor: req.query.cursor } : {}),
+            ...(req.query.after !== undefined ? { after: req.query.after } : {}),
             limit: req.query.limit ?? 50
           })
-          return { sessionId: page.sessionId, messages: page.messages, nextCursor: page.nextCursor ?? null }
+          return {
+            sessionId: page.sessionId,
+            messages: page.messages,
+            nextCursor: page.nextCursor ?? null,
+            liveCursor: page.liveCursor ?? null,
+            liveMore: page.liveMore ?? false
+          }
         } catch (err) {
           if (err instanceof NoConnection) {
             return reply

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -1,9 +1,8 @@
 /**
  * `http/routes/stream.ts` (design §2.1) — `GET /orgs/:orgId/stream` Server-Sent
- * Events. The WebUI live feed: subscribes to the `SessionEventSink` and relays
- * each converged `event/session` milestone (metadata only) as an SSE `data:`
- * line — filtered to the PATH org's daemons, so one tenant never sees
- * another's session milestones.
+ * Events. The WebUI live feed relays converged session milestones and body-free
+ * transcript invalidations — filtered to the PATH org's daemons, so one tenant
+ * never sees another's session activity.
  *
  * SSE is written on the raw response (`reply.hijack()`), so this route opts out
  * of zod response serialization. The subscription is torn down when the client
@@ -26,8 +25,11 @@ export function canStreamAgent(agent: (Shareable & { orgId: OrgId }) | null, org
 }
 
 function writeEvent(reply: FastifyReply, envelope: SessionEventEnvelope): void {
-  const payload = JSON.stringify({ daemonId: envelope.daemonId, event: envelope.event })
-  reply.raw.write(`event: session\n`)
+  const activity = envelope.activity
+  const payload = JSON.stringify(
+    activity ? { daemonId: envelope.daemonId, activity } : { daemonId: envelope.daemonId, event: envelope.event }
+  )
+  reply.raw.write(`event: ${activity ? 'session-activity' : 'session'}\n`)
   reply.raw.write(`data: ${payload}\n\n`)
 }
 
@@ -40,7 +42,7 @@ export function streamRoutes(deps: HttpDeps) {
           tags: [Tag.Stream],
           summary: 'Live session event stream',
           description:
-            'Server-sent event feed relaying each converged session milestone (metadata only) for the org’s daemons.',
+            'Server-sent event feed relaying session milestones and body-free transcript activity for the org’s daemons.',
           operationId: 'streamSessionEvents'
         }
       },
@@ -88,7 +90,8 @@ export function streamRoutes(deps: HttpDeps) {
         const unsubscribe = deps.events.subscribe((envelope) => {
           void (async () => {
             if (!(await inOrg(envelope.daemonId))) return
-            if (!(await canSeeAgent(envelope.event.agentId))) return
+            const agentId = envelope.activity?.agentId ?? envelope.event?.agentId
+            if (!agentId || !(await canSeeAgent(agentId))) return
             writeEvent(reply, envelope)
           })()
         })

--- a/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-activity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import type { DaemonConnection } from '../connection.js'
+import type { DaemonWsDeps } from '../deps.js'
+import { handleSessionActivity } from './event-session-activity.js'
+
+const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+function activityFrame(): AnyFrame {
+  return {
+    v: 1,
+    id: crypto.randomUUID(),
+    ts: '2026-07-27T00:00:00.000Z',
+    type: 'event/session-activity',
+    payload: {
+      sessionId: 'session-407',
+      agentId: AGENT_ID,
+      revision: '12',
+      ts: '2026-07-27T00:00:00.000Z'
+    }
+  }
+}
+
+describe('handleSessionActivity', () => {
+  it('publishes only after verifying the agent is placed on the reporting daemon', async () => {
+    const publishActivity = vi.fn()
+    const release = vi.fn()
+    const deps = {
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
+      agentMutations: { tryBeginMutation: vi.fn(() => release) },
+      events: { publishActivity }
+    } as unknown as DaemonWsDeps
+    const frame = activityFrame()
+
+    await handleSessionActivity(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(publishActivity).toHaveBeenCalledWith(DAEMON_ID, frame.payload)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('drops activity from a daemon that does not own the agent', async () => {
+    const publishActivity = vi.fn()
+    const deps = {
+      agent: { get: vi.fn().mockResolvedValue({ daemonId: crypto.randomUUID() }) },
+      agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
+      events: { publishActivity }
+    } as unknown as DaemonWsDeps
+
+    await handleSessionActivity(activityFrame(), { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(publishActivity).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/ws/handlers/event-session-activity.ts
+++ b/packages/control-plane/src/ws/handlers/event-session-activity.ts
@@ -1,0 +1,17 @@
+/**
+ * Body-free transcript activity invalidation. The daemon remains the transcript
+ * authority; the CP only verifies placement and fans the cursor signal to SSE.
+ */
+import { isFrame } from '@agentconnect.md/protocol'
+import { AgentId, DaemonId } from '../../domain/ids.js'
+import type { Handler } from './index.js'
+import { runForReportingAgent } from './reporting-agent.js'
+
+export const handleSessionActivity: Handler = async (frame, conn, deps) => {
+  if (!isFrame('event/session-activity')(frame)) return
+  const agentId = AgentId(frame.payload.agentId)
+  const daemonId = DaemonId(conn.daemonId)
+  await runForReportingAgent(agentId, daemonId, deps, async () => {
+    deps.events.publishActivity(daemonId, frame.payload)
+  })
+}

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -28,6 +28,7 @@ import { handleCronReport } from './cron-report.js'
 import { handleHookReport } from './hook-report.js'
 import { handleChannelAgents } from './channel-agents.js'
 import { handleEventSession } from './event-session.js'
+import { handleSessionActivity } from './event-session-activity.js'
 import { handleGitCredRequest } from './gitcred.js'
 import { handleHookStart } from './hook-start.js'
 import { handleGithubReviewAuthorize } from './github-review-authorize.js'
@@ -55,6 +56,7 @@ export class FrameRouter {
       'github/review-result': handleGithubReviewResult,
       'channel/agents': handleChannelAgents,
       'event/session': handleEventSession,
+      'event/session-activity': handleSessionActivity,
       'gitcred/request': handleGitCredRequest,
       ...overrides
     }
@@ -82,5 +84,6 @@ export {
   handleGithubReviewAuthorize,
   handleGithubReviewResult,
   handleChannelAgents,
-  handleEventSession
+  handleEventSession,
+  handleSessionActivity
 }

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -10,7 +10,7 @@
  * Idempotent: re-sending `register` re-runs reconcile and yields the same
  * snapshot (CP wins all conflicts) — reconnect is convergence, not replay.
  */
-import { isFrame } from '@agentconnect.md/protocol'
+import { isFrame, SESSION_LIVE_TAIL_FEATURE } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
 
@@ -42,7 +42,7 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
     ...snap,
     relays,
     ...(gitCommitIdentity ? { gitCommitIdentity } : {}),
-    serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1']
+    serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1', SESSION_LIVE_TAIL_FEATURE]
   })
   deps.connReg.markReady(conn.daemonId, conn)
 

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -563,7 +563,9 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
             attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
           }
         ],
-        nextCursor: 'c-50'
+        nextCursor: 'c-50',
+        liveCursor: '77',
+        liveMore: true
       }
     )
     running = buildHttpApp(prisma, undefined, LIVE, spy as unknown as ControlSender)
@@ -576,12 +578,29 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
     const body = res.json() as {
       messages: Array<{ text: string; attachments?: Array<{ name: string }> }>
       nextCursor: string | null
+      liveCursor: string | null
+      liveMore: boolean
     }
     expect(body.messages[0]!.text).toBe('ship it')
     expect(body.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(body.nextCursor).toBe('c-50')
+    expect(body.liveCursor).toBe('77')
+    expect(body.liveMore).toBe(true)
     expect(spy.histCalls[0]!.daemonId).toBe(DAEMON)
     expect(spy.histCalls[0]!.req).toEqual({ agentId: AGENT, sessionId: SESSION, cursor: 'c-100', limit: 25 })
+
+    const tail = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${SESSION}/messages?after=77&limit=200`
+    })
+    expect(tail.statusCode).toBe(200)
+    expect(spy.histCalls[1]!.req).toEqual({ agentId: AGENT, sessionId: SESSION, after: '77', limit: 200 })
+
+    const conflicting = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions/${SESSION}/messages?cursor=older&after=77`
+    })
+    expect(conflicting.statusCode).toBe(400)
   })
 
   it('404s for an unknown session', async () => {

--- a/packages/control-plane/test/integration/stream.route.test.ts
+++ b/packages/control-plane/test/integration/stream.route.test.ts
@@ -3,11 +3,13 @@
  * connection. Exercise it over a real socket so pending Fastify headers (most
  * importantly the global CORS headers) cannot be lost at `writeHead` again.
  */
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { get, type ClientRequest, type IncomingMessage } from 'node:http'
+import { randomUUID } from 'node:crypto'
 
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { prisma } from '../setup.db.js'
 
 const ORIGIN = 'https://app.example.com'
@@ -39,6 +41,40 @@ describe('session event stream', () => {
       expect(response.headers['content-type']).toBe('text/event-stream')
       expect(response.headers['access-control-allow-origin']).toBe(ORIGIN)
       expect(response.headers.vary).toContain('Origin')
+    } finally {
+      await new Promise<void>((resolve) => {
+        if (response.destroyed) return resolve()
+        response.once('close', resolve)
+        response.destroy()
+        request.destroy()
+      })
+    }
+  })
+
+  it('relays a body-free session activity event for a visible agent', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const app = buildHttpApp(prisma)
+    opened.push(app)
+    const base = await app.app.listen({ port: 0, host: '127.0.0.1' })
+    const { request, response } = await openStream(`${base}/api/v1/orgs/${DEFAULT_ORG_ID}/stream`)
+    const chunks: string[] = []
+    response.setEncoding('utf8')
+    response.on('data', (chunk: string) => chunks.push(chunk))
+
+    try {
+      app.events.publishActivity(daemonId, {
+        sessionId: 'session-live',
+        agentId,
+        revision: '12',
+        ts: '2026-07-27T00:00:00.000Z'
+      })
+      await vi.waitFor(() => {
+        const body = chunks.join('')
+        expect(body).toContain('event: session-activity')
+        expect(body).toContain('"sessionId":"session-live"')
+        expect(body).not.toContain('"text"')
+      })
     } finally {
       await new Promise<void>((resolve) => {
         if (response.destroyed) return resolve()

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -12,6 +12,7 @@ import type {
   FactsMcpServer,
   UsageReport,
   EventSession,
+  SessionActivity,
   IntegrationChannels,
   CronReport,
   HookReport,
@@ -64,7 +65,13 @@ import type {
   DreamFileReadReq,
   DreamSkillReviewReq
 } from '@agentconnect.md/protocol'
-import { buildEnvelope, decodeEnvelope, encode, MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import {
+  buildEnvelope,
+  decodeEnvelope,
+  encode,
+  MAX_FRAME_BYTES,
+  SESSION_LIVE_TAIL_FEATURE
+} from '@agentconnect.md/protocol'
 import type { SessionReader } from './session-reader.js'
 import { WorkspaceConflictError, WorkspaceViolationError, type WorkspaceReader } from './workspace-reader.js'
 import {
@@ -382,6 +389,13 @@ export class CpClient {
   emitEventSession(event: EventSession): void {
     if (this.state !== 'READY' && this.state !== 'DRAINING') return
     this.transport?.send(encode(buildEnvelope('event/session', event)))
+  }
+
+  /** Signal a durable transcript mutation without putting message content on the control WS. */
+  emitSessionActivity(activity: SessionActivity): void {
+    if (this.state !== 'READY' && this.state !== 'DRAINING') return
+    if (!this.supportsServerFeature(SESSION_LIVE_TAIL_FEATURE)) return
+    this.transport?.send(encode(buildEnvelope('event/session-activity', activity)))
   }
 
   /**

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -231,6 +231,10 @@ export function createSessionReader(
     history(req) {
       const rec = sessionForRead(store, req.agentId, req.sessionId)
       if (!rec) return { sessionId: req.sessionId, messages: [] }
+      const tailing = req.after !== undefined
+      const afterRevision = tailing ? Number(req.after) : null
+      if (afterRevision !== null && (!Number.isSafeInteger(afterRevision) || afterRevision < 0))
+        throw new Error('invalid transcript revision')
       // Slack can append an older platform row during warm-thread backfill, so its
       // authoritative history pages by normalized event time + seq tie-breaker. A
       // plain numeric cursor came from a pre-upgrade daemon: finish that page walk in
@@ -243,11 +247,15 @@ export function createSessionReader(
       // Scope to what THIS agent's session received + produced, not the whole shared
       // (channel, thread) thread — an agent-called session only ever saw the message handed
       // to it (context isolation), so the view must not leak other participants' cross-talk.
-      const { rows, hasMore } = chronologicalSlack
-        ? store.transcriptPageForAgentByEventTime(rec.channel, rec.thread, rec.agentId, eventCursor, req.limit)
-        : store.transcriptPageForAgent(rec.channel, rec.thread, rec.agentId, legacyBefore, req.limit)
+      const page =
+        afterRevision !== null
+          ? store.transcriptTailForAgent(rec.channel, rec.thread, rec.agentId, afterRevision, req.limit)
+          : chronologicalSlack
+            ? store.transcriptPageForAgentByEventTime(rec.channel, rec.thread, rec.agentId, eventCursor, req.limit)
+            : store.transcriptPageForAgent(rec.channel, rec.thread, rec.agentId, legacyBefore, req.limit)
+      const { rows, hasMore } = page
       // rows are newest-first; the page itself is oldest→newest.
-      const ordered = rows.slice().reverse()
+      const ordered = tailing ? rows : rows.slice().reverse()
       // Display names (cached in the store) for both senders AND `<@U…>` mentions in
       // message bodies; agent-id senders and unresolved ids have no entry, so
       // `senderName` is omitted (UI falls back) and mentions stay as the raw token.
@@ -286,6 +294,41 @@ export function createSessionReader(
         }
         return base
       })
+      if (tailing) {
+        // A forward page must retain the EARLIEST unseen mutations so its cursor
+        // always makes progress without skipping an insert or same-seq update.
+        const kept: SessionMessage[] = []
+        let acc = 0
+        for (const message of built) {
+          const enc = encodedBytes(message) + 1
+          if (kept.length > 0 && acc + enc > REPLY_BUDGET) break
+          kept.push(message)
+          acc += enc
+        }
+        const droppedToBudget = kept.length < built.length
+        const liveMore = hasMore || droppedToBudget
+        const lastMutationRow = kept.length > 0 ? rows[kept.length - 1] : undefined
+        const liveCursor =
+          liveMore && lastMutationRow
+            ? lastMutationRow.revision
+            : (page as ReturnType<LocalStore['transcriptTailForAgent']>).cursor
+        // Mutation order and display order differ when a Slack warm-thread backfill
+        // inserts an older platform message. Return a chronological page while the
+        // revision cursor above remains anchored to mutation order.
+        const rowBySeq = new Map(rows.map((row) => [row.seq, row]))
+        kept.sort((a, b) => {
+          if (rec.platform !== 'slack') return a.seq - b.seq
+          const ar = rowBySeq.get(a.seq)
+          const br = rowBySeq.get(b.seq)
+          return (ar?.eventTimeUs ?? 0) - (br?.eventTimeUs ?? 0) || a.seq - b.seq
+        })
+        return {
+          sessionId: req.sessionId,
+          messages: kept,
+          liveCursor: String(liveCursor),
+          ...(liveMore ? { liveMore: true } : {})
+        }
+      }
       // Per-page frame budget: keep the NEWEST rows that fit, drop older overflow, and
       // page older via nextCursor = oldest KEPT seq. `built` is oldest→newest, so we
       // accumulate from the newest end. A single ≤ 32 KiB preview always fits ⇒ progress.
@@ -314,6 +357,7 @@ export function createSessionReader(
       return {
         sessionId: req.sessionId,
         messages: kept,
+        liveCursor: String(store.currentTranscriptRevision()),
         ...(hasOlder && oldestKept
           ? {
               nextCursor:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -16,7 +16,8 @@ import {
   type InboxRow,
   type OrchestrationRow,
   type SessionRecord,
-  type SubtaskRow
+  type SubtaskRow,
+  type TranscriptMutation
 } from './store/local-store.js'
 import { AcpHost, turnFailureCode, turnFailureReason, type AcpPermissionPolicyEvent } from './acp/acp-host.js'
 import { detectSandbox, SandboxError, type SandboxMechanism } from './acp/sandbox.js'
@@ -221,6 +222,7 @@ import type {
   DrainDone,
   SessionKey,
   EventSession,
+  SessionActivity,
   SessionListItem,
   AgentLaunch,
   AgentLaunched,
@@ -1403,6 +1405,7 @@ export class Daemon {
   // Durable hook/report outbox drain. A READY socket may survive a temporary
   // CP/DB failure, so retries cannot depend only on reconnect callbacks.
   private hookReportRetryTimer?: TimerHandle
+  private transcriptActivityTimers = new Map<string, { timer: TimerHandle; activity: SessionActivity }>()
   private readonly hookReportInflight = new Set<string>()
   // Fresh per READY connection. Legacy CPs have no correlated ACK, so the local
   // outbox stamps each best-effort EVT with this generation and sends it at
@@ -1716,6 +1719,7 @@ export class Daemon {
     })
 
     this.store = new LocalStore(statePath(root))
+    this.store.setTranscriptMutationListener((mutation) => this.scheduleSessionActivity(mutation))
     this.memoryOutbox = new MemoryCaptureOutbox(this.store, this.memoryConnections, {
       log: { warn: (message) => this.log.warn(message) }
     })
@@ -12474,6 +12478,35 @@ export class Daemon {
     return { ok: false, reason: 'unknown cron' }
   }
 
+  /** Coalesce hot transcript writes into body-free, per-session invalidations. */
+  private scheduleSessionActivity(mutation: TranscriptMutation): void {
+    const ts = new Date(this.clock.now()).toISOString()
+    for (const agentId of mutation.agentIds) {
+      for (const sessionId of this.store.sessionIdsForTranscript(agentId, mutation.channel, mutation.thread)) {
+        const key = `${agentId}\0${sessionId}`
+        const existing = this.transcriptActivityTimers.get(key)
+        if (existing) {
+          existing.activity.revision = String(mutation.revision)
+          existing.activity.ts = ts
+          continue
+        }
+        const activity: SessionActivity = {
+          sessionId,
+          agentId,
+          revision: String(mutation.revision),
+          ts
+        }
+        const timer = this.clock.setTimeout(() => {
+          const pending = this.transcriptActivityTimers.get(key)
+          if (!pending || pending.timer !== timer) return
+          this.transcriptActivityTimers.delete(key)
+          this.cpClient?.emitSessionActivity(pending.activity)
+        }, 250)
+        this.transcriptActivityTimers.set(key, { timer, activity })
+      }
+    }
+  }
+
   private startCpClient(root: string): void {
     const cp = this.cfg.controlPlane
     if (!cp?.enabled || !cp.url || !cp.key) {
@@ -13058,6 +13091,9 @@ export class Daemon {
     // §2.5: gate new turns and let in-flight ones finish (deadline-bounded) BEFORE
     // tearing the hosts down — a hard kill mid-turn loses the reply + transcript.
     await this.drainForShutdown()
+    this.store.setTranscriptMutationListener()
+    for (const { timer } of this.transcriptActivityTimers.values()) this.clock.clearTimeout(timer)
+    this.transcriptActivityTimers.clear()
     const errors: unknown[] = []
     this.scheduler?.stop()
     this.dreamScheduler?.stop()

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -176,6 +176,8 @@ export interface TranscriptEntry {
  *  `toolCallId`/`body` columns carry through raw (NULL on text/reasoning rows). */
 export interface TranscriptRow extends TranscriptEntry {
   seq: number
+  /** Monotonic mutation watermark; changes when a stable row is updated in place. */
+  revision: number
   /** Normalized epoch microseconds used by chronological Slack history pagination. */
   eventTimeUs: number
   toolCallId?: string | null
@@ -186,6 +188,13 @@ export interface TranscriptRow extends TranscriptEntry {
 export interface TranscriptEventCursor {
   eventTimeUs: number
   seq: number
+}
+
+export interface TranscriptMutation {
+  channel: string
+  thread: string
+  agentIds: string[]
+  revision: number
 }
 
 export function sessionKey(platform: string, channel: string, thread: string, agentId: string): string {
@@ -374,6 +383,8 @@ function restrictPath(path: string, mode: number): void {
 
 export class LocalStore {
   private db: DatabaseSync
+  private transcriptRevision = 0
+  private transcriptMutationListener?: (mutation: TranscriptMutation) => void
 
   constructor(dbPath: string) {
     // This database holds every platform message body, agent reply, tool payload and
@@ -431,7 +442,7 @@ export class LocalStore {
         channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT,
         sender TEXT NOT NULL, kind TEXT NOT NULL, text TEXT NOT NULL,
         tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER,
-        attachmentsJson TEXT
+        attachmentsJson TEXT, revision INTEGER NOT NULL DEFAULT 0
       );
       CREATE INDEX IF NOT EXISTS transcript_thread_seq ON transcript (channel, thread, seq);
       -- Dedup conversational rows by platform ts (double-fired inbound / redelivery);
@@ -641,6 +652,7 @@ export class LocalStore {
     this.migrateTranscriptAttachments()
     this.migrateTranscriptRecipient()
     this.migrateTranscriptEventTime()
+    this.migrateTranscriptRevision()
     this.migrateInboxHookContext()
     this.migrateRuntimeCatalogDefaultMode()
     // A daemon restart loses the in-memory ACP resolver. Retain the audit row but
@@ -693,6 +705,22 @@ export class LocalStore {
     this.db.exec(
       'CREATE INDEX IF NOT EXISTS transcript_thread_event_time ON transcript (channel, thread, eventTimeUs DESC, seq DESC)'
     )
+  }
+
+  /** Stable-row updates need a cursor independent of insertion-order `seq`. */
+  private migrateTranscriptRevision(): void {
+    const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
+    if (!cols.some((c) => c.name === 'revision'))
+      this.db.exec('ALTER TABLE transcript ADD COLUMN revision INTEGER NOT NULL DEFAULT 0')
+    this.db.exec(`
+      UPDATE transcript SET revision = seq WHERE revision = 0;
+      CREATE INDEX IF NOT EXISTS transcript_thread_revision
+        ON transcript (channel, thread, revision);
+    `)
+    const row = this.db.prepare('SELECT COALESCE(MAX(revision), 0) AS revision FROM transcript').get() as {
+      revision: number
+    }
+    this.transcriptRevision = row.revision
   }
 
   /** R1 hook turns must retain their trusted dispatch fence and the poster's
@@ -1024,6 +1052,26 @@ export class LocalStore {
       .get(agentId, acpSessionId) as SessionRecord | undefined
   }
 
+  /** Addressable session ids whose authorized transcript scope may have changed. */
+  sessionIdsForTranscript(agentId: string, channel: string, thread: string): string[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT DISTINCT acpSessionId FROM sessions
+           WHERE agentId = ? AND channel = ? AND thread = ? AND acpSessionId IS NOT NULL`
+        )
+        .all(agentId, channel, thread) as { acpSessionId: string }[]
+    ).map((row) => row.acpSessionId)
+  }
+
+  currentTranscriptRevision(): number {
+    return this.transcriptRevision
+  }
+
+  setTranscriptMutationListener(listener?: (mutation: TranscriptMutation) => void): void {
+    this.transcriptMutationListener = listener
+  }
+
   /**
    * One newest-first page of a thread's user-visible transcript, for `session/history`.
    * Daemon housekeeping is excluded at read time as well as write time so rows stored
@@ -1179,6 +1227,49 @@ export class LocalStore {
           )) as unknown as TranscriptRow[]
     const hasMore = rows.length > limit
     return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore }
+  }
+
+  /**
+   * Forward mutation page for one authorized session view. Rows are revision-ordered,
+   * so inserts and same-seq tool updates share one lossless cursor. The returned
+   * cursor skips unrelated/global revisions only after this scope is fully drained.
+   */
+  transcriptTailForAgent(
+    channel: string,
+    thread: string,
+    agentId: string,
+    afterRevision: number,
+    limit: number
+  ): { rows: TranscriptRow[]; hasMore: boolean; cursor: number } {
+    const scope = `(sender = ? OR recipient = ? OR (transcript.kind = 'text' AND EXISTS (
+        SELECT 1 FROM transcript_recipient tr
+        WHERE tr.channel = transcript.channel AND tr.thread = transcript.thread
+          AND tr.ts = transcript.ts AND tr.agentId = ?)))`
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM transcript
+         WHERE channel = ? AND thread = ? AND revision > ?
+           AND ${scope}
+           AND NOT (kind = 'tool' AND text IN (?, ?))
+         ORDER BY revision ASC LIMIT ?`
+      )
+      .all(
+        channel,
+        thread,
+        afterRevision,
+        agentId,
+        agentId,
+        agentId,
+        ...SESSION_TITLE_TOOL_TITLES,
+        limit + 1
+      ) as unknown as TranscriptRow[]
+    const hasMore = rows.length > limit
+    const kept = hasMore ? rows.slice(0, limit) : rows
+    return {
+      rows: kept,
+      hasMore,
+      cursor: hasMore ? kept[kept.length - 1]!.revision : this.transcriptRevision
+    }
   }
 
   upsertSession(rec: SessionRecord): void {
@@ -1681,26 +1772,42 @@ export class LocalStore {
 
   appendTranscript(e: TranscriptEntry): void {
     const { attachments, ...entry } = e
-    this.db
+    const revision = this.transcriptRevision + 1
+    const inserted = this.db
       .prepare(
         `INSERT OR IGNORE INTO transcript
-           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson)
+           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, revision)
          VALUES
-           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson)`
+           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @revision)`
       )
       .run({
         ...entry,
         recipient: e.recipient ?? null,
         eventTimeUs: transcriptEventTimeUs(e.ts),
-        attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null
+        attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
+        revision
       } as unknown as SqlParams)
+    if (Number(inserted.changes) === 1) this.transcriptRevision = revision
     // Record the delivery separately so it survives the text-row dedup above: if this same
     // (channel, thread, ts) was already recorded by another agent, the INSERT OR IGNORE
     // dropped this row and its `recipient`, but the message WAS delivered to this agent too.
-    if (e.recipient && e.ts)
+    const delivered =
+      e.recipient && e.ts
+        ? this.db
+            .prepare('INSERT OR IGNORE INTO transcript_recipient (channel, thread, ts, agentId) VALUES (?, ?, ?, ?)')
+            .run(e.channel, e.thread, e.ts, e.recipient)
+        : undefined
+
+    if (Number(inserted.changes) === 1) {
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], revision)
+    } else if (e.recipient && Number(delivered?.changes ?? 0) === 1) {
+      const deliveryRevision = this.transcriptRevision + 1
       this.db
-        .prepare('INSERT OR IGNORE INTO transcript_recipient (channel, thread, ts, agentId) VALUES (?, ?, ?, ?)')
-        .run(e.channel, e.thread, e.ts, e.recipient)
+        .prepare("UPDATE transcript SET revision = ? WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'")
+        .run(deliveryRevision, e.channel, e.thread, e.ts)
+      this.transcriptRevision = deliveryRevision
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.recipient], deliveryRevision)
+    }
   }
 
   /** First sight of a tool call: insert its kind='tool' row (title in `text`, the
@@ -1716,11 +1823,12 @@ export class LocalStore {
     title: string
     body: string
   }): void {
-    this.db
+    const revision = this.transcriptRevision + 1
+    const inserted = this.db
       .prepare(
         `INSERT OR IGNORE INTO transcript
-           (channel, thread, ts, sender, kind, text, tool_call_id, body, eventTimeUs)
-         VALUES (@channel, @thread, @ts, @sender, 'tool', @text, @toolCallId, @body, @eventTimeUs)`
+           (channel, thread, ts, sender, kind, text, tool_call_id, body, eventTimeUs, revision)
+         VALUES (@channel, @thread, @ts, @sender, 'tool', @text, @toolCallId, @body, @eventTimeUs, @revision)`
       )
       .run({
         channel: e.channel,
@@ -1730,8 +1838,13 @@ export class LocalStore {
         text: e.title,
         toolCallId: e.toolCallId,
         body: e.body,
-        eventTimeUs: transcriptEventTimeUs(e.ts)
+        eventTimeUs: transcriptEventTimeUs(e.ts),
+        revision
       })
+    if (Number(inserted.changes) === 1) {
+      this.transcriptRevision = revision
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender], revision)
+    }
   }
 
   /** Later update for one agent's tool call. `seq`/`ts` keep their first-seen
@@ -1743,11 +1856,33 @@ export class LocalStore {
     toolCallId: string,
     patch: { title: string; body: string }
   ): void {
-    this.db
+    const revision = this.transcriptRevision + 1
+    const updated = this.db
       .prepare(
-        'UPDATE transcript SET text = ?, body = ? WHERE channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?'
+        `UPDATE transcript SET text = ?, body = ?, revision = ?
+         WHERE channel = ? AND thread = ? AND sender = ? AND tool_call_id = ?
+           AND (text IS NOT ? OR body IS NOT ?)`
       )
-      .run(patch.title, patch.body, channel, thread, agentId, toolCallId)
+      .run(patch.title, patch.body, revision, channel, thread, agentId, toolCallId, patch.title, patch.body)
+    if (Number(updated.changes) === 1) {
+      this.transcriptRevision = revision
+      this.notifyTranscriptMutation(channel, thread, [agentId], revision)
+    }
+  }
+
+  private notifyTranscriptMutation(
+    channel: string,
+    thread: string,
+    candidates: Array<string | undefined>,
+    revision: number
+  ): void {
+    const agentIds = [...new Set(candidates.filter((candidate): candidate is string => !!candidate))]
+    if (agentIds.length === 0) return
+    try {
+      this.transcriptMutationListener?.({ channel, thread, agentIds, revision })
+    } catch {
+      // Live-view invalidation is best-effort and must never fail a durable write.
+    }
   }
 
   /** One agent's full stored ToolBody JSON, or undefined if unknown/not owned. */

--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildEnvelope, decodeEnvelope, MAX_FRAME_BYTES } from '@agentconnect.md/protocol'
+import { buildEnvelope, decodeEnvelope, MAX_FRAME_BYTES, SESSION_LIVE_TAIL_FEATURE } from '@agentconnect.md/protocol'
 import { CpClient, type CpClientDeps } from '../../src/cp/client.js'
 import { WorkspaceViolationError } from '../../src/cp/workspace-reader.js'
 import { FakeTransport } from './fake-transport.js'
@@ -150,6 +150,25 @@ describe('CpClient dispatch', () => {
     const { client } = await readyClient({}, ['hook-report-ack-v1', 'gitcred-actions-v1'])
     expect(client.supportsServerFeature('gitcred-actions-v1')).toBe(true)
     expect(client.supportsServerFeature('future-feature')).toBe(false)
+  })
+
+  it('emits body-free session activity only when the CP negotiated live tails', async () => {
+    const activity = {
+      sessionId: 'session-live',
+      agentId: CRON_AGENT_ID,
+      revision: '12',
+      ts: '2026-07-27T00:00:00.000Z'
+    }
+    const current = await readyClient({}, [SESSION_LIVE_TAIL_FEATURE])
+    current.client.emitSessionActivity(activity)
+    expect(JSON.parse(current.t.sent[0]!)).toMatchObject({
+      type: 'event/session-activity',
+      payload: activity
+    })
+
+    const legacy = await readyClient({}, [])
+    legacy.client.emitSessionActivity(activity)
+    expect(legacy.t.sent).toHaveLength(0)
   })
 
   it('keeps hook/report correlated until the CP durably ACKs it', async () => {

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -395,6 +395,93 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('tails inserts, same-seq tool updates, and newly visible shared deliveries', () => {
+    const s = store()
+    seedHistorySession(s)
+    const reader = createSessionReader(s)
+    const initial = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
+    expect(initial.liveCursor).toBe('0')
+
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: 'U1',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'first'
+    })
+    s.insertToolCall({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '2',
+      sender: AGENT,
+      toolCallId: 'tc-live',
+      title: 'Running',
+      body: JSON.stringify({ toolCallId: 'tc-live', status: 'in_progress' })
+    })
+
+    const inserted = reader.history({
+      agentId: AGENT,
+      sessionId: 'acp-1',
+      after: initial.liveCursor!,
+      limit: 50
+    })
+    expect(inserted.messages.map((message) => message.text)).toEqual(['first', 'Running'])
+    expect(inserted.liveCursor).toBe('2')
+
+    const toolSeq = inserted.messages[1]!.seq
+    s.updateToolCall('C1', 'T1', AGENT, 'tc-live', {
+      title: 'Complete',
+      body: JSON.stringify({ toolCallId: 'tc-live', status: 'completed' })
+    })
+    const updated = reader.history({
+      agentId: AGENT,
+      sessionId: 'acp-1',
+      after: inserted.liveCursor!,
+      limit: 50
+    })
+    expect(updated.messages).toEqual([
+      expect.objectContaining({ seq: toolSeq, text: 'Complete', toolStatus: 'completed' })
+    ])
+
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '3',
+      sender: OTHER_AGENT,
+      kind: 'reasoning',
+      text: 'peer-private'
+    })
+    const privateAdvance = reader.history({
+      agentId: AGENT,
+      sessionId: 'acp-1',
+      after: updated.liveCursor!,
+      limit: 50
+    })
+    expect(privateAdvance.messages).toEqual([])
+
+    for (const recipient of [OTHER_AGENT, AGENT]) {
+      s.appendTranscript({
+        channel: 'C1',
+        thread: 'T1',
+        ts: '4',
+        sender: 'U1',
+        recipient,
+        kind: 'text',
+        text: 'shared-later'
+      })
+    }
+    const shared = reader.history({
+      agentId: AGENT,
+      sessionId: 'acp-1',
+      after: privateAdvance.liveCursor!,
+      limit: 50
+    })
+    expect(shared.messages.map((message) => message.text)).toEqual(['shared-later'])
+    s.close()
+  })
+
   it('orders Slack history by event time when older thread rows are backfilled after the trigger', () => {
     const s = store()
     seedHistorySession(s)

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -733,6 +733,22 @@ describe('session read-back frames (console history pull)', () => {
     if (!legacyReq.ok || !isFrame('session/history')(legacyReq.frame))
       throw new Error('expected legacy session/history')
     expect(legacyReq.frame.payload.agentId).toBeUndefined()
+    const tailReq = decodeEnvelope(
+      envelope('session/history', { agentId: AGENT_ID, sessionId: SESSION_ID, after: '42' })
+    )
+    expect(tailReq.ok).toBe(true)
+    if (!tailReq.ok || !isFrame('session/history')(tailReq.frame)) throw new Error('expected tail request')
+    expect(tailReq.frame.payload.after).toBe('42')
+    expect(
+      decodeEnvelope(
+        envelope('session/history', {
+          agentId: AGENT_ID,
+          sessionId: SESSION_ID,
+          cursor: 'older',
+          after: '42'
+        })
+      ).ok
+    ).toBe(false)
 
     const page = decodeEnvelope(
       envelope('session/history/page', {
@@ -747,7 +763,9 @@ describe('session read-back frames (console history pull)', () => {
             attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: 'aW1hZ2U=' }]
           }
         ],
-        nextCursor: 'c-50'
+        nextCursor: 'c-50',
+        liveCursor: '42',
+        liveMore: true
       })
     )
     expect(page.ok).toBe(true)
@@ -755,6 +773,8 @@ describe('session read-back frames (console history pull)', () => {
     expect(page.frame.payload.messages[0]!.text).toBe('ship it')
     expect(page.frame.payload.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(page.frame.payload.nextCursor).toBe('c-50')
+    expect(page.frame.payload.liveCursor).toBe('42')
+    expect(page.frame.payload.liveMore).toBe(true)
   })
 
   it('session/history/page carries an enriched tool row (body + tool metadata)', () => {
@@ -1080,6 +1100,21 @@ describe('event/session sessionKey (session-metadata sync)', () => {
     expect(r.frame.payload.channelName).toBe('deploys')
     expect(r.frame.payload.triggeredByName).toBe('Dana Reyes')
     expect(r.frame.payload.threadUrl).toBe('https://slack.example/archives/C123/pT9')
+  })
+
+  it('accepts a metadata-only session activity cursor', () => {
+    const decoded = decodeEnvelope(
+      envelope('event/session-activity', {
+        sessionId: 'acp-sess-01H9',
+        agentId: AGENT_ID,
+        revision: '43',
+        ts: '2026-07-05T00:00:02.000Z'
+      })
+    )
+    expect(decoded.ok).toBe(true)
+    if (!decoded.ok || !isFrame('event/session-activity')(decoded.frame))
+      throw new Error('expected event/session-activity')
+    expect(decoded.frame.payload.revision).toBe('43')
   })
 })
 

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -14,6 +14,9 @@ export const CP_SUBPROTOCOL = 'agentconnect.v1'
 /** The CP mount path the daemon↔CP WebSocket connects to. */
 export const CP_WS_PATH = '/daemon/ws'
 
+/** CP accepts metadata-only transcript activity invalidations from current daemons. */
+export const SESSION_LIVE_TAIL_FEATURE = 'session-live-tail-v1'
+
 /**
  * Exit code a daemon uses for a PLANNED lifecycle exit (drain-then-exit on a
  * `daemon/restart` or `daemon/upgrade`, cli-daemon-split.md §6). It must be

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -98,6 +98,7 @@ import {
 import {
   Heartbeat,
   EventSession,
+  SessionActivity,
   UsageReport,
   FactsRuntimeProfile,
   DaemonRuntimes,
@@ -190,6 +191,7 @@ export const FRAME_SCHEMAS = {
   'scope-attestation': ScopeAttestation,
   // ── dashboard / facts ──
   'event/session': EventSession,
+  'event/session-activity': SessionActivity,
   'usage/report': UsageReport,
   'facts/runtime-profile': FactsRuntimeProfile,
   'facts/daemon-runtimes': DaemonRuntimes,
@@ -361,6 +363,7 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('secrets/revoke', FRAME_SCHEMAS['secrets/revoke']),
   frame('scope-attestation', FRAME_SCHEMAS['scope-attestation']),
   frame('event/session', FRAME_SCHEMAS['event/session']),
+  frame('event/session-activity', FRAME_SCHEMAS['event/session-activity']),
   frame('usage/report', FRAME_SCHEMAS['usage/report']),
   frame('facts/runtime-profile', FRAME_SCHEMAS['facts/runtime-profile']),
   frame('facts/daemon-runtimes', FRAME_SCHEMAS['facts/daemon-runtimes']),

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -115,21 +115,37 @@ export const SessionMessage = z.object({
 export type SessionMessage = z.infer<typeof SessionMessage>
 
 /** C→D REQ: fetch one page of a session's history from the owning daemon. */
-export const SessionHistoryReq = z.object({
-  // Optional only for rolling compatibility with an older CP. A current CP always
-  // sends the authorized owner and the daemon re-checks the session binding.
-  agentId: z.string().uuid().optional(),
-  sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
-  cursor: z.string().optional(), // opaque; omit ⇒ newest page
-  limit: z.number().int().positive().max(200).default(50)
-})
+export const SessionHistoryReq = z
+  .object({
+    // Optional only for rolling compatibility with an older CP. A current CP always
+    // sends the authorized owner and the daemon re-checks the session binding.
+    agentId: z.string().uuid().optional(),
+    sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+    cursor: z.string().optional(), // opaque; omit ⇒ newest page
+    // Monotonic daemon-local transcript revision. Mutually exclusive with the
+    // backward-pagination cursor; used by an open console view to pull inserts
+    // and same-seq tool updates without replaying the whole transcript.
+    after: z
+      .string()
+      .regex(/^\d+$/)
+      .refine((value) => Number.isSafeInteger(Number(value)))
+      .optional(),
+    limit: z.number().int().positive().max(200).default(50)
+  })
+  .refine(({ cursor, after }) => cursor === undefined || after === undefined, {
+    message: 'cursor and after are mutually exclusive'
+  })
 export type SessionHistoryReq = z.infer<typeof SessionHistoryReq>
 
 /** D→C REP (corr = the req id): a page of messages + the cursor for the next page. */
 export const SessionHistoryPage = z.object({
   sessionId: z.string(), // opaque ACP session id (agent-assigned; NOT a wire UUID)
   messages: z.array(SessionMessage), // chronological oldest→newest within the page (seq breaks equal-time ties)
-  nextCursor: z.string().optional() // absent ⇒ no older messages
+  nextCursor: z.string().optional(), // absent ⇒ no older messages
+  // Optional for rolling compatibility. `liveCursor` is the next `after`
+  // watermark; `liveMore` means another forward page is immediately available.
+  liveCursor: z.string().optional(),
+  liveMore: z.boolean().optional()
 })
 export type SessionHistoryPage = z.infer<typeof SessionHistoryPage>
 

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -63,6 +63,19 @@ export const EventSession = z.object({
 export type EventSession = z.infer<typeof EventSession>
 
 /**
+ * Metadata-only transcript invalidation. Message/tool bodies remain daemon-local;
+ * an authorized browser uses this signal to pull the changed rows through
+ * `session/history.after`.
+ */
+export const SessionActivity = z.object({
+  sessionId: z.string(),
+  agentId: z.string().uuid(),
+  revision: z.string().regex(/^\d+$/),
+  ts: z.string().datetime()
+})
+export type SessionActivity = z.infer<typeof SessionActivity>
+
+/**
  * Per-session token-usage report — D→C EVT. The daemon meters usage from the
  * agent's ACP stream and reports the session's CUMULATIVE snapshot (latest-wins)
  * so the CP can persist it for the console's historical usage aggregates. This is

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,7 +9,7 @@
  */
 
 // ── cross-package wire + lifecycle constants ──
-export { CP_SUBPROTOCOL, CP_WS_PATH, RESERVED_RESTART_CODE } from './consts.js'
+export { CP_SUBPROTOCOL, CP_WS_PATH, RESERVED_RESTART_CODE, SESSION_LIVE_TAIL_FEATURE } from './consts.js'
 
 // ── envelope + control extension ──
 export { Envelope, ControlExt, NIL_UUID } from './envelope.js'

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -10,9 +10,10 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { agentLabel, type Agent, type Session, type SessionImage, type SessionStep } from '@/lib/data'
-import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError } from '@/lib/api'
+import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError, type SessionMessageDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
+import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
 import {
   acceptWebchatDone,
   acceptWebchatOutput,
@@ -51,10 +52,8 @@ interface PlaygroundData {
    *  below its fetched history. Empty until you send. Synthetic 'pg_' sessions don't use
    *  this (their whole transcript lives in the session's own `steps`). */
   getLiveSteps: (id: string) => SessionStep[]
-  /** Drop the optimistic live tail for a session — call when authoritative history is
-   *  (re)fetched, since those turns are now baked into the fetched transcript (else a
-   *  remount would render them twice: once from history, once from the stale tail). */
-  clearLiveSteps: (id: string) => void
+  /** Retire only optimistic turns confirmed by authoritative transcript rows. */
+  reconcileLiveSteps: (id: string, persisted: SessionMessageDto[], agentId: string) => void
 }
 
 // Synthetic playground session ids start with `pg_`; real CP session ids do not.
@@ -710,11 +709,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
-  const clearLiveSteps = useCallback((id: string): void => {
+  const reconcileLiveSteps = useCallback((id: string, persisted: SessionMessageDto[], agentId: string): void => {
     setWcSteps((cur) => {
-      if (!(id in cur)) return cur
+      const live = cur[id]
+      if (!live) return cur
+      const reconciled = reconcilePersistedLiveSteps(live, persisted, agentId)
+      if (reconciled === live) return cur
       const next = { ...cur }
-      delete next[id]
+      if (reconciled.length === 0) delete next[id]
+      else next[id] = reconciled
       return next
     })
   }, [])
@@ -737,7 +740,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       getPgSession,
       pgSessionList,
       getLiveSteps,
-      clearLiveSteps
+      reconcileLiveSteps
     }),
     [
       getPgInput,
@@ -755,7 +758,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       getPgSession,
       pgSessionList,
       getLiveSteps,
-      clearLiveSteps
+      reconcileLiveSteps
     ]
   )
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import useSWR from 'swr'
@@ -51,6 +51,7 @@ import { formatTranscriptTime, parseTranscriptTime } from '@/lib/transcript-time
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionSenderLabel } from '@/lib/session-trigger'
+import { mergeSessionMessages } from '@/lib/session-transcript'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
@@ -527,7 +528,16 @@ export default function SessionDetailView() {
   const { activeOrg, orgPath } = useOrgs()
   const router = useRouter()
   const { id } = useParams<{ id: string }>()
-  const { agents, allSessions, sessionsLoading, crons, daemons, members } = useConsoleData()
+  const {
+    agents,
+    allSessions,
+    sessionsLoading,
+    crons,
+    daemons,
+    members,
+    sessionActivityVersionById,
+    sessionStreamGeneration
+  } = useConsoleData()
   const {
     getPgSession,
     getLiveSteps,
@@ -550,6 +560,7 @@ export default function SessionDetailView() {
   const [msgLoading, setMsgLoading] = useState(false)
   const [msgPaging, setMsgPaging] = useState(false)
   const [msgErr, setMsgErr] = useState<string | null>(null)
+  const [tailReady, setTailReady] = useState(false)
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [showThinking, setShowThinking] = useState(true)
   const [showTools, setShowTools] = useState(true)
@@ -561,6 +572,11 @@ export default function SessionDetailView() {
     Record<string, { model?: string; effort?: string; permissionMode?: string }>
   >({})
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const liveCursorRef = useRef<string | null>(null)
+  const tailSessionRef = useRef<string | null>(null)
+  const tailReadyRef = useRef(false)
+  const tailInFlightRef = useRef<Promise<void> | null>(null)
+  const tailDirtyRef = useRef(false)
 
   const localSession = getPgSession(id) ?? allSessions.find((s) => s.id === id) ?? null
   // Relationship links can point outside the cursor pages loaded by SessionsView.
@@ -592,6 +608,8 @@ export default function SessionDetailView() {
   const agentRuntime = session?.runtime || owner?.runtime || ''
   const runtimeMeta = acpRuntime(acpRegistry, agentRuntime)
   const sessionBusy = session ? isPgBusy(session.id) : false
+  const sessionBusyRef = useRef(sessionBusy)
+  sessionBusyRef.current = sessionBusy
 
   // A fresh Playground starts on a synthetic `pg_…` route so it can render before
   // the runtime creates a durable session. As soon as the real id arrives, make it
@@ -631,13 +649,16 @@ export default function SessionDetailView() {
   useEffect(() => {
     if (!wantTranscript || !sid || !aid) return
     let active = true
+    tailSessionRef.current = sid
+    tailReadyRef.current = false
+    liveCursorRef.current = null
+    tailInFlightRef.current = null
+    tailDirtyRef.current = false
+    setTailReady(false)
     setMsgLoading(true)
     setMsgErr(null)
     setMsgs(null)
     setMsgPaging(false)
-    // We're loading authoritative history — drop any optimistic live tail from a prior
-    // visit so a resumed turn already in that history doesn't also render from the tail.
-    clearLiveSteps(sid)
     // Pull the WHOLE history, not just the newest frame-budgeted page: render the
     // first (newest) page immediately, then keep paging strictly older via
     // nextCursor, prepending each page. Bounded so a pathological session can't
@@ -646,20 +667,30 @@ export default function SessionDetailView() {
     ;(async () => {
       let all: SessionMessageDto[] = []
       let cursor: string | undefined
+      let liveCursor: string | null = null
       for (let i = 0; i < MAX_PAGES; i++) {
-        const page = await fetchSessionMessages(sid, cursor)
+        const page = await fetchSessionMessages(sid, { ...(cursor ? { cursor } : {}) })
         if (!active) return
+        if (i === 0) liveCursor = page.liveCursor ?? null
         all = [...page.messages, ...all]
         setMsgs(all)
         setMsgLoading(false)
         if (!page.nextCursor) {
           setMsgPaging(false)
+          liveCursorRef.current = liveCursor
+          tailReadyRef.current = true
+          setTailReady(true)
+          if (!sessionBusyRef.current) clearLiveSteps(sid)
           return
         }
         cursor = page.nextCursor
         setMsgPaging(true)
       }
       setMsgPaging(false)
+      liveCursorRef.current = liveCursor
+      tailReadyRef.current = true
+      setTailReady(true)
+      if (!sessionBusyRef.current) clearLiveSteps(sid)
     })().catch((e) => {
       if (!active) return
       setMsgErr(e instanceof Error ? e.message : String(e))
@@ -668,8 +699,63 @@ export default function SessionDetailView() {
     })
     return () => {
       active = false
+      if (tailSessionRef.current === sid) {
+        tailSessionRef.current = null
+        tailReadyRef.current = false
+      }
     }
   }, [wantTranscript, sid, aid, clearLiveSteps])
+
+  const refreshTranscriptTail = useCallback((): Promise<void> => {
+    if (!wantTranscript || !sid || !tailReadyRef.current || sessionBusyRef.current) return Promise.resolve()
+    if (tailInFlightRef.current) {
+      tailDirtyRef.current = true
+      return tailInFlightRef.current
+    }
+    const platform = session?.platform ?? ''
+    const run = (async () => {
+      let cursor = liveCursorRef.current
+      for (let pageNo = 0; pageNo < 20; pageNo++) {
+        const page = await fetchSessionMessages(sid, {
+          ...(cursor !== null ? { after: cursor } : {}),
+          limit: 200
+        })
+        if (tailSessionRef.current !== sid) return
+        setMsgs((current) => mergeSessionMessages(current ?? [], page.messages, platform))
+        if (page.liveCursor !== null) {
+          cursor = page.liveCursor
+          liveCursorRef.current = cursor
+        }
+        if (!page.liveMore || page.liveCursor === null) break
+      }
+      if (tailSessionRef.current === sid && !sessionBusyRef.current) clearLiveSteps(sid)
+    })()
+      .catch(() => {
+        // Keep the last good transcript. The next SSE signal, reconnect, or
+        // safety poll retries without replacing visible history with an error.
+      })
+      .finally(() => {
+        if (tailInFlightRef.current !== run) return
+        tailInFlightRef.current = null
+        const retry = tailDirtyRef.current && tailSessionRef.current === sid
+        tailDirtyRef.current = false
+        if (retry) void refreshTranscriptTail()
+      })
+    tailInFlightRef.current = run
+    return run
+  }, [wantTranscript, sid, session?.platform, clearLiveSteps])
+
+  const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
+  useEffect(() => {
+    if (!tailReady || sessionBusy) return
+    void refreshTranscriptTail()
+  }, [tailReady, sessionBusy, sessionActivityVersion, sessionStreamGeneration, refreshTranscriptTail])
+
+  useEffect(() => {
+    if (!tailReady) return
+    const timer = window.setInterval(() => void refreshTranscriptTail(), 15_000)
+    return () => window.clearInterval(timer)
+  }, [tailReady, refreshTranscriptTail])
 
   useEffect(() => {
     if (!session || (session.platform !== 'playground' && session.platform !== 'webchat') || !sessionBusy) return

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -304,12 +304,14 @@ function ContentBlock({ block }: { block: unknown }) {
 // locations, plus a "view full" affordance when only a truncated preview is inline.
 function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId: string }) {
   const [open, setOpen] = useState(false)
-  const [full, setFull] = useState<string | null>(null) // full body JSON, once fetched
+  const [full, setFull] = useState<{ source: SessionMessageDto; body: string } | null>(null)
   const [loading, setLoading] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
-  // Prefer the fetched full body over the inline preview once available.
-  const bodyStr = full ?? msg.body ?? null
+  // A same-seq live update replaces `msg`; associate the fetched body with the
+  // exact source row so an older full response can never mask the new preview.
+  const fullBody = full?.source === msg ? full.body : null
+  const bodyStr = fullBody ?? msg.body ?? null
   let body: ToolBody | null = null
   let parseErr = false
   if (bodyStr) {
@@ -320,7 +322,7 @@ function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId:
     }
   }
 
-  const truncated = msg.bodyTruncated && full == null
+  const truncated = msg.bodyTruncated && fullBody == null
   const badge = statusBadge(body?.status ?? msg.toolStatus)
   const kind = body?.kind ?? msg.toolKind
   const bytes = msg.bodyBytes
@@ -331,7 +333,7 @@ function ToolBodyDetail({ msg, sessionId }: { msg: SessionMessageDto; sessionId:
     setErr(null)
     fetchToolBody(sessionId, msg.toolCallId ?? body?.toolCallId ?? '').then(
       (s) => {
-        setFull(s)
+        setFull({ source: msg, body: s })
         setLoading(false)
         setOpen(true)
       },
@@ -541,7 +543,7 @@ export default function SessionDetailView() {
   const {
     getPgSession,
     getLiveSteps,
-    clearLiveSteps,
+    reconcileLiveSteps,
     getPgInput,
     getPgImage,
     isPgBusy,
@@ -680,7 +682,7 @@ export default function SessionDetailView() {
           liveCursorRef.current = liveCursor
           tailReadyRef.current = true
           setTailReady(true)
-          if (!sessionBusyRef.current) clearLiveSteps(sid)
+          if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
           return
         }
         cursor = page.nextCursor
@@ -690,7 +692,7 @@ export default function SessionDetailView() {
       liveCursorRef.current = liveCursor
       tailReadyRef.current = true
       setTailReady(true)
-      if (!sessionBusyRef.current) clearLiveSteps(sid)
+      if (!sessionBusyRef.current) reconcileLiveSteps(sid, all, aid)
     })().catch((e) => {
       if (!active) return
       setMsgErr(e instanceof Error ? e.message : String(e))
@@ -704,7 +706,7 @@ export default function SessionDetailView() {
         tailReadyRef.current = false
       }
     }
-  }, [wantTranscript, sid, aid, clearLiveSteps])
+  }, [wantTranscript, sid, aid, reconcileLiveSteps])
 
   const refreshTranscriptTail = useCallback((): Promise<void> => {
     if (!wantTranscript || !sid || !tailReadyRef.current || sessionBusyRef.current) return Promise.resolve()
@@ -715,12 +717,14 @@ export default function SessionDetailView() {
     const platform = session?.platform ?? ''
     const run = (async () => {
       let cursor = liveCursorRef.current
+      const persisted: SessionMessageDto[] = []
       for (let pageNo = 0; pageNo < 20; pageNo++) {
         const page = await fetchSessionMessages(sid, {
           ...(cursor !== null ? { after: cursor } : {}),
           limit: 200
         })
         if (tailSessionRef.current !== sid) return
+        persisted.push(...page.messages)
         setMsgs((current) => mergeSessionMessages(current ?? [], page.messages, platform))
         if (page.liveCursor !== null) {
           cursor = page.liveCursor
@@ -728,7 +732,7 @@ export default function SessionDetailView() {
         }
         if (!page.liveMore || page.liveCursor === null) break
       }
-      if (tailSessionRef.current === sid && !sessionBusyRef.current) clearLiveSteps(sid)
+      if (tailSessionRef.current === sid && !sessionBusyRef.current) reconcileLiveSteps(sid, persisted, aid)
     })()
       .catch(() => {
         // Keep the last good transcript. The next SSE signal, reconnect, or
@@ -743,7 +747,7 @@ export default function SessionDetailView() {
       })
     tailInFlightRef.current = run
     return run
-  }, [wantTranscript, sid, session?.platform, clearLiveSteps])
+  }, [wantTranscript, sid, aid, session?.platform, reconcileLiveSteps])
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
   useEffect(() => {

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -22,11 +22,13 @@ describe('subscribeSessionEvents', () => {
       return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
     })
     vi.stubGlobal('fetch', fetchMock)
-    const onInvalidate = vi.fn()
+    const onConnect = vi.fn()
+    const onSession = vi.fn()
+    const onActivity = vi.fn()
 
-    const unsubscribe = subscribeSessionEvents('org / 407', onInvalidate)
+    const unsubscribe = subscribeSessionEvents('org / 407', { onConnect, onSession, onActivity })
 
-    await vi.waitFor(() => expect(onInvalidate).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1))
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:8080/api/v1/orgs/org%20%2F%20407/stream',
       expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) })
@@ -36,7 +38,21 @@ describe('subscribeSessionEvents', () => {
     const encoder = new TextEncoder()
     streamController.enqueue(encoder.encode('event: sess'))
     streamController.enqueue(encoder.encode('ion\ndata: {"sessionId":"s407"}\n\n'))
-    await vi.waitFor(() => expect(onInvalidate).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(onSession).toHaveBeenCalledTimes(1))
+
+    streamController.enqueue(
+      encoder.encode(
+        'event: session-activity\ndata: {"activity":{"sessionId":"s407","agentId":"a407","revision":"12","ts":"2026-07-27T00:00:00.000Z"}}\n\n'
+      )
+    )
+    await vi.waitFor(() =>
+      expect(onActivity).toHaveBeenCalledWith({
+        sessionId: 's407',
+        agentId: 'a407',
+        revision: '12',
+        ts: '2026-07-27T00:00:00.000Z'
+      })
+    )
 
     unsubscribe()
     expect(requestSignal.aborted).toBe(true)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -383,6 +383,8 @@ export interface SessionHistoryDto {
   sessionId: string
   messages: SessionMessageDto[]
   nextCursor: string | null
+  liveCursor: string | null
+  liveMore: boolean
 }
 
 // A scheduled trigger (`/crons`): every `schedule` tick the owning agent is
@@ -942,7 +944,18 @@ async function apiGet<T>(path: string): Promise<T> {
   return (await res.json()) as T
 }
 
-type SessionInvalidationHandler = () => void
+export interface SessionActivityDto {
+  sessionId: string
+  agentId: string
+  revision: string
+  ts: string
+}
+
+export interface SessionEventHandlers {
+  onConnect: () => void
+  onSession: () => void
+  onActivity: (activity: SessionActivityDto) => void
+}
 
 function waitBeforeReconnect(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -960,7 +973,7 @@ function waitBeforeReconnect(ms: number, signal: AbortSignal): Promise<void> {
 async function readSessionEventStream(
   orgId: string,
   signal: AbortSignal,
-  onInvalidate: SessionInvalidationHandler
+  handlers: SessionEventHandlers
 ): Promise<void> {
   const path = `/orgs/${encodeURIComponent(orgId)}/stream`
   const res = await fetch(`${cpBase()}${path}`, {
@@ -974,12 +987,29 @@ async function readSessionEventStream(
   // The sink has no replay/event ids, so every successful (re)connect invalidates
   // the list once. This closes both a disconnect gap and the initial GET→subscribe
   // race without requiring a polling cache layer.
-  onInvalidate()
+  handlers.onConnect()
 
   const reader = res.body.getReader()
   const decoder = new TextDecoder()
   const parser = createSseParser((event) => {
-    if (event.event === 'session') onInvalidate()
+    if (event.event === 'session') {
+      handlers.onSession()
+      return
+    }
+    if (event.event !== 'session-activity') return
+    try {
+      const activity = (JSON.parse(event.data) as { activity?: SessionActivityDto }).activity
+      if (
+        activity &&
+        typeof activity.sessionId === 'string' &&
+        typeof activity.agentId === 'string' &&
+        /^\d+$/.test(activity.revision) &&
+        typeof activity.ts === 'string'
+      )
+        handlers.onActivity(activity)
+    } catch {
+      // A malformed optional invalidation is ignored; reconnect/fallback polling heals it.
+    }
   })
 
   try {
@@ -995,13 +1025,13 @@ async function readSessionEventStream(
 }
 
 /**
- * Subscribe to the org's session-milestone SSE feed with the same auth headers
- * as REST calls. The callback is an invalidation signal (on connect and on each
- * session event), not an authoritative event payload. Returns an abort cleanup.
+ * Subscribe to the org's session SSE feed with the same auth headers as REST.
+ * Lifecycle events invalidate lists; activity events identify the transcript
+ * that should pull its daemon-local tail. Returns an abort cleanup.
  */
 export function subscribeSessionEvents(
   orgId: string,
-  onInvalidate: SessionInvalidationHandler,
+  handlers: SessionEventHandlers,
   onError?: (error: unknown) => void
 ): () => void {
   const ctrl = new AbortController()
@@ -1010,7 +1040,7 @@ export function subscribeSessionEvents(
   void (async () => {
     while (!ctrl.signal.aborted) {
       try {
-        await readSessionEventStream(orgId, ctrl.signal, onInvalidate)
+        await readSessionEventStream(orgId, ctrl.signal, handlers)
         retryMs = 1000
       } catch (error) {
         if (ctrl.signal.aborted) return
@@ -1602,9 +1632,13 @@ export function fetchSessionDetail(sessionId: string, orgId?: string): Promise<S
 // One page of a session's transcript, proxied live from the owning daemon. The
 // CP resolves the owner and daemon from its SessionMeta row; 503 if that daemon
 // is offline or the owning agent is unplaced.
-export async function fetchSessionMessages(sessionId: string, cursor?: string, limit = 50): Promise<SessionHistoryDto> {
-  const q = new URLSearchParams({ limit: String(limit) })
-  if (cursor) q.set('cursor', cursor)
+export async function fetchSessionMessages(
+  sessionId: string,
+  options: { cursor?: string; after?: string; limit?: number } = {}
+): Promise<SessionHistoryDto> {
+  const q = new URLSearchParams({ limit: String(options.limit ?? 50) })
+  if (options.cursor) q.set('cursor', options.cursor)
+  if (options.after) q.set('after', options.after)
   return apiGet<SessionHistoryDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`)
 }
 

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -113,6 +113,10 @@ interface ConsoleData {
   allSessions: Session[]
   sessionFacets: SessionFacets
   sessionsNextCursor: string | null
+  /** Per-session body-free SSE invalidation counter for open transcript views. */
+  sessionActivityVersionById: Record<string, number>
+  /** Advances on every SSE (re)connect so views close any disconnect gap. */
+  sessionStreamGeneration: number
   crons: CronDto[]
   integrations: IntegrationRow[]
   /** Durable bot identities (freed + in-use) — Add-integration picker + Settings Bots card. */
@@ -569,6 +573,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const sessionRefreshGenerationRef = useRef(0)
   const sessionRefreshInFlightRef = useRef(false)
   const sessionRefreshDirtyRef = useRef(false)
+  const [sessionActivityVersionById, setSessionActivityVersionById] = useState<Record<string, number>>({})
+  const [sessionStreamGeneration, setSessionStreamGeneration] = useState(0)
 
   // Every cache key carries the org id. Unlike `keepPreviousData`, separate keys
   // never paint one org's stale rows under another org while the new pull starts.
@@ -732,6 +738,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     const generation = ++sessionRefreshGenerationRef.current
     sessionRefreshInFlightRef.current = false
     sessionRefreshDirtyRef.current = false
+    setSessionActivityVersionById({})
     if (orgLoading || !activeOrg) return
 
     const scheduleSessionRefresh = () => {
@@ -741,7 +748,18 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
         void drainSessionRefreshes(generation)
       }, SESSION_EVENT_REFRESH_DEBOUNCE_MS)
     }
-    const unsubscribe = subscribeSessionEvents(activeOrg.id, scheduleSessionRefresh)
+    const unsubscribe = subscribeSessionEvents(activeOrg.id, {
+      onConnect: () => {
+        scheduleSessionRefresh()
+        setSessionStreamGeneration((current) => current + 1)
+      },
+      onSession: scheduleSessionRefresh,
+      onActivity: ({ sessionId }) =>
+        setSessionActivityVersionById((current) => ({
+          ...current,
+          [sessionId]: (current[sessionId] ?? 0) + 1
+        }))
+    })
     return () => {
       sessionRefreshGenerationRef.current++
       sessionRefreshDirtyRef.current = false
@@ -1194,6 +1212,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       allSessions,
       sessionFacets,
       sessionsNextCursor,
+      sessionActivityVersionById,
+      sessionStreamGeneration,
       crons,
       integrations,
       bots,
@@ -1254,6 +1274,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       allSessions,
       sessionFacets,
       sessionsNextCursor,
+      sessionActivityVersionById,
+      sessionStreamGeneration,
       crons,
       integrations,
       bots,

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionMessageDto } from './api'
+import { mergeSessionMessages } from './session-transcript'
+
+function message(seq: number, ts: string, text: string): SessionMessageDto {
+  return { seq, ts, text, sender: 'agent', kind: 'reasoning' }
+}
+
+describe('mergeSessionMessages', () => {
+  it('upserts stable rows and restores chronological Slack order after a backfill', () => {
+    const current = [message(1, '1784098843.000000', 'trigger'), message(2, '1784098844000', 'running')]
+    const merged = mergeSessionMessages(
+      current,
+      [message(2, '1784098844000', 'complete'), message(3, '1784098711.000000', 'backfilled')],
+      'slack'
+    )
+
+    expect(merged.map(({ seq, text }) => [seq, text])).toEqual([
+      [3, 'backfilled'],
+      [1, 'trigger'],
+      [2, 'complete']
+    ])
+  })
+})

--- a/packages/web/src/lib/session-transcript.test.ts
+++ b/packages/web/src/lib/session-transcript.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { SessionMessageDto } from './api'
-import { mergeSessionMessages } from './session-transcript'
+import type { SessionStep } from './data'
+import { mergeSessionMessages, reconcilePersistedLiveSteps } from './session-transcript'
 
 function message(seq: number, ts: string, text: string): SessionMessageDto {
   return { seq, ts, text, sender: 'agent', kind: 'reasoning' }
@@ -20,5 +21,41 @@ describe('mergeSessionMessages', () => {
       [1, 'trigger'],
       [2, 'complete']
     ])
+  })
+})
+
+describe('reconcilePersistedLiveSteps', () => {
+  const agentId = 'agent'
+
+  function prompt(text: string, observedAtMs: number): SessionStep {
+    return { kind: 'msg', who: '@you', text, observedAtMs }
+  }
+
+  function persistedPrompt(seq: number, text: string, ts: number): SessionMessageDto {
+    return { seq, ts: String(ts), text, sender: '@you', kind: 'text' }
+  }
+
+  it('preserves an unpersisted failed turn when a tail refresh is empty', () => {
+    const live = [
+      prompt('ship it', 1_785_000_000_000),
+      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: 1_785_000_000_100 }
+    ] satisfies SessionStep[]
+
+    expect(reconcilePersistedLiveSteps(live, [], agentId)).toBe(live)
+  })
+
+  it('removes only the duplicate prompt closest to the persisted retry', () => {
+    const failedAt = 1_785_000_000_000
+    const retriedAt = failedAt + 30_000
+    const live = [
+      prompt('ship it', failedAt),
+      { kind: 'done', text: '⚠️ Could not reach the agent.', observedAtMs: failedAt + 100 },
+      prompt('ship it', retriedAt),
+      { kind: 'done', text: 'deployed', observedAtMs: retriedAt + 1_000 }
+    ] satisfies SessionStep[]
+
+    expect(reconcilePersistedLiveSteps(live, [persistedPrompt(1, 'ship it', retriedAt + 50)], agentId)).toEqual(
+      live.slice(0, 2)
+    )
   })
 })

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -1,0 +1,17 @@
+import type { SessionMessageDto } from '@/lib/api'
+import { parseTranscriptTime } from '@/lib/transcript-time'
+
+/** Upsert stable transcript rows and restore the platform's display ordering. */
+export function mergeSessionMessages(
+  current: SessionMessageDto[],
+  incoming: SessionMessageDto[],
+  platform: string
+): SessionMessageDto[] {
+  if (incoming.length === 0) return current
+  const bySeq = new Map(current.map((message) => [message.seq, message]))
+  for (const message of incoming) bySeq.set(message.seq, message)
+  return [...bySeq.values()].sort((a, b) => {
+    if (platform !== 'slack') return a.seq - b.seq
+    return (parseTranscriptTime(a.ts) ?? 0) - (parseTranscriptTime(b.ts) ?? 0) || a.seq - b.seq
+  })
+}

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -1,5 +1,8 @@
 import type { SessionMessageDto } from '@/lib/api'
+import type { SessionImage, SessionStep } from '@/lib/data'
 import { parseTranscriptTime } from '@/lib/transcript-time'
+
+const LIVE_TURN_CONFIRM_WINDOW_MS = 5 * 60_000
 
 /** Upsert stable transcript rows and restore the platform's display ordering. */
 export function mergeSessionMessages(
@@ -14,4 +17,69 @@ export function mergeSessionMessages(
     if (platform !== 'slack') return a.seq - b.seq
     return (parseTranscriptTime(a.ts) ?? 0) - (parseTranscriptTime(b.ts) ?? 0) || a.seq - b.seq
   })
+}
+
+function promptKey(text: string, image?: SessionImage): string {
+  return JSON.stringify([text, image?.name ?? null, image?.mimeType ?? null, image?.data ?? null])
+}
+
+/**
+ * Drop only adopted-WebChat turns whose optimistic user prompt has a matching,
+ * newly persisted transcript row. Failed pre-admission turns have no such row
+ * and therefore retain both the attempted prompt and its error feedback.
+ */
+export function reconcilePersistedLiveSteps(
+  live: SessionStep[],
+  persisted: SessionMessageDto[],
+  agentId: string
+): SessionStep[] {
+  if (live.length === 0 || persisted.length === 0) return live
+
+  const turns: Array<{ start: number; end: number; key: string; observedAtMs: number }> = []
+  for (let start = 0; start < live.length;) {
+    if (live[start]!.kind !== 'msg') {
+      start += 1
+      continue
+    }
+    let end = start + 1
+    while (end < live.length && live[end]!.kind !== 'msg') end += 1
+    const prompt = live[start]!
+    if (prompt.observedAtMs != null && Number.isFinite(prompt.observedAtMs)) {
+      turns.push({
+        start,
+        end,
+        key: promptKey(prompt.text, prompt.image),
+        observedAtMs: prompt.observedAtMs
+      })
+    }
+    start = end
+  }
+  if (turns.length === 0) return live
+
+  const confirmed = new Set<number>()
+  for (const message of persisted) {
+    if (message.kind.toLowerCase() !== 'text' || message.sender === agentId) continue
+    const persistedAtMs = parseTranscriptTime(message.ts)
+    if (persistedAtMs == null) continue
+    const key = promptKey(message.text, message.attachments?.[0])
+    let bestTurn = -1
+    let bestDelta = Number.POSITIVE_INFINITY
+    for (let index = 0; index < turns.length; index++) {
+      if (confirmed.has(index) || turns[index]!.key !== key) continue
+      const delta = Math.abs(turns[index]!.observedAtMs - persistedAtMs)
+      if (delta <= LIVE_TURN_CONFIRM_WINDOW_MS && delta < bestDelta) {
+        bestTurn = index
+        bestDelta = delta
+      }
+    }
+    if (bestTurn >= 0) confirmed.add(bestTurn)
+  }
+  if (confirmed.size === 0) return live
+
+  const removed = new Set<number>()
+  for (const index of confirmed) {
+    const turn = turns[index]!
+    for (let step = turn.start; step < turn.end; step++) removed.add(step)
+  }
+  return live.filter((_, index) => !removed.has(index))
 }


### PR DESCRIPTION
## Summary

- add monotonic daemon transcript revisions and authorized forward-tail reads for inserts and same-row tool updates
- send metadata-only session activity invalidations through the existing daemon-to-CP channel and organization SSE feed; transcript bodies remain daemon-local
- keep every real Session View live across Slack, Telegram, Discord, Feishu, hooks, schedules, and webchat, with reconnect and polling recovery plus webchat deduplication

## Validation

- protocol, daemon, control-plane, and web typechecks
- full protocol, daemon, control-plane unit, and web test suites
- focused control-plane Postgres integration tests for history tails and SSE activity
- pnpm lint (0 errors; 2 pre-existing warnings) and pnpm format:check
- desktop and 390px mobile Session View checks across Slack, Telegram, and Discord mock sessions

Created by Codex . GPT-5.6 Sol