### PR TITLE
fix(daemon): deliver a finished background task back to its session

### DIFF
--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -51,8 +51,9 @@ through `tasks`/`sdkState`, or spend its wake budget.
   agentId,
   tasks: Map<taskId, { description?, isSubagent }>,
   sdkState: "idle" | "running",
-  bgWakes,    // wakes already spent on this session, see §5.1
-  armedWakes  // wakes armed but not yet admitted, see §5.1
+  bgWakes,         // wakes already spent on this session, see §5.1
+  armedWakes,      // wake timers armed or deferred, see §5.1
+  deliveringWakes  // wake dispatches in flight, see §5.1
 }
 ```
 
@@ -75,7 +76,7 @@ repairs missed completion edges for tasks already observed through
 A session is SDK-quiescent when:
 
 ```text
-tasks.size == 0 && armedWakes == 0 && sdkState == "idle"
+tasks.size == 0 && armedWakes == 0 && deliveringWakes == 0 && sdkState == "idle"
 ```
 
 No lease means quiescent. Host reclamation separately requires that the daemon
@@ -85,9 +86,9 @@ has no foreground prompt pending for the agent.
 `tasks` **before** its completion wake is armed (§5.1). Without it, a task that
 outlived the session's idle TTL would leave the session quiescent for the whole
 grace window, and a sweep landing there would close the session and drop the
-lease — losing exactly the completion the wake exists to deliver. The count is
-held past the injected dispatch as well, until the woken turn is itself visible to
-the sweep; §5.1 covers why.
+lease — losing exactly the completion the wake exists to deliver. `deliveringWakes`
+extends the same fence past the injected dispatch, until the woken turn is itself
+visible to the sweep; §5.1 covers why both counters exist separately.
 
 ### Logical waiting state
 
@@ -196,35 +197,53 @@ The daemon therefore delivers it, as a new turn into the same session:
 The wake is armed on a `BG_TASK_WAKE_GRACE_MS` (4s) delay and every precondition
 is re-checked when it fires, never captured when it is armed:
 
-| Condition at fire time       | Behavior                                                                                  |
-| ---------------------------- | ----------------------------------------------------------------------------------------- |
-| No lease                     | Host was reclaimed; the ACP session is gone. Skip.                                        |
-| Another wake armed/in-flight | Several tasks settled on one edge, or a wake turn is already running. Skip.               |
-| `sdkState == "running"`      | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
-| `tasks.size > 0`             | Another task is still live; its completion carries the session forward. Skip.             |
-| Session missing or not idle  | Closed, or a real turn is already running and will observe the task. Skip.                |
-| Budget exhausted             | Warn and skip (see below).                                                                |
+| Condition at fire time      | Behavior                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| No lease                    | Host was reclaimed; the ACP session is gone. Skip.                                        |
+| Another timer still armed   | Several tasks settled on one edge; the last one delivers for all. Skip.                   |
+| `sdkState == "running"`     | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
+| `tasks.size > 0`            | Another task is still live; its completion carries the session forward. Skip.             |
+| Budget exhausted            | Warn and skip (see below).                                                                |
+| A turn is in flight         | **Defer** — retry this attempt once the active dispatch settles.                          |
+| Session missing or not idle | Closed. Skip.                                                                             |
 
-Arming takes `armedWakes` and every outcome releases it exactly once, so the count
-stays balanced. The release point differs by outcome, and that difference is the
-whole fence:
+Coalescing and deferring are **not** the same case, and conflating them loses
+results:
 
-- **Delivered** — the count is handed to the dispatch promise and released when it
-  settles, i.e. at turn completion. Releasing at dispatch time is NOT enough:
-  `dispatch()` claims the serial gate synchronously, but `dispatchOne` then awaits
-  thread history, attachments, and managed-memory recall before `SessionManager`
-  writes `state = 'prompting'`. Through that window the row is still `idle` and has
-  no `Pending`, so an already-expired session would read quiescent and a sweep
-  landing there would TTL-close it and stop the host mid-initialization.
-- **Re-armed** — the next attempt takes its count first, so the total never dips.
-- **Skipped or given up** — released immediately.
+- **Another timer still armed** is safely coalescible because none of those wakes
+  has run yet — an empty `background_tasks_changed` snapshot settles every task on
+  one edge, arming a timer each, and all of them then see an empty `tasks`. One turn
+  covers them all.
+- **A turn is in flight** is not. `sdkState` is already `idle` by this point, so
+  `host.prompt()` has returned and the model cannot observe the task in-turn — yet
+  the dispatch stays pending through renderer/finalization. Folding the new
+  completion into that finishing delivery discards it permanently. So the wake
+  defers instead: it retries the same attempt once
+  `activeDispatchDoneByKey` for the session resolves, holding a fence slot across
+  the hand-off. Aggregate progress is bounded by the wake budget, which caps
+  deliveries.
+
+The fence is two counters, and every outcome releases exactly one slot:
+
+| Counter           | Taken                    | Released                          |
+| ----------------- | ------------------------ | --------------------------------- |
+| `armedWakes`      | arming a timer / a defer | that timer firing                 |
+| `deliveringWakes` | just before `dispatch()` | when the dispatch promise settles |
+
+The two are separate precisely so the coalescing decision above can tell "armed"
+from "delivering". Re-arm and defer take the replacement slot **before** releasing
+the current one, so the total never dips to zero while a completion is owed.
+
+Delivery releases at dispatch-promise settle — turn completion, not admission.
+Releasing at dispatch time is not enough: `dispatch()` claims the serial gate
+synchronously, but `dispatchOne` then awaits thread history, attachments, and
+managed-memory recall before `SessionManager` writes `state = 'prompting'`. Through
+that window the row is still `idle` and has no `Pending`, so an already-expired
+session would read quiescent and a sweep landing there would TTL-close it and stop
+the host mid-initialization.
 
 A wake turn that never settles keeps the fence indefinitely; the absolute
 `agentMaxLifetimeMs` ceiling (§4) remains the backstop, as it is for a hung task.
-
-Holding past dispatch is also why "another wake armed **or delivering**" covers
-both: a task settling while a wake turn is in flight is handed to the model by the
-runtime in-turn, exactly as the session-state guard assumes.
 
 The `running` case is a **wait, not a stand-down**. The self-drain cycle delivers
 nothing (see §5), so treating it as the delivery is what strands the session; the

--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -40,14 +40,19 @@ plane WebSocket.
 
 ## 3. Lease State
 
-The daemon stores one lease per ACP session:
+The daemon stores one lease per **(agent, ACP session)** — keyed by `sdkLeaseKey`,
+never by the session id alone. ACP session ids are runtime-local, so two agents
+can each expose an `acp-1`; a shared entry would let one agent's task overwrite
+the other's record under a colliding task id, suppress its completion wake
+through `tasks`/`sdkState`, or spend its wake budget.
 
 ```text
 {
   agentId,
   tasks: Map<taskId, { description?, isSubagent }>,
   sdkState: "idle" | "running",
-  bgWakes  // wakes already spent on this session, see §5.1
+  bgWakes,    // wakes already spent on this session, see §5.1
+  armedWakes  // wakes armed but not yet admitted, see §5.1
 }
 ```
 
@@ -70,11 +75,17 @@ repairs missed completion edges for tasks already observed through
 A session is SDK-quiescent when:
 
 ```text
