### PR TITLE
fix(web): link integration bots to settings

### DIFF
--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -443,6 +443,8 @@ export default function AgentDetailView() {
 
   const tabCls = (t: DetailTab) => (tab === t ? 'tab on' : 'tab')
   const tabHref = (t: DetailTab) => orgPath(t === 'integrations' ? `/agents/${da.id}` : `/agents/${da.id}?tab=${t}`)
+  const botSettingsHref = (botId?: string) =>
+    orgPath(botId ? `/settings?bot=${encodeURIComponent(botId)}` : '/settings')
 
   // ── Single responsive tree. Base classes are the mobile (≤768px) push-detail
   // body (the Shell provides the top push bar there); `desktop:` variants restore
@@ -1053,17 +1055,21 @@ export default function AgentDetailView() {
                   {agentInts.map((g, i) => (
                     <div key={i} className={i > 0 ? 'border-t border-(--border-subtle)' : undefined}>
                       <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
-                        <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                          <PlatformMark platform={g.platform} />
-                        </span>
-                        <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                          <span className="font-sans text-[14px] font-semibold leading-normal">{g.name}</span>
-                          {g.channels[0] && (
-                            <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                              #{g.channels[0].name}
+                        <Link href={botSettingsHref(g.botId)} className="group flex min-w-0 flex-1 items-center gap-3">
+                          <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                            <PlatformMark platform={g.platform} />
+                          </span>
+                          <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                            <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
+                              {g.name}
                             </span>
-                          )}
-                        </span>
+                            {g.channels[0] && (
+                              <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                                #{g.channels[0].name}
+                              </span>
+                            )}
+                          </span>
+                        </Link>
                         <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
                           <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
                           connected
@@ -1159,27 +1165,31 @@ export default function AgentDetailView() {
                   {agentInts.map((g, i) => (
                     <div key={i} className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
                       <div className="flex items-center gap-3 px-[14px] py-3">
-                        <span className="imark h-[34px] w-[34px] rounded-md">
-                          <PlatformMark platform={g.platform} />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2">
-                            <span className="font-sans text-[13.5px] font-semibold leading-normal">{g.name}</span>
-                            <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
-                              <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
-                              connected
-                            </span>
-                            {g.shareable && (
-                              <span
-                                className="badge bg-(--surface-app) text-(--text-tertiary)"
-                                title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
-                              >
-                                <Icon name="users" size={11} />
-                                shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
+                        <Link href={botSettingsHref(g.botId)} className="group flex min-w-0 flex-1 items-center gap-3">
+                          <span className="imark h-[34px] w-[34px] rounded-md">
+                            <PlatformMark platform={g.platform} />
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
+                                {g.name}
                               </span>
-                            )}
+                              <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
+                                <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
+                                connected
+                              </span>
+                              {g.shareable && (
+                                <span
+                                  className="badge bg-(--surface-app) text-(--text-tertiary)"
+                                  title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
+                                >
+                                  <Icon name="users" size={11} />
+                                  shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
+                                </span>
+                              )}
+                            </div>
                           </div>
-                        </div>
+                        </Link>
                         {g.platform === 'discord' && g.discordAppId && (
                           <a
                             href={discordBotInviteUrl(g.discordAppId)}

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -10,6 +10,7 @@
 // default org, so the page is fully editable with no picker.
 
 import { Fragment, useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { Avatar, Button, Icon, Toggle } from '@/components/ui'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
@@ -400,6 +401,7 @@ function InviteLinksCard({ orgId }: { orgId: string }) {
 }
 
 export default function SettingsView() {
+  const targetBotId = useSearchParams().get('bot')
   const { me } = useProfile()
   const { activeOrg, myRole, refreshOrgs, error: orgError } = useOrgs()
   const { openModal } = useModal()
@@ -548,7 +550,7 @@ export default function SettingsView() {
           channel roster (a SHARED bot's channels each get an active-agent picker).
           Slack rows deep-link to the app's settings; Discord rows offer a ready-made
           "Add to Discord" invite built from the persisted application id. */}
-      <BotsCard canWrite={canWrite} me={me} onDelete={setDeletingBot} />
+      <BotsCard canWrite={canWrite} me={me} targetBotId={targetBotId} onDelete={setDeletingBot} />
 
       <GithubCard canWrite={canWrite} isOwner={isOwner} />
 
@@ -582,7 +584,17 @@ export default function SettingsView() {
 // are always shown together. Each row carries the Sharable toggle (PATCH
 // /bots/:id; the CP's 409 reason renders inline) + installed-agent stack and
 // expands to the bot's channel roster.
-function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | null; onDelete: (b: BotDto) => void }) {
+function BotsCard({
+  canWrite,
+  me,
+  targetBotId,
+  onDelete
+}: {
+  canWrite: boolean
+  me: MeDto | null
+  targetBotId: string | null
+  onDelete: (b: BotDto) => void
+}) {
   const { bots, integrations, getAgent, setBotShareable, setChannelAgent, loading: dataLoading } = useConsoleData()
   const [platform, setPlatform] = useState<BotPlatform>('slack')
   // Bot row expanded to its channel roster (one at a time), the bot whose
@@ -594,8 +606,22 @@ function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | n
   const [slackRefreshBusyId, setSlackRefreshBusyId] = useState<string | null>(null)
   const [slackRefresh, setSlackRefresh] = useState<Record<string, { result?: SlackBotRefreshDto; error?: string }>>({})
 
+  const targetBotPlatform = BOT_PLATFORMS.find(
+    (item) => item.platform === bots.find((bot) => bot.id === targetBotId)?.platform
+  )?.platform
   const { label, noun } = BOT_PLATFORMS.find((item) => item.platform === platform)!
   const platformBots = bots.filter((b) => b.platform === platform)
+
+  useEffect(() => {
+    if (!targetBotId || !targetBotPlatform) return
+    setPlatform(targetBotPlatform)
+    setOpenBotId(targetBotId)
+  }, [targetBotId, targetBotPlatform])
+
+  useEffect(() => {
+    if (!targetBotId || openBotId !== targetBotId) return
+    document.getElementById(`settings-bot-${targetBotId}`)?.scrollIntoView({ block: 'start' })
+  }, [openBotId, targetBotId])
 
   const flipShareable = async (b: BotDto, next: boolean) => {
     if (botBusyId) return
@@ -688,6 +714,7 @@ function BotsCard({ canWrite, me, onDelete }: { canWrite: boolean; me: MeDto | n
         return (
           <Fragment key={b.id}>
             <div
+              id={`settings-bot-${b.id}`}
               className={`row click ${BOT_GRID} items-center gap-[11px]`}
               onClick={() => setOpenBotId(open ? null : b.id)}
             >


### PR DESCRIPTION
## Summary

- make each IM bot identity on an agent's Integrations tab link to that bot in Settings
- use the durable bot id to select the correct platform and expand the target bot row
- scroll the expanded bot into view after navigation

## Why

The Integrations view exposed the bot identity but had no path to its organization-level settings. The Settings bot selection and expansion were also local-only, so the page could not represent a targeted bot deep link.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/AgentDetailView.tsx packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm --filter @agentconnect.md/web build`
- manual mock-console QA at 1280×720 and 390×844: verified the rendered link, platform selection, expanded target row, and no mobile horizontal overflow
- pre-push full-repository lint completed with only two existing duplicate-import warnings outside this change

Created by Codex . GPT-5
