### PR TITLE
fix(discord): name the server each channel row belongs to, and stop offering DMs as channels

### DIFF
--- a/packages/control-plane/prisma/migrations/20260728130000_integration_channel_space/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260728130000_integration_channel_space/migration.sql
@@ -2,8 +2,14 @@
 --
 -- One Discord bot is commonly invited to several servers, each of which has its own
 -- "#general". The channel name alone therefore does not identify the row the operator
--- is configuring, so the daemon reports the enclosing server's name alongside it.
--- Nullable: platforms with a single implicit container per bot (Slack workspace,
--- Telegram, Feishu tenant), DM rows, and Discord rows whose guild name has not been
--- resolved yet all leave it NULL.
+-- is configuring, so the daemon reports the enclosing server alongside it.
+--
+-- `spaceId` is the identity — Discord permits two distinct guilds to carry the SAME
+-- name, so grouping the console's rows on the label would merge them and hide the very
+-- ambiguity this resolves. `space` is the display label only.
+--
+-- Both nullable: platforms with a single implicit container per bot (Slack workspace,
+-- Telegram, Feishu tenant), DM rows, and Discord rows whose guild has not been resolved
+-- yet all leave them NULL.
+ALTER TABLE "integration_channel" ADD COLUMN "spaceId" TEXT;
 ALTER TABLE "integration_channel" ADD COLUMN "space" TEXT;

--- a/packages/control-plane/prisma/migrations/20260728130000_integration_channel_space/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260728130000_integration_channel_space/migration.sql
@@ -1,0 +1,9 @@
+-- The space (Discord guild / server) a reported conversation lives in.
+--
+-- One Discord bot is commonly invited to several servers, each of which has its own
+-- "#general". The channel name alone therefore does not identify the row the operator
+-- is configuring, so the daemon reports the enclosing server's name alongside it.
+-- Nullable: platforms with a single implicit container per bot (Slack workspace,
+-- Telegram, Feishu tenant), DM rows, and Discord rows whose guild name has not been
+-- resolved yet all leave it NULL.
+ALTER TABLE "integration_channel" ADD COLUMN "space" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1466,6 +1466,10 @@ model IntegrationChannel {
   integrationId String           @db.Uuid
   channelId     String // platform conversation id (Slack "C…" / DM "D…")
   name          String? // "#deploys" without the hash (or DM counterpart); null if lookup failed
+  // Enclosing space the conversation lives in — a Discord guild/server name. One bot
+  // spans several servers, each with its own "#general", so the console needs it to
+  // tell the rows apart. Null on single-container platforms, DMs, and until resolved.
+  space         String?
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)
   // Relay-backed channel rows repeat the effective trigger across each active

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1466,9 +1466,12 @@ model IntegrationChannel {
   integrationId String           @db.Uuid
   channelId     String // platform conversation id (Slack "C…" / DM "D…")
   name          String? // "#deploys" without the hash (or DM counterpart); null if lookup failed
-  // Enclosing space the conversation lives in — a Discord guild/server name. One bot
-  // spans several servers, each with its own "#general", so the console needs it to
-  // tell the rows apart. Null on single-container platforms, DMs, and until resolved.
+  // Enclosing space the conversation lives in — a Discord guild. One bot spans several
+  // servers, each with its own "#general", so the console needs it to tell the rows
+  // apart. `spaceId` (the guild snowflake) is the identity — two guilds may share a
+  // name — and `space` is the display label. Null on single-container platforms, on DM
+  // rows, and until the daemon resolves them.
+  spaceId       String?
   space         String?
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -702,8 +702,11 @@ export const CreateIntegrationBody = z
 export const IntegrationChannelDto = z.object({
   channelId: z.string(),
   name: z.string().nullable(), // "#deploys" without the hash (or DM counterpart); null if lookup failed
-  /** Enclosing space (Discord server) name — one bot spans several servers, each with
-   *  its own "#general". Null on single-container platforms, DMs, and until resolved. */
+  /** Enclosing space (Discord server) — one bot spans several servers, each with its
+   *  own "#general". `spaceId` is the identity the console groups on (two servers may
+   *  share a name); `space` is the label. Null on single-container platforms, on DMs,
+   *  and until resolved. */
+  spaceId: z.string().nullable(),
   space: z.string().nullable(),
   isPrivate: z.boolean(),
   kind: z.enum(['channel', 'im']),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -702,6 +702,9 @@ export const CreateIntegrationBody = z
 export const IntegrationChannelDto = z.object({
   channelId: z.string(),
   name: z.string().nullable(), // "#deploys" without the hash (or DM counterpart); null if lookup failed
+  /** Enclosing space (Discord server) name — one bot spans several servers, each with
+   *  its own "#general". Null on single-container platforms, DMs, and until resolved. */
+  space: z.string().nullable(),
   isPrivate: z.boolean(),
   kind: z.enum(['channel', 'im']),
   trigger: z.enum(['off', 'mention', 'any']),

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -47,6 +47,7 @@ function toChannelDto(c: IntegrationChannelRecord): IntegrationChannelDtoT {
   return {
     channelId: c.channelId,
     name: c.name,
+    spaceId: c.spaceId,
     space: c.space,
     isPrivate: c.isPrivate,
     kind: c.kind,

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -47,6 +47,7 @@ function toChannelDto(c: IntegrationChannelRecord): IntegrationChannelDtoT {
   return {
     channelId: c.channelId,
     name: c.name,
+    space: c.space,
     isPrivate: c.isPrivate,
     kind: c.kind,
     trigger: c.trigger,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2229,8 +2229,10 @@ export interface IntegrationChannelRecord {
   integrationId: IntegrationId
   channelId: string
   name: string | null
-  /** Enclosing space (Discord guild/server) name; null on single-container
-   *  platforms, on DM rows, and until the daemon has resolved it. */
+  /** Enclosing space (Discord guild) — `spaceId` is the identity (two guilds may
+   *  share a name), `space` the display label. Null on single-container platforms,
+   *  on DM rows, and until the daemon has resolved them. */
+  spaceId: string | null
   space: string | null
   isPrivate: boolean
   kind: ConversationKind
@@ -2244,7 +2246,9 @@ export interface IntegrationChannelRecord {
 export interface ReportedChannel {
   id: string
   name?: string
-  /** Enclosing Discord guild/server name; absent elsewhere and until resolved. */
+  /** Enclosing Discord guild — id (the identity) and display name. Absent on other
+   *  platforms and until resolved. */
+  spaceId?: string
   space?: string
   isPrivate?: boolean
   /** Absent = 'channel' (wire compatibility). */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2229,6 +2229,9 @@ export interface IntegrationChannelRecord {
   integrationId: IntegrationId
   channelId: string
   name: string | null
+  /** Enclosing space (Discord guild/server) name; null on single-container
+   *  platforms, on DM rows, and until the daemon has resolved it. */
+  space: string | null
   isPrivate: boolean
   kind: ConversationKind
   /** Repeated across shared-channel sibling rows; integration-scoped for DMs. */
@@ -2241,6 +2244,8 @@ export interface IntegrationChannelRecord {
 export interface ReportedChannel {
   id: string
   name?: string
+  /** Enclosing Discord guild/server name; absent elsewhere and until resolved. */
+  space?: string
   isPrivate?: boolean
   /** Absent = 'channel' (wire compatibility). */
   kind?: ConversationKind

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -366,6 +366,7 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     integrationId: IntegrationId(c.integrationId),
     channelId: c.channelId,
     name: c.name,
+    space: c.space,
     isPrivate: c.isPrivate,
     kind: c.kind as ConversationKind,
     trigger: c.trigger as ChannelTrigger,
@@ -400,6 +401,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
           integrationId,
           channelId: c.id,
           name: c.name ?? null,
+          space: c.space ?? null,
           isPrivate: c.isPrivate ?? false,
           kind: c.kind ?? 'channel',
           ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
@@ -408,6 +410,9 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         // re-report must never downgrade an established 'im' row (§14.3).
         update: {
           ...(authoritative || c.name !== undefined ? { name: c.name ?? null } : {}),
+          // The space resolves lazily (one guild lookup per channel, TTL-cached at the
+          // edge), so a report that carries none must not blank a known server name.
+          ...(c.space !== undefined ? { space: c.space } : {}),
           ...(authoritative || c.isPrivate !== undefined ? { isPrivate: c.isPrivate ?? false } : {}),
           ...(c.kind ? { kind: c.kind } : {})
         }
@@ -426,6 +431,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         integrationId,
         channelId: conversation.id,
         name: conversation.name ?? null,
+        space: conversation.space ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
         ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {}),
@@ -433,7 +439,10 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       },
       // Refresh only a KNOWN name — a nameless re-report must not clobber a
       // previously resolved counterpart name; trigger/agentId stay operator-owned.
-      update: conversation.name ? { name: conversation.name } : {}
+      update: {
+        ...(conversation.name ? { name: conversation.name } : {}),
+        ...(conversation.space ? { space: conversation.space } : {})
+      }
     })
     return toChannelRecord(row)
   }

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -366,6 +366,7 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     integrationId: IntegrationId(c.integrationId),
     channelId: c.channelId,
     name: c.name,
+    spaceId: c.spaceId,
     space: c.space,
     isPrivate: c.isPrivate,
     kind: c.kind as ConversationKind,
@@ -383,6 +384,14 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   // authoritative membership snapshot, drop channel rows that are no longer present.
   // DM rows and rows omitted from a non-authoritative observed-conversation report
   // are retained.
+  //
+  // A DM row is the one exception to `defaultTrigger`, and it is a SECURITY boundary
+  // (resource-visibility.md §14.3). Discovery reports DMs whether or not the owning
+  // agent is gated today, and visibility can flip to restricted later — at which point
+  // `gatedBindRules` enables every non-Off IM row. Storing a discovered DM with the
+  // ordinary 'mention' default would therefore let a newly-private agent keep answering
+  // a DM that no operator ever enabled. Created DM rows, and channel rows converting to
+  // DM, are pinned Off; an operator's later choice is untouched.
   async replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
@@ -393,28 +402,48 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         where: { integrationId, kind: 'channel', channelId: { notIn: channels.map((c) => c.id) } }
       })
     }
+    // The stored kind decides whether a reported DM is a conversion (fail closed) or an
+    // established row (operator-owned) — one read, not a round-trip per channel.
+    const stored = new Map(
+      (
+        await this.db.integrationChannel.findMany({
+          where: { integrationId },
+          select: { channelId: true, kind: true }
+        })
+      ).map((r) => [r.channelId, r.kind])
+    )
     for (const c of channels) {
       const authoritative = opts?.authoritative !== false
+      const convertedToIm = c.kind === 'im' && stored.get(c.id) === 'channel'
       await this.db.integrationChannel.upsert({
         where: { integrationId_channelId: { integrationId, channelId: c.id } },
         create: {
           integrationId,
           channelId: c.id,
           name: c.name ?? null,
+          spaceId: c.spaceId ?? null,
           space: c.space ?? null,
           isPrivate: c.isPrivate ?? false,
           kind: c.kind ?? 'channel',
-          ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {})
+          ...(c.kind === 'im'
+            ? { trigger: 'off' as const }
+            : opts?.defaultTrigger
+              ? { trigger: opts.defaultTrigger }
+              : {})
         },
         // kind updates only when explicitly reported: a kind-less membership/observed
         // re-report must never downgrade an established 'im' row (§14.3).
         update: {
           ...(authoritative || c.name !== undefined ? { name: c.name ?? null } : {}),
           // The space resolves lazily (one guild lookup per channel, TTL-cached at the
-          // edge), so a report that carries none must not blank a known server name.
+          // edge), so a report that carries none must not blank a known server.
+          ...(c.spaceId !== undefined ? { spaceId: c.spaceId } : {}),
           ...(c.space !== undefined ? { space: c.space } : {}),
           ...(authoritative || c.isPrivate !== undefined ? { isPrivate: c.isPrivate ?? false } : {}),
-          ...(c.kind ? { kind: c.kind } : {})
+          ...(c.kind ? { kind: c.kind } : {}),
+          // A row misclassified as a channel carried a channel's trigger. It is not an
+          // operator's DM choice, so the conversion resets it rather than inheriting it.
+          ...(convertedToIm ? { trigger: 'off' as const } : {})
         }
       })
     }
@@ -431,16 +460,24 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         integrationId,
         channelId: conversation.id,
         name: conversation.name ?? null,
+        spaceId: conversation.spaceId ?? null,
         space: conversation.space ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
-        ...(opts?.defaultTrigger ? { trigger: opts.defaultTrigger } : {}),
+        // Same fail-closed rule as replaceSnapshot: a created DM row starts Off however
+        // it was discovered, so a later flip to restricted cannot grandfather it in.
+        ...(conversation.kind === 'im'
+          ? { trigger: 'off' as const }
+          : opts?.defaultTrigger
+            ? { trigger: opts.defaultTrigger }
+            : {}),
         ...(opts?.agentId !== undefined ? { agentId: opts.agentId } : {})
       },
       // Refresh only a KNOWN name — a nameless re-report must not clobber a
       // previously resolved counterpart name; trigger/agentId stay operator-owned.
       update: {
         ...(conversation.name ? { name: conversation.name } : {}),
+        ...(conversation.spaceId ? { spaceId: conversation.spaceId } : {}),
         ...(conversation.space ? { space: conversation.space } : {})
       }
     })

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -392,6 +392,15 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   // ordinary 'mention' default would therefore let a newly-private agent keep answering
   // a DM that no operator ever enabled. Created DM rows, and channel rows converting to
   // DM, are pinned Off; an operator's later choice is untouched.
+  //
+  // The channel→DM transition is decided INSIDE the write, off the row's committed kind,
+  // never off a prior read. Channel reports are fire-and-forget and their handlers run
+  // concurrently — the daemon's own startup emits a kind-less snapshot and the resolver's
+  // later `saveScope` emits the same conversation as `im`. Two such writes racing with a
+  // read-then-write would both see "no row": the first creates channel/mention, the
+  // second flips the kind and inherits that trigger, landing exactly on the fail-open
+  // state above. `ON CONFLICT … DO UPDATE` re-reads the row under the write's own lock,
+  // so the conversion cannot be missed however the reports interleave.
   async replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
@@ -402,50 +411,44 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         where: { integrationId, kind: 'channel', channelId: { notIn: channels.map((c) => c.id) } }
       })
     }