-tasks.size == 0 && sdkState == "idle"
+tasks.size == 0 && armedWakes == 0 && sdkState == "idle"
 ```
 
 No lease means quiescent. Host reclamation separately requires that the daemon
 has no foreground prompt pending for the agent.
+
+`armedWakes` is part of the predicate because settling a task removes it from
+`tasks` **before** its completion wake is armed (§5.1). Without it, a task that
+outlived the session's idle TTL would leave the session quiescent for the whole
+grace window, and a sweep landing there would close the session and drop the
+lease — losing exactly the completion the wake exists to deliver.
 
 ### Logical waiting state
 
@@ -186,10 +197,16 @@ is re-checked when it fires, never captured when it is armed:
 | Condition at fire time      | Behavior                                                                                  |
 | --------------------------- | ----------------------------------------------------------------------------------------- |
 | No lease                    | Host was reclaimed; the ACP session is gone. Skip.                                        |
+| Another wake still armed    | Several tasks settled on one edge; let the LAST one deliver for all. Skip.                |
 | `sdkState == "running"`     | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
 | `tasks.size > 0`            | Another task is still live; its completion carries the session forward. Skip.             |
 | Session missing or not idle | Closed, or a real turn is already running and will observe the task. Skip.                |
 | Budget exhausted            | Warn and skip (see below).                                                                |
+
+Arming takes `armedWakes`; the fire path releases it before deciding anything, so
+every outcome — delivered, skipped, given up — leaves the count balanced, and the
+re-arm path takes it again. That is also what makes the "another wake still armed"
+row safe: the fence is held continuously across the hand-off.
 
 The `running` case is a **wait, not a stand-down**. The self-drain cycle delivers
 nothing (see §5), so treating it as the delivery is what strands the session; the

--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -85,7 +85,9 @@ has no foreground prompt pending for the agent.
 `tasks` **before** its completion wake is armed (§5.1). Without it, a task that
 outlived the session's idle TTL would leave the session quiescent for the whole
 grace window, and a sweep landing there would close the session and drop the
-lease — losing exactly the completion the wake exists to deliver.
+lease — losing exactly the completion the wake exists to deliver. The count is
+held past the injected dispatch as well, until the woken turn is itself visible to
+the sweep; §5.1 covers why.
 
 ### Logical waiting state
 
@@ -194,19 +196,35 @@ The daemon therefore delivers it, as a new turn into the same session:
 The wake is armed on a `BG_TASK_WAKE_GRACE_MS` (4s) delay and every precondition
 is re-checked when it fires, never captured when it is armed:
 
-| Condition at fire time      | Behavior                                                                                  |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| No lease                    | Host was reclaimed; the ACP session is gone. Skip.                                        |
-| Another wake still armed    | Several tasks settled on one edge; let the LAST one deliver for all. Skip.                |
-| `sdkState == "running"`     | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
-| `tasks.size > 0`            | Another task is still live; its completion carries the session forward. Skip.             |
-| Session missing or not idle | Closed, or a real turn is already running and will observe the task. Skip.                |
-| Budget exhausted            | Warn and skip (see below).                                                                |
+| Condition at fire time       | Behavior                                                                                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| No lease                     | Host was reclaimed; the ACP session is gone. Skip.                                        |
+| Another wake armed/in-flight | Several tasks settled on one edge, or a wake turn is already running. Skip.               |
+| `sdkState == "running"`      | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
+| `tasks.size > 0`             | Another task is still live; its completion carries the session forward. Skip.             |
+| Session missing or not idle  | Closed, or a real turn is already running and will observe the task. Skip.                |
+| Budget exhausted             | Warn and skip (see below).                                                                |
 
-Arming takes `armedWakes`; the fire path releases it before deciding anything, so
-every outcome — delivered, skipped, given up — leaves the count balanced, and the
-re-arm path takes it again. That is also what makes the "another wake still armed"
-row safe: the fence is held continuously across the hand-off.
+Arming takes `armedWakes` and every outcome releases it exactly once, so the count
+stays balanced. The release point differs by outcome, and that difference is the
+whole fence:
+
+- **Delivered** — the count is handed to the dispatch promise and released when it
+  settles, i.e. at turn completion. Releasing at dispatch time is NOT enough:
+  `dispatch()` claims the serial gate synchronously, but `dispatchOne` then awaits
+  thread history, attachments, and managed-memory recall before `SessionManager`
+  writes `state = 'prompting'`. Through that window the row is still `idle` and has
+  no `Pending`, so an already-expired session would read quiescent and a sweep
+  landing there would TTL-close it and stop the host mid-initialization.
+- **Re-armed** — the next attempt takes its count first, so the total never dips.
+- **Skipped or given up** — released immediately.
+
+A wake turn that never settles keeps the fence indefinitely; the absolute
+`agentMaxLifetimeMs` ceiling (§4) remains the backstop, as it is for a hung task.
+
+Holding past dispatch is also why "another wake armed **or delivering**" covers
+both: a task settling while a wake turn is in flight is handed to the model by the
+runtime in-turn, exactly as the session-state guard assumes.
 
 The `running` case is a **wait, not a stand-down**. The self-drain cycle delivers
 nothing (see §5), so treating it as the delivery is what strands the session; the

--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -46,7 +46,8 @@ The daemon stores one lease per ACP session:
 {
   agentId,
   tasks: Map<taskId, { description?, isSubagent }>,
-  sdkState: "idle" | "running"
+  sdkState: "idle" | "running",
+  bgWakes  // wakes already spent on this session, see §5.1
 }
 ```
 
@@ -140,8 +141,85 @@ Delivery follows these rules:
   status uses the description alone.
 
 The message is daemon-authored system output, not an agent reply, so it has no
