### PR TITLE
fix(web): align analytics and tools navigation

### DIFF
--- a/packages/web/src/app/(app)/[slug]/usage/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/usage/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import UsageView from '@/components/console/views/UsageView'
 import { LoadingState } from '@/components/marks'
 
-export const metadata: Metadata = { title: 'Usage · AgentConnect' }
+export const metadata: Metadata = { title: 'Analytics · AgentConnect' }
 
 // UsageView reads ?range via useSearchParams → Suspense.
 export default function Page() {

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -39,7 +39,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
   { href: '/daemons', label: 'Daemons', icon: 'server' },
   { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
-  { href: '/usage', label: 'Usage', icon: 'circle-gauge' }
+  { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
 ]
 
 // Bottom tab bar (mobile only) — exactly the design's 5-slot bar: the 4 primary
@@ -52,12 +52,12 @@ const MOBILE_NAV: NavItem[] = [
   { href: '/daemons', label: 'Daemons', icon: 'server' }
 ]
 
-// The "More" sheet's destinations — Usage / Tools & Skills / Settings (the desktop rail
+// The "More" sheet's destinations — Analytics / Tools & Skills / Settings (the desktop rail
 // items beyond the 4 primary tabs). Profile is NOT here: it lives in the mobile app
 // bar as a top-right avatar (mirroring the desktop top bar). The org switcher is
 // prepended separately, in the sheet itself.
 const MORE_ROWS: NavItem[] = [
-  { href: '/usage', label: 'Usage', icon: 'circle-gauge' },
+  { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
@@ -86,7 +86,7 @@ const SECTIONS: { prefix: string; label: string }[] = [
   { prefix: '/crons', label: 'Schedules' },
   { prefix: '/daemons', label: 'Daemons' },
   { prefix: '/tools', label: 'Tools & Skills' },
-  { prefix: '/usage', label: 'Usage' },
+  { prefix: '/usage', label: 'Analytics' },
   { prefix: '/settings', label: 'Settings' },
   { prefix: '/profile', label: 'Profile' }
 ]
@@ -422,7 +422,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // Mobile push-screen title: resolve the entity name from the route id (so the
   // back-button app bar reads "deploy-bot" / "edge-1" / the session title, matching
   // the design), falling back to the section crumb for top-level push pages
-  // (Profile / Usage / Tools & Skills / Settings) or before the entity has loaded.
+  // (Profile / Analytics / Tools & Skills / Settings) or before the entity has loaded.
   const seg = barePath.split('/').filter(Boolean)
   const pushTitle = (() => {
     if (seg.length < 2) return crumb
@@ -843,7 +843,7 @@ function KeyboardShortcutsModal({ onClose }: { onClose: () => void }) {
 }
 
 // Mobile-only bottom sheets reachable from the nav's "More" tab: the app's overflow
-// destinations (Profile/Usage/Tools & Skills/Settings) + the org switcher — the sole
+// destinations (Profile/Analytics/Tools & Skills/Settings) + the org switcher — the sole
 // mobile entry point for switching / creating orgs (the rail picker is hidden).
 function MobileSheets({
   which,

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -88,7 +88,7 @@ import {
   type HookReviewPolicy
 } from '@/lib/github-review-settings'
 
-type DetailTab = 'config' | 'integrations' | 'workspace' | 'memory' | 'api' | 'knowledge'
+type DetailTab = 'config' | 'integrations' | 'workspace' | 'memory' | 'api' | 'tools'
 const HOOK_REFRESH_MS = 30_000
 
 // One-liners for the empty-integrations tiles. The tile SET is derived from the
@@ -310,7 +310,7 @@ export default function AgentDetailView() {
   // Integrations is the default landing tab (first, no `?tab=`); everything else
   // is `?tab=<id>`.
   const tab: DetailTab =
-    rawTab === 'config' || rawTab === 'workspace' || rawTab === 'memory' || rawTab === 'api' || rawTab === 'knowledge'
+    rawTab === 'config' || rawTab === 'workspace' || rawTab === 'memory' || rawTab === 'api' || rawTab === 'tools'
       ? rawTab
       : 'integrations'
 
@@ -442,7 +442,7 @@ export default function AgentDetailView() {
   }
 
   const tabCls = (t: DetailTab) => (tab === t ? 'tab on' : 'tab')
-  const tabHref = (t: DetailTab) => (t === 'integrations' ? `/agents/${da.id}` : `/agents/${da.id}?tab=${t}`)
+  const tabHref = (t: DetailTab) => orgPath(t === 'integrations' ? `/agents/${da.id}` : `/agents/${da.id}?tab=${t}`)
 
   // ── Single responsive tree. Base classes are the mobile (≤768px) push-detail
   // body (the Shell provides the top push bar there); `desktop:` variants restore
@@ -621,7 +621,7 @@ export default function AgentDetailView() {
             ['workspace', 'Workspace'],
             ['memory', 'Memory'],
             ['api', 'API'],
-            ['knowledge', 'Tools & Skills']
+            ['tools', 'Tools & Skills']
           ] as [DetailTab, string][]
         ).map(([t, label]) => {
           const on = tab === t
@@ -1500,7 +1500,7 @@ export default function AgentDetailView() {
 
       {/* Tools & Skills tab — leads with the daemon runtime's MCP servers (Tools),
           then the workspace-indexed knowledge below it. */}
-      {tab === 'knowledge' && (
+      {tab === 'tools' && (
         <div className="flex flex-col gap-4 p-4 desktop:gap-[18px] desktop:p-0">
           <AgentToolsCard
             agentId={da.id}

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -88,7 +88,7 @@ export default function UsageView() {
   })
 
   // Mobile (≤768px) renders only the scroll-body — the Shell provides the app
-  // bar (title "Usage") + bottom nav, so the desktop page header is CSS-hidden
+  // bar (title "Analytics") + bottom nav, so the desktop page header is CSS-hidden
   // there rather than removed.
   return (
     <div className="wrap">


### PR DESCRIPTION
## Summary

- rename the console-facing Usage label to Analytics across desktop, mobile, section headers, and page metadata
- migrate the agent Tools & Skills tab identifier from `knowledge` to `tools`
- generate agent tab links with the active organization path and intentionally omit compatibility for `?tab=knowledge`

## Why

The UI still exposed an outdated Usage label, while the Tools & Skills tab encoded the stale `knowledge` query value. This made the visible product language and canonical URL disagree.

## Impact

Users now see Analytics consistently. Opening Tools & Skills keeps the current organization in the URL and uses `?tab=tools`; the former query value is no longer recognized.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web test` (359 tests)
- Prettier check on all changed files
- Desktop and 390px mobile browser verification

Created by Codex . GPT-5
