### PR TITLE
fix(memory): show per-dream session usage

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -434,8 +434,9 @@ bounded byte-count metadata. Every extraction is also represented as a `dream`
 session in the normal Sessions list and usage reports. Its history contains only
 safe lifecycle messages; the memory snapshot, source transcripts, model proposal,
 and skill bodies never enter session history, evaluation events, or logs. The
-Memory Dream list links both the execution session and its source sessions and
-shows model, duration, token/cost, and prompt/output byte metrics.
+Memory Dream list links the execution session and shows that run's model,
+duration, token/cost, and prompt/output byte metrics. Source-session selection is
+input metadata, not the Dream session's history or usage.
 
 ## 11. Explicitly out of scope (v1)
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -210,8 +210,8 @@ completed result available for manual review instead of replacing live memory.
 Each dream model run appears in Sessions with its runtime, model, token/cost usage,
 and a lifecycle-only history. Dream history and evaluation events must never copy
 memory bodies, source transcript text, model proposals, or mined skill bodies. The
-Memory page links the execution session and the source sessions so operators can
-move between cost/lifecycle evidence and the conversations that were selected.
+Memory page links the execution session; source-session selection remains input
+metadata and must not displace that run's own usage in the history presentation.
 
 ## GitHub informational review checks
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1822,6 +1822,7 @@ export const SessionKeyDto = z.object({
 /** Per-session token accounting surfaced to the console (see protocol `SessionUsage`).
  *  Token counts are session-cumulative; context/cost are the latest snapshot. */
 export const SessionUsageDto = z.object({
+  reportedAt: z.string().optional(),
   totalTokens: z.number().optional(),
   inputTokens: z.number().optional(),
   outputTokens: z.number().optional(),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1917,6 +1917,7 @@ export const SessionDetailDto = z.object({
   title: z.string().nullable(),
   status: z.string().nullable(),
   lastActivityAt: z.string(),
+  usage: SessionUsageDto.nullable(),
   triggeredBy: z.string().nullable(),
   channelName: z.string().nullable(),
   triggeredByName: z.string().nullable(),

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -417,9 +417,10 @@ export function sessionRoutes(deps: HttpDeps) {
         // is indistinguishable from no parent; hidden children are omitted.
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((a) => a.id)
         const visibleAgentIdSet = new Set<string>(visibleAgentIds)
-        const [parent, children] = await Promise.all([
+        const [parent, children, usage] = await Promise.all([
           s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
-          deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds)
+          deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds),
+          deps.repos.sessionUsage.get(s.agentId, s.id)
         ])
         return {
           id: s.id,
@@ -436,6 +437,7 @@ export function sessionRoutes(deps: HttpDeps) {
           title: s.title,
           status: s.status,
           lastActivityAt: s.lastActivityAt.toISOString(),
+          usage,
           triggeredBy: s.triggeredBy,
           channelName: s.channelName,
           triggeredByName: s.triggeredByName,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -981,6 +981,8 @@ export interface UsageAggregate {
 export interface SessionUsageRepo {
   /** Upsert a session's cumulative usage (idempotent on `(agentId, sessionId)`). */
   record(input: SessionUsageInput): Promise<void>
+  /** Read one session's latest cumulative usage snapshot. */
+  get(agentId: AgentId, sessionId: string): Promise<SessionUsageCounts | null>
   /** Aggregate usage for an org over sessions active at/after `since` (range window).
    *  When a `viewer` is supplied, sessions of restricted agents they can't see are
    *  excluded from both the totals and the per-agent breakdown (derived visibility,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -935,6 +935,8 @@ export interface WebchatConversationRepo {
 
 /** The token/cost snapshot carried by a `usage/report` EVT (protocol `SessionUsage`). */
 export interface SessionUsageCounts {
+  /** Daemon timestamp of the cumulative snapshot; orders competing list/detail reads. */
+  reportedAt?: string
   totalTokens?: number
   inputTokens?: number
   outputTokens?: number

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -11,9 +11,16 @@
  * for workspace-wide token totals.
  */
 import type { PrismaLike } from '../prisma.js'
-import type { SessionUsageRepo, SessionUsageInput, UsageAggregate, AgentUsageAggregate, ViewCtx } from '../ports.js'
+import type {
+  SessionUsageRepo,
+  SessionUsageInput,
+  SessionUsageCounts,
+  UsageAggregate,
+  AgentUsageAggregate,
+  ViewCtx
+} from '../ports.js'
 import { visibilityWhere } from '../ports.js'
-import type { OrgId } from '../../domain/ids.js'
+import type { AgentId, OrgId } from '../../domain/ids.js'
 
 export class PgSessionUsageRepo implements SessionUsageRepo {
   constructor(private readonly db: PrismaLike) {}
@@ -44,6 +51,25 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       create: { agentId: input.agentId, sessionId: input.sessionId, ...fields },
       update: fields
     })
+  }
+
+  async get(agentId: AgentId, sessionId: string): Promise<SessionUsageCounts | null> {
+    const usage = await this.db.sessionUsage.findUnique({
+      where: { agentId_sessionId: { agentId, sessionId } }
+    })
+    if (!usage) return null
+    return {
+      totalTokens: usage.totalTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      thoughtTokens: usage.thoughtTokens,
+      cachedReadTokens: usage.cachedReadTokens,
+      cachedWriteTokens: usage.cachedWriteTokens,
+      ...(usage.contextUsed !== null ? { contextUsed: usage.contextUsed } : {}),
+      ...(usage.contextSize !== null ? { contextSize: usage.contextSize } : {}),
+      ...(usage.costAmount !== 0 || usage.costCurrency ? { costAmount: usage.costAmount } : {}),
+      ...(usage.costCurrency ? { costCurrency: usage.costCurrency } : {})
+    }
   }
 
   async aggregate(orgId: OrgId, since: Date, viewer?: ViewCtx): Promise<UsageAggregate> {

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -59,6 +59,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     })
     if (!usage) return null
     return {
+      reportedAt: usage.lastActivityAt.toISOString(),
       totalTokens: usage.totalTokens,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -63,6 +63,7 @@ function usageKey(agentId: string, sessionId: string): string {
 }
 
 function usageCounts(u: {
+  lastActivityAt: Date
   totalTokens: number
   inputTokens: number
   outputTokens: number
@@ -75,6 +76,7 @@ function usageCounts(u: {
   costCurrency: string | null
 }): SessionUsageCounts {
   return {
+    reportedAt: u.lastActivityAt.toISOString(),
     totalTokens: u.totalTokens,
     inputTokens: u.inputTokens,
     outputTokens: u.outputTokens,

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -135,6 +135,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       outputMode: string | null
       daemonId: string | null
       usage: {
+        reportedAt: string
         totalTokens: number
         inputTokens: number
         outputTokens: number
@@ -157,6 +158,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect(body.outputMode).toBe('medium')
     expect(body.daemonId).toBe(DAEMON) // CP-stamped from the reporting WS connection
     expect(body.usage).toMatchObject({
+      reportedAt: '2026-07-05T00:00:01.000Z',
       totalTokens: 1_200,
       inputTokens: 1_000,
       outputTokens: 200,
@@ -192,7 +194,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
         permissionMode: string | null
         outputMode: string | null
         daemonId: string | null
-        usage: { totalTokens: number } | null
+        usage: { reportedAt: string; totalTokens: number } | null
       }>
     }
     expect(listBody.sessions[0]!.runtime).toBe('claude')
@@ -203,6 +205,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect(listBody.sessions[0]!.outputMode).toBe('medium')
     expect(listBody.sessions[0]!.daemonId).toBe(DAEMON)
     expect(listBody.sessions[0]!.usage?.totalTokens).toBe(1_200)
+    expect(listBody.sessions[0]!.usage?.reportedAt).toBe('2026-07-05T00:00:01.000Z')
   })
 
   it('is idempotent — a later milestone advances the same session row', async () => {

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -102,6 +102,20 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       outputMode: 'medium',
       ts: '2026-07-05T00:00:00.000Z'
     })
+    await prisma.sessionUsage.create({
+      data: {
+        agentId: AGENT,
+        sessionId: SESSION,
+        platform: 'slack',
+        channel: 'C123',
+        totalTokens: 1_200,
+        inputTokens: 1_000,
+        outputTokens: 200,
+        costAmount: 0.012,
+        costCurrency: 'USD',
+        lastActivityAt: new Date('2026-07-05T00:00:01.000Z')
+      }
+    })
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}` })
     expect(res.statusCode).toBe(200)
@@ -120,6 +134,13 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       permissionMode: string | null
       outputMode: string | null
       daemonId: string | null
+      usage: {
+        totalTokens: number
+        inputTokens: number
+        outputTokens: number
+        costAmount: number
+        costCurrency: string
+      }
     }
     expect(body.id).toBe(SESSION)
     expect(body.agentId).toBe(AGENT)
@@ -135,6 +156,13 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect(body.permissionMode).toBe('acceptEdits')
     expect(body.outputMode).toBe('medium')
     expect(body.daemonId).toBe(DAEMON) // CP-stamped from the reporting WS connection
+    expect(body.usage).toMatchObject({
+      totalTokens: 1_200,
+      inputTokens: 1_000,
+      outputTokens: 200,
+      costAmount: 0.012,
+      costCurrency: 'USD'
+    })
 
     const stored = await prisma.sessionMeta.findUniqueOrThrow({ where: { id: SESSION } })
     expect(stored.title).toBe('Roll out api@1.4.2')
@@ -164,6 +192,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
         permissionMode: string | null
         outputMode: string | null
         daemonId: string | null
+        usage: { totalTokens: number } | null
       }>
     }
     expect(listBody.sessions[0]!.runtime).toBe('claude')
@@ -173,6 +202,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect(listBody.sessions[0]!.permissionMode).toBe('acceptEdits')
     expect(listBody.sessions[0]!.outputMode).toBe('medium')
     expect(listBody.sessions[0]!.daemonId).toBe(DAEMON)
+    expect(listBody.sessions[0]!.usage?.totalTokens).toBe(1_200)
   })
 
   it('is idempotent — a later milestone advances the same session row', async () => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3434,7 +3434,7 @@ export class Daemon {
       ts: monotonicTs(),
       sender: agentId,
       kind: 'text',
-      text: `Memory dream started. ${context.sessionIds.length} source session${context.sessionIds.length === 1 ? '' : 's'} selected.`
+      text: 'Memory dream started.'
     })
     this.emitSessionMetadataSnapshot({
       sessionId,

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -206,6 +206,7 @@ describe('Daemon evaluation surface', () => {
       .map((row: { text: string }) => row.text)
       .join('\n')
     expect(history).toContain('Memory dream started.')
+    expect(history).not.toContain('source session')
     expect(history).toContain('Dream completed.')
     expect(history).not.toContain(proposal)
     expect(collector.events().map((event) => event.type)).toEqual(['memory.dream.started', 'memory.dream.completed'])

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -130,7 +130,14 @@ describe('DreamPanel', () => {
     expect(button(header as HTMLElement, 'Dream now')).toBeTruthy()
   })
 
-  it('shows model, duration, token/cost usage, and session links', async () => {
+  it('marks older completed runs without token metering as unavailable', async () => {
+    api.listDreams.mockResolvedValue([dream()])
+    const host = await render()
+    expect(host.textContent).toContain('Tokens unavailable')
+    expect(host.textContent).not.toContain('sessions mined')
+  })
+
+  it('leads with this run’s token/cost usage and links its execution session', async () => {
     api.listDreams.mockResolvedValue([
       dream({
         executionSessionId: 'dream-session-1',
@@ -156,7 +163,9 @@ describe('DreamPanel', () => {
     expect(host.textContent).toContain('$0.12')
     expect(host.textContent).toContain('2.0 KB prompt')
     expect(host.querySelector('a[href="/acme/sessions/dream-session-1"]')?.textContent).toContain('Open session')
-    expect(host.querySelector('a[href="/acme/sessions/s1"]')).not.toBeNull()
+    expect(host.textContent).not.toContain('sessions mined')
+    expect(host.textContent).not.toContain('Sources')
+    expect(host.querySelector('a[href="/acme/sessions/s1"]')).toBeNull()
   })
 
   it('blocks the trigger for a viewer, with the reason', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -236,10 +236,14 @@ export function DreamPanel({
         const duration = elapsed(dream.createdAt, dream.endedAt)
         const usage = dream.usage
         const metrics = [
+          usage?.totalTokens !== undefined
+            ? `${fmtCountCompact(usage.totalTokens)} tokens`
+            : isDreamTerminal(dream.status)
+              ? 'Tokens unavailable'
+              : null,
+          usage?.costAmount !== undefined ? fmtCost(usage.costAmount, usage.costCurrency) : null,
           dream.model,
-          duration,
-          usage?.totalTokens !== undefined ? `${fmtCountCompact(usage.totalTokens)} tokens` : null,
-          usage?.costAmount !== undefined ? fmtCost(usage.costAmount, usage.costCurrency) : null
+          duration
         ].filter((value): value is string => Boolean(value))
         const byteMetrics = usage
           ? `${fmtBytes(usage.inputBytes)} prompt · ${fmtBytes(usage.outputBytes)} output`
@@ -259,28 +263,12 @@ export function DreamPanel({
                 {dream.trigger === 'schedule' ? ' · scheduled' : ''}
               </span>
               <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                {when(dream.createdAt)} · {dream.sessionIds.length} session
-                {dream.sessionIds.length === 1 ? '' : 's'} mined
+                {when(dream.createdAt)}
                 {dream.error ? ` · ${dream.error.message}` : ''}
               </span>
               {metrics.length || byteMetrics ? (
                 <span className="font-mono text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
                   {[...metrics, ...(byteMetrics ? [byteMetrics] : [])].join(' · ')}
-                </span>
-              ) : null}
-              {sessionBasePath && dream.sessionIds.length ? (
-                <span className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
-                  <span>Sources</span>
-                  {dream.sessionIds.slice(0, 4).map((sessionId) => (
-                    <Link
-                      key={sessionId}
-                      href={`${sessionBasePath}/${encodeURIComponent(sessionId)}`}
-                      className="lnk font-mono text-[10.5px]"
-                    >
-                      {sessionId.slice(0, 10)}
-                    </Link>
-                  ))}
-                  {dream.sessionIds.length > 4 ? <span>+{dream.sessionIds.length - 4}</span> : null}
                 </span>
               ) : null}
             </span>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -33,6 +33,7 @@ import {
   fetchToolBody,
   fmtCountCompact,
   memberDisplayName,
+  mergeSessionDetailUsage,
   sessionFromDetailDto,
   type SessionDetailDto,
   type SessionMessageDto,
@@ -595,7 +596,11 @@ export default function SessionDetailView() {
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
     { refreshInterval: 30_000 }
   )
-  const sessionBase = localSession ?? (sessionDetail ? sessionFromDetailDto(sessionDetail) : null)
+  const detailSession = sessionDetail ? sessionFromDetailDto(sessionDetail) : null
+  // The cursor-loaded list row can predate the final Dream usage report. Keep
+  // its local/live fields, but let the independently refreshed detail snapshot
+  // supply the authoritative per-session token and cost totals.
+  const sessionBase = localSession ? mergeSessionDetailUsage(localSession, detailSession) : detailSession
   const owner = sessionBase ? agents.find((a) => a.id === sessionBase.agentId) : undefined
   const session =
     sessionBase && !localSession

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -331,6 +331,7 @@ export interface SessionDetailDto {
   title: string | null
   status: string | null
   lastActivityAt: string
+  usage: SessionUsageDto | null
   triggeredBy: string | null
   channelName: string | null
   triggeredByName: string | null
@@ -1497,8 +1498,8 @@ export function sessionFromDto(d: SessionDto): Session {
 }
 
 /** Hydrate a session detail that was not present in the currently loaded list
- *  pages. Usage stays unknown until its list page is loaded, but navigation and
- *  transcript pull have the same metadata as an ordinary list-derived session. */
+ *  pages. Detail carries its own latest usage snapshot so a direct link can show
+ *  this session's token/cost accounting without depending on list pagination. */
 export function sessionFromDetailDto(d: SessionDetailDto): Session {
   return sessionFromDto({
     sessionId: d.id,
@@ -1511,7 +1512,7 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
     title: d.title,
     status: d.status,
     lastActivityAt: d.lastActivityAt,
-    usage: null,
+    usage: d.usage,
     triggeredBy: d.triggeredBy,
     channelName: d.channelName,
     triggeredByName: d.triggeredByName,
@@ -1524,6 +1525,19 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
     outputMode: d.outputMode,
     daemonId: d.daemonId
   })
+}
+
+/** Keep local/live session fields while refreshing usage from the independently
+ *  polled detail endpoint. This closes the race where the list row arrived just
+ *  before the daemon's final cumulative usage report. */
+export function mergeSessionDetailUsage(local: Session, detail: Session | null): Session {
+  if (!detail?.usage) return local
+  return {
+    ...local,
+    usage: detail.usage,
+    tokens: detail.tokens,
+    cost: detail.cost
+  }
 }
 
 export function daemonFromDto(d: DaemonViewDto): DaemonRow {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -220,6 +220,7 @@ export interface AgentCallPolicyInput {
 // session-cumulative; context/cost are the latest snapshot. All fields optional —
 // a runtime that reports no usage yields absent fields.
 export interface SessionUsageDto {
+  reportedAt?: string
   totalTokens?: number
   inputTokens?: number
   outputTokens?: number
@@ -1532,6 +1533,15 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
  *  before the daemon's final cumulative usage report. */
 export function mergeSessionDetailUsage(local: Session, detail: Session | null): Session {
   if (!detail?.usage) return local
+  if (local.usage) {
+    const localReportedAt = local.usage.reportedAt ? Date.parse(local.usage.reportedAt) : Number.NaN
+    const detailReportedAt = detail.usage.reportedAt ? Date.parse(detail.usage.reportedAt) : Number.NaN
+    // A live session can have usage without a persisted timestamp. Preserve that
+    // state unless the detail snapshot proves it is newer; never let a cached
+    // detail response move cumulative token/cost totals backward.
+    if (!Number.isFinite(detailReportedAt)) return local
+    if (!Number.isFinite(localReportedAt) || detailReportedAt <= localReportedAt) return local
+  }
   return {
     ...local,
     usage: detail.usage,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -709,6 +709,8 @@ export interface SessionStep {
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.
 // Token counts are session-cumulative; context/cost are the latest snapshot.
 export interface SessionUsage {
+  /** Daemon timestamp of this cumulative snapshot (orders list/detail refreshes). */
+  reportedAt?: string
   totalTokens?: number
   inputTokens?: number
   outputTokens?: number

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -121,6 +121,7 @@ describe('sessionTriggerKind', () => {
       status: 'completed',
       lastActivityAt: '2026-07-27T00:00:00.000Z',
       usage: {
+        reportedAt: '2026-07-27T00:02:00.000Z',
         totalTokens: 12_400,
         inputTokens: 10_000,
         outputTokens: 2_400,
@@ -152,10 +153,45 @@ describe('sessionTriggerKind', () => {
       sessionDto({
         sessionId: detail.id,
         sessionKey: { platform: 'dream', channel: 'memory' },
-        usage: null
+        usage: {
+          reportedAt: '2026-07-27T00:03:00.000Z',
+          totalTokens: 20_000,
+          costAmount: 0.2,
+          costCurrency: 'USD'
+        }
       })
     )
     expect(mergeSessionDetailUsage(staleListRow, hydrated)).toMatchObject({
+      tokens: '20K',
+      cost: '$0.20',
+      usage: { totalTokens: 20_000 }
+    })
+
+    const freshDetail = {
+      ...hydrated,
+      tokens: '30K',
+      cost: '$0.30',
+      usage: {
+        ...hydrated.usage!,
+        reportedAt: '2026-07-27T00:04:00.000Z',
+        totalTokens: 30_000,
+        costAmount: 0.3
+      }
+    }
+    expect(mergeSessionDetailUsage(staleListRow, freshDetail)).toMatchObject({
+      tokens: '30K',
+      cost: '$0.30',
+      usage: { totalTokens: 30_000 }
+    })
+
+    const unmeteredListRow = sessionFromDto(
+      sessionDto({
+        sessionId: detail.id,
+        sessionKey: { platform: 'dream', channel: 'memory' },
+        usage: null
+      })
+    )
+    expect(mergeSessionDetailUsage(unmeteredListRow, hydrated)).toMatchObject({
       tokens: '12K',
       cost: '$0.12',
       usage: { totalTokens: 12_400 }

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { sessionFromDto, type SessionDto } from './api'
+import {
+  mergeSessionDetailUsage,
+  sessionFromDetailDto,
+  sessionFromDto,
+  type SessionDetailDto,
+  type SessionDto
+} from './api'
 import { sessionPlatform } from './data'
 import {
   githubRepoIdFromSessionTriggerFilter,
@@ -99,6 +105,60 @@ describe('sessionTriggerKind', () => {
       model: 'gpt-5.6',
       tokens: '120',
       cost: '$0.01'
+    })
+  })
+
+  it('hydrates token and cost usage from a direct session-detail response', () => {
+    const detail: SessionDetailDto = {
+      id: 'dream-session-1',
+      parentSession: null,
+      childSessions: [],
+      agentId: 'target-agent',
+      platform: 'dream',
+      channel: 'memory',
+      thread: 'drm-1',
+      title: 'Memory dream',
+      status: 'completed',
+      lastActivityAt: '2026-07-27T00:00:00.000Z',
+      usage: {
+        totalTokens: 12_400,
+        inputTokens: 10_000,
+        outputTokens: 2_400,
+        costAmount: 0.12,
+        costCurrency: 'USD'
+      },
+      triggeredBy: 'manual',
+      channelName: null,
+      triggeredByName: null,
+      threadUrl: null,
+      runtime: 'codex',
+      model: 'gpt-5.6',
+      effort: null,
+      fastMode: null,
+      permissionMode: 'read-only',
+      outputMode: null,
+      daemonId: 'daemon-1'
+    }
+
+    const hydrated = sessionFromDetailDto(detail)
+    expect(hydrated).toMatchObject({
+      platform: 'dream',
+      tokens: '12K',
+      cost: '$0.12',
+      usage: { inputTokens: 10_000, outputTokens: 2_400 }
+    })
+
+    const staleListRow = sessionFromDto(
+      sessionDto({
+        sessionId: detail.id,
+        sessionKey: { platform: 'dream', channel: 'memory' },
+        usage: null
+      })
+    )
+    expect(mergeSessionDetailUsage(staleListRow, hydrated)).toMatchObject({
+      tokens: '12K',
+      cost: '$0.12',
+      usage: { totalTokens: 12_400 }
     })
   })
 })


### PR DESCRIPTION
## What changed

- Return the latest token and cost snapshot from the session-detail API.
- Refresh a session detail with authoritative usage even when the Sessions list row is stale.
- Make each Dream run's own token/cost usage the primary Dream history metric.
- Remove source-session counts and links from Dream history and lifecycle transcript copy.
- Show `Tokens unavailable` for older completed Dream runs that predate metering.

## Why

This is a follow-up to #138. The observability unit should be one Dream execution session. Directly opening that session could previously lose usage because the detail endpoint returned no usage, leaving the source-session count (often 20) as the most visible history number.

## Impact

Operators can open one Memory Dream session and see the tokens and cost consumed by that specific run. Source-session selection remains internal input metadata and no longer reads like the run's usage/history. Existing runs without recorded token telemetry are marked unavailable rather than inferred.

## Validation

- Control-plane typecheck and 664 unit tests
- Control-plane session-detail integration tests (7)
- Web typecheck and 361 tests
- Daemon typecheck and Dream evaluation tests (8)
- Repository formatting and lint (no errors; two pre-existing unrelated warnings)