-agent-attribution footer. The runtime's own unsolicited follow-up narration is
-not routed as a reply when no foreground turn is pending.
+agent-attribution footer.
+
+The runtime's own unsolicited follow-up narration is not routed when no
+foreground turn is pending. This is not a stylistic choice — `onAcpUpdate`
+returns early on `!pending`, so **every** content-bearing update from such a
+cycle (message chunks, tool renders, transcript rows, the webchat sink) is
+discarded. Its MCP tool calls are unaffected: that socket is not `Pending`-gated,
+so side effects a self-drain performs — including a `sendMessage` report — do
+land. §5.1 depends on both halves of this.
+
+### 5.1 Waking the session
+
+The notification above tells the human. The model needs the completion too.
+
+`run_in_background` promises the model that it "will be notified when the task
+completes" — a **harness** guarantee, not an SDK one. Interactive Claude Code
+re-invokes the model when the task exits. Under ACP the foreground turn has
+already returned `end_turn` by then, so nothing delivers the result: the model
+reasonably ends its turn expecting a notification, and any obligation riding on
+that task (a `needsParentReply` report to a parent session, a deferred answer to
+the human) is silently dropped.
+
+The daemon therefore delivers it, as a new turn into the same session:
+
+- The turn is `source: "agent"` with sender `background-task:<task_id>`. Its text
+  states plainly that it is a daemon notification rather than a message from
+  anyone, names the task id to read output from, says that THIS turn is the one
+  actually delivered, tells the model not to repeat a report it already sent after
+  the task finished, and permits silence when the result needs no action.
+- It carries **no** `CallMeta`. It is not an agent call and must not look like
+  one. A child woken this way still reaches its parent, because
+  `replyToSession` authorizes against the origin persisted on the session
+  (session-concept §5.3) and `needsParentReply` is sticky.
+- `msgId` is `bgtask:<channel>:<task_id>` — stable in the task id, so a
+  duplicated settle edge cannot dispatch the wake twice. `transcriptTs` is a
+  monotonic "now" so the wake orders as new content.
+- The reply transport is resolved from the **session's** transport scope, not the
+  agent's default integration.
+
+The wake is armed on a `BG_TASK_WAKE_GRACE_MS` (4s) delay and every precondition
+is re-checked when it fires, never captured when it is armed:
+
+| Condition at fire time      | Behavior                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| No lease                    | Host was reclaimed; the ACP session is gone. Skip.                                        |
+| `sdkState == "running"`     | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
+| `tasks.size > 0`            | Another task is still live; its completion carries the session forward. Skip.             |
+| Session missing or not idle | Closed, or a real turn is already running and will observe the task. Skip.                |
+| Budget exhausted            | Warn and skip (see below).                                                                |
+
+The `running` case is a **wait, not a stand-down**. The self-drain cycle delivers
+nothing (see §5), so treating it as the delivery is what strands the session; the
+wake only defers to it so an injected turn does not race the runtime's own work,
+then delivers regardless. `MAX_BG_TASK_WAKE_REARMS` (15, ≈1 minute) bounds that
+wait so a cycle that never returns to `idle` is not polled forever.
+
+Observed sequence for a `sleep 30` in `run_in_background` (Claude
+claude-agent-acp 0.63.0), which is what this design is calibrated against:
+
+```text
+task_started {t}
+session_state_changed {idle}        # turn returned end_turn, task still live
+background_tasks_changed {live: 0}  # settles the task (arrives first)
+task_updated {completed}            # already settled — deduped
+task_notification                   # already settled — deduped
+session_state_changed {running}     # runtime's self-drain cycle
+session_state_changed {idle}        # ...which produced nothing observable
+```
+
+Internal subagent tasks never wake a session — the SDK joins them itself.
+
+Unlike an agent call, a wake carries no `hopCount` to bound, and a woken turn may
+start further background tasks. `MAX_BG_TASK_WAKES_PER_SESSION` (20, counted over
+the lease's life) is therefore the only backstop against a self-feeding loop;
+exhausting it logs a warning and leaves the completion undelivered.
+
+A wake is **not** gated on output mode. The channel notification in §5 is for the
+human and stays gated at `medium`; the wake is for the model and must happen at
+every output mode, including `low` and `none`.
 
 ## 6. Fallback and Runtime Limits
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1248,11 +1248,19 @@ export class Daemon {
       /** Background-task wakes already spent on this session — see
        *  {@link MAX_BG_TASK_WAKES_PER_SESSION}. */
       bgWakes: number
-      /** Wakes armed but not yet admitted. `settle()` removes the task BEFORE arming the
-       *  timer, so without counting these the session would read as quiescent during the
-       *  grace/re-arm window and an idle sweep could close it (and drop the lease) out from
-       *  under a completion that is about to be delivered. */
+      /** Wake timers armed (or deferred) but not yet fired. `settle()` removes the task
+       *  BEFORE arming the timer, so without counting these the session would read as
+       *  quiescent during the grace/re-arm window and an idle sweep could close it (and drop
+       *  the lease) out from under a completion that is about to be delivered. Deliberately
+       *  SEPARATE from {@link deliveringWakes}: several armed timers coalesce (none has run),
+       *  whereas a delivery in flight must never absorb a newly settled task. */
       armedWakes: number
+      /** Wake dispatches in flight — taken before `dispatch()` and released when its promise
+       *  settles, so the fence spans async turn initialization. Counted apart from
+       *  `armedWakes` because a delivery is past the point where it could carry another
+       *  task's completion: once `host.prompt()` has returned the model is no longer running,
+       *  yet the dispatch stays pending through renderer/finalization. */
+      deliveringWakes: number
     }
   >()
   /** Armed background-task wake checks (one per settled non-subagent task), tracked so
@@ -12045,7 +12053,8 @@ export class Daemon {
       tasks: new Map<string, { description?: string; isSubagent: boolean }>(),
       sdkState: 'idle' as const,
       bgWakes: 0,
-      armedWakes: 0
+      armedWakes: 0,
+      deliveringWakes: 0
     }
     // Release a task from the lease and, if it's a real background task (not an
     // internal subagent), announce its completion when the agent is verbose enough
@@ -12200,14 +12209,9 @@ export class Daemon {
       this.log.debug(`bg-task wake skipped (host reclaimed): "${what}" on ${acpSessionId}`)
       return
     }
-    // Release this attempt's fence — but NOT before the dispatch below is reclaim-visible.
-    // `dispatch()` only claims the serial gate synchronously; `dispatchOne` then awaits thread
-    // history, attachments, and managed-memory recall before SessionManager writes
-    // `state = 'prompting'`. Releasing here would reopen the very window this fence closes: an
-    // already-expired session would read quiescent AND idle, and a sweep landing there would
-    // TTL-close it and stop the host mid-initialization. So on the delivery path the fence is
-    // handed to the dispatch promise (which settles at turn completion) and released there;
-    // every other path releases immediately.
+    // This attempt's timer has fired, so release its slot of the fence — but the fence as a
+    // whole must not drop to zero while a delivery is still owed. Every branch below either
+    // takes a replacement slot first (re-arm, defer) or hands one to `deliveringWakes`.
     let released = false
     const release = (): void => {
       if (released) return
@@ -12218,15 +12222,12 @@ export class Daemon {
       release()
       this.log.debug(`bg-task wake skipped (${why}): "${what}" on ${acpSessionId}`)
     }
-    // A count above this attempt means another wake is either armed or still delivering:
-    //  • armed — several tasks settled on the SAME edge (an empty `background_tasks_changed`
-    //    snapshot settles all of them), arming a timer each. The `tasks.size` guard below
-    //    cannot catch that, since they are all already out of `tasks`. Let the LAST one
-    //    deliver for all of them rather than running one turn per task.
-    //  • delivering — a wake turn is in flight, and a task settling during a turn is handed to
-    //    the model by the runtime in-turn anyway (the same reasoning as the `state` guard).
-    // Either way the fence stays held by the other wake, so skipping here is safe.
-    if (lease.armedWakes > 1) return skip('another wake for this session is armed or delivering')
+    // Another timer still armed ⇒ several tasks settled on the SAME edge (an empty
+    // `background_tasks_changed` snapshot settles all of them), arming a timer each. The
+    // `tasks.size` guard below cannot catch that, since they are all already out of `tasks`.
+    // Coalescing is safe here precisely because NONE of them has run: the last one delivers
+    // for all, and it holds the fence meanwhile.
+    if (lease.armedWakes > 1) return skip('another wake for this session is still armed')
     if (lease.sdkState === 'running') {
       if (attempt >= MAX_BG_TASK_WAKE_REARMS) {
         release()
@@ -12251,6 +12252,22 @@ export class Daemon {
     }
     const rec = this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
     if (!rec) return skip('no session row')
+    // A turn is in flight for this session. It must NOT absorb this completion: `sdkState` is
+    // already idle above, so `host.prompt()` has returned and the model cannot observe the task
+    // in-turn, yet the dispatch stays pending through renderer/finalization. Dropping here is
+    // how a task started by a wake turn and settling in that cleanup window got lost. Defer
+    // instead — retry the same attempt once the active dispatch settles, holding a fence slot
+    // across the hand-off. Bounded in aggregate by the wake budget, which caps deliveries.
+    const active = this.activeDispatchDoneByKey.get(rec.key)
+    if (active) {
+      lease.armedWakes += 1 // the deferred retry's slot, taken before this one is released
+      const resume = (): void => {
+        lease.armedWakes = Math.max(0, lease.armedWakes - 1)
+        this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, description, status, attempt)
+      }
+      void active.then(resume, resume)
+      return skip('a turn is in flight — deferred until it settles')
+    }
     if (rec.state !== 'idle') return skip(`session is ${rec.state}`)
 
     const platform = this.narrowPlatform(rec.platform)
@@ -12289,13 +12306,19 @@ export class Daemon {
     }
     lease.bgWakes += 1
     this.log.info(`bg-task wake: "${what}" → agent "${agentId}" session ${acpSessionId} (${rec.key})`)
-    // The fence stays taken until this settles (which is turn completion, not admission), so
-    // initialization is never exposed to the idle sweep. `finally` covers rejection too — a
-    // failed wake must not pin the host. A turn that never settles at all is still bounded by
-    // the absolute `agentMaxLifetimeMs` ceiling (§4).
+    // Hand this attempt's fence slot over to `deliveringWakes` before releasing it, so the
+    // fence spans async turn initialization: `dispatch()` claims the serial gate synchronously,
+    // but `dispatchOne` then awaits thread history, attachments, and managed-memory recall
+    // before SessionManager writes `state = 'prompting'`. Released when the promise settles —
+    // turn completion, not admission. `finally` covers rejection too, so a failed wake cannot
+    // pin the host; a turn that never settles is still bounded by `agentMaxLifetimeMs` (§4).
+    lease.deliveringWakes += 1
+    release()
     void this.dispatch(agentId, msg, integrationId)
       .catch((err) => this.log.error(`bg-task wake dispatch failed for "${agentId}": ${formatErr(err)}`))
-      .finally(release)
+      .finally(() => {
+        lease.deliveringWakes = Math.max(0, lease.deliveringWakes - 1)
+      })
   }
 
   /** A session is SDK-quiescent when it has no live background tasks, no armed completion
@@ -12306,15 +12329,20 @@ export class Daemon {
   private sessionSdkQuiescent(agentId: string, acpSessionId: string | null | undefined): boolean {
     if (!acpSessionId) return true
     const l = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
-    return !l || (l.tasks.size === 0 && l.armedWakes === 0 && l.sdkState === 'idle')
+    return !l || (l.tasks.size === 0 && l.armedWakes === 0 && l.deliveringWakes === 0 && l.sdkState === 'idle')
   }
 
-  /** Whether any of an agent's sessions has in-flight background work — a live
-   *  background task, an armed completion wake, or a running SDK cycle (a self-initiated
-   *  followup turn that carries no `this.pending` entry). Gates idle host reclaim. */
+  /** Whether any of an agent's sessions has in-flight background work — a live background
+   *  task, a completion wake that is armed or delivering, or a running SDK cycle (a
+   *  self-initiated followup turn that carries no `this.pending` entry). Gates idle host
+   *  reclaim. */
   private agentHasLiveSdkWork(agentId: string): boolean {
     for (const l of this.sdkLease.values())
-      if (l.agentId === agentId && (l.tasks.size > 0 || l.armedWakes > 0 || l.sdkState === 'running')) return true
+      if (
+        l.agentId === agentId &&
+        (l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running')
+      )
+        return true
     return false
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -547,6 +547,13 @@ function pendingTurnKey(agentId: string, acpSessionId: string): string {
   return JSON.stringify([agentId, acpSessionId])
 }
 
+/** Background-task leases are per (agent, ACP session) for the same reason turns are: two
+ *  agents can each expose an `acp-1`. Sharing one entry would let one agent's live task
+ *  suppress the other's completion wake, or overwrite its task record under a colliding id. */
+function sdkLeaseKey(agentId: string, acpSessionId: string): string {
+  return pendingTurnKey(agentId, acpSessionId)
+}
+
 /** Cap on agent→agent hop depth (design §2.4/§4.5) — reject a `messageAgent` that
  *  would push the outgoing hopCount past this, so an A↔B wake loop can't run away. */
 const MAX_AGENT_CALL_HOPS = 8
@@ -1231,6 +1238,7 @@ export class Daemon {
   // AcpHost.prompt() is NOT the end of work. Absent (non-Claude runtime, or an
   // adapter that doesn't forward the feed) ⇒ treated as quiescent ⇒ plain-TTL behavior.
   // See docs/designs/background-task-aware-reclaim.md.
+  // Keyed by {@link sdkLeaseKey} — NOT by bare acpSessionId, which is runtime-local.
   private sdkLease = new Map<
     string,
     {
@@ -1240,6 +1248,11 @@ export class Daemon {
       /** Background-task wakes already spent on this session — see
        *  {@link MAX_BG_TASK_WAKES_PER_SESSION}. */
       bgWakes: number
+      /** Wakes armed but not yet admitted. `settle()` removes the task BEFORE arming the
+       *  timer, so without counting these the session would read as quiescent during the
+       *  grace/re-arm window and an idle sweep could close it (and drop the lease) out from
+       *  under a completion that is about to be delivered. */
+      armedWakes: number
     }
   >()
   /** Armed background-task wake checks (one per settled non-subagent task), tracked so
@@ -12026,11 +12039,13 @@ export class Daemon {
         live: Array.isArray(m.tasks) ? m.tasks.length : undefined
       })} on ${acpSessionId}`
     )
-    const lease = this.sdkLease.get(acpSessionId) ?? {
+    const leaseKey = sdkLeaseKey(agentId, acpSessionId)
+    const lease = this.sdkLease.get(leaseKey) ?? {
       agentId,
       tasks: new Map<string, { description?: string; isSubagent: boolean }>(),
       sdkState: 'idle' as const,
-      bgWakes: 0
+      bgWakes: 0,
+      armedWakes: 0
     }
     // Release a task from the lease and, if it's a real background task (not an
     // internal subagent), announce its completion when the agent is verbose enough
@@ -12085,7 +12100,7 @@ export class Daemon {
         return
     }
     lease.agentId = agentId
-    this.sdkLease.set(acpSessionId, lease)
+    this.sdkLease.set(leaseKey, lease)
   }
 
   /** Proactively announce a completed background task to its session's channel/thread
@@ -12115,7 +12130,12 @@ export class Daemon {
   /** Arm the deferred wake for a settled background task. Deliberately NOT immediate: the
    *  runtime re-enters a `running` cycle of its own to drain the completion, and a turn
    *  injected into that window would race it. `attempt` counts the re-arms spent waiting
-   *  for that cycle to end (see {@link MAX_BG_TASK_WAKE_REARMS}). */
+   *  for that cycle to end (see {@link MAX_BG_TASK_WAKE_REARMS}).
+   *
+   *  Arming bumps `armedWakes`, which keeps the session out of quiescence for the whole
+   *  wait — the task is already gone from `tasks`, so otherwise an idle sweep could close
+   *  the session and drop the lease before the timer fires. {@link wakeOnBackgroundTaskDone}
+   *  releases the count on every exit path. */
   private scheduleBackgroundTaskWake(
     agentId: string,
     acpSessionId: string,
@@ -12125,6 +12145,8 @@ export class Daemon {
     attempt = 0
   ): void {
     if (this.draining) return
+    const armed = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    if (armed) armed.armedWakes += 1
     const handle = this.clock.setTimeout(() => {
       this.bgWakeTimers.delete(handle)
       try {
@@ -12172,10 +12194,18 @@ export class Daemon {
     attempt = 0
   ): void {
     if (this.draining) return
-    const lease = this.sdkLease.get(acpSessionId)
+    const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
     const what = description?.trim() || 'background task'
     const skip = (why: string): void => this.log.debug(`bg-task wake skipped (${why}): "${what}" on ${acpSessionId}`)
     if (!lease) return skip('host reclaimed')
+    // This attempt is no longer armed. Release the fence FIRST so every exit below — deliver,
+    // skip, give up — leaves it balanced; the re-arm path re-takes it via schedule().
+    lease.armedWakes = Math.max(0, lease.armedWakes - 1)
+    // Several tasks can settle on the SAME edge (an empty `background_tasks_changed` snapshot
+    // settles all of them), arming a timer each. The `tasks.size` guard below does not catch
+    // that — they are all already out of `tasks` — so let the LAST armed wake deliver and drop
+    // the rest: one turn covers every completion, and the fence stays held meanwhile.
+    if (lease.armedWakes > 0) return skip('a later wake for this session is already armed')
     if (lease.sdkState === 'running') {
       if (attempt >= MAX_BG_TASK_WAKE_REARMS) {
         this.log.warn(
@@ -12240,20 +12270,23 @@ export class Daemon {
     )
   }
 
-  /** A session is SDK-quiescent when it has no live background tasks and the SDK's
-   *  top-level cycle is idle. Absent lease ⇒ quiescent (plain-TTL behavior). */
-  private sessionSdkQuiescent(acpSessionId: string | null | undefined): boolean {
+  /** A session is SDK-quiescent when it has no live background tasks, no armed completion
+   *  wake, and the SDK's top-level cycle is idle. Absent lease ⇒ quiescent (plain-TTL
+   *  behavior). An armed wake counts: the task it will deliver is already out of `tasks`,
+   *  so without it a long-running task's session could be TTL-closed inside the grace
+   *  window and the completion lost — the very thing §5.1 exists to prevent. */
+  private sessionSdkQuiescent(agentId: string, acpSessionId: string | null | undefined): boolean {
     if (!acpSessionId) return true
-    const l = this.sdkLease.get(acpSessionId)
-    return !l || (l.tasks.size === 0 && l.sdkState === 'idle')
+    const l = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    return !l || (l.tasks.size === 0 && l.armedWakes === 0 && l.sdkState === 'idle')
   }
 
   /** Whether any of an agent's sessions has in-flight background work — a live
-   *  background task, or a running SDK cycle (a self-initiated followup turn that
-   *  carries no `this.pending` entry). Gates idle host reclaim. */
+   *  background task, an armed completion wake, or a running SDK cycle (a self-initiated
+   *  followup turn that carries no `this.pending` entry). Gates idle host reclaim. */
   private agentHasLiveSdkWork(agentId: string): boolean {
     for (const l of this.sdkLease.values())
-      if (l.agentId === agentId && (l.tasks.size > 0 || l.sdkState === 'running')) return true
+      if (l.agentId === agentId && (l.tasks.size > 0 || l.armedWakes > 0 || l.sdkState === 'running')) return true
     return false
   }
 
@@ -12281,11 +12314,15 @@ export class Daemon {
     const maxLifetime = this.cfg.limits.agentMaxLifetimeMs
     // §7.3 idle→closed: a thread untouched past the TTL stops catching up — UNLESS it
     // still has in-flight background work (the SDK lease), which keeps it open.
-    const closed = this.store.closeIdleSessions(now, ttl, (acpSessionId) => !this.sessionSdkQuiescent(acpSessionId))
+    const closed = this.store.closeIdleSessions(
+      now,
+      ttl,
+      (agentId, acpSessionId) => !this.sessionSdkQuiescent(agentId, acpSessionId)
+    )
     if (closed.length) this.log.info(`idle: TTL-closed ${closed.length} session(s) (>${Math.round(ttl / 1000)}s)`)
     for (const row of closed) {
       if (!row.acpSessionId) continue
-      this.sdkLease.delete(row.acpSessionId) // the session is gone — drop its lease
+      this.sdkLease.delete(sdkLeaseKey(row.agentId, row.acpSessionId)) // the session is gone — drop its lease
       this.emitSessionMetadataSnapshot({
         sessionId: row.acpSessionId,
         agentId: row.agentId,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12196,29 +12196,53 @@ export class Daemon {
     if (this.draining) return
     const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
     const what = description?.trim() || 'background task'
-    const skip = (why: string): void => this.log.debug(`bg-task wake skipped (${why}): "${what}" on ${acpSessionId}`)
-    if (!lease) return skip('host reclaimed')
-    // This attempt is no longer armed. Release the fence FIRST so every exit below — deliver,
-    // skip, give up — leaves it balanced; the re-arm path re-takes it via schedule().
-    lease.armedWakes = Math.max(0, lease.armedWakes - 1)
-    // Several tasks can settle on the SAME edge (an empty `background_tasks_changed` snapshot
-    // settles all of them), arming a timer each. The `tasks.size` guard below does not catch
-    // that — they are all already out of `tasks` — so let the LAST armed wake deliver and drop
-    // the rest: one turn covers every completion, and the fence stays held meanwhile.
-    if (lease.armedWakes > 0) return skip('a later wake for this session is already armed')
+    if (!lease) {
+      this.log.debug(`bg-task wake skipped (host reclaimed): "${what}" on ${acpSessionId}`)
+      return
+    }
+    // Release this attempt's fence — but NOT before the dispatch below is reclaim-visible.
+    // `dispatch()` only claims the serial gate synchronously; `dispatchOne` then awaits thread
+    // history, attachments, and managed-memory recall before SessionManager writes
+    // `state = 'prompting'`. Releasing here would reopen the very window this fence closes: an
+    // already-expired session would read quiescent AND idle, and a sweep landing there would
+    // TTL-close it and stop the host mid-initialization. So on the delivery path the fence is
+    // handed to the dispatch promise (which settles at turn completion) and released there;
+    // every other path releases immediately.
+    let released = false
+    const release = (): void => {
+      if (released) return
+      released = true
+      lease.armedWakes = Math.max(0, lease.armedWakes - 1)
+    }
+    const skip = (why: string): void => {
+      release()
+      this.log.debug(`bg-task wake skipped (${why}): "${what}" on ${acpSessionId}`)
+    }
+    // A count above this attempt means another wake is either armed or still delivering:
+    //  • armed — several tasks settled on the SAME edge (an empty `background_tasks_changed`
+    //    snapshot settles all of them), arming a timer each. The `tasks.size` guard below
+    //    cannot catch that, since they are all already out of `tasks`. Let the LAST one
+    //    deliver for all of them rather than running one turn per task.
+    //  • delivering — a wake turn is in flight, and a task settling during a turn is handed to
+    //    the model by the runtime in-turn anyway (the same reasoning as the `state` guard).
+    // Either way the fence stays held by the other wake, so skipping here is safe.
+    if (lease.armedWakes > 1) return skip('another wake for this session is armed or delivering')
     if (lease.sdkState === 'running') {
       if (attempt >= MAX_BG_TASK_WAKE_REARMS) {
+        release()
         this.log.warn(
           `bg-task wake gave up after ${MAX_BG_TASK_WAKE_REARMS} re-arms — runtime cycle on ` +
             `${acpSessionId} never returned to idle ("${what}")`
         )
         return
       }
+      // Take the next attempt's fence BEFORE releasing this one so the count never dips to 0.
       this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, description, status, attempt + 1)
       return skip(`runtime cycle still running, re-armed ${attempt + 1}/${MAX_BG_TASK_WAKE_REARMS}`)
     }
     if (lease.tasks.size > 0) return skip('other background tasks still live')
     if (lease.bgWakes >= MAX_BG_TASK_WAKES_PER_SESSION) {
+      release()
       this.log.warn(
         `bg-task wake budget exhausted (${MAX_BG_TASK_WAKES_PER_SESSION}) on ${acpSessionId} — ` +
           `not waking for "${what}"`
@@ -12265,9 +12289,13 @@ export class Daemon {
     }
     lease.bgWakes += 1
     this.log.info(`bg-task wake: "${what}" → agent "${agentId}" session ${acpSessionId} (${rec.key})`)
-    void this.dispatch(agentId, msg, integrationId).catch((err) =>
-      this.log.error(`bg-task wake dispatch failed for "${agentId}": ${formatErr(err)}`)
-    )
+    // The fence stays taken until this settles (which is turn completion, not admission), so
+    // initialization is never exposed to the idle sweep. `finally` covers rejection too — a
+    // failed wake must not pin the host. A turn that never settles at all is still bounded by
+    // the absolute `agentMaxLifetimeMs` ceiling (§4).
+    void this.dispatch(agentId, msg, integrationId)
+      .catch((err) => this.log.error(`bg-task wake dispatch failed for "${agentId}": ${formatErr(err)}`))
+      .finally(release)
   }
 
   /** A session is SDK-quiescent when it has no live background tasks, no armed completion

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -551,6 +551,25 @@ function pendingTurnKey(agentId: string, acpSessionId: string): string {
  *  would push the outgoing hopCount past this, so an A↔B wake loop can't run away. */
 const MAX_AGENT_CALL_HOPS = 8
 
+/** Poll interval for the deferred background-task wake (background-task-aware-reclaim.md
+ *  §5.1). Claude re-enters a `running` cycle of its own to drain a settled task; the wake
+ *  waits that cycle out rather than firing into it, because a turn injected mid-cycle would
+ *  race the runtime's own work. It does NOT stand down for it — that cycle carries no
+ *  `Pending`, so everything it emits is dropped at `onAcpUpdate` and the user sees nothing. */
+const BG_TASK_WAKE_GRACE_MS = 4_000
+
+/** How many times the wake may re-arm while the runtime's self-drain cycle is still
+ *  `running` (≈1 minute at {@link BG_TASK_WAKE_GRACE_MS}). A cycle that never returns to
+ *  `idle` is either a genuinely long piece of work — which will produce its own turn-end —
+ *  or a wedged runtime; either way, stop re-arming instead of polling forever. */
+const MAX_BG_TASK_WAKE_REARMS = 15
+
+/** Per-session budget for background-task wakes. Unlike an agent call these carry no
+ *  hopCount to bound, and a woken turn may spawn further background tasks, so the
+ *  budget is the only backstop against a self-feeding wake loop. Counted over the
+ *  lease's life (i.e. until the host is reclaimed), not per turn. */
+const MAX_BG_TASK_WAKES_PER_SESSION = 20
+
 /**
  * DAEMON-PRIVATE trusted metadata for an agent→agent (`messageAgent`) turn. Authoritative
  * (never derived from model output or platform text): the caller identity the target can
@@ -1214,8 +1233,19 @@ export class Daemon {
   // See docs/designs/background-task-aware-reclaim.md.
   private sdkLease = new Map<
     string,
-    { agentId: string; tasks: Map<string, { description?: string; isSubagent: boolean }>; sdkState: 'idle' | 'running' }
+    {
+      agentId: string
+      tasks: Map<string, { description?: string; isSubagent: boolean }>
+      sdkState: 'idle' | 'running'
+      /** Background-task wakes already spent on this session — see
+       *  {@link MAX_BG_TASK_WAKES_PER_SESSION}. */
+      bgWakes: number
+    }
   >()
+  /** Armed background-task wake checks (one per settled non-subagent task), tracked so
+   *  daemon drain cannot leave a timer behind. The callback re-validates everything it
+   *  needs, so a lease dropped by stopHost simply makes the wake a no-op. */
+  private bgWakeTimers = new Set<TimerHandle>()
   private connections: SlackConnection[] = []
   // Telegram long-poll connections (one per bot token). Kept parallel to `connections`
   // (Slack) — the Slack socket layer (appToken keying, retry, refreshChannels) is
@@ -11985,18 +12015,33 @@ export class Daemon {
       tasks?: unknown
     } | null
     if (!m || m.type !== 'system' || typeof m.subtype !== 'string') return
+    // The lease's decisions (reclaim deferral, §5.1 wake) are only as good as this feed, and
+    // the feed is the one thing we cannot reproduce offline — log the accepted edges so a
+    // stranded session can be diagnosed from the daemon log alone.
+    this.log.debug(
+      `bg-task lifecycle: ${m.subtype} ${JSON.stringify({
+        task: m.task_id,
+        state: m.state,
+        status: m.patch?.status,
+        live: Array.isArray(m.tasks) ? m.tasks.length : undefined
+      })} on ${acpSessionId}`
+    )
     const lease = this.sdkLease.get(acpSessionId) ?? {
       agentId,
       tasks: new Map<string, { description?: string; isSubagent: boolean }>(),
-      sdkState: 'idle' as const
+      sdkState: 'idle' as const,
+      bgWakes: 0
     }
     // Release a task from the lease and, if it's a real background task (not an
-    // internal subagent), announce its completion when the agent is verbose enough.
+    // internal subagent), announce its completion when the agent is verbose enough
+    // and hand the completion back to the model so the work is not stranded.
     const settle = (taskId: string, status?: string) => {
       const rec = lease.tasks.get(taskId)
       if (!rec) return // already settled — dedup the near-simultaneous edges
       lease.tasks.delete(taskId)
-      if (!rec.isSubagent) this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
+      if (rec.isSubagent) return
+      this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
+      this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
     }
     switch (m.subtype) {
       case 'session_state_changed':
@@ -12064,6 +12109,134 @@ export class Daemon {
     const text = `🔔 Background task finished: ${what}${status ? ` (${status})` : ''}`
     void Promise.resolve(conn.postMessage(rec.channel, text, rec.thread || undefined)).catch((err) =>
       this.log.warn(`bg-task announce failed for "${agentId}": ${(err as Error).message}`)
+    )
+  }
+
+  /** Arm the deferred wake for a settled background task. Deliberately NOT immediate: the
+   *  runtime re-enters a `running` cycle of its own to drain the completion, and a turn
+   *  injected into that window would race it. `attempt` counts the re-arms spent waiting
+   *  for that cycle to end (see {@link MAX_BG_TASK_WAKE_REARMS}). */
+  private scheduleBackgroundTaskWake(
+    agentId: string,
+    acpSessionId: string,
+    taskId: string,
+    description?: string,
+    status?: string,
+    attempt = 0
+  ): void {
+    if (this.draining) return
+    const handle = this.clock.setTimeout(() => {
+      this.bgWakeTimers.delete(handle)
+      try {
+        this.wakeOnBackgroundTaskDone(agentId, acpSessionId, taskId, description, status, attempt)
+      } catch (err) {
+        this.log.error(`bg-task wake failed for "${agentId}": ${formatErr(err)}`)
+      }
+    }, BG_TASK_WAKE_GRACE_MS)
+    this.bgWakeTimers.add(handle)
+  }
+
+  /**
+   * Hand a completed background task back to the model as a fresh turn.
+   *
+   * The `run_in_background` contract the runtime shows its model ("you will be notified when
+   * it completes") is a HARNESS promise, not an SDK one: interactive Claude Code re-invokes
+   * the model when the task exits. Under ACP the foreground turn has already returned
+   * `end_turn` by then, so without this the completion is stranded — the model reasonably
+   * ends its turn expecting a notification that never arrives, and anything it owed (a
+   * `needsParentReply` report, a deferred answer) is silently dropped.
+   *
+   * The runtime's OWN self-drain cycle is not a substitute and must not be waited out
+   * indefinitely: it carries no `Pending`, so `onAcpUpdate` drops every chunk, tool render,
+   * and transcript row it produces (verified end-to-end — the model answered, the user got
+   * nothing). The wake therefore defers to it only for as long as it runs, then delivers
+   * anyway. Its MCP tool calls DO land (that socket is not Pending-gated), so the wake text
+   * tells the model not to repeat a report it already sent.
+   *
+   * Everything is re-validated here rather than captured at schedule time, so a session that
+   * moved on during the grace window is simply left alone:
+   *  - no lease ⇒ the host was reclaimed (leases are dropped in `stopHost`); the ACP session
+   *    is gone with it and there is nothing to wake.
+   *  - `sdkState === 'running'` ⇒ re-arm and let that cycle finish first (bounded).
+   *  - a live task in the lease ⇒ a later completion will carry the session forward; wake on
+   *    the last one instead of once per task.
+   *  - session missing / not `idle` ⇒ closed, or a real turn is already running (which will
+   *    observe the task itself).
+   */
+  private wakeOnBackgroundTaskDone(
+    agentId: string,
+    acpSessionId: string,
+    taskId: string,
+    description?: string,
+    status?: string,
+    attempt = 0
+  ): void {
+    if (this.draining) return
+    const lease = this.sdkLease.get(acpSessionId)
+    const what = description?.trim() || 'background task'
+    const skip = (why: string): void => this.log.debug(`bg-task wake skipped (${why}): "${what}" on ${acpSessionId}`)
+    if (!lease) return skip('host reclaimed')
+    if (lease.sdkState === 'running') {
+      if (attempt >= MAX_BG_TASK_WAKE_REARMS) {
+        this.log.warn(
+          `bg-task wake gave up after ${MAX_BG_TASK_WAKE_REARMS} re-arms — runtime cycle on ` +
+            `${acpSessionId} never returned to idle ("${what}")`
+        )
+        return
+      }
+      this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, description, status, attempt + 1)
+      return skip(`runtime cycle still running, re-armed ${attempt + 1}/${MAX_BG_TASK_WAKE_REARMS}`)
+    }
+    if (lease.tasks.size > 0) return skip('other background tasks still live')
+    if (lease.bgWakes >= MAX_BG_TASK_WAKES_PER_SESSION) {
+      this.log.warn(
+        `bg-task wake budget exhausted (${MAX_BG_TASK_WAKES_PER_SESSION}) on ${acpSessionId} — ` +
+          `not waking for "${what}"`
+      )
+      return
+    }
+    const rec = this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    if (!rec) return skip('no session row')
+    if (rec.state !== 'idle') return skip(`session is ${rec.state}`)
+
+    const platform = this.narrowPlatform(rec.platform)
+    // Reply transport resolved from the SESSION's scope, not the agent's default integration —
+    // a multi-platform agent would otherwise answer through integrations[0]'s client (mirrors
+    // replyToSession). A scoped session whose integration is gone has nowhere to answer.
+    const integrationId = this.integrationIdForTransportScope(agentId, platform, rec.transportScope)
+    if (rec.transportScope && !integrationId) return skip('integration for the session scope is gone')
+
+    // No CallMeta: this is not an agent call, it carries no hop chain, and it must not look
+    // like one. A child woken this way still reaches its parent — `replyToSession` falls back
+    // to the origin PERSISTED on the session for exactly this kind of turn (§5.3), and the
+    // report-back obligation is sticky on `needsParentReply`.
+    const msg: NormalizedMessage = {
+      // Stable in the task id so a duplicated settle edge cannot dispatch twice.
+      msgId: `bgtask:${rec.channel}:${taskId}`,
+      // A monotonic "now" so the wake orders as new content in the session (see replyToSession).
+      transcriptTs: monotonicTs(),
+      traceId: `bgtask:${taskId}`,
+      source: 'agent',
+      platform,
+      channel: rec.channel,
+      ...(rec.thread ? { thread: rec.thread } : {}),
+      ...(rec.transportScope ? { transportScope: rec.transportScope } : {}),
+      sender: { id: `background-task:${taskId}`, isBot: true },
+      text:
+        `[background task finished] ${what}${status ? ` — ${status}` : ''}\n\n` +
+        `This is a daemon notification, not a message from anyone. A background task you started ` +
+        `settled after your turn had already ended, so nothing you said about it reached anyone. Read its ` +
+        `output now (its task id is \`${taskId}\`) and finish what you were waiting on it for — this turn ` +
+        `is the one that is actually delivered. If you owe a report to another session, send it, unless ` +
+        `you already sent it after the task finished; do not report the same result twice. If the result ` +
+        `needs no action at all, stay silent.`,
+      mentionedBots: integrationId && this.botUserIds[integrationId] ? [this.botUserIds[integrationId]!] : [],
+      isDm: false
+    }
+    lease.bgWakes += 1
+    this.log.info(`bg-task wake: "${what}" → agent "${agentId}" session ${acpSessionId} (${rec.key})`)
+    void this.dispatch(agentId, msg, integrationId).catch((err) =>
+      this.log.error(`bg-task wake dispatch failed for "${agentId}": ${formatErr(err)}`)
     )
   }
 
@@ -13949,6 +14122,8 @@ export class Daemon {
       this.clock.clearTimeout(this.runtimeProbeTimer)
       this.runtimeProbeTimer = undefined
     }
+    for (const t of this.bgWakeTimers) this.clock.clearTimeout(t)
+    this.bgWakeTimers.clear()
     // Cancel in-flight catalog discoveries and kill their child processes.
     await this.modelCatalogSvc?.stop().catch(() => {})
     for (const t of this.cancelTimers.values()) this.clock.clearTimeout(t)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1712,7 +1712,9 @@ export class LocalStore {
   closeIdleSessions(
     now: number,
     ttlMs: number,
-    isExempt?: (acpSessionId: string | null) => boolean
+    // Both ids: ACP session ids are runtime-local, so an exemption that keys off one alone
+    // (e.g. the daemon's background-task lease) would confuse two agents' `acp-1`.
+    isExempt?: (agentId: string, acpSessionId: string | null) => boolean
   ): {
     key: string
     agentId: string
@@ -1734,7 +1736,7 @@ export class LocalStore {
       thread: string
       acpSessionId: string | null
     }[]
-    const rows = isExempt ? candidates.filter((r) => !isExempt(r.acpSessionId)) : candidates
+    const rows = isExempt ? candidates.filter((r) => !isExempt(r.agentId, r.acpSessionId)) : candidates
     if (rows.length) {
       const close = this.db.prepare("UPDATE sessions SET state = 'closed' WHERE key = ? AND state = 'idle'")
       this.db.exec('BEGIN')

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -142,6 +142,8 @@ const dm = (ts: string, text: string, thread = 'T1') => ({
 })
 
 const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', TRANSPORT_SCOPE)
+/** `sdkLeaseKey('bot-a', 'acp-1')` — leases are per (agent, ACP session), not per session id. */
+const LEASE_KEY = JSON.stringify(['bot-a', 'acp-1'])
 
 function pendingFor(daemon: Daemon, acpSessionId: string): any {
   return [...(daemon as any).pending.values()].find(
@@ -609,8 +611,18 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
     expect((daemon as any).store.getSession(KEY)?.state).toBe('idle')
 
-    // The task settles → quiescent → reclaimed + closed on the next sweep.
+    // The task settles, but its completion wake is now armed — that still fences reclaim, or
+    // the sweep would close the session out from under a delivery about to happen.
     ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+    clock.advance(1001) // past the TTL again, still inside the wake's grace window
+    ;(daemon as any).sweepIdle()
+    expect((daemon as any).hosts.has('bot-a')).toBe(true)
+    expect((daemon as any).store.getSession(KEY)?.state).toBe('idle')
+
+    // Wake fires and is delivered; once its turn settles the lease is quiescent for real.
+    clock.advance(4000)
+    await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
     await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
@@ -659,6 +671,13 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true) // still deferred
 
     ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
+    // Both settled on that one edge, so both completion wakes are armed and still fence reclaim.
+    clock.advance(1001)
+    ;(daemon as any).sweepIdle()
+    expect((daemon as any).hosts.has('bot-a')).toBe(true)
+
+    clock.advance(4000)
+    await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
     await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
@@ -835,6 +854,26 @@ describe('Daemon idle sweep — background-task lease', () => {
       await daemon.stop()
     }, 15_000)
 
+    // The armed wake must fence automatic cleanup: `settle()` removes the task before the
+    // timer is armed, so a session whose task outlived the TTL would otherwise be closed
+    // (and its lease dropped) inside the grace window — losing the completion again.
+    it('keeps the session non-quiescent while a wake is armed, and releases it after', async () => {
+      const clock = new FakeClock()
+      const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      expect((daemon as any).sdkLease.get(LEASE_KEY)?.tasks.size).toBe(0) // task already released
+      expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(1)
+      expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(false)
+      expect((daemon as any).agentHasLiveSdkWork('bot-a')).toBe(true)
+
+      clock.advance(4000)
+      await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+      expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true)
+      await daemon.stop()
+    }, 15_000)
+
     it('does not wake for an internal subagent task', async () => {
       const clock = new FakeClock()
       const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
@@ -878,10 +917,29 @@ describe('Daemon idle sweep — background-task lease', () => {
         clock.advance(4000)
         await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
       }
-      expect((daemon as any).sdkLease.get('acp-1')?.bgWakes).toBe(20)
+      expect((daemon as any).sdkLease.get(LEASE_KEY)?.bgWakes).toBe(20)
       await daemon.stop()
     }, 30_000)
   })
+
+  // ACP session ids are runtime-local: two agents can each expose `acp-1`. Sharing one lease
+  // entry would let one agent's task overwrite the other's record, suppress its completion
+  // wake (via `tasks.size`/`sdkState`), or spend its wake budget.
+  it('keys the lease per (agent, ACP session) so two agents sharing an id do not collide', async () => {
+    const clock = new FakeClock()
+    const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+    ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1', description: 'a-work' }))
+    ;(daemon as any).onSdkLifecycle('bot-b', 'acp-1', evt('task_started', { task_id: 't1', description: 'b-work' }))
+    expect((daemon as any).sdkLease.size).toBe(2)
+    expect((daemon as any).sdkLease.get(LEASE_KEY)?.tasks.get('t1')?.description).toBe('a-work')
+
+    // Settling bot-b's identically-named task must not settle bot-a's.
+    ;(daemon as any).onSdkLifecycle('bot-b', 'acp-1', evt('task_notification', { task_id: 't1' }))
+    expect((daemon as any).sdkLease.get(LEASE_KEY)?.tasks.size).toBe(1)
+    expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(false)
+    await daemon.stop()
+  }, 15_000)
 
   it('drops an agent lease when its host is torn down', async () => {
     const clock = new FakeClock()

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -751,6 +751,138 @@ describe('Daemon idle sweep — background-task lease', () => {
     await daemon.stop()
   }, 15_000)
 
+  // The `run_in_background` "you will be notified when it completes" contract is a HARNESS
+  // promise, not an SDK one. Under ACP the foreground turn has already returned end_turn by
+  // the time the task settles, so the daemon has to deliver the completion itself or the work
+  // (and anything the model owed on the back of it) is stranded.
+  describe('waking the session when a background task settles', () => {
+    it('wakes the idle session with a fresh turn once the grace period passes', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      ;(daemon as any).store.setOutputModeOverride(KEY, 'low') // a wake is NOT gated on output mode
+      expect(host.prompt).toHaveBeenCalledTimes(1) // just the human turn so far
+
+      ;(daemon as any).onSdkLifecycle(
+        'bot-a',
+        'acp-1',
+        evt('task_started', { task_id: 't1', description: 'Sleep 30s then print the time' })
+      )
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      expect(host.prompt).toHaveBeenCalledTimes(1) // deferred, not immediate
+
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      const woken = JSON.stringify((host.prompt as any).mock.calls[1])
+      expect(woken).toContain('background task finished')
+      expect(woken).toContain('Sleep 30s then print the time')
+      expect(woken).toContain('t1')
+      await daemon.stop()
+    }, 15_000)
+
+    // The runtime's own self-drain cycle produces NOTHING a user can see (no Pending ⇒
+    // onAcpUpdate drops it), so the wake waits it out but must never stand down for it.
+    it('waits out the runtime self-drain cycle, then wakes anyway', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      // Claude self-woke a followup cycle to drain it.
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+
+      clock.advance(4000) // re-armed, not abandoned
+      await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(1))
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await daemon.stop()
+    }, 15_000)
+
+    it('gives up re-arming if the runtime cycle never returns to idle', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+
+      // 15 re-arms then nothing left armed — a wedged cycle must not be polled forever.
+      for (let i = 0; i < 16; i++) {
+        clock.advance(4000)
+        await new Promise((r) => setImmediate(r))
+      }
+      expect((daemon as any).bgWakeTimers.size).toBe(0)
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+      await daemon.stop()
+    }, 15_000)
+
+    it('wakes once for the last task, not once per task', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      clock.advance(4000) // t2 is still live — t1's wake must stand down
+      await new Promise((r) => setImmediate(r))
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await daemon.stop()
+    }, 15_000)
+
+    it('does not wake for an internal subagent task', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle(
+        'bot-a',
+        'acp-1',
+        evt('task_started', { task_id: 's1', subagent_type: 'general' })
+      )
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 's1' }))
+      clock.advance(4000)
+      await new Promise((r) => setImmediate(r))
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+      await daemon.stop()
+    }, 15_000)
+
+    it('does not wake a session whose host was already reclaimed', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      await (daemon as any).stopHost('bot-a') // drops the lease with the ACP session
+
+      clock.advance(4000)
+      await new Promise((r) => setImmediate(r))
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+      await daemon.stop()
+    }, 15_000)
+
+    it('stops waking once the per-session budget is exhausted', async () => {
+      const clock = new FakeClock()
+      const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+
+      // 25 settle→wake cycles against a budget of 20: the extras must be refused, so a wake
+      // that keeps re-spawning background tasks cannot feed itself forever. The counter is
+      // the assertion (not host.prompt) because these turns are queued, never drained.
+      for (let i = 0; i < 25; i++) {
+        ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: `t${i}` }))
+        ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: `t${i}` }))
+        clock.advance(4000)
+        await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
+      }
+      expect((daemon as any).sdkLease.get('acp-1')?.bgWakes).toBe(20)
+      await daemon.stop()
+    }, 30_000)
+  })
+
   it('drops an agent lease when its host is torn down', async () => {
     const clock = new FakeClock()
     const { daemon } = await bootWithTurn(clock, {

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -619,9 +619,10 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
     expect((daemon as any).store.getSession(KEY)?.state).toBe('idle')
 
-    // Wake fires and is delivered; once its turn settles the lease is quiescent for real.
+    // Wake fires and is delivered; the fence is held until that turn SETTLES, not until it is
+    // dispatched, so wait on the count rather than on the timer set.
     clock.advance(4000)
-    await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
     await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
@@ -677,7 +678,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
 
     clock.advance(4000)
-    await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
+    await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
     await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
@@ -811,6 +812,7 @@ describe('Daemon idle sweep — background-task lease', () => {
 
       clock.advance(4000) // re-armed, not abandoned
       await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(1))
+      expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(1) // fence never dipped
       expect(host.prompt).toHaveBeenCalledTimes(1)
 
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
@@ -874,6 +876,47 @@ describe('Daemon idle sweep — background-task lease', () => {
       await daemon.stop()
     }, 15_000)
 
+    // The hand-off after the fence is released is its own race: `dispatch()` claims the serial
+    // gate synchronously, but `dispatchOne` then awaits thread history / attachments / memory
+    // recall before SessionManager writes `state = 'prompting'`. Releasing at dispatch time
+    // would leave an already-expired session reading quiescent AND idle for that whole window.
+    it('holds the fence through async turn initialization, not just up to dispatch', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, {
+        agentIdleTimeoutMs: 1000,
+        agentMaxLifetimeMs: 10_000_000,
+        idleSweepMs: 10_000_000
+      })
+      // Stall initialization exactly where it is slow in production (managed-memory recall),
+      // i.e. AFTER the wake's dispatch but BEFORE the row leaves `idle`.
+      let releaseRecall!: () => void
+      const recallBlocked = new Promise<void>((resolve) => (releaseRecall = resolve))
+      const memory = (daemon as any).memory
+      const realRecall = memory.recallForTurn.bind(memory)
+      memory.recallForTurn = async (...args: unknown[]) => {
+        await recallBlocked
+        return realRecall(...args)
+      }
+
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1)) // wake dispatched, stalled
+
+      // Past the TTL, mid-initialization: the row is still `idle` and has no Pending, so only
+      // the lease fence can keep the sweep off it.
+      clock.advance(1001)
+      ;(daemon as any).sweepIdle()
+      expect((daemon as any).store.getSession(KEY)?.state).not.toBe('closed')
+      expect((daemon as any).hosts.has('bot-a')).toBe(true)
+      expect(host.stop).not.toHaveBeenCalled()
+
+      releaseRecall()
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+      await daemon.stop()
+    }, 15_000)
+
     it('does not wake for an internal subagent task', async () => {
       const clock = new FakeClock()
       const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
@@ -904,20 +947,29 @@ describe('Daemon idle sweep — background-task lease', () => {
       await daemon.stop()
     }, 15_000)
 
+    // A wake has no hopCount to bound and a woken turn may start further background tasks, so
+    // the budget is the only backstop against a self-feeding loop.
     it('stops waking once the per-session budget is exhausted', async () => {
       const clock = new FakeClock()
-      const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
 
-      // 25 settle→wake cycles against a budget of 20: the extras must be refused, so a wake
-      // that keeps re-spawning background tasks cannot feed itself forever. The counter is
-      // the assertion (not host.prompt) because these turns are queued, never drained.
-      for (let i = 0; i < 25; i++) {
-        ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: `t${i}` }))
-        ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: `t${i}` }))
-        clock.advance(4000)
-        await vi.waitFor(() => expect((daemon as any).bgWakeTimers.size).toBe(0))
-      }
-      expect((daemon as any).sdkLease.get(LEASE_KEY)?.bgWakes).toBe(20)
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      clock.advance(4000)
+      const lease = (daemon as any).sdkLease.get(LEASE_KEY)
+      await vi.waitFor(() => expect(lease.armedWakes).toBe(0))
+      expect(host.prompt).toHaveBeenCalledTimes(2)
+      expect(lease.bgWakes).toBe(1) // a delivered wake is spent
+
+      // Pre-spend the rest rather than driving 19 more real turns: the property under test is
+      // the refusal at the cap, not the arithmetic getting there.
+      lease.bgWakes = 20
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
+      clock.advance(4000)
+      await vi.waitFor(() => expect(lease.armedWakes).toBe(0)) // fence released, but no wake
+      expect(host.prompt).toHaveBeenCalledTimes(2)
+      expect(lease.bgWakes).toBe(20) // never spends past the cap
       await daemon.stop()
     }, 30_000)
   })

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -145,6 +145,13 @@ const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', TRANSPORT_SCOPE)
 /** `sdkLeaseKey('bot-a', 'acp-1')` — leases are per (agent, ACP session), not per session id. */
 const LEASE_KEY = JSON.stringify(['bot-a', 'acp-1'])
 
+/** The wake fence is two counters — armed timers and in-flight deliveries. "Settled" means
+ *  both are clear; `armedWakes` alone hits 0 the moment a delivery starts. */
+function wakeFenceHeld(daemon: Daemon): boolean {
+  const lease = (daemon as any).sdkLease.get(LEASE_KEY)
+  return !!lease && (lease.armedWakes > 0 || lease.deliveringWakes > 0)
+}
+
 function pendingFor(daemon: Daemon, acpSessionId: string): any {
   return [...(daemon as any).pending.values()].find(
     (pending: any) => pending.agentId === 'bot-a' && pending.acpSessionId === acpSessionId
@@ -622,7 +629,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     // Wake fires and is delivered; the fence is held until that turn SETTLES, not until it is
     // dispatched, so wait on the count rather than on the timer set.
     clock.advance(4000)
-    await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
     await vi.waitFor(() => expect((daemon as any).store.getSession(KEY)?.state).toBe('idle'))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
@@ -678,7 +685,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect((daemon as any).hosts.has('bot-a')).toBe(true)
 
     clock.advance(4000)
-    await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+    await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
     clock.advance(1001)
     ;(daemon as any).sweepIdle()
     await vi.waitFor(() => expect((daemon as any).hosts.has('bot-a')).toBe(false))
@@ -871,7 +878,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       expect((daemon as any).agentHasLiveSdkWork('bot-a')).toBe(true)
 
       clock.advance(4000)
-      await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
       expect((daemon as any).sessionSdkQuiescent('bot-a', 'acp-1')).toBe(true)
       await daemon.stop()
     }, 15_000)
@@ -913,9 +920,70 @@ describe('Daemon idle sweep — background-task lease', () => {
 
       releaseRecall()
       await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
-      await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0))
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
       await daemon.stop()
     }, 15_000)
