### PR TITLE
fix(web): diff memory dream results

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -425,8 +425,9 @@ architecture invariant:
   `DreamRecord` metadata (including per-skill review states) for listing when
   the daemon is offline.
 - **Console** — the Background memory section (§3) plus, per dream: a review
-  screen showing current-vs-staged store files (reusing the file browser
-  components) with Adopt / Discard, and a "Recommended skills" list rendering
+  screen showing a current-to-staged line diff for each store file (reusing the
+  managed-memory history diff and file browser components) with Adopt / Discard,
+  and a "Recommended skills" list rendering
   each candidate's `SKILL.md` and scripts with Accept / Dismiss. Accepted
   skills also surface on the Tools & Skills page alongside imported sources.
   Both branches of the mobile/desktop split follow the existing

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -213,6 +213,11 @@ not justify renaming a topic. A rename, merge, or split is appropriate only when
 material content change makes the existing structure misleading; equally faithful
 proposals prefer the smallest diff.
 
+Reviewing a completed dream shows each file as the same live-to-proposed line diff
+used by managed-memory history. Added and deleted files use an empty live or proposed
+side respectively, so their entire contents are visibly marked as additions or
+removals before adoption.
+
 Each dream model run appears in Sessions with its runtime, model, token/cost usage,
 and a lifecycle-only history. Dream history and evaluation events must never copy
 memory bodies, source transcript text, model proposals, or mined skill bodies. The

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -195,7 +195,7 @@ describe('DreamPanel', () => {
     expect(button(host, 'Cancel')).toBeTruthy()
   })
 
