### PR TITLE
fix(web): unify file browser editing

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -282,6 +282,14 @@ and `Add file`, `Edit`, and `Delete` actions on the right. New-file naming happe
 in that breadcrumb; completed slash-separated directory names become breadcrumb
 segments. The preview pane does not repeat the file name, path, or workspace label.
 
+The managed and native Memory file browser uses the same shared inline file editor,
+breadcrumb naming field, and header actions as Workspace. It must not introduce a
+separate prompt or modal flow for adding or editing files; only the persistence API
+and Memory's flat Markdown filename validation differ. File-specific capabilities
+belong in the preview summary row: managed Memory exposes `History` there today, and
+repository-backed Workspace history must reuse the same action slot and history pane
+when it is added.
+
 For a GitHub workspace, show the effective `read` or `write` access beside the
 repository. The editor may switch freely between scratch and GitHub, choose another
 repository or branch, change the working subdirectory, edit read/write access, or bind

--- a/packages/web/src/components/console/FileBrowser.test.ts
+++ b/packages/web/src/components/console/FileBrowser.test.ts
@@ -1,7 +1,17 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { FileBrowserLayout, FileBrowserPreviewHeader, FileBrowserRow, FileBrowserShell } from './FileBrowser'
+import {
+  FileBrowserBreadcrumb,
+  FileBrowserEditor,
+  FileBrowserEditorActions,
+  FileBrowserHistoryButton,
+  FileBrowserLayout,
+  FileBrowserPreviewHeader,
+  FileBrowserPreviewSummary,
+  FileBrowserRow,
+  FileBrowserShell
+} from './FileBrowser'
 
 describe('shared file browser', () => {
   it('renders selected files with one shared navigation state', () => {
@@ -51,10 +61,73 @@ describe('shared file browser', () => {
     )
 
     expect(shell).toContain('cardhead')
+    expect(shell).toContain('min-h-[41px]')
+    expect(shell).toContain('py-[6px]')
     expect(shell).toContain('Memory')
     expect(shell).toContain('New')
     expect(preview).toContain('aria-label="Back to files"')
     expect(preview).toContain('contacts.md')
     expect(preview).toContain('Edit')
+  })
+
+  it('shares one inline create surface across file browsers', () => {
+    const draft = {
+      target: '',
+      directory: '',
+      name: 'notes.md',
+      content: '# Notes',
+      mtime: null,
+      loading: false,
+      saving: false,
+      error: null
+    }
+    const html = renderToStaticMarkup(
+      createElement(FileBrowserShell, {
+        title: createElement(FileBrowserBreadcrumb, {
+          root: 'Memory',
+          path: '',
+          creating: true,
+          draftName: draft.name,
+          onDraftNameChange: () => undefined,
+          nested: false,
+          inputAriaLabel: 'New memory file name'
+        }),
+        headerEnd: createElement(FileBrowserEditorActions, {
+          saving: false,
+          onCancel: () => undefined,
+          onSave: () => undefined
+        }),
+        children: createElement(FileBrowserEditor, {
+          draft,
+          onContentChange: () => undefined,
+          onCancel: () => undefined,
+          onSubmit: () => undefined
+        })
+      })
+    )
+
+    expect(html).toContain('aria-label="New memory file name"')
+    expect(html).toContain('value="notes.md"')
+    expect(html).toContain('h-7 min-h-7')
+    expect(html).toContain('Save changes')
+    expect(html).toContain('aria-label="New file content"')
+    expect(html).toContain('# Notes')
+  })
+
+  it('exposes optional file capabilities in the shared summary row', () => {
+    const html = renderToStaticMarkup(
+      createElement(FileBrowserPreviewSummary, {
+        meta: '60 B · edited 1d ago',
+        actions: createElement(FileBrowserHistoryButton, {
+          active: false,
+          onClick: () => undefined
+        })
+      })
+    )
+
+    expect(html).toContain('h-[37px]')
+    expect(html).toContain('60 B · edited 1d ago')
+    expect(html).toContain('aria-pressed="false"')
+    expect(html).toContain('History')
   })
 })

--- a/packages/web/src/components/console/FileBrowser.tsx
+++ b/packages/web/src/components/console/FileBrowser.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { Icon } from '@/components/ui'
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
+import { Spinner } from '@/components/marks'
+import { Button, Icon } from '@/components/ui'
 import { useIsMobile } from '@/lib/use-is-mobile'
 
 const CODE_EXT = new Set([
@@ -45,6 +46,43 @@ export function fileBrowserGlyph(name: string): string {
   return CODE_EXT.has(ext) ? 'file-code' : 'file-text'
 }
 
+export function formatFileSize(bytes: number | null): string {
+  if (bytes == null) return ''
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// Relative when recent (matches the fleet's "last seen" feel), short date otherwise.
+export function formatFileMtime(iso: string | null): string {
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000)
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  }
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+export type FileBrowserEditorDraft = {
+  target: string
+  directory: string
+  name: string
+  content: string
+  mtime: string | null
+  loading: boolean
+  saving: boolean
+  error: string | null
+}
+
 export function FileBrowserShell({
   title,
   headerEnd,
@@ -56,12 +94,192 @@ export function FileBrowserShell({
 }) {
   return (
     <div className="card overflow-hidden max-desktop:rounded-lg">
-      <div className="cardhead min-w-0 justify-between">
+      <div className="cardhead min-h-[41px] min-w-0 justify-between py-[6px]">
         <div className="cardtitle min-w-0 flex-1">{title}</div>
         {headerEnd}
       </div>
       {children}
     </div>
+  )
+}
+
+export function FileBrowserBreadcrumb({
+  root,
+  path,
+  creating,
+  draftName,
+  onDraftNameChange,
+  onBack,
+  disabled,
+  nested = true,
+  ariaLabel = 'File path',
+  inputAriaLabel = 'New file path'
+}: {
+  root: string
+  path: string
+  creating: boolean
+  draftName: string
+  onDraftNameChange: (name: string) => void
+  onBack?: () => void
+  disabled?: boolean
+  nested?: boolean
+  ariaLabel?: string
+  inputAriaLabel?: string
+}) {
+  const baseSegments = path.split('/').filter(Boolean)
+  const draftParts = creating ? (nested ? draftName.replace(/^\/+/, '').split('/') : [draftName]) : []
+  const draftDirectories = draftParts.slice(0, -1).filter(Boolean)
+  const draftLeaf = creating ? (draftParts.at(-1) ?? '') : ''
+  const segments = [...baseSegments, ...draftDirectories]
+  const updateDraftLeaf = (leaf: string) => onDraftNameChange([...draftDirectories, leaf].join('/'))
+
+  return (
+    <nav className="flex min-w-0 items-center gap-[6px] overflow-hidden" aria-label={ariaLabel}>
+      {onBack ? (
+        <button
+          type="button"
+          className="iconbtn h-7 w-7 flex-none"
+          onClick={onBack}
+          title="Back to files"
+          aria-label="Back to files"
+        >
+          <Icon name="arrow-left" size={15} />
+        </button>
+      ) : null}
+      <span
+        className={`mono max-w-[120px] flex-none truncate text-[12px] font-semibold text-(--text-primary) ${
+          segments.length > 0 || creating ? 'max-desktop:hidden' : ''
+        }`}
+      >
+        {root}
+      </span>
+      {segments.map((segment, index) => {
+        const current = !creating && index === segments.length - 1
+        const mobileCurrent = index === segments.length - 1
+        return (
+          <Fragment key={`${index}:${segment}`}>
+            <span className="flex-none text-[12px] font-normal text-(--text-tertiary) max-desktop:hidden" aria-hidden>
+              /
+            </span>
+            <span
+              className={`mono min-w-[24px] max-w-[140px] shrink truncate text-[12px] ${
+                current ? 'font-semibold text-(--text-primary)' : 'font-medium text-(--text-secondary)'
+              } ${mobileCurrent ? '' : 'max-desktop:hidden'}`}
+            >
+              {segment}
+            </span>
+          </Fragment>
+        )
+      })}
+      {segments.length === 0 && !creating ? (
+        <span className="flex-none text-[12px] font-normal text-(--text-tertiary)" aria-hidden>
+          /
+        </span>
+      ) : null}
+      {creating ? (
+        <>
+          <span className="flex-none text-[12px] font-normal text-(--text-tertiary)" aria-hidden>
+            /
+          </span>
+          <input
+            className="inp mono h-7 min-h-7 w-[96px] min-w-16 max-w-full shrink px-2 py-1 text-[12px] desktop:w-[170px] desktop:min-w-[80px] desktop:max-w-[30vw]"
+            value={draftLeaf}
+            onChange={(event) => updateDraftLeaf(event.target.value)}
+            onKeyDown={(event) => {
+              if (!nested || event.key !== 'Backspace' || draftLeaf || draftDirectories.length === 0) return
+              event.preventDefault()
+              onDraftNameChange([...draftDirectories.slice(0, -1), draftDirectories.at(-1)!].join('/'))
+            }}
+            placeholder="Name your file…"
+            aria-label={inputAriaLabel}
+            spellCheck={false}
+            disabled={disabled}
+            autoFocus
+          />
+        </>
+      ) : null}
+    </nav>
+  )
+}
+
+export function FileBrowserEditorActions({
+  saving,
+  disabled,
+  onCancel,
+  onSave
+}: {
+  saving: boolean
+  disabled?: boolean
+  onCancel: () => void
+  onSave: () => void
+}) {
+  return (
+    <div className="flex flex-none items-center gap-2">
+      <Button variant="secondary" size="xs" onClick={onCancel} disabled={saving}>
+        Cancel
+      </Button>
+      <Button size="xs" onClick={onSave} disabled={saving || disabled}>
+        {saving ? 'Saving…' : 'Save changes'}
+      </Button>
+    </div>
+  )
+}
+
+export function FileBrowserEditor({
+  draft,
+  disabled,
+  onContentChange,
+  onCancel,
+  onSubmit
+}: {
+  draft: FileBrowserEditorDraft
+  disabled?: boolean
+  onContentChange: (content: string) => void
+  onCancel: () => void
+  onSubmit: () => void
+}) {
+  const creating = draft.target === ''
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !draft.saving) onCancel()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [draft.saving, onCancel])
+
+  return (
+    <form
+      className="flex min-h-[300px] flex-1 flex-col"
+      aria-label={creating ? 'New file' : `Edit ${draft.target}`}
+      onSubmit={(event) => {
+        event.preventDefault()
+        onSubmit()
+      }}
+    >
+      {draft.loading ? (
+        <div className="flex flex-1 justify-center py-10">
+          <Spinner size={28} />
+        </div>
+      ) : (
+        <div className="flex flex-1 flex-col gap-3 p-4">
+          {draft.error ? (
+            <div className="text-[12.5px] text-(--status-error)" role="alert">
+              {draft.error}
+            </div>
+          ) : null}
+          <textarea
+            className="inp mono min-h-[390px] flex-1 resize-y items-start justify-start px-3 py-[10px] leading-[1.6] focus:border-(--brand) focus:outline-none"
+            value={draft.content}
+            onChange={(event) => onContentChange(event.target.value)}
+            aria-label={creating ? 'New file content' : `Edit ${draft.target}`}
+            spellCheck={false}
+            disabled={draft.saving || disabled}
+            autoFocus={!creating}
+          />
+        </div>
+      )}
+    </form>
   )
 }
 
@@ -224,5 +442,49 @@ export function FileBrowserPreviewHeader({
       )}
       {actions}
     </div>
+  )
+}
+
+export function FileBrowserPreviewSummary({
+  meta,
+  actions,
+  onBack
+}: {
+  meta?: ReactNode
+  actions?: ReactNode
+  onBack?: () => void
+}) {
+  return (
+    <div className="flex h-[37px] min-w-0 flex-none items-center gap-2 border-b border-(--border-subtle) px-4">
+      {onBack ? (
+        <button
+          type="button"
+          className="iconbtn h-7 w-7 flex-none"
+          onClick={onBack}
+          title="Back to files"
+          aria-label="Back to files"
+        >
+          <Icon name="arrow-left" size={15} />
+        </button>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+        {meta}
+      </span>
+      {actions}
+    </div>
+  )
+}
+
+export function FileBrowserHistoryButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={active ? 'dsbtn xs dsbtn-secondary bg-(--surface-active)' : 'dsbtn xs dsbtn-secondary'}
+      aria-pressed={active}
+      onClick={onClick}
+    >
+      <Icon name="history" size={14} />
+      History
+    </button>
   )
 }

--- a/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.test.tsx
@@ -43,7 +43,7 @@ function button(label: string): HTMLButtonElement | undefined {
 }
 
 describe('ManagedMemoryHistory', () => {
-  it('loads lazily, exposes expandable snapshots, and pages older changes', async () => {
+  it('loads on mount, exposes expandable snapshots, and pages older changes', async () => {
     const nextCursor = '11111111-1111-4111-8111-111111111111'
     mocks.listMemoryFileHistory
       .mockResolvedValueOnce({
@@ -91,15 +91,8 @@ describe('ManagedMemoryHistory', () => {
       root?.render(<ManagedMemoryHistory agentId="agent-1" path="notes.md" />)
     })
 
-    expect(mocks.listMemoryFileHistory).not.toHaveBeenCalled()
-    const disclosure = button('Change history')
-    expect(disclosure?.getAttribute('aria-expanded')).toBe('false')
-    expect(disclosure?.closest('section')?.classList.contains('mt-auto')).toBe(true)
-
-    await act(async () => disclosure?.click())
-
-    expect(disclosure?.getAttribute('aria-expanded')).toBe('true')
     expect(mocks.listMemoryFileHistory).toHaveBeenNthCalledWith(1, 'agent-1', 'notes.md', { limit: 5 })
+    expect(container.querySelector('section')?.classList.contains('flex-1')).toBe(true)
     expect(container.querySelectorAll('details')).toHaveLength(2)
     expect(container.textContent).toContain('Dream adoption')
     const firstEvent = container.querySelector('details') as HTMLDetailsElement
@@ -129,7 +122,7 @@ describe('ManagedMemoryHistory', () => {
     expect(container.textContent).toContain('Long snapshots were shortened')
   })
 
-  it('shows an empty state without eagerly reopening on collapse', async () => {
+  it('shows an empty state without refetching for the same file', async () => {
     mocks.listMemoryFileHistory.mockResolvedValue({ events: [], nextCursor: null })
     container = document.createElement('div')
     document.body.append(container)
@@ -138,11 +131,10 @@ describe('ManagedMemoryHistory', () => {
       root?.render(<ManagedMemoryHistory agentId="agent-1" path="MEMORY.md" />)
     })
 
-    const disclosure = button('Change history')
-    await act(async () => disclosure?.click())
     expect(container.textContent).toContain('No recorded changes for this file yet.')
-    await act(async () => disclosure?.click())
-    await act(async () => disclosure?.click())
+    await act(async () => {
+      root?.render(<ManagedMemoryHistory agentId="agent-1" path="MEMORY.md" />)
+    })
     expect(mocks.listMemoryFileHistory).toHaveBeenCalledTimes(1)
   })
 
@@ -167,7 +159,6 @@ describe('ManagedMemoryHistory', () => {
       root?.render(<ManagedMemoryHistory agentId="agent-1" path="MEMORY.md" />)
     })
 
-    await act(async () => button('Change history')?.click())
     await act(async () => container?.querySelector<HTMLElement>('details summary')?.click())
 
     expect(container.textContent).toContain('The before snapshot was not recorded for this older change.')

--- a/packages/web/src/components/console/ManagedMemoryHistory.tsx
+++ b/packages/web/src/components/console/ManagedMemoryHistory.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ApiError, listMemoryFileHistory, type MemoryFileHistoryEventDto } from '@/lib/api'
 import { Spinner } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -101,123 +101,94 @@ function HistoryEvent({ event }: { event: MemoryFileHistoryEventDto }) {
   )
 }
 
-/** Lazy, read-only view over managed memory's hidden `.history` sidecar. */
+/** Read-only panel over managed memory's hidden `.history` sidecar; its summary action mounts this lazily. */
 export function ManagedMemoryHistory({ agentId, path }: { agentId: string; path: string }) {
-  const regionId = useId()
   const request = useRef(0)
-  const [open, setOpen] = useState(false)
   const [events, setEvents] = useState<MemoryFileHistoryEventDto[] | null>(null)
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const load = useCallback(
+    async (cursor?: string, append = false) => {
+      const id = ++request.current
+      setLoading(true)
+      setError(null)
+      try {
+        const page = await listMemoryFileHistory(agentId, path, { ...(cursor ? { cursor } : {}), limit: PAGE_SIZE })
+        if (id !== request.current) return
+        setEvents((current) => (append ? [...(current ?? []), ...page.events] : page.events))
+        setNextCursor(page.nextCursor)
+      } catch (caught) {
+        if (id !== request.current) return
+        setError(
+          caught instanceof ApiError && caught.status === 503
+            ? "Couldn't load change history — this agent is currently unavailable."
+            : caught instanceof Error
+              ? caught.message
+              : String(caught)
+        )
+      } finally {
+        if (id === request.current) setLoading(false)
+      }
+    },
+    [agentId, path]
+  )
+
   useEffect(() => {
     request.current += 1
-    setOpen(false)
     setEvents(null)
     setNextCursor(null)
     setLoading(false)
     setError(null)
+    void load()
     return () => {
       request.current += 1
     }
-  }, [agentId, path])
-
-  const load = async (cursor?: string, append = false) => {
-    const id = ++request.current
-    setLoading(true)
-    setError(null)
-    try {
-      const page = await listMemoryFileHistory(agentId, path, { ...(cursor ? { cursor } : {}), limit: PAGE_SIZE })
-      if (id !== request.current) return
-      setEvents((current) => (append ? [...(current ?? []), ...page.events] : page.events))
-      setNextCursor(page.nextCursor)
-    } catch (caught) {
-      if (id !== request.current) return
-      setError(
-        caught instanceof ApiError && caught.status === 503
-          ? "Couldn't load change history — this agent is currently unavailable."
-          : caught instanceof Error
-            ? caught.message
-            : String(caught)
-      )
-    } finally {
-      if (id === request.current) setLoading(false)
-    }
-  }
-
-  const toggle = () => {
-    const next = !open
-    setOpen(next)
-    if (next && events === null && !loading) void load()
-  }
-
-  const loadedCount = events?.length ?? 0
+  }, [load])
 
   return (
-    <section className="mt-auto border-t border-(--border-subtle)" aria-label={`Change history for ${path}`}>
-      <button
-        type="button"
-        className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-4 py-3 text-left font-sans transition-colors hover:bg-(--surface-hover) focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-(--brand)"
-        aria-expanded={open}
-        aria-controls={regionId}
-        onClick={toggle}
-      >
-        <Icon name="history" size={14} className="text-(--text-tertiary)" />
-        <span className="text-[12px] font-semibold leading-normal text-(--text-secondary)">Change history</span>
-        {events !== null ? (
-          <span className="text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
-            {loadedCount}
-            {nextCursor ? '+' : ''} {loadedCount === 1 && !nextCursor ? 'change' : 'changes'}
-          </span>
-        ) : null}
-        <Icon
-          name="chevron-down"
-          size={14}
-          className={`ml-auto text-(--text-tertiary) transition-transform ${open ? 'rotate-180' : 'rotate-0'}`}
-        />
-      </button>
-
-      {open ? (
-        <div id={regionId} className="border-t border-(--border-subtle) bg-(--surface-sunken) p-3" aria-live="polite">
-          {loading && events === null ? (
-            <div className="flex items-center justify-center gap-2 py-6 text-[11.5px] text-(--text-tertiary)">
-              <Spinner size={16} />
-              Loading change history…
-            </div>
-          ) : error && events === null ? (
-            <div className="flex flex-col items-start gap-2 py-3 text-[11.5px] text-(--red-600)" role="alert">
+    <section
+      className="flex flex-1 flex-col bg-(--surface-sunken) p-3"
+      aria-label={`Change history for ${path}`}
+      aria-live="polite"
+    >
+      {loading && events === null ? (
+        <div className="flex items-center justify-center gap-2 py-6 text-[11.5px] text-(--text-tertiary)">
+          <Spinner size={16} />
+          Loading change history…
+        </div>
+      ) : error && events === null ? (
+        <div className="flex flex-col items-start gap-2 py-3 text-[11.5px] text-(--red-600)" role="alert">
+          <span>{error}</span>
+          <Button size="xs" variant="secondary" onClick={() => void load()}>
+            Retry
+          </Button>
+        </div>
+      ) : events?.length === 0 ? (
+        <div className="py-3 text-[11.5px] text-(--text-tertiary)">No recorded changes for this file yet.</div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {events?.map((event, index) => (
+            <HistoryEvent key={event.id ?? `${event.at}:${event.source}:${event.event}:${index}`} event={event} />
+          ))}
+          {error ? (
+            <div className="flex flex-wrap items-center gap-2 py-1 text-[11.5px] text-(--red-600)" role="alert">
               <span>{error}</span>
-              <Button size="xs" variant="secondary" onClick={() => void load()}>
+              <Button size="xs" variant="secondary" onClick={() => void load(nextCursor ?? undefined, true)}>
                 Retry
               </Button>
             </div>
-          ) : events?.length === 0 ? (
-            <div className="py-3 text-[11.5px] text-(--text-tertiary)">No recorded changes for this file yet.</div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {events?.map((event, index) => (
-                <HistoryEvent key={event.id ?? `${event.at}:${event.source}:${event.event}:${index}`} event={event} />
-              ))}
-              {error ? (
-                <div className="flex flex-wrap items-center gap-2 py-1 text-[11.5px] text-(--red-600)" role="alert">
-                  <span>{error}</span>
-                  <Button size="xs" variant="secondary" onClick={() => void load(nextCursor ?? undefined, true)}>
-                    Retry
-                  </Button>
-                </div>
-              ) : null}
-              {nextCursor && !error ? (
-                <div className="pt-1">
-                  <Button size="xs" variant="secondary" disabled={loading} onClick={() => void load(nextCursor, true)}>
-                    {loading ? 'Loading…' : 'Load older changes'}
-                  </Button>
-                </div>
-              ) : null}
+          ) : null}
+          {nextCursor && !error ? (
+            <div className="pt-1">
+              <Button size="xs" variant="secondary" disabled={loading} onClick={() => void load(nextCursor, true)}>
+                {loading ? 'Loading…' : 'Load older changes'}
+              </Button>
             </div>
-          )}
+          ) : null}
         </div>
-      ) : null}
+      )}
     </section>
   )
 }

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -4,7 +4,7 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ updateAgent: vi.fn() }))
+const mocks = vi.hoisted(() => ({ updateAgent: vi.fn(), isMobile: false }))
 
 vi.mock('next/dynamic', () => ({ default: () => () => null }))
 
@@ -44,7 +44,7 @@ vi.mock('@/components/console/FileBrowser', async () => {
   }
 })
 
-vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => false }))
+vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => mocks.isMobile }))
 
 vi.mock('@/components/console/RecordMemoryPanel', () => ({
   RecordMemoryPanel: () => <div data-testid="record-memory-view" />
@@ -70,6 +70,7 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 beforeEach(() => {
   mocks.updateAgent.mockReset().mockResolvedValue(undefined)
+  mocks.isMobile = false
   vi.mocked(listAgentMemory)
     .mockReset()
     .mockResolvedValue({
@@ -190,6 +191,44 @@ describe('MemoryPanel file editor', () => {
       'deploys.md',
       undefined
     )
+  })
+
+  it('returns mobile editing to the file list only from the breadcrumb back action', async () => {
+    mocks.isMobile = true
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="22222222-2222-4222-8222-222222222222"
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+        />
+      )
+      await Promise.resolve()
+    })
+
+    const memory = container.querySelector<HTMLElement>('[data-testid="file-memory-view"]')!
+    const tree = memory.querySelector<HTMLElement>('[data-file-browser-pane="tree"]')!
+    const preview = memory.querySelector<HTMLElement>('[data-file-browser-pane="preview"]')!
+    await clickButton(tree, 'MEMORY.md')
+    expect(tree.classList.contains('hidden')).toBe(true)
+    expect(preview.classList.contains('flex')).toBe(true)
+
+    await clickButton(memory, 'Edit')
+    await clickButton(memory, 'Cancel')
+    expect(tree.classList.contains('hidden')).toBe(true)
+    expect(preview.classList.contains('flex')).toBe(true)
+
+    await clickButton(memory, 'Edit')
+    const back = memory.querySelector<HTMLButtonElement>('button[aria-label="Back to files"]')
+    expect(back).not.toBeNull()
+    await act(async () => back?.click())
+    expect(tree.classList.contains('block')).toBe(true)
+    expect(preview.classList.contains('hidden')).toBe(true)
   })
 })
 

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -30,12 +30,21 @@ vi.mock('@/components/console/ExternalMemoryBindingFields', () => ({
   ExternalMemoryBindingFields: () => null
 }))
 
-vi.mock('@/components/console/FileBrowser', () => ({
-  FileBrowserShell: ({ children }: { children: ReactNode }) => <div data-testid="file-memory-view">{children}</div>,
-  FileBrowserLayout: () => null,
-  FileBrowserPreviewHeader: () => null,
-  FileBrowserRow: () => null
-}))
+vi.mock('@/components/console/FileBrowser', async () => {
+  const actual = await vi.importActual<typeof import('@/components/console/FileBrowser')>(
+    '@/components/console/FileBrowser'
+  )
+  return {
+    ...actual,
+    FileBrowserShell: (props: { title: ReactNode; headerEnd?: ReactNode; children: ReactNode }) => (
+      <div data-testid="file-memory-view">
+        <actual.FileBrowserShell {...props} />
+      </div>
+    )
+  }
+})
+
+vi.mock('@/lib/use-is-mobile', () => ({ useIsMobile: () => false }))
 
 vi.mock('@/components/console/RecordMemoryPanel', () => ({
   RecordMemoryPanel: () => <div data-testid="record-memory-view" />
@@ -45,6 +54,11 @@ vi.mock('@/components/console/DreamPanel', () => ({
   DreamPanel: () => <div data-testid="dream-memory-view" />
 }))
 
+vi.mock('@/components/console/ManagedMemoryHistory', () => ({
+  ManagedMemoryHistory: () => <div data-testid="memory-file-history" />
+}))
+
+import { fetchAgentMemoryFull, listAgentMemory, updateAgentMemory } from '@/lib/api'
 import { MemoryPanel } from './MemoryPanel'
 
 const CONNECTION_ID = '11111111-1111-4111-8111-111111111111'
@@ -56,6 +70,18 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 beforeEach(() => {
   mocks.updateAgent.mockReset().mockResolvedValue(undefined)
+  vi.mocked(listAgentMemory)
+    .mockReset()
+    .mockResolvedValue({
+      exists: true,
+      files: [{ name: 'MEMORY.md', size: 9, mtime: '2026-07-27T09:00:00.000Z' }]
+    })
+  vi.mocked(fetchAgentMemoryFull)
+    .mockReset()
+    .mockResolvedValue({ exists: true, content: '# Memory', mtime: '2026-07-27T09:00:00.000Z' })
+  vi.mocked(updateAgentMemory)
+    .mockReset()
+    .mockResolvedValue({ path: 'MEMORY.md', size: 9, mtime: '2026-07-27T09:01:00.000Z' })
 })
 
 afterEach(async () => {
@@ -80,6 +106,92 @@ const openSettings = async (host: HTMLElement) => {
   expect(editButton).toBeTruthy()
   await act(async () => editButton?.click())
 }
+
+const clickButton = async (host: HTMLElement, label: string) => {
+  const button = Array.from(host.querySelectorAll<HTMLButtonElement>('button')).find(
+    (candidate) => candidate.textContent?.trim() === label
+  )
+  expect(button, `${label} button`).toBeTruthy()
+  await act(async () => button?.click())
+}
+
+const changeValue = async (element: HTMLInputElement | HTMLTextAreaElement, value: string) => {
+  await act(async () => {
+    const prototype = element instanceof HTMLInputElement ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype
+    Object.getOwnPropertyDescriptor(prototype, 'value')?.set?.call(element, value)
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+describe('MemoryPanel file editor', () => {
+  it('places History in the shared file summary row', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="22222222-2222-4222-8222-222222222222"
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+        />
+      )
+      await Promise.resolve()
+    })
+
+    const history = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'History'
+    )
+    const summary = history?.closest('.h-\\[37px\\]')
+    expect(summary?.textContent).toContain('9 B')
+    expect(summary?.querySelector('button')).toBe(history)
+    expect(container.querySelector('[data-testid="memory-file-history"]')).toBeNull()
+
+    await act(async () => history?.click())
+    expect(container.querySelector('[data-testid="memory-file-history"]')).not.toBeNull()
+  })
+
+  it('uses the shared inline add flow instead of a browser prompt', async () => {
+    const prompt = vi.fn(() => 'legacy.md')
+    vi.stubGlobal('prompt', prompt)
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="22222222-2222-4222-8222-222222222222"
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+        />
+      )
+      await Promise.resolve()
+    })
+
+    await clickButton(container, 'Add file')
+    expect(prompt).not.toHaveBeenCalled()
+
+    const name = container.querySelector<HTMLInputElement>('input[aria-label="New memory file name"]')
+    const content = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="New file content"]')
+    expect(name?.closest('.cardhead')).not.toBeNull()
+    expect(content?.closest('.card')).not.toBeNull()
+
+    await changeValue(name!, 'deploys.md')
+    await changeValue(content!, '# Deploys')
+    await clickButton(container, 'Save changes')
+
+    expect(updateAgentMemory).toHaveBeenCalledWith(
+      '22222222-2222-4222-8222-222222222222',
+      '# Deploys',
+      'deploys.md',
+      undefined
+    )
+  })
+})
 
 describe('MemoryPanel settings draft', () => {
   it('defaults managed memory to daily dreaming and lets users disable automatic acceptance', async () => {

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -8,8 +8,8 @@
 // friendly notice.
 //
 // Left: the file list (index + topics). Right: the selected file, viewed as
-// markdown or edited in a textarea + Save (PUT). "New topic" creates a file. The
-// CP enforces edit permission (a 403 surfaces as an error), matching the console.
+// markdown or edited through the same inline file-browser surface as Workspace.
+// The CP enforces edit permission (a 403 surfaces as an error), matching the console.
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
@@ -42,16 +42,24 @@ import {
   type MemorySettingsDraft
 } from '@/components/console/memory-settings'
 import {
+  FileBrowserBreadcrumb,
+  FileBrowserEditor,
+  FileBrowserEditorActions,
+  FileBrowserHistoryButton,
   FileBrowserLayout,
-  FileBrowserPreviewHeader,
+  FileBrowserPreviewSummary,
   FileBrowserRow,
-  FileBrowserShell
+  FileBrowserShell,
+  formatFileMtime,
+  formatFileSize,
+  type FileBrowserEditorDraft
 } from '@/components/console/FileBrowser'
 import { RecordMemoryPanel } from '@/components/console/RecordMemoryPanel'
 import { DreamPanel } from '@/components/console/DreamPanel'
 import { DreamScheduleFields } from '@/components/console/DreamScheduleFields'
 import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
 import { ManagedMemoryHistory } from '@/components/console/ManagedMemoryHistory'
+import { useIsMobile } from '@/lib/use-is-mobile'
 
 const MarkdownView = dynamic(() => import('@/components/console/MarkdownView'), {
   ssr: false,
@@ -152,6 +160,7 @@ export function MemoryPanel({
   sessionBasePath?: string
 }) {
   const { updateAgent } = useConsoleData()
+  const isMobile = useIsMobile()
   const [files, setFiles] = useState<MemoryFileEntry[]>([])
   const [listLoading, setListLoading] = useState(true)
   const [listError, setListError] = useState<string | null>(null)
@@ -161,13 +170,11 @@ export function MemoryPanel({
   const [fileExists, setFileExists] = useState<boolean | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [historyOpen, setHistoryOpen] = useState(false)
   const loadRequest = useRef(0)
   const listRequest = useRef(0)
 
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
+  const [editor, setEditor] = useState<FileBrowserEditorDraft | null>(null)
 
   // Existing-agent memory settings are one explicit draft. The content below
   // continues to reflect `persistedSettings` until Save succeeds, so selecting a
@@ -187,7 +194,6 @@ export function MemoryPanel({
   const [savingProvider, setSavingProvider] = useState(false)
   const [providerError, setProviderError] = useState<string | null>(null)
   const [confirmingBackendChange, setConfirmingBackendChange] = useState(false)
-  const [previewRequest, setPreviewRequest] = useState(0)
   // The settings form is collapsed behind a one-line summary by default so the
   // memory content itself stays the page's focus. Closing the form discards any
   // unsaved draft — a closed form always summarizes the persisted settings.
@@ -355,7 +361,8 @@ export function MemoryPanel({
       const request = ++loadRequest.current
       setLoading(true)
       setError(null)
-      setEditing(false)
+      setEditor(null)
+      setHistoryOpen(false)
       setContent('')
       setLoadedMtime(null)
       setFileExists(null)
@@ -387,7 +394,8 @@ export function MemoryPanel({
     setFiles([])
     setSelected(INDEX)
     setContent('')
-    setEditing(false)
+    setEditor(null)
+    setHistoryOpen(false)
     setError(null)
     if (persistedProvider === 'none' || persistedProvider === 'external') {
       setListLoading(false)
@@ -413,44 +421,76 @@ export function MemoryPanel({
 
   const resolveMemoryLink = (href: string) => resolveMemoryMarkdownLink(href, select)
 
-  const newTopic = () => {
-    const name = window.prompt('New memory file name (e.g. "deploys.md"):')?.trim()
-    if (!name) return
-    if (!TOPIC_RE.test(name) || name === INDEX) {
-      window.alert('Use a flat .md file name, e.g. "deploys.md".')
-      return
-    }
-    loadRequest.current += 1
-    setLoading(false)
-    setSelected(name)
-    setContent('')
-    setLoadedMtime(null) // brand-new file — no precondition
-    setFileExists(false)
-    setError(null)
-    setDraft(`# ${name.replace(/\.md$/, '')}\n\n`)
-    setSaveError(null)
-    setEditing(true)
-    setPreviewRequest((request) => request + 1)
+  const startCreate = () => {
+    setHistoryOpen(false)
+    setEditor({
+      target: '',
+      directory: '',
+      name: '',
+      content: '',
+      mtime: null,
+      loading: false,
+      saving: false,
+      error: null
+    })
+  }
+
+  const startEdit = () => {
+    setHistoryOpen(false)
+    setEditor({
+      target: selected,
+      directory: '',
+      name: selected,
+      content,
+      mtime: loadedMtime,
+      loading: false,
+      saving: false,
+      error: null
+    })
+  }
+
+  const closeEditor = () => {
+    if (!editor?.saving) setEditor(null)
   }
 
   const save = async () => {
-    setSaving(true)
-    setSaveError(null)
+    if (!editor || editor.saving || editor.loading) return
+    const creating = editor.target === ''
+    const target = creating ? editor.name.trim() : editor.target
+    if (creating && (!TOPIC_RE.test(target) || target === INDEX)) {
+      setEditor({ ...editor, error: 'Use a flat .md file name, e.g. "deploys.md".' })
+      return
+    }
+    const savingEditor = { ...editor, saving: true, error: null }
+    setEditor(savingEditor)
     try {
-      const res = await updateAgentMemory(agentId, draft, selected === INDEX ? undefined : selected, loadedMtime)
-      setContent(draft)
+      const res = await updateAgentMemory(
+        agentId,
+        savingEditor.content,
+        target === INDEX ? undefined : target,
+        creating ? undefined : savingEditor.mtime
+      )
+      setSelected(target)
+      setContent(savingEditor.content)
       setLoadedMtime(res.mtime) // track the new mtime for the next edit
       setFileExists(true)
-      setEditing(false)
+      setEditor(null)
       await loadList() // a brand-new topic now shows in the list
     } catch (e) {
-      if (e instanceof ApiError && e.status === 409) {
-        setSaveError('This file changed since you opened it (the agent may have updated it). Reload before saving.')
-      } else {
-        setSaveError(e instanceof Error ? e.message : String(e))
-      }
-    } finally {
-      setSaving(false)
+      setEditor((current) =>
+        current?.target === savingEditor.target
+          ? {
+              ...current,
+              saving: false,
+              error:
+                e instanceof ApiError && e.status === 409
+                  ? 'This file changed since you opened it (the agent may have updated it). Reload before saving.'
+                  : e instanceof Error
+                    ? e.message
+                    : String(e)
+            }
+          : current
+      )
     }
   }
 
@@ -501,31 +541,29 @@ export function MemoryPanel({
     </>
   )
 
+  const selectedFile = files.find((file) => file.name === selected)
+  const previewMeta = [
+    formatFileSize(selectedFile?.size ?? null),
+    selectedFile?.mtime ? `edited ${formatFileMtime(selectedFile.mtime)}` : ''
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
   const renderPreview = (onBack?: () => void) => (
     <>
-      <FileBrowserPreviewHeader
-        icon={selected === INDEX ? 'book-marked' : fileExists === false ? 'file-plus' : 'file-text'}
-        name={selected}
+      <FileBrowserPreviewSummary
+        meta={previewMeta}
         onBack={onBack}
         actions={
-          !editing && canEdit && !loading && !error && fileExists !== null ? (
-            <Button
-              variant="secondary"
-              size="xs"
-              onClick={() => {
-                setDraft(content)
-                setSaveError(null)
-                setEditing(true)
-              }}
-            >
-              <Icon name="pencil" size={14} />
-              Edit
-            </Button>
+          persistedProvider === 'managed' && !loading && !error && fileExists === true ? (
+            <FileBrowserHistoryButton active={historyOpen} onClick={() => setHistoryOpen((open) => !open)} />
           ) : undefined
         }
       />
 
-      {loading ? (
+      {historyOpen && persistedProvider === 'managed' && fileExists === true ? (
+        <ManagedMemoryHistory key={`${agentId}:${selected}`} agentId={agentId} path={selected} />
+      ) : loading ? (
         <div className="flex items-center justify-center py-10">
           <Spinner />
         </div>
@@ -535,31 +573,6 @@ export function MemoryPanel({
           <Button variant="secondary" size="xs" onClick={() => void loadFile(selected)}>
             Retry
           </Button>
-        </div>
-      ) : editing ? (
-        <div className="flex flex-col gap-3 p-4">
-          <textarea
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            spellCheck={false}
-            className="mono min-h-[320px] w-full resize-y rounded-md border border-(--border-subtle) bg-(--surface-sunken) p-3 text-[12.5px] leading-[1.6] text-(--text-primary) outline-none focus:border-(--brand-soft-text)"
-            placeholder={
-              selected === INDEX
-                ? '# Agent memory index\n\nKeep it short — link to topic files and read them on demand.'
-                : '# Topic\n\nDurable notes for this topic…'
-            }
-          />
-          {saveError && (
-            <div className="font-sans text-[12.5px] font-normal leading-normal text-(--red-600)">{saveError}</div>
-          )}
-          <div className="flex items-center gap-2">
-            <Button variant="primary" size="sm" onClick={() => void (saving ? undefined : save())}>
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
-            <Button variant="secondary" size="sm" onClick={() => (saving ? undefined : setEditing(false))}>
-              Cancel
-            </Button>
-          </div>
         </div>
       ) : content.trim() ? (
         <div className="max-h-[520px] overflow-auto px-[18px] py-4">
@@ -578,13 +591,6 @@ export function MemoryPanel({
               }${canEdit ? ', or you can edit it here.' : '.'}`}
         </div>
       )}
-      {persistedProvider === 'managed' && !editing && !loading && !error && fileExists === true ? (
-        <ManagedMemoryHistory
-          key={`${agentId}:${selected}:${loadedMtime ?? 'unknown'}`}
-          agentId={agentId}
-          path={selected}
-        />
-      ) : null}
     </>
   )
 
@@ -819,25 +825,64 @@ export function MemoryPanel({
       ) : (
         <>
           <FileBrowserShell
-            title="Memory"
+            title={
+              <FileBrowserBreadcrumb
+                root="Memory"
+                path={editor?.target ?? selected}
+                creating={editor?.target === ''}
+                draftName={editor?.name ?? ''}
+                onDraftNameChange={(name) =>
+                  setEditor((current) => (current?.target === '' ? { ...current, name, error: null } : current))
+                }
+                onBack={isMobile && editor ? closeEditor : undefined}
+                disabled={editor?.saving}
+                nested={false}
+                ariaLabel="Memory file path"
+                inputAriaLabel="New memory file name"
+              />
+            }
             headerEnd={
-              canEdit ? (
-                <button
-                  type="button"
-                  onClick={newTopic}
-                  className="flex cursor-pointer items-center gap-[4px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-semibold leading-normal text-(--brand-soft-text)"
-                >
-                  <Icon name="plus" size={13} />
-                  New
-                </button>
+              editor ? (
+                <FileBrowserEditorActions
+                  saving={editor.saving}
+                  onCancel={closeEditor}
+                  onSave={() => void save()}
+                  disabled={editor.loading || (!editor.target && !editor.name.trim())}
+                />
+              ) : canEdit ? (
+                <div className="flex flex-none items-center gap-2">
+                  <Button variant="secondary" size="xs" className="flex-none" onClick={startCreate}>
+                    <Icon name="file-plus" size={13} />
+                    Add file
+                  </Button>
+                  {!loading && !error && fileExists !== null ? (
+                    <Button variant="secondary" size="xs" className="flex-none" onClick={startEdit}>
+                      <Icon name="pencil" size={13} />
+                      Edit
+                    </Button>
+                  ) : null}
+                </div>
               ) : undefined
             }
           >
             <FileBrowserLayout
               resetKey={agentId}
-              openPreviewSignal={previewRequest}
+              previewOpen={editor !== null}
               tree={renderFileTree}
-              preview={renderPreview}
+              preview={
+                editor
+                  ? () => (
+                      <FileBrowserEditor
+                        draft={editor}
+                        onContentChange={(content) =>
+                          setEditor((current) => (current ? { ...current, content, error: null } : current))
+                        }
+                        onCancel={closeEditor}
+                        onSubmit={() => void save()}
+                      />
+                    )
+                  : renderPreview
+              }
             />
           </FileBrowserShell>
           {/* Dreaming is managed-only and is secondary to the live memory

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -175,6 +175,7 @@ export function MemoryPanel({
   const listRequest = useRef(0)
 
   const [editor, setEditor] = useState<FileBrowserEditorDraft | null>(null)
+  const [mobileListSignal, setMobileListSignal] = useState(0)
 
   // Existing-agent memory settings are one explicit draft. The content below
   // continues to reflect `persistedSettings` until Save succeeds, so selecting a
@@ -451,6 +452,12 @@ export function MemoryPanel({
 
   const closeEditor = () => {
     if (!editor?.saving) setEditor(null)
+  }
+
+  const backFromEditor = () => {
+    if (editor?.saving) return
+    setEditor(null)
+    setMobileListSignal((signal) => signal + 1)
   }
 
   const save = async () => {
@@ -834,7 +841,7 @@ export function MemoryPanel({
                 onDraftNameChange={(name) =>
                   setEditor((current) => (current?.target === '' ? { ...current, name, error: null } : current))
                 }
-                onBack={isMobile && editor ? closeEditor : undefined}
+                onBack={isMobile && editor ? backFromEditor : undefined}
                 disabled={editor?.saving}
                 nested={false}
                 ariaLabel="Memory file path"
@@ -866,7 +873,7 @@ export function MemoryPanel({
             }
           >
             <FileBrowserLayout
-              resetKey={agentId}
+              resetKey={`${agentId}:${mobileListSignal}`}
               previewOpen={editor !== null}
               tree={renderFileTree}
               preview={

--- a/packages/web/src/components/console/WorkspaceFiles.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.test.tsx
@@ -168,7 +168,7 @@ it('keeps an inline new-file draft across the desktop-to-mobile breakpoint', asy
   mobile.value = true
   await rerenderWorkspace()
 
-  const editor = container?.querySelector('form[aria-label="New workspace file"]')
+  const editor = container?.querySelector('form[aria-label="New file"]')
   const mobilePath = container?.querySelector<HTMLInputElement>('input[aria-label="New file path"]')
   const mobileContent = container?.querySelector<HTMLTextAreaElement>('textarea[aria-label="New file content"]')
   expect(editor?.closest('.card')).not.toBeNull()

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -37,11 +37,18 @@ import type { WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import type { Agent } from '@/lib/data'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
 import {
+  FileBrowserBreadcrumb,
+  FileBrowserEditor,
+  FileBrowserEditorActions,
   FileBrowserLayout,
+  FileBrowserPreviewSummary,
   FileBrowserRow,
   FileBrowserShell,
   MARKDOWN_FILE_RE,
-  fileBrowserGlyph
+  fileBrowserGlyph,
+  formatFileMtime,
+  formatFileSize,
+  type FileBrowserEditorDraft
 } from '@/components/console/FileBrowser'
 
 // react-markdown + remark-gfm are heavy and only needed when a markdown file is
@@ -80,31 +87,6 @@ function entryIcon(e: WorkspaceEntryDto): string {
   if (e.type === 'symlink') return 'link-2'
   if (e.type === 'other') return 'file-question-mark'
   return fileBrowserGlyph(e.name)
-}
-
-function fmtBytes(n: number | null): string {
-  if (n == null) return ''
-  if (n < 1024) return `${n} B`
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`
-}
-
-// Relative when recent (matches the fleet's "last seen" feel), short date otherwise.
-function fmtMtime(iso: string | null): string {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ''
-  const ms = Date.now() - d.getTime()
-  const s = Math.round(ms / 1000)
-  if (!Number.isFinite(s) || s < 0) return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
-  if (s < 60) return `${s}s ago`
-  const m = Math.floor(s / 60)
-  if (m < 60) return `${m}m ago`
-  const h = Math.floor(m / 60)
-  if (h < 24) return `${h}h ago`
-  const dd = Math.floor(h / 24)
-  if (dd < 7) return `${dd}d ago`
-  return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
 // Parse a full git remote address (https or ssh) into a display label ("org/repo")
@@ -164,17 +146,6 @@ type Viewer = {
   loadingMore: boolean
 }
 
-type EditorDraft = {
-  target: string // '' creates; an existing path edits in place
-  directory: string
-  name: string
-  content: string
-  mtime: string | null
-  loading: boolean
-  saving: boolean
-  error: string | null
-}
-
 type DeleteDraft = {
   path: string
   mtime: string
@@ -201,7 +172,7 @@ export function WorkspaceFiles({
   const [dirs, setDirs] = useState<Record<string, DirState>>({})
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
   const [viewer, setViewer] = useState<Viewer | null>(null)
-  const [editor, setEditor] = useState<EditorDraft | null>(null)
+  const [editor, setEditor] = useState<FileBrowserEditorDraft | null>(null)
   const [deleteDraft, setDeleteDraft] = useState<DeleteDraft | null>(null)
   const [mobileListSignal, setMobileListSignal] = useState(0)
   // git-repo workspaces: current-checkout status + on-demand pull. Null while
@@ -387,19 +358,15 @@ export function WorkspaceFiles({
     }
   }, [agentId, editorTarget])
 
-  const mutationOpen = editor !== null || deleteDraft !== null
-  const mutationBusy = editor?.saving || deleteDraft?.deleting || false
-
   useEffect(() => {
-    if (!mutationOpen) return
+    if (!deleteDraft) return
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape' || mutationBusy) return
-      setEditor(null)
+      if (event.key !== 'Escape' || deleteDraft.deleting) return
       setDeleteDraft(null)
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [mutationOpen, mutationBusy])
+  }, [deleteDraft])
 
   // git status of the workspace checkout. A non-repo answer and a thrown request
   // (offline daemon) both leave `git` unset — the workspace card then renders the
@@ -665,7 +632,7 @@ export function WorkspaceFiles({
               </Fragment>
             )
           }
-          const meta = [fmtBytes(e.size), fmtMtime(e.mtime)].filter(Boolean).join(' · ')
+          const meta = [formatFileSize(e.size), formatFileMtime(e.mtime)].filter(Boolean).join(' · ')
           const status = dirtyMap.get(full)
           return (
             <FileBrowserRow
@@ -717,7 +684,7 @@ export function WorkspaceFiles({
     commit: git?.lastCommit
       ? {
           sha: git.lastCommit.shortSha,
-          time: fmtMtime(git.lastCommit.committedAt),
+          time: formatFileMtime(git.lastCommit.committedAt),
           title: git.lastCommit.subject
         }
       : null,
@@ -734,7 +701,7 @@ export function WorkspaceFiles({
 
       <FileBrowserShell
         title={
-          <WorkspaceBreadcrumb
+          <FileBrowserBreadcrumb
             root={workspaceRoot}
             path={breadcrumbPath}
             creating={editor?.target === ''}
@@ -742,64 +709,65 @@ export function WorkspaceFiles({
             onDraftNameChange={updateCreateName}
             onBack={isMobile && editor ? backFromEditor : undefined}
             disabled={editor?.saving}
+            ariaLabel="Workspace path"
           />
         }
         headerEnd={
-          <div className="flex flex-none items-center gap-2">
-            {editor ? (
-              <>
-                <Button variant="secondary" size="xs" onClick={closeEditor} disabled={editor.saving}>
-                  Cancel
-                </Button>
-                <Button
-                  size="xs"
-                  onClick={() => void saveEditor()}
-                  disabled={
-                    editor.saving ||
-                    editor.loading ||
-                    (!!editor.target && !editor.mtime) ||
-                    (!editor.target && !editor.name.trim().split('/').at(-1))
-                  }
-                >
-                  {editor.saving ? 'Saving…' : 'Save changes'}
-                </Button>
-              </>
-            ) : deleteDraft ? (
-              <>
-                <Button
-                  variant="secondary"
-                  size="xs"
-                  onClick={() => setDeleteDraft(null)}
-                  disabled={deleteDraft.deleting}
-                >
-                  Cancel
-                </Button>
-                <Button variant="danger" size="xs" onClick={() => void confirmDelete()} disabled={deleteDraft.deleting}>
-                  <Icon name="trash-2" size={13} />
-                  {deleteDraft.deleting ? 'Deleting…' : 'Delete file'}
-                </Button>
-              </>
-            ) : canEdit ? (
-              <>
-                <Button variant="secondary" size="xs" className="flex-none" onClick={startCreate}>
-                  <Icon name="file-plus" size={13} />
-                  Add file
-                </Button>
-                {viewerCanEdit ? (
-                  <Button variant="secondary" size="xs" className="flex-none" onClick={() => startEdit(viewer!.path)}>
-                    <Icon name="pencil" size={13} />
-                    Edit
+          editor ? (
+            <FileBrowserEditorActions
+              saving={editor.saving}
+              onCancel={closeEditor}
+              onSave={() => void saveEditor()}
+              disabled={
+                editor.loading ||
+                (!!editor.target && !editor.mtime) ||
+                (!editor.target && !editor.name.trim().split('/').at(-1))
+              }
+            />
+          ) : (
+            <div className="flex flex-none items-center gap-2">
+              {deleteDraft ? (
+                <>
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    onClick={() => setDeleteDraft(null)}
+                    disabled={deleteDraft.deleting}
+                  >
+                    Cancel
                   </Button>
-                ) : null}
-                {viewerCanDelete ? (
-                  <Button variant="secondary" size="xs" className="flex-none" onClick={startDelete}>
+                  <Button
+                    variant="danger"
+                    size="xs"
+                    onClick={() => void confirmDelete()}
+                    disabled={deleteDraft.deleting}
+                  >
                     <Icon name="trash-2" size={13} />
-                    Delete
+                    {deleteDraft.deleting ? 'Deleting…' : 'Delete file'}
                   </Button>
-                ) : null}
-              </>
-            ) : null}
-          </div>
+                </>
+              ) : canEdit ? (
+                <>
+                  <Button variant="secondary" size="xs" className="flex-none" onClick={startCreate}>
+                    <Icon name="file-plus" size={13} />
+                    Add file
+                  </Button>
+                  {viewerCanEdit ? (
+                    <Button variant="secondary" size="xs" className="flex-none" onClick={() => startEdit(viewer!.path)}>
+                      <Icon name="pencil" size={13} />
+                      Edit
+                    </Button>
+                  ) : null}
+                  {viewerCanDelete ? (
+                    <Button variant="secondary" size="xs" className="flex-none" onClick={startDelete}>
+                      <Icon name="trash-2" size={13} />
+                      Delete
+                    </Button>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          )
         }
       >
         {!editor && root?.loading && !root.entries && (
@@ -842,11 +810,13 @@ export function WorkspaceFiles({
             preview={
               editor
                 ? () => (
-                    <WorkspaceFileEditor
+                    <FileBrowserEditor
                       draft={editor}
+                      disabled={Boolean(editor.target && !editor.mtime)}
                       onContentChange={(content) =>
                         setEditor((current) => (current ? { ...current, content, error: null } : current))
                       }
+                      onCancel={closeEditor}
                       onSubmit={() => void saveEditor()}
                     />
                   )
@@ -883,99 +853,6 @@ function EmptyNote({ text }: { text: string }) {
       <Icon name="folder" size={20} color="var(--text-tertiary)" />
       <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">{text}</div>
     </div>
-  )
-}
-
-function WorkspaceBreadcrumb({
-  root,
-  path,
-  creating,
-  draftName,
-  onDraftNameChange,
-  onBack,
-  disabled
-}: {
-  root: string
-  path: string
-  creating: boolean
-  draftName: string
-  onDraftNameChange: (name: string) => void
-  onBack?: () => void
-  disabled?: boolean
-}) {
-  const baseSegments = path.split('/').filter(Boolean)
-  const draftParts = creating ? draftName.replace(/^\/+/, '').split('/') : []
-  const draftDirectories = draftParts.slice(0, -1).filter(Boolean)
-  const draftLeaf = creating ? (draftParts.at(-1) ?? '') : ''
-  const segments = [...baseSegments, ...draftDirectories]
-  const updateDraftLeaf = (leaf: string) => onDraftNameChange([...draftDirectories, leaf].join('/'))
-
-  return (
-    <nav className="flex min-w-0 items-center gap-[6px] overflow-hidden" aria-label="Workspace path">
-      {onBack ? (
-        <button
-          type="button"
-          className="iconbtn h-7 w-7 flex-none"
-          onClick={onBack}
-          title="Back to files"
-          aria-label="Back to files"
-        >
-          <Icon name="arrow-left" size={15} />
-        </button>
-      ) : null}
-      <span
-        className={`mono max-w-[120px] flex-none truncate text-[12px] font-semibold text-(--text-primary) ${
-          segments.length > 0 || creating ? 'max-desktop:hidden' : ''
-        }`}
-      >
-        {root}
-      </span>
-      {segments.map((segment, index) => {
-        const current = !creating && index === segments.length - 1
-        const mobileCurrent = index === segments.length - 1
-        return (
-          <Fragment key={`${index}:${segment}`}>
-            <span className="flex-none text-[12px] font-normal text-(--text-tertiary) max-desktop:hidden" aria-hidden>
-              /
-            </span>
-            <span
-              className={`mono min-w-[24px] max-w-[140px] shrink truncate text-[12px] ${
-                current ? 'font-semibold text-(--text-primary)' : 'font-medium text-(--text-secondary)'
-              } ${mobileCurrent ? '' : 'max-desktop:hidden'}`}
-            >
-              {segment}
-            </span>
-          </Fragment>
-        )
-      })}
-      {segments.length === 0 && !creating ? (
-        <span className="flex-none text-[12px] font-normal text-(--text-tertiary)" aria-hidden>
-          /
-        </span>
-      ) : null}
-      {creating ? (
-        <>
-          <span className="flex-none text-[12px] font-normal text-(--text-tertiary)" aria-hidden>
-            /
-          </span>
-          <input
-            className="inp mono h-7 w-[96px] min-w-16 max-w-full shrink px-2 py-1 text-[12px] desktop:w-[170px] desktop:min-w-[80px] desktop:max-w-[30vw]"
-            value={draftLeaf}
-            onChange={(event) => updateDraftLeaf(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== 'Backspace' || draftLeaf || draftDirectories.length === 0) return
-              event.preventDefault()
-              onDraftNameChange([...draftDirectories.slice(0, -1), draftDirectories.at(-1)!].join('/'))
-            }}
-            placeholder="Name your file…"
-            aria-label="New file path"
-            spellCheck={false}
-            disabled={disabled}
-            autoFocus
-          />
-        </>
-      ) : null}
-    </nav>
   )
 }
 
@@ -1042,38 +919,37 @@ function FilePreview({
     [isText, showCode, content, html]
   )
 
-  const meta = [fmtBytes(viewer.file?.size ?? null), viewer.file?.mtime ? `edited ${fmtMtime(viewer.file.mtime)}` : '']
+  const meta = [
+    formatFileSize(viewer.file?.size ?? null),
+    viewer.file?.mtime ? `edited ${formatFileMtime(viewer.file.mtime)}` : ''
+  ]
     .filter(Boolean)
     .join(' · ')
 
   return (
     <>
-      <div className="flex h-[37px] min-w-0 flex-none items-center gap-2 border-b border-(--border-subtle) px-4">
-        {onBack ? (
-          <button
-            type="button"
-            className="iconbtn h-7 w-7 flex-none"
-            onClick={onBack}
-            title="Back to files"
-            aria-label="Back to files"
-          >
-            <Icon name="arrow-left" size={15} />
-          </button>
-        ) : null}
-        <span className="min-w-0 flex-1 truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-          {meta}
-        </span>
-        {isMd && isText ? (
-          <span className="pillbar flex-none">
-            <button className={mode === 'preview' ? 'pill on' : 'pill'} onClick={() => setMode('preview')}>
-              Preview
-            </button>
-            <button className={mode === 'code' ? 'pill on' : 'pill'} onClick={() => setMode('code')}>
-              Code
-            </button>
-          </span>
-        ) : null}
-      </div>
+      <FileBrowserPreviewSummary
+        meta={meta}
+        onBack={onBack}
+        actions={
+          isMd && isText ? (
+            <span className="pillbar flex-none">
+              <button
+                className={mode === 'preview' ? 'pill on py-[3px]' : 'pill py-[3px]'}
+                onClick={() => setMode('preview')}
+              >
+                Preview
+              </button>
+              <button
+                className={mode === 'code' ? 'pill on py-[3px]' : 'pill py-[3px]'}
+                onClick={() => setMode('code')}
+              >
+                Code
+              </button>
+            </span>
+          ) : undefined
+        }
+      />
 
       {deletePrompt ? (
         <div
@@ -1110,7 +986,7 @@ function FilePreview({
       {!viewer.loading && !viewer.err && viewer.file?.exists && viewer.file.encoding === 'none' && (
         <div className="flex items-center gap-2 p-4 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
           <Icon name="file-question-mark" size={15} />
-          Binary file — not displayed ({fmtBytes(viewer.file.size)})
+          Binary file — not displayed ({formatFileSize(viewer.file.size)})
         </div>
       )}
 
@@ -1128,7 +1004,7 @@ function FilePreview({
           {viewer.file.truncated && (
             <div className="flex items-center gap-[10px] border-t border-(--border-subtle) px-4 pt-[10px] pb-[14px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
               <span>
-                Showing first {fmtBytes(viewer.file.nextOffset)} of {fmtBytes(viewer.file.size)}
+                Showing first {formatFileSize(viewer.file.nextOffset)} of {formatFileSize(viewer.file.size)}
               </span>
               <button className="lnk text-[12px]" onClick={onMore}>
                 {viewer.loadingMore ? 'Loading…' : viewer.moreErr ? 'Retry' : 'Load more'}
@@ -1141,51 +1017,5 @@ function FilePreview({
         </>
       )}
     </>
-  )
-}
-
-function WorkspaceFileEditor({
-  draft,
-  onContentChange,
-  onSubmit
-}: {
-  draft: EditorDraft
-  onContentChange: (content: string) => void
-  onSubmit: () => void
-}) {
-  const creating = draft.target === ''
-
-  return (
-    <form
-      className="flex min-h-[300px] flex-1 flex-col"
-      aria-label={creating ? 'New workspace file' : `Edit ${draft.target}`}
-      onSubmit={(event) => {
-        event.preventDefault()
-        onSubmit()
-      }}
-    >
-      {draft.loading ? (
-        <div className="flex flex-1 justify-center py-10">
-          <Spinner size={28} />
-        </div>
-      ) : (
-        <div className="flex flex-1 flex-col gap-3 p-4">
-          {draft.error ? (
-            <div className="text-[12.5px] text-(--status-error)" role="alert">
-              {draft.error}
-            </div>
-          ) : null}
-          <textarea
-            className="inp mono min-h-[390px] flex-1 resize-y items-start justify-start px-3 py-[10px] leading-[1.6] focus:border-(--brand) focus:outline-none"
-            value={draft.content}
-            onChange={(event) => onContentChange(event.target.value)}
-            aria-label={creating ? 'New file content' : `Edit ${draft.target}`}
-            spellCheck={false}
-            disabled={draft.saving || (!creating && !draft.mtime)}
-            autoFocus={!creating}
-          />
-        </div>
-      )}
-    </form>
   )
 }

--- a/packages/web/src/components/console/WorkspaceFilesMock.tsx
+++ b/packages/web/src/components/console/WorkspaceFilesMock.tsx
@@ -139,10 +139,16 @@ function MockPreview({
         actions={
           isMd && file.content ? (
             <span className="pillbar flex-none">
-              <button className={mode === 'preview' ? 'pill on' : 'pill'} onClick={() => setMode('preview')}>
+              <button
+                className={mode === 'preview' ? 'pill on py-[3px]' : 'pill py-[3px]'}
+                onClick={() => setMode('preview')}
+              >
                 Preview
               </button>
-              <button className={mode === 'code' ? 'pill on' : 'pill'} onClick={() => setMode('code')}>
+              <button
+                className={mode === 'code' ? 'pill on py-[3px]' : 'pill py-[3px]'}
+                onClick={() => setMode('code')}
+              >
                 Code
               </button>
             </span>


### PR DESCRIPTION
## Summary

- share the inline file editor, breadcrumb, header actions, preview summary, and metadata formatting between Workspace and Memory
- keep the file browser header stable while adding files and reduce the Markdown Preview/Code control height
- move managed Memory History into the top-right preview summary slot and establish that shared slot/pane for future repository-backed Workspace history
- preserve the shared mobile navigation contract: Cancel returns to preview, while the breadcrumb back action returns to the file list

## Why

Memory had drifted into a separate prompt-based add flow and a separate edit surface. That made equivalent file operations behave differently and caused the browser header height to change between states.

## Validation

- `pnpm --filter @agentconnect.md/web test` — 367 tests passed
- focused file-browser suite — 34 tests passed
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web build`
- Prettier and `git diff --check`
- visual QA in light/dark themes at desktop and 390px mobile widths

Created by Codex . GPT-5.6-Sol