+
+    // The dispatch promise deliberately outlives `host.prompt()` (renderer/finalization still
+    // runs). A task settling in THAT window cannot have been observed in-turn — the model has
+    // already stopped — so it must not be coalesced into the delivery that is finishing.
+    it('delivers a task that settles after a wake prompt returned but before its turn settles', async () => {
+      const clock = new FakeClock()
+      // Hold wake A's turn open (its prompt blocks) while telling the lease the model has gone
+      // idle — that pair IS the post-prompt/pre-cleanup window.
+      let releaseA!: () => void
+      const aBlocked = new Promise<void>((resolve) => (releaseA = resolve))
+      let prompts = 0
+      const host = {
+        start: vi.fn(async () => {}),
+        newSession: vi.fn(async () => 'acp-1'),
+        prompt: vi.fn(async () => {
+          if (++prompts === 2) await aBlocked
+          return 'end_turn'
+        }),
+        cancel: vi.fn(async () => {}),
+        stop: vi.fn(async () => {})
+      }
+      const daemon = new Daemon({
+        root: scaffold({ agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 }),
+        hostFactory: () => host as any,
+        clock
+      })
+      await daemon.start()
+      makeRoutable(daemon)
+      await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
+
+      // Wake A → prompt #2, which blocks. Its dispatch stays pending.
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 'a' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 'a' }))
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2))
+      // The model is done even though the turn is not — exactly what the SDK reports here.
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+
+      // Task B settles inside that window. It must be deferred, not folded into A.
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 'b' }))
+      ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 'b' }))
+      for (let i = 0; i < 3; i++) {
+        clock.advance(4000)
+        await new Promise((r) => setTimeout(r, 20))
+      }
+      expect(host.prompt).toHaveBeenCalledTimes(2) // not delivered while A is in flight…
+      expect(wakeFenceHeld(daemon)).toBe(true) // …and still owed, not discarded
+
+      releaseA()
+      // Once A settles, B's deferred wake re-arms and delivers: a THIRD prompt. Without the
+      // deferral B is dropped here and this never reaches 3.
+      await vi.waitFor(
+        async () => {
+          clock.advance(4000)
+          await new Promise((r) => setTimeout(r, 20))
+          expect(host.prompt).toHaveBeenCalledTimes(3)
+        },
+        { timeout: 8000, interval: 50 }
+      )
+      await daemon.stop()
+    }, 20_000)
 
     it('does not wake for an internal subagent task', async () => {
       const clock = new FakeClock()
@@ -957,7 +1025,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
       clock.advance(4000)
       const lease = (daemon as any).sdkLease.get(LEASE_KEY)
-      await vi.waitFor(() => expect(lease.armedWakes).toBe(0))
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false))
       expect(host.prompt).toHaveBeenCalledTimes(2)
       expect(lease.bgWakes).toBe(1) // a delivered wake is spent
 
