### PR TITLE
fix(daemon): scope platform routing to source bot

### DIFF
--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -70,7 +70,10 @@ export interface DreamStorePort {
   /** Proposals reconciled as superseded during a store upgrade. */
   supersededDreams(): DreamInfo[]
   /** Newest-first addressable sessions for the agent (transcript sources). */
-  dreamSessionSources(agentId: string, limit: number): { sessionId: string; channel: string; thread: string }[]
+  dreamSessionSources(
+    agentId: string,
+    limit: number
+  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null }[]
   /** Chronological text rows of one session thread, scoped to the agent. */
   dreamTranscriptText(
     channel: string,
@@ -78,7 +81,8 @@ export interface DreamStorePort {
     agentId: string,
     limit: number,
     /** Include tool TITLES too — the trajectory skill mining reads (never bodies). */
-    includeTools?: boolean
+    includeTools?: boolean,
+    transportScope?: string | null
   ): { sender: string; text: string; kind?: string; input?: string }[]
 }
 
@@ -336,7 +340,7 @@ export class DreamRunner {
   private async run(
     dream: DreamInfo,
     files: { name: string; content: string }[],
-    sources: { sessionId: string; channel: string; thread: string }[],
+    sources: { sessionId: string; channel: string; thread: string; transportScope?: string | null }[],
     signal: AbortSignal
   ): Promise<void> {
     const { agentId, dreamId } = dream
@@ -352,7 +356,8 @@ export class DreamRunner {
           source.thread,
           agentId,
           TRANSCRIPT_ROWS_PER_SESSION,
-          mineSkills
+          mineSkills,
+          source.transportScope
         )
       }))
 

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -23,7 +23,7 @@ import type {
   ToolBody,
   Platform
 } from '@agentconnect.md/protocol'
-import type { LocalStore, TranscriptEventCursor } from '../store/local-store.js'
+import { transcriptChannelKey, type LocalStore, type TranscriptEventCursor } from '../store/local-store.js'
 import { mentionedUserIds, substituteUserMentions } from '../slack/mentions.js'
 import { slackThreadUrl } from '../slack/permalink.js'
 
