### PR TITLE
feat(slack): support group DMs — scopes, message.mpim, and a conversation kind

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -89,15 +89,27 @@ restricted agents may independently enable or disable their own DM conversation 
 A Slack multi-person DM is a conversation between people that the agent happens to sit
 in, not a room addressed to the agent. It therefore follows a channel's rule, not a
 DM's: the agent answers when explicitly @-mentioned, and follow-ups in a thread it has
-joined need no further mention. "Every message" stays an operator's opt-in.
+joined need no further mention. A group DM never activates on an unmentioned message the
+way a DM does.
 
 Slack never reports a group DM as bot membership, so one is surfaced the way a DM is —
 on observation, when an inbound message names the bot — and never through a membership
-snapshot. A restricted agent's group DM therefore starts Off and stays unroutable until
-a Console editor enables it, exactly like its DM rows. A conversation first mistaken for
-a channel converts to a group DM once resolved, and that conversion returns it to Off:
-the trigger it carried was a channel's default, never an operator's choice for this
-conversation.
+snapshot. Conversation rows therefore exist only where observation creates them, which
+gives the two visibilities different surfaces, matching how DMs already behave:
+
+- An **org-visible** agent answers a group DM whenever it is @-mentioned, with no
+  per-conversation row and nothing to configure — the same way it always answers its
+  DMs.
+- A **restricted** agent's group DM is surfaced as a row that starts Off and stays
+  unroutable until a Console editor enables it, exactly like its DM rows. Because the
+  conversation is channel-like, that row carries a channel's trigger choice, so an
+  editor may also opt it into every message.
+
+A conversation first mistaken for a channel converts to a group DM once resolved, and
+that conversion returns it to Off: the trigger it carried was a channel's default, never
+an operator's choice for this conversation. The resolved classification is durable — it
+lives on the conversation row, not in daemon memory, so a daemon restart that re-reports
+the conversation provisionally as a channel cannot flip an enabled group DM back to Off.
 
 ## No-response control marker
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -84,6 +84,21 @@ automatic fallback to a restricted agent instead leaves the channel Off, because
 an authorized Console editor may enable it. Direct messages remain separate:
 restricted agents may independently enable or disable their own DM conversation rows.
 
+## Group direct messages
+
+A Slack multi-person DM is a conversation between people that the agent happens to sit
+in, not a room addressed to the agent. It therefore follows a channel's rule, not a
+DM's: the agent answers when explicitly @-mentioned, and follow-ups in a thread it has
+joined need no further mention. "Every message" stays an operator's opt-in.
+
+Slack never reports a group DM as bot membership, so one is surfaced the way a DM is —
+on observation, when an inbound message names the bot — and never through a membership
+snapshot. A restricted agent's group DM therefore starts Off and stays unroutable until
+a Console editor enables it, exactly like its DM rows. A conversation first mistaken for
+a channel converts to a group DM once resolved, and that conversion returns it to Off:
+the trigger it carried was a channel's default, never an operator's choice for this
+conversation.
+
 ## No-response control marker
 
 Every agent session receives the same standing response-choice instruction, independent

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -105,6 +105,19 @@ gives the two visibilities different surfaces, matching how DMs already behave:
   conversation is channel-like, that row carries a channel's trigger choice, so an
   editor may also opt it into every message.
 
+A preserved row does not outlive the visibility that created it. When a restricted agent
+becomes org-visible its group-DM and DM rows go inert — the Console stops showing them,
+so honouring one would leave the agent answering a conversation with no visible control
+to stop it. It falls back to the same defaults every org-visible agent has: mention in a
+group DM, every message in a DM.
+
+A shared bot is one Slack identity, so a mention in a group DM cannot name which agent
+behind it is meant, and the slug that disambiguates a shared DM does not apply — a DM
+activates on any message, which a slug can outrank, while a group DM activates on the
+mention itself. A group DM served by a shared bot therefore converges on exactly one
+agent, the same way an ownerless channel does: the bot's earliest active install among
+those that enabled it.
+
 A conversation first mistaken for a channel converts to a group DM once resolved, and
 that conversion returns it to Off: the trigger it carried was a channel's default, never
 an operator's choice for this conversation. The resolved classification is durable — it

--- a/packages/control-plane/prisma/migrations/20260729120000_conversation_kind_mpim/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260729120000_conversation_kind_mpim/migration.sql
@@ -1,0 +1,4 @@
+-- Slack multi-person DMs get their own conversation kind: reported on observation
+-- like an `im` (Slack never lists them as bot membership), but mention-gated like a
+-- channel. Additive — existing rows keep their kind.
+ALTER TYPE "ConversationKind" ADD VALUE IF NOT EXISTS 'mpim';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1450,11 +1450,14 @@ enum ChannelTrigger {
   any
 }
 
