### PR TITLE
feat(slack): add manage-session message shortcut

### DIFF
--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -348,9 +348,11 @@ Channel membership changes trigger a coalesced Slack membership refresh. The
 relay reports the complete channel snapshot through `rc/bot-channels`; CP
 updates control metadata and recompiles routes.
 
-Interactive session actions carry an opaque target bound to the exact agent,
-integration, and session that rendered the control. They do not follow a later
-channel-owner change.
+Interactive controls rendered by a session carry an opaque target bound to the
+exact agent, integration, and session that rendered them. They do not follow a
+later channel-owner change. The app-level message shortcut starts only with the
+selected message's channel and thread: the relay resolves current conversation
+ownership, then the daemon resolves and authorizes the exact bot-scoped session.
 
 ### 10.2 Durable thread affinity
 
@@ -440,8 +442,9 @@ relay has already returned 200. Duplicate deliveries that reach different
 instances are absorbed by daemon-side idempotency.
 
 Slack interactions are also HMAC-verified. Handlers that must return options in
-the HTTP response complete before the 200 response; other actions are forwarded
-to the exact session target.
+the HTTP response complete before the 200 response. Rendered controls are
+forwarded to their exact session target; message shortcuts are forwarded by
+conversation coordinates and resolved to an exact session by the daemon.
 
 Hook ingress responds quickly after verification and admission. Stable
 `deliveryKey` values support idempotency and observable run accounting, but

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -7,6 +7,7 @@ import {
   SLACK_BOT_EVENTS,
   DEFAULT_SLACK_APP_NAME
 } from './slack-manifest.js'
+import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
 
 // The PUBLIC form — `/v1`, not the internal `/api/v1` (see SLACK_OAUTH_CALLBACK_PATH).
 const REDIRECT = 'https://cp.example/v1/integrations/slack/oauth/callback'