-    // The stored kind decides whether a reported DM is a conversion (fail closed) or an
-    // established row (operator-owned) — one read, not a round-trip per channel.
-    const stored = new Map(
-      (
-        await this.db.integrationChannel.findMany({
-          where: { integrationId },
-          select: { channelId: true, kind: true }
-        })
-      ).map((r) => [r.channelId, r.kind])
-    )
+    const authoritative = opts?.authoritative !== false
     for (const c of channels) {
-      const authoritative = opts?.authoritative !== false
-      const convertedToIm = c.kind === 'im' && stored.get(c.id) === 'channel'
-      await this.db.integrationChannel.upsert({
-        where: { integrationId_channelId: { integrationId, channelId: c.id } },
-        create: {
-          integrationId,
-          channelId: c.id,
-          name: c.name ?? null,
-          spaceId: c.spaceId ?? null,
-          space: c.space ?? null,
-          isPrivate: c.isPrivate ?? false,
-          kind: c.kind ?? 'channel',
-          ...(c.kind === 'im'
-            ? { trigger: 'off' as const }
-            : opts?.defaultTrigger
-              ? { trigger: opts.defaultTrigger }
-              : {})
-        },
-        // kind updates only when explicitly reported: a kind-less membership/observed
-        // re-report must never downgrade an established 'im' row (§14.3).
-        update: {
-          ...(authoritative || c.name !== undefined ? { name: c.name ?? null } : {}),
-          // The space resolves lazily (one guild lookup per channel, TTL-cached at the
-          // edge), so a report that carries none must not blank a known server.
-          ...(c.spaceId !== undefined ? { spaceId: c.spaceId } : {}),
-          ...(c.space !== undefined ? { space: c.space } : {}),
-          ...(authoritative || c.isPrivate !== undefined ? { isPrivate: c.isPrivate ?? false } : {}),
-          ...(c.kind ? { kind: c.kind } : {}),
-          // A row misclassified as a channel carried a channel's trigger. It is not an
-          // operator's DM choice, so the conversion resets it rather than inheriting it.
-          ...(convertedToIm ? { trigger: 'off' as const } : {})
-        }
-      })
+      // Which columns a re-report is allowed to overwrite. An absent name/isPrivate is
+      // authoritative-only (a partial report must not blank them); an absent space keeps
+      // the known server (it resolves lazily at the edge); an absent kind must never
+      // downgrade an established 'im' row.
+      const setName = authoritative || c.name !== undefined
+      const setPrivate = authoritative || c.isPrivate !== undefined
+      const createTrigger = c.kind === 'im' ? 'off' : (opts?.defaultTrigger ?? 'mention')
+      await this.db.$executeRaw`
+        INSERT INTO "integration_channel"
+          ("integrationId", "channelId", "name", "spaceId", "space", "isPrivate", "kind", "trigger",
+           "firstSeenAt", "updatedAt")
+        VALUES (
+          ${integrationId}::uuid, ${c.id}, ${c.name ?? null}, ${c.spaceId ?? null}, ${c.space ?? null},
+          ${c.isPrivate ?? false}, ${c.kind ?? 'channel'}::"ConversationKind",
+          ${createTrigger}::"ChannelTrigger", NOW(), NOW()
+        )
+        ON CONFLICT ("integrationId", "channelId") DO UPDATE SET
+          "name" = CASE WHEN ${setName}::boolean THEN EXCLUDED."name" ELSE "integration_channel"."name" END,
+          "spaceId" = CASE WHEN ${c.spaceId !== undefined}::boolean THEN EXCLUDED."spaceId"
+                           ELSE "integration_channel"."spaceId" END,
+          "space" = CASE WHEN ${c.space !== undefined}::boolean THEN EXCLUDED."space"
+                         ELSE "integration_channel"."space" END,
+          "isPrivate" = CASE WHEN ${setPrivate}::boolean THEN EXCLUDED."isPrivate"
+                             ELSE "integration_channel"."isPrivate" END,
+          "kind" = CASE WHEN ${c.kind !== undefined}::boolean THEN EXCLUDED."kind"
+                        ELSE "integration_channel"."kind" END,
+          -- The fail-closed conversion, resolved against the COMMITTED kind: a row that
+          -- was a channel carried a channel's trigger, which is not an operator's DM
+          -- choice. An already-'im' row keeps whatever the operator set.
+          "trigger" = CASE
+            WHEN ${c.kind === 'im'}::boolean AND "integration_channel"."kind" <> 'im'::"ConversationKind"
+              THEN 'off'::"ChannelTrigger"
+            ELSE "integration_channel"."trigger"
+          END,
+          "updatedAt" = NOW()
+      `
     }
   }
 

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -112,6 +112,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       {
         channelId: 'C1',
         name: 'deploys',
+        spaceId: null,
         space: null,
         isPrivate: false,
         kind: 'channel',
@@ -121,6 +122,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       {
         channelId: 'C2',
         name: 'releases',
+        spaceId: null,
         space: null,
         isPrivate: true,
         kind: 'channel',
@@ -139,12 +141,19 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
     const id = await install(running)
 
-    await report(DAEMON, id, [{ id: 'C1', name: 'general', space: 'Acme HQ' }], undefined, undefined, false)
+    await report(
+      DAEMON,
+      id,
+      [{ id: 'C1', name: 'general', spaceId: 'G1', space: 'Acme HQ' }],
+      undefined,
+      undefined,
+      false
+    )
     await report(DAEMON, id, [{ id: 'C1', name: 'general' }], undefined, undefined, false)
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: { channelId: string; space: string | null }[] }[]
-    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'C1', space: 'Acme HQ' })])
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'C1', spaceId: 'G1', space: 'Acme HQ' })])
   })
 
   it("a restricted agent's fresh conversations default to OFF, and DM rows survive a membership re-report (§14)", async () => {
@@ -178,6 +187,72 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
+  })
+
+  it('stores a DM discovered while the agent is public as OFF, so a later gate stays closed (§14.3)', async () => {
+    // Observed-conversation discovery reports DMs whatever the agent's visibility, and
+    // visibility can flip later — at which point gatedBindRules enables every non-Off IM
+    // row. A DM stored with the ordinary 'mention' default would therefore keep being
+    // answered by a now-private agent that no operator ever enabled it for.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+
+    // Public agent: the DM is discovered (and a channel alongside it, for contrast).
+    await report(DAEMON, id, [
+      { id: 'C1', name: 'deploys' },
+      { id: 'D1', name: '@alice', kind: 'im' }
+    ])
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    const byId = new Map(dto!.channels.map((c) => [c.channelId, c]))
+    expect(byId.get('D1')).toMatchObject({ kind: 'im', trigger: 'off' })
+    expect(byId.get('C1')).toMatchObject({ kind: 'channel', trigger: 'mention' })
+
+    spy.upserts.length = 0
+    const put = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${integration.agentId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    expect(put.statusCode).toBe(200)
+    const u0 = spy.upserts[0]!.u
+    if (u0.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u0.slack.gated).toBe(true)
+    // No dm rule for D1: the private agent answers that DM only once enabled.
+    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+  })
+
+  it('resets the trigger when a row misclassified as a channel converts to a DM (§14.3)', async () => {
+    // Session-history discovery cannot tell a DM from a group, so a DM could already be
+    // stored as a channel carrying a channel's trigger. That is not an operator's DM
+    // choice, so the conversion must not inherit it into the gated DM rule set.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+
+    await report(DAEMON, id, [{ id: 'D1', name: '@alice' }], undefined, undefined, false)
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D1', 'any')
+    // The daemon now knows it is a DM and re-reports it as one.
+    await report(DAEMON, id, [{ id: 'D1', name: '@alice', kind: 'im' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'off' })])
+
+    spy.upserts.length = 0
+    await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${integration.agentId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    const u0 = spy.upserts[0]!.u
+    if (u0.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u0.slack.bindRules).toEqual([])
   })
 
   it('enabling conversations on a GATED integration pushes conversation-scoped rules ONLY (§14)', async () => {
@@ -654,6 +729,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     expect(res.json()).toEqual({
       channelId: 'C2',
       name: 'releases',
+      spaceId: null,
       space: null,
       isPrivate: false,
       kind: 'channel',

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -109,9 +109,42 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: unknown[] }[]
     expect(dto!.channels).toEqual([
-      { channelId: 'C1', name: 'deploys', isPrivate: false, kind: 'channel', trigger: 'mention', agentId: null },
-      { channelId: 'C2', name: 'releases', isPrivate: true, kind: 'channel', trigger: 'mention', agentId: null }
+      {
+        channelId: 'C1',
+        name: 'deploys',
+        space: null,
+        isPrivate: false,
+        kind: 'channel',
+        trigger: 'mention',
+        agentId: null
+      },
+      {
+        channelId: 'C2',
+        name: 'releases',
+        space: null,
+        isPrivate: true,
+        kind: 'channel',
+        trigger: 'mention',
+        agentId: null
+      }
     ])
+  })
+
+  it('keeps the reported space (the Discord server) and never blanks it on a report without one', async () => {
+    // A Discord bot spans several servers, each with its own "#general" — the space is
+    // what makes the row identifiable. It resolves lazily at the edge, so a later report
+    // that carries no space must leave the known server name standing.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+
+    await report(DAEMON, id, [{ id: 'C1', name: 'general', space: 'Acme HQ' }], undefined, undefined, false)
+    await report(DAEMON, id, [{ id: 'C1', name: 'general' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const [dto] = res.json() as { channels: { channelId: string; space: string | null }[] }[]
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'C1', space: 'Acme HQ' })])
   })
 
   it("a restricted agent's fresh conversations default to OFF, and DM rows survive a membership re-report (§14)", async () => {
@@ -621,6 +654,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     expect(res.json()).toEqual({
       channelId: 'C2',
       name: 'releases',
+      space: null,
       isPrivate: false,
       kind: 'channel',
       trigger: 'any',

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -94,6 +94,51 @@ async function report(
   await handleIntegrationChannels(frame, { daemonId } as DaemonConnection, deps)
 }
 
+/**
+ * Wrap a Prisma client so the FIRST channel-row read is held until `release()` — letting
+ * a test pin down the interleaving a pair of fire-and-forget reports can produce: reader
+ * takes a stale snapshot, a second writer commits, and only then does the reader write.
+ * `taken` resolves when that read is intercepted; a caller that classifies inside its
+ * write never takes one, so `taken` simply never resolves (callers race it with a
+ * timeout) and `release()` is a no-op.
+ */
+function holdFirstRead(db: typeof prisma): { db: typeof prisma; taken: Promise<void>; release: () => void } {
+  let held = false
+  let markTaken = () => {}
+  let release = () => {}
+  const taken = new Promise<void>((resolve) => {
+    markTaken = resolve
+  })
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const channelProxy = new Proxy(db.integrationChannel, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver)
+      if (prop !== 'findMany' || typeof value !== 'function') {
+        return typeof value === 'function' ? value.bind(target) : value
+      }
+      return async (...args: unknown[]) => {
+        const rows = await (value as (...a: unknown[]) => Promise<unknown>).apply(target, args)
+        if (!held) {
+          held = true
+          markTaken()
+          await gate
+        }
+        return rows
+      }
+    }
+  })
+  const proxied = new Proxy(db, {
+    get(target, prop, receiver) {
+      if (prop === 'integrationChannel') return channelProxy
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    }
+  })
+  return { db: proxied, taken, release }
+}
+
 describe('integration/channels EVT → integration_channel convergence', () => {
   it('inserts reported channels with the default @-mention trigger', async () => {
     await seedDaemon(prisma, DAEMON)
@@ -243,6 +288,51 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'off' })])
+
+    spy.upserts.length = 0
+    await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${integration.agentId}/sharing`,
+      payload: { visibility: 'restricted', sharedWith: [] }
+    })
+    const u0 = spy.upserts[0]!.u
+    if (u0.platform !== 'slack') throw new Error('expected slack integration')
+    expect(u0.slack.bindRules).toEqual([])
+  })
+
+  it('keeps the DM conversion fail-closed when a kind-less and an IM report OVERLAP (§14.3)', async () => {
+    // Channel reports are fire-and-forget and their handlers run concurrently: a daemon
+    // start emits a kind-less observed snapshot, and the resolver's later verdict emits
+    // the same conversation as a DM. Deciding the conversion from a read taken BEFORE the
+    // write loses that race — the reader sees no row, the kind-less report then creates
+    // channel/mention, and the DM write flips only the kind, inheriting a trigger no
+    // operator ever chose for a DM. A later gate would honour it.
+    //
+    // The sequence is pinned rather than left to the scheduler: the DM report's pre-write
+    // read is held, the kind-less report commits underneath it, then the DM write lands.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+
+    const gate = holdFirstRead(prisma)
+    const dmReport = new PgIntegrationChannelRepo(gate.db).replaceSnapshot(
+      IntegrationId(id),
+      [{ id: 'D1', name: '@alice', kind: 'im' }],
+      { authoritative: false }
+    )
+    // Resolves as soon as a pre-write read is taken; an implementation that takes none
+    // is let through by the timeout (its write may land in either order — both are safe).
+    await Promise.race([gate.taken, new Promise((r) => setTimeout(r, 300))])
+    await new PgIntegrationChannelRepo(prisma).replaceSnapshot(IntegrationId(id), [{ id: 'D1', name: '@alice' }], {
+      authoritative: false
+    })
+    gate.release()
+    await dmReport
+
+    const [row] = await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))
+    expect(row).toMatchObject({ channelId: 'D1', kind: 'im', trigger: 'off' })
 
     spy.upserts.length = 0
     await running.app.inject({

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2927,10 +2927,16 @@ export class Daemon {
           const priorById = new Map(prior.map((c) => [c.id, c]))
           const observedIds = new Set(observed.map((c) => c.id))
           const names = this.store.getDisplayNames([...new Set([...observedIds, ...prior.map((c) => c.id)])])
-          // The sessions table cannot distinguish DMs from groups. Preserve the kind
-          // established by explicit gated-conversation discovery for overlapping ids.
+          // The sessions table cannot distinguish DMs from groups, so the kind comes
+          // from the channel lookup's own verdict (`channel_scopes.isIm`), falling back
+          // to the kind explicit gated-conversation discovery established. Without it a
+          // DM surfaces as a configurable channel row named "@someone", which is not a
+          // channel anyone can invite the bot to or set a trigger on.
+          const kinds = this.store.getChannelScopes([...observedIds])
           const fromSessions: IntegrationChannel[] = observed.map((c) => {
             const previous = priorById.get(c.id)
+            const isIm = kinds.get(c.id)?.isIm
+            const kind = isIm === undefined ? previous?.kind : isIm ? ('im' as const) : ('channel' as const)
             const name = c.name ?? names.get(c.id)
             // The enclosing Discord server. Keep the last known label when this pass
             // can't resolve it (the guild name lands with the channel's name lookup),
@@ -2941,7 +2947,7 @@ export class Daemon {
               ...(name ? { name } : {}),
               ...(space ? { space } : {}),
               ...(previous?.isPrivate !== undefined ? { isPrivate: previous.isPrivate } : {}),
-              ...(previous?.kind ? { kind: previous.kind } : {})
+              ...(kind ? { kind } : {})
             }
           })
           const retained = prior

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2938,13 +2938,17 @@ export class Daemon {
             const isIm = kinds.get(c.id)?.isIm
             const kind = isIm === undefined ? previous?.kind : isIm ? ('im' as const) : ('channel' as const)
             const name = c.name ?? names.get(c.id)
-            // The enclosing Discord server. Keep the last known label when this pass
-            // can't resolve it (the guild name lands with the channel's name lookup),
-            // so the console never flickers back to a bare "#general".
+            // The enclosing Discord server: the guild snowflake is the identity the
+            // console groups on (two servers may share a name), the label is display
+            // only. Keep the last known values when this pass can't resolve them (the
+            // guild name lands with the channel's name lookup), so the console never
+            // flickers back to a bare "#general".
+            const spaceId = c.spaceId ?? previous?.spaceId
             const space = c.space ?? previous?.space
             return {
               id: c.id,
               ...(name ? { name } : {}),
+              ...(spaceId ? { spaceId } : {}),
               ...(space ? { space } : {}),
               ...(previous?.isPrivate !== undefined ? { isPrivate: previous.isPrivate } : {}),
               ...(kind ? { kind } : {})
@@ -2956,9 +2960,16 @@ export class Daemon {
               const name = names.get(c.id)
               // A retained row has no session behind it (a gated Off channel), so its
               // space is looked up directly rather than coming out of the collapse.
-              const space = (platform === 'discord' ? this.spaceNameFor(c.id) : undefined) ?? c.space
-              const next = { ...c, ...(name ? { name } : {}), ...(space ? { space } : {}) }
-              return next.name === c.name && next.space === c.space ? c : next
+              const found = platform === 'discord' ? this.spaceFor(c.id) : undefined
+              const spaceId = found?.id ?? c.spaceId
+              const space = found?.name ?? c.space
+              const next = {
+                ...c,
+                ...(name ? { name } : {}),
+                ...(spaceId ? { spaceId } : {}),
+                ...(space ? { space } : {})
+              }
+              return next.name === c.name && next.spaceId === c.spaceId && next.space === c.space ? c : next
             })
           const channels = [...fromSessions, ...retained]
           this.channelSnapshots.set(integ.id, { channels, authoritative: false })
@@ -3005,12 +3016,14 @@ export class Daemon {
     }
   }
 
-  /** Cached name of the space (Discord guild) a channel sits in — the label that keeps
-   *  one bot's several "#general" rows apart. Undefined until the channel's name lookup
-   *  has recorded its guild. */
-  private spaceNameFor(channelId: string): string | undefined {
-    const spaceId = this.store.getChannelScopes([channelId]).get(channelId)?.spaceId
-    return spaceId ? this.store.getDisplayNames([spaceId]).get(spaceId) : undefined
+  /** The space (Discord guild) a channel sits in — the id that keeps one bot's several
+   *  "#general" rows apart, plus its display name once resolved. Undefined until the
+   *  channel's name lookup has recorded its guild. */
+  private spaceFor(channelId: string): { id: string; name?: string } | undefined {
+    const id = this.store.getChannelScopes([channelId]).get(channelId)?.spaceId
+    if (!id) return undefined
+    const name = this.store.getDisplayNames([id]).get(id)
+    return { id, ...(name ? { name } : {}) }
   }
 
   /**
@@ -3024,7 +3037,7 @@ export class Daemon {
   private collapseObserved(
     observed: { id: string; name?: string }[],
     platform: 'telegram' | 'discord'
-  ): { id: string; name?: string; space?: string }[] {
+  ): { id: string; name?: string; spaceId?: string; space?: string }[] {
     if (platform !== 'discord') return observed
     // Two-step: the observed (thread) ids first, then the channels they fold onto —
     // whose OWN scope carries the guild, which a thread row may never have recorded.
@@ -11510,16 +11523,18 @@ export class Daemon {
     const current = existing.find((c) => c.id === channel)
     const kind = isDm ? ('im' as const) : ('channel' as const)
     const known = this.store.getDisplayNames([channel]).get(channel)
-    // Which Discord server the channel belongs to — see spaceNameFor. DM rows have none.
-    const space = !isDm && msg.platform === 'discord' ? this.spaceNameFor(channel) : undefined
-    if (current?.kind === kind && (!known || current.name === known) && (!space || current.space === space)) return
+    // Which Discord server the channel belongs to — see spaceFor. DM rows have none.
+    const found = !isDm && msg.platform === 'discord' ? this.spaceFor(channel) : undefined
+    const space = found ? { spaceId: found.id, ...(found.name ? { space: found.name } : {}) } : undefined
+    // Compare against what a write would actually change — a partially resolved space
+    // (id known, name not yet) must not re-emit the snapshot on every message.
+    const merged = current ? { ...current, ...(known ? { name: known } : {}), ...space, kind } : undefined
+    if (merged && JSON.stringify(merged) === JSON.stringify(current)) return
     // A previously-observed DM (Telegram/Discord session snapshots are kind-less)
     // is upgraded to 'im' rather than skipped after an org→restricted flip.
-    const next = current
-      ? existing.map((c) =>
-          c.id === channel ? { ...c, ...(known ? { name: known } : {}), ...(space ? { space } : {}), kind } : c
-        )
-      : [...existing, { id: channel, ...(known ? { name: known } : {}), ...(space ? { space } : {}), kind }]
+    const next = merged
+      ? existing.map((c) => (c.id === channel ? merged : c))
+      : [...existing, { id: channel, ...(known ? { name: known } : {}), ...space, kind }]
     this.channelSnapshots.set(integrationId, {
       channels: next,
       authoritative: cached?.authoritative ?? false

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2932,9 +2932,14 @@ export class Daemon {
           const fromSessions: IntegrationChannel[] = observed.map((c) => {
             const previous = priorById.get(c.id)
             const name = c.name ?? names.get(c.id)
+            // The enclosing Discord server. Keep the last known label when this pass
+            // can't resolve it (the guild name lands with the channel's name lookup),
+            // so the console never flickers back to a bare "#general".
+            const space = c.space ?? previous?.space
             return {
               id: c.id,
               ...(name ? { name } : {}),
+              ...(space ? { space } : {}),
               ...(previous?.isPrivate !== undefined ? { isPrivate: previous.isPrivate } : {}),
               ...(previous?.kind ? { kind: previous.kind } : {})
             }
@@ -2943,7 +2948,11 @@ export class Daemon {
             .filter((c) => !observedIds.has(c.id))
             .map((c) => {
               const name = names.get(c.id)
-              return name && name !== c.name ? { ...c, name } : c
+              // A retained row has no session behind it (a gated Off channel), so its
+              // space is looked up directly rather than coming out of the collapse.
+              const space = (platform === 'discord' ? this.spaceNameFor(c.id) : undefined) ?? c.space
+              const next = { ...c, ...(name ? { name } : {}), ...(space ? { space } : {}) }
+              return next.name === c.name && next.space === c.space ? c : next
             })
           const channels = [...fromSessions, ...retained]
           this.channelSnapshots.set(integ.id, { channels, authoritative: false })
@@ -2990,19 +2999,32 @@ export class Daemon {
     }
   }
 
+  /** Cached name of the space (Discord guild) a channel sits in — the label that keeps
+   *  one bot's several "#general" rows apart. Undefined until the channel's name lookup
+   *  has recorded its guild. */
+  private spaceNameFor(channelId: string): string | undefined {
+    const spaceId = this.store.getChannelScopes([channelId]).get(channelId)?.spaceId
+    return spaceId ? this.store.getDisplayNames([spaceId]).get(spaceId) : undefined
+  }
+
   /**
    * Fold the observed conversations of one platform onto the channel set the console
    * should offer. Discord sessions key on a THREAD channel (the daemon opens one off
    * every top-level mention), so the raw observed set repeats the same channel once per
-   * thread — collapse each row onto its enclosing channel and dedupe on
-   * (space, channel name). Telegram chats have neither notion; they pass through.
+   * thread — collapse each row onto its enclosing channel and dedupe on the channel
+   * snowflake, labelling each row with the guild it sits in (a bot in several servers
+   * reaches a "#general" in each). Telegram chats have neither notion; they pass through.
    */
   private collapseObserved(
     observed: { id: string; name?: string }[],
     platform: 'telegram' | 'discord'
-  ): { id: string; name?: string }[] {
+  ): { id: string; name?: string; space?: string }[] {
     if (platform !== 'discord') return observed
+    // Two-step: the observed (thread) ids first, then the channels they fold onto —
+    // whose OWN scope carries the guild, which a thread row may never have recorded.
     const scopes = this.store.getChannelScopes(observed.map((c) => c.id))
+    const parents = [...scopes.values()].map((s) => s.parentId).filter((id): id is string => !!id)
+    for (const [id, scope] of this.store.getChannelScopes(parents)) scopes.set(id, scope)
     const names = this.store.getDisplayNames(collapseNameLookupIds(observed, scopes))
     return collapseDiscordChannels(observed, scopes, names)
   }
@@ -11482,12 +11504,16 @@ export class Daemon {
     const current = existing.find((c) => c.id === channel)
     const kind = isDm ? ('im' as const) : ('channel' as const)
     const known = this.store.getDisplayNames([channel]).get(channel)
-    if (current?.kind === kind && (!known || current.name === known)) return
+    // Which Discord server the channel belongs to — see spaceNameFor. DM rows have none.
+    const space = !isDm && msg.platform === 'discord' ? this.spaceNameFor(channel) : undefined
+    if (current?.kind === kind && (!known || current.name === known) && (!space || current.space === space)) return
     // A previously-observed DM (Telegram/Discord session snapshots are kind-less)
     // is upgraded to 'im' rather than skipped after an org→restricted flip.
     const next = current
-      ? existing.map((c) => (c.id === channel ? { ...c, ...(known ? { name: known } : {}), kind } : c))
-      : [...existing, { id: channel, ...(known ? { name: known } : {}), kind }]
+      ? existing.map((c) =>
+          c.id === channel ? { ...c, ...(known ? { name: known } : {}), ...(space ? { space } : {}), kind } : c
+        )
+      : [...existing, { id: channel, ...(known ? { name: known } : {}), ...(space ? { space } : {}), kind }]
     this.channelSnapshots.set(integrationId, {
       channels: next,
       authoritative: cached?.authoritative ?? false

--- a/packages/daemon/src/discord/channels.ts
+++ b/packages/daemon/src/discord/channels.ts
@@ -20,6 +20,8 @@
 export interface ChannelScope {
   /** Enclosing channel id when this id is a thread. */
   parentId?: string
+  /** Enclosing guild id — one bot commonly spans several servers. */
+  spaceId?: string
 }
 
 /**
@@ -27,13 +29,18 @@ export interface ChannelScope {
  * preserved and newest occurrence winning. `scopes` and `displayNames` are the
  * LocalStore lookups keyed by conversation id; the enclosing channel's own cached
  * name wins over the observed row's label when present.
+ *
+ * Each row also carries its guild's name (`space`) when known: a bot invited to
+ * several servers surfaces one "#general" per server, and the channel name alone
+ * makes those rows indistinguishable in the console. The guild id resolves from the
+ * folded-onto channel's scope, falling back to the observed thread's own.
  */
 export function collapseDiscordChannels(
   observed: { id: string; name?: string }[],
   scopes: Map<string, ChannelScope>,
   displayNames: Map<string, string>
-): { id: string; name?: string }[] {
-  const out: { id: string; name?: string }[] = []
+): { id: string; name?: string; space?: string }[] {
+  const out: { id: string; name?: string; space?: string }[] = []
   const seen = new Set<string>()
   for (const c of observed) {
     const id = scopes.get(c.id)?.parentId ?? c.id
@@ -42,19 +49,24 @@ export function collapseDiscordChannels(
     // A thread row already carries its parent's name (the resolver labels a thread with
     // the enclosing channel), so the observed label is a sound fallback either way.
     const name = displayNames.get(id) ?? c.name
-    out.push({ id, ...(name ? { name } : {}) })
+    const spaceId = scopes.get(id)?.spaceId ?? scopes.get(c.id)?.spaceId
+    const space = spaceId ? displayNames.get(spaceId) : undefined
+    out.push({ id, ...(name ? { name } : {}), ...(space ? { space } : {}) })
   }
   return out
 }
 
-/** Every id whose cached display name the collapse needs — the observed ids plus the
- *  enclosing channels they fold onto. */
+/** Every id whose cached display name the collapse needs — the observed ids, the
+ *  enclosing channels they fold onto, and the guilds either of those sits in. */
 export function collapseNameLookupIds(observed: { id: string }[], scopes: Map<string, ChannelScope>): string[] {
   const ids: string[] = []
   for (const c of observed) {
     ids.push(c.id)
-    const parent = scopes.get(c.id)?.parentId
-    if (parent) ids.push(parent)
+    const scope = scopes.get(c.id)
+    if (scope?.parentId) ids.push(scope.parentId)
+    if (scope?.spaceId) ids.push(scope.spaceId)
+    const parentSpace = scope?.parentId ? scopes.get(scope.parentId)?.spaceId : undefined
+    if (parentSpace) ids.push(parentSpace)
   }
   return ids
 }

--- a/packages/daemon/src/discord/channels.ts
+++ b/packages/daemon/src/discord/channels.ts
@@ -30,17 +30,18 @@ export interface ChannelScope {
  * LocalStore lookups keyed by conversation id; the enclosing channel's own cached
  * name wins over the observed row's label when present.
  *
- * Each row also carries its guild's name (`space`) when known: a bot invited to
- * several servers surfaces one "#general" per server, and the channel name alone
- * makes those rows indistinguishable in the console. The guild id resolves from the
- * folded-onto channel's scope, falling back to the observed thread's own.
+ * Each row also carries the guild it sits in — `spaceId` (the snowflake, which is the
+ * space's identity: two guilds may share a name) plus `space` (that guild's name, once
+ * resolved). A bot invited to several servers surfaces one "#general" per server, and
+ * the channel name alone makes those rows indistinguishable in the console. The guild
+ * resolves from the folded-onto channel's scope, falling back to the observed thread's.
  */
 export function collapseDiscordChannels(
   observed: { id: string; name?: string }[],
   scopes: Map<string, ChannelScope>,
   displayNames: Map<string, string>
-): { id: string; name?: string; space?: string }[] {
-  const out: { id: string; name?: string; space?: string }[] = []
+): { id: string; name?: string; spaceId?: string; space?: string }[] {
+  const out: { id: string; name?: string; spaceId?: string; space?: string }[] = []
   const seen = new Set<string>()
   for (const c of observed) {
     const id = scopes.get(c.id)?.parentId ?? c.id
@@ -51,7 +52,7 @@ export function collapseDiscordChannels(
     const name = displayNames.get(id) ?? c.name
     const spaceId = scopes.get(id)?.spaceId ?? scopes.get(c.id)?.spaceId
     const space = spaceId ? displayNames.get(spaceId) : undefined
-    out.push({ id, ...(name ? { name } : {}), ...(space ? { space } : {}) })
+    out.push({ id, ...(name ? { name } : {}), ...(spaceId ? { spaceId } : {}), ...(space ? { space } : {}) })
   }
   return out
 }

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -612,6 +612,8 @@ export class DiscordConnection {
     isPrivate?: boolean
     parentId?: string
     parentName?: string
+    spaceId?: string
+    spaceName?: string
   }> {
     const ch = await this.client.channels.fetch(channel).catch(() => null)
     const c = ch as
@@ -620,6 +622,8 @@ export class DiscordConnection {
           isDMBased?: () => boolean
           isThread?: () => boolean
           parentId?: string | null
+          guildId?: string | null
+          guild?: { id: string; name?: string } | null
         })
       | null
     const isIm = typeof c?.isDMBased === 'function' ? c.isDMBased() : false
@@ -628,11 +632,18 @@ export class DiscordConnection {
     const isThread = typeof c?.isThread === 'function' && c.isThread()
     const parentId = isThread && c?.parentId ? c.parentId : undefined
     const parentName = parentId ? await this.channelName(parentId) : undefined
+    // The guild this conversation sits in. A bot in several servers reaches a
+    // "#general" in each of them, so the console can only tell the rows apart by
+    // the server that encloses them. DMs have no guild.
+    const spaceId = c?.guild?.id ?? c?.guildId ?? undefined
+    const spaceName = c?.guild?.name
     return {
       id: channel,
       ...(c?.name ? { name: c.name } : {}),
       ...(parentId ? { parentId } : {}),
       ...(parentName ? { parentName } : {}),
+      ...(spaceId ? { spaceId } : {}),
+      ...(spaceName ? { spaceName } : {}),
       isIm,
       // A guild channel's visibility depends on role overwrites we don't resolve here;
       // treat non-DM guild channels as non-private best-effort.

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -53,6 +53,9 @@ const MAX_TRACKED_IDS = 5000 // attempt-cache cap (oldest-evicted)
 export interface ResolvedChannelScope {
   parentId?: string
   spaceId?: string
+  /** The conversation is a 1:1 DM. Session history can't tell a DM from a group, so
+   *  without this observed discovery offers a DM as a configurable channel row. */
+  isIm?: boolean
 }
 
 export interface ChannelNameResolverOpts {
@@ -126,10 +129,11 @@ export class ChannelNameResolver {
       // Where the conversation sits: a thread folds onto its enclosing channel in
       // channel discovery. Saved before the name so a nameless lookup still contributes
       // the scope.
-      if (info.parentId || info.spaceId)
+      if (info.parentId || info.spaceId || info.isIm !== undefined)
         this.saveScope?.(channel, {
           ...(info.parentId ? { parentId: info.parentId } : {}),
-          ...(info.spaceId ? { spaceId: info.spaceId } : {})
+          ...(info.spaceId ? { spaceId: info.spaceId } : {}),
+          ...(info.isIm === undefined ? {} : { isIm: info.isIm })
         })
       // The enclosing channel is a reportable conversation of its own (channel discovery
       // labels the folded row from it) — cache its name, and the space both of them sit

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -16,6 +16,10 @@ export interface ChannelInfoSource {
     parentId?: string
     /** Enclosing channel name when `channel` is itself a thread (Discord). */
     parentName?: string
+    /** Enclosing space the conversation lives in — the Discord guild id. */
+    spaceId?: string
+    /** That space's display name (the Discord server name). */
+    spaceName?: string
   }>
   getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
 }
@@ -44,9 +48,11 @@ const FAIL_TTL_MS = 10 * 60 * 1000 // retry failed lookups (rate limit / outage)
 const MAX_TRACKED_IDS = 5000 // attempt-cache cap (oldest-evicted)
 
 /** Where a conversation sits — reported alongside its name so the daemon can fold a
- *  thread onto the enclosing channel it belongs to (see discord/channels.ts). */
+ *  thread onto the enclosing channel it belongs to (see discord/channels.ts), and so
+ *  a reported channel can name the space (Discord guild) that encloses it. */
 export interface ResolvedChannelScope {
   parentId?: string
+  spaceId?: string
 }
 
 export interface ChannelNameResolverOpts {
@@ -120,10 +126,20 @@ export class ChannelNameResolver {
       // Where the conversation sits: a thread folds onto its enclosing channel in
       // channel discovery. Saved before the name so a nameless lookup still contributes
       // the scope.
-      if (info.parentId) this.saveScope?.(channel, { parentId: info.parentId })
+      if (info.parentId || info.spaceId)
+        this.saveScope?.(channel, {
+          ...(info.parentId ? { parentId: info.parentId } : {}),
+          ...(info.spaceId ? { spaceId: info.spaceId } : {})
+        })
       // The enclosing channel is a reportable conversation of its own (channel discovery
-      // labels the folded row from it) — cache its name under ITS id too.
+      // labels the folded row from it) — cache its name, and the space both of them sit
+      // in, under THEIR ids too.
       if (info.parentId && info.parentName) this.save(info.parentId, info.parentName)
+      if (info.parentId && info.spaceId) this.saveScope?.(info.parentId, { spaceId: info.spaceId })
+      // The space's own name lands in the same id → name cache (a guild snowflake never
+      // collides with a channel or user id), so a reported channel can be labelled with
+      // the server it belongs to without a second live lookup.
+      if (info.spaceId && info.spaceName) this.save(info.spaceId, info.spaceName)
       // A named channel/group is saved bare (the console prefixes "#"); a DM that carries
       // its own handle (a Telegram @username) is saved "@name" so readers can tell it apart.
       // A Discord session keys on the THREAD id, whose own name is the turn's title — label

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -441,10 +441,12 @@ export class LocalStore {
       );
       -- Where a conversation id SITS: its enclosing channel (a Discord thread's parent
       -- channel — a session keys on the thread id, so the reachable channel it belongs
-      -- to is otherwise unrecoverable). Backs observed-channel collapsing: threads fold
-      -- onto their channel, whose snowflake is the uniqueness key of a reported row.
+      -- to is otherwise unrecoverable) and its enclosing space (the Discord guild, whose
+      -- name a reported channel row carries so a bot in several servers stays legible).
+      -- Backs observed-channel collapsing: threads fold onto their channel, whose
+      -- snowflake is the uniqueness key of a reported row.
       CREATE TABLE IF NOT EXISTS channel_scopes (
-        id TEXT PRIMARY KEY, parentId TEXT, updatedAt INTEGER
+        id TEXT PRIMARY KEY, parentId TEXT, spaceId TEXT, updatedAt INTEGER
       );
       CREATE TABLE IF NOT EXISTS permission_requests (
         id TEXT PRIMARY KEY,
@@ -682,6 +684,7 @@ export class LocalStore {
     this.migrateTranscriptRevision()
     this.migrateInboxHookContext()
     this.migrateRuntimeCatalogDefaultMode()
+    this.migrateChannelScopeSpace()
     // A daemon restart loses the in-memory ACP resolver. Retain the audit row but
     // never present it as actionable after recovery.
     this.db
@@ -689,6 +692,14 @@ export class LocalStore {
         "UPDATE permission_requests SET status = 'expired', resolvedAt = COALESCE(resolvedAt, ?) WHERE status = 'pending'"
       )
       .run(Date.now())
+  }
+
+  /** Add `channel_scopes.spaceId` (the Discord guild a conversation sits in) to a
+   *  pre-existing DB. Legacy rows have NULL — the next name lookup for that channel
+   *  fills it in, so a reported row is space-less only until the resolver's TTL. */
+  private migrateChannelScopeSpace(): void {
+    const cols = this.db.prepare('PRAGMA table_info(channel_scopes)').all() as { name: string }[]
+    if (!cols.some((c) => c.name === 'spaceId')) this.db.exec('ALTER TABLE channel_scopes ADD COLUMN spaceId TEXT')
   }
 
   /** Add the `transcript.recipient` column (the agent a row was delivered to) to a
@@ -2144,28 +2155,36 @@ export class LocalStore {
     return out
   }
 
-  /** Record where a conversation id sits — the channel enclosing it. Latest-wins; an
-   *  empty note writes nothing. */
-  setChannelScope(id: string, scope: { parentId?: string }, updatedAt: number): void {
-    if (scope.parentId === undefined) return
+  /** Record where a conversation id sits — the channel and/or space enclosing it.
+   *  Latest-wins per supplied dimension; an empty note writes nothing, and a note that
+   *  carries only one dimension leaves the other as it was (the message path knows the
+   *  parent channel immediately, the space arrives with the later name lookup). */
+  setChannelScope(id: string, scope: { parentId?: string; spaceId?: string }, updatedAt: number): void {
+    if (scope.parentId === undefined && scope.spaceId === undefined) return
     this.db
       .prepare(
-        `INSERT INTO channel_scopes (id, parentId, updatedAt) VALUES (?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET parentId = excluded.parentId, updatedAt = excluded.updatedAt`
+        `INSERT INTO channel_scopes (id, parentId, spaceId, updatedAt) VALUES (?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           parentId = COALESCE(excluded.parentId, channel_scopes.parentId),
+           spaceId = COALESCE(excluded.spaceId, channel_scopes.spaceId),
+           updatedAt = excluded.updatedAt`
       )
-      .run(id, scope.parentId, updatedAt)
+      .run(id, scope.parentId ?? null, scope.spaceId ?? null, updatedAt)
   }
 
   /** Scopes for a set of conversation ids — only the ids that have one. One batched
    *  `IN (…)` query, not a round-trip per id (mirrors getDisplayNames). */
-  getChannelScopes(ids: string[]): Map<string, { parentId?: string }> {
-    const out = new Map<string, { parentId?: string }>()
+  getChannelScopes(ids: string[]): Map<string, { parentId?: string; spaceId?: string }> {
+    const out = new Map<string, { parentId?: string; spaceId?: string }>()
     const unique = [...new Set(ids)]
     if (unique.length === 0) return out
     const rows = this.db
-      .prepare(`SELECT id, parentId FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
-      .all(...unique) as unknown as { id: string; parentId: string | null }[]
-    for (const r of rows) if (r.parentId) out.set(r.id, { parentId: r.parentId })
+      .prepare(`SELECT id, parentId, spaceId FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
+      .all(...unique) as unknown as { id: string; parentId: string | null; spaceId: string | null }[]
+    for (const r of rows) {
+      if (!r.parentId && !r.spaceId) continue
+      out.set(r.id, { ...(r.parentId ? { parentId: r.parentId } : {}), ...(r.spaceId ? { spaceId: r.spaceId } : {}) })
+    }
     return out
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -444,9 +444,11 @@ export class LocalStore {
       -- to is otherwise unrecoverable) and its enclosing space (the Discord guild, whose
       -- name a reported channel row carries so a bot in several servers stays legible).
       -- Backs observed-channel collapsing: threads fold onto their channel, whose
-      -- snowflake is the uniqueness key of a reported row.
+      -- snowflake is the uniqueness key of a reported row. isIm (1/0) records that the
+      -- conversation is a DM: the sessions table cannot tell a DM from a group, so
+      -- without it observed discovery reports a DM as a channel row named "@someone".
       CREATE TABLE IF NOT EXISTS channel_scopes (
-        id TEXT PRIMARY KEY, parentId TEXT, spaceId TEXT, updatedAt INTEGER
+        id TEXT PRIMARY KEY, parentId TEXT, spaceId TEXT, isIm INTEGER, updatedAt INTEGER
       );
       CREATE TABLE IF NOT EXISTS permission_requests (
         id TEXT PRIMARY KEY,
@@ -700,6 +702,8 @@ export class LocalStore {
   private migrateChannelScopeSpace(): void {
     const cols = this.db.prepare('PRAGMA table_info(channel_scopes)').all() as { name: string }[]
     if (!cols.some((c) => c.name === 'spaceId')) this.db.exec('ALTER TABLE channel_scopes ADD COLUMN spaceId TEXT')
+    // `isIm` shares this migration: both columns arrived with the same discovery fix.
+    if (!cols.some((c) => c.name === 'isIm')) this.db.exec('ALTER TABLE channel_scopes ADD COLUMN isIm INTEGER')
   }
 
   /** Add the `transcript.recipient` column (the agent a row was delivered to) to a
@@ -2159,31 +2163,49 @@ export class LocalStore {
    *  Latest-wins per supplied dimension; an empty note writes nothing, and a note that
    *  carries only one dimension leaves the other as it was (the message path knows the
    *  parent channel immediately, the space arrives with the later name lookup). */
-  setChannelScope(id: string, scope: { parentId?: string; spaceId?: string }, updatedAt: number): void {
-    if (scope.parentId === undefined && scope.spaceId === undefined) return
+  setChannelScope(id: string, scope: { parentId?: string; spaceId?: string; isIm?: boolean }, updatedAt: number): void {
+    if (scope.parentId === undefined && scope.spaceId === undefined && scope.isIm === undefined) return
     this.db
       .prepare(
-        `INSERT INTO channel_scopes (id, parentId, spaceId, updatedAt) VALUES (?, ?, ?, ?)
+        `INSERT INTO channel_scopes (id, parentId, spaceId, isIm, updatedAt) VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
            parentId = COALESCE(excluded.parentId, channel_scopes.parentId),
            spaceId = COALESCE(excluded.spaceId, channel_scopes.spaceId),
+           isIm = COALESCE(excluded.isIm, channel_scopes.isIm),
            updatedAt = excluded.updatedAt`
       )
-      .run(id, scope.parentId ?? null, scope.spaceId ?? null, updatedAt)
+      .run(
+        id,
+        scope.parentId ?? null,
+        scope.spaceId ?? null,
+        scope.isIm === undefined ? null : scope.isIm ? 1 : 0,
+        updatedAt
+      )
   }
 
   /** Scopes for a set of conversation ids — only the ids that have one. One batched
    *  `IN (…)` query, not a round-trip per id (mirrors getDisplayNames). */
-  getChannelScopes(ids: string[]): Map<string, { parentId?: string; spaceId?: string }> {
-    const out = new Map<string, { parentId?: string; spaceId?: string }>()
+  getChannelScopes(ids: string[]): Map<string, { parentId?: string; spaceId?: string; isIm?: boolean }> {
+    const out = new Map<string, { parentId?: string; spaceId?: string; isIm?: boolean }>()
     const unique = [...new Set(ids)]
     if (unique.length === 0) return out
     const rows = this.db
-      .prepare(`SELECT id, parentId, spaceId FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`)
-      .all(...unique) as unknown as { id: string; parentId: string | null; spaceId: string | null }[]
+      .prepare(
+        `SELECT id, parentId, spaceId, isIm FROM channel_scopes WHERE id IN (${unique.map(() => '?').join(',')})`
+      )
+      .all(...unique) as unknown as {
+      id: string
+      parentId: string | null
+      spaceId: string | null
+      isIm: number | null
+    }[]
     for (const r of rows) {
-      if (!r.parentId && !r.spaceId) continue
-      out.set(r.id, { ...(r.parentId ? { parentId: r.parentId } : {}), ...(r.spaceId ? { spaceId: r.spaceId } : {}) })
+      if (!r.parentId && !r.spaceId && r.isIm === null) continue
+      out.set(r.id, {
+        ...(r.parentId ? { parentId: r.parentId } : {}),
+        ...(r.spaceId ? { spaceId: r.spaceId } : {}),
+        ...(r.isIm === null ? {} : { isIm: r.isIm === 1 })
+      })
     }
     return out
   }

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -195,22 +195,46 @@ describe('collapseDiscordChannels', () => {
       ['G2', 'Side Project']
     ])
     expect(collapseDiscordChannels(observed, scopes, names)).toEqual([
-      { id: 'C1', name: 'general', space: 'Acme HQ' },
-      { id: 'C2', name: 'general', space: 'Side Project' }
+      { id: 'C1', name: 'general', spaceId: 'G1', space: 'Acme HQ' },
+      { id: 'C2', name: 'general', spaceId: 'G2', space: 'Side Project' }
     ])
   })
 
   it('takes the guild off the thread when the enclosing channel has no scope of its own', () => {
     const scopes = new Map([['T1', { parentId: 'C1', spaceId: 'G1' }]])
     expect(collapseDiscordChannels([{ id: 'T1', name: 'general' }], scopes, new Map([['G1', 'Acme HQ']]))).toEqual([
-      { id: 'C1', name: 'general', space: 'Acme HQ' }
+      { id: 'C1', name: 'general', spaceId: 'G1', space: 'Acme HQ' }
     ])
   })
 
-  it('omits the space until its name is resolved (never a raw guild snowflake)', () => {
+  it('carries the guild id even before its name resolves (identity, then label)', () => {
     const scopes = new Map([['C1', { spaceId: 'G1' }]])
     expect(collapseDiscordChannels([{ id: 'C1', name: 'general' }], scopes, new Map())).toEqual([
-      { id: 'C1', name: 'general' }
+      { id: 'C1', name: 'general', spaceId: 'G1' }
+    ])
+  })
+
+  it('keeps two SAME-NAMED guilds apart by id (Discord allows duplicate server names)', () => {
+    const scopes = new Map([
+      ['C1', { spaceId: 'G1' }],
+      ['C2', { spaceId: 'G2' }]
+    ])
+    const names = new Map([
+      ['G1', 'Acme'],
+      ['G2', 'Acme']
+    ])
+    expect(
+      collapseDiscordChannels(
+        [
+          { id: 'C1', name: 'general' },
+          { id: 'C2', name: 'general' }
+        ],
+        scopes,
+        names
+      )
+    ).toEqual([
+      { id: 'C1', name: 'general', spaceId: 'G1', space: 'Acme' },
+      { id: 'C2', name: 'general', spaceId: 'G2', space: 'Acme' }
     ])
   })
 

--- a/packages/daemon/test/discord-normalize.test.ts
+++ b/packages/daemon/test/discord-normalize.test.ts
@@ -178,9 +178,49 @@ describe('collapseDiscordChannels', () => {
     expect(collapseDiscordChannels([{ id: '900456' }], new Map(), new Map())).toEqual([{ id: '900456' }])
   })
 
-  it('lists the ids whose names the collapse needs — observed plus enclosing channels', () => {
-    const scopes = new Map([['T1', { parentId: 'C1' }]])
-    expect(collapseNameLookupIds([{ id: 'T1' }, { id: 'C2' }], scopes)).toEqual(['T1', 'C1', 'C2'])
+  it('labels each row with the server it sits in (one bot, a "#general" per guild)', () => {
+    const observed = [
+      { id: 'T1', name: 'general' },
+      { id: 'C2', name: 'general' }
+    ]
+    const scopes = new Map([
+      ['T1', { parentId: 'C1' }],
+      ['C1', { spaceId: 'G1' }],
+      ['C2', { spaceId: 'G2' }]
+    ])
+    const names = new Map([
+      ['C1', 'general'],
+      ['C2', 'general'],
+      ['G1', 'Acme HQ'],
+      ['G2', 'Side Project']
+    ])
+    expect(collapseDiscordChannels(observed, scopes, names)).toEqual([
+      { id: 'C1', name: 'general', space: 'Acme HQ' },
+      { id: 'C2', name: 'general', space: 'Side Project' }
+    ])
+  })
+
+  it('takes the guild off the thread when the enclosing channel has no scope of its own', () => {
+    const scopes = new Map([['T1', { parentId: 'C1', spaceId: 'G1' }]])
+    expect(collapseDiscordChannels([{ id: 'T1', name: 'general' }], scopes, new Map([['G1', 'Acme HQ']]))).toEqual([
+      { id: 'C1', name: 'general', space: 'Acme HQ' }
+    ])
+  })
+
+  it('omits the space until its name is resolved (never a raw guild snowflake)', () => {
+    const scopes = new Map([['C1', { spaceId: 'G1' }]])
+    expect(collapseDiscordChannels([{ id: 'C1', name: 'general' }], scopes, new Map())).toEqual([
+      { id: 'C1', name: 'general' }
+    ])
+  })
+
+  it('lists the ids whose names the collapse needs — observed, enclosing channels, guilds', () => {
+    const scopes = new Map([
+      ['T1', { parentId: 'C1' }],
+      ['C1', { spaceId: 'G1' }],
+      ['C2', { spaceId: 'G2' }]
+    ])
+    expect(collapseNameLookupIds([{ id: 'T1' }, { id: 'C2' }], scopes)).toEqual(['T1', 'C1', 'G1', 'C2', 'G2'])
   })
 })
 

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -582,6 +582,36 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     await daemon.stop()
   })
 
+  it('reports an observed DM as a DM row, never as a configurable channel', async () => {
+    // Session history cannot tell a DM from a group, so a Discord DM used to surface as
+    // a channel row labelled "@yulong" — a "channel" nobody can invite the bot to.
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    ;(daemon as any).agents = new Map([
+      ['bot-dc', { id: 'bot-dc', integrations: [{ id: 'dc-int', platform: 'discord', discord: { botToken: 'dc' } }] }]
+    ])
+    const store = (daemon as any).store
+    store.setChannelScope('900777', { isIm: true }, 1)
+    store.setChannelScope('900123', { isIm: false }, 1)
+    vi.spyOn(store, 'observedChannels').mockReturnValue([
+      { id: '900777', name: '@yulong' },
+      { id: '900123', name: 'general' }
+    ])
+
+    ;(daemon as any).refreshObservedChannels()
+
+    const channels = [
+      { id: '900777', name: '@yulong', kind: 'im' },
+      { id: '900123', name: 'general', kind: 'channel' }
+    ]
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
+    await daemon.stop()
+  })
+
   it('skips an agent with multiple Telegram bots (observed set is not per-bot)', async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -192,15 +192,19 @@ export type IntegrationRemove = z.infer<typeof IntegrationRemove>
  * (`kind: 'im'`, Slack "D…" ids) are reported only for gated integrations, on
  * first inbound DM; their `name` is the counterpart's display name.
  *
- * `space` names the container the conversation lives in — a Discord GUILD, whose
- * name a bot in several servers needs for the channel to be identifiable at all
- * (every server has a "#general"). Absent on platforms with one implicit container
- * per bot (Slack workspace, Telegram, Feishu tenant) and on DM rows.
+ * `spaceId`/`space` identify the container the conversation lives in — a Discord
+ * GUILD, which a bot in several servers needs for the channel to be identifiable at
+ * all (every server has a "#general"). The ID is the identity: two distinct guilds
+ * may carry the SAME name, so grouping on the name alone would merge them and hide
+ * the ambiguity it was meant to resolve. `space` is the display label only. Both are
+ * absent on platforms with one implicit container per bot (Slack workspace, Telegram,
+ * Feishu tenant) and on DM rows.
  */
 export const IntegrationChannel = z.object({
   id: z.string(), // platform conversation id (Slack "C…" / DM "D…")
   name: z.string().optional(), // "#deploys" without the hash (or DM counterpart); absent if lookup failed
-  space: z.string().optional(), // enclosing Discord guild/server name; absent until resolved
+  spaceId: z.string().optional(), // enclosing Discord guild snowflake — the space's IDENTITY
+  space: z.string().optional(), // that guild's display name; absent until resolved
   isPrivate: z.boolean().optional(),
   kind: z.enum(['channel', 'im']).optional() // absent = 'channel'
 })

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -191,10 +191,16 @@ export type IntegrationRemove = z.infer<typeof IntegrationRemove>
  * visibility.md §14.3): absent = 'channel' for wire compatibility. DM rows
  * (`kind: 'im'`, Slack "D…" ids) are reported only for gated integrations, on
  * first inbound DM; their `name` is the counterpart's display name.
+ *
+ * `space` names the container the conversation lives in — a Discord GUILD, whose
+ * name a bot in several servers needs for the channel to be identifiable at all
+ * (every server has a "#general"). Absent on platforms with one implicit container
+ * per bot (Slack workspace, Telegram, Feishu tenant) and on DM rows.
  */
 export const IntegrationChannel = z.object({
   id: z.string(), // platform conversation id (Slack "C…" / DM "D…")
   name: z.string().optional(), // "#deploys" without the hash (or DM counterpart); absent if lookup failed
+  space: z.string().optional(), // enclosing Discord guild/server name; absent until resolved
   isPrivate: z.boolean().optional(),
   kind: z.enum(['channel', 'im']).optional() // absent = 'channel'
 })

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { channelOwners, placePopover } from './IntegrationChannelList'
+import { channelOwners, groupBySpace, placePopover } from './IntegrationChannelList'
 import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
 
 // A shared bot fans its membership snapshot out to one integration per member
@@ -83,5 +83,34 @@ describe('placePopover', () => {
     // A short viewport with the button near the top: neither side fits, and
     // below is the one that keeps the button visible.
     expect(placePopover(btn(300, 40), 1280, 200).style).toEqual({ left: 300, top: 74 })
+  })
+})
+
+// One Discord bot commonly spans several servers, each with a "#general" of its own.
+describe('groupBySpace', () => {
+  const chan = (channelId: string, space?: string): IntegrationChannelRow => ({
+    channelId,
+    name: 'general',
+    kind: 'channel',
+    trigger: 'mention',
+    ...(space ? { space } : {})
+  })
+
+  it('bands the rows under their server, alphabetically', () => {
+    expect(groupBySpace([chan('C2', 'Side Project'), chan('C1', 'Acme HQ')])).toEqual([
+      ['Acme HQ', [chan('C1', 'Acme HQ')]],
+      ['Side Project', [chan('C2', 'Side Project')]]
+    ])
+  })
+
+  it('keeps a space-less platform one flat, unheaded list', () => {
+    expect(groupBySpace([chan('C1'), chan('C2')])).toEqual([['', [chan('C1'), chan('C2')]]])
+  })
+
+  it('leads with rows whose server has not resolved yet rather than mislabelling them', () => {
+    expect(groupBySpace([chan('C1', 'Acme HQ'), chan('C2')])).toEqual([
+      ['', [chan('C2')]],
+      ['Acme HQ', [chan('C1', 'Acme HQ')]]
+    ])
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -86,31 +86,48 @@ describe('placePopover', () => {
   })
 })
 
-// One Discord bot commonly spans several servers, each with a "#general" of its own.
+// One Discord bot commonly spans several servers, each with a "#general" of its own —
+// and Discord lets two of those servers carry the same NAME.
 describe('groupBySpace', () => {
-  const chan = (channelId: string, space?: string): IntegrationChannelRow => ({
+  const chan = (channelId: string, spaceId?: string, space?: string): IntegrationChannelRow => ({
     channelId,
     name: 'general',
     kind: 'channel',
     trigger: 'mention',
+    ...(spaceId ? { spaceId } : {}),
     ...(space ? { space } : {})
   })
 
   it('bands the rows under their server, alphabetically', () => {
-    expect(groupBySpace([chan('C2', 'Side Project'), chan('C1', 'Acme HQ')])).toEqual([
-      ['Acme HQ', [chan('C1', 'Acme HQ')]],
-      ['Side Project', [chan('C2', 'Side Project')]]
+    expect(groupBySpace([chan('C2', 'G2', 'Side Project'), chan('C1', 'G1', 'Acme HQ')])).toEqual([
+      { key: 'G1', label: 'Acme HQ', rows: [chan('C1', 'G1', 'Acme HQ')] },
+      { key: 'G2', label: 'Side Project', rows: [chan('C2', 'G2', 'Side Project')] }
     ])
+  })
+
+  it('keeps two SAME-NAMED servers apart and makes the duplication visible', () => {
+    // Grouping on the label would merge these, hiding the very ambiguity the server
+    // band exists to resolve — both channels are called "general" too.
+    const groups = groupBySpace([chan('C1', '90000001111', 'Acme'), chan('C2', '90000002222', 'Acme')])
+    expect(groups.map((g) => g.key)).toEqual(['90000001111', '90000002222'])
+    expect(groups.map((g) => g.label)).toEqual(['Acme · 1111', 'Acme · 2222'])
   })
 
   it('keeps a space-less platform one flat, unheaded list', () => {
-    expect(groupBySpace([chan('C1'), chan('C2')])).toEqual([['', [chan('C1'), chan('C2')]]])
+    expect(groupBySpace([chan('C1'), chan('C2')])).toEqual([{ key: '', rows: [chan('C1'), chan('C2')] }])
   })
 
-  it('leads with rows whose server has not resolved yet rather than mislabelling them', () => {
-    expect(groupBySpace([chan('C1', 'Acme HQ'), chan('C2')])).toEqual([
-      ['', [chan('C2')]],
-      ['Acme HQ', [chan('C1', 'Acme HQ')]]
+  it('heads a server whose name has not resolved yet by its id, not the flat group', () => {
+    const groups = groupBySpace([chan('C1', 'G1', 'Acme HQ'), chan('C2', '90000002222'), chan('C3')])
+    expect(groups).toEqual([
+      { key: '', rows: [chan('C3')] },
+      { key: 'G1', label: 'Acme HQ', rows: [chan('C1', 'G1', 'Acme HQ')] },
+      { key: '90000002222', label: 'server 2222', rows: [chan('C2', '90000002222')] }
     ])
+  })
+
+  it('takes the label from whichever row of the server carries one', () => {
+    const rows = [chan('C1', 'G1'), chan('C2', 'G1', 'Acme HQ')]
+    expect(groupBySpace(rows)).toEqual([{ key: 'G1', label: 'Acme HQ', rows }])
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -113,6 +113,26 @@ describe('groupBySpace', () => {
     expect(groups.map((g) => g.label)).toEqual(['Acme · 1111', 'Acme · 2222'])
   })
 
+  it('treats labels that READ alike as a clash — the header is uppercased', () => {
+    const groups = groupBySpace([chan('C1', '90000001111', 'acme'), chan('C2', '90000002222', 'ACME')])
+    expect(groups.map((g) => g.label)).toEqual(['acme · 1111', 'ACME · 2222'])
+  })
+
+  it('widens the id tail until the suffixes themselves differ', () => {
+    // Snowflakes of one shard share their low bits, so a fixed 4-char tail can collide —
+    // which would hand two distinct servers the same visible header.
+    const groups = groupBySpace([chan('C1', '11110000', 'Acme'), chan('C2', '22220000', 'Acme')])
+    // The 4-char tails are both "0000"; widening by one is enough here.
+    expect(groups.map((g) => g.label)).toEqual(['Acme · 10000', 'Acme · 20000'])
+  })
+
+  it('breaks a tie between a real name and a synthesized one', () => {
+    // A server can be NAMED like the header an unresolved one gets; only the real label
+    // can take a suffix, so that is the one that moves.
+    const groups = groupBySpace([chan('C1', '90000009999', 'server 2222'), chan('C2', '90000002222')])
+    expect(groups.map((g) => g.label)).toEqual(['server 2222', 'server 2222 · 9999'].sort())
+  })
+
   it('keeps a space-less platform one flat, unheaded list', () => {
     expect(groupBySpace([chan('C1'), chan('C2')])).toEqual([{ key: '', rows: [chan('C1'), chan('C2')] }])
   })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -106,9 +106,24 @@ export interface SpaceGroup {
   rows: IntegrationChannelRow[]
 }
 
-/** Discord servers may share a NAME, so two same-named bands are told apart by a tail
- *  of the server id — enough to distinguish them without printing a whole snowflake. */
-const spaceDiscriminator = (spaceId: string) => spaceId.slice(-4)
+/** How a band's header will actually READ once the CSS uppercases it — the form two
+ *  labels must differ in to be distinguishable on screen. "acme" and "Acme" collide. */
+const asDisplayed = (label: string) => label.toLocaleUpperCase().replace(/\s+/g, ' ').trim()
+
+/**
+ * Shortest tails of `ids` that are unique among them — the suffix that tells two
+ * same-named bands apart. Grows from 4 characters until no two ids share a tail (a fixed
+ * width is not collision-free: Discord snowflakes of one shard share their low bits),
+ * and falls back to the whole id when even that is exhausted.
+ */
+function spaceDiscriminators(ids: string[]): Map<string, string> {
+  const longest = Math.max(0, ...ids.map((id) => id.length))
+  for (let width = 4; width <= longest; width++) {
+    const tails = ids.map((id) => id.slice(-width))
+    if (new Set(tails).size === ids.length) return new Map(ids.map((id, i) => [id, tails[i]!]))
+  }
+  return new Map(ids.map((id) => [id, id]))
+}
 
 /**
  * Bucket channel rows by the space (Discord server) they sit in.
@@ -119,9 +134,10 @@ const spaceDiscriminator = (spaceId: string) => spaceId.slice(-4)
  *
  * Grouping keys on the server ID, never the label: Discord permits two distinct servers
  * to carry the same name, and banding those together would merge exactly the rows this
- * is here to separate. When two bands do end up with the same label they are suffixed
- * with a tail of their id, so the duplication is visible rather than silent. A server
- * whose name hasn't resolved yet still gets its own band, headed by that id tail alone.
+ * is here to separate. When two bands would READ alike — compared as the header renders
+ * them, uppercased, so "acme" and "Acme" count as a clash — both are suffixed with a
+ * tail of their id, widened until the tails themselves differ. A server whose name
+ * hasn't resolved yet still gets its own band, headed by that id tail alone.
  *
  * Platforms with one implicit container per bot (Slack, Telegram, Feishu) report no
  * space at all and stay one flat, unheaded list, which leads.
@@ -138,16 +154,24 @@ export function groupBySpace(rows: IntegrationChannelRow[]): SpaceGroup[] {
       group.label ??= c.space
     } else spaces.set(key, { ...(c.space ? { label: c.space } : {}), rows: [c] })
   }
-  const byLabel = new Map<string, number>()
-  for (const { label } of spaces.values()) if (label) byLabel.set(label, (byLabel.get(label) ?? 0) + 1)
+  const keyed = [...spaces.entries()].filter(([key]) => key)
+  const discriminator = spaceDiscriminators(keyed.map(([key]) => key))
+  // An unnamed server is headed by its discriminator alone — it is still a distinct
+  // server, and leaving it unheaded would silently pool it with the flat group. Those
+  // synthesized headers join the collision count too: a server could be NAMED "server
+  // 2222", and only a real label can take a suffix to break such a tie.
+  const proposed = (key: string, label?: string) => label ?? `server ${discriminator.get(key) ?? key}`
+  const seen = new Map<string, number>()
+  for (const [key, { label }] of keyed) {
+    const as = asDisplayed(proposed(key, label))
+    seen.set(as, (seen.get(as) ?? 0) + 1)
+  }
   return [...spaces.entries()]
     .map(([key, { label, rows }]) => {
       if (!key) return { key, rows }
-      // An unnamed server is headed by its discriminator alone — it is still a distinct
-      // server, and leaving it unheaded would silently pool it with the flat group.
-      const collides = label !== undefined && (byLabel.get(label) ?? 0) > 1
-      const suffix = spaceDiscriminator(key)
-      return { key, label: label === undefined ? `server ${suffix}` : collides ? `${label} · ${suffix}` : label, rows }
+      const clash = (seen.get(asDisplayed(proposed(key, label))) ?? 0) > 1
+      const suffix = discriminator.get(key) ?? key
+      return { key, label: clash && label !== undefined ? `${label} · ${suffix}` : proposed(key, label), rows }
     })
     .sort((a, b) => (!a.key ? -1 : !b.key ? 1 : (a.label ?? '').localeCompare(b.label ?? '')))
 }

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -361,7 +361,11 @@ export function IntegrationChannelList({
     return (explicit ? members.find((m) => m.id === explicit) : undefined) ?? members[0]
   }
   const channelRows = channels.filter((c) => c.kind !== 'im')
-  const dmRows = channels.filter((c) => c.kind === 'im')
+  // A DM is not a place the bot can be invited to and has no per-conversation choice
+  // to make unless the agent is gated (resource-visibility.md §14.3) — a non-gated bot
+  // always answers its DMs. The daemon still REPORTS them (that is how a DM previously
+  // mistaken for a channel converts), so hide them here rather than at the source.
+  const dmRows = gated ? channels.filter((c) => c.kind === 'im') : []
   const grouped = groupBySpace(channelRows)
   const row = (c: IntegrationChannelRow) => {
     const def = c.kind !== 'im' && shareable ? defaultAgent(c) : undefined

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { agentLabel, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
@@ -95,6 +95,42 @@ function TriggerToggle({
         {segs.map(([trigger, label, hint]) => seg(trigger, label, hint))}
       </div>
     </span>
+  )
+}
+
+/**
+ * Bucket channel rows by the space (Discord server) they sit in.
+ *
+ * A Discord bot is usually in several servers, each with its own "#general", so the
+ * channel name alone doesn't say which row an operator is configuring — the rows are
+ * banded under their server, alphabetically. Platforms with one implicit container per
+ * bot (Slack, Telegram, Feishu) report no space and stay one flat, unheaded list; so do
+ * the Discord rows whose server name hasn't resolved yet, which lead the list rather
+ * than hiding under a header that doesn't apply to them.
+ *
+ * Exported for its unit test.
+ */
+export function groupBySpace(rows: IntegrationChannelRow[]): [string, IntegrationChannelRow[]][] {
+  const spaces = new Map<string, IntegrationChannelRow[]>()
+  for (const c of rows) {
+    const key = c.space ?? ''
+    const group = spaces.get(key)
+    if (group) group.push(c)
+    else spaces.set(key, [c])
+  }
+  return [...spaces.entries()].sort(([a], [b]) => (a === '' ? -1 : b === '' ? 1 : a.localeCompare(b)))
+}
+
+/** The band that names a run of rows — a Discord server, or the DM section. */
+function groupHeader(label: string, padX: number) {
+  return (
+    <div
+      className="border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[11px] font-semibold leading-normal text-(--text-tertiary) uppercase"
+      style={{ padding: `6px ${padX}px` }}
+      title={label}
+    >
+      <span className="block truncate">{label}</span>
+    </div>
   )
 }
 
@@ -326,6 +362,7 @@ export function IntegrationChannelList({
   }
   const channelRows = channels.filter((c) => c.kind !== 'im')
   const dmRows = channels.filter((c) => c.kind === 'im')
+  const grouped = groupBySpace(channelRows)
   const row = (c: IntegrationChannelRow) => {
     const def = c.kind !== 'im' && shareable ? defaultAgent(c) : undefined
     return (
@@ -387,15 +424,13 @@ export function IntegrationChannelList({
           </span>
         </div>
       )}
-      {channelRows.map(row)}
-      {dmRows.length > 0 && (
-        <div
-          className="border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[11px] font-semibold leading-normal text-(--text-tertiary) uppercase"
-          style={{ padding: `6px ${padX}px` }}
-        >
-          Direct messages
-        </div>
-      )}
+      {grouped.map(([space, rows]) => (
+        <Fragment key={space || '(unscoped)'}>
+          {space && groupHeader(space, padX)}
+          {rows.map(row)}
+        </Fragment>
+      ))}
+      {dmRows.length > 0 && groupHeader('Direct messages', padX)}
       {dmRows.map(row)}
       <div
         className="flex items-center gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -98,27 +98,58 @@ function TriggerToggle({
   )
 }
 
+/** One band of the channel list: the rows of a single Discord server, with the header
+ *  to print above them (absent ⇒ no header, the flat lead group). */
+export interface SpaceGroup {
+  key: string
+  label?: string
+  rows: IntegrationChannelRow[]
+}
+
+/** Discord servers may share a NAME, so two same-named bands are told apart by a tail
+ *  of the server id — enough to distinguish them without printing a whole snowflake. */
+const spaceDiscriminator = (spaceId: string) => spaceId.slice(-4)
+
 /**
  * Bucket channel rows by the space (Discord server) they sit in.
  *
  * A Discord bot is usually in several servers, each with its own "#general", so the
  * channel name alone doesn't say which row an operator is configuring — the rows are
- * banded under their server, alphabetically. Platforms with one implicit container per
- * bot (Slack, Telegram, Feishu) report no space and stay one flat, unheaded list; so do
- * the Discord rows whose server name hasn't resolved yet, which lead the list rather
- * than hiding under a header that doesn't apply to them.
+ * banded under their server, alphabetically.
+ *
+ * Grouping keys on the server ID, never the label: Discord permits two distinct servers
+ * to carry the same name, and banding those together would merge exactly the rows this
+ * is here to separate. When two bands do end up with the same label they are suffixed
+ * with a tail of their id, so the duplication is visible rather than silent. A server
+ * whose name hasn't resolved yet still gets its own band, headed by that id tail alone.
+ *
+ * Platforms with one implicit container per bot (Slack, Telegram, Feishu) report no
+ * space at all and stay one flat, unheaded list, which leads.
  *
  * Exported for its unit test.
  */
-export function groupBySpace(rows: IntegrationChannelRow[]): [string, IntegrationChannelRow[]][] {
-  const spaces = new Map<string, IntegrationChannelRow[]>()
+export function groupBySpace(rows: IntegrationChannelRow[]): SpaceGroup[] {
+  const spaces = new Map<string, { label?: string; rows: IntegrationChannelRow[] }>()
   for (const c of rows) {
-    const key = c.space ?? ''
+    const key = c.spaceId ?? ''
     const group = spaces.get(key)
-    if (group) group.push(c)
-    else spaces.set(key, [c])
+    if (group) {
+      group.rows.push(c)
+      group.label ??= c.space
+    } else spaces.set(key, { ...(c.space ? { label: c.space } : {}), rows: [c] })
   }
-  return [...spaces.entries()].sort(([a], [b]) => (a === '' ? -1 : b === '' ? 1 : a.localeCompare(b)))
+  const byLabel = new Map<string, number>()
+  for (const { label } of spaces.values()) if (label) byLabel.set(label, (byLabel.get(label) ?? 0) + 1)
+  return [...spaces.entries()]
+    .map(([key, { label, rows }]) => {
+      if (!key) return { key, rows }
+      // An unnamed server is headed by its discriminator alone — it is still a distinct
+      // server, and leaving it unheaded would silently pool it with the flat group.
+      const collides = label !== undefined && (byLabel.get(label) ?? 0) > 1
+      const suffix = spaceDiscriminator(key)
+      return { key, label: label === undefined ? `server ${suffix}` : collides ? `${label} · ${suffix}` : label, rows }
+    })
+    .sort((a, b) => (!a.key ? -1 : !b.key ? 1 : (a.label ?? '').localeCompare(b.label ?? '')))
 }
 
 /** The band that names a run of rows — a Discord server, or the DM section. */
@@ -428,10 +459,10 @@ export function IntegrationChannelList({
           </span>
         </div>
       )}
-      {grouped.map(([space, rows]) => (
-        <Fragment key={space || '(unscoped)'}>
-          {space && groupHeader(space, padX)}
-          {rows.map(row)}
+      {grouped.map((g) => (
+        <Fragment key={g.key || '(unscoped)'}>
+          {g.label && groupHeader(g.label, padX)}
+          {g.rows.map(row)}
         </Fragment>
       ))}
       {dmRows.length > 0 && groupHeader('Direct messages', padX)}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -537,7 +537,8 @@ export type ChannelTrigger = 'off' | 'mention' | 'any'
 export interface IntegrationChannelDto {
   channelId: string
   name: string | null // "deploys" without the hash (or DM counterpart); null if lookup failed
-  space: string | null // enclosing Discord server name; null elsewhere and until resolved
+  spaceId: string | null // enclosing Discord server id — the identity (names are not unique)
+  space: string | null // that server's display name; null elsewhere and until resolved
   isPrivate: boolean
   kind: 'channel' | 'im'
   trigger: ChannelTrigger

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -537,6 +537,7 @@ export type ChannelTrigger = 'off' | 'mention' | 'any'
 export interface IntegrationChannelDto {
   channelId: string
   name: string | null // "deploys" without the hash (or DM counterpart); null if lookup failed
+  space: string | null // enclosing Discord server name; null elsewhere and until resolved
   isPrivate: boolean
   kind: 'channel' | 'im'
   trigger: ChannelTrigger

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -263,6 +263,7 @@ function integrationRowFromDto(
     channels: d.channels.map((c) => ({
       channelId: c.channelId,
       name: c.name || c.channelId,
+      ...(c.space ? { space: c.space } : {}),
       kind: c.kind,
       trigger: c.trigger,
       agentId: c.agentId

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -263,6 +263,7 @@ function integrationRowFromDto(
     channels: d.channels.map((c) => ({
       channelId: c.channelId,
       name: c.name || c.channelId,
+      ...(c.spaceId ? { spaceId: c.spaceId } : {}),
       ...(c.space ? { space: c.space } : {}),
       kind: c.kind,
       trigger: c.trigger,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1326,8 +1326,11 @@ export interface IntegrationChannelRow {
    *  For a DM row (kind 'im') the counterpart's name. Falls back to the raw id. */
   name: string
   /** The Discord server this channel belongs to. One bot spans several servers, each
-   *  with its own "#general", so the rows are grouped under it. Absent on platforms
-   *  with one implicit container per bot, on DM rows, and until the daemon resolves it. */
+   *  with its own "#general", so the rows are grouped under it. `spaceId` is the
+   *  identity — Discord permits two servers to share a NAME, so grouping on the label
+   *  would merge them — and `space` is that label. Absent on platforms with one
+   *  implicit container per bot, on DM rows, and until the daemon resolves them. */
+  spaceId?: string
   space?: string
   /** 'im' = a DM conversation row (gated/restricted agents only); absent = channel. */
   kind?: 'channel' | 'im'

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1325,6 +1325,10 @@ export interface IntegrationChannelRow {
   /** Bare channel name, no hash (e.g. "deploys"); the UI renders the leading "#".
    *  For a DM row (kind 'im') the counterpart's name. Falls back to the raw id. */
   name: string
+  /** The Discord server this channel belongs to. One bot spans several servers, each
+   *  with its own "#general", so the rows are grouped under it. Absent on platforms
+   *  with one implicit container per bot, on DM rows, and until the daemon resolves it. */
+  space?: string
   /** 'im' = a DM conversation row (gated/restricted agents only); absent = channel. */
   kind?: 'channel' | 'im'
   trigger: 'off' | 'mention' | 'any'


### PR DESCRIPTION
Two fixes to the same list — the Discord bot's channel list in the console.

## 1. Rows don't say which server they belong to

A Discord bot is commonly invited to several servers, and every one of them has a `#general`. The list showed only the channel name, so those rows were indistinguishable — an operator could not tell which server a row belonged to, let alone knowingly set its trigger.

Report the enclosing guild's name alongside the channel and band the rows under it.

- **daemon** — `getChannelInfo` now returns the guild id/name; the channel-name resolver records `spaceId` in `channel_scopes` (new column, migrated in place) and caches the guild name in the existing id → name cache. This rides the lookup that already resolves the channel name, so no extra platform call lands on any path. Both the observed-channel snapshot and the gated Off-conversation report carry the label.
- **protocol / CP** — `IntegrationChannel.space` on the wire, `integration_channel.space` in Postgres (+ migration), exposed on the integrations DTO.
- **web** — channel rows are banded under their server, alphabetically.

The label resolves lazily, so neither the daemon snapshot nor the CP upsert blanks a known server when a later report carries none. Platforms with one implicit container per bot (Slack, Telegram, Feishu) report no space and keep rendering as one flat list; Discord rows whose guild has not resolved yet lead the list unheaded rather than sitting under a header that isn't theirs.

## 2. A DM shows up as a channel

Observed-conversation discovery derives its rows from session history, which cannot tell a DM from a group — so a direct message to the agent surfaced as a row named `@someone`: a "channel" nobody can invite the bot to, whose trigger means nothing.

The channel lookup's own verdict is now recorded (`channel_scopes.isIm`, next to the guild it just learned to record) and those conversations are reported as DM rows. Reporting rather than dropping them is deliberate — it is what converts a conversation the CP already stored as a channel. The console then shows DM rows only for a gated (restricted) agent, where enabling each conversation is a real choice; a non-gated bot always answers its DMs, so there is nothing to set.

## Rollout

- The CP needs `prisma migrate deploy` for the new column.
- A running daemon labels a channel (and reclassifies a DM) only after that conversation's next name lookup — the resolver TTL is 6h on success. A daemon restart warms every live session's channel immediately via `backfillChannelNames`.

## Tests

`typecheck` + `lint` clean across all packages. daemon 2206 passed (4 new collapse cases, 1 new discovery case), web 394 (3 new `groupBySpace` cases), CP unit 668, CP integration 685 (new case: a reported space survives a later report without one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)