### PR TITLE
fix(daemon): ignore Telegram membership service messages

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -77,6 +77,7 @@ import {
   consolidateTelegram,
   TelegramConnection,
   type TelegramCallback,
+  type TelegramObservedChat,
   type InlineButton
 } from './telegram/connection.js'
 import { consolidateDiscord, DiscordConnection } from './discord/connection.js'
@@ -2647,6 +2648,11 @@ export class Daemon {
           this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
+        onBotAddedToChat: (chat) => {
+          const integrationIds = new Set(group.integrations.map(({ integrationId }) => integrationId))
+          for (const integrationId of this.srcIntegrationIds(conn)) integrationIds.add(integrationId)
+          this.observeTelegramChat(chat, [...integrationIds])
+        },
         onCallback: (cb) => this.handleTelegramCallback(cb, conn),
         log: this.log
       })
@@ -2907,6 +2913,43 @@ export class Daemon {
           this.cpClient?.emitIntegrationChannels({ integrationId: integ.id, channels, authoritative: false })
         }
       }
+    }
+  }
+
+  /**
+   * Telegram cannot enumerate a bot's chats. Its own `new_chat_members` service
+   * record therefore contributes one non-authoritative observed channel row, but
+   * never enters `onInbound` or creates an agent turn.
+   */
+  private observeTelegramChat(chat: TelegramObservedChat, integrationIds: readonly string[]): void {
+    if (chat.name) {
+      this.store.setDisplayName(chat.id, chat.name, Date.now())
+      this.emitSessionMetadataSnapshotsForDisplayName(chat.id)
+    }
+    for (const integrationId of integrationIds) {
+      const integration = this.integrationConfigById(integrationId)
+      if (!integration || integration.platform !== 'telegram') continue
+      const prior = this.channelSnapshots.get(integrationId)?.channels ?? []
+      const current = prior.find((channel) => channel.id === chat.id)
+      const observed: IntegrationChannel = {
+        ...current,
+        id: chat.id,
+        ...(chat.name ? { name: chat.name } : {}),
+        isPrivate: chat.isPrivate,
+        kind: 'channel'
+      }
+      if (
+        current?.name === observed.name &&
+        current?.isPrivate === observed.isPrivate &&
+        current?.kind === observed.kind
+      ) {
+        continue
+      }
+      const channels = current
+        ? prior.map((channel) => (channel.id === chat.id ? observed : channel))
+        : [...prior, observed]
+      this.channelSnapshots.set(integrationId, { channels, authoritative: false })
+      this.cpClient?.emitIntegrationChannels({ integrationId, channels, authoritative: false })
     }
   }
 

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -3,7 +3,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { SlackSendQueue } from '../slack/send-queue.js'
-import { normalizeTelegramMessage, type TelegramMessage } from './normalize.js'
+import { isTelegramMembershipServiceMessage, normalizeTelegramMessage, type TelegramMessage } from './normalize.js'
 
 /**
  * §Telegram edge unit. Mirrors slack/connection.ts but over grammY long-polling
@@ -71,9 +71,18 @@ export interface TelegramCallback {
   topicId?: string
 }
 
+/** A group/channel learned when Telegram reports that this bot was added. */
+export interface TelegramObservedChat {
+  id: string
+  name?: string
+  isPrivate: boolean
+}
+
 export interface TelegramDeps {
   group: ConsolidatedTelegramGroup
   onMessage: (msg: NormalizedMessage) => void
+  /** Membership service records discover chats but never enter message routing. */
+  onBotAddedToChat?: (chat: TelegramObservedChat) => void
   /** An inline-keyboard button was tapped (session-control cards — /models etc.). */
   onCallback?: (cb: TelegramCallback) => void
   newTraceId: () => string
@@ -227,6 +236,22 @@ export class TelegramConnection {
     log?.debug(`telegram: getMe ok → bot @${this.botUsername || '?'} (id ${this.botUserId || 'n/a'})`)
 
     this.bot.onMessage((message) => {
+      if (isTelegramMembershipServiceMessage(message)) {
+        const botWasAdded = message.new_chat_members?.some((member) => String(member.id) === this.botUserId) === true
+        if (botWasAdded) {
+          const chat = message.chat
+          this.deps.onBotAddedToChat?.({
+            id: String(chat.id),
+            ...(chat.title || chat.username ? { name: chat.title ?? chat.username } : {}),
+            isPrivate: chat.type === 'group' || chat.type === 'supergroup' ? !chat.username : chat.type !== 'channel'
+          })
+        }
+        log?.debug(
+          `telegram: membership service message ignored for routing ch=${message.chat.id}` +
+            (botWasAdded ? ' (bot added; chat observed)' : '')
+        )
+        return
+      }
       const msg = normalizeTelegramMessage(message, { traceId: this.deps.newTraceId() })
       log?.debug(
         `telegram: inbound ch=${msg.channel} user=${msg.sender.id} isBot=${msg.sender.isBot} isDm=${msg.isDm} ` +

--- a/packages/daemon/src/telegram/normalize.ts
+++ b/packages/daemon/src/telegram/normalize.ts
@@ -63,6 +63,16 @@ export interface TelegramMessage {
   caption_entities?: TelegramMessageEntity[]
   photo?: TelegramPhotoSize[]
   document?: TelegramDocument
+  /** Telegram membership service records. They are conversation metadata, not
+   *  user-authored chat, and must never become an agent turn. */
+  new_chat_members?: TelegramUser[]
+  left_chat_member?: TelegramUser
+}
+
+/** Membership changes arrive through grammY's broad `message` listener but are
+ * Telegram service records rather than user-authored messages. */
+export function isTelegramMembershipServiceMessage(msg: TelegramMessage): boolean {
+  return msg.new_chat_members !== undefined || msg.left_chat_member !== undefined
 }
 
 /**

--- a/packages/daemon/test/telegram-connection.test.ts
+++ b/packages/daemon/test/telegram-connection.test.ts
@@ -181,6 +181,39 @@ describe('TelegramConnection.start', () => {
     expect(received).toHaveLength(1)
     expect(received[0]).toMatchObject({ platform: 'telegram', channel: '-100', text: 'hi', sender: { id: '3' } })
   })
+
+  it('observes the chat when this bot is added but never forwards membership service messages', async () => {
+    const onBotAddedToChat = vi.fn()
+    const { conn, state, received } = makeConn({ onBotAddedToChat })
+    await conn.start()
+
+    state.onMessage!({
+      message_id: 5,
+      chat: { id: -100, type: 'supergroup', title: 'private group' },
+      from: { id: 3, username: 'ada' },
+      new_chat_members: [{ id: 99, is_bot: true, username: 'mybot' }]
+    })
+    state.onMessage!({
+      message_id: 6,
+      chat: { id: -100, type: 'supergroup', title: 'private group' },
+      from: { id: 3, username: 'ada' },
+      new_chat_members: [{ id: 4, username: 'grace' }]
+    })
+    state.onMessage!({
+      message_id: 7,
+      chat: { id: -100, type: 'supergroup', title: 'private group' },
+      from: { id: 3, username: 'ada' },
+      left_chat_member: { id: 4, username: 'grace' }
+    })
+
+    expect(received).toHaveLength(0)
+    expect(onBotAddedToChat).toHaveBeenCalledOnce()
+    expect(onBotAddedToChat).toHaveBeenCalledWith({
+      id: '-100',
+      name: 'private group',
+      isPrivate: true
+    })
+  })
 })
 
 describe('TelegramConnection outbound chrome', () => {

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -129,6 +129,25 @@ describe('gated Telegram conversation discovery', () => {
     expect(conn.postChrome).toHaveBeenCalledOnce()
     await daemon.stop()
   })
+
+  it('reports a newly joined group without routing its membership service message', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    makeTelegramGated(daemon)
+    const emitIntegrationChannels = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels, stop: vi.fn().mockResolvedValue(undefined) }
+
+    ;(daemon as any).observeTelegramChat({ id: '-200', name: 'new private group', isPrivate: true }, ['i-tg'])
+
+    const channels = [{ id: '-200', name: 'new private group', isPrivate: true, kind: 'channel' }]
+    expect(emitIntegrationChannels).toHaveBeenCalledWith({
+      integrationId: 'i-tg',
+      channels,
+      authoritative: false
+    })
+    expect((daemon as any).channelSnapshots.get('i-tg')).toEqual({ channels, authoritative: false })
+    await daemon.stop()
+  })
 })
 
 describe('Telegram ingress attribution', () => {


### PR DESCRIPTION
## Summary

- keep Telegram member-join and member-leave service records out of agent message routing
- preserve chat discovery when the connected bot itself is added by reporting a non-authoritative observed channel
- retain the existing restricted-agent behavior where newly observed conversations start Off

## Root cause

The grammY connection subscribed to the broad `message` event and normalized membership service records as if they were user-authored messages. In an enabled conversation, routing could therefore start an agent turn for the invite record. Simply dropping the event would also lose Telegram's only immediate signal that the bot had joined a new chat, so this change separates discovery from delivery at the connection boundary.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted Telegram connection and routing tests
- full daemon suite: 2,159 passed, 2 skipped
- ESLint and Prettier checks

Created by Codex . GPT-5.6-sol
