### PR TITLE
fix(daemon): stop a skill's own code fences from truncating the dream

### DIFF
--- a/packages/daemon/src/agents/memory-dreamer.ts
+++ b/packages/daemon/src/agents/memory-dreamer.ts
@@ -199,6 +199,37 @@ ${clamp(sessions.join('\n\n'), MAX_CONTEXT_BYTES - MAX_STORE_CONTEXT_BYTES)}
 }
 
 /**
+ * Recover the JSON object from a model reply.
+ *
+ * A mined skill body is itself Markdown, so it routinely contains fenced code
+ * blocks — the whole point of a procedural skill is to show the commands. Those
+ * inner fences sit inside a JSON string, but a lazy `` ```…``` `` match stops at
+ * the first one and hands back a truncated object, which fails to parse and
+ * loses the entire dream. So try the plausible readings in order and keep the
+ * first that parses: the outermost fence, then a brace slice (correct when the
+ * reply is a bare object, or a fence whose content is exactly the object), then
+ * the innermost fence for a reply that trails prose after the JSON.
+ */
+function parseDreamJson(text: string): unknown | undefined {
+  const candidates = [
+    text.match(/```(?:json)?\s*([\s\S]*)```/i)?.[1],
+    text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1),
+    text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    try {
+      const value: unknown = JSON.parse(candidate)
+      // A bare string or number parses but carries no proposal; keep looking.
+      if (value && typeof value === 'object') return value
+    } catch {
+      // Not this reading — fall through to the next.
+    }
+  }
+  return undefined
+}
+
+/**
  * Parse and harden the model's proposal. Returns null when the text carries no
  * usable JSON proposal (the dream then fails; partial staging is never written
  * from an unparseable reply). Individual entries are dropped, not repaired:
@@ -206,15 +237,8 @@ ${clamp(sessions.join('\n\n'), MAX_CONTEXT_BYTES - MAX_STORE_CONTEXT_BYTES)}
  * filtered the same way the distiller filters memories.
  */
 export function parseDreamProposal(text: string, minedSessionIds: readonly string[] = []): DreamProposal | null {
-  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]
-  const candidate = fenced ?? text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1)
-  if (!candidate) return null
-  let value: unknown
-  try {
-    value = JSON.parse(candidate)
-  } catch {
-    return null
-  }
+  const value = parseDreamJson(text)
+  if (value === undefined) return null
   const proposal = value as { index?: unknown; files?: unknown; skills?: unknown }
   if (typeof proposal?.index !== 'string' || !Array.isArray(proposal.files)) return null
 

--- a/packages/daemon/test/memory-dreamer.test.ts
+++ b/packages/daemon/test/memory-dreamer.test.ts
@@ -60,6 +60,48 @@ describe('dream proposal parsing', () => {
     }
   })
 
+  // Regression: a real model reply, fenced, whose mined skill body is Markdown
+  // containing its own fenced code blocks. A lazy fence match stopped at the
+  // first inner ``` and truncated the object mid-string, so the dream came back
+  // unparseable — losing the store proposal and every skill with it. Since a
+  // useful procedural skill always shows its commands, this broke mining for
+  // essentially every candidate worth keeping.
+  it('parses a fenced proposal whose skill body contains fenced code blocks', () => {
+    const skill =
+      '# deploy-api-staging\n\n' +
+      'Use when the user asks to ship the api service to staging.\n\n' +
+      '1. Build the workspace package:\n   ```\n   pnpm --filter api build\n   ```\n' +
+      '2. Build the image:\n   ```\n   docker build -t api:staging .\n   ```\n' +
+      '3. Roll it out:\n   ```\n   kubectl -n staging set image deploy/api api=api:staging\n   ```\n'
+    const reply =
+      '```json\n' +
+      JSON.stringify({
+        index: '# Memory\n\n_No persistent memories yet._\n',
+        files: [],
+        skills: [
+          {
+            name: 'deploy-api-staging',
+            description: 'Build and deploy the api service to the staging namespace',
+            skill,
+            scripts: [],
+            sessionIds: ['sess-a', 'sess-b']
+          }
+        ]
+      }) +
+      '\n```\n'
+
+    const proposal = parseDreamProposal(reply, ['sess-a', 'sess-b', 'sess-c'])
+    expect(proposal).not.toBeNull()
+    expect(proposal?.skills?.map((s) => s.name)).toEqual(['deploy-api-staging'])
+    expect(proposal?.skills?.[0]?.skill).toContain('docker build -t api:staging .')
+  })
+
+  it('parses a fenced proposal that trails prose after the JSON', () => {
+    const proposal = parseDreamProposal(`\`\`\`json\n${good}\n\`\`\`\n\nThat covers it — nothing else stood out.`)
+    expect(proposal?.files).toHaveLength(1)
+    expect(proposal?.index.startsWith('# Memory')).toBe(true)
+  })
+
   it('returns null for unparseable or index-less replies', () => {
     expect(parseDreamProposal('no json at all')).toBeNull()
     expect(parseDreamProposal('{"files": []}')).toBeNull()


### PR DESCRIPTION
## What

A mined skill body is Markdown, and a procedural skill exists to *show its commands* — so it almost always contains fenced code blocks. Those inner fences sit inside a JSON string, but `parseDreamProposal` matched the outer fence **lazily** (`` /```(?:json)?\s*([\s\S]*?)```/ ``) and stopped at the first ` ``` ` it saw, handing `JSON.parse` a truncated object.

The parse failed, so the **entire dream** was discarded — the store proposal and every mined skill, not just the offending candidate.

## How it was found

Every existing test passed because each fixture was hand-written JSON with no code block inside a skill body. Driving the production prompt builder and parser against a real model is what surfaced it: given three transcripts (two repeating a 4-step deploy procedure, one a one-off), the model returned exactly the right candidate, cited the two distinct sessions, and correctly ignored the one-off — and we threw all of it away.

Same probe after the fix:

```
store proposal parsed : yes
grounded skills       : [{ "name": "deploy-api-staging", ... }]
```

## Fix

Recover the JSON by trying the plausible readings in order and keeping the first that parses to an object:

1. outermost fence (greedy) — correct when the body carries its own fences;
2. brace slice — correct for a bare object, or a fence whose content is exactly the object;
3. innermost fence (lazy) — correct when the reply trails prose after the JSON.

## Tests

- regression: a fenced reply whose skill body contains code fences (**verified to fail** on the pre-fix parser);
- a fenced reply that trails prose after the JSON.

Full daemon suite: 2279 passed, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)