### PR TITLE
fix(control-plane): fence skill-source lifecycle against agent enable-list writes

### DIFF
--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -36,10 +36,14 @@ import type { DaemonView } from '../../ports.js'
 import { AgentId, DaemonId, type OrgId } from '../../domain/ids.js'
 import { mcpProxyDef, relayHttpOrigin } from '../../orchestrator/mcpProvider.js'
 import { serializeByProviderNames } from './mcp-providers.js'
+import { serializeBySkillSourceNames } from './skill-sources.js'
 
 /** Thrown inside the provider-name fence when the in-fence visibility re-check
  *  refuses an enable-list name; the route maps it to a 403. */
 class McpEnableDenied extends Error {}
+/** The skill-source twin: thrown inside the source-name fence when the in-fence
+ *  visibility re-check refuses a submitted skill-ref; the route maps it to a 403. */
+class SkillEnableDenied extends Error {}
 import { parseSkillRef, redactSourceCredentials } from '../../orchestrator/skillSource.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from '../../orchestrator/memoryConnection.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
@@ -645,6 +649,47 @@ export function agentRoutes(deps: HttpDeps) {
         : null
     }
 
+    // The skill-source twin of withSubmittedMcpProviderChains — same fence, same
+    // reasoning (see that helper and routes/skill-sources.ts): the write joins the
+    // (orgId, name) chain of every SOURCE its submitted skill-refs name, keyed off
+    // the whole submitted list (a stale full-replace PATCH may be the write that
+    // RESTORES a ref after a concurrent removal). Removal-only submissions ([] /
+    // null / untouched) join no chain.
+    //
+    // The visibility gate re-runs INSIDE the fence with the keep-exemption derived
+    // from the agent's COMMITTED refs (evaluated in the row-locked update
+    // transaction via AgentUpdateOpts.authorizeSkills): a kept ref's source can be
+    // neither deleted nor name-captured while held (both 409 while referenced), so
+    // the committed hold is exactly the authorization it was granted under. One
+    // skills-specific difference from MCP: there is no daemon-local fallback for a
+    // skill-ref — a submitted NEW ref whose source is unknown (e.g. just deleted in
+    // this very chain) or unviewable is refused, so a dangling ref can never be
+    // committed through this surface. A refusal surfaces as SkillEnableDenied (the
+    // route maps it to 403).
+    const withSubmittedSkillSourceChains = async <T>(
+      orgId: OrgId,
+      ctx: ViewCtx,
+      submitted: readonly string[] | null | undefined,
+      run: (authorizeSkills: (currentlyHeld: readonly string[]) => void) => Promise<T>
+    ): Promise<T> => {
+      if (!submitted || submitted.length === 0) return run(() => {})
+      const names = submitted.map((ref) => parseSkillRef(ref).source)
+      return serializeBySkillSourceNames(orgId, names, async () => {
+        const visible = new Set((await deps.repos.skillSource.listForOrg(orgId, ctx)).map((s) => s.name))
+        return run((currentlyHeld) => {
+          const held = new Set(currentlyHeld)
+          const blocked = [
+            ...new Set(submitted.filter((ref) => !held.has(ref)).map((ref) => parseSkillRef(ref).source))
+          ].filter((n) => !visible.has(n))
+          if (blocked.length) {
+            throw new SkillEnableDenied(
+              `cannot enable skills from a source you don't have access to: ${blocked.join(', ')}`
+            )
+          }
+        })
+      })
+    }
+
     const validateExternalMemoryBinding = async (
       memory: AgentRecord['memory'] | undefined,
       orgId: OrgId
@@ -935,59 +980,64 @@ export function agentRoutes(deps: HttpDeps) {
               : undefined
           // One transaction for the agent row + its initial secret rows (sealing
           // happens before it opens) — a failure can't leave a partial definition.
-          // Chained per submitted MCP provider name so the row can't commit inside a concurrent
-          // provider-delete's check→drop window.
+          // Chained per submitted MCP provider name AND per submitted skill-ref source
+          // name so the row can't commit inside a concurrent registry-delete's
+          // check→drop window. Nesting order (providers outer, sources inner) is fixed
+          // everywhere agent writes take both, so the two chain families can't cycle.
           let agent: AgentRecord
           try {
-            agent = await withSubmittedMcpProviderChains(orgOf(req), ctxOf(req), req.body.mcpServers, (authorize) => {
-              // A not-yet-created agent holds nothing, and nothing can concurrently
-              // remove from it — the empty-hold decision is stable through create.
-              authorize([])
-              return deps.repos.agentConfig.create(
-                {
-                  id: agentId,
-                  orgId: orgOf(req),
-                  name: req.body.name,
-                  ...(req.body.displayName !== undefined ? { displayName: req.body.displayName } : {}),
-                  // Absent ⇒ the repo assigns a random glyph+color combo (product default).
-                  ...(req.body.icon !== undefined ? { icon: req.body.icon } : {}),
-                  ...(req.body.description !== undefined ? { description: req.body.description } : {}),
-                  runtime: req.body.runtime,
-                  ...(req.body.model !== undefined ? { model: req.body.model } : {}),
-                  ...(req.body.reasoningEffort !== undefined ? { reasoningEffort: req.body.reasoningEffort } : {}),
-                  ...(req.body.outputMode !== undefined ? { outputMode: req.body.outputMode } : {}),
-                  ...(req.body.showFooter !== undefined ? { showFooter: req.body.showFooter } : {}),
-                  ...(req.body.fastMode !== undefined ? { fastMode: req.body.fastMode } : {}),
-                  ...(req.body.permissionMode !== undefined ? { permissionMode: req.body.permissionMode } : {}),
-                  ...(req.body.allowRuntimeChangesInChat !== undefined
-                    ? { allowRuntimeChangesInChat: req.body.allowRuntimeChangesInChat }
-                    : {}),
-                  ...(req.body.pause !== undefined ? { pause: req.body.pause } : {}),
-                  ...(req.body.introduceOnJoin !== undefined ? { introduceOnJoin: req.body.introduceOnJoin } : {}),
-                  restrictFileAccess,
-                  ...(req.body.env !== undefined ? { env: req.body.env } : {}),
-                  ...(req.body.mcpServers !== undefined ? { mcpServers: req.body.mcpServers } : {}),
-                  ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
-                  ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
-                  ...(req.body.daemonId !== undefined ? { daemonId: DaemonId(req.body.daemonId) } : {}),
-                  ...(workspace !== undefined ? { workspace } : {}),
-                  ...(workspaceRepoId !== undefined ? { workspaceRepoId } : {}),
-                  ...(req.principal ? { createdByUserId: req.principal.userId } : {}),
-                  ...(req.body.visibility ? { visibility: req.body.visibility } : {}),
-                  ...(initialSharedWith ? { sharedWith: initialSharedWith } : {}),
-                  ...(req.body.callPolicy ? { callPolicy: req.body.callPolicy } : {}),
-                  ...(initialAllowedCallers ? { allowedCallerAgentIds: initialAllowedCallers } : {}),
-                  ...(req.body.outboundPolicy ? { outboundPolicy: req.body.outboundPolicy } : {}),
-                  ...(initialAllowedTargets ? { allowedTargetAgentIds: initialAllowedTargets } : {}),
-                  capabilities: req.body.capabilities
-                },
-                // Initial write-only secrets — same transaction, so the first
-                // replicateUpsert below always sees the complete definition.
-                req.body.secrets
-              )
-            })
+            agent = await withSubmittedMcpProviderChains(orgOf(req), ctxOf(req), req.body.mcpServers, (authorize) =>
+              withSubmittedSkillSourceChains(orgOf(req), ctxOf(req), req.body.skills, (authorizeSkills) => {
+                // A not-yet-created agent holds nothing, and nothing can concurrently
+                // remove from it — the empty-hold decision is stable through create.
+                authorize([])
+                authorizeSkills([])
+                return deps.repos.agentConfig.create(
+                  {
+                    id: agentId,
+                    orgId: orgOf(req),
+                    name: req.body.name,
+                    ...(req.body.displayName !== undefined ? { displayName: req.body.displayName } : {}),
+                    // Absent ⇒ the repo assigns a random glyph+color combo (product default).
+                    ...(req.body.icon !== undefined ? { icon: req.body.icon } : {}),
+                    ...(req.body.description !== undefined ? { description: req.body.description } : {}),
+                    runtime: req.body.runtime,
+                    ...(req.body.model !== undefined ? { model: req.body.model } : {}),
+                    ...(req.body.reasoningEffort !== undefined ? { reasoningEffort: req.body.reasoningEffort } : {}),
+                    ...(req.body.outputMode !== undefined ? { outputMode: req.body.outputMode } : {}),
+                    ...(req.body.showFooter !== undefined ? { showFooter: req.body.showFooter } : {}),
+                    ...(req.body.fastMode !== undefined ? { fastMode: req.body.fastMode } : {}),
+                    ...(req.body.permissionMode !== undefined ? { permissionMode: req.body.permissionMode } : {}),
+                    ...(req.body.allowRuntimeChangesInChat !== undefined
+                      ? { allowRuntimeChangesInChat: req.body.allowRuntimeChangesInChat }
+                      : {}),
+                    ...(req.body.pause !== undefined ? { pause: req.body.pause } : {}),
+                    ...(req.body.introduceOnJoin !== undefined ? { introduceOnJoin: req.body.introduceOnJoin } : {}),
+                    restrictFileAccess,
+                    ...(req.body.env !== undefined ? { env: req.body.env } : {}),
+                    ...(req.body.mcpServers !== undefined ? { mcpServers: req.body.mcpServers } : {}),
+                    ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
+                    ...(req.body.memory !== undefined ? { memory: req.body.memory } : {}),
+                    ...(req.body.daemonId !== undefined ? { daemonId: DaemonId(req.body.daemonId) } : {}),
+                    ...(workspace !== undefined ? { workspace } : {}),
+                    ...(workspaceRepoId !== undefined ? { workspaceRepoId } : {}),
+                    ...(req.principal ? { createdByUserId: req.principal.userId } : {}),
+                    ...(req.body.visibility ? { visibility: req.body.visibility } : {}),
+                    ...(initialSharedWith ? { sharedWith: initialSharedWith } : {}),
+                    ...(req.body.callPolicy ? { callPolicy: req.body.callPolicy } : {}),
+                    ...(initialAllowedCallers ? { allowedCallerAgentIds: initialAllowedCallers } : {}),
+                    ...(req.body.outboundPolicy ? { outboundPolicy: req.body.outboundPolicy } : {}),
+                    ...(initialAllowedTargets ? { allowedTargetAgentIds: initialAllowedTargets } : {}),
+                    capabilities: req.body.capabilities
+                  },
+                  // Initial write-only secrets — same transaction, so the first
+                  // replicateUpsert below always sees the complete definition.
+                  req.body.secrets
+                )
+              })
+            )
           } catch (e) {
-            if (e instanceof McpEnableDenied) {
+            if (e instanceof McpEnableDenied || e instanceof SkillEnableDenied) {
               return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: e.message })
             }
             throw e
@@ -1366,8 +1416,9 @@ export function agentRoutes(deps: HttpDeps) {
           // The row patch and the secret merge commit as ONE transaction (sealing
           // outside it), so the replicateUpsert below can only ever ship a
           // definition that fully applied — never a half-updated one. Chained per
-          // submitted MCP provider name so the row can't commit inside a concurrent
-          // provider-delete's check→drop window.
+          // submitted MCP provider name AND per submitted skill-ref source name so
+          // the row can't commit inside a concurrent registry-delete's check→drop
+          // window (nesting order fixed: providers outer, sources inner).
           const { secrets: secretsPatch, ...bodyPatch } = req.body
           let agent: AgentRecord
           try {
@@ -1376,20 +1427,22 @@ export function agentRoutes(deps: HttpDeps) {
               ctxOf(req),
               req.body.mcpServers,
               (authorizeMcpServers) =>
-                deps.repos.agentConfig.update(
-                  AgentId(req.params.id),
-                  {
-                    ...bodyPatch,
-                    ...(req.principal ? { lastModifiedByUserId: req.principal.userId } : {})
-                  },
-                  secretsPatch,
-                  // Evaluated inside the row-locked transaction, against the same
-                  // committed list this write merges onto (see the fence helper).
-                  { authorizeMcpServers }
+                withSubmittedSkillSourceChains(orgOf(req), ctxOf(req), req.body.skills, (authorizeSkills) =>
+                  deps.repos.agentConfig.update(
+                    AgentId(req.params.id),
+                    {
+                      ...bodyPatch,
+                      ...(req.principal ? { lastModifiedByUserId: req.principal.userId } : {})
+                    },
+                    secretsPatch,
+                    // Evaluated inside the row-locked transaction, against the same
+                    // committed lists this write merges onto (see the fence helpers).
+                    { authorizeMcpServers, authorizeSkills }
+                  )
                 )
             )
           } catch (e) {
-            if (e instanceof McpEnableDenied) {
+            if (e instanceof McpEnableDenied || e instanceof SkillEnableDenied) {
               return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: e.message })
             }
             throw e

--- a/packages/control-plane/src/http/routes/skill-sources.test.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { serializeBySkillSource, serializeBySkillSourceNames } from './skill-sources.js'
+
+describe('serializeBySkillSourceNames', () => {
+  it('two multi-source writers naming the chains in opposite order both complete, mutually excluded', async () => {
+    // Unsorted entry would deadlock here: A holds s1 waiting on s2's tail while B
+    // holds s2 waiting on s1's. Sorted entry means both join s1 first — strict
+    // serialization, no cycle.
+    const order: string[] = []
+    const critical = (label: string) => async () => {
+      order.push(`start:${label}`)
+      await new Promise((r) => setTimeout(r, 10))
+      order.push(`end:${label}`)
+      return label
+    }
+    const [a, b] = await Promise.all([
+      serializeBySkillSourceNames('org-1', ['s1', 's2'], critical('A')),
+      serializeBySkillSourceNames('org-1', ['s2', 's1'], critical('B'))
+    ])
+    expect(a).toBe('A')
+    expect(b).toBe('B')
+    expect(order).toEqual(['start:A', 'end:A', 'start:B', 'end:B'])
+  })
+
+  it('a single-name writer queues behind a held serializeBySkillSource section (the DELETE↔agent-write fence)', async () => {
+    const order: string[] = []
+    let release!: () => void
+    const gate = new Promise<void>((r) => (release = r))
+    const del = serializeBySkillSource('org-1', 's1', async () => {
+      order.push('delete:checked')
+      await gate // parked mid-critical-section (the reference check just read its snapshot)
+      order.push('delete:dropped')
+    })
+    const write = serializeBySkillSourceNames('org-1', ['s1'], async () => {
+      order.push('agent:written')
+    })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(order).toEqual(['delete:checked']) // the write cannot land inside the window
+    release()
+    await Promise.all([del, write])
+    expect(order).toEqual(['delete:checked', 'delete:dropped', 'agent:written'])
+  })
+
+  it('chains are org-scoped — the same source name in another org does not serialize', async () => {
+    const order: string[] = []
+    let release!: () => void
+    const gate = new Promise<void>((r) => (release = r))
+    const held = serializeBySkillSource('org-1', 's1', async () => {
+      order.push('org1:held')
+      await gate
+    })
+    await serializeBySkillSourceNames('org-2', ['s1'], async () => {
+      order.push('org2:ran')
+    })
+    expect(order).toEqual(['org1:held', 'org2:ran']) // org-2 never waited
+    release()
+    await held
+  })
+})

--- a/packages/control-plane/src/http/routes/skill-sources.ts
+++ b/packages/control-plane/src/http/routes/skill-sources.ts
@@ -41,6 +41,62 @@ import {
   type SkillSourceDtoT
 } from '../dto/index.js'
 
+/**
+ * Serialize reference-sensitive skill-source lifecycle operations (modeled on
+ * `serializeByProvider` in routes/mcp-providers.ts). Agents bind a source by NAME —
+ * every enable-ref is "<source>/<skill>" / "<source>/*" / "<source>" — and DELETE
+ * refuses while any agent still enables it, but that check-then-delete is only safe
+ * if agent enable-list writes can't land inside the window. Chaining the DELETE's
+ * check→drop, the create-side name-capture guard, sharing flips, and every agent
+ * write whose submitted enable-list references this source
+ * (withSubmittedSkillSourceChains in routes/agents.ts) through one per-source
+ * promise chain makes each reference check a critical section.
+ *
+ * Chains are keyed by (orgId, name) — the DURABLE binding key — not the source row
+ * id: agents store the NAME, so lifecycle events on different rows under the same
+ * name (drop A, create B) must serialize with each other and with agent enable-list
+ * writes; an id-keyed chain dies with its row and lets a same-name recreate slip
+ * into the window. ponytail: in-process lock, sufficient because the CP is a single
+ * Fastify process; swap to pg_advisory_xact_lock (see
+ * persistence/repositories/hook.repo.ts) if it goes multi-instance.
+ */
+const sourceChains = new Map<string, Promise<unknown>>()
+
+const sourceChainKey = (orgId: string, name: string) => `${orgId} ${name}`
+
+export function serializeBySkillSource<T>(orgId: string, name: string, run: () => Promise<T>): Promise<T> {
+  const key = sourceChainKey(orgId, name)
+  const prev = sourceChains.get(key) ?? Promise.resolve()
+  const result = prev.then(run, run)
+  const settled = result.then(
+    () => undefined,
+    () => undefined
+  )
+  sourceChains.set(key, settled)
+  void settled.finally(() => {
+    if (sourceChains.get(key) === settled) sourceChains.delete(key)
+  })
+  return result
+}
+
+/**
+ * Serialize one operation across SEVERAL source-name chains — how an agent
+ * enable-list write (routes/agents.ts) joins the chain of every source its
+ * submitted refs name, so it cannot interleave with a DELETE between that delete's
+ * reference check and its row drop, nor with a same-name source create. Names are
+ * chained whether or not they currently resolve to a source row (the name IS the
+ * durable key). Chains are entered in sorted order so two multi-name writers can't
+ * deadlock waiting on each other's tails.
+ */
+export function serializeBySkillSourceNames<T>(
+  orgId: string,
+  names: readonly string[],
+  run: () => Promise<T>
+): Promise<T> {
+  const sorted = [...new Set(names)].sort()
+  return sorted.reduceRight<() => Promise<T>>((inner, n) => () => serializeBySkillSource(orgId, n, inner), run)()
+}
+
 /** Extract `{owner, repo, ref?}` from a source string (shorthand, https, or ssh
  *  GitHub form). Returns null for a non-GitHub / unparseable source. */
 function parseGithubRepo(source: string): { owner: string; repo: string; ref?: string; subDir?: string } | null {
@@ -258,10 +314,10 @@ export function skillSourceRoutes(deps: HttpDeps) {
           tags: [Tag.Skills],
           summary: 'Register a skill source',
           description:
-            'Register an org-level shared-skills source (a repo / git URL / tree path fed to `npx skills`). `skills` empty ⇒ install every skill the source exposes.',
+            'Register an org-level shared-skills source (a repo / git URL / tree path fed to `npx skills`). `skills` empty ⇒ install every skill the source exposes. Rejected with 409 while any agent already enables skills under the requested source name — agents bind by name, so a new source must not silently capture existing selections.',
           operationId: 'createSkillSource',
           body: CreateSkillSourceBody,
-          response: { 201: SkillSourceDto, 400: ErrorDto, 403: ErrorDto }
+          response: { 201: SkillSourceDto, 400: ErrorDto, 403: ErrorDto, 409: ErrorDto }
         }
       },
       async (req, reply) => {
@@ -281,19 +337,36 @@ export function skillSourceRoutes(deps: HttpDeps) {
         // A subdir source needs a ref; if we couldn't resolve one (owner has no org
         // installation, non-GitHub source) reject rather than let the daemon assume `main`.
         if (req.body.subDir && !ref) return reply.code(400).send(subdirNeedsRef)
-        const source = await deps.repos.skillSource.create({
-          orgId: orgOf(req),
-          name: req.body.name,
-          source: req.body.source,
-          ...(repoId !== undefined ? { githubRepoId: repoId } : {}),
-          ...(ref !== undefined ? { ref } : {}),
-          ...(req.body.subDir !== undefined ? { subDir: req.body.subDir } : {}),
-          skills: req.body.skills,
-          ...(req.body.visibility ? { visibility: req.body.visibility } : {}),
-          ...(sharedWith ? { sharedWith } : {}),
-          ...(req.principal ? { createdByUserId: req.principal.userId } : {})
+        // Name-capture guard — the mirror image of the delete guard, in the same
+        // (orgId, name) chain: agents bind by NAME, so registering a source under a
+        // name agents already enable would capture their installs onto this new
+        // source without any per-agent consent. Refuse while referenced; the chain
+        // makes check→create atomic against enable-list writes and a same-name delete.
+        const created = await serializeBySkillSource(orgOf(req), req.body.name, async () => {
+          const agents = await deps.repos.agent.list(orgOf(req))
+          if (agents.some((a) => a.skills.some((ref) => parseSkillRef(ref).source === req.body.name))) return null
+          return deps.repos.skillSource.create({
+            orgId: orgOf(req),
+            name: req.body.name,
+            source: req.body.source,
+            ...(repoId !== undefined ? { githubRepoId: repoId } : {}),
+            ...(ref !== undefined ? { ref } : {}),
+            ...(req.body.subDir !== undefined ? { subDir: req.body.subDir } : {}),
+            skills: req.body.skills,
+            ...(req.body.visibility ? { visibility: req.body.visibility } : {}),
+            ...(sharedWith ? { sharedWith } : {}),
+            ...(req.principal ? { createdByUserId: req.principal.userId } : {})
+          })
         })
-        return reply.code(201).send(toDto(source, ctxOf(req)))
+        if (!created) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message:
+              'an agent already enables skills from a source with this name; unselect it there first or pick another name'
+          })
+        }
+        return reply.code(201).send(toDto(created, ctxOf(req)))
       }
     )
 
@@ -375,10 +448,15 @@ export function skillSourceRoutes(deps: HttpDeps) {
           return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot change sharing' })
         }
         const sharedWith = await resolveShareSet(deps.repos.user, orgOf(req), req.body.sharedWith)
-        const source = await deps.repos.skillSource.setSharing(existing.id, {
-          visibility: req.body.visibility,
-          sharedWith
-        })
+        // The write joins the (orgId, name) chain: agent enable-list writes authorize
+        // against source visibility INSIDE that chain (routes/agents.ts), so a sharing
+        // flip must not land between their check and their commit.
+        const source = await serializeBySkillSource(orgOf(req), existing.name, () =>
+          deps.repos.skillSource.setSharing(existing.id, {
+            visibility: req.body.visibility,
+            sharedWith
+          })
+        )
         return toDto(source, ctxOf(req))
       }
     )
@@ -400,16 +478,30 @@ export function skillSourceRoutes(deps: HttpDeps) {
         if (denyViewerWrite(req, reply)) return
         const existing = await deps.repos.skillSource.get(req.params.id)
         if (!existing || existing.orgId !== orgOf(req) || !canView(existing, ctxOf(req))) return notFound(reply)
-        const agents = await deps.repos.agent.list(orgOf(req))
-        const referenced = agents.some((a) => a.skills.some((ref) => parseSkillRef(ref).source === existing.name))
-        if (referenced) {
+        // Agents bind a source by NAME (their enable-refs), so deleting while
+        // referenced would leave dangling selectors that silently re-bind to any
+        // future source recreated under the same name. The check lives INSIDE the
+        // (orgId, name) chain because agent enable-list writes and same-name source
+        // creates join it too (withSubmittedSkillSourceChains in routes/agents.ts,
+        // the create guard above): a concurrent enable cannot slip a reference in
+        // between this read and the row drop — it either commits first (we 409) or
+        // waits until the source is gone (its in-fence visibility check then refuses
+        // the now-unknown name, and the create guard keeps the name uncapturable
+        // while referenced).
+        const outcome = await serializeBySkillSource(orgOf(req), existing.name, async () => {
+          const agents = await deps.repos.agent.list(orgOf(req))
+          const referenced = agents.some((a) => a.skills.some((ref) => parseSkillRef(ref).source === existing.name))
+          if (referenced) return 'referenced' as const
+          await deps.repos.skillSource.delete(existing.id)
+          return 'deleted' as const
+        })
+        if (outcome === 'referenced') {
           return reply.code(409).send({
             error: 'Conflict',
             statusCode: 409,
             message: 'skill source is still enabled by one or more agents; unselect it there first'
           })
         }
-        await deps.repos.skillSource.delete(existing.id)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -639,17 +639,18 @@ export interface AgentRecord {
 
 export interface AgentUpdateOpts {
   authorizeMcpServers?: (currentlyHeld: readonly string[]) => void
+  authorizeSkills?: (currentlyHeld: readonly string[]) => void
 }
 
 export interface AgentRepo {
   create(input: CreateAgentInput): Promise<AgentRecord>
   get(agentId: AgentId): Promise<AgentRecord | null>
-  /** `opts.authorizeMcpServers` (only meaningful when the patch includes
-   *  `mcpServers`) runs INSIDE the row-locked transaction, right after the
-   *  committed runtimeOverrides read, with the agent's currently-held MCP list —
-   *  the one atomic point where an enable-list authorization decision and the
-   *  write it guards cannot be separated by a concurrent removal. A throw
-   *  aborts the transaction. */
+  /** `opts.authorizeMcpServers` / `opts.authorizeSkills` (only meaningful when
+   *  the patch includes `mcpServers` / `skills`) run INSIDE the row-locked
+   *  transaction, right after the committed runtimeOverrides read, with the
+   *  agent's currently-held MCP list / skill-ref list — the one atomic point
+   *  where an enable-list authorization decision and the write it guards cannot
+   *  be separated by a concurrent removal. A throw aborts the transaction. */
   update(agentId: AgentId, patch: UpdateAgentInput, opts?: AgentUpdateOpts): Promise<AgentRecord>
   /** Compare-and-set a workspace edit. The caller has already drained/proved
    *  an owning daemon when one exists. */

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -289,11 +289,12 @@ export class PgAgentRepo implements AgentRepo {
         Prisma.sql`SELECT "runtimeOverrides" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
       )
       const cur = (rows[0]?.runtimeOverrides ?? null) as RuntimeOverrides | null
-      // The enable-list authorization decision happens HERE, against the row-locked
-      // committed list — a removal-only write (which joins no provider-name chain)
+      // The enable-list authorization decisions happen HERE, against the row-locked
+      // committed lists — a removal-only write (which joins no registry-name chain)
       // can no longer land between the hold check and the write it authorized. A
       // throw aborts the transaction before any merge is computed.
       opts?.authorizeMcpServers?.(cur?.mcpServers ?? [])
+      opts?.authorizeSkills?.(cur?.skills ?? [])
       const next: RuntimeOverrides = { ...(cur ?? {}) }
       if (patch.model !== undefined) {
         if (patch.model === null) delete next.model

--- a/packages/control-plane/test/integration/skill-sources.route.test.ts
+++ b/packages/control-plane/test/integration/skill-sources.route.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Skill-source routes — the referenced-guard on DELETE and its (orgId, name)
+ * lifecycle fence. Agents bind a source by NAME (every enable-ref is
+ * "<source>/<skill>" / "<source>/*" / "<source>"), so deleting a source that
+ * agents still enable would leave dangling selectors that silently re-bind to any
+ * future source recreated under the same name. DELETE must 409 while referenced
+ * (same rule as MCP-provider delete), create must refuse a referenced name
+ * (name-capture guard), and agent enable-list writes serialize with both.
+ *
+ * One skills-specific difference from the MCP-provider fence: a skill-ref has no
+ * daemon-local fallback — the in-fence visibility check refuses a NEW ref whose
+ * source is unknown, so an agent write queued behind a delete is refused (403)
+ * rather than committing a dangling ref. Dangling refs can therefore only predate
+ * the fence (or bypass the routes); the capture guard still protects those.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import type { OrgMemberRole } from '../../src/persistence/ports.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const opened: HttpApp[] = []
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((a) => a.close()))
+})
+
+function makeApp(): HttpApp {
+  const app = buildHttpApp(prisma)
+  opened.push(app)
+  return app
+}
+
+/** Provision a user + add them to the default org with a role; returns their id. */
+async function makeUser(sub: string, role: OrgMemberRole): Promise<string> {
+  const email = `${sub}@acme.dev`
+  const { userId } = await new PgUserRepo(prisma).provisionOidcUser({ oidcSubject: sub, email, emailVerified: true })
+  await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, email, role)
+  return userId
+}
+
+/** An app whose devAuth principal is `userId` — i.e. "act as this user". The
+ *  source-name chains are module-global, so they serialize across app instances. */
+function appAs(userId: string): HttpApp {
+  const app = buildHttpApp(prisma, { DEFAULT_OWNER_ID: userId })
+  opened.push(app)
+  return app
+}
+
+async function createSource(app: HttpApp, name: string, extra: Record<string, unknown> = {}): Promise<string> {
+  const res = await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/skill-sources`,
+    payload: { name, source: 'example-org/example-kit', ...extra }
+  })
+  expect(res.statusCode).toBe(201)
+  return res.json().id as string
+}
+
+async function createAgent(app: HttpApp, name: string, skills: string[]): Promise<string> {
+  const res = await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/agents`,
+    payload: { name, runtime: 'claude', skills }
+  })
+  expect(res.statusCode).toBe(201)
+  return res.json().id as string
+}
+
+describe('DELETE /skill-sources/:id — referenced-guard', () => {
+  it('409s while an agent still enables the source; deletes once unselected', async () => {
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const agentId = await createAgent(app, 'enabler', ['kit/helper'])
+
+    const blocked = await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    expect(blocked.statusCode).toBe(409)
+    expect(blocked.json().message).toBe('skill source is still enabled by one or more agents; unselect it there first')
+
+    // The row survives the refused delete.
+    const still = await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${sourceId}` })
+    expect(still.statusCode).toBe(200)
+
+    // Unselect from the agent, then the delete goes through.
+    const patch = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: [] }
+    })
+    expect(patch.statusCode).toBe(200)
+
+    const freed = await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    expect(freed.statusCode).toBe(204)
+    const gone = await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${sourceId}` })
+    expect(gone.statusCode).toBe(404)
+  })
+
+  it('creating a source under a name an agent already references is refused (name-capture guard)', async () => {
+    // The mirror image of the delete guard: agents bind by NAME, so a new source
+    // under a referenced name would capture those agents' installs onto its
+    // content. The route surface can no longer mint a dangling ref (the in-fence
+    // check refuses unknown sources), so seed one through the repo layer — the
+    // shape pre-fence data (or non-route writers) can leave behind.
+    const app = makeApp()
+    await app.deps.repos.agent.create({
+      id: AgentId(randomUUID()),
+      orgId: OrgId(DEFAULT_ORG_ID),
+      name: 'ghost-holder',
+      runtime: 'claude',
+      skills: ['ghost/helper']
+    })
+
+    const captured = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'ghost', source: 'example-org/example-kit' }
+    })
+    expect(captured.statusCode).toBe(409)
+
+    const other = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'ghost-2', source: 'example-org/example-kit' }
+    })
+    expect(other.statusCode).toBe(201)
+  })
+
+  it('only an exact source-name match blocks — refs to a different source do not', async () => {
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    await createSource(app, 'toolbox')
+    await createAgent(app, 'other-enabler', ['toolbox/helper'])
+
+    const res = await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    expect(res.statusCode).toBe(204)
+  })
+
+  it('deleting an agent releases its reference', async () => {
+    const app = makeApp()
+    const sourceId = await createSource(app, 'notes')
+    const agentId = await createAgent(app, 'short-lived', ['notes/*'])
+
+    expect((await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })).statusCode).toBe(409)
+
+    const drop = await app.app.inject({ method: 'DELETE', url: `${ORG}/agents/${agentId}` })
+    expect(drop.statusCode).toBe(204)
+
+    expect((await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })).statusCode).toBe(204)
+  })
+})
+
+/**
+ * Park the DELETE inside its serialized reference check by intercepting the FIRST
+ * `agent.list` call (that check is the first caller during the delete; later calls
+ * pass through). Returns a release() that lets the delete proceed, plus a promise
+ * that resolves once the delete is parked.
+ */
+function parkDeleteAtReferenceCheck(app: HttpApp) {
+  const repo = app.deps.repos.agent
+  const realList = repo.list.bind(repo)
+  let release!: () => void
+  const gate = new Promise<void>((r) => (release = r))
+  let notifyParked!: () => void
+  const parked = new Promise<void>((r) => (notifyParked = r))
+  let intercepted = false
+  repo.list = async (orgId) => {
+    if (!intercepted) {
+      intercepted = true
+      notifyParked()
+      await gate
+    }
+    return realList(orgId)
+  }
+  return { release, parked }
+}
+
+const settleTick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+describe('DELETE /skill-sources/:id — serialized against agent enable-list writes', () => {
+  it('an agent CREATE adding a ref waits out the delete; it is refused rather than committing a dangling ref', async () => {
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const { release, parked } = parkDeleteAtReferenceCheck(app)
+
+    const del = app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    await parked
+
+    // Regression (the pre-fix bug): with the check outside the chain, this create
+    // completed DURING the parked window and the delete still returned 204, leaving
+    // the dangling selector. Now the write joins the source's chain and must block.
+    const create = app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'racer', runtime: 'claude', skills: ['kit/helper'] }
+    })
+    const winner = await Promise.race([
+      create.then(() => 'created' as const),
+      settleTick(300).then(() => 'blocked' as const)
+    ])
+    expect(winner).toBe('blocked')
+
+    release()
+    // The delete saw no reference (the write was queued behind it) — it completes;
+    // the queued create then re-checks visibility INSIDE the fence, finds the
+    // source gone, and is refused: no dangling ref is ever committed.
+    expect((await del).statusCode).toBe(204)
+    expect((await create).statusCode).toBe(403)
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${sourceId}` })).statusCode).toBe(404)
+    // Nothing holds the name, so a replacement source can be registered cleanly —
+    // with no captured selections anywhere.
+    const recreate = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'example-org/example-kit' }
+    })
+    expect(recreate.statusCode).toBe(201)
+  })
+
+  it('an agent PATCH adding a ref waits out the delete the same way', async () => {
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const agentId = await createAgent(app, 'patch-racer', [])
+    const { release, parked } = parkDeleteAtReferenceCheck(app)
+
+    const del = app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    await parked
+
+    const patch = app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] }
+    })
+    const winner = await Promise.race([
+      patch.then(() => 'patched' as const),
+      settleTick(300).then(() => 'blocked' as const)
+    ])
+    expect(winner).toBe('blocked')
+
+    release()
+    expect((await del).statusCode).toBe(204)
+    expect((await patch).statusCode).toBe(403) // the source is gone — the ref is refused, never dangling
+    const agent = (await app.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })).json()
+    expect(agent.skills).toEqual([])
+  })
+
+  it('a stale full-replace PATCH re-asserting a ref still fences the delete (no diff-based bypass)', async () => {
+    // Ordinary PATCHes overlap: PATCH-A submits ['kit/helper'] (unchanged from ITS
+    // snapshot), parks before persisting; PATCH-B removes the ref; DELETE then runs.
+    // With an added-vs-before diff the parked PATCH-A computed added=[] and skipped
+    // the chain, so DELETE saw B's empty list, returned 204, and A restored the ref
+    // onto a deleted source. Keyed off the SUBMITTED list, A holds the chain while
+    // parked — the DELETE queues behind it and 409s once A's restore commits.
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const agentId = await createAgent(app, 'stale-patcher', ['kit/helper'])
+
+    // Park the FIRST agent-row write (PATCH-A's persist step) inside whatever fences
+    // the route takes; later writes (PATCH-B) pass through.
+    const writer = app.deps.repos.agentConfig
+    const realUpdate = writer.update.bind(writer)
+    let releaseA!: () => void
+    const gateA = new Promise<void>((r) => (releaseA = r))
+    let notifyParkedA!: () => void
+    const parkedA = new Promise<void>((r) => (notifyParkedA = r))
+    let intercepted = false
+    writer.update = async (...args: Parameters<typeof realUpdate>) => {
+      if (!intercepted) {
+        intercepted = true
+        notifyParkedA()
+        await gateA
+      }
+      return realUpdate(...args)
+    }
+
+    const patchA = app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] } // full replace, "unchanged" from A's stale view
+    })
+    await parkedA
+
+    const patchB = await app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: [] }
+    })
+    expect(patchB.statusCode).toBe(200)
+
+    const del = app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })
+    const winner = await Promise.race([
+      del.then(() => 'deleted' as const),
+      settleTick(300).then(() => 'blocked' as const)
+    ])
+    expect(winner).toBe('blocked') // the delete waits behind the parked PATCH-A's chain hold
+
+    releaseA()
+    expect((await patchA).statusCode).toBe(200)
+    expect((await del).statusCode).toBe(409) // A's restore committed first — the reference is seen
+    expect((await app.app.inject({ method: 'GET', url: `${ORG}/skill-sources/${sourceId}` })).statusCode).toBe(200)
+  })
+
+  it('a restricted same-name replacement is not grandfathered by a stale full-replace PATCH', async () => {
+    // The keep-exemption must attach to what the agent actually HOLDS, not the
+    // name: org-visible A is enabled; A's delete parks; a RESTRICTED replacement B
+    // and a stale full-replace PATCH queue behind it; a concurrent removal frees the
+    // delete. B then commits — and the stale PATCH must NOT ride its old "kept ref"
+    // exemption onto B (a source the collaborator cannot even see): the in-fence
+    // check sees nothing held and refuses with 403.
+    const owner = await makeUser('skls-owner', 'owner')
+    const collab = await makeUser('skls-collab', 'collaborator')
+    const ownerApp = appAs(owner)
+    const collabApp = appAs(collab)
+
+    const sourceA = await createSource(ownerApp, 'kit')
+    const agentId = await createAgent(collabApp, 'identity-racer', ['kit/helper'])
+
+    const { release, parked } = parkDeleteAtReferenceCheck(ownerApp)
+    const del = ownerApp.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceA}` })
+    await parked
+
+    const bCreate = ownerApp.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'example-org/example-kit', visibility: 'restricted', sharedWith: [] }
+    })
+    await settleTick(150)
+    const stalePatch = collabApp.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] } // full replace — "unchanged" from its stale view of A
+    })
+    await settleTick(150)
+    // A concurrent removal (submits no refs → joins no chain) frees the delete.
+    const removal = await collabApp.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: [] }
+    })
+    expect(removal.statusCode).toBe(200)
+
+    release()
+    expect((await del).statusCode).toBe(204)
+    expect((await bCreate).statusCode).toBe(201) // replacement B exists, restricted
+    expect((await stalePatch).statusCode).toBe(403) // the exemption died with the hold; B is invisible
+
+    const agent = (await collabApp.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })).json()
+    expect(agent.skills).toEqual([]) // never bound to the invisible replacement
+  })
+
+  it('a replacement completed between the route-entry read and the fence cannot become the grandfather baseline', async () => {
+    // The keep-exemption derives from the agent's COMMITTED enable-list read inside
+    // the fence, never from request-time snapshots: here the stale PATCH captures
+    // `before=['kit/helper']` (bound to org-visible A) and then parks BEFORE any
+    // other read; a removal, A's delete, and a restricted same-name replacement B
+    // all complete during the pause. On resume the committed list no longer holds
+    // the ref, so the enable is fresh and B is invisible → 403.
+    const owner = await makeUser('sklb-owner', 'owner')
+    const collab = await makeUser('sklb-collab', 'collaborator')
+    const ownerApp = appAs(owner)
+    const collabApp = appAs(collab)
+
+    const sourceA = await createSource(ownerApp, 'kit')
+    const agentId = await createAgent(collabApp, 'baseline-racer', ['kit/helper'])
+
+    // Park the stale PATCH right after its optimistic-CAS re-read (the SECOND
+    // agent.get: #1 is the route-entry getOrgAgent, #2 refreshMutationAgent) — the
+    // last read before the fence.
+    const repo = collabApp.deps.repos.agent
+    const realGet = repo.get.bind(repo)
+    let releaseGet!: () => void
+    const gate = new Promise<void>((r) => (releaseGet = r))
+    let notifyParked!: () => void
+    const parked = new Promise<void>((r) => (notifyParked = r))
+    let calls = 0
+    repo.get = async (id) => {
+      const row = await realGet(id)
+      if (++calls === 2) {
+        notifyParked()
+        await gate
+      }
+      return row
+    }
+    const stalePatch = collabApp.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] }
+    })
+    await parked
+
+    // While it sleeps: the reference is removed, A is deleted, restricted B lands.
+    expect(
+      (await collabApp.app.inject({ method: 'PATCH', url: `${ORG}/agents/${agentId}`, payload: { skills: [] } }))
+        .statusCode
+    ).toBe(200)
+    expect((await ownerApp.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceA}` })).statusCode).toBe(
+      204
+    )
+    const bCreate = await ownerApp.app.inject({
+      method: 'POST',
+      url: `${ORG}/skill-sources`,
+      payload: { name: 'kit', source: 'example-org/example-kit', visibility: 'restricted', sharedWith: [] }
+    })
+    expect(bCreate.statusCode).toBe(201)
+
+    releaseGet()
+    expect((await stalePatch).statusCode).toBe(403) // committed list holds nothing — B is a fresh, invisible enable
+    const agent = (await collabApp.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })).json()
+    expect(agent.skills).toEqual([])
+  })
+
+  it('a removal committed between the fence and the row write cannot revive the hold exemption (row-locked authorize)', async () => {
+    // The hold decision is evaluated INSIDE the agent-row-locked update transaction,
+    // against the committed list that write merges onto. A removal-only PATCH joins
+    // no source-name chain, so it CAN commit inside the fence-to-write window — and
+    // any hold read taken earlier in the fence would wrongly keep exempting the
+    // stale writer. Here: restricted 'kit' held by the owner's agent; the
+    // collaborator's stale full-replace PATCH parks just before its row update; the
+    // owner's removal commits; on resume the row-locked read shows nothing held,
+    // so re-adding the invisible source is refused.
+    const owner = await makeUser('sklh-owner', 'owner')
+    const collab = await makeUser('sklh-collab', 'collaborator')
+    const ownerApp = appAs(owner)
+    const collabApp = appAs(collab)
+
+    await createSource(ownerApp, 'kit', { visibility: 'restricted', sharedWith: [] })
+    const agentId = await createAgent(ownerApp, 'held-agent', ['kit/helper'])
+
+    const writer = collabApp.deps.repos.agentConfig
+    const realUpdate = writer.update.bind(writer)
+    let releaseWriter!: () => void
+    const gate = new Promise<void>((r) => (releaseWriter = r))
+    let notifyParked!: () => void
+    const parked = new Promise<void>((r) => (notifyParked = r))
+    writer.update = async (...args: Parameters<typeof realUpdate>) => {
+      notifyParked()
+      await gate
+      return realUpdate(...args)
+    }
+    const stalePatch = collabApp.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] } // full replace — "unchanged" from its stale view
+    })
+    await parked
+
+    // The removal joins no chain — it lands inside the fence-to-write window.
+    expect(
+      (await ownerApp.app.inject({ method: 'PATCH', url: `${ORG}/agents/${agentId}`, payload: { skills: [] } }))
+        .statusCode
+    ).toBe(200)
+
+    releaseWriter()
+    expect((await stalePatch).statusCode).toBe(403) // row-locked read: nothing held; 'kit' is invisible
+    const agent = (await ownerApp.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })).json()
+    expect(agent.skills).toEqual([])
+  })
+
+  it('a sharing flip queues behind an in-flight enable (no check-to-commit visibility race)', async () => {
+    // PUT /skill-sources/:id/sharing joins the name chain: an agent write authorizes
+    // visibility INSIDE that chain, so a restrict must not land between its check
+    // and its commit. Park the enable at its persist step (in-fence, post-check) and
+    // assert the sharing flip waits for it.
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const agentId = await createAgent(app, 'share-racer', [])
+
+    const writer = app.deps.repos.agentConfig
+    const realUpdate = writer.update.bind(writer)
+    let releaseWriter!: () => void
+    const gate = new Promise<void>((r) => (releaseWriter = r))
+    let notifyParked!: () => void
+    const parked = new Promise<void>((r) => (notifyParked = r))
+    let intercepted = false
+    writer.update = async (...args: Parameters<typeof realUpdate>) => {
+      if (!intercepted) {
+        intercepted = true
+        notifyParked()
+        await gate
+      }
+      return realUpdate(...args)
+    }
+    const enable = app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: ['kit/helper'] }
+    })
+    await parked
+
+    const share = app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/skill-sources/${sourceId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    const winner = await Promise.race([
+      share.then(() => 'shared' as const),
+      settleTick(300).then(() => 'blocked' as const)
+    ])
+    expect(winner).toBe('blocked') // the flip waits behind the in-flight enable
+
+    releaseWriter()
+    expect((await enable).statusCode).toBe(200)
+    expect((await share).statusCode).toBe(200)
+  })
+
+  it('a sibling-field PATCH omitting skills cannot restore a concurrently-removed ref (atomic bag merge)', async () => {
+    // runtimeOverrides is ONE JsonB bag, so a model-only PATCH re-writes the whole
+    // bag from what it read. Unlocked, it could carry a stale skills key back after
+    // another PATCH removed it — behind the DELETE guard's back and without ever
+    // joining a source chain (it submits no skills). The repo row-locks the bag
+    // read (FOR UPDATE), so bag writers fully serialize and the sibling PATCH
+    // merges onto the post-removal bag. An external row lock parks BOTH patches at
+    // their bag read so they queue and serialize behind it.
+    const app = makeApp()
+    const sourceId = await createSource(app, 'kit')
+    const agentId = await createAgent(app, 'sibling-racer', ['kit/helper'])
+
+    let releaseRow!: () => void
+    const rowHeld = new Promise<void>((r) => (releaseRow = r))
+    let rowLocked!: () => void
+    const lockedRow = new Promise<void>((r) => (rowLocked = r))
+    const externalLock = prisma.$transaction(
+      async (tx) => {
+        await tx.$queryRaw`SELECT "id" FROM "agent" WHERE "id" = ${agentId} FOR UPDATE`
+        rowLocked()
+        await rowHeld
+      },
+      { timeout: 20_000 }
+    )
+    await lockedRow
+
+    const removal = app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { skills: [] }
+    })
+    await settleTick(250)
+    const sibling = app.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { model: 'stale-sibling' }
+    })
+    await settleTick(250)
+
+    releaseRow()
+    await externalLock
+    expect((await removal).statusCode).toBe(200)
+    expect((await sibling).statusCode).toBe(200)
+
+    const agent = (await app.app.inject({ method: 'GET', url: `${ORG}/agents/${agentId}` })).json()
+    expect(agent.model).toBe('stale-sibling')
+    expect(agent.skills).toEqual([]) // the omitted key did NOT restore 'kit/helper'
+    expect((await app.app.inject({ method: 'DELETE', url: `${ORG}/skill-sources/${sourceId}` })).statusCode).toBe(204)
+  })
+})


