### PR TITLE
fix(daemon): receive Discord direct messages

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -1,6 +1,7 @@
 import {
   Client,
   GatewayIntentBits,
+  Partials,
   Events,
   MessageFlags,
   type Message,
@@ -185,7 +186,10 @@ export class DiscordConnection {
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent, // privileged: needed to read message text
         GatewayIntentBits.DirectMessages
-      ]
+      ],
+      // Discord does not cache DM channels. Without this partial, discord.js drops
+      // MESSAGE_CREATE events from DMs before they reach our MessageCreate handler.
+      partials: [Partials.Channel]
     })
   }
 

--- a/packages/daemon/test/discord-connection.test.ts
+++ b/packages/daemon/test/discord-connection.test.ts
@@ -1,0 +1,17 @@
+import { GatewayIntentBits, Partials, type Client } from 'discord.js'
+import { describe, expect, it } from 'vitest'
+import { DiscordConnection } from '../src/discord/connection.js'
+
+describe('DiscordConnection gateway options', () => {
+  it('subscribes to direct messages and allows their uncached channels', () => {
+    const connection = new DiscordConnection({
+      group: { botToken: 'token', integrations: [] },
+      onMessage: () => {},
+      newTraceId: () => 'trace'
+    })
+    const client = (connection as unknown as { client: Client }).client
+
+    expect(client.options.intents.has(GatewayIntentBits.DirectMessages)).toBe(true)
+    expect(client.options.partials).toContain(Partials.Channel)
+  })
+})


### PR DESCRIPTION
## Summary

- enable Discord channel partials alongside the direct-message gateway intent
- add a focused regression test for the Discord client configuration

## Root cause

`discord.js` does not cache DM channels and does not emit `messageCreate` for an uncached channel unless `Partials.Channel` is enabled. AgentConnect subscribed to `DirectMessages`, so guild channels worked, but omitted the channel partial and never received DM events.

## Validation

- `node_modules/.bin/vitest run test/discord-connection.test.ts test/discord-normalize.test.ts` (29 tests passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/discord/connection.ts packages/daemon/test/discord-connection.test.ts`
- `pnpm exec prettier --check packages/daemon/src/discord/connection.ts packages/daemon/test/discord-connection.test.ts`
- pre-push repository lint completed with two pre-existing duplicate-import warnings in `packages/control-plane/src/http/routes/icon-upload.ts`

Created by Codex . gpt-5.6-sol
