### PR TITLE
fix(daemon): discover gated Telegram conversations

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -853,12 +853,14 @@ identities.
 
 **Conversation reporting.** The `integration/channels` D→C EVT and
 `IntegrationChannel` protocol shape gain `kind: 'channel' | 'im'` (absent =
-`'channel'` for wire compatibility). Channel rows keep coming from membership
-events as today; the membership snapshot must never delete `im` rows (they are
-reported incrementally). DM rows are reported on first inbound DM to a gated
-integration, carrying the counterpart's display name; an optional boot-time
-sweep (`conversations.list types=im`) can backfill DMs opened while the daemon
-was down.
+`'channel'` for wire compatibility). Slack channel rows keep coming from
+authoritative membership events. Platforms that cannot enumerate every
+conversation send `authoritative: false`; these reports upsert observed rows
+without deleting absent ones. An explicitly addressed Off group is reported
+before routing, because it deliberately creates no session. DM rows are likewise
+reported on first inbound DM to a gated integration, carrying the counterpart's
+display name. An optional boot-time sweep (`conversations.list types=im`) can
+backfill DMs opened while the daemon was down.
 
 _Shared bots:_ the relay's membership snapshot drops IMs, so DM rows take the
 incremental path there too — an unrouted DM to a bot backing ≥1 gated agent

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1406,11 +1406,11 @@ enum ConversationKind {
   im
 }
 
