### PR TITLE
fix(memory): honor dream auto-accept policy

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -1,7 +1,7 @@
 # Design: Memory Dreaming Mode — Offline Consolidation for Managed Memory
 
 > Status: D-1 shipped (protocol, daemon runner, CP REST, console config); D-2
-> shipped (auto-adopt gate, distillation rebase, scheduled dreams). D-3 (skill
+> shipped (auto-accept policy, distillation rebase, scheduled dreams). D-3 (skill
 > mining) remains a proposal — see §12.
 > Prerequisites: [memory-evolution.md](memory-evolution.md),
 > [memory-system-plan.md](memory-system-plan.md),
@@ -69,8 +69,9 @@ Three invariants:
 
 1. **The live store is never modified by a running dream.** The dream reads a
    snapshot and writes only into its own staging directory.
-2. **Adoption is explicit and reversible.** Adopting renames the live store to
-   a timestamped backup and moves the staged tree into place, appending a
+2. **Adoption is configured and reversible.** A user either reviews a proposal
+   explicitly or enables auto-accept. Adopting renames the live store to a
+   timestamped backup and moves the staged tree into place, appending a
    `dream-adopt` event to `.history`. The backup is retained until the next
    successful adoption.
 3. **The model proposes; the daemon disposes.** The runtime returns the
@@ -79,9 +80,11 @@ Three invariants:
    traversal) and performs all filesystem writes itself. `.history` is never
    part of the proposal — it is carried over verbatim and appended to.
 
-Invariant 3 bounds only what the dream _output_ can do: a bad proposal can at
-worst become a staged candidate a human reviews. It says nothing about what the
-_extraction run itself_ can do — the mined transcript is attacker-controlled, so
+Invariant 3 bounds only what the dream _output_ can do: a bad proposal can
+change only the managed-memory store, and only after staging and validation.
+Auto-accept deliberately skips a human content-quality check, as its console
+warning makes clear. The invariant says nothing about what the _extraction run
+itself_ can do — the mined transcript is attacker-controlled, so
 a prompt injection could drive the runtime's native shell/file/network tools
 before the model ever emits JSON, and staged-output review cannot undo those
 side effects. The executor therefore separates two independent gates:
@@ -92,12 +95,12 @@ side effects. The executor therefore separates two independent gates:
   rather than running with write access. This is what keeps the executor safe
   on runtimes without a trusted system-prompt channel (Codex has read-only
   mode), and it is stricter than "staging contains everything."
-- **Trusted system-prompt channel — SOFT.** When the runtime carries the system
+- **Trusted system-prompt channel — OBSERVED.** When the runtime carries the system
   prompt via `_meta.systemPrompt` the dream policy rides it; otherwise the
-  policy is prepended to the user prompt. That fallback is acceptable because
-  invariant 3 already contains bad _content_. The trusted channel gates only
-  **auto-adopt** (§6), the one unattended path with distillation-equivalent
-  blast radius.
+  policy is prepended to the user prompt. Auto-accept is the user's explicit
+  choice to apply a completed proposal without content review, so this transport
+  distinction does not override that choice. The verified non-mutating mode
+  above still gates the extraction run itself.
 
 ## 3. Configuration
 
@@ -119,9 +122,8 @@ export const MemoryDreamingPolicy = z
     instructions: z.string().max(4096).optional(),
     /** Also mine reusable procedures into candidate skills (§7). Default false. */
     mineSkills: z.boolean().optional(),
-    /** Adopt the memory store automatically on completion. Default true. Honored only when the
-     *  extraction ran on a trusted-channel runtime — the config still saves, but
-     *  an untrusted run leaves the dream reviewable instead of adopting it.
+    /** Adopt the memory store automatically on completion without content
+     *  review. Default true. Live-memory fence conflicts remain reviewable.
      *  Never applies to skills (§7). */
     autoAdopt: z.boolean().optional()
   })
@@ -206,8 +208,8 @@ interface DreamRecord {
    `failed`, with the partial staging left in place for inspection.
 5. **Finish.** Mark `completed`; emit `memory.dream.completed` on the
    evaluation-events channel (alongside the existing `memory.capture.*`
-   events). If `autoAdopt` is set and admissible, run §6 adoption for the
-   store — never for skills.
+   events). If `autoAdopt` is set, run §6 adoption for the store — never for
+   skills.
 
 Cancel moves `pending|running → canceled` and aborts the ACP prompt (same
 cancellation path as a turn).
@@ -247,13 +249,13 @@ with the same injection posture and a five-phase pipeline:
 
 Where the runtime has no trusted system-prompt channel (today: Codex ACP),
 the policy text is prepended to the user prompt instead. That is acceptable
