### PR TITLE
feat(collab): authorize agent discovery and A2A by call policy, not channel

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -308,35 +308,71 @@ did not disappear; they moved from _authorization_ to _coordinate validation_. A
 asserted coordinate channel that the snapshot knows about still requires the
 caller to be in it, and a visible post still resolves through the channel's
 definite reply integration (section 6.2). What changed is the consequence: a
-channel the directory has never heard of no longer makes a peer _unreachable_, it
-only makes the visible-post half of the request unsatisfiable.
+channel the directory has never heard of no longer makes a peer _unreachable_ —
+but it also no longer silently becomes that peer's session key.
 
-The rule is one predicate, `coordsAdmit(orgId, channelId, callerAgentId)`: **if the
-snapshot knows any non-empty membership at that coordinate, the caller must be in one of
-them; if it knows none, the coordinate is not a claim about a shared IM channel and needs
-no membership evidence.** It is implemented **identically** in
-`CollaborationRouter.coordsAdmit` (relay) and `CpCollabRoutes.coordsAdmit` (daemon), and
-called from **all three** wake paths so none can drift:
+The rule is **one three-way decision**, factored into a single place per package
+(`CollaborationRouter` on the relay, `CpCollabRoutes` on the daemon) that returns a tagged
+verdict rather than a bare boolean, so no call site re-derives it:
 
-| Wake path                       | Call site                                |
-| ------------------------------- | ---------------------------------------- |
-| cross-daemon ingress            | `AgentMsgRouter.route()` step (b2)       |
-| cross-daemon terminal-verify    | `Daemon.handleRelayAgentMsg`             |
-| same-daemon (and its preflight) | `Daemon.localWakeAuthorizationRejection` |
+| Asserted coordinate                                                                                                                                                               | Verdict                                                                                            | Why                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **KNOWN** — the snapshot holds a non-empty membership at `(orgId, channelId)`                                                                                                     | caller in it ⇒ use the **asserted** coordinate unchanged; caller absent ⇒ **reject** `not_allowed` | Preserves the deliberate "land in the same thread a human sees" behavior, and keeps the assertion honest.                                                                                                                               |
+| **UNKNOWN on a persisted IM platform** — `PERSISTED_IM_PLATFORMS` = `slack` / `telegram` / `discord` / `feishu`                                                                   | **reject** `not_allowed` — FAIL CLOSED                                                             | An unrecorded IM coordinate is either a conversation the caller cannot reach or a stale/departed row whose session is still resumable. Admitting it is exactly what let a caller alias an existing platform session.                    |
+| **UNKNOWN on anything else** — a channel-free platform (`webchat`, and on the same-daemon path also `dream` and a target-less `hook` session), or a value neither side recognises | **substitute** a synthetic coordinate `a2a:<callerAgentId>`                                        | Rejecting would kill the case the org-scoped directory exists for. Instead the asserted channel never becomes the session key: the woken peer's coordinate is derived from the TRUSTED caller, which cannot alias any platform session. |
 
-Two properties of the key are load-bearing:
+Fail-closed on the middle row is the intended direction: a brief snapshot lag can
+transiently reject a genuine wake, and the caller retries. Admitting it, by contrast, is
+unrecoverable — the aliased session has already been resumed and read back.
 
-- **Platform-free.** The coordinate platform is deliberately _not_ part of the key. The
-  woken session's key is computed from `Daemon.narrowPlatform`, which folds `feishu` — and
-  any value it does not recognise — into `'slack'`, while snapshot channel rows are keyed
-  by the **integration** platform. A platform-keyed check therefore searched a different
-  key space than the session key it protects, and the residual "unknown coordinate passes"
-  branch turned every miss into a **pass**: `coords.platform:'feishu'` over a Slack channel
-  id sailed through and still computed a bit-identical child session key, and in a Feishu
-  org (rows keyed `feishu`, honest coords already narrowed to `slack`) the gate was a
-  complete no-op. Matching on the channel id alone closes both directions and needs no
-  `narrowPlatform` twin on the relay, which has none. It over-blocks only if one org uses
-  the same channel id on two platforms — which then demands membership in one of them.
+**Which platform value each path feeds it.** The RAW trusted session platform, never
+`Daemon.narrowPlatform`'s output — that helper folds `dream` (and anything the
+`NormalizedMessage` union does not carry) into `'slack'`, which would classify a genuinely
+channel-free session as a persisted IM coordinate and fail it closed. So `localWakeDecision`
+passes `req.platform` verbatim, and `handleRelayAgentMsg` passes `msg.coords.platform`
+verbatim. **Accepted consequence** of the wire enum: `coords.platform` is
+`slack | telegram | webchat | discord | feishu`, and `messageAgent` maps a `hook` session's
+coords platform to `'slack'` before the relay hop (`narrowPlatform` does the same for
+`dream`), so a CROSS-DAEMON wake out of such a session lands on the middle row and is
+refused, while the same wake to a co-located peer takes the bottom row. Un-narrowing it needs
+a new coords platform value on the wire — a protocol change, deliberately out of scope here.
+
+The synthetic coordinate is collision-free by construction: real Slack / Telegram /
+Discord channel ids never contain `:`, and webchat conversation ids are UUIDs, so an
+`a2a:`-prefixed value can never equal a platform conversation id. Two different asserted
+channels from the same caller therefore collapse into **one pairwise session**, which is
+the right semantics for a postless agent-to-agent conversation.
+
+**Where each half runs.** The relay's job is validation only — it applies the KNOWN and
+persisted-IM rows and NAKs, byte-for-byte identically to the daemon. The substitution is
+applied where the session key is actually **minted**, on the daemon (`childSessionId` on
+the relay-forwarded path, `targetSession` on the same-daemon path), so relay and daemon can
+never disagree about the resulting key. All **three** wake paths run the decision so none
+can drift:
+
+| Wake path                       | Call site                          |
+| ------------------------------- | ---------------------------------- |
+| cross-daemon ingress            | `AgentMsgRouter.route()` step (b2) |
+| cross-daemon terminal-verify    | `Daemon.handleRelayAgentMsg`       |
+| same-daemon (and its preflight) | `Daemon.localWakeDecision`         |
+
+Two properties of the membership key are load-bearing:
+
+- **Platform-free _lookup_.** The coordinate platform is deliberately not part of the
+  membership key — it is consulted only afterwards, to classify a coordinate the lookup
+  did not find (reject vs. substitute). The woken session's key is computed from
+  `Daemon.narrowPlatform`, which folds `feishu` — and any value it does not recognise —
+  into `'slack'`, while snapshot channel rows are keyed by the **integration** platform. A
+  platform-keyed lookup therefore searched a different key space than the session key it
+  protects, and the original admit-on-miss branch turned every such mismatch into a
+  **pass**: `coords.platform:'feishu'` over a Slack channel id sailed through and still
+  computed a bit-identical child session key, and in a Feishu org (rows keyed `feishu`,
+  honest coords already narrowed to `slack`) the gate was a complete no-op. Matching on the
+  channel id alone closes both directions and needs no `narrowPlatform` twin on the relay,
+  which has none. Now that a miss on an IM platform rejects rather than passes, the
+  platform-free lookup also stops that mismatch from _rejecting_ honest coords. It
+  over-blocks only if one org uses the same channel id on two platforms — which then
+  demands membership in one of them.
 - **Non-empty membership counts as "known".** An agent-less row is a channel nobody in the
   org can reach, so treating it as known would reject every call naming it while
   protecting nothing.
@@ -344,15 +380,26 @@ Two properties of the key are load-bearing:
 The same-daemon path needs this as much as the relay hop, not less: `to.channel` and
 `to.thread` reach `MessageAgentReq` from the **model**, so without the check a
 prompt-injected agent could name a channel it cannot reach and resume a co-located peer's
-session living there. On that path the rule is strictly **weaker** than the
-`hasMembers(caller, target)` membership check it replaced — which is the point, since that
-check rejected every wake from a session with no channel row at all.
+session living there. Relative to the `hasMembers(caller, target)` membership check it
+replaced, the rule is weaker on the KNOWN row only (the **target** no longer has to be in
+the channel), unchanged on an unrecorded IM coordinate, and no longer keyed on the channel
+at all in the channel-free case — which is the case that check made unreachable.
 
-**Known limit (see §2.7).** "Unknown coordinate" cannot distinguish _"not an IM channel"_
-from _"an IM channel the CP does not record"_. Slack DMs and group DMs are deliberately
-never channel rows (`listBotChannels` skips `is_im`/`is_mpim`), and a row disappears when
-the bot leaves a channel or the integration goes inactive while the session stays
-resumable. Those coordinates take the pass branch.
+**What the fail-closed branch actually covers.** The verdict cannot ask "is this an IM
+channel the caller may speak in?"; it can only ask what the snapshot records. Direct
+conversations _are_ recordable — `IntegrationChannel.kind` is
+`channel | im | mpim`, and `IntegrationRepo.channelPlacements` selects the channel rows
+with **no** `kind` filter, so an `im`/`mpim` row that exists is a KNOWN coordinate with the
+owning integration's agent as a member. But such a row is only written where something
+observed it: Slack's authoritative membership snapshot enumerates
+`public_channel,private_channel` only, and the two paths that emit `im`/`mpim` —
+`Daemon.reportGatedConversation` and the CP's shared-bot `reportConversation` — both run
+solely for a **gated** integration's (or install's) not-yet-enabled conversations. So an ordinary org-wide integration's DM has no row, and an A2A wake whose
+coordinate is that DM is refused. That is deliberate, and it is not a regression: the
+membership check this replaced refused the same wake, and refusing is recoverable where
+admitting it is not (the aliased session has already been resumed and read back). The same
+applies to a row that has disappeared — bot removed, integration set inactive, or a
+snapshot that has not caught up.
 
 The data model stores:
 
@@ -400,12 +447,14 @@ paths enforce call policy from the sources above:
 Org-scoped discovery removed channel from **authorization**. These items are known
 remaining work and are deliberately out of that change's scope:
 
-1. **Channel-free session coordinates.** `channel` is still the _session key_:
-   `sessionKey = platform:channel:thread:agentId`, and a wake's `msgId` /
-   fallback thread are still `agentcall:<channel>:…`. So a peer with no IM
-   integration is discoverable and callable, but the woken session still carries
-   the caller's channel coordinate. Making the coordinate itself channel-free
-   (see open question 1 in section 5, `dm:`-style sessions) is a separate change.
+1. **A general channel-free session-coordinate scheme.** `channel` is still the
+   _session key_ (`sessionKey = platform:channel:thread:agentId`, with a wake's
+   `msgId` / fallback thread `agentcall:<channel>:…`), and the coordinate-integrity
+   verdict above now substitutes `a2a:<callerAgentId>` for it in exactly one case —
+   an unknown coordinate on a channel-free platform. Everything else keeps the
+   asserted coordinate verbatim, so a first-class `dm:`-style session identity for
+   agent-to-agent conversations generally (see open question 1 in section 5) is
+   still a separate change.
 2. **`ws/connection.ts` handler-throw hardening.** A throwing daemon↔CP WS handler
    still closes the whole control socket (`close(1011)`), which is why the
    `channel/agents` handler must short-circuit a session-identity platform before
@@ -417,16 +466,13 @@ remaining work and are deliberately out of that change's scope:
 4. Snapshot lifecycle (§6.5): per-entry tombstones, TTL after a CP disconnect,
    and fail-closed-on-stale remain unimplemented for the flat directory exactly
    as for `channels[]` — `generation` is the version hook, a live CP is assumed.
-5. **Coordinate integrity cannot see conversations the CP does not record.**
-   `coordsAdmit` classifies any coordinate with no channel row as "not a claim about a
-   shared IM channel" and passes it. That is correct for webchat/dream session ids, but it
-   also covers (a) Slack **DMs and group DMs**, which `listBotChannels` deliberately never
-   reports, and (b) a channel whose row has gone — bot removed, integration set inactive,
-   or a snapshot that has not caught up — while the session remains resumable. A caller
-   that already knows such a conversation id can therefore still name it. Closing this
-   needs a positive notion of "coordinates this agent may assert" (recording direct
-   conversations, or checking the asserted coordinate against the target's existing
-   **session** rows rather than the membership snapshot), not a tweak to this rule.
+5. **A positive notion of "coordinates this agent may assert."** The verdict above closes
+   the admit-on-unknown hole by failing closed, which costs recall: an unrecorded but
+   legitimate direct conversation is refused rather than admitted (see "What the
+   fail-closed branch actually covers"). Recovering that recall means recording direct
+   conversations for ungated integrations too, or checking the asserted coordinate against
+   the target's existing **session** rows rather than the membership snapshot. Neither is a
+   tweak to this rule.
 6. **The flat directory is pushed org-wide to every daemon.**
    `collabRoutes.broadcast` ships every placed agent's id, daemonId, name and all four
    policy fields to _every_ daemon in the org, because terminal-verify needs the (remote

--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -35,18 +35,19 @@ daemon remains on the message hot path and CP remains off it.
 
 ### 1.2 Current State
 
-| Stage                       | Current behavior                                                                                                                                                                                    |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Session identity**        | `sessionKey = platform:channel:thread:agentId`; the same platform thread maps to a separate session per agent.                                                                                      |
-| **Peer discovery**          | `listChannelAgents` uses the `channel/agents` control request and returns only peers visible to the authenticated requesting agent.                                                                 |
-| **Agent-to-agent delivery** | The `sendMessage` peer target invokes the internal `messageAgent` primitive locally or uses `rd/agentmsg` → `rd/agentmsg/fwd` → `rd/agentmsg/ack` across daemons. Message bodies never traverse CP. |
-| **Call authorization**      | The caller's outbound policy and target's inbound policy must both allow the edge; directory, source daemon, relay, and target daemon verify independently.                                         |
-| **Orchestration**           | `startOrchestration`, `getOrchestration`, and `cancelOrchestration` use durable daemon-local state, trusted correlation metadata, and deadline wakes.                                               |
-| **Concurrency**             | Different sessions run concurrently; a per-`sessionKey` admission gate serializes one conversation and enforces queue/capacity limits.                                                              |
+| Stage                       | Current behavior                                                                                                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Session identity**        | `sessionKey = platform:channel:thread:agentId`; the same platform thread maps to a separate session per agent.                                                                                                     |
+| **Peer discovery**          | `listAgents` (alias `listChannelAgents`) uses the `channel/agents` control request. Scope is the requester's **organization**, filtered by the directional call policy; `channel` is an optional narrowing filter. |
+| **Agent-to-agent delivery** | The `sendMessage` peer target invokes the internal `messageAgent` primitive locally or uses `rd/agentmsg` → `rd/agentmsg/fwd` → `rd/agentmsg/ack` across daemons. Message bodies never traverse CP.                |
+| **Call authorization**      | The caller's outbound policy and target's inbound policy must both allow the edge; directory, source daemon, relay, and target daemon verify independently.                                                        |
+| **Orchestration**           | `startOrchestration`, `getOrchestration`, and `cancelOrchestration` use durable daemon-local state, trusted correlation metadata, and deadline wakes.                                                              |
+| **Concurrency**             | Different sessions run concurrently; a per-`sessionKey` admission gate serializes one conversation and enforces queue/capacity limits.                                                                             |
 
 ### 1.3 Implemented Surface
 
-- `listChannelAgents` for authenticated peer discovery.
+- `listAgents` for authenticated, org-scoped peer discovery
+  (`listChannelAgents` remains a deprecated alias of the same handler).
 - `sendMessage` for peer wakes, parent-session replies, and visible platform
   posts; its peer branch uses the same-daemon or cross-daemon
   `messageAgent` delivery primitive.
@@ -58,7 +59,7 @@ daemon remains on the message hot path and CP remains off it.
 
 - Do **not** introduce synchronous "agent calls agent" RPC. Delivery is always an **asynchronous wake-up**: the message enters the peer's session and the peer handles it in its own turn, matching the asynchronous social-peer model.
 - Do **not** put CP on the message hot path. Cross-daemon message bodies use the **relay data plane (daemon -> relay -> daemon)** and **never pass through CP**. CP distributes only placement/routing metadata without message bodies through `rc/*`, including call policy.
-- Do **not** treat "same org + same channel" as authorization. Existing `callPolicy` / `allowedCallerAgentIds` determine authorization and are checked by a trusted endpoint against the authenticated caller (section 2.5).
+- Do **not** treat channel membership as authorization — not as a sufficient condition, and (since the org-scoped directory) not as a necessary one either. The directional call policy (`outboundPolicy` / `allowedTargetAgentIds` on the caller, `callPolicy` / `allowedCallerAgentIds` on the target) is the whole authorization predicate, org-scoped, and it is checked by a trusted endpoint against the authenticated caller (section 2.5).
 - Do **not** change ACP. The target agent processes an inbound agent message exactly as it processes a human message.
 
 ---
@@ -90,26 +91,61 @@ Two existing call sites **explicitly select an agent and bypass arbitration**:
 The daemon injects these tools from `packages/daemon/src/mcp/tools.ts`. It holds
 platform tokens and routing credentials; the agent never sees them.
 
-**`listChannelAgents`**
+**`listAgents`** (deprecated alias: `listChannelAgents`)
 
 ```ts
-// Input: { channel? }  // Omitted channel uses the current session coordinate.
+// Input: { channel? }  // OPTIONAL FILTER. Omitted => the whole org directory.
 // Output: [{ agentId, name, displayName?, description?, status }]
 ```
 
 The daemon derives `platform` and `requesterAgentId` from trusted session
-context, then sends `channel/agents` to the Control Plane. The Control Plane
-resolves the roster in the authenticated daemon's organization, returns an
-empty list unless the requester belongs to the target channel, and filters out
-peers blocked by either side's call policy. Tool input cannot override caller
-identity or platform.
+context, then sends `channel/agents` to the Control Plane. Tool input cannot
+override caller identity or platform; `channel` is the only agent-supplied
+field, and it can only narrow the answer.
+
+Two scopes, one roster (`packages/control-plane/src/ws/handlers/channel-agents.ts`):
+
+- **`channel` absent — the org-wide peer directory.** This is the default.
+  The CP reads `AgentRepo.orgDirectory(orgId)` for the _authenticated daemon's_
+  organization and applies the section 2.5 predicate. The reply omits `channel`.
+- **`channel` present — the same directory intersected with that channel's
+  membership** (`IntegrationRepo.agentsInChannel`). Literally a filter over the
+  org roster, never a substitute for it, which is what keeps an unroutable agent
+  out of _both_ scopes rather than only one of them. A session-identity platform
+  (`webchat` / `hook` / `dream`) has no persisted integration, so a channel
+  filter on one of those short-circuits to an empty roster instead of reaching
+  persistence.
+
+Both scopes are computed by the same `visibleToRequester()` filter, so they can
+never answer differently about a given agent.
+
+Why the default is org-wide, not the current channel:
+
+- **A2A delivery has been postless since #854.** A `sendMessage` with `toAgent`
+  and no `channel` publishes nothing, so the channel plays no part in _delivery_
+  and must not act as an authorization key either.
+- **Some sessions have no channel the CP has ever seen.** Webchat, webhook/`hook`,
+  dreaming, and memory-only agents have no IM integration at all, yet must still
+  collaborate. Under channel-gated discovery they were structurally undiscoverable.
+
+Rolling upgrade: the channel-less form exists only on a CP that advertises the
+`agent-directory-org-scope-v1` server feature in `register/ok.serverFeatures`.
+The daemon negotiates it — when the feature is absent it substitutes the caller's
+trusted _current_ channel (exactly the pre-change behavior) rather than sending a
+payload an older CP would reject. An explicitly requested `channel` filter is
+passed through to either CP unchanged.
+
+**Rename.** The tool is `listAgents`; `listChannelAgents` is kept as a
+deprecated alias with the same input schema, routed to the same handler, so a
+session already warm with the old tool set — and prompts or skills that learned
+the old name — keeps working.
 
 **`sendMessage` peer target**
 
 ```ts
 // Input: {
 //   to: {
-//     toAgent: string,          // From listChannelAgents.
+//     toAgent: string,          // From listAgents.
 //     channel?: string,         // Omit for a postless wake.
 //     thread?: string
 //   },
@@ -156,12 +192,32 @@ messageAgent(toAgentId, text, coords)
 **Cross daemon, where the target agent runs elsewhere:** use the **daemon -> relay -> daemon data plane**; the message body **does not pass through CP**. Reuse the physical shared-bot links—daemons connected to relays and relays holding connections by daemonId—described in [`shared-bot-relay.md`](shared-bot-relay.md), but **do not address through existing `members`**:
 
 - **Collaboration-routing snapshot:** CP sends bot-independent placement and
-  policy metadata to relays and daemons; it contains **no message bodies**:
-  - Key: channel membership by `(orgId, platform, channelId)`.
-  - Value per agent: `{ agentId, daemonId, integrationId?, callPolicy, allowedCallerAgentIds }`.
-  - Relay resolves `toAgentId` to its owning `daemonId`, then gets the connection through `relay-daemon-server.get(daemonId)`.
+  policy metadata to relays and daemons; it contains **no message bodies**. It has
+  two parallel parts, both FULL-REPLACE:
+  - `channels[]` — channel membership keyed by `(orgId, platform, channelId)`.
+    Value per agent: `{ agentId, daemonId, integrationId?, botAppId?, callPolicy,
+allowedCallerAgentIds, outboundPolicy, allowedTargetAgentIds, name?, displayName? }`.
+    Still the authority for the genuinely channel-shaped questions: which reply
+    integration to use for a visible post, and which inbound bot app belongs to
+    another AgentConnect agent.
+  - `agents[]` — the **flat, channel-free org directory** (`CollabOrgAgent` = a
+    placement plus its own `orgId`, minus the per-channel `integrationId` /
+    `botAppId`). This is the authorization input. The channel-keyed structure
+    _structurally cannot_ express an integration-less agent: such an agent appears
+    in no `channels[]` entry at all, so "which agents exist in this org" — exactly
+    the input channel-free authorization needs — is unanswerable from it. Unplaced
+    agents (`daemonId` null) are dropped from both parts: with no owning daemon
+    there is nothing to route to.
+  - Relay resolves `toAgentId` to its owning `daemonId` from `agents[]`, then gets the connection through `relay-daemon-server.get(daemonId)`.
   - `CollabRoutesSnapshot` travels to relay through `rc/collab-routes` and to
     daemons through `register/ok` plus `collaboration/routes`.
+  - **Old-CP fallback.** A CP that does not advertise
+    `agent-directory-org-scope-v1` sends no `agents[]` (it decodes to the schema
+    default `[]`). Relay and daemon then _derive_ the directory from the channel
+    rows — every row carries its `orgId` and its members are placements — so
+    integration-backed pairs keep resolving across a rolling upgrade. An
+    integration-less agent stays absent, and the predicate fails closed on it,
+    which is that CP's pre-existing behavior anyway.
 
 ```
 agentA@daemon-1
@@ -171,15 +227,16 @@ agentA@daemon-1
        over the direct rd/* data plane, not CP  // claimedFromAgentId is untrusted; see section 2.5.
   -> relay resolves B to owning daemonId through the collaboration-routing snapshot
      -> get(daemonId) obtains the connection
-  -> relay verifies that claimedFromAgentId belongs to the authenticated socket's daemonId,
-     is in the channel in the snapshot, and passes target call policy
-  -> relay then creates a trusted caller claim containing trustedFromAgentId + org/channel assertions
+  -> relay verifies that claimedFromAgentId belongs to the authenticated socket's daemonId
+     per the flat org directory, that caller and target are in the SAME org, and that both
+     directional call policies admit the edge  // channel membership is NOT consulted
+  -> relay then creates a trusted caller claim containing trustedFromAgentId + org assertions
      and sends it with the message to daemon-2
   -> daemon-2 handleRelayAgentMsg performs final verification of the trusted caller claim
      -> constructs NormalizedMessage -> dispatch(B, msg)
 ```
 
-- Relay op `rd/agentmsg` in `relay-daemon.ts` carries `{ claimedFromAgentId, toAgentId, text, coords, correlationId, hopCount }`. Because one authenticated daemon can host several agents, the socket's daemonId cannot identify which agent initiated a call. The frame therefore carries a **claimed, untrusted `fromAgentId`**. Relay verifies it against socket daemonId + snapshot membership for the channel, then and only then creates a trusted caller claim for forwarding.
+- Relay op `rd/agentmsg` in `relay-daemon.ts` carries `{ claimedFromAgentId, toAgentId, text, coords, correlationId, hopCount }`. Because one authenticated daemon can host several agents, the socket's daemonId cannot identify which agent initiated a call. The frame therefore carries a **claimed, untrusted `fromAgentId`**. Relay verifies it against socket daemonId + the flat org directory (the claimed id must exist and its placement must be owned by the authenticated sending daemon — that daemon-ownership check, not channel membership, is what makes the claim unforgeable), then and only then creates a trusted caller claim for forwarding. `msg.coords` rides along as the **delivery coordinate** for the woken session, never as an authorization input; the target's reply `integrationId` prefers its placement in the coords channel and falls back to its directory entry when it has no row there (an integration-less peer legitimately has none).
 - See section 2.5 for authorization, including target call policy and creation of trusted caller identity.
 
 ### 2.4 Target-Agent Experience
@@ -208,11 +265,94 @@ resetting chain depth.
 - The daemon rejects delivery above a threshold such as eight hops.
 - **Test:** omitting hop arguments or explicitly passing `hopCount:0` cannot reset chain depth; the daemon uses turn-bound hop + 1.
 
-### 2.5 Authorization: Target Call Policy, Not Merely Same Org + Channel
+### 2.5 Authorization: The Directional Call Policy, Org-Scoped
 
 Authorization is the intersection of the caller's outbound policy and the
-target's inbound policy. See
+target's inbound policy, within one organization. See
 [`directional-agent-visibility.md`](directional-agent-visibility.md).
+
+**The predicate.** Caller A may discover and wake target B iff **all** of:
+
+1. A and B are both **known in the org-scoped directory** — a missing entry fails
+   **CLOSED**, so a missing or stale snapshot never grants access;
+2. A and B are in the **same organization** (a cross-org pair never resolves, and
+   is reported indistinguishably from a nonexistent target so there is no
+   cross-org probing);
+3. **A's `outboundPolicy`** is `all`, or `allowedTargetAgentIds` contains B;
+4. **B's `callPolicy`** is `all`, or `allowedCallerAgentIds` contains A.
+
+A caller **always sees itself** in a _listing_: an agent whose `outboundPolicy`
+is `selected` does not normally name itself in its own allow-list, yet it must
+still appear in its own directory answer. (A self-_wake_ is still rejected
+separately, with `reason:'self'`.)
+
+**Channel membership is not part of the predicate** — in either direction. It is
+not sufficient (a `selected` policy still denies a channel-mate) and it is no
+longer necessary (peers that share no channel, and peers with no IM integration
+at all, are legitimate). The single implementation is
+`CpCollabRoutes.admits()` on the daemon and `CollaborationRouter.admits()` on the
+relay; `visibleToRequester()` is the CP-side twin used for both discovery scopes.
+
+**Two unrelated things are both called "visibility" — keep them apart:**
+
+| Field                                                                        | Governs                                                                          | Affects the peer directory?                                             |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `Agent.visibility` / `sharedWith` (`ResourceVisibility` org \| restricted)   | **Human** console access, see [`resource-visibility.md`](resource-visibility.md) | **Never.** A `restricted` agent is still a discoverable, callable peer. |
+| `callPolicy` / `outboundPolicy` (labelled "Agent visibility" in the console) | **Agent-to-agent** discovery and wakes                                           | **Yes — it is the whole gate.**                                         |
+
+The CP's `orgDirectory` read deliberately omits the `visibilityWhere` clause for
+exactly this reason.
+
+**Coordinate integrity is a separate check, not a removed one.** Channel checks
+did not disappear; they moved from _authorization_ to _coordinate validation_. An
+asserted coordinate channel that the snapshot knows about still requires the
+caller to be in it, and a visible post still resolves through the channel's
+definite reply integration (section 6.2). What changed is the consequence: a
+channel the directory has never heard of no longer makes a peer _unreachable_, it
+only makes the visible-post half of the request unsatisfiable.
+
+The rule is one predicate, `coordsAdmit(orgId, channelId, callerAgentId)`: **if the
+snapshot knows any non-empty membership at that coordinate, the caller must be in one of
+them; if it knows none, the coordinate is not a claim about a shared IM channel and needs
+no membership evidence.** It is implemented **identically** in
+`CollaborationRouter.coordsAdmit` (relay) and `CpCollabRoutes.coordsAdmit` (daemon), and
+called from **all three** wake paths so none can drift:
+
+| Wake path                       | Call site                                |
+| ------------------------------- | ---------------------------------------- |
+| cross-daemon ingress            | `AgentMsgRouter.route()` step (b2)       |
+| cross-daemon terminal-verify    | `Daemon.handleRelayAgentMsg`             |
+| same-daemon (and its preflight) | `Daemon.localWakeAuthorizationRejection` |
+
+Two properties of the key are load-bearing:
+
+- **Platform-free.** The coordinate platform is deliberately _not_ part of the key. The
+  woken session's key is computed from `Daemon.narrowPlatform`, which folds `feishu` — and
+  any value it does not recognise — into `'slack'`, while snapshot channel rows are keyed
+  by the **integration** platform. A platform-keyed check therefore searched a different
+  key space than the session key it protects, and the residual "unknown coordinate passes"
+  branch turned every miss into a **pass**: `coords.platform:'feishu'` over a Slack channel
+  id sailed through and still computed a bit-identical child session key, and in a Feishu
+  org (rows keyed `feishu`, honest coords already narrowed to `slack`) the gate was a
+  complete no-op. Matching on the channel id alone closes both directions and needs no
+  `narrowPlatform` twin on the relay, which has none. It over-blocks only if one org uses
+  the same channel id on two platforms — which then demands membership in one of them.
+- **Non-empty membership counts as "known".** An agent-less row is a channel nobody in the
+  org can reach, so treating it as known would reject every call naming it while
+  protecting nothing.
+
+The same-daemon path needs this as much as the relay hop, not less: `to.channel` and
+`to.thread` reach `MessageAgentReq` from the **model**, so without the check a
+prompt-injected agent could name a channel it cannot reach and resume a co-located peer's
+session living there. On that path the rule is strictly **weaker** than the
+`hasMembers(caller, target)` membership check it replaced — which is the point, since that
+check rejected every wake from a session with no channel row at all.
+
+**Known limit (see §2.7).** "Unknown coordinate" cannot distinguish _"not an IM channel"_
+from _"an IM channel the CP does not record"_. Slack DMs and group DMs are deliberately
+never channel rows (`listBotChannels` skips `is_im`/`is_mpim`), and a row disappears when
+the bot leaves a channel or the integration goes inactive while the session stays
+resumable. Those coordinates take the pass branch.
 
 The data model stores:
 
@@ -222,33 +362,80 @@ The data model stores:
   which peers the caller may select.
 
 `AgentSpec` carries local target policy, while the versioned collaboration
-snapshot supplies remote caller/target organization, channel, placement, and
-policy data. Missing or stale policy fails closed.
+snapshot supplies caller/target organization, placement, and policy data for
+_every_ agent in the org — local or remote. Missing or stale policy fails closed,
+which is also why a local-only daemon that has never received a snapshot cannot
+authorize an agent call at all.
 
 Checking only same org + same channel would bypass policy. A target may reject
 all calls or allow only specific callers. Both internal `messageAgent` delivery
 paths enforce call policy from the sources above:
 
-- **Same daemon:** the target spec carries policy fields, and the daemon checks
-  both directional policies before `dispatch`. Caller identity is the current
-  session agentId that invoked the tool and is locally trusted.
+- **Same daemon:** the daemon evaluates the org-scoped predicate against its
+  snapshot _before_ looking the target up locally — so the same verdict covers a
+  remote target and an id in no directory at all — and then also re-checks a
+  local target's spec policy. Caller identity is the current session agentId that
+  invoked the tool and is locally trusted. A local agent id is **not** sufficient
+  authority on its own.
 - **Cross daemon: never trust `claimedFromAgentId` from the frame.** `rd/hello` authenticates only the connection's **daemonId** through `relay-daemon-connection.ts` states AUTHENTICATING -> READY; one daemon can host multiple agents, so the socket cannot attest the agent:
   1. Relay binds the request to the socket's authenticated daemon identity.
-  2. Relay uses the trusted collaboration-routing snapshot to verify that `claimedFromAgentId` actually belongs to that daemon and channel.
-  3. Relay then creates a trusted caller claim (trustedFromAgentId + org/channel assertions, or a verifiable capability) and checks B's `callPolicy` / `allowedCallerAgentIds`; only an allowed caller proceeds.
-  4. The **target daemon performs final defense-in-depth verification** with its distributed policy/snapshot or relay-verifiable capability. It verifies caller org/placement and the target spec rather than trusting raw forwarded fields. Missing policy data fails closed.
+  2. Relay uses the trusted collaboration-routing snapshot to verify that `claimedFromAgentId` exists in the flat org directory and that its placement is owned by that daemon. Org is bound from the caller's own entry — the frame carries no `orgId`.
+  3. Relay resolves B in the **same org** (absent or cross-org ⇒ `not_found`), then checks A's outbound and B's inbound policy. The two halves stay separate calls (`outboundAdmits` / `inboundAdmits`) so each denial keeps its own log line. Only then does it create a trusted caller claim (trustedFromAgentId + org assertion, or a verifiable capability).
+  4. The **target daemon performs final defense-in-depth verification** with its distributed policy/snapshot or relay-verifiable capability. Terminal-verify is **org**-scoped, not `(org, channel)`-scoped: the relay's asserted org must equal the org the daemon's own directory records for the target, and `admits(trustedFromAgentId, toAgentId)` must hold. Missing snapshot / unknown agent fails closed.
 - On rejection, return `delivered:false, reason:'not_allowed'` and **do not wake** the target.
 - **Tests:** a caller outside a `selected` allowlist is rejected locally and cross-daemon; `all` permits it; cross-org is rejected; missing or stale policy/snapshot **fails closed**.
 
 ### 2.6 Implementation Map
 
-| Layer         | Current responsibility                                                                                                                                                                                     |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Protocol      | Defines `channel/agents`, relay `rd/agentmsg`, versioned collaboration-routing snapshots, and policy fields on `AgentSpec`; hop and claimed caller values remain untrusted until verified                  |
-| Daemon        | Injects `listChannelAgents` and unified `sendMessage`, performs local delivery and target-side verification, maintains trusted call metadata, and receives the versioned collaboration snapshot            |
-| Relay         | Routes `rd/agentmsg` using the bot-independent snapshot, binds the authenticated daemon, verifies claimed caller ownership, creates the trusted caller claim, and enforces policy                          |
-| Control plane | Distributes versioned membership, placement, route, and policy snapshots to relays and daemons without message bodies                                                                                      |
-| Tests         | Cover tool validation, local and relay delivery, directional-policy rejection, forged caller claims, missing/stale snapshots, cross-organization rejection, trusted correlation, and hop-depth enforcement |
+| Layer         | Current responsibility                                                                                                                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Protocol      | Defines `channel/agents`, relay `rd/agentmsg`, versioned collaboration-routing snapshots, and policy fields on `AgentSpec`; hop and claimed caller values remain untrusted until verified                                          |
+| Daemon        | Injects `listAgents` (alias `listChannelAgents`) and unified `sendMessage`, performs local delivery and org-scoped target-side verification, maintains trusted call metadata, and receives the versioned collaboration snapshot    |
+| Relay         | Routes `rd/agentmsg` using the bot-independent snapshot, binds the authenticated daemon, verifies claimed caller ownership, creates the trusted caller claim, and enforces policy                                                  |
+| Control plane | Distributes versioned membership, placement, route, and policy snapshots (channel-keyed `channels[]` **plus** the flat org `agents[]`) to relays and daemons without message bodies, and advertises `agent-directory-org-scope-v1` |
+| Tests         | Cover tool validation, local and relay delivery, directional-policy rejection, forged caller claims, missing/stale snapshots, cross-organization rejection, trusted correlation, and hop-depth enforcement                         |
+
+### 2.7 Follow-Ups (Explicitly Not Done Here)
+
+Org-scoped discovery removed channel from **authorization**. These items are known
+remaining work and are deliberately out of that change's scope:
+
+1. **Channel-free session coordinates.** `channel` is still the _session key_:
+   `sessionKey = platform:channel:thread:agentId`, and a wake's `msgId` /
+   fallback thread are still `agentcall:<channel>:…`. So a peer with no IM
+   integration is discoverable and callable, but the woken session still carries
+   the caller's channel coordinate. Making the coordinate itself channel-free
+   (see open question 1 in section 5, `dm:`-style sessions) is a separate change.
+2. **`ws/connection.ts` handler-throw hardening.** A throwing daemon↔CP WS handler
+   still closes the whole control socket (`close(1011)`), which is why the
+   `channel/agents` handler must short-circuit a session-identity platform before
+   reaching persistence rather than letting the repo throw. Turning a handler
+   fault into a per-request error is a separate change.
+3. **Optional org-level discovery-scope switch.** Org-wide is currently the only
+   default. An operator who wants the old channel-scoped default back has no
+   setting for it; an explicit per-org policy switch is a possible follow-up.
+4. Snapshot lifecycle (§6.5): per-entry tombstones, TTL after a CP disconnect,
+   and fail-closed-on-stale remain unimplemented for the flat directory exactly
+   as for `channels[]` — `generation` is the version hook, a live CP is assumed.
+5. **Coordinate integrity cannot see conversations the CP does not record.**
+   `coordsAdmit` classifies any coordinate with no channel row as "not a claim about a
+   shared IM channel" and passes it. That is correct for webchat/dream session ids, but it
+   also covers (a) Slack **DMs and group DMs**, which `listBotChannels` deliberately never
+   reports, and (b) a channel whose row has gone — bot removed, integration set inactive,
+   or a snapshot that has not caught up — while the session remains resumable. A caller
+   that already knows such a conversation id can therefore still name it. Closing this
+   needs a positive notion of "coordinates this agent may assert" (recording direct
+   conversations, or checking the asserted coordinate against the target's existing
+   **session** rows rather than the membership snapshot), not a tweak to this rule.
+6. **The flat directory is pushed org-wide to every daemon.**
+   `collabRoutes.broadcast` ships every placed agent's id, daemonId, name and all four
+   policy fields to _every_ daemon in the org, because terminal-verify needs the (remote
+   caller, local target) pair. So the `channel/agents` daemon-ownership bind is an
+   **integrity** control (only the owning daemon may speak as an agent) plus
+   confidentiality for `description`/`status` — it is _not_ what keeps
+   `callPolicy: 'selected'` unreadable, since a daemon can compute any org agent's
+   policy-filtered peer set from the pushed snapshot offline. Narrowing the per-daemon
+   push to the peers that daemon can actually reach is the follow-up.
 
 ---
 
@@ -332,7 +519,7 @@ else                                  -> remain pending; end the turn and yield.
 ```
 Human in thread T: @main please upgrade these three RPC nodes.
   main turn #1:
-    listChannelAgents() -> [workerA, workerB, workerC]
+    listAgents() -> [workerA, workerB, workerC]   // org-wide; no channel filter
     plan: three subtasks
     1. Persist orchestration o1 first:
        {mainSessionKey, subtasks:[o1.0->A, o1.1->B, o1.2->C all status=pending], deadline=null}
@@ -538,13 +725,22 @@ section is part of the contract, not an optional optimization.
   `session/new`. The daemon derives these fields from the real trigger; tools
   never trust caller-supplied identity or platform claims.
 - Caller identity, `mainSessionKey`, origin, and reply target for
-  `listChannelAgents`, the `sendMessage` peer branch, and orchestration tools
-  come entirely from trusted `SessionContext`.
+  `listAgents`, the `sendMessage` peer branch, and orchestration tools
+  come entirely from trusted `SessionContext`. `listAgents` takes only an
+  optional `channel` **filter** from tool input; the trusted current channel is
+  carried separately, and is used solely to build a compatible request for a CP
+  that lacks `agent-directory-org-scope-v1`.
 
 ### 6.2 Target Addressing: Deterministic `(platform, channel, toAgentId) -> {daemonId, integrationId}`
 
 - The destination snapshot must provide a **deterministic target `integrationId`** for `(platform, channel, toAgentId)`. It cannot be optional or fall back to the first connection. Propagate it through local/relay dispatch; otherwise a multi-platform / multi-integration agent can use the wrong platform or `replyConnFor` can fall back to the wrong connection.
 - Returning to the current session coordinates likewise depends on the true platform/integrationId injected by section 6.1.
+- Since the org-scoped directory the two halves of this lookup come from different
+  parts of the snapshot: **`daemonId` from the flat `agents[]`** (identity /
+  ownership, channel-free) and **`integrationId` from the channel row** for the
+  requested coordinates, falling back to the directory entry when the target has
+  no row there. That keeps "deterministic reply integration" intact for a
+  channel-backed target without making an integration-less target unroutable.
 
 ### 6.3 Stable deliveryId + Monotonic ts + Shared Admission Idempotency
 

--- a/docs/designs/agent-reachability-graph.md
+++ b/docs/designs/agent-reachability-graph.md
@@ -29,8 +29,10 @@ cannot reveal restricted agents or hidden allow-list entries.
 
 The graph is a **configured control-plane projection**. An arrow means the
 directional policies permit a direct call. Successful delivery can still depend
-on runtime conditions such as placement, daemon/relay availability, shared
-channel membership, and hop limits.
+on runtime conditions such as placement, daemon/relay availability, snapshot
+freshness, and hop limits. It does **not** depend on a shared channel: agent-to-agent
+authorization is org-scoped and channel-free (see
+[directional-agent-visibility.md](directional-agent-visibility.md)).
 
 The overview is therefore explanatory UI, not an authorization oracle and not
 a data-plane dependency. The daemon and relay continue to enforce every call.

--- a/docs/designs/agents-collaboration-design.md
+++ b/docs/designs/agents-collaboration-design.md
@@ -155,7 +155,11 @@ This boundary is also used by collaboration tools:
   still participates. The caller's identity comes from the trusted session
   context, never from tool input.
 - `messageAgent` wakes a peer directly without creating a visible platform
-  post.
+  post. Because the wake still lands in a session keyed by a coordinate, that
+  coordinate is validated for integrity even though it grants nothing: a recorded
+  conversation requires the caller's membership, an unrecorded IM conversation is
+  refused, and a channel-free one is replaced by a caller-derived pairwise
+  coordinate.
 - orchestration tools fan out work and collect correlated results.
 
 Tool registration, identity, and authorization are daemon responsibilities;

--- a/docs/designs/agents-collaboration-design.md
+++ b/docs/designs/agents-collaboration-design.md
@@ -148,8 +148,12 @@ validated platform metadata rather than handling raw credentials.
 
 This boundary is also used by collaboration tools:
 
-- `listChannelAgents` discovers peers visible and callable from the current
-  trusted session context.
+- `listAgents` (deprecated alias `listChannelAgents`) discovers the peers the
+  calling agent may reach **anywhere in its organization**, filtered by the
+  directional call policy alone. Channel membership is only an optional filter, so
+  an agent with no IM integration at all (webchat, webhook, dreaming, memory-only)
+  still participates. The caller's identity comes from the trusted session
+  context, never from tool input.
 - `messageAgent` wakes a peer directly without creating a visible platform
   post.
 - orchestration tools fan out work and collect correlated results.

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -591,7 +591,7 @@ present, the daemon fails closed on an `(agentId, sessionId)` mismatch.
 
 ### 7.7 `channel/agents` (D→C, REQ → REP) — agent collaboration directory
 
-So agents can collaborate, an agent needs to know **who else is in its channel** and what each does. A daemon-side agent tool issues `channel/agents`; the CP is the **only authority for the full roster** (agents in one channel may run on different daemons — `register/ok.agents[]` is scoped to each daemon's own agents, §3.3), so the daemon asks the CP rather than answering locally. Metadata only (name / displayName / description / status) — never message content. Direction is daemon→CP (like `auth`/`register`): the daemon sends the REQ, the CP replies `channel/agents/ok` (corr = req id).
+So agents can collaborate, an agent needs to know **which peers it may reach** and what each does. A daemon-side agent tool (`listAgents`, deprecated alias `listChannelAgents`) issues `channel/agents`; the CP is the **only authority for the full roster** (peers may run on different daemons — `register/ok.agents[]` is scoped to each daemon's own agents, §3.3), so the daemon asks the CP rather than answering locally. Metadata only (name / displayName / description / status) — never message content. Direction is daemon→CP (like `auth`/`register`): the daemon sends the REQ, the CP replies `channel/agents/ok` (corr = req id).
 
 ```ts
 const ChannelAgent = z.object({
@@ -603,19 +603,54 @@ const ChannelAgent = z.object({
 })
 const ChannelAgentsReq = z.object({
   platform: Platform,
-  channel: z.string(),
+  channel: z.string().optional(), // OPTIONAL — absent ⇒ the org-wide directory
   requesterAgentId: z.string().uuid()
 }) // D→C REQ
-const ChannelAgentsOk = z.object({ platform: Platform, channel: z.string(), agents: z.array(ChannelAgent) }) // C→D REP
+const ChannelAgentsOk = z.object({
+  platform: Platform,
+  channel: z.string().optional(), // echoes the REQ's scope; absent when org-wide
+  agents: z.array(ChannelAgent)
+}) // C→D REP
 ```
 
+**`channel` is optional, and that is the whole scope switch — two scopes, one roster.**
+Both are computed from the same org read and the same filter, so they can never
+answer differently about a given agent:
+
+- **absent → the ORG-WIDE peer directory** (`AgentRepo.orgDirectory`). The default.
+  Channel membership plays no part, so a session with no IM integration at all
+  (`webchat` / `hook` / `dream`, or a memory-only agent) can still discover peers.
+  The REP omits `channel`.
+- **present → the same directory, additionally narrowed to agents in that
+  channel** (`IntegrationRepo.agentsInChannel`). A filter, never a gate. A
+  session-identity platform has no persisted integration, so a channel filter on
+  one of those yields an empty roster (short-circuited before persistence — a repo
+  throw here would close the whole control socket).
+
 The daemon derives `requesterAgentId` and `platform` from trusted MCP session
-context. The CP joins the channel's active integrations
-(`integration_channel` → `integration.agentId` → `agent`) inside the requesting
-daemon's organization, returns an empty roster unless the requester belongs to
-that channel, and filters peers through both the requester's outbound policy and
-each target's inbound call policy. `listChannelAgents` cannot use tool input to
-impersonate another requester or probe another platform.
+context; `channel` is the only agent-supplied field and it can only narrow the
+answer. The roster is **policy-filtered, not membership-gated**: within the
+requesting daemon's own organization, an entry survives iff the requester's
+outbound policy admits it **and** its own inbound `callPolicy` admits the
+requester — and the requester is required to appear in the roster it asks about,
+so an unknown requester fails **CLOSED** (empty). A requester always sees itself.
+Discovery _is_ the authorization surface: a peer that fails the predicate is
+omitted entirely, never listed-but-uncallable, so an agent still cannot probe
+peers it may not call and cross-org never resolves. `Agent.visibility` /
+`sharedWith` is deliberately **not** consulted — that governs human console
+access, so a `restricted` agent is still a discoverable, callable peer.
+
+`listAgents` cannot use tool input to impersonate another requester or probe
+another platform.
+
+**Feature negotiation.** Only a CP advertising `agent-directory-org-scope-v1` in
+`register/ok.serverFeatures` (§3.3) accepts the channel-less form and ships the
+flat `collabRoutes.agents[]`. A daemon that does not see the feature substitutes
+the caller's trusted **current** channel — today's pre-change behavior — rather
+than sending a payload an older CP would reject. An explicitly requested `channel`
+filter is passed through to either CP unchanged. See
+[`agent-collaboration-implementation.md`](agent-collaboration-implementation.md)
+§2.2/§2.5 for the predicate and the rest of the rolling-upgrade rules.
 
 ---
 

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -79,7 +79,7 @@ This chapter summarizes the daemon's **modules and their responsibilities**. Eve
 | **Scheduler**                             | In process                      | Fires cron/loop **locally**, including while CP is offline, and injects synthetic messages into Router                                                            | sections 4.2/7.4    |
 | **ACP Host**                              | In process; local ACP client    | Starts and drives adapters through ACP; manages session lifecycles; **converges** streaming agent output                                                          | section 7           |
 | **ACP Adapters**                          | **Third-party child processes** | `claude-agent-acp` / `codex`: implement the ACP agent side and launch the local model harness                                                                     | sections 7.1/3.3    |
-| **MCP Tool Server**                       | In process; local MCP server    | Injects tools such as `sendPlatformMessage`, `listChannelAgents`, and `messageAgent`, filling ACP gaps                                                            | section 9.4         |
+| **MCP Tool Server**                       | In process; local MCP server    | Injects tools such as `sendMessage`, `listAgents` (org-scoped peer discovery), and `messageAgent`, filling ACP gaps                                               | section 9.4         |
 | **Workspace Manager**                     | In process                      | Manages `git-repo` and `from-scratch` workspaces, installs skills, and returns `cwd` from `prepareWorkspace`                                                      | section 4.3         |
 | **Local Store**                           | Embedded SQLite                 | Session state, route/cron cache for degradation, thread transcript, and pending telemetry buffer                                                                  | section 3.2         |
 | **Telemetry**                             | In process                      | Metrics/traces use direct OTLP side path (`startDaemonOpenTelemetry`, configured through `OTEL_*`); usage/facts use `usage/report` and `facts/*`; injects traceId | section 10.2        |
@@ -903,11 +903,21 @@ send-only SDK client under `src/feishu/`; see
 ACP can only reply to the current thread. Daemon's **MCP Tool Server** adds proactive platform send / agent calls. Declare it in `session/new.mcpServers`; platform tokens remain in the connection and invisible to the agent.
 
 Implemented tools in `src/mcp/tools.ts`: `sendPlatformMessage`; collaboration
-`listChannelAgents` / `messageAgent`; channel/user information
+`listAgents` (deprecated alias `listChannelAgents`) / `messageAgent`; channel/user information
 `getCurrentChannel`, `listChannels`, `listKnownUsers`, `listChannelMembers`,
 `getUserProfile`; attachment readers `readSlackFile`, `readTelegramFile`;
 memory `readMemory`, `writeMemory`, `searchMemory`; orchestration
 `startOrchestration`, `getOrchestration`, `cancelOrchestration`; and others.
+
+`listAgents` is **org**-scoped, not channel-scoped: it issues `channel/agents` with
+no channel and gets back every peer in the organization that the directional call
+policy admits, so a session with no IM integration (webchat, webhook, dreaming,
+memory-only) can still discover and wake peers. A `channel` argument is an optional
+filter. Authorization for a wake is that same call policy, evaluated against the
+daemon's copy of the collaboration snapshot (`CpCollabRoutes.admits`, fail-closed on
+an unknown agent); `channel` remains only the session/delivery coordinate. See
+[agent-collaboration-implementation.md](agent-collaboration-implementation.md) §2.2/§2.5
+and [daemon-cp-ws-protocol.md](daemon-cp-ws-protocol.md) §7.7.
 
 ---
 

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -915,7 +915,11 @@ policy admits, so a session with no IM integration (webchat, webhook, dreaming,
 memory-only) can still discover and wake peers. A `channel` argument is an optional
 filter. Authorization for a wake is that same call policy, evaluated against the
 daemon's copy of the collaboration snapshot (`CpCollabRoutes.admits`, fail-closed on
-an unknown agent); `channel` remains only the session/delivery coordinate. See
+an unknown agent); `channel` remains only the session/delivery coordinate — but as that
+coordinate it is checked for **integrity**: a recorded coordinate must have the caller in
+its membership, an unrecorded one on a persisted IM platform is refused, and an unrecorded
+one on a channel-free platform is replaced by the caller-derived `a2a:<callerAgentId>`
+before the session key is minted. See
 [agent-collaboration-implementation.md](agent-collaboration-implementation.md) §2.2/§2.5
 and [daemon-cp-ws-protocol.md](daemon-cp-ws-protocol.md) §7.7.
 

--- a/docs/designs/directional-agent-visibility.md
+++ b/docs/designs/directional-agent-visibility.md
@@ -4,6 +4,15 @@
 >
 > Scope: agent-to-agent discovery and direct delivery. Human console access remains
 > governed by `ResourceVisibility` and is intentionally separate.
+>
+> **Two unrelated things are called "visibility".** `callPolicy` / `outboundPolicy`
+> — the subject of this document, labelled "Agent visibility" in the console — is
+> the **only** gate on agent-to-agent discovery and wakes. `Agent.visibility` /
+> `sharedWith` (`ResourceVisibility`: `org` | `restricted`, see
+> [`resource-visibility.md`](resource-visibility.md)) governs **human** console
+> access and must **never** affect the peer directory: a `restricted` agent is
+> still a discoverable, callable peer. The control plane's peer-directory read
+> deliberately omits the `ResourceVisibility` clause for exactly this reason.
 
 ## Problem
 
@@ -26,9 +35,21 @@ Each agent now has an outbound half as well:
 
 For two distinct agents A and B, A may discover or message B only when all of these hold:
 
-1. A and B are in the same organization and are members of the addressed channel.
-2. A's outbound policy is `all`, or `allowedTargetAgentIds` contains B.
-3. B's inbound `callPolicy` is `all`, or `allowedCallerAgentIds` contains A.
+1. A and B are both **known in the org-scoped peer directory** — an agent the
+   directory has never seen fails **CLOSED**, so a missing or stale snapshot never
+   grants access.
+2. A and B are in the **same organization**. Channel membership is **not** part of
+   the predicate: since A2A delivery became postless the channel has no role in
+   delivery, so it must not act as an authorization key, and agents with no IM
+   integration at all (webchat / hook / dream / memory-only) have no CP-visible
+   channel yet must still collaborate. Channel survives only as an **optional
+   filter** on a directory listing.
+3. A's outbound policy is `all`, or `allowedTargetAgentIds` contains B.
+4. B's inbound `callPolicy` is `all`, or `allowedCallerAgentIds` contains A.
+
+A caller always resolves **itself** in a listing, even under a `selected` policy
+that omits it — an agent does not normally name itself in its own allow-list, yet
+it must still appear in its own directory answer. A self-_wake_ stays forbidden.
 
 This is an intersection, not an override. Selecting B on A never grants A access through
 B's inbound restriction, and selecting A on B never expands A's outbound scope. Self-call
@@ -58,17 +79,28 @@ or a live push fails.
 
 ## Data-plane enforcement
 
-`listChannelAgents` computes the effective A → B edge and omits B unless both directional
-checks pass. The requester still sees itself as directory context, but self-message stays
-forbidden.
+`listAgents` (deprecated alias `listChannelAgents`) computes the effective A → B edge over
+the requester's **organization** and omits B unless both directional checks pass. The
+requester still sees itself as directory context, but self-message stays forbidden. A
+`channel` argument only narrows that answer to the agents present in that channel.
+Discovery is the authorization surface — a peer that fails the predicate is omitted, never
+listed-but-uncallable.
 
 `sendMessage({toAgent})` repeats authorization at every trust boundary:
 
-- source daemon: validates the trusted local caller's outbound policy;
-- same-daemon delivery: also validates the target's inbound policy;
-- relay: validates the authenticated caller placement, caller outbound policy, and target
-  inbound policy from the collaboration snapshot;
-- target daemon: terminal-verifies both policies against its own snapshot before wakeup.
+- source daemon: validates the trusted local caller's outbound policy, then the org-scoped
+  directional predicate against its own copy of the collaboration snapshot (which also
+  decides a _remote_ target, because that snapshot is org-wide rather than per-daemon);
+- same-daemon delivery: also validates a local target's inbound policy from its spec;
+- relay: validates that the claimed caller exists in the flat org directory and is owned by
+  the authenticated sending daemon, then caller outbound + target inbound policy in the
+  same org;
+- target daemon: terminal-verifies the asserted org and both policies against its own
+  snapshot before wakeup.
+
+None of these consult channel membership. `coords` still travels with a wake, but as the
+**delivery coordinate** for the woken session — and as the preferred source of the target's
+reply integration for a visible post — not as an authorization input.
 
 All policy denials return `delivered:false, reason:'not_allowed'` and create no visible
 platform message or shared-transcript row. Live routing still carries only
@@ -91,9 +123,16 @@ control-plane payload, both outbound fields remain absent so the daemon preserve
 complete on-disk outbound half instead of retaining `selected` while clearing its list.
 Once a `selected` outbound policy is received, enforcement is fail-closed: missing targets
 are denied. Local and cross-daemon delivery both fail closed when the collaboration
-snapshot cannot prove caller and target channel membership. Consequently, a local-only
-daemon that has never received a control-plane collaboration snapshot cannot authorize
-same-daemon direct agent calls.
+snapshot does not contain **both** the caller and the target in one organization.
+Consequently, a local-only daemon that has never received a control-plane collaboration
+snapshot cannot authorize same-daemon direct agent calls.
+
+Rolling upgrade: the flat org directory arrives only from a control plane that advertises
+`agent-directory-org-scope-v1`. Against an older control plane, relay and daemon derive the
+directory from the channel-keyed rows they do receive, so integration-backed pairs keep
+resolving; an integration-less agent stays invisible until the flat list arrives, which is
+exactly the pre-change behavior. A daemon likewise keeps sending the caller's current
+channel with a discovery request until the feature appears.
 
 A data-plane consumer from before this design ignores the new fields and therefore keeps
 the historical unrestricted outbound behavior. A selected outbound restriction is fully

--- a/docs/designs/directional-agent-visibility.md
+++ b/docs/designs/directional-agent-visibility.md
@@ -102,6 +102,17 @@ None of these consult channel membership. `coords` still travels with a wake, bu
 **delivery coordinate** for the woken session — and as the preferred source of the target's
 reply integration for a visible post — not as an authorization input.
 
+`coords` is nonetheless validated, because it is still the woken peer's session key: a
+caller that could assert any coordinate could compute its way into an existing session of
+the target and read it back. Every wake path runs one three-way **coordinate-integrity**
+verdict: a coordinate the snapshot records with non-empty membership requires the caller to
+be in it (else `not_allowed`) and is then used verbatim; an **unrecorded** coordinate on a
+persisted IM platform is refused — fail closed; and an unrecorded coordinate on a
+channel-free platform (`webchat` / `dream`) is neither refused nor used, the woken session
+instead keying on the caller-derived `a2a:<callerAgentId>`, which cannot alias a platform
+session. See
+[agent-collaboration-implementation.md](agent-collaboration-implementation.md) §2.5.
+
 All policy denials return `delivered:false, reason:'not_allowed'` and create no visible
 platform message or shared-transcript row. Live routing still carries only
 placement and policy metadata through the control plane; message bodies remain

--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -212,8 +212,15 @@ Every field is optional. Two orthogonal decisions use different fields:
   or a `toAgent` to wake. The daemon rejects an empty action.
 - Separate `toUser` and `toAgent` make human delivery and agent wake-up
   explicit in the type system. The daemon no longer guesses whether an ID is a
-  platform user or an AgentConnect agent. `toAgent` comes from
-  `listChannelAgents`; `toUser` is a platform member ID.
+  platform user or an AgentConnect agent. `toAgent` comes from `listAgents`
+  (deprecated alias `listChannelAgents`), which lists every peer in the caller's
+  organization that the directional call policy admits — a peer need not share a
+  channel with the caller, and need not have an IM integration at all. `toUser` is
+  a platform member ID.
+- A `toAgent` wake is authorized by that call policy alone; `channel` is a
+  **delivery coordinate**, not an authorization key. It still decides where the
+  optional visible post lands and, through the session key, which session the peer
+  is woken in.
 - Omitting `platform` means the current session platform. Cross-platform cases
   3 and 3b specify it. The daemon owns all bot tokens and selects the connection
   by platform and, when necessary, integration. The model sees no token.

--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -220,7 +220,14 @@ Every field is optional. Two orthogonal decisions use different fields:
 - A `toAgent` wake is authorized by that call policy alone; `channel` is a
   **delivery coordinate**, not an authorization key. It still decides where the
   optional visible post lands and, through the session key, which session the peer
-  is woken in.
+  is woken in — which is why the coordinate itself is validated even though it
+  authorizes nothing. A coordinate the routing snapshot records requires the caller
+  to be one of its members and is then used verbatim; an **unrecorded** coordinate on
+  a persisted IM platform is refused (`not_allowed`) rather than silently becoming a
+  session key it could alias; and an unrecorded coordinate on a channel-free platform
+  (`webchat` / `dream`) is replaced by the caller-derived `a2a:<callerAgentId>`, so
+  every wake from one caller into one peer shares a single pairwise session. See
+  [agent-collaboration-implementation.md](agent-collaboration-implementation.md) §2.5.
 - Omitting `platform` means the current session platform. Cross-platform cases
   3 and 3b specify it. The daemon owns all bot tokens and selects the connection
   by platform and, when necessary, integration. The model sees no token.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -184,14 +184,64 @@ assertion, and the original user text is not rewritten.
 
 Agent-to-agent visibility is the intersection of two independently configured directions.
 The source agent decides which peer agents it may discover and message; the target agent
-decides which peer agents may call it. An A → B edge exists only when both policies allow
-it and both agents are otherwise eligible in the same organization and channel.
+decides which peer agents may call it. An A → B edge exists exactly when all four of these
+hold, and nothing else is consulted:
 
-The agent-directory tool must hide peers that fail either side of this check. Message
+1. A and B are both **known in the org-scoped peer directory**. An agent the directory has
+   never seen — or that a missing or stale snapshot cannot prove — fails **closed**.
+2. A and B are in the **same organization**.
+3. A's outbound policy is `all`, or its allowed-target list contains B.
+4. B's inbound call policy is `all`, or its allowed-caller list contains A.
+
+**A shared channel is not part of that predicate — in either direction.** An agent-to-agent
+wake is postless: nothing is left in any channel, so a shared channel is not evidence of
+anything and must not act as an authorization key. It is also not expressible for the
+populations that legitimately need to collaborate — peers that share no channel, and agents
+with no IM integration at all (webchat, webhook, dreaming, memory-only). A channel may only
+**narrow** a directory listing as an optional filter; it can never widen one. A caller
+always sees **itself** in a listing, even under a `selected` outbound policy that does not
+name it (a self-_wake_ is still refused separately).
+
+The agent-directory tool must hide peers that fail any part of this check. Message
 delivery must repeat the same authorization instead of trusting discovery: a remembered,
 guessed, or stale agent id must not bypass either policy. Rejection does not wake the
 target and uses the same `not_allowed` result as an inbound-policy denial. Both directions
 default to all peers so existing agents retain their current collaboration behavior.
+
+**Two unrelated settings are both called "visibility".** The `callPolicy` /
+`outboundPolicy` pair above is what the console labels "Agent visibility", and it is the
+whole agent-to-agent gate. `Agent.visibility` / `sharedWith` governs **human** console
+access to an agent and is **never** consulted for peer discovery or wakes: a `restricted`
+agent is still a discoverable, callable peer.
+
+### Channel's remaining role: coordinate integrity
+
+Channel checks did not disappear; they moved from authorization to the integrity of the
+**coordinate a wake lands on**. The woken peer's session is keyed by its coordinate, so an
+asserted channel a caller cannot reach would otherwise let that caller resume a
+conversation it has no access to and read it back. Three cases, applied identically on
+every wake path:
+
+- **A coordinate the platform records, with known members** — the caller must be one of
+  them, otherwise the wake is refused with `not_allowed`. When it is, the peer is woken in
+  exactly that conversation, so a wake naming a channel a human is already looking at still
+  lands in the same place it always did. Recorded conversations include direct and group
+  conversations, which the product records separately from a bot's channel membership — a
+  wake originating from one keeps working wherever such a row exists.
+- **An unrecorded coordinate on a persisted IM platform** (Slack, Telegram, Discord,
+  Feishu) — refused with `not_allowed`. Such a coordinate is either a conversation the
+  caller cannot reach or a stale one whose record has gone, and admitting it is what would
+  allow aliasing an existing session. This fails closed on purpose: a brief lag in the
+  routing snapshot can transiently refuse a genuine wake, and the caller retries. A direct
+  conversation that was never recorded — because nothing in the product had reason to
+  observe it — falls here too, which is the same outcome it had before channel membership
+  stopped being the authorization key.
+- **A genuinely channel-free coordinate** (webchat, dreaming) — never refused, because this
+  is the collaboration case the org-scoped directory exists to serve. Instead the asserted
+  coordinate is not used at all: the peer is woken in a session derived from the calling
+  agent's own identity, which cannot collide with any platform conversation. Two different
+  asserted coordinates from the same caller therefore collapse into one pairwise
+  conversation, which is the right shape for a postless agent-to-agent exchange.
 
 An agent replying to the exact session that invoked it is a return path, not a new peer
 selection. That reply remains governed by the existing origin-only session capability, so

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -457,7 +457,7 @@ export function buildContainer(
 
   // Bot-agnostic collaboration routing snapshot fan-out (agent-collaboration
   // §2.3/§6.2): relays get the all-org table; daemons get their org-scoped copy.
-  const collabRoutes = new CollabRoutesService(repos.daemon, repos.integration, relayControl, sender)
+  const collabRoutes = new CollabRoutesService(repos.daemon, repos.integration, repos.agent, relayControl, sender)
   const agentMutations = new AgentMutationGate()
   const memoryConnectionMutations = new ExclusiveMutationGate()
 

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1058,6 +1058,30 @@ export function agentRoutes(deps: HttpDeps) {
           // closed until the registry validates it.
           await pushExternalMemoryBeforeAgent(agent)
           await replicateUpsert(agent) // no-op until placed; reconcile carries it otherwise
+          // A create that arrives already PLACED (`daemonId` in the body) must also enter
+          // the peer directory now. `replicateUpsert` only ships the AgentSpec (same-daemon
+          // authorization); a peer WAKE is authorized against the collaboration snapshot,
+          // whose flat `agents[]` is the only structure an agent with no IM integration can
+          // appear in — and channel membership no longer gates the directory, so there is no
+          // later `integration/channels` push to rely on. Without this the agent would be
+          // DISCOVERABLE (channel/agents reads the DB live) yet un-wakeable until an
+          // unrelated change bumped the snapshot: the listed-but-uncallable state that
+          // discovery-as-authorization forbids. Gated on placement for the same reason
+          // `replicateUpsert` is — `buildCollabSnapshot` drops daemonId-less rows, so an
+          // unplaced create has nothing to publish and must not churn every routingEpoch.
+          // Best-effort for the same reason as `replicateUpsert` above: the agent row is
+          // ALREADY committed, so a snapshot-push hiccup must not turn a successful create
+          // into a 500. `register/ok` carries the same directory as the reconnect backstop.
+          if (agent.daemonId) {
+            try {
+              await deps.collabRoutes.broadcast(agent.orgId)
+            } catch (err) {
+              app.log.warn(
+                { err, agentId: agent.id, orgId: agent.orgId },
+                'collaboration routes push failed after agent create (backstop: reconnect snapshot)'
+              )
+            }
+          }
           if (agent.daemonId) await syncMcpDefsForAgent(orgOf(req), agent.daemonId, [], agent.mcpServers)
           return reply.code(201).send({
             ...toDto(
@@ -1872,6 +1896,24 @@ export function agentRoutes(deps: HttpDeps) {
           // every HookDef, tombstones their durable review projections, and
           // cascades the Agent/HookDef rows in one transaction.
           const removedHooks = await deps.repos.agent.delete(AgentId(req.params.id))
+          // WITHDRAW it from the peer directory now, the mirror of the create path above.
+          // Discovery (`channel/agents`) reads the DB live while a peer WAKE is authorized
+          // against the pushed snapshot, so without this every daemon in the org keeps a flat
+          // `agents[]` entry whose `admits()` still says yes — a wake routed at a row that no
+          // longer exists. Gated on placement for the same reason as the create: an unplaced
+          // agent was never in a snapshot, so there is nothing to withdraw and no reason to
+          // churn every routingEpoch. Best-effort — the row is already gone, and `register/ok`
+          // carries the corrected directory as the reconnect backstop.
+          if (current.daemonId) {
+            try {
+              await deps.collabRoutes.broadcast(current.orgId)
+            } catch (err) {
+              app.log.warn(
+                { err, agentId: current.id, orgId: current.orgId },
+                'collaboration routes push failed after agent delete (backstop: reconnect snapshot)'
+              )
+            }
+          }
           await replicateRemove(current.id, current.daemonId)
           if (current.daemonId && current.memory?.provider === 'external') {
             await removeExternalMemoryFromDaemonIfUnused(current.orgId, current.daemonId, current.memory.connectionId)

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -320,6 +320,22 @@ export function daemonRoutes(deps: HttpDeps) {
         await deps.registry.remove(DaemonId(req.params.id))
         // The daemon (and its FK-cascaded keys) is gone — tell relays to drop it (§9).
         deps.relayControl.daemonRevoke(req.params.id)
+        // Its agents just became UNPLACED (Agent.daemonId is SetNull), so they leave the
+        // collaboration snapshot — but only if we push one. Every other holder of the
+        // snapshot (relay + the remaining daemons) otherwise keeps flat `agents[]` entries
+        // naming this dead daemonId, and `admits()` keeps admitting wakes the relay can only
+        // answer 'offline' to. Best-effort, after the row is already gone; `register/ok`
+        // carries the corrected directory as the reconnect backstop.
+        if (placedAgents.length > 0) {
+          try {
+            await deps.collabRoutes.broadcast(existing.orgId)
+          } catch (err) {
+            req.log.warn(
+              { err, daemonId: req.params.id, orgId: existing.orgId },
+              'collaboration routes push failed after daemon delete (backstop: reconnect snapshot)'
+            )
+          }
+        }
         // Re-converge the unplaced agents' hook rules NOW: their compiled rules
         // still name the dead daemonId in every relay's table and would fail
         // each delivery with daemon_offline until a relay re-register replay.

--- a/packages/control-plane/src/orchestrator/collabRoutes.service.test.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import type { CollabRoutesSnapshot, RcCollabRoutes } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
-import type { ChannelPlacementRecord, DaemonRecord, DaemonRepo, IntegrationRepo } from '../persistence/ports.js'
+import type {
+  AgentRepo,
+  ChannelPlacementRecord,
+  DaemonRecord,
+  DaemonRepo,
+  IntegrationRepo,
+  OrgAgentRecord
+} from '../persistence/ports.js'
 import type { RelayControlSender } from './relayControl.js'
 import type { ControlSender } from './outbound.js'
 import { NoConnection } from './outbound.js'
@@ -47,6 +54,27 @@ function placement(orgId: OrgId, daemonId: string, suffix: string): ChannelPlace
   }
 }
 
+/** Flat org peer directory (agent-collaboration §2.5): one placed agent per org, with
+ *  NO integration — so it can only ever reach a snapshot through `agents[]`. */
+function agentRepo(byOrg: Record<string, OrgAgentRecord[]> = {}): AgentRepo {
+  return { orgDirectory: async (orgId: string) => byOrg[orgId] ?? [] } as unknown as AgentRepo
+}
+
+function orgAgent(orgId: string, daemonId: string, suffix: string): OrgAgentRecord {
+  return {
+    agentId: placement(OrgId(orgId), daemonId, suffix).agentId,
+    name: `agent-${suffix}`,
+    displayName: null,
+    description: null,
+    status: 'active',
+    daemonId,
+    callPolicy: 'all',
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all',
+    allowedTargetAgentIds: []
+  }
+}
+
 describe('CollabRoutesService placement broadcast', () => {
   it('sends an all-org full replacement to relays and org-scoped copies to daemons', async () => {
     let relay: RcCollabRoutes | undefined
@@ -57,6 +85,7 @@ describe('CollabRoutesService placement broadcast', () => {
         channelPlacements: async (orgId: string) =>
           orgId === ORG_A ? [placement(ORG_A, D_A, '1')] : [placement(ORG_B, D_B, '2')]
       } as unknown as IntegrationRepo,
+      agentRepo({ [ORG_A]: [orgAgent(ORG_A, D_A, '3')], [ORG_B]: [orgAgent(ORG_B, D_B, '4')] }),
       { collabRoutes: (snapshot: RcCollabRoutes) => void (relay = snapshot) } as unknown as RelayControlSender,
       {
         collaborationRoutes: async (daemonId: string, snapshot: CollabRoutesSnapshot) => {
@@ -74,6 +103,10 @@ describe('CollabRoutesService placement broadcast', () => {
     expect(daemonSends.find((s) => s.daemonId === D_A)?.snapshot.generation).toBe(5)
     expect(daemonSends.find((s) => s.daemonId === D_B)?.snapshot.generation).toBe(10)
     expect(relay?.generation).toBe(10)
+    // The flat directory is all-org too: the relay table is a FULL replacement, so a
+    // per-org emit would wipe the other tenant's peers just like `channels`.
+    expect(relay?.agents.map((a) => a.orgId).sort()).toEqual([ORG_A, ORG_B].sort())
+    expect(daemonSends.find((s) => s.daemonId === D_A)?.snapshot.agents.map((a) => a.orgId)).toEqual([ORG_A])
   })
 
   it('refreshes only the changed org daemons and tolerates disconnected ones', async () => {
@@ -81,6 +114,7 @@ describe('CollabRoutesService placement broadcast', () => {
     const service = new CollabRoutesService(
       daemonRepo(),
       { channelPlacements: async () => [] } as unknown as IntegrationRepo,
+      agentRepo(),
       { collabRoutes: () => undefined } as unknown as RelayControlSender,
       {
         collaborationRoutes: async (daemonId: string) => {
@@ -102,8 +136,8 @@ describe('CollabRoutesService placement broadcast', () => {
     } as unknown as RelayControlSender
     const integrations = { channelPlacements: async () => [] } as unknown as IntegrationRepo
 
-    await new CollabRoutesService(repo, integrations, relay).broadcast()
-    await new CollabRoutesService(repo, integrations, relay).broadcast()
+    await new CollabRoutesService(repo, integrations, agentRepo(), relay).broadcast()
+    await new CollabRoutesService(repo, integrations, agentRepo(), relay).broadcast()
 
     expect(generations).toEqual([10, 11])
   })
@@ -128,6 +162,7 @@ describe('CollabRoutesService placement broadcast', () => {
           return []
         }
       } as unknown as IntegrationRepo,
+      agentRepo(),
       {
         collabRoutes: (snapshot: RcCollabRoutes) => void generations.push(snapshot.generation)
       } as unknown as RelayControlSender

--- a/packages/control-plane/src/orchestrator/collabRoutes.service.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.ts
@@ -13,9 +13,9 @@
 import type { RelayControlSender } from './relayControl.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 import type { RelayChannel } from '../ws/relay-registry.js'
-import type { DaemonRecord, DaemonRepo, IntegrationRepo } from '../persistence/ports.js'
+import type { AgentRepo, DaemonRecord, DaemonRepo, IntegrationRepo, OrgAgentRecord } from '../persistence/ports.js'
 import { buildCollabSnapshot } from './collabSnapshot.js'
-import type { CollabChannelRoute } from '@agentconnect.md/protocol'
+import type { CollabChannelRoute, CollabOrgAgent } from '@agentconnect.md/protocol'
 import type { OrgId } from '../domain/ids.js'
 
 export class CollabRoutesService {
@@ -24,6 +24,7 @@ export class CollabRoutesService {
   constructor(
     private readonly daemons: DaemonRepo,
     private readonly integrations: IntegrationRepo,
+    private readonly agents: AgentRepo,
     private readonly relayControl: RelayControlSender,
     private readonly control?: ControlSender
   ) {}
@@ -37,18 +38,24 @@ export class CollabRoutesService {
     return result
   }
 
-  /** Build the combined snapshot across every org that has a daemon. */
+  /** Build the combined snapshot across every org that has a daemon. Both the
+   *  channel-keyed routes AND the flat per-org peer directory are all-org here, for the
+   *  same reason: the relay table is a FULL replacement, so omitting an org wipes it. */
   private async build(
     daemonRows: DaemonRecord[],
     generation: number
-  ): Promise<{ generation: number; channels: CollabChannelRoute[] }> {
+  ): Promise<{ generation: number; channels: CollabChannelRoute[]; agents: CollabOrgAgent[] }> {
     const orgIds = [...new Set(daemonRows.map((d) => d.orgId))]
     const channels: CollabChannelRoute[] = []
+    const agents: CollabOrgAgent[] = []
     for (const orgId of orgIds) {
       const placements = await this.integrations.channelPlacements(orgId)
-      channels.push(...buildCollabSnapshot(orgId, placements, generation).channels)
+      const orgAgents = await this.agents.orgDirectory(orgId)
+      const snapshot = buildCollabSnapshot(orgId, placements, generation, orgAgents)
+      channels.push(...snapshot.channels)
+      agents.push(...snapshot.agents)
     }
-    return { generation, channels }
+    return { generation, channels, agents }
   }
 
   private durableGeneration(rows: DaemonRecord[]): number {
@@ -100,14 +107,23 @@ export class CollabRoutesService {
     const targetRows = changedOrgId ? daemonRows.filter((d) => d.orgId === changedOrgId) : daemonRows
     const orgIds = [...new Set(targetRows.map((d) => d.orgId))]
     const placementsByOrg = new Map<string, Awaited<ReturnType<IntegrationRepo['channelPlacements']>>>()
+    // Batched per ORG (not per daemon): several daemons share an org, and the peer
+    // directory is org-wide, so one query each keeps this out of an N+1 over agents.
+    const orgAgentsByOrg = new Map<string, OrgAgentRecord[]>()
     for (const orgId of orgIds) {
       placementsByOrg.set(orgId, await this.integrations.channelPlacements(orgId))
+      orgAgentsByOrg.set(orgId, await this.agents.orgDirectory(orgId))
     }
     await Promise.all(
       targetRows.map(async (daemon) => {
         const placements = placementsByOrg.get(daemon.orgId)
         if (!placements) return
-        const snapshot = buildCollabSnapshot(daemon.orgId, placements, Number(daemon.routingEpoch))
+        const snapshot = buildCollabSnapshot(
+          daemon.orgId,
+          placements,
+          Number(daemon.routingEpoch),
+          orgAgentsByOrg.get(daemon.orgId) ?? []
+        )
         try {
           await this.control!.collaborationRoutes(daemon.id, snapshot)
         } catch (err) {

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import { buildCollabSnapshot } from './collabSnapshot.js'
-import type { ChannelPlacementRecord } from '../persistence/ports.js'
+import type { ChannelPlacementRecord, OrgAgentRecord } from '../persistence/ports.js'
 import { AgentId, IntegrationId } from '../domain/ids.js'
 import { DEFAULT_ORG_ID } from '../config/defaults.js'
 
@@ -9,7 +9,24 @@ const DAEMON_1 = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 const DAEMON_2 = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
 const AGENT_1 = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
 const AGENT_2 = AgentId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+const AGENT_3 = AgentId('cccccccc-cccc-4ccc-8ccc-cccccccccccc')
 const INTEGRATION = IntegrationId('ffffffff-ffff-4fff-8fff-ffffffffffff')
+
+function orgAgent(over: Partial<OrgAgentRecord>): OrgAgentRecord {
+  return {
+    agentId: AGENT_1,
+    name: 'agent-one',
+    displayName: null,
+    description: null,
+    status: 'active',
+    daemonId: DAEMON_1,
+    callPolicy: 'all',
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all',
+    allowedTargetAgentIds: [],
+    ...over
+  }
+}
 
 function rec(over: Partial<ChannelPlacementRecord>): ChannelPlacementRecord {
   return {
@@ -35,7 +52,8 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
         rec({ agentId: AGENT_1, daemonId: DAEMON_1, botAppId: 'A111' }),
         rec({ agentId: AGENT_2, daemonId: DAEMON_2, botAppId: 'A222' })
       ],
-      7
+      7,
+      []
     )
     // Regression: register/ok must remain wire-valid for the real opaque org-id
     // domain; UUID-only fixtures previously hid this production failure.
@@ -48,7 +66,7 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
   })
 
   it('drops unplaced agents (daemonId null) — they are not routable', () => {
-    const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [rec({ daemonId: null })], 1)
+    const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [rec({ daemonId: null })], 1, [])
     expect(snap.channels).toHaveLength(0)
   })
 
@@ -56,7 +74,8 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     const snap = buildCollabSnapshot(
       DEFAULT_ORG_ID,
       [rec({ channelId: 'C1' }), rec({ channelId: 'C2', agentId: AGENT_2 })],
-      1
+      1,
+      []
     )
     expect(snap.channels.map((c) => c.channelId).sort()).toEqual(['C1', 'C2'])
   })
@@ -65,9 +84,45 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     const snap = buildCollabSnapshot(
       DEFAULT_ORG_ID,
       [rec({ agentId: AGENT_1, name: 'deploy-bot', displayName: 'Deploy Bot' })],
-      1
+      1,
+      []
     )
     expect(CollabRoutesSnapshot.parse(snap)).toEqual(snap)
     expect(snap.channels[0].agents[0]).toMatchObject({ name: 'deploy-bot', displayName: 'Deploy Bot' })
+  })
+
+  it('carries an integration-less agent in the flat org directory (the whole point of agents[])', () => {
+    // AGENT_1 reaches a channel; AGENT_3 has NO integration at all, so it appears in
+    // zero channels[] entries — the flat list is its only carrier.
+    const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [rec({ agentId: AGENT_1 })], 3, [
+      orgAgent({ agentId: AGENT_1, name: 'deploy-bot', displayName: 'Deploy Bot' }),
+      orgAgent({
+        agentId: AGENT_3,
+        name: 'webchat-only',
+        daemonId: DAEMON_2,
+        callPolicy: 'selected',
+        allowedCallerAgentIds: [AGENT_1]
+      })
+    ])
+    expect(CollabRoutesSnapshot.parse(snap)).toEqual(snap)
+    expect(snap.channels.flatMap((c) => c.agents).map((a) => a.agentId)).toEqual([AGENT_1])
+    expect(snap.agents.map((a) => a.agentId).sort()).toEqual([AGENT_1, AGENT_3].sort())
+    expect(snap.agents.find((a) => a.agentId === AGENT_3)).toEqual({
+      orgId: DEFAULT_ORG_ID,
+      agentId: AGENT_3,
+      daemonId: DAEMON_2,
+      name: 'webchat-only',
+      callPolicy: 'selected',
+      allowedCallerAgentIds: [AGENT_1],
+      outboundPolicy: 'all',
+      allowedTargetAgentIds: []
+    })
+    // displayName is omitted (not null) when unset, and set when present.
+    expect(snap.agents.find((a) => a.agentId === AGENT_1)?.displayName).toBe('Deploy Bot')
+  })
+
+  it('drops an unplaced agent from the flat directory — nothing to route a wake to', () => {
+    const snap = buildCollabSnapshot(DEFAULT_ORG_ID, [], 1, [orgAgent({ agentId: AGENT_3, daemonId: null })])
+    expect(snap.agents).toEqual([])
   })
 })

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -2,7 +2,9 @@
  * `buildCollabSnapshot` — assemble the bot-AGNOSTIC collaboration routing snapshot
  * (agent-collaboration §2.3/§6.2) from an org's channel placements. Groups the flat
  * placement records into per-channel `CollabChannelRoute`s, dropping unplaced agents
- * (no daemonId ⇒ not routable). Bodiless routing/policy metadata only.
+ * (no daemonId ⇒ not routable), plus the FLAT org-scoped `agents[]` directory built
+ * from `orgAgents` — the only carrier for an agent that has no IM integration and so
+ * appears in no channel at all. Bodiless routing/policy metadata only.
  *
  * The SAME snapshot is shipped to the relay (`rc/collab-routes`, full org) and to a
  * daemon (`register/ok.collabRoutes` / `collaboration/routes` EVT). The daemon copy is
@@ -11,13 +13,14 @@
  * FOLLOW-UP (P2 scope-down, §6.5): `generation` is a plain counter passed by the
  * caller; per-entry tombstone / TTL / fail-closed-on-stale is not implemented.
  */
-import type { CollabRoutesSnapshot, CollabChannelRoute } from '@agentconnect.md/protocol'
-import type { ChannelPlacementRecord } from '../persistence/ports.js'
+import type { CollabRoutesSnapshot, CollabChannelRoute, CollabOrgAgent } from '@agentconnect.md/protocol'
+import type { ChannelPlacementRecord, OrgAgentRecord } from '../persistence/ports.js'
 
 export function buildCollabSnapshot(
   orgId: string,
   placements: ChannelPlacementRecord[],
-  generation: number
+  generation: number,
+  orgAgents: OrgAgentRecord[]
 ): CollabRoutesSnapshot {
   // (platform, channelId) → CollabChannelRoute
   const byChannel = new Map<string, CollabChannelRoute>()
@@ -42,5 +45,27 @@ export function buildCollabSnapshot(
       ...(p.displayName !== undefined ? { displayName: p.displayName } : {})
     })
   }
-  return { generation, channels: [...byChannel.values()] }
+
+  // The FLAT org directory, alongside the channel-keyed routes. An agent with no IM
+  // integration appears in NO `channels[]` entry, so this list is the only place a
+  // holder of the snapshot can learn it exists — and channel-free A2A authorization
+  // needs exactly that. Unplaced agents (daemonId null) are dropped for the same
+  // reason as in `channels[]`: with no owning daemon there is nothing to route to.
+  // No `integrationId`/`botAppId`: both are per-channel reply coordinates, not
+  // identity, and this entry is deliberately channel-free.
+  const agents: CollabOrgAgent[] = orgAgents
+    .filter((a): a is OrgAgentRecord & { daemonId: string } => a.daemonId !== null)
+    .map((a) => ({
+      orgId,
+      agentId: a.agentId,
+      daemonId: a.daemonId,
+      callPolicy: a.callPolicy,
+      allowedCallerAgentIds: a.allowedCallerAgentIds,
+      outboundPolicy: a.outboundPolicy,
+      allowedTargetAgentIds: a.allowedTargetAgentIds,
+      name: a.name,
+      ...(a.displayName !== null ? { displayName: a.displayName } : {})
+    }))
+
+  return { generation, channels: [...byChannel.values()], agents }
 }

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -458,8 +458,14 @@ export class Placement implements ReconcileService {
     // the org-wide channel placement/policy set, so THIS daemon can terminal-verify a
     // REMOTE agent caller (§2.5 #4). Org-scoped, bodiless. `generation` reuses the
     // routingEpoch as a monotonic version hook (fuller lifecycle is a follow-up, §6.5).
-    const placements = await this.integrations.channelPlacements(daemon.orgId)
-    const collabRoutes = buildCollabSnapshot(daemon.orgId, placements, Number(daemon.routingEpoch))
+    // `orgDirectory` is the flat companion: policy-only rows for EVERY org agent,
+    // including the integration-less ones no channel placement can express. One
+    // org-scoped query, not a per-agent fan-out.
+    const [placements, orgDirectory] = await Promise.all([
+      this.integrations.channelPlacements(daemon.orgId),
+      this.agents.orgDirectory(daemon.orgId)
+    ])
+    const collabRoutes = buildCollabSnapshot(daemon.orgId, placements, Number(daemon.routingEpoch), orgDirectory)
 
     // drop = localState − desired. Agent/integration replicas need an explicit
     // ownership proof so hand-authored local config survives. A legacy replica

--- a/packages/control-plane/src/persistence/platform.ts
+++ b/packages/control-plane/src/persistence/platform.ts
@@ -13,10 +13,17 @@
 import type { Platform as ProtocolPlatform } from '@agentconnect.md/protocol'
 import type { Platform as DbPlatform } from '../generated/prisma/enums.js'
 
+/** True for the session-identity-only platforms, which have no persisted row. Lets a
+ *  caller decide BEFORE reaching persistence — a read whose answer is "nothing is
+ *  persisted for this platform" should return the empty answer, not raise. */
+export function isSessionIdentityPlatform(p: ProtocolPlatform): p is 'webchat' | 'hook' | 'dream' {
+  return p === 'webchat' || p === 'hook' || p === 'dream'
+}
+
 /** Narrow a protocol platform to a persisted (DB) platform, or throw on the
  *  session-identity-only members (`webchat`, `hook`, `dream`). */
 export function toDbPlatform(p: ProtocolPlatform): DbPlatform {
-  if (p === 'webchat' || p === 'hook' || p === 'dream') {
+  if (isSessionIdentityPlatform(p)) {
     throw new Error(`${p} is a session-identity platform and is never persisted`)
   }
   return p

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -729,6 +729,26 @@ export interface AgentRepo {
   /** Agents placed on a specific daemon — the reconcile roster (`register/ok.agents`).
    *  A daemon only ever receives the specs of the agents it owns (1 agent : 1 machine). */
   listForDaemon(daemonId: DaemonId): Promise<AgentRecord[]>
+  /**
+   * The org's PEER directory: every agent, with only the fields the collaboration
+   * roster filter needs. This is the channel-free discovery/authorization input —
+   * an agent with no IM integration (webchat, hook, dream, memory-only) reaches
+   * peers through this list and appears in NO channel-keyed structure at all.
+   *
+   * Deliberately NOT {@link AgentRepo.list}: that applies `visibilityWhere(viewer)`.
+   * `ResourceVisibility` governs HUMAN console access only — a `restricted` agent is
+   * still discoverable and callable by its peers. The only gate here is the
+   * directional agent-call policy, applied by the caller over the returned rows.
+   */
+  orgDirectory(orgId: OrgId): Promise<OrgAgentRecord[]>
+}
+
+/** One agent in the org peer directory — {@link ChannelAgentRecord} (so the roster
+ *  filter is literally the same code in both the org-wide and channel-filtered
+ *  scopes) plus the owning daemon, which the flat `CollabRoutesSnapshot.agents[]`
+ *  entry routes on. `daemonId` is null for an unplaced agent (not routable). */
+export interface OrgAgentRecord extends ChannelAgentRecord {
+  daemonId: string | null
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -13,6 +13,7 @@ import type {
   AgentWorkspace,
   CreateAgentInput,
   HookRecord,
+  OrgAgentRecord,
   UpdateAgentInput,
   ViewCtx
 } from '../ports.js'
@@ -710,5 +711,51 @@ export class PgAgentRepo implements AgentRepo {
       include: withUsers
     })
     return rows.map(toRecord)
+  }
+
+  // The org PEER directory (agent-collaboration §2.5/§6.1). A narrow `select` on the
+  // agent table alone — no `withUsers` join (audit identities are console-only) and
+  // deliberately NO `visibilityWhere`: ResourceVisibility gates human console access,
+  // while peer discovery is gated ONLY by the directional call policy the caller
+  // applies over these rows. Unlike `IntegrationRepo.agentsInChannel` there is no
+  // integration join, so an agent with no IM integration is included — that is the
+  // whole point of the flat directory.
+  //
+  // `daemonId: { not: null }` is NOT an optimization: this one query feeds BOTH the
+  // `channel/agents` roster a model discovers peers from AND the flat
+  // `CollabRoutesSnapshot.agents[]` wakes are authorized against, and
+  // `buildCollabSnapshot` drops daemonId-less rows there (no owning daemon ⇒ nothing to
+  // route a wake to). Listing an unplaced agent would therefore advertise a peer that is
+  // discoverable but not callable — the model gets a bare 'not_allowed' and retries — so
+  // the exclusion belongs in the shared read, where the two surfaces cannot disagree.
+  async orgDirectory(orgId: OrgId): Promise<OrgAgentRecord[]> {
+    const rows = await this.db.agent.findMany({
+      where: { orgId, daemonId: { not: null } },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        name: true,
+        displayName: true,
+        description: true,
+        status: true,
+        daemonId: true,
+        callPolicy: true,
+        allowedCallerAgentIds: true,
+        outboundPolicy: true,
+        allowedTargetAgentIds: true
+      }
+    })
+    return rows.map((row) => ({
+      agentId: AgentId(row.id),
+      name: row.name,
+      displayName: row.displayName,
+      description: row.description,
+      status: row.status as OrgAgentRecord['status'],
+      daemonId: row.daemonId,
+      callPolicy: row.callPolicy as AgentCallPolicy,
+      allowedCallerAgentIds: row.allowedCallerAgentIds,
+      outboundPolicy: row.outboundPolicy as AgentCallPolicy,
+      allowedTargetAgentIds: row.allowedTargetAgentIds
+    }))
   }
 }

--- a/packages/control-plane/src/ws/handlers/channel-agents.test.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.test.ts
@@ -1,0 +1,225 @@
+/**
+ * `visibleToRequester` — the ONE authorization predicate behind both `channel/agents`
+ * scopes (org-wide directory and channel-filtered). Tested directly because it is the
+ * discovery-IS-authorization surface: anything it leaks is callable.
+ *
+ * Plus the handler-level DAEMON-OWNERSHIP BIND that runs before it: `requesterAgentId` is
+ * the daemon's word, so a daemon must not be able to read the directory of an agent placed
+ * on someone else (the read-side twin of the relay's `claimedFromAgentId` check).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { handleChannelAgents, visibleToRequester } from './channel-agents.js'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import type { ChannelAgentRecord, OrgAgentRecord } from '../../persistence/ports.js'
+import type { DaemonConnection } from '../connection.js'
+import type { DaemonWsDeps } from '../deps.js'
+import { AgentId } from '../../domain/ids.js'
+
+const CALLER = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+const PEER = AgentId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+const OTHER = AgentId('cccccccc-cccc-4ccc-8ccc-cccccccccccc')
+const ASKING_DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const ORG = 'org-a'
+
+function rec(over: Partial<ChannelAgentRecord> & { agentId: ChannelAgentRecord['agentId'] }): ChannelAgentRecord {
+  return {
+    name: 'agent',
+    displayName: null,
+    description: null,
+    status: 'active',
+    callPolicy: 'all',
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all',
+    allowedTargetAgentIds: [],
+    ...over
+  }
+}
+
+const ids = (roster: ChannelAgentRecord[]): string[] => roster.map((a) => a.agentId).sort()
+
+describe('visibleToRequester (agent-collaboration discovery predicate)', () => {
+  it('reveals every peer when both policies are open', () => {
+    const visible = visibleToRequester([rec({ agentId: CALLER }), rec({ agentId: PEER })], CALLER)
+    expect(ids(visible)).toEqual([CALLER, PEER].sort())
+  })
+
+  it('hides a peer whose INBOUND policy does not admit the caller', () => {
+    const visible = visibleToRequester(
+      [
+        rec({ agentId: CALLER }),
+        rec({ agentId: PEER, callPolicy: 'selected', allowedCallerAgentIds: [OTHER] }),
+        rec({ agentId: OTHER, callPolicy: 'selected', allowedCallerAgentIds: [CALLER] })
+      ],
+      CALLER
+    )
+    expect(ids(visible)).toEqual([CALLER, OTHER].sort())
+  })
+
+  it("hides a peer outside the caller's OUTBOUND allow-list", () => {
+    const visible = visibleToRequester(
+      [
+        rec({ agentId: CALLER, outboundPolicy: 'selected', allowedTargetAgentIds: [PEER] }),
+        rec({ agentId: PEER }),
+        rec({ agentId: OTHER })
+      ],
+      CALLER
+    )
+    expect(ids(visible)).toEqual([CALLER, PEER].sort())
+  })
+
+  it('requires BOTH directions — an outbound-allowed peer that refuses the caller stays hidden', () => {
+    const visible = visibleToRequester(
+      [
+        rec({ agentId: CALLER, outboundPolicy: 'selected', allowedTargetAgentIds: [PEER] }),
+        rec({ agentId: PEER, callPolicy: 'selected', allowedCallerAgentIds: [OTHER] })
+      ],
+      CALLER
+    )
+    expect(ids(visible)).toEqual([CALLER])
+  })
+
+  it('always shows the caller itself, even under a selected outbound policy that omits it', () => {
+    // An agent does not list itself in its own allow-list, yet must see itself.
+    const visible = visibleToRequester(
+      [rec({ agentId: CALLER, outboundPolicy: 'selected', allowedTargetAgentIds: [] })],
+      CALLER
+    )
+    expect(ids(visible)).toEqual([CALLER])
+  })
+
+  it('fails CLOSED when the requester is not in the roster', () => {
+    // The roster is always already org-scoped, so this is also how a CROSS-ORG
+    // requester is rejected: it simply is not in the target org's directory. A
+    // deleted/unknown requesterAgentId lands here too — empty, never open.
+    expect(visibleToRequester([rec({ agentId: PEER }), rec({ agentId: OTHER })], CALLER)).toEqual([])
+  })
+
+  it('never materializes a cross-org peer just because an allow-list names it', () => {
+    // OTHER lives in another org, so it is absent from this org-scoped roster;
+    // naming it on both sides cannot conjure an entry.
+    const visible = visibleToRequester(
+      [rec({ agentId: CALLER, outboundPolicy: 'selected', allowedTargetAgentIds: [OTHER] })],
+      CALLER
+    )
+    expect(ids(visible)).toEqual([CALLER])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// The daemon-ownership bind (§2.2/§6.1)
+// ───────────────────────────────────────────────────────────────────────────
+
+function frame(payload: Record<string, unknown>): AnyFrame {
+  return {
+    v: 1,
+    id: crypto.randomUUID(),
+    ts: '2026-07-29T00:00:00.000Z',
+    type: 'channel/agents',
+    payload: { platform: 'slack', requesterAgentId: CALLER, ...payload }
+  } as AnyFrame
+}
+
+function fakeConn() {
+  return { daemonId: ASKING_DAEMON, replyTo: vi.fn() } as unknown as DaemonConnection & {
+    replyTo: ReturnType<typeof vi.fn>
+  }
+}
+
+/**
+ * Deps whose whole org roster is callable; `placedOn` is where the CP says the CALLER runs.
+ * `channelExtra` is an agent the CHANNEL query returns that the org directory does not — the
+ * unplaced-but-still-integrated shape (`agentsInChannel` joins integrations, not placements).
+ */
+function fakeDeps(placedOn: string | null, channelExtra?: ChannelAgentRecord) {
+  const orgRoster: OrgAgentRecord[] = [
+    { ...rec({ agentId: CALLER }), daemonId: placedOn },
+    { ...rec({ agentId: PEER }), daemonId: ASKING_DAEMON }
+  ]
+  const agentsInChannel = vi.fn(async (): Promise<ChannelAgentRecord[]> => [
+    rec({ agentId: CALLER }),
+    rec({ agentId: PEER }),
+    ...(channelExtra ? [channelExtra] : [])
+  ])
+  return {
+    deps: {
+      registry: { get: async () => ({ id: ASKING_DAEMON, orgId: ORG }) },
+      agent: {
+        // `orgDirectory` never returns an unplaced row (see PgAgentRepo), so a
+        // `placedOn: null` caller is simply absent from it.
+        orgDirectory: async () => orgRoster.filter((a) => a.daemonId !== null)
+      },
+      integration: { agentsInChannel }
+    } as unknown as DaemonWsDeps,
+    agentsInChannel
+  }
+}
+
+const rosterNames = (conn: ReturnType<typeof fakeConn>): string[] =>
+  ((conn.replyTo.mock.calls[0]![2] as { agents: Array<{ agentId: string }> }).agents ?? []).map((a) => a.agentId)
+
+describe('handleChannelAgents — daemon-ownership bind on requesterAgentId', () => {
+  it('serves the roster when the CP agrees the requester is placed on the asking daemon', async () => {
+    for (const channel of [undefined, 'C1']) {
+      const { deps } = fakeDeps(ASKING_DAEMON)
+      const conn = fakeConn()
+      await handleChannelAgents(frame({ ...(channel !== undefined ? { channel } : {}) }), conn, deps)
+      expect(conn.replyTo.mock.calls[0]![1]).toBe('channel/agents/ok')
+      expect(rosterNames(conn).sort()).toEqual([CALLER, PEER].sort())
+    }
+  })
+
+  // The forgery this bind exists to stop: daemon D1 asserts an agent that the CP has
+  // placed on D2 and reads its policy-filtered peer directory. Both scopes must refuse.
+  it('fails CLOSED in BOTH scopes when the requester is placed on ANOTHER daemon', async () => {
+    for (const channel of [undefined, 'C1']) {
+      const { deps, agentsInChannel } = fakeDeps(OTHER_DAEMON)
+      const conn = fakeConn()
+      await handleChannelAgents(frame({ ...(channel !== undefined ? { channel } : {}) }), conn, deps)
+      // A reply, not an error: a forged id looks exactly like "nobody is callable".
+      expect(conn.replyTo.mock.calls[0]![1]).toBe('channel/agents/ok')
+      expect(rosterNames(conn)).toEqual([])
+      // The channel scope must not even read the membership it was asked about.
+      expect(agentsInChannel).not.toHaveBeenCalled()
+    }
+  })
+
+  it('fails CLOSED in BOTH scopes for an UNPLACED requester', async () => {
+    // No owning daemon ⇒ no daemon may speak for it, including the brief window while an
+    // agent MOVE is in flight (the CP row is the authority on ownership).
+    for (const channel of [undefined, 'C1']) {
+      const { deps } = fakeDeps(null)
+      const conn = fakeConn()
+      await handleChannelAgents(frame({ ...(channel !== undefined ? { channel } : {}) }), conn, deps)
+      expect(rosterNames(conn)).toEqual([])
+    }
+  })
+
+  it('fails CLOSED when the asserted requester is unknown to the CP', async () => {
+    // Unknown, or in ANOTHER ORG: the bind reads the org-scoped directory, so a foreign
+    // requester is refused HERE rather than by the downstream visibility filter — and the
+    // channel membership it asked about is never even read.
+    for (const channel of [undefined, 'C1']) {
+      const { deps, agentsInChannel } = fakeDeps(ASKING_DAEMON)
+      const conn = fakeConn()
+      await handleChannelAgents(frame({ ...(channel !== undefined ? { channel } : {}) }), conn, {
+        ...deps,
+        agent: { orgDirectory: async () => [] }
+      } as unknown as DaemonWsDeps)
+      expect(rosterNames(conn)).toEqual([])
+      expect(agentsInChannel).not.toHaveBeenCalled()
+    }
+  })
+
+  // F3, the half that survived the `orgDirectory` fix: `agentsInChannel` joins INTEGRATIONS,
+  // so an unplaced agent whose bot still sits in the channel comes back from it — while
+  // `buildCollabSnapshot` drops daemonId-less rows from the `agents[]` wakes are authorized
+  // against. Listing it would advertise a peer that cannot be called (the model gets a bare
+  // 'not_allowed' and retries). The channel scope is an INTERSECTION for exactly this reason.
+  it('omits a channel member the org directory does not place (listed-but-uncallable)', async () => {
+    const { deps } = fakeDeps(ASKING_DAEMON, rec({ agentId: OTHER }))
+    const conn = fakeConn()
+    await handleChannelAgents(frame({ channel: 'C1' }), conn, deps)
+    expect(rosterNames(conn).sort()).toEqual([CALLER, PEER].sort())
+  })
+})

--- a/packages/control-plane/src/ws/handlers/channel-agents.ts
+++ b/packages/control-plane/src/ws/handlers/channel-agents.ts
@@ -1,28 +1,72 @@
 /**
- * `channel/agents` handler — the agent-collaboration directory lookup.
+ * `channel/agents` handler — the agent-collaboration peer directory lookup.
  *
- * A daemon-side agent tool asks "who else is in this channel?"; the daemon
- * forwards it as a `channel/agents` REQ. The CP is the ONLY authority for the
- * FULL roster (agents in one channel may run on different daemons), so it joins
- * the channel's active integrations to their agents and replies with their
- * public metadata (name / displayName / description / status). Metadata only —
- * never message content (§1/§12). Reply: `channel/agents/ok` (corr = req id).
+ * A daemon-side agent tool asks "who can I talk to?"; the daemon forwards it as a
+ * `channel/agents` REQ. The CP is the ONLY authority for the FULL roster (peers may
+ * run on different daemons), so it replies with their public metadata (name /
+ * displayName / description / status). Metadata only — never message content
+ * (§1/§12). Reply: `channel/agents/ok` (corr = req id).
  *
- * The roster is org-scoped to the REQUESTING daemon's org (resolved from its
- * authenticated `daemonId`) — a daemon can never enumerate another org's agents.
+ * TWO SCOPES, ONE ROSTER (see `agent-directory-org-scope-v1`): both scopes are the SAME
+ * `AgentRepo.orgDirectory` read, behind the SAME org-scoped daemon-ownership bind, filtered
+ * by the SAME {@link visibleToRequester} predicate — so they cannot disagree about whether a
+ * given agent exists or may be called.
+ *  - `channel` ABSENT → the ORG-WIDE directory. This is the default scope now that A2A
+ *    delivery is postless (#854): a `sendMessage` with `toAgent` never posts, so the
+ *    channel plays no part in DELIVERY and must not act as an authorization key either.
+ *    Sessions with no IM integration (webchat, hook, dream, memory-only agents) have no
+ *    channel the CP has ever seen, yet must still collaborate. The reply omits `channel`.
+ *  - `channel` PRESENT → that same org roster INTERSECTED with the channel's membership
+ *    (`IntegrationRepo.agentsInChannel`, used for its id set only). A FILTER on top of the
+ *    org scope, never a wider grant. It is a literal intersection on purpose: reading the
+ *    channel roster on its own would list an UNPLACED agent whose bot still sits in the
+ *    channel (that query joins integrations, not placements), and `buildCollabSnapshot`
+ *    drops daemonId-less rows from the `agents[]` that wakes are authorized against — so
+ *    such an agent would be discoverable-but-uncallable, the state the design forbids.
  *
- * SECURITY (§2.2/§6.1): `requesterAgentId` is derived by the daemon from the MCP
- * session context (never a tool input). Before returning anything, the CP verifies
- * the requester is ACTUALLY a member of the target (platform, channel) — a
- * non-member gets an empty roster, so an agent cannot probe an arbitrary (e.g.
- * private) channel it isn't in. The requester always sees itself; every peer is
- * revealed only when the requester's outbound policy admits the peer AND the
- * peer's inbound policy admits the requester. Discovery is the authorization
- * surface — non-callable peers are not leaked.
+ * Authorization is the directional call policy alone, org-scoped to the REQUESTING
+ * daemon's org (resolved from its authenticated `daemonId`) — a daemon can never
+ * enumerate another org's agents, and a cross-org pair never resolves.
+ * `Agent.visibility`/`sharedWith` is deliberately NOT consulted: it governs HUMAN
+ * console access, so a `restricted` agent is still a discoverable, callable peer.
+ *
+ * SECURITY (§2.2/§6.1): `requesterAgentId` is derived by the daemon from the MCP session
+ * context (never a tool input), but the CP still must not take the daemon's word for
+ * WHICH agent is asking — see the daemon-ownership bind below, the read-side twin of the
+ * relay's `claimedFromAgentId` check. On top of that {@link visibleToRequester} requires
+ * the requester to appear in the roster it is asking about (fail closed), always shows it
+ * itself, and reveals a peer only when the requester's outbound policy admits the peer AND
+ * the peer's inbound policy admits the requester. Discovery is the authorization
+ * surface — non-callable peers are not leaked. NOTE the one reply that passes NO bind: a
+ * channel-filtered ask on a session-identity platform short-circuits to an empty roster
+ * before any repo read (see below) — nothing to leak, so nothing to bind.
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { DaemonId } from '../../domain/ids.js'
+import { isSessionIdentityPlatform } from '../../persistence/platform.js'
+import type { ChannelAgentRecord } from '../../persistence/ports.js'
 import type { Handler } from './index.js'
+
+/**
+ * The roster visibility filter — the SINGLE authorization predicate, shared verbatim
+ * by the org-wide and channel-filtered scopes so the two can never drift.
+ *
+ * `roster` is always already org-scoped by its query, which is how "cross-org never
+ * resolves" is enforced: a foreign requester simply is not in it, and a missing
+ * requester fails CLOSED (empty roster) rather than defaulting to open.
+ */
+export function visibleToRequester<T extends ChannelAgentRecord>(roster: T[], requesterAgentId: string): T[] {
+  const requester = roster.find((a) => a.agentId === requesterAgentId)
+  if (!requester) return []
+  return roster.filter(
+    (a) =>
+      // Always see yourself: an agent with outboundPolicy 'selected' does not normally
+      // list itself in its own allow-list, yet must still appear in its own listing.
+      a.agentId === requesterAgentId ||
+      ((requester.outboundPolicy === 'all' || requester.allowedTargetAgentIds.includes(a.agentId)) &&
+        (a.callPolicy === 'all' || a.allowedCallerAgentIds.includes(requesterAgentId)))
+  )
+}
 
 export const handleChannelAgents: Handler = async (frame, conn, deps) => {
   if (!isFrame('channel/agents')(frame)) return
@@ -31,24 +75,64 @@ export const handleChannelAgents: Handler = async (frame, conn, deps) => {
   const daemon = await deps.registry.get(DaemonId(conn.daemonId))
   if (!daemon) return // unknown daemon (should not happen post-auth) — drop silently
 
-  const roster = await deps.integration.agentsInChannel(daemon.orgId, platform, channel)
+  const roster: ChannelAgentRecord[] = await (async () => {
+    // A session-identity platform (`webchat`/`hook`/`dream`) has no persisted
+    // integration, so `toDbPlatform` rejects it by design and a repo call would
+    // throw — which `ws/connection.ts` turns into close(1011), killing the control
+    // socket. Short-circuit BEFORE persistence: reaching the repo with one of these
+    // is now impossible by construction, and the correct answer is an EMPTY roster
+    // rather than an exception, because such a channel has no CP-side identity to
+    // enumerate members of at all. (Channel-free callers send no channel and land
+    // in the org-wide scope below.)
+    if (channel !== undefined && isSessionIdentityPlatform(platform)) return []
 
-  // Membership check: the requester must itself be in the target channel. This is
-  // the roster's own membership set, so a non-member (probing an arbitrary/private
-  // channel) sees nothing — fail closed with an empty roster.
-  const requester = roster.find((a) => a.agentId === requesterAgentId)
-  const visible = requester
-    ? roster.filter(
-        (a) =>
-          a.agentId === requesterAgentId || // always see yourself
-          ((requester.outboundPolicy === 'all' || requester.allowedTargetAgentIds.includes(a.agentId)) &&
-            (a.callPolicy === 'all' || a.allowedCallerAgentIds.includes(requesterAgentId)))
-      )
-    : []
+    // ONE org-scoped read, feeding both scopes and the bind (see the header). It is also
+    // literally the read `buildCollabSnapshot` builds `agents[]` from, which is what keeps
+    // "discoverable" and "callable" from disagreeing.
+    const orgRoster = await deps.agent.orgDirectory(daemon.orgId)
+
+    // THE DAEMON-OWNERSHIP BIND (§2.2/§6.1) — the read-side twin of the relay's
+    // `claimedFromAgentId` / `caller.daemonId !== fromDaemonId` check. `requesterAgentId`
+    // arrives from the daemon, so without this a daemon could name ANY agent of its org and
+    // read that agent's policy-filtered peer directory. Binding off `orgRoster` makes the
+    // check org-scoped for free: a foreign-org requester is simply absent from it, so it is
+    // refused HERE rather than by the downstream filter. Fail CLOSED (empty roster, never an
+    // error) so a forged id is indistinguishable from an agent nobody may call.
+    //
+    // What it does and does NOT buy. It is an INTEGRITY control: only the daemon the CP
+    // places an agent on may speak as that agent, and it is the exclusive protection for the
+    // fields only this reply carries — `description` (the peer's system-prompt seed) and
+    // live `status`. It is NOT a confidentiality boundary for the policy graph: the CP pushes
+    // the whole flat org directory (ids, daemonIds, names and all four policy fields) to
+    // EVERY daemon in the org as `register/ok.collabRoutes` / `collaboration/routes`, because
+    // terminal-verify needs it, so a daemon can compute any org agent's policy-filtered peer
+    // set locally without asking. Narrowing that push to the peers a daemon actually needs is
+    // a follow-up (§2.7); until then do not write "this makes `callPolicy: 'selected'`
+    // unreadable" here, because it does not.
+    //
+    // Consequence during an agent MOVE: the CP row may already name the TARGET daemon while
+    // the source daemon still holds a session, and such an ask is refused. Correct, and in
+    // practice near-unreachable — `AgentMoveService` takes the move only when the source is
+    // idle and detaches it before the placement CAS — so treat this as fail-closed
+    // belt-and-braces, not a window anything depends on.
+    const requester = orgRoster.find((a) => a.agentId === requesterAgentId)
+    if (requester?.daemonId !== conn.daemonId) return [] // null/undefined never equals a daemonId
+
+    if (channel === undefined) return orgRoster
+    // The channel scope is a literal INTERSECTION: `agentsInChannel` supplies the membership
+    // id set, the org roster supplies the records (and the placement filter).
+    const inChannel = new Set(
+      (await deps.integration.agentsInChannel(daemon.orgId, platform, channel)).map((a) => a.agentId)
+    )
+    return orgRoster.filter((a) => inChannel.has(a.agentId))
+  })()
+
+  const visible = visibleToRequester(roster, requesterAgentId)
 
   conn.replyTo(frame, 'channel/agents/ok', {
     platform,
-    channel,
+    // Echo the scope back: absent channel ⇒ the org-wide directory.
+    ...(channel !== undefined ? { channel } : {}),
     agents: visible.map((a) => ({
       agentId: a.agentId,
       name: a.name,

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -42,7 +42,17 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
     ...snap,
     relays,
     ...(gitCommitIdentity ? { gitCommitIdentity } : {}),
-    serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1', SESSION_LIVE_TAIL_FEATURE, SESSION_VISIBILITY_FEATURE]
+    // `agent-directory-org-scope-v1`: this CP accepts a `channel/agents` REQ with NO
+    // channel (the org-wide, policy-filtered peer directory) and ships the flat
+    // `collabRoutes.agents[]`. A daemon that does not see it must keep substituting the
+    // caller's current channel, because an older CP rejects a channel-less payload.
+    serverFeatures: [
+      'hook-report-ack-v1',
+      'gitcred-actions-v1',
+      'agent-directory-org-scope-v1',
+      SESSION_LIVE_TAIL_FEATURE,
+      SESSION_VISIBILITY_FEATURE
+    ]
   })
   deps.connReg.markReady(conn.daemonId, conn)
 

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -239,7 +239,7 @@ export function buildHttpApp(
       new PgSessionRepo(prisma),
       { info() {}, warn() {}, debug() {} }
     ),
-    collabRoutes: new CollabRoutesService(daemonRepo, integrationRepo, relayControl, sender),
+    collabRoutes: new CollabRoutesService(daemonRepo, integrationRepo, agentRepo, relayControl, sender),
     agentMutations: new AgentMutationGate(),
     memoryConnectionMutations: new ExclusiveMutationGate(),
     sessionOwners: connReg,

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -124,6 +124,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const collabRoutes = new CollabRoutesService(
     repos.daemon,
     repos.integration,
+    repos.agent,
     new RelayControlSender(new RelayRegistry()),
     sender
   )

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -85,6 +85,46 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
     expect(spy.collaboration.at(-1)).toMatchObject({ daemonId: DAEMON, snapshot: { channels: [] } })
   })
 
+  it('creating an already-PLACED agent publishes it into the flat peer directory', async () => {
+    // Regression: discovery (`channel/agents`) reads the DB live, but a peer WAKE is
+    // authorized against the pushed collaboration snapshot. If creation did not push one,
+    // a brand-new agent would be listed-but-uncallable — and since the directory is no
+    // longer channel-gated, no `integration/channels` report would ever fix it.
+    await seedDaemon(prisma, DAEMON)
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'placed-at-birth', runtime: 'claude', daemonId: DAEMON, callPolicy: 'all' }
+    })
+    expect(created.statusCode).toBe(201)
+    const { id } = created.json() as { id: string }
+
+    const snapshot = spy.collaboration.at(-1)
+    expect(snapshot?.daemonId).toBe(DAEMON)
+    // Present in the flat org directory despite having NO integration/channel at all.
+    expect(snapshot?.snapshot.channels).toEqual([])
+    expect(snapshot?.snapshot.agents).toEqual([
+      expect.objectContaining({ agentId: id, daemonId: DAEMON, orgId: DEFAULT_ORG_ID, callPolicy: 'all' })
+    ])
+  })
+
+  it('creating an UNPLACED agent pushes no snapshot — nothing routable to publish yet', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const { app, spy } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'unplaced', runtime: 'claude' }
+    })
+    expect(created.statusCode).toBe(201)
+    // `buildCollabSnapshot` drops daemonId-less rows, so a broadcast here would publish
+    // nothing while bumping every daemon's routingEpoch. Reconcile is the backstop.
+    expect(spy.collaboration).toHaveLength(0)
+  })
+
   it('PATCH on a PLACED agent pushes agent/upsert with the edited spec to its daemon', async () => {
     await seedDaemon(prisma, DAEMON)
     const agentId = randomUUID()
@@ -234,6 +274,25 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
     expect(spy.removes[0]!).toEqual({ daemonId: DAEMON, r: { agentId } })
   })
 
+  it('DELETE on a PLACED agent also WITHDRAWS it from the flat peer directory', async () => {
+    // The mirror of the create push. `agent/remove` only clears the daemon's local spec
+    // replica (same-daemon authorization); a peer WAKE is authorized against the pushed
+    // collaboration snapshot, so without a broadcast every OTHER daemon in the org keeps a
+    // flat `agents[]` entry whose `admits()` still says yes — a wake routed at a row that
+    // no longer exists.
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const { app, spy } = withSpy()
+
+    const del = await app.app.inject({ method: 'DELETE', url: `${ORG}/agents/${agentId}` })
+    expect(del.statusCode).toBe(204)
+
+    const snapshot = spy.collaboration.at(-1)
+    expect(snapshot?.daemonId).toBe(DAEMON)
+    expect(snapshot?.snapshot.agents.map((a) => a.agentId)).not.toContain(agentId)
+  })
+
   it('an UNPLACED agent (no daemonId) pushes nothing — reconcile is the backstop', async () => {
     const { app, spy } = withSpy()
 
@@ -248,6 +307,9 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
 
     expect(spy.upserts).toHaveLength(0)
     expect(spy.removes).toHaveLength(0)
+    // Nor a collaboration snapshot: an unplaced agent was never in one, so there is nothing
+    // to publish or withdraw and no reason to churn every daemon's routingEpoch.
+    expect(spy.collaboration).toHaveLength(0)
   })
 
   it('a NoConnection from an offline daemon is swallowed — the request still succeeds', async () => {

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -1,14 +1,21 @@
 /**
- * `channel/agents` (D→C REQ → `channel/agents/ok`) — the agent-collaboration
- * directory. A daemon asks "who else is in this channel?"; the CP returns EVERY
- * agent in the channel across ALL daemons (it is the only authority for the full
- * roster), as public metadata. Org-scoped to the requesting daemon's org.
+ * `channel/agents` (D→C REQ → `channel/agents/ok`) — the agent-collaboration peer
+ * directory. The CP is the only authority for the full roster, so it returns EVERY
+ * reachable peer across ALL daemons as public metadata, org-scoped to the requesting
+ * daemon's org.
+ *
+ * TWO SCOPES: no `channel` ⇒ the ORG-WIDE directory (the default now that A2A delivery
+ * is postless, #854 — includes agents with no IM integration at all); a `channel` ⇒ the
+ * same directory additionally filtered to that channel's membership. Authorization is
+ * the directional call policy in BOTH scopes.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
+import { WebSocket } from 'ws'
 import { prisma } from '../setup.db.js'
 import { seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { buildDaemonApp, type DaemonApp } from '../fakes/build-app.js'
 import {
   PgIntegrationRepo,
   PgIntegrationChannelRepo,
@@ -23,7 +30,7 @@ import { systemClock } from '../../src/domain/clock.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
-import type { AnyFrame, IntegrationChannel } from '@agentconnect.md/protocol'
+import { isFrame, type AnyFrame, type IntegrationChannel } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { AgentId } from '../../src/domain/ids.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
@@ -31,9 +38,12 @@ import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 
 let running: HttpApp | undefined
+let runningWs: DaemonApp | undefined
 afterEach(async () => {
   await running?.close()
   running = undefined
+  await runningWs?.close()
+  runningWs = undefined
 })
 
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
@@ -45,6 +55,10 @@ class SpyControl {
   async agentRemove(): Promise<void> {}
   async integrationUpsert(): Promise<void> {}
   async integrationRemove(): Promise<void> {}
+  // Creating a PLACED agent publishes the collaboration snapshot too; this suite only
+  // cares about the `channel/agents` REPLY (served from a live DB read), so the push is
+  // accepted and ignored. Present so the fake does not diverge from ControlSender.
+  async collaborationRoutes(): Promise<void> {}
 }
 
 /** Create an agent (via REST, with displayName/description) + install its slack integration. */
@@ -69,6 +83,22 @@ async function installAgent(
   return { agentId, integrationId: (res.json() as { id: string }).id }
 }
 
+/** Create an agent with NO integration — it exists only in the org peer directory and
+ *  can appear in no channel-keyed structure at all (webchat / hook / memory-only agents). */
+async function createAgent(
+  app: HttpApp,
+  daemonId: string,
+  agent: { name: string; displayName?: string; description?: string }
+): Promise<string> {
+  const created = await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/agents`,
+    payload: { ...agent, runtime: 'claude', daemonId }
+  })
+  expect(created.statusCode).toBe(201)
+  return (created.json() as { id: string }).id
+}
+
 /** Populate an integration's channel membership via the real integration/channels handler. */
 async function reportChannels(daemonId: string, integrationId: string, channels: IntegrationChannel[]): Promise<void> {
   const frame = {
@@ -90,13 +120,18 @@ async function reportChannels(daemonId: string, integrationId: string, channels:
 /** Dispatch a `channel/agents` REQ from `daemonId` and capture the reply payload.
  *  `requesterAgentId` is the trusted session-derived caller the CP checks membership
  *  and call-policy against (§2.2/§6.1). */
+type RosterReply = {
+  platform: string
+  channel?: string
+  agents: Array<{ agentId: string; name: string; displayName?: string; description?: string; status: string }>
+}
+
 async function askChannelAgents(
   daemonId: string,
-  channel: string,
-  requesterAgentId: string
-): Promise<{
-  agents: Array<{ agentId: string; name: string; displayName?: string; description?: string; status: string }>
-}> {
+  channel: string | undefined,
+  requesterAgentId: string,
+  platform: 'slack' | 'webchat' = 'slack'
+): Promise<RosterReply> {
   let replied: { type: string; payload: unknown } | undefined
   const conn = {
     daemonId,
@@ -119,13 +154,11 @@ async function askChannelAgents(
     id: randomUUID(),
     ts: new Date().toISOString(),
     type: 'channel/agents',
-    payload: { platform: 'slack', channel, requesterAgentId }
+    payload: { platform, ...(channel !== undefined ? { channel } : {}), requesterAgentId }
   } as AnyFrame
   await handleChannelAgents(frame, conn, deps)
   expect(replied?.type).toBe('channel/agents/ok')
-  return replied!.payload as {
-    agents: Array<{ agentId: string; name: string; displayName?: string; description?: string; status: string }>
-  }
+  return replied!.payload as RosterReply
 }
 
 describe('channel/agents (agent collaboration directory)', () => {
@@ -258,5 +291,256 @@ describe('channel/agents (agent collaboration directory)', () => {
 
     const { agents } = await askChannelAgents(DAEMON, 'C1', caller.agentId)
     expect(agents.map((candidate) => candidate.name).sort()).toEqual(['allowed-peer', 'caller'])
+  })
+})
+
+describe('channel/agents — ORG-WIDE scope (no channel)', () => {
+  it('returns the whole org directory, including an agent with NO integration', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+
+    // The caller reaches #deploys; `webchat-only` has no integration at all, so it is
+    // absent from every channel-keyed structure and reachable ONLY org-wide.
+    const caller = await installAgent(running, DAEMON, { name: 'caller' })
+    await reportChannels(DAEMON, caller.integrationId, [{ id: 'C1', name: 'deploys' }])
+    const solo = await createAgent(running, OTHER_DAEMON, {
+      name: 'webchat-only',
+      displayName: 'Webchat Only',
+      description: 'no IM integration'
+    })
+    // A `restricted` agent is a console-access decision, NOT a peer-directory one —
+    // it must remain discoverable (ResourceVisibility never gates A2A).
+    const hidden = await createAgent(running, DAEMON, { name: 'restricted-peer' })
+    await prisma.agent.update({ where: { id: hidden }, data: { visibility: 'restricted' } })
+
+    const reply = await askChannelAgents(DAEMON, undefined, caller.agentId)
+    expect(reply.channel).toBeUndefined() // the reply echoes the org-wide scope
+    expect(reply.agents.map((a) => a.name).sort()).toEqual(['caller', 'restricted-peer', 'webchat-only'])
+    const byId = Object.fromEntries(reply.agents.map((a) => [a.agentId, a]))
+    expect(byId[solo]).toMatchObject({ displayName: 'Webchat Only', description: 'no IM integration' })
+
+    // Channel is now a FILTER, not a gate: the same caller scoped to #deploys sees
+    // only the channel's members, while the org-wide ask above saw everyone.
+    const scoped = await askChannelAgents(DAEMON, 'C1', caller.agentId)
+    expect(scoped.channel).toBe('C1')
+    expect(scoped.agents.map((a) => a.name)).toEqual(['caller'])
+  })
+
+  it('fails closed (empty roster) for a requester outside the requesting daemon org', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    await createAgent(running, DAEMON, { name: 'local-agent' })
+
+    // A foreign-org agent id cannot be in this org's directory, so nothing resolves —
+    // cross-org discovery never succeeds and the roster is not leaked.
+    const foreignOrgId = `org-foreign-${randomUUID().slice(0, 8)}`
+    await prisma.org.create({ data: { id: foreignOrgId, slug: foreignOrgId } })
+    const foreignAgent = await prisma.agent.create({
+      data: { id: randomUUID(), orgId: foreignOrgId, name: 'foreigner', runtime: 'claude' }
+    })
+
+    const reply = await askChannelAgents(DAEMON, undefined, foreignAgent.id)
+    expect(reply.agents).toEqual([])
+  })
+
+  it('applies the bidirectional call policy org-wide, exactly as in the channel scope', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const agentRepo = new PgAgentRepo(prisma)
+
+    const caller = await createAgent(running, DAEMON, { name: 'caller' })
+    const openPeer = await createAgent(running, DAEMON, { name: 'open-peer' })
+    const refusingPeer = await createAgent(running, DAEMON, { name: 'refusing-peer' })
+    const unlistedPeer = await createAgent(running, DAEMON, { name: 'unlisted-peer' })
+
+    // Inbound: refusing-peer admits somebody else, not the caller.
+    await agentRepo.setCallPolicy(AgentId(refusingPeer), {
+      callPolicy: 'selected',
+      allowedCallerAgentIds: [randomUUID()]
+    })
+    // Outbound: the caller only targets open-peer + refusing-peer, so unlisted-peer is
+    // invisible even though ITS inbound policy is open.
+    await agentRepo.setCallPolicy(AgentId(caller), {
+      callPolicy: 'all',
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'selected',
+      allowedTargetAgentIds: [openPeer, refusingPeer]
+    })
+
+    const reply = await askChannelAgents(DAEMON, undefined, caller)
+    // Self is always visible even though the caller omits itself from its own list.
+    expect(reply.agents.map((a) => a.name).sort()).toEqual(['caller', 'open-peer'])
+    expect(unlistedPeer).toBeTruthy()
+  })
+
+  // The org roster and the flat `CollabRoutesSnapshot.agents[]` wakes are authorized
+  // against come from the SAME `orgDirectory` read, and the snapshot drops daemonId-less
+  // rows — so an UNPLACED agent must not be advertised here either, or the model discovers
+  // a peer it cannot call and only learns so from a bare 'not_allowed'. (Twin of
+  // collabSnapshot.test.ts "drops an unplaced agent from the flat directory".)
+  it('omits an UNPLACED agent from the org-wide roster (no owning daemon ⇒ not callable)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+
+    const caller = await createAgent(running, DAEMON, { name: 'caller' })
+    // Created WITHOUT a daemonId: a real state (agent configured before placement, or
+    // drained off its daemon) that no wake can be routed to.
+    const created = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'unplaced-peer', runtime: 'claude' }
+    })
+    expect(created.statusCode).toBe(201)
+    expect((created.json() as { daemonId: string | null }).daemonId).toBeNull()
+
+    const reply = await askChannelAgents(DAEMON, undefined, caller)
+    expect(reply.agents.map((a) => a.name)).toEqual(['caller'])
+  })
+
+  // The daemon's word on WHICH agent is asking is not evidence: with the roster widened to
+  // the whole org, an unbound `requesterAgentId` would let any daemon read any org agent's
+  // policy-filtered directory — the read-side twin of the relay's `claimedFromAgentId`
+  // check. Fail closed, in both scopes.
+  it('fails closed when the asserted requester is placed on ANOTHER daemon', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+
+    const victim = await installAgent(running, OTHER_DAEMON, { name: 'victim' })
+    const peer = await installAgent(running, OTHER_DAEMON, { name: 'peer' })
+    await reportChannels(OTHER_DAEMON, victim.integrationId, [{ id: 'C1', name: 'deploys' }])
+    await reportChannels(OTHER_DAEMON, peer.integrationId, [{ id: 'C1', name: 'deploys' }])
+
+    // DAEMON impersonates `victim`, which the CP has placed on OTHER_DAEMON.
+    expect((await askChannelAgents(DAEMON, undefined, victim.agentId)).agents).toEqual([])
+    expect((await askChannelAgents(DAEMON, 'C1', victim.agentId)).agents).toEqual([])
+    // ...while the daemon that actually owns it is served.
+    expect((await askChannelAgents(OTHER_DAEMON, 'C1', victim.agentId)).agents.map((a) => a.name).sort()).toEqual([
+      'peer',
+      'victim'
+    ])
+  })
+
+  // The CHANNEL-filtered half of the same invariant, and the one that survived the
+  // `orgDirectory` fix: `agentsInChannel` joins INTEGRATIONS, not placements, so an agent
+  // that lost its daemon while its bot stayed in the channel still comes back from that
+  // query. Reachable with no DB surgery — `DELETE /daemons/:id` sets `Agent.daemonId` null
+  // (onDelete: SetNull) and leaves the integration active. Both roster scopes must agree
+  // with the snapshot, which drops daemonId-less rows.
+  it('omits an UNPLACED-but-still-integrated agent from the CHANNEL roster too', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+
+    const caller = await installAgent(running, DAEMON, { name: 'caller' })
+    const ghost = await installAgent(running, OTHER_DAEMON, { name: 'ghost-peer' })
+    await reportChannels(DAEMON, caller.integrationId, [{ id: 'C1', name: 'ops' }])
+    await reportChannels(OTHER_DAEMON, ghost.integrationId, [{ id: 'C1', name: 'ops' }])
+    // Both are callable while ghost-peer is placed.
+    expect((await askChannelAgents(DAEMON, 'C1', caller.agentId)).agents.map((a) => a.name).sort()).toEqual([
+      'caller',
+      'ghost-peer'
+    ])
+
+    // Detach the daemon that hosted ghost-peer. Its integration + channel row survive.
+    const deleted = await running.app.inject({ method: 'DELETE', url: `${ORG}/daemons/${OTHER_DAEMON}` })
+    expect(deleted.statusCode).toBe(204)
+    expect(await prisma.agent.findUnique({ where: { id: ghost.agentId }, select: { daemonId: true } })).toEqual({
+      daemonId: null
+    })
+
+    // Neither scope may advertise it now: there is no daemon to route a wake to.
+    expect((await askChannelAgents(DAEMON, 'C1', caller.agentId)).agents.map((a) => a.name)).toEqual(['caller'])
+    expect((await askChannelAgents(DAEMON, undefined, caller.agentId)).agents.map((a) => a.name)).toEqual(['caller'])
+  })
+
+  it('returns an empty roster for a channel-scoped webchat request instead of throwing', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const caller = await createAgent(running, DAEMON, { name: 'caller' })
+
+    // `webchat` has no persisted integration (toDbPlatform rejects it by design), so a
+    // channel-scoped ask must short-circuit to empty — never raise.
+    const reply = await askChannelAgents(DAEMON, 'sess-abc', caller, 'webchat')
+    expect(reply.agents).toEqual([])
+    expect(reply.channel).toBe('sess-abc')
+  })
+})
+
+/** The regression this PR fixes, over a REAL socket: a channel-scoped `channel/agents`
+ *  for a session-identity platform used to raise inside the handler, and
+ *  `ws/connection.ts` turns any handler throw into close(1011) — killing the whole
+ *  daemon↔CP control connection (the daemon then failed the request with
+ *  "connection closed"). Asserting the reply alone is not enough; the connection has to
+ *  survive, so a FOLLOWING request must still be answered on the same socket. */
+describe('channel/agents over a live control socket', () => {
+  const WS_DAEMON = 'd3d3d3d3-dddd-4ddd-8ddd-dddddddddddd'
+  const SUBPROTOCOL = 'agentconnect.v1'
+
+  function nextFrame(ws: WebSocket, type: string): Promise<AnyFrame> {
+    return new Promise((resolve, reject) => {
+      const onMsg = (data: Buffer): void => {
+        const frame = JSON.parse(data.toString()) as AnyFrame
+        if (frame.type === type) {
+          ws.off('message', onMsg)
+          resolve(frame)
+        }
+      }
+      ws.on('message', onMsg)
+      ws.once('close', (code) => reject(new Error(`closed waiting for ${type}: ${code}`)))
+    })
+  }
+
+  function sendFrame(ws: WebSocket, type: string, payload: unknown): string {
+    const id = randomUUID()
+    ws.send(JSON.stringify({ v: 1, id, ts: new Date().toISOString(), type, payload }))
+    return id
+  }
+
+  it('answers a webchat channel request and LEAVES THE CONNECTION OPEN', async () => {
+    const app = buildDaemonApp(prisma)
+    runningWs = app
+    const address = await app.listen()
+    const token = await app.mintToken(WS_DAEMON)
+    const ws = new WebSocket(`${address.replace(/^http/, 'ws')}/daemon/ws`, SUBPROTOCOL)
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve())
+      ws.once('error', reject)
+    })
+    try {
+      sendFrame(ws, 'auth', { apiKey: token, daemonId: WS_DAEMON, agentVersion: '1.4.0' })
+      await nextFrame(ws, 'auth/ok')
+      sendFrame(ws, 'register', {
+        host: 'host-1',
+        capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true },
+        maxAgents: 4,
+        localState: { assignments: [], crons: [], leases: [] }
+      })
+      const regOk = await nextFrame(ws, 'register/ok')
+      if (!isFrame('register/ok')(regOk)) throw new Error('expected register/ok')
+      // The negotiated feature the daemon keys its channel-less requests off.
+      expect(regOk.payload.serverFeatures).toContain('agent-directory-org-scope-v1')
+
+      const webchatId = sendFrame(ws, 'channel/agents', {
+        platform: 'webchat',
+        channel: 'sess-abc',
+        requesterAgentId: randomUUID()
+      })
+      const first = await nextFrame(ws, 'channel/agents/ok')
+      if (!isFrame('channel/agents/ok')(first)) throw new Error('expected channel/agents/ok')
+      expect(first.corr).toBe(webchatId)
+      expect(first.payload.agents).toEqual([])
+
+      // Still alive: the org-wide follow-up is answered on the SAME socket.
+      const orgWideId = sendFrame(ws, 'channel/agents', { platform: 'webchat', requesterAgentId: randomUUID() })
+      const second = await nextFrame(ws, 'channel/agents/ok')
+      if (!isFrame('channel/agents/ok')(second)) throw new Error('expected channel/agents/ok')
+      expect(second.corr).toBe(orgWideId)
+      expect(second.payload.channel).toBeUndefined()
+      expect(ws.readyState).toBe(WebSocket.OPEN)
+    } finally {
+      ws.close()
+    }
   })
 })

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -477,6 +477,30 @@ describe('DELETE /daemons/:id — remove from fleet', () => {
     expect((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).daemonId).toBeNull()
   })
 
+  it('re-broadcasts the collaboration snapshot (its agents just left the peer directory)', async () => {
+    // `Agent.daemonId` is SetNull, so the daemon's agents become UNPLACED and
+    // `buildCollabSnapshot` drops them — but only for holders that receive a new snapshot.
+    // Without this push every relay + remaining daemon keeps flat `agents[]` entries naming
+    // the dead daemonId, and `admits()` keeps admitting wakes nothing can deliver.
+    await seedDaemon()
+    await seedAgent(prisma, randomUUID(), { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+    const collabSpy = vi.spyOn(running.deps.collabRoutes, 'broadcast')
+
+    const res = await running.app.inject({ method: 'DELETE', url: `${ORG}/daemons/${DAEMON}` })
+    expect(res.statusCode).toBe(204)
+    expect(collabSpy).toHaveBeenCalledWith(DEFAULT_ORG_ID)
+  })
+
+  it('pushes NO collaboration snapshot when the daemon hosted no agents', async () => {
+    await seedDaemon()
+    running = buildHttpApp(prisma)
+    const collabSpy = vi.spyOn(running.deps.collabRoutes, 'broadcast')
+
+    expect((await running.app.inject({ method: 'DELETE', url: `${ORG}/daemons/${DAEMON}` })).statusCode).toBe(204)
+    expect(collabSpy).not.toHaveBeenCalled() // nothing left the directory ⇒ no routingEpoch churn
+  })
+
   it('refuses (409) while the daemon is live + reachable', async () => {
     await seedDaemon()
     running = buildHttpApp(prisma, undefined, liveness({ [DAEMON]: { state: 'READY', reachable: true } }))

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -526,6 +526,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const collabRoutes = new CollabRoutesService(
       new PgDaemonRepo(prisma),
       new PgIntegrationRepo(prisma),
+      new PgAgentRepo(prisma),
       { collabRoutes: () => undefined } as unknown as RelayControlSender,
       spy as unknown as ControlSender
     )

--- a/packages/control-plane/test/integration/memory-connections.route.test.ts
+++ b/packages/control-plane/test/integration/memory-connections.route.test.ts
@@ -56,6 +56,12 @@ class SpyControl {
   async agentRemove(daemonId: string, agentId: string): Promise<void> {
     this.events.push({ kind: 'agent-remove', daemonId, agentId })
   }
+
+  // Creating a PLACED agent also publishes the collaboration snapshot (the flat peer
+  // directory). Deliberately NOT recorded in `events`: this suite asserts the exact
+  // memory/AgentSpec push ORDER, and the real ControlSender must simply not be missing
+  // a method here — an absent one would surface as a swallowed TypeError, not a failure.
+  async collaborationRoutes(): Promise<void> {}
 }
 
 class SpyRelayControl {

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -212,7 +212,7 @@ export const AgentSchema = z.object({
   allowedTargetAgentIds: z.array(z.string()).default([]),
   // Opt-in (issue #536): when true, on a GENUINE new channel join the agent
   // proactively introduces itself to the other agents already there (via
-  // listChannelAgents → messageAgent) so peers can record it in memory. Default
+  // listAgents → a sendMessage wake) so peers can record it in memory. Default
   // off — the daemon seeds each integration's channel baseline silently, so only
   // channels joined AFTER the baseline (never a restart/re-list) trigger an intro.
   introduceOnJoin: z.boolean().default(false),

--- a/packages/daemon/src/agents/channel-intro.ts
+++ b/packages/daemon/src/agents/channel-intro.ts
@@ -4,8 +4,9 @@ import type { NormalizedMessage } from '../messages/normalized.js'
  * Self-introduce-on-channel-join (issue #536).
  *
  * When an agent genuinely JOINS a channel, it proactively introduces itself to the
- * other agents already there (via `listChannelAgents` → `messageAgent`) so those
- * peers can record it in their memory and know who to delegate to later. This module
+ * other agents already there (via `listAgents` FILTERED to that channel → a `sendMessage`
+ * wake) so those peers can record it in their memory and know who to delegate to later.
+ * The filter is load-bearing: `listAgents` is org-wide by default. This module
  * is the pure decision layer + the synthetic-turn builder; the daemon wires the
  * durable state and dispatch around it (see Daemon.maybeIntroduceOnJoin).
  *
@@ -60,16 +61,22 @@ export function planChannelIntros(
 }
 
 /** The one-shot instruction the joining agent runs. The turn is keyed to the REAL
- *  channel (but headless — no channel output), so `listChannelAgents` / `sendMessage`
- *  default to it and reach the right peers. Deliberately tightly bounded: introduce,
- *  then stop. `channel` is included only for the agent's own context/wording. */
+ *  channel (but headless — no channel output) so `sendMessage` defaults to it, and the
+ *  discovery step pins `listAgents` to that channel EXPLICITLY: `listAgents` now
+ *  defaults to the whole ORG directory, and an unfiltered call would fan an
+ *  introduction out to every agent in the organization on one channel join.
+ *  BELT AND BRACES — the instruction is not the bound: the daemon FORCES this channel as
+ *  the directory filter for an intro turn from the turn's trusted `CallMeta.introChannel`,
+ *  so a model that ignores (or rewrites) the argument still discovers only these peers.
+ *  Deliberately tightly bounded: introduce, then stop. */
 export function introPrompt(channel: string, agentId: string): string {
   return [
     `You've just joined the channel \`${channel}\`. Introduce yourself to the OTHER agents ` +
       `there so they can note who you are and delegate work to you later.`,
     ``,
     `Do exactly this and nothing else:`,
-    `1. Call \`listChannelAgents\` (it defaults to this channel) to see who else is here (ignore yourself).`,
+    `1. Call \`listAgents\` with the exact shape \`{"channel":"${channel}"}\` — the channel filter is REQUIRED ` +
+      `here, so you introduce yourself only to the agents in THIS channel — to see who else is here (ignore yourself).`,
     `2. For EACH other agent, call \`sendMessage\` with the exact shape ` +
       `\`{"to":{"toAgent":"<their id>"},"message":"<short introduction>"}\` (no \`channel\`, so it is a ` +
       `silent wake). The introduction should contain your name, one line on what you do, and that they can reach ` +
@@ -77,7 +84,7 @@ export function introPrompt(channel: string, agentId: string): string {
       `their memory and tell them no reply is needed.`,
     ``,
     `Introduce yourself ONLY — do not post to the channel, do not @mention or ping any human, and ` +
-      `do not start any task or ask questions. If \`listChannelAgents\` returns no other agents, do nothing.`
+      `do not start any task or ask questions. If \`listAgents\` returns no other agents, do nothing.`
   ].join('\n')
 }
 
@@ -88,9 +95,10 @@ export function introPrompt(channel: string, agentId: string): string {
  * itself purely through `sendMessage` (silent `to.toAgent` wakes), and (via the caller turn's
  * `deliverHeadless` callMeta) the woken peers run headless too, recording it silently.
  *
- * The turn is keyed to the REAL `channel` so `ctx.channel` drives `listChannelAgents` /
- * `sendMessage` defaults and peer turns inherit a REAL channel (never a synthetic key
- * that a peer would fail to post to). A distinct synthetic `thread`, equal to
+ * The turn is keyed to the REAL `channel` so `ctx.channel` drives the `sendMessage`
+ * defaults (and the `listAgents` channel filter the prompt passes explicitly) and peer
+ * turns inherit a REAL channel (never a synthetic key that a peer would fail to post
+ * to). A distinct synthetic `thread`, equal to
  * `transcriptTs`, keeps it a root message (no thread-history backfill) on its own session.
  */
 export function buildIntroMessage(

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -561,12 +561,17 @@ export class CpClient {
   }
 
   /**
-   * `channel/agents` (D→C REQ) → the channel's agent roster. The peer-discovery
+   * `channel/agents` (D→C REQ) → the caller's callable peers. The peer-discovery
    * half of agent collaboration: the daemon asks the CP (the only authority for
-   * the full cross-daemon roster) who else is in a channel. State-GATED like
+   * the full cross-daemon roster) which peers this agent may reach. State-GATED like
    * `requestGitCred` (outside READY/DRAINING it fails fast, never queues on a dead
    * socket). `requesterAgentId` is set by the caller from the trusted MCP session
-   * context — the CP uses it for membership + call-policy filtering.
+   * context — the CP uses it for the bidirectional call-policy filter.
+   *
+   * `payload.channel` is optional (absent ⇒ the ORG-WIDE directory) and only a CP
+   * advertising `agent-directory-org-scope-v1` understands that form, so the CALLER
+   * negotiates it via {@link supportsServerFeature} — it owns the trusted current-channel
+   * coordinate to substitute for an older CP (see the daemon's `channelAgents` dep).
    */
   async channelAgents(payload: ChannelAgentsReq): Promise<ChannelAgentsOk> {
     if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -9,7 +9,7 @@
  * on a STALE snapshot is not implemented — `generation` is tracked, a live CP is
  * assumed. Documented in the PR description.
  */
-import type { CollabRoutesSnapshot, CollabAgentPlacement } from '@agentconnect.md/protocol'
+import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
 
 export interface CollabResolved extends CollabAgentPlacement {
   orgId: string
@@ -18,11 +18,9 @@ export interface CollabResolved extends CollabAgentPlacement {
 export class CpCollabRoutes {
   private generation = -1
   private readonly channels = new Map<string, Map<string, CollabResolved>>()
-  // Secondary index used by same-daemon delivery, whose trusted MCP request has
-  // platform/channel coordinates but no model-controlled org id. A daemon's
-  // snapshot is org-scoped; the array keeps the lookup fail-closed even if a
-  // malformed snapshot ever repeats the same coordinates across organizations.
-  private readonly channelsByCoordinates = new Map<string, Map<string, CollabResolved>[]>()
+  // (orgId,channel) → the member maps of EVERY platform row sharing that channel id.
+  // The coordinate-integrity index; platform-free on purpose ({@link coordsAdmit}).
+  private readonly byOrgChannel = new Map<string, Map<string, CollabResolved>[]>()
   // The daemon snapshot is org-scoped, so platform + channel safely scopes the
   // managed bot-app identities used for platform-message suppression.
   private readonly botAppsByChannel = new Map<string, Set<string>>()
@@ -30,13 +28,20 @@ export class CpCollabRoutes {
   // map lets the daemon label a REMOTE peer (caller or target of an agent-call) by name in a
   // visible post without knowing the org/channel or having listed it (see agentDisplayLabel).
   private readonly names = new Map<string, { name?: string; displayName?: string }>()
+  // FLAT, channel-free directory: agentId → its org-scoped placement + call policy.
+  // A2A authorization is channel-free (A2A delivery already is — see the postless
+  // note in Daemon.messageAgent, #854), so the authorization input must be a
+  // structure an agent with NO IM integration can appear in at all. The
+  // channel-keyed maps above structurally cannot express that (see CollabOrgAgent).
+  private readonly byAgent = new Map<string, CollabOrgAgent>()
 
   private key(orgId: string, platform: string, channelId: string): string {
     return orgId + '\u0000' + platform + '\u0000' + channelId
   }
 
-  private coordinatesKey(platform: string, channelId: string): string {
-    return platform + '\u0000' + channelId
+  /** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link coordsAdmit}. */
+  private coordsKey(orgId: string, channelId: string): string {
+    return orgId + '\u0000' + channelId
   }
 
   /** FULL-REPLACE from a CP snapshot (converge-don't-diff); ignore an older generation.
@@ -46,9 +51,10 @@ export class CpCollabRoutes {
     if (snap.generation < this.generation) return
     this.generation = snap.generation
     this.channels.clear()
-    this.channelsByCoordinates.clear()
+    this.byOrgChannel.clear()
     this.botAppsByChannel.clear()
     this.names.clear()
+    this.byAgent.clear()
     for (const ch of snap.channels) {
       const byAgent = new Map<string, CollabResolved>()
       const botApps = new Set<string>()
@@ -59,12 +65,64 @@ export class CpCollabRoutes {
           this.names.set(a.agentId, { name: a.name, displayName: a.displayName })
       }
       this.channels.set(this.key(ch.orgId, ch.platform, ch.channelId), byAgent)
-      const coordinatesKey = this.coordinatesKey(ch.platform, ch.channelId)
-      const coordinateChannels = this.channelsByCoordinates.get(coordinatesKey) ?? []
-      coordinateChannels.push(byAgent)
-      this.channelsByCoordinates.set(coordinatesKey, coordinateChannels)
+      const ck = this.coordsKey(ch.orgId, ch.channelId)
+      const sharing = this.byOrgChannel.get(ck)
+      if (sharing) sharing.push(byAgent)
+      else this.byOrgChannel.set(ck, [byAgent])
       if (botApps.size > 0) this.botAppsByChannel.set(`${ch.platform}:${ch.channelId}`, botApps)
     }
+    // The flat directory is the authority when the CP sends one (it advertises
+    // `agent-directory-org-scope-v1`), because it is the only list that includes
+    // integration-less agents. FULL-REPLACE applies to it exactly like the
+    // channel table: cleared above, rebuilt here, no diffing.
+    const flat = snap.agents ?? []
+    if (flat.length > 0) {
+      for (const a of flat) this.byAgent.set(a.agentId, a)
+      return
+    }
+    // OLD-CP FALLBACK: a CP that predates the flat list sends channel entries only.
+    // Derive what we can from them — every channel entry carries its `orgId` and its
+    // members are placements — so `admits()` keeps working for integration-backed
+    // agents. Integration-less agents are simply absent from such a snapshot, and
+    // `admits()` fails closed on them, which is that CP's existing behavior anyway.
+    for (const ch of snap.channels) {
+      for (const a of ch.agents)
+        if (!this.byAgent.has(a.agentId)) this.byAgent.set(a.agentId, { ...a, orgId: ch.orgId })
+    }
+  }
+
+  /** The org that owns `agentId` per the latest snapshot, or undefined when unknown. */
+  orgForAgent(agentId: string): string | undefined {
+    return this.byAgent.get(agentId)?.orgId
+  }
+
+  /** `agentId`'s org-scoped directory entry (placement + call policy), or undefined. */
+  agent(agentId: string): CollabOrgAgent | undefined {
+    return this.byAgent.get(agentId)
+  }
+
+  /**
+   * THE agent-call authorization predicate: may `callerAgentId` discover and wake
+   * `targetAgentId`? Channel membership plays no part — only the directional
+   * call-policy pair, within one org. Fails CLOSED when either agent is unknown to
+   * the snapshot (a missing/stale snapshot never grants access) or the orgs differ.
+   *
+   * NOTE this is the call policy (`callPolicy`/`outboundPolicy`, labelled "Agent
+   * visibility" in the console), NOT `Agent.visibility`/`sharedWith` — the latter
+   * governs HUMAN console access and must never affect the peer directory.
+   */
+  admits(callerAgentId: string, targetAgentId: string): boolean {
+    const caller = this.byAgent.get(callerAgentId)
+    const target = this.byAgent.get(targetAgentId)
+    if (!caller || !target) return false
+    if (caller.orgId !== target.orgId) return false
+    // A caller always resolves ITSELF: an agent with outboundPolicy 'selected' does
+    // not normally list itself in its own allow-list, yet it must still see itself in
+    // a directory listing. (A self-WAKE is rejected earlier, with reason 'self'.)
+    if (callerAgentId === targetAgentId) return true
+    if (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(targetAgentId)) return false
+    if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(callerAgentId)) return false
+    return true
   }
 
   /** The placement of `agentId` in `(orgId,platform,channel)`, or undefined. */
@@ -72,12 +130,53 @@ export class CpCollabRoutes {
     return this.channels.get(this.key(orgId, platform, channelId))?.get(agentId)
   }
 
-  /** True only when every requested agent is present in one org-scoped channel
-   *  entry. Used to keep same-daemon delivery aligned with relay membership
-   *  checks without trusting an org id from the tool request. */
-  hasMembers(platform: string, channelId: string, agentIds: readonly string[]): boolean {
-    const channels = this.channelsByCoordinates.get(this.coordinatesKey(platform, channelId)) ?? []
-    return channels.some((agents) => agentIds.every((agentId) => agents.has(agentId)))
+  /**
+   * COORDINATE INTEGRITY for a wake (§2.5 #4 / agent-collaboration §6.2), as ONE atomic
+   * predicate: may `callerAgentId` assert the delivery coordinate `(orgId, channelId)`?
+   *
+   * Channel stopped being an authorization key — A2A delivery is postless (#854) — but it
+   * is still the woken peer's SESSION key, so an asserted `coords` the caller cannot reach
+   * would let it RESUME (and, with `needsReply`, read back) a target session living in a
+   * channel it has no access to. The rule: if the snapshot knows any NON-EMPTY membership
+   * at that coordinate, the caller must be in one of them; if it knows none, the coordinate
+   * is not a claim about a shared IM channel and needs no membership evidence. The relay
+   * applies the IDENTICAL predicate on the ingress side, and all three wake paths here
+   * (`handleRelayAgentMsg` terminal-verify, `localWakeAuthorizationRejection`, and through
+   * it `wakeRejectionReason`'s preflight) go through this one method.
+   *
+   * PLATFORM-FREE ON PURPOSE. The coordinate platform must NOT be part of the key: the
+   * woken session's key is computed from {@link Daemon.narrowPlatform}, which folds
+   * `feishu` — and any value it does not recognise — into `'slack'`, while snapshot rows
+   * are keyed by the INTEGRATION platform. A platform-keyed check therefore searched a
+   * different key space than the session key it protects, and the "unknown coordinate
+   * passes" branch silently swallowed the mismatch in BOTH directions: `coords.platform:
+   * 'feishu'` over a Slack channel id, and (in a Feishu org) an honest narrowed `'slack'`
+   * over a `feishu` row. Either missed the row, passed, and still computed a bit-identical
+   * child session key. Matching on the channel id alone closes both, keeps the daemon and
+   * the relay — which has no `narrowPlatform` — expressing literally the same rule, and
+   * over-blocks only if one org uses the same channel id on two platforms (which then
+   * demands membership in one of them, not a bypass).
+   *
+   * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
+   * anyone in this org can reach, so gating on it would reject every call naming it while
+   * protecting nothing.
+   *
+   * KNOWN LIMIT (follow-up, not closed here): "unknown coordinate" cannot distinguish
+   * "not an IM channel" from "an IM channel the CP does not record". Slack DMs and group
+   * DMs are deliberately never channel rows (`listBotChannels` skips `is_im`/`is_mpim`),
+   * and a row disappears when the bot leaves or the integration goes inactive while the
+   * session stays resumable — such coordinates take the pass branch.
+   */
+  coordsAdmit(orgId: string, channelId: string, callerAgentId: string): boolean {
+    const sharing = this.byOrgChannel.get(this.coordsKey(orgId, channelId))
+    if (sharing === undefined) return true
+    let known = false
+    for (const members of sharing) {
+      if (members.size === 0) continue
+      known = true
+      if (members.has(callerAgentId)) return true
+    }
+    return !known
   }
 
   /** Directory name of `agentId` from the latest snapshot (across any channel), or undefined. */

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -15,11 +15,48 @@ export interface CollabResolved extends CollabAgentPlacement {
   orgId: string
 }
 
+/**
+ * The verdict of {@link CpCollabRoutes.coordsDecision} (agent-collaboration §6.2).
+ * Three outcomes, not two, because a channel-free wake must neither be rejected nor be
+ * allowed to keep the coordinate it named:
+ *  - `reject`    — the assertion is not admissible; NAK / refuse the wake `not_allowed`.
+ *  - `asserted`  — use the coordinate as given (a channel row the caller is in).
+ *  - `synthetic` — admissible, but the woken session must key off `channel` (derived from
+ *                  the TRUSTED caller) instead of the asserted one.
+ *
+ * This daemon is where the session key is MINTED, so it is the side that acts on
+ * `synthetic`; the relay's byte-identical twin (`packages/relay/src/collaboration-router.ts`)
+ * only rejects. Change one, change both.
+ */
+export type CoordsVerdict = { verdict: 'reject' } | { verdict: 'asserted' } | { verdict: 'synthetic'; channel: string }
+
+/**
+ * The platforms whose conversations are PERSISTED as `integration_channel` rows and
+ * therefore appear in this snapshot — i.e. the protocol `Platform` enum minus the
+ * session-identity members (`webchat`/`hook`/`dream`, which have no persisted row; see the
+ * CP's `isSessionIdentityPlatform`). An UNKNOWN coordinate on one of these is evidence of a
+ * problem, not of a channel-free session, so it fails closed ({@link
+ * CpCollabRoutes.coordsDecision}).
+ */
+const PERSISTED_IM_PLATFORMS: ReadonlySet<string> = new Set(['slack', 'telegram', 'discord', 'feishu'])
+
+/**
+ * The coordinate a channel-free wake lands on: derived from the TRUSTED caller, never from
+ * anything the caller asserted. Collision-free against every real conversation id by
+ * construction — Slack/Telegram/Discord/Feishu channel ids never contain `:` and webchat
+ * conversation ids are UUIDs — so it can never alias an existing platform session. Two
+ * different asserted channels from one caller therefore collapse onto ONE pairwise session,
+ * which is the right shape for a postless agent-to-agent conversation (#854).
+ */
+export function a2aCoordChannel(callerAgentId: string): string {
+  return `a2a:${callerAgentId}`
+}
+
 export class CpCollabRoutes {
   private generation = -1
   private readonly channels = new Map<string, Map<string, CollabResolved>>()
   // (orgId,channel) → the member maps of EVERY platform row sharing that channel id.
-  // The coordinate-integrity index; platform-free on purpose ({@link coordsAdmit}).
+  // The coordinate-integrity index; platform-free on purpose ({@link coordsDecision}).
   private readonly byOrgChannel = new Map<string, Map<string, CollabResolved>[]>()
   // The daemon snapshot is org-scoped, so platform + channel safely scopes the
   // managed bot-app identities used for platform-message suppression.
@@ -39,7 +76,7 @@ export class CpCollabRoutes {
     return orgId + '\u0000' + platform + '\u0000' + channelId
   }
 
-  /** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link coordsAdmit}. */
+  /** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link coordsDecision}. */
   private coordsKey(orgId: string, channelId: string): string {
     return orgId + '\u0000' + channelId
   }
@@ -132,51 +169,89 @@ export class CpCollabRoutes {
 
   /**
    * COORDINATE INTEGRITY for a wake (§2.5 #4 / agent-collaboration §6.2), as ONE atomic
-   * predicate: may `callerAgentId` assert the delivery coordinate `(orgId, channelId)`?
+   * decision: may `callerAgentId` assert the delivery coordinate `(orgId, platform,
+   * channelId)`, and if so, which channel may the woken session actually key off?
    *
    * Channel stopped being an authorization key — A2A delivery is postless (#854) — but it
    * is still the woken peer's SESSION key, so an asserted `coords` the caller cannot reach
    * would let it RESUME (and, with `needsReply`, read back) a target session living in a
-   * channel it has no access to. The rule: if the snapshot knows any NON-EMPTY membership
-   * at that coordinate, the caller must be in one of them; if it knows none, the coordinate
-   * is not a claim about a shared IM channel and needs no membership evidence. The relay
-   * applies the IDENTICAL predicate on the ingress side, and all three wake paths here
-   * (`handleRelayAgentMsg` terminal-verify, `localWakeAuthorizationRejection`, and through
-   * it `wakeRejectionReason`'s preflight) go through this one method.
+   * channel it has no access to. Three branches, evaluated in this order:
    *
-   * PLATFORM-FREE ON PURPOSE. The coordinate platform must NOT be part of the key: the
-   * woken session's key is computed from {@link Daemon.narrowPlatform}, which folds
-   * `feishu` — and any value it does not recognise — into `'slack'`, while snapshot rows
-   * are keyed by the INTEGRATION platform. A platform-keyed check therefore searched a
-   * different key space than the session key it protects, and the "unknown coordinate
-   * passes" branch silently swallowed the mismatch in BOTH directions: `coords.platform:
-   * 'feishu'` over a Slack channel id, and (in a Feishu org) an honest narrowed `'slack'`
-   * over a `feishu` row. Either missed the row, passed, and still computed a bit-identical
-   * child session key. Matching on the channel id alone closes both, keeps the daemon and
-   * the relay — which has no `narrowPlatform` — expressing literally the same rule, and
-   * over-blocks only if one org uses the same channel id on two platforms (which then
-   * demands membership in one of them, not a bypass).
+   * (1) KNOWN coordinate — the snapshot holds a NON-EMPTY membership at (org, channel id):
+   *     the caller must be in one of them, else `reject`. Otherwise `asserted`, which
+   *     preserves the deliberate "land in the same thread a human sees" behavior. This
+   *     branch is PLATFORM-FREE (below), so a DIRECT conversation counts wherever its row
+   *     exists: `IntegrationChannel.kind` is `channel | im | mpim` and
+   *     `IntegrationRepo.channelPlacements` selects the rows with NO `kind` filter, so an
+   *     `im`/`mpim` row is an ordinary KNOWN coordinate with its owning integration's agent
+   *     as a member.
+   *
+   * (2) UNKNOWN on a PERSISTED IM platform ({@link PERSISTED_IM_PLATFORMS}) — `reject`,
+   *     FAIL CLOSED. An unrecorded IM coordinate is either a conversation the caller cannot
+   *     reach or a stale/departed row; admitting it is exactly what let a caller alias an
+   *     existing platform session. A brief snapshot lag can therefore transiently reject a
+   *     genuine wake — the correct direction for a security boundary, and the caller retries.
+   *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
+   *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
+   *     observed it — Slack's authoritative membership snapshot enumerates
+   *     `public_channel,private_channel` only, and the two paths that DO emit `im`/`mpim`
+   *     (this daemon's `reportGatedConversation` and the CP's shared-bot
+   *     `reportConversation`) both fire only for a GATED integration/install's
+   *     not-yet-enabled conversations — so an ordinary integration's DM has no row and a
+   *     wake asserting it is refused here. Deliberate, and not a regression: the
+   *     `hasMembers(caller, target)` check this replaced refused the identical wake.
+   *
+   * (3) UNKNOWN and channel-free (anything else: `webchat`, `dream`, a target-less `hook`
+   *     session's own platform, or an unrecognised value) — `synthetic`. NOT a reject: this
+   *     is the case the org-scoped directory exists for. Instead the asserted channel never
+   *     becomes the session coordinate at all; {@link a2aCoordChannel} derives it from the
+   *     trusted caller, which cannot alias any platform session.
+   *
+   * Branch (1) running FIRST and platform-free is what keeps (3) from being an escape hatch:
+   * relabelling a real channel's coordinate as `webchat` still hits branch 1 and still
+   * demands membership.
+   *
+   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key must NOT include the coordinate
+   * platform: the woken session's key is computed from {@link Daemon.narrowPlatform}, which
+   * folds `feishu` — and any value it does not recognise — into `'slack'`, while snapshot
+   * rows are keyed by the INTEGRATION platform. Keying the LOOKUP on it searched a different
+   * key space than the session key it protects, and the old "unknown coordinate passes"
+   * branch silently swallowed the mismatch in BOTH directions: `coords.platform:'feishu'`
+   * over a Slack channel id, and (in a Feishu org) an honest narrowed `'slack'` over a
+   * `feishu` row. Either missed the row, passed, and still computed a bit-identical child
+   * session key. Matching on the channel id alone closes both and keeps this and the relay's
+   * copy — which has no `narrowPlatform` — expressing literally the same rule. The platform
+   * is consulted ONLY to pick between branch 2 and branch 3, and only for a coordinate
+   * branch 1 already found nothing for, where the collapse cannot help an attacker because
+   * branch 3 hands back a caller-derived channel rather than the asserted one.
    *
    * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
    * anyone in this org can reach, so gating on it would reject every call naming it while
    * protecting nothing.
    *
-   * KNOWN LIMIT (follow-up, not closed here): "unknown coordinate" cannot distinguish
-   * "not an IM channel" from "an IM channel the CP does not record". Slack DMs and group
-   * DMs are deliberately never channel rows (`listBotChannels` skips `is_im`/`is_mpim`),
-   * and a row disappears when the bot leaves or the integration goes inactive while the
-   * session stays resumable — such coordinates take the pass branch.
+   * The relay applies a BYTE-IDENTICAL twin on the ingress side, and all three wake paths
+   * here (`handleRelayAgentMsg` terminal-verify, `localWakeDecision`, and through it
+   * `wakeRejectionReason`'s preflight) go through this one method.
+   *
+   * ACCEPTED CONSEQUENCE of the wire's platform narrowing: `RdAgentMsg.coords.platform` is
+   * `slack | telegram | webchat | discord | feishu`, so `messageAgent` maps a target-less
+   * `hook` session's coords platform to `'slack'` before handing them to the relay (and
+   * {@link Daemon.narrowPlatform} does the same for `dream`). A CROSS-DAEMON wake out of such
+   * a session therefore lands in branch 2 and is rejected, while the same wake to a
+   * co-located peer — which passes the RAW `req.platform` — takes branch 3. Un-narrowing it
+   * needs a new coords platform value on the wire: a protocol change, out of scope here.
    */
-  coordsAdmit(orgId: string, channelId: string, callerAgentId: string): boolean {
+  coordsDecision(orgId: string, platform: string, channelId: string, callerAgentId: string): CoordsVerdict {
     const sharing = this.byOrgChannel.get(this.coordsKey(orgId, channelId))
-    if (sharing === undefined) return true
     let known = false
-    for (const members of sharing) {
+    for (const members of sharing ?? []) {
       if (members.size === 0) continue
       known = true
-      if (members.has(callerAgentId)) return true
+      if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
-    return !known
+    if (known) return { verdict: 'reject' }
+    if (PERSISTED_IM_PLATFORMS.has(platform)) return { verdict: 'reject' }
+    return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
   }
 
   /** Directory name of `agentId` from the latest snapshot (across any channel), or undefined. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -293,7 +293,8 @@ import type {
   ChildSessionStatus,
   ChildSessionStatusProbe,
   SessionVisibilityPush,
-  WebchatMcpDelegationReference
+  WebchatMcpDelegationReference,
+  ChannelAgentsOk
 } from '@agentconnect.md/protocol'
 
 /** Format an error for logs, surfacing a JSON-RPC/ACP RequestError's `code` and
@@ -661,6 +662,16 @@ interface CallMeta {
    *  with no channel output. Set only by the self-introduce-on-join fan-out; does
    *  NOT cascade (the peer's own callMeta doesn't carry it). */
   deliverHeadless?: boolean
+  /** Daemon-internal (issue #536, never a tool input): the channel this turn exists to
+   *  introduce the agent into. It HARD-BOUNDS peer discovery for the turn — the
+   *  `channelAgents` dep forces this channel as the directory filter even when the model
+   *  omits (or widens, or redirects) the tool's `channel` argument. Without a code-level
+   *  bound the org-wide default would fan one channel join out to every agent in the org;
+   *  `MAX_AGENT_CALL_HOPS` bounds depth and `INTRO_MAX_BURST` bounds channels per snapshot,
+   *  but neither bounds PEERS per intro. The prompt asks for the same filter (belt and
+   *  braces); this is what makes it true regardless of model compliance. Set only by the
+   *  self-introduce-on-join dispatch and, like `deliverHeadless`, does NOT cascade. */
+  introChannel?: string
   /** session-concept §5.3: the waking parent asked this session to report back when it is done
    *  or has failed (`sendMessage`'s `toAgent.needsReply`). Handed to prompt assembly, which turns
    *  it into a standing directive on the child naming `originSessionId` as the reply target.
@@ -1410,7 +1421,7 @@ export class Daemon {
   private feishuConnecting = new Set<string>()
   // Slack id → display-name resolver (created with the store in start()).
   private nameResolver?: SlackNameResolver
-  // agentId → its channel-directory name, learned from `channelAgents` (listChannelAgents)
+  // agentId → its directory name, learned from `channelAgents` (the listAgents tool)
   // responses. REMOTE agents (hosted on another daemon) aren't in `this.agents`, so this is
   // the only local source for their display name when addressing them in a visible agent-call
   // post. Warm whenever a call is legitimately made — the caller must have listed the channel
@@ -2095,16 +2106,61 @@ export class Daemon {
       },
       // Peer discovery goes to the CP (the only authority for the cross-daemon
       // roster). Resolve the client lazily; fail closed when it isn't connected.
-      channelAgents: async (req) => {
+      channelAgents: async ({ currentChannel, currentThread, currentTransportScope, ...req }) => {
         const client = this.cpClient
         if (!client) throw Object.assign(new Error('control plane is not connected'), { code: 'INTERNAL' })
-        const ok = await client.channelAgents(req)
         // Cache each peer's directory name so the caller-framed text delivered to a messaged
         // agent can name a REMOTE caller by directory name instead of its raw agentId
         // (see agentDisplayLabel / prepareAgentDelivery).
-        if (this.channelAgentNames.size >= 5000) this.channelAgentNames.clear()
-        for (const a of ok.agents) this.channelAgentNames.set(a.agentId, { name: a.name, displayName: a.displayName })
-        return ok
+        const cacheNames = (ok: ChannelAgentsOk): ChannelAgentsOk => {
+          if (this.channelAgentNames.size >= 5000) this.channelAgentNames.clear()
+          for (const a of ok.agents) this.channelAgentNames.set(a.agentId, { name: a.name, displayName: a.displayName })
+          return ok
+        }
+        // Rolling-upgrade negotiation: only a CP advertising `agent-directory-org-scope-v1`
+        // accepts a channel-less request (the org-wide directory). An older CP can answer
+        // exactly one question — "who is in this channel" — so a channel-less ask has to be
+        // narrowed to the caller's CURRENT channel for it, which is today's behavior.
+        const orgScope = client.supportsServerFeature('agent-directory-org-scope-v1')
+        // A daemon-initiated channel-intro turn is HARD-BOUND to the channel it joined:
+        // the scope is decided HERE, from the turn's trusted CallMeta, not from the tool
+        // args (see CallMeta.introChannel — an unfiltered listing would fan one join out
+        // to the entire org). It also overrides an explicit arg: an intro turn has exactly
+        // one legitimate scope, so a model asking for another channel gets its own.
+        const introChannel = this.introChannelForTurn(req.requesterAgentId, req.platform, {
+          channel: currentChannel,
+          thread: currentThread,
+          transportScope: currentTransportScope
+        })
+        const channel = introChannel ?? req.channel ?? (orgScope ? undefined : currentChannel)
+        if (channel === undefined) {
+          // Org-wide, and the CP understands it.
+          if (orgScope) return cacheNames(await client.channelAgents(req))
+          // Old CP + nothing to narrow to (a session that does not know its own channel):
+          // a channel-less REQ is a BAD_PAYLOAD there and an invented channel would be
+          // worse, so answer locally. An old CP has nothing to say about a directory scope
+          // it does not implement anyway.
+          this.log.debug('channelAgents: CP predates agent-directory-org-scope-v1 and no channel to narrow to')
+          return { platform: req.platform, agents: [] }
+        }
+        // A channel-scoped question must name a PERSISTED coordinate. A hook turn's session
+        // platform is 'hook' but it LANDS on real Slack coordinates, so its channel filter is
+        // a Slack one (the same mapping the removed local wake check applied) — otherwise the
+        // CP's session-identity short-circuit silently answers `agents: []` and the agent
+        // concludes nobody is there. webchat/dream have no persisted channel at all, so an
+        // empty roster is the honest answer — and it must be computed HERE, because an old CP
+        // would THROW on such a payload (`toDbPlatform`) and `ws/connection.ts` turns that
+        // into close(1011), killing the whole control socket and every in-flight request.
+        // A current CP already short-circuits it to this same empty roster.
+        const coordPlatform = req.platform === 'hook' ? 'slack' : req.platform
+        if (coordPlatform === 'webchat' || coordPlatform === 'dream') {
+          return { platform: req.platform, channel, agents: [] }
+        }
+        const ok = await client.channelAgents({ ...req, platform: coordPlatform, channel })
+        // Echo the SESSION's own platform back to the caller, not the coordinate platform we
+        // may have rewritten above: everything else the agent sees about a hook turn calls it
+        // 'hook', and the roster is the same either way.
+        return cacheNames({ ...ok, platform: req.platform })
       },
       // Agent→agent wake (§2.2). Same-daemon delivery only in P1; the daemon owns the
       // trusted caller identity + policy check + dispatch (a target elsewhere gets
@@ -3370,7 +3426,16 @@ export class Daemon {
       // worker-report side effect (recordWorkerReport only fires on a correlationId).
       // No origin fields (§5.3): a self-introduce is root-like — the woken peer has no parent
       // session to reply into, so it gets no `Parent session` line and no SessionTarget.
-      const callMeta: CallMeta = { callFrom: agent.id, hopCount: 0, deliveryId: traceId, deliverHeadless: true }
+      // `introChannel` is the CODE-level bound on the fan-out: discovery in this turn is
+      // pinned to the joined channel whatever the model passes to `listAgents` (the prompt
+      // asks for the same filter, but a prompt is not a bound — see CallMeta.introChannel).
+      const callMeta: CallMeta = {
+        callFrom: agent.id,
+        hopCount: 0,
+        deliveryId: traceId,
+        deliverHeadless: true,
+        introChannel: ch
+      }
       void this.dispatch(agent.id, msg, integrationId, undefined, callMeta).catch((err) =>
         this.log.warn(`intro: dispatch failed for agent "${agent.id}" in ${ch}: ${formatErr(err)}`)
       )
@@ -5431,24 +5496,35 @@ export class Daemon {
     // don't trust that blindly — this is the placement authority for OUR agents).
     if (!this.agents.get(msg.toAgentId)) return record(nak('not_found'))
 
-    // TERMINAL-VERIFY against the local collaboration snapshot (§2.5 #4). Both the
-    // trusted caller and target must be members of the asserted (org, channel), and
-    // both directional policies must admit caller→target. Missing snapshot ⇒ fail closed.
-    const target = this.cpCollab.resolve(msg.orgId, platform, channel, msg.toAgentId)
-    const caller = this.cpCollab.resolve(msg.orgId, platform, channel, msg.trustedFromAgentId)
-    if (!target || !caller) {
+    // TERMINAL-VERIFY against the local collaboration snapshot (§2.5 #4), now ORG-scoped
+    // rather than (org, channel)-scoped: the relay's asserted org must be the org this
+    // daemon's directory records for the target, and the directional call policy must admit
+    // caller→target. Channel is only the session coordinate here (A2A is postless, #854), so
+    // a caller and target that share no channel — or a target with no IM integration at all —
+    // is legitimate. Missing snapshot / unknown agent ⇒ fail closed, as before.
+    if (this.cpCollab.orgForAgent(msg.toAgentId) !== msg.orgId) {
       this.log.warn(`relay: rd/agentmsg/fwd terminal-verify failed (no placement) for ${msg.toAgentId} — fail closed`)
       return record(nak('not_allowed'))
     }
-    if (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(msg.toAgentId)) {
+    if (!this.cpCollab.admits(msg.trustedFromAgentId, msg.toAgentId)) {
       this.log.info(
-        `relay: rd/agentmsg/fwd not_allowed — ${msg.trustedFromAgentId} outbound policy excludes ${msg.toAgentId}`
+        `relay: rd/agentmsg/fwd not_allowed — call policy excludes ${msg.trustedFromAgentId} → ${msg.toAgentId}`
       )
       return record(nak('not_allowed'))
     }
-    if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(msg.trustedFromAgentId)) {
-      this.log.info(
-        `relay: rd/agentmsg/fwd not_allowed — ${msg.trustedFromAgentId} → ${msg.toAgentId} (target selected)`
+    // COORDINATE INTEGRITY (§2.5 #4), the second half of terminal-verify and the reason
+    // dropping channel from the POLICY predicate is not the same as dropping it entirely:
+    // `coords` is still the woken peer's SESSION key (see childSessionId below), so a caller
+    // that could assert any channel could compute its way INTO an existing session of the
+    // target in a channel the caller has no access to — resuming that conversation and, with
+    // `needsReply`, reporting its content back. `coordsAdmit` is the single mirrored
+    // predicate the relay's ingress applies too, and it is keyed on the CHANNEL ID without
+    // the platform on purpose: `narrowPlatform` below folds feishu/unknown into 'slack' when
+    // computing the session key, so a platform-keyed check would search a different key
+    // space than the key it protects.
+    if (!this.cpCollab.coordsAdmit(msg.orgId, channel, msg.trustedFromAgentId)) {
+      this.log.warn(
+        `relay: rd/agentmsg/fwd not_allowed — ${msg.trustedFromAgentId} asserted coords ${platform}:${channel} it is not in`
       )
       return record(nak('not_allowed'))
     }
@@ -5530,7 +5606,7 @@ export class Daemon {
    *  a LOCAL agent from `this.agents`; else the collab snapshot the CP pushes to every daemon
    *  (`cpCollab`, authoritative + always present, so it resolves a REMOTE peer even in the
    *  reply direction where this daemon never listed the channel); else the name cached from a
-   *  `channelAgents` (listChannelAgents) response; else the raw agentId (keeps a cold lookup
+   *  `channelAgents` (listAgents) response; else the raw agentId (keeps a cold lookup
    *  from throwing). */
   private agentDisplayLabel(agentId: string): string {
     const local = this.agents.get(agentId)
@@ -5565,6 +5641,24 @@ export class Daemon {
   }
 
   /**
+   * The channel a DAEMON-INITIATED channel-intro turn is bound to (issue #536), resolved
+   * from the turn's trusted `CallMeta` — the same §6.7 active-turn lookup a nested
+   * `messageAgent` uses to inherit hop/origin, keyed by the caller's LOGICAL sessionKey.
+   * Returns undefined for every ordinary turn, which is what keeps `listAgents` org-wide
+   * by default. The coordinates come from the trusted MCP session context, never tool input,
+   * so an agent cannot fabricate (or escape) an intro scope.
+   */
+  private introChannelForTurn(
+    agentId: string,
+    platform: string,
+    coords: { channel?: string; thread?: string; transportScope?: string }
+  ): string | undefined {
+    if (coords.channel === undefined || coords.thread === undefined) return undefined
+    const key = sessionKey(platform, coords.channel, coords.thread, agentId, coords.transportScope)
+    return this.activeTurnCallMeta.get(key)?.introChannel
+  }
+
+  /**
    * Agent→agent attention routing behind the `messageAgent` MCP tool. The message is
    * delivered directly to the target and wakes it — there is no visible thread event.
    * Trusted `CallMeta` is a separate workflow projection for hop limits and
@@ -5575,28 +5669,49 @@ export class Daemon {
    * would reject this wake with for a LOCALLY-decidable cause, else null. `sendMessage` uses it
    * to avoid leaving a visible channel post for a `toAgent`+`channel` wake that will never be
    * delivered. MUST stay in sync with the fail-closed guards in {@link messageAgent}: a reason
-   * added there but not here would let a doomed wake still post. A remote target's call-policy
-   * is NOT decidable here (that verdict lives on the owning daemon) — returns null for an
-   * absent local target, matching messageAgent routing it cross-daemon.
+   * added there but not here would let a doomed wake still post. A remote target's LOCAL
+   * agent config is not readable here (that verdict lives on the owning daemon) — but the
+   * org-scoped directory below covers a remote target too, because the CP snapshot is
+   * org-wide rather than per-daemon.
+   *
+   * Two independent checks, in order: the directional call POLICY (`admits`, channel-free)
+   * and the COORDINATE INTEGRITY of `req.channel` (`coordsAdmit`). Dropping channel from
+   * the policy predicate did not drop it as a session coordinate, and this is the
+   * same-daemon twin of the relay/terminal-verify gate.
    */
-  private localWakeAuthorizationRejection(req: MessageAgentReq, platform: string): string | null {
+  private localWakeAuthorizationRejection(req: MessageAgentReq): string | null {
     const caller = this.agents.get(req.callerAgentId)
     if (!caller || (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(req.toAgentId))) {
+      return 'not_allowed'
+    }
+
+    // A local id is not sufficient authority: the org-scoped directional call policy must
+    // admit caller→target (CpCollabRoutes.admits). Channel membership is NOT consulted —
+    // A2A delivery is already postless (#854), so `channel` is only a session coordinate,
+    // and a session with no IM integration must still be able to collaborate. Evaluated
+    // BEFORE the local-target lookup so it also decides a REMOTE target and an id that is
+    // in no directory at all (previously the latter fell through to a misleading
+    // 'offline'). Fails closed on an absent/stale snapshot, as before.
+    if (!this.cpCollab.admits(req.callerAgentId, req.toAgentId)) return 'not_allowed'
+
+    // COORDINATE INTEGRITY — the SAME predicate the relay's ingress and this daemon's
+    // `rd/agentmsg` terminal-verify apply, so all three wake paths enforce one rule. Channel
+    // stopped AUTHORIZING the call, but `req.channel` (a model-supplied `to.channel`, or the
+    // turn's own channel) is still the woken peer's session coordinate, so without this a
+    // model could name a channel its agent cannot reach and RESUME a co-located peer's
+    // session there. Org comes from the caller's own directory entry, never from the
+    // request; `admits` above already proved the entry exists, so undefined is unreachable
+    // and fails closed anyway. STRICTLY WEAKER than the membership check this replaced,
+    // which demanded caller AND target in the channel and so rejected every wake from a
+    // session with no channel row (webchat/hook/dream) — the case this PR exists to allow.
+    const callerOrg = this.cpCollab.orgForAgent(req.callerAgentId)
+    if (callerOrg === undefined || !this.cpCollab.coordsAdmit(callerOrg, req.channel, req.callerAgentId)) {
       return 'not_allowed'
     }
 
     const target = this.agents.get(req.toAgentId)
     if (!target) return null
     if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(req.callerAgentId)) {
-      return 'not_allowed'
-    }
-
-    // A local id is not sufficient authority: both agents must be present in the
-    // same org-scoped collaboration entry for the addressed channel. This mirrors
-    // relay and target-daemon snapshot verification and fails closed when the
-    // snapshot is absent or stale. Hook turns use their Slack landing coordinates.
-    const coordinatePlatform = platform === 'hook' ? 'slack' : platform
-    if (!this.cpCollab.hasMembers(coordinatePlatform, req.channel, [req.callerAgentId, req.toAgentId])) {
       return 'not_allowed'
     }
     return null
@@ -5618,7 +5733,7 @@ export class Daemon {
     )
     const inbound = this.activeTurnCallMeta.get(callerKey)
     if (inbound !== undefined && inbound.hopCount >= MAX_AGENT_CALL_HOPS) return 'hop_limit'
-    return this.localWakeAuthorizationRejection(req, platform)
+    return this.localWakeAuthorizationRejection(req)
   }
 
   private async messageAgent(req: MessageAgentReq): Promise<MessageAgentResult> {
@@ -5664,7 +5779,7 @@ export class Daemon {
         reason: 'capability_disabled'
       })
     }
-    // `toAgentId` is an AgentConnect id from listChannelAgents / the trusted agent-call
+    // `toAgentId` is an AgentConnect id from listAgents / the trusted agent-call
     // envelope, never a platform member id. In particular, accepting Slack's U…/W… ids
     // here produces a visible `@U…` fallback before the relay can reject the unknown
     // target. Fail before publishing so a model that copied the human-facing Slack
@@ -5740,9 +5855,9 @@ export class Daemon {
     }
 
     // Repeat the same side-effect-free authorization used by sendMessage's
-    // preflight. This covers caller existence/outbound policy, a local target's
-    // inbound policy, and same-channel membership before any local wake.
-    if (this.localWakeAuthorizationRejection(req, platform) !== null) {
+    // preflight. This covers caller existence/outbound policy, the org-scoped
+    // directional call policy, and a local target's inbound policy before any local wake.
+    if (this.localWakeAuthorizationRejection(req) !== null) {
       this.log.info(`messageAgent: ${req.callerAgentId} not allowed to call ${req.toAgentId} in ${req.channel}`)
       return record({ delivered: false, targetSession, reason: 'not_allowed' })
     }
@@ -11808,7 +11923,7 @@ export class Daemon {
       this.permissionEvaluationDetails.set(evaluationParams, { reason: 'memory_extraction' })
       return { outcome: { outcome: 'cancelled' } }
     }
-    // Platform system tools (this daemon's OWN MCP tools — sendMessage, listChannelAgents,
+    // Platform system tools (this daemon's OWN MCP tools — sendMessage, listAgents,
     // orchestration, memory, …) are always granted: a human should never
     // have to approve them per call. Auto-allow without rendering a card. Non-system tools
     // (incl. the runtime's dangerous built-ins) fall through to the interactive policy below.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5514,20 +5514,26 @@ export class Daemon {
     }
     // COORDINATE INTEGRITY (§2.5 #4), the second half of terminal-verify and the reason
     // dropping channel from the POLICY predicate is not the same as dropping it entirely:
-    // `coords` is still the woken peer's SESSION key (see childSessionId below), so a caller
+    // `coords` is still the woken peer's SESSION key (see sessionChannel below), so a caller
     // that could assert any channel could compute its way INTO an existing session of the
     // target in a channel the caller has no access to — resuming that conversation and, with
-    // `needsReply`, reporting its content back. `coordsAdmit` is the single mirrored
-    // predicate the relay's ingress applies too, and it is keyed on the CHANNEL ID without
-    // the platform on purpose: `narrowPlatform` below folds feishu/unknown into 'slack' when
-    // computing the session key, so a platform-keyed check would search a different key
-    // space than the key it protects.
-    if (!this.cpCollab.coordsAdmit(msg.orgId, channel, msg.trustedFromAgentId)) {
+    // `needsReply`, reporting its content back. `coordsDecision` is the single mirrored
+    // decision the relay's ingress applies too (see CpCollabRoutes.coordsDecision for the
+    // three branches and why the LOOKUP is platform-free while the branch is not).
+    const coordsVerdict = this.cpCollab.coordsDecision(msg.orgId, platform, channel, msg.trustedFromAgentId)
+    if (coordsVerdict.verdict === 'reject') {
       this.log.warn(
-        `relay: rd/agentmsg/fwd not_allowed — ${msg.trustedFromAgentId} asserted coords ${platform}:${channel} it is not in`
+        `relay: rd/agentmsg/fwd not_allowed — ${msg.trustedFromAgentId} may not assert coords ${platform}:${channel}`
       )
       return record(nak('not_allowed'))
     }
+    // Branch 3: a channel-free coordinate is admitted but must NOT become the session key —
+    // this is where that key is minted, so it is where the substitution belongs (the relay
+    // forwards `coords` verbatim, so only one side may rewrite them or the two would disagree
+    // about the `childSessionId` this ACK reports). The replacement is derived from the
+    // RELAY-MINTED trusted caller, so it cannot alias any existing platform session, and every
+    // wake from that caller collapses onto the one pairwise session.
+    const sessionChannel = coordsVerdict.verdict === 'synthetic' ? coordsVerdict.channel : channel
 
     // Build the trusted turn context + NormalizedMessage (source:'agent'), reusing the
     // same shape as the same-daemon path. callFrom = the RELAY-minted trusted caller.
@@ -5560,8 +5566,17 @@ export class Daemon {
     const childTransportScope =
       integrationId !== undefined ? this.transportScopeForIntegrationIds([integrationId]) : undefined
     // Mirror `transcriptCoords` exactly: an absent thread resolves to the msgId, NOT ''.
-    const childMsgId = `agentcall:${channel}:${msg.deliveryId}`
-    const childSessionId = sessionKey(narrowed, channel, thread ?? childMsgId, msg.toAgentId, childTransportScope)
+    // `sessionChannel` — not the raw asserted `channel` — is the coordinate from here on, so the
+    // key, the msgId and the dispatched message all agree on one channel (branches 1 and 2 leave
+    // it exactly as asserted; only the channel-free branch 3 substitutes).
+    const childMsgId = `agentcall:${sessionChannel}:${msg.deliveryId}`
+    const childSessionId = sessionKey(
+      narrowed,
+      sessionChannel,
+      thread ?? childMsgId,
+      msg.toAgentId,
+      childTransportScope
+    )
     if (msg.originSessionId !== undefined) {
       if (this.childSessionLinks.size >= 2000) this.childSessionLinks.clear()
       this.childSessionLinks.set(childSessionId, {
@@ -5575,7 +5590,7 @@ export class Daemon {
       traceId: msg.deliveryId,
       source: 'agent',
       platform: narrowed,
-      channel,
+      channel: sessionChannel,
       ...(thread !== undefined ? { thread } : {}),
       sender: { id: msg.trustedFromAgentId, isBot: true },
       // The forwarded text already names the caller (`@caller: …`, built on the caller's
@@ -5665,24 +5680,26 @@ export class Daemon {
    * orchestration correlation.
    */
   /**
-   * Side-effect-free preflight for a peer wake — returns the typed reason {@link messageAgent}
-   * would reject this wake with for a LOCALLY-decidable cause, else null. `sendMessage` uses it
-   * to avoid leaving a visible channel post for a `toAgent`+`channel` wake that will never be
-   * delivered. MUST stay in sync with the fail-closed guards in {@link messageAgent}: a reason
-   * added there but not here would let a doomed wake still post. A remote target's LOCAL
-   * agent config is not readable here (that verdict lives on the owning daemon) — but the
-   * org-scoped directory below covers a remote target too, because the CP snapshot is
-   * org-wide rather than per-daemon.
+   * Side-effect-free authorization for a peer wake on the SAME-DAEMON path — the typed reason
+   * {@link messageAgent} would reject it with for a LOCALLY-decidable cause, or, when it is
+   * admitted, the CHANNEL the woken session may key off. `sendMessage` uses the rejection half
+   * as a preflight, so it never leaves a visible channel post for a `toAgent`+`channel` wake
+   * that will never be delivered; `messageAgent` uses BOTH halves, which is why they are one
+   * method — a coordinate decided twice could be decided differently. MUST stay in sync with
+   * the fail-closed guards in {@link messageAgent}: a reason added there but not here would let
+   * a doomed wake still post. A remote target's LOCAL agent config is not readable here (that
+   * verdict lives on the owning daemon) — but the org-scoped directory below covers a remote
+   * target too, because the CP snapshot is org-wide rather than per-daemon.
    *
    * Two independent checks, in order: the directional call POLICY (`admits`, channel-free)
-   * and the COORDINATE INTEGRITY of `req.channel` (`coordsAdmit`). Dropping channel from
+   * and the COORDINATE INTEGRITY of `req.channel` (`coordsDecision`). Dropping channel from
    * the policy predicate did not drop it as a session coordinate, and this is the
    * same-daemon twin of the relay/terminal-verify gate.
    */
-  private localWakeAuthorizationRejection(req: MessageAgentReq): string | null {
+  private localWakeDecision(req: MessageAgentReq): { rejection: string } | { rejection: null; channel: string } {
     const caller = this.agents.get(req.callerAgentId)
     if (!caller || (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(req.toAgentId))) {
-      return 'not_allowed'
+      return { rejection: 'not_allowed' }
     }
 
     // A local id is not sufficient authority: the org-scoped directional call policy must
@@ -5692,29 +5709,36 @@ export class Daemon {
     // BEFORE the local-target lookup so it also decides a REMOTE target and an id that is
     // in no directory at all (previously the latter fell through to a misleading
     // 'offline'). Fails closed on an absent/stale snapshot, as before.
-    if (!this.cpCollab.admits(req.callerAgentId, req.toAgentId)) return 'not_allowed'
+    if (!this.cpCollab.admits(req.callerAgentId, req.toAgentId)) return { rejection: 'not_allowed' }
 
-    // COORDINATE INTEGRITY — the SAME predicate the relay's ingress and this daemon's
+    // COORDINATE INTEGRITY — the SAME decision the relay's ingress and this daemon's
     // `rd/agentmsg` terminal-verify apply, so all three wake paths enforce one rule. Channel
     // stopped AUTHORIZING the call, but `req.channel` (a model-supplied `to.channel`, or the
     // turn's own channel) is still the woken peer's session coordinate, so without this a
     // model could name a channel its agent cannot reach and RESUME a co-located peer's
     // session there. Org comes from the caller's own directory entry, never from the
     // request; `admits` above already proved the entry exists, so undefined is unreachable
-    // and fails closed anyway. STRICTLY WEAKER than the membership check this replaced,
-    // which demanded caller AND target in the channel and so rejected every wake from a
-    // session with no channel row (webchat/hook/dream) — the case this PR exists to allow.
+    // and fails closed anyway.
+    //
+    // The platform is the RAW trusted session platform, deliberately NOT `narrowPlatform`'s
+    // output: that helper folds `dream` (and any value the NormalizedMessage union does not
+    // carry) into 'slack', which would classify a genuinely channel-free session as a
+    // persisted IM coordinate and fail it closed. Only the branch-2/branch-3 split reads the
+    // platform at all — the row lookup itself stays platform-free — so passing the raw value
+    // cannot re-open the platform-relabelling dodge.
     const callerOrg = this.cpCollab.orgForAgent(req.callerAgentId)
-    if (callerOrg === undefined || !this.cpCollab.coordsAdmit(callerOrg, req.channel, req.callerAgentId)) {
-      return 'not_allowed'
-    }
+    if (callerOrg === undefined) return { rejection: 'not_allowed' }
+    const coords = this.cpCollab.coordsDecision(callerOrg, req.platform, req.channel, req.callerAgentId)
+    if (coords.verdict === 'reject') return { rejection: 'not_allowed' }
 
     const target = this.agents.get(req.toAgentId)
-    if (!target) return null
-    if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(req.callerAgentId)) {
-      return 'not_allowed'
+    if (target?.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(req.callerAgentId)) {
+      return { rejection: 'not_allowed' }
     }
-    return null
+    // Branch 3 substitutes the coordinate rather than refusing the wake; branch 1 hands back
+    // `req.channel` untouched so a wake into a shared channel still lands in the thread a
+    // human sees.
+    return { rejection: null, channel: coords.verdict === 'synthetic' ? coords.channel : req.channel }
   }
 
   private wakeRejectionReason(req: MessageAgentReq): string | null {
@@ -5733,7 +5757,7 @@ export class Daemon {
     )
     const inbound = this.activeTurnCallMeta.get(callerKey)
     if (inbound !== undefined && inbound.hopCount >= MAX_AGENT_CALL_HOPS) return 'hop_limit'
-    return this.localWakeAuthorizationRejection(req)
+    return this.localWakeDecision(req).rejection
   }
 
   private async messageAgent(req: MessageAgentReq): Promise<MessageAgentResult> {
@@ -5834,13 +5858,23 @@ export class Daemon {
     const integrationId = resolved?.integrationId
     const targetTransportScope =
       integrationId !== undefined ? this.transportScopeForIntegrationIds([integrationId]) : undefined
+    // The same side-effect-free authorization sendMessage's preflight ran (caller existence +
+    // outbound policy, the org-scoped directional call policy, a local target's inbound policy,
+    // and COORDINATE INTEGRITY). It is resolved BEFORE the coordinate is minted because it also
+    // decides WHICH channel may be minted: a channel-free coordinate the snapshot knows nothing
+    // about is admitted but must not become the session key, so `localWakeDecision` hands back a
+    // caller-derived channel (`a2a:<callerAgentId>`) that cannot alias any platform session. The
+    // rejection path keeps reporting the ASSERTED channel — nothing was opened, and the reason,
+    // not the coordinate, is what the caller acts on.
+    const wake = this.localWakeDecision(req)
+    const coordChannel = wake.rejection === null ? wake.channel : req.channel
     // A2A delivery is direct and postless (#854): the woken peer receives a caller-framed
     // message and nothing is left in any channel. session-concept case 2c (pure wake) is thus
     // the default — a `sendMessage` with `toAgent` never posts, regardless of `channel`.
     const event = this.prepareAgentDelivery(req)
     const { deliveryId } = event
-    const msgId = `agentcall:${req.channel}:${deliveryId}`
-    const targetSession = sessionKey(platform, req.channel, event.thread, req.toAgentId, targetTransportScope)
+    const msgId = `agentcall:${coordChannel}:${deliveryId}`
+    const targetSession = sessionKey(platform, coordChannel, event.thread, req.toAgentId, targetTransportScope)
 
     const prior = this.agentCallDeliveries.get(deliveryId)
     if (prior) return observe('collaboration.delivery.deduplicated', prior, deliveryId)
@@ -5854,10 +5888,7 @@ export class Daemon {
       )
     }
 
-    // Repeat the same side-effect-free authorization used by sendMessage's
-    // preflight. This covers caller existence/outbound policy, the org-scoped
-    // directional call policy, and a local target's inbound policy before any local wake.
-    if (this.localWakeAuthorizationRejection(req) !== null) {
+    if (wake.rejection !== null) {
       this.log.info(`messageAgent: ${req.callerAgentId} not allowed to call ${req.toAgentId} in ${req.channel}`)
       return record({ delivered: false, targetSession, reason: 'not_allowed' })
     }
@@ -5870,6 +5901,9 @@ export class Daemon {
         { ...req, text: event.text, thread: event.thread },
         {
           platform: coordPlatform,
+          // The ASSERTED coordinate, not `coordChannel`: the relay validates what the caller
+          // named, and the OWNING daemon mints the session key (and any channel-free
+          // substitution) — we take that canonical key back off the ACK below.
           channel: req.channel,
           thread: event.thread,
           deliveryId,
@@ -5930,8 +5964,10 @@ export class Daemon {
       msgId,
       traceId: deliveryId,
       source: 'agent',
+      // `coordChannel`, so the dispatched turn lands on exactly the key `targetSession`
+      // reports (identical to `req.channel` outside the channel-free branch).
       platform,
-      channel: req.channel,
+      channel: coordChannel,
       thread: event.thread,
       ...(targetTransportScope !== undefined ? { transportScope: targetTransportScope } : {}),
       sender: { id: req.callerAgentId, isBot: true },

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -59,7 +59,7 @@ export interface SessionContext {
   agentId: string
   /** The platform that triggered this session (slack/telegram/…). Trusted — set
    *  by the daemon from the real triggering message, never a tool input. Used to
-   *  build the coords for peer-discovery (`listChannelAgents`). */
+   *  build the coords for peer-discovery (`listAgents`). */
   platform: string
   /** The exact platform integration that delivered this session. Absent for a
    *  platform-free session; daemon-local universal tools still work there. */
@@ -279,6 +279,23 @@ export const MEMORY_WRITE_BLOCKED =
   'This session is private, so it cannot write to the agent memory shared with other users. Keep the information in ' +
   'this conversation instead; do not retry.'
 
+/**
+ * A peer-discovery request, i.e. `ChannelAgentsReq` plus the caller's own session
+ * coordinates. `channel` is what the AGENT asked for (absent ⇒ the org-wide directory);
+ * every `current*` field is the TRUSTED session context, never tool input, carried
+ * separately for two daemon-side jobs:
+ *  - substituting the current channel when the CP does not advertise
+ *    `agent-directory-org-scope-v1` (an old CP rejects a channel-less payload), and
+ *  - resolving the caller's LOGICAL sessionKey, so the daemon can recognize a turn whose
+ *    discovery scope it FIXED itself (the self-introduce-on-join turn, whose fan-out must
+ *    stay bounded to the joined channel however the model calls the tool).
+ */
+export interface ChannelAgentsRequest extends ChannelAgentsReq {
+  currentChannel?: string
+  currentThread?: string
+  currentTransportScope?: string
+}
+
 export interface OpsDeps {
   /** Fail-closed turn gate checked before every daemon bridge tool. Used to make
    *  pause/cancel/loop interrupts terminal even while the runtime is still unwinding. */
@@ -295,11 +312,12 @@ export interface OpsDeps {
    *  Backs `listKnownUsers` so an agent can find a user id to DM where there is no
    *  user directory to search. */
   observedUsers?: (agentId: string, platform: string) => { id: string; name?: string }[]
-  /** Ask the CP for the roster of agents in a channel (peer discovery). The daemon
-   *  fills `requesterAgentId` from the trusted session context, never tool input.
-   *  Rejects (throws) when the control plane isn't connected — discovery fails
-   *  closed rather than returning a partial/empty roster. */
-  channelAgents: (req: ChannelAgentsReq) => Promise<ChannelAgentsOk>
+  /** Ask the CP for the caller's callable peers (peer discovery). The daemon fills
+   *  `requesterAgentId` from the trusted session context, never tool input. An absent
+   *  `channel` asks for the ORG-WIDE directory; a present one narrows it to that
+   *  channel. Rejects (throws) when the control plane isn't connected — discovery
+   *  fails closed rather than returning a partial/empty roster. */
+  channelAgents: (req: ChannelAgentsRequest) => Promise<ChannelAgentsOk>
   /** Deliver a message into another agent's session (agent→agent wake). The daemon
    *  fills the trusted caller identity from the session context; this callback owns
    *  the same-daemon delivery (policy check, coord/integration resolution, dispatch)
@@ -648,18 +666,33 @@ export async function executeTool(
     }
   }
 
-  // Peer discovery is daemon→CP (not a platform gateway op) and coords-level, so it
-  // is handled before the gateway gate — a memory-only agent can still discover peers.
+  // Peer discovery is daemon→CP (not a platform gateway op) and org-level, so it is
+  // handled before the gateway gate — a memory-only agent can still discover peers.
+  // `channel` is now an OPTIONAL FILTER with NO default: omitted ⇒ the org-wide
+  // directory of peers the call policy admits, which is the only scope a session with
+  // no IM integration (webchat, hook, dream) can be listed in at all. `listChannelAgents`
+  // stays a working alias so sessions already warm with the old tool set keep working.
   // SECURITY: requesterAgentId + platform come from the trusted session context, never
-  // from tool input; only `channel` may be overridden (defaults to the current channel).
-  if (name === 'listChannelAgents') {
-    const channel = optionalString(args, 'channel') ?? ctx.channel
+  // from tool input; `channel` is the only agent-supplied field, and it can only narrow —
+  // and even that is overridden for a turn the daemon itself scoped (see the `current*`
+  // coords below / ChannelAgentsRequest).
+  if (name === 'listAgents' || name === 'listChannelAgents') {
+    const channel = optionalString(args, 'channel')
     const res = await deps.channelAgents({
       platform: ctx.platform as Platform,
-      channel,
+      ...(channel !== undefined ? { channel } : {}),
+      // Trusted coordinates, not a scope request — see ChannelAgentsRequest (they carry the
+      // old-CP fallback channel and identify THIS turn for a daemon-fixed discovery scope).
+      currentChannel: ctx.channel,
+      currentThread: ctx.thread,
+      ...(ctx.transportScope !== undefined ? { currentTransportScope: ctx.transportScope } : {}),
       requesterAgentId: ctx.agentId
     })
-    return { platform: res.platform, channel: res.channel, agents: res.agents }
+    return {
+      platform: res.platform,
+      ...(res.channel !== undefined ? { channel: res.channel } : {}),
+      agents: res.agents
+    }
   }
 
   // Unified outbound send (session-concept §3). One tool merges the old `sendPlatformMessage`

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -97,7 +97,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
               minLength: 1,
               title: 'Agent id',
               description:
-                'AgentConnect agent id from listChannelAgents or the [agent-id] sender envelope. Never a platform ' +
+                'AgentConnect agent id from listAgents or the [agent-id] sender envelope. Never a platform ' +
                 'member id such as Slack `U…`.'
             },
             {
@@ -108,7 +108,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
                     type: 'string',
                     minLength: 1,
                     description:
-                      'AgentConnect agent id from listChannelAgents or the [agent-id] sender envelope. Never a ' +
+                      'AgentConnect agent id from listAgents or the [agent-id] sender envelope. Never a ' +
                       'platform member id such as Slack `U…`.'
                   },
                   needsReply: {
@@ -206,7 +206,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'form:\n' +
         '- Peer agent (direct wake): `{"to":{"toAgent":"<agent id>"},"message":"..."}` is a postless wake. Add a ' +
         '`channel` (and optional `thread`) to also post a visible message and thread the peer’s reply there. Get the ' +
-        'id from listChannelAgents and send one call per peer; never substitute a platform member id. When the wake ' +
+        'id from listAgents and send one call per peer; never substitute a platform member id. When the wake ' +
         'opens a session for the peer, the result carries its `childSessionId` — pass that to `viewSessionStatus` to ' +
         'check whether the peer is still working. Use ' +
         '`{"to":{"toAgent":{"agentId":"<agent id>","needsReply":true}},"message":"..."}` to also instruct that ' +
@@ -302,7 +302,7 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
       description:
         'List the platform users and bot accounts in a channel/chat (id, name, is_bot) — the way to discover a HUMAN ' +
         'user id to @mention or DM. This is NOT how you find peer AI agents to collaborate with: it returns raw ' +
-        'platform member accounts (including unrelated bots), not AgentConnect agents — use `listChannelAgents` for ' +
+        'platform member accounts (including unrelated bots), not AgentConnect agents — use `listAgents` for ' +
         '"the agents in this channel". Pass `platform` to target another connected platform and `integrationId` to ' +
         'choose a specific bot; omit `channel` to use the current conversation (same platform only). Note: Telegram ' +
         'only exposes administrators for large groups.',
@@ -537,30 +537,45 @@ export const EXTERNAL_MEMORY_TOOL_NAMES = new Set(
 
 /**
  * Agent-collaboration tools — available to EVERY agent regardless of platform
- * (discovery is org/coords-level, not platform-gated). `listChannelAgents` asks
- * the CP who else is in the current channel so an agent can find peers to work
- * with. Waking a peer is no longer a separate tool: it is `sendMessage` with
- * `to.toAgent` (session-concept §4). The requesting agent's identity is injected
- * by the daemon from the session context — it is NOT a tool input.
+ * (discovery is org-level, not platform- or channel-gated). `listAgents` asks the CP
+ * which peers this agent may reach in its organization so it can find someone to work
+ * with; channel membership is only an optional filter on that answer. Waking a peer is
+ * no longer a separate tool: it is `sendMessage` with `to.toAgent` (session-concept §4).
+ * The requesting agent's identity is injected by the daemon from the session context —
+ * it is NOT a tool input.
  */
+const LIST_AGENTS_INPUT_SCHEMA = () =>
+  obj({
+    channel: {
+      type: 'string',
+      description:
+        'OPTIONAL filter: only list agents present in this channel/chat. Omit to list every agent you can reach.'
+    }
+  })
+
+const LIST_AGENTS_DESCRIPTION =
+  'List the other AI agents you can work with — their id, name, displayName, description, and status — so you ' +
+  'can discover peers to collaborate with. By DEFAULT this lists every agent in your organization that you are ' +
+  'allowed to reach, whether or not it shares a channel with you. This is the canonical meaning of "the agents ' +
+  'here": whenever you are asked to greet, message, collaborate with, or delegate to the agents/peers around you, ' +
+  'discover them with THIS tool — NOT `listChannelMembers` (which lists platform user/bot accounts, not ' +
+  'AgentConnect agents). Then reach each one with `sendMessage` using ' +
+  '`{"to":{"toAgent":"<agent id>"},"message":"..."}` (a direct, postless wake), rather than @mentioning member ids ' +
+  'in a channel post. Pass `channel` only as a FILTER, to narrow the list to the agents present in that channel. ' +
+  'Only agents you are allowed to reach are returned.'
+
 export const COLLABORATION_TOOLS: ToolDescriptor[] = [
   {
+    name: 'listAgents',
+    description: LIST_AGENTS_DESCRIPTION,
+    inputSchema: LIST_AGENTS_INPUT_SCHEMA()
+  },
+  {
+    // Kept so a session already warm with the old tool set (and prompts/skills that
+    // learned the old name) keeps working; the daemon routes both names to one handler.
     name: 'listChannelAgents',
-    description:
-      'List the other AI agents present in a channel — their id, name, displayName, description, and status — so you ' +
-      'can discover peers to collaborate with. This is the canonical meaning of "the agents in this channel": whenever ' +
-      'you are asked to greet, message, collaborate with, or delegate to the agents/peers here, discover them with THIS ' +
-      'tool — NOT `listChannelMembers` (which lists platform user/bot accounts, not AgentConnect agents). Then reach ' +
-      'each one with `sendMessage` using `{"to":{"toAgent":"<agent id>"},"message":"..."}` (a direct, postless ' +
-      'wake), rather than @mentioning member ids in a channel post. Omit `channel` to list agents in the channel this ' +
-      'conversation is happening in. Only channels you are a member of can be listed, and only agents you are allowed ' +
-      'to reach are returned.',
-    inputSchema: obj({
-      channel: {
-        type: 'string',
-        description: 'Channel/chat id to list agents for. Defaults to the current channel.'
-      }
-    })
+    description: `Deprecated alias of \`listAgents\` — prefer that name. ${LIST_AGENTS_DESCRIPTION}`,
+    inputSchema: LIST_AGENTS_INPUT_SCHEMA()
   },
   {
     name: 'viewSessionStatus',

--- a/packages/daemon/test/channel-intro.test.ts
+++ b/packages/daemon/test/channel-intro.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { planChannelIntros, buildIntroMessage, introPrompt, INTRO_MAX_BURST } from '../src/agents/channel-intro.js'
+import { Daemon } from '../src/daemon.js'
 
 const state = (seeded: boolean, introduced: string[] = []) => ({ seeded, introduced: new Set(introduced) })
 
@@ -57,13 +61,13 @@ describe('buildIntroMessage', () => {
     expect(msg.source).toBe('cron')
     expect(msg.platform).toBe('slack')
     // keyed to the REAL channel (headless ⇒ no channel output; ctx.channel drives
-    // listChannelAgents/sendMessage defaults and gives peers a real channel to inherit)
+    // sendMessage defaults and gives peers a real channel to inherit)
     expect(msg.channel).toBe('C1')
     // a distinct synthetic thread === transcriptTs (root) so no thread-history backfill runs
     expect(msg.thread).toBe(msg.transcriptTs)
     expect(msg.thread).toBe('intro:C1:trace-1')
     expect(msg.text).toContain('bot-a')
-    expect(msg.text).toContain('listChannelAgents')
+    expect(msg.text).toContain('listAgents')
     // Waking a peer is now a complete sendMessage agent-target call (a silent wake), not messageAgent.
     expect(msg.text).toContain('sendMessage')
     expect(msg.text).toContain('{"to":{"toAgent":"<their id>"},"message":"<short introduction>"}')
@@ -78,6 +82,17 @@ describe('introPrompt', () => {
     expect(p).toContain('do not post to the channel')
   })
 
+  // `listAgents` now defaults to the whole ORG directory, so the discovery step MUST pin
+  // the channel explicitly — otherwise one channel join fans an intro out to every agent
+  // in the organization.
+  it('pins discovery to THIS channel with an explicit filter (never the org-wide default)', () => {
+    const p = introPrompt('C1', 'bot-a')
+    expect(p).toContain('`listAgents`')
+    expect(p).toContain('{"channel":"C1"}')
+    expect(p).not.toContain('listChannelAgents')
+    expect(p).not.toContain('defaults to this channel')
+  })
+
   it('gives a complete sendMessage agent-target call (silent wake), not dotted pseudo-syntax', () => {
     const p = introPrompt('C1', 'bot-a')
     expect(p).toContain('sendMessage')
@@ -85,5 +100,75 @@ describe('introPrompt', () => {
     expect(p).toContain('silent wake')
     expect(p).not.toContain('to.toAgent')
     expect(p).not.toContain('messageAgent')
+  })
+})
+
+/**
+ * The prompt above asks the model for a channel filter; this is the part that does not
+ * depend on the model obeying. The dispatched intro turn carries `introChannel` on its
+ * trusted CallMeta, which the daemon's `channelAgents` dep turns into a forced filter —
+ * without it the org-wide default would wake every agent in the org on one channel join.
+ */
+describe('Daemon.maybeIntroduceOnJoin: the intro turn carries its own discovery bound', () => {
+  function scaffold(): string {
+    const root = mkdtempSync(join(tmpdir(), 'ac-daemon-intro-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: ['unused'] } }
+      })
+    )
+    const adir = join(root, 'agents', 'bot-a')
+    mkdirSync(adir, { recursive: true })
+    writeFileSync(
+      join(adir, 'agent.json'),
+      JSON.stringify({
+        id: 'bot-a',
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+        // No integration on disk: the in-memory record below stands in for one, so the
+        // test never opens a real Slack socket.
+        integrations: [],
+        output: { mode: 'low' }
+      })
+    )
+    return root
+  }
+
+  it('stamps the joined channel on the dispatched turn’s CallMeta', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => ({}) as never })
+    await daemon.start()
+    const agent = (daemon as never as { agents: Map<string, Record<string, unknown>> }).agents.get('bot-a')!
+    agent.integrations = [{ id: 'int-1', platform: 'slack' }]
+    agent.introduceOnJoin = true
+    const calls: { agentId: string; msg: { channel: string }; callMeta?: { introChannel?: string } }[] = []
+    ;(daemon as never as { dispatch: unknown }).dispatch = async (
+      agentId: string,
+      msg: { channel: string },
+      _integrationId?: string,
+      _wc?: unknown,
+      callMeta?: { introChannel?: string }
+    ) => {
+      calls.push({ agentId, msg, callMeta })
+      return 'acp-1'
+    }
+    const introduce = (channels: string[]): void =>
+      (daemon as never as { maybeIntroduceOnJoin: (i: string, c: { id: string }[]) => void }).maybeIntroduceOnJoin(
+        'int-1',
+        channels.map((id) => ({ id }))
+      )
+    // First snapshot seeds the baseline silently; only a LATER channel is a genuine join.
+    introduce(['C_OLD'])
+    expect(calls).toHaveLength(0)
+    introduce(['C_OLD', 'C_JOINED'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.msg.channel).toBe('C_JOINED')
+    // THE bound: peer discovery in this turn is pinned to the joined channel in CODE.
+    expect(calls[0]!.callMeta?.introChannel).toBe('C_JOINED')
+    await daemon.stop()
   })
 })

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { CpCollabRoutes } from '../../src/cp/cp-collab-routes.js'
+import { Daemon } from '../../src/daemon.js'
+import { sessionKey } from '../../src/store/local-store.js'
+
+/**
+ * Org-scoped peer directory: `CpCollabRoutes.admits()` is THE agent-call authorization
+ * predicate (channel membership is only a discovery filter), plus the daemon-side
+ * `agent-directory-org-scope-v1` negotiation that keeps an older CP working.
+ */
+
+const ORG = 'org_a'
+const OTHER_ORG = 'org_b'
+
+const agent = (agentId: string, over: Record<string, unknown> = {}) => ({
+  agentId,
+  daemonId: 'd1',
+  orgId: ORG,
+  callPolicy: 'all' as const,
+  allowedCallerAgentIds: [] as string[],
+  outboundPolicy: 'all' as const,
+  allowedTargetAgentIds: [] as string[],
+  ...over
+})
+
+const routes = (agents: ReturnType<typeof agent>[], channels: unknown[] = []): CpCollabRoutes => {
+  const r = new CpCollabRoutes()
+  r.replace({ generation: 1, channels, agents } as never)
+  return r
+}
+
+describe('CpCollabRoutes: org-scoped directory', () => {
+  it('admits a pair whose policies are both "all", in either direction', () => {
+    const r = routes([agent('a'), agent('b')])
+    expect(r.admits('a', 'b')).toBe(true)
+    expect(r.admits('b', 'a')).toBe(true)
+    expect(r.orgForAgent('a')).toBe(ORG)
+    expect(r.agent('b')?.daemonId).toBe('d1')
+  })
+
+  it('needs BOTH directions: the target inbound policy and the caller outbound policy', () => {
+    const inbound = routes([agent('a'), agent('b', { callPolicy: 'selected', allowedCallerAgentIds: ['c'] })])
+    expect(inbound.admits('a', 'b')).toBe(false)
+    expect(
+      routes([agent('a'), agent('b', { callPolicy: 'selected', allowedCallerAgentIds: ['a'] })]).admits('a', 'b')
+    ).toBe(true)
+
+    const outbound = routes([agent('a', { outboundPolicy: 'selected', allowedTargetAgentIds: ['c'] }), agent('b')])
+    expect(outbound.admits('a', 'b')).toBe(false)
+    expect(
+      routes([agent('a', { outboundPolicy: 'selected', allowedTargetAgentIds: ['b'] }), agent('b')]).admits('a', 'b')
+    ).toBe(true)
+  })
+
+  it('always resolves the caller ITSELF, even under a selected policy that omits it', () => {
+    // An agent restricted in both directions does not list itself in its own allow-lists,
+    // yet it must still appear in its own directory listing.
+    const r = routes([
+      agent('a', {
+        callPolicy: 'selected',
+        allowedCallerAgentIds: ['z'],
+        outboundPolicy: 'selected',
+        allowedTargetAgentIds: ['z']
+      })
+    ])
+    expect(r.admits('a', 'a')).toBe(true)
+  })
+
+  it('never resolves across organizations, whatever the policies say', () => {
+    const r = routes([agent('a'), agent('b', { orgId: OTHER_ORG })])
+    expect(r.admits('a', 'b')).toBe(false)
+    expect(r.admits('b', 'a')).toBe(false)
+  })
+
+  it('fails CLOSED when either agent is unknown, or the snapshot is empty', () => {
+    const r = routes([agent('a')])
+    expect(r.admits('a', 'ghost')).toBe(false)
+    expect(r.admits('ghost', 'a')).toBe(false)
+    expect(r.orgForAgent('ghost')).toBeUndefined()
+    expect(new CpCollabRoutes().admits('a', 'b')).toBe(false)
+  })
+
+  it('OLD CP (no flat agents[]): derives the directory from the channel entries', () => {
+    // Channel entries carry orgId + placements, so integration-backed agents stay callable —
+    // even across two different channels, since membership is no longer a gate.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [
+        { orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] },
+        { orgId: ORG, platform: 'slack', channelId: 'C2', agents: [agent('b')] },
+        { orgId: OTHER_ORG, platform: 'slack', channelId: 'C9', agents: [agent('x', { orgId: OTHER_ORG })] }
+      ]
+    } as never)
+    expect(r.admits('a', 'b')).toBe(true)
+    expect(r.orgForAgent('b')).toBe(ORG)
+    expect(r.admits('a', 'x')).toBe(false)
+    // The channel-keyed lookups other call sites use keep working, so coordinate integrity
+    // is enforced against an old CP's derived snapshot exactly as against a current one.
+    expect(r.coordsAdmit(ORG, 'C1', 'a')).toBe(true)
+    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
+  })
+
+  it('coordsAdmit gates a KNOWN coordinate on caller membership and passes an unknown one', () => {
+    // The coordinate-integrity gate for a wake: a KNOWN coordinate demands caller membership,
+    // an UNKNOWN one is no claim about a shared IM channel. An EMPTY row is not "known" —
+    // nobody in this org can reach it, so gating on it would protect nothing.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [
+        { orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] },
+        { orgId: ORG, platform: 'slack', channelId: 'C_EMPTY', agents: [] }
+      ],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    expect(r.coordsAdmit(ORG, 'C1', 'a')).toBe(true)
+    // 'b' is a callable directory-only peer, but it cannot ASSERT C1 as a coordinate.
+    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
+    expect(r.coordsAdmit(ORG, 'C_EMPTY', 'b')).toBe(true)
+    expect(r.coordsAdmit(ORG, 'C_NEVER_SEEN', 'b')).toBe(true)
+    expect(r.coordsAdmit(ORG, 'wc-1', 'b')).toBe(true)
+    // Org-scoped like every other lookup here: another org's row is not this org's coordinate.
+    expect(r.coordsAdmit(OTHER_ORG, 'C1', 'b')).toBe(true)
+    // A directory-only agent (no channel row) is callable but reaches no channel coordinate.
+    expect(r.resolve(ORG, 'slack', 'C1', 'b')).toBeUndefined()
+  })
+
+  it('coordsAdmit ignores the coordinate PLATFORM — the session key narrows it away', () => {
+    // `Daemon.narrowPlatform` folds `feishu` (and any unrecognised value) into 'slack' when
+    // computing the woken session key, while snapshot rows are keyed by the INTEGRATION
+    // platform. A platform-keyed check therefore searched a different key space than the key
+    // it protects, and "unknown coordinate passes" swallowed the mismatch in BOTH directions.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [
+        { orgId: ORG, platform: 'slack', channelId: 'C_EXECS', agents: [agent('b')] },
+        { orgId: ORG, platform: 'feishu', channelId: 'oc_execs', agents: [agent('b')] }
+      ],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    // (1) A Slack row asserted as 'feishu' coords — still that Slack channel's coordinate.
+    expect(r.coordsAdmit(ORG, 'C_EXECS', 'a')).toBe(false)
+    expect(r.coordsAdmit(ORG, 'C_EXECS', 'b')).toBe(true)
+    // (2) The mirror: a Feishu org, where an honest daemon narrows its own coords to 'slack'.
+    expect(r.coordsAdmit(ORG, 'oc_execs', 'a')).toBe(false)
+    expect(r.coordsAdmit(ORG, 'oc_execs', 'b')).toBe(true)
+  })
+
+  it('coordsAdmit accepts membership in ANY platform row sharing one channel id', () => {
+    // Two platforms colliding on one channel id inside one org is not a real configuration,
+    // but the rule must stay a membership test rather than an accidental reject-all.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [
+        { orgId: ORG, platform: 'slack', channelId: 'SHARED', agents: [agent('a')] },
+        { orgId: ORG, platform: 'telegram', channelId: 'SHARED', agents: [agent('b')] }
+      ],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    expect(r.coordsAdmit(ORG, 'SHARED', 'a')).toBe(true)
+    expect(r.coordsAdmit(ORG, 'SHARED', 'b')).toBe(true)
+    expect(r.coordsAdmit(ORG, 'SHARED', 'c')).toBe(false)
+  })
+
+  it('FULL-REPLACE rebuilds the coordinate index too', () => {
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
+    // The channel is gone from the newer snapshot — the stale row must not linger and keep
+    // rejecting (nor keep gating, which is the fail-OPEN half of the same staleness).
+    r.replace({ generation: 2, channels: [], agents: [agent('a'), agent('b')] } as never)
+    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(true)
+  })
+
+  it('FULL-REPLACE applies to the flat index too — a later snapshot drops removed agents', () => {
+    const r = routes([agent('a'), agent('b')])
+    r.replace({ generation: 2, channels: [], agents: [agent('a')] } as never)
+    expect(r.admits('a', 'b')).toBe(false)
+    expect(r.orgForAgent('b')).toBeUndefined()
+  })
+})
+
+/** Minimal daemon root — enough to boot and read the MCP deps bundle. */
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-daemon-directory-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', 'bot-a')
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+  )
+  return root
+}
+
+describe("daemon channelAgents dep: 'agent-directory-org-scope-v1' negotiation", () => {
+  async function bootWithCp(supports: boolean) {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => ({}) as never })
+    await daemon.start()
+    const sent: unknown[] = []
+    ;(daemon as never as { cpClient: unknown }).cpClient = {
+      stop: vi.fn(async () => {}),
+      supportsServerFeature: (feature: string) => supports && feature === 'agent-directory-org-scope-v1',
+      channelAgents: async (payload: { channel?: string }) => {
+        sent.push(payload)
+        return {
+          platform: 'slack',
+          ...(payload.channel !== undefined ? { channel: payload.channel } : {}),
+          agents: [{ agentId: 'peer-1', name: 'peer', displayName: 'Peer', status: 'active' as const }]
+        }
+      }
+    }
+    const dep = (daemon as never as { mcp: { deps: { channelAgents: (req: unknown) => Promise<unknown> } } }).mcp.deps
+      .channelAgents
+    return { daemon, sent, dep }
+  }
+
+  it('sends a channel-LESS request when the CP advertises the feature', async () => {
+    const { daemon, sent, dep } = await bootWithCp(true)
+    const ok = (await dep({
+      platform: 'slack',
+      currentChannel: 'C_CURRENT',
+      requesterAgentId: 'bot-a'
+    })) as { channel?: string }
+    expect(sent).toEqual([{ platform: 'slack', requesterAgentId: 'bot-a' }])
+    expect(ok.channel).toBeUndefined()
+    // The peer's directory name is still cached for caller-framed delivery text.
+    expect((daemon as never as { channelAgentNames: Map<string, unknown> }).channelAgentNames.get('peer-1')).toEqual({
+      name: 'peer',
+      displayName: 'Peer'
+    })
+    await daemon.stop()
+  })
+
+  it('substitutes the caller CURRENT channel against an old CP (never a payload it would reject)', async () => {
+    const { daemon, sent, dep } = await bootWithCp(false)
+    await dep({ platform: 'slack', currentChannel: 'C_CURRENT', requesterAgentId: 'bot-a' })
+    expect(sent).toEqual([{ platform: 'slack', requesterAgentId: 'bot-a', channel: 'C_CURRENT' }])
+    await daemon.stop()
+  })
+
+  it('passes an explicitly requested channel filter through to either CP', async () => {
+    for (const supports of [true, false]) {
+      const { daemon, sent, dep } = await bootWithCp(supports)
+      await dep({ platform: 'slack', channel: 'C_OTHER', currentChannel: 'C_CURRENT', requesterAgentId: 'bot-a' })
+      expect(sent).toEqual([{ platform: 'slack', channel: 'C_OTHER', requesterAgentId: 'bot-a' }])
+      await daemon.stop()
+    }
+  })
+
+  /**
+   * #536 fan-out bound. `listAgents` defaults to the whole ORG, so a channel-intro turn
+   * that discovered peers org-wide would wake every agent in the organization on one
+   * channel join. The prompt asks for a channel filter, but the BOUND has to be in code:
+   * the daemon forces the joined channel from the turn's trusted CallMeta.
+   */
+  describe('self-introduce turn: the joined channel is FORCED, not requested', () => {
+    const INTRO_THREAD = 'intro:C_JOINED:trace-1'
+    /** Install the active-turn CallMeta `dispatch` would have installed for an intro turn. */
+    function markIntroTurn(daemon: unknown, channel: string, thread = INTRO_THREAD): void {
+      ;(daemon as { activeTurnCallMeta: Map<string, unknown> }).activeTurnCallMeta.set(
+        sessionKey('slack', channel, thread, 'bot-a'),
+        { callFrom: 'bot-a', hopCount: 0, deliveryId: 'trace-1', deliverHeadless: true, introChannel: channel }
+      )
+    }
+
+    it('forces the joined channel when the tool args are EMPTY (model non-compliance)', async () => {
+      const { daemon, sent, dep } = await bootWithCp(true)
+      markIntroTurn(daemon, 'C_JOINED')
+      const ok = (await dep({
+        platform: 'slack',
+        currentChannel: 'C_JOINED',
+        currentThread: INTRO_THREAD,
+        requesterAgentId: 'bot-a'
+      })) as { channel?: string }
+      // NOT the org-wide listing this same request would get on any other turn.
+      expect(sent).toEqual([{ platform: 'slack', channel: 'C_JOINED', requesterAgentId: 'bot-a' }])
+      expect(ok.channel).toBe('C_JOINED')
+      await daemon.stop()
+    })
+
+    it('overrides an intro turn that asks for a DIFFERENT channel', async () => {
+      const { daemon, sent, dep } = await bootWithCp(true)
+      markIntroTurn(daemon, 'C_JOINED')
+      await dep({
+        platform: 'slack',
+        channel: 'C_SOMEWHERE_ELSE',
+        currentChannel: 'C_JOINED',
+        currentThread: INTRO_THREAD,
+        requesterAgentId: 'bot-a'
+      })
+      expect(sent).toEqual([{ platform: 'slack', channel: 'C_JOINED', requesterAgentId: 'bot-a' }])
+      await daemon.stop()
+    })
+
+    it('leaves an ORDINARY turn on the same coordinates org-wide', async () => {
+      // The bound is per-turn (CallMeta), never per-channel: the agent's normal session in
+      // the very same channel still gets the whole org directory.
+      const { daemon, sent, dep } = await bootWithCp(true)
+      markIntroTurn(daemon, 'C_JOINED')
+      await dep({
+        platform: 'slack',
+        currentChannel: 'C_JOINED',
+        currentThread: '900.1',
+        requesterAgentId: 'bot-a'
+      })
+      expect(sent).toEqual([{ platform: 'slack', requesterAgentId: 'bot-a' }])
+      await daemon.stop()
+    })
+  })
+
+  /**
+   * An OLD CP throws on a session-identity platform reaching persistence (`toDbPlatform`),
+   * and `ws/connection.ts` turns that into close(1011) — the whole daemon↔CP control socket
+   * plus every in-flight request. The daemon must never manufacture such a payload; where it
+   * cannot ask, it answers locally.
+   */
+  describe('never sends a request the CP cannot answer', () => {
+    it('old CP + webchat session: answers an empty roster LOCALLY, sending nothing', async () => {
+      const { daemon, sent, dep } = await bootWithCp(false)
+      const ok = (await dep({
+        platform: 'webchat',
+        currentChannel: 'wc-session-1',
+        currentThread: 'wc-session-1',
+        requesterAgentId: 'bot-a'
+      })) as { platform: string; agents: unknown[] }
+      expect(sent).toEqual([])
+      expect(ok.platform).toBe('webchat')
+      expect(ok.agents).toEqual([])
+      await daemon.stop()
+    })
+
+    it('old CP + a session that does not know its channel: no channel-LESS request either', async () => {
+      // A channel-less REQ is a BAD_PAYLOAD against an old CP, so "I have no channel to
+      // narrow to" must not fall through to sending one anyway.
+      const { daemon, sent, dep } = await bootWithCp(false)
+      const ok = (await dep({ platform: 'slack', requesterAgentId: 'bot-a' })) as {
+        platform: string
+        channel?: string
+        agents: unknown[]
+      }
+      expect(sent).toEqual([])
+      expect(ok).toEqual({ platform: 'slack', agents: [] })
+      await daemon.stop()
+    })
+
+    it('a channel-FILTERED webchat/dream ask short-circuits locally on ANY CP', async () => {
+      // A current CP already answers this with an empty roster (its session-identity
+      // short-circuit); deciding it locally makes the answer independent of CP version.
+      for (const platform of ['webchat', 'dream']) {
+        const { daemon, sent, dep } = await bootWithCp(true)
+        const ok = (await dep({
+          platform,
+          channel: 'not-a-real-channel',
+          currentChannel: 'not-a-real-channel',
+          currentThread: 't',
+          requesterAgentId: 'bot-a'
+        })) as { platform: string; channel?: string; agents: unknown[] }
+        expect(sent).toEqual([])
+        expect(ok).toEqual({ platform, channel: 'not-a-real-channel', agents: [] })
+        await daemon.stop()
+      }
+    })
+  })
+
+  /**
+   * A hook turn's session platform is 'hook' but it lands on REAL Slack coordinates. Sending
+   * `platform:'hook'` with a channel hits the CP's session-identity short-circuit, so the
+   * agent is told nobody is there — while the identical call from a Slack-triggered session
+   * works. Map the coordinate the way the removed local wake check did.
+   */
+  describe('hook session: the channel coordinate is a SLACK one', () => {
+    it('sends platform slack for a channel-filtered ask, and echoes the session platform back', async () => {
+      const { daemon, sent, dep } = await bootWithCp(true)
+      const ok = (await dep({
+        platform: 'hook',
+        channel: 'C_SLACK',
+        currentChannel: 'C_SLACK',
+        currentThread: '900.1',
+        requesterAgentId: 'bot-a'
+      })) as { platform: string; channel?: string; agents: unknown[] }
+      expect(sent).toEqual([{ platform: 'slack', channel: 'C_SLACK', requesterAgentId: 'bot-a' }])
+      // NOT an empty roster: the CP was asked a question it can answer.
+      expect(ok.agents).toHaveLength(1)
+      // Everything else the agent sees about a hook turn calls it 'hook' — stay coherent.
+      expect(ok.platform).toBe('hook')
+      expect(ok.channel).toBe('C_SLACK')
+      await daemon.stop()
+    })
+
+    it('keeps the session platform on the channel-LESS (org-wide) ask, which asserts no coordinate', async () => {
+      const { daemon, sent, dep } = await bootWithCp(true)
+      await dep({ platform: 'hook', currentChannel: 'C_SLACK', currentThread: '900.1', requesterAgentId: 'bot-a' })
+      expect(sent).toEqual([{ platform: 'hook', requesterAgentId: 'bot-a' }])
+      await daemon.stop()
+    })
+
+    it('old CP + hook session: narrows to the REAL slack channel instead of a fatal payload', async () => {
+      const { daemon, sent, dep } = await bootWithCp(false)
+      await dep({ platform: 'hook', currentChannel: 'C_SLACK', currentThread: '900.1', requesterAgentId: 'bot-a' })
+      expect(sent).toEqual([{ platform: 'slack', channel: 'C_SLACK', requesterAgentId: 'bot-a' }])
+      await daemon.stop()
+    })
+  })
+})

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -100,14 +100,13 @@ describe('CpCollabRoutes: org-scoped directory', () => {
     expect(r.admits('a', 'x')).toBe(false)
     // The channel-keyed lookups other call sites use keep working, so coordinate integrity
     // is enforced against an old CP's derived snapshot exactly as against a current one.
-    expect(r.coordsAdmit(ORG, 'C1', 'a')).toBe(true)
-    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'a')).toEqual({ verdict: 'asserted' })
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'b')).toEqual({ verdict: 'reject' })
   })
 
-  it('coordsAdmit gates a KNOWN coordinate on caller membership and passes an unknown one', () => {
-    // The coordinate-integrity gate for a wake: a KNOWN coordinate demands caller membership,
-    // an UNKNOWN one is no claim about a shared IM channel. An EMPTY row is not "known" —
-    // nobody in this org can reach it, so gating on it would protect nothing.
+  it('coordsDecision: KNOWN coordinate ⇒ membership required, and it is used as asserted', () => {
+    // Branch 1. An EMPTY row is not "known" — nobody in this org can reach it, so gating on
+    // it would protect nothing (it falls through to the unknown-coordinate branches).
     const r = new CpCollabRoutes()
     r.replace({
       generation: 1,
@@ -117,22 +116,83 @@ describe('CpCollabRoutes: org-scoped directory', () => {
       ],
       agents: [agent('a'), agent('b')]
     } as never)
-    expect(r.coordsAdmit(ORG, 'C1', 'a')).toBe(true)
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'a')).toEqual({ verdict: 'asserted' })
     // 'b' is a callable directory-only peer, but it cannot ASSERT C1 as a coordinate.
-    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
-    expect(r.coordsAdmit(ORG, 'C_EMPTY', 'b')).toBe(true)
-    expect(r.coordsAdmit(ORG, 'C_NEVER_SEEN', 'b')).toBe(true)
-    expect(r.coordsAdmit(ORG, 'wc-1', 'b')).toBe(true)
-    // Org-scoped like every other lookup here: another org's row is not this org's coordinate.
-    expect(r.coordsAdmit(OTHER_ORG, 'C1', 'b')).toBe(true)
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'b')).toEqual({ verdict: 'reject' })
+    // Org-scoped like every other lookup here: another org's row is not this org's coordinate,
+    // so this is an UNKNOWN slack coordinate — which now fails closed rather than passing.
+    expect(r.coordsDecision(OTHER_ORG, 'slack', 'C1', 'b')).toEqual({ verdict: 'reject' })
     // A directory-only agent (no channel row) is callable but reaches no channel coordinate.
     expect(r.resolve(ORG, 'slack', 'C1', 'b')).toBeUndefined()
   })
 
-  it('coordsAdmit ignores the coordinate PLATFORM — the session key narrows it away', () => {
+  it('coordsDecision: an UNKNOWN coordinate on a PERSISTED IM platform FAILS CLOSED', () => {
+    // Branch 2 — the review finding. "Unknown ⇒ pass" admitted not only channel-free
+    // coordinates but Slack DMs/group DMs and channels whose row has since disappeared, which
+    // is exactly how a caller lands on an EXISTING platform session of the target and, with
+    // `needsReply`, reads it back. An unrecorded IM coordinate is now refused on every one of
+    // the four persisted platforms; a transient snapshot lag rejecting a genuine wake is the
+    // correct direction, and the caller retries.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    for (const platform of ['slack', 'telegram', 'discord', 'feishu']) {
+      expect(r.coordsDecision(ORG, platform, 'C_NEVER_SEEN', 'a')).toEqual({ verdict: 'reject' })
+      expect(r.coordsDecision(ORG, platform, 'D0PPELGANGER', 'a')).toEqual({ verdict: 'reject' })
+    }
+  })
+
+  it('coordsDecision: a DM row the caller owns is KNOWN, so DM-origin A2A keeps working', () => {
+    // The over-block guard. A DM or group DM is an ORDINARY channel row wherever one exists —
+    // `IntegrationChannel.kind` is `channel | im | mpim` and `channelPlacements` selects with
+    // no `kind` filter — so branch 1 covers it and fail-closed does not strand a caller whose
+    // session lives in a recorded DM. (Such a row is only written for a GATED integration's
+    // not-yet-enabled conversations; an ungated integration's DM has none and takes branch 2,
+    // which is what the channel-membership check this replaced did too — §2.7 item 5.) This
+    // case therefore only goes red if that premise breaks, which is exactly what it guards.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [
+        { orgId: ORG, platform: 'slack', channelId: 'D01ALICE', agents: [agent('a')] }, // a "D…" DM row
+        { orgId: ORG, platform: 'slack', channelId: 'G01TEAM', agents: [agent('a')] } // an mpim row
+      ],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    expect(r.coordsDecision(ORG, 'slack', 'D01ALICE', 'a')).toEqual({ verdict: 'asserted' })
+    expect(r.coordsDecision(ORG, 'slack', 'G01TEAM', 'a')).toEqual({ verdict: 'asserted' })
+    // …and someone else's DM is still not assertable.
+    expect(r.coordsDecision(ORG, 'slack', 'D01ALICE', 'b')).toEqual({ verdict: 'reject' })
+  })
+
+  it('coordsDecision: an UNKNOWN channel-free coordinate is admitted with a CALLER-derived channel', () => {
+    // Branch 3 — the feature this rule exists to keep alive. A webchat/dream/hook session has
+    // no channel row at all, so rejecting would kill channel-free collaboration; instead the
+    // asserted channel never becomes the session coordinate. `a2a:<caller>` cannot collide
+    // with a real conversation id (no platform channel id contains ':'), so two different
+    // asserted channels from one caller collapse onto ONE pairwise session.
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
+      agents: [agent('a'), agent('b')]
+    } as never)
+    expect(r.coordsDecision(ORG, 'webchat', 'wc-1', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    expect(r.coordsDecision(ORG, 'webchat', 'wc-2', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    expect(r.coordsDecision(ORG, 'dream', 'memory', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    expect(r.coordsDecision(ORG, 'hook', 'hook-id-1', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    // A KNOWN row still wins: relabelling a real channel as channel-free is not an escape —
+    // branch 1 runs first and is platform-free.
+    expect(r.coordsDecision(ORG, 'webchat', 'C1', 'b')).toEqual({ verdict: 'reject' })
+  })
+
+  it('coordsDecision ignores the coordinate PLATFORM when LOOKING UP the row', () => {
     // `Daemon.narrowPlatform` folds `feishu` (and any unrecognised value) into 'slack' when
     // computing the woken session key, while snapshot rows are keyed by the INTEGRATION
-    // platform. A platform-keyed check therefore searched a different key space than the key
+    // platform. A platform-keyed lookup therefore searched a different key space than the key
     // it protects, and "unknown coordinate passes" swallowed the mismatch in BOTH directions.
     const r = new CpCollabRoutes()
     r.replace({
@@ -144,14 +204,17 @@ describe('CpCollabRoutes: org-scoped directory', () => {
       agents: [agent('a'), agent('b')]
     } as never)
     // (1) A Slack row asserted as 'feishu' coords — still that Slack channel's coordinate.
-    expect(r.coordsAdmit(ORG, 'C_EXECS', 'a')).toBe(false)
-    expect(r.coordsAdmit(ORG, 'C_EXECS', 'b')).toBe(true)
+    expect(r.coordsDecision(ORG, 'feishu', 'C_EXECS', 'a')).toEqual({ verdict: 'reject' })
+    expect(r.coordsDecision(ORG, 'feishu', 'C_EXECS', 'b')).toEqual({ verdict: 'asserted' })
     // (2) The mirror: a Feishu org, where an honest daemon narrows its own coords to 'slack'.
-    expect(r.coordsAdmit(ORG, 'oc_execs', 'a')).toBe(false)
-    expect(r.coordsAdmit(ORG, 'oc_execs', 'b')).toBe(true)
+    expect(r.coordsDecision(ORG, 'slack', 'oc_execs', 'a')).toEqual({ verdict: 'reject' })
+    expect(r.coordsDecision(ORG, 'slack', 'oc_execs', 'b')).toEqual({ verdict: 'asserted' })
+    // (3) …and the channel-free label does not dodge either row.
+    expect(r.coordsDecision(ORG, 'webchat', 'C_EXECS', 'a')).toEqual({ verdict: 'reject' })
+    expect(r.coordsDecision(ORG, 'webchat', 'oc_execs', 'a')).toEqual({ verdict: 'reject' })
   })
 
-  it('coordsAdmit accepts membership in ANY platform row sharing one channel id', () => {
+  it('coordsDecision accepts membership in ANY platform row sharing one channel id', () => {
     // Two platforms colliding on one channel id inside one org is not a real configuration,
     // but the rule must stay a membership test rather than an accidental reject-all.
     const r = new CpCollabRoutes()
@@ -163,9 +226,9 @@ describe('CpCollabRoutes: org-scoped directory', () => {
       ],
       agents: [agent('a'), agent('b')]
     } as never)
-    expect(r.coordsAdmit(ORG, 'SHARED', 'a')).toBe(true)
-    expect(r.coordsAdmit(ORG, 'SHARED', 'b')).toBe(true)
-    expect(r.coordsAdmit(ORG, 'SHARED', 'c')).toBe(false)
+    expect(r.coordsDecision(ORG, 'slack', 'SHARED', 'a')).toEqual({ verdict: 'asserted' })
+    expect(r.coordsDecision(ORG, 'slack', 'SHARED', 'b')).toEqual({ verdict: 'asserted' })
+    expect(r.coordsDecision(ORG, 'slack', 'SHARED', 'c')).toEqual({ verdict: 'reject' })
   })
 
   it('FULL-REPLACE rebuilds the coordinate index too', () => {
@@ -175,11 +238,13 @@ describe('CpCollabRoutes: org-scoped directory', () => {
       channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
       agents: [agent('a'), agent('b')]
     } as never)
-    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(false)
-    // The channel is gone from the newer snapshot — the stale row must not linger and keep
-    // rejecting (nor keep gating, which is the fail-OPEN half of the same staleness).
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'b')).toEqual({ verdict: 'reject' })
+    // The channel is gone from the newer snapshot — the stale row must not linger. It becomes
+    // an UNKNOWN slack coordinate, which fails closed for a different reason; the point is
+    // that the index no longer holds the departed row.
     r.replace({ generation: 2, channels: [], agents: [agent('a'), agent('b')] } as never)
-    expect(r.coordsAdmit(ORG, 'C1', 'b')).toBe(true)
+    expect(r.coordsDecision(ORG, 'slack', 'C1', 'b')).toEqual({ verdict: 'reject' })
+    expect(r.coordsDecision(ORG, 'webchat', 'C1', 'b')).toEqual({ verdict: 'synthetic', channel: 'a2a:b' })
   })
 
   it('FULL-REPLACE applies to the flat index too — a later snapshot drops removed agents', () => {

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -8,6 +8,9 @@ import { sessionKey } from '../src/store/local-store.js'
 import * as monotonic from '../src/store/monotonic-ts.js'
 
 const TEST_ORG = '00000000-0000-0000-0000-0000000000a1'
+/** Peers this suite wakes that are NOT on the daemon under test — they must still be in
+ *  the org directory, exactly as a real CP snapshot would list them. */
+const REMOTE_PEERS = ['bot-a', 'bot-b', 'bot-c', 'main', 'worker', 'third', 'peer', 'joiner', 'elsewhere']
 
 /**
  * Same-daemon `messageAgent` delivery (design P1). These drive the daemon's internal
@@ -83,9 +86,24 @@ async function bootWithDispatchSpy(root: string) {
     outboundPolicy: agent.outboundPolicy,
     allowedTargetAgentIds: agent.allowedTargetAgentIds
   }))
+  // A2A authorization now reads the FLAT org directory (channel membership is only a
+  // discovery filter), so every peer this suite addresses — including the ones that live on
+  // ANOTHER daemon — must appear there or the wake fails closed before it can be routed.
+  const orgAgents = [...localAgents, ...REMOTE_PEERS.map((agentId) => ({ agentId, daemonId: 'other-daemon' }))]
+    .map((agent: any) => ({
+      callPolicy: 'all',
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'all',
+      allowedTargetAgentIds: [],
+      ...agent,
+      orgId: TEST_ORG
+    }))
+    // Local placements come first, so a local agent's real policy wins over its remote stub.
+    .filter((agent: any, i: number, all: any[]) => all.findIndex((other) => other.agentId === agent.agentId) === i)
   ;(daemon as any).cpCollab.replace({
     generation: 0,
-    channels: [{ orgId: TEST_ORG, platform: 'slack', channelId: 'C1', agents: localAgents }]
+    channels: [{ orgId: TEST_ORG, platform: 'slack', channelId: 'C1', agents: localAgents }],
+    agents: orgAgents
   })
   const calls: { agentId: string; msg: any; integrationId?: string; callMeta?: any }[] = []
   ;(daemon as any).dispatch = vi.fn(
@@ -289,15 +307,18 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
-  it('rejects a local target that is not a member of the addressed channel', async () => {
+  // Channel membership is NO LONGER an authorization key — A2A delivery is postless, so
+  // `channel` is only a session coordinate. Two agents that share no channel (and an agent
+  // with no integration at all) collaborate as long as the call policy admits them.
+  it('allows a local target that shares no channel with the caller (policy is the only gate)', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, calls, call } = await bootWithDispatchSpy(root)
     const placement = (agentId: string) => ({
       agentId,
       daemonId: 'local-daemon',
-      callPolicy: 'all',
+      callPolicy: 'all' as const,
       allowedCallerAgentIds: [],
-      outboundPolicy: 'all',
+      outboundPolicy: 'all' as const,
       allowedTargetAgentIds: []
     })
     ;(daemon as any).cpCollab.replace({
@@ -305,12 +326,96 @@ describe('messageAgent: same-daemon delivery', () => {
       channels: [
         { orgId: TEST_ORG, platform: 'slack', channelId: 'C1', agents: [placement('bot-a')] },
         { orgId: TEST_ORG, platform: 'slack', channelId: 'C2', agents: [placement('bot-b')] }
+      ],
+      agents: [
+        { ...placement('bot-a'), orgId: TEST_ORG },
+        { ...placement('bot-b'), orgId: TEST_ORG }
       ]
     })
 
-    expect((daemon as any).wakeRejectionReason(baseReq())).toBe('not_allowed')
+    expect((daemon as any).wakeRejectionReason(baseReq())).toBeNull()
     const result = await call(baseReq())
+    expect(result).toMatchObject({ delivered: true })
+    expect(calls).toHaveLength(1)
+    await daemon.stop()
+  })
+
+  // COORDINATE INTEGRITY on the SAME-DAEMON path — the third wake path, and the one whose
+  // coordinate is MODEL-supplied (`to.channel` / `to.thread` reach `req` verbatim). The
+  // relay hop and `rd/agentmsg` terminal-verify both gate the asserted coordinate; without
+  // the same gate here a model could name a channel its own agent cannot reach and RESUME a
+  // co-located peer's session living there.
+  it('rejects a model-chosen channel the CALLER cannot reach, and never posts for it', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const placement = (agentId: string) => ({
+      agentId,
+      daemonId: 'local-daemon',
+      callPolicy: 'all' as const,
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'all' as const,
+      allowedTargetAgentIds: []
+    })
+    // bot-a is in C1 only; bot-b is in C1 AND C_EXECS (where it has a live session).
+    ;(daemon as any).cpCollab.replace({
+      generation: 5,
+      channels: [
+        { orgId: TEST_ORG, platform: 'slack', channelId: 'C1', agents: [placement('bot-a'), placement('bot-b')] },
+        { orgId: TEST_ORG, platform: 'slack', channelId: 'C_EXECS', agents: [placement('bot-b')] }
+      ],
+      agents: [
+        { ...placement('bot-a'), orgId: TEST_ORG },
+        { ...placement('bot-b'), orgId: TEST_ORG }
+      ]
+    })
+    const attack = baseReq({ channel: 'C_EXECS', thread: '900.1' })
+    // The preflight must agree, or `sendMessage` leaves a visible post for a doomed wake.
+    expect((daemon as any).wakeRejectionReason(attack)).toBe('not_allowed')
+    expect(await call(attack)).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(0)
+    // The shared channel still delivers — policy, not membership, is the authorization.
+    expect(await call(baseReq())).toMatchObject({ delivered: true })
+    expect(calls).toHaveLength(1)
+    await daemon.stop()
+  })
+
+  // Channel-free collaboration is unaffected: a coordinate the snapshot knows nothing about
+  // (a webchat/dream session id, an integration-less agent's own channel) asserts nothing.
+  it('allows a coordinate the snapshot knows nothing about (channel-free session)', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    const req = baseReq({ platform: 'webchat', callerChannel: 'wc-1', channel: 'wc-1' })
+    expect((daemon as any).wakeRejectionReason(req)).toBeNull()
+    expect(await call(req)).toMatchObject({ delivered: true })
+    expect(calls).toHaveLength(1)
+    await daemon.stop()
+  })
+
+  // The org directory is the fail-closed authority: an id in NO directory entry is rejected
+  // as not_allowed instead of falling through to a misleading 'offline'/relay attempt.
+  it('rejects a target id that is in no directory entry at all', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    ;(daemon as any).relays = {
+      stop: vi.fn(async () => {}),
+      sendAgentMsg: vi.fn(async () => {
+        throw new Error('an unknown target must never reach the relay')
+      })
+    }
+    expect((daemon as any).wakeRejectionReason(baseReq({ toAgentId: 'test2' }))).toBe('not_allowed')
+    const result = await call(baseReq({ toAgentId: 'test2' }))
     expect(result).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(0)
+    await daemon.stop()
+  })
+
+  // An empty/stale snapshot must not grant access, even for two LOCAL agents.
+  it('fails closed when the org directory is empty (no snapshot yet)', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    ;(daemon as any).cpCollab.replace({ generation: 1, channels: [], agents: [] })
+    expect((daemon as any).wakeRejectionReason(baseReq())).toBe('not_allowed')
+    expect(await call(baseReq())).toMatchObject({ delivered: false, reason: 'not_allowed' })
     expect(calls).toHaveLength(0)
     await daemon.stop()
   })
@@ -652,6 +757,34 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     })
   }
 
+  /** bot-a (remote, d1) is in `pub` only; bot-b (local, d2) is in `pub` AND `execs` — the
+   *  F1 attack shape. `platform` keys the CHANNEL ROWS, which is what the coordinate the
+   *  caller asserts must be checked against regardless of the platform it names. */
+  function withExecsSnapshot(daemon: any, platform: string, execs = 'C_EXECS', pub = 'C_PUBLIC'): void {
+    const placement = (agentId: string, daemonId: string) => ({
+      agentId,
+      daemonId,
+      callPolicy: 'all',
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'all',
+      allowedTargetAgentIds: []
+    })
+    daemon.cpCollab.replace({
+      generation: 4,
+      channels: [
+        { orgId: ORG, platform, channelId: pub, agents: [placement('bot-a', 'd1'), placement('bot-b', 'd2')] },
+        { orgId: ORG, platform, channelId: execs, agents: [placement('bot-b', 'd2')] }
+      ],
+      agents: [
+        { ...placement('bot-a', 'd1'), orgId: ORG },
+        { ...placement('bot-b', 'd2'), orgId: ORG }
+      ]
+    })
+    // Policies are all 'all' and both agents are in the org directory, so `admits()` passes —
+    // only the coordinate check can stop the wake.
+    expect(daemon.cpCollab.admits('bot-a', 'bot-b')).toBe(true)
+  }
+
   const fwd = (over: any = {}) => ({
     trustedFromAgentId: 'bot-a',
     orgId: ORG,
@@ -720,10 +853,110 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
   it('fails closed when the local snapshot has no placement (defense in depth)', async () => {
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
-    // No snapshot installed → terminal-verify cannot confirm caller/target.
+    // Empty snapshot → terminal-verify cannot confirm the caller/target directory entries.
+    ;(daemon as any).cpCollab.replace({ generation: 2, channels: [], agents: [] })
     const ack = await (daemon as any).handleRelayAgentMsg(fwd())
     expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
     expect(calls).toHaveLength(0)
+    await daemon.stop()
+  })
+
+  it('rejects coords naming a KNOWN channel the trusted caller is not in (coordinate integrity)', async () => {
+    // The attack channel dropping membership from the POLICY predicate opened: `coords` is
+    // still the woken peer's SESSION key, so a source daemon that asserts a channel its
+    // caller cannot reach would resume the target's session THERE — and with `needsReply`
+    // read that private conversation back. bot-a is only in C_PUBLIC; bot-b is in both.
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    const placement = (agentId: string, daemonId: string) => ({
+      agentId,
+      daemonId,
+      callPolicy: 'all',
+      allowedCallerAgentIds: [],
+      outboundPolicy: 'all',
+      allowedTargetAgentIds: []
+    })
+    ;(daemon as any).cpCollab.replace({
+      generation: 3,
+      channels: [
+        {
+          orgId: ORG,
+          platform: 'slack',
+          channelId: 'C_PUBLIC',
+          agents: [placement('bot-a', 'd1'), placement('bot-b', 'd2')]
+        },
+        { orgId: ORG, platform: 'slack', channelId: 'C_EXECS', agents: [placement('bot-b', 'd2')] }
+      ],
+      agents: [
+        { ...placement('bot-a', 'd1'), orgId: ORG },
+        { ...placement('bot-b', 'd2'), orgId: ORG }
+      ]
+    })
+    // Policies are all 'all' and both agents are in the org directory, so `admits()` passes —
+    // only the coordinate check can stop this.
+    expect((daemon as any).cpCollab.admits('bot-a', 'bot-b')).toBe(true)
+    const ack = await (daemon as any).handleRelayAgentMsg(
+      fwd({ coords: { platform: 'slack', channel: 'C_EXECS', thread: '900.1' }, needsReply: true })
+    )
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(0)
+    // The same call into a channel they genuinely share is delivered.
+    const shared = await (daemon as any).handleRelayAgentMsg(
+      fwd({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'C_PUBLIC', thread: '900.1' } })
+    )
+    expect(shared.delivered).toBe(true)
+    await daemon.stop()
+  })
+
+  // The bypass an earlier revision of the coordinate gate had: it looked the coordinate up
+  // under the RAW wire platform, while the session key is computed from `narrowPlatform`,
+  // which folds `feishu` (and anything unrecognised) into 'slack'. The two key spaces
+  // differed and "unknown coordinate passes" hid it, so the SAME attack went through with a
+  // legal `coords.platform:'feishu'` and still produced a bit-identical childSessionId.
+  it('rejects the attack when the coordinate PLATFORM is switched to dodge the lookup', async () => {
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withExecsSnapshot(daemon, 'slack')
+    const ack = await (daemon as any).handleRelayAgentMsg(
+      fwd({ coords: { platform: 'feishu', channel: 'C_EXECS', thread: '900.1' }, needsReply: true })
+    )
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(0)
+    await daemon.stop()
+  })
+
+  // The mirror of the same root cause, and the one that made the gate a no-op for a whole
+  // tenant class: in a FEISHU org the rows are keyed 'feishu' while `messageAgent` narrows
+  // its own coords to 'slack', so every honest wake already carries 'slack'. The attack then
+  // needs no exotic platform value at all.
+  it('rejects the attack in a FEISHU org, where honest coords are already narrowed to slack', async () => {
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withExecsSnapshot(daemon, 'feishu', 'oc_execs', 'oc_pub')
+    const ack = await (daemon as any).handleRelayAgentMsg(
+      fwd({ coords: { platform: 'slack', channel: 'oc_execs', thread: '900.1' }, needsReply: true })
+    )
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(calls).toHaveLength(0)
+    // ...and the shared channel still routes, likewise with a narrowed platform.
+    const shared = await (daemon as any).handleRelayAgentMsg(
+      fwd({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'oc_pub', thread: '900.1' } })
+    )
+    expect(shared.delivered).toBe(true)
+    await daemon.stop()
+  })
+
+  it('passes coords the snapshot knows NOTHING about (webchat/hook/integration-less wake)', async () => {
+    // Channel-free collaboration must keep working: a coordinate that names no known IM
+    // channel is not a claim about a shared channel, so it needs no membership evidence.
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withSnapshot(daemon) // knows only slack C1
+    const ack = await (daemon as any).handleRelayAgentMsg(
+      fwd({ coords: { platform: 'webchat', channel: 'wc-session-1' } })
+    )
+    expect(ack.delivered).toBe(true)
+    expect(calls).toHaveLength(1)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -379,15 +379,64 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
-  // Channel-free collaboration is unaffected: a coordinate the snapshot knows nothing about
-  // (a webchat/dream session id, an integration-less agent's own channel) asserts nothing.
-  it('allows a coordinate the snapshot knows nothing about (channel-free session)', async () => {
+  // The same-daemon half of the review finding. `localWakeDecision` is BOTH the sendMessage
+  // preflight and the enforcement gate, so the identical three-branch rule must hold here.
+  it('rejects an UNKNOWN IM coordinate on the same-daemon path too (fail closed)', async () => {
+    // The snapshot knows only slack C1 (seeded by bootWithDispatchSpy), so `C_GHOST` is an
+    // unrecorded IM coordinate: a DM, a departed row, or a guess. Admitting it is what let a
+    // model land on a co-located peer's existing session at that channel:thread.
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls, call } = await bootWithDispatchSpy(root)
+    for (const platform of ['slack', 'telegram', 'discord', 'feishu']) {
+      const attack = baseReq({ platform, channel: 'C_GHOST', thread: '900.1' })
+      // The preflight must agree, or `sendMessage` leaves a visible post for a doomed wake.
+      expect((daemon as any).wakeRejectionReason(attack)).toBe('not_allowed')
+      expect(await call(attack)).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    }
+    expect(calls).toHaveLength(0)
+    // The channel they genuinely share still delivers.
+    expect(await call(baseReq())).toMatchObject({ delivered: true, targetSession: 'slack:C1:100.1:bot-b' })
+    await daemon.stop()
+  })
+
+  // Channel-free collaboration is unaffected in the sense that matters — the wake is still
+  // ADMITTED — but the asserted coordinate no longer becomes the session key.
+  it('keys a channel-free wake off the trusted caller, and collapses two asserted channels into one session', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, calls, call } = await bootWithDispatchSpy(root)
     const req = baseReq({ platform: 'webchat', callerChannel: 'wc-1', channel: 'wc-1' })
     expect((daemon as any).wakeRejectionReason(req)).toBeNull()
-    expect(await call(req)).toMatchObject({ delivered: true })
-    expect(calls).toHaveLength(1)
+    const first = await call(req)
+    // `a2a:bot-a`, NOT `webchat:wc-1:…` — the webchat conversation id is the caller's own
+    // session coordinate and must not be able to name the woken peer's.
+    expect(first).toMatchObject({ delivered: true, targetSession: 'webchat:a2a:bot-a:100.1:bot-b' })
+    expect(calls[0]!.msg.channel).toBe('a2a:bot-a')
+    expect(calls[0]!.msg.msgId).toMatch(/^agentcall:a2a:bot-a:\d+$/)
+
+    // A2A is postless (#854), so the conversation is the PAIR: a second wake naming a
+    // different channel-free coordinate resumes the same pairwise session.
+    const second = await call(baseReq({ platform: 'webchat', callerChannel: 'wc-1', channel: 'wc-9' }))
+    expect(second.targetSession).toBe(first.targetSession)
+    expect(calls).toHaveLength(2)
+    await daemon.stop()
+  })
+
+  // A `dream` turn's platform is folded to 'slack' by `narrowPlatform` when the session key is
+  // computed, so the coordinate decision must read the RAW session platform — otherwise a
+  // genuinely channel-free session would be classified as a persisted IM coordinate and fail
+  // closed. (`hook` is the same shape: a target-less hook session's channel is the hook id.)
+  it('treats a raw session-identity platform as channel-free even though the session key narrows it', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, call } = await bootWithDispatchSpy(root)
+    const dream = baseReq({ platform: 'dream', callerChannel: 'memory', channel: 'memory', thread: 'dream-1' })
+    expect((daemon as any).wakeRejectionReason(dream)).toBeNull()
+    // narrowPlatform('dream') === 'slack', hence the slack prefix — but the CHANNEL is the
+    // caller-derived one, not 'memory'.
+    expect(await call(dream)).toMatchObject({ delivered: true, targetSession: 'slack:a2a:bot-a:dream-1:bot-b' })
+
+    const hook = baseReq({ platform: 'hook', callerChannel: 'hook-1', channel: 'hook-1', thread: 'delivery-1' })
+    expect((daemon as any).wakeRejectionReason(hook)).toBeNull()
+    expect(await call(hook)).toMatchObject({ delivered: true, targetSession: 'hook:a2a:bot-a:delivery-1:bot-b' })
     await daemon.stop()
   })
 
@@ -946,17 +995,86 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
     await daemon.stop()
   })
 
-  it('passes coords the snapshot knows NOTHING about (webchat/hook/integration-less wake)', async () => {
-    // Channel-free collaboration must keep working: a coordinate that names no known IM
-    // channel is not a claim about a shared channel, so it needs no membership evidence.
+  it('rejects an UNKNOWN IM coordinate — fail closed, not "unknown ⇒ pass"', async () => {
+    // The review finding on the target side. "Unknown coordinate passes" also admitted Slack
+    // DMs and channels whose row has gone, so a compromised source daemon could name any
+    // conversation, land on the target's EXISTING session at that channel:thread and (with
+    // `needsReply`) read it back. Nothing in the snapshot vouches for `C_GHOST`, so the wake
+    // is refused rather than silently keyed to it. Policies are 'all' — only this can stop it.
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withSnapshot(daemon) // knows only slack C1
+    for (const [i, platform] of ['slack', 'telegram', 'discord', 'feishu'].entries()) {
+      const ack = await (daemon as any).handleRelayAgentMsg(
+        fwd({ deliveryId: `d-im-${i}`, coords: { platform, channel: 'C_GHOST', thread: '900.1' }, needsReply: true })
+      )
+      expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    }
+    expect(calls).toHaveLength(0)
+    await daemon.stop()
+  })
+
+  it('admits a channel-free coordinate but keys the child off the TRUSTED CALLER, not the asserted channel', async () => {
+    // Channel-free collaboration must keep working — but not by trusting the coordinate.
+    // The wake is admitted and the child session key is derived from `trustedFromAgentId`,
+    // so it can no longer alias any session living at the asserted coordinate.
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
     withSnapshot(daemon) // knows only slack C1
     const ack = await (daemon as any).handleRelayAgentMsg(
-      fwd({ coords: { platform: 'webchat', channel: 'wc-session-1' } })
+      fwd({ coords: { platform: 'webchat', channel: 'wc-session-1', thread: 'wc-session-1' } })
     )
     expect(ack.delivered).toBe(true)
+    // THE assertion: the exact key handed back to the caller. `a2a:bot-a` — never
+    // `webchat:wc-session-1:…`, which is what a webchat session of bot-b would be keyed by.
+    expect(ack.childSessionId).toBe('webchat:a2a:bot-a:wc-session-1:bot-b')
+    expect(ack.childSessionId).not.toContain('wc-session-1:wc-session-1')
     expect(calls).toHaveLength(1)
+    // The dispatched turn lands on the SAME coordinate the ACK reports, or the row the child
+    // creates would not be the one the caller was told to follow.
+    expect(calls[0]!.msg.channel).toBe('a2a:bot-a')
+    expect(calls[0]!.msg.thread).toBe('wc-session-1')
+    expect(calls[0]!.msg.msgId).toBe('agentcall:a2a:bot-a:d-1')
+    await daemon.stop()
+  })
+
+  it('two channel-free wakes from one caller asserting DIFFERENT channels converge on ONE pairwise session', async () => {
+    // A2A is postless (#854), so the "conversation" between two agents is the pair, not a
+    // channel. Since the substituted channel is derived from the caller alone, a caller that
+    // names two different channel-free coordinates in one thread resumes the same session
+    // instead of forking a fresh one per asserted string.
+    const root = scaffold([{ id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    withSnapshot(daemon)
+    const first = await (daemon as any).handleRelayAgentMsg(
+      fwd({ deliveryId: 'd-1', coords: { platform: 'webchat', channel: 'wc-1', thread: 'T' } })
+    )
+    const second = await (daemon as any).handleRelayAgentMsg(
+      fwd({ deliveryId: 'd-2', coords: { platform: 'webchat', channel: 'wc-2', thread: 'T' } })
+    )
+    expect(first.delivered).toBe(true)
+    expect(second.delivered).toBe(true)
+    expect(second.childSessionId).toBe(first.childSessionId)
+    expect(first.childSessionId).toBe('webchat:a2a:bot-a:T:bot-b')
+    expect(calls).toHaveLength(2)
+    // A DIFFERENT caller is a different pair, so it must NOT collapse into that session.
+    ;(daemon as any).cpCollab.replace({
+      generation: 2,
+      channels: [],
+      agents: [
+        { agentId: 'bot-a', daemonId: 'd1', orgId: ORG, callPolicy: 'all', allowedCallerAgentIds: [] },
+        { agentId: 'bot-c', daemonId: 'd3', orgId: ORG, callPolicy: 'all', allowedCallerAgentIds: [] },
+        { agentId: 'bot-b', daemonId: 'd2', orgId: ORG, callPolicy: 'all', allowedCallerAgentIds: [] }
+      ]
+    })
+    const other = await (daemon as any).handleRelayAgentMsg(
+      fwd({
+        deliveryId: 'd-3',
+        trustedFromAgentId: 'bot-c',
+        coords: { platform: 'webchat', channel: 'wc-1', thread: 'T' }
+      })
+    )
+    expect(other.childSessionId).toBe('webchat:a2a:bot-c:T:bot-b')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -704,24 +704,29 @@ describe('executeTool: telegram tool names dispatch through the same gateway', (
   })
 })
 
-describe('executeTool: listChannelAgents', () => {
+describe('executeTool: listAgents', () => {
   // A deps bundle whose channelAgents dep records the request it received and
   // returns a canned roster. gatewayFor throws to prove discovery does NOT need a
   // platform gateway (it runs before the gateway gate).
   function discoveryDeps(over: Partial<OpsDeps> = {}): {
     deps: OpsDeps
-    calls: { platform: string; channel: string; requesterAgentId: string }[]
+    calls: { platform: string; channel?: string; currentChannel?: string; requesterAgentId: string }[]
   } {
-    const calls: { platform: string; channel: string; requesterAgentId: string }[] = []
+    const calls: { platform: string; channel?: string; currentChannel?: string; requesterAgentId: string }[] = []
     const d = makeDeps({
       gatewayFor: () => {
-        throw new Error('gatewayFor must not be called for listChannelAgents')
+        throw new Error('gatewayFor must not be called for listAgents')
       },
       channelAgents: async (req) => {
-        calls.push({ platform: req.platform, channel: req.channel, requesterAgentId: req.requesterAgentId })
-        return {
+        calls.push({
           platform: req.platform,
           channel: req.channel,
+          currentChannel: req.currentChannel,
+          requesterAgentId: req.requesterAgentId
+        })
+        return {
+          platform: req.platform,
+          ...(req.channel !== undefined ? { channel: req.channel } : {}),
           agents: [{ agentId: 'peer-1', name: 'peer', status: 'active' as const }]
         }
       },
@@ -731,32 +736,75 @@ describe('executeTool: listChannelAgents', () => {
     return { deps: d, calls }
   }
 
-  it('defaults platform+channel to the session coords and returns the roster', async () => {
+  // The whole point of the org-scoped directory: NO channel is sent unless the agent asked
+  // for one, so a session with no IM integration can still discover peers.
+  it('sends NO channel by default (org-wide scope) and returns a channel-less roster', async () => {
     const { deps: d, calls } = discoveryDeps()
-    const res = (await executeTool(ctx, 'listChannelAgents', {}, d)) as { channel: string; agents: unknown[] }
-    expect(calls).toEqual([{ platform: 'slack', channel: 'C_CURRENT', requesterAgentId: 'bot-a' }])
-    expect(res.channel).toBe('C_CURRENT')
+    const res = (await executeTool(ctx, 'listAgents', {}, d)) as { channel?: string; agents: unknown[] }
+    expect(calls).toEqual([
+      { platform: 'slack', channel: undefined, currentChannel: 'C_CURRENT', requesterAgentId: 'bot-a' }
+    ])
+    expect(res).not.toHaveProperty('channel')
     expect(res.agents).toEqual([{ agentId: 'peer-1', name: 'peer', status: 'active' }])
   })
 
-  it('lets `channel` be overridden but keeps the current channel by default', async () => {
+  it('passes `channel` through as a filter when the agent asks for one', async () => {
     const { deps: d, calls } = discoveryDeps()
-    await executeTool(ctx, 'listChannelAgents', { channel: 'C_OTHER' }, d)
-    expect(calls[0]).toMatchObject({ channel: 'C_OTHER' })
+    const res = (await executeTool(ctx, 'listAgents', { channel: 'C_OTHER' }, d)) as { channel?: string }
+    expect(calls[0]).toMatchObject({ channel: 'C_OTHER', currentChannel: 'C_CURRENT' })
+    expect(res.channel).toBe('C_OTHER')
+  })
+
+  it('still answers to the deprecated `listChannelAgents` name, with the same org-wide default', async () => {
+    const { deps: d, calls } = discoveryDeps()
+    const res = (await executeTool(ctx, 'listChannelAgents', {}, d)) as { agents: unknown[] }
+    expect(calls[0]).toEqual({
+      platform: 'slack',
+      channel: undefined,
+      currentChannel: 'C_CURRENT',
+      requesterAgentId: 'bot-a'
+    })
+    expect(res.agents).toHaveLength(1)
   })
 
   it('takes requesterAgentId + platform from the session context, NOT tool input', async () => {
     const { deps: d, calls } = discoveryDeps()
     // Attacker-controlled args attempt to impersonate another agent / probe another
     // platform — both must be ignored in favor of the trusted session context.
-    await executeTool(ctx, 'listChannelAgents', { requesterAgentId: 'someone-else', platform: 'telegram' }, d)
-    expect(calls[0]).toEqual({ platform: 'slack', channel: 'C_CURRENT', requesterAgentId: 'bot-a' })
+    await executeTool(ctx, 'listAgents', { requesterAgentId: 'someone-else', platform: 'telegram' }, d)
+    expect(calls[0]).toEqual({
+      platform: 'slack',
+      channel: undefined,
+      currentChannel: 'C_CURRENT',
+      requesterAgentId: 'bot-a'
+    })
+  })
+
+  // The daemon identifies the CALLING TURN by its logical sessionKey, which is how a turn
+  // whose discovery scope the daemon fixed itself (the #536 self-introduce turn) can be
+  // bounded in code rather than by prompt. All three coordinates are trusted context.
+  it('carries the trusted turn coordinates (thread + transport scope) so the daemon can identify the turn', async () => {
+    const calls: Record<string, unknown>[] = []
+    const d = makeDeps({
+      channelAgents: async (req) => {
+        calls.push({ ...req })
+        return { platform: req.platform, agents: [] }
+      }
+    })
+    await executeTool({ ...ctx, transportScope: 'bot-1' }, 'listAgents', {}, d)
+    expect(calls[0]).toMatchObject({
+      currentChannel: 'C_CURRENT',
+      currentThread: '111.1',
+      currentTransportScope: 'bot-1',
+      requesterAgentId: 'bot-a'
+    })
+    // A session with no physical-bot scope simply omits it (never a literal undefined on the wire).
+    await executeTool(ctx, 'listAgents', {}, d)
+    expect(calls[1]).not.toHaveProperty('currentTransportScope')
+    expect(calls[1]).toMatchObject({ currentThread: '111.1' })
   })
 })
 
-// The unified `sendMessage` tool's A2A/wake path (§4) and SessionTarget reply path (§5),
-// the former `messageAgent` tool. `to.toAgent` wakes a peer through `deps.messageAgent`;
-// `to.sessionId` replies into an origin session through `deps.replyToSession`.
 describe('executeTool: sendMessage (wake / reply)', () => {
   function wakeDeps(over: Partial<OpsDeps> = {}): {
     deps: OpsDeps

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -199,6 +199,8 @@ describe('toolsForIntegrations', () => {
     expect(tools.map((t) => t.name)).toEqual([
       'readMemory',
       'writeMemory',
+      'listAgents',
+      // still offered under the old name, for sessions already warm with it
       'listChannelAgents',
       'viewSessionStatus',
       'startOrchestration',
@@ -216,7 +218,9 @@ describe('toolsForIntegrations', () => {
 
     const tools = toolsForIntegrations([slackInt], { collaboration: false })
     const names = tools.map((tool) => tool.name)
-    expect(names).not.toEqual(expect.arrayContaining(['listChannelAgents', 'startOrchestration', 'getOrchestration']))
+    expect(names).not.toEqual(
+      expect.arrayContaining(['listAgents', 'listChannelAgents', 'startOrchestration', 'getOrchestration'])
+    )
     expect(names).toContain('sendMessage')
     const send = tools.find((tool) => tool.name === 'sendMessage')!
     const to = (send.inputSchema.properties as Record<string, ObjectSchema>).to

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -63,16 +63,23 @@ async function boot(root: string) {
     outboundPolicy: agent.outboundPolicy,
     allowedTargetAgentIds: agent.allowedTargetAgentIds
   }))
+  const ORG = '00000000-0000-0000-0000-0000000000a1'
   ;(daemon as any).cpCollab.replace({
     generation: 0,
-    channels: [
-      {
-        orgId: '00000000-0000-0000-0000-0000000000a1',
-        platform: 'slack',
-        channelId: 'C1',
-        agents: localAgents
-      }
-    ]
+    channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: localAgents }],
+    // A2A authorization reads the FLAT org directory, not channel membership, so a worker
+    // that is not on this daemon ('wB' in the not_local case) must still be in the org.
+    agents: [...localAgents, { agentId: 'wB', daemonId: 'other-daemon' }, { agentId: 'wA', daemonId: 'other-daemon' }]
+      .map((a: any) => ({
+        callPolicy: 'all',
+        allowedCallerAgentIds: [],
+        outboundPolicy: 'all',
+        allowedTargetAgentIds: [],
+        ...a,
+        orgId: ORG
+      }))
+      // Local placements come first, so a local agent's real policy wins over the remote stub.
+      .filter((a: any, i: number, all: any[]) => all.findIndex((b) => b.agentId === a.agentId) === i)
   })
   const calls: { agentId: string; msg: any; integrationId?: string; callMeta?: any }[] = []
   ;(daemon as any).dispatch = vi.fn(

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1127,6 +1127,85 @@ describe('channel agent directory frames (agent collaboration)', () => {
     expect(ok.frame.payload.agents[0]!.description).toBe('ships deploys')
     expect(ok.frame.payload.agents[1]!.displayName).toBeUndefined()
   })
+
+  // Channel is a filter, not a gate: the channel-less form is what a session with no IM
+  // integration (webchat / hook / dream) sends, and it must decode on both legs.
+  it('channel/agents REQ + REP round-trip with NO channel (org-wide directory)', () => {
+    const req = decodeEnvelope(envelope('channel/agents', { platform: 'webchat', requesterAgentId: AGENT_ID }))
+    expect(req.ok).toBe(true)
+    if (!req.ok || !isFrame('channel/agents')(req.frame)) throw new Error('expected channel/agents')
+    expect(req.frame.payload.channel).toBeUndefined()
+
+    const ok = decodeEnvelope(
+      envelope('channel/agents/ok', {
+        platform: 'webchat',
+        agents: [{ agentId: AGENT_ID, name: 'deploy-bot', status: 'active' }]
+      })
+    )
+    expect(ok.ok).toBe(true)
+    if (!ok.ok || !isFrame('channel/agents/ok')(ok.frame)) throw new Error('expected channel/agents/ok')
+    expect(ok.frame.payload.channel).toBeUndefined()
+    expect(ok.frame.payload.agents).toHaveLength(1)
+  })
+})
+
+describe('collaboration/routes snapshot', () => {
+  const ORG_ID = 'org_default000000000000000'
+
+  it('round-trips the flat org-scoped agents[] alongside channels[]', () => {
+    const r = decodeEnvelope(
+      envelope('collaboration/routes', {
+        generation: 7,
+        channels: [
+          {
+            orgId: ORG_ID,
+            platform: 'slack',
+            channelId: 'C123',
+            agents: [{ agentId: AGENT_ID, daemonId: DAEMON_ID }]
+          }
+        ],
+        // The integration-less agent exists ONLY here — no channels[] entry can carry it.
+        agents: [
+          {
+            agentId: LAUNCH_ID,
+            daemonId: DAEMON_ID,
+            orgId: ORG_ID,
+            outboundPolicy: 'selected',
+            allowedTargetAgentIds: [AGENT_ID],
+            name: 'dreamer'
+          }
+        ]
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('collaboration/routes')(r.frame)) throw new Error('expected collaboration/routes')
+    expect(r.frame.payload.channels).toHaveLength(1)
+    expect(r.frame.payload.agents).toHaveLength(1)
+    expect(r.frame.payload.agents[0]!.orgId).toBe(ORG_ID)
+    expect(r.frame.payload.agents[0]!.allowedTargetAgentIds).toEqual([AGENT_ID])
+    // Placement defaults still apply through the .extend()
+    expect(r.frame.payload.agents[0]!.callPolicy).toBe('all')
+    expect(r.frame.payload.agents[0]!.allowedCallerAgentIds).toEqual([])
+  })
+
+  // An older CP emits no `agents` at all — the snapshot must still decode (default []).
+  it('decodes an old-shape snapshot with no agents[]', () => {
+    const r = decodeEnvelope(
+      envelope('collaboration/routes', {
+        generation: 1,
+        channels: [{ orgId: ORG_ID, platform: 'slack', channelId: 'C1', agents: [] }]
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('collaboration/routes')(r.frame)) throw new Error('expected collaboration/routes')
+    expect(r.frame.payload.agents).toEqual([])
+  })
+
+  // orgId is required on a flat entry — cross-org authorization has no fallback scope.
+  it('rejects a flat agent entry without orgId', () => {
+    const r = decodeEnvelope(envelope('collaboration/routes', { agents: [{ agentId: AGENT_ID, daemonId: DAEMON_ID }] }))
+    expect(r.ok).toBe(false)
+  })
 })
 
 describe('event/session sessionKey (session-metadata sync)', () => {

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -244,7 +244,7 @@ export const AgentSpec = z.object({
   outboundPolicy: z.enum(['all', 'selected']).optional(),
   allowedTargetAgentIds: z.array(z.string()).optional(),
   // Self-introduce-on-join (issue #536): when true, on a genuine new channel join the
-  // agent proactively introduces itself to the peers already there (via listChannelAgents
+  // agent proactively introduces itself to the peers already there (via listAgents
   // → messageAgent) so they can record it in memory. Replicated CP→daemon. Optional
   // (absent ⇒ leave the on-disk agent.json value alone — same contract as pause/fastMode).
   introduceOnJoin: z.boolean().optional(),

--- a/packages/protocol/src/frames/channel.ts
+++ b/packages/protocol/src/frames/channel.ts
@@ -14,12 +14,23 @@ import { Platform } from './route.js'
  * Direction is daemon→CP (like `auth` / `register`): the daemon sends the REQ and
  * the CP replies with `channel/agents/ok` (corr = the req id).
  *
+ * `channel` is OPTIONAL, and that is the whole scope switch:
+ *  - ABSENT → the ORG-WIDE peer directory. Channel membership plays no part; a
+ *    session with no IM integration at all (webchat, hook, dream) can still
+ *    discover peers.
+ *  - PRESENT → the same directory, ADDITIONALLY narrowed to agents present in that
+ *    channel. A filter, never a gate.
+ * Only a CP advertising `agent-directory-org-scope-v1` understands the channel-less
+ * form; against an older CP the daemon substitutes the caller's current channel
+ * (today's behavior) rather than sending a payload that CP would reject.
+ *
  * The REQ is bound to the requesting daemon's authenticated org AND to the
- * session-derived `requesterAgentId` (never a tool input — §2.2/§6.1): the CP
- * verifies the requester actually belongs to the target (platform, channel)
- * before returning the roster, and filters it by call policy so non-callable /
- * private peers are not leaked. This stops one agent from probing arbitrary
- * (including private) channels of its own org.
+ * session-derived `requesterAgentId` (never a tool input — §2.2/§6.1). The roster is
+ * POLICY-filtered, not membership-gated: an entry survives iff the caller's outbound
+ * policy admits it and its own inbound `callPolicy` admits the caller, within the one
+ * org (the caller always sees itself). Discovery IS the authorization surface — a peer
+ * that fails the predicate is omitted entirely, never listed-but-uncallable — so an
+ * agent still cannot probe peers it may not call, and cross-org never resolves.
  */
 
 /** One agent visible in a channel — the collaboration directory entry. */
@@ -32,21 +43,23 @@ export const ChannelAgent = z.object({
 })
 export type ChannelAgent = z.infer<typeof ChannelAgent>
 
-/** D→C REQ: list the agents in a channel (for the asking agent's collaboration tool). */
+/** D→C REQ: list the caller's callable peers (for the asking agent's collaboration tool). */
 export const ChannelAgentsReq = z.object({
   platform: Platform,
-  channel: z.string(), // platform channel id
+  /** Platform channel id. Omit for the org-wide directory; present = channel filter. */
+  channel: z.string().optional(),
   /** The agent asking, derived by the daemon from the MCP session context — NEVER
-   *  a tool input (§6.1). The CP uses it to verify the requester belongs to the
-   *  target channel and to apply per-peer call-policy visibility filtering. */
+   *  a tool input (§6.1). The CP resolves it in the org directory and applies the
+   *  bidirectional call-policy filter; an unknown requester fails CLOSED. */
   requesterAgentId: z.string().uuid()
 })
 export type ChannelAgentsReq = z.infer<typeof ChannelAgentsReq>
 
-/** C→D REP (corr = req id): every agent in the channel across all daemons. */
+/** C→D REP (corr = req id): the policy-filtered roster across all daemons. `channel`
+ *  echoes the REQ's scope — absent when the listing was org-wide. */
 export const ChannelAgentsOk = z.object({
   platform: Platform,
-  channel: z.string(),
+  channel: z.string().optional(),
   agents: z.array(ChannelAgent)
 })
 export type ChannelAgentsOk = z.infer<typeof ChannelAgentsOk>

--- a/packages/protocol/src/frames/collab.ts
+++ b/packages/protocol/src/frames/collab.ts
@@ -54,6 +54,26 @@ export const CollabAgentPlacement = z.object({
 })
 export type CollabAgentPlacement = z.infer<typeof CollabAgentPlacement>
 
+/**
+ * One agent's placement + call policy carried OUTSIDE any channel — the org-scoped
+ * peer directory entry.
+ *
+ * Every structure on the CP→daemon and CP→relay wires is channel-keyed, so an agent
+ * with NO IM integration (webchat, hook, dream, memory-only) never appears in any
+ * `channels[]` entry at all. The channel-keyed snapshot structurally cannot express
+ * "which agents exist in this org", which is precisely the input channel-free
+ * authorization needs: discovery and A2A authorization depend only on the directional
+ * call policy (`outboundPolicy`/`allowedTargetAgentIds` on the caller,
+ * `callPolicy`/`allowedCallerAgentIds` on the target), org-scoped, with channel
+ * demoted to an optional filter. Hence the flat list below.
+ */
+export const CollabOrgAgent = CollabAgentPlacement.extend({
+  // Org ids are opaque strings (see CollabChannelRoute) — carried per entry because
+  // the flat list is not nested under an org-keyed parent. Cross-org pairs never resolve.
+  orgId: z.string().min(1)
+})
+export type CollabOrgAgent = z.infer<typeof CollabOrgAgent>
+
 /** All agents present in one channel, across daemons. `orgId` scopes routing +
  *  authorization: a cross-org caller/target pair never resolves (§2.5 — cross-org
  *  rejected). */
@@ -75,6 +95,13 @@ export type CollabChannelRoute = z.infer<typeof CollabChannelRoute>
  */
 export const CollabRoutesSnapshot = z.object({
   generation: z.number().int().nonnegative().default(0),
-  channels: z.array(CollabChannelRoute).default([])
+  channels: z.array(CollabChannelRoute).default([]),
+  /**
+   * FLAT org-scoped directory, alongside (not instead of) `channels`. It is the only
+   * place an integration-less agent can appear — see `CollabOrgAgent` — and therefore
+   * the authorization input for channel-free A2A. `default([])` keeps a snapshot from
+   * an older CP (which advertises no `agent-directory-org-scope-v1`) decodable.
+   */
+  agents: z.array(CollabOrgAgent).default([])
 })
 export type CollabRoutesSnapshot = z.infer<typeof CollabRoutesSnapshot>

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -101,7 +101,7 @@ export const RegisterOk = z.object({
   // the reconnect BASELINE for this daemon's terminal-verify of REMOTE agent callers.
   // Scoped to channels this daemon's agents participate in. Hot changes ride the
   // `collaboration/routes` EVT. Defaulted so a pre-collab CP's snapshot still parses.
-  collabRoutes: CollabRoutesSnapshot.default({ generation: 0, channels: [] }),
+  collabRoutes: CollabRoutesSnapshot.default({ generation: 0, channels: [], agents: [] }),
   drop: z.object({
     // things in localState the CP says to release
     assignments: z.array(z.string()),

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -391,22 +391,35 @@ export type RdAgentMsg = z.infer<typeof RdAgentMsg>
  * target daemon TERMINAL-verifies this claim + both directional policies against its
  * LOCAL snapshot (defense in depth, §2.5 #4) before dispatching `source:'agent'`.
  *
- * What `coords` is and is NOT: it is the DELIVERY coordinate the target derives the woken
- * session's key from, not evidence of a shared channel — A2A authorization is channel-free
- * (postless delivery, #854), so caller and target need share no channel and the target may
- * have no IM integration at all. It is still integrity-checked, on BOTH sides and by the
- * identical rule (`coordsAdmit`): when the snapshot knows any non-empty placement at
- * `(orgId, channel)` the caller must resolve in it, so it cannot name an IM channel it has
- * no access to and resume a target session living there. The rule keys on the CHANNEL ID
- * alone, deliberately NOT on `coords.platform`: the woken session's key is computed from a
- * NARROWED platform (the daemon folds `feishu` and anything it does not recognise into
- * `'slack'`) while snapshot rows are keyed by the integration platform, so a platform-keyed
- * check would search a different key space than the key it protects — and its every miss
- * would fall into the pass branch below. A coordinate the snapshot knows nothing about
- * (webchat / any integration-less coords, and also a direct conversation or a channel whose
- * row has gone — agent-collaboration §2.7 item 5) asserts nothing about a shared channel and
- * carries no membership guarantee — read `coords` as "verified reachable-or-channel-free",
- * never as "verified member of".
+ * What `coords` is and is NOT: it is the ASSERTED delivery coordinate, not evidence of a
+ * shared channel — A2A authorization is channel-free (postless delivery, #854), so caller and
+ * target need share no channel and the target may have no IM integration at all. It is
+ * integrity-checked on BOTH sides by one identical rule (`coordsDecision`), which has three
+ * outcomes rather than two:
+ *   (1) the snapshot holds a non-empty placement at `(orgId, channel)` ⇒ the caller must
+ *       resolve in it, else the wake is refused `not_allowed`. A direct conversation counts
+ *       wherever its row exists — placements are selected with no `kind` filter, so an
+ *       `im`/`mpim` row is an ordinary placement. Admitted, and the woken session keys off
+ *       `coords` as sent, which is how a wake deliberately lands in the same thread a human sees;
+ *   (2) no such placement and `coords.platform` is a PERSISTED IM platform (slack / telegram /
+ *       discord / feishu) ⇒ refused, FAIL CLOSED. An unrecorded IM coordinate is a channel the
+ *       caller cannot reach, a departed row, or a guess, and admitting it is what would let a
+ *       caller alias an existing platform session (and with `needsReply`, read it back). Note
+ *       an `im`/`mpim` row is only WRITTEN for a GATED integration's not-yet-enabled
+ *       conversations, so an ordinary integration's DM lands here — deliberate, and the same
+ *       answer the channel-membership check this replaced gave;
+ *   (3) no such placement and the platform is channel-free (`webchat`, and anything else) ⇒
+ *       admitted, but the asserted channel NEVER becomes the session coordinate: the TARGET
+ *       daemon keys the woken session off `a2a:<trustedFromAgentId>` instead, which cannot
+ *       collide with any real conversation id. The relay forwards `coords` verbatim; only the
+ *       daemon that mints the key substitutes, so the two can never disagree about it.
+ * The row LOOKUP keys on the CHANNEL ID alone, deliberately NOT on `coords.platform`: the
+ * woken session's key is computed from a NARROWED platform (the daemon folds `feishu` and
+ * anything it does not recognise into `'slack'`) while snapshot rows are keyed by the
+ * integration platform, so a platform-keyed lookup would search a different key space than
+ * the key it protects. The platform only picks between (2) and (3), for a coordinate (1)
+ * already found nothing for. Read `coords` as "the caller may assert this", never as
+ * "verified member of" — and never assume the woken session key echoes it (case 3).
  */
 export const RdAgentMsgFwd = z.object({
   trustedFromAgentId: z.string().uuid(), // minted by the relay — the target may trust this

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -386,10 +386,27 @@ export type RdAgentMsg = z.infer<typeof RdAgentMsg>
 /**
  * R→D REQ → `rd/agentmsg/ack`. The relay forwards the validated call to the TARGET's
  * owning daemon, replacing the untrusted `claimedFromAgentId` with a TRUSTED caller
- * claim the relay minted after snapshot validation: `trustedFromAgentId` + the
- * asserted `orgId`/`platform`/`channel` the caller was verified in. The target daemon
- * TERMINAL-verifies this claim + both directional policies against its LOCAL
- * snapshot (defense in depth, §2.5 #4) before dispatching `source:'agent'`.
+ * claim the relay minted after snapshot validation: `trustedFromAgentId` + the `orgId`
+ * the caller's own directory entry places it in (never an org the frame asserted). The
+ * target daemon TERMINAL-verifies this claim + both directional policies against its
+ * LOCAL snapshot (defense in depth, §2.5 #4) before dispatching `source:'agent'`.
+ *
+ * What `coords` is and is NOT: it is the DELIVERY coordinate the target derives the woken
+ * session's key from, not evidence of a shared channel — A2A authorization is channel-free
+ * (postless delivery, #854), so caller and target need share no channel and the target may
+ * have no IM integration at all. It is still integrity-checked, on BOTH sides and by the
+ * identical rule (`coordsAdmit`): when the snapshot knows any non-empty placement at
+ * `(orgId, channel)` the caller must resolve in it, so it cannot name an IM channel it has
+ * no access to and resume a target session living there. The rule keys on the CHANNEL ID
+ * alone, deliberately NOT on `coords.platform`: the woken session's key is computed from a
+ * NARROWED platform (the daemon folds `feishu` and anything it does not recognise into
+ * `'slack'`) while snapshot rows are keyed by the integration platform, so a platform-keyed
+ * check would search a different key space than the key it protects — and its every miss
+ * would fall into the pass branch below. A coordinate the snapshot knows nothing about
+ * (webchat / any integration-less coords, and also a direct conversation or a channel whose
+ * row has gone — agent-collaboration §2.7 item 5) asserts nothing about a shared channel and
+ * carries no membership guarantee — read `coords` as "verified reachable-or-channel-free",
+ * never as "verified member of".
  */
 export const RdAgentMsgFwd = z.object({
   trustedFromAgentId: z.string().uuid(), // minted by the relay — the target may trust this

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
-import type { CollabRoutesSnapshot, RdAgentMsg, RdAgentMsgFwd, RdAgentMsgAck } from '@agentconnect.md/protocol'
+import type {
+  CollabAgentPlacement,
+  CollabOrgAgent,
+  CollabRoutesSnapshot,
+  RdAgentMsg,
+  RdAgentMsgFwd,
+  RdAgentMsgAck
+} from '@agentconnect.md/protocol'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
 import type { RelayDaemonServer } from './relay-daemon-server.js'
@@ -14,9 +21,36 @@ const INT = '00000000-0000-0000-0000-0000000000f1'
 
 const noopLog = { info() {}, warn() {}, error() {}, debug() {} }
 
+/** An org-scoped directory entry (the flat `agents[]` shape) with policy defaults. */
+function orgAgent(over: Partial<CollabOrgAgent> & { agentId: string; daemonId: string }): CollabOrgAgent {
+  return {
+    orgId: ORG,
+    callPolicy: 'all',
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all',
+    allowedTargetAgentIds: [],
+    ...over
+  }
+}
+
+/** One channel-row placement (the `channels[].agents[]` shape) with policy defaults. */
+function placement(over: Partial<CollabAgentPlacement> & { agentId: string; daemonId: string }): CollabAgentPlacement {
+  return {
+    integrationId: INT,
+    callPolicy: 'all',
+    allowedCallerAgentIds: [],
+    outboundPolicy: 'all',
+    allowedTargetAgentIds: [],
+    ...over
+  }
+}
+
 function snap(): CollabRoutesSnapshot {
   return {
     generation: 1,
+    // The flat directory is the authorization surface; `channels[]` below only carries the
+    // delivery/ingress facts (integration, bot app id).
+    agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
     channels: [
       {
         orgId: ORG,
@@ -167,10 +201,174 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(forwards).toHaveLength(0)
   })
 
+  it('coords integrity: caller asserting a KNOWN channel it is NOT in → not_allowed, nothing forwarded', async () => {
+    // F1 regression. Channel is no longer an AUTHORIZATION key, but it is still the woken
+    // peer's SESSION key, so the assertion still needs integrity: A lives only in C1, while
+    // B is in C1 *and* C_EXECS with a live C_EXECS session. Were the coords unchecked, the
+    // wake would land on the SAME computed childSessionId as that session and RESUME it —
+    // and with needsReply, report its content back into A's session. Policies are all 'all'
+    // here on purpose: the policy pair cannot see this, only the coordinate check can.
+    const s = snap()
+    s.channels.push({
+      orgId: ORG,
+      platform: 'slack',
+      channelId: 'C_EXECS',
+      agents: [placement({ agentId: B, daemonId: D2, integrationId: '00000000-0000-0000-0000-0000000000f2' })]
+    })
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const ack = await route(
+      D1,
+      baseMsg({
+        coords: { platform: 'slack', channel: 'C_EXECS', thread: '1784297789.871789' },
+        needsReply: true,
+        originSessionId: 'acp-parent-1'
+      })
+    )
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(0)
+  })
+
+  it('coords integrity: caller IS in the asserted channel → delivered, with that channel’s reply integration', async () => {
+    // The gate rejects only the channels the caller cannot reach; a legitimate second
+    // channel keeps working end to end.
+    const INT2 = '00000000-0000-0000-0000-0000000000f2'
+    const s = snap()
+    s.channels.push({
+      orgId: ORG,
+      platform: 'slack',
+      channelId: 'C_EXECS',
+      agents: [
+        placement({ agentId: A, daemonId: D1, integrationId: INT2 }),
+        placement({ agentId: B, daemonId: D2, integrationId: INT2 })
+      ]
+    })
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const ack = await route(D1, baseMsg({ coords: { platform: 'slack', channel: 'C_EXECS' } }))
+    expect(ack.delivered).toBe(true)
+    expect(forwards).toHaveLength(1)
+    expect(forwards[0].integrationId).toBe(INT2)
+    expect(forwards[0].coords).toEqual({ platform: 'slack', channel: 'C_EXECS' })
+  })
+
+  it('coords integrity: switching the coordinate PLATFORM does not dodge the gate', async () => {
+    // The bypass a platform-KEYED gate had. The target computes the woken session key with a
+    // NARROWED platform (`narrowPlatform` folds feishu — and any unrecognised value — into
+    // 'slack'), so looking the coordinate up under the raw wire platform searched a different
+    // key space than the key being protected, and the residual "unknown coordinate passes"
+    // branch turned the miss into a PASS. `feishu` is a legal value of the coords enum, so
+    // this was the same attack as above with one field changed.
+    const s = snap()
+    s.channels.push({
+      orgId: ORG,
+      platform: 'slack',
+      channelId: 'C_EXECS',
+      agents: [placement({ agentId: B, daemonId: D2, integrationId: '00000000-0000-0000-0000-0000000000f2' })]
+    })
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const ack = await route(
+      D1,
+      baseMsg({ coords: { platform: 'feishu', channel: 'C_EXECS', thread: '1784297789.871789' }, needsReply: true })
+    )
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(0)
+  })
+
+  it('coords integrity: holds in a FEISHU org, where honest coords are already narrowed to slack', async () => {
+    // The mirror of the same root cause, and the reason a platform-keyed gate was a NO-OP for
+    // a whole tenant class: channel rows are keyed by the INTEGRATION platform ('feishu'),
+    // while the source daemon narrows its own coords to 'slack' before sending them. So the
+    // attack needed no exotic value at all — every honest wake in such an org already carries
+    // a platform the gate would fail to find.
+    const router = new CollaborationRouter()
+    router.replace({
+      generation: 1,
+      agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
+      channels: [
+        {
+          orgId: ORG,
+          platform: 'feishu',
+          channelId: 'oc_pub',
+          agents: [placement({ agentId: A, daemonId: D1 }), placement({ agentId: B, daemonId: D2 })]
+        },
+        { orgId: ORG, platform: 'feishu', channelId: 'oc_execs', agents: [placement({ agentId: B, daemonId: D2 })] }
+      ]
+    })
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const ack = await route(D1, baseMsg({ coords: { platform: 'slack', channel: 'oc_execs', thread: '900.1' } }))
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(0)
+    // The channel they genuinely share still routes, with the same narrowed platform.
+    const shared = await route(
+      D1,
+      baseMsg({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'oc_pub', thread: '900.1' } })
+    )
+    expect(shared.delivered).toBe(true)
+    expect(forwards).toHaveLength(1)
+  })
+
+  it('coords integrity: an UNKNOWN coordinate passes untouched — the gate is not a membership requirement', async () => {
+    // The snapshot knows only slack:C1, so neither coordinate below names a shared IM
+    // channel it could make a claim about: a session-identity platform (webchat/hook/dream)
+    // and an IM channel with no placement at all must both route on policy alone, otherwise
+    // the channel-free directory would be dead on arrival for integration-less peers.
+    const router = new CollaborationRouter()
+    router.replace(snap())
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const webchat = await route(D1, baseMsg({ coords: { platform: 'webchat', channel: 'wc-1' } }))
+    expect(webchat.delivered).toBe(true)
+    expect(forwards[0].coords).toEqual({ platform: 'webchat', channel: 'wc-1' })
+    // No channel row for the coordinate ⇒ the reply integration falls back to the target's
+    // directory entry, which here has none.
+    expect(forwards[0].integrationId).toBeUndefined()
+
+    const unknownChannel = await route(
+      D1,
+      baseMsg({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'C_NOT_IN_SNAPSHOT' } })
+    )
+    expect(unknownChannel.delivered).toBe(true)
+    expect(forwards).toHaveLength(2)
+  })
+
   it('target callPolicy=selected, caller not allowed → NAK not_allowed at the relay', async () => {
     const s = snap()
-    s.channels[0].agents[1].callPolicy = 'selected'
-    s.channels[0].agents[1].allowedCallerAgentIds = [] // A not allowed
+    s.agents[1].callPolicy = 'selected'
+    s.agents[1].allowedCallerAgentIds = [] // A not allowed
     const router = new CollaborationRouter()
     router.replace(s)
     const forwards: RdAgentMsgFwd[] = []
@@ -187,8 +385,8 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
 
   it('caller outboundPolicy=selected, target not allowed → NAK not_allowed at the relay', async () => {
     const s = snap()
-    s.channels[0]!.agents[0]!.outboundPolicy = 'selected'
-    s.channels[0]!.agents[0]!.allowedTargetAgentIds = []
+    s.agents[0]!.outboundPolicy = 'selected'
+    s.agents[0]!.allowedTargetAgentIds = []
     const router = new CollaborationRouter()
     router.replace(s)
     const forwards: RdAgentMsgFwd[] = []
@@ -203,9 +401,10 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(forwards).toHaveLength(0)
   })
 
-  it('target not in any channel row → NAK not_found', async () => {
+  it('target absent from the org directory → NAK not_found', async () => {
     const s = snap()
-    s.channels[0].agents = s.channels[0].agents.filter((a) => a.agentId !== B) // drop B
+    s.agents = s.agents.filter((a) => a.agentId !== B) // drop B from the directory
+    s.channels[0].agents = s.channels[0].agents.filter((a) => a.agentId !== B)
     const router = new CollaborationRouter()
     router.replace(s)
     const route = createAgentMsgRouter({
@@ -231,18 +430,12 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(ack.reason).toBe('offline')
   })
 
-  it('cross-org target → rejected (caller/target never share a channel row)', async () => {
-    // Caller A is in ORG/C1; a same-id channel in ORG2 holds a different target — the
-    // caller does not resolve in ORG2, so its org binds to ORG and B-in-ORG2 is unseen.
+  it('cross-org target → rejected even though both sit in the same channel id', async () => {
+    // Org scoping is now the ONLY isolation boundary (channel is not consulted), so put
+    // B in ORG2 and leave the identical channel id in place: it must still not resolve,
+    // and the reason must be indistinguishable from "no such agent" (no cross-org probing).
     const s = snap()
-    s.channels.push({
-      orgId: ORG2,
-      platform: 'slack',
-      channelId: 'C1',
-      agents: [{ agentId: B, daemonId: D2, integrationId: INT, callPolicy: 'all', allowedCallerAgentIds: [] }]
-    })
-    // Remove B from ORG so it only exists cross-org.
-    s.channels[0].agents = s.channels[0].agents.filter((a) => a.agentId !== B)
+    s.agents[1].orgId = ORG2
     const router = new CollaborationRouter()
     router.replace(s)
     const route = createAgentMsgRouter({
@@ -252,7 +445,94 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     })
     const ack = await route(D1, baseMsg())
     expect(ack.delivered).toBe(false)
-    expect(ack.reason).toBe('not_found') // resolved in caller's org (ORG), where B is absent
+    expect(ack.reason).toBe('not_found')
+    expect(router.admits(A, B)).toBe(false)
+  })
+
+  it('org-scoped resolve: caller and target share NO channel at all → still delivered', async () => {
+    // The whole point of the org-scoped directory: an integration-less peer (webchat/hook/
+    // dream) appears in no `channels[]` row, so channel membership cannot be the gate.
+    const s: CollabRoutesSnapshot = {
+      generation: 1,
+      agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
+      channels: [] // nobody has an IM integration
+    }
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const ack = await route(D1, baseMsg({ coords: { platform: 'webchat', channel: 'wc-1' } }))
+    expect(ack.delivered).toBe(true)
+    expect(forwards[0].trustedFromAgentId).toBe(A)
+    expect(forwards[0].orgId).toBe(ORG)
+    // No channel placement ⇒ no reply integration, and coords ride through as the delivery
+    // coordinate regardless.
+    expect(forwards[0].integrationId).toBeUndefined()
+    expect(forwards[0].coords).toEqual({ platform: 'webchat', channel: 'wc-1' })
+  })
+
+  it('forged caller is still rejected with no channel in play (placement belongs to another daemon)', async () => {
+    const s: CollabRoutesSnapshot = {
+      generation: 1,
+      agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
+      channels: []
+    }
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+    // Socket authenticated as D2, but it claims A — whose directory placement is on D1.
+    const ack = await route(D2, baseMsg())
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(0)
+  })
+
+  it('unknown target id (never in the directory) → not_found, and admits() fails closed', async () => {
+    const router = new CollaborationRouter()
+    router.replace(snap())
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, []),
+      log: noopLog
+    })
+    const ghost = '00000000-0000-0000-0000-0000000000ff'
+    const ack = await route(D1, baseMsg({ toAgentId: ghost }))
+    expect(ack).toMatchObject({ delivered: false, reason: 'not_found' })
+    expect(router.admits(A, ghost)).toBe(false)
+    expect(router.admits(ghost, A)).toBe(false)
+    // A caller always admits ITSELF, even with a 'selected' outbound policy that omits it.
+    expect(router.admits(A, A)).toBe(true)
+  })
+
+  it('old CP (no flat agents[]): the directory is derived from the channel rows', async () => {
+    // Rolling upgrade: an old CP advertises no `agent-directory-org-scope-v1` and sends no
+    // `agents[]` (schema default `[]`), so an integration-backed pair must keep authorizing.
+    const s = snap()
+    s.agents = []
+    const router = new CollaborationRouter()
+    router.replace(s)
+    expect(router.orgForAgent(A)).toBe(ORG)
+    expect(router.admits(A, B)).toBe(true)
+
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+    const ack = await route(D1, baseMsg())
+    expect(ack.delivered).toBe(true)
+    expect(forwards[0].orgId).toBe(ORG)
+    expect(forwards[0].integrationId).toBe(INT)
   })
 
   it('per-hop dedup: same deliveryId twice → single forward', async () => {
@@ -278,13 +558,11 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     // Add a second caller A2 that lives on D2 so a call FROM D2 is a valid, distinct call.
     const A2 = '00000000-0000-0000-0000-0000000000a3'
     const s = snap()
-    s.channels[0].agents.push({
-      agentId: A2,
-      daemonId: D2,
-      integrationId: INT,
-      callPolicy: 'all',
-      allowedCallerAgentIds: []
-    })
+    s.agents.push(orgAgent({ agentId: A2, daemonId: D2, integrationId: INT }))
+    // A2 needs a C1 placement too: both calls below assert coords slack:C1, and the
+    // coordinate-integrity gate requires a caller asserting a KNOWN channel to actually
+    // be in it (see the F1 regression test above).
+    s.channels[0].agents.push(placement({ agentId: A2, daemonId: D2 }))
     // Target A is on D1 so the D2-originated call forwards to D1's connection.
     const router = new CollaborationRouter()
     router.replace(s)
@@ -321,19 +599,30 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     // The bot-agnostic snapshot co-locates them by (org, platform, channel).
     const s: CollabRoutesSnapshot = {
       generation: 1,
+      agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
       channels: [
         {
           orgId: ORG,
           platform: 'slack',
           channelId: 'C1',
           agents: [
-            { agentId: A, daemonId: D1, integrationId: INT, callPolicy: 'all', allowedCallerAgentIds: [] },
+            {
+              agentId: A,
+              daemonId: D1,
+              integrationId: INT,
+              callPolicy: 'all',
+              allowedCallerAgentIds: [],
+              outboundPolicy: 'all',
+              allowedTargetAgentIds: []
+            },
             {
               agentId: B,
               daemonId: D2,
               integrationId: '00000000-0000-0000-0000-0000000000f2', // different bot's integration
               callPolicy: 'all',
-              allowedCallerAgentIds: []
+              allowedCallerAgentIds: [],
+              outboundPolicy: 'all',
+              allowedTargetAgentIds: []
             }
           ]
         }

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -295,6 +295,21 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     )
     expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
     expect(forwards).toHaveLength(0)
+
+    // The new label worth trying now that channel-free coordinates are admitted: claim the
+    // real Slack channel is a `webchat` conversation. The KNOWN-row branch runs FIRST and is
+    // platform-free, so the row is still found and membership is still demanded — the
+    // channel-free branch is only reachable for a coordinate no row exists for.
+    const asWebchat = await route(
+      D1,
+      baseMsg({
+        deliveryId: 'd-webchat',
+        coords: { platform: 'webchat', channel: 'C_EXECS', thread: '1784297789.871789' },
+        needsReply: true
+      })
+    )
+    expect(asWebchat).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(0)
   })
 
   it('coords integrity: holds in a FEISHU org, where honest coords are already narrowed to slack', async () => {
@@ -336,13 +351,17 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(forwards).toHaveLength(1)
   })
 
-  it('coords integrity: an UNKNOWN coordinate passes untouched — the gate is not a membership requirement', async () => {
-    // The snapshot knows only slack:C1, so neither coordinate below names a shared IM
-    // channel it could make a claim about: a session-identity platform (webchat/hook/dream)
-    // and an IM channel with no placement at all must both route on policy alone, otherwise
-    // the channel-free directory would be dead on arrival for integration-less peers.
+  it('coords integrity: an UNKNOWN IM coordinate FAILS CLOSED, while a channel-free one still routes', async () => {
+    // The review finding, and the assertion this test used to make. "Unknown coordinate
+    // passes" was too wide: it admitted not only the intended channel-free coordinates but
+    // any Slack channel the snapshot happens not to hold — a DM, a channel the bot left, or
+    // one the caller simply guessed. An authenticated-but-compromised source daemon could
+    // therefore land on the target's EXISTING session at that platform:channel:thread and use
+    // `needsReply` to pull its context back. So the two coordinates below must now split:
+    // the IM one is refused, the channel-free one is not (rejecting it would kill the
+    // integration-less collaboration the org-scoped directory exists for).
     const router = new CollaborationRouter()
-    router.replace(snap())
+    router.replace(snap()) // knows only slack:C1
     const forwards: RdAgentMsgFwd[] = []
     const route = createAgentMsgRouter({
       router,
@@ -352,6 +371,8 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
 
     const webchat = await route(D1, baseMsg({ coords: { platform: 'webchat', channel: 'wc-1' } }))
     expect(webchat.delivered).toBe(true)
+    // The relay forwards `coords` VERBATIM — the target daemon is the side that replaces a
+    // channel-free coordinate when it mints the session key, so the two cannot disagree.
     expect(forwards[0].coords).toEqual({ platform: 'webchat', channel: 'wc-1' })
     // No channel row for the coordinate ⇒ the reply integration falls back to the target's
     // directory entry, which here has none.
@@ -361,7 +382,75 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
       D1,
       baseMsg({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'C_NOT_IN_SNAPSHOT' } })
     )
-    expect(unknownChannel.delivered).toBe(true)
+    expect(unknownChannel).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    expect(forwards).toHaveLength(1) // nothing forwarded for the IM coordinate
+
+    // …on every persisted IM platform, not just Slack.
+    for (const [i, platform] of ['telegram', 'discord', 'feishu'].entries()) {
+      const ack = await route(
+        D1,
+        baseMsg({ deliveryId: `d-im-${i}`, coords: { platform: platform as 'telegram', channel: 'NOT_A_ROW' } })
+      )
+      expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    }
+    expect(forwards).toHaveLength(1)
+  })
+
+  it('coords integrity: a DM / group-DM row the caller owns is KNOWN, so DM-origin A2A still routes', async () => {
+    // The over-block this fail-closed branch could have caused, and the claim it rests on: a
+    // direct conversation is an ORDINARY channel row wherever one exists. `IntegrationChannel
+    // .kind` is `channel | im | mpim` and `IntegrationRepo.channelPlacements` selects the
+    // channels with NO filter on `kind`, so a recorded DM arrives in this snapshot as a plain
+    // row with its owning agent in it — branch 1, not the fail-closed one. (Only a GATED
+    // integration's not-yet-enabled conversations get such a row; an ungated integration's DM
+    // has none and takes branch 2 — the same answer the membership check this replaced gave.)
+    const INT_DM = '00000000-0000-0000-0000-0000000000f3'
+    const s = snap()
+    s.channels.push(
+      // Slack "D…" one-to-one DM between the human and A's bot.
+      { orgId: ORG, platform: 'slack', channelId: 'D01ALICE', agents: [placement({ agentId: A, daemonId: D1 })] },
+      // Slack "G…" mpim (group DM) the same bot sits in.
+      {
+        orgId: ORG,
+        platform: 'slack',
+        channelId: 'G01TEAM',
+        agents: [placement({ agentId: A, daemonId: D1, integrationId: INT_DM })]
+      }
+    )
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+
+    const dm = await route(D1, baseMsg({ coords: { platform: 'slack', channel: 'D01ALICE', thread: '900.1' } }))
+    expect(dm.delivered).toBe(true)
+    expect(forwards[0].coords).toEqual({ platform: 'slack', channel: 'D01ALICE', thread: '900.1' })
+
+    const groupDm = await route(
+      D1,
+      baseMsg({ deliveryId: 'd-2', coords: { platform: 'slack', channel: 'G01TEAM', thread: '900.2' } })
+    )
+    expect(groupDm.delivered).toBe(true)
+    expect(forwards).toHaveLength(2)
+
+    // A DM row the caller does NOT own is still not assertable — the branch is membership,
+    // not "any DM goes".
+    s.channels.push({
+      orgId: ORG,
+      platform: 'slack',
+      channelId: 'D02BOB',
+      agents: [placement({ agentId: B, daemonId: D2 })]
+    })
+    router.replace({ ...s, generation: 2 })
+    const foreignDm = await route(
+      D1,
+      baseMsg({ deliveryId: 'd-3', coords: { platform: 'slack', channel: 'D02BOB', thread: '900.3' } })
+    )
+    expect(foreignDm).toMatchObject({ delivered: false, reason: 'not_allowed' })
     expect(forwards).toHaveLength(2)
   })
 

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -13,8 +13,9 @@
  *     key is computed from a narrowed platform — the caller must be a member of one of
  *     them. Membership no longer AUTHORIZES the call, but `coords` is still the woken
  *     peer's session key, so an unchecked assertion would let a caller resume a session in
- *     a channel it cannot reach. A coordinate the snapshot knows nothing about (webchat,
- *     and any conversation the CP records no channel row for) asserts nothing and passes;
+ *     a channel it cannot reach. An UNKNOWN coordinate on a persisted IM platform fails
+ *     CLOSED; an unknown one on a channel-free platform (webchat/dream) is admitted and the
+ *     TARGET daemon keys the woken session off the trusted caller instead;
  *  c) resolve the TARGET `toAgentId` in the SAME org → owning daemonId. Channel-free:
  *     A2A delivery is postless, so caller and target need share no channel (and an
  *     integration-less peer has none). `msg.coords` still rides along as the DELIVERY
@@ -94,14 +95,19 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     // existing session there (with `needsReply`, reading that conversation back into its own).
     // Same threat model as the `caller.daemonId !== fromDaemonId` check above: a compromised or
     // buggy source daemon asserting something the relay is the only one able to falsify.
-    // One atomic predicate, keyed on (org, CHANNEL ID) and deliberately NOT on the coordinate
-    // platform — the woken session's key is computed from a narrowed platform while rows are
-    // keyed by the integration platform, so a platform-keyed check searched a different key
-    // space than the key it protects (see CollaborationRouter.coordsAdmit). The target daemon
-    // applies the IDENTICAL predicate on its terminal verify, so the two never disagree.
-    if (!router.coordsAdmit(orgId, msg.coords.channel, msg.claimedFromAgentId)) {
+    // ONE decision (see CollaborationRouter.coordsDecision): a KNOWN coordinate demands
+    // membership; an UNKNOWN one on a PERSISTED IM platform fails CLOSED, because an
+    // unrecorded Slack/Telegram/Discord/Feishu conversation — a DM whose row this snapshot
+    // has not caught up with, a channel the bot left, an id the caller simply guessed — is
+    // precisely how a caller aliases an existing platform session; an UNKNOWN one on a
+    // channel-free platform is admitted, and the TARGET DAEMON (not the relay) replaces the
+    // asserted channel with a caller-derived one when it mints the session key. The relay
+    // therefore forwards `coords` verbatim and acts only on `reject`.
+    if (
+      router.coordsDecision(orgId, msg.coords.platform, msg.coords.channel, msg.claimedFromAgentId).verdict === 'reject'
+    ) {
       deps.log.warn(
-        `relay: rd/agentmsg not_allowed — ${msg.claimedFromAgentId} asserted ${msg.coords.platform}:${msg.coords.channel} it is not in`
+        `relay: rd/agentmsg not_allowed — ${msg.claimedFromAgentId} may not assert coords ${msg.coords.platform}:${msg.coords.channel}`
       )
       return nak(msg.deliveryId, 'not_allowed')
     }

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -6,10 +6,19 @@
  * Steps (§2.5 / §6.2):
  *  a) bind the request to the socket's AUTHENTICATED `fromDaemonId` (passed in — never
  *     the frame's `claimedFromAgentId`);
- *  b) validate `claimedFromAgentId` actually belongs to that daemon AND is in the
- *     `(platform, channel)` via the collaboration snapshot (a forged claim → reject);
- *  c) resolve the TARGET `toAgentId` in the SAME org/channel → owning daemonId (the
- *     bot-agnostic fix: target may be on a different bot but same channel);
+ *  b) validate `claimedFromAgentId` actually belongs to that daemon via the org-scoped
+ *     collaboration directory (a forged claim → reject);
+ *  b2) verify the INTEGRITY of the asserted `msg.coords`: if the snapshot knows any
+ *     membership at that (org, channel id) — under ANY platform, since the woken session's
+ *     key is computed from a narrowed platform — the caller must be a member of one of
+ *     them. Membership no longer AUTHORIZES the call, but `coords` is still the woken
+ *     peer's session key, so an unchecked assertion would let a caller resume a session in
+ *     a channel it cannot reach. A coordinate the snapshot knows nothing about (webchat,
+ *     and any conversation the CP records no channel row for) asserts nothing and passes;
+ *  c) resolve the TARGET `toAgentId` in the SAME org → owning daemonId. Channel-free:
+ *     A2A delivery is postless, so caller and target need share no channel (and an
+ *     integration-less peer has none). `msg.coords` still rides along as the DELIVERY
+ *     coordinate for the woken session, not as an authorization input;
  *  d) check the caller's outbound policy AND the target's inbound policy
  *     (cross-org / either denial → typed NAK);
  *  e) increment hopCount (inbound+1, cap 8, §2.4);
@@ -25,6 +34,7 @@
  */
 import type { RdAgentMsg, RdAgentMsgAck, RdAgentMsgReason } from '@agentconnect.md/protocol'
 import type { CollaborationRouter } from './collaboration-router.js'
+import { inboundAdmits, outboundAdmits } from './collaboration-router.js'
 import type { RelayDaemonServer } from './relay-daemon-server.js'
 import type { Logger } from './log.js'
 
@@ -65,33 +75,54 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
 
   async function route(fromDaemonId: string, msg: RdAgentMsg): Promise<RdAgentMsgAck> {
     const { router } = deps
-    const { platform, channel } = msg.coords
-
-    // (b) Validate the UNTRUSTED claimedFromAgentId: it must resolve to a channel member
-    // whose placement is owned by the AUTHENTICATED sending daemon. Bind org from the
-    // caller's own placement (the frame carries no org — cross-org can't share a row).
-    const orgId = router.channelOrgFor(platform, channel, msg.claimedFromAgentId)
-    const caller = orgId ? router.resolve(orgId, platform, channel, msg.claimedFromAgentId) : undefined
-    if (!orgId || !caller || caller.daemonId !== fromDaemonId) {
+    // (b) Validate the UNTRUSTED claimedFromAgentId against the ORG-SCOPED directory: the
+    // claimed id must exist and its placement must be owned by the AUTHENTICATED sending
+    // daemon — that daemon-ownership check, not channel membership, is what makes the claim
+    // unforgeable. Org is bound from the caller's own entry (the frame carries no org).
+    const caller = router.agent(msg.claimedFromAgentId)
+    if (!caller || caller.daemonId !== fromDaemonId) {
       deps.log.warn(
         `relay: rd/agentmsg rejected — forged/unknown caller ${msg.claimedFromAgentId} on daemon ${fromDaemonId}`
       )
       return nak(msg.deliveryId, 'not_allowed')
     }
+    const orgId = caller.orgId
 
-    // (c) Resolve the TARGET in the SAME org/channel (bot-agnostic). Not there ⇒ not_found.
-    const target = router.resolve(orgId, platform, channel, msg.toAgentId)
-    if (!target) return nak(msg.deliveryId, 'not_found')
+    // (b2) COORDINATE INTEGRITY. Channel is no longer an authorization key, but it is still
+    // the DELIVERY coordinate the target daemon derives the woken session's key from — so an
+    // unchecked `coords` lets a caller name a channel it cannot reach and RESUME the target's
+    // existing session there (with `needsReply`, reading that conversation back into its own).
+    // Same threat model as the `caller.daemonId !== fromDaemonId` check above: a compromised or
+    // buggy source daemon asserting something the relay is the only one able to falsify.
+    // One atomic predicate, keyed on (org, CHANNEL ID) and deliberately NOT on the coordinate
+    // platform — the woken session's key is computed from a narrowed platform while rows are
+    // keyed by the integration platform, so a platform-keyed check searched a different key
+    // space than the key it protects (see CollaborationRouter.coordsAdmit). The target daemon
+    // applies the IDENTICAL predicate on its terminal verify, so the two never disagree.
+    if (!router.coordsAdmit(orgId, msg.coords.channel, msg.claimedFromAgentId)) {
+      deps.log.warn(
+        `relay: rd/agentmsg not_allowed — ${msg.claimedFromAgentId} asserted ${msg.coords.platform}:${msg.coords.channel} it is not in`
+      )
+      return nak(msg.deliveryId, 'not_allowed')
+    }
+
+    // (c) Resolve the TARGET in the SAME org, channel-free: A2A delivery is postless, so a
+    // shared channel is neither required nor evidence of anything. Absent/cross-org ⇒ not_found
+    // (cross-org is indistinguishable from nonexistent by design — no cross-org probing).
+    const target = router.agent(msg.toAgentId)
+    if (!target || target.orgId !== orgId) return nak(msg.deliveryId, 'not_found')
 
     // (d) Directional policy: A→B requires caller A to admit B and target B to
     // admit A. A guessed/stale target id therefore cannot bypass the directory.
-    if (caller.outboundPolicy === 'selected' && !caller.allowedTargetAgentIds.includes(msg.toAgentId)) {
+    // Kept as two explicit checks rather than router.admits() so each denial keeps its
+    // own log line (the reason an operator can tell the two directions apart).
+    if (!outboundAdmits(caller, msg.toAgentId)) {
       deps.log.info(
         `relay: rd/agentmsg not_allowed — ${msg.claimedFromAgentId} outbound policy excludes ${msg.toAgentId}`
       )
       return nak(msg.deliveryId, 'not_allowed')
     }
-    if (target.callPolicy === 'selected' && !target.allowedCallerAgentIds.includes(msg.claimedFromAgentId)) {
+    if (!inboundAdmits(target, msg.claimedFromAgentId)) {
       deps.log.info(`relay: rd/agentmsg not_allowed — ${msg.claimedFromAgentId} → ${msg.toAgentId} (target selected)`)
       return nak(msg.deliveryId, 'not_allowed')
     }
@@ -104,12 +135,19 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
     const conn = deps.daemons()?.get(target.daemonId)
     if (!conn) return nak(msg.deliveryId, 'offline')
 
+    // Delivery detail, NOT authorization: the DEFINITE reply integration (§6.2). The same
+    // agent can reach two channels via two different bots, so prefer its placement in the
+    // coords channel and fall back to the directory entry when it has no row there (an
+    // integration-less peer legitimately has none).
+    const { platform, channel } = msg.coords
+    const integrationId = router.resolve(orgId, platform, channel, msg.toAgentId)?.integrationId ?? target.integrationId
+
     try {
       return await conn.forwardAgentMsg({
         trustedFromAgentId: msg.claimedFromAgentId, // now VALIDATED — the target may trust it
         orgId,
         toAgentId: msg.toAgentId,
-        ...(target.integrationId !== undefined ? { integrationId: target.integrationId } : {}),
+        ...(integrationId !== undefined ? { integrationId } : {}),
         text: msg.text,
         coords: msg.coords,
         ...(msg.correlationId !== undefined ? { correlationId: msg.correlationId } : {}),

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -17,10 +17,9 @@
  * holds it and answers the three questions the `rd/agentmsg` router asks:
  *  - is the CLAIMED caller actually this daemon's agent? (§6.2)
  *  - who OWNS the target, and do caller outbound + target inbound policies agree?
- *  - is the asserted `coords` a shared IM channel the caller can actually reach?
- *    ({@link coordsAdmit}) — channel stopped being an authorization key but is still the
- *    woken peer's SESSION key, so the assertion still needs integrity even though
- *    membership no longer grants anything.
+ *  - may the caller assert the `coords` it named? ({@link coordsDecision}) — channel
+ *    stopped being an authorization key but is still the woken peer's SESSION key, so the
+ *    assertion still needs integrity even though membership no longer grants anything.
  *
  * FOLLOW-UP (P2 scope-down, §6.5): per-entry tombstone / TTL-after-CP-disconnect /
  * fail-closed-on-stale is not implemented — `generation` is tracked but a live CP is
@@ -39,9 +38,46 @@ const SEP = '\u0000'
 function key(orgId: string, platform: string, channelId: string): string {
   return orgId + SEP + platform + SEP + channelId
 }
-/** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link CollaborationRouter.coordsAdmit}. */
+/** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link CollaborationRouter.coordsDecision}. */
 function coordsKey(orgId: string, channelId: string): string {
   return orgId + SEP + channelId
+}
+
+/**
+ * The verdict of {@link CollaborationRouter.coordsDecision} (agent-collaboration §6.2).
+ * Three outcomes, not two, because a channel-free wake must neither be rejected nor be
+ * allowed to keep the coordinate it named:
+ *  - `reject`    — the assertion is not admissible; NAK `not_allowed`.
+ *  - `asserted`  — use the coordinate as given (a channel row the caller is in).
+ *  - `synthetic` — admissible, but the woken session must key off `channel` (derived from
+ *                  the TRUSTED caller) instead of the asserted one.
+ *
+ * The relay only ever acts on `reject`; the `synthetic` channel is minted where the session
+ * key actually is (the target daemon), so the two sides cannot disagree about the result.
+ * The daemon carries a BYTE-IDENTICAL twin of this type and of {@link coordsDecision} in
+ * `packages/daemon/src/cp/cp-collab-routes.ts` — change one, change both.
+ */
+export type CoordsVerdict = { verdict: 'reject' } | { verdict: 'asserted' } | { verdict: 'synthetic'; channel: string }
+
+/**
+ * The platforms whose conversations are PERSISTED as `integration_channel` rows and
+ * therefore appear in this snapshot — i.e. the protocol `Platform` enum minus the
+ * session-identity members (`webchat`/`hook`/`dream`, which have no persisted row; see the
+ * CP's `isSessionIdentityPlatform`). An UNKNOWN coordinate on one of these is evidence of a
+ * problem, not of a channel-free session, so it fails closed ({@link coordsDecision}).
+ */
+const PERSISTED_IM_PLATFORMS: ReadonlySet<string> = new Set(['slack', 'telegram', 'discord', 'feishu'])
+
+/**
+ * The coordinate a channel-free wake lands on: derived from the TRUSTED caller, never from
+ * anything the caller asserted. Collision-free against every real conversation id by
+ * construction — Slack/Telegram/Discord/Feishu channel ids never contain `:` and webchat
+ * conversation ids are UUIDs — so it can never alias an existing platform session. Two
+ * different asserted channels from one caller therefore collapse onto ONE pairwise session,
+ * which is the right shape for a postless agent-to-agent conversation (#854).
+ */
+export function a2aCoordChannel(callerAgentId: string): string {
+  return `a2a:${callerAgentId}`
 }
 
 /** Caller-side half of the directional predicate: does A's outbound policy admit B? */
@@ -59,7 +95,7 @@ export class CollaborationRouter {
   // (orgId,platform,channel) → (agentId → placement)
   private readonly channels = new Map<string, Map<string, CollabResolved>>()
   // (orgId,channel) → the member maps of EVERY platform row sharing that channel id.
-  // The coordinate-integrity index; platform-free on purpose ({@link coordsAdmit}).
+  // The coordinate-integrity index; platform-free on purpose ({@link coordsDecision}).
   private readonly byOrgChannel = new Map<string, Map<string, CollabResolved>[]>()
   // agentId → org-scoped directory entry. Agent ids are globally unique UUIDs, so one
   // agent belongs to exactly one org and a flat index loses no addressing precision.
@@ -107,49 +143,86 @@ export class CollaborationRouter {
 
   /**
    * COORDINATE INTEGRITY for `rd/agentmsg` (agent-collaboration §6.2), as ONE atomic
-   * predicate: may `callerAgentId` assert the delivery coordinate `(orgId, channelId)`?
+   * decision: may `callerAgentId` assert the delivery coordinate `(orgId, platform,
+   * channelId)`, and if so, which channel may the woken session actually key off?
    *
    * Channel is no longer an authorization key, but it is still the woken peer's SESSION
    * key, so an asserted `coords` the caller cannot reach would let it resume (and, with
-   * `needsReply`, read back) a target session in a channel it has no access to. The rule:
-   * if the snapshot knows any NON-EMPTY membership at that coordinate, the caller must be
-   * in one of them; if it knows none, the coordinate is not a claim about a shared IM
-   * channel and needs no membership evidence. The target daemon's terminal-verify applies
-   * the IDENTICAL predicate — the two must never disagree.
+   * `needsReply`, read back) a target session in a channel it has no access to. Three
+   * branches, evaluated in this order:
    *
-   * PLATFORM-FREE ON PURPOSE. The coordinate platform must NOT be part of the key: the
-   * woken session's key is computed from a NARROWED platform (the daemon's
-   * `narrowPlatform` folds `feishu` — and any value it does not recognise — into
-   * `'slack'`), while snapshot rows are keyed by the INTEGRATION platform. Keying this
-   * check on the raw wire platform therefore searched a different key space than the
-   * session key it protects, and the "unknown coordinate passes" branch silently
-   * swallowed the mismatch: `coords.platform:'feishu'` over a Slack channel id (or, in a
-   * Feishu org, an honest narrowed `'slack'` over a `feishu` row) missed the row, passed,
-   * and still computed a bit-identical child session key. Matching on the channel id
-   * alone closes both directions and needs no `narrowPlatform` twin on the relay side. It
-   * over-blocks only if one org uses the same channel id on two platforms — which then
-   * requires membership in one of them, not a bypass.
+   * (1) KNOWN coordinate — the snapshot holds a NON-EMPTY membership at (org, channel id):
+   *     the caller must be in one of them, else `reject`. Otherwise `asserted`: the wake
+   *     deliberately lands in the same thread a human sees. This branch is PLATFORM-FREE
+   *     (below), so a DIRECT conversation counts wherever its row exists:
+   *     `IntegrationChannel.kind` is `channel | im | mpim` and `channelPlacements` selects
+   *     the rows with NO `kind` filter, so an `im`/`mpim` row is an ordinary KNOWN
+   *     coordinate with its owning integration's agent as a member.
+   *
+   * (2) UNKNOWN on a PERSISTED IM platform ({@link PERSISTED_IM_PLATFORMS}) — `reject`,
+   *     FAIL CLOSED. An unrecorded IM coordinate is either a channel the caller cannot
+   *     reach or a stale/departed row; admitting it is exactly what let a caller alias an
+   *     existing platform session. A brief snapshot lag can therefore transiently reject a
+   *     genuine wake — the correct direction for a security boundary, and the caller retries.
+   *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
+   *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
+   *     observed it — Slack's authoritative membership snapshot enumerates
+   *     `public_channel,private_channel` only, and the two paths that DO emit `im`/`mpim`
+   *     (the daemon's `reportGatedConversation` and the CP's shared-bot
+   *     `reportConversation`) both fire only for a GATED integration/install's
+   *     not-yet-enabled conversations — so an ordinary integration's DM has no row and a
+   *     wake asserting it is refused here.
+   *     Deliberate, and not a regression: the `hasMembers(caller, target)` check this
+   *     replaced refused the identical wake.
+   *
+   * (3) UNKNOWN and channel-free (anything else — on the wire, where `coords.platform` is
+   *     `slack | telegram | webchat | discord | feishu`, only `webchat` can reach here; a
+   *     `dream`/`hook` session's own platform reaches the daemon's twin on its same-daemon
+   *     path) — `synthetic`. NOT a reject: this is the case the org-scoped directory exists
+   *     for. Instead the asserted channel never becomes the session coordinate at all;
+   *     {@link a2aCoordChannel} derives it from the trusted caller, which cannot alias any
+   *     platform session. The relay does not apply the substitution (see below), only skips
+   *     the rejection.
+   *
+   * Branch (1) running FIRST and platform-free is what keeps (3) from being an escape
+   * hatch: relabelling a real channel's coordinate as `webchat` still hits branch 1 and
+   * still demands membership.
+   *
+   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key must NOT include the
+   * coordinate platform: the woken session's key is computed from a NARROWED platform (the
+   * daemon's `narrowPlatform` folds `feishu` — and any value it does not recognise — into
+   * `'slack'`), while snapshot rows are keyed by the INTEGRATION platform. Keying the
+   * LOOKUP on the raw wire platform searched a different key space than the session key it
+   * protects, and the old "unknown coordinate passes" branch silently swallowed the
+   * mismatch: `coords.platform:'feishu'` over a Slack channel id (or, in a Feishu org, an
+   * honest narrowed `'slack'` over a `feishu` row) missed the row, passed, and still
+   * computed a bit-identical child session key. Matching on the channel id alone closes
+   * both directions and needs no `narrowPlatform` twin on the relay side; it over-blocks
+   * only if one org uses the same channel id on two platforms, which then requires
+   * membership in one of them, not a bypass. The platform is consulted ONLY to pick between
+   * branch 2 and branch 3, and only for a coordinate branch 1 already found nothing for —
+   * where the collapse cannot help an attacker, because branch 3 hands back a
+   * caller-derived channel rather than the asserted one.
    *
    * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
    * anyone in this org can reach, so gating on it would reject every call naming it while
    * protecting nothing.
    *
-   * KNOWN LIMIT (follow-up, not closed here): "unknown coordinate" cannot distinguish
-   * "not an IM channel" from "an IM channel the CP does not record". Slack DMs and group
-   * DMs are deliberately never channel rows, and a row disappears when the bot leaves or
-   * the integration goes inactive while the session stays resumable — such coordinates
-   * take the pass branch.
+   * The target daemon applies a BYTE-IDENTICAL twin of this on its terminal-verify
+   * (`CpCollabRoutes.coordsDecision`) and is the side that MINTS the synthetic channel —
+   * the relay only rejects.
    */
-  coordsAdmit(orgId: string, channelId: string, callerAgentId: string): boolean {
+  coordsDecision(orgId: string, platform: string, channelId: string, callerAgentId: string): CoordsVerdict {
     const sharing = this.byOrgChannel.get(coordsKey(orgId, channelId))
-    if (sharing === undefined) return true
     let known = false
-    for (const members of sharing) {
+    for (const members of sharing ?? []) {
       if (members.size === 0) continue
       known = true
-      if (members.has(callerAgentId)) return true
+      if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
-    return !known
+    if (known) return { verdict: 'reject' }
+    if (PERSISTED_IM_PLATFORMS.has(platform)) return { verdict: 'reject' }
+    return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
   }
 
   /** The org-scoped directory entry for `agentId`, or undefined if the directory has

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -1,21 +1,32 @@
 /**
  * `CollaborationRouter` — the relay's bot-AGNOSTIC agent-collaboration routing table
  * (agent-collaboration §2.3 / §6.2). Unlike {@link BotArbitrationRouter} (keyed by botId,
- * so two agents in the same channel on DIFFERENT bots aren't co-resolvable), this is
- * keyed by `(orgId, platform, channelId)` and holds every agent's placement + call
- * directional policy in that channel — which is what a cross-daemon `rd/agentmsg` needs to
- * resolve `toAgentId → owning daemonId` and authorize the caller.
+ * so two agents in the same channel on DIFFERENT bots aren't co-resolvable), the
+ * channel table is keyed by `(orgId, platform, channelId)` and holds every agent's
+ * placement + directional call policy in that channel.
+ *
+ * On top of that it holds the FLAT org-scoped directory (`snap.agents`), which is what
+ * `rd/agentmsg` now authorizes against: A2A delivery is postless, so a shared channel
+ * is no longer evidence of anything — discovery/authorization depend ONLY on the
+ * directional call policy, org-scoped, and an integration-less agent (webchat, hook,
+ * dream) exists in no channel row at all. The channel table survives for the ingress
+ * questions that are genuinely channel-shaped ({@link isAgentBotAppFor}, shared-bot
+ * resolution).
  *
  * The CP ships the whole snapshot via `rc/collab-routes` (FULL-REPLACE). This class
- * holds it and answers the two questions the `rd/agentmsg` router asks:
- *  - is the CLAIMED caller actually this daemon's agent, in this channel? (§6.2)
+ * holds it and answers the three questions the `rd/agentmsg` router asks:
+ *  - is the CLAIMED caller actually this daemon's agent? (§6.2)
  *  - who OWNS the target, and do caller outbound + target inbound policies agree?
+ *  - is the asserted `coords` a shared IM channel the caller can actually reach?
+ *    ({@link coordsAdmit}) — channel stopped being an authorization key but is still the
+ *    woken peer's SESSION key, so the assertion still needs integrity even though
+ *    membership no longer grants anything.
  *
  * FOLLOW-UP (P2 scope-down, §6.5): per-entry tombstone / TTL-after-CP-disconnect /
  * fail-closed-on-stale is not implemented — `generation` is tracked but a live CP is
  * assumed. Documented in the PR description.
  */
-import type { CollabRoutesSnapshot, CollabAgentPlacement } from '@agentconnect.md/protocol'
+import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
 
 /** The resolved placement of one agent in a channel (a snapshot value). */
 export interface CollabResolved extends CollabAgentPlacement {
@@ -28,11 +39,31 @@ const SEP = '\u0000'
 function key(orgId: string, platform: string, channelId: string): string {
   return orgId + SEP + platform + SEP + channelId
 }
+/** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link CollaborationRouter.coordsAdmit}. */
+function coordsKey(orgId: string, channelId: string): string {
+  return orgId + SEP + channelId
+}
+
+/** Caller-side half of the directional predicate: does A's outbound policy admit B? */
+export function outboundAdmits(caller: CollabOrgAgent, targetAgentId: string): boolean {
+  return caller.outboundPolicy !== 'selected' || caller.allowedTargetAgentIds.includes(targetAgentId)
+}
+
+/** Target-side half: does B's inbound call policy admit A? */
+export function inboundAdmits(target: CollabOrgAgent, callerAgentId: string): boolean {
+  return target.callPolicy !== 'selected' || target.allowedCallerAgentIds.includes(callerAgentId)
+}
 
 export class CollaborationRouter {
   private generation = -1
   // (orgId,platform,channel) → (agentId → placement)
   private readonly channels = new Map<string, Map<string, CollabResolved>>()
+  // (orgId,channel) → the member maps of EVERY platform row sharing that channel id.
+  // The coordinate-integrity index; platform-free on purpose ({@link coordsAdmit}).
+  private readonly byOrgChannel = new Map<string, Map<string, CollabResolved>[]>()
+  // agentId → org-scoped directory entry. Agent ids are globally unique UUIDs, so one
+  // agent belongs to exactly one org and a flat index loses no addressing precision.
+  private readonly byAgent = new Map<string, CollabOrgAgent>()
 
   /** FULL-REPLACE the table from a CP snapshot. Ignores an older generation (a
    *  reordered/stale re-push) so the newest snapshot wins. */
@@ -40,12 +71,31 @@ export class CollaborationRouter {
     if (snap.generation < this.generation) return
     this.generation = snap.generation
     this.channels.clear()
+    this.byOrgChannel.clear()
+    this.byAgent.clear()
+    for (const a of snap.agents) this.byAgent.set(a.agentId, a)
+    // Old-CP fallback: a CP that does not advertise `agent-directory-org-scope-v1` sends
+    // no `agents[]` (it decodes to the schema default `[]`). Derive the directory from the
+    // channel rows so integration-backed pairs keep resolving across a rolling upgrade;
+    // an integration-less agent stays invisible until the CP ships the flat list, which
+    // is exactly the pre-change behavior.
+    if (snap.agents.length === 0) {
+      for (const ch of snap.channels) {
+        for (const a of ch.agents) {
+          if (!this.byAgent.has(a.agentId)) this.byAgent.set(a.agentId, { ...a, orgId: ch.orgId })
+        }
+      }
+    }
     for (const ch of snap.channels) {
       const byAgent = new Map<string, CollabResolved>()
       for (const a of ch.agents) {
         byAgent.set(a.agentId, { ...a, orgId: ch.orgId, platform: ch.platform, channelId: ch.channelId })
       }
       this.channels.set(key(ch.orgId, ch.platform, ch.channelId), byAgent)
+      const ck = coordsKey(ch.orgId, ch.channelId)
+      const sharing = this.byOrgChannel.get(ck)
+      if (sharing) sharing.push(byAgent)
+      else this.byOrgChannel.set(ck, [byAgent])
     }
   }
 
@@ -55,18 +105,86 @@ export class CollaborationRouter {
     return this.channels.get(key(orgId, platform, channelId))?.get(agentId)
   }
 
-  /** Find which org a channel-member agent belongs to WITHOUT the caller asserting an
-   *  org — used to bind an inbound `rd/agentmsg` (which carries no orgId) to the org
-   *  its `(platform, channel, callerAgentId)` actually resolves in. Cross-org callers
-   *  never share a channel row, so caller and target resolve in the SAME org or the
-   *  call is rejected (§2.5). */
-  channelOrgFor(platform: string, channelId: string, callerAgentId: string): string | undefined {
-    for (const byAgent of this.channels.values()) {
-      const hit = byAgent.get(callerAgentId)
-      if (hit && hit.platform === platform && hit.channelId === channelId) return hit.orgId
+  /**
+   * COORDINATE INTEGRITY for `rd/agentmsg` (agent-collaboration §6.2), as ONE atomic
+   * predicate: may `callerAgentId` assert the delivery coordinate `(orgId, channelId)`?
+   *
+   * Channel is no longer an authorization key, but it is still the woken peer's SESSION
+   * key, so an asserted `coords` the caller cannot reach would let it resume (and, with
+   * `needsReply`, read back) a target session in a channel it has no access to. The rule:
+   * if the snapshot knows any NON-EMPTY membership at that coordinate, the caller must be
+   * in one of them; if it knows none, the coordinate is not a claim about a shared IM
+   * channel and needs no membership evidence. The target daemon's terminal-verify applies
+   * the IDENTICAL predicate — the two must never disagree.
+   *
+   * PLATFORM-FREE ON PURPOSE. The coordinate platform must NOT be part of the key: the
+   * woken session's key is computed from a NARROWED platform (the daemon's
+   * `narrowPlatform` folds `feishu` — and any value it does not recognise — into
+   * `'slack'`), while snapshot rows are keyed by the INTEGRATION platform. Keying this
+   * check on the raw wire platform therefore searched a different key space than the
+   * session key it protects, and the "unknown coordinate passes" branch silently
+   * swallowed the mismatch: `coords.platform:'feishu'` over a Slack channel id (or, in a
+   * Feishu org, an honest narrowed `'slack'` over a `feishu` row) missed the row, passed,
+   * and still computed a bit-identical child session key. Matching on the channel id
+   * alone closes both directions and needs no `narrowPlatform` twin on the relay side. It
+   * over-blocks only if one org uses the same channel id on two platforms — which then
+   * requires membership in one of them, not a bypass.
+   *
+   * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
+   * anyone in this org can reach, so gating on it would reject every call naming it while
+   * protecting nothing.
+   *
+   * KNOWN LIMIT (follow-up, not closed here): "unknown coordinate" cannot distinguish
+   * "not an IM channel" from "an IM channel the CP does not record". Slack DMs and group
+   * DMs are deliberately never channel rows, and a row disappears when the bot leaves or
+   * the integration goes inactive while the session stays resumable — such coordinates
+   * take the pass branch.
+   */
+  coordsAdmit(orgId: string, channelId: string, callerAgentId: string): boolean {
+    const sharing = this.byOrgChannel.get(coordsKey(orgId, channelId))
+    if (sharing === undefined) return true
+    let known = false
+    for (const members of sharing) {
+      if (members.size === 0) continue
+      known = true
+      if (members.has(callerAgentId)) return true
     }
-    return undefined
+    return !known
   }
+
+  /** The org-scoped directory entry for `agentId`, or undefined if the directory has
+   *  never seen it — every authorization decision below fails CLOSED on that. */
+  agent(agentId: string): CollabOrgAgent | undefined {
+    return this.byAgent.get(agentId)
+  }
+
+  /** Which org owns `agentId`, WITHOUT the caller asserting an org — binds an inbound
+   *  `rd/agentmsg` (the frame carries no orgId) to the org its authenticated caller
+   *  actually lives in, so a cross-org pair can never resolve (§2.5). Channel-free:
+   *  the caller need share no channel with anyone. */
+  orgForAgent(agentId: string): string | undefined {
+    return this.byAgent.get(agentId)?.orgId
+  }
+
+  /** The single authorization predicate: both peers known, same org, the caller's
+   *  outbound policy admits the target AND the target's inbound policy admits the
+   *  caller. A caller always admits ITSELF — an agent with `outboundPolicy: 'selected'`
+   *  does not list itself in its own allow-list yet must still see itself in a
+   *  directory listing. Callers that need the NAK reason use the halves directly
+   *  ({@link outboundAdmits} / {@link inboundAdmits}). */
+  admits(callerAgentId: string, targetAgentId: string): boolean {
+    const caller = this.byAgent.get(callerAgentId)
+    const target = this.byAgent.get(targetAgentId)
+    if (!caller || !target || caller.orgId !== target.orgId) return false
+    if (callerAgentId === targetAgentId) return true
+    return outboundAdmits(caller, targetAgentId) && inboundAdmits(target, callerAgentId)
+  }
+
+  // `channelOrgFor(platform, channel, callerAgentId)` used to bind an inbound `rd/agentmsg`
+  // to the org its CHANNEL row resolved in. Removed with the channel-membership predicate:
+  // org is now bound from the caller's own directory entry ({@link orgForAgent}), which is
+  // strictly better — it works for a caller that shares no channel with anyone and for one
+  // with no IM integration at all.
 
   /** Whether `appId` backs an AgentConnect agent alongside `targetAgentId` in the
    *  same org/platform/channel row. Target scoping avoids cross-workspace channel-id


### PR DESCRIPTION
## Why

A2A delivery has been **postless since #854** — a `sendMessage` with `to.toAgent` wakes the peer directly and leaves nothing in any channel. So a shared channel had stopped being evidence of anything, yet it was still the gate on both peer discovery and peer wakes. Consequences:

- Peers that share no channel cannot collaborate.
- An agent with **no IM integration at all** (webchat / hook / dream / memory-only) appears in no channel row, so it can neither discover nor be discovered. A channel-keyed table structurally cannot express it.
- It **crashed**: `listChannelAgents` from a webchat session made the CP call `toDbPlatform('webchat')`, which throws by design; `ws/connection.ts` turns a handler throw into `close(1011)`, killing the whole daemon↔CP control socket — so every other in-flight request (gitcred mints, child-session probes, BFF reads) failed with `connection closed`, for every agent on that daemon.
- An unknown or unplaced target id fell through the channel checks into a misleading `offline`.

## What changed

Authorization is now **the directional call policy alone, org-scoped**. Caller A may discover or wake B iff both are known in the directory (**fail CLOSED** if either is missing), same org, `A.outboundPolicy` admits B, and `B.callPolicy` admits A. A caller always sees itself in a listing. **Discovery remains the authorization surface** — a peer failing the predicate is *omitted*, never listed-then-rejected.

`Agent.visibility` / `sharedWith` is deliberately **not** consulted: it governs *human console access*, so a `restricted` agent is still a discoverable, callable peer. (The console labels `callPolicy`/`outboundPolicy` "Agent visibility"; the two are unrelated — the design doc now has a table.)

| Package | Change |
|---|---|
| `protocol` | `CollabRoutesSnapshot` gains a flat, channel-free `agents: CollabOrgAgent[]` — the only structure that can express an integration-less agent. `ChannelAgentsReq/Ok.channel` becomes optional. |
| `control-plane` | New `AgentRepo.orgDirectory`. `handleChannelAgents` serves both scopes over **one** org read and **one** `visibleToRequester()` filter — a channel is a literal *intersection*, never a wider grant. Binds `requesterAgentId` to the authenticated daemon. Advertises `agent-directory-org-scope-v1`. |
| `daemon` | `CpCollabRoutes` gains a flat by-agent index + `orgForAgent` / `agent` / `admits`. Tool renamed **`listAgents`**, with `listChannelAgents` kept as a deprecated alias. `channel` is an optional **filter**, no longer a default. |
| `relay` | Same flat index; `agent-msg-router` binds org from the caller's directory entry. |

## Channel checks did not disappear — they moved to coordinate integrity

Dropping channel from the *policy* predicate is not dropping channel checks. `coords` is still the woken peer's **session key**, so an unchecked assertion would let a compromised or buggy source daemon name a channel its agent cannot reach, compute a bit-identical `childSessionId`, **resume the target's existing session** there, and with `needsReply` read that conversation back into its own.

`coordsAdmit(orgId, channelId, callerAgentId)` enforces this on **all three wake paths** — relay ingress, the target daemon's terminal-verify, and the same-daemon path — with byte-identical logic so they can never disagree:

> If the snapshot knows any non-empty membership at `(orgId, channelId)`, the caller must be in it → else `not_allowed`. A coordinate the snapshot knows nothing about (webchat / any integration-less coords) asserts nothing about a shared IM channel and passes.

It is deliberately **platform-free**. An earlier revision keyed it on `(orgId, platform, channel)`; adversarial review found that dodgeable, because `narrowPlatform` collapses unrecognized platforms to `'slack'` — asserting `platform: 'feishu'` with a Slack channel id missed the lookup but still landed on the real Slack session key. Keying on the org/channel pair the session key actually lives in closes that without depending on `narrowPlatform` being fixed.

`sessionKey()` and every `agentcall:${channel}:…` msgId/fallbackThread construction are **unchanged**.

## Rolling upgrade

Feature-negotiated via `agent-directory-org-scope-v1` in `register/ok.serverFeatures`.

- **New daemon ↔ old CP** — a channel-less ask is narrowed to the session's current channel. A new daemon **never** sends a channel-less request, nor a session-identity-platform channel, to an old CP: that is exactly the payload that triggers `close(1011)`. With nothing answerable to narrow to, the daemon answers `{ platform, agents: [] }` **locally** without calling the CP.
- **New CP ↔ old daemon** — unaffected; an old daemon always sends a channel.
- **Old CP snapshot ↔ new daemon/relay** — the flat directory is derived from the channel entries. Integration-less agents are simply absent, and `admits()` fails closed on them, which is that CP's existing behavior anyway.

## Behavior changes a reviewer must notice

1. **`not_allowed` replaces a misleading `offline`.** An unknown or unplaced target is now rejected by the policy predicate *before* the local-target lookup. More accurate, but any dashboard or skill keying on `offline` will see the shift.
2. **`listAgents` defaults to org-wide.** A user-authored skill calling the deprecated alias with no `channel` and relying on the old channel default **is silently widened**.
3. **`introduceOnJoin` fan-out regains a code-level bound.** The joined channel rides the trusted `CallMeta.introChannel` and is *forced* as the filter even when the tool args are empty. Previously the only bound was a prompt instruction — a 40-agent org where one agent has `introduceOnJoin=true` joining a 3-agent channel could have issued 39 postless wakes (39 billed sessions) on one join. `MAX_AGENT_CALL_HOPS` bounds depth and `INTRO_MAX_BURST` bounds channels; neither bounds peers per intro.
4. **A `webchat` peer-discovery call no longer kills the control socket.** This PR makes that path *more* reachable by positioning `listAgents` as the canonical tool for exactly those integration-less sessions, so the fix is load-bearing.
5. **An unplaced agent (`daemonId: null`) is no longer listed** — `orgDirectory` excludes it, matching `buildCollabSnapshot`, so one read feeds both surfaces and they cannot disagree.
6. **The CP now binds `requesterAgentId` to the authenticated daemon** (read-side twin of the relay's `claimedFromAgentId` check). During an agent **move** the CP row may name the target daemon while the source still has a live session, so an in-flight ask fails closed for the width of the move — correct, and soft (an empty roster, not an error frame).

## Reviewer attention, ranked

1. `relay/src/agent-msg-router.ts:102` + `daemon/src/daemon.ts:4994` + `:5173` — the three `coordsAdmit` call sites. Confirm all three share one predicate and that it is platform-free.
2. `control-plane/src/ws/handlers/channel-agents.ts` — the daemon-ownership bind and the `isSessionIdentityPlatform` short-circuit *ordering*: the short-circuit must stay above any repo read, or the `close(1011)` regression returns through the channel branch.
3. `daemon/src/daemon.ts:1978-2001` — three fixes land in one ~35-line scope decision (intro force, old-CP local short-circuit, `hook → slack`). Order is deliberate.
4. `daemon/src/daemon.ts:5116` `introChannelForTurn` — the fan-out bound depends on its `sessionKey(...)` matching the key `activeTurnCallMeta` was stored under. See *Not fully proven* below.
5. `control-plane/src/persistence/repositories/agent.repo.ts` `daemonId: { not: null }` — one line, but it is the only thing keeping discovery and wake authorization in agreement.

## Testing

```
pnpm --filter @agentconnect.md/protocol build && pnpm typecheck && pnpm lint && pnpm format:check
pnpm --filter @agentconnect.md/{protocol,relay} test
pnpm --filter @agentconnect.md/control-plane test:unit
pnpm --filter @agentconnect.md/control-plane test:int   # needs Docker
pnpm --filter @agentconnect.md/daemon test              # run ALONE
```

Verified on this branch rebased onto `a4905add`: typecheck 0 errors · lint 0 errors (2 pre-existing warnings in an untouched file) · format clean · protocol 198 · relay 327 · CP unit 696 · CP int 707 (real Docker) · daemon 2315.

⚠️ **The daemon suite is intermittently flaky under load** — across runs, different timing-heavy and unrelated tests failed (`reconcile-watch`, `scheduler` DST, `acp-matrix`), each passing 100% in isolation and in clean full runs. None touch this PR's surface. Pre-existing, but worth someone owning.

Security-critical cases: `relay/src/agent-msg-router.test.ts` (coords integrity, incl. the platform-switch dodge), `daemon/test/daemon-message-agent.test.ts`, `daemon/test/cp/cp-agent-directory.test.ts`, `control-plane/src/ws/handlers/channel-agents.test.ts`, `control-plane/test/integration/channel-agents.route.test.ts`.

## Not fully proven — please look here first

- **The intro fan-out bound is argued structurally, not executed end-to-end.** Both halves are tested separately, but nothing exercises real-dispatch → real-MCP-tool-call through the actual key. The argument it holds: `McpControlServer.canRun` computes the identical `sessionKey(...)` from the same `key` variable, so a mismatch would break *every* MCP tool in an intro turn — a loud failure, not a silent loss of the bound. Believable, unverified.
- **`narrowPlatform` still omits `feishu`** (falls through to `'slack'`). Pre-existing and no longer exploitable here, but it looks stale.
- Two raster docs assets (`agent-reachability-graph.jpg`, `agent-visibility-policy-layout.png`) may still render the channel-scoped model. Not textually inspectable, so left untouched.

## Deferred follow-ups

- **Channel-free session coordinates** — `channel` is still the session key; this PR only removed its authorization role. Was planned as PR-3.
- **`ws/connection.ts` handler-throw hardening** — a throwing WS handler still closes the entire control socket. This PR only stops one caller from triggering it.
- **`coordsAdmit` pass branch** — DM / group-DM coordinates and channels whose bot has left are never channel rows, so they take the pass branch. Narrowing it naively would over-block every legitimate A2A call made from a DM session; a proper fix checks the asserted coordinate against the target's own session rows.
- Remove the now-dead `CpCollabRoutes.hasMembers()` and `CollaborationRouter.channelOrgFor()`.
- Optional org-level `agentDiscoveryScope: 'channel' | 'org'` switch, if the widened default proves too permissive for some org.
- §6.5 snapshot staleness (TTL / tombstone / fail-closed on a stale snapshot).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
