### PR TITLE
fix(control-plane): filter native connector services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # CRON_RUN_REAP_INTERVAL_SEC=300 # how often the CronRunReaper sweeps
 # SECRETS_PROVIDER=memory
 
+# ── open-connector integration (optional) ───────────────────────────────────
+# OPEN_CONNECTOR_URL=                 # unset ⇒ Add connectors is hidden
+# OPEN_CONNECTOR_PROVIDER_WHITELIST=* # `*` or unset ⇒ allow every service
+# Native AgentConnect integrations stay out of the connector catalog by default.
+# Override only when a deployment intentionally wants overlapping providers.
+# OPEN_CONNECTOR_PROVIDER_BLOCKLIST=github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot
+
 # ── At-rest secret encryption (docs/designs/secret-store-seams.md) ──────────
 # Every stored tenant secret (bot tokens, agent secret env vars, hook HMAC keys,
 # MCP headers/grants, Slack config tokens) passes ONE SecretCipher. `none`

--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -164,7 +164,12 @@ export const AppConfigSchema = z.object({
   OPEN_CONNECTOR_URL: z.string().url().optional(),
   // Provider whitelist for the connectors catalog. '*' (or unset) ⇒ every provider;
   // otherwise a comma-separated list of `service` ids.
-  OPEN_CONNECTOR_PROVIDER_WHITELIST: z.string().optional()
+  OPEN_CONNECTOR_PROVIDER_WHITELIST: z.string().optional(),
+  // Provider blocklist applied after the whitelist. Defaults to the exact open-connector
+  // service ids that overlap AgentConnect's native integrations.
+  OPEN_CONNECTOR_PROVIDER_BLOCKLIST: z
+    .string()
+    .default('github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot')
 })
 
 export type AppConfig = z.infer<typeof AppConfigSchema>

--- a/packages/control-plane/src/connectors/client.ts
+++ b/packages/control-plane/src/connectors/client.ts
@@ -12,6 +12,7 @@ export interface ConnectorsClientOptions {
   baseUrl: string
   fetch: FetchLike
   whitelist: Set<string> | null
+  blocklist: Set<string>
 }
 
 export class ConnectorsError extends Error {
@@ -28,11 +29,13 @@ export class ConnectorsClient {
   private readonly base: string
   private readonly doFetch: FetchLike
   private readonly whitelist: Set<string> | null
+  private readonly blocklist: Set<string>
 
   constructor(opts: ConnectorsClientOptions) {
     this.base = opts.baseUrl.replace(/\/+$/, '')
     this.doFetch = opts.fetch
     this.whitelist = opts.whitelist
+    this.blocklist = opts.blocklist
   }
 
   /** The open-connector MCP endpoint — the upstream url stored on each connection's
@@ -69,7 +72,7 @@ export class ConnectorsClient {
       this.json<OcProvider[]>('/api/providers'),
       this.json<OcOAuthConfig[]>('/api/oauth/configs')
     ])
-    return { providers: filterCatalog(providers, oauthConfigs, this.whitelist) }
+    return { providers: filterCatalog(providers, oauthConfigs, this.whitelist, this.blocklist) }
   }
 
   /** Save an api-key / custom / no-auth connection under a profile name. */

--- a/packages/control-plane/src/connectors/filter.test.ts
+++ b/packages/control-plane/src/connectors/filter.test.ts
@@ -3,6 +3,7 @@ import {
   composeProfileName,
   filterCatalog,
   isValidConnectionName,
+  parseBlocklist,
   parseWhitelist,
   type OcOAuthConfig,
   type OcProvider
@@ -43,33 +44,44 @@ describe('filterCatalog', () => {
     const providers = [provider('github'), provider('slack'), provider('stripe', { oauth: false })]
     const configs = [config('github', true), config('slack', false)]
 
-    const kept = filterCatalog(providers, configs, null)
+    const kept = filterCatalog(providers, configs, null, new Set())
     expect(kept.map((p) => p.service)).toEqual(['github', 'stripe'])
     expect(kept.every((p) => p.actions === undefined)).toBe(true)
   })
 
   it('keeps a non-oauth provider even with no oauth config', () => {
-    expect(filterCatalog([provider('stripe', { oauth: false })], [], null).map((p) => p.service)).toEqual(['stripe'])
+    expect(filterCatalog([provider('stripe', { oauth: false })], [], null, new Set()).map((p) => p.service)).toEqual([
+      'stripe'
+    ])
   })
 
   it('keeps a dual provider but strips the oauth2 method when its secret is unconfigured', () => {
-    const kept = filterCatalog([dualProvider('linear')], [config('linear', false)], null)
+    const kept = filterCatalog([dualProvider('linear')], [config('linear', false)], null, new Set())
     expect(kept.map((p) => p.service)).toEqual(['linear'])
     expect(kept[0].auth.map((a) => a.type)).toEqual(['api_key'])
     expect(kept[0].authTypes).toEqual(['api_key'])
   })
 
   it('keeps both methods on a dual provider when oauth IS configured', () => {
-    const kept = filterCatalog([dualProvider('linear')], [config('linear', true)], null)
+    const kept = filterCatalog([dualProvider('linear')], [config('linear', true)], null, new Set())
     expect(kept[0].auth.map((a) => a.type)).toEqual(['oauth2', 'api_key'])
     expect(kept[0].authTypes).toEqual(['oauth2', 'api_key'])
   })
 
   it('applies the whitelist', () => {
     const providers = [provider('github'), provider('stripe', { oauth: false })]
-    expect(filterCatalog(providers, [config('github', true)], new Set(['github'])).map((p) => p.service)).toEqual([
-      'github'
-    ])
+    expect(
+      filterCatalog(providers, [config('github', true)], new Set(['github']), new Set()).map((p) => p.service)
+    ).toEqual(['github'])
+  })
+
+  it('applies the blocklist after the whitelist', () => {
+    const providers = [provider('github'), provider('stripe', { oauth: false })]
+    expect(
+      filterCatalog(providers, [config('github', true)], new Set(['github', 'stripe']), new Set(['github'])).map(
+        (p) => p.service
+      )
+    ).toEqual(['stripe'])
   })
 })
 
@@ -80,6 +92,15 @@ describe('parseWhitelist', () => {
   })
   it('parses a comma list, trimming blanks', () => {
     expect(parseWhitelist('github, google ,, slack')).toEqual(new Set(['github', 'google', 'slack']))
+  })
+})
+
+describe('parseBlocklist', () => {
+  it('parses exact service ids and treats blank input as no exclusions', () => {
+    expect(parseBlocklist(undefined)).toEqual(new Set())
+    expect(parseBlocklist('github, telegram ,, feishu_app_bot')).toEqual(
+      new Set(['github', 'telegram', 'feishu_app_bot'])
+    )
   })
 })
 

