### PR TITLE
chore(daemon): refresh OpenAI pricing verification

### DIFF
--- a/packages/daemon/src/usage/openai-public-pricing.ts
+++ b/packages/daemon/src/usage/openai-public-pricing.ts
@@ -6,10 +6,10 @@
  * `$update-model-pricing` skill and keep the focused tests in sync.
  *
  * Source: https://developers.openai.com/api/docs/pricing
- * Verified: 2026-07-11
+ * Verified: 2026-07-29
  */
 
-export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-07-11'
+export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-07-29'
 export const OPENAI_PUBLIC_PRICING_SOURCE = 'https://developers.openai.com/api/docs/pricing'
 
 const TOKENS_PER_MILLION = 1_000_000


### PR DESCRIPTION
## Summary

- Re-verify the daemon's offline OpenAI Standard API pricing against the current official pricing, model, prompt-caching, and reasoning documentation.
- Refresh `OPENAI_PUBLIC_PRICING_AS_OF` and the source comment to `2026-07-29`.
- Keep the existing numeric rates and exact model mappings unchanged because they still match the official tables; leave `gpt-5.3-codex-spark` unsupported because OpenAI does not publish a Standard API token rate for it.

## Impact

Future fallback estimates report the refreshed pricing snapshot date. Cost calculations and historical stored amounts are unchanged.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/openai-public-pricing.test.ts test/local-store.test.ts test/acp-host.test.ts` (105 passed)
- The three cost-focused `daemon-webchat` assertions passed; the full local file run still exits non-zero after passing all assertions because macOS FSEvents reports the existing `EMFILE: too many open files, watch` teardown issue.
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm format:check`
- Pre-push ESLint completed with two existing duplicate-import warnings in `packages/control-plane/src/http/routes/icon-upload.ts` and no errors.

Created by Codex . gpt-5.6-sol
