### PR TITLE
fix(slack): keep shortcut name within Slack limit

### DIFF
--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -168,7 +168,7 @@ describe('mergeManagedSlackManifest', () => {
     expect(merged.features.slash_commands).toEqual(current.features.slash_commands)
     expect(merged.features.shortcuts).toEqual([
       expect.objectContaining({
-        name: 'Manage AgentConnect session',
+        name: 'Manage session',
         callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID
       }),
       current.features.shortcuts[0]

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -115,7 +115,7 @@ function buildManagedManifest(name: string, httpRelayBase?: string, backgroundCo
       },
       shortcuts: [
         {
-          name: 'Manage AgentConnect session',
+          name: 'Manage session',
           type: 'message',
           callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
           description: 'View or update the AgentConnect session for this conversation'

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -70,9 +70,10 @@ describe('buildSlackManifest', () => {
     const manifest = buildSlackManifest({ name: 'acme' })
 
     expect(manifest.oauth_config.scopes.bot).toContain('commands')
+    expect(manifest.features.shortcuts[0]!.name.length).toBeLessThanOrEqual(24)
     expect(manifest.features.shortcuts).toEqual([
       {
-        name: 'Manage AgentConnect session',
+        name: 'Manage session',
         type: 'message',
         callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
         description: 'View or update the AgentConnect session for this conversation'

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -136,7 +136,7 @@ export function buildSlackManifest(names: SlackAppNames, opts?: SlackManifestOpt
       },
       shortcuts: [
         {
-          name: 'Manage AgentConnect session',
+          name: 'Manage session',
           type: 'message',
           callback_id: SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
           description: 'View or update the AgentConnect session for this conversation'


### PR DESCRIPTION
## Summary

- Shorten the managed Slack message shortcut name from `Manage AgentConnect session` to `Manage session`.
- Keep the generated web and control-plane manifests aligned.
- Add a regression assertion for Slack's 24-character shortcut-name limit.

## Root cause

The original shortcut name was 27 characters, so Slack rejected it when editing or applying the app configuration.

## Validation

- Control-plane Slack manifest tests: 10 passed
- Web Slack manifest tests: 5 passed
- Control-plane and web typechecks
- ESLint on all changed files

Created by Codex . GPT-5