-_only_ because of invariant 3 + staged output: a prompt-injected dream can at
-worst produce a bad candidate the review step catches. Independently, the
-extraction session is **hard-gated on a verified read-only / plan mode** (§2) —
-so even on that untrusted-channel path a prompt injection cannot cause tool
-side effects during the run; a runtime with no non-mutating mode fails the
-dream. `autoAdopt` remains gated on `trustedExtractionMode` (§6), so the
-unattended path never runs on an untrusted channel.
+because invariant 3 + staged output constrain the proposal to validated
+managed-memory content. Independently, the extraction session is **hard-gated
+on a verified read-only / plan mode** (§2) — so even on that untrusted-channel
+path a prompt injection cannot cause tool side effects during the run; a
+runtime with no non-mutating mode fails the dream. When `autoAdopt` is enabled,
+a valid completed proposal is accepted on either prompt transport; the console
+warns that this skips content review.
 
 ## 6. Adoption (memory store)
 
@@ -277,10 +279,9 @@ unattended path never runs on an untrusted channel.
 `discardDream` deletes the staging directory and marks `discarded`. Backups
 are pruned to the most recent one on each successful adoption.
 
-`autoAdopt` runs the same path immediately on completion, and is admissible
-only when (a) the runtime passes `trustedExtractionMode` and (b) the fence in
-step 2 passes — on fence conflict the dream completes as reviewable instead of
-failing.
+`autoAdopt` runs the same path immediately on completion without content
+review. The fence in step 2 still applies — on conflict the dream completes as
+reviewable instead of failing, preserving newer live-memory changes.
 
 ## 7. Skill mining and recommendations
 
@@ -335,10 +336,11 @@ Distillation and dreaming are two layers of one background-memory system —
 per-turn additive capture and periodic reconstructive consolidation. The
 constraints are deliberately coupled: distillation may write to the live store
 unreviewed _because_ it is additive-only and rides a trusted channel; dreaming