-  it('shows the live store beside the staged one when reviewing, then adopts', async () => {
+  it('shows the shared line diff from the live store to the staged one, then adopts', async () => {
     api.listDreams.mockResolvedValue([dream()])
     const host = await render()
 
@@ -203,9 +203,9 @@ describe('DreamPanel', () => {
     await act(async () => {
       await Promise.resolve()
     })
-    // Both sides are visible — the point of a staged dream.
-    expect(host.textContent).toContain('# Memory (old)')
-    expect(host.textContent).toContain('# Memory (rebuilt)')
+    const lineDiff = host.querySelector('table[aria-label="Line changes"]')
+    expect(lineDiff?.querySelector('[data-diff-kind="delete"]')?.textContent).toContain('# Memory (old)')
+    expect(lineDiff?.querySelector('[data-diff-kind="add"]')?.textContent).toContain('# Memory (rebuilt)')
 
     // Adopt is confirmed first (it replaces live memory) — nothing is called
     // until the user confirms in the dialog.
@@ -276,8 +276,9 @@ describe('DreamPanel', () => {
     // Named up front, and the live-only file is selectable and marked.
     expect(host.textContent).toContain('Adopting removes 1 file')
     expect(host.textContent).toContain('stale.md')
-    expect(host.textContent).toContain('Deleted by this dream')
-    expect(host.textContent).toContain('- an obsolete note')
+    const lineDiff = host.querySelector('table[aria-label="Line changes"]')
+    expect(lineDiff?.querySelector('[data-diff-kind="delete"]')?.textContent).toContain('- an obsolete note')
+    expect(lineDiff?.querySelector('[data-diff-kind="add"]')).toBeNull()
   })
 
   it('keeps revalidating once settled, so an externally started dream appears', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -8,7 +8,7 @@
 //      the copy says so, and the button reflects the one-in-flight rule rather
 //      than letting the user hit a raw 409.
 //   2. The job list, polled while anything is pending/running.
-//   3. Review — the staged store a completed dream produced, side by side with
+//   3. Review — the staged store a completed dream produced, diffed against
 //      what is live now, plus Adopt / Discard. A dream is STAGED by design, so
 //      the trigger without this review surface would be a dead end.
 //
@@ -37,6 +37,7 @@ import {
 import { Icon, Button } from '@/components/ui'
 import { Spinner } from '@/components/marks'
 import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
+import { LineDiff } from '@/components/console/LineDiff'
 
 /** While a dream is in flight the list changes fast. */
 const POLL_MS = 4000
@@ -418,7 +419,7 @@ export function DreamPanel({
   )
 }
 
-/** Side-by-side of one staged file and what is live now, for a completed dream. */
+/** Line diff of one staged file against what is live now, for a completed dream. */
 function DreamReview({
   agentId,
   dreamId,
@@ -495,7 +496,6 @@ function DreamReview({
     })()
   }, [agentId, dreamId, selected])
 
-  const current = paths?.find((p) => p.name === selected)
   const deleting = (paths ?? []).filter((p) => p.live && !p.staged)
 
   return (
@@ -547,28 +547,7 @@ function DreamReview({
           <Spinner /> Loading…
         </div>
       ) : selected ? (
-        <div className="grid grid-cols-1 gap-3 desktop:grid-cols-2">
-          <div className="flex flex-col gap-1">
-            <span className="font-sans text-[11px] font-semibold leading-normal text-(--text-tertiary)">Live now</span>
-            <pre className="m-0 max-h-[320px] overflow-auto rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2 font-mono text-[11.5px] leading-[1.5] whitespace-pre-wrap text-(--text-secondary)">
-              {live || '(this file does not exist yet)'}
-            </pre>
-          </div>
-          <div className="flex flex-col gap-1">
-            <span
-              className={
-                current && current.live && !current.staged
-                  ? 'font-sans text-[11px] font-semibold leading-normal text-(--status-error)'
-                  : 'font-sans text-[11px] font-semibold leading-normal text-(--brand-soft-text)'
-              }
-            >
-              {current && current.live && !current.staged ? 'Deleted by this dream' : 'Staged by this dream'}
-            </span>
-            <pre className="m-0 max-h-[320px] overflow-auto rounded-sm border border-(--border-subtle) bg-(--surface-card) p-2 font-mono text-[11.5px] leading-[1.5] whitespace-pre-wrap text-(--text-primary)">
-              {current && current.live && !current.staged ? '(removed — this file will be deleted)' : staged}
-            </pre>
-          </div>
-        </div>
+        <LineDiff before={live} after={staged} />
       ) : null}
     </div>
   )

--- a/packages/web/src/components/console/LineDiff.test.ts
+++ b/packages/web/src/components/console/LineDiff.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { diffLines, type LineDiffRow } from './LineDiff'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { diffLines, LineDiff, type LineDiffRow } from './LineDiff'
 
 function rebuild(rows: LineDiffRow[], side: 'old' | 'new'): string {
   const contentKind = side === 'old' ? 'delete' : 'add'
@@ -93,19 +95,21 @@ describe('diffLines', () => {
     }
   })
 
-  it('handles a newline-heavy 4 KB snapshot without a quadratic matrix', () => {
+  it('groups a newline-heavy 4 KB snapshot into bounded render rows', () => {
     const before = `a${'\n'.repeat(3_998)}x`
     const after = `b${'\n'.repeat(3_998)}y`
 
     const rows = diffLines(before, after)
 
-    expect(rows.filter((row) => row.kind === 'context')).toHaveLength(3_997)
-    expect(rows.filter((row) => row.kind === 'delete').map((row) => row.text)).toEqual(['a', 'x'])
-    expect(rows.filter((row) => row.kind === 'add').map((row) => row.text)).toEqual(['b', 'y'])
-    expect(rows.filter((row) => row.kind === 'meta')).toHaveLength(2)
+    expect(rows.filter((row) => row.kind === 'context')).toHaveLength(0)
+    expect(rows.filter((row) => row.kind === 'delete')).toHaveLength(1)
+    expect(rows.filter((row) => row.kind === 'add')).toHaveLength(1)
+    expect(rows.filter((row) => row.kind === 'meta')).toHaveLength(3)
+    expect(rebuild(rows, 'old')).toBe(before)
+    expect(rebuild(rows, 'new')).toBe(after)
   })
 
-  it('simplifies a large changed middle while preserving both complete files', () => {
+  it('groups a large changed middle while preserving both complete files', () => {
     const before = [
       'head',
       ...Array.from({ length: 2_300 }, (_, index) => [`same-${index}`, `old-${index}`]).flat(),
@@ -119,14 +123,28 @@ describe('diffLines', () => {
 
     const rows = diffLines(before, after)
 
-    expect(rows.filter((row) => row.kind === 'context').map((row) => row.text)).toEqual(['head', 'same-0', 'tail'])
+    expect(rows.filter((row) => row.kind === 'context').map((row) => row.text)).toEqual(['head\nsame-0', 'tail'])
     expect(rows).toContainEqual(
       expect.objectContaining({
         kind: 'meta',
-        text: expect.stringContaining('Large diff simplified')
+        text: expect.stringContaining('Large diff grouped')
       })
     )
     expect(rebuild(rows, 'old')).toBe(before)
     expect(rebuild(rows, 'new')).toBe(after)
+  })
+
+  it('bounds rendered rows for maximum-size newline-heavy dream files', () => {
+    const before = 'a\n'.repeat(128_000)
+    const after = 'b\n'.repeat(128_000)
+
+    const rows = diffLines(before, after)
+    const markup = renderToStaticMarkup(createElement(LineDiff, { before, after }))
+
+    expect(rows).toHaveLength(3)
+    expect(rows.find((row) => row.kind === 'delete')?.oldLineCount).toBe(128_000)
+    expect(rows.find((row) => row.kind === 'add')?.newLineCount).toBe(128_000)
+    expect(markup.match(/<tr/g)).toHaveLength(3)
+    expect(Buffer.byteLength(markup)).toBeLessThan(2_000_000)
   })
 })

--- a/packages/web/src/components/console/LineDiff.test.ts
+++ b/packages/web/src/components/console/LineDiff.test.ts
@@ -104,4 +104,29 @@ describe('diffLines', () => {
     expect(rows.filter((row) => row.kind === 'add').map((row) => row.text)).toEqual(['b', 'y'])
     expect(rows.filter((row) => row.kind === 'meta')).toHaveLength(2)
   })
+
+  it('simplifies a large changed middle while preserving both complete files', () => {
+    const before = [
+      'head',
+      ...Array.from({ length: 2_300 }, (_, index) => [`same-${index}`, `old-${index}`]).flat(),
+      'tail'
+    ].join('\n')
+    const after = [
+      'head',
+      ...Array.from({ length: 2_300 }, (_, index) => [`same-${index}`, `new-${index}`]).flat(),
+      'tail'
+    ].join('\n')
+
+    const rows = diffLines(before, after)
+
+    expect(rows.filter((row) => row.kind === 'context').map((row) => row.text)).toEqual(['head', 'same-0', 'tail'])
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        kind: 'meta',
+        text: expect.stringContaining('Large diff simplified')
+      })
+    )
+    expect(rebuild(rows, 'old')).toBe(before)
+    expect(rebuild(rows, 'new')).toBe(after)
+  })
 })

--- a/packages/web/src/components/console/LineDiff.tsx
+++ b/packages/web/src/components/console/LineDiff.tsx
@@ -5,6 +5,8 @@ export interface LineDiffRow {
   text: string
   oldLine?: number
   newLine?: number
+  oldLineCount?: number
+  newLineCount?: number
   eofSide?: 'old' | 'new' | 'both'
 }
 
@@ -33,10 +35,10 @@ interface LineMatch {
   newIndex: number
 }
 
-/** Hirschberg is memory-linear but still quadratic in time. History snapshots
- * are capped at 4 KB, while dream review can compare a complete 256 KB memory
- * file, so bound exact work before the shared renderer is used there. */
-const MAX_EXACT_DIFF_CELLS = 20_000_000
+/** Bounds both quadratic matching and the number of table rows. History
+ * snapshots are capped at 4 KB, while dream review can compare a complete
+ * 256 KB memory file containing hundreds of thousands of tiny lines. */
+const MAX_DETAILED_DIFF_LINES = 2_000
 
 function prefixLcsLengths(
   oldLines: LineToken[],
@@ -141,17 +143,19 @@ function addEofMarkers(rows: LineDiffRow[], oldLines: LineToken[], newLines: Lin
   const withMarkers: LineDiffRow[] = []
   for (const row of rows) {
     withMarkers.push(row)
-    if (row.kind === 'delete' && row.oldLine === oldCount && oldMissingNewline) {
+    const oldEnd = row.oldLine === undefined ? undefined : row.oldLine + (row.oldLineCount ?? 1) - 1
+    const newEnd = row.newLine === undefined ? undefined : row.newLine + (row.newLineCount ?? 1) - 1
+    if (row.kind === 'delete' && oldEnd === oldCount && oldMissingNewline) {
       withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'old' })
     }
-    if (row.kind === 'add' && row.newLine === newCount && newMissingNewline) {
+    if (row.kind === 'add' && newEnd === newCount && newMissingNewline) {
       withMarkers.push({ kind: 'meta', text: 'No newline at end of file', eofSide: 'new' })
     }
     if (
       hasChanges &&
       row.kind === 'context' &&
-      row.oldLine === oldCount &&
-      row.newLine === newCount &&
+      oldEnd === oldCount &&
+      newEnd === newCount &&
       oldMissingNewline &&
       newMissingNewline
     ) {
@@ -161,11 +165,69 @@ function addEofMarkers(rows: LineDiffRow[], oldLines: LineToken[], newLines: Lin
   return withMarkers
 }
 
+function groupedDiffRows(oldLines: LineToken[], newLines: LineToken[], prefix: number, suffix: number): LineDiffRow[] {
+  const rows: LineDiffRow[] = []
+  const blockText = (lines: LineToken[], start: number, end: number) =>
+    lines
+      .slice(start, end)
+      .map((line) => line.text)
+      .join('\n')
+  if (prefix > 0) {
+    rows.push({
+      kind: 'context',
+      text: blockText(oldLines, 0, prefix),
+      oldLine: 1,
+      newLine: 1,
+      oldLineCount: prefix,
+      newLineCount: prefix
+    })
+  }
+
+  const oldMiddleEnd = oldLines.length - suffix
+  const newMiddleEnd = newLines.length - suffix
+  const oldMiddleCount = oldMiddleEnd - prefix
+  const newMiddleCount = newMiddleEnd - prefix
+  if (oldMiddleCount > 0 && newMiddleCount > 0) {
+    rows.push({
+      kind: 'meta',
+      text: 'Large diff grouped; unchanged lines inside this block may appear removed and added.'
+    })
+  }
+  if (oldMiddleCount > 0) {
+    rows.push({
+      kind: 'delete',
+      text: blockText(oldLines, prefix, oldMiddleEnd),
+      oldLine: prefix + 1,
+      oldLineCount: oldMiddleCount
+    })
+  }
+  if (newMiddleCount > 0) {
+    rows.push({
+      kind: 'add',
+      text: blockText(newLines, prefix, newMiddleEnd),
+      newLine: prefix + 1,
+      newLineCount: newMiddleCount
+    })
+  }
+  if (suffix > 0) {
+    rows.push({
+      kind: 'context',
+      text: blockText(oldLines, oldMiddleEnd, oldLines.length),
+      oldLine: oldMiddleEnd + 1,
+      newLine: newMiddleEnd + 1,
+      oldLineCount: suffix,
+      newLineCount: suffix
+    })
+  }
+  return rows
+}
+
 /**
  * Exact line diff for bounded text snapshots. Hirschberg keeps working memory
  * linear even when a valid 4 KB snapshot contains thousands of tiny lines.
- * For a larger changed middle, retain exact common edges and render the middle
- * as one delete/add block instead of freezing the browser on quadratic work.
+ * Larger files retain exact common edges but group each edge and changed side
+ * into a bounded number of rendered blocks, avoiding quadratic work and an
+ * unbounded number of DOM rows.
  */
 export function diffLines(before: string, after: string): LineDiffRow[] {
   const oldLines = splitLines(before)
@@ -183,13 +245,11 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
     suffix += 1
   }
 
-  const oldMiddleLength = oldLines.length - prefix - suffix
-  const newMiddleLength = newLines.length - prefix - suffix
-  const simplified = oldMiddleLength * newMiddleLength > MAX_EXACT_DIFF_CELLS
-  const matches: LineMatch[] = oldLines.slice(0, prefix).map((_text, index) => ({ oldIndex: index, newIndex: index }))
-  if (!simplified) {
-    collectLcsMatches(oldLines, prefix, oldLines.length - suffix, newLines, prefix, newLines.length - suffix, matches)
+  if (oldLines.length + newLines.length > MAX_DETAILED_DIFF_LINES) {
+    return addEofMarkers(groupedDiffRows(oldLines, newLines, prefix, suffix), oldLines, newLines)
   }
+  const matches: LineMatch[] = oldLines.slice(0, prefix).map((_text, index) => ({ oldIndex: index, newIndex: index }))
+  collectLcsMatches(oldLines, prefix, oldLines.length - suffix, newLines, prefix, newLines.length - suffix, matches)
   for (let index = 0; index < suffix; index += 1) {
     matches.push({
       oldIndex: oldLines.length - suffix + index,
@@ -226,12 +286,6 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
     rows.push({ kind: 'add', text: newLines[newIndex]!.text, newLine: newIndex + 1 })
     newIndex += 1
   }
-  if (simplified) {
-    rows.splice(prefix, 0, {
-      kind: 'meta',
-      text: 'Large diff simplified; unchanged lines inside this block may appear removed and added.'
-    })
-  }
   return addEofMarkers(rows, oldLines, newLines)
 }
 
@@ -247,6 +301,12 @@ const MARKER: Record<LineDiffKind, string> = {
   add: '+',
   delete: '−',
   meta: '\\'
+}
+
+function lineLabel(start: number | undefined, count: number | undefined): string {
+  if (start === undefined) return ''
+  if (!count || count === 1) return String(start)
+  return `${start}–${start + count - 1}`
 }
 
 export function LineDiff({ before, after }: { before: string; after: string }) {
@@ -270,13 +330,13 @@ export function LineDiff({ before, after }: { before: string; after: string }) {
                   className={ROW_STYLE[row.kind]}
                   data-diff-kind={row.kind}
                 >
-                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right text-(--text-tertiary)">
-                    {row.oldLine ?? ''}
+                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right align-top text-(--text-tertiary)">
+                    {lineLabel(row.oldLine, row.oldLineCount)}
                   </td>
-                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right text-(--text-tertiary)">
-                    {row.newLine ?? ''}
+                  <td className="w-9 select-none border-r border-(--border-subtle) px-2 py-px text-right align-top text-(--text-tertiary)">
+                    {lineLabel(row.newLine, row.newLineCount)}
                   </td>
-                  <td className="w-7 select-none px-2 py-px text-center font-semibold">{MARKER[row.kind]}</td>
+                  <td className="w-7 select-none px-2 py-px text-center align-top font-semibold">{MARKER[row.kind]}</td>
                   <td className="whitespace-pre px-2 py-px pr-4">{row.text || '\u00a0'}</td>
                 </tr>
               ))}

--- a/packages/web/src/components/console/LineDiff.tsx
+++ b/packages/web/src/components/console/LineDiff.tsx
@@ -33,6 +33,11 @@ interface LineMatch {
   newIndex: number
 }
 
+/** Hirschberg is memory-linear but still quadratic in time. History snapshots
+ * are capped at 4 KB, while dream review can compare a complete 256 KB memory
+ * file, so bound exact work before the shared renderer is used there. */
+const MAX_EXACT_DIFF_CELLS = 20_000_000
+
 function prefixLcsLengths(
   oldLines: LineToken[],
   oldStart: number,
@@ -159,6 +164,8 @@ function addEofMarkers(rows: LineDiffRow[], oldLines: LineToken[], newLines: Lin
 /**
  * Exact line diff for bounded text snapshots. Hirschberg keeps working memory
  * linear even when a valid 4 KB snapshot contains thousands of tiny lines.
+ * For a larger changed middle, retain exact common edges and render the middle
+ * as one delete/add block instead of freezing the browser on quadratic work.
  */
 export function diffLines(before: string, after: string): LineDiffRow[] {
   const oldLines = splitLines(before)
@@ -176,8 +183,13 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
     suffix += 1
   }
 
+  const oldMiddleLength = oldLines.length - prefix - suffix
+  const newMiddleLength = newLines.length - prefix - suffix
+  const simplified = oldMiddleLength * newMiddleLength > MAX_EXACT_DIFF_CELLS
   const matches: LineMatch[] = oldLines.slice(0, prefix).map((_text, index) => ({ oldIndex: index, newIndex: index }))
-  collectLcsMatches(oldLines, prefix, oldLines.length - suffix, newLines, prefix, newLines.length - suffix, matches)
+  if (!simplified) {
+    collectLcsMatches(oldLines, prefix, oldLines.length - suffix, newLines, prefix, newLines.length - suffix, matches)
+  }
   for (let index = 0; index < suffix; index += 1) {
     matches.push({
       oldIndex: oldLines.length - suffix + index,
@@ -213,6 +225,12 @@ export function diffLines(before: string, after: string): LineDiffRow[] {
   while (newIndex < newLines.length) {
     rows.push({ kind: 'add', text: newLines[newIndex]!.text, newLine: newIndex + 1 })
     newIndex += 1
+  }
+  if (simplified) {
+    rows.splice(prefix, 0, {
+      kind: 'meta',
+      text: 'Large diff simplified; unchanged lines inside this block may appear removed and added.'
+    })
   }
   return addEofMarkers(rows, oldLines, newLines)
 }


### PR DESCRIPTION
## What changed

- replace the dream review panel’s raw side-by-side snapshots with the shared managed-memory `LineDiff` renderer
- show updates, additions, deletions, and unchanged files with the same line-level presentation as memory history
- bound exact diff work for complete dream files and show a transparent simplified block for unusually large comparisons
- update the dreaming design and product conventions

## Root cause

Memory history already used the reusable line-diff component, but dream review independently rendered two `<pre>` snapshots. That made proposed changes harder to scan and created inconsistent review behavior across the two memory surfaces.

## User impact

Users can now inspect a dream proposal as a live-to-staged unified line diff before adopting it, including whole-file additions and removals.

## Validation

- `pnpm --filter @agentconnect.md/web test` (369 passed)
- `pnpm --filter @agentconnect.md/web typecheck`
- ESLint on all changed TypeScript files
- Prettier check on all changed files
- `git diff --check`
- repository pre-push lint (0 errors; 2 pre-existing warnings outside this change)