### PR TITLE
fix(daemon): structure GitHub session titles

### DIFF
--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -182,9 +182,9 @@ export function createSessionReader(
   return {
     list(req) {
       const rows = store.listSessions(req.agentId)
-      // Title = the title supplied by ACP or the AgentConnect title tool, else a
-      // fallback derived from the session's FIRST user message. Before the agent has
-      // a meaningful request to name, this keeps the console better than "Session <id>".
+      // Title = the ingress/runtime/tool title, else a fallback derived from the
+      // session's FIRST user message. Before the agent has a meaningful request to
+      // name, this keeps the console better than "Session <id>".
       // firstMessageText only runs for untitled rows (`||` short-circuits).
       const enriched = rows.map((r) => ({
         r,

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -43,6 +43,36 @@ function splitSessionKey(msg: RdMsgHook): { channel: string; thread?: string } {
 
 /** The well-known payload fields a caller can speak through, in priority order. */
 const MESSAGE_FIELDS = ['prompt', 'text', 'message'] as const
+const SESSION_TITLE_MAX_CHARS = 80
+
+function clampSessionTitle(title: string): string {
+  const chars = [...title]
+  return chars.length > SESSION_TITLE_MAX_CHARS
+    ? `${chars
+        .slice(0, SESSION_TITLE_MAX_CHARS - 1)
+        .join('')
+        .trimEnd()}…`
+    : title
+}
+
+/** Initial console title from the signed GitHub envelope. Prefer the separate,
+ *  body-free subject metadata when a current relay provides it; the context
+ *  fields keep rolling upgrades readable. */
+function githubSessionTitle(msg: RdMsgHook): string | undefined {
+  const context = msg.context
+  if (context?.source !== 'github') return undefined
+
+  const subjectKind =
+    msg.github?.subjectKind ??
+    (context.event?.startsWith('pull_request') ? 'pull_request' : context.event === 'issues' ? 'issue' : undefined)
+  const label = subjectKind === 'pull_request' ? 'PR' : subjectKind === 'issue' ? 'Issue' : 'GitHub'
+  const repo = msg.github?.repoFullName ?? context.repo
+  const number = subjectKind === 'pull_request' ? (msg.github?.pullNumber ?? context.number) : context.number
+  const target = `${repo ?? ''}${number !== undefined ? `#${number}` : ''}`
+  const prefix = target ? `${label} ${target}` : label
+  const detail = context.title?.replace(/\s+/g, ' ').trim()
+  return clampSessionTitle(detail ? `${prefix}: ${detail}` : prefix)
+}
 
 /**
  * Pull the caller's message out of the delivery body: a bare JSON string is
@@ -242,6 +272,7 @@ export function hookAnchorText(msg: RdMsgHook): string {
 
 export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMessage {
   const { channel, thread } = splitSessionKey(msg)
+  const initialSessionTitle = githubSessionTitle(msg)
   // `msgId` is the collision-free delivery identity but is not a timestamp. Keep
   // the display/order key in epoch milliseconds and append the complete identity
   // so distinct same-millisecond deliveries cannot share a transcript primary key.
@@ -262,6 +293,7 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
       thread: msg.msgId,
       sender: { id: `hook:${msg.hookId}`, isBot: false },
       text: buildHookText(msg),
+      ...(initialSessionTitle ? { initialSessionTitle } : {}),
       mentionedBots: [],
       isDm: false,
       trigger: 'hook'
@@ -277,6 +309,7 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
     ...(thread ? { thread } : {}),
     sender: { id: `hook:${msg.hookId}`, isBot: false },
     text: buildHookText(msg),
+    ...(initialSessionTitle ? { initialSessionTitle } : {}),
     mentionedBots: [],
     isDm: false,
     trigger: 'hook',

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -43,6 +43,9 @@ export interface NormalizedMessage {
     appId?: string
   }
   text: string
+  /** Ingress-derived title applied only when this message creates a logical
+   *  session. A later runtime title remains authoritative and replaces it. */
+  initialSessionTitle?: string
   mentionedBots: string[]
   attachments?: Attachment[]
   isDm: boolean

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -286,6 +286,7 @@ export class SessionManager {
     })
 
     let rec = this.deps.store.getSession(key)
+    const isNewLogicalSession = rec === undefined
     if (rec) {
       const persistedMemoryProvider = rec.memoryProvider ?? 'managed'
       if (persistedMemoryProvider !== currentMemoryProvider) {
@@ -542,6 +543,9 @@ export class SessionManager {
         ...(effectiveOriginSessionId ? { originSessionId: effectiveOriginSessionId } : {})
       }
       this.deps.store.upsertSession(rec)
+      if (isNewLogicalSession && msg.initialSessionTitle?.trim()) {
+        this.deps.store.setSessionTitle(key, msg.initialSessionTitle.trim())
+      }
     } else if (host.hasSession?.(rec.acpSessionId) === false) {
       const persistedSessionId = rec.acpSessionId
       // Persisted, but unknown to THIS agent process (daemon restart / host eviction):

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -77,9 +77,9 @@ export interface SessionRecord {
   // NULL on legacy rows / non-platform sessions). Display-name resolution is a
   // separate `display_names` lookup keyed by this id.
   triggeredBy?: string | null
-  // Human-facing session title supplied by the runtime (ACP
-  // `session_info_update`) or AgentConnect's `setSessionTitle` tool. NULL until
-  // either source reports one.
+  // Human-facing session title supplied by an ingress when the session is
+  // created, by the runtime (ACP `session_info_update`), or by AgentConnect's
+  // `setSessionTitle` tool. Later runtime/tool updates win.
   title?: string | null
   // Slack-only chrome: the current in-thread status-bar message ts. One per session
   // so later turns edit the same status line instead of posting duplicates.
@@ -1356,8 +1356,8 @@ export class LocalStore {
     }
   }
 
-  /** Human-facing session title from ACP or the AgentConnect title tool (latest
-   *  wins; null clears per ACP semantics). No-op on an unknown key. */
+  /** Human-facing session title from ingress, ACP, or the AgentConnect title
+   *  tool (latest wins; null clears per ACP semantics). No-op on an unknown key. */
   setSessionTitle(key: string, title: string | null): void {
     this.db.prepare('UPDATE sessions SET title = ? WHERE key = ?').run(title, key)
   }

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -152,6 +152,41 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('persists a structured initial title for a GitHub pull-request session', async () => {
+    const { factory } = streamingHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as never as { cpClient: unknown }).cpClient = cp
+    ;(daemon as any).makeGithubReply = vi.fn(() => ({
+      poster: { publish: vi.fn(async () => {}) },
+      collector: new GithubReplyCollector()
+    }))
+
+    const ack = await (daemon as any).handleRelayMsg(
+      fire({
+        sessionKey: 'agentconnect-md/agentconnect#144',
+        context: {
+          source: 'github',
+          event: 'pull_request',
+          action: 'opened',
+          repo: 'agentconnect-md/agentconnect',
+          number: 144,
+          title: 'perf(github): speed up review delivery',
+          truncated: false
+        }
+      }),
+      () => {}
+    )
+
+    expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
+    await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
+    expect((daemon as any).store.getSessionByAcpId('acp-hook-1')?.title).toBe(
+      'PR agentconnect-md/agentconnect#144: perf(github): speed up review delivery'
+    )
+    await daemon.stop()
+  }, 15_000)
+
   it.each([
     {
       name: 'provider quota exhaustion',
@@ -1635,6 +1670,32 @@ describe('buildHookMessage', () => {
       const anchor = hookAnchorText(ghFire())
       expect(anchor).toBe('🪝 issues:opened — acme/infra#42 — db down')
       expect(anchor).not.toContain('ignore all previous')
+    })
+
+    it('builds concise structured titles for GitHub subjects', () => {
+      const issue = buildHookMessage(ghFire(), 'trace-issue')
+      expect(issue.initialSessionTitle).toBe('Issue acme/infra#42: db down')
+
+      const pullRequest = buildHookMessage(
+        ghFire(
+          { event: 'issue_comment', action: 'created', repo: 'display-only/wrong', number: 999 },
+          {
+            github: {
+              repoId: '123',
+              repoFullName: 'acme/infra',
+              sourceInstallationId: '456',
+              subjectKind: 'pull_request',
+              pullNumber: 144
+            }
+          }
+        ),
+        'trace-pr'
+      )
+      expect(pullRequest.initialSessionTitle).toBe('PR acme/infra#144: db down')
+
+      const long = buildHookMessage(ghFire({ title: 'x'.repeat(100) }), 'trace-long').initialSessionTitle!
+      expect([...long]).toHaveLength(80)
+      expect(long.endsWith('…')).toBe(true)
     })
 
     it('a numbered thread carries the auto-reply hint (do not self-comment); a threadless push does not', () => {


### PR DESCRIPTION
## Summary

- derive GitHub session titles from structured subject metadata
- format pull requests as `PR org/repo#number: title` and issues as `Issue org/repo#number: title`
- cap initial titles at 80 characters while preserving later runtime/tool title overrides

## Root cause

GitHub hook sessions fell back to the first prompt line, so the event-name prefix consumed most of the visible title and made the session list repetitive.

## Validation

- daemon TypeScript typecheck
- ESLint on all changed files
- focused GitHub hook/session-title tests
- full daemon suite: 133 files and 2143 tests passed

Created by Codex . GPT-5
