### PR TITLE
feat(web): make webhook signing optional

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1040,10 +1040,11 @@ export default function AddIntegrationModal({
     transport: 'socket' | 'http'
   } | null>(null)
 
-  // Webhook path: the form (just a name), then the created row — which carries
-  // the ONE-TIME signing-secret echo, so once it exists the platform is locked
-  // (switching away would discard a secret the user can never see again).
+  // Webhook path: the form, then the created row. HMAC is an optional second
+  // factor; when selected, the row carries the ONE-TIME signing-secret echo.
+  // Once created the platform is locked so the completed hook is not orphaned.
   const [hookName, setHookName] = useState('')
+  const [hookHmac, setHookHmac] = useState(false)
   const [createdHook, setCreatedHook] = useState<CreatedHookDto | null>(null)
   const [copiedHook, setCopiedHook] = useState<'url' | 'secret' | 'curl' | null>(null)
   const [hookTestMessage, setHookTestMessage] = useState(DEFAULT_HOOK_TEST_MESSAGE)
@@ -1278,11 +1279,9 @@ export default function AddIntegrationModal({
   const manifestJson = slackManifestJson(manifestNames, manifestOpts)
   const createUrl = slackCreateAppUrl(manifestNames, manifestOpts)
 
-  // Webhook path: create the hook (secret always minted), then flip to the reveal
-  // step — the response is the ONLY time the signing secret is ever shown. Nothing
-  // to validate: the name defaults to the agent's; there is no fixed prompt — the
-  // agent's description is its standing context and the caller speaks through
-  // the delivery payload.
+  // Webhook path: create the capability URL, optionally minting an HMAC secret,
+  // then flip to the endpoint/reveal step. There is no fixed prompt — the
+  // agent's description is standing context and the delivery payload speaks.
   const submitHook = async () => {
     if (busyRef.current || createdHook) return
     busyRef.current = true
@@ -1291,7 +1290,8 @@ export default function AddIntegrationModal({
     try {
       const created = await createHook({
         agentId: agent.id,
-        name: hookName.trim() || `${agent.name}-webhook`
+        name: hookName.trim() || `${agent.name}-webhook`,
+        hmac: hookHmac
       })
       setCreatedHook(created)
     } catch (e) {
@@ -1817,7 +1817,7 @@ export default function AddIntegrationModal({
   // action inline (step ① "Create & install" next to the name; step ② the token field),
   // so the footer is the final commit — "Connect" (finalize), live only once the app is
   // installed and a valid app-level token is pasted. The webhook path is two-step:
-  // create (mints URL + secret) → reveal → Done.
+  // create (mints a URL and optional secret) → reveal → Done.
   // Auto-install (config-token funnel) works for BOTH transports: socket ends with the
   // operator pasting the app-level (xapp) token; http is fully automatic — the CP builds
   // an Events-API manifest and captures the signing secret from apps.manifest.create, so
@@ -1843,7 +1843,7 @@ export default function AddIntegrationModal({
     platform === 'webhook'
       ? createdHook
         ? { label: 'Done', act: onClose, enabled: true }
-        : { label: 'Connect & authorize', act: () => void submitHook(), enabled: true }
+        : { label: 'Create webhook', act: () => void submitHook(), enabled: true }
       : platform === 'github'
         ? {
             label: 'Connect',
@@ -1919,12 +1919,22 @@ export default function AddIntegrationModal({
                 onChange={(e) => setHookName(e.target.value)}
               />
             </div>
+            <label className="mt-3 flex cursor-pointer items-start gap-2.5 rounded-md border border-(--border-default) bg-(--surface-card) px-3 py-[10px]">
+              <input
+                type="checkbox"
+                className="mt-[2px] flex-none accent-(--brand)"
+                checked={hookHmac}
+                onChange={(e) => setHookHmac(e.target.checked)}
+              />
+              <span className="font-sans text-[12px] font-medium leading-[1.5] text-(--text-secondary)">
+                Require HMAC signature
+              </span>
+            </label>
             <div className="mt-3 flex items-start gap-2 font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
               <Icon name="info" size={13} className="mt-[1px] flex-none" />
               <span>
                 The payload is the message — the <span className="mono">message</span> field in your JSON tells the
-                agent what to do (its description already sets the standing context). Connecting mints the URL and
-                signing secret next.
+                agent what to do. The generated URL contains a random token and works like an API key; keep it private.
               </span>
             </div>
           </div>
@@ -1947,8 +1957,8 @@ export default function AddIntegrationModal({
             </div>
             <div className="mt-2 font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
               Send a JSON POST here and each request runs this agent — the payload is the message (the{' '}
-              <span className="mono">message</span> field speaks for the caller). The endpoint lives on the relay pool —
-              payloads never touch the control plane.
+              <span className="mono">message</span> field speaks for the caller). Keep the full URL private: its random
+              token authenticates each request.
             </div>
             {createdHook.hmacSecret && (
               <div className="mt-[14px] border-t border-dashed border-(--border-default) pt-[13px]">
@@ -1968,7 +1978,7 @@ export default function AddIntegrationModal({
                 </div>
                 <div className="mt-2 font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
                   Send <span className="mono">X-AC-Signature: sha256=&lt;hmac&gt;</span> computed over the raw request
-                  body. The relay verifies it before dispatching to the agent.{' '}
+                  body. The signature is verified before the request reaches the agent.{' '}
                   <span className="font-medium text-(--text-secondary)">Shown only once — copy it now.</span>
                 </div>
               </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2548,6 +2548,8 @@ export interface HookRunDto {
 export interface CreateHookInput {
   agentId: string
   name: string
+  /** Add X-AC-Signature verification on top of the capability URL. */
+  hmac?: boolean
 }
 
 // github kind: the repo must sit inside one of the org's GitHub App
@@ -2574,9 +2576,10 @@ export async function fetchAgentHooks(agentId: string, orgId?: string): Promise<
   return apiGet<HookDto[]>(`${orgBase(orgId)}/agents/${encodeURIComponent(agentId)}/hooks`)
 }
 
-// Always mints a signing secret (`hmac: true`) — the create modal reveals it once.
+// The capability URL is sufficient by default. HMAC is an optional second
+// factor, with its signing secret revealed once by the create response.
 export async function createHook(input: CreateHookInput): Promise<CreatedHookDto> {
-  const hook = await apiPost<CreatedHookDto>(`${orgBase()}/hooks`, { kind: 'webhook', hmac: true, ...input })
+  const hook = await apiPost<CreatedHookDto>(`${orgBase()}/hooks`, { kind: 'webhook', ...input })
   track('hook_created', { org_id: apiOrgId, agent_id: hook.agentId, hook_kind: hook.kind, hook_id: hook.id })
   return hook
 }


### PR DESCRIPTION
## Summary

- default generic webhook creation to the existing capability-URL verification
- add an opt-in HMAC checkbox for senders that can sign the raw request body
- keep the one-time signing-secret reveal and signed curl example only when HMAC is enabled
- clarify that the full webhook URL must be protected like an API key

## Why

The webhook API and relay already support hooks without HMAC, but the Console hardcoded `hmac: true`. That made every integration compute `X-AC-Signature`, even when the sending system could only issue a JSON POST to a private URL.

## Validation

- `pnpm exec prettier --check packages/web/src/lib/api.ts packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm exec eslint packages/web/src/lib/api.ts packages/web/src/components/console/modals/AddIntegrationModal.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @agentconnect.md/web test` (56 files, 385 tests)
- `pnpm --filter @agentconnect.md/relay exec vitest run src/hooks/ingress.test.ts` (24 tests)
- visually verified URL-only and HMAC flows at desktop and 390px mobile widths
- verified create payloads send `hmac: false` by default and `hmac: true` when selected

Created by Codex . GPT-5