@@ -188,7 +188,9 @@ export function createSessionReader(
       // firstMessageText only runs for untitled rows (`||` short-circuits).
       const enriched = rows.map((r) => ({
         r,
-        rawTitle: r.title || deriveTitle(store.firstMessageText(r.channel, r.thread, r.agentId))
+        rawTitle:
+          r.title ||
+          deriveTitle(store.firstMessageText(transcriptChannelKey(r.channel, r.transportScope), r.thread, r.agentId))
       }))
       // Display names for every channel + triggering sender + `<@U…>` mention in a
       // title we know one for (daemon-resolved + cached; absent ids just stay raw).
@@ -244,15 +246,22 @@ export function createSessionReader(
       const legacyBefore = Number.isSafeInteger(numericCursor) ? numericCursor : null
       const chronologicalSlack =
         rec.platform === 'slack' && (req.cursor === undefined || eventCursor !== null || legacyBefore === null)
+      const transcriptChannel = transcriptChannelKey(rec.channel, rec.transportScope)
       // Scope to what THIS agent's session received + produced, not the whole shared
       // (channel, thread) thread — an agent-called session only ever saw the message handed
       // to it (context isolation), so the view must not leak other participants' cross-talk.
       const page =
         afterRevision !== null
-          ? store.transcriptTailForAgent(rec.channel, rec.thread, rec.agentId, afterRevision, req.limit)
+          ? store.transcriptTailForAgent(transcriptChannel, rec.thread, rec.agentId, afterRevision, req.limit)
           : chronologicalSlack
-            ? store.transcriptPageForAgentByEventTime(rec.channel, rec.thread, rec.agentId, eventCursor, req.limit)
-            : store.transcriptPageForAgent(rec.channel, rec.thread, rec.agentId, legacyBefore, req.limit)
+            ? store.transcriptPageForAgentByEventTime(
+                transcriptChannel,
+                rec.thread,
+                rec.agentId,
+                eventCursor,
+                req.limit
+              )
+            : store.transcriptPageForAgent(transcriptChannel, rec.thread, rec.agentId, legacyBefore, req.limit)
       const { rows, hasMore } = page
       // rows are newest-first; the page itself is oldest→newest.
       const ordered = tailing ? rows : rows.slice().reverse()
@@ -377,7 +386,12 @@ export function createSessionReader(
         totalBytes: 0
       }
       if (!rec) return empty
-      const body = store.getToolBodyForAgent(rec.channel, rec.thread, rec.agentId, req.toolCallId)
+      const body = store.getToolBodyForAgent(
+        transcriptChannelKey(rec.channel, rec.transportScope),
+        rec.thread,
+        rec.agentId,
+        req.toolCallId
+      )
       if (body === undefined) return empty
       const buf = Buffer.from(body, 'utf8')
       const totalBytes = buf.length

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -205,7 +205,7 @@ import type {
   RequestPermissionResponse
 } from '@agentclientprotocol/sdk'
 import type { Agent, CronDef, Integration } from './agents/agent-schema.js'
-import type { NormalizedMessage } from './messages/normalized.js'
+import { stableMessageId, stableTurnId, type NormalizedMessage } from './messages/normalized.js'
 import type {
   RegisterReq,
   RegisterOk,
@@ -1499,7 +1499,7 @@ export class Daemon {
   }
 
   private evaluationTurnIdFor(agentId: string, msg: NormalizedMessage): string {
-    return `${agentId}:${msg.platform === 'webchat' ? msg.traceId : msg.msgId}`
+    return stableTurnId(agentId, msg)
   }
 
   /** Drive a real daemon turn through the same SessionManager, ACP host, memory,
@@ -7060,15 +7060,16 @@ export class Daemon {
    * nothing. WEBCHAT turns are skipped (§6.9 #367): their `sink` is a live in-memory transport
    * that can't be restored across a restart and a dead browser socket can't be resumed, so a
    * durable row would be un-replayable. Sets `entry.inboxId` so every terminal path can delete
-   * the row. The row id is the message's stable deliveryId/msgId (§6.3) — idempotent re-append.
+   * the row. Its id is the stable deliveryId or bot-scoped platform message id (§6.3), making
+   * same-bot re-appends idempotent without colliding across physical bots.
    */
   private persistInbox(
     entry: QueueEntry,
     key: string,
-    options: { required?: boolean; adoptExisting?: boolean } = {}
+    options: { required?: boolean; adoptExisting?: boolean; existingId?: string } = {}
   ): 'inserted' | 'adopted' | 'existing' | 'skipped' | 'failed' {
     if (entry.webchat) return 'skipped' // non-persistable live sink — see §6.9 #367
-    const id = entry.callMeta?.deliveryId ?? entry.msg.msgId
+    const id = options.existingId ?? entry.callMeta?.deliveryId ?? stableMessageId(entry.msg)
     try {
       const inserted = this.store.appendInbox({
         id,
@@ -7597,7 +7598,8 @@ export class Daemon {
         try {
           persistence = this.persistInbox(entry, key, {
             required: opts?.requireDurable,
-            adoptExisting: opts?.adoptExistingInbox
+            adoptExisting: opts?.adoptExistingInbox,
+            existingId: opts?.inboxReplayId
           })
         } catch (err) {
           settleAdmission({ accepted: false, reason: 'durability' })
@@ -7630,7 +7632,8 @@ export class Daemon {
       try {
         persistence = this.persistInbox(entry, key, {
           required: opts?.requireDurable,
-          adoptExisting: opts?.adoptExistingInbox
+          adoptExisting: opts?.adoptExistingInbox,
+          existingId: opts?.inboxReplayId
         })
       } catch (err) {
         settleAdmission({ accepted: false, reason: 'durability' })
@@ -8470,7 +8473,7 @@ export class Daemon {
       this.queueMemoryPostTurn(
         agentId,
         sessionId,
-        p.webchat?.turnId ?? handled.turnId ?? `${agentId}:${msg.msgId}`,
+        p.webchat?.turnId ?? handled.turnId ?? stableTurnId(agentId, msg),
         handled.captureInput ?? msg.text,
         p.replyText,
         agent.memory,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import { hostname, tmpdir } from 'node:os'
 import { existsSync, readFileSync } from 'node:fs'
@@ -13,6 +13,7 @@ import { resolveRoot, statePath, mcpSocketPath, daemonEntryForShims, cliEntryPoi
 import {
   LocalStore,
   sessionKey,
+  transcriptChannelKey,
   type InboxRow,
   type OrchestrationRow,
   type SessionRecord,
@@ -877,6 +878,8 @@ interface Pending {
    *  or queued renderer action may publish output, even if the gate is later reset. */
   outputSuppressed?: TurnInterruptReason
   channel: string
+  /** Internal transcript namespace for this physical bot connection. */
+  transcriptChannel: string
   /** thread_ts for body posts (undefined for a top-level message). */
   thread?: string
   /** Telegram reply target: the message id every post this turn replies to (the
@@ -1876,9 +1879,9 @@ export class Daemon {
       cancelOrchestration: (req) => Promise.resolve(this.cancelOrchestrationForOwner(req)),
       submitGithubReview: (req) => this.submitGithubReview(req),
       memory: this.memory,
-      recordOutbound: (ctx, channel, thread, text, ts) =>
+      recordOutbound: (ctx, channel, thread, text, ts, integrationId) =>
         this.store.appendTranscript({
-          channel,
+          channel: transcriptChannelKey(channel, this.transportScopeForIntegrationIds([integrationId])),
           thread: thread ?? ctx.thread,
           ts,
           sender: ctx.agentId,
@@ -3710,7 +3713,10 @@ export class Daemon {
       return
     }
     if (msg.replyTo) {
-      const owner = this.store.telegramThreadForMessage(msg.channel, msg.replyTo)
+      const owner = this.store.telegramThreadForMessage(
+        transcriptChannelKey(msg.channel, msg.transportScope),
+        msg.replyTo
+      )
       msg.thread = owner ?? `tg:${msg.replyTo}`
       return
     }
@@ -3755,13 +3761,15 @@ export class Daemon {
       this.log.debug(`routing: dropping AgentConnect bot message ${msg.msgId}`)
       return
     }
+    msg.transportScope ??= this.transportScopeForIntegrationIds(srcIntegrationIds)
     // A mention in a watched Slack channel can arrive via both `message.*` and
     // `app_mention`; both share channel:ts, so dedup the double-fire from ONE bot
     // connection. Do not dedup across bot connections: several Slack apps receive
     // the same channel:ts, and Telegram DMs to different bots can share user chat ids
     // plus per-bot message numbers.
     const sourceKey =
-      srcIntegrationIds === undefined ? '' : [...srcIntegrationIds].sort((a, b) => a.localeCompare(b)).join(',')
+      msg.transportScope ??
+      (srcIntegrationIds === undefined ? '' : [...srcIntegrationIds].sort((a, b) => a.localeCompare(b)).join(','))
     const seenMsgId = `${sourceKey}|${msg.msgId}`
     if (this.seenMsgIds.has(seenMsgId)) {
       this.log.debug(`routing: duplicate ${msg.msgId} ignored`)
@@ -4439,6 +4447,7 @@ export class Daemon {
     }
     // The wire payload is structurally the daemon's NormalizedMessage.
     const normalized = msg.payload as NormalizedMessage
+    normalized.transportScope ??= this.transportScopeForIntegrationIds([msg.integrationId])
     // Socket-mode ingress resolves Slack ids before onInbound(); relay ingress
     // bypasses that callback, but its send-only connection exposes the same Web
     // API. Mirror the lookup here so session metadata/history can label the sender.
@@ -6148,17 +6157,20 @@ export class Daemon {
    *  held a session would record forever (no session-`closed` lifecycle yet). */
   private recordUnrouted(msg: NormalizedMessage): void {
     const { thread, ts } = transcriptCoords(msg)
+    const transcriptChannel = transcriptChannelKey(msg.channel, msg.transportScope)
     // Active = a session touched within the idle window OR a turn in flight right
     // now. The in-flight check is load-bearing: session.updatedAt is stamped at
     // turn START, so a single long turn (> idle timeout — common for coding agents)
     // would otherwise look stale and we'd wrongly drop a message that arrives while
     // the agent is still working, defeating the catch-up it's meant to enable.
     const sinceTs = Date.now() - this.cfg.limits.agentIdleTimeoutMs
-    const recentlyActive = this.store.activeSessionCountSince(msg.channel, thread, sinceTs) > 0
-    const inFlight = [...this.pending.values()].some((p) => p.channel === msg.channel && p.statusThread === thread)
+    const recentlyActive = this.store.activeSessionCountSince(msg.channel, thread, sinceTs, msg.transportScope) > 0
+    const inFlight = [...this.pending.values()].some(
+      (p) => p.transcriptChannel === transcriptChannel && p.statusThread === thread
+    )
     if (!recentlyActive && !inFlight) return
     this.store.appendTranscript({
-      channel: msg.channel,
+      channel: transcriptChannel,
       thread,
       ts,
       sender: msg.sender.id,
@@ -6256,30 +6268,34 @@ export class Daemon {
     msg: NormalizedMessage,
     srcIntegrationIds?: readonly string[]
   ): { agentId: string; integrationId: string; via: RouteVia } | null {
-    const latest = this.store.latestSessionInChannel(msg.channel)
-    if (!latest) return null
-    // A command sent inside an existing Slack thread must NOT be answered by an agent
-    // whose latest session lives in a DIFFERENT thread. Without this, a bare `!stop`
-    // (no @mention, thread not owned locally → routeRules misses) falls back to the
-    // channel's latest session and every agent idle elsewhere in the channel replies
-    // "Nothing is running" — leaking commands to threads they don't own. Slack top-level
-    // commands (no thread) and Telegram's per-command reply threads are unaffected.
-    if (msg.platform === 'slack' && msg.thread !== undefined && latest.thread !== msg.thread) return null
-    const agent = this.agents.get(latest.agentId)
-    const integ = agent?.integrations.find(
-      (i) => i.platform === msg.platform && this.integrationBelongsToSource(i.id, srcIntegrationIds)
+    const transportScope = msg.transportScope ?? this.transportScopeForIntegrationIds(srcIntegrationIds)
+    const thread = msg.platform === 'slack' ? msg.thread : undefined
+    const candidates: Array<{
+      agentId: string
+      integrationId: string
+      updatedAt: number
+    }> = []
+    for (const [agentId, agent] of this.agents) {
+      for (const integration of agent.integrations) {
+        if (
+          integration.platform !== msg.platform ||
+          !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
+          !this.gatedAdmission(integration.id, msg) ||
+          !this.commandSenderAllowed(agentId, integration.id, msg)
+        )
+          continue
+        const latest = this.store.latestSessionForTransport(agentId, msg.channel, transportScope, thread)
+        if (latest) candidates.push({ agentId, integrationId: integration.id, updatedAt: latest.updatedAt })
+      }
+    }
+    candidates.sort(
+      (a, b) =>
+        b.updatedAt - a.updatedAt ||
+        a.agentId.localeCompare(b.agentId) ||
+        a.integrationId.localeCompare(b.integrationId)
     )
-    if (!integ) return null
-    const allowed =
-      integ.platform === 'telegram'
-        ? integ.telegram.allowedUserIds
-        : integ.platform === 'discord'
-          ? integ.discord.allowedUserIds
-          : integ.platform === 'feishu'
-            ? integ.feishu.allowedUserIds
-            : integ.slack.allowedUserIds
-    if (allowed.length > 0 && !allowed.includes(msg.sender.id)) return null
-    return { agentId: latest.agentId, integrationId: integ.id, via: 'thread' }
+    const latest = candidates[0]
+    return latest ? { agentId: latest.agentId, integrationId: latest.integrationId, via: 'thread' } : null
   }
 
   /** Validate the relay-arbitrated command target against the local agent spec. Shared
@@ -6400,26 +6416,35 @@ export class Daemon {
     let thread = replyThread
     let key = sessionKey(msg.platform, msg.channel, thread, target.agentId)
     let rec = this.store.getSession(key)
+    const transportScope = msg.transportScope ?? ''
+    if ((rec?.transportScope ?? '') !== transportScope) rec = undefined
     // A cold turn owns its logical key before SessionManager persists the session row.
     // Prefer that exact live gate over the channel's latest historical session; otherwise
     // a `!stop` sent in the cold thread can mute/cancel an older thread and leave the
     // actual turn running. Check all gate representations because commands can race the
     // short hand-offs between them.
-    const directGateActive =
-      this.inflight.has(key) || this.activeGateEntries.has(key) || (this.serialQueue.get(key)?.length ?? 0) > 0
+    const gateActiveFor = (candidateKey: string): boolean => {
+      const directEntry = this.activeGateEntries.get(candidateKey)
+      return (
+        (directEntry !== undefined && (directEntry.msg.transportScope ?? '') === transportScope) ||
+        (this.serialQueue.get(candidateKey) ?? []).some((entry) => (entry.msg.transportScope ?? '') === transportScope)
+      )
+    }
+    let directGateActive = gateActiveFor(key)
     if (!rec && !directGateActive) {
-      const latest = this.store.latestSession(target.agentId, msg.channel)
+      const latest = this.store.latestSessionForTransport(target.agentId, msg.channel, msg.transportScope)
       if (latest) {
         rec = latest
         key = latest.key
         thread = latest.thread
+        directGateActive = gateActiveFor(key)
       }
     }
     const acpSessionId = rec?.acpSessionId
     // §6.9 #390: liveness is observed on the LOGICAL sessionKey gate (a turn currently
     // owns the key), not just the ACP-id-keyed `pending` — so `!cancel`/`!stop`/`!queue`
     // also see a session that is gate-owned or queued (cold session with no ACP id yet).
-    const inflight = this.inflight.has(key)
+    const inflight = directGateActive
     // Post a short control reply on the right surface: Slack threads on `thread_ts`;
     // Telegram replies to the command message (reply-based threading), which is also a
     // non-numeric `tg:`/`dm` thread so it never posts as a forum topic.
@@ -6772,7 +6797,13 @@ export class Daemon {
     }
     const kind = SELECT_CODE_KIND[m[1] as keyof typeof SELECT_CODE_KIND]
     const idx = Number(m[2])
-    const session = this.commandSessionForLatest(cb.channel, cb.userId)
+    const srcIntegrationIds = this.srcIntegrationIds(conn)
+    const session = this.commandSessionForLatest(
+      cb.channel,
+      cb.userId,
+      srcIntegrationIds,
+      this.transportScopeForIntegrationIds(srcIntegrationIds)
+    )
     if (!session) {
       void conn.answerCallback(cb.id, 'No active session here.')
       return
@@ -6802,14 +6833,28 @@ export class Daemon {
    *  integration, or the user isn't allowed. */
   private commandSessionForLatest(
     channel: string,
-    userId: string
+    userId: string,
+    srcIntegrationIds: readonly string[],
+    transportScope?: string
   ): { agentId: string; key: string; acpSessionId?: string } | null {
-    const latest = this.store.latestSessionInChannel(channel)
-    if (!latest) return null
-    const integ = this.agents.get(latest.agentId)?.integrations.find((i) => i.platform === 'telegram')
-    if (!integ || integ.platform !== 'telegram') return null
-    if (integ.telegram.allowedUserIds.length > 0 && !integ.telegram.allowedUserIds.includes(userId)) return null
-    return { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined }
+    const candidates: SessionRecord[] = []
+    for (const [agentId, agent] of this.agents) {
+      for (const integration of agent.integrations) {
+        if (
+          integration.platform !== 'telegram' ||
+          !srcIntegrationIds.includes(integration.id) ||
+          (integration.telegram.allowedUserIds.length > 0 && !integration.telegram.allowedUserIds.includes(userId))
+        )
+          continue
+        const routing = integrationRouting(integration)
+        if (routing.gated && !routing.bindRules.some((rule) => rule.channel === channel)) continue
+        const session = this.store.latestSessionForTransport(agentId, channel, transportScope)
+        if (session) candidates.push(session)
+      }
+    }
+    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
+    const latest = candidates[0]
+    return latest ? { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined } : null
   }
 
   /** Local layer (agent.json) ∪ resolved CP layer; unservable CP rules are dropped + warn-logged. */
@@ -6864,6 +6909,7 @@ export class Daemon {
       webchat?: WebchatTurnContext
       replyConn?: SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection
       channel: string
+      transcriptChannel: string
       thread?: string
       statusThread?: string
     }
@@ -6899,7 +6945,7 @@ export class Daemon {
     // empty reply for a failed turn.
     if (ctx.statusThread) {
       this.store.appendTranscript({
-        channel: ctx.channel,
+        channel: ctx.transcriptChannel,
         thread: ctx.statusThread,
         ts: monotonicTs(),
         sender: ctx.agentId,
@@ -6932,6 +6978,7 @@ export class Daemon {
     ctx: {
       replyConn?: SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection
       channel: string
+      transcriptChannel: string
       thread?: string
       statusThread: string
     }
@@ -6946,7 +6993,7 @@ export class Daemon {
         .catch((err) => this.log.warn(`spawn: notice post failed for agent "${agentId}": ${(err as Error).message}`))
     }
     this.store.appendTranscript({
-      channel: ctx.channel,
+      channel: ctx.transcriptChannel,
       thread: ctx.statusThread,
       ts: monotonicTs(),
       sender: agentId,
@@ -7344,6 +7391,9 @@ export class Daemon {
     hookContext?: HookDispatchContext,
     posterPublishState: QueueEntry['posterPublishState'] = githubReply ? 'not_started' : undefined
   ): Promise<string | null> {
+    if (integrationId !== undefined) {
+      msg.transportScope ??= this.transportScopeForIntegrationIds([integrationId])
+    }
     return new Promise<string | null>((resolve, reject) => {
       let admissionSettled = false
       const settleAdmission = (result: { accepted: boolean; reason?: string; duplicate?: boolean }): void => {
@@ -7886,6 +7936,7 @@ export class Daemon {
     // Capture cold/warm BEFORE sessions.handle(), which boots the host via hostFor().
     const wasRunning = this.hostStarts.has(agentId)
     const statusThread = msg.thread ?? msg.msgId
+    const currentTranscriptChannel = () => transcriptChannelKey(msg.channel, msg.transportScope)
     // Daemon-side rendering only (not ACP); a fresh converger is built per turn, so a change
     // applies from the next turn on, not mid-turn (see `mode`, resolved above before replyConn).
     const conv =
@@ -7968,6 +8019,7 @@ export class Daemon {
             webchat,
             replyConn,
             channel: msg.channel,
+            transcriptChannel: currentTranscriptChannel(),
             thread: msg.thread,
             statusThread
           })
@@ -7988,6 +8040,7 @@ export class Daemon {
       throw err
     }
     const { sessionId, blocks, created } = handled
+    const transcriptChannel = currentTranscriptChannel()
     evaluationSessionId = sessionId
     if (handled.skipped) {
       finishEvaluation('turn.cancelled', { reason: 'already_delivered' })
@@ -8046,7 +8099,13 @@ export class Daemon {
     if (stagedRuntime?.fastMode !== undefined) this.store.setFastModeOverride(key, stagedRuntime.fastMode)
     // sessions.handle() booted the host — surface any spawn-time config warnings
     // (config-file secret conflicts / write failures) into this session.
-    this.flushSpawnNotices(agentId, { replyConn, channel: msg.channel, thread: msg.thread, statusThread })
+    this.flushSpawnNotices(agentId, {
+      replyConn,
+      channel: msg.channel,
+      transcriptChannel,
+      thread: msg.thread,
+      statusThread
+    })
     // First metadata snapshot: enough for the CP's DB-backed session list/detail to
     // resolve this daemon-local session without pulling `session/list` on every view.
     if (created) {
@@ -8091,6 +8150,7 @@ export class Daemon {
       sessionKey: key,
       acpSessionId: sessionId,
       channel: msg.channel,
+      transcriptChannel,
       thread: msg.thread,
       ...(this.telegramReplyTarget(msg) !== undefined ? { tgReplyTo: this.telegramReplyTarget(msg) } : {}),
       statusThread,
@@ -8313,7 +8373,7 @@ export class Daemon {
         // Slack path records this at its `post` boundary, which webchat never hits.
         if (p.webchat.replyText.trim())
           this.store.appendTranscript({
-            channel: p.channel,
+            channel: p.transcriptChannel,
             thread: statusThread,
             // Shares the strictly-monotonic clock with the inbound user message so a fast
             // turn can't stamp both with the same ms and lose the reply to the unique index.
@@ -8351,7 +8411,7 @@ export class Daemon {
         for (const action of finals) this.enqueueApply(p, action)
       }
       // …and any trailing reasoning the agent emitted after its last reply.
-      for (const ev of rec.onFinal()) this.recordEvent(agentId, msg.channel, statusThread, ev)
+      for (const ev of rec.onFinal()) this.recordEvent(agentId, transcriptChannel, statusThread, ev)
       await p.applyChain
       // The user-visible reply is now delivered. Enqueue provider work without
       // awaiting it: managed may distill, while external only commits its durable
@@ -8423,12 +8483,13 @@ export class Daemon {
           webchat,
           replyConn,
           channel: msg.channel,
+          transcriptChannel,
           thread: msg.thread,
           statusThread
         })
         if (p.webchat.replyText.trim())
           this.store.appendTranscript({
-            channel: p.channel,
+            channel: p.transcriptChannel,
             thread: statusThread,
             ts: monotonicTs(),
             sender: agentId,
@@ -8499,7 +8560,7 @@ export class Daemon {
         p.github && !p.outputSuppressed && finalPhase === 'end' ? p.github.collector.finalText(true) : undefined
       if (p.github?.deferredFinalTranscript && githubFinal?.trim()) {
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: monotonicTs(),
           sender: p.agentId,
@@ -8845,7 +8906,7 @@ export class Daemon {
    *  runs even headless (no conn). */
   private recordReplySegment(p: Pending, text: string): void {
     this.store.appendTranscript({
-      channel: p.channel,
+      channel: p.transcriptChannel,
       thread: p.statusThread,
       ts: monotonicTs(),
       sender: p.agentId,
@@ -8924,7 +8985,7 @@ export class Daemon {
       // still be readable in the session transcript.
       if (action.kind === 'post') {
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: monotonicTs(),
           sender: p.agentId,
@@ -8960,7 +9021,7 @@ export class Daemon {
         // strip the footer from this turn's previous section and move the pointer.
         const ts = await this.postSlackReply(conn, p, action.text, trackReply)
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: ts ?? `local-${Date.now()}`,
           sender: p.agentId,
@@ -9153,7 +9214,7 @@ export class Daemon {
       case 'post': {
         const id = await conn.postMessage(p.channel, action.text, p.thread, { replyTo: p.tgReplyTo })
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: id ?? `local-${Date.now()}`,
           sender: p.agentId,
@@ -9251,7 +9312,7 @@ export class Daemon {
       case 'post': {
         const id = await conn.postMessage(p.channel, action.text, p.thread)
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: id ?? `local-${Date.now()}`,
           sender: p.agentId,
@@ -9357,7 +9418,7 @@ export class Daemon {
       case 'post': {
         const id = await conn.postMessage(p.channel, action.text, p.thread)
         this.store.appendTranscript({
-          channel: p.channel,
+          channel: p.transcriptChannel,
           thread: p.statusThread,
           ts: id ?? `local-${Date.now()}`,
           sender: p.agentId,
@@ -10850,7 +10911,7 @@ export class Daemon {
       this.armIdle(p)
     }
     // Full activity log (tool/reasoning), recorded regardless of output mode.
-    for (const ev of p.rec.onUpdate(update)) this.recordEvent(p.agentId, p.channel, p.statusThread, ev)
+    for (const ev of p.rec.onUpdate(update)) this.recordEvent(p.agentId, p.transcriptChannel, p.statusThread, ev)
   }
 
   /**
@@ -11087,6 +11148,57 @@ export class Daemon {
       if (int) return int
     }
     return undefined
+  }
+
+  /** Stable opaque identity for one physical platform connection. Integrations
+   * consolidated onto the same credential receive the same scope, while no raw
+   * credential is ever persisted or logged. */
+  private transportScopeForIntegration(integration: Integration): string {
+    let connectionIdentity: string
+    switch (integration.platform) {
+      case 'slack':
+        connectionIdentity =
+          integration.slack.mode === 'shared'
+            ? integration.slack.botToken
+            : (integration.slack.appToken ?? integration.slack.botToken)
+        break
+      case 'telegram': {
+        // BotFather tokens start with the stable public bot id, which survives a
+        // secret rotation. Non-standard test/config tokens fall back to the full
+        // high-entropy credential before hashing.
+        const botId = integration.telegram.botToken.split(':', 1)[0]
+        connectionIdentity = /^\d+$/.test(botId ?? '') ? botId! : integration.telegram.botToken
+        break
+      }
+      case 'discord':
+        connectionIdentity = integration.discord.botToken
+        break
+      case 'feishu':
+        connectionIdentity = `${integration.feishu.region}:${integration.feishu.appId}`
+        break
+    }
+    const digest = createHash('sha256')
+      .update(`${integration.platform}\0${connectionIdentity}`)
+      .digest('hex')
+      .slice(0, 24)
+    return `${integration.platform}:${digest}`
+  }
+
+  /** Source integrations on one live ingress share a physical connection. The
+   * combined fallback stays fail-closed if malformed config ever violates that. */
+  private transportScopeForIntegrationIds(integrationIds?: readonly string[]): string | undefined {
+    if (!integrationIds?.length) return undefined
+    const scopes = [
+      ...new Set(
+        integrationIds
+          .map((id) => this.integrationConfigById(id))
+          .filter((integration): integration is Integration => integration !== undefined)
+          .map((integration) => this.transportScopeForIntegration(integration))
+      )
+    ].sort()
+    if (scopes.length === 0) return undefined
+    if (scopes.length === 1) return scopes[0]
+    return `mixed:${createHash('sha256').update(scopes.join('\0')).digest('hex').slice(0, 24)}`
   }
 
   /** Every integrationId served by `conn` — ingress attribution for gating. A Slack

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -580,11 +580,19 @@ interface CallMeta {
 
 type TurnInterruptReason = 'pause' | 'loop protection' | 'stop' | 'cancel' | 'shutdown'
 
-/** One durable loop-guard scope shared by every agent in a conversation. DMs are
- *  keyed at channel level because malformed platform wrappers may lose thread
- *  coordinates; threaded channel conversations retain their canonical thread. */
-function loopGuardScopeFromCoords(platform: string, channel: string, thread: string, isDm: boolean): string {
-  return `${platform}:${channel}:${isDm ? 'dm' : thread}`
+/** One durable loop-guard scope shared by every agent on one physical bot.
+ *  DMs are keyed at channel level because malformed platform wrappers may lose
+ *  thread coordinates; threaded channel conversations retain their canonical
+ *  thread. Platform coordinates can overlap across bot installations. */
+function loopGuardScopeFromCoords(
+  platform: string,
+  channel: string,
+  thread: string,
+  isDm: boolean,
+  transportScope?: string
+): string {
+  const base = `${platform}:${channel}:${isDm ? 'dm' : thread}`
+  return transportScope ? `${base}:${transportScope}` : base
 }
 
 function slackTopLevelLoopGuardScope(channel: string): string {
@@ -600,7 +608,7 @@ function loopGuardScope(msg: NormalizedMessage): string {
     // forever and every message gets a brand-new guard scope.
     if (eventTs !== undefined && msg.thread === eventTs) return slackTopLevelLoopGuardScope(msg.channel)
   }
-  return loopGuardScopeFromCoords(msg.platform, msg.channel, msg.thread ?? msg.msgId, msg.isDm)
+  return loopGuardScopeFromCoords(msg.platform, msg.channel, msg.thread ?? msg.msgId, msg.isDm, msg.transportScope)
 }
 
 function isTrustedHumanTurn(msg: NormalizedMessage): boolean {
@@ -779,7 +787,7 @@ function authorizedReviewTarget(
  * §4.3/§6.9). Carries the FULL DispatchContext so a queued turn dispatches identically to
  * one that ran immediately — same reply transport (`integrationId`), same webchat sink,
  * same trusted `callMeta` — and settles its OWN `dispatch()` promise (§6.9 #367). The gate
- * is keyed by the LOGICAL sessionKey (platform:channel:thread:agentId), NOT the ACP
+ * is keyed by the LOGICAL sessionKey (platform:channel:thread:agentId[:transportScope]), NOT the ACP
  * sessionId, so a cold session (no ACP id yet) is serialized too.
  */
 interface QueueEntry {
@@ -869,7 +877,7 @@ interface Pending {
   isDm: boolean
   /** Durable loop-breaker scope captured from the original event shape. */
   loopGuardScope: string
-  /** Local session key (platform:channel:thread:agentId) — for state writes. */
+  /** Local session key (platform:channel:thread:agentId[:transportScope]) — for state writes. */
   sessionKey: string
   /** The live ACP session id for this turn (part of the `this.pending` map key) — surfaced
    *  in the status bar so the console can deep-link to the session detail page. */
@@ -1840,7 +1848,7 @@ export class Daemon {
       log: this.log,
       now: () => Date.now(),
       canRun: (ctx) => {
-        const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId)
+        const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
         const active = this.activeGateEntries.get(key)
         // A transient safety drain only gates NEW admissions while an interrupted turn
         // unwinds. It must not break MCP tools in an unrelated, already-running turn.
@@ -1934,7 +1942,7 @@ export class Daemon {
       // ACP session to its exact channel/thread/delivery integration.
       // The agent's enabled daemon-configured MCP servers are appended AFTER the bridge entry, gated
       // on the runtime's probed transport caps.
-      mcpServersFor: ({ agent, platform, channel, thread, integrationId, isDm }) => {
+      mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
           collaboration: this.evaluationProfile.collaboration === 'configured'
@@ -1958,6 +1966,7 @@ export class Daemon {
             agentId: agent.id,
             platform,
             ...(integrationId ? { integrationId } : {}),
+            ...(transportScope ? { transportScope } : {}),
             isDm,
             channel,
             thread,
@@ -3810,7 +3819,7 @@ export class Daemon {
       return
     }
 
-    const result = routeRules(msg, routingRules, (c, t) => this.sessions.threadOwner(c, t))
+    const result = routeRules(msg, routingRules, (c, t) => this.sessions.threadOwner(c, t, msg.transportScope))
     if (!result) {
       // §8.5: a message that activates no agent (a human @human reply, or one
       // addressed to another bot) must still enter the transcript when a session
@@ -3843,7 +3852,7 @@ export class Daemon {
     // auto / dm) never dispatches — only an explicit @mention does, and it clears the
     // mute. Muted-thread traffic still enters the transcript (recordUnrouted) so the
     // agent catches up on it when re-activated (§8.5).
-    const muteKey = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, result.agentId)
+    const muteKey = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, result.agentId, msg.transportScope)
     if (this.isSessionMuted(muteKey)) {
       if (result.via !== 'mention') {
         this.recordUnrouted(msg)
@@ -4493,7 +4502,8 @@ export class Daemon {
       normalized.platform,
       normalized.channel,
       normalized.thread ?? normalized.msgId,
-      msg.agentId
+      msg.agentId,
+      normalized.transportScope
     )
     if (this.isSessionMuted(muteKey)) {
       if (normalized.trigger !== 'mention') {
@@ -4785,7 +4795,13 @@ export class Daemon {
       return 'invalid_target'
     }
     if (req.toAgentId === req.callerAgentId) return 'self'
-    const callerKey = sessionKey(platform, req.callerChannel, req.callerThread, req.callerAgentId)
+    const callerKey = sessionKey(
+      platform,
+      req.callerChannel,
+      req.callerThread,
+      req.callerAgentId,
+      req.callerTransportScope
+    )
     const inbound = this.activeTurnCallMeta.get(callerKey)
     if (inbound !== undefined && inbound.hopCount >= MAX_AGENT_CALL_HOPS) return 'hop_limit'
     return this.localWakeAuthorizationRejection(req, platform)
@@ -4793,7 +4809,13 @@ export class Daemon {
 
   private async messageAgent(req: MessageAgentReq): Promise<MessageAgentResult> {
     const platform = this.narrowPlatform(req.platform)
-    const callerKey = sessionKey(platform, req.callerChannel, req.callerThread, req.callerAgentId)
+    const callerKey = sessionKey(
+      platform,
+      req.callerChannel,
+      req.callerThread,
+      req.callerAgentId,
+      req.callerTransportScope
+    )
     const observe = (
       type:
         'collaboration.delivery.admitted' | 'collaboration.delivery.rejected' | 'collaboration.delivery.deduplicated',
@@ -4879,13 +4901,17 @@ export class Daemon {
       req.correlationId !== undefined ? req.correlationId : isReply ? inbound.correlationId : undefined
 
     const target = this.agents.get(req.toAgentId)
+    const resolved = target ? this.resolveCpAgent(req.toAgentId, platform === 'hook' ? 'slack' : platform) : null
+    const integrationId = resolved?.integrationId
+    const targetTransportScope =
+      integrationId !== undefined ? this.transportScopeForIntegrationIds([integrationId]) : undefined
     // A2A delivery is direct and postless (#854): the woken peer receives a caller-framed
     // message and nothing is left in any channel. session-concept case 2c (pure wake) is thus
     // the default — a `sendMessage` with `toAgent` never posts, regardless of `channel`.
     const event = this.prepareAgentDelivery(req)
     const { deliveryId } = event
     const msgId = `agentcall:${req.channel}:${deliveryId}`
-    const targetSession = sessionKey(platform, req.channel, event.thread, req.toAgentId)
+    const targetSession = sessionKey(platform, req.channel, event.thread, req.toAgentId, targetTransportScope)
 
     const prior = this.agentCallDeliveries.get(deliveryId)
     if (prior) return observe('collaboration.delivery.deduplicated', prior, deliveryId)
@@ -4952,12 +4978,6 @@ export class Daemon {
       originCoords
     }
 
-    // The reply/attribution integration for the target (a definite value, not a fallback
-    // — §6.2). Same-daemon: the target's own first integration (may be absent for a
-    // memory-only agent — dispatch handles that).
-    const resolved = this.resolveCpAgent(req.toAgentId)
-    const integrationId = resolved?.integrationId
-
     const normalized: NormalizedMessage = {
       msgId,
       traceId: deliveryId,
@@ -4965,6 +4985,7 @@ export class Daemon {
       platform,
       channel: req.channel,
       thread: event.thread,
+      ...(targetTransportScope !== undefined ? { transportScope: targetTransportScope } : {}),
       sender: { id: req.callerAgentId, isBot: true },
       text: event.text,
       mentionedBots: resolved?.botUserId ? [resolved.botUserId] : [],
@@ -5005,7 +5026,13 @@ export class Daemon {
    */
   private async replyToSession(req: ReplyToSessionReq): Promise<ReplyToSessionResult> {
     const platform = this.narrowPlatform(req.platform)
-    const callerKey = sessionKey(platform, req.callerChannel, req.callerThread, req.callerAgentId)
+    const callerKey = sessionKey(
+      platform,
+      req.callerChannel,
+      req.callerThread,
+      req.callerAgentId,
+      req.callerTransportScope
+    )
     const inbound = this.activeTurnCallMeta.get(callerKey)
     const callerRec = this.store.getSession(callerKey)
     // Origin authorization is DURABLE (§5.3): a session spawned by a parent may reply into it on
@@ -5060,8 +5087,11 @@ export class Daemon {
       // otherwise post the reply through integrations[0]'s client, and a Telegram chat id
       // sent via the Slack client fails with channel_not_found (the reply turn runs but its
       // answer never reaches the origin channel).
+      const integrationId = this.integrationIdForTransportScope(originOwner, narrowedLocal, local.transportScope)
+      if (local.transportScope && !integrationId) {
+        return { delivered: false, targetSession: local.key, reason: 'not_found' }
+      }
       const resolved = this.resolveCpAgent(originOwner, narrowedLocal)
-      const integrationId = resolved?.integrationId
       const normalized: NormalizedMessage = {
         msgId: `agentcall:${local.channel}:${deliveryId}`,
         traceId: deliveryId,
@@ -5069,6 +5099,7 @@ export class Daemon {
         platform: narrowedLocal,
         channel: local.channel,
         ...(local.thread ? { thread: local.thread } : {}),
+        ...(local.transportScope ? { transportScope: local.transportScope } : {}),
         // A monotonic "now" ts so the reply is ordered as a NEW message in the origin session.
         // Without it, transcriptCoords derives the ts from the msgId's random UUID, which the
         // origin's dedup mis-orders — the parent turn then runs with no new content and the reply
@@ -5076,7 +5107,13 @@ export class Daemon {
         transcriptTs: monotonicTs(),
         sender: { id: req.callerAgentId, isBot: true },
         text: req.text,
-        mentionedBots: resolved?.botUserId ? [resolved.botUserId] : [],
+        mentionedBots: integrationId
+          ? this.botUserIds[integrationId]
+            ? [this.botUserIds[integrationId]!]
+            : []
+          : resolved?.botUserId
+            ? [resolved.botUserId]
+            : [],
         isDm: false
       }
       void this.dispatch(originOwner, normalized, integrationId, undefined, callMeta).catch((err) =>
@@ -5139,6 +5176,7 @@ export class Daemon {
     thread: string
     text: string
     originPlatform?: string
+    originTransportScope?: string
     originChannel: string
     originThread: string
   }): void {
@@ -5147,7 +5185,13 @@ export class Daemon {
     // turn posting to Slack). Key the origin lookup by the ORIGIN's platform, not the target's,
     // or the caller session is never found and the new session loses its parent lineage.
     const originPlatform = this.narrowPlatform(req.originPlatform ?? req.platform)
-    const originKey = sessionKey(originPlatform, req.originChannel, req.originThread, req.agentId)
+    const originKey = sessionKey(
+      originPlatform,
+      req.originChannel,
+      req.originThread,
+      req.agentId,
+      req.originTransportScope
+    )
     const inbound = this.activeTurnCallMeta.get(originKey)
     // A self-post from a plain human/platform turn (no active callMeta) starts the self-chain at 1.
     const hopCount = inbound ? inbound.hopCount + 1 : 1
@@ -5169,6 +5213,9 @@ export class Daemon {
         ...(req.originThread ? { thread: req.originThread } : {})
       }
     }
+    const transportScope = this.transportScopeForIntegrationIds(
+      req.integrationId !== undefined ? [req.integrationId] : undefined
+    )
     const normalized: NormalizedMessage = {
       msgId: `agentcall:${req.channel}:${deliveryId}`,
       traceId: deliveryId,
@@ -5176,6 +5223,7 @@ export class Daemon {
       platform,
       channel: req.channel,
       thread: req.thread,
+      ...(transportScope !== undefined ? { transportScope } : {}),
       // The seed's transcript ts MUST be the post's real ts (the new thread's root), not the
       // random deliveryId — otherwise the session's lastDeliveredTs becomes a non-ts string and
       // a later real reply in this thread is mis-compared and wrongly skipped as already-delivered.
@@ -5188,7 +5236,7 @@ export class Daemon {
       // output — an agent must not visibly answer its own top-level post.
       headless: true
     }
-    const targetSession = sessionKey(platform, req.channel, req.thread, req.agentId)
+    const targetSession = sessionKey(platform, req.channel, req.thread, req.agentId, transportScope)
     void this.dispatch(req.agentId, normalized, req.integrationId, undefined, callMeta).catch((err) =>
       this.log.error(`channel-root session spawn failed for agent "${req.agentId}": ${formatErr(err)}`)
     )
@@ -5277,7 +5325,7 @@ export class Daemon {
     const platform = this.narrowPlatform(req.platform)
     // The main's session key is the exact coords its tool call ran under, so a deadline
     // fire and a worker report both key to the SAME session as the caller.
-    const mainSessionKey = sessionKey(platform, req.channel, req.thread, req.mainAgentId)
+    const mainSessionKey = sessionKey(platform, req.channel, req.thread, req.mainAgentId, req.transportScope)
     const now = this.clock.now()
     const deadline =
       req.deadlineMs !== undefined && req.deadlineMs > 0 ? now + Math.min(req.deadlineMs, 2_147_483_647) : null
@@ -5334,6 +5382,7 @@ export class Daemon {
           callerAgentId: req.mainAgentId,
           platform: req.platform,
           ...(req.integrationId !== undefined ? { callerIntegrationId: req.integrationId } : {}),
+          ...(req.transportScope !== undefined ? { callerTransportScope: req.transportScope } : {}),
           callerChannel: req.channel,
           callerThread: req.thread,
           toAgentId: s.toAgentId,
@@ -5557,7 +5606,13 @@ export class Daemon {
   private ownedOrchestration(req: OrchestrationOwnerReq): OrchestrationRow | undefined {
     const orch = this.store.getOrchestration(req.orchestrationId)
     if (!orch) return undefined
-    const requesterKey = sessionKey(this.narrowPlatform(req.platform), req.channel, req.thread, req.mainAgentId)
+    const requesterKey = sessionKey(
+      this.narrowPlatform(req.platform),
+      req.channel,
+      req.thread,
+      req.mainAgentId,
+      req.transportScope
+    )
     if (orch.mainSessionKey !== requesterKey || orch.mainAgentId !== req.mainAgentId) return undefined
     return orch
   }
@@ -5896,7 +5951,7 @@ export class Daemon {
   }
 
   private async submitGithubReview(req: SubmitGithubReviewReq): Promise<GithubReviewEffect> {
-    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId)
+    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
     const active = this.activeGithubTurnMeta.get(key)
     if (!active || active.hook.agentId !== req.agentId) {
       throw new Error('formal GitHub review is only available during the active PR hook turn')
@@ -6228,7 +6283,7 @@ export class Daemon {
 
   // ── §4.3/§6.9 per-sessionKey serial admission gate ────────────────────────────
   // The UNIFIED admission queue (design §6.9 #390): one FIFO per LOGICAL sessionKey
-  // (platform:channel:thread:agentId), NOT per ACP sessionId. `inflight` records the
+  // (platform:channel:thread:agentId[:transportScope]), NOT per ACP sessionId. `inflight` records the
   // keys a `runLoop` currently OWNS; ownership is claimed synchronously (before any
   // await) in `dispatch()` so two concurrent dispatches for the same key can never both
   // enter `sessions.handle()` and overwrite `pending`. While a key is owned, further
@@ -6385,7 +6440,9 @@ export class Daemon {
   ): boolean {
     let target =
       explicitTarget ??
-      routeRules(msg, this.mergedRulesForSource(srcIntegrationIds), (c, t) => this.sessions.threadOwner(c, t))
+      routeRules(msg, this.mergedRulesForSource(srcIntegrationIds), (c, t) =>
+        this.sessions.threadOwner(c, t, msg.transportScope)
+      )
     if (!target) {
       // Routing found no agent — the common group case: a bare `/status@bot` carries no
       // mention entity, no reply, and its fresh thread has no session. Resolve the agent
@@ -6414,22 +6471,15 @@ export class Daemon {
     // than on a phantom empty thread. `thread`/`key` follow the resolved session so a
     // `/queue` dispatch continues it and the sticky overrides land on the right key.
     let thread = replyThread
-    let key = sessionKey(msg.platform, msg.channel, thread, target.agentId)
+    let key = sessionKey(msg.platform, msg.channel, thread, target.agentId, msg.transportScope)
     let rec = this.store.getSession(key)
-    const transportScope = msg.transportScope ?? ''
-    if ((rec?.transportScope ?? '') !== transportScope) rec = undefined
     // A cold turn owns its logical key before SessionManager persists the session row.
     // Prefer that exact live gate over the channel's latest historical session; otherwise
     // a `!stop` sent in the cold thread can mute/cancel an older thread and leave the
     // actual turn running. Check all gate representations because commands can race the
     // short hand-offs between them.
-    const gateActiveFor = (candidateKey: string): boolean => {
-      const directEntry = this.activeGateEntries.get(candidateKey)
-      return (
-        (directEntry !== undefined && (directEntry.msg.transportScope ?? '') === transportScope) ||
-        (this.serialQueue.get(candidateKey) ?? []).some((entry) => (entry.msg.transportScope ?? '') === transportScope)
-      )
-    }
+    const gateActiveFor = (candidateKey: string): boolean =>
+      this.activeGateEntries.has(candidateKey) || (this.serialQueue.get(candidateKey)?.length ?? 0) > 0
     let directGateActive = gateActiveFor(key)
     if (!rec && !directGateActive) {
       const latest = this.store.latestSessionForTransport(target.agentId, msg.channel, msg.transportScope)
@@ -6463,7 +6513,7 @@ export class Daemon {
       const directScope =
         thread === replyThread
           ? loopGuardScope(msg)
-          : loopGuardScopeFromCoords(msg.platform, msg.channel, thread, msg.isDm)
+          : loopGuardScopeFromCoords(msg.platform, msg.channel, thread, msg.isDm, msg.transportScope)
       const topLevelScope = msg.platform === 'slack' && !msg.isDm ? slackTopLevelLoopGuardScope(msg.channel) : undefined
       // A top-level feedback loop posts its warning into the triggering root. A
       // trusted !resume from that warning thread (or elsewhere in the channel)
@@ -7468,7 +7518,7 @@ export class Daemon {
         }
         return
       }
-      const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, agentId)
+      const key = sessionKey(msg.platform, msg.channel, msg.thread ?? msg.msgId, agentId, msg.transportScope)
       const loopScope = loopGuardScope(msg)
       // A latched circuit is checked at the common dispatch seam, so startup replay,
       // cron/hook turns, webchat, and agent→agent calls cannot bypass it. Purging here
@@ -10729,7 +10779,7 @@ export class Daemon {
    *  their lifetime. The tool input contains only the title; every coordinate and
    *  delivery route was captured in the trusted SessionContext. */
   private async setSessionTitleFromTool(req: SetSessionTitleReq): Promise<void> {
-    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId)
+    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
     const rec = this.store.getSession(key)
     if (!rec?.acpSessionId) throw new Error('the current session is not addressable yet')
 
@@ -11199,6 +11249,18 @@ export class Daemon {
     if (scopes.length === 0) return undefined
     if (scopes.length === 1) return scopes[0]
     return `mixed:${createHash('sha256').update(scopes.join('\0')).digest('hex').slice(0, 24)}`
+  }
+
+  /** Resolve the live integration that owns a persisted bot-scoped session. */
+  private integrationIdForTransportScope(
+    agentId: string,
+    platform: string,
+    transportScope?: string | null
+  ): string | undefined {
+    const candidates = this.agents.get(agentId)?.integrations.filter((integration) => integration.platform === platform)
+    if (!candidates?.length) return undefined
+    if (!transportScope) return candidates[0]?.id
+    return candidates.find((integration) => this.transportScopeForIntegration(integration) === transportScope)?.id
   }
 
   /** Every integrationId served by `conn` — ingress attribution for gating. A Slack

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3755,13 +3755,19 @@ export class Daemon {
       this.log.debug(`routing: dropping AgentConnect bot message ${msg.msgId}`)
       return
     }
-    // A mention in a watched channel can arrive via both `message.*` and
-    // `app_mention`; both share channel:ts, so msgId dedups the double-fire.
-    if (this.seenMsgIds.has(msg.msgId)) {
+    // A mention in a watched Slack channel can arrive via both `message.*` and
+    // `app_mention`; both share channel:ts, so dedup the double-fire from ONE bot
+    // connection. Do not dedup across bot connections: several Slack apps receive
+    // the same channel:ts, and Telegram DMs to different bots can share user chat ids
+    // plus per-bot message numbers.
+    const sourceKey =
+      srcIntegrationIds === undefined ? '' : [...srcIntegrationIds].sort((a, b) => a.localeCompare(b)).join(',')
+    const seenMsgId = `${sourceKey}|${msg.msgId}`
+    if (this.seenMsgIds.has(seenMsgId)) {
       this.log.debug(`routing: duplicate ${msg.msgId} ignored`)
       return
     }
-    this.seenMsgIds.add(msg.msgId)
+    this.seenMsgIds.add(seenMsgId)
     if (this.seenMsgIds.size > 2000) this.seenMsgIds.clear()
 
     // Telegram reply-based session threading: derive the session thread from the reply
@@ -3776,6 +3782,7 @@ export class Daemon {
     // session will be created. Report-only: the notice remains conditional on the
     // message actually resolving to no admitted target.
     this.discoverGatedConversations(msg, srcIntegrationIds ?? [])
+    const routingRules = this.mergedRulesForSource(srcIntegrationIds)
 
     // In-conversation control commands (`!stop` / `!queue …`) act on the running
     // agent and never reach it as a prompt — intercept before routing/dispatch.
@@ -3790,11 +3797,12 @@ export class Daemon {
       }
       // §14.3: a command that resolved no admitted target in an Off gated
       // conversation gets the same one-time notice as an unrouted message.
-      if (!this.handleCommand(command, msg)) this.maybeGatedNotice(msg, srcIntegrationIds ?? [])
+      if (!this.handleCommand(command, msg, undefined, srcIntegrationIds))
+        this.maybeGatedNotice(msg, srcIntegrationIds ?? [])
       return
     }
 
-    const result = routeRules(msg, this.mergedRules(), (c, t) => this.sessions.threadOwner(c, t))
+    const result = routeRules(msg, routingRules, (c, t) => this.sessions.threadOwner(c, t))
     if (!result) {
       // §8.5: a message that activates no agent (a human @human reply, or one
       // addressed to another bot) must still enter the transcript when a session
@@ -6245,7 +6253,8 @@ export class Daemon {
    * no matching integration, or the sender isn't allowed.
    */
   private resolveCommandTargetFromLatest(
-    msg: NormalizedMessage
+    msg: NormalizedMessage,
+    srcIntegrationIds?: readonly string[]
   ): { agentId: string; integrationId: string; via: RouteVia } | null {
     const latest = this.store.latestSessionInChannel(msg.channel)
     if (!latest) return null
@@ -6257,7 +6266,9 @@ export class Daemon {
     // commands (no thread) and Telegram's per-command reply threads are unaffected.
     if (msg.platform === 'slack' && msg.thread !== undefined && latest.thread !== msg.thread) return null
     const agent = this.agents.get(latest.agentId)
-    const integ = agent?.integrations.find((i) => i.platform === msg.platform)
+    const integ = agent?.integrations.find(
+      (i) => i.platform === msg.platform && this.integrationBelongsToSource(i.id, srcIntegrationIds)
+    )
     if (!integ) return null
     const allowed =
       integ.platform === 'telegram'
@@ -6288,7 +6299,8 @@ export class Daemon {
    *  latest session to route a bare `!resume` through. Select only an integration
    *  that independently authorizes this human, preferring an explicitly mentioned bot. */
   private resolveTopLevelResumeTarget(
-    msg: NormalizedMessage
+    msg: NormalizedMessage,
+    srcIntegrationIds?: readonly string[]
   ): { agentId: string; integrationId: string; via: RouteVia } | null {
     if (msg.platform !== 'slack' || msg.isDm || !this.store.isLoopGuardOpen(slackTopLevelLoopGuardScope(msg.channel))) {
       return null
@@ -6301,7 +6313,12 @@ export class Daemon {
     }> = []
     for (const [agentId, agent] of this.agents) {
       for (const integration of agent.integrations) {
-        if (integration.platform !== 'slack' || !this.commandSenderAllowed(agentId, integration.id, msg)) continue
+        if (
+          integration.platform !== 'slack' ||
+          !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
+          !this.commandSenderAllowed(agentId, integration.id, msg)
+        )
+          continue
         const mentioned =
           integration.slack.botUserId !== undefined && msg.mentionedBots.includes(integration.slack.botUserId)
         candidates.push({
@@ -6347,17 +6364,20 @@ export class Daemon {
   private handleCommand(
     command: AgentCommand,
     msg: NormalizedMessage,
-    explicitTarget?: { agentId: string; integrationId: string; via: RouteVia }
+    explicitTarget?: { agentId: string; integrationId: string; via: RouteVia },
+    srcIntegrationIds?: readonly string[]
   ): boolean {
-    let target = explicitTarget ?? routeRules(msg, this.mergedRules(), (c, t) => this.sessions.threadOwner(c, t))
+    let target =
+      explicitTarget ??
+      routeRules(msg, this.mergedRulesForSource(srcIntegrationIds), (c, t) => this.sessions.threadOwner(c, t))
     if (!target) {
       // Routing found no agent — the common group case: a bare `/status@bot` carries no
       // mention entity, no reply, and its fresh thread has no session. Resolve the agent
       // from the channel's latest session so the command still lands on it (subject to
       // that agent's per-integration allowedUserIds authz).
-      target = this.resolveCommandTargetFromLatest(msg)
+      target = this.resolveCommandTargetFromLatest(msg, srcIntegrationIds)
     }
-    if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg)
+    if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg, srcIntegrationIds)
     if (!target) {
       this.log.debug(`command: '${command.kind}' in ch=${msg.channel} — no agent resolved, ignoring`)
       return false
@@ -11078,6 +11098,18 @@ export class Daemon {
     for (const [id, c] of this.dcConnByIntegration) if (c === conn) out.push(id)
     for (const [id, c] of this.fsConnByIntegration) if (c === conn) out.push(id)
     return out
+  }
+
+  /** Direct platform ingress is owned by one physical bot connection. Rules from
+   *  another bot on the same platform must never arbitrate that message. Undefined
+   *  preserves internal/test callers with no connection attribution; an empty live
+   *  source fails closed during the tiny connect→binding window. */
+  private integrationBelongsToSource(integrationId: string, srcIntegrationIds?: readonly string[]): boolean {
+    return srcIntegrationIds === undefined || srcIntegrationIds.includes(integrationId)
+  }
+
+  private mergedRulesForSource(srcIntegrationIds?: readonly string[]): RoutingRule[] {
+    return this.mergedRules().filter((rule) => this.integrationBelongsToSource(rule.integrationId, srcIntegrationIds))
   }
 
   /** §14 admission for a pre-addressed (relay) message: a gated integration accepts

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -295,7 +295,14 @@ export interface OpsDeps {
    *  Universal (every agent has memory), independent of the platform. */
   memory: MemoryProvider
   /** Record an agent-sent message into the session transcript. */
-  recordOutbound: (ctx: SessionContext, channel: string, thread: string | undefined, text: string, ts: string) => void
+  recordOutbound: (
+    ctx: SessionContext,
+    channel: string,
+    thread: string | undefined,
+    text: string,
+    ts: string,
+    integrationId: string
+  ) => void
   /** Monotonic-ish clock for synthesizing a message id when the platform doesn't return one. */
   now: () => number
   /** Byte cap for `read*File` downloads (defaults to 8 MiB). */
@@ -643,7 +650,7 @@ export async function executeTool(
         (Object.keys(identity).length > 0
           ? await gw.postMessage(channel, body, thread, identity)
           : await gw.postMessage(channel, body, thread)) ?? `local-${deps.now()}`
-      deps.recordOutbound(ctx, channel, thread, body, ts)
+      deps.recordOutbound(ctx, channel, thread, body, ts, targetId)
       post = { platform: wantPlatform, integrationId: targetId, channel, thread: thread ?? null, ts }
       postedThread = thread ?? (ts.startsWith('local-') ? undefined : ts)
       // session-concept case 2a: a ROOT post (no thread) with NO peer wake seeds a NEW session

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -61,6 +61,9 @@ export interface SessionContext {
   /** The exact platform integration that delivered this session. Absent for a
    *  platform-free session; daemon-local universal tools still work there. */
   integrationId?: string
+  /** Opaque physical-bot identity captured by the daemon. Platform coordinates
+   *  can overlap across bots, so daemon-local session lookups include this scope. */
+  transportScope?: string
   /** Whether the trusted source conversation is a direct message. Slack native
    *  thread titles are valid only for app-DM sessions. */
   isDm: boolean
@@ -85,6 +88,7 @@ export interface SetSessionTitleReq {
   agentId: string
   platform: string
   integrationId?: string
+  transportScope?: string
   isDm: boolean
   channel: string
   thread: string
@@ -104,6 +108,8 @@ export interface MessageAgentReq {
   /** Trusted source integration. Used to publish the agent's first-class thread
    *  message through the same platform identity as its current session. */
   callerIntegrationId?: string
+  /** Trusted physical-bot scope of the caller session. */
+  callerTransportScope?: string
   /** Trusted caller session coords (== the caller's {@link SessionContext} channel/thread).
    *  Never a tool input. The daemon uses these + `callerAgentId` to recompute the caller's
    *  logical sessionKey and resolve the CURRENT turn's trusted call metadata (§6.7), so a
@@ -149,6 +155,7 @@ export interface ReplyToSessionReq {
   callerAgentId: string
   /** Trusted source platform / caller session coords (== the caller's {@link SessionContext}). */
   platform: string
+  callerTransportScope?: string
   callerChannel: string
   callerThread: string
   /** The ONLY untrusted field: the target session's stable id (the child's `Parent session`).
@@ -189,6 +196,7 @@ export interface StartOrchestrationReq {
   channel: string
   thread: string
   integrationId?: string
+  transportScope?: string
   subtasks: OrchestrationSubtaskInput[]
   deadlineMs?: number
   replyTarget?: string
@@ -207,6 +215,7 @@ export interface OrchestrationOwnerReq {
   platform: string
   channel: string
   thread: string
+  transportScope?: string
   orchestrationId: string
 }
 
@@ -217,6 +226,7 @@ export interface SubmitGithubReviewReq extends SubmitGithubReviewInput {
   platform: string
   channel: string
   thread: string
+  transportScope?: string
 }
 
 export interface OpsDeps {
@@ -275,6 +285,7 @@ export interface OpsDeps {
      *  may be on a DIFFERENT platform than the post (e.g. a Telegram turn posting to Slack),
      *  so its platform must travel too — otherwise the origin session key can't be resolved. */
     originPlatform: string
+    originTransportScope?: string
     originChannel: string
     originThread: string
   }) => void
@@ -409,6 +420,7 @@ export async function executeTool(
       agentId: ctx.agentId,
       platform: ctx.platform,
       ...(ctx.integrationId !== undefined ? { integrationId: ctx.integrationId } : {}),
+      ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       isDm: ctx.isDm,
       channel: ctx.channel,
       thread: ctx.thread,
@@ -568,6 +580,7 @@ export async function executeTool(
       return await deps.replyToSession({
         callerAgentId: ctx.agentId,
         platform: ctx.platform,
+        ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
         callerChannel: ctx.channel,
         callerThread: ctx.thread,
         sessionId,
@@ -597,6 +610,7 @@ export async function executeTool(
             callerAgentId: ctx.agentId,
             platform: ctx.platform,
             ...(ctx.integrationId !== undefined ? { callerIntegrationId: ctx.integrationId } : {}),
+            ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
             callerChannel: ctx.channel,
             callerThread: ctx.thread,
             toAgentId: toAgent,
@@ -666,6 +680,7 @@ export async function executeTool(
           thread: ts,
           text: body,
           originPlatform: ctx.platform,
+          ...(ctx.transportScope !== undefined ? { originTransportScope: ctx.transportScope } : {}),
           originChannel: ctx.channel,
           originThread: ctx.thread
         })
@@ -722,6 +737,7 @@ export async function executeTool(
       channel: ctx.channel,
       thread: ctx.thread,
       ...(ctx.integrationId !== undefined ? { integrationId: ctx.integrationId } : {}),
+      ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       subtasks,
       ...(deadlineMs !== undefined ? { deadlineMs } : {}),
       ...(replyTarget !== undefined ? { replyTarget } : {})
@@ -735,6 +751,7 @@ export async function executeTool(
       platform: ctx.platform,
       channel: ctx.channel,
       thread: ctx.thread,
+      ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       orchestrationId
     }
     if (name === 'getOrchestration') {
@@ -761,6 +778,7 @@ export async function executeTool(
       platform: ctx.platform,
       channel: ctx.channel,
       thread: ctx.thread,
+      ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
       event,
       verdict,
       body,

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -34,6 +34,14 @@ export interface NormalizedMessage {
   platform: 'slack' | 'telegram' | 'webchat' | 'discord' | 'feishu' | 'hook'
   channel: string
   thread?: string
+  /**
+   * Opaque identity of the physical platform bot/connection that received this
+   * message. Platform channel ids are only unique within one bot installation
+   * (Telegram DMs in particular reuse the user's numeric id across bots), so the
+   * daemon uses this scope for private transcript and session lookup boundaries.
+   * It is internal metadata: user-facing channel/thread coordinates stay unchanged.
+   */
+  transportScope?: string
   sender: {
     id: string
     isBot: boolean

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -91,3 +91,17 @@ export interface NormalizedMessage {
   // synthetic key, not a real platform channel.
   headless?: boolean
 }
+
+type MessageIdentityFields = Pick<NormalizedMessage, 'msgId' | 'platform' | 'traceId' | 'transportScope'>
+
+/** Stable daemon-local delivery identity. Platform ids are only unique within
+ * one physical bot; webchat instead needs its per-turn trace id. */
+export function stableMessageId(msg: MessageIdentityFields): string {
+  const sourceId = msg.platform === 'webchat' ? msg.traceId : msg.msgId
+  return msg.transportScope ? `${msg.transportScope}\u001f${sourceId}` : sourceId
+}
+
+/** Stable operation fence shared by evaluation and memory lifecycle events. */
+export function stableTurnId(agentId: string, msg: MessageIdentityFields): string {
+  return `${agentId}:${stableMessageId(msg)}`
+}

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -1,5 +1,5 @@
 import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
-import { LocalStore, sessionKey } from '../store/local-store.js'
+import { LocalStore, sessionKey, transcriptChannelKey } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { prepareWorkspace } from '../workspace/workspace-manager.js'
 import { memoryKindOf, type MemoryProvider } from '../agents/memory-provider.js'
@@ -267,13 +267,17 @@ export class SessionManager {
     // whole conversation is recorded, and thread stays stable → one session.
     const ts = msg.platform === 'webchat' ? monotonicTs() : coordTs
     const key = sessionKey(msg.platform, msg.channel, thread, agentId)
+    let rec = this.deps.store.getSession(key)
+    const transportScope = msg.transportScope ?? rec?.transportScope ?? undefined
+    const transcriptChannel = transcriptChannelKey(msg.channel, transportScope)
+    if (transportScope !== undefined) msg.transportScope = transportScope
 
     // record the triggering message in the transcript (with an attachment mention
     // for prompt replay; bounded inline webchat images remain daemon-local for UI replay)
     const mention = attachmentMention(msg.attachments)
     const transcriptAttachments = transcriptImageAttachments(msg.attachments)
     this.deps.store.appendTranscript({
-      channel: msg.channel,
+      channel: transcriptChannel,
       thread,
       ts,
       sender: msg.sender.id,
@@ -285,22 +289,30 @@ export class SessionManager {
       ...(transcriptAttachments.length ? { attachments: transcriptAttachments } : {})
     })
 
-    let rec = this.deps.store.getSession(key)
     const isNewLogicalSession = rec === undefined
     if (rec) {
       const persistedMemoryProvider = rec.memoryProvider ?? 'managed'
-      if (persistedMemoryProvider !== currentMemoryProvider) {
+      // A pre-scope session may already contain context admitted through another
+      // physical bot. It cannot be attributed safely during migration, so the first
+      // scoped turn starts a clean runtime session instead of adopting that context.
+      const transportChanged = transportScope != null && rec.transportScope !== transportScope
+      if (persistedMemoryProvider !== currentMemoryProvider || transportChanged) {
         rec = {
           ...rec,
           acpSessionId: null,
           memoryProvider: currentMemoryProvider,
+          transportScope: transportScope ?? null,
           state: rec.state === 'closed' ? 'closed' : 'idle',
           lastDeliveredTs: null,
           updatedAt: Date.now()
         }
         this.deps.store.upsertSession(rec)
-      } else if (rec.memoryProvider == null) {
-        rec = { ...rec, memoryProvider: currentMemoryProvider }
+      } else if (rec.memoryProvider == null || rec.transportScope == null) {
+        rec = {
+          ...rec,
+          memoryProvider: currentMemoryProvider,
+          ...(transportScope !== undefined ? { transportScope } : {})
+        }
         this.deps.store.upsertSession(rec)
       }
     }
@@ -531,6 +543,7 @@ export class SessionManager {
         platform: msg.platform,
         channel: msg.channel,
         thread,
+        transportScope: transportScope ?? null,
         acpSessionId,
         state: 'idle',
         lastDeliveredTs: null,
@@ -635,7 +648,7 @@ export class SessionManager {
         // them (low/medium/high record at the send boundary WITH the Slack ts, so they dedup).
         if (h.sender === agentId) continue
         this.deps.store.appendTranscript({
-          channel: msg.channel,
+          channel: transcriptChannel,
           thread,
           ts: h.ts,
           sender: h.sender,
@@ -654,7 +667,7 @@ export class SessionManager {
     const blocks: ContentBlock[] = []
     {
       const gap = this.deps.store
-        .transcriptSince(msg.channel, thread, markerBefore)
+        .transcriptSince(transcriptChannel, thread, markerBefore)
         .filter(
           (e) =>
             snapshotCutoffTs === undefined ||

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -178,6 +178,7 @@ export class SessionManager {
         channel: string
         thread: string
         integrationId?: string
+        transportScope?: string
         isDm: boolean
       }) => McpServer[]
       /**
@@ -214,8 +215,8 @@ export class SessionManager {
   private readonly turnsSinceReminder = new Map<string, number>()
   private readonly lastContextUsed = new Map<string, number>()
 
-  threadOwner(channel: string, thread: string): string | null {
-    const owners = this.deps.store.openSessionAgents(channel, thread)
+  threadOwner(channel: string, thread: string, transportScope?: string | null): string | null {
+    const owners = this.deps.store.openSessionAgents(channel, thread, transportScope)
     // 2+ live owners actively share the thread → ambiguous, fall through to
     // mention-gating (§8.2). Exactly one → thread continuity.
     if (owners.length > 0) return owners.length === 1 ? owners[0]! : null
@@ -224,7 +225,7 @@ export class SessionManager {
     // the sole agent that previously owned this thread — SessionManager.handle then
     // recreates/resumes its ACP session. Still gated at exactly one, and the `!stop`
     // mute check downstream (onInbound) keeps a muted thread suppressed regardless.
-    const dormant = this.deps.store.closedSessionAgents(channel, thread)
+    const dormant = this.deps.store.closedSessionAgents(channel, thread, transportScope)
     return dormant.length === 1 ? dormant[0]! : null
   }
 
@@ -266,11 +267,17 @@ export class SessionManager {
     // daemon.ts, so the user message and its reply never collide on the same ms) — the
     // whole conversation is recorded, and thread stays stable → one session.
     const ts = msg.platform === 'webchat' ? monotonicTs() : coordTs
-    const key = sessionKey(msg.platform, msg.channel, thread, agentId)
+    const transportScope = msg.transportScope
+    const legacyKey = sessionKey(msg.platform, msg.channel, thread, agentId)
+    const key = sessionKey(msg.platform, msg.channel, thread, agentId, transportScope)
     let rec = this.deps.store.getSession(key)
-    const transportScope = msg.transportScope ?? rec?.transportScope ?? undefined
+    if (!rec && transportScope) {
+      // A pre-scope session may already contain traffic admitted through another
+      // physical bot. The store moves it onto the attributable key and discards
+      // unsafe runtime context when its old bot scope is unknown.
+      rec = this.deps.store.adoptLegacySessionScope(legacyKey, key, transportScope, Date.now())
+    }
     const transcriptChannel = transcriptChannelKey(msg.channel, transportScope)
-    if (transportScope !== undefined) msg.transportScope = transportScope
 
     // record the triggering message in the transcript (with an attachment mention
     // for prompt replay; bounded inline webchat images remain daemon-local for UI replay)
@@ -292,9 +299,7 @@ export class SessionManager {
     const isNewLogicalSession = rec === undefined
     if (rec) {
       const persistedMemoryProvider = rec.memoryProvider ?? 'managed'
-      // A pre-scope session may already contain context admitted through another
-      // physical bot. It cannot be attributed safely during migration, so the first
-      // scoped turn starts a clean runtime session instead of adopting that context.
+      // Defensive corruption fence: a scoped key and its stored scope must agree.
       const transportChanged = transportScope != null && rec.transportScope !== transportScope
       if (persistedMemoryProvider !== currentMemoryProvider || transportChanged) {
         rec = {
@@ -533,6 +538,7 @@ export class SessionManager {
           channel: msg.channel,
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
+          ...(transportScope !== undefined ? { transportScope } : {}),
           isDm: msg.isDm
         }) ?? []
       const acpSessionId = await newRuntimeSession(cwd, mcpServers, metaContext)
@@ -579,6 +585,7 @@ export class SessionManager {
           channel: msg.channel,
           thread,
           ...(integrationId !== undefined ? { integrationId } : {}),
+          ...(transportScope !== undefined ? { transportScope } : {}),
           isDm: msg.isDm
         }) ?? []
       let resumed = false

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -9,7 +9,7 @@ import { recalledMemoryBlock, recallQueryFromBlocks, sanitizeRecallRecords } fro
 import type { AcpHost } from '../acp/acp-host.js'
 import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
-import type { Attachment, NormalizedMessage } from '../messages/normalized.js'
+import { stableTurnId, type Attachment, type NormalizedMessage } from '../messages/normalized.js'
 import { buildAttachmentBlocks, attachmentMention, transcriptImageAttachments } from './attachment-block.js'
 import { EXPLICIT_MENTION_REMINDER, NO_RESPONSE_RULE, NO_RESPONSE_REMINDER } from './no-response.js'
 
@@ -755,10 +755,11 @@ export class SessionManager {
     // prompt exists. Its result is appended as a trailing, explicitly untrusted
     // reference block — never as the first user block/title seed (#398).
     const captureInput = recallQueryFromBlocks(blocks)
-    // Platform message ids are stable across redelivery and therefore make a
-    // durable operation fence. Webchat deliberately reuses one msgId for the
-    // whole conversation, so use its per-turn trace id instead.
-    const turnId = `${agentId}:${msg.platform === 'webchat' ? msg.traceId : msg.msgId}`
+    // Platform message ids are stable across redelivery within one physical bot
+    // and therefore make a durable operation fence once bot-scoped. Webchat
+    // deliberately reuses one msgId for the whole conversation, so use its
+    // per-turn trace id instead.
+    const turnId = stableTurnId(agentId, msg)
     const recallScope = { agentId, sessionId: rec.acpSessionId! }
     const recallPolicy = memoryEnabled ? this.deps.memory.recallPolicy(recallScope) : undefined
     if (captureInput && recallPolicy?.mode === 'auto') {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -61,6 +61,8 @@ export interface SessionRecord {
   platform: string
   channel: string
   thread: string
+  /** Opaque physical-bot scope for transcript/session lookup isolation. */
+  transportScope?: string | null
   acpSessionId: string | null
   // §7.3 session lifecycle. `prompting` ⇒ a turn is in flight; `cancelling` ⇒
   // a `!stop` was issued and we're awaiting the agent (with a force backstop);
@@ -199,6 +201,12 @@ export interface TranscriptMutation {
 
 export function sessionKey(platform: string, channel: string, thread: string, agentId: string): string {
   return `${platform}:${channel}:${thread}:${agentId}`
+}
+
+/** Internal transcript namespace. Platform-visible coordinates remain raw on the
+ * session row and wire; only local transcript storage uses the physical-bot scope. */
+export function transcriptChannelKey(channel: string, transportScope?: string | null): string {
+  return transportScope ? `${channel}\u001f${transportScope}` : channel
 }
 
 /**
@@ -408,7 +416,7 @@ export class LocalStore {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS sessions (
         key TEXT PRIMARY KEY, agentId TEXT, platform TEXT, channel TEXT, thread TEXT,
-        acpSessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
+        transportScope TEXT, acpSessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
         usage TEXT, muted INTEGER, triggeredBy TEXT, title TEXT, modelOverride TEXT,
         effortOverride TEXT, permissionModeOverride TEXT, fastModeOverride INTEGER,
         outputModeOverride TEXT, statusBarTs TEXT, memoryProvider TEXT
@@ -903,6 +911,8 @@ export class LocalStore {
       this.db.exec('ALTER TABLE sessions ADD COLUMN memoryProvider TEXT')
     if (!cols.some((c) => c.name === 'originSessionId'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN originSessionId TEXT')
+    if (!cols.some((c) => c.name === 'transportScope'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN transportScope TEXT')
   }
 
   /**
@@ -1045,6 +1055,28 @@ export class LocalStore {
       .get(agentId, channel) as SessionRecord | undefined
   }
 
+  /** Latest addressable session for one physical platform bot. The explicit
+   * transport scope prevents equal Telegram chat ids on different bots from
+   * stealing command/callback targeting from one another. */
+  latestSessionForTransport(
+    agentId: string,
+    channel: string,
+    transportScope?: string,
+    thread?: string
+  ): SessionRecord | undefined {
+    const args: SQLInputValue[] = [agentId, channel, transportScope ?? '']
+    const threadClause = thread === undefined ? '' : ' AND thread = ?'
+    if (thread !== undefined) args.push(thread)
+    return this.db
+      .prepare(
+        `SELECT * FROM sessions
+         WHERE agentId = ? AND channel = ? AND COALESCE(transportScope, '') = ?
+           AND acpSessionId IS NOT NULL${threadClause}
+         ORDER BY updatedAt DESC LIMIT 1`
+      )
+      .get(...args) as SessionRecord | undefined
+  }
+
   /** The most recently active addressable session (has an ACP id) in a channel, across
    *  ALL agents — or undefined. Used to resolve which agent a bare command targets when
    *  routing can't (e.g. a group `/status@bot` with no mention entity / thread). */
@@ -1070,14 +1102,15 @@ export class LocalStore {
 
   /** Addressable session ids whose authorized transcript scope may have changed. */
   sessionIdsForTranscript(agentId: string, channel: string, thread: string): string[] {
-    return (
-      this.db
-        .prepare(
-          `SELECT DISTINCT acpSessionId FROM sessions
-           WHERE agentId = ? AND channel = ? AND thread = ? AND acpSessionId IS NOT NULL`
-        )
-        .all(agentId, channel, thread) as { acpSessionId: string }[]
-    ).map((row) => row.acpSessionId)
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT acpSessionId, channel, transportScope FROM sessions
+         WHERE agentId = ? AND thread = ? AND acpSessionId IS NOT NULL`
+      )
+      .all(agentId, thread) as { acpSessionId: string; channel: string; transportScope: string | null }[]
+    return rows
+      .filter((row) => transcriptChannelKey(row.channel, row.transportScope) === channel)
+      .map((row) => row.acpSessionId)
   }
 
   currentTranscriptRevision(): number {
@@ -1299,14 +1332,15 @@ export class LocalStore {
     this.db
       .prepare(
         `INSERT INTO sessions
-           (key, agentId, platform, channel, thread, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, memoryProvider, originSessionId)
+           (key, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, memoryProvider, originSessionId)
          VALUES
-           (@key, @agentId, @platform, @channel, @thread, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
+           (@key, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
             CASE WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = @key) THEN 1 ELSE NULL END,
             @triggeredBy, @memoryProvider, @originSessionId)
          ON CONFLICT(key) DO UPDATE SET
            acpSessionId=excluded.acpSessionId, state=excluded.state,
            lastDeliveredTs=excluded.lastDeliveredTs, updatedAt=excluded.updatedAt,
+           transportScope=excluded.transportScope,
            muted=CASE
              WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = excluded.key) THEN 1
              ELSE sessions.muted
@@ -1323,6 +1357,7 @@ export class LocalStore {
         platform: rec.platform,
         channel: rec.channel,
         thread: rec.thread,
+        transportScope: rec.transportScope ?? null,
         acpSessionId: rec.acpSessionId,
         state: rec.state,
         lastDeliveredTs: rec.lastDeliveredTs,
@@ -1716,14 +1751,23 @@ export class LocalStore {
   }
 
   /** Newest-first addressable sessions to mine as dream transcript sources. */
-  dreamSessionSources(agentId: string, limit: number): { sessionId: string; channel: string; thread: string }[] {
-    return this.db
+  dreamSessionSources(
+    agentId: string,
+    limit: number
+  ): { sessionId: string; channel: string; thread: string; transportScope?: string | null }[] {
+    const rows = this.db
       .prepare(
-        `SELECT acpSessionId AS sessionId, channel, thread FROM sessions
+        `SELECT acpSessionId AS sessionId, channel, thread, transportScope FROM sessions
          WHERE agentId = ? AND acpSessionId IS NOT NULL AND platform <> 'dream'
          ORDER BY updatedAt DESC LIMIT ?`
       )
-      .all(agentId, limit) as { sessionId: string; channel: string; thread: string }[]
+      .all(agentId, limit) as {
+      sessionId: string
+      channel: string
+      thread: string
+      transportScope: string | null
+    }[]
+    return rows.map(({ transportScope, ...row }) => (transportScope ? { ...row, transportScope } : row))
   }
 
   /** Chronological conversational text of one session thread, scoped like
@@ -1761,8 +1805,10 @@ export class LocalStore {
     thread: string,
     agentId: string,
     limit: number,
-    includeTools = false
+    includeTools = false,
+    transportScope?: string | null
   ): { sender: string; text: string; kind?: string }[] {
+    const transcriptChannel = transcriptChannelKey(channel, transportScope)
     const rows = this.db
       .prepare(
         // SECURITY: gate the delivery-table match on `kind = 'text'`, exactly as
@@ -1780,7 +1826,7 @@ export class LocalStore {
            AND NOT (kind = 'tool' AND text IN (?, ?))
          ORDER BY seq DESC LIMIT ?`
       )
-      .all(channel, thread, agentId, agentId, agentId, ...SESSION_TITLE_TOOL_TITLES, limit) as {
+      .all(transcriptChannel, thread, agentId, agentId, agentId, ...SESSION_TITLE_TOOL_TITLES, limit) as {
       sender: string
       text: string
       kind?: string
@@ -1994,12 +2040,14 @@ export class LocalStore {
   /** Count non-closed sessions in (channel, thread) touched at/after `sinceTs`
    *  (epoch ms). Used to bound unrouted-transcript growth to recently-active
    *  threads, since there is no session-`closed` lifecycle yet. */
-  activeSessionCountSince(channel: string, thread: string, sinceTs: number): number {
+  activeSessionCountSince(channel: string, thread: string, sinceTs: number, transportScope?: string | null): number {
     const row = this.db
       .prepare(
-        "SELECT COUNT(*) AS n FROM sessions WHERE channel = ? AND thread = ? AND state != 'closed' AND updatedAt >= ?"
+        `SELECT COUNT(*) AS n FROM sessions
+         WHERE channel = ? AND thread = ? AND COALESCE(transportScope, '') = ?
+           AND state != 'closed' AND updatedAt >= ?`
       )
-      .get(channel, thread, sinceTs) as { n: number } | undefined
+      .get(channel, thread, transportScope ?? '', sinceTs) as { n: number } | undefined
     return row?.n ?? 0
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2200,8 +2200,9 @@ export class LocalStore {
   }
 
   /** §6.9 #353 durable inbox: persist an admitted message BEFORE its admission ACK. Keyed
-   *  by the stable id (deliveryId/msgId). A re-append preserves the original payload/FIFO
-   *  position and may only advance the durable loop-accounting marker from 0 to 1. */
+   *  by the stable delivery id (agent deliveryId or bot-scoped platform message id).
+   *  A re-append preserves the original payload/FIFO position and may only advance
+   *  the durable loop-accounting marker from 0 to 1. */
   appendInbox(row: InboxRow): boolean {
     const inserted = this.db
       .prepare(

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -199,8 +199,15 @@ export interface TranscriptMutation {
   revision: number
 }
 
-export function sessionKey(platform: string, channel: string, thread: string, agentId: string): string {
-  return `${platform}:${channel}:${thread}:${agentId}`
+export function sessionKey(
+  platform: string,
+  channel: string,
+  thread: string,
+  agentId: string,
+  transportScope?: string | null
+): string {
+  const base = `${platform}:${channel}:${thread}:${agentId}`
+  return transportScope ? `${base}:${transportScope}` : base
 }
 
 /** Internal transcript namespace. Platform-visible coordinates remain raw on the
@@ -938,6 +945,57 @@ export class LocalStore {
 
   getSession(key: string): SessionRecord | undefined {
     return this.db.prepare('SELECT * FROM sessions WHERE key = ?').get(key) as SessionRecord | undefined
+  }
+
+  /** Move one pre-scope session onto its first attributable physical-bot key.
+   * Legacy runtime context is discarded because it may already contain traffic
+   * admitted through another bot; rows written by the partially scoped rollout
+   * retain their ACP id when the persisted scope matches. */
+  adoptLegacySessionScope(
+    legacyKey: string,
+    scopedKey: string,
+    transportScope: string,
+    updatedAt: number
+  ): SessionRecord | undefined {
+    if (legacyKey === scopedKey) return this.getSession(scopedKey)
+    const current = this.getSession(scopedKey)
+    if (current) return current
+    const legacy = this.getSession(legacyKey)
+    if (!legacy || (legacy.transportScope != null && legacy.transportScope !== transportScope)) return undefined
+    const resetRuntime = legacy.transportScope == null
+    this.db.exec('BEGIN')
+    try {
+      this.db
+        .prepare(
+          'INSERT OR IGNORE INTO session_mutes (key) SELECT ? WHERE EXISTS (SELECT 1 FROM session_mutes WHERE key = ?)'
+        )
+        .run(scopedKey, legacyKey)
+      this.db.prepare('DELETE FROM session_mutes WHERE key = ?').run(legacyKey)
+      this.db
+        .prepare(
+          `UPDATE sessions
+           SET key = ?, transportScope = ?,
+               acpSessionId = CASE WHEN ? = 1 THEN NULL ELSE acpSessionId END,
+               state = CASE WHEN ? = 1 AND state != 'closed' THEN 'idle' ELSE state END,
+               lastDeliveredTs = CASE WHEN ? = 1 THEN NULL ELSE lastDeliveredTs END,
+               updatedAt = ?
+           WHERE key = ?`
+        )
+        .run(
+          scopedKey,
+          transportScope,
+          resetRuntime ? 1 : 0,
+          resetRuntime ? 1 : 0,
+          resetRuntime ? 1 : 0,
+          updatedAt,
+          legacyKey
+        )
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+    return this.getSession(scopedKey)
   }
 
   createPermissionRequest(record: PermissionRequestRecord): void {
@@ -2016,11 +2074,13 @@ export class LocalStore {
     return row?.thread
   }
 
-  openSessionAgents(channel: string, thread: string): string[] {
+  openSessionAgents(channel: string, thread: string, transportScope?: string | null): string[] {
     return (
       this.db
-        .prepare("SELECT agentId FROM sessions WHERE channel = ? AND thread = ? AND state != 'closed'")
-        .all(channel, thread) as { agentId: string }[]
+        .prepare(
+          "SELECT agentId FROM sessions WHERE channel = ? AND thread = ? AND COALESCE(transportScope, '') = ? AND state != 'closed'"
+        )
+        .all(channel, thread, transportScope ?? '') as { agentId: string }[]
     ).map((r) => r.agentId)
   }
 
@@ -2029,11 +2089,13 @@ export class LocalStore {
    *  to the sole agent that previously owned it, and SessionManager.handle recreates/
    *  resumes the ACP session. Kept separate from `openSessionAgents` so the live
    *  multi-agent disambiguation (2+ open owners → mention-gated) is never perturbed. */
-  closedSessionAgents(channel: string, thread: string): string[] {
+  closedSessionAgents(channel: string, thread: string, transportScope?: string | null): string[] {
     return (
       this.db
-        .prepare("SELECT agentId FROM sessions WHERE channel = ? AND thread = ? AND state = 'closed'")
-        .all(channel, thread) as { agentId: string }[]
+        .prepare(
+          "SELECT agentId FROM sessions WHERE channel = ? AND thread = ? AND COALESCE(transportScope, '') = ? AND state = 'closed'"
+        )
+        .all(channel, thread, transportScope ?? '') as { agentId: string }[]
     ).map((r) => r.agentId)
   }
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -10,7 +11,7 @@ import {
   type RdMsgSlackAction
 } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
-import { LocalStore } from '../src/store/local-store.js'
+import { LocalStore, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 
 const AGENT_IDENTITY = {
@@ -22,6 +23,7 @@ const STATUS_BAR_POST_OPTIONS = {
   icon_url: AGENT_IDENTITY.iconUrl,
   chrome: true
 }
+const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 
 function hasPending(daemon: Daemon, acpSessionId: string): boolean {
   return [...(daemon as any).pending.values()].some(
@@ -115,6 +117,7 @@ const dm = (ts: string, text: string) => ({
   platform: 'slack' as const,
   channel: 'C1',
   thread: 'T1',
+  transportScope: TRANSPORT_SCOPE,
   sender: { id: 'U1', isBot: false },
   text,
   mentionedBots: [] as string[],
@@ -453,6 +456,7 @@ describe('Daemon in-conversation commands', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope: TRANSPORT_SCOPE,
       acpSessionId: 'acp-old',
       state: 'idle',
       lastDeliveredTs: null,
@@ -552,7 +556,9 @@ describe('Daemon in-conversation commands', () => {
     expect(blocked.prompts).toHaveLength(1) // the follow-up was dropped, not dispatched (memory prefixes the 'hello' turn)
     expect(blocked.prompts[0]).toContain('hello')
     expect(
-      store.transcriptSince('C1', 'T1', null).some((r: any) => r.text === 'humans talking amongst themselves')
+      store
+        .transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+        .some((r: any) => r.text === 'humans talking amongst themselves')
     ).toBe(true)
 
     // explicit @mention clears the mute and dispatches (with the missed context replayed)
@@ -906,12 +912,13 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope: TRANSPORT_SCOPE,
       sender: { id: 'B999', isBot: true },
       text: 'beep from another bot',
       mentionedBots: ['UOTHER'],
       isDm: false
     })
-    const rows = store.transcriptSince('C1', 'T1', null)
+    const rows = store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
     expect(rows.some((r: any) => r.text === 'beep from another bot' && r.sender === 'B999')).toBe(true)
 
     await daemon.stop()
@@ -989,7 +996,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     // age the session record so the recency window alone would exclude it
     const rec = store.getSession('slack:C1:T1:bot-a')
     store.upsertSession({ ...rec, updatedAt: rec.updatedAt - 60 * 60 * 1000 })
-    expect(store.activeSessionCountSince('C1', 'T1', Date.now() - 900_000)).toBe(0)
+    expect(store.activeSessionCountSince('C1', 'T1', Date.now() - 900_000, TRANSPORT_SCOPE)).toBe(0)
 
     // An unrouted peer mention arrives mid-turn → still recorded (in-flight keeps it active).
     ;(daemon as any).onInbound({
@@ -999,12 +1006,17 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope: TRANSPORT_SCOPE,
       sender: { id: 'B999', isBot: true },
       text: 'mid-turn peer message',
       mentionedBots: ['UOTHER'],
       isDm: false
     })
-    expect(store.transcriptSince('C1', 'T1', null).some((r: any) => r.text === 'mid-turn peer message')).toBe(true)
+    expect(
+      store
+        .transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+        .some((r: any) => r.text === 'mid-turn peer message')
+    ).toBe(true)
 
     blocked.release()
     await turn

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -11,7 +11,7 @@ import {
   type RdMsgSlackAction
 } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
-import { LocalStore, transcriptChannelKey } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 
 const AGENT_IDENTITY = {
@@ -24,6 +24,8 @@ const STATUS_BAR_POST_OPTIONS = {
   chrome: true
 }
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
+const SESSION_KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', TRANSPORT_SCOPE)
+const LOOP_SCOPE = `slack:C1:dm:${TRANSPORT_SCOPE}`
 
 function hasPending(daemon: Daemon, acpSessionId: string): boolean {
   return [...(daemon as any).pending.values()].some(
@@ -132,7 +134,7 @@ describe('Daemon in-conversation commands', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').integrations[0].slack.allowedUserIds = ['U1']
-    const scope = 'slack:C1:dm'
+    const scope = LOOP_SCOPE
     ;(daemon as any).store.tripLoopGuard(scope, 1, 'test_loop')
 
     ;(daemon as any).onInbound({ ...dm('100', '!resume'), sender: { id: 'unknown', isBot: false } })
@@ -205,7 +207,7 @@ describe('Daemon in-conversation commands', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').integrations[0].slack.allowedUserIds = ['U1']
-    const scope = 'slack:C1:dm'
+    const scope = LOOP_SCOPE
     ;(daemon as any).store.tripLoopGuard(scope, 1, 'test_loop')
 
     const relayResume = (msgId: string, sender: { id: string; isBot: boolean }): RdMsgIm => ({
@@ -276,7 +278,7 @@ describe('Daemon in-conversation commands', () => {
     await daemon.start()
     makeRoutable(daemon)
     // The session the shared bot's inbound keys to (sessionKey(platform, channel, thread, agent)).
-    const muteKey = 'slack:C1:T1:bot-a'
+    const muteKey = SESSION_KEY
     ;(daemon as any).store.setSessionMuted(muteKey, true)
 
     const relayIm = (msgId: string, text: string, trigger: 'dm' | 'mention'): RdMsgIm => ({
@@ -321,7 +323,7 @@ describe('Daemon in-conversation commands', () => {
 
     // queue a follow-up while the turn is in flight
     ;(daemon as any).onInbound(dm('200', '!queue do it'))
-    expect((daemon as any).serialQueue.get('slack:C1:T1:bot-a')).toHaveLength(1)
+    expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(1)
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Queued'), 'T1')
     expect(blocked.prompts).toHaveLength(1) // the 2nd message is queued, not dispatched yet
     expect(blocked.prompts[0]).toContain('hello') // (prefixed by the injected memory block)
@@ -331,7 +333,7 @@ describe('Daemon in-conversation commands', () => {
     await turn
     await vi.waitFor(() => expect(blocked.prompts.length).toBe(2))
     expect(blocked.prompts[1]).toContain('do it')
-    expect((daemon as any).serialQueue.has('slack:C1:T1:bot-a')).toBe(false)
+    expect((daemon as any).serialQueue.has(SESSION_KEY)).toBe(false)
 
     await daemon.stop()
   }, 15_000)
@@ -362,9 +364,9 @@ describe('Daemon in-conversation commands', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
 
     for (let i = 0; i < 10; i++) (daemon as any).onInbound(dm(`${200 + i}`, `!queue m${i}`))
-    expect((daemon as any).serialQueue.get('slack:C1:T1:bot-a')).toHaveLength(10)
+    expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(10)
     ;(daemon as any).onInbound(dm('999', '!queue overflow')) // 11th → rejected
-    expect((daemon as any).serialQueue.get('slack:C1:T1:bot-a')).toHaveLength(10)
+    expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(10)
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('full'), 'T1')
 
     blocked.release()
@@ -408,7 +410,7 @@ describe('Daemon in-conversation commands', () => {
     const daemon = new Daemon({ root, hostFactory: () => host as any })
     await daemon.start()
     makeRoutable(daemon)
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'cold'), 'int-a')
     await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled())
@@ -448,14 +450,15 @@ describe('Daemon in-conversation commands', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
     await daemon.start()
     makeRoutable(daemon)
-    const oldKey = 'slack:C1:T1:bot-a'
-    const coldKey = 'slack:C1:T2:bot-a'
+    const oldKey = SESSION_KEY
+    const coldKey = sessionKey('slack', 'C1', 'T2', 'bot-a', TRANSPORT_SCOPE)
     ;(daemon as any).store.upsertSession({
       key: oldKey,
       agentId: 'bot-a',
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope: TRANSPORT_SCOPE,
       transportScope: TRANSPORT_SCOPE,
       acpSessionId: 'acp-old',
       state: 'idle',
@@ -492,7 +495,7 @@ describe('Daemon in-conversation commands', () => {
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Cancelled'), 'T1')
     // unlike !stop, the session is NOT muted — follow-ups keep dispatching.
     const store = (daemon as any).store
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(false)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(false)
 
     blocked.release()
     await turn
@@ -521,9 +524,9 @@ describe('Daemon in-conversation commands', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
 
     ;(daemon as any).onInbound(dm('200', '!queue later')) // buffered behind the turn
-    expect((daemon as any).serialQueue.get('slack:C1:T1:bot-a')).toHaveLength(1)
+    expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(1)
     ;(daemon as any).onInbound(dm('300', '!stop')) // clears the queue + cancels
-    expect((daemon as any).serialQueue.has('slack:C1:T1:bot-a')).toBe(false)
+    expect((daemon as any).serialQueue.has(SESSION_KEY)).toBe(false)
 
     blocked.release()
     await turn
@@ -546,7 +549,7 @@ describe('Daemon in-conversation commands', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
 
     ;(daemon as any).onInbound(dm('200', '!stop'))
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(true)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(true)
     blocked.release()
     await turn
 
@@ -564,7 +567,7 @@ describe('Daemon in-conversation commands', () => {
     // explicit @mention clears the mute and dispatches (with the missed context replayed)
     ;(daemon as any).onInbound({ ...dm('400', '<@UBOTA> resume please'), mentionedBots: ['UBOTA'] })
     await vi.waitFor(() => expect(blocked.prompts.length).toBe(2))
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(false)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(false)
     expect(blocked.prompts[1]).toContain('humans talking amongst themselves')
 
     // thread affinity works again after the un-mute
@@ -586,7 +589,7 @@ describe('Daemon in-conversation commands', () => {
     const store = (daemon as any).store
 
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(false)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(false)
 
     // channel message (not a DM, no mention) in a thread bot-a does not own → routeRules
     // misses, and the guarded channel-latest fallback declines to cross into T-other.
@@ -600,7 +603,7 @@ describe('Daemon in-conversation commands', () => {
     ;(daemon as any).onInbound(channelStop)
     await new Promise((r) => setTimeout(r, 20))
     expect(conn.postMessage).not.toHaveBeenCalled()
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(false)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(false)
 
     // A top-level channel command (no thread) still reaches the channel's active session.
     ;(daemon as any).onInbound({ ...channelStop, msgId: 'slack:C1:300', thread: undefined })
@@ -619,7 +622,7 @@ describe('Daemon in-conversation commands', () => {
     // open a session in T1, let its turn finish, then stand the agent down
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
     ;(daemon as any).onInbound(dm('200', '!stop'))
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(true)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(true)
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Muted'), 'T1')
 
     // follow-up in the muted thread does not start a turn
@@ -631,7 +634,7 @@ describe('Daemon in-conversation commands', () => {
     // latest session (T1): reports it's idle + (re)mutes T1, but still replies in T9.
     ;(daemon as any).onInbound({ ...dm('400', '!stop'), thread: 'T9' })
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Nothing is running'), 'T9')
-    expect(store.isSessionMuted('slack:C1:T1:bot-a')).toBe(true)
+    expect(store.isSessionMuted(SESSION_KEY)).toBe(true)
 
     await daemon.stop()
   }, 15_000)
@@ -664,7 +667,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const store = (daemon as any).store
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
 
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
 
@@ -688,7 +691,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const store = (daemon as any).store
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
 
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
 
@@ -738,7 +741,7 @@ describe('Daemon in-conversation commands', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     const store = (daemon as any).store
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
 
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
 
@@ -874,7 +877,7 @@ describe('Daemon managed-agent bot ingress', () => {
       {
         source: 'im',
         agentId: 'bot-a',
-        sessionKey: 'slack:C1:T1:bot-a',
+        sessionKey: SESSION_KEY,
         msgId: relayManaged.msgId,
         botId: 'shared-bot',
         integrationId: 'int-a',
@@ -902,7 +905,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
 
     // open a session in thread T1 via a routable DM
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
-    expect(store.openSessionAgents('C1', 'T1')).toContain('bot-a')
+    expect(store.openSessionAgents('C1', 'T1', TRANSPORT_SCOPE)).toContain('bot-a')
 
     // A mention of an unknown bot must not fall back to this thread owner.
     ;(daemon as any).onInbound({
@@ -994,7 +997,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
 
     // age the session record so the recency window alone would exclude it
-    const rec = store.getSession('slack:C1:T1:bot-a')
+    const rec = store.getSession(SESSION_KEY)
     store.upsertSession({ ...rec, updatedAt: rec.updatedAt - 60 * 60 * 1000 })
     expect(store.activeSessionCountSince('C1', 'T1', Date.now() - 900_000, TRANSPORT_SCOPE)).toBe(0)
 
@@ -1206,7 +1209,7 @@ describe('Slack interactive status bar', () => {
       v: 1,
       agentId: 'bot-a',
       integrationId: 'int-a',
-      sessionKey: 'slack:C1:T1:bot-a'
+      sessionKey: SESSION_KEY
     })
     expect(call[4]).toEqual(STATUS_BAR_POST_OPTIONS)
 
@@ -1247,7 +1250,7 @@ describe('Slack interactive status bar', () => {
       v: 1,
       agentId: 'bot-a',
       integrationId: 'int-a',
-      sessionKey: 'slack:C1:T1:bot-a'
+      sessionKey: SESSION_KEY
     })
     // Agent identity is preserved in shared mode, and the message remains marked as chrome.
     expect(call[4]).toEqual(STATUS_BAR_POST_OPTIONS)
@@ -1265,8 +1268,8 @@ describe('Slack interactive status bar', () => {
     integration.slack.mode = 'shared'
     delete integration.slack.appToken
 
-    const KEY = 'slack:C1:T1:bot-a'
-    const FOREIGN_KEY = 'slack:C1:T2:bot-a'
+    const KEY = SESSION_KEY
+    const FOREIGN_KEY = sessionKey('slack', 'C1', 'T2', 'bot-a', TRANSPORT_SCOPE)
     const openStatusModal = vi.fn(async () => {})
     const updateBlocks = vi.fn(async () => true)
     ;(daemon as any).connByIntegration.set('int-a', { openStatusModal, updateBlocks })
@@ -1287,6 +1290,7 @@ describe('Slack interactive status bar', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T2',
+      transportScope: TRANSPORT_SCOPE,
       acpSessionId: 'acp-2',
       state: 'idle',
       lastDeliveredTs: null,
@@ -1368,9 +1372,9 @@ describe('Slack interactive status bar', () => {
       action: 'accept',
       content: { language: 'TypeScript' }
     })
-    const [triggerId, sessionKey, privateMetadata] = openStatusModal.mock.calls[0]!
+    const [triggerId, openedSessionKey, privateMetadata] = openStatusModal.mock.calls[0]!
     expect(triggerId).toBe('trig-1')
-    expect(sessionKey).toBe(KEY)
+    expect(openedSessionKey).toBe(KEY)
     expect(decodeSharedSlackStatusTarget(privateMetadata)).toEqual({
       v: 1,
       agentId: 'bot-a',
@@ -1422,7 +1426,7 @@ describe('Slack interactive status bar', () => {
       )
     )
     expect(conn.postBlocks).not.toHaveBeenCalled()
-    expect((daemon as any).store.getStatusBarTs('slack:C1:T1:bot-a')).toBe('111.1')
+    expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).toBe('111.1')
 
     release()
     await turn
@@ -1490,7 +1494,7 @@ describe('Slack interactive status bar', () => {
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
     // The connection queries statusInfoForKey to build the modal; it resolves the deep link.
-    const data = (daemon as any).statusInfoForKey('slack:C1:T1:bot-a')
+    const data = (daemon as any).statusInfoForKey(SESSION_KEY)
     expect(data.link).toBe('https://console.example.com/sessions/acp-1')
     expect(data.info.models).toEqual(['opus-4.8', 'sonnet-5'])
     expect(data.identity).toMatchObject({
@@ -1499,12 +1503,12 @@ describe('Slack interactive status bar', () => {
       iconUrl: AGENT_IDENTITY.iconUrl
     })
     expect(data.identity.sessionTitle).toBeUndefined()
-    ;(daemon as any).store.setSessionTitle('slack:C1:T1:bot-a', 'Fix login flow')
-    expect((daemon as any).statusInfoForKey('slack:C1:T1:bot-a').identity.sessionTitle).toBe('Fix login flow')
+    ;(daemon as any).store.setSessionTitle(SESSION_KEY, 'Fix login flow')
+    expect((daemon as any).statusInfoForKey(SESSION_KEY).identity.sessionTitle).toBe('Fix login flow')
     expect(data.cancellable).toBe(true)
     release()
     await t1
-    expect((daemon as any).statusInfoForKey('slack:C1:T1:bot-a').cancellable).toBe(false)
+    expect((daemon as any).statusInfoForKey(SESSION_KEY).cancellable).toBe(false)
     await daemon.stop()
   }, 15_000)
 
@@ -1522,7 +1526,7 @@ describe('Slack interactive status bar', () => {
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     routableWithBlocks(daemon)
 
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
     release()
@@ -1552,7 +1556,7 @@ describe('Slack interactive status bar', () => {
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = routableWithBlocks(daemon)
     const store = (daemon as any).store
-    const key = 'slack:C1:T1:bot-a'
+    const key = SESSION_KEY
 
     const t1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -141,7 +141,7 @@ const dm = (ts: string, text: string, thread = 'T1') => ({
   trigger: 'dm' as const
 })
 
-const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a')
+const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', TRANSPORT_SCOPE)
 
 function pendingFor(daemon: Daemon, acpSessionId: string): any {
   return [...(daemon as any).pending.values()].find(
@@ -215,7 +215,7 @@ describe('Daemon session lifecycle (#118)', () => {
       username: 'Review Bot',
       icon_url: 'https://console.example.test/icons/review-bot'
     })
-    const key = sessionKey('slack', 'C1', '100.100000', 'bot-a')
+    const key = sessionKey('slack', 'C1', '100.100000', 'bot-a', TRANSPORT_SCOPE)
     expect((daemon as any).store.getSession(key)?.lastDeliveredTs).toBe('100.100000')
 
     await (daemon as any).dispatch(
@@ -309,7 +309,7 @@ describe('Daemon session lifecycle (#118)', () => {
     const second = (daemon as any).dispatch('bot-a', dm('200', 'second', 'T2'))
     await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2))
     const queued = (daemon as any).dispatch('bot-a', dm('300', 'queued', 'T1'))
-    expect((daemon as any).serialQueue.get(sessionKey('slack', 'C1', 'T1', 'bot-a'))).toHaveLength(1)
+    expect((daemon as any).serialQueue.get(KEY)).toHaveLength(1)
 
     writePause(root, true)
     await daemon.reconcile()

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -6,6 +7,8 @@ import { Daemon } from '../src/daemon.js'
 import { configFilesDir } from '../src/agents/config-file-env.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { FakeClock } from './cp/fake-clock.js'
+
+const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 
 /** A daemon root with one DM-less agent (we attach routing + a fake conn by hand,
  *  exactly like daemon-commands.test.ts). `limits` overrides the lifecycle tunables. */
@@ -130,6 +133,7 @@ const dm = (ts: string, text: string, thread = 'T1') => ({
   platform: 'slack' as const,
   channel: 'C1',
   thread,
+  transportScope: TRANSPORT_SCOPE,
   sender: { id: 'U1', isBot: false },
   text,
   mentionedBots: [] as string[],

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
-import type { TranscriptEntry } from '../src/store/local-store.js'
+import { transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
+
+const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
+const TRANSCRIPT_CHANNEL = transcriptChannelKey('C1', TRANSPORT_SCOPE)
 
 function scaffold(mode: 'minimal' | 'low' | 'medium' | 'high', agentExtra: Record<string, unknown> = {}): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-tx-'))
@@ -93,6 +97,7 @@ const dm = (ts: string, text: string) => ({
   platform: 'slack' as const,
   channel: 'C1',
   thread: 'T1',
+  transportScope: TRANSPORT_SCOPE,
   sender: { id: 'U1', isBot: false },
   text,
   mentionedBots: [] as string[],
@@ -101,13 +106,13 @@ const dm = (ts: string, text: string) => ({
 })
 
 function transcript(daemon: Daemon): TranscriptEntry[] {
-  return (daemon as any).store.transcriptSince('C1', 'T1', null)
+  return (daemon as any).store.transcriptSince(TRANSCRIPT_CHANNEL, 'T1', null)
 }
 
 /** Full activity log (all kinds), insertion order — what the Web UI reads. */
 function activity(daemon: Daemon): { kind: string; sender: string; text: string }[] {
   return (daemon as any).store
-    .threadTranscript('C1', 'T1')
+    .threadTranscript(TRANSCRIPT_CHANNEL, 'T1')
     .map((r: any) => ({ kind: r.kind, sender: r.sender, text: r.text }))
 }
 
@@ -590,7 +595,7 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
 
     // A *different* agent replaying the thread sees conversational text only — never
     // bot-a's tool calls or reasoning fed back as "context you may have missed".
-    const gap = (daemon as any).store.transcriptSince('C1', 'T1', null)
+    const gap = (daemon as any).store.transcriptSince(TRANSCRIPT_CHANNEL, 'T1', null)
     expect(gap.every((r: TranscriptEntry) => r.kind === 'text')).toBe(true)
     expect(gap.map((r: TranscriptEntry) => r.text)).toEqual(['go', 'here is the answer'])
     await daemon.stop()
@@ -627,7 +632,7 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
 
     await (daemon as any).dispatch('bot-a', dm('100', 'is TestSA in the env?'), 'int-a')
 
-    const rows = (daemon as any).store.threadTranscript('C1', 'T1')
+    const rows = (daemon as any).store.threadTranscript(TRANSCRIPT_CHANNEL, 'T1')
     expect(JSON.stringify(rows)).not.toContain('s3cret-value')
     const reply = rows.find((r: any) => r.kind === 'text' && r.sender === 'bot-a')
     expect(reply.text).toBe('yes, TestSA is set to [secret:TestSA]')

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import { transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
+import { stableTurnId } from '../src/messages/normalized.js'
 
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 const TRANSCRIPT_CHANNEL = transcriptChannelKey('C1', TRANSPORT_SCOPE)
@@ -171,7 +172,7 @@ describe('Daemon transcript records the agent reply', () => {
     expect(recordTurn).toHaveBeenCalledWith(
       { agentId: 'bot-a', sessionId: 'acp-1' },
       {
-        turnId: 'bot-a:slack:C1:100',
+        turnId: stableTurnId('bot-a', dm('100', 'question?')),
         sessionId: 'acp-1',
         input: 'question?',
         output: 'here is my answer'

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { LocalStore, sessionKey, type InboxRow } from '../src/store/local-store.js'
 import { statePath } from '../src/paths.js'
 import { Daemon } from '../src/daemon.js'
+import { stableMessageId } from '../src/messages/normalized.js'
 import type { WebchatOutput, WebchatDone } from '@agentconnect.md/protocol'
 
 /**
@@ -396,6 +397,35 @@ describe('daemon durable inbox', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('namespaces durable message identity per physical bot and deduplicates within one bot', async () => {
+    const g = gatedHost()
+    g.host.newSession = vi.fn().mockResolvedValueOnce('acp-a').mockResolvedValueOnce('acp-b')
+    const root = scaffold()
+    const daemon = await boot(root, g.host)
+    const botA = { ...msg('100', 'from A'), transportScope: 'slack:scope-a' }
+    const botB = { ...msg('100', 'from B'), transportScope: 'slack:scope-b' }
+
+    const pA = (daemon as any).dispatch('bot-a', botA, 'int-a')
+    const pB = (daemon as any).dispatch('bot-a', botB, 'int-b')
+    await vi.waitFor(() => expect(g.blockedCount()).toBe(2))
+    expect((daemon as any).evaluationTurnIdFor('bot-a', botA)).not.toBe(
+      (daemon as any).evaluationTurnIdFor('bot-a', botB)
+    )
+    expect(
+      inbox(root)
+        .map((row) => row.id)
+        .sort()
+    ).toEqual([stableMessageId(botA), stableMessageId(botB)].sort())
+
+    await expect((daemon as any).dispatch('bot-a', { ...botA }, 'int-a')).resolves.toBeNull()
+    expect(inbox(root)).toHaveLength(2)
+
+    g.releaseAll()
+    await Promise.all([pA, pB])
+    expect(inbox(root)).toHaveLength(0)
+    await daemon.stop()
+  }, 15_000)
+
   it('a fail-stopped queued rest has its rows removed too', async () => {
     const g = gatedHost()
     g.failNext(1)
@@ -420,14 +450,16 @@ describe('daemon durable inbox', () => {
   it('startup replay: pre-seeded rows for a sessionKey are re-admitted through the gate in FIFO order', async () => {
     const g = gatedHost()
     const root = scaffold()
-    const key = sessionKey('slack', 'C1', 'T1', 'bot-a')
+    const transportScope = 'slack:scope-a'
+    const key = sessionKey('slack', 'C1', 'T1', 'bot-a', transportScope)
+    const replayMsg = (ts: string, text: string) => ({ ...msg(ts, text), transportScope })
     // Pre-seed the durable inbox out of enqueuedAt order to prove FIFO ordering on replay.
     const s = new LocalStore(statePath(root))
     s.appendInbox({
       id: 'slack:C1:300',
       sessionKey: key,
       agentId: 'bot-a',
-      msg: JSON.stringify(msg('300', 'third')),
+      msg: JSON.stringify(replayMsg('300', 'third')),
       integrationId: 'int-a',
       callMeta: null,
       isQueueCmd: null,
@@ -437,7 +469,7 @@ describe('daemon durable inbox', () => {
       id: 'slack:C1:100',
       sessionKey: key,
       agentId: 'bot-a',
-      msg: JSON.stringify(msg('100', 'first')),
+      msg: JSON.stringify(replayMsg('100', 'first')),
       integrationId: 'int-a',
       callMeta: null,
       isQueueCmd: null,
@@ -447,7 +479,7 @@ describe('daemon durable inbox', () => {
       id: 'slack:C1:200',
       sessionKey: key,
       agentId: 'bot-a',
-      msg: JSON.stringify(msg('200', 'second')),
+      msg: JSON.stringify(replayMsg('200', 'second')),
       integrationId: 'int-a',
       callMeta: null,
       isQueueCmd: null,
@@ -460,6 +492,8 @@ describe('daemon durable inbox', () => {
     await vi.waitFor(() => expect(g.started.length).toBe(1))
     expect(g.started[0]).toContain('first')
     expect((daemon as any).serialQueue.get(key)).toHaveLength(2)
+    // Adopt the legacy raw ids instead of duplicating them under the new scoped identity.
+    expect(inbox(root).map((row) => row.id)).toEqual(['slack:C1:100', 'slack:C1:200', 'slack:C1:300'])
     // Every migrated row is marked only after its replay admission was charged.
     expect(inbox(root).every((row) => row.loopGuardCounted === 1)).toBe(true)
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { LocalStore, sessionKey } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { SessionManager, isStandingContextTitleEcho } from '../src/session/session-manager.js'
 import { createManagedMemoryProvider } from '../src/agents/memory-provider.js'
 import { writeMemoryFile, MEMORY_INDEX } from '../src/agents/memory.js'
@@ -68,6 +68,44 @@ describe('SessionManager', () => {
     expect(created).toBe(true) // brand-new ACP session → daemon emits event/session start
     expect(host.newSession).toHaveBeenCalledOnce()
     expect(blocks.map((b: any) => b.text).join('')).toContain('first')
+    store.close()
+  })
+
+  it('does not replay transcript context from another physical bot with the same channel coordinates', async () => {
+    const store = newStore()
+    const agentB = { ...agent, id: 'bot-b', name: 'bot-b' }
+    const hosts = new Map([
+      ['bot-a', { newSession: vi.fn(async () => 'acp-a') } as any],
+      ['bot-b', { newSession: vi.fn(async () => 'acp-b') } as any]
+    ])
+    const sm = new SessionManager({
+      store,
+      hostFor: async (agentId) => hosts.get(agentId)!,
+      agentById: (agentId) => (agentId === 'bot-a' ? agent : agentId === 'bot-b' ? agentB : undefined),
+      memory
+    })
+    store.upsertSession({
+      key: sessionKey('slack', 'C1', '100.1', 'bot-b'),
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C1',
+      thread: '100.1',
+      acpSessionId: 'legacy-acp-b',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: 1
+    })
+
+    await sm.handle('bot-a', msg({ ts: '100.1', text: 'private text for bot A', transportScope: 'slack:scope-a' }))
+    const turnB = await sm.handle('bot-b', msg({ ts: '100.2', text: 'hello bot B', transportScope: 'slack:scope-b' }))
+
+    expect(turnB.sessionId).toBe('acp-b')
+    expect(hosts.get('bot-b')?.newSession).toHaveBeenCalledOnce()
+    expect(JSON.stringify(turnB.blocks)).not.toContain('private text for bot A')
+    expect(JSON.stringify(turnB.blocks)).toContain('hello bot B')
+    expect(store.threadTranscript(transcriptChannelKey('C1', 'slack:scope-a'), '100.1')).toHaveLength(1)
+    expect(store.threadTranscript(transcriptChannelKey('C1', 'slack:scope-b'), '100.1')).toHaveLength(1)
+    expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-b'))?.transportScope).toBe('slack:scope-b')
     store.close()
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -124,12 +124,13 @@ describe('SessionManager', () => {
     const keyB = sessionKey('slack', 'C1', '100.1', 'bot-a', scopeB)
 
     const firstA = await sm.handle('bot-a', msg({ ts: '100.1', text: 'A1', transportScope: scopeA }))
-    const firstB = await sm.handle('bot-a', msg({ ts: '100.2', text: 'B1', transportScope: scopeB }))
+    const firstB = await sm.handle('bot-a', msg({ ts: '100.1', text: 'B1', transportScope: scopeB }))
     store.setModelOverride(keyA, 'model-a')
     store.setSessionMuted(keyA, true)
     const secondA = await sm.handle('bot-a', msg({ ts: '100.3', text: 'A2', transportScope: scopeA }))
 
     expect([firstA.sessionId, firstB.sessionId, secondA.sessionId]).toEqual(['acp-a', 'acp-b', 'acp-a'])
+    expect(firstA.turnId).not.toBe(firstB.turnId)
     expect(host.newSession).toHaveBeenCalledTimes(2)
     expect(store.getSession(keyA)?.acpSessionId).toBe('acp-a')
     expect(store.getSession(keyB)?.acpSessionId).toBe('acp-b')

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -105,7 +105,38 @@ describe('SessionManager', () => {
     expect(JSON.stringify(turnB.blocks)).toContain('hello bot B')
     expect(store.threadTranscript(transcriptChannelKey('C1', 'slack:scope-a'), '100.1')).toHaveLength(1)
     expect(store.threadTranscript(transcriptChannelKey('C1', 'slack:scope-b'), '100.1')).toHaveLength(1)
-    expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-b'))?.transportScope).toBe('slack:scope-b')
+    expect(store.getSession(sessionKey('slack', 'C1', '100.1', 'bot-b', 'slack:scope-b'))?.transportScope).toBe(
+      'slack:scope-b'
+    )
+    store.close()
+  })
+
+  it('reuses independent ACP and sticky state when one agent serves identical coordinates on two bots', async () => {
+    const store = newStore()
+    const host = {
+      newSession: vi.fn().mockResolvedValueOnce('acp-a').mockResolvedValueOnce('acp-b'),
+      hasSession: vi.fn(() => true)
+    } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const scopeA = 'slack:scope-a'
+    const scopeB = 'slack:scope-b'
+    const keyA = sessionKey('slack', 'C1', '100.1', 'bot-a', scopeA)
+    const keyB = sessionKey('slack', 'C1', '100.1', 'bot-a', scopeB)
+
+    const firstA = await sm.handle('bot-a', msg({ ts: '100.1', text: 'A1', transportScope: scopeA }))
+    const firstB = await sm.handle('bot-a', msg({ ts: '100.2', text: 'B1', transportScope: scopeB }))
+    store.setModelOverride(keyA, 'model-a')
+    store.setSessionMuted(keyA, true)
+    const secondA = await sm.handle('bot-a', msg({ ts: '100.3', text: 'A2', transportScope: scopeA }))
+
+    expect([firstA.sessionId, firstB.sessionId, secondA.sessionId]).toEqual(['acp-a', 'acp-b', 'acp-a'])
+    expect(host.newSession).toHaveBeenCalledTimes(2)
+    expect(store.getSession(keyA)?.acpSessionId).toBe('acp-a')
+    expect(store.getSession(keyB)?.acpSessionId).toBe('acp-b')
+    expect(store.getModelOverride(keyA)).toBe('model-a')
+    expect(store.getModelOverride(keyB)).toBeUndefined()
+    expect(store.isSessionMuted(keyA)).toBe(true)
+    expect(store.isSessionMuted(keyB)).toBe(false)
     store.close()
   })
 
@@ -1127,13 +1158,14 @@ describe('SessionManager', () => {
 })
 
 describe('SessionManager.threadOwner (§7.3 idle→closed thread-affinity revival)', () => {
-  const seed = (store: LocalStore, agentId: string, state: 'idle' | 'closed', thread = 'T1') =>
+  const seed = (store: LocalStore, agentId: string, state: 'idle' | 'closed', thread = 'T1', transportScope?: string) =>
     store.upsertSession({
-      key: sessionKey('slack', 'C1', thread, agentId),
+      key: sessionKey('slack', 'C1', thread, agentId, transportScope),
       agentId,
       platform: 'slack',
       channel: 'C1',
       thread,
+      ...(transportScope ? { transportScope } : {}),
       acpSessionId: `acp-${agentId}`,
       state,
       lastDeliveredTs: null,
@@ -1185,6 +1217,15 @@ describe('SessionManager.threadOwner (§7.3 idle→closed thread-affinity reviva
   it('is null for a thread nobody ever owned', () => {
     const store = newStore()
     expect(sm(store).threadOwner('C1', 'T1')).toBeNull()
+    store.close()
+  })
+
+  it('does not make equal coordinates on another physical bot ambiguous', () => {
+    const store = newStore()
+    seed(store, 'bot-a', 'idle', 'T1', 'slack:scope-a')
+    seed(store, 'bot-b', 'idle', 'T1', 'slack:scope-b')
+    expect(sm(store).threadOwner('C1', 'T1', 'slack:scope-a')).toBe('bot-a')
+    expect(sm(store).threadOwner('C1', 'T1', 'slack:scope-b')).toBe('bot-b')
     store.close()
   })
 })

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
-import { LocalStore, sessionKey } from '../src/store/local-store.js'
+import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { createSessionReader } from '../src/cp/session-reader.js'
 
 const AGENT = '11111111-1111-4111-8111-111111111111'
@@ -28,6 +28,48 @@ function seedHistorySession(s: LocalStore, { platform = 'slack', channel = 'C1',
 }
 
 describe('SessionReader', () => {
+  it('reads only the transcript namespace persisted on the session', () => {
+    const s = store()
+    s.upsertSession({
+      key: sessionKey('telegram', '42', 'dm', AGENT),
+      agentId: AGENT,
+      platform: 'telegram',
+      channel: '42',
+      thread: 'dm',
+      transportScope: 'telegram:bot-b',
+      acpSessionId: 'acp-scoped',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: 1
+    })
+    s.appendTranscript({
+      channel: transcriptChannelKey('42', 'telegram:bot-a'),
+      thread: 'dm',
+      ts: '1',
+      sender: 'user-a',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'private to bot A'
+    })
+    s.appendTranscript({
+      channel: transcriptChannelKey('42', 'telegram:bot-b'),
+      thread: 'dm',
+      ts: '1',
+      sender: 'user-b',
+      recipient: AGENT,
+      kind: 'text',
+      text: 'private to bot B'
+    })
+
+    const history = createSessionReader(s).history({
+      agentId: AGENT,
+      sessionId: 'acp-scoped',
+      limit: 20
+    })
+    expect(history.messages.map((message) => message.text)).toEqual(['private to bot B'])
+    s.close()
+  })
+
   it('list joins cached channel/triggeredBy names; unresolved ids omit the fields', () => {
     const s = store()
     s.upsertSession({

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -131,6 +131,55 @@ describe('gated Telegram conversation discovery', () => {
   })
 })
 
+describe('Telegram ingress attribution', () => {
+  it('routes and deduplicates DMs within the bot connection that received them', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const wrong = (daemon as any).agents.get('bot-a')
+    wrong.integrations = [
+      {
+        id: 'wrong-tg',
+        platform: 'telegram',
+        telegram: {
+          botToken: 'wrong-token',
+          allowedUserIds: [],
+          bindRules: [{ match: { kind: 'dm' } }]
+        }
+      }
+    ]
+    ;(daemon as any).agents.set('target', {
+      ...wrong,
+      id: 'target',
+      name: 'target',
+      integrations: [
+        {
+          id: 'target-tg',
+          platform: 'telegram',
+          telegram: {
+            botToken: 'target-token',
+            allowedUserIds: [],
+            bindRules: [{ channel: '424242', match: { kind: 'dm' } }],
+            gated: true
+          }
+        }
+      ]
+    })
+    const dispatch = vi.spyOn(daemon as any, 'dispatch').mockResolvedValue('acp')
+
+    // Separate bot chats can produce the same normalized chat/message coordinates.
+    // Each physical connection must route only through its own integration and must
+    // not suppress the other bot's event as a duplicate.
+    ;(daemon as any).onInbound(tg(1, { channel: '424242', isDm: true }), ['wrong-tg'])
+    ;(daemon as any).onInbound(tg(1, { channel: '424242', isDm: true }), ['target-tg'])
+
+    expect(dispatch.mock.calls.map(([agentId, , integrationId]) => [agentId, integrationId])).toEqual([
+      ['bot-a', 'wrong-tg'],
+      ['target', 'target-tg']
+    ])
+    await daemon.stop()
+  })
+})
+
 describe('canonicalizeTelegramThread', () => {
   it('roots a fresh group @mention at its own message (tg:<id>)', async () => {
     const daemon = new Daemon({ root: scaffold() })

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -178,6 +178,52 @@ describe('Telegram ingress attribution', () => {
     ])
     await daemon.stop()
   })
+
+  it('keeps a loop-guard trip on one bot from blocking the same DM coordinates on another bot', async () => {
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-b'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async () => 'end_turn'),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    const agent = (daemon as any).agents.get('bot-a')
+    agent.integrations = [
+      {
+        id: 'i-a',
+        platform: 'telegram',
+        telegram: { botToken: '111:a', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      },
+      {
+        id: 'i-b',
+        platform: 'telegram',
+        telegram: { botToken: '222:b', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      }
+    ]
+    const scopeA = (daemon as any).transportScopeForIntegrationIds(['i-a'])
+    const scopeB = (daemon as any).transportScopeForIntegrationIds(['i-b'])
+    ;(daemon as any).store.tripLoopGuard(`telegram:42:dm:${scopeA}`, 1, 'test_loop')
+
+    await expect(
+      (daemon as any).dispatch(
+        'bot-a',
+        tg(1, { channel: '42', thread: 'dm', transportScope: scopeB, isDm: true, headless: true }),
+        'i-b'
+      )
+    ).resolves.toBe('acp-b')
+    await expect(
+      (daemon as any).dispatch(
+        'bot-a',
+        tg(1, { channel: '42', thread: 'dm', transportScope: scopeA, isDm: true, headless: true }),
+        'i-a'
+      )
+    ).resolves.toBeNull()
+    expect(host.prompt).toHaveBeenCalledOnce()
+    await daemon.stop()
+  })
 })
 
 describe('canonicalizeTelegramThread', () => {
@@ -303,6 +349,24 @@ describe('reply-based session continuity (routing)', () => {
     expect(routed).toMatchObject({ agentId: 'bot-a', via: 'thread' })
   })
 
+  it('resolves identical thread coordinates independently on each receiving bot', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    makeScopedTelegramPair(daemon)
+    seedSession(daemon, '-100', 'tg:77', { agentId: 'bot-a', integrationId: 'i-a' })
+    seedSession(daemon, '-100', 'tg:77', { agentId: 'bot-b', integrationId: 'i-b' })
+    const dispatch = vi.spyOn(daemon as any, 'dispatch').mockResolvedValue('acp')
+
+    ;(daemon as any).onInbound(tg(78, { telegramThreadRoot: '77', text: 'follow up A' }), ['i-a'])
+    ;(daemon as any).onInbound(tg(78, { telegramThreadRoot: '77', text: 'follow up B' }), ['i-b'])
+
+    expect(dispatch.mock.calls.map(([agentId, , integrationId]) => [agentId, integrationId])).toEqual([
+      ['bot-a', 'i-a'],
+      ['bot-b', 'i-b']
+    ])
+    await daemon.stop()
+  })
+
   it('a fresh @mention with no reply starts a new, distinct session thread', async () => {
     const daemon = new Daemon({ root: scaffold() })
     await daemon.start()
@@ -342,18 +406,21 @@ function seedSession(
 ) {
   const agentId = opts.agentId ?? 'bot-a'
   const integrationId = opts.integrationId ?? 'i-tg'
+  const transportScope = (daemon as any).transportScopeForIntegrationIds([integrationId])
+  const key = sessionKey('telegram', channel, thread, agentId, transportScope)
   ;(daemon as any).store.upsertSession({
-    key: sessionKey('telegram', channel, thread, agentId),
+    key,
     agentId,
     platform: 'telegram',
     channel,
     thread,
-    transportScope: (daemon as any).transportScopeForIntegrationIds([integrationId]),
+    transportScope,
     acpSessionId: opts.acpSessionId ?? `acp-${agentId}`,
     state: 'idle',
     lastDeliveredTs: null,
     updatedAt: opts.updatedAt ?? Date.now()
   })
+  return key
 }
 
 function makeScopedTelegramPair(daemon: Daemon) {
@@ -493,8 +560,7 @@ describe('session-control cards (/models tappable buttons)', () => {
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
     const conn = makeTelegramRoutable(daemon)
     injectHost(daemon)
-    seedSession(daemon, '-100', 'tg:100')
-    const key = sessionKey('telegram', '-100', 'tg:100', 'bot-a')
+    const key = seedSession(daemon, '-100', 'tg:100')
 
     ;(daemon as any).handleTelegramCallback(
       { id: 'cb1', data: 'm:1', channel: '-100', messageId: 55, userId: 'U1' },
@@ -539,13 +605,13 @@ describe('session-control cards (/models tappable buttons)', () => {
     const conn = makeTelegramRoutable(daemon)
     injectHost(daemon)
     ;(daemon as any).agents.get('bot-a').integrations[0].telegram.allowedUserIds = ['999']
-    seedSession(daemon, '-100', 'tg:100')
+    const key = seedSession(daemon, '-100', 'tg:100')
 
     ;(daemon as any).handleTelegramCallback(
       { id: 'cb2', data: 'm:1', channel: '-100', messageId: 55, userId: 'U1' },
       conn
     )
-    expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:100', 'bot-a'))).toBeUndefined()
+    expect((daemon as any).store.getModelOverride(key)).toBeUndefined()
     expect(conn.answerCallback).toHaveBeenCalledWith('cb2', expect.stringContaining('No active session'))
     expect(conn.editCard).not.toHaveBeenCalled()
   })
@@ -570,12 +636,12 @@ describe('session-control cards (/models tappable buttons)', () => {
     ;(daemon as any).hosts.set('bot-a', host)
     ;(daemon as any).hosts.set('bot-b', host)
     const now = Date.now()
-    seedSession(daemon, '-100', 'tg:a', {
+    const keyA = seedSession(daemon, '-100', 'tg:a', {
       agentId: 'bot-a',
       integrationId: 'i-a',
       updatedAt: now
     })
-    seedSession(daemon, '-100', 'tg:b', {
+    const keyB = seedSession(daemon, '-100', 'tg:b', {
       agentId: 'bot-b',
       integrationId: 'i-b',
       updatedAt: now - 1_000
@@ -586,8 +652,8 @@ describe('session-control cards (/models tappable buttons)', () => {
       connB
     )
 
-    expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:b', 'bot-b'))).toBe('sonnet')
-    expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:a', 'bot-a'))).toBeUndefined()
+    expect((daemon as any).store.getModelOverride(keyB)).toBe('sonnet')
+    expect((daemon as any).store.getModelOverride(keyA)).toBeUndefined()
     expect(connB.answerCallback).toHaveBeenCalledWith('cb-scoped', expect.stringContaining('sonnet'))
     await daemon.stop()
   })

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -321,26 +321,87 @@ describe('reply targeting', () => {
     await daemon.start()
     const conn = makeTelegramRoutable(daemon)
     // A DM `/status` with no live session → the "no session" note, replied to message 900.
-    ;(daemon as any).onInbound(tg(900, { channel: '42', isDm: true, text: '/status' }))
+    ;(daemon as any).onInbound(tg(900, { channel: '42', isDm: true, text: '/status' }), ['i-tg'])
     expect(conn.postMessage).toHaveBeenCalledWith('42', expect.stringContaining('No active session'), 'dm', {
       replyTo: 900
     })
   })
 })
 
-/** Seed an addressable session for bot-a in a channel so command routing can resolve it. */
-function seedSession(daemon: Daemon, channel: string, thread: string) {
+/** Seed an addressable session in one physical Telegram bot scope. */
+function seedSession(
+  daemon: Daemon,
+  channel: string,
+  thread: string,
+  opts: {
+    agentId?: string
+    integrationId?: string
+    acpSessionId?: string
+    updatedAt?: number
+  } = {}
+) {
+  const agentId = opts.agentId ?? 'bot-a'
+  const integrationId = opts.integrationId ?? 'i-tg'
   ;(daemon as any).store.upsertSession({
-    key: sessionKey('telegram', channel, thread, 'bot-a'),
-    agentId: 'bot-a',
+    key: sessionKey('telegram', channel, thread, agentId),
+    agentId,
     platform: 'telegram',
     channel,
     thread,
-    acpSessionId: 'acp-x',
+    transportScope: (daemon as any).transportScopeForIntegrationIds([integrationId]),
+    acpSessionId: opts.acpSessionId ?? `acp-${agentId}`,
     state: 'idle',
     lastDeliveredTs: null,
-    updatedAt: Date.now()
+    updatedAt: opts.updatedAt ?? Date.now()
   })
+}
+
+function makeScopedTelegramPair(daemon: Daemon) {
+  const agentA = (daemon as any).agents.get('bot-a')
+  agentA.integrations = [
+    {
+      id: 'i-a',
+      platform: 'telegram',
+      telegram: {
+        botToken: '111:a',
+        botUsername: 'bota',
+        allowedUserIds: [],
+        bindRules: [{ match: { kind: 'mention' } }]
+      }
+    }
+  ]
+  const agentB = {
+    ...agentA,
+    id: 'bot-b',
+    name: 'bot-b',
+    integrations: [
+      {
+        id: 'i-b',
+        platform: 'telegram',
+        telegram: {
+          botToken: '222:b',
+          botUsername: 'botb',
+          allowedUserIds: [],
+          bindRules: [{ match: { kind: 'mention' } }]
+        }
+      }
+    ]
+  }
+  ;(daemon as any).agents.set('bot-b', agentB)
+  const connection = () => ({
+    postMessage: vi.fn(async () => 'out-1'),
+    postChrome: vi.fn(async () => 'chrome-1'),
+    postCard: vi.fn(async () => 'card-1'),
+    editCard: vi.fn(async () => {}),
+    answerCallback: vi.fn(async () => {})
+  })
+  const connA = connection()
+  const connB = connection()
+  ;(daemon as any).tgConnByIntegration.set('i-a', connA)
+  ;(daemon as any).tgConnByIntegration.set('i-b', connB)
+  ;(daemon as any).botUserIds['i-a'] = 'bota'
+  ;(daemon as any).botUserIds['i-b'] = 'botb'
+  return { agentA, agentB, connA, connB }
 }
 
 describe('group command routing (no mention entity)', () => {
@@ -351,7 +412,7 @@ describe('group command routing (no mention entity)', () => {
     seedSession(daemon, '-100', 'tg:100')
     // A group `/status@mybot`: no mention entity, no reply, not a DM — routeRules can't
     // place it, so it must fall back to the channel's latest session (not be dropped).
-    ;(daemon as any).onInbound(tg(200, { text: '/status@mybot' }))
+    ;(daemon as any).onInbound(tg(200, { text: '/status@mybot' }), ['i-tg'])
     expect(conn.postChrome).toHaveBeenCalled()
     const [ch, , opts] = conn.postChrome.mock.calls.at(-1)!
     expect(ch).toBe('-100')
@@ -365,9 +426,32 @@ describe('group command routing (no mention entity)', () => {
     ;(daemon as any).agents.get('bot-a').integrations[0].telegram.allowedUserIds = ['999']
     seedSession(daemon, '-100', 'tg:100')
     // Sender U1 (id 'U1') is not in the allow-list → the command is ignored.
-    ;(daemon as any).onInbound(tg(200, { text: '/status@mybot' }))
+    ;(daemon as any).onInbound(tg(200, { text: '/status@mybot' }), ['i-tg'])
     expect(conn.postChrome).not.toHaveBeenCalled()
     expect(conn.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('finds the latest eligible session on the bot that received the command', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const { connA, connB } = makeScopedTelegramPair(daemon)
+    const now = Date.now()
+    seedSession(daemon, '-100', 'tg:a', {
+      agentId: 'bot-a',
+      integrationId: 'i-a',
+      updatedAt: now
+    })
+    seedSession(daemon, '-100', 'tg:b', {
+      agentId: 'bot-b',
+      integrationId: 'i-b',
+      updatedAt: now - 1_000
+    })
+
+    ;(daemon as any).onInbound(tg(201, { text: '/status@botb' }), ['i-b'])
+
+    expect(connB.postChrome).toHaveBeenCalled()
+    expect(connA.postChrome).not.toHaveBeenCalled()
+    await daemon.stop()
   })
 })
 
@@ -396,7 +480,7 @@ describe('session-control cards (/models tappable buttons)', () => {
     injectHost(daemon)
     seedSession(daemon, '-100', 'tg:100')
 
-    ;(daemon as any).onInbound(tg(200, { text: '/models@mybot' }))
+    ;(daemon as any).onInbound(tg(200, { text: '/models@mybot' }), ['i-tg'])
     expect(conn.postCard).toHaveBeenCalled()
     const [ch, , buttons] = conn.postCard.mock.calls.at(-1)!
     expect(ch).toBe('-100')
@@ -464,5 +548,47 @@ describe('session-control cards (/models tappable buttons)', () => {
     expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:100', 'bot-a'))).toBeUndefined()
     expect(conn.answerCallback).toHaveBeenCalledWith('cb2', expect.stringContaining('No active session'))
     expect(conn.editCard).not.toHaveBeenCalled()
+  })
+
+  it('applies a callback only to a session owned by the bot that delivered the tap', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const { agentA, agentB, connB } = makeScopedTelegramPair(daemon)
+    agentA.allowRuntimeChangesInChat = true
+    agentB.allowRuntimeChangesInChat = true
+    const host = {
+      hasSession: () => true,
+      modelOptions: () => ({ current: 'opus', models: ['opus', 'sonnet'] }),
+      effortOptions: () => ({ current: 'medium', efforts: ['low', 'medium', 'high'] }),
+      permissionModeOptions: () => ({ current: 'default', modes: ['default', 'plan'] }),
+      fastModeOption: () => null,
+      setSessionModel: vi.fn(async () => true),
+      setSessionEffort: vi.fn(async () => true),
+      setSessionPermissionMode: vi.fn(async () => true),
+      stop: vi.fn(async () => {})
+    }
+    ;(daemon as any).hosts.set('bot-a', host)
+    ;(daemon as any).hosts.set('bot-b', host)
+    const now = Date.now()
+    seedSession(daemon, '-100', 'tg:a', {
+      agentId: 'bot-a',
+      integrationId: 'i-a',
+      updatedAt: now
+    })
+    seedSession(daemon, '-100', 'tg:b', {
+      agentId: 'bot-b',
+      integrationId: 'i-b',
+      updatedAt: now - 1_000
+    })
+
+    ;(daemon as any).handleTelegramCallback(
+      { id: 'cb-scoped', data: 'm:1', channel: '-100', messageId: 55, userId: 'U1' },
+      connB
+    )
+
+    expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:b', 'bot-b'))).toBe('sonnet')
+    expect((daemon as any).store.getModelOverride(sessionKey('telegram', '-100', 'tg:a', 'bot-a'))).toBeUndefined()
+    expect(connB.answerCallback).toHaveBeenCalledWith('cb-scoped', expect.stringContaining('sonnet'))
+    await daemon.stop()
   })
 })


### PR DESCRIPTION
## Summary

- scope direct platform routing and duplicate suppression to the physical bot connection that received the message
- include a stable opaque bot scope in logical session identity, transcripts, runtime tool context, and persisted state
- scope thread affinity, loop protection, command fallbacks, reply lookup, and Telegram callbacks to the receiving bot
- namespace durable inbox and evaluation/memory turn identities by physical bot while preserving same-bot redelivery

## Root cause

Platform conversation and message coordinates are not globally unique across physical bot connections. Direct ingress originally routed against every integration on the platform, while session, transcript, affinity, loop-guard, latest-session, durable-inbox, turn-identity, and callback state used global channel or message coordinates. Equivalent Telegram DM coordinates could therefore route to another agent, reuse another bot's ACP context or sticky state, appear affinity-ambiguous, share a loop circuit, replay private text, suppress a valid event as a duplicate, or alias durable memory/evaluation work.

## Impact

Messages, ACP sessions, queues, durable admissions, sticky controls, conversation history, commands, memory/evaluation turns, and Telegram inline controls now remain within the bot connection that received them. Existing unscoped runtime sessions start clean on their first scoped turn because their prior context cannot be attributed safely; legacy durable rows are adopted in place during replay.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- changed-file Prettier and ESLint checks
- daemon full suite: 2157 passed, 2 skipped
- pre-push `eslint .` completed with two existing warnings and no errors

Created by Codex . GPT-5.6-sol