-// Conversation kind (resource-visibility.md §14.3): a member channel vs a DM
-// conversation. DM rows exist only for gated (restricted-agent) integrations.
+// Conversation kind (resource-visibility.md §14.3): a member channel vs a direct
+// conversation. `im` rows exist only for gated (restricted-agent) integrations.
+// `mpim` is a Slack multi-person DM — reported on observation like `im` (Slack
+// never lists them as bot membership), but mention-gated like a channel.
 enum ConversationKind {
   channel
   im
+  mpim
 }
 
 // One conversation the integration's bot participates in. `integration/channels`

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -698,7 +698,8 @@ export const CreateIntegrationBody = z
 /** One conversation the integration's bot is in + how it activates there.
  *  `off` = conversation gating (resource-visibility.md §14): the agent does not
  *  activate there — the default for every conversation of a restricted agent.
- *  `kind: 'im'` rows are DM conversations (gated integrations only). */
+ *  `kind: 'im'` rows are DM conversations and `kind: 'mpim'` rows are Slack group
+ *  DMs (both gated integrations only — neither is ever enumerated). */
 export const IntegrationChannelDto = z.object({
   channelId: z.string(),
   name: z.string().nullable(), // "#deploys" without the hash (or DM counterpart); null if lookup failed
@@ -709,7 +710,7 @@ export const IntegrationChannelDto = z.object({
   spaceId: z.string().nullable(),
   space: z.string().nullable(),
   isPrivate: z.boolean(),
-  kind: z.enum(['channel', 'im']),
+  kind: z.enum(['channel', 'im', 'mpim']),
   trigger: z.enum(['off', 'mention', 'any']),
   /** Effective per-channel owner for a shared bot (§10.1); null before convergence
    *  or when ownership does not apply. */

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -101,6 +101,7 @@ describe('buildInstallManifest', () => {
       'message.channels',
       'message.groups',
       'message.im',
+      'message.mpim',
       'member_joined_channel',
       'channel_left',
       'group_left'

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -85,6 +85,9 @@ describe('buildInstallManifest', () => {
       'groups:history',
       'groups:read',
       'im:history',
+      'im:write',
+      'mpim:history',
+      'mpim:read',
       'reactions:write',
       'assistant:write',
       'users:read'

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -16,7 +16,12 @@
  */
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
 
-/** Bot token scopes the daemon's Slack adapter requires. */
+/**
+ * Bot token scopes the Slack app requests. Widening this list later forces every
+ * workspace that already installed the app to re-authorize, so it covers group
+ * DMs (`mpim:*`) and agent-initiated DMs (`im:write`) alongside the channel and
+ * thread surfaces the adapter reads today.
+ */
 export const SLACK_BOT_SCOPES = [
   'files:read',
   'app_mentions:read',
@@ -29,6 +34,9 @@ export const SLACK_BOT_SCOPES = [
   'groups:history',
   'groups:read',
   'im:history',
+  'im:write',
+  'mpim:history',
+  'mpim:read',
   'reactions:write',
   'assistant:write',
   'users:read'

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -49,6 +49,7 @@ export const SLACK_BOT_EVENTS = [
   'message.channels',
   'message.groups',
   'message.im',
+  'message.mpim',
   'member_joined_channel',
   'channel_left',
   'group_left'

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -25,7 +25,7 @@ const SECRET = { botToken: 'xoxb-abc', appToken: 'xapp-def' }
 const channel = (
   channelId: string,
   trigger: 'off' | 'mention' | 'any',
-  kind: 'channel' | 'im' = 'channel'
+  kind: 'channel' | 'im' | 'mpim' = 'channel'
 ): IntegrationChannelRecord => ({
   integrationId: INTEGRATION.id,
   channelId,
@@ -54,6 +54,22 @@ describe('integrationToSpec bindRules', () => {
       { match: { kind: 'dm' } },
       { channel: 'C2', match: { kind: 'auto' } },
       { channel: 'C3', match: { kind: 'auto' } }
+    ])
+  })
+
+  // §14.4: a direct row only exists because observation created it while the agent was
+  // restricted, and the console hides it once the agent is org-visible. Compiling its
+  // "any message" would leave the agent answering with no visible control to stop it.
+  it('ignores a preserved DM / group-DM row set to "any" for a non-gated agent', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [
+      channel('C1', 'any'),
+      channel('D1', 'any', 'im'),
+      channel('G1', 'any', 'mpim')
+    ])
+    expect(spec.slack.bindRules).toEqual([
+      { match: { kind: 'mention' } },
+      { match: { kind: 'dm' } },
+      { channel: 'C1', match: { kind: 'auto' } }
     ])
   })
 

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -61,6 +61,7 @@ import type {
   ExternalMemoryGrantRepo,
   MemoryPluginInstallationRepo
 } from '../persistence/ports.js'
+import { isDirectConversationKind } from '../persistence/ports.js'
 import { mcpProxyDef, relayHttpOrigin } from './mcpProvider.js'
 import { memoryConnectionSpec, stdioMemoryConnectionSpec } from './memoryConnection.js'
 import type { DaemonId } from '../domain/ids.js'
@@ -214,8 +215,13 @@ export function integrationToSpec(
   channels: IntegrationChannelRecord[] = [],
   gated = false
 ): IntegrationSpec {
+  // A preserved DIRECT row (§14.4) is inert here. Its "any message" was an editor's
+  // choice while the agent was restricted, and the console hides the row once it is
+  // not — honouring it would leave an org-visible agent answering every message in a
+  // conversation with no visible control to turn it off. Such an agent reaches its DMs
+  // through the unscoped dm default and a group DM through the unscoped mention default.
   const channelRules: IntegrationBindRule[] = channels
-    .filter((c) => c.trigger === 'any' && c.kind !== 'im')
+    .filter((c) => c.trigger === 'any' && !isDirectConversationKind(c.kind))
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
   const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
   if (i.platform === 'telegram') {

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -418,6 +418,33 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect(compiled).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
     })
 
+    // One Slack identity cannot say WHICH agent a group-DM mention meant, and the slug
+    // that disambiguates a shared DM does not apply (the mention rung outranks keyword).
+    // Two identical scoped mention routes would let relay order decide silently, so the
+    // conversation converges on the earliest install instead.
+    it('converges a group DM enabled by TWO gated agents onto the earliest install', async () => {
+      gatedAgents = new Set([ALICE, BOB])
+      channels = [
+        channel({ integrationId: INT_B, channelId: 'G42', kind: 'mpim', agentId: BOB, trigger: 'mention' }),
+        channel({ integrationId: INT_A, channelId: 'G42', kind: 'mpim', agentId: ALICE, trigger: 'mention' })
+      ]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      const g42 = assign.routes.filter((r) => r.scope?.channel === 'G42')
+      // ALICE is the earliest install (INT_A) — one route, hers, regardless of row order.
+      expect(g42).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
+    })
+
+    // §14.4: the console hides a preserved direct row once its owner is org-visible, so
+    // compiling it would be behaviour the operator cannot see or stop.
+    it('makes a preserved group-DM row inert once its owner is no longer gated', async () => {
+      gatedAgents = new Set()
+      channels = [channel({ integrationId: INT_A, channelId: 'G42', kind: 'mpim', agentId: ALICE, trigger: 'any' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'G42')).toEqual([])
+    })
+
     it('recordNoticePosted re-stamps the pool with the DELIVERED conversation', async () => {
       gatedAgents = new Set([ALICE])
       const orch = makeOrch()

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -398,6 +398,26 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect(ch.sends.filter((s) => s.type === 'rc/routes')).toHaveLength(0)
     })
 
+    // A group DM must survive the fan-out as itself. Stamping it 'im' would compile an
+    // `auto` route once enabled — the agent answering every message in a room full of
+    // people — instead of the mention rule a channel-like conversation gets.
+    it('reportConversation preserves a group DM and compiles a MENTION route once enabled', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      const orch = makeOrch()
+      await orch.reportConversation(BOT, { id: 'G42', name: 'mpim-alice--bob-1', kind: 'mpim' })
+      const row = channels.find((c) => c.integrationId === INT_A && c.channelId === 'G42')
+      expect(row).toMatchObject({ kind: 'mpim', trigger: 'off', agentId: ALICE })
+
+      ch.sends.length = 0
+      row!.trigger = 'mention'
+      await orch.syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      const compiled = assign.routes.filter((r) => r.scope?.channel === 'G42')
+      // A mention rule, and none of the `auto` / slug-keyword pair an 'im' row gets.
+      expect(compiled).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
+    })
+
     it('recordNoticePosted re-stamps the pool with the DELIVERED conversation', async () => {
       gatedAgents = new Set([ALICE])
       const orch = makeOrch()

--- a/packages/control-plane/src/orchestrator/sharedBot.test.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.test.ts
@@ -435,6 +435,22 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect(g42).toEqual([expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })])
     })
 
+    // The two rules meet here: an INERT row must not win the convergence it is excluded
+    // from. Alice's preserved row is earlier, but she is org-visible and compiles
+    // nothing — electing her would leave the conversation served by nobody.
+    it('skips an org-visible agent when electing the group DM owner', async () => {
+      gatedAgents = new Set([BOB])
+      channels = [
+        channel({ integrationId: INT_A, channelId: 'G42', kind: 'mpim', agentId: ALICE, trigger: 'any' }),
+        channel({ integrationId: INT_B, channelId: 'G42', kind: 'mpim', agentId: BOB, trigger: 'mention' })
+      ]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'G42')).toEqual([
+        expect.objectContaining({ agentId: BOB, match: { kind: 'mention' } })
+      ])
+    })
+
     // §14.4: the console hides a preserved direct row once its owner is org-visible, so
     // compiling it would be behaviour the operator cannot see or stop.
     it('makes a preserved group-DM row inert once its owner is no longer gated', async () => {

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -338,10 +338,12 @@ export class SharedBotOrchestrator {
   }
 
   /**
-   * §14.3: fan an INCREMENTAL DM-conversation report across the bot's GATED installs
-   * as `kind:'im'` rows (default Off, owned by each install's agent) so console
-   * editors can enable the DM. Non-gated installs are untouched — their DMs already
-   * route via `defaultAgentId`. Idempotent, and no route recompile: an Off row
+   * §14.3: fan an INCREMENTAL direct-conversation report across the bot's GATED
+   * installs as `kind:'im'` / `kind:'mpim'` rows (default Off, owned by each install's
+   * agent) so console editors can enable it. The reported kind is preserved: a group DM
+   * stays mention-gated, and stamping it 'im' would compile an `auto` route that answers
+   * every message in a room full of people. Non-gated installs are untouched — their DMs
+   * already route via `defaultAgentId`. Idempotent, and no route recompile: an Off row
    * compiles nothing; the recompile happens when an editor enables it.
    */
   async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
@@ -356,7 +358,7 @@ export class SharedBotOrchestrator {
       if (!agent || !isGatedAgent(agent)) continue
       await this.channels.upsertConversation(
         install.id,
-        { ...conversation, kind: 'im' },
+        { ...conversation, kind: conversation.kind === 'mpim' ? 'mpim' : 'im' },
         { agentId: AgentId(install.agentId), defaultTrigger: 'off' }
       )
     }

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -588,8 +588,14 @@ export class SharedBotOrchestrator {
     // it either: unlike a DM's `auto` base, the mention rung outranks keyword. So a group
     // DM converges on ONE agent exactly as an ownerless channel does (§10.1) — the bot's
     // earliest active install among those that enabled it.
+    //
+    // Only a GATED install can be a candidate. A preserved row of a now-org-visible agent
+    // is inert (it is skipped below), so letting it claim ownership would elect an owner
+    // that compiles nothing AND lock out the restricted agent that actually has the
+    // conversation enabled — leaving the group DM served by nobody.
     const groupDmOwner = new Map<string, string>()
     for (const p of placed) {
+      if (!p.gated) continue
       for (const c of chans) {
         if (c.kind !== 'mpim' || c.trigger === 'off' || c.agentId !== p.integration.agentId) continue
         if (!groupDmOwner.has(c.channelId)) groupDmOwner.set(c.channelId, p.integration.agentId)

--- a/packages/control-plane/src/orchestrator/sharedBot.ts
+++ b/packages/control-plane/src/orchestrator/sharedBot.ts
@@ -41,6 +41,7 @@ import type {
 } from '../persistence/ports.js'
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
+import { isDirectConversationKind } from '../persistence/ports.js'
 import { isGatedAgent, sharedIntegrationToSpec } from './placement.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
@@ -580,6 +581,20 @@ export class SharedBotOrchestrator {
     //    routes to that agent, respecting the channel's trigger (any → auto rule,
     //    mention → mention rule). Emitted FIRST so a scoped rule wins arbitration.
     const chans = await this.channels.listForBot(bot.id)
+    // A group DM has no owner picker — it is not a place the bot was invited to, so the
+    // observation fan-out gives every gated install its own row. Two agents enabling the
+    // same one would compile two IDENTICAL scoped mention routes and relay order would
+    // silently decide, permanently hiding the loser. Slug disambiguation cannot rescue
+    // it either: unlike a DM's `auto` base, the mention rung outranks keyword. So a group
+    // DM converges on ONE agent exactly as an ownerless channel does (§10.1) — the bot's
+    // earliest active install among those that enabled it.
+    const groupDmOwner = new Map<string, string>()
+    for (const p of placed) {
+      for (const c of chans) {
+        if (c.kind !== 'mpim' || c.trigger === 'off' || c.agentId !== p.integration.agentId) continue
+        if (!groupDmOwner.has(c.channelId)) groupDmOwner.set(c.channelId, p.integration.agentId)
+      }
+    }
     for (const c of chans) {
       if (!c.agentId) continue
       const p = byAgent.get(c.agentId)
@@ -587,11 +602,15 @@ export class SharedBotOrchestrator {
       // Conversation gating (§14): an Off conversation compiles NO route for a
       // GATED owner (fail-closed until an editor enables it). For a non-gated
       // owner a preserved row is inert (§14.4): a channel keeps its
-      // mention-trigger ownership (matching integrationToSpec()), while an im
-      // row compiles nothing at all — §14 DM rows only steer gated members;
-      // non-gated DMs route via defaultAgentId as they always did.
-      if (c.kind === 'im' && (!p.gated || c.trigger === 'off')) continue
+      // mention-trigger ownership (matching integrationToSpec()), while a DIRECT
+      // row (a DM or a group DM) compiles nothing at all — §14 direct rows only
+      // steer gated members, and the console hides them for everyone else, so
+      // honouring one would be behaviour with no visible control. Non-gated DMs
+      // route via defaultAgentId as they always did, and a non-gated group DM via
+      // the unscoped mention default.
+      if (isDirectConversationKind(c.kind) && (!p.gated || c.trigger === 'off')) continue
       if (c.trigger === 'off' && p.gated) continue
+      if (c.kind === 'mpim' && groupDmOwner.get(c.channelId) !== c.agentId) continue
       // A DM conversation row activates on any message once enabled (no mention
       // inside a DM); channels follow their trigger.
       const match: BindMatch = c.kind === 'im' || c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2225,6 +2225,13 @@ export type ChannelTrigger = 'off' | 'mention' | 'any'
  *  Slack group DM: observed like an `im`, mention-gated like a channel. */
 export type ConversationKind = 'channel' | 'im' | 'mpim'
 
+/** A conversation the bot was never invited to and that is never enumerated — a DM or a
+ *  Slack group DM. Its row exists only because observation created it, which is why a
+ *  preserved one is inert for a non-gated owner: there is no console control over it. */
+export function isDirectConversationKind(kind: ConversationKind | undefined): boolean {
+  return kind === 'im' || kind === 'mpim'
+}
+
 /** One conversation the integration's bot participates in, as reported by the daemon. */
 export interface IntegrationChannelRecord {
   integrationId: IntegrationId

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2221,8 +2221,9 @@ export interface ChannelPlacementRecord {
 
 export type ChannelTrigger = 'off' | 'mention' | 'any'
 
-/** Member channel vs DM conversation (resource-visibility.md §14.3). */
-export type ConversationKind = 'channel' | 'im'
+/** Member channel vs direct conversation (resource-visibility.md §14.3). `mpim` is a
+ *  Slack group DM: observed like an `im`, mention-gated like a channel. */
+export type ConversationKind = 'channel' | 'im' | 'mpim'
 
 /** One conversation the integration's bot participates in, as reported by the daemon. */
 export interface IntegrationChannelRecord {

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -419,7 +419,12 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       // downgrade an established 'im' row.
       const setName = authoritative || c.name !== undefined
       const setPrivate = authoritative || c.isPrivate !== undefined
-      const createTrigger = c.kind === 'im' ? 'off' : (opts?.defaultTrigger ?? 'mention')
+      // Direct conversations (a DM, or a Slack group DM) are only ever reported by
+      // observation, never enumerated — so they are pinned Off on creation and on
+      // conversion for the same fail-closed reason, and an authoritative channel
+      // snapshot (which cannot contain them) must not delete them.
+      const direct = c.kind === 'im' || c.kind === 'mpim'
+      const createTrigger = direct ? 'off' : (opts?.defaultTrigger ?? 'mention')
       await this.db.$executeRaw`
         INSERT INTO "integration_channel"
           ("integrationId", "channelId", "name", "spaceId", "space", "isPrivate", "kind", "trigger",
@@ -440,10 +445,12 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
           "kind" = CASE WHEN ${c.kind !== undefined}::boolean THEN EXCLUDED."kind"
                         ELSE "integration_channel"."kind" END,
           -- The fail-closed conversion, resolved against the COMMITTED kind: a row that
-          -- was a channel carried a channel's trigger, which is not an operator's DM
-          -- choice. An already-'im' row keeps whatever the operator set.
+          -- was a channel carried a channel's trigger, which is not an operator's choice
+          -- for a direct conversation. A row already of the reported kind keeps whatever
+          -- the operator set. (Slack classifies a group DM late — an app_mention payload
+          -- carries no channel_type — so channel to mpim is a real transition, not a race.)
           "trigger" = CASE
-            WHEN ${c.kind === 'im'}::boolean AND "integration_channel"."kind" <> 'im'::"ConversationKind"
+            WHEN ${direct}::boolean AND "integration_channel"."kind" <> EXCLUDED."kind"
               THEN 'off'::"ChannelTrigger"
             ELSE "integration_channel"."trigger"
           END,
@@ -467,9 +474,10 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         space: conversation.space ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
-        // Same fail-closed rule as replaceSnapshot: a created DM row starts Off however
-        // it was discovered, so a later flip to restricted cannot grandfather it in.
-        ...(conversation.kind === 'im'
+        // Same fail-closed rule as replaceSnapshot: a created direct-conversation row
+        // (DM or group DM) starts Off however it was discovered, so a later flip to
+        // restricted cannot grandfather it in.
+        ...(conversation.kind === 'im' || conversation.kind === 'mpim'
           ? { trigger: 'off' as const }
           : opts?.defaultTrigger
             ? { trigger: opts.defaultTrigger }

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -442,8 +442,22 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
                          ELSE "integration_channel"."space" END,
           "isPrivate" = CASE WHEN ${setPrivate}::boolean THEN EXCLUDED."isPrivate"
                              ELSE "integration_channel"."isPrivate" END,
-          "kind" = CASE WHEN ${c.kind !== undefined}::boolean THEN EXCLUDED."kind"
-                        ELSE "integration_channel"."kind" END,
+          -- A committed direct kind is never downgraded back to 'channel'. Slack
+          -- classifies a group DM late, so a daemon that has lost its cache (a restart,
+          -- a snapshot refresh) re-reports the conversation as a provisional 'channel'
+          -- before conversations.info corrects it. Accepting that would flip the row
+          -- twice and, through the fail-closed conversion below, silently reset an
+          -- operator's enabled trigger to Off on every restart. The classification lives
+          -- here, not in daemon memory.
+          "kind" = CASE
+            WHEN ${c.kind !== undefined}::boolean
+              AND NOT (
+                "integration_channel"."kind" IN ('im'::"ConversationKind", 'mpim'::"ConversationKind")
+                AND EXCLUDED."kind" = 'channel'::"ConversationKind"
+              )
+              THEN EXCLUDED."kind"
+            ELSE "integration_channel"."kind"
+          END,
           -- The fail-closed conversion, resolved against the COMMITTED kind: a row that
           -- was a channel carried a channel's trigger, which is not an operator's choice
           -- for a direct conversation. A row already of the reported kind keeps whatever

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -300,6 +300,33 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(u0.slack.bindRules).toEqual([])
   })
 
+  it('stores a group DM OFF and keeps a channel→group-DM conversion fail-closed (§14.3)', async () => {
+    // Slack classifies a group DM late: an `app_mention` payload carries no
+    // channel_type, so the conversation first lands as a channel with a channel's
+    // trigger. That is not an operator's choice for this conversation, so resolving it
+    // must reset to Off — and an authoritative channel snapshot (which can never list a
+    // group DM) must not delete the row.
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma)
+    const id = await install(running)
+
+    await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1' }], undefined, undefined, false)
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'G1', 'any')
+    await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1', kind: 'mpim' }], undefined, undefined, false)
+
+    const channelsOf = async () => {
+      const res = await running!.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+      const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+      return new Map(dto!.channels.map((c) => [c.channelId, c]))
+    }
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'off' })
+
+    // An operator enables it; a later authoritative channel snapshot leaves it alone.
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'G1', 'mention')
+    await report(DAEMON, id, [{ id: 'C1', name: 'general' }])
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+  })
+
   it('keeps the DM conversion fail-closed when a kind-less and an IM report OVERLAP (§14.3)', async () => {
     // Channel reports are fire-and-forget and their handlers run concurrently: a daemon
     // start emits a kind-less observed snapshot, and the resolver's later verdict emits

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -325,6 +325,33 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'G1', 'mention')
     await report(DAEMON, id, [{ id: 'C1', name: 'general' }])
     expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+
+    // A daemon restart loses the classification cache, so the next app_mention is
+    // re-reported as a provisional channel — and the daemon stamps a kind on every
+    // observed row, so this arrives as an EXPLICIT 'channel', not the absent-kind case
+    // the existing preservation rule covers. Accepting it would flip the row twice and
+    // reset the operator's trigger to Off on every restart.
+    await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1', kind: 'channel' }], undefined, undefined, false)
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+    // The daemon's own conversations.info correction lands afterwards and is a no-op.
+    await report(DAEMON, id, [{ id: 'G1', name: 'mpim-alice--bob-1', kind: 'mpim' }], undefined, undefined, false)
+    expect((await channelsOf()).get('G1')).toMatchObject({ kind: 'mpim', trigger: 'mention' })
+  })
+
+  it('an enabled DM row survives a provisional channel re-report too (§14.3)', async () => {
+    // Same durability rule, on the kind that already existed: session-history discovery
+    // can re-observe a DM without knowing it is one.
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma)
+    const id = await install(running)
+
+    await report(DAEMON, id, [{ id: 'D1', name: '@alice', kind: 'im' }], undefined, undefined, false)
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D1', 'any')
+    await report(DAEMON, id, [{ id: 'D1', name: '@alice', kind: 'channel' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const [dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'D1', kind: 'im', trigger: 'any' })])
   })
 
   it('keeps the DM conversion fail-closed when a kind-less and an IM report OVERLAP (§14.3)', async () => {

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -174,7 +174,14 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     await seedAgent(prisma, AGENT_A)
     await seedAgent(prisma, AGENT_B)
     const now = new Date()
-    const recent = (mins: number) => new Date(now.getTime() - mins * 60_000)
+    // A d30 series buckets by DAY on the requested tz's boundary, which defaults to
+    // UTC — and the assertions below require all three rows in the FINAL bucket. A
+    // naive "N minutes ago" silently crosses into yesterday's bucket whenever the suite
+    // runs within N minutes of UTC midnight, so clamp the offset to the time actually
+    // elapsed since that boundary. (Everything stays comfortably inside the 30-day
+    // window either way, so the totals and the tz-shift sums are unaffected.)
+    const sinceUtcMidnight = now.getTime() - Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    const recent = (mins: number) => new Date(now.getTime() - Math.min(mins * 60_000, sinceUtcMidnight))
 
     // Agent A: two in-range sessions + one stale (100 days old, excluded from d30/d90).
     await prisma.sessionUsage.createMany({

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11883,10 +11883,15 @@ export class Daemon {
     // discovery reports (a per-thread row would be a duplicate of it).
     const channel = (!isDm && msg.parentChannel) || msg.channel
     const current = existing.find((c) => c.id === channel)
-    const kind = isDm ? ('im' as const) : ('channel' as const)
+    // A group DM is neither: reported on observation like a DM, mention-gated like a
+    // channel. `app_mention` payloads carry no channel_type, so a row already resolved
+    // to 'mpim' must never be downgraded back to 'channel' by a later mention —
+    // otherwise the two classifications would fight and re-emit on every message.
+    const observed = isDm ? ('im' as const) : msg.isGroupDm ? ('mpim' as const) : ('channel' as const)
+    const kind = observed === 'channel' && current?.kind === 'mpim' ? ('mpim' as const) : observed
     const known = this.store.getDisplayNames([channel]).get(channel)
-    // Which Discord server the channel belongs to — see spaceFor. DM rows have none.
-    const found = !isDm && msg.platform === 'discord' ? this.spaceFor(channel) : undefined
+    // Which Discord server the channel belongs to — see spaceFor. Direct rows have none.
+    const found = kind === 'channel' && msg.platform === 'discord' ? this.spaceFor(channel) : undefined
     const space = found ? { spaceId: found.id, ...(found.name ? { space: found.name } : {}) } : undefined
     // Compare against what a write would actually change — a partially resolved space
     // (id known, name not yet) must not re-emit the snapshot on every message.
@@ -11902,24 +11907,59 @@ export class Daemon {
       authoritative: cached?.authoritative ?? false
     })
     this.cpClient?.emitIntegrationChannels({ integrationId, channels: next, authoritative: false })
-    if (!isDm || known || current?.name) return
     const conn = this.connForIntegration(integrationId)
     if (!(conn instanceof SlackConnection)) return
-    void conn
-      .getUserProfile(msg.sender.id)
-      .then((prof) => {
-        const name = prof.realName || prof.name
-        if (!name) return
-        const cached = this.channelSnapshots.get(integrationId)
-        const snap = cached?.channels ?? []
-        const updated = snap.map((c) => (c.id === channel && !c.name ? { ...c, name: `@${name}` } : c))
-        this.channelSnapshots.set(integrationId, {
-          channels: updated,
-          authoritative: cached?.authoritative ?? false
+    if (isDm) {
+      if (known || current?.name) return
+      void conn
+        .getUserProfile(msg.sender.id)
+        .then((prof) => {
+          const name = prof.realName || prof.name
+          if (!name) return
+          this.refineObservedConversation(integrationId, channel, (c) => (c.name ? null : { ...c, name: `@${name}` }))
         })
-        this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated, authoritative: false })
+        .catch(() => {})
+      return
+    }
+    // Slack "G…" ids are shared by group DMs and legacy private channels, and an
+    // `app_mention` payload omits channel_type — so a conversation that reached us
+    // only through a mention is classified here rather than guessed from the id. One
+    // lookup per conversation: the resolved row short-circuits the next call above.
+    if (kind !== 'channel' || msg.platform !== 'slack') return
+    void conn
+      .getChannelInfo(channel)
+      .then((info) => {
+        if (!info.isMpim) return
+        this.refineObservedConversation(integrationId, channel, (c) => {
+          const name = c.name ?? info.name
+          if (c.kind === 'mpim' && c.name === name) return null
+          return { ...c, kind: 'mpim' as const, ...(name ? { name } : {}) }
+        })
       })
       .catch(() => {})
+  }
+
+  /** Apply a late-resolved detail (a DM counterpart's name, a group-DM classification)
+   *  to one observed conversation row and re-emit the snapshot. The updater returns
+   *  null when the row already carries the detail, so a no-op never re-emits. */
+  private refineObservedConversation(
+    integrationId: string,
+    channel: string,
+    update: (row: IntegrationChannel) => IntegrationChannel | null
+  ): void {
+    const cached = this.channelSnapshots.get(integrationId)
+    const snap = cached?.channels ?? []
+    let changed = false
+    const updated = snap.map((c) => {
+      if (c.id !== channel) return c
+      const next = update(c)
+      if (!next) return c
+      changed = true
+      return next
+    })
+    if (!changed) return
+    this.channelSnapshots.set(integrationId, { channels: updated, authoritative: cached?.authoritative ?? false })
+    this.cpClient?.emitIntegrationChannels({ integrationId, channels: updated, authoritative: false })
   }
 
   /** Re-assert cached reports after a CP reconnect without upgrading a partial

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -58,6 +58,14 @@ export interface NormalizedMessage {
   attachments?: Attachment[]
   isDm: boolean
   /**
+   * A multi-person direct conversation (Slack `mpim`) — several humans and the bot in a
+   * room with no channel identity. Deliberately NOT `isDm`: a one-to-one DM is addressed
+   * to the agent by construction, whereas a group DM is a conversation between people
+   * that the agent happens to sit in, so it stays mention-gated like a channel. The flag
+   * exists so the console can label the conversation row for what it is.
+   */
+  isGroupDm?: boolean
+  /**
    * Platform id of the message this one replies to, when the platform models replies
    * (Telegram `reply_to_message.message_id`). The daemon stitches a reply back to its
    * session with it (reply-based Telegram threading); absent when not a reply.

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -254,9 +254,16 @@ type AppLike = {
       delete: (a: unknown) => Promise<unknown>
     }
     conversations: {
-      info: (
-        a: unknown
-      ) => Promise<{ channel?: { id?: string; name?: string; is_im?: boolean; is_private?: boolean; user?: string } }>
+      info: (a: unknown) => Promise<{
+        channel?: {
+          id?: string
+          name?: string
+          is_im?: boolean
+          is_mpim?: boolean
+          is_private?: boolean
+          user?: string
+        }
+      }>
       members: (a: unknown) => Promise<{ members?: string[] }>
       list: (a: unknown) => Promise<{ channels?: { id?: string; name?: string; is_private?: boolean }[] }>
       replies: (a: unknown) => Promise<{
@@ -1043,11 +1050,20 @@ export class SlackConnection {
 
   async getChannelInfo(
     channel: string
-  ): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean; user?: string }> {
+  ): Promise<{ id: string; name?: string; isIm?: boolean; isMpim?: boolean; isPrivate?: boolean; user?: string }> {
     const res = await this.app.client.conversations.info({ channel })
     const c = res.channel ?? {}
-    // `user` is the DM counterpart — only set on im ("D…") conversations.
-    return { id: c.id ?? channel, name: c.name, isIm: c.is_im, isPrivate: c.is_private, user: c.user }
+    // `user` is the DM counterpart — only set on im ("D…") conversations. `is_mpim`
+    // marks a multi-person DM, which shares the "G…" id space with legacy private
+    // channels and so cannot be told apart from the id alone.
+    return {
+      id: c.id ?? channel,
+      name: c.name,
+      isIm: c.is_im,
+      isMpim: c.is_mpim,
+      isPrivate: c.is_private,
+      user: c.user
+    }
   }
 
   async listMembers(channel: string): Promise<{ id: string; name?: string; isBot?: boolean }[]> {

--- a/packages/daemon/src/slack/normalize.ts
+++ b/packages/daemon/src/slack/normalize.ts
@@ -73,6 +73,12 @@ export function normalizeSlackEvent(event: SlackMessageEvent, ctx: { traceId: st
     text,
     mentionedBots,
     ...(attachments.length ? { attachments } : {}),
-    isDm: event.channel_type === 'im'
+    isDm: event.channel_type === 'im',
+    // A group DM is mention-gated like a channel, so this only classifies the
+    // conversation — it never makes the message addressed. `app_mention` payloads
+    // omit channel_type, so an unflagged mpim mention is classified later from the
+    // conversation lookup rather than guessed from the id (Slack "G…" ids are
+    // shared with legacy private channels).
+    ...(event.channel_type === 'mpim' ? { isGroupDm: true } : {})
   }
 }

--- a/packages/daemon/test/normalize.test.ts
+++ b/packages/daemon/test/normalize.test.ts
@@ -15,6 +15,30 @@ describe('normalizeSlackEvent', () => {
     expect(m.sender).toEqual({ id: 'U1', isBot: false })
   })
 
+  // A group DM holds several humans, so it is classified but never treated as
+  // addressed — routing keeps it mention-gated like a channel.
+  it('classifies a group DM without making it a DM', () => {
+    const m = normalizeSlackEvent(
+      { type: 'message', channel: 'G1', channel_type: 'mpim', ts: '2.1', user: 'U1', text: 'hey <@BOTA>' },
+      { traceId: 't2' }
+    )
+    expect(m.isGroupDm).toBe(true)
+    expect(m.isDm).toBe(false)
+    expect(m.mentionedBots).toEqual(['BOTA'])
+  })
+
+  // `app_mention` payloads carry no channel_type; the daemon resolves those from the
+  // conversation lookup instead, so normalization must not guess from the "G…" id
+  // (legacy private channels share it).
+  it('leaves the group-DM flag unset when the payload omits channel_type', () => {
+    const m = normalizeSlackEvent(
+      { type: 'app_mention', channel: 'G1', ts: '2.2', user: 'U1', text: 'hey <@BOTA>' },
+      { traceId: 't3' }
+    )
+    expect(m.isGroupDm).toBeUndefined()
+    expect(m.isDm).toBe(false)
+  })
+
   it('uses visible Block Kit text when the top-level fallback omits the message body', () => {
     const m = normalizeSlackEvent(
       {

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -187,10 +187,14 @@ export type IntegrationRemove = z.infer<typeof IntegrationRemove>
 
 /**
  * One conversation the bot participates in (metadata only — no messages).
- * `kind` distinguishes member channels from DM conversations (resource-
+ * `kind` distinguishes member channels from direct conversations (resource-
  * visibility.md §14.3): absent = 'channel' for wire compatibility. DM rows
  * (`kind: 'im'`, Slack "D…" ids) are reported only for gated integrations, on
- * first inbound DM; their `name` is the counterpart's display name.
+ * first inbound DM; their `name` is the counterpart's display name. Group DMs
+ * (`kind: 'mpim'`, Slack multi-person DMs) are reported on observation the same
+ * way — never enumerated, because Slack does not list them as bot membership —
+ * but they behave like a channel: several humans share the room, so the agent
+ * stays mention-gated there rather than answering every message.
  *
  * `spaceId`/`space` identify the container the conversation lives in — a Discord
  * GUILD, which a bot in several servers needs for the channel to be identifiable at
@@ -206,7 +210,7 @@ export const IntegrationChannel = z.object({
   spaceId: z.string().optional(), // enclosing Discord guild snowflake — the space's IDENTITY
   space: z.string().optional(), // that guild's display name; absent until resolved
   isPrivate: z.boolean().optional(),
-  kind: z.enum(['channel', 'im']).optional() // absent = 'channel'
+  kind: z.enum(['channel', 'im', 'mpim']).optional() // absent = 'channel'
 })
 export type IntegrationChannel = z.infer<typeof IntegrationChannel>
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -147,6 +147,9 @@ export const WireNormalizedMessage = z.object({
   mentionedBots: z.array(z.string()),
   attachments: z.array(WireAttachment).optional(),
   isDm: z.boolean(),
+  // Slack `mpim` — several humans and the bot in a direct conversation with no channel
+  // identity. Classification only: a group DM stays mention-gated like a channel.
+  isGroupDm: z.boolean().optional(),
   replyTo: z.string().optional(),
   telegramTopicId: z.string().optional(),
   telegramThreadRoot: z.string().optional(),

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -363,8 +363,10 @@ export class SharedBotManager {
     // the gated installs still need their pending Off row to ever be enableable.
     // A group DM is discovered the same way — Slack never lists one as membership, so
     // an unreported one could never be enabled. It is only ever *addressed* by mention,
-    // so unlike a DM it is reported only when it names this bot.
-    const addressesBot = msg.isDm || (msg.isGroupDm === true && msg.mentionedBots.length > 0)
+    // so unlike a DM it is reported only when it names THIS bot: `mentionedBots` also
+    // holds the humans and other apps named in the same message.
+    const namesThisBot = assignment?.botUserId !== undefined && msg.mentionedBots.includes(assignment.botUserId)
+    const addressesBot = msg.isDm || (msg.isGroupDm === true && namesThisBot)
     if (addressesBot && !msg.sender.isBot && hasGatedMembers) await this.reportGatedConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
     let tgt = this.router.route(botId, msg)

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -361,7 +361,11 @@ export class SharedBotManager {
     // §14.3 DM discovery must NOT depend on the arbitration outcome: on a
     // mixed-visibility bot the public default agent wins every unslugged DM, yet
     // the gated installs still need their pending Off row to ever be enableable.
-    if (msg.isDm && !msg.sender.isBot && hasGatedMembers) await this.reportGatedDmConversation(botId, msg)
+    // A group DM is discovered the same way — Slack never lists one as membership, so
+    // an unreported one could never be enabled. It is only ever *addressed* by mention,
+    // so unlike a DM it is reported only when it names this bot.
+    const addressesBot = msg.isDm || (msg.isGroupDm === true && msg.mentionedBots.length > 0)
+    if (addressesBot && !msg.sender.isBot && hasGatedMembers) await this.reportGatedConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
     let tgt = this.router.route(botId, msg)
     if (tgt) {
@@ -432,20 +436,22 @@ export class SharedBotManager {
   }
 
   /**
-   * §14.3: surface one human DM conversation to the CP as an incremental
-   * `kind:'im'` report (fanned to gated installs as pending Off rows — the console
-   * enablement path). Fires for EVERY human DM on a bot with gated members,
-   * routed or not; latched per conversation per relay lifetime (the CP upsert is
-   * idempotent, this only bounds chatter — a relay restart re-reports harmlessly).
-   * Channel rows need no report here — membership snapshots already carry them.
+   * §14.3: surface one human direct conversation to the CP as an incremental
+   * `kind:'im'` / `kind:'mpim'` report (fanned to gated installs as pending Off rows —
+   * the console enablement path). Fires for EVERY human DM on a bot with gated members,
+   * routed or not, and for an addressed group DM; latched per conversation per relay
+   * lifetime (the CP upsert is idempotent, this only bounds chatter — a relay restart
+   * re-reports harmlessly). Channel rows need no report here — membership snapshots
+   * already carry them, and neither of these kinds appears in one.
    */
-  private async reportGatedDmConversation(botId: string, msg: WireNormalizedMessage): Promise<void> {
+  private async reportGatedConversation(botId: string, msg: WireNormalizedMessage): Promise<void> {
     const latch = `${botId}:${msg.channel}`
     if (this.gatedDmReported.has(latch)) return
-    const name = await this.ingests.get(botId)?.lookupUserName(msg.sender.id)
+    // A group DM's counterpart is the room, not the sender, so it carries no name here.
+    const name = msg.isDm ? await this.ingests.get(botId)?.lookupUserName(msg.sender.id) : undefined
     const sent = this.deps.reportBotConversation({
       botId,
-      conversation: { id: msg.channel, ...(name ? { name } : {}), kind: 'im' }
+      conversation: { id: msg.channel, ...(name ? { name } : {}), kind: msg.isDm ? 'im' : 'mpim' }
     })
     // Latch only a delivered report — a CP-link-down drop retries on the next DM.
     if (sent) this.gatedDmReported.add(latch)

--- a/packages/relay/src/slack-shared-ingest.test.ts
+++ b/packages/relay/src/slack-shared-ingest.test.ts
@@ -12,6 +12,7 @@ import {
   encodeSharedSlackStatusTarget
 } from '@agentconnect.md/protocol'
 import {
+  normalizeSlackMessage,
   parseSharedSlackAgentSelection,
   parseSharedSlackAgentSwitch,
   parseSharedSlackSessionAction,
@@ -455,6 +456,35 @@ describe('SlackSharedIngest channel membership events', () => {
     await ingest.handleEvent({ type, channel: 'CLEFT' })
 
     expect(onChannelsChanged).toHaveBeenCalledWith([{ id: 'C1', name: 'remaining' }])
+  })
+})
+
+// Mirrors the daemon's slack/normalize.ts: a group DM is classified but never
+// treated as addressed, so it stays mention-gated like a channel.
+describe('normalizeSlackMessage conversation kinds', () => {
+  const event = (channel: string, channelType?: string) => ({
+    type: 'message',
+    channel,
+    ...(channelType ? { channel_type: channelType } : {}),
+    ts: '1.1',
+    user: 'U1',
+    text: 'hi <@BOTA>'
+  })
+
+  it('flags a group DM without marking it a DM', () => {
+    const m = normalizeSlackMessage(event('G1', 'mpim'))
+    expect(m).toMatchObject({ isDm: false, isGroupDm: true })
+  })
+
+  it('marks a DM and leaves the group-DM flag unset', () => {
+    expect(normalizeSlackMessage(event('D1', 'im'))).toMatchObject({ isDm: true })
+    expect(normalizeSlackMessage(event('D1', 'im'))?.isGroupDm).toBeUndefined()
+  })
+
+  it('leaves both unset when the payload omits channel_type (app_mention)', () => {
+    const m = normalizeSlackMessage(event('G1'))
+    expect(m?.isDm).toBe(false)
+    expect(m?.isGroupDm).toBeUndefined()
   })
 })
 

--- a/packages/relay/src/slack-shared-ingest.ts
+++ b/packages/relay/src/slack-shared-ingest.ts
@@ -348,7 +348,11 @@ export function normalizeSlackMessage(e: SlackMessageEvent): WireNormalizedMessa
     text,
     mentionedBots,
     ...(attachments.length ? { attachments } : {}),
-    isDm: e.channel_type === 'im'
+    isDm: e.channel_type === 'im',
+    // Classification only — a group DM stays mention-gated like a channel. `app_mention`
+    // payloads omit channel_type; the daemon classifies those from the conversation
+    // lookup rather than guessing from the id.
+    ...(e.channel_type === 'mpim' ? { isGroupDm: true } : {})
   }
 }
 

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -37,9 +37,13 @@ describe('channelOwners', () => {
     expect(owners.get('C-deploys')).toBe('bob')
   })
 
-  it('ignores installs of other bots and DM rows', () => {
+  it('ignores installs of other bots and direct-conversation rows', () => {
     const other = { ...install('int_other', 'zoe', [chan('C-deploys', 'zoe')]), botId: 'bot_other' }
-    const dm = install('int_dm', 'bob', [{ ...chan('D-bob', 'bob'), kind: 'im' as const }])
+    // Neither a DM nor a group DM is a channel a shared bot can hand out ownership of.
+    const dm = install('int_dm', 'bob', [
+      { ...chan('D-bob', 'bob'), kind: 'im' as const },
+      { ...chan('G-team', 'bob'), kind: 'mpim' as const }
+    ])
     const owners = channelOwners('bot_shared', [other, dm, install('int_bob', 'bob', [chan('C-deploys', 'bob')])])
     expect([...owners]).toEqual([['C-deploys', 'bob']])
   })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { agentLabel, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
+import { agentLabel, isDirectConversation, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
@@ -55,7 +55,9 @@ function TriggerToggle({
   // A DM conversation activates on any message once enabled — binary off/on. A
   // channel keeps the any/mention choice (mention last); "off" appears when
   // gated (and, so the state stays visible, on an inert off row of a
-  // no-longer-gated integration).
+  // no-longer-gated integration). A GROUP DM takes the channel's three-way choice,
+  // not the DM's: several people share it, so "every message" must stay opt-in.
+  const here = channel.kind === 'mpim' ? 'this group DM' : 'this channel'
   const segs: [IntegrationChannelRow['trigger'], string, string][] =
     channel.kind === 'im'
       ? [
@@ -64,8 +66,8 @@ function TriggerToggle({
         ]
       : gated || channel.trigger === 'off'
         ? [
-            ['off', 'off', "The agent doesn't respond in this channel."],
-            ['any', 'any message', 'The agent responds to every message in this channel.'],
+            ['off', 'off', `The agent doesn't respond in ${here}.`],
+            ['any', 'any message', `The agent responds to every message in ${here}.`],
             [
               'mention',
               '@-mention',
@@ -73,7 +75,7 @@ function TriggerToggle({
             ]
           ]
         : [
-            ['any', 'any message', 'The agent responds to every message in this channel.'],
+            ['any', 'any message', `The agent responds to every message in ${here}.`],
             [
               'mention',
               '@-mention',
@@ -234,7 +236,7 @@ export function channelOwners(botId: string, integrations: IntegrationRow[]): Ma
   for (const i of integrations) {
     if (i.botId !== botId) continue
     for (const c of i.channels) {
-      if (c.kind === 'im' || !c.agentId || owners.has(c.channelId)) continue
+      if (isDirectConversation(c.kind) || !c.agentId || owners.has(c.channelId)) continue
       owners.set(c.channelId, c.agentId)
     }
   }
@@ -415,15 +417,16 @@ export function IntegrationChannelList({
     const explicit = c.agentId ?? owners?.get(c.channelId)
     return (explicit ? members.find((m) => m.id === explicit) : undefined) ?? members[0]
   }
-  const channelRows = channels.filter((c) => c.kind !== 'im')
-  // A DM is not a place the bot can be invited to and has no per-conversation choice
-  // to make unless the agent is gated (resource-visibility.md §14.3) — a non-gated bot
-  // always answers its DMs. The daemon still REPORTS them (that is how a DM previously
-  // mistaken for a channel converts), so hide them here rather than at the source.
-  const dmRows = gated ? channels.filter((c) => c.kind === 'im') : []
+  const channelRows = channels.filter((c) => !isDirectConversation(c.kind))
+  // A direct conversation is not a place the bot can be invited to and has no
+  // per-conversation choice to make unless the agent is gated (resource-visibility.md
+  // §14.3) — a non-gated bot always answers its DMs, and answers a group DM whenever
+  // it is @-mentioned. The daemon still REPORTS them (that is how a conversation
+  // previously mistaken for a channel converts), so hide them here, not at the source.
+  const dmRows = gated ? channels.filter((c) => isDirectConversation(c.kind)) : []
   const grouped = groupBySpace(channelRows)
   const row = (c: IntegrationChannelRow) => {
-    const def = c.kind !== 'im' && shareable ? defaultAgent(c) : undefined
+    const def = !isDirectConversation(c.kind) && shareable ? defaultAgent(c) : undefined
     return (
       <div
         key={c.channelId}
@@ -431,12 +434,12 @@ export function IntegrationChannelList({
         style={{ padding: `10px ${padX}px` }}
       >
         <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
-          {c.kind === 'im' ? '@' : '#'}
+          {c.kind === 'im' ? '@' : c.kind === 'mpim' ? '@@' : '#'}
         </span>
         {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
             renders the marker, so strip a leading @ to avoid "@@Alice". */}
         <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">
-          {c.kind === 'im' ? c.name.replace(/^@+/, '') : c.name}
+          {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
         </span>
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
           {def && (

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -44,7 +44,7 @@ import {
   type OrgInviteLinkDto,
   type SlackBotRefreshDto
 } from '@/lib/api'
-import { agentLabel, type IntegrationRow } from '@/lib/data'
+import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
 import { slackAppSettingsUrl } from '@/lib/slack-manifest'
 import { slackRefreshNoticeState } from '@/lib/slack-refresh-notice'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
@@ -111,7 +111,7 @@ type BotPlatform = (typeof BOT_PLATFORMS)[number]['platform']
 interface BotChannelView {
   channelId: string
   name: string
-  kind: 'channel' | 'im'
+  kind: 'channel' | 'im' | 'mpim'
   /** Effective per-channel owner; null only before legacy state converges. */
   agentId: string | null
   /** Any integration whose snapshot row backs this channel; ownership PATCHes
@@ -142,8 +142,11 @@ function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelVie
       }
     }
   }
+  // Channels first, then the direct conversations (DMs and group DMs) under one
+  // heading — the roster's second half is "places the bot was not invited to".
   return [...merged.values()].sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === 'channel' ? -1 : 1
+    const rank = (k: BotChannelView['kind']) => (isDirectConversation(k) ? 1 : 0)
+    if (rank(a.kind) !== rank(b.kind)) return rank(a.kind) - rank(b.kind)
     return a.name.localeCompare(b.name)
   })
 }
@@ -871,7 +874,7 @@ function BotsCard({
                     <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
                       {channels.map((c, index) => (
                         <Fragment key={c.channelId}>
-                          {c.kind === 'im' && channels[index - 1]?.kind !== 'im' && (
+                          {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
                             <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
                               Direct messages
                             </div>
@@ -881,13 +884,17 @@ function BotsCard({
                           >
                             <span className="mono flex min-w-0 items-center gap-[7px] text-[12px]">
                               <Icon
-                                name={c.kind === 'im' ? 'at-sign' : 'hash'}
+                                name={c.kind === 'mpim' ? 'users' : c.kind === 'im' ? 'at-sign' : 'hash'}
                                 size={12}
                                 color="var(--text-tertiary)"
                                 className="flex-none"
                               />
-                              <span className="sr-only">{c.kind === 'im' ? 'Direct message' : 'Channel'}: </span>
-                              <span className="truncate">{c.kind === 'im' ? c.name.replace(/^@+/, '') : c.name}</span>
+                              <span className="sr-only">
+                                {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : 'Channel'}:{' '}
+                              </span>
+                              <span className="truncate">
+                                {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
+                              </span>
                             </span>
                             {showDefaultDispatch && c.kind === 'channel' && (
                               <DefaultDispatchPicker

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -533,14 +533,15 @@ export interface SlackConfigInput {
 export type ChannelTrigger = 'off' | 'mention' | 'any'
 
 // One conversation the integration's bot is in (daemon-reported) + its trigger
-// choice. kind 'im' rows are DM conversations (gated/restricted agents only).
+// choice. kind 'im' rows are DM conversations and 'mpim' rows are Slack group DMs
+// (both gated/restricted agents only — neither is enumerable).
 export interface IntegrationChannelDto {
   channelId: string
   name: string | null // "deploys" without the hash (or DM counterpart); null if lookup failed
   spaceId: string | null // enclosing Discord server id — the identity (names are not unique)
   space: string | null // that server's display name; null elsewhere and until resolved
   isPrivate: boolean
-  kind: 'channel' | 'im'
+  kind: 'channel' | 'im' | 'mpim'
   trigger: ChannelTrigger
   agentId: string | null // effective shared-channel owner; null before convergence / when not applicable
 }

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1332,11 +1332,20 @@ export interface IntegrationChannelRow {
    *  implicit container per bot, on DM rows, and until the daemon resolves them. */
   spaceId?: string
   space?: string
-  /** 'im' = a DM conversation row (gated/restricted agents only); absent = channel. */
-  kind?: 'channel' | 'im'
+  /** 'im' = a DM conversation row, 'mpim' = a Slack group DM (both gated/restricted
+   *  agents only); absent = channel. */
+  kind?: 'channel' | 'im' | 'mpim'
   trigger: 'off' | 'mention' | 'any'
   /** Effective per-channel owner for a shared bot. */
   agentId?: string | null
+}
+
+/** A direct conversation — a DM or a Slack group DM. Neither is a place the bot can be
+ *  invited to, so neither is ever enumerated: they are listed apart from channels and
+ *  only appear once observed. A group DM still holds several humans, so unlike a DM it
+ *  keeps a channel's @-mention trigger rather than a binary on/off. */
+export function isDirectConversation(kind: IntegrationChannelRow['kind']): boolean {
+  return kind === 'im' || kind === 'mpim'
 }
 
 export interface IntegrationRow {

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -1,5 +1,54 @@
 import { describe, expect, it } from 'vitest'
-import { buildSlackManifest, slackCreateAppUrl, SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from './slack-manifest'
+import {
+  buildSlackManifest,
+  slackCreateAppUrl,
+  SLACK_BOT_SCOPES,
+  SLACK_BOT_EVENTS,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID
+} from './slack-manifest'
+
+// The manual manifest must request exactly what the CP's auto-install manifest does, or
+// an app a user creates by hand is short a permission the daemon needs. The two lists
+// live in separate packages, so each pins the same literal: changing one side alone
+// fails its own drift guard, here or in
+// packages/control-plane/src/http/slack-manifest.test.ts.
+describe('manifest parity with the Control Plane', () => {
+  it('pins the exact bot scopes (drift guard)', () => {
+    expect([...SLACK_BOT_SCOPES]).toEqual([
+      'files:read',
+      'app_mentions:read',
+      'channels:history',
+      'channels:read',
+      'commands',
+      'chat:write',
+      'chat:write.customize',
+      'files:write',
+      'groups:history',
+      'groups:read',
+      'im:history',
+      'im:write',
+      'mpim:history',
+      'mpim:read',
+      'reactions:write',
+      'assistant:write',
+      'users:read'
+    ])
+  })
+
+  it('pins the exact bot events (drift guard)', () => {
+    expect([...SLACK_BOT_EVENTS]).toEqual([
+      'app_mention',
+      'assistant_thread_started',
+      'message.channels',
+      'message.groups',
+      'message.im',
+      'message.mpim',
+      'member_joined_channel',
+      'channel_left',
+      'group_left'
+    ])
+  })
+})
 
 describe('buildSlackManifest', () => {
   it('brands the app with the given background_color, and omits it otherwise', () => {

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -28,7 +28,10 @@
 /** Kept in lock-step with the protocol callback consumed by daemon + relay. */
 export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
 
-/** Bot token scopes the daemon's Slack adapter requires. */
+/** Bot token scopes the Slack app requests. Widening this list later forces every
+ *  workspace that already installed the app to re-authorize, so it covers group DMs
+ *  (`mpim:*`) and agent-initiated DMs (`im:write`) alongside the channel and thread
+ *  surfaces the adapter reads today. */
 export const SLACK_BOT_SCOPES = [
   'files:read',
   'app_mentions:read',
@@ -41,6 +44,9 @@ export const SLACK_BOT_SCOPES = [
   'groups:history',
   'groups:read',
   'im:history',
+  'im:write',
+  'mpim:history',
+  'mpim:read',
   'reactions:write',
   'assistant:write',
   'users:read'

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -61,6 +61,7 @@ export const SLACK_BOT_EVENTS = [
   'message.channels',
   'message.groups',
   'message.im',
+  'message.mpim',
   'member_joined_channel',
   'channel_left',
   'group_left'


### PR DESCRIPTION
A Slack app cannot widen its OAuth scopes without every workspace that already installed it re-authorizing. That is cheap while installs are few and self-created, and expensive once an app is distributed — so this lands the permission surface we need *and* the feature that uses it, rather than leaving a dormant scope behind.

## Scopes

Added to both manifests — the CP's auto-install funnel (`packages/control-plane/src/http/slack-manifest.ts`) and the console's manual deep link (`packages/web/src/lib/slack-manifest.ts`), kept in lock-step by the existing drift-guard test:

| Scope | Why |
| --- | --- |
| `mpim:history`, `mpim:read` | Group DMs — used by this PR. |
| `im:write` | Lets an agent open a DM it did not receive first (`conversations.open`). **No caller yet** — see below. |

I checked the existing 13 against actual Slack API usage in `packages/daemon/src` and `packages/relay/src` first: `users.conversations` is only ever called with `types: 'public_channel,private_channel'`, and there are no `conversations.open` / `conversations.join` calls. So the current list is exactly what the adapter uses, and these are genuinely new surface.

## Group DMs

Group DMs were not a supported surface: without the `message.mpim` subscription an agent never sees an un-mentioned follow-up in one, and without the mpim scopes the thread and conversation lookups it needs fail with `missing_scope`.

This subscribes `message.mpim` and gives a Slack multi-person DM its own conversation kind end to end — protocol `IntegrationChannel.kind`, the `ConversationKind` Postgres enum (additive migration), the REST DTO, and the console.

**Behaviour** (documented in `docs/product-conventions.md`): a group DM is a conversation between people that the agent happens to sit in, not a room addressed to it. So it follows a channel's rule, not a DM's — the agent answers when @-mentioned, thread follow-ups need no further mention, and "every message" stays an operator's opt-in. `isDm` therefore stays false for `mpim`; the new `isGroupDm` flag only classifies.

Slack never lists a group DM as bot membership, so it is surfaced the way a DM is: on observation, when an inbound message names the bot. Consequences carried through:

- a gated (restricted-agent) group DM is created **Off** and stays unroutable until a Console editor enables it, and an authoritative channel snapshot — which can never contain one — does not delete the row;
- an `app_mention` payload carries no `channel_type`, and Slack's `G…` ids are shared with legacy private channels, so a conversation that arrives only through a mention is classified from `conversations.info` rather than guessed from the id. The resolved kind is never downgraded back to `channel` by a later mention;
- that channel→mpim conversion **resets the trigger to Off** — the trigger the row carried was a channel's default, not an operator's choice for this conversation.

Non-gated agents need no configuration: their unscoped mention rule already covers a group DM once the events arrive.

**Console:** group DMs list beside DMs under "Direct messages" with their own glyph and label, but keep the channel's three-way trigger rather than a DM's binary on/off.

## What is deliberately not here

`im:write` has **no caller**. Nothing in the daemon or relay opens a DM today, and the natural way to use it — letting `sendMessage` target a human directly — is a new capability with its own abuse surface (an agent DMing arbitrary workspace members), not a Slack-ingress change. It is declared now only so enabling it later is a code change rather than a forced re-authorization across every installed workspace.

## Effect on existing installs

Existing managed apps pick the new scopes up through the additive manifest union on refresh (`mergeManagedSlackManifest`). Until such a bot is reinstalled, the refresh check reports `authorization: 'reinstall_required'` listing them as missing. That is accurate — the installed token does not hold them — but existing Slack bots will surface the "Reinstall it to grant the missing scopes" notice before group DMs work for them. Reinstall-on-your-own-schedule now, versus a forced re-authorization across every workspace later.

## Verification

- `pnpm -r test` — all suites green, including the CP integration project against real Postgres (which exercises the new migration): protocol 194, web 399, connection 27, mem0 13, CP unit 677 + CP integration 689, cli 109, relay 316, daemon 2265.
- New coverage: daemon + relay normalization (mpim classified, not a DM; unset when `channel_type` is absent), CP integration (group DM stored Off, channel→mpim conversion resets the trigger, authoritative snapshot preserves the row), console (ownership skips direct conversations).
- `pnpm build`, `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)