@@ -967,7 +1035,7 @@ describe('Daemon idle sweep — background-task lease', () => {
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2' }))
       ;(daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
       clock.advance(4000)
-      await vi.waitFor(() => expect(lease.armedWakes).toBe(0)) // fence released, but no wake
+      await vi.waitFor(() => expect(wakeFenceHeld(daemon)).toBe(false)) // fence released, no wake
       expect(host.prompt).toHaveBeenCalledTimes(2)
       expect(lease.bgWakes).toBe(20) // never spends past the cap
       await daemon.stop()

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -847,7 +847,7 @@ describe('LocalStore session lifecycle (§7.3/#111/#118)', () => {
     seed(s, 'busy', 'bot-a', 'idle', 100) // idle + past TTL, but has live background work
     seed(s, 'done', 'bot-a', 'idle', 100) // idle + past TTL, quiescent
     // Exempt the one whose acpSessionId is still working.
-    const closed = s.closeIdleSessions(1000, 500, (acpSessionId) => acpSessionId === 'acp-busy')
+    const closed = s.closeIdleSessions(1000, 500, (_agentId, acpSessionId) => acpSessionId === 'acp-busy')
     expect(closed.map((r) => r.key)).toEqual(['done'])
     expect(s.getSession('busy')?.state).toBe('idle') // spared
     expect(s.getSession('done')?.state).toBe('closed') // closed as usual


### PR DESCRIPTION
## Problem

`run_in_background` promises the model it "will be notified when the task completes" — that is a **harness** guarantee, not an SDK one. Interactive Claude Code re-invokes the model when the task exits. Under ACP the foreground turn has already returned `end_turn` by then, so nothing delivers the result.

Reproduced end-to-end on the test CP (Slack `#ai-playground`, two live agents):

1. Human `@test`: *"给 agent test2 发消息，内容是「30秒后回复我当前时间是什么」，然后监听一下它的工作进度"*
2. `test` → `sendMessage({toAgent: test2, needsReply: true})` ✅
3. `test2` backgrounds `sleep 30; date`, says "已开始计时", **turn ends**
4. The background command finishes and writes the time — **nobody reads it**
5. `test2` sits `idle` with `needsParentReply=1` forever; `test` waits forever

## Why the runtime's own follow-up doesn't save it

The runtime is not idle in that window — it re-enters a `running` cycle to drain the completion. That cycle is **not a delivery**: it carries no `Pending`, so `onAcpUpdate` returns early on `!p` and discards every content-bearing update it produces (message chunks, tool renders, transcript rows, the webchat sink). Verified directly — driving `test2` through the public Agent API with the webchat socket held open for 120s past turn end received *nothing* after `done`, while the daemon log showed the self-drain cycle run and finish.

Its MCP tool calls **do** land (that socket is not `Pending`-gated), which is why the wake text tells the model not to repeat a report it already sent.

Observed lifecycle sequence (claude-agent-acp 0.63.0), now recorded in the design doc:

```text
task_started {t}
session_state_changed {idle}        # turn returned end_turn, task still live
background_tasks_changed {live: 0}  # settles the task (arrives first)
task_updated {completed}            # already settled — deduped
task_notification                   # already settled — deduped
session_state_changed {running}     # runtime's self-drain cycle
session_state_changed {idle}        # ...which produced nothing observable
```

## Change

On a non-subagent task settling, the daemon injects a turn into the session carrying the completion.

- Defers to the self-drain cycle **only while it runs** (re-arm at 4s, bounded by `MAX_BG_TASK_WAKE_REARMS` = 15), then delivers regardless. An earlier revision stood down for that cycle entirely — that reproduced the original bug, since the cycle delivers nothing.
- `source: 'agent'`, sender `background-task:<task_id>`, **no `CallMeta`** — it is not an agent call and must not look like one. A child woken this way still reaches its parent via the origin persisted on the session (session-concept §5.3); `needsParentReply` is sticky.
- `msgId` = `bgtask:<channel>:<task_id>` — stable in the task id, so a duplicated settle edge cannot dispatch twice.
- Reply transport resolved from the **session's** transport scope, not the agent's default integration.
- **Not** gated on output mode. The `🔔` channel notice (§5) is for the human and stays gated at `medium`; this is for the model and must fire at `low`/`none` too — the repro agent runs at `low`, which is why it saw nothing at all.
- `MAX_BG_TASK_WAKES_PER_SESSION` (20, per lease life) bounds a self-feeding loop: a wake has no `hopCount` to cap and a woken turn may start further background tasks.
- Accepted SDK lifecycle edges are now logged at debug. That feed cannot be reproduced offline and was the only way to establish the sequence above.

## Verification

Re-ran the exact scenario in Slack after the fix:

```text
bg-task wake skipped (runtime cycle still running, re-armed 1/15)  … 2/15 … 3/15 … 4/15
session_state_changed {idle}
bg-task wake: "Wait 30s then print current time" → agent test2 session 63004d54…
```

and the chain closed:

| seq | action |
| --- | --- |
| 684 | daemon wake notification → `test2` |
| 687 | `test2` → `mcp__agentconnect__sendMessage` |
| 688 | report lands in `test`'s session: `2026-07-29 00:26:11 (+08)` |
| 692 | `test` relays to the channel |

`pnpm --filter @agentconnect.md/daemon test` — 2270 passed. 8 new cases in `daemon-lifecycle.test.ts` cover: wake after grace (at output mode `low`), wait-out-then-wake, give up on a never-idle cycle, once for the last of several tasks, no wake for subagents, no wake after host reclaim, budget exhaustion.

## Not in scope

- The daemon still has **no** fallback when a turn ends with `needsParentReply=1` and never called `sendMessage` — the obligation is prompt-enforced only. This PR makes that path much less likely to trigger; it does not add the backstop.
- Two separate webchat/Agent-API findings from the same session: `listChannelAgents` always fails there (it uses the conversation UUID as a channel for daemon→CP peer discovery), and a2a is structurally impossible from a webchat session (`cpCollab.hasMembers` can never hold), reported to the model as an indistinguishable `not_allowed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)