### PR TITLE
fix(web): align daemon upgrading badge

### DIFF
--- a/packages/web/src/components/console/DaemonLifecycleBadge.tsx
+++ b/packages/web/src/components/console/DaemonLifecycleBadge.tsx
@@ -1,22 +1,28 @@
 import { Spinner } from '@/components/marks'
 import type { DaemonLifecycleOp } from '@/lib/data'
 
+// Pending daemon lifecycle state. The list uses a compact action label so the
+// running version remains readable; detail views keep the full target version.
 export function daemonLifecycleLabel(op: DaemonLifecycleOp): string {
   const action = op.op === 'upgrade' ? 'Upgrading' : 'Restarting'
   return `${action}${op.targetVersion ? ` to ${op.targetVersion}` : ''}…`
 }
 
-export function DaemonLifecycleBadge({ op }: { op: DaemonLifecycleOp | null }) {
+export function DaemonLifecycleBadge({ op, size = 'sm' }: { op: DaemonLifecycleOp | null; size?: 'sm' | 'md' }) {
   if (op?.status !== 'pending') return null
 
-  const label = daemonLifecycleLabel(op)
+  const fullLabel = daemonLifecycleLabel(op)
+  const md = size === 'md'
+  const label = md ? fullLabel : `${op.op === 'upgrade' ? 'Upgrading' : 'Restarting'}…`
 
   return (
     <span
-      title={label}
-      className="inline-flex flex-none items-center gap-[5px] rounded-full border border-(--brand) bg-(--surface-sunken) py-[2px] pr-[9px] pl-[6px] font-sans text-[11px] font-semibold leading-normal text-(--brand)"
+      title={fullLabel}
+      className={`inline-flex flex-none items-center rounded-full border border-(--brand) bg-(--surface-sunken) font-sans font-semibold leading-normal text-(--brand) ${
+        md ? 'gap-[5px] py-[2px] pr-[9px] pl-[6px] text-[11px]' : 'gap-1 py-[1px] pr-[7px] pl-[5px] text-[10.5px]'
+      }`}
     >
-      <Spinner size={11} />
+      <Spinner size={md ? 11 : 10} />
       {label}
     </span>
   )

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -165,7 +165,7 @@ export default function DaemonDetailView() {
             {daemon.version}
           </span>
           {pending ? (
-            <DaemonLifecycleBadge op={op} />
+            <DaemonLifecycleBadge op={op} size="md" />
           ) : (
             <DaemonUpgradeBadge
               show={daemon.upgradeAvailable}
@@ -512,7 +512,7 @@ export default function DaemonDetailView() {
               <span className="mono text-[12px]">{daemon.version}</span>
             </span>
             {pending ? (
-              <DaemonLifecycleBadge op={op} />
+              <DaemonLifecycleBadge op={op} size="md" />
             ) : (
               <DaemonUpgradeBadge
                 show={daemon.upgradeAvailable}

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -194,12 +194,13 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
             <span className="dot hidden flex-none desktop:inline-block" style={{ background: s.dot }} />
           </div>
           {/* Version meta — mobile appends the host (when it differs from the name); desktop shows
-              version only. The available-upgrade hint is hidden while an operation is in flight. */}
+              version only. A pending lifecycle operation replaces the available-upgrade hint. */}
           <div className="flex min-w-0 items-center gap-[7px]">
             <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:text-[11px] desktop:leading-[1.5] desktop:tabular-nums">
               {m.version}
               {m.host && m.host !== m.name && <span className="desktop:hidden">{` · ${m.host}`}</span>}
             </span>
+            <DaemonLifecycleBadge op={m.lifecycleOp} />
             <DaemonUpgradeBadge
               show={!pending && m.upgradeAvailable}
               latest={m.latestVersion}
@@ -291,11 +292,6 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
           participate directly in the card's flex-col gap-3; on desktop it is the
           padded section under the header border. */}
       <div className="contents desktop:flex desktop:flex-col desktop:gap-3 desktop:px-4 desktop:py-[14px]">
-        {pending && (
-          <div className="flex">
-            <DaemonLifecycleBadge op={m.lifecycleOp} />
-          </div>
-        )}
         <div className="flex w-full gap-4 desktop:flex-col desktop:gap-3">
           <UtilBar label="CPU" pct={m.cpu} color={barColor} hot={hot} />
           <UtilBar label="Memory" mobileLabel="MEM" pct={m.mem} color={barColor} hot={hot} />


### PR DESCRIPTION
## Summary

- move pending daemon lifecycle status into the version row, matching the existing `Outdated` badge placement
- use a compact list label so the running version stays readable, while preserving the full target version in the tooltip
- keep the full lifecycle label on daemon detail views

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- changed-file ESLint and Prettier checks
- `pnpm --filter @agentconnect.md/web test` (54 files, 367 tests)
- `pnpm --filter @agentconnect.md/web build`
- visually verified desktop light/dark and 390px mobile layouts

Created by Codex . GPT-5