-// One conversation the integration's bot participates in (daemon-reported snapshot
-// via `integration/channels`, latest-wins for kind=channel; DM rows are reported on
-// first inbound DM and never dropped by the membership snapshot) + the operator's
-// per-conversation trigger choice. Channel id/name are control metadata — never
-// message content (§1/§12).
+// One conversation the integration's bot participates in. `integration/channels`
+// carries either an authoritative membership snapshot or a partial observed-
+// conversation report; DM rows and rows absent from partial reports are retained.
+// The operator's per-conversation trigger survives both forms. Channel id/name are
+// control metadata — never message content (§1/§12).
 model IntegrationChannel {
   integrationId String           @db.Uuid
   channelId     String // platform conversation id (Slack "C…" / DM "D…")

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2236,18 +2236,19 @@ export interface ReportedChannel {
 
 export interface IntegrationChannelRepo {
   /**
-   * Converge to the daemon's membership snapshot (latest-wins): upsert every
-   * reported conversation (refreshing name/isPrivate, PRESERVING the stored
-   * trigger), delete kind='channel' rows the bot is no longer a member of. DM
-   * (kind='im') rows are NEVER deleted by the snapshot — they are reported
-   * incrementally on first inbound DM (§14.3), so a membership-only report must
-   * not wipe them. `defaultTrigger` seeds NEW rows only ('off' for a gated
-   * integration, 'mention' otherwise); existing rows keep their trigger.
+   * Converge to the daemon's channel report (latest-wins): upsert every reported
+   * conversation (refreshing name/isPrivate, PRESERVING the stored trigger).
+   * Authoritative membership snapshots delete kind='channel' rows the bot is no
+   * longer a member of; non-authoritative observed-conversation reports retain
+   * missing rows because platforms such as Telegram cannot enumerate all chats.
+   * DM (kind='im') rows are always retained. `defaultTrigger` seeds NEW rows only
+   * ('off' for a gated integration, 'mention' otherwise); existing rows keep
+   * their trigger.
    */
   replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
-    opts?: { defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger; authoritative?: boolean }
   ): Promise<void>
   listForIntegration(integrationId: IntegrationId): Promise<IntegrationChannelRecord[]>
   /** Incremental conversation upsert (§14.3, DM rows): create the row (kind, name,

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -376,21 +376,24 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
 export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   constructor(private readonly db: PrismaLike) {}
 
-  // Converge to the daemon's membership snapshot: refresh name/isPrivate on known
+  // Converge to a daemon channel report: refresh supplied metadata on known
   // conversations (PRESERVING the operator's trigger), insert new ones (trigger =
-  // `defaultTrigger`, 'mention' unless the integration is gated), and drop
-  // kind='channel' rows the bot is no longer a member of. DM (kind='im') rows are
-  // reported incrementally on first inbound DM (§14.3), so the membership snapshot
-  // must never delete them.
+  // `defaultTrigger`, 'mention' unless the integration is gated), and, for an
+  // authoritative membership snapshot, drop channel rows that are no longer present.
+  // DM rows and rows omitted from a non-authoritative observed-conversation report
+  // are retained.
   async replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
-    opts?: { defaultTrigger?: ChannelTrigger }
+    opts?: { defaultTrigger?: ChannelTrigger; authoritative?: boolean }
   ): Promise<void> {
-    await this.db.integrationChannel.deleteMany({
-      where: { integrationId, kind: 'channel', channelId: { notIn: channels.map((c) => c.id) } }
-    })
+    if (opts?.authoritative !== false) {
+      await this.db.integrationChannel.deleteMany({
+        where: { integrationId, kind: 'channel', channelId: { notIn: channels.map((c) => c.id) } }
+      })
+    }
     for (const c of channels) {
+      const authoritative = opts?.authoritative !== false
       await this.db.integrationChannel.upsert({
         where: { integrationId_channelId: { integrationId, channelId: c.id } },
         create: {
@@ -403,7 +406,11 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         },
         // kind updates only when explicitly reported: a kind-less membership/observed
         // re-report must never downgrade an established 'im' row (§14.3).
-        update: { name: c.name ?? null, isPrivate: c.isPrivate ?? false, ...(c.kind ? { kind: c.kind } : {}) }
+        update: {
+          ...(authoritative || c.name !== undefined ? { name: c.name ?? null } : {}),
+          ...(authoritative || c.isPrivate !== undefined ? { isPrivate: c.isPrivate ?? false } : {}),
+          ...(c.kind ? { kind: c.kind } : {})
+        }
       })
     }
   }

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -53,13 +53,13 @@ export interface DaemonWsDeps {
   events: SessionEventSink
   /** Ownership check for the `integration/channels` EVT (integration → daemon scope). */
   integration: IntegrationRepo
-  /** Persists channel-membership snapshots from the `integration/channels` EVT. */
+  /** Persists authoritative membership snapshots and partial conversation reports. */
   integrationChannel: IntegrationChannelRepo
-  /** Shares the HTTP agent-move boundary with daemon-originated channel snapshots. */
+  /** Shares the HTTP agent-move boundary with daemon-originated conversation reports. */
   agentMutations: AgentMutationGate
   /** Resumes durable move tombstones advertised by a reconnecting daemon. */
   recoverStagedAgent: (agentId: AgentId, daemonId: DaemonId, moveId: string) => Promise<void>
-  /** Refreshes relay and daemon collaboration snapshots after accepted membership changes. */
+  /** Refreshes relay and daemon collaboration snapshots after accepted conversation changes. */
   collabRoutes: CollabRoutesService
   /** Stamps `lastRunAt` from the `cron/report` EVT (daemon-scoped, latest-wins). */
   cron: CronRepo

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -1,13 +1,12 @@
 /**
- * `integration/channels` handler (per-channel trigger config).
+ * `integration/channels` handler (per-conversation trigger config).
  *
- * A fire-and-forget EVT (no reply). The daemon reports the FULL set of channels
- * an integration's bot is currently a member of (on socket start + every invite/
- * remove); the CP converges `integration_channel` to that snapshot (latest-wins,
- * idempotent), PRESERVING each stored channel's operator-chosen trigger. Channel
- * ids/names are control metadata — never message content (§1/§12). Every accepted
- * replacement also hot-pushes the derived collaboration routes so joins and
- * removals converge without waiting for reconnect.
+ * A fire-and-forget EVT (no reply). Slack reports the full membership set; a
+ * platform that cannot enumerate its chats reports `authoritative:false`, which
+ * upserts observed conversations without deleting older rows. Both forms
+ * PRESERVE each stored conversation's operator-chosen trigger. Channel ids/names
+ * are control metadata — never message content (§1/§12). Every accepted report
+ * also hot-pushes the derived collaboration routes without waiting for reconnect.
  *
  * Scope check: the integration's owning agent must be placed on the REPORTING
  * daemon (the same daemon-scoped join as `register/ok.integrations[]`) — a daemon
@@ -43,15 +42,20 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     await deps.integrationChannel.replaceSnapshot(
       integration.id,
       p.channels,
-      defaultTrigger ? { defaultTrigger } : undefined
+      defaultTrigger || p.authoritative === false
+        ? {
+            ...(defaultTrigger ? { defaultTrigger } : {}),
+            ...(p.authoritative === false ? { authoritative: false } : {})
+          }
+        : undefined
     )
   } finally {
     release()
   }
 
-  // Membership is part of the effective agent-call edge. Refresh both relay and
-  // daemon full-replace snapshots immediately after accepting a join/removal so
-  // the data plane does not wait for an unrelated policy edit or reconnect.
+  // Conversation availability is part of the effective agent-call edge. Refresh
+  // relay and daemon collaboration snapshots immediately after accepting a report
+  // so the data plane does not wait for an unrelated policy edit or reconnect.
   // Register baselines remain the durable backstop if this best-effort push fails.
   try {
     await deps.collabRoutes.broadcast(integration.orgId)

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -1,10 +1,10 @@
 /**
  * Per-channel trigger config, end to end on the CP side:
  *
- *  - `integration/channels` (D→C EVT) converges `integration_channel` to the
- *    daemon's membership snapshot — new channels default to '@-mention', names
- *    refresh, channels the bot left are dropped, and the operator's trigger
- *    choice SURVIVES re-reports (latest-wins on membership, never on trigger).
+ *  - `integration/channels` (D→C EVT) converges `integration_channel` to either
+ *    an authoritative membership snapshot or a partial observed-conversation
+ *    report. New channels default to '@-mention', authoritative omissions drop
+ *    channels, and the operator's trigger choice SURVIVES every re-report.
  *  - The handler is daemon-scoped: a report from a daemon that does not own the
  *    integration's agent is dropped.
  *  - `PATCH /integrations/:id/channels/:channelId {trigger}` persists the choice,
@@ -74,14 +74,15 @@ async function report(
   integrationId: string,
   channels: IntegrationChannel[],
   agentMutations = new AgentMutationGate(),
-  collabRoutes = { broadcast: async () => undefined } as unknown as CollabRoutesService
+  collabRoutes = { broadcast: async () => undefined } as unknown as CollabRoutesService,
+  authoritative?: boolean
 ): Promise<void> {
   const frame = {
     v: 1,
     id: randomUUID(),
     ts: new Date().toISOString(),
     type: 'integration/channels',
-    payload: { integrationId, channels }
+    payload: { integrationId, channels, ...(authoritative === undefined ? {} : { authoritative }) }
   } as AnyFrame
   const deps = {
     integration: new PgIntegrationRepo(prisma),
@@ -246,6 +247,22 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     await report(DAEMON, id, [{ id: 'C1', name: 'ship' }])
     rows = await channels.listForIntegration(IntegrationId(id))
     expect(rows.map((c) => c.channelId)).toEqual(['C1']) // C2 dropped
+  })
+
+  it('a non-authoritative observed-conversation report upserts without deleting missing channels', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const channels = new PgIntegrationChannelRepo(prisma)
+
+    await report(DAEMON, id, [{ id: '-1001', name: 'First group' }], undefined, undefined, false)
+    await report(DAEMON, id, [{ id: '-1002', name: 'Second group' }], undefined, undefined, false)
+    await report(DAEMON, id, [{ id: '-1001' }], undefined, undefined, false)
+
+    const rows = await channels.listForIntegration(IntegrationId(id))
+    expect(rows.map((c) => c.channelId).sort()).toEqual(['-1001', '-1002'])
+    expect(rows.find((c) => c.channelId === '-1001')?.name).toBe('First group')
   })
 
   it('hot-pushes collaboration routes after both channel joins and removals', async () => {

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -399,10 +399,11 @@ export class CpClient {
   }
 
   /**
-   * Report an integration's channel-membership snapshot (D→C `integration/channels`
-   * EVT, fire-and-forget, latest-wins). No-op unless READY/DRAINING — the daemon
-   * re-emits its cached snapshots on each (re)connect (see onReady in daemon.ts),
-   * so a dropped report only delays the console's channel list, never loses it.
+   * Report an integration's channels (D→C `integration/channels` EVT,
+   * fire-and-forget, latest-wins). Slack sends an authoritative membership
+   * snapshot; non-enumerable platforms send observed rows with
+   * `authoritative:false`. No-op unless READY/DRAINING — the daemon re-emits its
+   * cached reports on each (re)connect (see onReady in daemon.ts).
    */
   emitIntegrationChannels(snapshot: IntegrationChannels): void {
     if (this.state !== 'READY' && this.state !== 'DRAINING') return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1326,9 +1326,9 @@ export class Daemon {
   private cpClient?: CpClient
   private relays?: RelayManager
   private cpCrons?: CpCronRegistry
-  // Latest channel-membership snapshot per integrationId (from users.conversations),
-  // re-emitted to the CP on each (re)connect (emit is a no-op while disconnected).
-  private channelSnapshots = new Map<string, IntegrationChannel[]>()
+  // Latest channel report per integrationId plus whether it came from a complete
+  // membership listing. Replayed with the same authority on each CP (re)connect.
+  private channelSnapshots = new Map<string, { channels: IntegrationChannel[]; authoritative: boolean }>()
   private cpAgents?: CpAgentRegistry
   private cpIntegrations?: CpIntegrationRegistry
   private botUserIds: Record<string, string> = {}
@@ -2867,7 +2867,7 @@ export class Daemon {
         // still be refreshed safely when several bots share the agent.
         const observed = integrations.length === 1 ? this.store.observedChannels(agent.id, platform) : []
         for (const integ of integrations) {
-          const prior = this.channelSnapshots.get(integ.id) ?? []
+          const prior = this.channelSnapshots.get(integ.id)?.channels ?? []
           if (observed.length === 0 && prior.length === 0) continue
           const priorById = new Map(prior.map((c) => [c.id, c]))
           const observedIds = new Set(observed.map((c) => c.id))
@@ -2891,7 +2891,7 @@ export class Daemon {
               return name && name !== c.name ? { ...c, name } : c
             })
           const channels = [...fromSessions, ...retained]
-          this.channelSnapshots.set(integ.id, channels)
+          this.channelSnapshots.set(integ.id, { channels, authoritative: false })
           this.cpClient?.emitIntegrationChannels({ integrationId: integ.id, channels, authoritative: false })
         }
       }
@@ -2922,9 +2922,9 @@ export class Daemon {
         // only, but a gated integration's snapshot also holds DM conversations — a
         // refresh must not wipe them (the CP protects them too; this keeps the
         // in-memory snapshot honest for the reconnect re-assert).
-        const ims = (this.channelSnapshots.get(integrationId) ?? []).filter((x) => x.kind === 'im')
+        const ims = (this.channelSnapshots.get(integrationId)?.channels ?? []).filter((x) => x.kind === 'im')
         const merged = [...channels, ...ims]
-        this.channelSnapshots.set(integrationId, merged)
+        this.channelSnapshots.set(integrationId, { channels: merged, authoritative: true })
         this.cpClient?.emitIntegrationChannels({ integrationId, channels: merged })
         this.maybeIntroduceOnJoin(integrationId, channels)
       }
@@ -11158,7 +11158,8 @@ export class Daemon {
    *  Name resolution is best-effort. Telegram/Discord getChat results land through
    *  refreshObservedChannels; Slack DMs retain the existing profile fallback below. */
   private reportGatedConversation(integrationId: string, msg: NormalizedMessage, isDm: boolean): void {
-    const existing = this.channelSnapshots.get(integrationId) ?? []
+    const cached = this.channelSnapshots.get(integrationId)
+    const existing = cached?.channels ?? []
     const current = existing.find((c) => c.id === msg.channel)
     const kind = isDm ? ('im' as const) : ('channel' as const)
     const known = this.store.getDisplayNames([msg.channel]).get(msg.channel)
@@ -11168,7 +11169,10 @@ export class Daemon {
     const next = current
       ? existing.map((c) => (c.id === msg.channel ? { ...c, ...(known ? { name: known } : {}), kind } : c))
       : [...existing, { id: msg.channel, ...(known ? { name: known } : {}), kind }]
-    this.channelSnapshots.set(integrationId, next)
+    this.channelSnapshots.set(integrationId, {
+      channels: next,
+      authoritative: cached?.authoritative ?? false
+    })
     this.cpClient?.emitIntegrationChannels({ integrationId, channels: next, authoritative: false })
     if (!isDm || known || current?.name) return
     const conn = this.connForIntegration(integrationId)
@@ -11178,12 +11182,28 @@ export class Daemon {
       .then((prof) => {
         const name = prof.realName || prof.name
         if (!name) return
-        const snap = this.channelSnapshots.get(integrationId) ?? []
+        const cached = this.channelSnapshots.get(integrationId)
+        const snap = cached?.channels ?? []
         const updated = snap.map((c) => (c.id === msg.channel && !c.name ? { ...c, name: `@${name}` } : c))
-        this.channelSnapshots.set(integrationId, updated)
+        this.channelSnapshots.set(integrationId, {
+          channels: updated,
+          authoritative: cached?.authoritative ?? false
+        })
         this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated, authoritative: false })
       })
       .catch(() => {})
+  }
+
+  /** Re-assert cached reports after a CP reconnect without upgrading a partial
+   *  observation (including Slack gated-conversation discovery) to a full snapshot. */
+  private replayChannelSnapshots(): void {
+    for (const [integrationId, snapshot] of this.channelSnapshots) {
+      this.cpClient?.emitIntegrationChannels({
+        integrationId,
+        channels: snapshot.channels,
+        ...(snapshot.authoritative ? {} : { authoritative: false })
+      })
+    }
   }
 
   /** The live platform connection serving `integrationId`, any platform. */
@@ -12848,14 +12868,7 @@ export class Daemon {
         this.cpClient?.emitMemoryConnectionFacts(this.memoryConnections?.facts() ?? [])
         this.hookReportConnectionId = randomUUID()
         this.replayHookTerminalReports()
-        for (const [integrationId, channels] of this.channelSnapshots) {
-          const platform = this.integrationConfigById(integrationId)?.platform
-          this.cpClient?.emitIntegrationChannels({
-            integrationId,
-            channels,
-            ...(platform && platform !== 'slack' ? { authoritative: false } : {})
-          })
-        }
+        this.replayChannelSnapshots()
         // ...and each CP cron's stored last-run stamp — fires while the CP was
         // unreachable would otherwise never land (latest-wins upsert, so
         // re-asserting an already-known stamp is a no-op).

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2844,48 +2844,56 @@ export class Daemon {
   }
 
   /**
-   * Approach-A channel discovery for Telegram and Discord: the bot cannot cheaply
-   * enumerate the chats/channels it actually participates in (Telegram's API can't
-   * list them at all, and Discord's ready-cache enumeration would surface every text
-   * channel in a guild rather than the ones the bot is engaged in), so the observed
-   * session history IS the reachable set. Build a membership-style snapshot from
-   * stored sessions + cached display names and report it to the CP over the same
-   * `integration/channels` path Slack uses (refreshChannels), so the console lists
-   * these chats under the integration. Idempotent + latest-wins: safe to call on
-   * every reconcile, on a newly-created session, and whenever a channel name resolves
-   * (re-emitted from ChannelNameResolver's save sink — names fill in lazily and the
-   * console falls back to the raw chat id until then). The emit is a no-op while the
-   * CP is down; the cached snapshot re-asserts on the next reconnect.
+   * Observed-conversation discovery for Telegram and Discord. These platforms do
+   * not give us an authoritative set of chats the bot is engaged in, so stored
+   * session history is merged with explicitly-addressed Off conversations already
+   * cached for the integration. Reports carry `authoritative:false`: the CP upserts
+   * what we know but never treats an absent row as a leave.
+   *
+   * Names fill in lazily through ChannelNameResolver. Re-merging the cached rows
+   * here is important for Off conversations: they have no session row, so without
+   * preserving and enriching the cached entry an async Telegram getChat result
+   * could never replace the console's raw numeric id.
    */
   private refreshObservedChannels(): void {
     for (const agent of this.agents.values()) {
       for (const platform of ['telegram', 'discord'] as const) {
-        const [integ, ...rest] = agent.integrations.filter((i) => i.platform === platform)
+        const integrations = agent.integrations.filter((i) => i.platform === platform)
+        if (integrations.length === 0) continue
         // observedChannels is agent+platform-scoped, not per-bot (the sessions table
         // carries no integrationId). With several bots of the same platform on one
-        // agent we can't tell which bot saw which chat, so fanning the same set out to
-        // every integration would attribute chats to the wrong bot. Only report when
-        // there's exactly one — the common case — and skip the ambiguous multi-bot agent.
-        if (!integ || rest.length > 0) continue
-        // The sessions table can't tell a DM chat from a group, so observed rows are
-        // kind-less. Preserve previously established `im` kinds (§14.3): re-mark
-        // overlapping ids and keep im-only entries, otherwise a refresh would
-        // downgrade a reported DM row back to 'channel' on the CP.
-        const priorIms = new Set(
-          (this.channelSnapshots.get(integ.id) ?? []).filter((x) => x.kind === 'im').map((x) => x.id)
-        )
-        const observed: IntegrationChannel[] = this.store.observedChannels(agent.id, platform).map((c) => ({
-          id: c.id,
-          ...(c.name ? { name: c.name } : {}),
-          ...(priorIms.has(c.id) ? { kind: 'im' as const } : {})
-        }))
-        const observedIds = new Set(observed.map((x) => x.id))
-        const keptIms = (this.channelSnapshots.get(integ.id) ?? []).filter(
-          (x) => x.kind === 'im' && !observedIds.has(x.id)
-        )
-        const channels = [...observed, ...keptIms]
-        this.channelSnapshots.set(integ.id, channels)
-        this.cpClient?.emitIntegrationChannels({ integrationId: integ.id, channels })
+        // agent we can't tell which bot saw which session. Only merge session history
+        // in the common single-integration case; integration-attributed Off rows can
+        // still be refreshed safely when several bots share the agent.
+        const observed = integrations.length === 1 ? this.store.observedChannels(agent.id, platform) : []
+        for (const integ of integrations) {
+          const prior = this.channelSnapshots.get(integ.id) ?? []
+          if (observed.length === 0 && prior.length === 0) continue
+          const priorById = new Map(prior.map((c) => [c.id, c]))
+          const observedIds = new Set(observed.map((c) => c.id))
+          const names = this.store.getDisplayNames([...new Set([...observedIds, ...prior.map((c) => c.id)])])
+          // The sessions table cannot distinguish DMs from groups. Preserve the kind
+          // established by explicit gated-conversation discovery for overlapping ids.
+          const fromSessions: IntegrationChannel[] = observed.map((c) => {
+            const previous = priorById.get(c.id)
+            const name = c.name ?? names.get(c.id)
+            return {
+              id: c.id,
+              ...(name ? { name } : {}),
+              ...(previous?.isPrivate !== undefined ? { isPrivate: previous.isPrivate } : {}),
+              ...(previous?.kind ? { kind: previous.kind } : {})
+            }
+          })
+          const retained = prior
+            .filter((c) => !observedIds.has(c.id))
+            .map((c) => {
+              const name = names.get(c.id)
+              return name && name !== c.name ? { ...c, name } : c
+            })
+          const channels = [...fromSessions, ...retained]
+          this.channelSnapshots.set(integ.id, channels)
+          this.cpClient?.emitIntegrationChannels({ integrationId: integ.id, channels, authoritative: false })
+        }
       }
     }
   }
@@ -3762,12 +3770,12 @@ export class Daemon {
     // continues it). No-op on other platforms.
     this.canonicalizeTelegramThread(msg)
 
-    // §14.3: gated-DM ROW discovery must precede command interception AND routing —
-    // an Off DM whose first inbound is a control command is refused by command
-    // authz but still needs its pending row, and on a consolidated connection
-    // EVERY Off gated integration needs its own row. Report-only: the notice stays
-    // conditional on the message actually resolving to no admitted target.
-    this.discoverGatedDms(msg, srcIntegrationIds ?? [])
+    // §14.3: gated-conversation discovery must precede command interception AND
+    // routing. An Off DM whose first inbound is a command still needs its row; an
+    // explicitly-mentioned Off channel likewise needs a pending row even though no
+    // session will be created. Report-only: the notice remains conditional on the
+    // message actually resolving to no admitted target.
+    this.discoverGatedConversations(msg, srcIntegrationIds ?? [])
 
     // In-conversation control commands (`!stop` / `!queue …`) act on the running
     // agent and never reach it as a prompt — intercept before routing/dispatch.
@@ -11084,26 +11092,25 @@ export class Daemon {
   /**
    * §14: an explicitly-addressed message (a mention of a gated integration's bot, or
    * a DM to it) that routed nowhere gets a ONE-TIME per-conversation notice — the
-   * bot must never look silently broken — and a gated DM conversation is reported to
+   * bot must never look silently broken — and the Off conversation is reported to
    * the CP so the console can offer enabling it. Bot senders are never noticed.
    */
-  /** §14.3 DM ROW discovery, report-only: fan the pending-row report across EVERY
-   *  gated src integration whose conversation is Off. Runs before command
-   *  interception and routing for each inbound DM. No notice and no early return —
-   *  on a consolidated connection an Off sibling must not post a misleading lock
-   *  while another integration goes on to handle the DM, and every Off gated
-   *  integration needs its own row. */
-  private discoverGatedDms(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
+  /** §14.3 pending-conversation discovery, report-only: fan an Off DM across every
+   *  gated source integration, and report an Off channel when the message explicitly
+   *  mentions that integration's bot. This runs before commands/routing so discovery
+   *  is independent of which sibling integration ultimately handles the message. */
+  private discoverGatedConversations(msg: NormalizedMessage, srcIntegrationIds: string[]): void {
     if (msg.sender.isBot || msg.source !== 'user') return
     const isDm = msg.isDm || (msg.platform === 'slack' && msg.channel.startsWith('D'))
-    if (!isDm) return
     for (const integrationId of srcIntegrationIds) {
       const int = this.integrationConfigById(integrationId)
       if (!int || int.platform !== msg.platform) continue
       const routing = integrationRouting(int)
       if (!routing.gated) continue
       if (routing.bindRules.some((r) => r.channel === msg.channel)) continue // enabled
-      this.reportGatedDm(integrationId, msg)
+      const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
+      if (!isDm && (botUserId === '' || !msg.mentionedBots.includes(botUserId))) continue
+      this.reportGatedConversation(integrationId, msg, isDm)
     }
   }
 
@@ -11122,7 +11129,7 @@ export class Daemon {
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
       const addressed = isDm || (botUserId !== '' && msg.mentionedBots.includes(botUserId))
       if (!addressed) continue
-      if (isDm) this.reportGatedDm(integrationId, msg)
+      if (isDm) this.reportGatedConversation(integrationId, msg, true)
       const latch = `${integrationId}:${msg.channel}`
       if (this.gatedNoticesSent.has(latch)) return
       this.gatedNoticesSent.add(latch)
@@ -11143,24 +11150,27 @@ export class Daemon {
     }
   }
 
-  /** §14.3: surface a gated DM conversation as a `kind:'im'` row (latest-wins
-   *  snapshot merge) so the console lists it for enablement. Name resolution is
-   *  best-effort: the display-name store first, then a Slack profile lookup that
-   *  re-reports when it lands. */
-  private reportGatedDm(integrationId: string, msg: NormalizedMessage): void {
+  /** §14.3: surface an explicitly-addressed Off conversation as a pending row so
+   *  the console can enable it. This is an observed/incremental report, not a full
+   *  membership snapshot: Telegram cannot enumerate all chats, and the conversation
+   *  deliberately creates no session while Off.
+   *
+   *  Name resolution is best-effort. Telegram/Discord getChat results land through
+   *  refreshObservedChannels; Slack DMs retain the existing profile fallback below. */
+  private reportGatedConversation(integrationId: string, msg: NormalizedMessage, isDm: boolean): void {
     const existing = this.channelSnapshots.get(integrationId) ?? []
     const current = existing.find((c) => c.id === msg.channel)
-    if (current?.kind === 'im') return
+    const kind = isDm ? ('im' as const) : ('channel' as const)
     const known = this.store.getDisplayNames([msg.channel]).get(msg.channel)
-    // A previously-observed DM (telegram/discord observed-channel snapshots are
-    // kind-less) is UPGRADED to 'im' rather than skipped — e.g. after an
-    // org→restricted flip the chat already sits in the snapshot as 'channel'.
+    if (current?.kind === kind && (!known || current.name === known)) return
+    // A previously-observed DM (Telegram/Discord session snapshots are kind-less)
+    // is upgraded to 'im' rather than skipped after an org→restricted flip.
     const next = current
-      ? existing.map((c) => (c.id === msg.channel ? { ...c, kind: 'im' as const } : c))
-      : [...existing, { id: msg.channel, ...(known ? { name: known } : {}), kind: 'im' as const }]
+      ? existing.map((c) => (c.id === msg.channel ? { ...c, ...(known ? { name: known } : {}), kind } : c))
+      : [...existing, { id: msg.channel, ...(known ? { name: known } : {}), kind }]
     this.channelSnapshots.set(integrationId, next)
-    this.cpClient?.emitIntegrationChannels({ integrationId, channels: next })
-    if (known || current?.name) return
+    this.cpClient?.emitIntegrationChannels({ integrationId, channels: next, authoritative: false })
+    if (!isDm || known || current?.name) return
     const conn = this.connForIntegration(integrationId)
     if (!(conn instanceof SlackConnection)) return
     void conn
@@ -11171,7 +11181,7 @@ export class Daemon {
         const snap = this.channelSnapshots.get(integrationId) ?? []
         const updated = snap.map((c) => (c.id === msg.channel && !c.name ? { ...c, name: `@${name}` } : c))
         this.channelSnapshots.set(integrationId, updated)
-        this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated })
+        this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated, authoritative: false })
       })
       .catch(() => {})
   }
@@ -12838,8 +12848,14 @@ export class Daemon {
         this.cpClient?.emitMemoryConnectionFacts(this.memoryConnections?.facts() ?? [])
         this.hookReportConnectionId = randomUUID()
         this.replayHookTerminalReports()
-        for (const [integrationId, channels] of this.channelSnapshots)
-          this.cpClient?.emitIntegrationChannels({ integrationId, channels })
+        for (const [integrationId, channels] of this.channelSnapshots) {
+          const platform = this.integrationConfigById(integrationId)?.platform
+          this.cpClient?.emitIntegrationChannels({
+            integrationId,
+            channels,
+            ...(platform && platform !== 'slack' ? { authoritative: false } : {})
+          })
+        }
         // ...and each CP cron's stored last-run stamp — fires while the CP was
         // unreachable would otherwise never land (latest-wins upsert, so
         // re-asserting an already-known stamp is a no-op).

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -127,7 +127,9 @@ export interface TelegramApi {
   answerCallbackQuery(callbackQueryId: string, opts?: { text?: string }): Promise<unknown>
   sendChatAction(chatId: number | string, action: string): Promise<unknown>
   setMyCommands(commands: { command: string; description: string }[]): Promise<unknown>
-  getChat(chatId: number | string): Promise<{ id: number; type: string; title?: string; username?: string }>
+  getChat(
+    chatId: number | string
+  ): Promise<{ id: number; type: string; title?: string; username?: string; first_name?: string; last_name?: string }>
   getChatMember(chatId: number | string, userId: number): Promise<{ user: TgUser }>
   getChatAdministrators(chatId: number | string): Promise<{ user: TgUser }[]>
   getFile(fileId: string): Promise<{ file_path?: string; file_size?: number }>
@@ -460,9 +462,10 @@ export class TelegramConnection {
 
   async getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }> {
     const c = await this.bot.api.getChat(channel)
+    const privateName = [c.first_name, c.last_name].filter(Boolean).join(' ')
     return {
       id: String(c.id ?? channel),
-      name: c.title ?? c.username,
+      name: (c.title ?? c.username ?? privateName) || undefined,
       isIm: c.type === 'private',
       // A group/supergroup without a public @username is effectively private.
       isPrivate: c.type === 'group' || c.type === 'supergroup' ? !c.username : c.type !== 'channel'

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -480,8 +480,8 @@ describe('Daemon.reconcileSlackConnections', () => {
   })
 })
 
-describe('Daemon.refreshObservedChannels (approach-A Telegram/Discord discovery)', () => {
-  it('reports observed Telegram chats as an integration/channels snapshot (Slack is left to its own path)', async () => {
+describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
+  it('reports observed Telegram chats as a non-authoritative integration/channels update', async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)
     await daemon.start()
@@ -513,7 +513,7 @@ describe('Daemon.refreshObservedChannels (approach-A Telegram/Discord discovery)
     // A named chat carries its name; an unresolved one is id-only (console falls back to the id).
     const channels = [{ id: '-100123', name: 'Team Chat' }, { id: '-100456' }]
     expect(emit).toHaveBeenCalledOnce()
-    expect(emit).toHaveBeenCalledWith({ integrationId: 'tg-int', channels })
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'tg-int', channels, authoritative: false })
     // Cached so it re-asserts on the next CP reconnect.
     expect((daemon as any).channelSnapshots.get('tg-int')).toEqual(channels)
     await daemon.stop()
@@ -543,7 +543,7 @@ describe('Daemon.refreshObservedChannels (approach-A Telegram/Discord discovery)
 
     expect(observed).toHaveBeenCalledWith('bot-dc', 'discord')
     const channels = [{ id: '900123', name: 'general' }, { id: '900456' }]
-    expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels })
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
     expect((daemon as any).channelSnapshots.get('dc-int')).toEqual(channels)
     await daemon.stop()
   })
@@ -574,6 +574,34 @@ describe('Daemon.refreshObservedChannels (approach-A Telegram/Discord discovery)
     // Ambiguous which bot saw which chat ⇒ report nothing rather than mis-attribute.
     expect(observed).not.toHaveBeenCalled()
     expect(emit).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
+  it('retains an explicitly discovered Off chat and fills its asynchronously resolved name', async () => {
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    ;(daemon as any).agents = new Map([
+      [
+        'bot-tg',
+        {
+          id: 'bot-tg',
+          integrations: [{ id: 'tg-int', platform: 'telegram', telegram: { botToken: 'tg' } }]
+        }
+      ]
+    ])
+    ;(daemon as any).channelSnapshots.set('tg-int', [{ id: '-100999', kind: 'channel' }])
+    ;(daemon as any).store.setDisplayName('-100999', 'New private group', Date.now())
+    vi.spyOn((daemon as any).store, 'observedChannels').mockReturnValue([])
+
+    ;(daemon as any).refreshObservedChannels()
+
+    const channels = [{ id: '-100999', kind: 'channel', name: 'New private group' }]
+    expect((daemon as any).channelSnapshots.get('tg-int')).toEqual(channels)
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'tg-int', channels, authoritative: false })
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -375,7 +375,10 @@ describe('Daemon.reconcileSlackConnections', () => {
     ;(daemon as any).connByIntegration.set('int-detached', conn)
     ;(daemon as any).connByIntegration.set('int-live', conn)
     ;(daemon as any).botUserIds = { 'int-detached': 'U_A', 'int-live': 'U_A' }
-    ;(daemon as any).channelSnapshots.set('int-detached', [{ id: 'C-old' }])
+    ;(daemon as any).channelSnapshots.set('int-detached', {
+      channels: [{ id: 'C-old' }],
+      authoritative: true
+    })
     ;(daemon as any).agents = new Map([
       [
         'bot-live',
@@ -515,7 +518,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     expect(emit).toHaveBeenCalledOnce()
     expect(emit).toHaveBeenCalledWith({ integrationId: 'tg-int', channels, authoritative: false })
     // Cached so it re-asserts on the next CP reconnect.
-    expect((daemon as any).channelSnapshots.get('tg-int')).toEqual(channels)
+    expect((daemon as any).channelSnapshots.get('tg-int')).toEqual({ channels, authoritative: false })
     await daemon.stop()
   })
 
@@ -544,7 +547,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     expect(observed).toHaveBeenCalledWith('bot-dc', 'discord')
     const channels = [{ id: '900123', name: 'general' }, { id: '900456' }]
     expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
-    expect((daemon as any).channelSnapshots.get('dc-int')).toEqual(channels)
+    expect((daemon as any).channelSnapshots.get('dc-int')).toEqual({ channels, authoritative: false })
     await daemon.stop()
   })
 
@@ -593,15 +596,38 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
         }
       ]
     ])
-    ;(daemon as any).channelSnapshots.set('tg-int', [{ id: '-100999', kind: 'channel' }])
+    ;(daemon as any).channelSnapshots.set('tg-int', {
+      channels: [{ id: '-100999', kind: 'channel' }],
+      authoritative: false
+    })
     ;(daemon as any).store.setDisplayName('-100999', 'New private group', Date.now())
     vi.spyOn((daemon as any).store, 'observedChannels').mockReturnValue([])
 
     ;(daemon as any).refreshObservedChannels()
 
     const channels = [{ id: '-100999', kind: 'channel', name: 'New private group' }]
-    expect((daemon as any).channelSnapshots.get('tg-int')).toEqual(channels)
+    expect((daemon as any).channelSnapshots.get('tg-int')).toEqual({ channels, authoritative: false })
     expect(emit).toHaveBeenCalledWith({ integrationId: 'tg-int', channels, authoritative: false })
+    await daemon.stop()
+  })
+
+  it('replays a cached partial Slack report as non-authoritative after a CP reconnect', async () => {
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const channels = [{ id: 'C-new', kind: 'channel' }]
+    ;(daemon as any).channelSnapshots.set('slack-int', { channels, authoritative: false })
+
+    ;(daemon as any).replayChannelSnapshots()
+
+    expect(emit).toHaveBeenCalledWith({
+      integrationId: 'slack-int',
+      channels,
+      authoritative: false
+    })
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/telegram-connection.test.ts
+++ b/packages/daemon/test/telegram-connection.test.ts
@@ -234,6 +234,21 @@ describe('TelegramConnection gateway', () => {
     expect(info).toEqual({ id: '-100', name: 'devs', isIm: false, isPrivate: false })
   })
 
+  it('getChannelInfo labels a private chat from first/last name when there is no username', async () => {
+    const { conn } = makeConn(
+      {},
+      fakeApi({
+        getChat: vi.fn(async () => ({ id: 42, type: 'private', first_name: 'Ada', last_name: 'Lovelace' }))
+      })
+    )
+    expect(await conn.getChannelInfo('42')).toEqual({
+      id: '42',
+      name: 'Ada Lovelace',
+      isIm: true,
+      isPrivate: true
+    })
+  })
+
   it('listMembers returns administrators (id/name/isBot), best-effort []', async () => {
     const { conn } = makeConn()
     expect(await conn.listMembers('-100')).toEqual([

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -125,7 +125,7 @@ describe('gated Telegram conversation discovery', () => {
       channels,
       authoritative: false
     })
-    expect((daemon as any).channelSnapshots.get('i-tg')).toEqual(channels)
+    expect((daemon as any).channelSnapshots.get('i-tg')).toEqual({ channels, authoritative: false })
     expect(conn.postChrome).toHaveBeenCalledOnce()
     await daemon.stop()
   })

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -65,6 +65,29 @@ function makeTelegramRoutable(daemon: Daemon) {
   return conn
 }
 
+/** Attach a fail-closed Telegram integration with no enabled conversations. */
+function makeTelegramGated(daemon: Daemon) {
+  const a = (daemon as any).agents.get('bot-a')
+  a.integrations = [
+    {
+      id: 'i-tg',
+      platform: 'telegram',
+      telegram: {
+        botToken: '123:abc',
+        allowedUserIds: [],
+        bindRules: [],
+        gated: true
+      }
+    }
+  ]
+  const conn = {
+    postChrome: vi.fn(async () => 'notice-1')
+  }
+  ;(daemon as any).tgConnByIntegration.set('i-tg', conn)
+  ;(daemon as any).botUserIds['i-tg'] = 'mybot'
+  return conn
+}
+
 /** A normalized Telegram message as it arrives from the connection (thread unset — the
  *  daemon derives it). `id` is the Telegram message id; chat is the group -100 unless a
  *  DM is requested. */
@@ -85,6 +108,28 @@ function tg(id: number, over: Partial<NormalizedMessage> = {}): NormalizedMessag
 }
 
 const owner = (daemon: Daemon) => (c: string, t: string) => (daemon as any).sessions.threadOwner(c, t)
+
+describe('gated Telegram conversation discovery', () => {
+  it('reports an explicitly mentioned Off group before routing drops the message', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const conn = makeTelegramGated(daemon)
+    const emitIntegrationChannels = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels, stop: vi.fn().mockResolvedValue(undefined) }
+
+    ;(daemon as any).onInbound(tg(90, { mentionedBots: ['mybot'] }), ['i-tg'])
+
+    const channels = [{ id: '-100', kind: 'channel' }]
+    expect(emitIntegrationChannels).toHaveBeenCalledWith({
+      integrationId: 'i-tg',
+      channels,
+      authoritative: false
+    })
+    expect((daemon as any).channelSnapshots.get('i-tg')).toEqual(channels)
+    expect(conn.postChrome).toHaveBeenCalledOnce()
+    await daemon.stop()
+  })
+})
 
 describe('canonicalizeTelegramThread', () => {
   it('roots a fresh group @mention at its own message (tg:<id>)', async () => {

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -571,11 +571,13 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     const r = decodeEnvelope(
       envelope('integration/channels', {
         integrationId: INTEGRATION_ID,
-        channels: [{ id: 'D111', name: '@alice', kind: 'im' }, { id: 'C123' }]
+        channels: [{ id: 'D111', name: '@alice', kind: 'im' }, { id: 'C123' }],
+        authoritative: false
       })
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/channels')(r.frame)) throw new Error('expected integration/channels')
+    expect(r.frame.payload.authoritative).toBe(false)
     expect(r.frame.payload.channels[0]).toEqual({ id: 'D111', name: '@alice', kind: 'im' })
     expect(r.frame.payload.channels[1]).toEqual({ id: 'C123' }) // absent kind = channel
   })

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -201,13 +201,16 @@ export const IntegrationChannel = z.object({
 export type IntegrationChannel = z.infer<typeof IntegrationChannel>
 
 /**
- * D→C EVT — the FULL set of channels the integration's bot is a member of
- * (fire-and-forget, latest-wins). Emitted on socket start and whenever the bot
- * is invited to / removed from a channel, so the console can offer per-channel
- * trigger config. Channel names are control metadata, never message content.
+ * D→C EVT — channels observed by an integration's bot (fire-and-forget,
+ * latest-wins). Slack reports an authoritative membership snapshot; platforms
+ * such as Telegram that cannot enumerate every chat set `authoritative:false`,
+ * so the CP upserts what was observed without deleting older rows that are
+ * absent from this report. An absent flag means authoritative for wire
+ * compatibility. Channel names are control metadata, never message content.
  */
 export const IntegrationChannels = z.object({
   integrationId: z.string().uuid(),
-  channels: z.array(IntegrationChannel)
+  channels: z.array(IntegrationChannel),
+  authoritative: z.boolean().optional()
 })
 export type IntegrationChannels = z.infer<typeof IntegrationChannels>


### PR DESCRIPTION
## Summary

- surface explicitly mentioned Off Telegram groups in the integration conversation list
- treat observed Telegram/Discord and incremental gated-conversation reports as non-authoritative so later reports do not delete prior Off rows
- preserve each cached report authority across reconnects, including partial Slack gated-conversation discovery
- resolve Telegram private-chat display names from first/last name when no username exists

## Root cause

Gated discovery only reported direct messages. Telegram group discovery fell back to created sessions, but an Off group intentionally creates no session. Partial reports were also handled like full membership snapshots, so later observations or reconnect replay could remove earlier rows.

## Validation

- protocol codec: 65 tests passed
- daemon Telegram/reconcile: 55 tests passed with polling and one worker
- control-plane integration-channels: 15 tests passed against Postgres
- protocol, daemon, and control-plane typechecks passed
- ESLint and Prettier checks passed on changed files

Created by Codex . GPT-5.6-sol