### PR TITLE
feat(web): add first-run onboarding wizard

### DIFF
--- a/packages/web/src/app/(app)/[slug]/onboarding/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/onboarding/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next'
+import OnboardingView from '@/components/console/views/OnboardingView'
+
+export const metadata: Metadata = { title: 'Get started · AgentConnect' }
+
+export default function Page() {
+  return <OnboardingView />
+}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -2002,7 +2002,7 @@ export default function AddIntegrationModal({
                           <span>{'  -d \'{"message":"'}</span>
                           <textarea
                             ref={hookMessageRef}
-                            className="mx-[2px] min-h-[20px] min-w-[18ch] flex-1 resize-none overflow-hidden rounded-xs border border-(--border-subtle) bg-(--surface-active) px-[3px] py-0 font-mono text-[12px] leading-[1.65] text-[#cdd6e0] outline-none focus:border-(--brand)"
+                            className="mx-[2px] min-h-[20px] min-w-[18ch] flex-1 resize-none overflow-hidden rounded-xs border border-(--gray-800) bg-(--gray-900) px-[3px] py-0 font-mono text-[12px] leading-[1.65] text-[#cdd6e0] outline-none focus:border-(--brand)"
                             rows={1}
                             spellCheck={false}
                             aria-label="Webhook test message"

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -16,7 +16,7 @@ import { useProfile } from '@/lib/profile'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { AgentReachabilityOverview } from '@/components/console/AgentReachabilityOverview'
-import { isOnboardingSkipped } from '@/lib/onboarding'
+import { isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
 
 // Two-letter avatar initials for a creator name — first letters of the first two
 // words, or the first two chars of a single token.
@@ -103,14 +103,23 @@ export default function AgentsView() {
   // clicked; clicking the active column flips direction. Text columns default ascending,
   // numeric columns descending (highest first is the useful default).
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null)
-  // Fresh-workspace onboarding lives on its own /onboarding route. When this org has no
-  // daemon and no agent, redirect there — unless the operator already chose "Explore the
-  // console first" this session (the skip flag), which would otherwise loop right back.
+  // Fresh-workspace onboarding lives on its own /onboarding route. An offline daemon is
+  // recoverable there, so only an online daemon or an agent counts as initialized.
   const router = useRouter()
   const params = useParams()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
-  const notInitialized = !agentsLoading && !daemonsLoading && agents.length === 0 && daemons.length === 0
-  const redirectToOnboarding = notInitialized && !isOnboardingSkipped(orgKey)
+  const [skipState, setSkipState] = useState<{ orgKey: string; skipped: boolean } | null>(null)
+  const onboardingSkipped = skipState?.orgKey === orgKey ? skipState.skipped : null
+  useEffect(() => {
+    setSkipState({ orgKey, skipped: isOnboardingSkipped(orgKey) })
+  }, [orgKey])
+  const notInitialized = needsOnboarding(
+    agentsLoading,
+    daemonsLoading,
+    agents.length,
+    daemons.some((daemon) => daemon.status === 'online')
+  )
+  const redirectToOnboarding = notInitialized && onboardingSkipped === false
   useEffect(() => {
     if (redirectToOnboarding) router.replace(`/${orgKey}/onboarding`)
   }, [redirectToOnboarding, router, orgKey])
@@ -199,7 +208,7 @@ export default function AgentsView() {
 
   // While the redirect to /onboarding is in flight, hold a spinner so the empty
   // table/metrics never flash behind it.
-  if (redirectToOnboarding) return <LoadingState fill />
+  if (notInitialized && onboardingSkipped !== true) return <LoadingState fill />
 
   if (view === 'topology') {
     if (isMobile) {

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
 import { agentLabel, agentModelDisplay, effectiveAgentStatus, runtimeLabel, status, type Agent } from '@/lib/data'
 import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
@@ -15,6 +16,7 @@ import { useProfile } from '@/lib/profile'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { AgentReachabilityOverview } from '@/components/console/AgentReachabilityOverview'
+import { isOnboardingSkipped } from '@/lib/onboarding'
 
 // Two-letter avatar initials for a creator name — first letters of the first two
 // words, or the first two chars of a single token.
@@ -47,7 +49,8 @@ function parseCompact(s: string): number {
 export default function AgentsView() {
   const acpRegistry = useAcpRegistry()
   const { orgPath } = useOrgs()
-  const { agents, daemons, integrations, members, getSessions, usage24h, agentsLoading } = useConsoleData()
+  const { agents, daemons, integrations, members, getSessions, usage24h, agentsLoading, daemonsLoading } =
+    useConsoleData()
   const { me } = useProfile()
   const { openModal } = useModal()
   // Agent/Daemon/Repo/Integrations are flex tracks that absorb spare width; Creator is
@@ -100,6 +103,17 @@ export default function AgentsView() {
   // clicked; clicking the active column flips direction. Text columns default ascending,
   // numeric columns descending (highest first is the useful default).
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null)
+  // Fresh-workspace onboarding lives on its own /onboarding route. When this org has no
+  // daemon and no agent, redirect there — unless the operator already chose "Explore the
+  // console first" this session (the skip flag), which would otherwise loop right back.
+  const router = useRouter()
+  const params = useParams()
+  const orgKey = typeof params.slug === 'string' ? params.slug : '-'
+  const notInitialized = !agentsLoading && !daemonsLoading && agents.length === 0 && daemons.length === 0
+  const redirectToOnboarding = notInitialized && !isOnboardingSkipped(orgKey)
+  useEffect(() => {
+    if (redirectToOnboarding) router.replace(`/${orgKey}/onboarding`)
+  }, [redirectToOnboarding, router, orgKey])
   const onSort = (key: SortKey) =>
     setSort((prev) =>
       prev?.key === key
@@ -182,6 +196,10 @@ export default function AgentsView() {
       </button>
     )
   }
+
+  // While the redirect to /onboarding is in flight, hold a spinner so the empty
+  // table/metrics never flash behind it.
+  if (redirectToOnboarding) return <LoadingState fill />
 
   if (view === 'topology') {
     if (isMobile) {

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -128,4 +128,26 @@ describe('daemon onboarding lifecycle', () => {
     await click('Add a Daemon')
     expect(mocks.reconnectDaemon).toHaveBeenCalledTimes(2)
   })
+
+  it('never deletes a claimed daemon that disconnects before Finish', async () => {
+    mocks.provisionDaemon.mockResolvedValue({
+      daemonId: 'new-1',
+      apiKey: 'secret',
+      displayTail: 'tail',
+      command: 'agentconnect run'
+    })
+    await click('Add a Daemon')
+
+    mocks.daemons = [{ daemonId: 'new-1', status: 'online', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
+    await act(async () => root.render(<OnboardingView />))
+    await click('Create an agent')
+
+    mocks.agents = [{ id: 'agent-1', daemon: 'new-1', hookKinds: [] }]
+    mocks.daemons = [{ daemonId: 'new-1', status: 'offline', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
+    await act(async () => root.render(<OnboardingView />))
+    await click('Set up integration')
+    await click('Finish')
+
+    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
+  })
 })

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import type { ButtonHTMLAttributes } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  agents: [] as Array<Record<string, unknown>>,
+  daemons: [] as Array<Record<string, unknown>>,
+  integrations: [] as Array<Record<string, unknown>>,
+  provisionDaemon: vi.fn(),
+  reconnectDaemon: vi.fn(),
+  deleteDaemon: vi.fn(),
+  refresh: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: 'acme' }),
+  useRouter: () => ({ push: vi.fn() })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: mocks.agents,
+    daemons: mocks.daemons,
+    integrations: mocks.integrations,
+    agentsLoading: false,
+    daemonsLoading: false,
+    provisionDaemon: mocks.provisionDaemon,
+    reconnectDaemon: mocks.reconnectDaemon,
+    deleteDaemon: mocks.deleteDaemon,
+    refresh: mocks.refresh
+  })
+}))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
+vi.mock('@/lib/onboarding', () => ({ skipOnboarding: vi.fn() }))
+vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
+vi.mock('@/lib/data', () => ({ agentLabel: () => 'Agent' }))
+vi.mock('@/components/marks', () => ({
+  LogoMark: () => <span>logo</span>,
+  Spinner: () => <span>loading</span>,
+  LoadingState: () => <span>loading data</span>
+}))
+vi.mock('@/components/ui', () => ({
+  Button: ({
+    variant: _variant,
+    size: _size,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string; size?: string }) => <button {...props} />,
+  Icon: () => <span />
+}))
+
+import OnboardingView from './OnboardingView'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLDivElement
+
+const button = (label: string) => {
+  const match = [...host.querySelectorAll('button')].find((item) => item.textContent?.includes(label))
+  if (!match) throw new Error(`Missing button: ${label}`)
+  return match
+}
+
+const click = async (label: string) => {
+  await act(async () => {
+    button(label).click()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+beforeEach(async () => {
+  mocks.agents = []
+  mocks.daemons = []
+  mocks.integrations = []
+  mocks.provisionDaemon.mockReset()
+  mocks.reconnectDaemon.mockReset()
+  mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
+  mocks.refresh.mockReset()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => root.render(<OnboardingView />))
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  document.body.innerHTML = ''
+})
+
+describe('daemon onboarding lifecycle', () => {
+  it('deletes an unclaimed row and provisions a fresh command after Back', async () => {
+    mocks.provisionDaemon.mockImplementation(async () => ({
+      daemonId: `new-${mocks.provisionDaemon.mock.calls.length}`,
+      apiKey: 'secret',
+      displayTail: 'tail',
+      command: 'agentconnect run'
+    }))
+
+    await click('Add a Daemon')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
+
+    await click('Back')
+    expect(mocks.deleteDaemon).toHaveBeenCalledWith('new-1')
+
+    await click('Add a Daemon')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps an offline daemon on step 1 and mints a recoverable reconnect command', async () => {
+    mocks.daemons = [{ daemonId: 'offline-1', status: 'offline', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
+    mocks.reconnectDaemon.mockResolvedValue({
+      apiKeyId: 'key-1',
+      apiKey: 'secret',
+      displayTail: 'tail',
+      command: 'agentconnect run'
+    })
+    await act(async () => root.render(<OnboardingView />))
+
+    await click('Add a Daemon')
+    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('offline-1')
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(button('Create an agent').disabled).toBe(true)
+
+    await click('Back')
+    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
+    await click('Add a Daemon')
+    expect(mocks.reconnectDaemon).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   agents: [] as Array<Record<string, unknown>>,
   daemons: [] as Array<Record<string, unknown>>,
   integrations: [] as Array<Record<string, unknown>>,
+  agentsLoading: false,
+  daemonsLoading: false,
   provisionDaemon: vi.fn(),
   reconnectDaemon: vi.fn(),
   deleteDaemon: vi.fn(),
@@ -23,8 +25,8 @@ vi.mock('@/lib/data-context', () => ({
     agents: mocks.agents,
     daemons: mocks.daemons,
     integrations: mocks.integrations,
-    agentsLoading: false,
-    daemonsLoading: false,
+    agentsLoading: mocks.agentsLoading,
+    daemonsLoading: mocks.daemonsLoading,
     provisionDaemon: mocks.provisionDaemon,
     reconnectDaemon: mocks.reconnectDaemon,
     deleteDaemon: mocks.deleteDaemon,
@@ -74,6 +76,8 @@ beforeEach(async () => {
   mocks.agents = []
   mocks.daemons = []
   mocks.integrations = []
+  mocks.agentsLoading = false
+  mocks.daemonsLoading = false
   mocks.provisionDaemon.mockReset()
   mocks.reconnectDaemon.mockReset()
   mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
@@ -127,6 +131,27 @@ describe('daemon onboarding lifecycle', () => {
     expect(mocks.deleteDaemon).not.toHaveBeenCalled()
     await click('Add a Daemon')
     expect(mocks.reconnectDaemon).toHaveBeenCalledTimes(2)
+  })
+
+  it('resumes at the live step when daemons resolve before agents/integrations', async () => {
+    act(() => root.unmount())
+    // First load: daemons resolve for a fully-live org while agents are still loading.
+    mocks.daemons = [{ daemonId: 'new-1', status: 'online', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
+    mocks.agents = []
+    mocks.integrations = []
+    mocks.agentsLoading = true
+    mocks.daemonsLoading = false
+    root = createRoot(host)
+    await act(async () => root.render(<OnboardingView />))
+    // Must not seed a mid-wizard step from the partial data — still on the welcome screen.
+    expect(host.textContent).toContain('Welcome to AgentConnect')
+
+    // Agents/integrations finish loading — the wizard now resumes at the final step.
+    mocks.agents = [{ id: 'agent-1', daemon: 'new-1', hookKinds: [] }]
+    mocks.integrations = [{ id: 'int-1' }]
+    mocks.agentsLoading = false
+    await act(async () => root.render(<OnboardingView />))
+    expect(host.textContent).toContain('You’re live')
   })
 
   it('never deletes a claimed daemon that disconnects before Finish', async () => {

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -85,6 +85,7 @@ export default function OnboardingView() {
   const provisioned = useRef(false)
   const commandPending = useRef<Promise<DaemonCommand> | null>(null)
   const createdByWizard = useRef(false)
+  const connectedOnce = useRef(false)
   useEffect(() => {
     if (!entered || step !== 0 || daemonOnline || provisioned.current) return
     provisioned.current = true
@@ -102,18 +103,29 @@ export default function OnboardingView() {
 
   const provisionedRow = connect ? daemons.find((d) => d.daemonId === connect.daemonId) : undefined
   useEffect(() => {
-    if (!connect || provisionedRow?.status === 'online') return
+    if (provisionedRow?.status === 'online') {
+      connectedOnce.current = true
+      return
+    }
+    if (!connect) return
     const id = setInterval(refresh, 3000)
     return () => clearInterval(id)
   }, [connect, provisionedRow?.status, refresh])
 
-  // Drop an unclaimed provisioned row when leaving the daemon step before it connects.
+  // Drop only a wizard-created row that was never claimed. Once it has connected or
+  // hosts an agent, a later disconnect must not turn leaving onboarding into deletion.
   const cleanupPending = async () => {
     const pendingConnect = connect ?? (await commandPending.current?.catch(() => null))
     const pendingRow = pendingConnect ? daemons.find((d) => d.daemonId === pendingConnect.daemonId) : undefined
-    if (pendingRow?.status === 'online') return
+    const hostsAgent = pendingConnect ? agents.some((agent) => agent.daemon === pendingConnect.daemonId) : false
+    const shouldDelete =
+      pendingConnect &&
+      createdByWizard.current &&
+      !connectedOnce.current &&
+      !hostsAgent &&
+      pendingRow?.status !== 'online'
     try {
-      if (pendingConnect && createdByWizard.current) await deleteDaemon(pendingConnect.daemonId)
+      if (shouldDelete) await deleteDaemon(pendingConnect.daemonId)
     } catch {
       /* best-effort cleanup — an unclaimed provisioned row is harmless */
     } finally {
@@ -122,6 +134,7 @@ export default function OnboardingView() {
       provisioned.current = false
       commandPending.current = null
       createdByWizard.current = false
+      connectedOnce.current = false
     }
   }
   const goConsole = () => {

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -12,6 +12,8 @@ import { skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
 import type { DaemonConnectDto } from '@/lib/api'
 
+type DaemonCommand = Pick<DaemonConnectDto, 'daemonId' | 'command'>
+
 // Onboarding wizard (design: "AgentConnect Onboarding") — a 3-step guided setup rendered
 // directly in the console content area: Welcome → Add a Daemon → Create an agent → Set up
 // integration → live. The daemon step is inline and functional (mints a real join command
@@ -39,16 +41,25 @@ const WELCOME_CARDS = [
 export default function OnboardingView() {
   const router = useRouter()
   const params = useParams()
-  const { agents, daemons, integrations, agentsLoading, daemonsLoading, provisionDaemon, deleteDaemon, refresh } =
-    useConsoleData()
+  const {
+    agents,
+    daemons,
+    integrations,
+    agentsLoading,
+    daemonsLoading,
+    provisionDaemon,
+    reconnectDaemon,
+    deleteDaemon,
+    refresh
+  } = useConsoleData()
   const { openModal } = useModal()
   const { orgPath } = useOrgs()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
 
-  // Presence drives resume/initialization (an org with any daemon + agents is already set
-  // up, even if the daemon is momentarily offline). `daemonOnline` is the stricter signal
-  // that gates leaving the daemon step — you can't create an agent until one is connected.
-  const hasDaemon = daemons.length > 0
+  // Only a serving daemon completes step 1. An offline row may be a provisioned daemon
+  // whose one-time command was lost on reload; the daemon step reconnects it below.
+  const daemonOnline = daemons.some((d) => d.status === 'online')
+  const offlineDaemonId = daemons.find((d) => d.status !== 'online')?.daemonId
   const hasAgent = agents.length > 0
   const hasIntegration = integrations.length > 0 || agents.some((a) => (a.hookKinds ?? []).length > 0)
 
@@ -63,25 +74,33 @@ export default function OnboardingView() {
   useEffect(() => {
     if (didInit.current || loading) return
     didInit.current = true
-    const s = !hasDaemon ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
+    const s = !daemonOnline ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
     setStep(s)
     setEntered(s > 0)
-  }, [loading, hasDaemon, hasAgent, hasIntegration])
+  }, [loading, daemonOnline, hasAgent, hasIntegration])
 
   // --- Daemon provisioning (step 0), mirrors AddDaemonModal --------------------------
-  const [connect, setConnect] = useState<DaemonConnectDto | null>(null)
+  const [connect, setConnect] = useState<DaemonCommand | null>(null)
   const [mintErr, setMintErr] = useState<string | null>(null)
   const provisioned = useRef(false)
+  const commandPending = useRef<Promise<DaemonCommand> | null>(null)
+  const createdByWizard = useRef(false)
   useEffect(() => {
-    if (!entered || step !== 0 || hasDaemon || provisioned.current) return
+    if (!entered || step !== 0 || daemonOnline || provisioned.current) return
     provisioned.current = true
-    provisionDaemon()
-      .then(setConnect)
-      .catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
-  }, [entered, step, hasDaemon, provisionDaemon])
+    setMintErr(null)
+    createdByWizard.current = !offlineDaemonId
+    const command: Promise<DaemonCommand> = offlineDaemonId
+      ? reconnectDaemon(offlineDaemonId).then((minted) => ({
+          daemonId: offlineDaemonId,
+          command: minted.command
+        }))
+      : provisionDaemon()
+    commandPending.current = command
+    command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
+  }, [entered, step, daemonOnline, offlineDaemonId, provisionDaemon, reconnectDaemon])
 
   const provisionedRow = connect ? daemons.find((d) => d.daemonId === connect.daemonId) : undefined
-  const daemonOnline = daemons.some((d) => d.status === 'online')
   useEffect(() => {
     if (!connect || provisionedRow?.status === 'online') return
     const id = setInterval(refresh, 3000)
@@ -89,12 +108,24 @@ export default function OnboardingView() {
   }, [connect, provisionedRow?.status, refresh])
 
   // Drop an unclaimed provisioned row when leaving the daemon step before it connects.
-  const cleanupPending = () => {
-    if (connect && provisionedRow && provisionedRow.status !== 'online')
-      void deleteDaemon(connect.daemonId).catch(() => {})
+  const cleanupPending = async () => {
+    const pendingConnect = connect ?? (await commandPending.current?.catch(() => null))
+    const pendingRow = pendingConnect ? daemons.find((d) => d.daemonId === pendingConnect.daemonId) : undefined
+    if (pendingRow?.status === 'online') return
+    try {
+      if (pendingConnect && createdByWizard.current) await deleteDaemon(pendingConnect.daemonId)
+    } catch {
+      /* best-effort cleanup — an unclaimed provisioned row is harmless */
+    } finally {
+      setConnect(null)
+      setMintErr(null)
+      provisioned.current = false
+      commandPending.current = null
+      createdByWizard.current = false
+    }
   }
   const goConsole = () => {
-    cleanupPending()
+    void cleanupPending()
     skipOnboarding(orgKey)
     router.push(orgPath('/agents'))
   }
@@ -162,13 +193,13 @@ export default function OnboardingView() {
           {step === 0 && (
             <StepBody
               title="Add a Daemon"
-              sub="Run this on the host where your agents should run. It launches a Daemon that connects to the Control Plane and keeps running."
+              sub="Run this on the host where your agents should run. It launches a Daemon that connects to AgentConnect and stays available."
               footer={
                 <>
                   <Button
                     variant="ghost"
-                    onClick={() => {
-                      cleanupPending()
+                    onClick={async () => {
+                      await cleanupPending()
                       setEntered(false)
                     }}
                   >
@@ -188,7 +219,7 @@ export default function OnboardingView() {
                 name={provisionedRow?.name}
                 host={provisionedRow?.host}
                 version={provisionedRow?.version}
-                resumed={!provisionedRow && hasDaemon}
+                resumed={daemonOnline && !provisionedRow}
                 resumedName={daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name}
               />
               <div className="mt-[14px] flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
@@ -369,7 +400,7 @@ function StepRail({ current }: { current: number }) {
 
 // Dark terminal block with Run / Install-as-service tabs + copy — the real minted join
 // command (or a minting/error placeholder), matching AddDaemonModal's CommandBox.
-function Terminal({ connect, err }: { connect: DaemonConnectDto | null; err: string | null }) {
+function Terminal({ connect, err }: { connect: DaemonCommand | null; err: string | null }) {
   const cmds = connect ? daemonCommands(connect.command) : null
   const tabs = [
     { key: 'run', label: 'Run', command: cmds?.run ?? null },

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -1,0 +1,542 @@
+'use client'
+
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { LogoMark, Spinner, LoadingState } from '@/components/marks'
+import { Button, Icon } from '@/components/ui'
+import { agentLabel } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
+import { useModal } from '@/components/console/ModalProvider'
+import { useOrgs } from '@/lib/org-context'
+import { skipOnboarding } from '@/lib/onboarding'
+import { daemonCommands } from '@/lib/daemon-commands'
+import type { DaemonConnectDto } from '@/lib/api'
+
+// Onboarding wizard (design: "AgentConnect Onboarding") — a 3-step guided setup rendered
+// directly in the console content area: Welcome → Add a Daemon → Create an agent → Set up
+// integration → live. The daemon step is inline and functional (mints a real join command
+// and polls for the daemon to come online, like AddDaemonModal). The agent and integration
+// steps hand off to the existing modals — those flows are 1.5k / 3.3k lines of validated
+// logic, so the wizard frames them and launches them rather than re-implementing the forms.
+
+const STEPS = [
+  { title: 'Add a Daemon', sub: 'Run the Daemon' },
+  { title: 'Create an agent', sub: 'Repo & model' },
+  { title: 'Set up integration', sub: 'Assign a bot' }
+] as const
+
+const WELCOME_CARDS = [
+  { icon: 'server', n: 'step 1', title: 'Add a Daemon', desc: 'Run one command to launch a Daemon on your own host.' },
+  {
+    icon: 'bot',
+    n: 'step 2',
+    title: 'Create an agent',
+    desc: 'Point it at a GitHub repo and working folder, pick a model.'
+  },
+  { icon: 'plug', n: 'step 3', title: 'Set up integration', desc: 'Assign a bot so the agent can talk in a channel.' }
+] as const
+
+export default function OnboardingView() {
+  const router = useRouter()
+  const params = useParams()
+  const { agents, daemons, integrations, agentsLoading, daemonsLoading, provisionDaemon, deleteDaemon, refresh } =
+    useConsoleData()
+  const { openModal } = useModal()
+  const { orgPath } = useOrgs()
+  const orgKey = typeof params.slug === 'string' ? params.slug : '-'
+
+  // Presence drives resume/initialization (an org with any daemon + agents is already set
+  // up, even if the daemon is momentarily offline). `daemonOnline` is the stricter signal
+  // that gates leaving the daemon step — you can't create an agent until one is connected.
+  const hasDaemon = daemons.length > 0
+  const hasAgent = agents.length > 0
+  const hasIntegration = integrations.length > 0 || agents.some((a) => (a.hookKinds ?? []).length > 0)
+
+  // 0 daemon · 1 agent · 2 integration · 3 live. `entered` gates the welcome screen.
+  const [step, setStep] = useState(0)
+  const [entered, setEntered] = useState(false)
+  const didInit = useRef(false)
+  const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
+
+  // Seed the resume position once, after the first data load: jump straight to the first
+  // incomplete step (past the welcome) when the org is already part-way set up.
+  useEffect(() => {
+    if (didInit.current || loading) return
+    didInit.current = true
+    const s = !hasDaemon ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
+    setStep(s)
+    setEntered(s > 0)
+  }, [loading, hasDaemon, hasAgent, hasIntegration])
+
+  // --- Daemon provisioning (step 0), mirrors AddDaemonModal --------------------------
+  const [connect, setConnect] = useState<DaemonConnectDto | null>(null)
+  const [mintErr, setMintErr] = useState<string | null>(null)
+  const provisioned = useRef(false)
+  useEffect(() => {
+    if (!entered || step !== 0 || hasDaemon || provisioned.current) return
+    provisioned.current = true
+    provisionDaemon()
+      .then(setConnect)
+      .catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
+  }, [entered, step, hasDaemon, provisionDaemon])
+
+  const provisionedRow = connect ? daemons.find((d) => d.daemonId === connect.daemonId) : undefined
+  const daemonOnline = daemons.some((d) => d.status === 'online')
+  useEffect(() => {
+    if (!connect || provisionedRow?.status === 'online') return
+    const id = setInterval(refresh, 3000)
+    return () => clearInterval(id)
+  }, [connect, provisionedRow?.status, refresh])
+
+  // Drop an unclaimed provisioned row when leaving the daemon step before it connects.
+  const cleanupPending = () => {
+    if (connect && provisionedRow && provisionedRow.status !== 'online')
+      void deleteDaemon(connect.daemonId).catch(() => {})
+  }
+  const goConsole = () => {
+    cleanupPending()
+    skipOnboarding(orgKey)
+    router.push(orgPath('/agents'))
+  }
+
+  if (loading) return <LoadingState fill />
+
+  // --- Welcome -----------------------------------------------------------------------
+  if (!entered) {
+    return (
+      <div className="mx-auto flex w-full max-w-[720px] flex-col items-center px-6 py-10 pb-24 text-center desktop:py-14 desktop:pb-14">
+        <LogoMark size={50} />
+        <div className="mt-[22px] font-mono text-[12px] font-semibold uppercase leading-none tracking-[.1em] text-(--brand)">
+          Get started
+        </div>
+        <h1 className="mt-[10px] font-sans text-[32px] font-semibold leading-[1.15] tracking-[-.02em] text-(--text-primary)">
+          Welcome to AgentConnect
+        </h1>
+        <p className="mt-3 max-w-[500px] font-sans text-[16px] font-normal leading-[1.55] text-(--text-secondary)">
+          Run AI agents on your own Daemons and drive them from Slack, Telegram, and Discord. Three steps to your first
+          session.
+        </p>
+        <div className="mb-[26px] mt-[30px] grid w-full grid-cols-1 gap-3 desktop:grid-cols-3">
+          {WELCOME_CARDS.map((c) => (
+            <div
+              key={c.title}
+              className="rounded-md border border-(--border-subtle) bg-(--surface-card) p-4 text-left shadow-(--shadow-xs)"
+            >
+              <div className="flex items-center gap-2">
+                <div className="flex h-[34px] w-[34px] items-center justify-center rounded-md bg-(--brand-soft) text-(--brand-soft-text)">
+                  <Icon name={c.icon} size={18} />
+                </div>
+                <span className="font-mono text-[11px] leading-normal text-(--text-tertiary)">{c.n}</span>
+              </div>
+              <div className="mt-3 font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
+                {c.title}
+              </div>
+              <div className="mt-[3px] font-sans text-[12.5px] font-normal leading-[1.45] text-(--text-tertiary)">
+                {c.desc}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col items-center gap-[10px] desktop:flex-row">
+          <Button size="lg" onClick={() => setEntered(true)}>
+            <Icon name="arrow-right" size={16} />
+            Add a Daemon
+          </Button>
+          <Button size="lg" variant="ghost" onClick={goConsole}>
+            Explore the console first
+          </Button>
+        </div>
+        <div className="mt-[18px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+          You&rsquo;ll run one command on the host where your agents should run.
+        </div>
+      </div>
+    )
+  }
+
+  // --- Stepper wizard ----------------------------------------------------------------
+  return (
+    <div className="mx-auto w-full max-w-[1000px] px-6 py-8 pb-24 desktop:py-10 desktop:pb-10">
+      <div className="flex flex-col gap-8 desktop:flex-row desktop:gap-10">
+        <StepRail current={step < 3 ? step : 3} />
+        <div className="min-w-0 flex-1">
+          {step === 0 && (
+            <StepBody
+              title="Add a Daemon"
+              sub="Run this on the host where your agents should run. It launches a Daemon that connects to the Control Plane and keeps running."
+              footer={
+                <>
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      cleanupPending()
+                      setEntered(false)
+                    }}
+                  >
+                    Back
+                  </Button>
+                  <div className="flex-1" />
+                  <Button disabled={!daemonOnline} onClick={() => setStep(1)}>
+                    Create an agent
+                    <Icon name="arrow-right" size={15} />
+                  </Button>
+                </>
+              }
+            >
+              <Terminal connect={connect} err={mintErr} />
+              <ConnectedCard
+                online={!!provisionedRow && provisionedRow.status === 'online'}
+                name={provisionedRow?.name}
+                host={provisionedRow?.host}
+                version={provisionedRow?.version}
+                resumed={!provisionedRow && hasDaemon}
+                resumedName={daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name}
+              />
+              <div className="mt-[14px] flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                <Icon name="info" size={15} className="mt-[1px] flex-none" />
+                <span>
+                  Keep this process running. The daemon runs agents locally over ACP and holds your platform
+                  connections.
+                </span>
+              </div>
+            </StepBody>
+          )}
+
+          {step === 1 && (
+            <StepBody
+              title="Create an agent"
+              sub="It runs on the Daemon you just added. Point it at a repo and working directory, then pick a model."
+              footer={
+                <>
+                  <Button variant="ghost" onClick={() => setStep(0)}>
+                    Back
+                  </Button>
+                  <div className="flex-1" />
+                  <Button disabled={!hasAgent} onClick={() => setStep(2)}>
+                    Set up integration
+                    <Icon name="arrow-right" size={15} />
+                  </Button>
+                </>
+              }
+            >
+              <ActionPanel
+                icon="bot"
+                done={hasAgent}
+                doneLabel={hasAgent && agents[0] ? `${agentLabel(agents[0])} created` : ''}
+                title={hasAgent ? 'Agent created' : 'Create your first agent'}
+                desc={
+                  hasAgent
+                    ? 'Add more later from the console — each with its own repo, model, and bot.'
+                    : 'Give it a name, choose the Daemon and model, and point it at a GitHub repo and working directory.'
+                }
+                cta={hasAgent ? 'Create another' : 'Create an agent'}
+                onCta={() => openModal('agent')}
+              />
+            </StepBody>
+          )}
+
+          {step === 2 && (
+            <StepBody
+              title="Set up integration"
+              sub={`Give ${agents[0] ? agentLabel(agents[0]) : 'your agent'} a bot identity so it can read and post in a channel — Slack, Telegram, or Discord.`}
+              footer={
+                <>
+                  <Button variant="ghost" onClick={() => setStep(1)}>
+                    Back
+                  </Button>
+                  <div className="flex-1" />
+                  <Button onClick={goConsole}>
+                    <Icon name="radio" size={15} />
+                    {hasIntegration ? 'Go live' : 'Finish'}
+                  </Button>
+                </>
+              }
+            >
+              <ActionPanel
+                icon="plug"
+                done={hasIntegration}
+                doneLabel={hasIntegration ? 'Integration connected' : ''}
+                title={hasIntegration ? 'Integration connected' : 'Connect a channel'}
+                desc={
+                  hasIntegration
+                    ? 'Your agent can now read and post in the connected channel.'
+                    : 'Assign a bot identity and pick a channel. This step is optional — you can do it later from the agent page.'
+                }
+                cta={hasIntegration ? 'Add another' : 'Set up integration'}
+                onCta={() => agents[0] && openModal('integration', agents[0])}
+              />
+            </StepBody>
+          )}
+
+          {step === 3 && (
+            <div className="flex flex-col items-start">
+              <span className="flex h-14 w-14 items-center justify-center rounded-xl bg-(--brand) text-white">
+                <Icon name="check" size={30} />
+              </span>
+              <h2 className="mt-5 font-sans text-[26px] font-semibold leading-[1.15] tracking-[-.02em] text-(--text-primary)">
+                You&rsquo;re live
+              </h2>
+              <p className="mt-2 max-w-[460px] font-sans text-[15px] font-normal leading-[1.55] text-(--text-secondary)">
+                {agents[0] ? agentLabel(agents[0]) : 'Your agent'} is running on{' '}
+                {daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name ?? 'your Daemon'}. Open the
+                console to watch its first session.
+              </p>
+              <div className="mt-7">
+                <Button size="lg" onClick={goConsole}>
+                  Go to console
+                  <Icon name="arrow-right" size={16} />
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// A step's main column: heading + sub, content, and a bottom footer nav (divider above).
+function StepBody({
+  title,
+  sub,
+  children,
+  footer
+}: {
+  title: string
+  sub: string
+  children: ReactNode
+  footer: ReactNode
+}) {
+  return (
+    <div className="flex min-h-[420px] flex-col">
+      <h2 className="font-sans text-[24px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
+        {title}
+      </h2>
+      <p className="mt-[6px] max-w-[620px] font-sans text-[14px] font-normal leading-[1.5] text-(--text-secondary)">
+        {sub}
+      </p>
+      <div className="mt-[22px]">{children}</div>
+      <div className="mt-8 flex items-center gap-[10px] border-t border-(--border-subtle) pt-5">{footer}</div>
+    </div>
+  )
+}
+
+// The 3-step progress rail — a left column on desktop, a horizontal strip on mobile.
+function StepRail({ current }: { current: number }) {
+  return (
+    <div className="flex flex-none gap-2 desktop:w-60 desktop:flex-col desktop:gap-1 desktop:border-r desktop:border-(--border-subtle) desktop:pr-6">
+      <div className="hidden font-mono text-[12px] font-semibold uppercase leading-none tracking-[.06em] text-(--text-tertiary) desktop:mb-[10px] desktop:block">
+        Setup
+      </div>
+      {STEPS.map((s, i) => {
+        const done = i < current
+        const active = i === current
+        return (
+          <div
+            key={s.title}
+            className={`flex flex-1 items-center gap-3 rounded-md px-[10px] py-[11px] desktop:flex-none ${
+              active ? 'bg-(--surface-sunken)' : ''
+            }`}
+          >
+            <span
+              className={`flex h-[26px] w-[26px] flex-none items-center justify-center rounded-full font-mono text-[12px] font-semibold ${
+                done
+                  ? 'bg-(--brand) text-white'
+                  : active
+                    ? 'border-2 border-(--brand) bg-(--surface-card) text-(--brand)'
+                    : 'border-[1.5px] border-(--border-strong) bg-(--surface-app) text-(--text-tertiary)'
+              }`}
+            >
+              {done ? <Icon name="check" size={15} /> : i + 1}
+            </span>
+            <div className="min-w-0">
+              <div
+                className={`truncate font-sans text-[13.5px] leading-normal ${
+                  active || done ? 'font-semibold text-(--text-primary)' : 'font-medium text-(--text-secondary)'
+                }`}
+              >
+                {s.title}
+              </div>
+              <div className="hidden truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:block">
+                {s.sub}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Dark terminal block with Run / Install-as-service tabs + copy — the real minted join
+// command (or a minting/error placeholder), matching AddDaemonModal's CommandBox.
+function Terminal({ connect, err }: { connect: DaemonConnectDto | null; err: string | null }) {
+  const cmds = connect ? daemonCommands(connect.command) : null
+  const tabs = [
+    { key: 'run', label: 'Run', command: cmds?.run ?? null },
+    { key: 'service', label: 'Install as service', command: cmds?.login ?? null }
+  ]
+  const [active, setActive] = useState(0)
+  const [copied, setCopied] = useState(false)
+  const command = tabs[active]?.command ?? null
+  const copy = async () => {
+    if (!command) return
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+  return (
+    <div className="overflow-hidden rounded-[10px] border border-(--gray-800) bg-(--gray-1000)">
+      <div className="flex items-stretch border-b border-(--gray-800)">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => {
+              setActive(i)
+              setCopied(false)
+            }}
+            aria-selected={i === active}
+            className={`inline-flex cursor-pointer items-center gap-[6px] border-0 border-b-2 bg-transparent px-[13px] py-[9px] font-mono text-[11px] font-medium leading-normal ${
+              i === active
+                ? 'border-(--magenta-300) text-[#cdd6e0]'
+                : 'border-transparent text-(--text-inverse-dim) hover:text-[#cdd6e0]'
+            }`}
+          >
+            <Icon name="terminal" size={13} />
+            {tab.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={copy}
+          disabled={!command}
+          className="ml-auto inline-flex cursor-pointer items-center gap-[5px] border-0 bg-transparent px-[13px] py-[9px] font-mono text-[11px] font-medium leading-normal text-(--text-inverse-dim) disabled:cursor-default disabled:opacity-50"
+        >
+          <Icon name={copied ? 'check' : 'copy'} size={12} />
+          {copied ? 'copied' : 'copy'}
+        </button>
+      </div>
+      <div className="break-all px-[16px] py-[15px] font-mono text-[12.5px] leading-[1.75] text-[#cdd6e0]">
+        {command ? (
+          <div>
+            <span className="text-(--magenta-300)">$</span> {command}
+          </div>
+        ) : err ? (
+          <div className="text-(--status-error)">Could not provision a key — {err}</div>
+        ) : (
+          <div className="text-(--text-inverse-dim)">Minting key…</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// The connected / waiting daemon card under the terminal.
+function ConnectedCard({
+  online,
+  name,
+  host,
+  version,
+  resumed,
+  resumedName
+}: {
+  online: boolean
+  name?: string
+  host?: string
+  version?: string
+  resumed?: boolean
+  resumedName?: string
+}) {
+  if (resumed) {
+    return (
+      <div className="mt-4 flex items-center gap-[11px] rounded-[10px] border border-(--brand-soft-border) bg-(--brand-soft) px-[14px] py-[13px]">
+        <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--brand-soft-border) bg-(--surface-card)">
+          <Icon name="server" size={19} color="var(--brand)" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
+            {resumedName ?? 'A daemon'} already connected
+          </div>
+          <div className="mono text-[12px] text-(--text-secondary)">Continue to the next step.</div>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="mt-4 flex items-center gap-[11px] rounded-[10px] border border-dashed border-(--border-strong) px-[14px] py-[13px]">
+      {online ? (
+        <span className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-(--status-online)">
+          <Icon name="check" size={13} color="#fff" />
+        </span>
+      ) : (
+        <span className="flex-none leading-[0]">
+          <Spinner size={22} />
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
+          {online ? `${name ?? 'Daemon'} connected` : 'Waiting for daemon…'}
+        </div>
+        <div className="mono text-[12px] text-(--text-tertiary)">
+          {online ? `${host ?? ''}${version ? ` · v${version}` : ''}` : "It'll appear here once it connects."}
+        </div>
+      </div>
+      {online ? (
+        <span className="flex flex-none items-center gap-[6px] rounded-full bg-(--status-online-soft) px-[9px] py-[3px]">
+          <span className="h-[7px] w-[7px] rounded-full bg-(--status-online)" />
+          <span className="font-mono text-[11px] font-medium leading-normal text-[#0f7a48]">online</span>
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+// A centered call-to-action panel for the agent / integration steps: an icon, a title +
+// description, a completion chip once done, and the primary button that opens the modal.
+function ActionPanel({
+  icon,
+  title,
+  desc,
+  cta,
+  onCta,
+  done,
+  doneLabel
+}: {
+  icon: string
+  title: string
+  desc: string
+  cta: string
+  onCta: () => void
+  done: boolean
+  doneLabel: string
+}) {
+  return (
+    <div className="flex flex-col items-start rounded-[10px] border border-(--border-subtle) bg-(--surface-app) px-6 py-7">
+      <span className="flex h-11 w-11 items-center justify-center rounded-md bg-(--brand-soft) text-(--brand-soft-text)">
+        <Icon name={icon} size={22} />
+      </span>
+      {done && doneLabel ? (
+        <div className="mt-4 inline-flex items-center gap-2 rounded-md bg-(--brand-soft) px-3 py-2">
+          <Icon name="check" size={14} className="text-(--brand-soft-text)" />
+          <span className="font-sans text-[12.5px] font-medium leading-normal text-(--brand-soft-text)">
+            {doneLabel}
+          </span>
+        </div>
+      ) : null}
+      <div className="mt-4 font-sans text-[16px] font-semibold leading-normal text-(--text-primary)">{title}</div>
+      <p className="mt-[3px] max-w-[520px] font-sans text-[13px] font-normal leading-[1.5] text-(--text-tertiary)">
+        {desc}
+      </p>
+      <div className="mt-5">
+        <Button variant={done ? 'secondary' : 'primary'} onClick={onCta}>
+          <Icon name="plus" size={15} />
+          {cta}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -69,15 +69,16 @@ export default function OnboardingView() {
   const didInit = useRef(false)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
-  // Seed the resume position once, after the first data load: jump straight to the first
-  // incomplete step (past the welcome) when the org is already part-way set up.
+  // Seed the resume position once, after BOTH lists finish loading: jump straight to the
+  // first incomplete step (past the welcome) when the org is already part-way set up.
+  // Gating on emptiness would seed from partial data when one SWR key resolves first.
   useEffect(() => {
-    if (didInit.current || loading) return
+    if (didInit.current || agentsLoading || daemonsLoading) return
     didInit.current = true
     const s = !daemonOnline ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
     setStep(s)
     setEntered(s > 0)
-  }, [loading, daemonOnline, hasAgent, hasIntegration])
+  }, [agentsLoading, daemonsLoading, daemonOnline, hasAgent, hasIntegration])
 
   // --- Daemon provisioning (step 0), mirrors AddDaemonModal --------------------------
   const [connect, setConnect] = useState<DaemonCommand | null>(null)

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { needsOnboarding } from './onboarding'
+
+describe('needsOnboarding', () => {
+  it('recovers an empty org whose only daemon is offline', () => {
+    expect(needsOnboarding(false, false, 0, false)).toBe(true)
+  })
+
+  it('waits for data and preserves initialized orgs', () => {
+    expect(needsOnboarding(true, false, 0, false)).toBe(false)
+    expect(needsOnboarding(false, false, 1, false)).toBe(false)
+    expect(needsOnboarding(false, false, 0, true)).toBe(false)
+  })
+})

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -1,0 +1,23 @@
+// Per-tab "skip onboarding" flag. The agents view redirects an uninitialized org to
+// the onboarding route; "Explore the console first" sets this so the very next agents
+// render doesn't bounce straight back (which would be an infinite redirect). Scoped to
+// sessionStorage by org slug, so a fresh tab/session shows onboarding again while the
+// org stays empty.
+const key = (org: string) => `ac:onboarding-skip:${org}`
+
+export function isOnboardingSkipped(org: string): boolean {
+  try {
+    return sessionStorage.getItem(key(org)) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function skipOnboarding(org: string): void {
+  try {
+    sessionStorage.setItem(key(org), '1')
+  } catch {
+    // ponytail: sessionStorage can throw (private mode / disabled). Worst case the
+    // redirect loops once more — not worth a fallback store.
+  }
+}

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -5,6 +5,15 @@
 // org stays empty.
 const key = (org: string) => `ac:onboarding-skip:${org}`
 
+export function needsOnboarding(
+  agentsLoading: boolean,
+  daemonsLoading: boolean,
+  agentCount: number,
+  hasOnlineDaemon: boolean
+): boolean {
+  return !agentsLoading && !daemonsLoading && agentCount === 0 && !hasOnlineDaemon
+}
+
 export function isOnboardingSkipped(org: string): boolean {
   try {
     return sessionStorage.getItem(key(org)) === '1'


### PR DESCRIPTION
## Intent

Provide a first-run onboarding flow that remains recoverable across navigation, reloads, partial data loading, and daemon disconnects. A daemon that has connected or hosts an agent must never be deleted by onboarding cleanup, while an organization with no agents and no online daemon must be able to return to the recovery flow. The session-scoped **Explore the console first** choice must remain respected.

## What changed

- Added a three-step onboarding wizard for connecting a daemon, creating an agent, and configuring an integration.
- Added resumable daemon provisioning and reconnect commands for abandoned offline rows.
- Restricted cleanup to wizard-created daemon rows that have never connected and do not host an agent.
- Redirected organizations with no agents and no online daemon back to recoverable onboarding.
- Made the session skip check hydration-safe.
- Delayed resume-step seeding until both daemon and agent data have finished loading.
- Improved the webhook test field contrast in the light theme.
- Added focused regression coverage for cleanup, reconnect, redirect, hydration, and partial-load resume behavior.

## Risk

Low. The changes are limited to the web onboarding and redirect flow, reuse existing daemon provisioning and reconnect APIs, and add no protocol or persistence migrations.

## Validation

- Full web Vitest suite: 391 tests across 58 files passed.
- Six focused onboarding lifecycle regression tests passed.
- Web TypeScript check passed.
- ESLint and Prettier checks passed.
- `git diff --check` passed.
- Automated review identified the partial-load resume race; the gate fixed it and re-review passed.

## Review notes

- A claimed daemon remains intact if it disconnects before **Finish** or **Go live**.
- An offline-only, agentless organization re-enters onboarding and receives a reconnect command instead of creating another daemon identity.
- Resume state is computed only from complete initial daemon and agent data.
- The `mono` class is an intentional project semantic class documented in `packages/web/STYLE.md`.