@@ -21,12 +22,19 @@ describe('buildInstallManifest', () => {
 
   it('enables Socket Mode and carries the daemon scopes + events', () => {
     const m = buildInstallManifest('acme-bot', REDIRECT) as {
+      features: { shortcuts: { callback_id: string; type: string }[] }
       oauth_config: { scopes: { bot: string[] } }
       settings: { socket_mode_enabled: boolean; event_subscriptions: { bot_events: string[] } }
     }
     expect(m.settings.socket_mode_enabled).toBe(true)
     expect(m.oauth_config.scopes.bot).toEqual([...SLACK_BOT_SCOPES])
     expect(m.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
+    expect(m.features.shortcuts).toEqual([
+      expect.objectContaining({
+        callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+        type: 'message'
+      })
+    ])
   })
 
   it('http mode: disables Socket Mode and points the Events API request_urls at the relay', () => {
@@ -70,6 +78,7 @@ describe('buildInstallManifest', () => {
       'app_mentions:read',
       'channels:history',
       'channels:read',
+      'commands',
       'chat:write',
       'chat:write.customize',
       'files:write',
@@ -104,7 +113,11 @@ describe('mergeManagedSlackManifest', () => {
       features: {
         bot_user: { display_name: 'Custom bot', always_online: false },
         app_home: { home_tab_enabled: true },
-        slash_commands: [{ command: '/custom', description: 'Keep me' }]
+        slash_commands: [{ command: '/custom', description: 'Keep me' }],
+        shortcuts: [
+          { name: 'Keep shortcut', type: 'message', callback_id: 'custom_shortcut' },
+          { name: 'Old managed name', type: 'message', callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID }
+        ]
       },
       oauth_config: {
         redirect_urls: ['https://custom.example/slack/callback'],
@@ -134,6 +147,7 @@ describe('mergeManagedSlackManifest', () => {
         }
         agent_view: { agent_description: string }
         slash_commands: unknown[]
+        shortcuts: { name: string; callback_id: string }[]
       }
       oauth_config: { redirect_urls: string[]; scopes: { bot: string[]; user: string[] } }
       settings: {
@@ -148,6 +162,13 @@ describe('mergeManagedSlackManifest', () => {
     expect(merged.display_information).toEqual({ name: 'Custom app', description: 'Keep this description' })
     expect(merged.features.bot_user).toEqual({ display_name: 'Custom bot', always_online: true })
     expect(merged.features.slash_commands).toEqual(current.features.slash_commands)
+    expect(merged.features.shortcuts).toEqual([
+      expect.objectContaining({
+        name: 'Manage AgentConnect session',
+        callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID
+      }),
+      current.features.shortcuts[0]
+    ])
     expect(merged.features.app_home.home_tab_enabled).toBe(true)
     expect(merged.features.app_home.messages_tab_enabled).toBe(true)
     expect(merged.features.app_home.messages_tab_read_only_enabled).toBe(false)

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -14,6 +14,7 @@
  * lists below are pinned by a drift-guard test (slack-manifest.test.ts); when you
  * change them here, change them in packages/web/src/lib/slack-manifest.ts too.
  */
+import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
 
 /** Bot token scopes the daemon's Slack adapter requires. */
 export const SLACK_BOT_SCOPES = [
@@ -21,6 +22,7 @@ export const SLACK_BOT_SCOPES = [
   'app_mentions:read',
   'channels:history',
   'channels:read',
+  'commands',
   'chat:write',
   'chat:write.customize',
   'files:write',
@@ -61,6 +63,15 @@ function unionStrings(current: unknown, required: readonly string[]): string[] {
   return [...new Set([...stringList(current), ...required])]
 }
 
+function mergeManagedShortcuts(current: unknown, managed: unknown): unknown[] {
+  const required = Array.isArray(managed) ? managed : []
+  const callbackIds = new Set(required.map((shortcut) => asRecord(shortcut).callback_id))
+  const existing = Array.isArray(current)
+    ? current.filter((shortcut) => !callbackIds.has(asRecord(shortcut).callback_id))
+    : []
+  return [...required, ...existing]
+}
+
 /** The relay pool's Events API endpoints, derived from its public HTTPS base
  *  (slack-http-mode §6): the manifest's `request_url`s Slack POSTs inbound to. */
 export function slackEventsRequestUrl(relayHttpBase: string): string {
@@ -92,7 +103,15 @@ function buildManagedManifest(name: string, httpRelayBase?: string, backgroundCo
       agent_view: {
         agent_description: `${displayName} is an AgentConnect agent that responds to Slack conversations and works in threads.`,
         suggested_prompts: []
-      }
+      },
+      shortcuts: [
+        {
+          name: 'Manage AgentConnect session',
+          type: 'message',
+          callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+          description: 'View or update the AgentConnect session for this conversation'
+        }
+      ]
     },
     oauth_config: {
       scopes: { bot: [...SLACK_BOT_SCOPES] }
@@ -196,7 +215,8 @@ export function mergeManagedSlackManifest(
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false
       },
-      agent_view: { ...managedAgentView, ...currentAgentView }
+      agent_view: { ...managedAgentView, ...currentAgentView },
+      shortcuts: mergeManagedShortcuts(currentFeatures.shortcuts, managedFeatures.shortcuts)
     },
     oauth_config: {
       ...managedOauth,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2107,6 +2107,7 @@ export class Daemon {
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         onChannelsChanged: () => void this.refreshChannels(conn),
+        onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
         onStatusAction: (a) => this.handleStatusAction(a),
         onStatusInfo: (key) => this.statusInfoForKey(key),
         onPermissionChoice: (a) => this.handlePermissionChoice(a),
@@ -2599,6 +2600,7 @@ export class Daemon {
             this.onInbound(msg, this.srcIntegrationIds(conn))
           },
           onChannelsChanged: () => void this.refreshChannels(conn),
+          onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
           onStatusAction: (a) => this.handleStatusAction(a),
           onStatusInfo: (key) => this.statusInfoForKey(key),
           onPermissionChoice: (a) => this.handlePermissionChoice(a),
@@ -3229,7 +3231,7 @@ export class Daemon {
     this.log.info(
       `slack: background retry for appToken (${group.integrations.length} integration(s): ${group.integrations.map((i) => i.agentId).join(', ')})…`
     )
-    const conn = new SlackConnection({
+    const conn: SlackConnection = new SlackConnection({
       group,
       newTraceId: () => randomUUID(),
       onMessage: (msg) => {
@@ -3239,6 +3241,7 @@ export class Daemon {
         this.onInbound(msg, this.srcIntegrationIds(conn))
       },
       onChannelsChanged: () => void this.refreshChannels(conn),
+      onMessageShortcut: (shortcut) => this.slackShortcutSession(shortcut, this.srcIntegrationIds(conn)),
       onStatusAction: (a) => this.handleStatusAction(a),
       onStatusInfo: (key) => this.statusInfoForKey(key),
       onPermissionChoice: (a) => this.handlePermissionChoice(a),
@@ -4748,10 +4751,10 @@ export class Daemon {
     return { msgId: msg.msgId, accepted: true }
   }
 
-  /** Apply one shared-bot status interaction after the relay has validated the opaque
-   *  target against its live bot assignment. Re-check every daemon-owned boundary before
-   *  opening or mutating anything: the agent, shared Slack integration, local connection,
-   *  session owner, and (when retained) exact delivery binding must all still agree. */
+  /** Apply one shared-bot interaction after relay routing. Re-check every daemon-owned
+   *  boundary before opening or mutating anything: the agent, shared Slack integration,
+   *  local connection, session owner, and (when retained) exact delivery binding must all
+   *  still agree. Message shortcuts resolve their channel/thread coordinates here. */
   private handleRelaySlackAction(msg: RdMsgSlackAction): RdAck {
     const agent = this.agents.get(msg.agentId)
     if (!agent) {
@@ -4773,6 +4776,33 @@ export class Daemon {
       this.log.warn(`relay: Slack action for unavailable integration ${msg.integrationId} — dropping`)
       return { msgId: msg.msgId, accepted: false, reason: 'unavailable' }
     }
+    const payload = msg.payload
+    if (payload.kind === 'open-config-for-thread') {
+      const routing = integrationRouting(integration)
+      const unauthorized =
+        (routing.allowedUserIds.length > 0 && (!msg.userId || !routing.allowedUserIds.includes(msg.userId))) ||
+        (routing.gated && !routing.bindRules.some((rule) => rule.channel === payload.channelId))
+      const transportScope = this.transportScopeForIntegrationIds([integration.id])
+      const rec = unauthorized
+        ? undefined
+        : this.store.latestSessionForTransport(msg.agentId, payload.channelId, transportScope, payload.threadTs)
+      const binding = rec ? this.sessionDeliveryBindings.get(rec.key) : undefined
+      const validBinding =
+        !binding ||
+        (binding.agentId === msg.agentId && binding.platform === 'slack' && binding.integrationId === msg.integrationId)
+      if (!rec || rec.platform !== 'slack' || !validBinding) {
+        void conn.openStatusModal(payload.triggerId)
+        return { msgId: msg.msgId, accepted: true }
+      }
+      const privateMetadata = encodeSharedSlackStatusTarget({
+        agentId: msg.agentId,
+        integrationId: msg.integrationId,
+        sessionKey: rec.key
+      })
+      void conn.openStatusModal(payload.triggerId, rec.key, privateMetadata)
+      return { msgId: msg.msgId, accepted: true }
+    }
+
     const rec = this.store.getSession(msg.sessionKey)
     if (!rec || rec.agentId !== msg.agentId || rec.platform !== 'slack') {
       this.log.warn(`relay: Slack action for stale or foreign session ${msg.sessionKey} — dropping`)
@@ -4787,7 +4817,6 @@ export class Daemon {
       return { msgId: msg.msgId, accepted: false, reason: 'stale' }
     }
 
-    const payload = msg.payload
     // The relay forwards the tapping user when it knows one; an older relay omits it
     // and the action records as an unknown actor rather than a guessed one.
     const actor = msg.userId ? { userId: msg.userId } : undefined
@@ -7349,6 +7378,28 @@ export class Daemon {
     candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
     const latest = candidates[0]
     return latest ? { agentId: latest.agentId, key: latest.key, acpSessionId: latest.acpSessionId ?? undefined } : null
+  }
+
+  /** Resolve a direct Slack message shortcut to the newest addressable session in
+   *  that exact bot-scoped conversation, retaining routing gates and user allowlists. */
+  private slackShortcutSession(
+    shortcut: { channel: string; thread: string; userId: string },
+    srcIntegrationIds: readonly string[]
+  ): string | undefined {
+    const transportScope = this.transportScopeForIntegrationIds(srcIntegrationIds)
+    const candidates: SessionRecord[] = []
+    for (const [agentId, agent] of this.agents) {
+      for (const integration of agent.integrations) {
+        if (integration.platform !== 'slack' || !srcIntegrationIds.includes(integration.id)) continue
+        const routing = integrationRouting(integration)
+        if (routing.allowedUserIds.length > 0 && !routing.allowedUserIds.includes(shortcut.userId)) continue
+        if (routing.gated && !routing.bindRules.some((rule) => rule.channel === shortcut.channel)) continue
+        const session = this.store.latestSessionForTransport(agentId, shortcut.channel, transportScope, shortcut.thread)
+        if (session) candidates.push(session)
+      }
+    }
+    candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
+    return candidates[0]?.key
   }
 
   /** Local layer (agent.json) ∪ resolved CP layer; unservable CP rules are dropped + warn-logged. */

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -4,7 +4,8 @@ import { fetch as undiciFetch, ProxyAgent, type Dispatcher } from 'undici'
 import {
   decodeSlackStatusOverflowValue,
   extractSlackMessageText,
-  isSlackSystemMessage
+  isSlackSystemMessage,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
 import { normalizeSlackEvent, toAttachment, type SlackFile, type SlackMessageEvent } from './normalize.js'
@@ -19,6 +20,7 @@ import {
   PERMISSION_UPDATE_ACTION,
   buildPermissionUpdateCard,
   buildStatusModal,
+  buildStatusUnavailableModal,
   decodePermValue,
   type StatusBarInfo,
   type StatusModalIdentity
@@ -160,6 +162,9 @@ export interface SlackDeps {
   onStatusInfo?: (
     sessionKey: string
   ) => { info: StatusBarInfo; identity?: StatusModalIdentity; link?: string; cancellable: boolean } | undefined
+  /** Resolve the exact local session owned by the selected Slack conversation.
+   *  Runs synchronously so the one-shot shortcut trigger can open its modal promptly. */
+  onMessageShortcut?: (a: { channel: string; thread: string; userId: string }) => string | undefined
   /** Fired when a user taps a button on an interactive permission card
    *  (render.buildPermissionCard). The decoded `requestId` ties the click back to the
    *  pending ACP `session/request_permission`; `optionId` is the chosen option. */
@@ -208,6 +213,16 @@ type BlockActionArgs = {
   }
 }
 
+type MessageShortcutArgs = {
+  ack: () => Promise<void>
+  shortcut: {
+    trigger_id?: string
+    channel?: { id?: string }
+    message?: { ts?: string; thread_ts?: string }
+    user?: { id?: string }
+  }
+}
+
 /** The clicking user off a `block_actions` payload, for the action's audit record. */
 function actorOf(body: BlockActionArgs['body']): InteractionActor | undefined {
   return body?.user?.id ? { userId: body.user.id } : undefined
@@ -217,6 +232,7 @@ type AppLike = {
   message: (handler: (args: { message: unknown }) => Promise<void> | void) => void
   event: (type: string, handler: (args: { event: unknown }) => Promise<void> | void) => void
   action: (actionId: string | RegExp, handler: (args: BlockActionArgs) => Promise<void> | void) => void
+  shortcut: (callbackId: string, handler: (args: MessageShortcutArgs) => Promise<void> | void) => void
   client: {
     views: {
       open: (a: unknown) => Promise<unknown>
@@ -380,6 +396,7 @@ function sendOnlyApp(botToken: string): AppLike {
     message: () => {},
     event: () => {},
     action: () => {},
+    shortcut: () => {},
     client: client as unknown as AppLike['client'],
     start: async () => {},
     stop: async () => {}
@@ -530,6 +547,17 @@ export class SlackConnection {
         this.deps.onChannelsChanged?.()
       })
     }
+    this.app.shortcut(SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID, async ({ ack, shortcut }) => {
+      await ack()
+      const triggerId = shortcut.trigger_id
+      if (!triggerId) return
+      const channel = shortcut.channel?.id
+      const thread = shortcut.message?.thread_ts ?? shortcut.message?.ts
+      const userId = shortcut.user?.id
+      const sessionKey =
+        channel && thread && userId ? this.deps.onMessageShortcut?.({ channel, thread, userId }) : undefined
+      await this.openStatusModal(triggerId, sessionKey)
+    })
     // Status-bar interactivity (Block Kit block_actions over Socket Mode). Each handler
     // MUST ack() promptly (Slack drops the interaction / trigger_id after ~3s). Configure
     // opens the controls modal; the modal's select/Cancel carry the session key in
@@ -632,13 +660,15 @@ export class SlackConnection {
    *  local Socket Mode action handler; shared bots call it after the relay forwards the
    *  click over `rd/msg(slack_action)`. `privateMetadata` stays opaque to Slack and lets the
    *  relay route subsequent select/cancel interactions back to this daemon. */
-  async openStatusModal(triggerId: string, sessionKey: string, privateMetadata = sessionKey): Promise<void> {
-    const data = this.deps.onStatusInfo?.(sessionKey)
-    if (!data) return // session gone / not ours
+  async openStatusModal(triggerId: string, sessionKey?: string, privateMetadata = sessionKey ?? ''): Promise<void> {
+    const data = sessionKey ? this.deps.onStatusInfo?.(sessionKey) : undefined
     try {
       await this.app.client.views.open({
         trigger_id: triggerId,
-        view: buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.cancellable, data.identity)
+        view:
+          data && sessionKey
+            ? buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.cancellable, data.identity)
+            : buildStatusUnavailableModal()
       })
     } catch (err) {
       this.deps.log?.debug(`slack: views.open failed: ${(err as Error).message}`)

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -563,6 +563,25 @@ function fmtCount(n?: number): string | undefined {
   return String(n)
 }
 
+/** Small terminal modal for a shortcut whose selected conversation has no
+ * addressable AgentConnect session (or is not visible to the clicking user). */
+export function buildStatusUnavailableModal(): Record<string, unknown> {
+  return {
+    type: 'modal',
+    title: { type: 'plain_text', text: 'Session options' },
+    close: { type: 'plain_text', text: 'Close' },
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'No AgentConnect session was found for this conversation.'
+        }
+      }
+    ]
+  }
+}
+
 /**
  * Build the controls modal opened from Configure (a snapshot — Slack modals don't
  * stream). `private_metadata` carries either the direct session key or a shared-bot

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
-import { encodeSlackStatusOverflowValue } from '@agentconnect.md/protocol'
+import { encodeSlackStatusOverflowValue, SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
 import { consolidate, SlackConnection } from '../src/slack/connection.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
@@ -47,6 +47,7 @@ function fakeAppWith(
     message() {},
     event() {},
     action() {},
+    shortcut() {},
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage },
@@ -143,6 +144,7 @@ describe('SlackConnection.listBotChannels', () => {
       message() {},
       event() {},
       action() {},
+      shortcut() {},
       client: {
         auth: { test: async () => ({ user_id: 'U1' }) },
         users: {
@@ -197,6 +199,7 @@ describe('SlackConnection.listBotChannels', () => {
           message() {},
           event() {},
           action() {},
+          shortcut() {},
           client: {
             auth: { test: async () => ({ user_id: 'U1' }) },
             users: {
@@ -235,6 +238,7 @@ describe('SlackConnection.getThreadReplies', () => {
           message() {},
           event() {},
           action() {},
+          shortcut() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -275,6 +279,7 @@ describe('SlackConnection.getThreadReplies', () => {
           message() {},
           event() {},
           action() {},
+          shortcut() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -312,6 +317,7 @@ describe('SlackConnection.getThreadReplies', () => {
           message() {},
           event() {},
           action() {},
+          shortcut() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -344,6 +350,7 @@ describe('SlackConnection.getThreadReplies', () => {
           message() {},
           event() {},
           action() {},
+          shortcut() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -361,7 +368,8 @@ describe('SlackConnection membership events', () => {
   const fakeAppWithEvents = (
     handlers: Map<string, (a: { event: unknown }) => unknown>,
     actions?: Map<string, (a: any) => unknown>,
-    opened?: any[]
+    opened?: any[],
+    shortcuts?: Map<string, (a: any) => unknown>
   ) => ({
     message() {},
     event(type: string, h: (a: { event: unknown }) => unknown) {
@@ -369,6 +377,9 @@ describe('SlackConnection membership events', () => {
     },
     action(id: string, h: (a: any) => unknown) {
       actions?.set(id, h)
+    },
+    shortcut(id: string, h: (a: any) => unknown) {
+      shortcuts?.set(id, h)
     },
     client: {
       auth: { test: async () => ({ user_id: 'UBOT' }) },
@@ -483,6 +494,62 @@ describe('SlackConnection membership events', () => {
     ])
   })
 
+  it('opens the selected conversation session from the message shortcut', async () => {
+    const KEY = 'slack:C1:T1:bot-a'
+    const shortcuts = new Map<string, (a: any) => unknown>()
+    const opened: any[] = []
+    const resolve = vi.fn().mockReturnValueOnce(KEY).mockReturnValueOnce(undefined)
+    const conn = new SlackConnection(
+      {
+        ...deps(),
+        onMessageShortcut: resolve,
+        onStatusInfo: (key: string) => ({
+          info: { model: 'opus-4.8' },
+          link: `https://app/s/${key}`,
+          cancellable: false
+        })
+      } as any,
+      () => fakeAppWithEvents(new Map(), new Map(), opened, shortcuts) as any
+    )
+    await conn.start()
+    const handler = shortcuts.get(SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID)!
+    const ack = vi.fn(async () => {})
+
+    await handler({
+      ack,
+      shortcut: {
+        trigger_id: 'trig-shortcut',
+        channel: { id: 'C1' },
+        message: { ts: 'T1.2', thread_ts: 'T1' },
+        user: { id: 'U1' }
+      }
+    })
+
+    expect(ack).toHaveBeenCalledOnce()
+    expect(resolve).toHaveBeenCalledWith({ channel: 'C1', thread: 'T1', userId: 'U1' })
+    expect(opened[0]).toMatchObject({
+      trigger_id: 'trig-shortcut',
+      view: { private_metadata: KEY }
+    })
+
+    await handler({
+      ack: async () => {},
+      shortcut: {
+        trigger_id: 'trig-missing',
+        channel: { id: 'C2' },
+        message: { ts: 'T2' },
+        user: { id: 'U1' }
+      }
+    })
+    expect(opened[1]).toMatchObject({
+      trigger_id: 'trig-missing',
+      view: {
+        title: { text: 'Session options' },
+        blocks: [{ text: { text: 'No AgentConnect session was found for this conversation.' } }]
+      }
+    })
+  })
+
   it('openStatusModal lets a forwarded shared click override view.private_metadata', async () => {
     const KEY = 'slack:C1:T1:bot-a'
     const TARGET = JSON.stringify({ v: 1, agentId: 'bot-a', integrationId: 'int-a', sessionKey: KEY })
@@ -528,6 +595,7 @@ describe('SlackConnection assistant DM threads', () => {
             events.set(type, h)
           },
           action() {},
+          shortcut() {},
           client: {
             auth: { test: async () => ({ user_id: 'UBOT' }) },
             views: { open: async () => {}, update: async () => {} }
@@ -583,6 +651,7 @@ describe('SlackConnection assistant DM threads', () => {
           },
           event() {},
           action() {},
+          shortcut() {},
           client: {
             auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BSELF' }) },
             views: { open: async () => {}, update: async () => {} }
@@ -869,6 +938,7 @@ describe('SlackConnection.updateBlocks', () => {
     message() {},
     event() {},
     action() {},
+    shortcut() {},
     client: { chat: { update } },
     start: async () => {},
     stop: async () => {}
@@ -930,6 +1000,7 @@ describe('SlackConnection custom message username', () => {
     message() {},
     event() {},
     action() {},
+    shortcut() {},
     client: { chat: { postMessage } },
     start: async () => {},
     stop: async () => {}

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1268,8 +1268,9 @@ describe('Slack interactive status bar', () => {
     integration.slack.mode = 'shared'
     delete integration.slack.appToken
 
-    const KEY = SESSION_KEY
-    const FOREIGN_KEY = sessionKey('slack', 'C1', 'T2', 'bot-a', TRANSPORT_SCOPE)
+    const sharedTransportScope = `slack:${createHash('sha256').update('slack\0b').digest('hex').slice(0, 24)}`
+    const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', sharedTransportScope)
+    const FOREIGN_KEY = sessionKey('slack', 'C1', 'T2', 'bot-a', sharedTransportScope)
     const openStatusModal = vi.fn(async () => {})
     const updateBlocks = vi.fn(async () => true)
     ;(daemon as any).connByIntegration.set('int-a', { openStatusModal, updateBlocks })
@@ -1279,6 +1280,7 @@ describe('Slack interactive status bar', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope: sharedTransportScope,
       acpSessionId: 'acp-1',
       state: 'idle',
       lastDeliveredTs: null,
@@ -1290,7 +1292,7 @@ describe('Slack interactive status bar', () => {
       platform: 'slack',
       channel: 'C1',
       thread: 'T2',
-      transportScope: TRANSPORT_SCOPE,
+      transportScope: sharedTransportScope,
       acpSessionId: 'acp-2',
       state: 'idle',
       lastDeliveredTs: null,
@@ -1310,6 +1312,31 @@ describe('Slack interactive status bar', () => {
 
     expect((daemon as any).handleRelayMsg(action(), () => {})).toEqual({ msgId: 'action-ok', accepted: true })
     expect(openStatusModal).toHaveBeenCalledTimes(1)
+    expect(
+      (daemon as any).handleRelayMsg(
+        action({
+          sessionKey: 'C1/T1',
+          msgId: 'action-shortcut',
+          userId: 'U1',
+          payload: {
+            kind: 'open-config-for-thread',
+            triggerId: 'trig-shortcut',
+            channelId: 'C1',
+            threadTs: 'T1'
+          }
+        }),
+        () => {}
+      )
+    ).toEqual({ msgId: 'action-shortcut', accepted: true })
+    expect(openStatusModal).toHaveBeenCalledTimes(2)
+    const [, shortcutSessionKey, shortcutMetadata] = openStatusModal.mock.calls[1]!
+    expect(shortcutSessionKey).toBe(KEY)
+    expect(decodeSharedSlackStatusTarget(shortcutMetadata)).toEqual({
+      v: 1,
+      agentId: 'bot-a',
+      integrationId: 'int-a',
+      sessionKey: KEY
+    })
 
     const permissionResolved = vi.fn()
     const permissionRequestId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -1385,7 +1412,7 @@ describe('Slack interactive status bar', () => {
     // HTTP interactions may be redelivered. A replayed receipt must
     // not consume the same trigger_id by opening a second modal.
     expect((daemon as any).handleRelayMsg(action(), () => {})).toEqual({ msgId: 'action-ok', accepted: true })
-    expect(openStatusModal).toHaveBeenCalledTimes(1)
+    expect(openStatusModal).toHaveBeenCalledTimes(2)
 
     const rejected = [
       action({ sessionKey: 'slack:C1:missing:bot-a', msgId: 'action-missing' }),
@@ -1399,7 +1426,7 @@ describe('Slack interactive status bar', () => {
         reason: 'not_found'
       })
     }
-    expect(openStatusModal).toHaveBeenCalledTimes(1)
+    expect(openStatusModal).toHaveBeenCalledTimes(2)
 
     await daemon.stop()
   })

--- a/packages/daemon/test/slack-status-actor.test.ts
+++ b/packages/daemon/test/slack-status-actor.test.ts
@@ -23,6 +23,7 @@ function fakeApp(actions: Map<string, Handler>) {
     message: () => {},
     event: () => {},
     action: (id: string | RegExp, handler: Handler) => actions.set(String(id), handler),
+    shortcut: () => {},
     start: async () => {},
     stop: async () => {},
     client: { auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BBOT', url: 'https://x.slack.test/' }) } }

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -387,6 +387,11 @@ export const SHARED_CONFIG_ACTION_ID = 'ac_shared_channel_config'
  *  use that id for the legacy 👤 button + modal flow. */
 export const SHARED_AGENT_SELECT_ACTION_ID = 'ac_shared_agent_select'
 
+/** App-level Slack message shortcut for opening the controls of the session that
+ * owns the selected message's conversation. Direct apps receive it over Socket
+ * Mode; shared apps receive the same callback through the relay HTTP edge. */
+export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
+
 /** Slack action ids shared by the daemon-owned status modal and the relay-owned
  *  HTTP interaction edge. Dedicated bots handle them in the daemon directly; shared bots
  *  forward them from the relay to the target daemon. */

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -207,6 +207,12 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     const actions = [
       { kind: 'open-config', triggerId: 'trigger-1' },
+      {
+        kind: 'open-config-for-thread',
+        triggerId: 'trigger-2',
+        channelId: 'C123',
+        threadTs: '1720000000.000100'
+      },
       { kind: 'set-model', model: 'opus-4.8' },
       { kind: 'set-effort', effort: 'high' },
       { kind: 'set-permission-mode', permissionMode: 'plan' },
@@ -223,6 +229,12 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     }
     expect(RdMsg.safeParse({ ...base, payload: { kind: 'set-output', outputMode: 'verbose' } }).success).toBe(false)
     expect(RdMsg.safeParse({ ...base, payload: { kind: 'open-config', triggerId: '' } }).success).toBe(false)
+    expect(
+      RdMsg.safeParse({
+        ...base,
+        payload: { kind: 'open-config-for-thread', triggerId: 'trigger-2', channelId: 'C123', threadTs: '' }
+      }).success
+    ).toBe(false)
     expect(RdMsg.safeParse({ ...base, integrationId: 'not-a-uuid', payload: { kind: 'cancel' } }).success).toBe(false)
   })
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -179,6 +179,12 @@ export type RdMsgIm = z.infer<typeof RdMsgIm>
 // existing receipt, dedup, and relay→daemon delivery path.
 export const RdSlackAction = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('open-config'), triggerId: z.string().min(1) }),
+  z.object({
+    kind: z.literal('open-config-for-thread'),
+    triggerId: z.string().min(1),
+    channelId: z.string().min(1),
+    threadTs: z.string().min(1)
+  }),
   z.object({ kind: z.literal('set-model'), model: z.string().min(1) }),
   z.object({ kind: z.literal('set-effort'), effort: z.string().min(1) }),
   z.object({ kind: z.literal('set-permission-mode'), permissionMode: z.string().min(1) }),
@@ -190,8 +196,10 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
 ])
 export type RdSlackAction = z.infer<typeof RdSlackAction>
 
-/** R→D REQ → rd/ack. The relay has validated the opaque Slack target against its
- *  current shared-bot assignment and names the canonical agent + integration. */
+/** R→D REQ → rd/ack. The relay has validated either an opaque rendered-control
+ *  target or a message shortcut's current conversation owner against its shared-bot
+ *  assignment, and names the canonical agent + integration. Coordinate shortcuts
+ *  are resolved to an exact bot-scoped session again by the daemon. */
 export const RdMsgSlackAction = z.object({
   source: z.literal('slack_action'),
   agentId: z.string().uuid(),

--- a/packages/relay/src/shared-bot-manager.test.ts
+++ b/packages/relay/src/shared-bot-manager.test.ts
@@ -8,9 +8,14 @@ import type {
   WireNormalizedMessage
 } from '@agentconnect.md/protocol'
 import { FakeClock } from '@agentconnect.md/connection'
-import { SharedBotManager, type SharedBotManagerDeps, sharedSlackActionMsgId } from './shared-bot-manager.js'
+import {
+  SharedBotManager,
+  type SharedBotManagerDeps,
+  sharedSlackActionMsgId,
+  sharedSlackShortcutMsgId
+} from './shared-bot-manager.js'
 import { SharedBotRouter, type BotAssignment } from './shared-bot-router.js'
-import type { SharedSlackSessionAction } from './slack-shared-ingest.js'
+import type { SharedSlackSessionAction, SharedSlackSessionShortcut } from './slack-shared-ingest.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 import type { Logger } from './log.js'
 
@@ -79,6 +84,7 @@ interface ManagerInternals {
   reportChannels(snapshot: RcBotChannels): void
   selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void
   forwardSessionAction(botId: string, action: SharedSlackSessionAction): void
+  forwardSessionShortcut(botId: string, shortcut: SharedSlackSessionShortcut): boolean
   forward(botId: string, msg: WireNormalizedMessage): Promise<void>
 }
 
@@ -161,6 +167,45 @@ describe('SharedBotManager shared Slack session actions', () => {
     })
     expect(second.msgId).toBe(first.msgId)
     expect(first.msgId).toMatch(/^slack-action:[a-f0-9]{64}$/)
+  })
+
+  it('forwards a message shortcut through the current thread affinity', () => {
+    const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const daemon = { sendMsg } as unknown as RelayDaemonConnection
+    const manager = new SharedBotManager(
+      deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
+    )
+    const internals = manager as unknown as ManagerInternals
+    internals.router.upsert(assignment())
+    internals.router.setAffinity(BOT_ID, 'C123/T1', {
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID,
+      integrationId: INTEGRATION_ID
+    })
+    const shortcut: SharedSlackSessionShortcut = {
+      triggerId: 'trigger-shortcut',
+      channelId: 'C123',
+      threadTs: 'T1',
+      interactionId: 'trigger-shortcut',
+      userId: 'U-ALICE'
+    }
+
+    expect(internals.forwardSessionShortcut(BOT_ID, shortcut)).toBe(true)
+    expect(sendMsg).toHaveBeenCalledWith({
+      source: 'slack_action',
+      agentId: AGENT_ID,
+      integrationId: INTEGRATION_ID,
+      sessionKey: 'C123/T1',
+      msgId: sharedSlackShortcutMsgId(BOT_ID, shortcut),
+      botId: BOT_ID,
+      userId: 'U-ALICE',
+      payload: {
+        kind: 'open-config-for-thread',
+        triggerId: 'trigger-shortcut',
+        channelId: 'C123',
+        threadTs: 'T1'
+      }
+    })
   })
 
   it('forwards the tapping user, and omits it entirely when the interaction named none', () => {

--- a/packages/relay/src/shared-bot-manager.ts
+++ b/packages/relay/src/shared-bot-manager.ts
@@ -29,7 +29,11 @@ import type {
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from './log.js'
 import { SharedBotRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './shared-bot-router.js'
-import { SlackSharedIngest, type SharedSlackSessionAction } from './slack-shared-ingest.js'
+import {
+  SlackSharedIngest,
+  type SharedSlackSessionAction,
+  type SharedSlackSessionShortcut
+} from './slack-shared-ingest.js'
 import { verifySlackSignature } from './hooks/signature.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 
@@ -113,6 +117,21 @@ export function sharedSlackActionMsgId(botId: string, action: SharedSlackSession
         interactionId,
         kind,
         value
+      })
+    )
+    .digest('hex')
+  return `slack-action:${digest}`
+}
+
+export function sharedSlackShortcutMsgId(botId: string, shortcut: SharedSlackSessionShortcut): string {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify({
+        v: 1,
+        botId,
+        channelId: shortcut.channelId,
+        threadTs: shortcut.threadTs,
+        interactionId: shortcut.interactionId
       })
     )
     .digest('hex')
@@ -207,6 +226,7 @@ export class SharedBotManager {
         onSelectThreadAgent: (channelId, threadTs, agentId) =>
           this.selectThreadAgent(a.botId, channelId, threadTs, agentId),
         onSessionAction: (action) => this.forwardSessionAction(a.botId, action),
+        onSessionShortcut: (shortcut) => this.forwardSessionShortcut(a.botId, shortcut),
         log: this.deps.log
       }
     )
@@ -509,5 +529,58 @@ export class SharedBotManager {
       .catch((err) =>
         this.deps.log.warn(`shared-bot(${botId}): session action forward failed: ${(err as Error).message}`)
       )
+  }
+
+  /** Resolve a message shortcut from live conversation ownership, then let the
+   *  daemon resolve the exact bot-scoped session before it opens the modal. */
+  private forwardSessionShortcut(botId: string, shortcut: SharedSlackSessionShortcut): boolean {
+    const sessionKey = sessionKeyOf({ channel: shortcut.channelId, thread: shortcut.threadTs })
+    const assignment = this.router.get(botId)
+    if (!assignment) return false
+    const allowedInChannel = (agentId: string): boolean =>
+      !assignment.gatedAgentIds?.includes(agentId) ||
+      assignment.routes.some((route) => route.agentId === agentId && route.scope?.channel === shortcut.channelId)
+    const affinity = this.router.peekAffinity(botId, sessionKey)
+    const affinityRoute =
+      affinity && allowedInChannel(affinity.agentId)
+        ? this.router.targetForAgent(botId, affinity.agentId, affinity.integrationId)
+        : undefined
+    const channelOwner = this.router.channelOwner(botId, shortcut.channelId)
+    const route =
+      affinityRoute ??
+      (channelOwner && allowedInChannel(channelOwner)
+        ? this.router.targetForAgentId(botId, channelOwner)
+        : undefined) ??
+      (assignment.defaultAgentId && allowedInChannel(assignment.defaultAgentId)
+        ? this.router.targetForAgentId(botId, assignment.defaultAgentId)
+        : undefined)
+    if (!route) return false
+    const daemon = this.deps.getDaemon(route.daemonId)
+    if (!daemon) return false
+    const rd: RdMsgSlackAction = {
+      source: 'slack_action',
+      agentId: route.agentId,
+      integrationId: route.integrationId,
+      sessionKey,
+      msgId: sharedSlackShortcutMsgId(botId, shortcut),
+      botId,
+      ...(shortcut.userId ? { userId: shortcut.userId } : {}),
+      payload: {
+        kind: 'open-config-for-thread',
+        triggerId: shortcut.triggerId,
+        channelId: shortcut.channelId,
+        threadTs: shortcut.threadTs
+      }
+    }
+    void daemon
+      .sendMsg(rd)
+      .then((ack) => {
+        if (!ack.accepted)
+          this.deps.log.warn(`shared-bot(${botId}): daemon rejected session shortcut (${ack.reason ?? 'unknown'})`)
+      })
+      .catch((err) =>
+        this.deps.log.warn(`shared-bot(${botId}): session shortcut forward failed: ${(err as Error).message}`)
+      )
+    return true
   }
 }

--- a/packages/relay/src/slack-shared-ingest.test.ts
+++ b/packages/relay/src/slack-shared-ingest.test.ts
@@ -6,6 +6,7 @@ import {
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
   encodeSlackStatusOverflowValue,
   encodeSharedSlackStatusTarget
@@ -330,6 +331,7 @@ describe('SlackSharedIngest.handleInteraction', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
+    onSessionShortcut: vi.fn(() => false),
     log: silentLog,
     ...over
   })
@@ -360,6 +362,32 @@ describe('SlackSharedIngest.handleInteraction', () => {
     expect(result).toBe('')
     expect(onSelectThreadAgent).toHaveBeenCalledWith('C123', '1720000000.000100', AGENT_ID)
   })
+
+  it('forwards a message shortcut with the selected conversation coordinates', async () => {
+    const onSessionShortcut = vi.fn(() => true)
+    const ingest = new SlackSharedIngest(
+      'bot',
+      { botToken: 'xoxb', signingSecret: 's' },
+      ingestDeps({ onSessionShortcut })
+    )
+    const result = await ingest.handleInteraction({
+      type: 'message_action',
+      callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+      trigger_id: 'trigger-shortcut',
+      channel: { id: 'C123' },
+      message: { ts: '1720000000.000200', thread_ts: '1720000000.000100' },
+      user: { id: 'U-ALICE' }
+    })
+
+    expect(result).toBe('')
+    expect(onSessionShortcut).toHaveBeenCalledWith({
+      triggerId: 'trigger-shortcut',
+      channelId: 'C123',
+      threadTs: '1720000000.000100',
+      interactionId: 'trigger-shortcut',
+      userId: 'U-ALICE'
+    })
+  })
 })
 
 describe('SlackSharedIngest channel membership events', () => {
@@ -373,6 +401,7 @@ describe('SlackSharedIngest channel membership events', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
+    onSessionShortcut: vi.fn(() => false),
     webClientFactory: () => web as never,
     log: silentLog,
     ...over
@@ -446,6 +475,7 @@ describe('SlackSharedIngest message events', () => {
         onSetChannelAgent: vi.fn(),
         onSelectThreadAgent: vi.fn(),
         onSessionAction: vi.fn(),
+        onSessionShortcut: vi.fn(() => false),
         webClientFactory: () => web as never,
         log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
       }

--- a/packages/relay/src/slack-shared-ingest.ts
+++ b/packages/relay/src/slack-shared-ingest.ts
@@ -23,6 +23,7 @@ import {
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
   decodePermValue,
   decodeSlackStatusOverflowValue,
@@ -47,6 +48,7 @@ export interface SlackInteractiveBody {
   team?: { id?: string }
   user?: { id?: string }
   trigger_id?: string
+  callback_id?: string
   action_id?: string
   block_id?: string
   value?: string
@@ -79,7 +81,14 @@ export type SharedSlackSessionAction = SharedSlackInteractionReceipt & {
   /** Who tapped it (Slack `body.user`), forwarded so the daemon can attribute the
    *  session change. Absent when the payload names no user. */
   userId?: string
-} & RdSlackAction
+} & Exclude<RdSlackAction, { kind: 'open-config-for-thread' }>
+
+export interface SharedSlackSessionShortcut extends SharedSlackInteractionReceipt {
+  channelId: string
+  threadTs: string
+  triggerId: string
+  userId?: string
+}
 
 type SharedSlackAgent = { agentId: string; name: string }
 
@@ -383,6 +392,9 @@ export interface SlackSharedIngestDeps {
   onSelectThreadAgent: (channelId: string, threadTs: string, agentId: string) => void
   /** Forward the current agent/session controls to its owning daemon. */
   onSessionAction: (action: SharedSlackSessionAction) => void
+  /** Resolve and forward the app-level message shortcut. False opens a local
+   *  unavailable modal while the one-shot trigger id is still valid. */
+  onSessionShortcut: (shortcut: SharedSlackSessionShortcut) => boolean
   /** Test seam for the bot-token Web API client. */
   webClientFactory?: (botToken: string, options?: WebClientOptions) => WebClient
   log: Logger
@@ -548,6 +560,24 @@ export class SlackSharedIngest {
         // The one branch whose result rides the 200 body (replaces `ack({ options })`).
         return { options: sharedSlackAgentOptions(this.deps.agents(), body.value) }
       }
+      if (body.type === 'message_action' && body.callback_id === SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID) {
+        const triggerId = body.trigger_id
+        const channelId = body.channel?.id
+        const threadTs = body.message?.thread_ts ?? body.message?.ts
+        const forwarded =
+          !!triggerId &&
+          !!channelId &&
+          !!threadTs &&
+          this.deps.onSessionShortcut({
+            triggerId,
+            channelId,
+            threadTs,
+            interactionId: triggerId,
+            ...(body.user?.id ? { userId: body.user.id } : {})
+          })
+        if (triggerId && !forwarded) void this.openUnavailableModal(triggerId)
+        return ''
+      }
       if (
         body.type === 'block_actions' &&
         body.actions?.some((action) => action.action_id === SHARED_AGENT_SELECT_ACTION_ID)
@@ -594,6 +624,30 @@ export class SlackSharedIngest {
     } catch (err) {
       this.deps.log.warn(`shared-ingest(${this.botId}): interactive error: ${(err as Error).message}`)
       return ''
+    }
+  }
+
+  private async openUnavailableModal(triggerId: string): Promise<void> {
+    try {
+      await this.web?.views.open({
+        trigger_id: triggerId,
+        view: {
+          type: 'modal',
+          title: { type: 'plain_text', text: 'Session options' },
+          close: { type: 'plain_text', text: 'Close' },
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: 'No AgentConnect session was found for this conversation.'
+              }
+            }
+          ]
+        }
+      } as never)
+    } catch (err) {
+      this.deps.log.warn(`shared-ingest(${this.botId}): views.open failed: ${(err as Error).message}`)
     }
   }
 

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildSlackManifest, slackCreateAppUrl } from './slack-manifest'
+import { buildSlackManifest, slackCreateAppUrl, SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from './slack-manifest'
 
 describe('buildSlackManifest', () => {
   it('brands the app with the given background_color, and omits it otherwise', () => {
@@ -15,5 +15,19 @@ describe('buildSlackManifest', () => {
 
     expect(url.searchParams.get('new_app')).toBe('1')
     expect(JSON.parse(url.searchParams.get('manifest_json')!)).toEqual(buildSlackManifest({ name: 'acme' }))
+  })
+
+  it('declares the message shortcut and its required commands scope', () => {
+    const manifest = buildSlackManifest({ name: 'acme' })
+
+    expect(manifest.oauth_config.scopes.bot).toContain('commands')
+    expect(manifest.features.shortcuts).toEqual([
+      {
+        name: 'Manage AgentConnect session',
+        type: 'message',
+        callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+        description: 'View or update the AgentConnect session for this conversation'
+      }
+    ])
   })
 })

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -25,12 +25,16 @@
 // agent_view turns on Slack's Agent experience for newly-created apps (side panel,
 // app threads, and agent-oriented thread affordances).
 
+/** Kept in lock-step with the protocol callback consumed by daemon + relay. */
+export const SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID = 'ac_manage_session'
+
 /** Bot token scopes the daemon's Slack adapter requires. */
 export const SLACK_BOT_SCOPES = [
   'files:read',
   'app_mentions:read',
   'channels:history',
   'channels:read',
+  'commands',
   'chat:write',
   'chat:write.customize',
   'files:write',
@@ -65,6 +69,7 @@ export interface SlackAppManifest {
     bot_user: { display_name: string; always_online: boolean }
     app_home: { home_tab_enabled: boolean; messages_tab_enabled: boolean; messages_tab_read_only_enabled: boolean }
     agent_view: { agent_description: string; suggested_prompts: { title: string; message: string }[] }
+    shortcuts: { name: string; type: 'message'; callback_id: string; description: string }[]
   }
   oauth_config: { scopes: { bot: string[] }; pkce_enabled: boolean }
   settings: {
@@ -121,7 +126,15 @@ export function buildSlackManifest(names: SlackAppNames, opts?: SlackManifestOpt
       agent_view: {
         agent_description: `${displayName} is an AgentConnect agent that responds to Slack conversations and works in threads.`,
         suggested_prompts: []
-      }
+      },
+      shortcuts: [
+        {
+          name: 'Manage AgentConnect session',
+          type: 'message',
+          callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+          description: 'View or update the AgentConnect session for this conversation'
+        }
+      ]
     },
     oauth_config: { scopes: { bot: [...SLACK_BOT_SCOPES] }, pkce_enabled: false },
     settings: {


### PR DESCRIPTION
## Summary

- add a `Manage AgentConnect session` message shortcut and its required `commands` scope to manual and managed Slack manifests
- handle the shortcut in both direct Socket Mode and shared HTTP relay modes, reusing the existing session controls modal
- resolve the selected channel/thread against the exact bot-scoped session while preserving conversation gates and user allowlists
- show a neutral unavailable modal when no authorized AgentConnect session exists

Existing Slack apps must refresh their manifest and grant the added `commands` scope before the shortcut appears.

## Testing

- protocol relay-daemon tests
- relay shared-ingest and shared-bot-manager tests
- daemon Slack connection and daemon command tests
- control-plane and web Slack manifest tests
- relevant package typechecks, ESLint, and Prettier check

Created by Codex . GPT-5
