### PR TITLE
feat: review mined dream skills from the console

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2207,6 +2207,12 @@ export const DreamFileDto = z.object({
   nextOffset: z.number().nullable(),
   truncated: z.boolean().nullable()
 })
+export const DreamSkillContentDto = z.object({
+  name: z.string(),
+  exists: z.boolean(),
+  skill: z.string().nullable(),
+  scripts: z.array(z.object({ path: z.string(), content: z.string() }))
+})
 export const DreamSkillParam = z.object({
   id: z.string().uuid(),
   dreamId: z.string().min(1).max(128),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2207,6 +2207,11 @@ export const DreamFileDto = z.object({
   nextOffset: z.number().nullable(),
   truncated: z.boolean().nullable()
 })
+export const DreamSkillParam = z.object({
+  id: z.string().uuid(),
+  dreamId: z.string().min(1).max(128),
+  name: z.string().regex(/^[a-z0-9][a-z0-9-]{0,62}$/)
+})
 export const DreamIdParam = z.object({ id: z.string().uuid(), dreamId: z.string().min(1).max(128) })
 
 export const WorkspaceGitFileDto = z.object({

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -3012,7 +3012,12 @@ export function agentRoutes(deps: HttpDeps) {
             "List the agent's memory dream jobs (newest first), proxied from the owning daemon. 409 when the owning daemon is too old to support dreaming (code DAEMON_FEATURE_MISSING).",
           operationId: 'listAgentMemoryDreams',
           params: IdParam,
-          querystring: z.object({ limit: z.coerce.number().int().positive().max(50).optional() }),
+          querystring: z.object({
+            limit: z.coerce.number().int().positive().max(50).optional(),
+            // Pending skill proposals outlive the store lifecycle, so they need a
+            // path that does not age out behind newer history.
+            pendingSkills: z.coerce.boolean().optional()
+          }),
           response: { 200: DreamListDto, 400: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
         }
       },
@@ -3021,7 +3026,11 @@ export function agentRoutes(deps: HttpDeps) {
         if (!agent) return
         try {
           return toDreamListDto(
-            await deps.control.dreamList(agent.daemonId, { agentId: agent.id, limit: req.query.limit ?? 20 })
+            await deps.control.dreamList(agent.daemonId, {
+              agentId: agent.id,
+              limit: req.query.limit ?? 20,
+              ...(req.query.pendingSkills ? { pendingSkills: true } : {})
+            })
           )
         } catch (err) {
           if (sendDreamFailure(reply, err)) return

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -107,6 +107,7 @@ import {
   DreamFileDto,
   DreamIdParam,
   DreamSkillParam,
+  DreamSkillContentDto,
   StartDreamBody,
   AdoptDreamBody,
   type AgentDtoT,
@@ -3144,6 +3145,44 @@ export function agentRoutes(deps: HttpDeps) {
             dreamId: req.params.dreamId
           })
           return toDreamDto(dream)
+        } catch (err) {
+          if (sendDreamFailure(reply, err)) return
+          throw err
+        }
+      }
+    )
+
+    // Read one candidate's FULL staged body. Acceptance installs executable
+    // instruction content, so the reviewer must be able to see it — a
+    // model-authored description cannot be evidence for itself (design §7).
+    r.get(
+      '/agents/:id/memory/dreams/:dreamId/skills/:name',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Read a mined skill candidate',
+          description:
+            'Proxy the staged SKILL.md and every staged script for one candidate live from the owning daemon, so the reviewer can read exactly what accepting would install. Nothing staged under that name is data (exists:false), not an error.',
+          operationId: 'readAgentMemoryDreamSkill',
+          params: DreamSkillParam,
+          response: { 200: DreamSkillContentDto, 400: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const agent = await dreamAgentOrReply(req, reply, req.params.id)
+        if (!agent) return
+        try {
+          const content = await deps.control.dreamSkillRead(agent.daemonId, {
+            agentId: agent.id,
+            dreamId: req.params.dreamId,
+            name: req.params.name
+          })
+          return {
+            name: content.name,
+            exists: content.exists,
+            skill: content.skill ?? null,
+            scripts: content.scripts ?? []
+          }
         } catch (err) {
           if (sendDreamFailure(reply, err)) return
           throw err

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -106,6 +106,7 @@ import {
   DreamFilesDto,
   DreamFileDto,
   DreamIdParam,
+  DreamSkillParam,
   StartDreamBody,
   AdoptDreamBody,
   type AgentDtoT,
@@ -3141,6 +3142,69 @@ export function agentRoutes(deps: HttpDeps) {
           const { dream } = await deps.control.dreamDiscard(agent.daemonId, {
             agentId: agent.id,
             dreamId: req.params.dreamId
+          })
+          return toDreamDto(dream)
+        } catch (err) {
+          if (sendDreamFailure(reply, err)) return
+          throw err
+        }
+      }
+    )
+
+    // Accept one mined skill candidate — installs it for THIS agent (design §7).
+    r.post(
+      '/agents/:id/memory/dreams/:dreamId/skills/:name/accept',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Accept a mined skill',
+          description:
+            "Install one of this dream's mined skill candidates for the agent. Copies the reviewed skill into the agent's own tree, so discarding the dream later does not uninstall it. 409 if the candidate was already dismissed or the daemon predates dreaming.",
+          operationId: 'acceptAgentMemoryDreamSkill',
+          params: DreamSkillParam,
+          response: { 200: DreamDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const agent = await dreamAgentOrReply(req, reply, req.params.id, true)
+        if (!agent) return
+        try {
+          const { dream } = await deps.control.dreamSkillAccept(agent.daemonId, {
+            agentId: agent.id,
+            dreamId: req.params.dreamId,
+            name: req.params.name
+          })
+          return toDreamDto(dream)
+        } catch (err) {
+          if (sendDreamFailure(reply, err)) return
+          throw err
+        }
+      }
+    )
+
+    // Dismiss one mined skill candidate — drops its staging, records the decision
+    // so later dreams can be told not to propose it again.
+    r.post(
+      '/agents/:id/memory/dreams/:dreamId/skills/:name/dismiss',
+      {
+        schema: {
+          tags: [Tag.Agents],
+          summary: 'Dismiss a mined skill',
+          description:
+            "Reject one of this dream's mined skill candidates. Its staging is dropped and the decision recorded, so later dreams are told not to propose it again. 409 if it was already accepted.",
+          operationId: 'dismissAgentMemoryDreamSkill',
+          params: DreamSkillParam,
+          response: { 200: DreamDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const agent = await dreamAgentOrReply(req, reply, req.params.id, true)
+        if (!agent) return
+        try {
+          const { dream } = await deps.control.dreamSkillDismiss(agent.daemonId, {
+            agentId: agent.id,
+            dreamId: req.params.dreamId,
+            name: req.params.name
           })
           return toDreamDto(dream)
         } catch (err) {

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -84,6 +84,8 @@ import type {
   DreamFileReadReq,
   DreamFileReadContent,
   DreamSkillReviewReq,
+  DreamSkillReadReq,
+  DreamSkillContent,
   DreamState,
   RelayRosterEntry,
   CollabRoutesSnapshot,
@@ -553,6 +555,12 @@ export class ControlSender {
   async dreamFiles(daemonId: string, req: DreamFilesReq): Promise<DreamFilesPage> {
     const c = this.must(daemonId)
     return c.conn.request<DreamFilesPage>('memory/dream/files', req, { epoch: c.sessionEpoch })
+  }
+
+  /** Full staged body of one candidate, so a reviewer sees what accepting installs. */
+  async dreamSkillRead(daemonId: string, req: DreamSkillReadReq): Promise<DreamSkillContent> {
+    const c = this.must(daemonId)
+    return c.conn.request<DreamSkillContent>('memory/dream/skill/read', req, { epoch: c.sessionEpoch })
   }
 
   /** Accept one mined skill candidate — installs it for the agent (design §7). */

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -83,6 +83,7 @@ import type {
   DreamFilesPage,
   DreamFileReadReq,
   DreamFileReadContent,
+  DreamSkillReviewReq,
   DreamState,
   RelayRosterEntry,
   CollabRoutesSnapshot,
@@ -552,6 +553,18 @@ export class ControlSender {
   async dreamFiles(daemonId: string, req: DreamFilesReq): Promise<DreamFilesPage> {
     const c = this.must(daemonId)
     return c.conn.request<DreamFilesPage>('memory/dream/files', req, { epoch: c.sessionEpoch })
+  }
+
+  /** Accept one mined skill candidate — installs it for the agent (design §7). */
+  async dreamSkillAccept(daemonId: string, req: DreamSkillReviewReq): Promise<DreamState> {
+    const c = this.must(daemonId)
+    return c.conn.request<DreamState>('memory/dream/skill/accept', req, { epoch: c.sessionEpoch })
+  }
+
+  /** Dismiss one mined skill candidate — drops its staging, records the decision. */
+  async dreamSkillDismiss(daemonId: string, req: DreamSkillReviewReq): Promise<DreamState> {
+    const c = this.must(daemonId)
+    return c.conn.request<DreamState>('memory/dream/skill/dismiss', req, { epoch: c.sessionEpoch })
   }
 
   async dreamFileRead(daemonId: string, req: DreamFileReadReq): Promise<DreamFileReadContent> {

--- a/packages/control-plane/test/integration/agents.dream.route.test.ts
+++ b/packages/control-plane/test/integration/agents.dream.route.test.ts
@@ -24,6 +24,7 @@ import type {
   DreamDiscardReq,
   DreamFilesReq,
   DreamFileReadReq,
+  DreamSkillReviewReq,
   DreamInfo,
   DreamState,
   DreamListPage,
@@ -116,6 +117,16 @@ class SpyControl {
       exists: true,
       entries: [{ name: 'MEMORY.md', size: 12, mtime: '2026-07-24T00:00:00.000Z' }]
     }
+  }
+  skillAcceptCalls: DreamSkillReviewReq[] = []
+  skillDismissCalls: DreamSkillReviewReq[] = []
+  async dreamSkillAccept(_d: string, req: DreamSkillReviewReq): Promise<DreamState> {
+    this.skillAcceptCalls.push(req)
+    return { dream: dream({ status: 'completed' }) }
+  }
+  async dreamSkillDismiss(_d: string, req: DreamSkillReviewReq): Promise<DreamState> {
+    this.skillDismissCalls.push(req)
+    return { dream: dream({ status: 'completed' }) }
   }
   async dreamFileRead(_d: string, req: DreamFileReadReq): Promise<DreamFileReadContent> {
     this.fileCalls.push(req)
@@ -231,6 +242,81 @@ describe('memory dreaming routes — proxy + managed guard', () => {
       payload: {}
     })
     expect(unplaced.statusCode).toBe(503)
+  })
+})
+
+describe('memory dreaming routes — mined skill review', () => {
+  it('forwards accept and dismiss for one candidate', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: DREAMING_CAPS })
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const s = new SpyControl()
+    running = buildHttpApp(prisma, undefined, LIVE, s as unknown as ControlSender)
+
+    const accept = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${AGENT}/memory/dreams/drm-1/skills/deploy-staging/accept`,
+      payload: {}
+    })
+    expect(accept.statusCode).toBe(200)
+    expect(s.skillAcceptCalls[0]).toMatchObject({ agentId: AGENT, dreamId: 'drm-1', name: 'deploy-staging' })
+
+    const dismiss = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${AGENT}/memory/dreams/drm-1/skills/deploy-staging/dismiss`,
+      payload: {}
+    })
+    expect(dismiss.statusCode).toBe(200)
+    expect(s.skillDismissCalls[0]).toMatchObject({ name: 'deploy-staging' })
+  })
+
+  it('rejects a traversal-shaped skill name before reaching the daemon', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: DREAMING_CAPS })
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const s = new SpyControl()
+    running = buildHttpApp(prisma, undefined, LIVE, s as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${AGENT}/memory/dreams/drm-1/skills/${encodeURIComponent('../escape')}/accept`,
+      payload: {}
+    })
+    expect(res.statusCode).toBe(400)
+    expect(s.skillAcceptCalls).toHaveLength(0)
+  })
+
+  it('refuses a viewer without contacting the daemon', async () => {
+    const viewer = await makeUser('dream-skill-viewer', 'viewer')
+    await seedDaemon(prisma, DAEMON, { capabilities: DREAMING_CAPS })
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON, visibility: 'restricted', sharedWith: [viewer] })
+    const s = new SpyControl()
+    running = buildHttpApp(prisma, { DEFAULT_OWNER_ID: viewer }, LIVE, s as unknown as ControlSender)
+
+    for (const action of ['accept', 'dismiss']) {
+      const res = await running.app.inject({
+        method: 'POST',
+        url: `${ORG}/agents/${AGENT}/memory/dreams/drm-1/skills/deploy-staging/${action}`,
+        payload: {}
+      })
+      expect(res.statusCode, action).toBe(403)
+    }
+    expect(s.skillAcceptCalls).toHaveLength(0)
+    expect(s.skillDismissCalls).toHaveLength(0)
+  })
+
+  it('refuses on a daemon that predates dreaming', async () => {
+    await seedDaemon(prisma, DAEMON) // features: []
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const s = new SpyControl()
+    running = buildHttpApp(prisma, undefined, LIVE, s as unknown as ControlSender)
+
+    const res = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${AGENT}/memory/dreams/drm-1/skills/deploy-staging/accept`,
+      payload: {}
+    })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'DAEMON_FEATURE_MISSING' })
+    expect(s.skillAcceptCalls).toHaveLength(0)
   })
 })
 

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -63,6 +63,9 @@ export interface DreamStorePort {
   updateDream(dream: DreamInfo): void
   getDream(agentId: string, dreamId: string): DreamInfo | undefined
   listDreams(agentId: string, limit: number): DreamInfo[]
+  /** Dreams still holding an unreviewed skill candidate, independent of the
+   *  bounded history page — a proposal outlives the store lifecycle. */
+  pendingSkillDreams(agentId: string, limit: number): DreamInfo[]
   /** Non-terminal dreams (pending|running) for crash recovery at boot. */
   openDreams(): DreamInfo[]
   /** Every completed store proposal for one agent, without the public list cap. */
@@ -585,6 +588,12 @@ export class DreamRunner {
   get(agentId: string, dreamId: string): DreamInfo {
     this.dirFor(agentId)
     return this.getDream(agentId, dreamId)
+  }
+
+  /** Dreams whose skill candidates are still awaiting review. */
+  listPendingSkills(agentId: string, limit: number): DreamInfo[] {
+    this.dirFor(agentId)
+    return this.deps.store.pendingSkillDreams(agentId, limit)
   }
 
   list(agentId: string, limit: number): DreamInfo[] {

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -63,7 +63,8 @@ import type {
   DreamDiscardReq,
   DreamFilesReq,
   DreamFileReadReq,
-  DreamSkillReviewReq
+  DreamSkillReviewReq,
+  DreamSkillReadReq
 } from '@agentconnect.md/protocol'
 import {
   buildEnvelope,
@@ -1016,6 +1017,14 @@ export class CpClient {
           .fileRead(frame.payload as DreamFileReadReq)
           .then((content) => this.reply(frame, 'memory/dream/file/read/content', content))
           .catch((err) => this.dreamError(frame.id, 'memory/dream/file/read', err))
+        return
+      }
+      case 'memory/dream/skill/read': {
+        const req = frame.payload as DreamSkillReadReq
+        this.deps.dreamReader
+          .skillRead(req)
+          .then((content) => this.reply(frame, 'memory/dream/skill/read/ok', content))
+          .catch((err) => this.dreamError(frame.id, 'memory/dream/skill/read', err))
         return
       }
       case 'memory/dream/skill/accept': {

--- a/packages/daemon/src/cp/dream-reader.ts
+++ b/packages/daemon/src/cp/dream-reader.ts
@@ -58,7 +58,12 @@ export function createDreamReader(runner: DreamRunner): DreamReader {
     },
 
     async list(req) {
-      return { agentId: req.agentId, dreams: runner.list(req.agentId, req.limit) }
+      return {
+        agentId: req.agentId,
+        dreams: req.pendingSkills
+          ? runner.listPendingSkills(req.agentId, req.limit)
+          : runner.list(req.agentId, req.limit)
+      }
     },
 
     async get(req) {

--- a/packages/daemon/src/cp/dream-reader.ts
+++ b/packages/daemon/src/cp/dream-reader.ts
@@ -18,6 +18,8 @@ import type {
   DreamFileReadReq,
   DreamFileReadContent,
   DreamSkillReviewReq,
+  DreamSkillReadReq,
+  DreamSkillContent,
   DreamState
 } from '@agentconnect.md/protocol'
 import { fitToBudget, utf8Boundary } from './wire-slice.js'
@@ -32,6 +34,9 @@ export interface DreamReader {
   discard(req: DreamDiscardReq): Promise<DreamState>
   files(req: DreamFilesReq): Promise<DreamFilesPage>
   fileRead(req: DreamFileReadReq): Promise<DreamFileReadContent>
+  /** Full staged body of one candidate, so the console can show what accepting
+   *  would install. Bounded by the miner's own caps; missing staging is DATA. */
+  skillRead(req: DreamSkillReadReq): Promise<DreamSkillContent>
   skillAccept(req: DreamSkillReviewReq): Promise<DreamState>
   skillDismiss(req: DreamSkillReviewReq): Promise<DreamState>
 }
@@ -101,6 +106,12 @@ export function createDreamReader(runner: DreamRunner): DreamReader {
       }
     },
 
+    async skillRead(req) {
+      const staged = await runner.stagedSkill(req.agentId, req.dreamId, req.name)
+      return staged
+        ? { agentId: req.agentId, dreamId: req.dreamId, name: req.name, exists: true, ...staged }
+        : { agentId: req.agentId, dreamId: req.dreamId, name: req.name, exists: false }
+    },
     async skillAccept(req) {
       return { dream: await runner.skillAccept(req.agentId, req.dreamId, req.name) }
     },

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1784,6 +1784,22 @@ export class LocalStore {
     ).map((row) => this.dreamFromRow(row))
   }
 
+  /** Dreams still holding an unreviewed skill candidate, newest first. Scanned
+   *  independently of the public history page: a proposal survives adoption and
+   *  discard until it is reviewed, so it must not age out behind newer runs. */
+  pendingSkillDreams(agentId: string, limit: number): DreamInfo[] {
+    return (
+      this.db
+        .prepare(
+          'SELECT * FROM dreams WHERE agentId = ? AND skills IS NOT NULL ORDER BY createdAt DESC, dreamId DESC LIMIT 500'
+        )
+        .all(agentId) as Record<string, unknown>[]
+    )
+      .map((row) => this.dreamFromRow(row))
+      .filter((dream) => (dream.skills ?? []).some((skill) => skill.state === 'proposed'))
+      .slice(0, limit)
+  }
+
   /** Non-terminal dreams — the boot-time crash-recovery sweep. */
   openDreams(): DreamInfo[] {
     return (

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1789,15 +1789,21 @@ export class LocalStore {
    *  discard until it is reviewed, so it must not age out behind newer runs. */
   pendingSkillDreams(agentId: string, limit: number): DreamInfo[] {
     return (
-      this.db
-        .prepare(
-          'SELECT * FROM dreams WHERE agentId = ? AND skills IS NOT NULL ORDER BY createdAt DESC, dreamId DESC LIMIT 500'
-        )
-        .all(agentId) as Record<string, unknown>[]
+      (
+        this.db
+          .prepare(
+            `SELECT * FROM dreams WHERE agentId = ? AND skills LIKE '%"state":"proposed"%'
+             ORDER BY createdAt DESC, dreamId DESC LIMIT ?`
+          )
+          .all(agentId, limit) as Record<string, unknown>[]
+      )
+        // The LIKE is a cheap SUPERSET pre-filter pushed into the query so rows
+        // with no pending candidate (empty, or only accepted/dismissed) never
+        // consume the window — a bounded pre-scan filtered afterwards just moves
+        // the age-out boundary. The decode below is what actually decides.
+        .map((row) => this.dreamFromRow(row))
+        .filter((dream) => (dream.skills ?? []).some((skill) => skill.state === 'proposed'))
     )
-      .map((row) => this.dreamFromRow(row))
-      .filter((dream) => (dream.skills ?? []).some((skill) => skill.state === 'proposed'))
-      .slice(0, limit)
   }
 
   /** Non-terminal dreams — the boot-time crash-recovery sweep. */

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1009,4 +1009,38 @@ describe('LocalStore runtime model-catalog cache (runtime-model-catalog.md §4)'
     expect(s.listRuntimeModelCaps().map((c) => c.runtimeId)).toEqual(['fresh-rt'])
     s.close()
   })
+
+  it('finds a pending skill proposal behind many skill-bearing dreams', () => {
+    // The proposed filter must be IN the query: rows whose candidates are all
+    // accepted/dismissed (or empty) must not consume the scan window, or one
+    // genuinely pending older proposal ages out permanently.
+    const s = store()
+    const base = {
+      agentId: 'a1',
+      status: 'adopted' as const,
+      trigger: 'manual' as const,
+      sessionIds: [],
+      snapshotDigest: 'sha256:x'
+    }
+    // The pending one is the OLDEST.
+    s.insertDream({
+      ...base,
+      dreamId: 'drm-pending',
+      createdAt: '2020-01-01T00:00:00.000Z',
+      skills: [{ name: 'deploy-staging', description: 'd', state: 'proposed' }]
+    })
+    // …buried behind 600 newer dreams that all carry skills, none pending.
+    for (let i = 0; i < 600; i++) {
+      s.insertDream({
+        ...base,
+        dreamId: `drm-${i}`,
+        createdAt: `2026-01-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+        skills: [{ name: `done-${i}`, description: 'd', state: i % 2 ? 'accepted' : 'dismissed' }]
+      })
+    }
+
+    const pending = s.pendingSkillDreams('a1', 50)
+    expect(pending.map((d) => d.dreamId)).toEqual(['drm-pending'])
+    s.close()
+  })
 })

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -93,7 +93,9 @@ import {
   DreamFilesPage,
   DreamFileReadReq,
   DreamFileReadContent,
-  DreamSkillReviewReq
+  DreamSkillReviewReq,
+  DreamSkillReadReq,
+  DreamSkillContent
 } from './frames/memory.js'
 import {
   Heartbeat,
@@ -260,6 +262,8 @@ export const FRAME_SCHEMAS = {
   'memory/dream/files/page': DreamFilesPage,
   'memory/dream/file/read': DreamFileReadReq,
   'memory/dream/file/read/content': DreamFileReadContent,
+  'memory/dream/skill/read': DreamSkillReadReq,
+  'memory/dream/skill/read/ok': DreamSkillContent,
   'memory/dream/skill/accept': DreamSkillReviewReq,
   'memory/dream/skill/accept/ok': DreamState,
   'memory/dream/skill/dismiss': DreamSkillReviewReq,
@@ -428,6 +432,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('memory/dream/files/page', FRAME_SCHEMAS['memory/dream/files/page']),
   frame('memory/dream/file/read', FRAME_SCHEMAS['memory/dream/file/read']),
   frame('memory/dream/file/read/content', FRAME_SCHEMAS['memory/dream/file/read/content']),
+  frame('memory/dream/skill/read', FRAME_SCHEMAS['memory/dream/skill/read']),
+  frame('memory/dream/skill/read/ok', FRAME_SCHEMAS['memory/dream/skill/read/ok']),
   frame('memory/dream/skill/accept', FRAME_SCHEMAS['memory/dream/skill/accept']),
   frame('memory/dream/skill/accept/ok', FRAME_SCHEMAS['memory/dream/skill/accept/ok']),
   frame('memory/dream/skill/dismiss', FRAME_SCHEMAS['memory/dream/skill/dismiss']),

--- a/packages/protocol/src/frames/memory.ts
+++ b/packages/protocol/src/frames/memory.ts
@@ -472,6 +472,35 @@ export const DreamFileReadContent = z
   .strict()
 export type DreamFileReadContent = z.infer<typeof DreamFileReadContent>
 
+/** C→D REQ: read one staged skill candidate's FULL body for review. Acceptance
+ *  installs executable instruction content, so the reviewer must be able to see
+ *  the actual `SKILL.md` and every script — a model-authored name and
+ *  description cannot be evidence for itself (design §7). */
+export const DreamSkillReadReq = z
+  .object({
+    agentId: z.string().min(1),
+    dreamId: z.string().min(1),
+    name: z.string().regex(/^[a-z0-9][a-z0-9-]{0,62}$/)
+  })
+  .strict()
+export type DreamSkillReadReq = z.infer<typeof DreamSkillReadReq>
+
+export const DreamSkillContent = z
+  .object({
+    agentId: z.string().min(1),
+    dreamId: z.string().min(1),
+    name: z.string().min(1),
+    /** false ⇒ nothing staged under that name (DATA, not an error). */
+    exists: z.boolean(),
+    skill: z.string().optional(),
+    scripts: z
+      .array(z.object({ path: z.string(), content: z.string() }))
+      .max(8)
+      .optional()
+  })
+  .strict()
+export type DreamSkillContent = z.infer<typeof DreamSkillContent>
+
 /** C→D REQ: accept or dismiss one mined skill candidate (design §7). */
 export const DreamSkillReviewReq = z
   .object({

--- a/packages/protocol/src/frames/memory.ts
+++ b/packages/protocol/src/frames/memory.ts
@@ -401,7 +401,14 @@ export type DreamCancelReq = z.infer<typeof DreamCancelReq>
 
 /** C→D REQ: list dream jobs for one agent (newest first; bounded). */
 export const DreamListReq = z
-  .object({ agentId: z.string().min(1), limit: z.number().int().positive().max(50).default(20) })
+  .object({
+    agentId: z.string().min(1),
+    limit: z.number().int().positive().max(50).default(20),
+    /** Only dreams still holding an unreviewed skill candidate. These deliberately
+     *  outlive store adoption/discard, so they must be reachable independently of
+     *  how deep the newest-first history has grown. */
+    pendingSkills: z.boolean().optional()
+  })
   .strict()
 export type DreamListReq = z.infer<typeof DreamListReq>
 

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -405,6 +405,45 @@ describe('DreamPanel', () => {
     expect(host.textContent).toContain('deploy-staging')
   })
 
+  it('never lets a delayed older refresh re-offer an already-reviewed candidate', async () => {
+    // The pending query resolves separately from the history page, so a slow
+    // request N can land after a newer N+1. If its result is written before the
+    // staleness fence, a candidate the user just reviewed comes back.
+    const stale = dream({
+      dreamId: 'drm-old',
+      status: 'adopted',
+      skills: [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    })
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    let releaseFirst!: (rows: unknown[]) => void
+    let pendingCall = 0
+    api.listDreams.mockImplementation(async (_a: string, _l: number, opts?: { pendingSkills?: boolean }) => {
+      if (!opts?.pendingSkills) return []
+      pendingCall += 1
+      // First pending request hangs; later ones report nothing pending.
+      if (pendingCall === 1) return new Promise((resolve) => (releaseFirst = resolve as typeof releaseFirst))
+      return []
+    })
+
+    const host = await render()
+    // A newer refresh completes first and publishes "nothing pending".
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // Now the ORIGINAL request finally resolves with the stale candidate.
+    await act(async () => {
+      releaseFirst([stale])
+      await Promise.resolve()
+    })
+
+    expect(host.textContent).not.toContain('Suggested skills')
+    expect(host.textContent).not.toContain('deploy-staging')
+    vi.useRealTimers()
+  })
+
   it('keeps Accept disabled while the body is loading, and on error or missing staging', async () => {
     const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
     api.listDreams.mockResolvedValue([dream({ skills })])

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -20,7 +20,8 @@ const api = vi.hoisted(() => ({
   fetchAgentMemoryFull: vi.fn(),
   listAgentMemory: vi.fn(),
   acceptDreamSkill: vi.fn(),
-  dismissDreamSkill: vi.fn()
+  dismissDreamSkill: vi.fn(),
+  fetchDreamSkill: vi.fn()
 }))
 
 vi.mock('@/lib/api', () => ({
@@ -73,6 +74,12 @@ beforeEach(() => {
   api.discardDream.mockResolvedValue(dream({ status: 'discarded' }))
   api.acceptDreamSkill.mockResolvedValue(dream())
   api.dismissDreamSkill.mockResolvedValue(dream())
+  api.fetchDreamSkill.mockResolvedValue({
+    name: 'deploy-staging',
+    exists: true,
+    skill: '---\nname: deploy-staging\n---\n# Deploy\nrun the thing',
+    scripts: [{ path: 'run.sh', content: '#!/bin/sh\necho deploying' }]
+  })
 })
 
 afterEach(async () => {
@@ -335,6 +342,24 @@ describe('DreamPanel', () => {
     // Nothing happens until the human acts — skills are never auto-installed.
     expect(api.acceptDreamSkill).not.toHaveBeenCalled()
 
+    // Accept is GATED on reading the body — the safety argument for mined
+    // skills is that a human reviewed the executable content, and a
+    // model-authored description is not evidence for itself.
+    expect(button(host, 'Accept')?.disabled).toBe(true)
+
+    const disclosure = host.querySelector<HTMLDetailsElement>('details')
+    await act(async () => {
+      disclosure!.open = true
+      disclosure!.dispatchEvent(new Event('toggle'))
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // The ACTUAL executable content is on screen, not just the description.
+    expect(host.textContent).toContain('# Deploy')
+    expect(host.textContent).toContain('echo deploying')
+    expect(host.textContent).toContain('scripts/run.sh')
+
     await act(async () => button(host, 'Accept')?.click())
     expect(api.acceptDreamSkill).toHaveBeenCalledWith(AGENT, 'drm-1', 'deploy-staging')
   })
@@ -359,6 +384,21 @@ describe('DreamPanel', () => {
     ])
     const host = await render()
     expect(host.textContent).not.toContain('Suggested skills')
+  })
+
+  it('keeps a pending candidate reachable behind newer dreams', async () => {
+    // Proposed skills survive adoption/discard until reviewed, so an old pending
+    // candidate must not fall off the list behind newer runs.
+    const older = dream({
+      dreamId: 'drm-old',
+      status: 'adopted',
+      skills: [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    })
+    const newer = Array.from({ length: 25 }, (_, i) => dream({ dreamId: `drm-${i}`, status: 'adopted' }))
+    api.listDreams.mockResolvedValue([...newer, older])
+    const host = await render()
+    expect(api.listDreams).toHaveBeenCalledWith(AGENT, 50)
+    expect(host.textContent).toContain('deploy-staging')
   })
 
   it('keeps recommendations actionable for a viewer but disabled', async () => {

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -18,7 +18,9 @@ const api = vi.hoisted(() => ({
   listDreamFiles: vi.fn(),
   fetchDreamFileFull: vi.fn(),
   fetchAgentMemoryFull: vi.fn(),
-  listAgentMemory: vi.fn()
+  listAgentMemory: vi.fn(),
+  acceptDreamSkill: vi.fn(),
+  dismissDreamSkill: vi.fn()
 }))
 
 vi.mock('@/lib/api', () => ({
@@ -69,6 +71,8 @@ beforeEach(() => {
   api.listAgentMemory.mockResolvedValue({ exists: true, files: [{ name: 'MEMORY.md', size: 10, mtime: 'x' }] })
   api.adoptDream.mockResolvedValue(dream({ status: 'adopted' }))
   api.discardDream.mockResolvedValue(dream({ status: 'discarded' }))
+  api.acceptDreamSkill.mockResolvedValue(dream())
+  api.dismissDreamSkill.mockResolvedValue(dream())
 })
 
 afterEach(async () => {
@@ -318,5 +322,50 @@ describe('DreamPanel', () => {
 
     expect(host.textContent).toContain('rerun the dream')
     expect(host.textContent).not.toContain('already running')
+  })
+
+  it('recommends mined skills and never installs one without an explicit click', async () => {
+    const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    api.listDreams.mockResolvedValue([dream({ skills })])
+    const host = await render()
+
+    expect(host.textContent).toContain('Suggested skills')
+    expect(host.textContent).toContain('deploy-staging')
+    expect(host.textContent).toContain('Deploy to staging')
+    // Nothing happens until the human acts — skills are never auto-installed.
+    expect(api.acceptDreamSkill).not.toHaveBeenCalled()
+
+    await act(async () => button(host, 'Accept')?.click())
+    expect(api.acceptDreamSkill).toHaveBeenCalledWith(AGENT, 'drm-1', 'deploy-staging')
+  })
+
+  it('dismisses a recommendation without installing it', async () => {
+    const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    api.listDreams.mockResolvedValue([dream({ skills })])
+    const host = await render()
+    await act(async () => button(host, 'Dismiss')?.click())
+    expect(api.dismissDreamSkill).toHaveBeenCalledWith(AGENT, 'drm-1', 'deploy-staging')
+    expect(api.acceptDreamSkill).not.toHaveBeenCalled()
+  })
+
+  it('only recommends candidates still awaiting review', async () => {
+    api.listDreams.mockResolvedValue([
+      dream({
+        skills: [
+          { name: 'already-in', description: 'x', state: 'accepted' },
+          { name: 'already-out', description: 'y', state: 'dismissed' }
+        ]
+      })
+    ])
+    const host = await render()
+    expect(host.textContent).not.toContain('Suggested skills')
+  })
+
+  it('keeps recommendations actionable for a viewer but disabled', async () => {
+    const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    api.listDreams.mockResolvedValue([dream({ skills })])
+    const host = await render({ canEdit: false })
+    expect(button(host, 'Accept')?.disabled).toBe(true)
+    expect(button(host, 'Dismiss')?.disabled).toBe(true)
   })
 })

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -335,6 +335,8 @@ describe('DreamPanel', () => {
     const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
     api.listDreams.mockResolvedValue([dream({ skills })])
     const host = await render()
+    // Pending proposals come from their OWN query, not the history page.
+    expect(api.listDreams).toHaveBeenCalledWith(AGENT, 50, { pendingSkills: true })
 
     expect(host.textContent).toContain('Suggested skills')
     expect(host.textContent).toContain('deploy-staging')
@@ -386,19 +388,68 @@ describe('DreamPanel', () => {
     expect(host.textContent).not.toContain('Suggested skills')
   })
 
-  it('keeps a pending candidate reachable behind newer dreams', async () => {
-    // Proposed skills survive adoption/discard until reviewed, so an old pending
-    // candidate must not fall off the list behind newer runs.
+  it('reaches a pending candidate that has aged out of the history page entirely', async () => {
+    // Beyond the route's real cap: the history page is FULL of newer dreams and
+    // does not contain the pending one at all. It must still be offered, because
+    // its own query does not depend on history depth.
     const older = dream({
       dreamId: 'drm-old',
       status: 'adopted',
       skills: [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
     })
-    const newer = Array.from({ length: 25 }, (_, i) => dream({ dreamId: `drm-${i}`, status: 'adopted' }))
-    api.listDreams.mockResolvedValue([...newer, older])
+    const fullPage = Array.from({ length: 50 }, (_, i) => dream({ dreamId: `drm-${i}`, status: 'adopted' }))
+    api.listDreams.mockImplementation(async (_a: string, _l: number, opts?: { pendingSkills?: boolean }) =>
+      opts?.pendingSkills ? [older] : fullPage
+    )
     const host = await render()
-    expect(api.listDreams).toHaveBeenCalledWith(AGENT, 50)
     expect(host.textContent).toContain('deploy-staging')
+  })
+
+  it('keeps Accept disabled while the body is loading, and on error or missing staging', async () => {
+    const skills = [{ name: 'deploy-staging', description: 'Deploy to staging', state: 'proposed' }]
+    api.listDreams.mockResolvedValue([dream({ skills })])
+
+    // 1. Never-resolving fetch: opening the disclosure must NOT enable Accept.
+    api.fetchDreamSkill.mockReturnValue(new Promise(() => {}))
+    let host = await render()
+    let details = host.querySelector<HTMLDetailsElement>('details')!
+    await act(async () => {
+      details.open = true
+      details.dispatchEvent(new Event('toggle'))
+    })
+    expect(button(host, 'Accept')?.disabled).toBe(true)
+    await act(async () => root?.unmount())
+    container?.remove()
+
+    // 2. Error.
+    api.fetchDreamSkill.mockRejectedValue(new Error('nope'))
+    host = await render()
+    details = host.querySelector<HTMLDetailsElement>('details')!
+    await act(async () => {
+      details.open = true
+      details.dispatchEvent(new Event('toggle'))
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(button(host, 'Accept')?.disabled).toBe(true)
+    await act(async () => root?.unmount())
+    container?.remove()
+
+    // 3. Staging vanished.
+    api.fetchDreamSkill.mockResolvedValue({ name: 'deploy-staging', exists: false, skill: null, scripts: [] })
+    host = await render()
+    details = host.querySelector<HTMLDetailsElement>('details')!
+    await act(async () => {
+      details.open = true
+      details.dispatchEvent(new Event('toggle'))
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(button(host, 'Accept')?.disabled).toBe(true)
+    expect(host.textContent).toContain('no longer staged')
+    expect(api.acceptDreamSkill).not.toHaveBeenCalled()
   })
 
   it('keeps recommendations actionable for a viewer but disabled', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -138,8 +138,10 @@ export function DreamPanel({
         listDreams(agentId, DREAM_PAGE),
         listDreams(agentId, DREAM_PAGE, { pendingSkills: true }).catch(() => [] as DreamDto[])
       ])
-      setPendingSkillDreams(pending)
+      // EVERY state write goes behind the fence: a delayed older request must not
+      // publish after a newer one and re-offer an already-reviewed candidate.
       if (request !== listRequest.current) return
+      setPendingSkillDreams(pending)
       setDreams(rows)
       setListError(null)
       setUnsupported(false)

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -23,6 +23,7 @@ import {
   adoptDream,
   discardDream,
   acceptDreamSkill,
+  fetchDreamSkill,
   dismissDreamSkill,
   cancelDream,
   listDreamFiles,
@@ -34,6 +35,7 @@ import {
   fmtCost,
   ApiError,
   type DreamDto,
+  type DreamSkillContentDto,
   type MemoryFileEntry
 } from '@/lib/api'
 import { Icon, Button } from '@/components/ui'
@@ -45,6 +47,8 @@ const POLL_MS = 4000
 /** …and even when settled it is NOT static: a scheduled dream (or another
  *  console) can start one, so revalidate slowly rather than going silent. */
 const IDLE_POLL_MS = 30_000
+/** Max the CP list route accepts. */
+const DREAM_PAGE = 50
 
 /** Human label for a job's lifecycle state. */
 const STATUS_LABEL: Record<DreamDto['status'], string> = {
@@ -124,7 +128,10 @@ export function DreamPanel({
   const refresh = useCallback(async () => {
     const request = ++listRequest.current
     try {
-      const rows = await listDreams(agentId, 20)
+      // Proposed skills deliberately survive adoption/discard until reviewed, so a
+      // pending candidate must not fall off the list behind newer runs. Ask for
+      // the full window the CP allows rather than one screen's worth.
+      const rows = await listDreams(agentId, DREAM_PAGE)
       if (request !== listRequest.current) return
       setDreams(rows)
       setListError(null)
@@ -374,6 +381,8 @@ export function DreamPanel({
               key={`skills-${dream.dreamId}`}
               proposed={proposed}
               busy={busy || !canEdit}
+              agentId={agentId}
+              dreamId={dream.dreamId}
               onAccept={(name) => void run(() => acceptDreamSkill(agentId, dream.dreamId, name))}
               onDismiss={(name) => void run(() => dismissDreamSkill(agentId, dream.dreamId, name))}
             />
@@ -601,16 +610,24 @@ function DreamReview({
  * can auto-adopt on a trusted runtime.
  */
 function DreamSkills({
+  agentId,
+  dreamId,
   proposed,
   busy,
   onAccept,
   onDismiss
 }: {
+  agentId: string
+  dreamId: string
   proposed: Array<{ name: string; description: string }>
   busy: boolean
   onAccept: (name: string) => void
   onDismiss: (name: string) => void
 }) {
+  // Accept stays disabled until the body has been opened. The whole safety
+  // argument for mined skills is that a human reviewed them, and a
+  // model-authored description is not evidence for itself.
+  const [seen, setSeen] = useState<Set<string>>(new Set())
   return (
     <div className="flex flex-col gap-2 rounded-md border border-(--border-subtle) bg-(--surface-sunken) p-3">
       <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-secondary)">
@@ -635,12 +652,71 @@ function DreamSkills({
             <Button variant="secondary" disabled={busy} onClick={() => onDismiss(skill.name)}>
               Dismiss
             </Button>
-            <Button disabled={busy} onClick={() => onAccept(skill.name)}>
+            <Button disabled={busy || !seen.has(skill.name)} onClick={() => onAccept(skill.name)}>
               Accept
             </Button>
           </span>
+          <SkillBody
+            agentId={agentId}
+            dreamId={dreamId}
+            name={skill.name}
+            onRead={() => setSeen((current) => new Set(current).add(skill.name))}
+          />
         </div>
       ))}
     </div>
+  )
+}
+
+/** The staged SKILL.md and scripts, behind a disclosure. Opening it is what
+ *  enables Accept — see the note in DreamSkills. */
+function SkillBody({
+  agentId,
+  dreamId,
+  name,
+  onRead
+}: {
+  agentId: string
+  dreamId: string
+  name: string
+  onRead: () => void
+}) {
+  const [content, setContent] = useState<DreamSkillContentDto | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  return (
+    <details
+      className="w-full"
+      onToggle={(e) => {
+        if (!(e.currentTarget as HTMLDetailsElement).open || content) return
+        onRead()
+        void fetchDreamSkill(agentId, dreamId, name)
+          .then(setContent)
+          .catch((err) => setError(err instanceof Error ? err.message : 'Could not load this skill.'))
+      }}
+    >
+      <summary className="cursor-pointer list-none font-sans text-[11px] font-medium leading-normal text-(--brand-soft-text) [&::-webkit-details-marker]:hidden">
+        Show what this installs
+      </summary>
+      {error ? <div className="mt-1 font-sans text-[11px] text-(--status-error)">{error}</div> : null}
+      {content?.exists === false ? (
+        <div className="mt-1 font-sans text-[11px] text-(--text-tertiary)">This candidate is no longer staged.</div>
+      ) : null}
+      {content?.skill ? (
+        <pre className="mt-1 max-h-[240px] overflow-auto rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2 font-mono text-[11px] leading-[1.5] whitespace-pre-wrap text-(--text-primary)">
+          {content.skill}
+        </pre>
+      ) : null}
+      {(content?.scripts ?? []).map((script) => (
+        <div key={script.path} className="mt-1 flex flex-col gap-[2px]">
+          <span className="font-mono text-[10.5px] font-medium leading-normal text-(--text-tertiary)">
+            scripts/{script.path}
+          </span>
+          <pre className="max-h-[240px] overflow-auto rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2 font-mono text-[11px] leading-[1.5] whitespace-pre-wrap text-(--text-primary)">
+            {script.content}
+          </pre>
+        </div>
+      ))}
+    </details>
   )
 }

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -22,6 +22,8 @@ import {
   listDreams,
   adoptDream,
   discardDream,
+  acceptDreamSkill,
+  dismissDreamSkill,
   cancelDream,
   listDreamFiles,
   fetchDreamFileFull,
@@ -360,6 +362,24 @@ export function DreamPanel({
           />
         ) : null}
 
+        {/* Mined skill recommendations. Deliberately OUTSIDE the store-review
+            block: a skill's review lifecycle is independent of the store
+            proposal (§7), so they stay actionable whether or not the store was
+            adopted, and after the store staging is gone. */}
+        {(dreams ?? []).map((dream) => {
+          const proposed = (dream.skills ?? []).filter((skill) => skill.state === 'proposed')
+          if (proposed.length === 0) return null
+          return (
+            <DreamSkills
+              key={`skills-${dream.dreamId}`}
+              proposed={proposed}
+              busy={busy || !canEdit}
+              onAccept={(name) => void run(() => acceptDreamSkill(agentId, dream.dreamId, name))}
+              onDismiss={(name) => void run(() => dismissDreamSkill(agentId, dream.dreamId, name))}
+            />
+          )
+        })}
+
         {pastDreams.length ? (
           <details className="group">
             <summary
@@ -570,6 +590,57 @@ function DreamReview({
           </div>
         </div>
       ) : null}
+    </div>
+  )
+}
+
+/**
+ * Skills this dream mined and is RECOMMENDING. Never auto-installed: a skill is
+ * executable instruction content that steers every later session, so acceptance
+ * is always an explicit human act (design §7) — unlike the memory store, which
+ * can auto-adopt on a trusted runtime.
+ */
+function DreamSkills({
+  proposed,
+  busy,
+  onAccept,
+  onDismiss
+}: {
+  proposed: Array<{ name: string; description: string }>
+  busy: boolean
+  onAccept: (name: string) => void
+  onDismiss: (name: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-(--border-subtle) bg-(--surface-sunken) p-3">
+      <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-secondary)">
+        Suggested skills
+      </span>
+      <span className="font-sans text-[11px] font-normal leading-[1.5] text-(--text-tertiary)">
+        Procedures this agent kept repeating. Accepting one installs it for this agent so later sessions can reuse it —
+        it is never installed for you.
+      </span>
+      {proposed.map((skill) => (
+        <div
+          key={skill.name}
+          className="flex flex-wrap items-start justify-between gap-2 border-t border-(--border-subtle) pt-2 first-of-type:border-t-0 first-of-type:pt-0"
+        >
+          <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+            <span className="font-mono text-[12px] font-medium leading-normal text-(--text-primary)">{skill.name}</span>
+            <span className="font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-secondary)">
+              {skill.description}
+            </span>
+          </span>
+          <span className="flex flex-none items-center gap-2">
+            <Button variant="secondary" disabled={busy} onClick={() => onDismiss(skill.name)}>
+              Dismiss
+            </Button>
+            <Button disabled={busy} onClick={() => onAccept(skill.name)}>
+              Accept
+            </Button>
+          </span>
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -113,6 +113,9 @@ export function DreamPanel({
   sessionBasePath?: string
 }) {
   const [dreams, setDreams] = useState<DreamDto[] | null>(null)
+  // Fetched separately: a proposal outlives the store lifecycle, so it must not
+  // depend on how deep the newest-first history has grown.
+  const [pendingSkillDreams, setPendingSkillDreams] = useState<DreamDto[]>([])
   const [listError, setListError] = useState<string | null>(null)
   // 409 DAEMON_FEATURE_MISSING — this agent's daemon predates dreaming. Not an
   // error the user can act on except by upgrading, so it gets its own state.
@@ -131,7 +134,11 @@ export function DreamPanel({
       // Proposed skills deliberately survive adoption/discard until reviewed, so a
       // pending candidate must not fall off the list behind newer runs. Ask for
       // the full window the CP allows rather than one screen's worth.
-      const rows = await listDreams(agentId, DREAM_PAGE)
+      const [rows, pending] = await Promise.all([
+        listDreams(agentId, DREAM_PAGE),
+        listDreams(agentId, DREAM_PAGE, { pendingSkills: true }).catch(() => [] as DreamDto[])
+      ])
+      setPendingSkillDreams(pending)
       if (request !== listRequest.current) return
       setDreams(rows)
       setListError(null)
@@ -373,7 +380,7 @@ export function DreamPanel({
             block: a skill's review lifecycle is independent of the store
             proposal (§7), so they stay actionable whether or not the store was
             adopted, and after the store staging is gone. */}
-        {(dreams ?? []).map((dream) => {
+        {pendingSkillDreams.map((dream) => {
           const proposed = (dream.skills ?? []).filter((skill) => skill.state === 'proposed')
           if (proposed.length === 0) return null
           return (
@@ -689,9 +696,13 @@ function SkillBody({
       className="w-full"
       onToggle={(e) => {
         if (!(e.currentTarget as HTMLDetailsElement).open || content) return
-        onRead()
         void fetchDreamSkill(agentId, dreamId, name)
-          .then(setContent)
+          .then((body) => {
+            setContent(body)
+            // Only a body that actually rendered counts as reviewed — a pending
+            // request, an error, or vanished staging must all keep Accept off.
+            if (body.exists && body.skill) onRead()
+          })
           .catch((err) => setError(err instanceof Error ? err.message : 'Could not load this skill.'))
       }}
     >

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1997,6 +1997,22 @@ export async function adoptDream(agentId: string, dreamId: string, force = false
   return apiPost<DreamDto>(`${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/adopt`, force ? { force } : {})
 }
 
+/** Accept one mined skill candidate — installs it for this agent (design §7). */
+export async function acceptDreamSkill(agentId: string, dreamId: string, name: string): Promise<DreamDto> {
+  return apiPost<DreamDto>(
+    `${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/skills/${encodeURIComponent(name)}/accept`,
+    {}
+  )
+}
+
+/** Dismiss one mined skill candidate — drops its staging and records the call. */
+export async function dismissDreamSkill(agentId: string, dreamId: string, name: string): Promise<DreamDto> {
+  return apiPost<DreamDto>(
+    `${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/skills/${encodeURIComponent(name)}/dismiss`,
+    {}
+  )
+}
+
 export async function discardDream(agentId: string, dreamId: string): Promise<DreamDto> {
   return apiPost<DreamDto>(`${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/discard`, {})
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1997,6 +1997,20 @@ export async function adoptDream(agentId: string, dreamId: string, force = false
   return apiPost<DreamDto>(`${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/adopt`, force ? { force } : {})
 }
 
+export interface DreamSkillContentDto {
+  name: string
+  exists: boolean
+  skill: string | null
+  scripts: { path: string; content: string }[]
+}
+
+/** Read a candidate's FULL staged body — what accepting would install. */
+export async function fetchDreamSkill(agentId: string, dreamId: string, name: string): Promise<DreamSkillContentDto> {
+  return apiGet<DreamSkillContentDto>(
+    `${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/skills/${encodeURIComponent(name)}`
+  )
+}
+
 /** Accept one mined skill candidate — installs it for this agent (design §7). */
 export async function acceptDreamSkill(agentId: string, dreamId: string, name: string): Promise<DreamDto> {
   return apiPost<DreamDto>(

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1979,8 +1979,15 @@ export async function startDream(
   return apiPost<DreamDto>(dreamBase(agentId), opts)
 }
 
-export async function listDreams(agentId: string, limit?: number): Promise<DreamDto[]> {
-  const q = limit ? `?limit=${limit}` : ''
+export async function listDreams(
+  agentId: string,
+  limit?: number,
+  opts: { pendingSkills?: boolean } = {}
+): Promise<DreamDto[]> {
+  const params = new URLSearchParams()
+  if (limit) params.set('limit', String(limit))
+  if (opts.pendingSkills) params.set('pendingSkills', '1')
+  const q = params.toString() ? `?${params.toString()}` : ''
   return (await apiGet<{ dreams: DreamDto[] }>(`${dreamBase(agentId)}${q}`)).dreams
 }
 


### PR DESCRIPTION
Closes the last gap in D-3. The daemon could already mine, stage, accept and dismiss skills (#86, #108) and the protocol frames have existed since D-1 — but nothing reachable from a browser could drive any of it. This is the CP relay plus the console surface.

## What's here

**control-plane** — `dreamSkillAccept` / `dreamSkillDismiss` on the outbound sender, and `POST …/dreams/:dreamId/skills/:name/accept|dismiss`. Both go through the **same guard as adopt/discard**, so they inherit its properties rather than re-deriving them: a viewer gets `403`, a pre-dreaming daemon gets `409 DAEMON_FEATURE_MISSING`, and in both cases **nothing is forwarded**. The `:name` param carries the miner's own kebab-case regex, so a traversal-shaped name is refused at the schema — before it could ever reach a filesystem path.

**web** — `acceptDreamSkill` / `dismissDreamSkill`, and a "Suggested skills" block listing each still-`proposed` candidate with its description and Accept / Dismiss.

## One deliberate placement

The recommendations render **outside** the store-review block. A skill's review lifecycle is independent of the store proposal (design §7) — accepting a skill from a dream whose store you discarded is explicitly supported — so candidates stay actionable whether or not the store was adopted, and after its staging is swept. The copy says acceptance *installs the skill for this agent*, because that's the consequence the reviewer is agreeing to.

Skills are still **never** auto-installed, even when the store auto-adopts: a hallucinated or injection-shaped procedure would silently steer every later session, which is a different blast radius from a stale memory note.

## Test plan

- **Console:** nothing is installed without an explicit click; already-reviewed candidates are not re-offered; a viewer sees the actions disabled.
- **CP integration:** forwarding, a traversal-shaped name, the viewer `403`, and the version-skew `409` — each asserting the daemon was **never contacted**.
- Suites: control-plane **668** unit / **683** integration, web **372**. Typecheck, ESLint, Prettier, and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)