### PR TITLE
style(web): polish console rows, search hint, and bot avatar stacking

### DIFF
--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -64,6 +64,12 @@ export function GlobalSearch({
   const [sel, setSel] = useState(0)
   const [activeType, setActiveType] = useState<TypeFilter>('all')
   const inputRef = useRef<HTMLInputElement>(null)
+  // Shortcut hint: ⌘K on macOS, Ctrl K elsewhere. Detected post-mount so SSR
+  // (which has no `navigator`) hydrates cleanly, then flips if on Windows/Linux.
+  const [isMac, setIsMac] = useState(true)
+  useEffect(() => {
+    setIsMac(/Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent))
+  }, [])
 
   const query = q.trim().toLowerCase()
 
@@ -438,7 +444,11 @@ export function GlobalSearch({
           onKeyDown={onKeyDown}
           onFocus={() => setOpen(true)}
         />
-        {!open && <span className="kbd">⌘K</span>}
+        {!open && (
+          <span className="kbd inline-flex items-center gap-[2px]">
+            {isMac ? <Icon name="command" size={11} strokeWidth={1.5} /> : 'Ctrl'}K
+          </span>
+        )}
         {open && q !== '' && (
           <button
             onClick={() => {

--- a/packages/web/src/components/console/views/CronsView.tsx
+++ b/packages/web/src/components/console/views/CronsView.tsx
@@ -167,7 +167,7 @@ function CronRow({ c }: { c: CronDto }) {
   }
 
   return (
-    <div className={`row cursor-pointer ${GRID}`} onClick={() => router.push(orgPath(`/crons/${c.id}`))}>
+    <div className={`row click ${GRID}`} onClick={() => router.push(orgPath(`/crons/${c.id}`))}>
       <div className="min-w-0">
         <div
           className={`font-sans text-[13px] font-semibold leading-normal ${

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -191,7 +191,7 @@ export default function SessionsView() {
     [params, router, orgPath]
   )
 
-  const cols = 'grid-cols-[2.3fr_1.1fr_1.4fr_.9fr_.8fr_28px]'
+  const cols = 'grid-cols-[2.3fr_1.1fr_1.4fr_.9fr_.8fr_28px] gap-3'
 
   // ── Filter options — each carries a `face` (the design puts a per-option visual
   //    in both the dropdown button and its menu rows): agent marks, platform marks,

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -770,8 +770,8 @@ function BotsCard({
                       <span
                         key={id}
                         title={ag ? agentLabel(ag) : id}
-                        className={`av h-[22px] w-[22px] rounded-[6px] border-2 border-(--surface-card) ${
-                          idx > 0 ? '-ml-[6px]' : ''
+                        className={`av h-[22px] w-[22px] rounded-[6px] ${
+                          idx > 0 ? '-ml-[6px] shadow-[-1px_0_0_0_var(--surface-card)]' : ''
                         }`}
                       >
                         <AgentIconView icon={ag?.icon} runtime={ag?.runtime || ag?.model || ''} size={22} />


### PR DESCRIPTION
## What changed

Small console UI-polish pass:

- **Settings → Bots card:** overlapping agent avatars now carry the same `-1px 0 0 0 var(--surface-card)` separator ring that `.imark-overlap` uses, applied only to avatars after the first — so a stack of installed agents reads as distinct chips instead of blending together.
- **GlobalSearch:** the `⌘K` hint now renders the lucide `command` glyph on macOS and `Ctrl K` on Windows/Linux. Platform is detected post-mount so SSR (no `navigator`) hydrates cleanly, then flips off-Mac. The keydown handler already accepted `metaKey`/`ctrlKey`, so behavior is unchanged — only the hint label.
- **CronsView:** the clickable `CronRow` now uses the shared `.row.click` class (`cursor: pointer` + `:hover` background fill) instead of a bare `cursor-pointer`, matching every other clickable row in the console.
- **SessionsView:** added `gap-3` between the session grid columns.

## Why

Consistency with existing patterns — reuse `.imark-overlap`'s ring, `.row.click`'s hover affordance — and correct the Windows shortcut hint.

## Reviewer notes

- No logic changes; styling + a platform-aware label only.
- Pre-existing eslint warnings in `control-plane/.../icon-upload.ts` are unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)