### PR DESCRIPTION
## What

`DELETE /skill-sources/:id` refuses (409) while any agent's enable-list still references the source by name — but the check-then-delete was not serialized against agent create/patch. A concurrent agent write could commit a new skill ref after the check read its agent snapshot and before `skillSource.delete` ran, so DELETE returned 204 and left a dangling name-based selector that would silently re-bind to any future source recreated under the same name.

This mirrors the **final** MCP-provider lifecycle fence from #136 for skill sources:

- **`skill-sources.ts`** — `serializeBySkillSource` / `serializeBySkillSourceNames`, keyed by **(orgId, name)** — the durable binding key, not the row id — so lifecycle events on different rows under one name (drop A, create B) serialize with each other and with agent enable-list writes. The DELETE reference check runs inside the chain; **create gains the mirror-image name-capture guard** (409 while any agent references the requested name); **sharing flips join the chain** so a restrict can't land between an agent write's in-fence visibility check and its commit.
- **`agents.ts`** — `withSubmittedSkillSourceChains`: agent writes join the chain of every source their **submitted** skill-refs name (not an added-vs-before diff — a stale full-replace PATCH may be the write that *restores* a ref after a concurrent removal). Nested inside the MCP fence in a fixed order (providers outer, sources inner) so the two chain families cannot deadlock. The skills visibility gate re-runs **inside the fence**, with the keep-exemption derived from the agent's **committed** refs.
- **`ports.ts` / `agent.repo.ts`** — new `AgentUpdateOpts.authorizeSkills` hook (twin of `authorizeMcpServers`), evaluated inside the row-locked (`FOR UPDATE`) update transaction against the committed `skills` list — the one atomic point where the hold check and the write it guards can't be separated by a concurrent removal-only PATCH.

