### PR TITLE
feat(web): show daemon lifecycle status in list

### DIFF
--- a/packages/web/src/components/console/DaemonLifecycleBadge.tsx
+++ b/packages/web/src/components/console/DaemonLifecycleBadge.tsx
@@ -1,0 +1,23 @@
+import { Spinner } from '@/components/marks'
+import type { DaemonLifecycleOp } from '@/lib/data'
+
+export function daemonLifecycleLabel(op: DaemonLifecycleOp): string {
+  const action = op.op === 'upgrade' ? 'Upgrading' : 'Restarting'
+  return `${action}${op.targetVersion ? ` to ${op.targetVersion}` : ''}…`
+}
+
+export function DaemonLifecycleBadge({ op }: { op: DaemonLifecycleOp | null }) {
+  if (op?.status !== 'pending') return null
+
+  const label = daemonLifecycleLabel(op)
+
+  return (
+    <span
+      title={label}
+      className="inline-flex flex-none items-center gap-[5px] rounded-full border border-(--brand) bg-(--surface-sunken) py-[2px] pr-[9px] pl-[6px] font-sans text-[11px] font-semibold leading-normal text-(--brand)"
+    >
+      <Spinner size={11} />
+      {label}
+    </span>
+  )
+}

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -15,9 +15,10 @@ import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
 import { useModal } from '@/components/console/ModalProvider'
 import { VisibilityValue } from '@/components/console/VisibilityField'
+import { DaemonLifecycleBadge, daemonLifecycleLabel } from '@/components/console/DaemonLifecycleBadge'
 import { DaemonUpgradeBadge } from '@/components/console/DaemonUpgradeBadge'
 import { NotFound } from '@/components/console/NotFound'
-import { AgentIconView, AgentMark, LoadingState, Spinner } from '@/components/marks'
+import { AgentIconView, AgentMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { useIsMobile } from '@/lib/use-is-mobile'
@@ -89,24 +90,12 @@ export default function DaemonDetailView() {
   // lifecycle actions are hidden (the CP 409s a second one) and a badge shows.
   const op = daemon.lifecycleOp
   const pending = op?.status === 'pending'
-  const pendingLabel =
-    op?.op === 'upgrade' ? `Upgrading${op.targetVersion ? ` to ${op.targetVersion}` : ''}…` : 'Restarting…'
+  const pendingLabel = op ? daemonLifecycleLabel(op) : ''
   // Restart/upgrade are owner-only fleet ops (server denyNonOwner) — gate the controls on
   // the DTO capability so non-owners never see an action they'd 403 on. Restart needs the
   // daemon live; upgrade additionally needs the resolver to have surfaced other versions.
   const canRestart = online && !pending && daemon.canManageLifecycle
   const canUpgrade = canRestart && daemon.availableVersions.some((v) => v !== daemon.version)
-
-  // Shared in-flight badge (both forks) — mirrors DaemonUpgradeBadge's shape.
-  const pendingPill = pending ? (
-    <span
-      title={pendingLabel}
-      className="inline-flex flex-none items-center gap-[5px] rounded-full border border-(--brand) bg-(--surface-sunken) py-[2px] pr-[9px] pl-[6px] font-sans text-[11px] font-semibold leading-normal text-(--brand)"
-    >
-      <Spinner size={11} />
-      {pendingLabel}
-    </span>
-  ) : null
 
   const hosted = agents.filter((a) => a.daemon === daemon.daemonId)
   const runtimes = daemon.runtimeModels.length
@@ -176,7 +165,7 @@ export default function DaemonDetailView() {
             {daemon.version}
           </span>
           {pending ? (
-            pendingPill
+            <DaemonLifecycleBadge op={op} />
           ) : (
             <DaemonUpgradeBadge
               show={daemon.upgradeAvailable}
@@ -523,7 +512,7 @@ export default function DaemonDetailView() {
               <span className="mono text-[12px]">{daemon.version}</span>
             </span>
             {pending ? (
-              pendingPill
+              <DaemonLifecycleBadge op={op} />
             ) : (
               <DaemonUpgradeBadge
                 show={daemon.upgradeAvailable}

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -6,6 +6,7 @@ import { status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
+import { DaemonLifecycleBadge } from '@/components/console/DaemonLifecycleBadge'
 import { DaemonUpgradeBadge } from '@/components/console/DaemonUpgradeBadge'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -193,14 +194,14 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
             <span className="dot hidden flex-none desktop:inline-block" style={{ background: s.dot }} />
           </div>
           {/* Version meta — mobile appends the host (when it differs from the name); desktop shows
-              version only. An amber "Outdated" chip trails it when a newer release is available. */}
+              version only. The available-upgrade hint is hidden while an operation is in flight. */}
           <div className="flex min-w-0 items-center gap-[7px]">
             <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11px] desktop:leading-[1.5] desktop:tabular-nums">
               {m.version}
               {m.host && m.host !== m.name && <span className="desktop:hidden">{` · ${m.host}`}</span>}
             </span>
             <DaemonUpgradeBadge
-              show={m.upgradeAvailable}
+              show={!pending && m.upgradeAvailable}
               latest={m.latestVersion}
               onClick={canUpgrade ? () => openModal('upgradeDaemon', m) : undefined}
             />
@@ -290,6 +291,11 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
           participate directly in the card's flex-col gap-3; on desktop it is the
           padded section under the header border. */}
       <div className="contents desktop:flex desktop:flex-col desktop:gap-3 desktop:px-4 desktop:py-[14px]">
+        {pending && (
+          <div className="flex">
+            <DaemonLifecycleBadge op={m.lifecycleOp} />
+          </div>
+        )}
         <div className="flex w-full gap-4 desktop:flex-col desktop:gap-3">
           <UtilBar label="CPU" pct={m.cpu} color={barColor} hot={hot} />
           <UtilBar label="Memory" mobileLabel="MEM" pct={m.mem} color={barColor} hot={hot} />

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1442,7 +1442,7 @@ export interface DaemonRow {
   availableVersions: string[]
   /** The most recent CP-commanded restart/upgrade op (cli-daemon-split.md §7), or null.
    *  `status` is expiry-projected server-side; the modal tracks its own command by `id`
-   *  and the detail view derives the in-flight badge from `status === 'pending'`. */
+   *  and the daemon views derive the in-flight badge from `status === 'pending'`. */
   lifecycleOp: DaemonLifecycleOp | null
   /** Whether the caller may command restart/upgrade on this daemon (org owner only). */
   canManageLifecycle: boolean


### PR DESCRIPTION
## Summary

- show pending daemon upgrade and restart status directly on each daemon list card
- reuse one lifecycle badge across the list and detail views, including the upgrade target version
- hide the stale `Outdated` hint while a lifecycle operation is in flight

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm exec eslint packages/web/src/components/console/DaemonLifecycleBadge.tsx packages/web/src/components/console/views/DaemonsView.tsx packages/web/src/components/console/views/DaemonDetailView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/DaemonLifecycleBadge.tsx packages/web/src/components/console/views/DaemonsView.tsx packages/web/src/components/console/views/DaemonDetailView.tsx packages/web/src/lib/data.ts`
- visually verified pending-upgrade cards in light and dark themes at desktop and 390px mobile widths; regression-checked the detail badge

Created by Codex . GPT-5