--- a/packages/control-plane/src/connectors/filter.ts
+++ b/packages/control-plane/src/connectors/filter.ts
@@ -38,15 +38,24 @@ export interface OcOAuthConfig {
   clientId: string | null
 }
 
+function parseServiceIds(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
 /** `'*'` (the default) or unset ⇒ null (no restriction); else a set of `service` ids. */
 export function parseWhitelist(raw: string | undefined): Set<string> | null {
   const trimmed = raw?.trim()
   if (!trimmed || trimmed === '*') return null
-  const entries = trimmed
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
+  const entries = parseServiceIds(trimmed)
   return entries.length > 0 ? new Set(entries) : null
+}
+
+/** Unset/blank ⇒ no exclusions; else the exact `service` ids to omit. */
+export function parseBlocklist(raw: string | undefined): Set<string> {
+  return new Set(parseServiceIds(raw))
 }
 
 /**
@@ -54,7 +63,7 @@ export function parseWhitelist(raw: string | undefined): Set<string> | null {
  * from each. A method is connectable when it's api-key / custom / no-auth (the user just
  * fills it in) OR it's OAuth whose client secret is configured upstream. Concretely:
  *
- * - whitelist-allowed only;
+ * - whitelist-allowed and not blocklisted;
  * - drop the `oauth2` method when its client secret ISN'T configured — but KEEP the
  *   provider if it still offers another method (e.g. a provider that does both OAuth and
  *   api-key shows just the api-key form while OAuth is unconfigured);
@@ -66,12 +75,13 @@ export function parseWhitelist(raw: string | undefined): Set<string> | null {
 export function filterCatalog(
   providers: OcProvider[],
   oauthConfigs: OcOAuthConfig[],
-  whitelist: Set<string> | null
+  whitelist: Set<string> | null,
+  blocklist: Set<string>
 ): OcProvider[] {
   const configuredOAuth = new Set(oauthConfigs.filter((c) => c.configured).map((c) => c.service))
   const kept: OcProvider[] = []
   for (const p of providers) {
-    if (whitelist !== null && !whitelist.has(p.service)) continue
+    if (blocklist.has(p.service) || (whitelist !== null && !whitelist.has(p.service))) continue
     const { actions: _actions, ...rest } = p
     // Configured OAuth (or a provider with no OAuth to gate) passes through untouched.
     if (configuredOAuth.has(p.service)) {

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -19,7 +19,7 @@ import { HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED } from '@agentconnect.md/p
 import { type AppConfig, resolveWebAppUrl } from './config/env.js'
 import { resolveGithubAppConfig } from './github/config.js'
 import type { FetchLike } from './github/api.js'
-import { ConnectorsClient, parseWhitelist } from './connectors/index.js'
+import { ConnectorsClient, parseBlocklist, parseWhitelist } from './connectors/index.js'
 import { GithubService } from './github/service.js'
 import { GithubInstallationDoorbell } from './github/installation-doorbell.service.js'
 import { GithubCommentAuthzService } from './github/comment-authz.service.js'
@@ -337,7 +337,8 @@ export function buildContainer(
       ? new ConnectorsClient({
           baseUrl: config.OPEN_CONNECTOR_URL,
           fetch: connectorsFetch,
-          whitelist: parseWhitelist(config.OPEN_CONNECTOR_PROVIDER_WHITELIST)
+          whitelist: parseWhitelist(config.OPEN_CONNECTOR_PROVIDER_WHITELIST),
+          blocklist: parseBlocklist(config.OPEN_CONNECTOR_PROVIDER_BLOCKLIST)
         })
       : undefined
 

--- a/packages/control-plane/src/http/routes/connectors.ts
+++ b/packages/control-plane/src/http/routes/connectors.ts
@@ -64,7 +64,7 @@ export function connectorRoutes(deps: HttpDeps) {
           tags: [Tag.Mcp],
           summary: 'Browse connector providers',
           description:
-            'The open-connector provider catalog, filtered to connectable providers (non-OAuth, or OAuth with a configured client secret) and any provider whitelist. 404 when the integration is not configured.',
+            'The open-connector provider catalog, filtered to connectable providers (non-OAuth, or OAuth with a configured client secret), the provider whitelist, and the provider blocklist. 404 when the integration is not configured.',
           operationId: 'listConnectorProviders',
           response: { 200: ConnectorCatalogDto, 404: ErrorDto, 502: ErrorDto }
         }

--- a/packages/control-plane/test/integration/connectors.route.test.ts
+++ b/packages/control-plane/test/integration/connectors.route.test.ts
@@ -71,7 +71,12 @@ function stubConnectors(opts: { failSave?: boolean } = {}) {
     }
     throw new Error(`unexpected fetch ${method} ${url}`)
   }
-  const client = new ConnectorsClient({ baseUrl: 'http://oc.example.com', fetch: doFetch, whitelist: null })
+  const client = new ConnectorsClient({
+    baseUrl: 'http://oc.example.com',
+    fetch: doFetch,
+    whitelist: null,
+    blocklist: new Set(['github', 'slack'])
+  })
   return { client, calls }
 }
 
@@ -96,8 +101,8 @@ describe('connectors routes', () => {
     expect((await app.app.inject({ method: 'GET', url: `${ORG}/connectors/config` })).json()).toEqual({ enabled: true })
     const res = await app.app.inject({ method: 'GET', url: `${ORG}/connectors/catalog` })
     expect(res.statusCode).toBe(200)
-    // github (configured oauth) + stripe (non-oauth); slack (unconfigured oauth) dropped.
-    expect(res.json().providers.map((p: { service: string }) => p.service)).toEqual(['github', 'stripe'])
+    // Native GitHub/Slack integrations are blocklisted; only the non-conflicting provider remains.
+    expect(res.json().providers.map((p: { service: string }) => p.service)).toEqual(['stripe'])
   })
 
   it('creates an open_connector provider + saves the profile for an api-key connection', async () => {

--- a/packages/web/src/components/console/ConnectorsModal.tsx
+++ b/packages/web/src/components/console/ConnectorsModal.tsx
@@ -181,7 +181,7 @@ function ProviderBrowser({
             <div className="font-sans text-[13px] font-semibold leading-normal">No connectors available</div>
             <div className="mx-auto mt-1 max-w-[430px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
               Non-OAuth connectors and OAuth providers with a configured client secret appear here, subject to the
-              provider whitelist. Configure one upstream or widen the whitelist to make it available.
+              configured catalog filters. Configure one upstream or adjust those filters to make it available.
             </div>
           </div>
         ) : shown.length === 0 ? (


### PR DESCRIPTION
## Summary

- add `OPEN_CONNECTOR_PROVIDER_BLOCKLIST` as a catalog policy applied after the existing whitelist
- default the blocklist to open-connector service IDs that overlap AgentConnect's native GitHub, Slack, Telegram, Discord, and Feishu/Lark integrations
- document the configuration and keep the connector browser's empty-state copy accurate

## Root cause

The Control Plane catalog only filtered by connectable authentication methods and an optional whitelist. With the whitelist unset or broad, open-connector providers that duplicate AgentConnect's native integrations remained visible and could lead users into overlapping connection paths.

## Impact

The default catalog now excludes `github`, `slack`, `telegram`, `discord`, `discordbot`, `feishu`, `feishu_app_bot`, and `feishu_custom_bot`. Deployments can override the blocklist only when they intentionally want overlapping providers.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run src/connectors/filter.test.ts` (12 tests)
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/connectors.route.test.ts` (14 tests)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- changed-file ESLint, Prettier, and `git diff --check`
- repository pre-push ESLint completed with no errors

Created by Codex . GPT-5
