### PR TITLE
feat(web): let the console turn on dream skill mining

### DIFF
--- a/packages/web/src/components/console/MemoryPanel.test.tsx
+++ b/packages/web/src/components/console/MemoryPanel.test.tsx
@@ -277,6 +277,52 @@ describe('MemoryPanel settings draft', () => {
     })
   })
 
+  // Skill mining is off unless the policy says otherwise, and the daemon keys
+  // three separate things off that one flag (the extract-procedures phase, the
+  // tool rows in the prompt, and the grounding set). Without a control here it
+  // could never be turned on, so a dream would silently mine nothing forever.
+  it('turns skill mining on and sends it with the memory binding', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <MemoryPanel
+          agentId="22222222-2222-4222-8222-222222222222"
+          canEdit
+          memoryProvider="managed"
+          autoDistill={false}
+        />
+      )
+    })
+
+    await openSettings(container)
+    const checkboxFor = (text: string) =>
+      [...container!.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')].find((box) =>
+        box.parentElement?.textContent?.includes(text)
+      )
+
+    expect(checkboxFor('Also mine reusable skills')?.checked).toBe(false)
+    expect(container.textContent).not.toContain('at least two sessions')
+
+    await act(async () => checkboxFor('Also mine reusable skills')?.click())
+    expect(container.textContent).toContain('at least two sessions')
+
+    const save = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent === 'Save memory settings'
+    )
+    await act(async () => save?.click())
+
+    expect(mocks.updateAgent).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', {
+      memory: {
+        provider: 'managed',
+        autoDistill: false,
+        dreaming: { enabled: true, schedule: '0 4 * * *', autoAdopt: true, mineSkills: true }
+      }
+    })
+  })
+
   it('collapses the settings form behind a summary of the persisted backend', async () => {
     container = document.createElement('div')
     document.body.append(container)

--- a/packages/web/src/components/console/MemoryPanel.tsx
+++ b/packages/web/src/components/console/MemoryPanel.tsx
@@ -311,6 +311,7 @@ export function MemoryPanel({
           'Managed directory',
           `Auto-distill ${persistedSettings.autoDistill ? 'on' : 'off'}`,
           dreaming.enabled ? `Dreaming ${cadence}` : 'Dreaming off',
+          ...(dreaming.enabled && dreaming.mineSkills === true ? ['Skill mining on'] : []),
           `Auto-accept ${dreaming.autoAdopt ? 'on' : 'off'}`,
           'Agent scope'
         ].join(' · ')
@@ -734,6 +735,29 @@ export function MemoryPanel({
                         <div className="ml-6 font-sans text-[11px] font-normal leading-[1.5] text-(--amber-500)">
                           Warning: Dream memory results can be inaccurate. Conflicting changes to live memory while a
                           dream runs still pause the result for review.
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="flex items-start gap-2 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
+                        <input
+                          type="checkbox"
+                          checked={settings.dreaming.mineSkills === true}
+                          disabled={!canEdit || savingProvider}
+                          onChange={() => {
+                            setSettings((current) => ({
+                              ...current,
+                              dreaming: { ...current.dreaming, mineSkills: current.dreaming.mineSkills !== true }
+                            }))
+                            setProviderError(null)
+                          }}
+                        />
+                        Also mine reusable skills from repeated procedures.
+                      </label>
+                      {settings.dreaming.mineSkills === true ? (
+                        <div className="ml-6 font-sans text-[11px] font-normal leading-[1.5] text-(--text-tertiary)">
+                          Dreams read which commands ran, not just what was said, and recommend a procedure seen in at
+                          least two sessions. Skills are never installed automatically — you review each one.
                         </div>
                       ) : null}
                     </div>

--- a/packages/web/src/components/console/memory-settings.ts
+++ b/packages/web/src/components/console/memory-settings.ts
@@ -7,11 +7,11 @@ import {
 
 /**
  * Managed-only dreaming policy as a form draft. It carries the COMPLETE policy —
- * including fields the console doesn't yet edit (`sessionWindow`, `timezone`, and
- * the later-phase `mineSkills`) — because a managed-memory save PATCHes the
- * `memory` binding wholesale, so anything the draft drops is lost. The UI edits
- * `enabled`, `schedule`, `autoAdopt`, and `instructions`; the rest is preserved
- * verbatim from whatever the API (or a later phase) set.
+ * including fields the console doesn't yet edit (`sessionWindow`) — because a
+ * managed-memory save PATCHes the `memory` binding wholesale, so anything the
+ * draft drops is lost. The UI edits `enabled`, `schedule`, `timezone`,
+ * `mineSkills`, `autoAdopt`, and `instructions`; the rest is preserved verbatim
+ * from whatever the API (or a later phase) set.
  */
 export interface DreamingDraft {
   enabled: boolean


### PR DESCRIPTION
## Why

Skill mining shipped with **no way to switch it on**. `mineSkills` defaults to `false`, and the console never edited it — the draft only carried the value through so that a wholesale `memory` PATCH wouldn't drop it (the comment in `memory-settings.ts` called it a "later-phase" field). So every dream ran with mining off and produced nothing, with no indication why.

Found by running a dream and getting zero skills back.

## What was invisible

The daemon keys three separate things off that one flag ([dream-runner.ts:348](../blob/main/packages/daemon/src/agents/dream-runner.ts#L348)):

1. `dreamSystemPrompt(false)` omits the extract-procedures phase entirely — the model is never asked for skills;
2. transcripts are gathered with `includeTools = mineSkills`, so the **trajectory** the miner reads (which commands ran, in order) isn't in the prompt either;
3. `parseDreamProposal(output, [])` gets an empty mined-session list, so even a volunteered candidate is dropped by the grounding rule.

## Change

- Checkbox next to auto-adopt: *"Also mine reusable skills from repeated procedures."*
- When on, explain what it changes — dreams read which commands ran, a procedure must be seen in at least two sessions, and skills are **never** installed without review.
- `Skill mining on` in the collapsed summary so the persisted state is visible without opening the form.
- Drop the now-stale "console doesn't yet edit" comment.

## Tests

New `MemoryPanel` case: mining is off by default, toggling it reveals the explanation and sends `mineSkills: true` with the binding. Web typecheck, ESLint, `MemoryPanel` (13) and `memory-settings` (11) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)