**One skills-specific difference from MCP:** a skill-ref has no daemon-local fallback, so a NEW ref to an unknown source is refused. An agent write queued behind a delete therefore gets **403** instead of committing a dangling ref — the route surface can no longer mint dangling selectors at all. The create-side capture guard still protects pre-existing (pre-fence or non-route-written) dangling refs.

## Tests

- **Unit** (`skill-sources.test.ts`): chain mutual exclusion, opposite-order multi-name acquisition (deadlock-freedom), and org scoping of the chain key.
- **Integration** (`skill-sources.route.test.ts`, 12 tests) — mirrors the MCP suite from #136:
  - referenced-guard basics: 409 while referenced / capture guard on a seeded dangling ref / exact-name matching / agent deletion releases the reference;
  - the parked-delete CREATE and PATCH racers (the write blocks instead of slipping into the check→drop window; the queued write is then refused, never dangling);
  - the stale full-replace PATCH fences the delete (no diff-based bypass);
  - a restricted same-name replacement is not grandfathered (both the queued-behind-delete and the route-entry-snapshot orderings → 403, agent never bound);
  - a removal inside the fence-to-write window cannot revive the hold exemption (row-locked authorize);
  - a sharing flip queues behind an in-flight enable;
  - a sibling-field PATCH omitting `skills` cannot restore a removed ref (atomic bag merge).

`typecheck` clean; `test:unit` 668/668; `test:int` 674/674 (Docker); eslint + prettier clean.

## Reviewer notes

- Built directly on top of the merged #136 — reuses its row-locked `runtimeOverrides` read and follows its (orgId, name) chain design exactly; no changes to the MCP side beyond nesting the new skills fence alongside it in the two agent-write call sites.
- Like the provider chains, this is an in-process lock — sufficient while the CP is a single Fastify process; the documented escalation path is `pg_advisory_xact_lock` if it goes multi-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)