### PR TITLE
fix(daemon): collapse Discord threads into channels, collect user names

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -81,6 +81,7 @@ import {
   type InlineButton
 } from './telegram/connection.js'
 import { consolidateDiscord, DiscordConnection } from './discord/connection.js'
+import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channels.js'
 import { consolidateFeishu, FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { splitIntoSections } from './slack/formatter.js'
@@ -1777,14 +1778,25 @@ export class Daemon {
       this.emitSessionMetadataSnapshotsForDisplayName(id)
     }, this.log)
     // Same cache-then-emit sink for Discord/Telegram channel-name resolution.
-    this.channelNameResolver = new ChannelNameResolver((id, name) => {
-      this.store.setDisplayName(id, name, Date.now())
-      this.emitSessionMetadataSnapshotsForDisplayName(id)
-      // A freshly-resolved Telegram/Discord channel name should also refresh that
-      // integration's observed-channel snapshot (approach-A discovery) so the console
-      // shows the human name rather than the raw chat/channel id.
-      this.refreshObservedChannels()
-    }, this.log)
+    this.channelNameResolver = new ChannelNameResolver(
+      (id, name) => {
+        this.store.setDisplayName(id, name, Date.now())
+        this.emitSessionMetadataSnapshotsForDisplayName(id)
+        // A freshly-resolved Telegram/Discord channel name should also refresh that
+        // integration's observed-channel snapshot (approach-A discovery) so the console
+        // shows the human name rather than the raw chat/channel id.
+        this.refreshObservedChannels()
+      },
+      {
+        // A newly-learnt scope changes which rows the observed set collapses onto (a
+        // Discord thread folds into its channel), so re-emit the snapshot with it.
+        saveScope: (id, scope) => {
+          this.store.setChannelScope(id, scope, Date.now())
+          this.refreshObservedChannels()
+        },
+        log: this.log
+      }
+    )
     this.cpRouting = new CpRoutingLayer({
       load: () => {
         const row = this.store.getCpRouting()
@@ -2713,7 +2725,14 @@ export class Daemon {
         group,
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
-          this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
+          // The gateway message already knows where it sits — record it before the
+          // (async, TTL-cached) name lookup so channel discovery can fold this thread
+          // onto its channel on the very first turn.
+          this.noteChannelScope(msg)
+          // Unlike Telegram, Discord CAN resolve an arbitrary user id — collect the
+          // sender's (and mentioned users') display names so session read-back labels
+          // them by name the way Slack does.
+          this.channelNameResolver?.noteMessage(conn, { ...msg, mentionedUserIds: msg.mentionedBots })
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onStatusAction: (a) => this.handleStatusAction(a),
@@ -2862,6 +2881,30 @@ export class Daemon {
   }
 
   /**
+   * Record where an inbound conversation sits (its enclosing channel and space name)
+   * straight from the message, which already carries both — no platform call, and no
+   * waiting on the TTL-cached name lookup. Channel discovery folds a thread onto the
+   * channel it belongs to with it; a message that carries neither is a no-op.
+   */
+  private noteChannelScope(msg: NormalizedMessage): void {
+    if (!msg.parentChannel && !msg.spaceName) return
+    this.store.setChannelScope(
+      msg.channel,
+      {
+        ...(msg.parentChannel ? { parentId: msg.parentChannel } : {}),
+        ...(msg.spaceName ? { spaceName: msg.spaceName } : {})
+      },
+      this.clock.now()
+    )
+    // The enclosing channel is itself a reportable conversation — carry the space onto
+    // it so its own row dedupes on (space, name) too.
+    if (msg.parentChannel && msg.spaceName) {
+      this.store.setChannelScope(msg.parentChannel, { spaceName: msg.spaceName }, this.clock.now())
+    }
+    this.refreshObservedChannels()
+  }
+
+  /**
    * Observed-conversation discovery for Telegram and Discord. These platforms do
    * not give us an authoritative set of chats the bot is engaged in, so stored
    * session history is merged with explicitly-addressed Off conversations already
@@ -2872,6 +2915,9 @@ export class Daemon {
    * here is important for Off conversations: they have no session row, so without
    * preserving and enriching the cached entry an async Telegram getChat result
    * could never replace the console's raw numeric id.
+   *
+   * Discord rows are folded onto the channel they belong to first (a session keys on
+   * the thread, so raw history repeats one channel per thread) — see collapseObserved.
    */
   private refreshObservedChannels(): void {
     for (const agent of this.agents.values()) {
@@ -2883,7 +2929,10 @@ export class Daemon {
         // agent we can't tell which bot saw which session. Only merge session history
         // in the common single-integration case; integration-attributed Off rows can
         // still be refreshed safely when several bots share the agent.
-        const observed = integrations.length === 1 ? this.store.observedChannels(agent.id, platform) : []
+        const observed =
+          integrations.length === 1
+            ? this.collapseObserved(this.store.observedChannels(agent.id, platform), platform)
+            : []
         for (const integ of integrations) {
           const prior = this.channelSnapshots.get(integ.id)?.channels ?? []
           if (observed.length === 0 && prior.length === 0) continue
@@ -2951,6 +3000,23 @@ export class Daemon {
       this.channelSnapshots.set(integrationId, { channels, authoritative: false })
       this.cpClient?.emitIntegrationChannels({ integrationId, channels, authoritative: false })
     }
+  }
+
+  /**
+   * Fold the observed conversations of one platform onto the channel set the console
+   * should offer. Discord sessions key on a THREAD channel (the daemon opens one off
+   * every top-level mention), so the raw observed set repeats the same channel once per
+   * thread — collapse each row onto its enclosing channel and dedupe on
+   * (space, channel name). Telegram chats have neither notion; they pass through.
+   */
+  private collapseObserved(
+    observed: { id: string; name?: string }[],
+    platform: 'telegram' | 'discord'
+  ): { id: string; name?: string }[] {
+    if (platform !== 'discord') return observed
+    const scopes = this.store.getChannelScopes(observed.map((c) => c.id))
+    const names = this.store.getDisplayNames(collapseNameLookupIds(observed, scopes))
+    return collapseDiscordChannels(observed, scopes, names)
   }
 
   /**
@@ -3937,9 +4003,18 @@ export class Daemon {
     const threadId = conn ? await conn.createThread(msg.channel, messageId, discordThreadName(msg.text)) : undefined
     if (threadId) {
       this.log.info(`discord: opened thread ${threadId} for ch=${msg.channel} msg=${messageId}`)
+      // The session is about to key on the thread; record the channel it belongs to (and
+      // its space) NOW, while `msg.channel` still names the parent — channel discovery
+      // then reports this one channel instead of a row per thread we open under it.
+      this.store.setChannelScope(
+        threadId,
+        { parentId: msg.channel, ...(msg.spaceName ? { spaceName: msg.spaceName } : {}) },
+        this.clock.now()
+      )
       // Re-key the turn onto the thread channel (channel == thread == session; see
       // discord/normalize.ts). msgId keeps the original message id → its `ts`, which
       // equals the thread id, so the session treats this message as the thread root.
+      msg.parentChannel = msg.channel
       msg.channel = threadId
       msg.thread = threadId
       // The session now keys on the thread id, not the parent channel the inbound
@@ -6464,7 +6539,8 @@ export class Daemon {
     // Conversation gating (§14): control commands resolve their target OUTSIDE
     // routeRules' scope filter (latest-session fallbacks), so they must repeat the
     // admission check — an Off conversation of a gated integration takes no commands.
-    if (routing.gated && !routing.bindRules.some((r) => r.channel === msg.channel)) return false
+    if (routing.gated && !routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel))
+      return false
     const allowed = routing.allowedUserIds
     return allowed.length === 0 || allowed.includes(msg.sender.id)
   }
@@ -11338,7 +11414,7 @@ export class Daemon {
     const int = this.integrationConfigById(integrationId)
     if (!int) return true // unknown here — agent/integration existence is checked separately
     const routing = integrationRouting(int)
-    return !routing.gated || routing.bindRules.some((r) => r.channel === msg.channel)
+    return !routing.gated || routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel)
   }
 
   /**
@@ -11359,7 +11435,9 @@ export class Daemon {
       if (!int || int.platform !== msg.platform) continue
       const routing = integrationRouting(int)
       if (!routing.gated) continue
-      if (routing.bindRules.some((r) => r.channel === msg.channel)) continue // enabled
+      // Enabled — including a thread of an enabled channel (the rule is scoped to the
+      // enclosing channel, which is what the console offers).
+      if (routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel)) continue
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
       if (!isDm && (botUserId === '' || !msg.mentionedBots.includes(botUserId))) continue
       this.reportGatedConversation(integrationId, msg, isDm)
@@ -11376,8 +11454,9 @@ export class Daemon {
       const routing = integrationRouting(int)
       if (!routing.gated) continue
       // An ENABLED conversation never gets a report/notice — this guard makes the
-      // helper safe from the pre-command call site, which sees every DM.
-      if (routing.bindRules.some((r) => r.channel === msg.channel)) continue
+      // helper safe from the pre-command call site, which sees every DM. A thread of an
+      // enabled channel is enabled too (the rule is scoped to the enclosing channel).
+      if (routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel)) continue
       const botUserId = this.botUserIds[integrationId] ?? routing.staticBotUserId ?? ''
       const addressed = isDm || (botUserId !== '' && msg.mentionedBots.includes(botUserId))
       if (!addressed) continue
@@ -11412,15 +11491,19 @@ export class Daemon {
   private reportGatedConversation(integrationId: string, msg: NormalizedMessage, isDm: boolean): void {
     const cached = this.channelSnapshots.get(integrationId)
     const existing = cached?.channels ?? []
-    const current = existing.find((c) => c.id === msg.channel)
+    // A channel row is reported as the ENCLOSING channel when the message arrived in a
+    // thread: that is the conversation an operator enables, and the one observed
+    // discovery reports (a per-thread row would be a duplicate of it).
+    const channel = (!isDm && msg.parentChannel) || msg.channel
+    const current = existing.find((c) => c.id === channel)
     const kind = isDm ? ('im' as const) : ('channel' as const)
-    const known = this.store.getDisplayNames([msg.channel]).get(msg.channel)
+    const known = this.store.getDisplayNames([channel]).get(channel)
     if (current?.kind === kind && (!known || current.name === known)) return
     // A previously-observed DM (Telegram/Discord session snapshots are kind-less)
     // is upgraded to 'im' rather than skipped after an org→restricted flip.
     const next = current
-      ? existing.map((c) => (c.id === msg.channel ? { ...c, ...(known ? { name: known } : {}), kind } : c))
-      : [...existing, { id: msg.channel, ...(known ? { name: known } : {}), kind }]
+      ? existing.map((c) => (c.id === channel ? { ...c, ...(known ? { name: known } : {}), kind } : c))
+      : [...existing, { id: channel, ...(known ? { name: known } : {}), kind }]
     this.channelSnapshots.set(integrationId, {
       channels: next,
       authoritative: cached?.authoritative ?? false
@@ -11436,7 +11519,7 @@ export class Daemon {
         if (!name) return
         const cached = this.channelSnapshots.get(integrationId)
         const snap = cached?.channels ?? []
-        const updated = snap.map((c) => (c.id === msg.channel && !c.name ? { ...c, name: `@${name}` } : c))
+        const updated = snap.map((c) => (c.id === channel && !c.name ? { ...c, name: `@${name}` } : c))
         this.channelSnapshots.set(integrationId, {
           channels: updated,
           authoritative: cached?.authoritative ?? false

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2881,26 +2881,14 @@ export class Daemon {
   }
 
   /**
-   * Record where an inbound conversation sits (its enclosing channel and space name)
-   * straight from the message, which already carries both — no platform call, and no
-   * waiting on the TTL-cached name lookup. Channel discovery folds a thread onto the
-   * channel it belongs to with it; a message that carries neither is a no-op.
+   * Record the enclosing channel of an inbound conversation straight from the message,
+   * which already carries it — no platform call, and no waiting on the TTL-cached name
+   * lookup. Channel discovery folds a thread onto the channel it belongs to with it; a
+   * message that carries none is a no-op.
    */
   private noteChannelScope(msg: NormalizedMessage): void {
-    if (!msg.parentChannel && !msg.spaceName) return
-    this.store.setChannelScope(
-      msg.channel,
-      {
-        ...(msg.parentChannel ? { parentId: msg.parentChannel } : {}),
-        ...(msg.spaceName ? { spaceName: msg.spaceName } : {})
-      },
-      this.clock.now()
-    )
-    // The enclosing channel is itself a reportable conversation — carry the space onto
-    // it so its own row dedupes on (space, name) too.
-    if (msg.parentChannel && msg.spaceName) {
-      this.store.setChannelScope(msg.parentChannel, { spaceName: msg.spaceName }, this.clock.now())
-    }
+    if (!msg.parentChannel) return
+    this.store.setChannelScope(msg.channel, { parentId: msg.parentChannel }, this.clock.now())
     this.refreshObservedChannels()
   }
 
@@ -4006,11 +3994,7 @@ export class Daemon {
       // The session is about to key on the thread; record the channel it belongs to (and
       // its space) NOW, while `msg.channel` still names the parent — channel discovery
       // then reports this one channel instead of a row per thread we open under it.
-      this.store.setChannelScope(
-        threadId,
-        { parentId: msg.channel, ...(msg.spaceName ? { spaceName: msg.spaceName } : {}) },
-        this.clock.now()
-      )
+      this.store.setChannelScope(threadId, { parentId: msg.channel }, this.clock.now())
       // Re-key the turn onto the thread channel (channel == thread == session; see
       // discord/normalize.ts). msgId keeps the original message id → its `ts`, which
       // equals the thread id, so the session treats this message as the thread root.

--- a/packages/daemon/src/discord/channels.ts
+++ b/packages/daemon/src/discord/channels.ts
@@ -9,19 +9,17 @@
  * labelled with the same enclosing channel name ("#general" ×3).
  *
  * Fold each observed id onto its enclosing channel (LocalStore `channel_scopes`, learnt
- * from the inbound message and from the channel-name lookup) and dedupe on
- * **(space, channel name)** — the guild plus the channel name — so the same channel
- * reported under two ids collapses while same-named channels in two different guilds
- * stay separate rows. Rows with no known space (DM conversations, and channels whose
- * scope hasn't been resolved yet) dedupe on id alone, which is the only key that can't
- * merge two genuinely different conversations.
+ * from the inbound message and from the channel-name lookup) and dedupe on the resulting
+ * channel SNOWFLAKE. Identity is deliberately never the display name: Discord permits
+ * two distinct channels of one guild to carry the same name, so a (guild, name) key
+ * would silently hide one of them from the console and make its trigger unconfigurable.
+ * An id whose scope isn't known yet therefore stays a row of its own until the lookup
+ * resolves its parent — a transient duplicate is recoverable, a hidden channel is not.
  */
 
 export interface ChannelScope {
   /** Enclosing channel id when this id is a thread. */
   parentId?: string
-  /** Guild ("server") display name. */
-  spaceName?: string
 }
 
 /**
@@ -38,18 +36,12 @@ export function collapseDiscordChannels(
   const out: { id: string; name?: string }[] = []
   const seen = new Set<string>()
   for (const c of observed) {
-    const scope = scopes.get(c.id)
-    const id = scope?.parentId ?? c.id
+    const id = scopes.get(c.id)?.parentId ?? c.id
+    if (seen.has(id)) continue
+    seen.add(id)
     // A thread row already carries its parent's name (the resolver labels a thread with
     // the enclosing channel), so the observed label is a sound fallback either way.
     const name = displayNames.get(id) ?? c.name
-    const byId = `i:${id}`
-    // Length-prefixed so a space name containing the separator cannot forge another
-    // space's key.
-    const key = scope?.spaceName && name ? `s:${scope.spaceName.length}:${scope.spaceName}/${name}` : byId
-    if (seen.has(key) || seen.has(byId)) continue
-    seen.add(key)
-    seen.add(byId)
     out.push({ id, ...(name ? { name } : {}) })
   }
   return out

--- a/packages/daemon/src/discord/channels.ts
+++ b/packages/daemon/src/discord/channels.ts
@@ -1,0 +1,68 @@
+/**
+ * Collapsing observed Discord conversations into the channel set the console shows.
+ *
+ * A Discord session keys on the concrete channel a message arrived in — which is the
+ * THREAD's own id whenever the bot answers in a thread (see discord/normalize.ts), and
+ * the daemon opens a thread off every top-level @mention. Approach-A discovery
+ * (daemon.refreshObservedChannels) derives the reachable set from that session history,
+ * so a channel the bot has been mentioned in three times surfaced as three rows, all
+ * labelled with the same enclosing channel name ("#general" ×3).
+ *
+ * Fold each observed id onto its enclosing channel (LocalStore `channel_scopes`, learnt
+ * from the inbound message and from the channel-name lookup) and dedupe on
+ * **(space, channel name)** — the guild plus the channel name — so the same channel
+ * reported under two ids collapses while same-named channels in two different guilds
+ * stay separate rows. Rows with no known space (DM conversations, and channels whose
+ * scope hasn't been resolved yet) dedupe on id alone, which is the only key that can't
+ * merge two genuinely different conversations.
+ */
+
+export interface ChannelScope {
+  /** Enclosing channel id when this id is a thread. */
+  parentId?: string
+  /** Guild ("server") display name. */
+  spaceName?: string
+}
+
+/**
+ * Pure: observed conversations (newest-first) → the deduped channel set, order
+ * preserved and newest occurrence winning. `scopes` and `displayNames` are the
+ * LocalStore lookups keyed by conversation id; the enclosing channel's own cached
+ * name wins over the observed row's label when present.
+ */
+export function collapseDiscordChannels(
+  observed: { id: string; name?: string }[],
+  scopes: Map<string, ChannelScope>,
+  displayNames: Map<string, string>
+): { id: string; name?: string }[] {
+  const out: { id: string; name?: string }[] = []
+  const seen = new Set<string>()
+  for (const c of observed) {
+    const scope = scopes.get(c.id)
+    const id = scope?.parentId ?? c.id
+    // A thread row already carries its parent's name (the resolver labels a thread with
+    // the enclosing channel), so the observed label is a sound fallback either way.
+    const name = displayNames.get(id) ?? c.name
+    const byId = `i:${id}`
+    // Length-prefixed so a space name containing the separator cannot forge another
+    // space's key.
+    const key = scope?.spaceName && name ? `s:${scope.spaceName.length}:${scope.spaceName}/${name}` : byId
+    if (seen.has(key) || seen.has(byId)) continue
+    seen.add(key)
+    seen.add(byId)
+    out.push({ id, ...(name ? { name } : {}) })
+  }
+  return out
+}
+
+/** Every id whose cached display name the collapse needs — the observed ids plus the
+ *  enclosing channels they fold onto. */
+export function collapseNameLookupIds(observed: { id: string }[], scopes: Map<string, ChannelScope>): string[] {
+  const ids: string[] = []
+  for (const c of observed) {
+    ids.push(c.id)
+    const parent = scopes.get(c.id)?.parentId
+    if (parent) ids.push(parent)
+  }
+  return ids
+}

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -320,7 +320,6 @@ export class DiscordConnection {
       ...(interaction.channel?.isThread() && interaction.channel.parentId
         ? { parentChannelId: interaction.channel.parentId }
         : {}),
-      ...(interaction.guild?.name ? { guildName: interaction.guild.name } : {}),
       attachments: []
     }
   }
@@ -342,7 +341,6 @@ export class DiscordConnection {
         [...message.mentions.users.values()].map((u) => [u.id, u.globalName ?? u.username])
       ),
       ...(message.channel.isThread() && message.channel.parentId ? { parentChannelId: message.channel.parentId } : {}),
-      ...(message.guild?.name ? { guildName: message.guild.name } : {}),
       attachments: [...message.attachments.values()].map((a) => ({
         id: a.id,
         name: a.name,
@@ -610,7 +608,6 @@ export class DiscordConnection {
     isPrivate?: boolean
     parentId?: string
     parentName?: string
-    spaceName?: string
   }> {
     const ch = await this.client.channels.fetch(channel).catch(() => null)
     const c = ch as
@@ -619,7 +616,6 @@ export class DiscordConnection {
           isDMBased?: () => boolean
           isThread?: () => boolean
           parentId?: string | null
-          guild?: { name?: string } | null
         })
       | null
     const isIm = typeof c?.isDMBased === 'function' ? c.isDMBased() : false
@@ -633,7 +629,6 @@ export class DiscordConnection {
       ...(c?.name ? { name: c.name } : {}),
       ...(parentId ? { parentId } : {}),
       ...(parentName ? { parentName } : {}),
-      ...(c?.guild?.name ? { spaceName: c.guild.name } : {}),
       isIm,
       // A guild channel's visibility depends on role overwrites we don't resolve here;
       // treat non-DM guild channels as non-private best-effort.

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -317,6 +317,10 @@ export class DiscordConnection {
       inGuild: interaction.inGuild(),
       isThread: interaction.channel?.isThread() ?? false,
       mentionUserIds: [],
+      ...(interaction.channel?.isThread() && interaction.channel.parentId
+        ? { parentChannelId: interaction.channel.parentId }
+        : {}),
+      ...(interaction.guild?.name ? { guildName: interaction.guild.name } : {}),
       attachments: []
     }
   }
@@ -332,6 +336,13 @@ export class DiscordConnection {
       inGuild: message.inGuild(),
       isThread: message.channel.isThread(),
       mentionUserIds: [...message.mentions.users.keys()],
+      // The gateway ships the mentioned users inline — humanize `<@id>` to a real
+      // handle without any extra REST call.
+      mentionUserNames: Object.fromEntries(
+        [...message.mentions.users.values()].map((u) => [u.id, u.globalName ?? u.username])
+      ),
+      ...(message.channel.isThread() && message.channel.parentId ? { parentChannelId: message.channel.parentId } : {}),
+      ...(message.guild?.name ? { guildName: message.guild.name } : {}),
       attachments: [...message.attachments.values()].map((a) => ({
         id: a.id,
         name: a.name,
@@ -597,21 +608,32 @@ export class DiscordConnection {
     name?: string
     isIm?: boolean
     isPrivate?: boolean
+    parentId?: string
     parentName?: string
+    spaceName?: string
   }> {
     const ch = await this.client.channels.fetch(channel).catch(() => null)
     const c = ch as
-      | (Channel & { name?: string; isDMBased?: () => boolean; isThread?: () => boolean; parentId?: string | null })
+      | (Channel & {
+          name?: string
+          isDMBased?: () => boolean
+          isThread?: () => boolean
+          parentId?: string | null
+          guild?: { name?: string } | null
+        })
       | null
     const isIm = typeof c?.isDMBased === 'function' ? c.isDMBased() : false
     // A thread's own name is the turn title the bot generated; readers that want the
-    // enclosing channel ("#general") get it as `parentName`.
-    const parentName =
-      typeof c?.isThread === 'function' && c.isThread() && c.parentId ? await this.channelName(c.parentId) : undefined
+    // enclosing channel ("#general") get it as `parentId`/`parentName`.
+    const isThread = typeof c?.isThread === 'function' && c.isThread()
+    const parentId = isThread && c?.parentId ? c.parentId : undefined
+    const parentName = parentId ? await this.channelName(parentId) : undefined
     return {
       id: channel,
       ...(c?.name ? { name: c.name } : {}),
+      ...(parentId ? { parentId } : {}),
       ...(parentName ? { parentName } : {}),
+      ...(c?.guild?.name ? { spaceName: c.guild.name } : {}),
       isIm,
       // A guild channel's visibility depends on role overwrites we don't resolve here;
       // treat non-DM guild channels as non-private best-effort.

--- a/packages/daemon/src/discord/normalize.ts
+++ b/packages/daemon/src/discord/normalize.ts
@@ -47,6 +47,14 @@ export interface DiscordMessageLike {
   isThread: boolean
   /** Ids of every user mentioned (`<@id>` / `<@!id>`). */
   mentionUserIds: string[]
+  /** Display name per mentioned user id, from the gateway message's own mention cache
+   *  — so the humanized text (and the session title derived from it) reads "@alice"
+   *  rather than the raw snowflake. Ids missing here stay as `@id`. */
+  mentionUserNames?: Record<string, string>
+  /** Enclosing channel id when `channelId` is a thread (null/absent otherwise). */
+  parentChannelId?: string | null
+  /** Guild ("server") display name; absent in a DM. */
+  guildName?: string | null
   attachments: DiscordAttachmentLike[]
 }
 
@@ -66,22 +74,23 @@ export function toAttachment(a: DiscordAttachmentLike | null | undefined): Attac
 /**
  * Humanize Discord's inline entity tokens so the agent sees readable text rather
  * than raw markup — the analog of the leading '@' / entity handling Telegram does
- * via message entities. Pure (no user/role/channel name cache), so ids that can't
- * be resolved to names are left as compact `@id` / `#id` / `:name:` forms:
- *   `<@id>` / `<@!id>`     → `@id`      (user mention)
+ * via message entities. Pure: user mentions resolve through the caller-supplied
+ * `userNames` (the gateway message's own mention cache), and anything unresolved is
+ * left as a compact `@id` / `#id` / `:name:` form:
+ *   `<@id>` / `<@!id>`     → `@alice`   (user mention; `@id` when the name is unknown)
  *   `<@&roleid>`           → `@&roleid` (role mention)
  *   `<#chanid>`            → `#chanid`  (channel mention)
  *   `<a?:name:id>`         → `:name:`   (custom / animated emoji)
  *   `<t:unix(:style)?>`    → ISO-8601   (Discord timestamp)
  */
-export function humanizeDiscordText(text: string): string {
+export function humanizeDiscordText(text: string, userNames?: Record<string, string>): string {
   return text
     .replace(/<a?:(\w+):\d+>/g, ':$1:')
     .replace(/<t:(\d+)(?::[a-zA-Z])?>/g, (_m, unix: string) => {
       const d = new Date(Number(unix) * 1000)
       return Number.isFinite(d.getTime()) ? d.toISOString() : _m
     })
-    .replace(/<@!?(\d+)>/g, '@$1')
+    .replace(/<@!?(\d+)>/g, (_m, id: string) => `@${userNames?.[id] ?? id}`)
     .replace(/<@&(\d+)>/g, '@&$1')
     .replace(/<#(\d+)>/g, '#$1')
 }
@@ -99,10 +108,15 @@ export function normalizeDiscordMessage(msg: DiscordMessageLike, ctx: { traceId:
     // Discord channel (incl. a thread channel) == conversation == session (see header).
     thread: msg.channelId,
     sender: { id: msg.authorId, isBot: msg.authorIsBot },
-    text: humanizeDiscordText(msg.content),
+    text: humanizeDiscordText(msg.content, msg.mentionUserNames),
     mentionedBots: msg.mentionUserIds,
     ...(attachments.length ? { attachments } : {}),
     isDm,
+    // The enclosing channel of a thread message: the reachable CHANNEL this
+    // conversation belongs to, where the session keys on the thread (see header).
+    // Channel-scoped routing/gating and channel discovery both key on it.
+    ...(msg.isThread && msg.parentChannelId ? { parentChannel: msg.parentChannelId } : {}),
+    ...(msg.guildName ? { spaceName: msg.guildName } : {}),
     // Top-level guild message → the daemon opens a thread off it and re-keys the turn.
     ...(!isDm && !msg.isThread ? { discordTopLevel: true } : {})
   }

--- a/packages/daemon/src/discord/normalize.ts
+++ b/packages/daemon/src/discord/normalize.ts
@@ -53,8 +53,6 @@ export interface DiscordMessageLike {
   mentionUserNames?: Record<string, string>
   /** Enclosing channel id when `channelId` is a thread (null/absent otherwise). */
   parentChannelId?: string | null
-  /** Guild ("server") display name; absent in a DM. */
-  guildName?: string | null
   attachments: DiscordAttachmentLike[]
 }
 
@@ -116,7 +114,6 @@ export function normalizeDiscordMessage(msg: DiscordMessageLike, ctx: { traceId:
     // conversation belongs to, where the session keys on the thread (see header).
     // Channel-scoped routing/gating and channel discovery both key on it.
     ...(msg.isThread && msg.parentChannelId ? { parentChannel: msg.parentChannelId } : {}),
-    ...(msg.guildName ? { spaceName: msg.guildName } : {}),
     // Top-level guild message → the daemon opens a thread off it and re-keys the turn.
     ...(!isDm && !msg.isThread ? { discordTopLevel: true } : {})
   }

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -12,8 +12,12 @@ export interface ChannelInfoSource {
     name?: string
     isIm?: boolean
     isPrivate?: boolean
+    /** Enclosing channel id when `channel` is itself a thread (Discord). */
+    parentId?: string
     /** Enclosing channel name when `channel` is itself a thread (Discord). */
     parentName?: string
+    /** Space ("server"/guild) display name the conversation lives in. */
+    spaceName?: string
   }>
   getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
 }
@@ -41,15 +45,36 @@ const OK_TTL_MS = 6 * 60 * 60 * 1000 // re-check successful lookups (renames) ev
 const FAIL_TTL_MS = 10 * 60 * 1000 // retry failed lookups (rate limit / outage) after 10min
 const MAX_TRACKED_IDS = 5000 // attempt-cache cap (oldest-evicted)
 
+/** Where a conversation sits — reported alongside its name so the daemon can fold a
+ *  thread onto its enclosing channel and keep same-named channels of different spaces
+ *  apart (see discord/channels.ts). */
+export interface ResolvedChannelScope {
+  parentId?: string
+  spaceName?: string
+}
+
+export interface ChannelNameResolverOpts {
+  /** Sink for the conversation's scope, saved next to its display name. */
+  saveScope?: (id: string, scope: ResolvedChannelScope) => void
+  log?: Logger
+  now?: () => number
+}
+
 export class ChannelNameResolver {
   /** channel id → epoch ms until which we won't re-attempt a lookup. */
   private nextAttemptAt = new Map<string, number>()
+  private saveScope?: (id: string, scope: ResolvedChannelScope) => void
+  private log?: Logger
+  private now: () => number
 
   constructor(
     private save: (id: string, name: string) => void,
-    private log?: Logger,
-    private now: () => number = Date.now
-  ) {}
+    opts: ChannelNameResolverOpts = {}
+  ) {
+    this.saveScope = opts.saveScope
+    this.log = opts.log
+    this.now = opts.now ?? Date.now
+  }
 
   /**
    * Kick off (cached) resolution for one channel id against its owning connection.
@@ -58,6 +83,22 @@ export class ChannelNameResolver {
    */
   noteChannel(src: ChannelInfoSource, channel: string, triggeredBy?: string): void {
     void this.resolveChannel(src, channel, triggeredBy)
+  }
+
+  /**
+   * Kick off (cached) resolution for a whole inbound message: its channel plus the
+   * human sender and everyone they mentioned — so session read-back can label the
+   * triggering user by name instead of a raw platform id (Slack-parity, where
+   * SlackNameResolver.noteMessage does the same over the Web API). Bot senders are
+   * skipped: agent-authored frames are labelled by agentId upstream.
+   */
+  noteMessage(
+    src: ChannelInfoSource,
+    msg: { channel: string; sender: { id: string; isBot: boolean }; mentionedUserIds?: string[] }
+  ): void {
+    void this.resolveChannel(src, msg.channel, msg.sender.id)
+    if (!msg.sender.isBot) void this.resolveUser(src, msg.sender.id)
+    for (const id of msg.mentionedUserIds ?? []) void this.resolveUser(src, id)
   }
 
   private claim(id: string): boolean {
@@ -80,6 +121,16 @@ export class ChannelNameResolver {
     if (!this.claim(channel)) return
     try {
       const info = await src.getChannelInfo(channel)
+      // Where the conversation sits: a thread folds onto its enclosing channel, and the
+      // space name keeps two guilds' "#general" apart in channel discovery. Saved before
+      // the name so a nameless lookup still contributes the scope.
+      this.saveScope?.(channel, {
+        ...(info.parentId ? { parentId: info.parentId } : {}),
+        ...(info.spaceName ? { spaceName: info.spaceName } : {})
+      })
+      // The enclosing channel is a reportable conversation of its own (channel discovery
+      // labels the folded row from it) — cache its name under ITS id too.
+      if (info.parentId && info.parentName) this.save(info.parentId, info.parentName)
       // A named channel/group is saved bare (the console prefixes "#"); a DM that carries
       // its own handle (a Telegram @username) is saved "@name" so readers can tell it apart.
       // A Discord session keys on the THREAD id, whose own name is the turn's title — label
@@ -101,6 +152,21 @@ export class ChannelNameResolver {
     } catch (err) {
       this.nextAttemptAt.set(channel, this.now() + FAIL_TTL_MS)
       this.log?.debug(`name lookup failed for channel ${channel}: ${(err as Error).message}`)
+    }
+  }
+
+  /** Cache one user id's display name (Slack-parity `resolveUser`). Platforms whose bot
+   *  API can't resolve arbitrary users just return a nameless profile — the attempt is
+   *  still cached, so the miss costs one call per TTL. */
+  private async resolveUser(src: ChannelInfoSource, user: string): Promise<void> {
+    if (!this.claim(user)) return
+    try {
+      const p = await src.getUserProfile(user)
+      const name = p.realName || p.name
+      if (name) this.save(user, name)
+    } catch (err) {
+      this.nextAttemptAt.set(user, this.now() + FAIL_TTL_MS)
+      this.log?.debug(`name lookup failed for user ${user}: ${(err as Error).message}`)
     }
   }
 }

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -16,8 +16,6 @@ export interface ChannelInfoSource {
     parentId?: string
     /** Enclosing channel name when `channel` is itself a thread (Discord). */
     parentName?: string
-    /** Space ("server"/guild) display name the conversation lives in. */
-    spaceName?: string
   }>
   getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
 }
@@ -46,11 +44,9 @@ const FAIL_TTL_MS = 10 * 60 * 1000 // retry failed lookups (rate limit / outage)
 const MAX_TRACKED_IDS = 5000 // attempt-cache cap (oldest-evicted)
 
 /** Where a conversation sits — reported alongside its name so the daemon can fold a
- *  thread onto its enclosing channel and keep same-named channels of different spaces
- *  apart (see discord/channels.ts). */
+ *  thread onto the enclosing channel it belongs to (see discord/channels.ts). */
 export interface ResolvedChannelScope {
   parentId?: string
-  spaceName?: string
 }
 
 export interface ChannelNameResolverOpts {
@@ -121,13 +117,10 @@ export class ChannelNameResolver {
     if (!this.claim(channel)) return
     try {
       const info = await src.getChannelInfo(channel)
-      // Where the conversation sits: a thread folds onto its enclosing channel, and the
-      // space name keeps two guilds' "#general" apart in channel discovery. Saved before
-      // the name so a nameless lookup still contributes the scope.
-      this.saveScope?.(channel, {
-        ...(info.parentId ? { parentId: info.parentId } : {}),
-        ...(info.spaceName ? { spaceName: info.spaceName } : {})
-      })
+      // Where the conversation sits: a thread folds onto its enclosing channel in
+      // channel discovery. Saved before the name so a nameless lookup still contributes
+      // the scope.
+      if (info.parentId) this.saveScope?.(channel, { parentId: info.parentId })
       // The enclosing channel is a reportable conversation of its own (channel discovery
       // labels the folded row from it) — cache its name under ITS id too.
       if (info.parentId && info.parentName) this.save(info.parentId, info.parentName)

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -83,6 +83,20 @@ export interface NormalizedMessage {
    * flooding the channel (Slack-parity). Absent for DMs and in-thread messages.
    */
   discordTopLevel?: boolean
+  /**
+   * The enclosing CHANNEL when `channel` is itself a thread conversation (Discord: a
+   * session keys on the thread's own channel id). Channel-scoped routing rules and
+   * conversation gating match it as well as `channel`, so a trigger set on "#general"
+   * governs the threads the bot opens under it — and channel discovery reports the
+   * enclosing channel rather than one row per thread. Absent outside a thread.
+   */
+  parentChannel?: string
+  /**
+   * Display name of the SPACE the conversation lives in (a Discord guild / "server").
+   * Metadata only: it disambiguates same-named channels across spaces. Absent in DMs
+   * and on platforms with a single implicit space.
+   */
+  spaceName?: string
   /** Trusted activation cause when known. In particular, `mention` means the router
    *  matched a raw platform token against this integration's own bound bot identity. */
   trigger?: 'mention' | 'dm' | 'keyword' | 'auto' | 'cron' | 'hook'

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -91,12 +91,6 @@ export interface NormalizedMessage {
    * enclosing channel rather than one row per thread. Absent outside a thread.
    */
   parentChannel?: string
-  /**
-   * Display name of the SPACE the conversation lives in (a Discord guild / "server").
-   * Metadata only: it disambiguates same-named channels across spaces. Absent in DMs
-   * and on platforms with a single implicit space.
-   */
-  spaceName?: string
   /** Trusted activation cause when known. In particular, `mention` means the router
    *  matched a raw platform token against this integration's own bound bot identity. */
   trigger?: 'mention' | 'dm' | 'keyword' | 'auto' | 'cron' | 'hook'

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -5,16 +5,24 @@ import type { RoutingRule } from './routing-rule.js'
 
 const KIND_ORDER = ['mention', 'dm', 'keyword', 'auto'] as const
 
+/**
+ * Does a rule's channel scope cover this message? A channel-scoped rule also serves the
+ * threads INSIDE that channel: a Discord session keys on the thread's own channel id, so
+ * a trigger the operator set on "#general" would otherwise stop applying the moment the
+ * bot opens a thread there. Every channel-scope comparison in the ladder goes through
+ * here — the scope filter AND the CP-override check — so the two can't disagree.
+ */
+function channelInScope(scopeChannel: string | undefined, msg: NormalizedMessage): boolean {
+  if (scopeChannel === undefined) return true
+  return scopeChannel === msg.channel || scopeChannel === msg.parentChannel
+}
+
 function scopeMatches(r: RoutingRule, msg: NormalizedMessage): boolean {
   // A platform-tagged rule only serves its own platform, so an unscoped Slack
   // `dm`/`auto` rule can't route a Telegram message (and vice-versa). Undefined
   // platform (legacy/tests) matches any.
   if (r.platform !== undefined && r.platform !== msg.platform) return false
-  // A channel-scoped rule also serves the threads INSIDE that channel: a Discord
-  // session keys on the thread's own channel id, so a trigger the operator set on
-  // "#general" would otherwise stop applying the moment the bot opens a thread there.
-  if (r.scope.channel !== undefined && r.scope.channel !== msg.channel && r.scope.channel !== msg.parentChannel)
-    return false
+  if (!channelInScope(r.scope.channel, msg)) return false
   if (r.scope.thread !== undefined && r.scope.thread !== msg.thread) return false
   return true
 }
@@ -100,10 +108,13 @@ export function routeRules(
   }
 
   // 3. CP per-sessionKey override (§8.3: CP authoritative).
+  // A rule scoped to the channel this message sits in (its enclosing channel counts —
+  // same predicate as the scope filter), NOT an unscoped global CP rule.
   const cpInChannel = kindCandidates.some(
     (r) =>
       r.source === 'cp' &&
-      r.scope.channel === msg.channel &&
+      r.scope.channel !== undefined &&
+      channelInScope(r.scope.channel, msg) &&
       (r.scope.thread === undefined || r.scope.thread === msg.thread)
   )
   const layer = cpInChannel ? kindCandidates.filter((r) => r.source === 'cp') : kindCandidates

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -10,7 +10,11 @@ function scopeMatches(r: RoutingRule, msg: NormalizedMessage): boolean {
   // `dm`/`auto` rule can't route a Telegram message (and vice-versa). Undefined
   // platform (legacy/tests) matches any.
   if (r.platform !== undefined && r.platform !== msg.platform) return false
-  if (r.scope.channel !== undefined && r.scope.channel !== msg.channel) return false
+  // A channel-scoped rule also serves the threads INSIDE that channel: a Discord
+  // session keys on the thread's own channel id, so a trigger the operator set on
+  // "#general" would otherwise stop applying the moment the bot opens a thread there.
+  if (r.scope.channel !== undefined && r.scope.channel !== msg.channel && r.scope.channel !== msg.parentChannel)
+    return false
   if (r.scope.thread !== undefined && r.scope.thread !== msg.thread) return false
   return true
 }

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -439,6 +439,14 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS display_names (
         id TEXT PRIMARY KEY, name TEXT NOT NULL, updatedAt INTEGER
       );
+      -- Where a conversation id SITS: its enclosing channel (a Discord thread's parent
+      -- channel — a session keys on the thread id, so the reachable channel it belongs
+      -- to is otherwise unrecoverable) and its space (the Discord guild / "server"
+      -- name). Backs observed-channel collapsing: threads fold into their channel, and
+      -- (space, name) is the uniqueness key of a reported channel row.
+      CREATE TABLE IF NOT EXISTS channel_scopes (
+        id TEXT PRIMARY KEY, parentId TEXT, spaceName TEXT, updatedAt INTEGER
+      );
       CREATE TABLE IF NOT EXISTS permission_requests (
         id TEXT PRIMARY KEY,
         agentId TEXT NOT NULL,
@@ -2134,6 +2142,40 @@ export class LocalStore {
       .prepare(`SELECT id, name FROM display_names WHERE id IN (${unique.map(() => '?').join(',')})`)
       .all(...unique) as unknown as { id: string; name: string }[]
     for (const r of rows) if (r.name) out.set(r.id, r.name)
+    return out
+  }
+
+  /** Record where a conversation id sits — its enclosing channel and/or its space
+   *  (guild) name. Field-wise latest-wins: a partial note (only a parent, only a
+   *  space) never clears what another lookup already established. */
+  setChannelScope(id: string, scope: { parentId?: string; spaceName?: string }, updatedAt: number): void {
+    if (scope.parentId === undefined && scope.spaceName === undefined) return
+    this.db
+      .prepare(
+        `INSERT INTO channel_scopes (id, parentId, spaceName, updatedAt) VALUES (?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           parentId = COALESCE(excluded.parentId, channel_scopes.parentId),
+           spaceName = COALESCE(excluded.spaceName, channel_scopes.spaceName),
+           updatedAt = excluded.updatedAt`
+      )
+      .run(id, scope.parentId ?? null, scope.spaceName ?? null, updatedAt)
+  }
+
+  /** Scopes for a set of conversation ids — only the ids that have one. One batched
+   *  `IN (…)` query, not a round-trip per id (mirrors getDisplayNames). */
+  getChannelScopes(ids: string[]): Map<string, { parentId?: string; spaceName?: string }> {
+    const out = new Map<string, { parentId?: string; spaceName?: string }>()
+    const unique = [...new Set(ids)]
+    if (unique.length === 0) return out
+    const rows = this.db
+      .prepare(`SELECT id, parentId, spaceName FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
+      .all(...unique) as unknown as { id: string; parentId: string | null; spaceName: string | null }[]
+    for (const r of rows) {
+      out.set(r.id, {
+        ...(r.parentId ? { parentId: r.parentId } : {}),
+        ...(r.spaceName ? { spaceName: r.spaceName } : {})
+      })
+    }
     return out
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -441,11 +441,10 @@ export class LocalStore {
       );
       -- Where a conversation id SITS: its enclosing channel (a Discord thread's parent
       -- channel — a session keys on the thread id, so the reachable channel it belongs
-      -- to is otherwise unrecoverable) and its space (the Discord guild / "server"
-      -- name). Backs observed-channel collapsing: threads fold into their channel, and
-      -- (space, name) is the uniqueness key of a reported channel row.
+      -- to is otherwise unrecoverable). Backs observed-channel collapsing: threads fold
+      -- onto their channel, whose snowflake is the uniqueness key of a reported row.
       CREATE TABLE IF NOT EXISTS channel_scopes (
-        id TEXT PRIMARY KEY, parentId TEXT, spaceName TEXT, updatedAt INTEGER
+        id TEXT PRIMARY KEY, parentId TEXT, updatedAt INTEGER
       );
       CREATE TABLE IF NOT EXISTS permission_requests (
         id TEXT PRIMARY KEY,
@@ -2145,37 +2144,28 @@ export class LocalStore {
     return out
   }
 
-  /** Record where a conversation id sits — its enclosing channel and/or its space
-   *  (guild) name. Field-wise latest-wins: a partial note (only a parent, only a
-   *  space) never clears what another lookup already established. */
-  setChannelScope(id: string, scope: { parentId?: string; spaceName?: string }, updatedAt: number): void {
-    if (scope.parentId === undefined && scope.spaceName === undefined) return
+  /** Record where a conversation id sits — the channel enclosing it. Latest-wins; an
+   *  empty note writes nothing. */
+  setChannelScope(id: string, scope: { parentId?: string }, updatedAt: number): void {
+    if (scope.parentId === undefined) return
     this.db
       .prepare(
-        `INSERT INTO channel_scopes (id, parentId, spaceName, updatedAt) VALUES (?, ?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET
-           parentId = COALESCE(excluded.parentId, channel_scopes.parentId),
-           spaceName = COALESCE(excluded.spaceName, channel_scopes.spaceName),
-           updatedAt = excluded.updatedAt`
+        `INSERT INTO channel_scopes (id, parentId, updatedAt) VALUES (?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET parentId = excluded.parentId, updatedAt = excluded.updatedAt`
       )
-      .run(id, scope.parentId ?? null, scope.spaceName ?? null, updatedAt)
+      .run(id, scope.parentId, updatedAt)
   }
 
   /** Scopes for a set of conversation ids — only the ids that have one. One batched
    *  `IN (…)` query, not a round-trip per id (mirrors getDisplayNames). */
-  getChannelScopes(ids: string[]): Map<string, { parentId?: string; spaceName?: string }> {
-    const out = new Map<string, { parentId?: string; spaceName?: string }>()
+  getChannelScopes(ids: string[]): Map<string, { parentId?: string }> {
+    const out = new Map<string, { parentId?: string }>()
     const unique = [...new Set(ids)]
     if (unique.length === 0) return out
     const rows = this.db
-      .prepare(`SELECT id, parentId, spaceName FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
-      .all(...unique) as unknown as { id: string; parentId: string | null; spaceName: string | null }[]
-    for (const r of rows) {
-      out.set(r.id, {
-        ...(r.parentId ? { parentId: r.parentId } : {}),
-        ...(r.spaceName ? { spaceName: r.spaceName } : {})
-      })
-    }
+      .prepare(`SELECT id, parentId FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
+      .all(...unique) as unknown as { id: string; parentId: string | null }[]
+    for (const r of rows) if (r.parentId) out.set(r.id, { parentId: r.parentId })
     return out
   }
 

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -12,6 +12,7 @@ import {
   buildDiscordSelectComponents,
   buildLinkComponents
 } from '../src/discord/render.js'
+import { collapseDiscordChannels, collapseNameLookupIds } from '../src/discord/channels.js'
 
 const base: DiscordMessageLike = {
   id: '111',
@@ -73,6 +74,28 @@ describe('normalizeDiscordMessage', () => {
   it('marks a bot author', () => {
     expect(normalizeDiscordMessage({ ...base, authorIsBot: true }, { traceId: 't' }).sender.isBot).toBe(true)
   })
+
+  it('carries the enclosing channel of a thread message, plus the guild name', () => {
+    const m = normalizeDiscordMessage(
+      { ...base, channelId: 'T555', isThread: true, parentChannelId: 'C777', guildName: 'Acme' },
+      { traceId: 't' }
+    )
+    // The session still keys on the thread; `parentChannel` is the reachable channel it
+    // belongs to (channel-scoped triggers + channel discovery both key on it).
+    expect(m.channel).toBe('T555')
+    expect(m.parentChannel).toBe('C777')
+    expect(m.spaceName).toBe('Acme')
+  })
+
+  it('leaves parentChannel unset outside a thread (the channel IS the conversation)', () => {
+    const m = normalizeDiscordMessage({ ...base, parentChannelId: 'C777' }, { traceId: 't' })
+    expect(m.parentChannel).toBeUndefined()
+  })
+
+  it('renders a mention with the gateway-supplied handle, so a derived title reads a name', () => {
+    const m = normalizeDiscordMessage({ ...base, mentionUserNames: { '999': 'acp-tester' } }, { traceId: 't' })
+    expect(m.text).toBe('hello @acp-tester')
+  })
 })
 
 describe('humanizeDiscordText', () => {
@@ -84,6 +107,78 @@ describe('humanizeDiscordText', () => {
 
   it('rewrites a <t:unix> timestamp to ISO-8601 and leaves plain markdown untouched', () => {
     expect(humanizeDiscordText('at <t:0:F> **bold**')).toBe('at 1970-01-01T00:00:00.000Z **bold**')
+  })
+
+  it('uses supplied handles for user mentions and keeps the id when one is unknown', () => {
+    expect(humanizeDiscordText('hi <@12> and <@!34>', { '12': 'alice' })).toBe('hi @alice and @34')
+  })
+})
+
+describe('collapseDiscordChannels', () => {
+  it('folds every thread of a channel onto one row (the duplicate-"#general" bug)', () => {
+    const observed = [
+      { id: 'T3', name: 'general' },
+      { id: 'T2', name: 'general' },
+      { id: 'T1', name: 'general' }
+    ]
+    const scopes = new Map([
+      ['T1', { parentId: 'C1', spaceName: 'Acme' }],
+      ['T2', { parentId: 'C1', spaceName: 'Acme' }],
+      ['T3', { parentId: 'C1', spaceName: 'Acme' }]
+    ])
+    expect(collapseDiscordChannels(observed, scopes, new Map([['C1', 'general']]))).toEqual([
+      { id: 'C1', name: 'general' }
+    ])
+  })
+
+  it('keeps same-named channels of DIFFERENT servers apart (the key is space + name)', () => {
+    const observed = [
+      { id: 'T1', name: 'general' },
+      { id: 'T2', name: 'general' }
+    ]
+    const scopes = new Map([
+      ['T1', { parentId: 'C1', spaceName: 'Acme' }],
+      ['T2', { parentId: 'C2', spaceName: 'Globex' }]
+    ])
+    expect(collapseDiscordChannels(observed, scopes, new Map())).toEqual([
+      { id: 'C1', name: 'general' },
+      { id: 'C2', name: 'general' }
+    ])
+  })
+
+  it('collapses one channel reported under two ids within the same server', () => {
+    // Two threads whose parent lookup landed differently (one unresolved) still name the
+    // same channel of the same guild — a second "#general" row would be a duplicate.
+    const observed = [
+      { id: 'C1', name: 'general' },
+      { id: 'T9', name: 'general' }
+    ]
+    const scopes = new Map([
+      ['C1', { spaceName: 'Acme' }],
+      ['T9', { spaceName: 'Acme' }]
+    ])
+    expect(collapseDiscordChannels(observed, scopes, new Map())).toEqual([{ id: 'C1', name: 'general' }])
+  })
+
+  it('dedupes on id alone when there is no space (DM conversations must not merge)', () => {
+    const observed = [
+      { id: 'D1', name: '@dana' },
+      { id: 'D2', name: '@dana' },
+      { id: 'D1', name: '@dana' }
+    ]
+    expect(collapseDiscordChannels(observed, new Map(), new Map())).toEqual([
+      { id: 'D1', name: '@dana' },
+      { id: 'D2', name: '@dana' }
+    ])
+  })
+
+  it('passes an unresolved row through id-only (the console falls back to the id)', () => {
+    expect(collapseDiscordChannels([{ id: '900456' }], new Map(), new Map())).toEqual([{ id: '900456' }])
+  })
+
+  it('lists the ids whose names the collapse needs — observed plus enclosing channels', () => {
+    const scopes = new Map([['T1', { parentId: 'C1' }]])
+    expect(collapseNameLookupIds([{ id: 'T1' }, { id: 'C2' }], scopes)).toEqual(['T1', 'C1', 'C2'])
   })
 })
 

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -75,16 +75,15 @@ describe('normalizeDiscordMessage', () => {
     expect(normalizeDiscordMessage({ ...base, authorIsBot: true }, { traceId: 't' }).sender.isBot).toBe(true)
   })
 
-  it('carries the enclosing channel of a thread message, plus the guild name', () => {
+  it('carries the enclosing channel of a thread message', () => {
     const m = normalizeDiscordMessage(
-      { ...base, channelId: 'T555', isThread: true, parentChannelId: 'C777', guildName: 'Acme' },
+      { ...base, channelId: 'T555', isThread: true, parentChannelId: 'C777' },
       { traceId: 't' }
     )
     // The session still keys on the thread; `parentChannel` is the reachable channel it
     // belongs to (channel-scoped triggers + channel discovery both key on it).
     expect(m.channel).toBe('T555')
     expect(m.parentChannel).toBe('C777')
-    expect(m.spaceName).toBe('Acme')
   })
 
   it('leaves parentChannel unset outside a thread (the channel IS the conversation)', () => {
@@ -122,45 +121,48 @@ describe('collapseDiscordChannels', () => {
       { id: 'T1', name: 'general' }
     ]
     const scopes = new Map([
-      ['T1', { parentId: 'C1', spaceName: 'Acme' }],
-      ['T2', { parentId: 'C1', spaceName: 'Acme' }],
-      ['T3', { parentId: 'C1', spaceName: 'Acme' }]
+      ['T1', { parentId: 'C1' }],
+      ['T2', { parentId: 'C1' }],
+      ['T3', { parentId: 'C1' }]
     ])
     expect(collapseDiscordChannels(observed, scopes, new Map([['C1', 'general']]))).toEqual([
       { id: 'C1', name: 'general' }
     ])
   })
 
-  it('keeps same-named channels of DIFFERENT servers apart (the key is space + name)', () => {
+  it('keeps two same-named channels of ONE guild apart (Discord allows duplicate names)', () => {
+    // Identity is the snowflake, never the label: merging these would hide a real
+    // conversation and make its trigger unconfigurable.
     const observed = [
       { id: 'T1', name: 'general' },
-      { id: 'T2', name: 'general' }
+      { id: 'T2', name: 'general' },
+      { id: 'C3', name: 'general' }
     ]
     const scopes = new Map([
-      ['T1', { parentId: 'C1', spaceName: 'Acme' }],
-      ['T2', { parentId: 'C2', spaceName: 'Globex' }]
+      ['T1', { parentId: 'C1' }],
+      ['T2', { parentId: 'C2' }]
     ])
     expect(collapseDiscordChannels(observed, scopes, new Map())).toEqual([
       { id: 'C1', name: 'general' },
-      { id: 'C2', name: 'general' }
+      { id: 'C2', name: 'general' },
+      { id: 'C3', name: 'general' }
     ])
   })
 
-  it('collapses one channel reported under two ids within the same server', () => {
-    // Two threads whose parent lookup landed differently (one unresolved) still name the
-    // same channel of the same guild — a second "#general" row would be a duplicate.
+  it('keeps an unresolved id distinct from the channel it may belong to', () => {
+    // A thread whose parent isn't known yet stays its own row until the lookup resolves
+    // it — a transient duplicate is recoverable, a hidden channel is not.
     const observed = [
       { id: 'C1', name: 'general' },
       { id: 'T9', name: 'general' }
     ]
-    const scopes = new Map([
-      ['C1', { spaceName: 'Acme' }],
-      ['T9', { spaceName: 'Acme' }]
+    expect(collapseDiscordChannels(observed, new Map(), new Map())).toEqual([
+      { id: 'C1', name: 'general' },
+      { id: 'T9', name: 'general' }
     ])
-    expect(collapseDiscordChannels(observed, scopes, new Map())).toEqual([{ id: 'C1', name: 'general' }])
   })
 
-  it('dedupes on id alone when there is no space (DM conversations must not merge)', () => {
+  it('dedupes repeated ids (DM conversations keep one row each)', () => {
     const observed = [
       { id: 'D1', name: '@dana' },
       { id: 'D2', name: '@dana' },

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -478,16 +478,15 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     s.close()
   })
 
-  it('channel scopes: field-wise latest-wins, batch lookup returns only known ids', () => {
+  it('channel scopes: latest-wins, batch lookup returns only known ids', () => {
     const s = store()
     s.setChannelScope('T1', { parentId: 'C1' }, 1)
-    // A later note carrying only the space must not clear the parent (and vice-versa).
-    s.setChannelScope('T1', { spaceName: 'Acme' }, 2)
-    s.setChannelScope('C1', { spaceName: 'Acme' }, 2)
+    s.setChannelScope('T2', { parentId: 'C1' }, 2)
+    // A moved thread re-parents (latest-wins).
     s.setChannelScope('T1', { parentId: 'C2' }, 3)
-    const scopes = s.getChannelScopes(['T1', 'C1', 'unknown'])
-    expect(scopes.get('T1')).toEqual({ parentId: 'C2', spaceName: 'Acme' })
-    expect(scopes.get('C1')).toEqual({ spaceName: 'Acme' })
+    const scopes = s.getChannelScopes(['T1', 'T2', 'unknown'])
+    expect(scopes.get('T1')).toEqual({ parentId: 'C2' })
+    expect(scopes.get('T2')).toEqual({ parentId: 'C1' })
     expect(scopes.has('unknown')).toBe(false)
     // An empty note writes no row at all.
     s.setChannelScope('T9', {}, 4)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -478,6 +478,24 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     s.close()
   })
 
+  it('channel scopes: field-wise latest-wins, batch lookup returns only known ids', () => {
+    const s = store()
+    s.setChannelScope('T1', { parentId: 'C1' }, 1)
+    // A later note carrying only the space must not clear the parent (and vice-versa).
+    s.setChannelScope('T1', { spaceName: 'Acme' }, 2)
+    s.setChannelScope('C1', { spaceName: 'Acme' }, 2)
+    s.setChannelScope('T1', { parentId: 'C2' }, 3)
+    const scopes = s.getChannelScopes(['T1', 'C1', 'unknown'])
+    expect(scopes.get('T1')).toEqual({ parentId: 'C2', spaceName: 'Acme' })
+    expect(scopes.get('C1')).toEqual({ spaceName: 'Acme' })
+    expect(scopes.has('unknown')).toBe(false)
+    // An empty note writes no row at all.
+    s.setChannelScope('T9', {}, 4)
+    expect(s.getChannelScopes(['T9']).size).toBe(0)
+    expect(s.getChannelScopes([]).size).toBe(0)
+    s.close()
+  })
+
   it('observedChannels/observedUsers: distinct per agent+platform, newest-first, name-joined', () => {
     const s = store()
     const sess = (key: string, platform: string, channel: string, triggeredBy: string, updatedAt: number) =>

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -111,20 +111,21 @@ describe('ChannelNameResolver', () => {
     expect(saved.get('C1')).toBe('general')
   })
 
-  it('reports a thread scope (enclosing channel + space) and names the channel itself', async () => {
+  it('reports a thread scope (its enclosing channel) and names the channel itself', async () => {
     const saved = new Map<string, string>()
-    const scopes = new Map<string, { parentId?: string; spaceName?: string }>()
+    const scopes = new Map<string, { parentId?: string }>()
     const r = new ChannelNameResolver((id, name) => saved.set(id, name), {
       saveScope: (id, scope) => scopes.set(id, scope)
     })
-    r.noteChannel(
-      source({ id: 'T1', name: 'deploy the docs', parentId: 'C1', parentName: 'general', spaceName: 'Acme' }),
-      'T1'
-    )
+    r.noteChannel(source({ id: 'T1', name: 'deploy the docs', parentId: 'C1', parentName: 'general' }), 'T1')
     await flush()
-    expect(scopes.get('T1')).toEqual({ parentId: 'C1', spaceName: 'Acme' })
+    expect(scopes.get('T1')).toEqual({ parentId: 'C1' })
     // The enclosing channel is a reportable conversation of its own.
     expect(saved.get('C1')).toBe('general')
+    // A non-thread channel has no scope to report.
+    r.noteChannel(source({ id: 'C9', name: 'ops' }), 'C9')
+    await flush()
+    expect(scopes.has('C9')).toBe(false)
   })
 
   it('noteMessage caches the human sender and the users they mentioned', async () => {

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -110,4 +110,40 @@ describe('ChannelNameResolver', () => {
     await flush()
     expect(saved.get('C1')).toBe('general')
   })
+
+  it('reports a thread scope (enclosing channel + space) and names the channel itself', async () => {
+    const saved = new Map<string, string>()
+    const scopes = new Map<string, { parentId?: string; spaceName?: string }>()
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name), {
+      saveScope: (id, scope) => scopes.set(id, scope)
+    })
+    r.noteChannel(
+      source({ id: 'T1', name: 'deploy the docs', parentId: 'C1', parentName: 'general', spaceName: 'Acme' }),
+      'T1'
+    )
+    await flush()
+    expect(scopes.get('T1')).toEqual({ parentId: 'C1', spaceName: 'Acme' })
+    // The enclosing channel is a reportable conversation of its own.
+    expect(saved.get('C1')).toBe('general')
+  })
+
+  it('noteMessage caches the human sender and the users they mentioned', async () => {
+    const saved = new Map<string, string>()
+    const src = source({ id: 'C1', name: 'general' })
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    r.noteMessage(src, { channel: 'C1', sender: { id: 'U9', isBot: false }, mentionedUserIds: ['U7'] })
+    await flush()
+    expect(saved.get('U9')).toBe('Dana Reyes')
+    expect(saved.get('U7')).toBe('Dana Reyes')
+  })
+
+  it('noteMessage skips a bot sender (agent frames are labelled by agentId upstream)', async () => {
+    const saved = new Map<string, string>()
+    const src = source({ id: 'C1', name: 'general' })
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    r.noteMessage(src, { channel: 'C1', sender: { id: 'B1', isBot: true } })
+    await flush()
+    expect(src.getUserProfile).not.toHaveBeenCalled()
+    expect(saved.has('B1')).toBe(false)
+  })
 })

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -551,6 +551,37 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     await daemon.stop()
   })
 
+  it('folds observed Discord threads onto their enclosing channel (one row per channel)', async () => {
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    ;(daemon as any).agents = new Map([
+      ['bot-dc', { id: 'bot-dc', integrations: [{ id: 'dc-int', platform: 'discord', discord: { botToken: 'dc' } }] }]
+    ])
+    // Three turns in #general ⇒ three thread channels, each labelled with the enclosing
+    // channel — the console showed "#general" three times before the fold.
+    const store = (daemon as any).store
+    for (const t of ['900001', '900002', '900003']) {
+      store.setChannelScope(t, { parentId: '900123', spaceName: 'Acme' }, 1)
+    }
+    store.setDisplayName('900123', 'general', 1)
+    vi.spyOn(store, 'observedChannels').mockReturnValue([
+      { id: '900003', name: 'general' },
+      { id: '900002', name: 'general' },
+      { id: '900001', name: 'general' }
+    ])
+
+    ;(daemon as any).refreshObservedChannels()
+
+    const channels = [{ id: '900123', name: 'general' }]
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
+    expect((daemon as any).channelSnapshots.get('dc-int')).toEqual({ channels, authoritative: false })
+    await daemon.stop()
+  })
+
   it('skips an agent with multiple Telegram bots (observed set is not per-bot)', async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -565,7 +565,7 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     // channel — the console showed "#general" three times before the fold.
     const store = (daemon as any).store
     for (const t of ['900001', '900002', '900003']) {
-      store.setChannelScope(t, { parentId: '900123', spaceName: 'Acme' }, 1)
+      store.setChannelScope(t, { parentId: '900123' }, 1)
     }
     store.setDisplayName('900123', 'general', 1)
     vi.spyOn(store, 'observedChannels').mockReturnValue([

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -170,6 +170,14 @@ describe('routeRules platform isolation', () => {
     const rules = [rule({ agentId: 'tg', match: { kind: 'auto' }, platform: 'telegram' })]
     expect(routeRules(msg({ platform: 'slack' }), rules, noOwner)).toBeNull()
   })
+
+  it("a channel-scoped rule serves that channel's threads (Discord keys a session on the thread)", () => {
+    const rules = [rule({ agentId: 'a', scope: { channel: 'C1' }, match: { kind: 'auto' }, platform: 'discord' })]
+    const inThread = msg({ platform: 'discord', channel: 'T9', thread: 'T9', parentChannel: 'C1' })
+    expect(routeRules(inThread, rules, noOwner)?.agentId).toBe('a')
+    // Another channel's thread is still out of scope.
+    expect(routeRules({ ...inThread, parentChannel: 'C2' }, rules, noOwner)).toBeNull()
+  })
 })
 
 const tgAgent = (over: Partial<Agent> = {}): Agent =>

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -178,6 +178,32 @@ describe('routeRules platform isolation', () => {
     // Another channel's thread is still out of scope.
     expect(routeRules({ ...inThread, parentChannel: 'C2' }, rules, noOwner)).toBeNull()
   })
+
+  it('a CP rule scoped to the enclosing channel still overrides a local rule in a thread', () => {
+    // The CP-override check uses the same channel-scope predicate as the scope filter,
+    // so a parent-scoped CP rule wins even when the local rule is listed first.
+    const rules = [
+      rule({ agentId: 'local', source: 'config', scope: { channel: 'C1' }, match: { kind: 'auto' } }),
+      rule({ agentId: 'cpAgent', source: 'cp', scope: { channel: 'C1' }, match: { kind: 'auto' } })
+    ]
+    const inThread = msg({ platform: 'discord', channel: 'T1', thread: 'T1', parentChannel: 'C1' })
+    expect(routeRules(inThread, rules, noOwner)?.agentId).toBe('cpAgent')
+  })
+
+  it('an UNSCOPED cp rule does not claim the channel layer (local scoped rule still wins)', () => {
+    const rules = [
+      rule({
+        agentId: 'local',
+        source: 'config',
+        scope: { channel: 'C1' },
+        match: { kind: 'keyword', value: 'hello' }
+      }),
+      rule({ agentId: 'cpGlobal', source: 'cp', scope: {}, match: { kind: 'auto' } })
+    ]
+    // Keyword outranks auto within the merged layer; a global CP rule must not promote
+    // the CP layer just because it matched.
+    expect(routeRules(msg(), rules, noOwner)?.agentId).toBe('local')
+  })
 })
 
 const tgAgent = (over: Partial<Agent> = {}): Agent =>


### PR DESCRIPTION
## Problem

Two Discord edge issues in the console:

1. **Channel discovery repeats the same channel.** A Discord session keys on the concrete channel a message arrived in — the *thread's* own id, and the daemon opens a thread off every top-level mention. Observed-conversation discovery derives the reachable set from session history, so three turns in `#general` surfaced three rows, all labelled `#general`.
2. **Discord user names were never collected.** Only Slack ran sender/mention resolution, so `display_names` held no Discord user: the session list fell back to the raw snowflake (`@1524225313192542270 …`) where Slack shows a name.

## Change

**Fold threads onto the channel they belong to.** New `channel_scopes` table (`id → parentId`) plus a pure `collapseDiscordChannels`: each observed conversation folds onto its enclosing channel, and rows dedupe on the resulting channel **snowflake**. Identity is deliberately never the display name — Discord permits two distinct channels of one guild to share a name, so a (guild, name) key would silently hide one of them and make its trigger unconfigurable. An id whose scope isn't resolved yet stays a row of its own: a transient duplicate is recoverable, a hidden channel is not.

Scope is learnt three ways: from the inbound gateway message (`channel.parentId` — no API call), when the daemon opens the thread itself, and from the TTL-cached `getChannelInfo` lookup, which also backfills already-stored sessions and caches the enclosing channel's own name.

**Channel-scoped rules follow the fold.** Because the reported id is now the channel rather than a thread, `parentChannel` is on `NormalizedMessage` and one shared `channelInScope` predicate serves both `routeRules`' scope filter and the CP-override check (so a CP rule scoped to the enclosing channel still beats a preceding local rule in a thread), plus the §14 gating checks: admission, command admission, the Off notice, and pending-conversation discovery, which now reports the enclosing channel. A trigger set on `#general` governs the threads underneath it — before, it stopped applying the moment the bot threaded.

**User names.** `ChannelNameResolver` gains `noteMessage`/`resolveUser` (Slack-parity; bot senders skipped), wired into the Discord inbound path, so `triggeredByName` reaches the console. Separately, mention tokens humanize through the gateway message's own mention cache, so text and derived titles read `@acp-tester` rather than the snowflake.

## Note on existing rows

Discord reports are `authoritative:false`, and a non-authoritative snapshot never deletes omitted rows — so thread rows already stored from before this change are **not** pruned by the next report. New reports are correct from the first turn; the stale rows need an explicit cleanup (or a development database reset).

## Tests

Cases across the collapse helper, normalize, the resolver, the store, routing scope/CP precedence, and the daemon snapshot — including same-named channels within one guild and the parent-scoped CP-vs-local regression. Full daemon suite green (2177), lint and format clean.
