### PR TITLE
fix(web): use Lark label in bot settings

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -102,7 +102,7 @@ const BOT_PLATFORMS = [
   { platform: 'slack', label: 'Slack', noun: 'app' },
   { platform: 'discord', label: 'Discord', noun: 'bot' },
   { platform: 'telegram', label: 'Telegram', noun: 'bot' },
-  { platform: 'feishu', label: 'Feishu', noun: 'bot' }
+  { platform: 'feishu', label: 'Lark', noun: 'bot' }
 ] as const
 type BotPlatform = (typeof BOT_PLATFORMS)[number]['platform']
 


### PR DESCRIPTION
## Summary

- show `Lark` instead of `Feishu` on the Settings > Bots platform tab
- keep the internal `feishu` platform key and Feishu/Lark region behavior unchanged

## Root cause

The Bots settings card maintained its own platform-label table, so it retained the older Feishu-facing label after the integration onboarding UI moved to Lark-first branding.

## Validation

- `packages/web/node_modules/.bin/tsc --noEmit -p packages/web/tsconfig.json`
- `node_modules/.bin/eslint packages/web/src/components/console/views/SettingsView.tsx`
- `node_modules/.bin/prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `git diff --check`
- pre-push repository lint (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . gpt-5.6-sol
