### PR TITLE
fix(daemon): render GitHub attribution as footer

### DIFF
--- a/packages/daemon/src/github/poster.ts
+++ b/packages/daemon/src/github/poster.ts
@@ -244,14 +244,13 @@ function markdownUrl(raw: string): string | undefined {
 
 /** Small inline avatar ahead of the agent name. GitHub's comment sanitizer
  * keeps `img` (src/width/height/alt) and proxies src through camo, so the same
- * public URL Slack fetches for icon_url renders here too. Its default baseline
- * leaves the icon slightly above the adjacent text, while `align="middle"`
- * renders visibly low; `sub` aligns their bottom edges. Decorative: the agent
- * name follows as text, so a blocked/broken image loses nothing. */
+ * public URL Slack fetches for icon_url renders here too. The nested `sub`
+ * aligns the icon with the surrounding footer text. Decorative: the agent name
+ * follows as text, so a blocked/broken image loses nothing. */
 function attributionIconImage(raw: string | undefined): string {
   const src = raw ? safeHttpUrl(raw) : undefined
   if (src === undefined) return ''
-  return `<sub><img src="${src.replace(/"/g, '%22')}" width="14" height="14" alt=""></sub> `
+  return `<sub><img src="${src.replace(/"/g, '%22')}" width="11" height="11" alt=""></sub> `
 }
 
 /** Shared public attribution chrome for both ordinary comments and formal
@@ -264,12 +263,13 @@ export function githubAttributionFooter(attribution?: GithubCommentAttribution):
   const agentUrl = markdownUrl(attribution.agentUrl)
   const sessionUrl = markdownUrl(attribution.sessionUrl)
   const agent = `${attributionIconImage(attribution.iconUrl)}${agentUrl ? `[${name}](${agentUrl})` : name}`
-  return `\n\n${renderAttributionMessage({
+  const message = renderAttributionMessage({
     agent,
     runtime,
     model,
     renderSession: sessionUrl ? (label) => `[${escapeMarkdownText(label)}](${sessionUrl})` : undefined
-  })}`
+  })
+  return `\n\n<sub>${message}\n</sub>`
 }
 
 interface MarkdownFence {

--- a/packages/daemon/test/github/poster.test.ts
+++ b/packages/daemon/test/github/poster.test.ts
@@ -352,33 +352,35 @@ describe('GithubFinalPoster', () => {
         method: 'POST',
         url: 'https://api.github.com/repos/acme/infra/pulls/42/comments/3565283658/replies',
         body:
-          'Paths must stay in the archive directory.\n\nsent by ' +
+          'Paths must stay in the archive directory.\n\n<sub>sent by ' +
           '[review-bot](<https://app.example.test/acme/agents/review-bot>) (Codex · gpt-5.6-luna) · ' +
-          '[open in session](<https://app.example.test/acme/sessions/session-1>)'
+          '[open in session](<https://app.example.test/acme/sessions/session-1>)\n</sub>'
       }
     ])
   })
 
   it('omits an unsafe session link without leaving dangling separator chrome', () => {
     expect(githubAttributionFooter({ ...attribution, sessionUrl: 'file:///tmp/session-1' })).toBe(
-      '\n\nsent by [review-bot](<https://app.example.test/acme/agents/review-bot>) (Codex · gpt-5.6-luna)'
+      '\n\n<sub>sent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
+        '(Codex · gpt-5.6-luna)\n</sub>'
     )
   })
 
   it('renders the agent avatar inline ahead of the agent name when attribution carries an icon URL', () => {
     const iconUrl = 'https://api.example.test/v1/agents/agent-1/icon?v=1700000000000'
     expect(githubAttributionFooter({ ...attribution, iconUrl })).toBe(
-      `\n\nsent by <sub><img src="${iconUrl}" width="14" height="14" alt=""></sub> ` +
+      `\n\n<sub>sent by <sub><img src="${iconUrl}" width="11" height="11" alt=""></sub> ` +
         '[review-bot](<https://app.example.test/acme/agents/review-bot>) (Codex · gpt-5.6-luna) · ' +
-        '[open in session](<https://app.example.test/acme/sessions/session-1>)'
+        '[open in session](<https://app.example.test/acme/sessions/session-1>)\n</sub>'
     )
   })
 
   it('drops a non-http icon URL and keeps the text-only footer', () => {
     for (const iconUrl of ['data:image/png;base64,AAAA', 'javascript:alert(1)', 'not a url', '']) {
       expect(githubAttributionFooter({ ...attribution, iconUrl })).toBe(
-        '\n\nsent by [review-bot](<https://app.example.test/acme/agents/review-bot>) (Codex · gpt-5.6-luna) · ' +
-          '[open in session](<https://app.example.test/acme/sessions/session-1>)'
+        '\n\n<sub>sent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
+          '(Codex · gpt-5.6-luna) · ' +
+          '[open in session](<https://app.example.test/acme/sessions/session-1>)\n</sub>'
       )
     }
   })
@@ -409,8 +411,8 @@ describe('GithubFinalPoster', () => {
     await poster.publish('Answer')
 
     expect(f.calls[0]!.body).toBe(
-      'Answer\n\nsent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
-        '(Codex · gpt-5.6-luna) · [open in session](<https://app.example.test/acme/sessions/session-1>)'
+      'Answer\n\n<sub>sent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
+        '(Codex · gpt-5.6-luna) · [open in session](<https://app.example.test/acme/sessions/session-1>)\n</sub>'
     )
     expect(f.calls[0]!.body.match(/open in session/g)).toHaveLength(1)
   })
@@ -441,8 +443,9 @@ describe('GithubFinalPoster', () => {
     expect(body).toContain('_(truncated — see the session transcript for the full reply)_')
     expect(
       body.endsWith(
-        'sent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
-          '(Codex · gpt-5.6-luna) · [open in session](<https://app.example.test/acme/sessions/session-1>)'
+        '<sub>sent by [review-bot](<https://app.example.test/acme/agents/review-bot>) ' +
+          '(Codex · gpt-5.6-luna) · ' +
+          '[open in session](<https://app.example.test/acme/sessions/session-1>)\n</sub>'
       )
     ).toBe(true)
   })
@@ -478,7 +481,7 @@ describe('GithubFinalPoster', () => {
 
     await poster.publish(fence + 'ts\nconst answer = 42')
 
-    expect(f.calls[0]!.body).toContain('const answer = 42\n' + fence + '\n\nsent by ')
+    expect(f.calls[0]!.body).toContain('const answer = 42\n' + fence + '\n\n<sub>sent by ')
   })
 
   it('degrades a non-auth create failure to one warning without rejecting or retrying', async () => {

--- a/packages/daemon/test/github/review.test.ts
+++ b/packages/daemon/test/github/review.test.ts
@@ -140,7 +140,7 @@ describe('GithubReviewClient', () => {
     const body = (JSON.parse(String(init?.body)) as { body: string }).body
     const footerAt = body.indexOf('sent by [review-bot]')
     const markerAt = body.indexOf('<!-- agentconnect-review:')
-    expect(body).toContain(`const answer = 42\n${fence}\n\nsent by `)
+    expect(body).toContain(`const answer = 42\n${fence}\n\n<sub>sent by `)
     expect(body.split(fence)).toHaveLength(3)
     expect(markerAt).toBeGreaterThan(footerAt)
   })


### PR DESCRIPTION
## Summary

- render the shared GitHub attribution line as a visually secondary footer using GitHub-supported `<sub>` markup
- resize the nested agent avatar to 11×11 so it aligns with the smaller footer text
- keep agent/runtime/model/session links and formal-review correlation marker ordering unchanged

## Why

GitHub review attribution currently has the same visual weight as the review itself. The markup verified in GitHub makes the attribution read as footer chrome without introducing a separate review-only path.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/github/poster.test.ts test/github/review.test.ts` (53 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/github/poster.ts packages/daemon/test/github/poster.test.ts packages/daemon/test/github/review.test.ts`
- `pnpm exec prettier --check packages/daemon/src/github/poster.ts packages/daemon/test/github/poster.test.ts packages/daemon/test/github/review.test.ts`
- pre-push `eslint .` (0 errors; 2 existing warnings outside this diff)

Created by Codex . GPT-5
