### PR TITLE
fix(daemon): complete webchat CP client test fake

### DIFF
--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -100,6 +100,7 @@ function fakeCpClient() {
     dones,
     usageReports,
     emitUsageReport: vi.fn((report: unknown) => usageReports.push(report)),
+    emitSessionActivity: vi.fn(),
     stop: vi.fn(async () => {}),
     // The transport-neutral reply sink a dispatch()/handleRelayMsg call threads in (the
     // turn engine writes here instead of a hardcoded client; captures the same arrays).


### PR DESCRIPTION
## Summary

- add the missing `emitSessionActivity` method to the shared daemon webchat `CpClient` test fake
- prevent the debounced transcript-activity callback from producing an unhandled Vitest error after otherwise successful tests

## Root cause

PR #133 added `CpClient.emitSessionActivity`, but `daemon-webchat.test.ts` replaces the private client with an untyped shared fake that did not implement the new method. On a slower runner, the 250 ms transcript-activity timer fired before teardown and called the missing fake method.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-webchat.test.ts` (34 tests)
- `pnpm --filter @agentconnect.md/daemon test:unit` (132 files, 2,119 tests)
- targeted ESLint and Prettier checks
- pre-push full lint: 0 errors, 2 pre-existing warnings

Created by Codex . GPT-5.6 Sol