-may rewrite and delete _because_ its output is staged and reviewed. Neither
-subsumes the other: capture keeps facts available in near-real-time; dreaming
-compacts what capture accumulates and catches cross-session patterns capture
-cannot see. On runtimes where distillation is unavailable (no trusted
+may rewrite and delete because its output is staged, validated, reversible, and
+either reviewed or covered by the user's auto-accept policy. Neither subsumes
+the other: capture keeps facts available in near-real-time; dreaming compacts
+what capture accumulates and catches cross-session patterns capture cannot see.
+On runtimes where distillation is unavailable (no trusted
 system-prompt channel — Codex today), dreaming's transcript mining is the
 only automatic capture path, which is why the dream pipeline mines transcripts
 directly rather than assuming distillation output exists.
@@ -376,7 +378,8 @@ Concrete unification points:
     caps (the swap bypasses `writeMemoryFile`, so its limits are re-enforced
     here).
 
-  Any write with a tool, console, or other source hard-fences to manual review.
+  Any write with a tool, console, or other source hard-fences to manual review,
+  including when auto-accept is enabled.
 
 - **Serialization.** Snapshot and adoption take the shared per-memory-dir lock,
   and a distillation batch holds that same lock end to end — it reads the index
@@ -465,7 +468,7 @@ input metadata, not the Dream session's history or usage.
 | Phase | Scope                                                                                                                                                                                |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | D-1   | Protocol schema (`MemoryDreamingPolicy`), shared extraction-session helper, daemon `DreamRunner` + staged store pipeline, manual trigger via frames, console review + adopt/discard. |
-| D-2a  | `autoAdopt` behind `trustedExtractionMode`, the distillation rebase rule, backup pruning. **Done.**                                                                                  |
+| D-2a  | `autoAdopt` independent of prompt-channel trust, the distillation rebase rule, backup pruning. **Done.**                                                                             |
 | D-2b  | Scheduled dreams (`DreamScheduler` cron trigger + reconciliation) and the console schedule control. **Done.** Evaluation-event dashboards remain.                                    |
 | D-3   | Skill mining (`mineSkills`): extract-procedures phase, staged skill candidates, console recommendations with accept/dismiss, integration with the shared-skills install flow.        |
 | D-4   | Idle-trigger heuristic; revisit external-provider dreaming.                                                                                                                          |

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -243,9 +243,11 @@ timezone and automatically accepting the completed store proposal. Users can tur
 dreaming off, remove its schedule to keep only manual runs, or turn automatic acceptance
 off independently.
 
-Automatic acceptance remains a safe best-effort path: a runtime without a trusted
-extraction channel, an adoption fence conflict, or another failed swap leaves the
-completed result available for manual review instead of replacing live memory.
+Automatic acceptance applies to every successfully completed proposal, regardless of
+whether the runtime carries the dream policy through a dedicated system-prompt channel.
+The console must warn that these results replace live memory without content review.
+An adoption fence conflict or failed swap still leaves the completed result available
+for manual review instead of replacing newer live-memory changes.
 
 Dream proposals preserve existing topic boundaries, filenames, and byte-identical
 content by default. Small wording, formatting, ordering, or consistency changes do

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -91,7 +91,6 @@ export interface DreamStorePort {
 
 export interface DreamExtractionResult {
   output: string
-  trustedChannel: boolean
   /** The short-lived ACP id is retained for correlation after the runtime
    *  session itself is discarded. */
   sessionId?: string
@@ -188,10 +187,6 @@ export class DreamRunner {
    *  aborts it so daemon.ts can drive the host's session-cancel path and the
    *  extraction promise settles promptly (releasing the reservation). */
   private readonly aborters = new Map<string, AbortController>()
-
-  /** Trust verdict of the host that produced each dream's proposal, captured at
-   *  extraction time. Auto-adopt reads THIS, never the agent's current host. */
-  private readonly extractionTrust = new Map<string, boolean>()
 
   /** Per-agent serial mutex over the mutating critical sections (snapshot+reserve,
    *  the adopt fence/swap, discard). Ordering matters: the adopt swap must not
@@ -327,7 +322,6 @@ export class DreamRunner {
         // while a dream is in flight, and this dream holds that slot until here.
         .then(() => this.maybeAutoAdopt(agentId, dream.dreamId))
         .catch(() => {})
-        .finally(() => this.extractionTrust.delete(dream.dreamId))
       return dream
     })
   }
@@ -401,11 +395,6 @@ export class DreamRunner {
         outputBytes: Buffer.byteLength(output),
         ...(extracted.usage ?? {})
       }
-      // Bind auto-adopt's gate to the host that ACTUALLY produced this proposal.
-      // Re-reading the agent's current host later would let a host replacement
-      // between extraction and adoption authorize an untrusted proposal.
-      this.extractionTrust.set(dreamId, extracted.trustedChannel)
-
       // The mined session ids are what grounds a skill candidate — a citation the
       // model invented can't be used to justify a recommendation (design §7).
       const proposal = parseDreamProposal(output, mineSkills ? sources.map((s) => s.sessionId) : [])
@@ -475,7 +464,7 @@ export class DreamRunner {
     prompt: string,
     signal: AbortSignal,
     mineSkills = false
-  ): Promise<({ abandoned: false } & DreamExtractionResult) | { abandoned: true; output: ''; trustedChannel: false }> {
+  ): Promise<({ abandoned: false } & DreamExtractionResult) | { abandoned: true; output: '' }> {
     const graceMs = this.deps.cancelGraceMs ?? 30_000
     const extraction = this.deps
       .extract(dream.agentId, dreamSystemPrompt(mineSkills), prompt, signal, {
@@ -485,9 +474,9 @@ export class DreamRunner {
       })
       .then((result) => ({ abandoned: false as const, ...result }))
     let timer: ReturnType<typeof setTimeout> | undefined
-    const backstop = new Promise<{ abandoned: true; output: ''; trustedChannel: false }>((resolve) => {
+    const backstop = new Promise<{ abandoned: true; output: '' }>((resolve) => {
       const arm = () => {
-        timer = setTimeout(() => resolve({ abandoned: true, output: '', trustedChannel: false }), graceMs)
+        timer = setTimeout(() => resolve({ abandoned: true, output: '' }), graceMs)
       }
       if (signal.aborted) arm()
       else signal.addEventListener('abort', arm, { once: true })
@@ -765,26 +754,19 @@ export class DreamRunner {
 
   /**
    * Adopt a just-completed dream without review when the agent opted in
-   * (`dreaming.autoAdopt`) AND its runtime carries a trusted system-prompt
-   * channel. Unattended adoption has distillation-equivalent blast radius, so it
-   * inherits distillation's gate: an untrusted-channel runtime keeps the dream
-   * reviewable instead (design §2/§6). Never throws — a fence conflict or a
-   * failed swap just leaves the dream `completed` and awaiting review.
+   * (`dreaming.autoAdopt`). The user explicitly opted out of reviewing completed
+   * results, so the runtime's system-prompt transport does not add a second
+   * review gate. Never throws — a live-memory fence conflict or failed swap
+   * still leaves the dream `completed` and awaiting review.
    */
   private async maybeAutoAdopt(agentId: string, dreamId: string): Promise<void> {
     const dream = this.deps.store.getDream(agentId, dreamId)
     if (dream?.status !== 'completed') return
     const policy = this.deps.dreamingPolicyFor(agentId)
     if (!policy?.autoAdopt) return
-    if (!this.extractionTrust.get(dreamId)) {
-      this.deps.log.warn(
-        `dream ${dreamId}: auto-adopt skipped for agent ${agentId} — the extraction ran on a runtime without a trusted system-prompt channel; review it manually`
-      )
-      return
-    }
     try {
-      // Never force: a fence conflict the rebase can't explain must fall back to
-      // human review rather than clobber a live tool/console write.
+      // Never force: a fence conflict the rebase can't explain must still fall
+      // back to human review rather than clobber a live tool/console write.
       await this.adopt(agentId, dreamId, false)
       this.deps.log.info(`dream ${dreamId} auto-adopted for agent ${agentId}`)
     } catch (err) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3579,11 +3579,11 @@ export class Daemon {
    *   mode and throw if the runtime has none or the switch doesn't take — the
    *   dream then fails rather than running with write access. (Passing `[]`
    *   mcpServers only drops our MCP tools, not the runtime's built-ins.)
-   * - **Trusted system-prompt channel — SOFT.** When the runtime carries the
+   * - **Trusted system-prompt channel — OBSERVED.** When the runtime carries the
    *   system prompt via `_meta.systemPrompt` the dream policy rides it; otherwise
-   *   the policy is prepended to the user prompt. That fallback is acceptable
-   *   because the output is staged and reviewed — bad *content* can't reach the
-   *   live store. `autoAdopt` (D-2) is what stays gated on the trusted channel.
+   *   the policy is prepended to the user prompt. Auto-accept is the user's
+   *   explicit choice to skip content review, so this transport distinction does
+   *   not override it; the verified non-mutating mode above still gates the run.
    */
   private async runDreamExtraction(
     agentId: string,
@@ -3593,7 +3593,6 @@ export class Daemon {
     context: { dreamId: string; trigger: 'manual' | 'schedule' | 'auto'; sessionIds: string[] }
   ): Promise<{
     output: string
-    trustedChannel: boolean
     sessionId: string
     runtime: string
     model?: string
@@ -3729,7 +3728,6 @@ export class Daemon {
         const usage = this.store.getUsage(executionKey)
         return {
           output: chunks.join(''),
-          trustedChannel: trusted,
           sessionId,
           runtime: agent.runtime,
           ...(model ? { model } : {}),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3602,9 +3602,8 @@ export class Daemon {
     const agent = this.agents.get(agentId)
     if (!agent) throw new Error(`unknown agent ${agentId}`)
     const host = await this.ensureHostAsync(agentId)
-    // Captured from THIS host, and returned with the output — the runner binds
-    // auto-adopt's gate to the extraction that actually produced the proposal,
-    // so a later host replacement can't retro-authorize an untrusted one.
+    // Capture the transport capability from THIS host so the extraction policy
+    // uses the same dedicated-system-prompt or inline path as the proposal run.
     const trusted = host.usesMetaSystemPrompt()
     let cwd = this.memoryExtractionDirs.get(agentId)
     if (!cwd) {

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -182,7 +182,7 @@ describe('Daemon evaluation surface', () => {
     let dream
     await vi.waitFor(() => {
       dream = (daemon as any).store.getDream(AGENT_ID, started.dreamId)
-      expect(dream?.status).toBe('completed')
+      expect(dream?.status).toBe('adopted')
     })
 
     expect(dream).toMatchObject({
@@ -209,7 +209,11 @@ describe('Daemon evaluation surface', () => {
     expect(history).not.toContain('source session')
     expect(history).toContain('Dream completed.')
     expect(history).not.toContain(proposal)
-    expect(collector.events().map((event) => event.type)).toEqual(['memory.dream.started', 'memory.dream.completed'])
+    expect(collector.events().map((event) => event.type)).toEqual([
+      'memory.dream.started',
+      'memory.dream.completed',
+      'memory.dream.adopted'
+    ])
     expect(host.discardSession).toHaveBeenCalledWith('dream-session-1')
 
     ;(daemon as any).recordDreamLifecycle({
@@ -269,7 +273,7 @@ describe('Daemon evaluation surface', () => {
     let dream
     await vi.waitFor(() => {
       dream = (daemon as any).store.getDream(AGENT_ID, started.dreamId)
-      expect(dream?.status).toBe('completed')
+      expect(dream?.status).toBe('adopted')
     })
 
     expect(dream).not.toHaveProperty('model')

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -79,7 +79,6 @@ async function setup(opts: {
   extract?: (agentId: string, systemPrompt: string, prompt: string, signal: AbortSignal) => Promise<string>
   policy?: MemoryDreamingPolicy
   cancelGraceMs?: number
-  trustedExtraction?: boolean
   extractionResult?: DreamExtractionResult
   onEvent?: (event: DreamLifecycleEvent) => void
 }) {
@@ -96,9 +95,7 @@ async function setup(opts: {
       prompts.push({ systemPrompt, prompt })
       if (opts.extractionResult) return opts.extractionResult
       const output = opts.extract ? await opts.extract(agentId, systemPrompt, prompt, signal) : PROPOSAL
-      // The producing host's verdict rides WITH the output (a later host swap
-      // must not be able to retro-authorize an untrusted proposal).
-      return { output, trustedChannel: opts.trustedExtraction ?? false }
+      return { output }
     },
     ...(opts.onEvent ? { onEvent: opts.onEvent } : {}),
     ...(opts.cancelGraceMs !== undefined ? { cancelGraceMs: opts.cancelGraceMs } : {}),
@@ -144,7 +141,6 @@ describe('DreamRunner pipeline', () => {
     const { store, runner } = await setup({
       extractionResult: {
         output: PROPOSAL,
-        trustedChannel: false,
         sessionId: 'dream-session-1',
         runtime: 'codex',
         model: 'gpt-5.6',
@@ -227,7 +223,7 @@ describe('DreamRunner pipeline', () => {
       agentDirByAgent: () => dir,
       dreamingPolicyFor: () => ({ enabled: true }),
       store,
-      extract: async () => ({ output: PROPOSAL, trustedChannel: false }),
+      extract: async () => ({ output: PROPOSAL }),
       log: silent
     })
     const started = await runner.start('a1', { trigger: 'manual' })
@@ -256,7 +252,7 @@ describe('DreamRunner pipeline', () => {
       agentDirByAgent: () => dir,
       dreamingPolicyFor: () => ({ enabled: true }),
       store,
-      extract: async () => ({ output: PROPOSAL, trustedChannel: false }),
+      extract: async () => ({ output: PROPOSAL }),
       onStaged: (agentId, dreamId) => {
         runner.cancel(agentId, dreamId) // cancel after staging, before completion
       },
@@ -515,7 +511,7 @@ describe('DreamRunner adoption', () => {
     )
   })
 
-  it('auto-adopts on a trusted runtime, but leaves an untrusted one for review', async () => {
+  it('auto-adopts completed results without a runtime trust gate', async () => {
     const settleAdoption = async (store: FakeStore, dreamId: string) => {
       // Auto-adopt runs after the run promise settles (the reservation must be
       // free first), so poll past `completed` for the terminal state.
@@ -526,26 +522,17 @@ describe('DreamRunner adoption', () => {
       return store.dreams.get(dreamId)!
     }
 
-    const trusted = await setup({ policy: { enabled: true, autoAdopt: true }, trustedExtraction: true })
-    const a = await trusted.runner.start('a1', { trigger: 'schedule' })
-    await settle(trusted.store, a.dreamId)
-    expect((await settleAdoption(trusted.store, a.dreamId)).status).toBe('adopted')
+    const result = await setup({ policy: { enabled: true, autoAdopt: true } })
+    const started = await result.runner.start('a1', { trigger: 'schedule' })
+    await settle(result.store, started.dreamId)
+    expect((await settleAdoption(result.store, started.dreamId)).status).toBe('adopted')
     // The live store really was replaced, unattended.
-    expect(await readMemoryFile(trusted.dir, 'prefs.md')).toContain('Uses tabs, not spaces (2026-07-24).')
-
-    // Same policy, untrusted channel ⇒ gate holds; the dream stays reviewable.
-    const untrusted = await setup({ policy: { enabled: true, autoAdopt: true }, trustedExtraction: false })
-    const b = await untrusted.runner.start('a1', { trigger: 'schedule' })
-    await settle(untrusted.store, b.dreamId)
-    await new Promise((r) => setTimeout(r, 40))
-    expect(untrusted.store.dreams.get(b.dreamId)?.status).toBe('completed')
-    expect(await readMemoryFile(untrusted.dir, 'prefs.md')).toBe('- uses tabs\n- uses tabs again\n')
+    expect(await readMemoryFile(result.dir, 'prefs.md')).toContain('Uses tabs, not spaces (2026-07-24).')
   })
 
   it('leaves the dream reviewable when auto-adopt hits an unrebasable fence', async () => {
     const { dir, store, runner } = await setup({
       policy: { enabled: true, autoAdopt: true },
-      trustedExtraction: true,
       // Hold the extraction open so a console write lands inside the dream window.
       extract: async () => {
         await writeMemoryFile(dir, 'notes.md', '- human note mid-dream\n', undefined, 'console')
@@ -777,7 +764,7 @@ describe('DreamRunner crash recovery', () => {
       agentDirByAgent: (agentId) => (agentId === 'a1' ? dir : undefined),
       dreamingPolicyFor: () => undefined,
       store,
-      extract: async () => ({ output: '', trustedChannel: false }),
+      extract: async () => ({ output: '' }),
       log: silent
     })
     for (let i = 0; i < 20; i++) {
@@ -790,7 +777,7 @@ describe('DreamRunner crash recovery', () => {
   })
 })
 
-describe('DreamRunner store + trust binding', () => {
+describe('DreamRunner store persistence', () => {
   it('round-trips snapshotWrites through the real LocalStore (not just the fake)', async () => {
     // Regression: the runner wrote `snapshotWrites`, but if LocalStore's schema
     // and mappers omit it the value is dropped on insert and EVERY production
@@ -843,7 +830,7 @@ describe('DreamRunner store + trust binding', () => {
       agentDirByAgent: () => dir,
       dreamingPolicyFor: () => ({ enabled: true }),
       store,
-      extract: async () => ({ output: PROPOSAL, trustedChannel: false }),
+      extract: async () => ({ output: PROPOSAL }),
       log: silent
     })
     const started = await runner.start('a1', { trigger: 'manual' })
@@ -855,32 +842,6 @@ describe('DreamRunner store + trust binding', () => {
     }
     expect(store.getDream('a1', started.dreamId)?.snapshotWrites).toBeDefined()
     store.close()
-  })
-
-  it('binds auto-adopt to the extracting host, so a later trust flip cannot authorize it', async () => {
-    // The untrusted host produced the proposal; the agent's host is replaced by a
-    // trusted one while staging runs. Auto-adopt must honor the ORIGINAL verdict.
-    const dir = await mkdtemp(join(tmpdir(), 'ac-dream-'))
-    ensureMemory(dir, 'bot')
-    await writeMemoryFile(dir, 'prefs.md', '- uses tabs\n', undefined, 'tool')
-    const store = new FakeStore()
-    let hostIsTrusted = false
-    const runner = new DreamRunner({
-      agentDirByAgent: () => dir,
-      dreamingPolicyFor: () => ({ enabled: true, autoAdopt: true }),
-      store,
-      extract: async () => ({ output: PROPOSAL, trustedChannel: hostIsTrusted }),
-      onStaged: () => {
-        hostIsTrusted = true // host replaced mid-flight by a trusted one
-      },
-      log: silent
-    })
-    const started = await runner.start('a1', { trigger: 'manual' })
-    await settle(store, started.dreamId)
-    await new Promise((r) => setTimeout(r, 40))
-
-    expect(store.dreams.get(started.dreamId)?.status).toBe('completed') // NOT adopted
-    expect(await readMemoryFile(dir, 'prefs.md')).toBe('- uses tabs\n')
   })
 })
 
@@ -964,7 +925,7 @@ describe('DreamRunner skill mining (D-3)', () => {
       agentDirByAgent: (id) => (id === 'a1' ? dir : undefined),
       dreamingPolicyFor: () => ({ enabled: true, mineSkills: true }),
       store,
-      extract: async () => ({ output: proposal, trustedChannel: false }),
+      extract: async () => ({ output: proposal }),
       ...(onEvent ? { onEvent } : {}),
       log: silent
     })
@@ -998,7 +959,7 @@ describe('DreamRunner skill mining (D-3)', () => {
       store,
       extract: async (_a, systemPrompt) => {
         prompts.push(systemPrompt)
-        return { output: grounded, trustedChannel: false }
+        return { output: grounded }
       },
       log: silent
     })
@@ -1088,7 +1049,7 @@ describe('DreamRunner skill mining — review findings', () => {
       store,
       extract: async (_a, _s, prompt) => {
         prompts.push(prompt)
-        return { output: opts.proposal ?? proposalWith([candidate()]), trustedChannel: false }
+        return { output: opts.proposal ?? proposalWith([candidate()]) }
       },
       log: silent
     })
@@ -1120,7 +1081,7 @@ describe('DreamRunner skill mining — review findings', () => {
       store,
       extract: async (_a, _s, prompt) => {
         prompts.push(prompt)
-        return { output: PROPOSAL, trustedChannel: false }
+        return { output: PROPOSAL }
       },
       log: silent
     })

--- a/packages/protocol/src/frames/memory-connection.ts
+++ b/packages/protocol/src/frames/memory-connection.ts
@@ -43,8 +43,9 @@ export type MemoryCapturePolicy = z.infer<typeof MemoryCapturePolicy>
  * Dreaming — periodic offline consolidation of the MANAGED store
  * (design: docs/designs/memory-dreaming.md). Valid only with
  * `provider: 'managed'`; the daemon stages a rebuilt store per dream and the
- * user (or the gated auto-adopt path) reviews and adopts it. Bounds mirror the
- * design: sessionWindow ≤ 100 mined transcripts, instructions ≤ 4096 chars.
+ * user reviews and adopts it, or an enabled auto-accept policy adopts it.
+ * Bounds mirror the design: sessionWindow ≤ 100 mined transcripts,
+ * instructions ≤ 4096 chars.
  */
 export const MemoryDreamingPolicy = z
   .object({
@@ -61,9 +62,9 @@ export const MemoryDreamingPolicy = z
     instructions: z.string().max(4096).optional(),
     /** Also mine reusable procedures into candidate skills (never auto-installed). */
     mineSkills: z.boolean().optional(),
-    /** Adopt the staged store automatically on completion. Admissible only on
-     *  runtimes with a trusted extraction channel; the daemon enforces that.
-     *  Absent defaults to true for effective managed-memory policies. */
+    /** Adopt the staged store automatically on completion without content
+     *  review. Live-memory fence conflicts remain reviewable. Absent defaults
+     *  to true for effective managed-memory policies. */
     autoAdopt: z.boolean().optional()
   })
   .strict()

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -90,12 +90,19 @@ afterEach(async () => {
   vi.restoreAllMocks()
 })
 
-async function render(props: { canEdit?: boolean; sessionBasePath?: string } = {}) {
+async function render(props: { canEdit?: boolean; autoAcceptMemory?: boolean; sessionBasePath?: string } = {}) {
   container = document.createElement('div')
   document.body.append(container)
   root = createRoot(container)
   await act(async () => {
-    root?.render(<DreamPanel agentId={AGENT} canEdit={props.canEdit ?? true} sessionBasePath={props.sessionBasePath} />)
+    root?.render(
+      <DreamPanel
+        agentId={AGENT}
+        canEdit={props.canEdit ?? true}
+        autoAcceptMemory={props.autoAcceptMemory ?? false}
+        sessionBasePath={props.sessionBasePath}
+      />
+    )
   })
   return container
 }
@@ -108,10 +115,20 @@ describe('DreamPanel', () => {
     const host = await render()
     await act(async () => button(host, 'Dream now')?.click())
     expect(document.body.textContent).toContain('uses model tokens')
+    expect(document.body.textContent).toContain('review and adopt the memory result')
+    expect(document.body.textContent).toContain('Suggested skills still require review')
     expect(api.startDream).not.toHaveBeenCalled()
 
     await act(async () => button(document.body, 'Start dream')?.click())
     expect(api.startDream).toHaveBeenCalledWith(AGENT)
+  })
+
+  it('explains memory auto-accept without implying that generated skills are installed', async () => {
+    const host = await render({ autoAcceptMemory: true })
+    await act(async () => button(host, 'Dream now')?.click())
+    expect(document.body.textContent).toContain('memory result is adopted automatically')
+    expect(document.body.textContent).toContain('Suggested skills still require review')
+    expect(document.body.textContent).not.toContain('Nothing changes until you review')
   })
 
   it('keeps terminal history collapsed by default', async () => {
@@ -340,6 +357,7 @@ describe('DreamPanel', () => {
     expect(api.listDreams).toHaveBeenCalledWith(AGENT, 50, { pendingSkills: true })
 
     expect(host.textContent).toContain('Suggested skills')
+    expect(host.textContent).toContain('Generated skills always require review before installation')
     expect(host.textContent).toContain('deploy-staging')
     expect(host.textContent).toContain('Deploy to staging')
     // Nothing happens until the human acts — skills are never auto-installed.

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -107,10 +107,12 @@ function fmtBytes(bytes: number): string {
 export function DreamPanel({
   agentId,
   canEdit,
+  autoAcceptMemory,
   sessionBasePath
 }: {
   agentId: string
   canEdit: boolean
+  autoAcceptMemory: boolean
   sessionBasePath?: string
 }) {
   const [dreams, setDreams] = useState<DreamDto[] | null>(null)
@@ -428,8 +430,11 @@ export function DreamPanel({
               void run(() => startDream(agentId), 'start')
             }}
           >
-            This runs a model over the agent’s memory and recent sessions. It takes a few minutes and uses model tokens.
-            Nothing changes until you review and adopt the result.
+            {`This runs a model over the agent’s memory and recent sessions. It takes a few minutes and uses model tokens. ${
+              autoAcceptMemory
+                ? 'The memory result is adopted automatically unless live-memory changes conflict. Suggested skills still require review.'
+                : 'Nothing changes until you review and adopt the memory result. Suggested skills still require review.'
+            }`}
           </ConfirmationDialog>
         ) : null}
 
@@ -594,8 +599,8 @@ function DreamReview({
 /**
  * Skills this dream mined and is RECOMMENDING. Never auto-installed: a skill is
  * executable instruction content that steers every later session, so acceptance
- * is always an explicit human act (design §7) — unlike the memory store, which
- * can auto-adopt on a trusted runtime.
+ * is always an explicit human act (design §7), independent of the memory store's
+ * auto-accept policy.
  */
 function DreamSkills({
   agentId,
@@ -622,8 +627,8 @@ function DreamSkills({
         Suggested skills
       </span>
       <span className="font-sans text-[11px] font-normal leading-[1.5] text-(--text-tertiary)">
-        Procedures this agent kept repeating. Accepting one installs it for this agent so later sessions can reuse it —
-        it is never installed for you.
+        Generated skills always require review before installation. Accepting one installs it for this agent so later
+        sessions can reuse it.
       </span>
       {proposed.map((skill) => (
         <div

--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -257,10 +257,12 @@ describe('MemoryPanel settings draft', () => {
 
     expect(checkboxFor('Enable dreaming')?.checked).toBe(true)
     expect(checkboxFor('Run on a schedule')?.checked).toBe(true)
-    expect(checkboxFor('Automatically accept completed results')?.checked).toBe(true)
+    expect(checkboxFor('Automatically adopt completed memory results')?.checked).toBe(true)
     expect(container.textContent).toContain('Daily')
+    expect(container.textContent).toContain('Dream memory results can be inaccurate')
 
-    await act(async () => checkboxFor('Automatically accept completed results')?.click())
+    await act(async () => checkboxFor('Automatically adopt completed memory results')?.click())
+    expect(container.textContent).not.toContain('Dream memory results can be inaccurate')
     const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent === 'Save memory settings'
     )

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -714,22 +714,29 @@ export function MemoryPanel({
                         setProviderError(null)
                       }}
                     />
-                    <label className="flex items-start gap-2 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
-                      <input
-                        type="checkbox"
-                        checked={settings.dreaming.autoAdopt}
-                        disabled={!canEdit || savingProvider}
-                        onChange={() => {
-                          setSettings((current) => ({
-                            ...current,
-                            dreaming: { ...current.dreaming, autoAdopt: !current.dreaming.autoAdopt }
-                          }))
-                          setProviderError(null)
-                        }}
-                      />
-                      Automatically accept completed results and replace live memory. If a result cannot be applied
-                      safely, it stays ready for review.
-                    </label>
+                    <div className="flex flex-col gap-1">
+                      <label className="flex items-start gap-2 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
+                        <input
+                          type="checkbox"
+                          checked={settings.dreaming.autoAdopt}
+                          disabled={!canEdit || savingProvider}
+                          onChange={() => {
+                            setSettings((current) => ({
+                              ...current,
+                              dreaming: { ...current.dreaming, autoAdopt: !current.dreaming.autoAdopt }
+                            }))
+                            setProviderError(null)
+                          }}
+                        />
+                        Automatically adopt completed memory results without review.
+                      </label>
+                      {settings.dreaming.autoAdopt ? (
+                        <div className="ml-6 font-sans text-[11px] font-normal leading-[1.5] text-(--amber-500)">
+                          Warning: Dream memory results can be inaccurate. Conflicting changes to live memory while a
+                          dream runs still pause the result for review.
+                        </div>
+                      ) : null}
+                    </div>
                     <label className="flex flex-col gap-1 font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
                       Instructions (optional — steer what the dream focuses on)
                       <textarea
@@ -897,7 +904,13 @@ export function MemoryPanel({
               persisted policy is on; otherwise its trigger would be noise. */}
           {persistedSettings.dreaming.enabled ? (
             <div className="mt-4">
-              <DreamPanel key={agentId} agentId={agentId} canEdit={canEdit} sessionBasePath={sessionBasePath} />
+              <DreamPanel
+                key={agentId}
+                agentId={agentId}
+                canEdit={canEdit}
+                autoAcceptMemory={persistedSettings.dreaming.autoAdopt}
+                sessionBasePath={sessionBasePath}
+              />
             </div>
           ) : null}
         </>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -141,7 +141,7 @@ export interface MemoryDreamingConfig {
   timezone?: string // IANA zone the schedule is evaluated in (absent ⇒ daemon local)
   instructions?: string // operator steering text (≤4096 chars)
   mineSkills?: boolean // also mine reusable procedures (D-3)
-  autoAdopt?: boolean // adopt automatically on completion; absent defaults on (trusted runtimes only)
+  autoAdopt?: boolean // adopt automatically without content review; absent defaults on
 }
 
 export type AgentMemoryConfig =


### PR DESCRIPTION
## Summary

- honor managed-memory auto-accept for every completed dream proposal, independent of the runtime's prompt-channel transport
- retain the non-forced live-memory adoption fence, so conflicting changes still pause for review
- distinguish memory auto-accept from generated-skill approval in settings and the Dream confirmation UX
- keep generated skills on their independent, explicit content-review path
- update product conventions, design documentation, protocol comments, and focused tests

## Why

The daemon previously treated an untrusted system-prompt transport as an extra auto-accept gate. That left completed memory results asking for manual review even when the user had explicitly enabled auto-accept. Prompt transport and the user's adoption policy are separate decisions; the verified read-only extraction mode still protects the run itself.

Generated skills are different from memory results because they may contain executable instructions and scripts. They remain individually reviewable and are never covered by memory auto-accept.

## User impact

When memory auto-accept is enabled, a completed memory result is adopted automatically unless a conflicting live-memory write trips the existing fence. The console warns that memory content is not reviewed automatically and clearly states that suggested skills still require review before installation.

## Validation

- daemon dream-runner: 50 tests
- web MemoryPanel + DreamPanel: 36 tests
- protocol memory-dream: 9 tests
- daemon, web, and protocol typechecks
- focused ESLint and repository pre-push lint
- Prettier and git diff checks
