### PR TITLE
feat(web): guided onboarding + getting-started checklist

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2941,3 +2941,38 @@
     opacity: 0;
   }
 }
+
+/* Onboarding reveal (design: "AgentConnect Onboarding") — the checklist rises in and
+   the "daemon online" check pops when the daemon connects. Honors reduced-motion. */
+.ac-rise {
+  animation: acRise 0.34s var(--ease-out, cubic-bezier(0.2, 0.8, 0.3, 1)) both;
+}
+.ac-pop {
+  animation: acPop 0.34s var(--ease-out, cubic-bezier(0.2, 0.8, 0.3, 1)) both;
+}
+@keyframes acRise {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes acPop {
+  from {
+    opacity: 0;
+    transform: scale(0.72);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ac-rise,
+  .ac-pop {
+    animation-duration: 0.01ms;
+  }
+}

--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+// Getting-started placement 1a + 1b (design: "Getting Started Placement.dc.html").
+// 1a is the floating pill in the console's bottom-right corner; 1b is the 400px
+// slide-over drawer it opens. Both sit OUT of the content flow (the Agents view keeps
+// its stats-then-table) — a persistent, non-blocking checklist derived from live state
+// (lib/getting-started.ts). The pill vanishes for good once every item is complete.
+//
+// Not built yet (no shipped backing — added when their signals land, preset-agents.md
+// §3/§6): the "runtime signed in" needs-attention item (probe status, §6.2) and the
+// per-item "Ask Assistant" automation (the assistant preset + delegated MCP writes,
+// §6.3/§6.4). The footer's "Ask an agent" instead opens the Playground on a real agent,
+// the one conversational entry that works today.
+
+import { useMemo, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { useConsoleData } from '@/lib/data-context'
+import { usePlayground } from './PlaygroundProvider'
+import { isAuthConfigured } from '@/lib/auth'
+import { computeGettingStarted } from '@/lib/getting-started'
+import { GsRows, MeetYourAgents, useGsActions } from './GettingStartedChecklist'
+import { Button, Icon } from '@/components/ui'
+
+// A r=10.5 progress ring (viewBox 0 0 26 26), rotated so it fills clockwise from 12
+// o'clock — the exact svg the design uses in the pill, drawer header and rail.
+function Ring({ ring, size, track }: { ring: string; size: number; track: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 26 26" className="flex-none -rotate-90">
+      <circle cx="13" cy="13" r="10.5" fill="none" stroke="var(--gray-150)" strokeWidth={track} />
+      <circle
+        cx="13"
+        cy="13"
+        r="10.5"
+        fill="none"
+        stroke="var(--brand)"
+        strokeWidth={track}
+        strokeLinecap="round"
+        strokeDasharray={ring}
+      />
+    </svg>
+  )
+}
+
+export default function GettingStarted() {
+  const { agents, daemons, integrations, allSessions, members, agentsLoading, daemonsLoading } = useConsoleData()
+  const { openPlayground } = usePlayground()
+  const { runAction, firstAgent } = useGsActions()
+  const pathname = usePathname()
+  const authOn = isAuthConfigured()
+
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  const gs = useMemo(
+    () => computeGettingStarted({ agents, daemons, integrations, sessions: allSessions, members, authOn }),
+    [agents, daemons, integrations, allSessions, members, authOn]
+  )
+
+  // Show on every console page while the checklist is incomplete — including a
+  // brand-new org, where "Connect a daemon" is the first open step. The full-screen
+  // /onboarding wizard is a separate route (AgentsView redirects an empty org there);
+  // the pill only steps aside for that route, not for the empty-org state itself.
+  const onOnboardingRoute = pathname?.includes('/onboarding')
+  const loading = agentsLoading || daemonsLoading
+  if (loading || gs.allDone || onOnboardingRoute) return null
+
+  const shortLabel = `${gs.done}/${gs.total}`
+
+  return (
+    <>
+      {/* 1a — floating pill (desktop only; mobile has the bottom-tab chrome) */}
+      {!drawerOpen && (
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          title="Getting started — open checklist"
+          className="fixed right-[26px] bottom-[22px] z-[60] hidden h-10 cursor-pointer items-center gap-[9px] rounded-full border border-(--border-default) bg-(--surface-card) pr-[15px] pl-[9px] shadow-(--shadow-lg) hover:border-(--border-strong) hover:shadow-(--shadow-xl) max-desktop:hidden desktop:inline-flex"
+        >
+          <Ring ring={gs.ring} size={22} track={3.4} />
+          <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+            Getting started
+          </span>
+          <span className="font-mono text-[12px] leading-normal text-(--text-tertiary)">{shortLabel}</span>
+        </button>
+      )}
+
+      {/* 1b — slide-over drawer */}
+      {drawerOpen && (
+        <>
+          <div
+            onClick={() => setDrawerOpen(false)}
+            className="fixed inset-0 z-[70] bg-[rgba(17,22,29,.26)] backdrop-blur-[2px]"
+          />
+          <aside className="fixed top-0 right-0 bottom-0 z-[80] flex w-full max-w-[400px] flex-col border-l border-(--border-default) bg-(--surface-card) shadow-(--shadow-xl)">
+            <div className="flex-none border-b border-(--border-subtle) py-[15px] pr-3 pl-[18px]">
+              <div className="flex items-center gap-[10px]">
+                <Ring ring={gs.ring} size={26} track={3} />
+                <span className="min-w-0 flex-1 font-sans text-[15px] font-semibold leading-normal text-(--text-primary)">
+                  Getting started
+                </span>
+                <span className="font-mono text-[12px] leading-normal text-(--text-tertiary)">
+                  {gs.done} of {gs.total}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setDrawerOpen(false)}
+                  title="Close — the checklist stays in the corner"
+                  className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover)"
+                >
+                  <Icon name="x" size={16} />
+                </button>
+              </div>
+              <div className="mt-3 h-[5px] overflow-hidden rounded-[3px] bg-(--gray-150)">
+                <div
+                  className="h-full rounded-[3px] bg-(--brand)"
+                  style={{ width: `${Math.round(gs.fraction * 100)}%` }}
+                />
+              </div>
+              <div className="mt-[10px] flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                <Icon name="info" size={12} className="flex-none" />
+                Close it anytime — the checklist stays in the corner until it&rsquo;s done.
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-auto">
+              <GsRows
+                items={gs.items}
+                expanded={expanded}
+                onToggle={(key) => setExpanded((cur) => (cur === key ? null : key))}
+                runAction={(action) => {
+                  setDrawerOpen(false)
+                  runAction(action)
+                }}
+                renderItem={(it, ctx) =>
+                  it.key === 'agent' ? (
+                    <MeetYourAgents
+                      done={it.done}
+                      open={ctx.open}
+                      toggle={ctx.toggle}
+                      onConnect={() => {
+                        setDrawerOpen(false)
+                        runAction(it.action)
+                      }}
+                    />
+                  ) : null
+                }
+              />
+            </div>
+
+            {firstAgent && (
+              <div className="flex flex-none items-center gap-[10px] border-t border-(--border-subtle) bg-(--surface-app) py-[11px] pr-[14px] pl-4">
+                <span className="flex-1 font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                  Stuck on a step? Ask an agent to walk you through it.
+                </span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setDrawerOpen(false)
+                    void openPlayground(firstAgent)
+                  }}
+                >
+                  <span className="inline-flex items-center gap-[6px]">
+                    <Icon name="sparkles" size={14} />
+                    Ask an agent
+                  </span>
+                </Button>
+              </div>
+            )}
+          </aside>
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -69,10 +69,9 @@ export default function GettingStarted() {
   // Modals (add daemon, set up agent, connect Slack) stack above the drawer (their scrim
   // is z-900, the drawer z-80), so the checklist stays open behind them — the user returns
   // to it when the modal closes. Only close the drawer for actions that navigate the page
-  // away (runtime sign-in, GitHub workspace, Home chat, invite teammates → router.push).
+  // away (GitHub workspace, Home chat, invite teammates → router.push).
   const runFromDrawer = (action: GsAction) => {
-    const navigates =
-      action.kind === 'runtime' || action.kind === 'github' || action.kind === 'chat' || action.kind === 'members'
+    const navigates = action.kind === 'github' || action.kind === 'chat' || action.kind === 'members'
     if (navigates) setDrawerOpen(false)
     runAction(action)
   }

--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -79,13 +79,14 @@ export default function GettingStarted() {
 
   return (
     <>
-      {/* 1a — floating pill (desktop only; mobile has the bottom-tab chrome) */}
+      {/* 1a — floating pill. On mobile it floats above the bottom-tab chrome (the
+          drawer below is already full-width there). */}
       {!drawerOpen && (
         <button
           type="button"
           onClick={() => setDrawerOpen(true)}
           title="Getting started — open checklist"
-          className="fixed right-[26px] bottom-[22px] z-[60] hidden h-10 cursor-pointer items-center gap-[9px] rounded-full border border-(--border-default) bg-(--surface-card) pr-[15px] pl-[9px] shadow-(--shadow-lg) hover:border-(--border-strong) hover:shadow-(--shadow-xl) max-desktop:hidden desktop:inline-flex"
+          className="fixed right-[26px] bottom-[22px] z-[60] inline-flex h-10 cursor-pointer items-center gap-[9px] rounded-full border border-(--border-default) bg-(--surface-card) pr-[15px] pl-[9px] shadow-(--shadow-lg) hover:border-(--border-strong) hover:shadow-(--shadow-xl) max-desktop:right-4 max-desktop:bottom-[96px]"
         >
           <Ring ring={gs.ring} size={22} track={3.4} />
           <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">

--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -17,8 +17,8 @@ import { usePathname } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from './PlaygroundProvider'
 import { isAuthConfigured } from '@/lib/auth'
-import { computeGettingStarted } from '@/lib/getting-started'
-import { GsRows, MeetYourAgents, useGsActions } from './GettingStartedChecklist'
+import { computeGettingStarted, type GsAction } from '@/lib/getting-started'
+import { AddToSlackRow, GsRows, MeetYourAgents, useGsActions } from './GettingStartedChecklist'
 import { Button, Icon } from '@/components/ui'
 
 // A r=10.5 progress ring (viewBox 0 0 26 26), rotated so it fills clockwise from 12
@@ -65,6 +65,17 @@ export default function GettingStarted() {
   if (loading || gs.allDone || onOnboardingRoute) return null
 
   const shortLabel = `${gs.done}/${gs.total}`
+
+  // Modals (add daemon, set up agent, connect Slack) stack above the drawer (their scrim
+  // is z-900, the drawer z-80), so the checklist stays open behind them — the user returns
+  // to it when the modal closes. Only close the drawer for actions that navigate the page
+  // away (runtime sign-in, GitHub workspace, Home chat, invite teammates → router.push).
+  const runFromDrawer = (action: GsAction) => {
+    const navigates =
+      action.kind === 'runtime' || action.kind === 'github' || action.kind === 'chat' || action.kind === 'members'
+    if (navigates) setDrawerOpen(false)
+    runAction(action)
+  }
 
   return (
     <>
@@ -127,20 +138,21 @@ export default function GettingStarted() {
                 items={gs.items}
                 expanded={expanded}
                 onToggle={(key) => setExpanded((cur) => (cur === key ? null : key))}
-                runAction={(action) => {
-                  setDrawerOpen(false)
-                  runAction(action)
-                }}
+                runAction={runFromDrawer}
                 renderItem={(it, ctx) =>
                   it.key === 'agent' ? (
                     <MeetYourAgents
                       done={it.done}
                       open={ctx.open}
                       toggle={ctx.toggle}
-                      onConnect={() => {
-                        setDrawerOpen(false)
-                        runAction(it.action)
-                      }}
+                      onConnect={() => runFromDrawer(it.action)}
+                    />
+                  ) : it.key === 'slack' ? (
+                    <AddToSlackRow
+                      done={it.done}
+                      open={ctx.open}
+                      toggle={ctx.toggle}
+                      onManual={() => runFromDrawer(it.action)}
                     />
                   ) : null
                 }

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+// Shared getting-started checklist pieces, so the console pill/drawer (GettingStarted.tsx)
+// and the onboarding reveal (OnboardingView.tsx) render the SAME checklist from the SAME
+// derivation (lib/getting-started.ts) — the design's explicit goal: onboarding "hands over
+// the same getting-started checklist as the console".
+//
+//   useGsActions() — maps a GsAction (pure, from computeGettingStarted) to the real console
+//                    surface that completes it (open a modal, route, open the Playground).
+//   <GsRows/>      — the expandable item rows (mark · label · chevron → explanation + CTA).
+
+import { Fragment, type ReactNode } from 'react'
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { useConsoleData } from '@/lib/data-context'
+import { useOrgs } from '@/lib/org-context'
+import { useModal } from './ModalProvider'
+import { usePlayground } from './PlaygroundProvider'
+import type { GsAction, GsItem } from '@/lib/getting-started'
+import { Button, Icon } from '@/components/ui'
+
+/** The action-runner + the agent the agent-scoped steps act on, wired to the live console. */
+export function useGsActions() {
+  const { agents } = useConsoleData()
+  const { orgPath } = useOrgs()
+  const { openModal } = useModal()
+  const { openPlayground } = usePlayground()
+  const router = useRouter()
+  const firstAgent = agents[0]
+
+  const runAction = useCallback(
+    (action: GsAction) => {
+      switch (action.kind) {
+        case 'daemon':
+          return openModal('daemon')
+        case 'agent':
+          return openModal('agent')
+        case 'agentRepo':
+          return action.agentId ? router.push(orgPath(`/agents/${action.agentId}`)) : openModal('agent')
+        case 'slack':
+          return firstAgent ? openModal('integration', firstAgent, { platform: 'slack' }) : openModal('agent')
+        case 'github':
+          return action.agentId ? router.push(orgPath(`/agents/${action.agentId}`)) : openModal('agent')
+        case 'chat':
+          return firstAgent ? void openPlayground(firstAgent) : openModal('agent')
+        case 'members':
+          return router.push(orgPath('/settings'))
+      }
+    },
+    [openModal, openPlayground, router, orgPath, firstAgent]
+  )
+
+  return { runAction, firstAgent }
+}
+
+// The checklist item rows. `runAction` is supplied by the caller so each surface can
+// wrap it (the drawer closes itself first); the wrapper stops the CTA click from
+// bubbling to the row's expand/collapse toggle.
+export function GsRows({
+  items,
+  expanded,
+  onToggle,
+  runAction,
+  renderItem
+}: {
+  items: GsItem[]
+  expanded: string | null
+  onToggle: (key: string) => void
+  runAction: (action: GsAction) => void
+  /** Per-item override: return a full custom row for `item` (e.g. onboarding's rich
+   *  "Meet your agents" row), or null/undefined to use the default row. */
+  renderItem?: (item: GsItem, ctx: { open: boolean; toggle: () => void }) => ReactNode | null
+}): ReactNode {
+  return items.map((it) => {
+    const open = expanded === it.key
+    const custom = renderItem?.(it, { open, toggle: () => onToggle(it.key) })
+    if (custom != null) return <Fragment key={it.key}>{custom}</Fragment>
+    return (
+      <div
+        key={it.key}
+        onClick={() => onToggle(it.key)}
+        className="flex cursor-pointer gap-3 border-b border-(--border-subtle) py-3 pr-[14px] pl-4 last:border-b-0 hover:bg-(--surface-hover)"
+      >
+        <span
+          className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
+            it.done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
+          }`}
+        >
+          {it.done && <Icon name="check" size={12} />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <span
+            className={`font-sans text-[13.5px] leading-normal ${
+              it.done ? 'font-normal text-(--text-tertiary) line-through' : 'font-medium text-(--text-primary)'
+            }`}
+          >
+            {it.label}
+          </span>
+          {open && (
+            <>
+              <div className="mt-[5px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                {it.expl}
+              </div>
+              {!it.done && (
+                <div className="mt-[11px]" onClick={(e) => e.stopPropagation()}>
+                  <Button size="sm" onClick={() => runAction(it.action)}>
+                    {it.ctaLabel}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        <span
+          className="mt-[2px] flex flex-none text-(--text-tertiary) transition-transform"
+          style={{ transform: open ? 'rotate(180deg)' : 'none' }}
+        >
+          <Icon name="chevron-down" size={15} />
+        </span>
+      </div>
+    )
+  })
+}
+
+// "Meet your agents" — the design's one-click built-in-agent step (replaces the plain
+// "Create your first agent" row) in both the onboarding reveal and the console drawer.
+// The two cards are the shipped-later preset agents (preset-agents.md §3): `agentconnect`
+// (general) + `agentconnect-admin` (private operator assistant). Until those presets + the
+// built-in AgentConnect Bot (§5) exist, this is forward-looking UI: `onConnect` falls back
+// to the real create-agent flow (the 'agent' GsAction), and `done` reflects whether a real
+// agent exists yet.
+// TODO(preset-agents): show the actual placed preset agents and make Connect a one-click
+// built-in-Bot bind instead of opening the create-agent modal.
+export function MeetYourAgents({
+  done,
+  open,
+  toggle,
+  onConnect
+}: {
+  done: boolean
+  open: boolean
+  toggle: () => void
+  onConnect: () => void
+}) {
+  return (
+    <div
+      onClick={toggle}
+      className="flex cursor-pointer gap-3 border-b border-(--border-subtle) py-3 pr-[14px] pl-4 last:border-b-0 hover:bg-(--surface-hover)"
+    >
+      <span
+        className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
+          done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
+        }`}
+      >
+        {done && <Icon name="check" size={12} />}
+      </span>
+      <div className="min-w-0 flex-1">
+        <span className="inline-flex items-center gap-2">
+          <span className="font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+            Meet your agents
+          </span>
+          <span className="font-mono text-[11.5px] leading-none text-(--text-disabled)">built-in</span>
+        </span>
+        {open && (
+          <div className="mt-[9px] flex flex-col gap-2">
+            {/* agentconnect — general, connectable. Stacked (icon+meta, then action on
+                its own row) so it never crams in the 400px drawer. */}
+            <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
+              <div className="flex items-start gap-3">
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[8px] bg-(--surface-inverse) text-white">
+                  <Icon name="bot" size={17} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                      agentconnect
+                    </span>
+                    <span className="flex-none whitespace-nowrap rounded-[5px] bg-(--surface-active) px-[6px] py-[1px] font-sans text-[10px] font-medium leading-normal text-(--text-secondary)">
+                      Built-in
+                    </span>
+                  </div>
+                  <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
+                    A general agent for coding, code review, and everyday tasks
+                  </div>
+                </div>
+              </div>
+              <div className="mt-[10px] flex justify-end" onClick={(e) => e.stopPropagation()}>
+                <Button size="sm" onClick={onConnect}>
+                  <Icon name="plug" size={14} />
+                  Connect
+                </Button>
+              </div>
+            </div>
+            {/* agentconnect-admin — private operator assistant, no channel */}
+            <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
+              <div className="flex items-start gap-3">
+                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[8px] bg-(--surface-inverse) text-white">
+                  <Icon name="bot" size={17} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                      agentconnect-admin
+                    </span>
+                    <span className="inline-flex flex-none items-center gap-1 whitespace-nowrap font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                      <Icon name="lock" size={12} />
+                      Private to you
+                    </span>
+                  </div>
+                  <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
+                    Helps you set up and operate AgentConnect
+                  </div>
+                </div>
+              </div>
+              {/* Mirrors the Connect button's slot on the card above: same row, same size. */}
+              <div className="mt-[10px] flex justify-end">
+                <span className="inline-flex h-[30px] items-center gap-[6px] whitespace-nowrap rounded-(--radius-sm) border border-(--border-subtle) bg-(--surface-card) px-3 font-sans text-[12.5px] leading-none text-(--text-tertiary)">
+                  <Icon name="check" size={14} />
+                  No channel needed
+                </span>
+              </div>
+            </div>
+            <div className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+              One click uses the built-in AgentConnect Bot — no Slack app, no token, no scopes to pick.
+            </div>
+          </div>
+        )}
+      </div>
+      <span
+        className="mt-[2px] flex flex-none text-(--text-tertiary) transition-transform"
+        style={{ transform: open ? 'rotate(180deg)' : 'none' }}
+      >
+        <Icon name="chevron-down" size={15} />
+      </span>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -44,8 +44,13 @@ export function useGsActions() {
           return router.push(orgPath(action.daemonId ? `/daemons/${action.daemonId}` : '/daemons'))
         case 'agent':
           return builtinAgent ? openModal('editAgent', builtinAgent, { focusSection: 'basics' }) : openModal('agent')
-        case 'slack':
-          return firstAgent ? openModal('integration', firstAgent, { platform: 'slack' }) : openModal('agent')
+        case 'slack': {
+          // The action targets the built-in preset; honor it — agents[0] is commonly an
+          // older custom agent in backfilled orgs, and the manual fallback must not
+          // configure Slack on the wrong agent.
+          const target = agents.find((a) => a.id === action.agentId) ?? builtinAgent
+          return target ? openModal('integration', target, { platform: 'slack' }) : openModal('agent')
+        }
         case 'github':
           // Land on the Workspace tab with the workspace editor auto-opened on the
           // GitHub mode (`editws` is consumed one-shot by WorkspaceCard).
@@ -61,7 +66,7 @@ export function useGsActions() {
           return router.push(orgPath('/settings?invite=1'))
       }
     },
-    [openModal, router, orgPath, firstAgent, builtinAgent]
+    [openModal, router, orgPath, firstAgent, builtinAgent, agents]
   )
 
   return { runAction, firstAgent }

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -38,10 +38,6 @@ export function useGsActions() {
       switch (action.kind) {
         case 'daemon':
           return openModal('daemon')
-        case 'runtime':
-          // Sign-in happens on the daemon host; the daemon detail page carries the
-          // auth-required warning strip with the exact login command.
-          return router.push(orgPath(action.daemonId ? `/daemons/${action.daemonId}` : '/daemons'))
         case 'agent':
           return builtinAgent ? openModal('editAgent', builtinAgent, { focusSection: 'basics' }) : openModal('agent')
         case 'slack': {
@@ -102,14 +98,10 @@ export function GsRows({
       >
         <span
           className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
-            it.done
-              ? 'bg-(--brand) text-white'
-              : it.warn
-                ? 'bg-(--status-paused-soft) text-(--amber-500)'
-                : 'border-[1.5px] border-(--border-strong)'
+            it.done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
           }`}
         >
-          {it.done ? <Icon name="check" size={12} /> : it.warn ? <Icon name="triangle-alert" size={11} /> : null}
+          {it.done && <Icon name="check" size={12} />}
         </span>
         <div className="min-w-0 flex-1">
           <span
@@ -119,11 +111,6 @@ export function GsRows({
           >
             {it.label}
           </span>
-          {!it.done && it.warn && (
-            <span className="ml-2 font-sans text-[12px] font-medium leading-normal text-(--amber-500)">
-              Needs attention
-            </span>
-          )}
           {open && (
             <>
               <div className="mt-[5px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -15,39 +15,53 @@ import { useRouter } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { useModal } from './ModalProvider'
-import { usePlayground } from './PlaygroundProvider'
 import type { GsAction, GsItem } from '@/lib/getting-started'
+import { agentIsPlaced, agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
+import { useSlackPlatformInstall } from '@/lib/use-slack-platform-install'
 import { Button, Icon } from '@/components/ui'
+import { PlatformMark } from '@/components/marks'
 
 /** The action-runner + the agent the agent-scoped steps act on, wired to the live console. */
 export function useGsActions() {
   const { agents } = useConsoleData()
   const { orgPath } = useOrgs()
   const { openModal } = useModal()
-  const { openPlayground } = usePlayground()
   const router = useRouter()
   const firstAgent = agents[0]
+  // Every org ships the built-in `agentconnect` preset, so "set up your agent" edits it
+  // (placement + runtime/model) rather than creating a new one — only a truly empty org
+  // (no preset row) falls back to the create modal.
+  const builtinAgent = agents.find((a) => a.builtin) ?? firstAgent
 
   const runAction = useCallback(
     (action: GsAction) => {
       switch (action.kind) {
         case 'daemon':
           return openModal('daemon')
+        case 'runtime':
+          // Sign-in happens on the daemon host; the daemon detail page carries the
+          // auth-required warning strip with the exact login command.
+          return router.push(orgPath(action.daemonId ? `/daemons/${action.daemonId}` : '/daemons'))
         case 'agent':
-          return openModal('agent')
-        case 'agentRepo':
-          return action.agentId ? router.push(orgPath(`/agents/${action.agentId}`)) : openModal('agent')
+          return builtinAgent ? openModal('editAgent', builtinAgent, { focusSection: 'basics' }) : openModal('agent')
         case 'slack':
           return firstAgent ? openModal('integration', firstAgent, { platform: 'slack' }) : openModal('agent')
         case 'github':
-          return action.agentId ? router.push(orgPath(`/agents/${action.agentId}`)) : openModal('agent')
+          // Land on the Workspace tab with the workspace editor auto-opened on the
+          // GitHub mode (`editws` is consumed one-shot by WorkspaceCard).
+          return action.agentId
+            ? router.push(orgPath(`/agents/${action.agentId}?tab=workspace&editws=github`))
+            : openModal('agent')
         case 'chat':
-          return firstAgent ? void openPlayground(firstAgent) : openModal('agent')
+          // The chat-first Home landing is where conversations start.
+          return router.push(orgPath('/home'))
         case 'members':
-          return router.push(orgPath('/settings'))
+          // Land on Settings with the invite-members dialog auto-opened (`invite` is
+          // consumed one-shot by SettingsView).
+          return router.push(orgPath('/settings?invite=1'))
       }
     },
-    [openModal, openPlayground, router, orgPath, firstAgent]
+    [openModal, router, orgPath, firstAgent, builtinAgent]
   )
 
   return { runAction, firstAgent }
@@ -83,10 +97,14 @@ export function GsRows({
       >
         <span
           className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
-            it.done ? 'bg-(--brand) text-white' : 'border-[1.5px] border-(--border-strong)'
+            it.done
+              ? 'bg-(--brand) text-white'
+              : it.warn
+                ? 'bg-(--status-paused-soft) text-(--amber-500)'
+                : 'border-[1.5px] border-(--border-strong)'
           }`}
         >
-          {it.done && <Icon name="check" size={12} />}
+          {it.done ? <Icon name="check" size={12} /> : it.warn ? <Icon name="triangle-alert" size={11} /> : null}
         </span>
         <div className="min-w-0 flex-1">
           <span
@@ -96,6 +114,11 @@ export function GsRows({
           >
             {it.label}
           </span>
+          {!it.done && it.warn && (
+            <span className="ml-2 font-sans text-[12px] font-medium leading-normal text-(--amber-500)">
+              Needs attention
+            </span>
+          )}
           {open && (
             <>
               <div className="mt-[5px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
@@ -112,7 +135,7 @@ export function GsRows({
           )}
         </div>
         <span
-          className="mt-[2px] flex flex-none text-(--text-tertiary) transition-transform"
+          className="mt-[2px] flex flex-none self-start text-(--text-tertiary) transition-transform"
           style={{ transform: open ? 'rotate(180deg)' : 'none' }}
         >
           <Icon name="chevron-down" size={15} />
@@ -122,25 +145,22 @@ export function GsRows({
   })
 }
 
-// "Meet your agents" — the design's one-click built-in-agent step (replaces the plain
-// "Create your first agent" row) in both the onboarding reveal and the console drawer.
-// The two cards are the shipped-later preset agents (preset-agents.md §3): `agentconnect`
-// (general) + `agentconnect-admin` (private operator assistant). Until those presets + the
-// built-in AgentConnect Bot (§5) exist, this is forward-looking UI: `onConnect` falls back
-// to the real create-agent flow (the 'agent' GsAction), and `done` reflects whether a real
-// agent exists yet.
-// TODO(preset-agents): show the actual placed preset agents and make Connect a one-click
-// built-in-Bot bind instead of opening the create-agent modal.
-export function MeetYourAgents({
+// Shared row chrome (mark · label · chevron + expandable body) for the two custom
+// getting-started rows below, so they line up pixel-for-pixel with the default GsRows.
+function CustomRow({
   done,
   open,
   toggle,
-  onConnect
+  title,
+  tag,
+  children
 }: {
   done: boolean
   open: boolean
   toggle: () => void
-  onConnect: () => void
+  title: string
+  tag?: string
+  children: ReactNode
 }) {
   return (
     <div
@@ -156,82 +176,171 @@ export function MeetYourAgents({
       </span>
       <div className="min-w-0 flex-1">
         <span className="inline-flex items-center gap-2">
-          <span className="font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
-            Meet your agents
+          <span
+            className={`font-sans text-[13.5px] leading-normal ${
+              done ? 'font-normal text-(--text-tertiary) line-through' : 'font-medium text-(--text-primary)'
+            }`}
+          >
+            {title}
           </span>
-          <span className="font-mono text-[11.5px] leading-none text-(--text-disabled)">built-in</span>
+          {tag && <span className="font-mono text-[11.5px] leading-none text-(--text-disabled)">{tag}</span>}
         </span>
-        {open && (
-          <div className="mt-[9px] flex flex-col gap-2">
-            {/* agentconnect — general, connectable. Stacked (icon+meta, then action on
-                its own row) so it never crams in the 400px drawer. */}
-            <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
-              <div className="flex items-start gap-3">
-                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[8px] bg-(--surface-inverse) text-white">
-                  <Icon name="bot" size={17} />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                      agentconnect
-                    </span>
-                    <span className="flex-none whitespace-nowrap rounded-[5px] bg-(--surface-active) px-[6px] py-[1px] font-sans text-[10px] font-medium leading-normal text-(--text-secondary)">
-                      Built-in
-                    </span>
-                  </div>
-                  <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
-                    A general agent for coding, code review, and everyday tasks
-                  </div>
-                </div>
-              </div>
-              <div className="mt-[10px] flex justify-end" onClick={(e) => e.stopPropagation()}>
-                <Button size="sm" onClick={onConnect}>
-                  <Icon name="plug" size={14} />
-                  Connect
-                </Button>
-              </div>
-            </div>
-            {/* agentconnect-admin — private operator assistant, no channel */}
-            <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
-              <div className="flex items-start gap-3">
-                <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[8px] bg-(--surface-inverse) text-white">
-                  <Icon name="bot" size={17} />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                      agentconnect-admin
-                    </span>
-                    <span className="inline-flex flex-none items-center gap-1 whitespace-nowrap font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                      <Icon name="lock" size={12} />
-                      Private to you
-                    </span>
-                  </div>
-                  <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
-                    Helps you set up and operate AgentConnect
-                  </div>
-                </div>
-              </div>
-              {/* Mirrors the Connect button's slot on the card above: same row, same size. */}
-              <div className="mt-[10px] flex justify-end">
-                <span className="inline-flex h-[30px] items-center gap-[6px] whitespace-nowrap rounded-(--radius-sm) border border-(--border-subtle) bg-(--surface-card) px-3 font-sans text-[12.5px] leading-none text-(--text-tertiary)">
-                  <Icon name="check" size={14} />
-                  No channel needed
-                </span>
-              </div>
-            </div>
-            <div className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-              One click uses the built-in AgentConnect Bot — no Slack app, no token, no scopes to pick.
-            </div>
-          </div>
-        )}
+        {open && <div className="mt-[9px] flex flex-col gap-2">{children}</div>}
       </div>
       <span
-        className="mt-[2px] flex flex-none text-(--text-tertiary) transition-transform"
+        className="mt-[2px] flex flex-none self-start text-(--text-tertiary) transition-transform"
         style={{ transform: open ? 'rotate(180deg)' : 'none' }}
       >
         <Icon name="chevron-down" size={15} />
       </span>
     </div>
+  )
+}
+
+// "Meet your agent" — the FIRST half of the split (the 'agent' step): configure the org's
+// built-in `agentconnect` preset (preset-agents.md §3), no `agentconnect-admin` (cancelled;
+// its capabilities fold into this one agent). Placed (daemon + runtime) ⇒ show runtime ·
+// model; unplaced ⇒ the set-up CTA (`onConnect` → the 'agent' GsAction). Slack now lives in
+// its own step (AddToSlackRow). Falls back to the first agent if no preset row exists.
+export function MeetYourAgents({
+  done,
+  open,
+  toggle,
+  onConnect
+}: {
+  done: boolean
+  open: boolean
+  toggle: () => void
+  onConnect: () => void
+}) {
+  const { agents } = useConsoleData()
+  const builtin = agents.find((a) => a.builtin) ?? agents[0]
+  const placed = !!builtin && agentIsPlaced(builtin)
+  return (
+    <CustomRow done={done} open={open} toggle={toggle} title="Meet your agent" tag="built-in">
+      <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
+        <div className="flex items-start gap-3">
+          <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[8px] bg-(--surface-inverse) text-white">
+            <Icon name="bot" size={17} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                {builtin ? agentLabel(builtin) : 'agentconnect'}
+              </span>
+              <span className="flex-none whitespace-nowrap rounded-[5px] bg-(--surface-active) px-[6px] py-[1px] font-sans text-[10px] font-medium leading-normal text-(--text-secondary)">
+                Built-in
+              </span>
+            </div>
+            <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
+              A general agent for coding, code review, and everyday tasks
+            </div>
+          </div>
+        </div>
+        <div className="mt-[10px] flex justify-end" onClick={(e) => e.stopPropagation()}>
+          {placed ? (
+            <span className="inline-flex h-[30px] items-center gap-[6px] whitespace-nowrap rounded-(--radius-sm) border border-(--border-subtle) bg-(--surface-card) px-3 font-sans text-[12.5px] leading-none text-(--text-tertiary)">
+              <Icon name="check" size={14} />
+              {runtimeLabel(builtin.runtime)}
+              {builtin.model ? ` · ${modelLabel(builtin.model)}` : ''}
+            </span>
+          ) : (
+            <Button size="sm" onClick={onConnect}>
+              <Icon name="sliders-horizontal" size={14} />
+              Set up
+            </Button>
+          )}
+        </div>
+      </div>
+      <div className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+        Place it on a daemon and pick a runtime and model — then talk to it from the Playground or a channel.
+      </div>
+    </CustomRow>
+  )
+}
+
+// "Add to Slack" — the SECOND half of the split (the 'slack' step): the one-click built-in
+// Slack Bot for the preset (preset-agents.md §5.3), the SAME flow as AddIntegrationModal's
+// "Add to Slack" button via the shared hook. Only meaningful once the agent is placed; a
+// failed install (e.g. no published platform app on this CP) or the manual link falls back
+// to the full integration modal, which handles every path. `onManual` opens that modal.
+export function AddToSlackRow({
+  done,
+  open,
+  toggle,
+  onManual
+}: {
+  done: boolean
+  open: boolean
+  toggle: () => void
+  onManual: () => void
+}) {
+  const { agents, refresh } = useConsoleData()
+  const builtin = agents.find((a) => a.builtin) ?? agents[0]
+  const placed = !!builtin && agentIsPlaced(builtin)
+  const slack = useSlackPlatformInstall(builtin?.id ?? '', refresh)
+  return (
+    <CustomRow done={done} open={open} toggle={toggle} title="Add to Slack" tag="built-in bot">
+      <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) px-3 py-[11px]">
+        <div className="flex items-start gap-3">
+          <span className="imark h-8 w-8 flex-none border-0 bg-transparent">
+            <PlatformMark platform="slack" />
+          </span>
+          <div className="min-w-0 flex-1 font-sans text-[12px] font-normal leading-[1.45] text-(--text-secondary)">
+            {done
+              ? 'Connected — the built-in bot can read and post in your Slack channel.'
+              : placed
+                ? 'One click installs the built-in AgentConnect bot — no Slack app, token, or scopes to pick.'
+                : 'Set up your agent first, then connect it to Slack in one click.'}
+          </div>
+        </div>
+        {!done && (
+          <div className="mt-[10px] flex justify-end" onClick={(e) => e.stopPropagation()}>
+            {!placed ? (
+              <Button size="sm" variant="secondary" disabled>
+                <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
+                  <PlatformMark platform="slack" />
+                </span>
+                Add to Slack
+              </Button>
+            ) : slack.phase === 'authorizing' ? (
+              <button
+                type="button"
+                onClick={() => slack.cancel()}
+                title="Cancel — closed the Slack tab? Click to try again"
+                className="group inline-flex h-[30px] cursor-pointer items-center gap-[6px] whitespace-nowrap rounded-(--radius-sm) border-0 bg-(--surface-inverse) px-3 font-sans text-[12.5px] font-medium leading-none text-white"
+              >
+                <Icon name="loader" size={14} className="animate-spin group-hover:hidden" />
+                <Icon name="x" size={14} className="hidden group-hover:inline" />
+                <span className="group-hover:hidden">Waiting for Slack…</span>
+                <span className="hidden group-hover:inline">Cancel</span>
+              </button>
+            ) : (
+              <Button size="sm" onClick={() => void slack.start()}>
+                <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
+                  <PlatformMark platform="slack" />
+                </span>
+                Add to Slack
+              </Button>
+            )}
+          </div>
+        )}
+        {slack.err && (
+          <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--danger)">
+            {slack.err}{' '}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onManual()
+              }}
+              className="cursor-pointer border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold text-(--brand) underline"
+            >
+              Set up Slack another way
+            </button>
+          </div>
+        )}
+      </div>
+    </CustomRow>
   )
 }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -10,6 +10,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { agentLabel, type Agent, type Session, type SessionImage, type SessionStep } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
 import { webchatWsUrl, fmtCountCompact, fmtCost, ApiError, type SessionMessageDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
@@ -158,6 +159,7 @@ type WebchatRuntimeConfig = {
 }
 
 export function PlaygroundProvider({ children }: { children: ReactNode }) {
+  const { refreshSessions } = useConsoleData()
   const [pgSessions, setPgSessions] = useState<Record<string, Session>>({})
   // Live tail for adopted webchat sessions (real CP ids). Kept apart from `pgSessions`
   // so an adopted session still renders from its authoritative CP row + fetched history,
@@ -606,9 +608,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       streamCursors.current.set(id, createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
       if (conversationId) conversationIds.current.set(id, conversationId)
       reconnectAttempts.current.delete(id)
+      // First send of a fresh conversation mints a real session on the daemon. The SSE
+      // start-milestone is the immediate signal, but it can be delayed/buffered in some
+      // setups (leaving the getting-started "first conversation" tick to the 60s poll) —
+      // so nudge the session lists shortly after the send lands.
+      const isNewConversation = !conversationId && !conversationIds.current.get(id)
       const conn = connect(id, agentForId, conversationId)
       conn.ready
-        .then((ws) =>
+        .then((ws) => {
           ws.send(
             JSON.stringify({
               text,
@@ -617,7 +624,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               ...(stagedRuntime.current.get(id) ? { runtime: stagedRuntime.current.get(id) } : {})
             })
           )
-        )
+          if (isNewConversation) setTimeout(refreshSessions, 2500)
+        })
         .catch((err) => {
           // A 503 from the token mint means the CP has no relay pool configured — the
           // agent may be perfectly healthy, so name the real cause instead of "unreachable".
@@ -632,7 +640,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           setBusy(id, false)
         })
     },
-    [pgBusyBy, pgImageBy, pgInputBy, connect, pushStep, setPgImage, setPgInput, setBusy]
+    [pgBusyBy, pgImageBy, pgInputBy, connect, pushStep, setPgImage, setPgInput, setBusy, refreshSessions]
   )
 
   /** Switch the session's model (fire-and-forget over the conversation socket). Updates

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -17,6 +17,7 @@ import { agentLabel } from '@/lib/data'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
 import ConnectAiModal from './ConnectAiModal'
+import GettingStarted from './GettingStarted'
 import { GlobalSearch } from './GlobalSearch'
 import { TooltipLayer } from './Tooltip'
 import { SearchOpenContext } from './search-open'
@@ -268,7 +269,6 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // (`/acme/agents` → `/agents`); hrefs go the other way via orgPath().
   const barePath = subPath(pathname, typeof params.slug === 'string' ? decodeURIComponent(params.slug) : '-')
   const router = useRouter()
-  const [userMenu, setUserMenu] = useState(false)
   // Rail-footer help popover + the shortcuts modal it can open.
   const [helpMenu, setHelpMenu] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
@@ -377,7 +377,6 @@ function ShellChrome({ children }: { children: ReactNode }) {
   }, [])
 
   const signOut = useCallback(() => {
-    setUserMenu(false)
     if (isAuthConfigured()) void logout()
     else router.push('/login')
   }, [router])
@@ -404,6 +403,34 @@ function ShellChrome({ children }: { children: ReactNode }) {
     return (
       <div className="loadgate">
         <LoadingState fill />
+      </div>
+    )
+
+  // Onboarding is a full-screen takeover (design: "AgentConnect Onboarding") — no rail,
+  // but it keeps a slim top bar consistent with the rest of the console (theme toggle +
+  // user menu), rendered here so it reuses the shell's own theme/sign-out state.
+  // OnboardingView renders just the centered content. Providers (org, data, modal,
+  // playground) live ABOVE ShellChrome, so the checklist CTAs' modals still work.
+  if (barePath === '/onboarding')
+    return (
+      <div className="fixed inset-0 flex flex-col overflow-hidden bg-(--surface-app)">
+        <header className="flex h-14 flex-none items-center gap-[14px] border-b border-(--border-subtle) bg-(--surface-card) px-5 desktop:px-[22px]">
+          <Link
+            href={orgPath('/agents')}
+            className="flex items-center gap-[10px] no-underline"
+            aria-label="AgentConnect"
+          >
+            <LogoMark size={24} />
+            <span className="font-sans text-[16px] font-semibold leading-none tracking-[-.02em] text-(--text-primary)">
+              Agent<span className="text-(--brand)">Connect</span>
+            </span>
+          </Link>
+          <div className="flex-1" />
+          <ThemeToggle theme={theme} onToggle={toggleTheme} />
+          {isAuthConfigured() && <UserMenu display={display} orgPath={orgPath} onSignOut={signOut} />}
+        </header>
+        <div className="flex-1 overflow-auto">{children}</div>
+        <TooltipLayer />
       </div>
     )
 
@@ -617,62 +644,8 @@ function ShellChrome({ children }: { children: ReactNode }) {
             </div>
             <div className="topspacer flex-1" />
             <GlobalSearch />
-            <button
-              type="button"
-              className="iconbtn"
-              onClick={toggleTheme}
-              title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-              aria-label="Toggle theme"
-            >
-              <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
-            </button>
-            {authOn && (
-              <div className="relative">
-                <button
-                  onClick={() => setUserMenu((v) => !v)}
-                  className="cursor-pointer border-0 bg-transparent p-0 leading-[0]"
-                  title="Your profile"
-                >
-                  <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
-                </button>
-                {userMenu && (
-                  <>
-                    <div className="fixed inset-0 z-40" onClick={() => setUserMenu(false)} />
-                    <div className="usermenu">
-                      <div className="usermenu-head">
-                        <Avatar src={display.picture} initials={display.initials} size={34} fontSize={12} />
-                        <div className="min-w-0">
-                          <div className="font-sans text-[13px] font-semibold leading-normal">{display.name}</div>
-                          {display.email && (
-                            <div className="mono text-[11px] text-(--text-tertiary)">{display.email}</div>
-                          )}
-                        </div>
-                      </div>
-                      <Link
-                        href={orgPath('/profile')}
-                        className="usermenu-item no-underline"
-                        onClick={() => setUserMenu(false)}
-                      >
-                        <Icon name="user" size={15} color="var(--text-tertiary)" />
-                        Your profile
-                      </Link>
-                      <Link
-                        href={orgPath('/settings')}
-                        className="usermenu-item no-underline"
-                        onClick={() => setUserMenu(false)}
-                      >
-                        <Icon name="settings" size={15} color="var(--text-tertiary)" />
-                        Settings
-                      </Link>
-                      <button className="usermenu-item" onClick={signOut}>
-                        <Icon name="log-out" size={15} color="var(--text-tertiary)" />
-                        Sign out
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
-            )}
+            <ThemeToggle theme={theme} onToggle={toggleTheme} />
+            {authOn && <UserMenu display={display} orgPath={orgPath} onSignOut={signOut} />}
           </header>
 
           {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
@@ -786,11 +759,81 @@ function ShellChrome({ children }: { children: ReactNode }) {
         {mobileSearch && <GlobalSearch mobile autoFocus onClose={() => setMobileSearch(false)} />}
         {shortcutsOpen && <KeyboardShortcutsModal onClose={() => setShortcutsOpen(false)} />}
         {connectAiOpen && <ConnectAiModal onClose={() => setConnectAiOpen(false)} moreUrl={help.mcp} />}
+        {/* Getting-started pill + drawer (design 1a/1b): a corner checklist derived from
+          live state, self-gated (desktop, setup-started, incomplete). */}
+        <GettingStarted />
         {/* Renders every `title` in the console on the design system's timing
           instead of the browser's ~1s native tooltip. Portals to <body>. */}
         <TooltipLayer />
       </div>
     </MobileFilterContext.Provider>
+  )
+}
+
+// Top-bar theme toggle (light ↔ dark). Shared by the console top bar and the onboarding
+// header so both flip the same shell-owned theme state.
+function ThemeToggle({ theme, onToggle }: { theme: Theme; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      className="iconbtn"
+      onClick={onToggle}
+      title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+      aria-label="Toggle theme"
+    >
+      <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
+    </button>
+  )
+}
+
+// Avatar button + dropdown (profile / settings / sign out). Self-manages its open state;
+// shared by the console top bar and the onboarding header.
+function UserMenu({
+  display,
+  orgPath,
+  onSignOut
+}: {
+  display: { picture?: string | null; initials: string; name: string; email?: string }
+  orgPath: (path: string) => string
+  onSignOut: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="cursor-pointer border-0 bg-transparent p-0 leading-[0]"
+        title="Your profile"
+      >
+        <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="usermenu">
+            <div className="usermenu-head">
+              <Avatar src={display.picture} initials={display.initials} size={34} fontSize={12} />
+              <div className="min-w-0">
+                <div className="font-sans text-[13px] font-semibold leading-normal">{display.name}</div>
+                {display.email && <div className="mono text-[11px] text-(--text-tertiary)">{display.email}</div>}
+              </div>
+            </div>
+            <Link href={orgPath('/profile')} className="usermenu-item no-underline" onClick={() => setOpen(false)}>
+              <Icon name="user" size={15} color="var(--text-tertiary)" />
+              Your profile
+            </Link>
+            <Link href={orgPath('/settings')} className="usermenu-item no-underline" onClick={() => setOpen(false)}>
+              <Icon name="settings" size={15} color="var(--text-tertiary)" />
+              Settings
+            </Link>
+            <button className="usermenu-item" onClick={onSignOut}>
+              <Icon name="log-out" size={15} color="var(--text-tertiary)" />
+              Sign out
+            </button>
+          </div>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/packages/web/src/components/console/WorkspaceCard.test.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.test.tsx
@@ -11,6 +11,11 @@ vi.mock('@/lib/api', () => ({
   deleteAgentRepo: vi.fn(),
   fetchAgentRepos: vi.fn()
 }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => '/acme/agents/a1',
+  useSearchParams: () => new URLSearchParams()
+}))
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org-1' } }) }))
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
 vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ refresh: vi.fn() }) }))

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -24,7 +24,8 @@
 // (the design's inline add-expander is skipped — established precedent: the
 // modal owns the picker/tier/preflight flow).
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { GithubMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
@@ -96,6 +97,24 @@ export function WorkspaceCard({
   const [err, setErr] = useState<string | null>(null)
 
   const ws = agent.workspace
+
+  // `?editws=github|scratch` auto-opens the workspace editor on that mode (the
+  // getting-started "Connect GitHub" CTA lands here with it). One-shot: the param is
+  // stripped from the URL immediately so back/refresh doesn't reopen the modal.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const autoEdited = useRef(false)
+  useEffect(() => {
+    const mode = searchParams.get('editws')
+    if (autoEdited.current || !mode) return
+    autoEdited.current = true
+    if (agent.canManageSharing) setEditMode(mode === 'scratch' ? 'scratch' : 'github')
+    const sp = new URLSearchParams(searchParams)
+    sp.delete('editws')
+    router.replace(`${pathname}${sp.size ? `?${sp}` : ''}`, { scroll: false })
+  }, [searchParams, agent.canManageSharing, pathname, router])
+
   const isGithub = ws.mode === 'github'
   const isGithubApp = ws.mode === 'github' && !!ws.installationId
   const reposKey = consoleKeys.agentRepos(activeOrg?.id, agent.id)

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -195,6 +195,21 @@ export default function EditAgentModal({
     )
   }, [agent.id])
 
+  // An unplaced agent (the built-in `agentconnect` preset ships this way) defaults its
+  // daemon to the first placement-eligible one, so opening the editor to place it starts
+  // on that daemon instead of an empty picker when a daemon already exists. `initialDaemonId`
+  // stays '' so this reads as an initial placement (arms Save + requires runtime/model).
+  // One-shot: the user can still switch it back to "No daemon".
+  const autofilledDaemon = useRef(false)
+  useEffect(() => {
+    if (!loaded || autofilledDaemon.current || initialDaemonId.current || daemonId) return
+    const target = daemons.find((d) => d.status === 'online' && d.caps.features.includes('agent-move-v1'))
+    if (target) {
+      autofilledDaemon.current = true
+      setDaemonId(target.daemonId)
+    }
+  }, [loaded, daemons, daemonId])
+
   // Jump to the requested section once the form has rendered. Both `scrollIntoView`
   // and `scrollTo` resolve to a no-op inside the dialog's nested overflow
   // containers, so the pane's `scrollTop` is assigned outright (same technique the

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useMemo, useState } from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
 import { agentLabel, agentModelDisplay, effectiveAgentStatus, runtimeLabel, status, type Agent } from '@/lib/data'
 import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
@@ -17,7 +16,7 @@ import { useProfile } from '@/lib/profile'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { AgentReachabilityOverview } from '@/components/console/AgentReachabilityOverview'
-import { daemonCompletesOnboarding, isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
+import { useOnboardingRedirect } from '@/lib/use-onboarding-redirect'
 
 // Two-letter avatar initials for a creator name — first letters of the first two
 // words, or the first two chars of a single token.
@@ -109,26 +108,9 @@ export default function AgentsView() {
   // clicked; clicking the active column flips direction. Text columns default ascending,
   // numeric columns descending (highest first is the useful default).
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null)
-  // Fresh-workspace onboarding lives on its own /onboarding route. An offline daemon is
-  // recoverable there, so only an online daemon or an agent counts as initialized.
-  const router = useRouter()
-  const params = useParams()
-  const orgKey = typeof params.slug === 'string' ? params.slug : '-'
-  const [skipState, setSkipState] = useState<{ orgKey: string; skipped: boolean } | null>(null)
-  const onboardingSkipped = skipState?.orgKey === orgKey ? skipState.skipped : null
-  useEffect(() => {
-    setSkipState({ orgKey, skipped: isOnboardingSkipped(orgKey) })
-  }, [orgKey])
-  const notInitialized = needsOnboarding(
-    agentsLoading,
-    daemonsLoading,
-    agents.length,
-    daemons.some(daemonCompletesOnboarding)
-  )
-  const redirectToOnboarding = notInitialized && onboardingSkipped === false
-  useEffect(() => {
-    if (redirectToOnboarding) router.replace(`/${orgKey}/onboarding`)
-  }, [redirectToOnboarding, router, orgKey])
+  // Fresh-workspace onboarding lives on its own /onboarding route (shared hook —
+  // Home, the default landing, runs the same redirect).
+  const holdForOnboarding = useOnboardingRedirect()
   const onSort = (key: SortKey) =>
     setSort((prev) =>
       prev?.key === key
@@ -224,7 +206,7 @@ export default function AgentsView() {
 
   // While the redirect to /onboarding is in flight, hold a spinner so the empty
   // table/metrics never flash behind it.
-  if (notInitialized && onboardingSkipped !== true) return <LoadingState fill />
+  if (holdForOnboarding) return <LoadingState fill />
 
   if (view === 'topology') {
     if (isMobile) {

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -24,6 +24,8 @@ vi.mock('next/link', () => ({
   default: ({ children }: { children: React.ReactNode }) => <a>{children}</a>
 }))
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (p: string) => `/acme${p}` }) }))
+// The fresh-org bounce is covered by its own logic (lib/onboarding); hold it open here.
+vi.mock('@/lib/use-onboarding-redirect', () => ({ useOnboardingRedirect: () => false }))
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     agents: mocks.agents,

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -419,7 +419,6 @@ export default function HomeView() {
           ) : (
             recent.map((s) => {
               const owner = s.agentId ? getAgent(s.agentId) : undefined
-              console.log('recent session', s, owner)
               return (
                 <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
                   <span className="min-w-0">

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useOrgs } from '@/lib/org-context'
+import { useOnboardingRedirect } from '@/lib/use-onboarding-redirect'
 import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
@@ -91,11 +92,16 @@ export default function HomeView() {
   const { orgPath } = useOrgs()
   const { agents, daemons, crons, allSessions, usage24h, getAgent, loading } = useConsoleData()
   const { openPlayground, pgSend, pgSetModel, pgSetEffort, pgSetPermissionMode } = usePlayground()
+  // Home is the default landing, so it owns the fresh-org bounce to /onboarding.
+  const holdForOnboarding = useOnboardingRedirect()
 
   // An agent can take a session only when its owning daemon is serving AND that
   // runtime is signed in (its last probe wasn't rejected with ACP auth-required).
   const isOnline = (a: Agent) =>
-    effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status) === 'online'
+    effectiveAgentStatus(
+      a.status,
+      daemons.find((d) => d.daemonId === a.daemon)
+    ) === 'online'
   const authRequiredFor = (a: Agent) =>
     !!daemons.find((d) => d.daemonId === a.daemon)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
   const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)
@@ -245,6 +251,10 @@ export default function HomeView() {
       )
     }
   })
+
+  // While the redirect to /onboarding is in flight (or the skip flag is still being
+  // read), hold a spinner so the empty composer never flashes behind it.
+  if (holdForOnboarding) return <LoadingState fill />
 
   return (
     <div className="wrap max-w-[1000px] max-desktop:px-4 max-desktop:pt-4 max-desktop:pb-24">

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -419,6 +419,7 @@ export default function HomeView() {
           ) : (
             recent.map((s) => {
               const owner = s.agentId ? getAgent(s.agentId) : undefined
+              console.log('recent session', s, owner)
               return (
                 <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
                   <span className="min-w-0">

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   provisionDaemon: vi.fn(),
   reconnectDaemon: vi.fn(),
   deleteDaemon: vi.fn(),
+  updateAgent: vi.fn(),
+  moveAgent: vi.fn(),
   refresh: vi.fn(),
   push: vi.fn(),
   skipOnboarding: vi.fn()
@@ -36,8 +38,14 @@ vi.mock('@/lib/data-context', () => ({
     provisionDaemon: mocks.provisionDaemon,
     reconnectDaemon: mocks.reconnectDaemon,
     deleteDaemon: mocks.deleteDaemon,
+    updateAgent: mocks.updateAgent,
+    moveAgent: mocks.moveAgent,
     refresh: mocks.refresh
   })
+}))
+// RuntimeSelect pulls the ACP registry context + AgentMark; stub it to the picked value.
+vi.mock('@/components/console/RuntimeSelect', () => ({
+  RuntimeSelect: ({ value }: { value: string }) => `runtime-${value}`
 }))
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { email: 'dana@acme.dev', initials: 'DR' } }) }))
@@ -100,6 +108,8 @@ beforeEach(() => {
   mocks.reconnectDaemon.mockReset()
   mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
+  mocks.updateAgent.mockReset().mockResolvedValue(undefined)
+  mocks.moveAgent.mockReset().mockResolvedValue(undefined)
   mocks.push.mockReset()
   mocks.skipOnboarding.mockReset()
   host = document.createElement('div')
@@ -160,5 +170,46 @@ describe('onboarding — daemon online reveal', () => {
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
     // an online daemon that has connected is never deleted on the way out
     expect(mocks.deleteDaemon).not.toHaveBeenCalled()
+  })
+})
+
+describe('onboarding — configure the built-in agent', () => {
+  beforeEach(() => {
+    mocks.daemons = [
+      {
+        daemonId: 'dmn_new',
+        status: 'online',
+        name: 'edge-1',
+        runtimeModels: [{ runtime: 'claude', models: ['claude-sonnet-4-5'] }]
+      }
+    ]
+    // The org's unplaced built-in preset: no daemon, deferred runtime.
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+  })
+
+  it('shows the configure step for an unplaced built-in agent instead of the reveal', async () => {
+    await render()
+    expect(host.textContent).toContain('Configure')
+    expect(host.textContent).toContain('runtime-claude') // RuntimeSelect stub, seeded from the daemon
+    expect(host.textContent).not.toContain('Your daemon is online')
+  })
+
+  it('sets the runtime BEFORE moving the agent onto the connected daemon, then reveals', async () => {
+    await render()
+    await click('Save and continue')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
+    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', 'dmn_new')
+    // Order matters: the CP rejects a move on a runtime-less agent.
+    const updateOrder = mocks.updateAgent.mock.invocationCallOrder[0] ?? 0
+    const moveOrder = mocks.moveAgent.mock.invocationCallOrder[0] ?? Infinity
+    expect(updateOrder).toBeLessThan(moveOrder)
+    expect(mocks.refresh).toHaveBeenCalled()
+  })
+
+  it('lets the user skip to the reveal without configuring', async () => {
+    await render()
+    await click('Skip for now')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Your daemon is online')
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -175,6 +175,17 @@ describe('onboarding — connect step', () => {
     expect(host.textContent).toContain('agentconnect run')
   })
 
+  // A failed refresh leaves the stale snapshot — re-arming against it could duplicate
+  // an ambiguously-successful provision. Stay latched, show the error, keep Retry.
+  it('does not re-arm provisioning when the fleet refresh itself fails', async () => {
+    mocks.provisionDaemon.mockRejectedValueOnce(new Error('cp unreachable'))
+    mocks.refreshDaemons.mockRejectedValue(new Error('network down'))
+    await render()
+    await click('Retry')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1) // no second mint
+    expect(host.textContent).toContain('Could not refresh the daemon list')
+  })
+
   // Ambiguous success: the failed provision actually landed server-side. Retry must
   // observe the refreshed fleet (the new offline row) and reconnect it — never mint
   // a second daemon against the stale empty list.

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -148,6 +148,28 @@ describe('onboarding — connect step', () => {
     expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
   })
+
+  // Partial-load regression: agents resolving first (every org ships the builtin
+  // preset) must NOT trigger a mint while the fleet list is still loading — the
+  // pending response may already contain a connected daemon.
+  it('does not mint while the daemon list is still loading, even with agents loaded', async () => {
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    mocks.daemonsLoading = true
+    await render()
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(mocks.reconnectDaemon).not.toHaveBeenCalled()
+  })
+
+  it('offers Retry after a mint failure and re-drives the request', async () => {
+    mocks.provisionDaemon
+      .mockRejectedValueOnce(new Error('cp unreachable'))
+      .mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
+    expect(host.textContent).toContain('cp unreachable')
+    await click('Retry')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
+    expect(host.textContent).toContain('agentconnect run')
+  })
 })
 
 describe('onboarding — daemon online reveal', () => {

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -8,23 +8,29 @@ const mocks = vi.hoisted(() => ({
   agents: [] as Array<Record<string, unknown>>,
   daemons: [] as Array<Record<string, unknown>>,
   integrations: [] as Array<Record<string, unknown>>,
+  allSessions: [] as Array<Record<string, unknown>>,
+  members: [] as Array<Record<string, unknown>>,
   agentsLoading: false,
   daemonsLoading: false,
   provisionDaemon: vi.fn(),
   reconnectDaemon: vi.fn(),
   deleteDaemon: vi.fn(),
-  refresh: vi.fn()
+  refresh: vi.fn(),
+  push: vi.fn(),
+  skipOnboarding: vi.fn()
 }))
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ slug: 'acme' }),
-  useRouter: () => ({ push: vi.fn() })
+  useRouter: () => ({ push: mocks.push })
 }))
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     agents: mocks.agents,
     daemons: mocks.daemons,
     integrations: mocks.integrations,
+    allSessions: mocks.allSessions,
+    members: mocks.members,
     agentsLoading: mocks.agentsLoading,
     daemonsLoading: mocks.daemonsLoading,
     provisionDaemon: mocks.provisionDaemon,
@@ -33,20 +39,24 @@ vi.mock('@/lib/data-context', () => ({
     refresh: mocks.refresh
   })
 }))
-vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { email: 'dana@acme.dev', initials: 'DR' } }) }))
+vi.mock('@/lib/auth', () => ({ isAuthConfigured: () => true }))
 vi.mock('@/lib/onboarding', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/onboarding')>()
-  return { ...actual, skipOnboarding: vi.fn() }
+  return { ...actual, skipOnboarding: mocks.skipOnboarding }
 })
 vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
-vi.mock('@/lib/data', () => ({ agentLabel: () => 'Agent' }))
+vi.mock('@/components/console/GettingStartedChecklist', () => ({
+  useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
+  GsRows: () => <div>rows</div>
+}))
 vi.mock('@/components/marks', () => ({
   LogoMark: () => <span>logo</span>,
-  Spinner: () => <span>loading</span>,
   LoadingState: () => <span>loading data</span>
 }))
 vi.mock('@/components/ui', () => ({
+  Avatar: () => <span>avatar</span>,
   Button: ({
     variant: _variant,
     size: _size,
@@ -67,28 +77,34 @@ const button = (label: string) => {
   if (!match) throw new Error(`Missing button: ${label}`)
   return match
 }
-
 const click = async (label: string) => {
   await act(async () => {
     button(label).click()
     await new Promise((resolve) => setTimeout(resolve, 0))
   })
 }
+const render = async () => {
+  await act(async () => root.render(<OnboardingView />))
+  await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+}
 
-beforeEach(async () => {
+beforeEach(() => {
   mocks.agents = []
   mocks.daemons = []
   mocks.integrations = []
+  mocks.allSessions = []
+  mocks.members = []
   mocks.agentsLoading = false
   mocks.daemonsLoading = false
   mocks.provisionDaemon.mockReset()
   mocks.reconnectDaemon.mockReset()
   mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
+  mocks.push.mockReset()
+  mocks.skipOnboarding.mockReset()
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
-  await act(async () => root.render(<OnboardingView />))
 })
 
 afterEach(() => {
@@ -96,86 +112,53 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('daemon onboarding lifecycle', () => {
-  it('deletes an unclaimed row and provisions a fresh command after Back', async () => {
-    mocks.provisionDaemon.mockImplementation(async () => ({
-      daemonId: `new-${mocks.provisionDaemon.mock.calls.length}`,
-      apiKey: 'secret',
-      displayTail: 'tail',
-      command: 'agentconnect run'
-    }))
-
-    await click('Add a Daemon')
+describe('onboarding — connect step', () => {
+  it('mints a join command on mount when no daemon is online', async () => {
+    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
     expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
-
-    await click('Back')
-    expect(mocks.deleteDaemon).toHaveBeenCalledWith('new-1')
-
-    await click('Add a Daemon')
-    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
+    expect(host.textContent).toContain('Connect your daemon')
+    expect(host.textContent).toContain('agentconnect run')
+    expect(host.textContent).toContain('Listening for dmn_new')
   })
 
-  it('keeps an offline daemon on step 1 and mints a recoverable reconnect command', async () => {
-    mocks.daemons = [{ daemonId: 'offline-1', status: 'offline', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
-    mocks.reconnectDaemon.mockResolvedValue({
-      apiKeyId: 'key-1',
-      apiKey: 'secret',
-      displayTail: 'tail',
-      command: 'agentconnect run'
-    })
-    await act(async () => root.render(<OnboardingView />))
-
-    await click('Add a Daemon')
+  it('reconnects an existing offline daemon instead of provisioning a new one', async () => {
+    mocks.daemons = [{ daemonId: 'offline-1', status: 'offline' }]
+    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
+    await render()
     expect(mocks.reconnectDaemon).toHaveBeenCalledWith('offline-1')
     expect(mocks.provisionDaemon).not.toHaveBeenCalled()
-    expect(button('Create an agent').disabled).toBe(true)
-
-    await click('Back')
-    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
-    await click('Add a Daemon')
-    expect(mocks.reconnectDaemon).toHaveBeenCalledTimes(2)
   })
 
-  it('resumes at the live step when daemons resolve before agents/integrations', async () => {
-    act(() => root.unmount())
-    // First load: daemons resolve for a fully-live org while agents are still loading.
-    mocks.daemons = [{ daemonId: 'new-1', status: 'online', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
-    mocks.agents = []
-    mocks.integrations = []
-    mocks.agentsLoading = true
-    mocks.daemonsLoading = false
-    root = createRoot(host)
-    await act(async () => root.render(<OnboardingView />))
-    // Must not seed a mid-wizard step from the partial data — still on the welcome screen.
-    expect(host.textContent).toContain('Welcome to AgentConnect')
+  it('deletes an unclaimed provisioned daemon when exploring the console instead', async () => {
+    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
+    await click('Explore the console first')
+    expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_new')
+    expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
+    expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+  })
+})
 
-    // Agents/integrations finish loading — the wizard now resumes at the final step.
-    mocks.agents = [{ id: 'agent-1', daemon: 'new-1', hookKinds: [] }]
-    mocks.integrations = [{ id: 'int-1' }]
-    mocks.agentsLoading = false
-    await act(async () => root.render(<OnboardingView />))
-    expect(host.textContent).toContain('You’re live')
+describe('onboarding — daemon online reveal', () => {
+  beforeEach(() => {
+    mocks.daemons = [{ daemonId: 'dmn_new', status: 'online', name: 'edge-1' }]
   })
 
-  it('never deletes a claimed daemon that disconnects before Finish', async () => {
-    mocks.provisionDaemon.mockResolvedValue({
-      daemonId: 'new-1',
-      apiKey: 'secret',
-      displayTail: 'tail',
-      command: 'agentconnect run'
-    })
-    await click('Add a Daemon')
+  it('reveals the checklist and never provisions a daemon', async () => {
+    await render()
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Your daemon is online')
+    expect(host.textContent).toContain('Getting started')
+    expect(host.textContent).toContain('rows') // <GsRows/> stub
+  })
 
-    mocks.daemons = [{ daemonId: 'new-1', status: 'online', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
-    await act(async () => root.render(<OnboardingView />))
-    await click('Create an agent')
-
-    mocks.agents = [{ id: 'agent-1', daemon: 'new-1', hookKinds: [] }]
-    mocks.daemons = [{ daemonId: 'new-1', status: 'offline', name: 'edge-1', host: 'edge-1', version: '1.0.0' }]
-    await act(async () => root.render(<OnboardingView />))
-    await click('Set up integration')
-    await click('Finish')
-
+  it('finish stays disabled until every step is done; skip always exits to the console', async () => {
+    await render() // only the daemon step is done → finish disabled
+    expect(button('Finish onboarding').disabled).toBe(true)
+    await click('Skip for now')
+    expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+    // an online daemon that has connected is never deleted on the way out
     expect(mocks.deleteDaemon).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   updateAgent: vi.fn(),
   moveAgent: vi.fn(),
   refresh: vi.fn(),
+  refreshDaemons: vi.fn(),
   push: vi.fn(),
   skipOnboarding: vi.fn()
 }))
@@ -40,7 +41,8 @@ vi.mock('@/lib/data-context', () => ({
     deleteDaemon: mocks.deleteDaemon,
     updateAgent: mocks.updateAgent,
     moveAgent: mocks.moveAgent,
-    refresh: mocks.refresh
+    refresh: mocks.refresh,
+    refreshDaemons: mocks.refreshDaemons
   })
 }))
 // RuntimeSelect pulls the ACP registry context + AgentMark; stub it to the picked value.
@@ -108,6 +110,7 @@ beforeEach(() => {
   mocks.reconnectDaemon.mockReset()
   mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
+  mocks.refreshDaemons.mockReset().mockResolvedValue(undefined)
   mocks.updateAgent.mockReset().mockResolvedValue(undefined)
   mocks.moveAgent.mockReset().mockResolvedValue(undefined)
   mocks.push.mockReset()
@@ -167,8 +170,25 @@ describe('onboarding — connect step', () => {
     await render()
     expect(host.textContent).toContain('cp unreachable')
     await click('Retry')
+    expect(mocks.refreshDaemons).toHaveBeenCalled()
     expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
     expect(host.textContent).toContain('agentconnect run')
+  })
+
+  // Ambiguous success: the failed provision actually landed server-side. Retry must
+  // observe the refreshed fleet (the new offline row) and reconnect it — never mint
+  // a second daemon against the stale empty list.
+  it('retries via reconnect when the failed provision succeeded server-side', async () => {
+    mocks.provisionDaemon.mockRejectedValueOnce(new Error('response lost'))
+    mocks.refreshDaemons.mockImplementation(async () => {
+      mocks.daemons = [{ daemonId: 'dmn_ghost', status: 'offline' }]
+    })
+    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
+    await render()
+    expect(host.textContent).toContain('response lost')
+    await click('Retry')
+    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('dmn_ghost')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -10,7 +10,10 @@ import { isAuthConfigured } from '@/lib/auth'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
 import { computeGettingStarted } from '@/lib/getting-started'
-import { GsRows, MeetYourAgents, useGsActions } from '@/components/console/GettingStartedChecklist'
+import { AddToSlackRow, GsRows, MeetYourAgents, useGsActions } from '@/components/console/GettingStartedChecklist'
+import { RuntimeSelect } from '@/components/console/RuntimeSelect'
+import { FALLBACK_RUNTIME_IDS, agentIsPlaced, agentLabel, modelLabel, preferredModelFor } from '@/lib/data'
+import type { Agent, DaemonRow } from '@/lib/data'
 import type { DaemonConnectDto } from '@/lib/api'
 
 // Onboarding (design: "AgentConnect Onboarding"). Connecting a daemon is the ONLY
@@ -42,6 +45,8 @@ export default function OnboardingView() {
     provisionDaemon,
     reconnectDaemon,
     deleteDaemon,
+    updateAgent,
+    moveAgent,
     refresh
   } = useConsoleData()
   const { orgPath } = useOrgs()
@@ -55,6 +60,36 @@ export default function OnboardingView() {
   const daemonReady = daemons.some(daemonCompletesOnboarding)
   const offlineDaemonId = firstReconnectableDaemonId(daemons)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
+
+  // Once a daemon is serving, configure the org's built-in `agentconnect` preset before
+  // the checklist reveal: auto-assign it to that daemon and let the user pick a runtime +
+  // model (design: the built-in agent replaces "create your first agent"). The preset
+  // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
+  // orgs without the preset just skip straight to the reveal.
+  const builtinAgent = agents.find((a) => a.builtin)
+  const placementDaemon = daemons.find((d) => d.status === 'online') ?? daemons.find(daemonCompletesOnboarding)
+  const needsAgentSetup = !!builtinAgent && !!placementDaemon && !agentIsPlaced(builtinAgent)
+  const [skipSetup, setSkipSetup] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveErr, setSaveErr] = useState<string | null>(null)
+
+  // Runtime becomes mandatory at placement, so set it FIRST, then move onto the daemon
+  // (the CP rejects a move on a runtime-less agent). refresh() flips needsAgentSetup off,
+  // advancing the screen to the reveal on its own.
+  const saveAgentSetup = async (runtime: string, model: string) => {
+    if (!builtinAgent || !placementDaemon) return
+    setSaving(true)
+    setSaveErr(null)
+    try {
+      await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
+      await moveAgent(builtinAgent.id, placementDaemon.daemonId)
+      await refresh()
+    } catch (e) {
+      setSaveErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
 
   // --- Daemon provisioning (mirrors AddDaemonModal / the old wizard step 0) ----------
   const [connect, setConnect] = useState<DaemonCommand | null>(null)
@@ -133,13 +168,7 @@ export default function OnboardingView() {
     <div className="flex min-h-full items-center justify-center px-5 py-10">
       {loading ? (
         <LoadingState fill />
-      ) : daemonReady ? (
-        <RevealChecklist
-          gs={computeGettingStarted({ agents, daemons, integrations, sessions: allSessions, members, authOn })}
-          runAction={runAction}
-          onFinish={goConsole}
-        />
-      ) : (
+      ) : !daemonReady ? (
         <ConnectDaemon
           cmd={cmd}
           mintErr={mintErr}
@@ -148,6 +177,21 @@ export default function OnboardingView() {
           listeningId={listeningId}
           elapsedLabel={elapsedLabel}
           onExplore={goConsole}
+        />
+      ) : needsAgentSetup && !skipSetup ? (
+        <ConfigureAgent
+          agent={builtinAgent!}
+          daemon={placementDaemon!}
+          saving={saving}
+          err={saveErr}
+          onSave={saveAgentSetup}
+          onSkip={() => setSkipSetup(true)}
+        />
+      ) : (
+        <RevealChecklist
+          gs={computeGettingStarted({ agents, daemons, integrations, sessions: allSessions, members, authOn })}
+          runAction={runAction}
+          onFinish={goConsole}
         />
       )}
     </div>
@@ -254,6 +298,137 @@ function ConnectDaemon({
   )
 }
 
+// --- Phase 1.5: place + configure the built-in agent on the just-connected daemon ----
+// Daemon is fixed (the one we just brought online); the user only picks runtime + model.
+// Mirrors AddAgentModal's Daemon/Runtime/Model row: runtime ids come from the daemon's
+// reported profiles (else the static fallback), models from the chosen runtime's profile.
+function ConfigureAgent({
+  agent,
+  daemon,
+  saving,
+  err,
+  onSave,
+  onSkip
+}: {
+  agent: Agent
+  daemon: DaemonRow
+  saving: boolean
+  err: string | null
+  onSave: (runtime: string, model: string) => void
+  onSkip: () => void
+}) {
+  const runtimeIds = daemon.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const [runtime, setRuntime] = useState(runtimeIds[0] ?? '')
+  const effectiveRuntime = runtimeIds.includes(runtime) ? runtime : (runtimeIds[0] ?? '')
+  const models = daemon.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
+  const [model, setModel] = useState('')
+  // Keep the selection valid as the runtime (and so the model set) changes.
+  const selectedModel = models.includes(model) ? model : preferredModelFor(daemon, effectiveRuntime)
+
+  return (
+    <div className="flex w-full max-w-[520px] flex-col gap-[22px]">
+      <div className="flex flex-col items-center gap-[11px] text-center">
+        <span className="flex h-11 w-11 items-center justify-center rounded-[11px] border border-(--border-default) bg-(--surface-card) text-(--brand) shadow-(--shadow-xs)">
+          <Icon name="bot" size={21} />
+        </span>
+        <div className="font-mono text-[11px] font-semibold uppercase leading-none tracking-[.12em] text-(--brand)">
+          Set up your agent
+        </div>
+        <h1 className="font-sans text-[28px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
+          Configure {agentLabel(agent)}
+        </h1>
+        <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
+          Your org&rsquo;s built-in agent runs on the daemon you just connected. Pick a runtime and model, and
+          it&rsquo;s ready to work.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
+        <div className="fld">
+          <span className="fldlbl">Daemon</span>
+          <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
+            <span className="truncate text-(--text-primary)">{daemon.name}</span>
+            <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
+              just connected
+            </span>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
+          <div className="fld">
+            <span className="fldlbl">Runtime</span>
+            <RuntimeSelect
+              value={effectiveRuntime}
+              options={runtimeIds}
+              onChange={(next) => {
+                setRuntime(next)
+                setModel('')
+              }}
+            />
+          </div>
+          <div className="fld">
+            <span className="fldlbl">Model</span>
+            <div
+              className={models.length ? 'inp relative' : 'inp cursor-not-allowed'}
+              title={models.length ? undefined : 'This runtime reports no selectable models'}
+            >
+              <span className={`truncate ${models.length ? '' : 'text-(--text-tertiary)'}`}>
+                {models.length ? modelLabel(selectedModel) : '—'}
+              </span>
+              {models.length > 0 && (
+                <>
+                  <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="flex-none" />
+                  <select
+                    value={selectedModel}
+                    onChange={(e) => setModel(e.target.value)}
+                    className="absolute inset-0 cursor-pointer opacity-0"
+                    aria-label="Model"
+                  >
+                    {models.map((m) => (
+                      <option key={m} value={m}>
+                        {modelLabel(m)}
+                      </option>
+                    ))}
+                  </select>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        {err && (
+          <div className="flex items-start gap-2 font-sans text-[12.5px] leading-[1.5] text-(--status-error)">
+            <Icon name="alert-triangle" size={15} className="mt-[1px] flex-none" />
+            <span>{err}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex w-full flex-col items-stretch gap-[10px] desktop:w-auto desktop:flex-row desktop:items-center desktop:justify-center">
+          <Button
+            size="lg"
+            disabled={saving || !effectiveRuntime}
+            onClick={() => onSave(effectiveRuntime, selectedModel)}
+          >
+            {saving ? (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+            ) : (
+              <Icon name="check" size={16} />
+            )}
+            {saving ? 'Saving…' : 'Save and continue'}
+          </Button>
+          <Button size="lg" variant="ghost" disabled={saving} onClick={onSkip}>
+            Skip for now
+            <Icon name="arrow-right" size={15} />
+          </Button>
+        </div>
+        <div className="text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+          You can change the runtime and model any time from the agent&rsquo;s settings.
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // --- Phase 2: daemon online → the same checklist the console shows -------------------
 function RevealChecklist({
   gs,
@@ -309,6 +484,13 @@ function RevealChecklist({
                   open={ctx.open}
                   toggle={ctx.toggle}
                   onConnect={() => runAction(it.action)}
+                />
+              ) : it.key === 'slack' ? (
+                <AddToSlackRow
+                  done={it.done}
+                  open={ctx.open}
+                  toggle={ctx.toggle}
+                  onManual={() => runAction(it.action)}
                 />
               ) : null
             }

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -125,14 +125,16 @@ export default function OnboardingView() {
   // A transient mint failure must not strand the single blocking step. AWAIT the fleet
   // refresh before re-arming: if the failed provision actually succeeded server-side
   // (response lost), the refreshed list contains that daemon as an offline row, so the
-  // re-run reconnects it via `offlineDaemonId` instead of minting a duplicate. A failed
-  // refresh still re-arms — retrying against the stale list beats staying stranded.
+  // re-run reconnects it via `offlineDaemonId` instead of minting a duplicate. A FAILED
+  // refresh must NOT re-arm — the stale snapshot is exactly what could duplicate an
+  // ambiguously-successful provision; stay latched and keep the Retry on screen.
   const retryMint = async () => {
     setMintErr(null)
     try {
       await refreshDaemons()
     } catch {
-      /* stale list — the retry below is still better than a dead end */
+      setMintErr('Could not refresh the daemon list — check your connection and retry.')
+      return
     }
     provisioned.current = false
     commandPending.current = null

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -47,7 +47,8 @@ export default function OnboardingView() {
     deleteDaemon,
     updateAgent,
     moveAgent,
-    refresh
+    refresh,
+    refreshDaemons
   } = useConsoleData()
   const { orgPath } = useOrgs()
   const { runAction } = useGsActions()
@@ -121,14 +122,20 @@ export default function OnboardingView() {
     command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
   }, [agentsLoading, daemonsLoading, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, mintAttempt])
 
-  // A transient mint failure must not strand the single blocking step: re-arm the
-  // one-shot guard and re-run the effect (refresh first so an ambiguous success shows
-  // up as an offline row and the retry reconnects it rather than minting a duplicate).
-  const retryMint = () => {
+  // A transient mint failure must not strand the single blocking step. AWAIT the fleet
+  // refresh before re-arming: if the failed provision actually succeeded server-side
+  // (response lost), the refreshed list contains that daemon as an offline row, so the
+  // re-run reconnects it via `offlineDaemonId` instead of minting a duplicate. A failed
+  // refresh still re-arms — retrying against the stale list beats staying stranded.
+  const retryMint = async () => {
+    setMintErr(null)
+    try {
+      await refreshDaemons()
+    } catch {
+      /* stale list — the retry below is still better than a dead end */
+    }
     provisioned.current = false
     commandPending.current = null
-    setMintErr(null)
-    refresh()
     setMintAttempt((n) => n + 1)
   }
 
@@ -193,7 +200,7 @@ export default function OnboardingView() {
           mintErr={mintErr}
           copied={copied}
           onCopy={copy}
-          onRetry={retryMint}
+          onRetry={() => void retryMint()}
           listeningId={listeningId}
           elapsedLabel={elapsedLabel}
           onExplore={goConsole}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -96,13 +96,21 @@ export default function OnboardingView() {
   const [mintErr, setMintErr] = useState<string | null>(null)
   const [elapsed, setElapsed] = useState(0)
   const [copied, setCopied] = useState(false)
+  // Bumped by the error state's Retry — re-arms the mint effect after a failure.
+  const [mintAttempt, setMintAttempt] = useState(0)
   const provisioned = useRef(false)
   const commandPending = useRef<Promise<DaemonCommand> | null>(null)
   const createdByWizard = useRef(false)
   const connectedOnce = useRef(false)
 
+  // Mint only once BOTH lists have settled: agents can resolve first (every org ships
+  // the builtin preset, so `loading` clears on partial data) while the pending fleet
+  // response still contains a connected daemon — minting against the empty snapshot
+  // would provision a duplicate. Duplicate-safe on retry too: a provision that
+  // succeeded server-side surfaces as an offline row on the next refresh, which routes
+  // the retry through reconnect instead of a second provision.
   useEffect(() => {
-    if (daemonReady || provisioned.current || loading) return
+    if (agentsLoading || daemonsLoading || daemonReady || provisioned.current) return
     provisioned.current = true
     setMintErr(null)
     createdByWizard.current = !offlineDaemonId
@@ -111,7 +119,18 @@ export default function OnboardingView() {
       : provisionDaemon()
     commandPending.current = command
     command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
-  }, [daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, loading])
+  }, [agentsLoading, daemonsLoading, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, mintAttempt])
+
+  // A transient mint failure must not strand the single blocking step: re-arm the
+  // one-shot guard and re-run the effect (refresh first so an ambiguous success shows
+  // up as an offline row and the retry reconnects it rather than minting a duplicate).
+  const retryMint = () => {
+    provisioned.current = false
+    commandPending.current = null
+    setMintErr(null)
+    refresh()
+    setMintAttempt((n) => n + 1)
+  }
 
   // Poll until the daemon connects; tick the elapsed timer while waiting.
   useEffect(() => {
@@ -174,6 +193,7 @@ export default function OnboardingView() {
           mintErr={mintErr}
           copied={copied}
           onCopy={copy}
+          onRetry={retryMint}
           listeningId={listeningId}
           elapsedLabel={elapsedLabel}
           onExplore={goConsole}
@@ -204,6 +224,7 @@ function ConnectDaemon({
   mintErr,
   copied,
   onCopy,
+  onRetry,
   listeningId,
   elapsedLabel,
   onExplore
@@ -212,6 +233,7 @@ function ConnectDaemon({
   mintErr: string | null
   copied: boolean
   onCopy: () => void
+  onRetry: () => void
   listeningId: string
   elapsedLabel: string
   onExplore: () => void
@@ -258,7 +280,17 @@ function ConnectDaemon({
               <span>{cmd}</span>
             </>
           ) : mintErr ? (
-            <span className="text-(--status-error)">Could not provision a key — {mintErr}</span>
+            <span className="flex flex-wrap items-center gap-2">
+              <span className="text-(--status-error)">Could not provision a key — {mintErr}</span>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex h-[24px] cursor-pointer items-center gap-[5px] rounded-md border border-white/15 bg-white/5 px-2 font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10"
+              >
+                <Icon name="refresh-cw" size={11} />
+                Retry
+              </button>
+            </span>
           ) : (
             <span className="text-(--text-inverse-dim)">Minting key…</span>
           )}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -1,42 +1,32 @@
 'use client'
 
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { LogoMark, Spinner, LoadingState } from '@/components/marks'
+import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
-import { agentLabel } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
-import { useModal } from '@/components/console/ModalProvider'
 import { useOrgs } from '@/lib/org-context'
+import { isAuthConfigured } from '@/lib/auth'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
+import { computeGettingStarted } from '@/lib/getting-started'
+import { GsRows, MeetYourAgents, useGsActions } from '@/components/console/GettingStartedChecklist'
 import type { DaemonConnectDto } from '@/lib/api'
 
+// Onboarding (design: "AgentConnect Onboarding"). Connecting a daemon is the ONLY
+// blocking step; when one comes online the screen transitions in place and reveals the
+// SAME getting-started checklist the console shows (lib/getting-started.ts). No more
+// 3-step wizard — the remaining steps live in the checklist and follow the user into
+// the console (the corner pill in GettingStarted.tsx). Rendered full-screen (no rail)
+// by the shell on the /onboarding route.
+//
+// The daemon step is inline and functional: it mints a real join command and polls for
+// the daemon to come online (like AddDaemonModal). Not shipped yet, so not shown as
+// "done for you": preset agents + the one-click built-in Bot connect (preset-agents.md
+// §3/§5) — the revealed checklist derives from real state, so "Create your first agent"
+// etc. appear as ordinary open steps until those land.
+
 type DaemonCommand = Pick<DaemonConnectDto, 'daemonId' | 'command'>
-
-// Onboarding wizard (design: "AgentConnect Onboarding") — a 3-step guided setup rendered
-// directly in the console content area: Welcome → Add a Daemon → Create an agent → Set up
-// integration → live. The daemon step is inline and functional (mints a real join command
-// and polls for the daemon to come online, like AddDaemonModal). The agent and integration
-// steps hand off to the existing modals — those flows are 1.5k / 3.3k lines of validated
-// logic, so the wizard frames them and launches them rather than re-implementing the forms.
-
-const STEPS = [
-  { title: 'Add a Daemon', sub: 'Run the Daemon' },
-  { title: 'Create an agent', sub: 'Repo & model' },
-  { title: 'Set up integration', sub: 'Assign a bot' }
-] as const
-
-const WELCOME_CARDS = [
-  { icon: 'server', n: 'step 1', title: 'Add a Daemon', desc: 'Run one command to launch a Daemon on your own host.' },
-  {
-    icon: 'bot',
-    n: 'step 2',
-    title: 'Create an agent',
-    desc: 'Point it at a GitHub repo and working folder, pick a model.'
-  },
-  { icon: 'plug', n: 'step 3', title: 'Set up integration', desc: 'Assign a bot so the agent can talk in a channel.' }
-] as const
 
 export default function OnboardingView() {
   const router = useRouter()
@@ -45,6 +35,8 @@ export default function OnboardingView() {
     agents,
     daemons,
     integrations,
+    allSessions,
+    members,
     agentsLoading,
     daemonsLoading,
     provisionDaemon,
@@ -52,90 +44,67 @@ export default function OnboardingView() {
     deleteDaemon,
     refresh
   } = useConsoleData()
-  const { openModal } = useModal()
   const { orgPath } = useOrgs()
+  const { runAction } = useGsActions()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
+  const authOn = isAuthConfigured()
 
-  // A live daemon or a planned relaunch completes step 1. Only an unexpected offline
-  // row is eligible for a replacement connect token.
+  // A live daemon or a planned relaunch reveals the checklist. Only an unexpected offline
+  // row is eligible for a replacement connect token — it may be a provisioned daemon whose
+  // one-time command was lost on reload; the mint below reconnects it.
   const daemonReady = daemons.some(daemonCompletesOnboarding)
   const offlineDaemonId = firstReconnectableDaemonId(daemons)
-  const hasAgent = agents.length > 0
-  const hasIntegration = integrations.length > 0 || agents.some((a) => (a.hookKinds ?? []).length > 0)
-
-  // 0 daemon · 1 agent · 2 integration · 3 live. `entered` gates the welcome screen.
-  const [step, setStep] = useState(0)
-  const [entered, setEntered] = useState(false)
-  const didInit = useRef(false)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
-  // Seed the resume position once, after BOTH lists finish loading: jump straight to the
-  // first incomplete step (past the welcome) when the org is already part-way set up.
-  // Gating on emptiness would seed from partial data when one SWR key resolves first.
-  useEffect(() => {
-    if (didInit.current || agentsLoading || daemonsLoading) return
-    didInit.current = true
-    const s = !daemonReady ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
-    setStep(s)
-    setEntered(s > 0)
-  }, [agentsLoading, daemonsLoading, daemonReady, hasAgent, hasIntegration])
-
-  // --- Daemon provisioning (step 0), mirrors AddDaemonModal --------------------------
+  // --- Daemon provisioning (mirrors AddDaemonModal / the old wizard step 0) ----------
   const [connect, setConnect] = useState<DaemonCommand | null>(null)
   const [mintErr, setMintErr] = useState<string | null>(null)
+  const [elapsed, setElapsed] = useState(0)
+  const [copied, setCopied] = useState(false)
   const provisioned = useRef(false)
   const commandPending = useRef<Promise<DaemonCommand> | null>(null)
   const createdByWizard = useRef(false)
   const connectedOnce = useRef(false)
+
   useEffect(() => {
-    if (!entered || step !== 0 || daemonReady || provisioned.current) return
+    if (daemonReady || provisioned.current || loading) return
     provisioned.current = true
     setMintErr(null)
     createdByWizard.current = !offlineDaemonId
     const command: Promise<DaemonCommand> = offlineDaemonId
-      ? reconnectDaemon(offlineDaemonId).then((minted) => ({
-          daemonId: offlineDaemonId,
-          command: minted.command
-        }))
+      ? reconnectDaemon(offlineDaemonId).then((minted) => ({ daemonId: offlineDaemonId, command: minted.command }))
       : provisionDaemon()
     commandPending.current = command
     command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
-  }, [entered, step, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon])
+  }, [daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, loading])
 
-  const provisionedRow = connect ? daemons.find((d) => d.daemonId === connect.daemonId) : undefined
+  // Poll until the daemon connects; tick the elapsed timer while waiting.
   useEffect(() => {
-    if (provisionedRow?.status === 'online') {
+    if (daemonReady) {
       connectedOnce.current = true
       return
     }
     if (!connect) return
-    const id = setInterval(refresh, 3000)
-    return () => clearInterval(id)
-  }, [connect, provisionedRow?.status, refresh])
+    const poll = setInterval(refresh, 3000)
+    const tick = setInterval(() => setElapsed((s) => s + 1), 1000)
+    return () => {
+      clearInterval(poll)
+      clearInterval(tick)
+    }
+  }, [connect, daemonReady, refresh])
 
   // Drop only a wizard-created row that was never claimed. Once it has connected or
-  // hosts an agent, a later disconnect must not turn leaving onboarding into deletion.
+  // hosts an agent, leaving onboarding must never turn into a deletion.
   const cleanupPending = async () => {
-    const pendingConnect = connect ?? (await commandPending.current?.catch(() => null))
-    const pendingRow = pendingConnect ? daemons.find((d) => d.daemonId === pendingConnect.daemonId) : undefined
-    const hostsAgent = pendingConnect ? agents.some((agent) => agent.daemon === pendingConnect.daemonId) : false
+    const pending = connect ?? (await commandPending.current?.catch(() => null))
+    const row = pending ? daemons.find((d) => d.daemonId === pending.daemonId) : undefined
+    const hostsAgent = pending ? agents.some((a) => a.daemon === pending.daemonId) : false
     const shouldDelete =
-      pendingConnect &&
-      createdByWizard.current &&
-      !connectedOnce.current &&
-      !hostsAgent &&
-      pendingRow?.status !== 'online'
+      pending && createdByWizard.current && !connectedOnce.current && !hostsAgent && row?.status !== 'online'
     try {
-      if (shouldDelete) await deleteDaemon(pendingConnect.daemonId)
+      if (shouldDelete) await deleteDaemon(pending.daemonId)
     } catch {
-      /* best-effort cleanup — an unclaimed provisioned row is harmless */
-    } finally {
-      setConnect(null)
-      setMintErr(null)
-      provisioned.current = false
-      commandPending.current = null
-      createdByWizard.current = false
-      connectedOnce.current = false
+      /* best-effort — an unclaimed provisioned row is harmless */
     }
   }
   const goConsole = () => {
@@ -144,443 +113,223 @@ export default function OnboardingView() {
     router.push(orgPath('/home'))
   }
 
-  if (loading) return <LoadingState fill />
-
-  // --- Welcome -----------------------------------------------------------------------
-  if (!entered) {
-    return (
-      <div className="mx-auto flex w-full max-w-[720px] flex-col items-center px-6 py-10 pb-24 text-center desktop:py-14 desktop:pb-14">
-        <LogoMark size={50} />
-        <div className="mt-[22px] font-mono text-[12px] font-semibold uppercase leading-none tracking-[.1em] text-(--brand)">
-          Get started
-        </div>
-        <h1 className="mt-[10px] font-sans text-[32px] font-semibold leading-[1.15] tracking-[-.02em] text-(--text-primary)">
-          Welcome to AgentConnect
-        </h1>
-        <p className="mt-3 max-w-[500px] font-sans text-[16px] font-normal leading-[1.55] text-(--text-secondary)">
-          Run AI agents on your own Daemons and drive them from Slack, Telegram, and Discord. Three steps to your first
-          session.
-        </p>
-        <div className="mb-[26px] mt-[30px] grid w-full grid-cols-1 gap-3 desktop:grid-cols-3">
-          {WELCOME_CARDS.map((c) => (
-            <div
-              key={c.title}
-              className="rounded-md border border-(--border-subtle) bg-(--surface-card) p-4 text-left shadow-(--shadow-xs)"
-            >
-              <div className="flex items-center gap-2">
-                <div className="flex h-[34px] w-[34px] items-center justify-center rounded-md bg-(--brand-soft) text-(--brand-soft-text)">
-                  <Icon name={c.icon} size={18} />
-                </div>
-                <span className="font-mono text-[11px] leading-normal text-(--text-tertiary)">{c.n}</span>
-              </div>
-              <div className="mt-3 font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
-                {c.title}
-              </div>
-              <div className="mt-[3px] font-sans text-[12.5px] font-normal leading-[1.45] text-(--text-tertiary)">
-                {c.desc}
-              </div>
-            </div>
-          ))}
-        </div>
-        <div className="flex flex-col items-center gap-[10px] desktop:flex-row">
-          <Button size="lg" onClick={() => setEntered(true)}>
-            <Icon name="arrow-right" size={16} />
-            Add a Daemon
-          </Button>
-          <Button size="lg" variant="ghost" onClick={goConsole}>
-            Explore the console first
-          </Button>
-        </div>
-        <div className="mt-[18px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-          You&rsquo;ll run one command on the host where your agents should run.
-        </div>
-      </div>
-    )
-  }
-
-  // --- Stepper wizard ----------------------------------------------------------------
-  return (
-    <div className="mx-auto w-full max-w-[1000px] px-6 py-8 pb-24 desktop:py-10 desktop:pb-10">
-      <div className="flex flex-col gap-8 desktop:flex-row desktop:gap-10">
-        <StepRail current={step < 3 ? step : 3} />
-        <div className="min-w-0 flex-1">
-          {step === 0 && (
-            <StepBody
-              title="Add a Daemon"
-              sub="Run this on the host where your agents should run. It launches a Daemon that connects to AgentConnect and stays available."
-              footer={
-                <>
-                  <Button
-                    variant="ghost"
-                    onClick={async () => {
-                      await cleanupPending()
-                      setEntered(false)
-                    }}
-                  >
-                    Back
-                  </Button>
-                  <div className="flex-1" />
-                  <Button disabled={!daemonReady} onClick={() => setStep(1)}>
-                    Create an agent
-                    <Icon name="arrow-right" size={15} />
-                  </Button>
-                </>
-              }
-            >
-              <Terminal connect={connect} err={mintErr} />
-              <ConnectedCard
-                online={!!provisionedRow && provisionedRow.status === 'online'}
-                name={provisionedRow?.name}
-                host={provisionedRow?.host}
-                version={provisionedRow?.version}
-                resumed={daemonReady && !provisionedRow}
-                resumedName={daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name}
-              />
-              <div className="mt-[14px] flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                <Icon name="info" size={15} className="mt-[1px] flex-none" />
-                <span>
-                  Keep this process running. The daemon runs agents locally over ACP and holds your platform
-                  connections.
-                </span>
-              </div>
-            </StepBody>
-          )}
-
-          {step === 1 && (
-            <StepBody
-              title="Create an agent"
-              sub="It runs on the Daemon you just added. Point it at a repo and working directory, then pick a model."
-              footer={
-                <>
-                  <Button variant="ghost" onClick={() => setStep(0)}>
-                    Back
-                  </Button>
-                  <div className="flex-1" />
-                  <Button disabled={!hasAgent} onClick={() => setStep(2)}>
-                    Set up integration
-                    <Icon name="arrow-right" size={15} />
-                  </Button>
-                </>
-              }
-            >
-              <ActionPanel
-                icon="bot"
-                done={hasAgent}
-                doneLabel={hasAgent && agents[0] ? `${agentLabel(agents[0])} created` : ''}
-                title={hasAgent ? 'Agent created' : 'Create your first agent'}
-                desc={
-                  hasAgent
-                    ? 'Add more later from the console — each with its own repo, model, and bot.'
-                    : 'Give it a name, choose the Daemon and model, and point it at a GitHub repo and working directory.'
-                }
-                cta={hasAgent ? 'Create another' : 'Create an agent'}
-                onCta={() => openModal('agent')}
-              />
-            </StepBody>
-          )}
-
-          {step === 2 && (
-            <StepBody
-              title="Set up integration"
-              sub={`Give ${agents[0] ? agentLabel(agents[0]) : 'your agent'} a bot identity so it can read and post in a channel — Slack, Telegram, or Discord.`}
-              footer={
-                <>
-                  <Button variant="ghost" onClick={() => setStep(1)}>
-                    Back
-                  </Button>
-                  <div className="flex-1" />
-                  <Button onClick={goConsole}>
-                    <Icon name="radio" size={15} />
-                    {hasIntegration ? 'Go live' : 'Finish'}
-                  </Button>
-                </>
-              }
-            >
-              <ActionPanel
-                icon="plug"
-                done={hasIntegration}
-                doneLabel={hasIntegration ? 'Integration connected' : ''}
-                title={hasIntegration ? 'Integration connected' : 'Connect a channel'}
-                desc={
-                  hasIntegration
-                    ? 'Your agent can now read and post in the connected channel.'
-                    : 'Assign a bot identity and pick a channel. This step is optional — you can do it later from the agent page.'
-                }
-                cta={hasIntegration ? 'Add another' : 'Set up integration'}
-                onCta={() => agents[0] && openModal('integration', agents[0])}
-              />
-            </StepBody>
-          )}
-
-          {step === 3 && (
-            <div className="flex flex-col items-start">
-              <span className="flex h-14 w-14 items-center justify-center rounded-xl bg-(--brand) text-white">
-                <Icon name="check" size={30} />
-              </span>
-              <h2 className="mt-5 font-sans text-[26px] font-semibold leading-[1.15] tracking-[-.02em] text-(--text-primary)">
-                You&rsquo;re live
-              </h2>
-              <p className="mt-2 max-w-[460px] font-sans text-[15px] font-normal leading-[1.55] text-(--text-secondary)">
-                {agents[0] ? agentLabel(agents[0]) : 'Your agent'} is running on{' '}
-                {daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name ?? 'your Daemon'}. Open the
-                console to watch its first session.
-              </p>
-              <div className="mt-7">
-                <Button size="lg" onClick={goConsole}>
-                  Go to console
-                  <Icon name="arrow-right" size={16} />
-                </Button>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// A step's main column: heading + sub, content, and a bottom footer nav (divider above).
-function StepBody({
-  title,
-  sub,
-  children,
-  footer
-}: {
-  title: string
-  sub: string
-  children: ReactNode
-  footer: ReactNode
-}) {
-  return (
-    <div className="flex min-h-[420px] flex-col">
-      <h2 className="font-sans text-[24px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
-        {title}
-      </h2>
-      <p className="mt-[6px] max-w-[620px] font-sans text-[14px] font-normal leading-[1.5] text-(--text-secondary)">
-        {sub}
-      </p>
-      <div className="mt-[22px]">{children}</div>
-      <div className="mt-8 flex items-center gap-[10px] border-t border-(--border-subtle) pt-5">{footer}</div>
-    </div>
-  )
-}
-
-// The 3-step progress rail — a left column on desktop, a horizontal strip on mobile.
-function StepRail({ current }: { current: number }) {
-  return (
-    <div className="flex flex-none gap-2 desktop:w-60 desktop:flex-col desktop:gap-1 desktop:border-r desktop:border-(--border-subtle) desktop:pr-6">
-      <div className="hidden font-mono text-[12px] font-semibold uppercase leading-none tracking-[.06em] text-(--text-tertiary) desktop:mb-[10px] desktop:block">
-        Setup
-      </div>
-      {STEPS.map((s, i) => {
-        const done = i < current
-        const active = i === current
-        return (
-          <div
-            key={s.title}
-            className={`flex flex-1 items-center gap-3 rounded-md px-[10px] py-[11px] desktop:flex-none ${
-              active ? 'bg-(--surface-sunken)' : ''
-            }`}
-          >
-            <span
-              className={`flex h-[26px] w-[26px] flex-none items-center justify-center rounded-full font-mono text-[12px] font-semibold ${
-                done
-                  ? 'bg-(--brand) text-white'
-                  : active
-                    ? 'border-2 border-(--brand) bg-(--surface-card) text-(--brand)'
-                    : 'border-[1.5px] border-(--border-strong) bg-(--surface-app) text-(--text-tertiary)'
-              }`}
-            >
-              {done ? <Icon name="check" size={15} /> : i + 1}
-            </span>
-            <div className="min-w-0">
-              <div
-                className={`truncate font-sans text-[13.5px] leading-normal ${
-                  active || done ? 'font-semibold text-(--text-primary)' : 'font-medium text-(--text-secondary)'
-                }`}
-              >
-                {s.title}
-              </div>
-              <div className="hidden truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) desktop:block">
-                {s.sub}
-              </div>
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-// Dark terminal block with Run / Install-as-service tabs + copy — the real minted join
-// command (or a minting/error placeholder), matching AddDaemonModal's CommandBox.
-function Terminal({ connect, err }: { connect: DaemonCommand | null; err: string | null }) {
-  const cmds = connect ? daemonCommands(connect.command) : null
-  const tabs = [
-    { key: 'run', label: 'Run', command: cmds?.run ?? null },
-    { key: 'service', label: 'Install as service', command: cmds?.login ?? null }
-  ]
-  const [active, setActive] = useState(0)
-  const [copied, setCopied] = useState(false)
-  const command = tabs[active]?.command ?? null
+  const cmd = connect ? daemonCommands(connect.command).run : null
   const copy = async () => {
-    if (!command) return
+    if (!cmd) return
     try {
-      await navigator.clipboard.writeText(command)
+      await navigator.clipboard.writeText(cmd)
       setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
+      setTimeout(() => setCopied(false), 1700)
     } catch {
       /* clipboard unavailable */
     }
   }
-  return (
-    <div className="overflow-hidden rounded-[10px] border border-(--gray-800) bg-(--gray-1000)">
-      <div className="flex items-stretch border-b border-(--gray-800)">
-        {tabs.map((tab, i) => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => {
-              setActive(i)
-              setCopied(false)
-            }}
-            aria-selected={i === active}
-            className={`inline-flex cursor-pointer items-center gap-[6px] border-0 border-b-2 bg-transparent px-[13px] py-[9px] font-mono text-[11px] font-medium leading-normal ${
-              i === active
-                ? 'border-(--magenta-300) text-[#cdd6e0]'
-                : 'border-transparent text-(--text-inverse-dim) hover:text-[#cdd6e0]'
-            }`}
-          >
-            <Icon name="terminal" size={13} />
-            {tab.label}
-          </button>
-        ))}
-        <button
-          type="button"
-          onClick={copy}
-          disabled={!command}
-          className="ml-auto inline-flex cursor-pointer items-center gap-[5px] border-0 bg-transparent px-[13px] py-[9px] font-mono text-[11px] font-medium leading-normal text-(--text-inverse-dim) disabled:cursor-default disabled:opacity-50"
-        >
-          <Icon name={copied ? 'check' : 'copy'} size={12} />
-          {copied ? 'copied' : 'copy'}
-        </button>
-      </div>
-      <div className="break-all px-[16px] py-[15px] font-mono text-[12.5px] leading-[1.75] text-[#cdd6e0]">
-        {command ? (
-          <div>
-            <span className="text-(--magenta-300)">$</span> {command}
-          </div>
-        ) : err ? (
-          <div className="text-(--status-error)">Could not provision a key — {err}</div>
-        ) : (
-          <div className="text-(--text-inverse-dim)">Minting key…</div>
-        )}
-      </div>
-    </div>
-  )
-}
+  const listeningId = connect?.daemonId ?? offlineDaemonId ?? ''
+  const elapsedLabel = `${Math.floor(elapsed / 60)}:${String(elapsed % 60).padStart(2, '0')}`
 
-// The connected / waiting daemon card under the terminal.
-function ConnectedCard({
-  online,
-  name,
-  host,
-  version,
-  resumed,
-  resumedName
-}: {
-  online: boolean
-  name?: string
-  host?: string
-  version?: string
-  resumed?: boolean
-  resumedName?: string
-}) {
-  if (resumed) {
-    return (
-      <div className="mt-4 flex items-center gap-[11px] rounded-[10px] border border-(--brand-soft-border) bg-(--brand-soft) px-[14px] py-[13px]">
-        <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--brand-soft-border) bg-(--surface-card)">
-          <Icon name="server" size={19} color="var(--brand)" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
-            {resumedName ?? 'A daemon'} already connected
-          </div>
-          <div className="mono text-[12px] text-(--text-secondary)">Continue to the next step.</div>
-        </div>
-      </div>
-    )
-  }
+  // The shell renders the full-screen frame + slim top bar (logo · theme · user menu)
+  // for the /onboarding route; this is just the centered content.
   return (
-    <div className="mt-4 flex items-center gap-[11px] rounded-[10px] border border-dashed border-(--border-strong) px-[14px] py-[13px]">
-      {online ? (
-        <span className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-(--status-online)">
-          <Icon name="check" size={13} color="#fff" />
-        </span>
+    <div className="flex min-h-full items-center justify-center px-5 py-10">
+      {loading ? (
+        <LoadingState fill />
+      ) : daemonReady ? (
+        <RevealChecklist
+          gs={computeGettingStarted({ agents, daemons, integrations, sessions: allSessions, members, authOn })}
+          runAction={runAction}
+          onFinish={goConsole}
+        />
       ) : (
-        <span className="flex-none leading-[0]">
-          <Spinner size={22} />
-        </span>
+        <ConnectDaemon
+          cmd={cmd}
+          mintErr={mintErr}
+          copied={copied}
+          onCopy={copy}
+          listeningId={listeningId}
+          elapsedLabel={elapsedLabel}
+          onExplore={goConsole}
+        />
       )}
-      <div className="min-w-0 flex-1">
-        <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
-          {online ? `${name ?? 'Daemon'} connected` : 'Waiting for daemon…'}
-        </div>
-        <div className="mono text-[12px] text-(--text-tertiary)">
-          {online ? `${host ?? ''}${version ? ` · v${version}` : ''}` : "It'll appear here once it connects."}
-        </div>
-      </div>
-      {online ? (
-        <span className="flex flex-none items-center gap-[6px] rounded-full bg-(--status-online-soft) px-[9px] py-[3px]">
-          <span className="h-[7px] w-[7px] rounded-full bg-(--status-online)" />
-          <span className="font-mono text-[11px] font-medium leading-normal text-[#0f7a48]">online</span>
-        </span>
-      ) : null}
     </div>
   )
 }
 
-// A centered call-to-action panel for the agent / integration steps: an icon, a title +
-// description, a completion chip once done, and the primary button that opens the modal.
-function ActionPanel({
-  icon,
-  title,
-  desc,
-  cta,
-  onCta,
-  done,
-  doneLabel
+// --- Phase 1: connect your daemon (the one blocking step) ----------------------------
+function ConnectDaemon({
+  cmd,
+  mintErr,
+  copied,
+  onCopy,
+  listeningId,
+  elapsedLabel,
+  onExplore
 }: {
-  icon: string
-  title: string
-  desc: string
-  cta: string
-  onCta: () => void
-  done: boolean
-  doneLabel: string
+  cmd: string | null
+  mintErr: string | null
+  copied: boolean
+  onCopy: () => void
+  listeningId: string
+  elapsedLabel: string
+  onExplore: () => void
 }) {
   return (
-    <div className="flex flex-col items-start rounded-[10px] border border-(--border-subtle) bg-(--surface-app) px-6 py-7">
-      <span className="flex h-11 w-11 items-center justify-center rounded-md bg-(--brand-soft) text-(--brand-soft-text)">
-        <Icon name={icon} size={22} />
-      </span>
-      {done && doneLabel ? (
-        <div className="mt-4 inline-flex items-center gap-2 rounded-md bg-(--brand-soft) px-3 py-2">
-          <Icon name="check" size={14} className="text-(--brand-soft-text)" />
-          <span className="font-sans text-[12.5px] font-medium leading-normal text-(--brand-soft-text)">
-            {doneLabel}
+    <div className="flex w-full max-w-[560px] flex-col gap-[22px]">
+      <div className="flex flex-col items-center gap-[11px] text-center">
+        <span className="flex h-11 w-11 items-center justify-center rounded-[11px] border border-(--border-default) bg-(--surface-card) text-(--brand) shadow-(--shadow-xs)">
+          <Icon name="server" size={21} />
+        </span>
+        <div className="font-mono text-[11px] font-semibold uppercase leading-none tracking-[.12em] text-(--brand)">
+          Setup
+        </div>
+        <h1 className="font-sans text-[28px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
+          Connect your daemon
+        </h1>
+        <p className="max-w-[450px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
+          A daemon runs your agents on your own hardware. Run this one command wherever you want them to run — it
+          connects to AgentConnect and keeps running.
+        </p>
+      </div>
+
+      {/* Dark terminal block — the real minted join command */}
+      <div className="overflow-hidden rounded-[10px] border border-(--gray-800) bg-(--gray-1000) shadow-(--shadow-xs)">
+        <div className="flex items-center gap-2 border-b border-(--gray-800) py-[9px] pr-[10px] pl-[13px]">
+          <Icon name="terminal" size={13} color="var(--text-inverse-dim)" />
+          <span className="font-mono text-[11px] font-medium leading-normal tracking-[.02em] text-(--text-inverse-dim)">
+            one command · macOS, Linux, WSL
+          </span>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={!cmd}
+            className="ml-auto inline-flex h-[26px] cursor-pointer items-center gap-[6px] rounded-md border border-white/15 bg-white/5 px-[9px] font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10 disabled:cursor-default disabled:opacity-50"
+          >
+            <Icon name={copied ? 'check' : 'copy'} size={12} />
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <div className="flex gap-[9px] break-all p-[15px] font-mono text-[13px] leading-[1.6] text-[#cdd6e0]">
+          {cmd ? (
+            <>
+              <span className="text-(--magenta-300)">$</span>
+              <span>{cmd}</span>
+            </>
+          ) : mintErr ? (
+            <span className="text-(--status-error)">Could not provision a key — {mintErr}</span>
+          ) : (
+            <span className="text-(--text-inverse-dim)">Minting key…</span>
+          )}
+        </div>
+      </div>
+
+      {/* Waiting card — auto-continues when the daemon comes online */}
+      <div className="flex items-center gap-[13px] rounded-[10px] border border-(--border-default) bg-(--surface-card) px-4 py-[14px] shadow-(--shadow-xs)">
+        <span className="h-[18px] w-[18px] flex-none animate-spin rounded-full border-2 border-(--gray-200) border-t-(--brand)" />
+        <div className="min-w-0 flex-1">
+          <div className="font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+            Waiting for your daemon to come online…
+          </div>
+          <div className="mt-[2px] font-mono text-[11.5px] leading-normal text-(--text-tertiary)">
+            {listeningId ? `Listening for ${listeningId} · ` : ''}this page continues on its own
+          </div>
+        </div>
+        <span className="flex-none font-mono text-[12px] tabular-nums text-(--text-tertiary)">{elapsedLabel}</span>
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <a
+          href="https://docs.agentconnect.md/docs/install-the-daemon"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-[6px] font-sans text-[12.5px] text-(--text-tertiary) no-underline hover:text-(--brand)"
+        >
+          Daemon not showing up? Read the setup guide
+          <Icon name="arrow-up-right" size={13} />
+        </a>
+        <Button variant="secondary" size="sm" onClick={onExplore}>
+          Explore the console first
+          <Icon name="arrow-right" size={14} />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// --- Phase 2: daemon online → the same checklist the console shows -------------------
+function RevealChecklist({
+  gs,
+  runAction,
+  onFinish
+}: {
+  gs: ReturnType<typeof computeGettingStarted>
+  runAction: (action: import('@/lib/getting-started').GsAction) => void
+  onFinish: () => void
+}) {
+  const [expanded, setExpanded] = useState<string | null>('daemon')
+  return (
+    <div className="ac-rise flex w-full max-w-[580px] flex-col gap-4">
+      <div className="flex flex-col items-center gap-[10px] text-center">
+        <span className="ac-pop flex h-[46px] w-[46px] items-center justify-center rounded-full bg-(--green-50) text-(--green-500)">
+          <Icon name="check" size={23} />
+        </span>
+        <h1 className="font-sans text-[24px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
+          Your daemon is online
+        </h1>
+        <p className="max-w-[440px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-secondary)">
+          Connected and ready — here&rsquo;s your getting-started checklist. Work through the rest any time; it follows
+          you into the console.
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-[10px] border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)">
+        <div className="flex items-center gap-[10px] py-[14px] pr-[14px] pl-4">
+          <Icon name="list-checks" size={16} color="var(--brand)" />
+          <span className="min-w-0 flex-1 font-sans text-[14.5px] font-semibold leading-none tracking-[-.01em] text-(--text-primary)">
+            Getting started
+          </span>
+          <span className="font-mono text-[12px] tabular-nums leading-none text-(--text-tertiary)">
+            {gs.done} of {gs.total}
+          </span>
+          <span className="h-[5px] w-[120px] flex-none overflow-hidden rounded-[3px] bg-(--gray-150)">
+            <span
+              className="block h-full rounded-[3px] bg-(--brand) transition-[width] duration-300"
+              style={{ width: `${Math.round(gs.fraction * 100)}%` }}
+            />
           </span>
         </div>
-      ) : null}
-      <div className="mt-4 font-sans text-[16px] font-semibold leading-normal text-(--text-primary)">{title}</div>
-      <p className="mt-[3px] max-w-[520px] font-sans text-[13px] font-normal leading-[1.5] text-(--text-tertiary)">
-        {desc}
-      </p>
-      <div className="mt-5">
-        <Button variant={done ? 'secondary' : 'primary'} onClick={onCta}>
-          <Icon name="plus" size={15} />
-          {cta}
-        </Button>
+        <div className="border-t border-(--border-subtle)">
+          <GsRows
+            items={gs.items}
+            expanded={expanded}
+            onToggle={(key) => setExpanded((cur) => (cur === key ? null : key))}
+            runAction={runAction}
+            renderItem={(it, ctx) =>
+              it.key === 'agent' ? (
+                <MeetYourAgents
+                  done={it.done}
+                  open={ctx.open}
+                  toggle={ctx.toggle}
+                  onConnect={() => runAction(it.action)}
+                />
+              ) : null
+            }
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex w-full flex-col items-stretch gap-[10px] desktop:w-auto desktop:flex-row desktop:items-center desktop:justify-center">
+          <Button size="lg" disabled={!gs.allDone} onClick={onFinish}>
+            <Icon name="check" size={16} />
+            {gs.allDone ? 'Finish onboarding' : `Finish onboarding · ${gs.total - gs.done} left`}
+          </Button>
+          <Button size="lg" variant="ghost" onClick={onFinish}>
+            Skip for now
+            <Icon name="arrow-right" size={15} />
+          </Button>
+        </div>
+        <div className="text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+          Finish the remaining steps to complete onboarding — or skip ahead; the checklist follows you into the console.
+        </div>
       </div>
     </div>
   )

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -10,7 +10,7 @@
 // default org, so the page is fully editable with no picker.
 
 import { Fragment, useCallback, useEffect, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { Avatar, Button, Icon, Toggle } from '@/components/ui'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
@@ -487,6 +487,20 @@ export default function SettingsView() {
   const [editing, setEditing] = useState<MemberTarget | null>(null)
   const [inviting, setInviting] = useState(false)
   const [deletingBot, setDeletingBot] = useState<BotDto | null>(null)
+
+  // `?invite=1` auto-opens the invite-members dialog (the getting-started "Invite
+  // teammates" CTA lands here with it). One-shot: the param is stripped immediately
+  // so back/refresh doesn't reopen the modal.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  useEffect(() => {
+    if (!searchParams.get('invite')) return
+    setInviting(true)
+    const sp = new URLSearchParams(searchParams)
+    sp.delete('invite')
+    router.replace(`${pathname}${sp.size ? `?${sp}` : ''}`, { scroll: false })
+  }, [searchParams, pathname, router])
 
   // A member change can affect ME (self-demote/-remove) — re-pull the org list
   // too so myRole / the active org stay honest instead of 403-ing controls.

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -186,7 +186,6 @@ export function GithubMark({ color = 'currentColor' }: { color?: string }) {
 }
 
 export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fillPct?: number }) {
-  console.log('platform', platform)
   const x = (platform || '').toLowerCase()
   // Marks render at 60% of their box to sit inside .av / .imark tiles; callers can override
   // fillPct — e.g. the Bots row fills a 14px box (fillPct=100) to match the design's full-bleed mark.

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -186,6 +186,7 @@ export function GithubMark({ color = 'currentColor' }: { color?: string }) {
 }
 
 export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fillPct?: number }) {
+  console.log('platform', platform)
   const x = (platform || '').toLowerCase()
   // Marks render at 60% of their box to sit inside .av / .imark tiles; callers can override
   // fillPct — e.g. the Bots row fills a 14px box (fillPct=100) to match the design's full-bleed mark.

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -213,6 +213,9 @@ interface ConsoleData {
   /** Command a daemon to install `version` + relaunch onto it; returns the opened op. */
   upgradeDaemon: (daemonId: string, version: string) => Promise<DaemonLifecycleOpDto>
   refresh: () => void
+  /** Revalidate ONLY the session lists — for after an action known to mint a session
+   *  (e.g. a Playground send), without re-pulling every console read model. */
+  refreshSessions: () => void
   /** True until the very first pull of ALL read models has settled (any org switch re-arms it). */
   loading: boolean
   /** Per-model first-load flags — each clears when ITS pull settles, so a slow
@@ -720,6 +723,9 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const refresh = useCallback(() => {
     void revalidateConsole()
   }, [revalidateConsole])
+  const refreshSessions = useCallback(() => {
+    void revalidateSessionLists()
+  }, [revalidateSessionLists])
 
   const drainSessionRefreshes = useCallback(
     async (generation: number) => {
@@ -1271,6 +1277,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       restartDaemon,
       upgradeDaemon,
       refresh,
+      refreshSessions,
       loading,
       agentsLoading,
       sessionsLoading,
@@ -1333,6 +1340,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       restartDaemon,
       upgradeDaemon,
       refresh,
+      refreshSessions,
       loading,
       agentsLoading,
       sessionsLoading,

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -216,6 +216,10 @@ interface ConsoleData {
   /** Revalidate ONLY the session lists — for after an action known to mint a session
    *  (e.g. a Playground send), without re-pulling every console read model. */
   refreshSessions: () => void
+  /** Revalidate ONLY the daemon fleet and resolve once the fresh list is committed —
+   *  for flows that must observe the post-refresh fleet before acting (e.g. the
+   *  onboarding mint retry, which reconnects an ambiguously-provisioned row). */
+  refreshDaemons: () => Promise<void>
   /** True until the very first pull of ALL read models has settled (any org switch re-arms it). */
   loading: boolean
   /** Per-model first-load flags — each clears when ITS pull settles, so a slow
@@ -726,6 +730,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const refreshSessions = useCallback(() => {
     void revalidateSessionLists()
   }, [revalidateSessionLists])
+  const refreshDaemons = useCallback(() => mutateDaemons().then(() => undefined), [mutateDaemons])
 
   const drainSessionRefreshes = useCallback(
     async (generation: number) => {
@@ -1278,6 +1283,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       upgradeDaemon,
       refresh,
       refreshSessions,
+      refreshDaemons,
       loading,
       agentsLoading,
       sessionsLoading,
@@ -1341,6 +1347,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       upgradeDaemon,
       refresh,
       refreshSessions,
+      refreshDaemons,
       loading,
       agentsLoading,
       sessionsLoading,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -69,6 +69,14 @@ export function effectiveAgentStatus(
   return agentStatus
 }
 
+// "Placed" = the agent has a daemon AND a runtime, so it can actually run. Every org
+// ships the built-in `agentconnect` preset UNPLACED (daemon '—', deferred runtime '');
+// configuring it (onboarding's agent step) or creating a user agent flips this true. It
+// is the signal for "the org is set up" — used by the onboarding gate + getting-started.
+export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime'>): boolean {
+  return agent.daemon !== '—' && agent.runtime !== ''
+}
+
 export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done'
 
 export interface LaneInfo {

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { computeGettingStarted } from './getting-started'
+import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
+import type { MemberDto } from '@/lib/api'
+
+const agent = (over: Partial<Agent> = {}): Agent =>
+  ({ id: 'a1', name: 'bot', model: 'default', runtime: 'claude', workspace: { mode: 'scratch' }, ...over }) as Agent
+const daemon = (status: DaemonRow['status']): DaemonRow => ({ daemonId: 'd1', status }) as DaemonRow
+const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
+
+describe('computeGettingStarted', () => {
+  it('starts all-incomplete for a fresh org and reports progress', () => {
+    const gs = computeGettingStarted(empty)
+    expect(gs.done).toBe(0)
+    expect(gs.total).toBe(7) // 6 core + invite (auth mode)
+    expect(gs.fraction).toBe(0)
+    expect(gs.allDone).toBe(false)
+  })
+
+  it('drops the invite item in no-auth mode', () => {
+    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(6)
+    expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
+  })
+
+  it('marks daemon done only for an online daemon', () => {
+    const done = (rows: DaemonRow[]) =>
+      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
+    expect(done([daemon('offline')])).toBe(false)
+    expect(done([daemon('online')])).toBe(true)
+  })
+
+  it('derives agent, repo, and github items from the agent shape', () => {
+    const scratch = computeGettingStarted({ ...empty, agents: [agent()] })
+    expect(scratch.items.find((i) => i.key === 'agent')!.done).toBe(true)
+    expect(scratch.items.find((i) => i.key === 'repo')!.done).toBe(false)
+    expect(scratch.items.find((i) => i.key === 'github')!.done).toBe(false)
+
+    const wired = computeGettingStarted({
+      ...empty,
+      agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })]
+    })
+    expect(wired.items.find((i) => i.key === 'repo')!.done).toBe(true)
+    expect(wired.items.find((i) => i.key === 'github')!.done).toBe(true)
+  })
+
+  it('marks slack, conversation, and invite from their signals', () => {
+    const gs = computeGettingStarted({
+      ...empty,
+      integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
+      sessions: [{ id: 's1' } as Session],
+      members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto]
+    })
+    expect(gs.items.find((i) => i.key === 'slack')!.done).toBe(true)
+    expect(gs.items.find((i) => i.key === 'conversation')!.done).toBe(true)
+    expect(gs.items.find((i) => i.key === 'invite')!.done).toBe(true)
+  })
+
+  it('points agent-scoped CTAs at the first agent, else falls back to create-agent', () => {
+    expect(computeGettingStarted(empty).items.find((i) => i.key === 'repo')!.action).toEqual({
+      kind: 'agentRepo',
+      agentId: null
+    })
+    const withAgent = computeGettingStarted({ ...empty, agents: [agent({ id: 'a9' })] })
+    expect(withAgent.items.find((i) => i.key === 'slack')!.action).toEqual({ kind: 'slack', agentId: 'a9' })
+  })
+
+  it('reaches allDone with a full ring when every signal is satisfied', () => {
+    const gs = computeGettingStarted({
+      agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
+      daemons: [daemon('online')],
+      integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
+      sessions: [{ id: 's1' } as Session],
+      members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],
+      authOn: true
+    })
+    expect(gs.allDone).toBe(true)
+    expect(gs.fraction).toBe(1)
+    // dash length equals the full circumference (2π·10.5 ≈ 65.97)
+    expect(gs.ring.split(' ')[0]).toBe(gs.ring.split(' ')[1])
+  })
+})

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -13,8 +13,10 @@ const agent = (over: Partial<Agent> = {}): Agent =>
     workspace: { mode: 'scratch' },
     ...over
   }) as Agent
-const daemon = (status: DaemonRow['status'], runtimeModels: { runtime: string; authRequired?: boolean }[] = []) =>
-  ({ daemonId: 'd1', status, runtimeModels }) as DaemonRow
+const daemon = (
+  status: DaemonRow['status'],
+  runtimeModels: { runtime: string; authRequired?: boolean; models?: string[] }[] = []
+) => ({ daemonId: 'd1', status, runtimeModels: runtimeModels.map((r) => ({ models: ['m1'], ...r })) }) as DaemonRow
 const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
 
 describe('computeGettingStarted', () => {
@@ -60,7 +62,10 @@ describe('computeGettingStarted', () => {
     const warned = rt([daemon('online', [{ runtime: 'claude', authRequired: true }])])
     expect(warned).toMatchObject({ done: false, warn: true })
     expect(warned.action).toEqual({ kind: 'runtime', daemonId: 'd1' })
-    // online with a signed-in runtime: done
+    // probe pending/failed (no advertised models) is NOT signed in — authRequired
+    // absence alone must not tick the step
+    expect(rt([daemon('online', [{ runtime: 'claude', models: [] }])])).toMatchObject({ done: false, warn: true })
+    // online with a probed, signed-in runtime: done
     expect(rt([daemon('online', [{ runtime: 'claude' }])]).done).toBe(true)
     // hasWarn surfaces the amber state
     const gs = computeGettingStarted({
@@ -77,6 +82,14 @@ describe('computeGettingStarted', () => {
     expect(done([agent()])).toBe(true)
   })
 
+  it('tracks the BUILT-IN preset when present — a placed custom agent alone must not tick the row', () => {
+    const done = (agents: Agent[]) =>
+      computeGettingStarted({ ...empty, agents }).items.find((i) => i.key === 'agent')!.done
+    // placed custom agent + unplaced preset: the card still shows Set up, so the row stays open
+    expect(done([agent({ id: 'custom' }), agent({ id: 'ac', builtin: true, daemon: '—', runtime: '' })])).toBe(false)
+    expect(done([agent({ id: 'custom', daemon: '—', runtime: '' }), agent({ id: 'ac', builtin: true })])).toBe(true)
+  })
+
   it('merges GitHub + repository into one step, done when a repo is attached', () => {
     const gh = (agents: Agent[]) => computeGettingStarted({ ...empty, agents }).items.find((i) => i.key === 'github')!
     expect(gh([agent()]).done).toBe(false)
@@ -89,12 +102,20 @@ describe('computeGettingStarted', () => {
     const gs = computeGettingStarted({
       ...empty,
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
-      sessions: [{ id: 's1' } as Session],
+      sessions: [{ id: 's1', statusLabel: 'completed' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto]
     })
     expect(gs.items.find((i) => i.key === 'slack')!.done).toBe(true)
     expect(gs.items.find((i) => i.key === 'conversation')!.done).toBe(true)
     expect(gs.items.find((i) => i.key === 'invite')!.done).toBe(true)
+  })
+
+  it('requires a COMPLETED conversation — running or failed sessions do not tick the item', () => {
+    const convo = (sessions: Session[]) =>
+      computeGettingStarted({ ...empty, sessions }).items.find((i) => i.key === 'conversation')!.done
+    expect(convo([{ id: 's1', statusLabel: 'running' } as Session])).toBe(false)
+    expect(convo([{ id: 's1', statusLabel: 'failed' } as Session])).toBe(false)
+    expect(convo([{ id: 's1', statusLabel: 'completed' } as Session])).toBe(true)
   })
 
   it('points agent-scoped CTAs at the built-in agent first, else the first agent', () => {
@@ -114,7 +135,7 @@ describe('computeGettingStarted', () => {
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
       daemons: [daemon('online', [{ runtime: 'claude' }])],
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
-      sessions: [{ id: 's1' } as Session],
+      sessions: [{ id: 's1', statusLabel: 'completed' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],
       authOn: true
     })

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -13,26 +13,23 @@ const agent = (over: Partial<Agent> = {}): Agent =>
     workspace: { mode: 'scratch' },
     ...over
   }) as Agent
-const daemon = (
-  status: DaemonRow['status'],
-  runtimeModels: { runtime: string; authRequired?: boolean; models?: string[] }[] = []
-) => ({ daemonId: 'd1', status, runtimeModels: runtimeModels.map((r) => ({ models: ['m1'], ...r })) }) as DaemonRow
+const daemon = (status: DaemonRow['status']): DaemonRow => ({ daemonId: 'd1', status }) as DaemonRow
 const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
 
 describe('computeGettingStarted', () => {
   it('starts all-incomplete for a fresh org and reports progress', () => {
     const gs = computeGettingStarted(empty)
     expect(gs.done).toBe(0)
-    expect(gs.total).toBe(7) // 6 core + invite (auth mode)
+    expect(gs.total).toBe(6) // 5 core + invite (auth mode)
     expect(gs.fraction).toBe(0)
     expect(gs.allDone).toBe(false)
-    expect(gs.hasWarn).toBe(false) // no online daemon ⇒ the daemon step owns the attention
   })
 
-  it('orders the steps per the design: daemon, runtime, agent, slack, github, conversation, invite', () => {
+  it('orders the steps per the design: daemon, agent, slack, github, conversation, invite', () => {
+    // The "Runtime signed in" step is deferred until the explicit probe-status
+    // signal ships (neither authRequired nor advertised models encode readiness).
     expect(computeGettingStarted(empty).items.map((i) => i.key)).toEqual([
       'daemon',
-      'runtime',
       'agent',
       'slack',
       'github',
@@ -42,7 +39,7 @@ describe('computeGettingStarted', () => {
   })
 
   it('drops the invite item in no-auth mode', () => {
-    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(6)
+    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(5)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
   })
 
@@ -51,28 +48,6 @@ describe('computeGettingStarted', () => {
       computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
     expect(done([daemon('offline')])).toBe(false)
     expect(done([daemon('online')])).toBe(true)
-  })
-
-  it('turns the runtime step amber only when a daemon is online with nothing signed in', () => {
-    const rt = (rows: DaemonRow[]) =>
-      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'runtime')!
-    // no online daemon: open but calm
-    expect(rt([daemon('offline')])).toMatchObject({ done: false, warn: false })
-    // online, every runtime auth-required: needs attention
-    const warned = rt([daemon('online', [{ runtime: 'claude', authRequired: true }])])
-    expect(warned).toMatchObject({ done: false, warn: true })
-    expect(warned.action).toEqual({ kind: 'runtime', daemonId: 'd1' })
-    // probe pending/failed (no advertised models) is NOT signed in — authRequired
-    // absence alone must not tick the step
-    expect(rt([daemon('online', [{ runtime: 'claude', models: [] }])])).toMatchObject({ done: false, warn: true })
-    // online with a probed, signed-in runtime: done
-    expect(rt([daemon('online', [{ runtime: 'claude' }])]).done).toBe(true)
-    // hasWarn surfaces the amber state
-    const gs = computeGettingStarted({
-      ...empty,
-      daemons: [daemon('online', [{ runtime: 'claude', authRequired: true }])]
-    })
-    expect(gs.hasWarn).toBe(true)
   })
 
   it('marks agent done only once some agent is placed (daemon + runtime)', () => {
@@ -133,7 +108,7 @@ describe('computeGettingStarted', () => {
   it('reaches allDone with a full ring when every signal is satisfied', () => {
     const gs = computeGettingStarted({
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
-      daemons: [daemon('online', [{ runtime: 'claude' }])],
+      daemons: [daemon('online')],
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
       sessions: [{ id: 's1', statusLabel: 'completed' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -4,8 +4,17 @@ import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
 import type { MemberDto } from '@/lib/api'
 
 const agent = (over: Partial<Agent> = {}): Agent =>
-  ({ id: 'a1', name: 'bot', model: 'default', runtime: 'claude', workspace: { mode: 'scratch' }, ...over }) as Agent
-const daemon = (status: DaemonRow['status']): DaemonRow => ({ daemonId: 'd1', status }) as DaemonRow
+  ({
+    id: 'a1',
+    name: 'bot',
+    model: 'default',
+    runtime: 'claude',
+    daemon: 'd1',
+    workspace: { mode: 'scratch' },
+    ...over
+  }) as Agent
+const daemon = (status: DaemonRow['status'], runtimeModels: { runtime: string; authRequired?: boolean }[] = []) =>
+  ({ daemonId: 'd1', status, runtimeModels }) as DaemonRow
 const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
 
 describe('computeGettingStarted', () => {
@@ -15,6 +24,19 @@ describe('computeGettingStarted', () => {
     expect(gs.total).toBe(7) // 6 core + invite (auth mode)
     expect(gs.fraction).toBe(0)
     expect(gs.allDone).toBe(false)
+    expect(gs.hasWarn).toBe(false) // no online daemon ⇒ the daemon step owns the attention
+  })
+
+  it('orders the steps per the design: daemon, runtime, agent, slack, github, conversation, invite', () => {
+    expect(computeGettingStarted(empty).items.map((i) => i.key)).toEqual([
+      'daemon',
+      'runtime',
+      'agent',
+      'slack',
+      'github',
+      'conversation',
+      'invite'
+    ])
   })
 
   it('drops the invite item in no-auth mode', () => {
@@ -29,18 +51,38 @@ describe('computeGettingStarted', () => {
     expect(done([daemon('online')])).toBe(true)
   })
 
-  it('derives agent, repo, and github items from the agent shape', () => {
-    const scratch = computeGettingStarted({ ...empty, agents: [agent()] })
-    expect(scratch.items.find((i) => i.key === 'agent')!.done).toBe(true)
-    expect(scratch.items.find((i) => i.key === 'repo')!.done).toBe(false)
-    expect(scratch.items.find((i) => i.key === 'github')!.done).toBe(false)
-
-    const wired = computeGettingStarted({
+  it('turns the runtime step amber only when a daemon is online with nothing signed in', () => {
+    const rt = (rows: DaemonRow[]) =>
+      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'runtime')!
+    // no online daemon: open but calm
+    expect(rt([daemon('offline')])).toMatchObject({ done: false, warn: false })
+    // online, every runtime auth-required: needs attention
+    const warned = rt([daemon('online', [{ runtime: 'claude', authRequired: true }])])
+    expect(warned).toMatchObject({ done: false, warn: true })
+    expect(warned.action).toEqual({ kind: 'runtime', daemonId: 'd1' })
+    // online with a signed-in runtime: done
+    expect(rt([daemon('online', [{ runtime: 'claude' }])]).done).toBe(true)
+    // hasWarn surfaces the amber state
+    const gs = computeGettingStarted({
       ...empty,
-      agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })]
+      daemons: [daemon('online', [{ runtime: 'claude', authRequired: true }])]
     })
-    expect(wired.items.find((i) => i.key === 'repo')!.done).toBe(true)
-    expect(wired.items.find((i) => i.key === 'github')!.done).toBe(true)
+    expect(gs.hasWarn).toBe(true)
+  })
+
+  it('marks agent done only once some agent is placed (daemon + runtime)', () => {
+    const done = (agents: Agent[]) =>
+      computeGettingStarted({ ...empty, agents }).items.find((i) => i.key === 'agent')!.done
+    expect(done([agent({ daemon: '—', runtime: '' })])).toBe(false) // the unplaced built-in preset
+    expect(done([agent()])).toBe(true)
+  })
+
+  it('merges GitHub + repository into one step, done when a repo is attached', () => {
+    const gh = (agents: Agent[]) => computeGettingStarted({ ...empty, agents }).items.find((i) => i.key === 'github')!
+    expect(gh([agent()]).done).toBe(false)
+    expect(gh([agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'] })]).done).toBe(true)
+    // the old separate 'repo' step is gone
+    expect(computeGettingStarted(empty).items.some((i) => i.key === 'repo')).toBe(false)
   })
 
   it('marks slack, conversation, and invite from their signals', () => {
@@ -55,19 +97,22 @@ describe('computeGettingStarted', () => {
     expect(gs.items.find((i) => i.key === 'invite')!.done).toBe(true)
   })
 
-  it('points agent-scoped CTAs at the first agent, else falls back to create-agent', () => {
-    expect(computeGettingStarted(empty).items.find((i) => i.key === 'repo')!.action).toEqual({
-      kind: 'agentRepo',
+  it('points agent-scoped CTAs at the built-in agent first, else the first agent', () => {
+    const withBuiltin = computeGettingStarted({
+      ...empty,
+      agents: [agent({ id: 'a9' }), agent({ id: 'ac', builtin: true })]
+    })
+    expect(withBuiltin.items.find((i) => i.key === 'slack')!.action).toEqual({ kind: 'slack', agentId: 'ac' })
+    expect(computeGettingStarted(empty).items.find((i) => i.key === 'github')!.action).toEqual({
+      kind: 'github',
       agentId: null
     })
-    const withAgent = computeGettingStarted({ ...empty, agents: [agent({ id: 'a9' })] })
-    expect(withAgent.items.find((i) => i.key === 'slack')!.action).toEqual({ kind: 'slack', agentId: 'a9' })
   })
 
   it('reaches allDone with a full ring when every signal is satisfied', () => {
     const gs = computeGettingStarted({
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
-      daemons: [daemon('online')],
+      daemons: [daemon('online', [{ runtime: 'claude' }])],
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
       sessions: [{ id: 's1' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -4,23 +4,26 @@
 // item is incomplete and vanishes for good once the list is complete — there is no
 // manual dismiss, so the only state this module owns is the pure derivation.
 //
-// What is derivable client-side today is a subset of §6.2: the items whose backing
-// (probe status, preset placement, the assistant, delegated-key "Ask" automation)
-// isn't shipped yet are intentionally left out rather than faked — add them here as
-// their signals land. See the note in GettingStarted.tsx.
+// Seven steps, in the design's order: daemon → runtime signed in → meet your agent →
+// Slack → GitHub+repo (one merged step) → first conversation → invite. "Runtime signed
+// in" is the needs-attention item: it derives from the daemons' probe-reported
+// `authRequired` and turns amber when a daemon is online but no runtime can take a
+// session. Still not derivable client-side (left out rather than faked): the per-item
+// "Ask agentconnect" automation (§6.3/§6.4 delegated writes).
 
-import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
-import type { MemberDto } from '@/lib/api'
+import { agentIsPlaced } from './data'
+import type { Agent, DaemonRow, IntegrationRow, Session } from './data'
+import type { MemberDto } from './api'
 
 // What the item's primary CTA drives. The component maps kind → a real handler
 // (open a modal, route to a page) so this stays pure and testable.
 export type GsAction =
   | { kind: 'daemon' }
+  | { kind: 'runtime'; daemonId: string | null }
   | { kind: 'agent' }
-  | { kind: 'agentRepo'; agentId: string | null }
   | { kind: 'slack'; agentId: string | null }
   | { kind: 'github'; agentId: string | null }
-  | { kind: 'chat'; agentId: string | null }
+  | { kind: 'chat' }
   | { kind: 'members' }
 
 export interface GsItem {
@@ -29,6 +32,8 @@ export interface GsItem {
   /** One-line explanation shown when the row is expanded. */
   expl: string
   done: boolean
+  /** Needs-attention: the step is blocking (amber mark + note) rather than merely open. */
+  warn?: boolean
   ctaLabel: string
   action: GsAction
 }
@@ -42,6 +47,8 @@ export interface GettingStarted {
   /** `stroke-dasharray` value for a r=10.5 progress ring (dash then a full-circle gap). */
   ring: string
   allDone: boolean
+  /** Some item is in the needs-attention state (drives the amber banner / pill tint). */
+  hasWarn: boolean
 }
 
 // r=10.5 matches every ring svg in the design (pill, drawer header, rail).
@@ -57,58 +64,75 @@ export function computeGettingStarted(input: {
   authOn: boolean
 }): GettingStarted {
   const { agents, daemons, integrations, sessions, members, authOn } = input
-  // Pick a chat-capable / bindable agent for the agent-scoped CTAs. First agent is fine
-  // — these steps only need *an* agent to act on, and the general preset will be it.
-  const firstAgent = agents[0]?.id ?? null
+  // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
+  // `agentconnect` preset — the canonical agent every org gets — else the first agent.
+  const firstAgent = (agents.find((a) => a.builtin) ?? agents[0])?.id ?? null
+  // Every org is born with the unplaced built-in preset (daemon '—', deferred runtime),
+  // so "an agent exists" is no longer the signal. The step is done once *some* agent is
+  // placed on a daemon with a runtime — i.e. the built-in got configured (onboarding's
+  // agent step) or a user created a real one.
+  const placedAgent = agents.some(agentIsPlaced)
+
+  // Runtime sign-in state, from the daemons' probe reports: a runtime whose last probe
+  // was NOT rejected with ACP auth-required can take a session. Amber only when a daemon
+  // is online yet nothing is signed in — with no online daemon the daemon step already
+  // owns the attention.
+  const onlineDaemons = daemons.filter((d) => d.status === 'online')
+  const runtimes = (d: DaemonRow) => d.runtimeModels ?? []
+  const runtimeSignedIn = onlineDaemons.some((d) => runtimes(d).some((r) => !r.authRequired))
+  const runtimeWarn = onlineDaemons.length > 0 && !runtimeSignedIn
+  const signInDaemon =
+    onlineDaemons.find((d) => runtimes(d).some((r) => r.authRequired))?.daemonId ?? onlineDaemons[0]?.daemonId ?? null
 
   const items: GsItem[] = [
     {
       key: 'daemon',
       label: 'Connect a daemon',
       expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
-      done: daemons.some((d) => d.status === 'online'),
+      done: onlineDaemons.length > 0,
       ctaLabel: 'Add a daemon',
       action: { kind: 'daemon' }
     },
     {
-      key: 'agent',
-      label: 'Create your first agent',
-      expl: 'Give it a name, choose a daemon and model, and point it at a repo. Agents are the workers that answer in your channels.',
-      done: agents.length > 0,
-      ctaLabel: 'Create an agent',
-      action: { kind: 'agent' }
+      key: 'runtime',
+      label: 'Sign in an AI runtime',
+      expl: 'Agents can’t take a session until a runtime (Claude, Codex, …) is signed in on the daemon host. Open the daemon page for the sign-in command.',
+      done: runtimeSignedIn,
+      warn: runtimeWarn,
+      ctaLabel: 'Sign in',
+      action: { kind: 'runtime', daemonId: signInDaemon }
     },
     {
-      key: 'repo',
-      label: 'Give your agent a repository',
-      expl: 'Attach a GitHub repo and working directory so the agent can read and change real code instead of a scratch workspace.',
-      done: agents.some((a) => a.workspace?.mode === 'github'),
-      ctaLabel: 'Attach a repository',
-      action: { kind: 'agentRepo', agentId: firstAgent }
+      key: 'agent',
+      label: 'Set up your agent',
+      expl: 'Your org comes with a built-in AgentConnect agent. Place it on a daemon and pick a runtime and model so it can run — or create your own.',
+      done: placedAgent,
+      ctaLabel: 'Set up your agent',
+      action: { kind: 'agent' }
     },
     {
       key: 'slack',
       label: 'Connect Slack',
-      expl: 'Give an agent a bot identity so it can read and post in a Slack channel. Telegram and Discord work the same way.',
+      expl: 'Assign a bot so your agents can read and post in Slack channels — one click connects the built-in AgentConnect Bot.',
       done: integrations.some((i) => i.platform === 'slack'),
       ctaLabel: 'Connect Slack',
       action: { kind: 'slack', agentId: firstAgent }
     },
     {
       key: 'github',
-      label: 'Connect GitHub',
-      expl: 'Subscribe an agent to a repository so pushes, PRs, and issues can trigger it automatically.',
-      done: agents.some((a) => (a.hookKinds ?? []).includes('github')),
+      label: 'Connect GitHub and assign a repository',
+      expl: 'Install the GitHub App, then point an agent at a repo, branch and working directory so it has code to work in.',
+      done: agents.some((a) => a.workspace?.mode === 'github'),
       ctaLabel: 'Connect GitHub',
       action: { kind: 'github', agentId: firstAgent }
     },
     {
       key: 'conversation',
-      label: 'Finish your first conversation',
-      expl: 'Send an agent a message from the Playground or a connected channel and watch it work end to end.',
+      label: 'Complete your first conversation',
+      expl: 'Send one message and watch the agent work — in a connected channel or in the Playground.',
       done: sessions.length > 0,
       ctaLabel: 'Start a conversation',
-      action: { kind: 'chat', agentId: firstAgent }
+      action: { kind: 'chat' }
     }
   ]
 
@@ -117,7 +141,7 @@ export function computeGettingStarted(input: {
     items.push({
       key: 'invite',
       label: 'Invite teammates',
-      expl: 'Add people to this organization so they can share agents, daemons, and channels with you.',
+      expl: 'Add operators to your workspace so they can run agents and watch sessions.',
       done: members.length > 1,
       ctaLabel: 'Invite teammates',
       action: { kind: 'members' }
@@ -133,6 +157,7 @@ export function computeGettingStarted(input: {
     total,
     fraction,
     ring: `${(fraction * RING_CIRCUMFERENCE).toFixed(2)} ${RING_CIRCUMFERENCE.toFixed(2)}`,
-    allDone: done === total
+    allDone: done === total,
+    hasWarn: items.some((i) => !i.done && i.warn)
   }
 }

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -1,0 +1,138 @@
+// Getting-started checklist logic (design: "Getting Started Placement" 1a/1b — the
+// floating pill + slide-over drawer). Every item is DERIVED from live console state,
+// never a stored "done" tick (preset-agents.md §6.2). The pill persists while any
+// item is incomplete and vanishes for good once the list is complete — there is no
+// manual dismiss, so the only state this module owns is the pure derivation.
+//
+// What is derivable client-side today is a subset of §6.2: the items whose backing
+// (probe status, preset placement, the assistant, delegated-key "Ask" automation)
+// isn't shipped yet are intentionally left out rather than faked — add them here as
+// their signals land. See the note in GettingStarted.tsx.
+
+import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
+import type { MemberDto } from '@/lib/api'
+
+// What the item's primary CTA drives. The component maps kind → a real handler
+// (open a modal, route to a page) so this stays pure and testable.
+export type GsAction =
+  | { kind: 'daemon' }
+  | { kind: 'agent' }
+  | { kind: 'agentRepo'; agentId: string | null }
+  | { kind: 'slack'; agentId: string | null }
+  | { kind: 'github'; agentId: string | null }
+  | { kind: 'chat'; agentId: string | null }
+  | { kind: 'members' }
+
+export interface GsItem {
+  key: string
+  label: string
+  /** One-line explanation shown when the row is expanded. */
+  expl: string
+  done: boolean
+  ctaLabel: string
+  action: GsAction
+}
+
+export interface GettingStarted {
+  items: GsItem[]
+  done: number
+  total: number
+  /** Fraction complete, 0..1. */
+  fraction: number
+  /** `stroke-dasharray` value for a r=10.5 progress ring (dash then a full-circle gap). */
+  ring: string
+  allDone: boolean
+}
+
+// r=10.5 matches every ring svg in the design (pill, drawer header, rail).
+const RING_CIRCUMFERENCE = 2 * Math.PI * 10.5
+
+export function computeGettingStarted(input: {
+  agents: Agent[]
+  daemons: DaemonRow[]
+  integrations: IntegrationRow[]
+  sessions: Session[]
+  members: MemberDto[]
+  /** Auth mode: no-auth deployments have a single implicit org and no member list. */
+  authOn: boolean
+}): GettingStarted {
+  const { agents, daemons, integrations, sessions, members, authOn } = input
+  // Pick a chat-capable / bindable agent for the agent-scoped CTAs. First agent is fine
+  // — these steps only need *an* agent to act on, and the general preset will be it.
+  const firstAgent = agents[0]?.id ?? null
+
+  const items: GsItem[] = [
+    {
+      key: 'daemon',
+      label: 'Connect a daemon',
+      expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
+      done: daemons.some((d) => d.status === 'online'),
+      ctaLabel: 'Add a daemon',
+      action: { kind: 'daemon' }
+    },
+    {
+      key: 'agent',
+      label: 'Create your first agent',
+      expl: 'Give it a name, choose a daemon and model, and point it at a repo. Agents are the workers that answer in your channels.',
+      done: agents.length > 0,
+      ctaLabel: 'Create an agent',
+      action: { kind: 'agent' }
+    },
+    {
+      key: 'repo',
+      label: 'Give your agent a repository',
+      expl: 'Attach a GitHub repo and working directory so the agent can read and change real code instead of a scratch workspace.',
+      done: agents.some((a) => a.workspace?.mode === 'github'),
+      ctaLabel: 'Attach a repository',
+      action: { kind: 'agentRepo', agentId: firstAgent }
+    },
+    {
+      key: 'slack',
+      label: 'Connect Slack',
+      expl: 'Give an agent a bot identity so it can read and post in a Slack channel. Telegram and Discord work the same way.',
+      done: integrations.some((i) => i.platform === 'slack'),
+      ctaLabel: 'Connect Slack',
+      action: { kind: 'slack', agentId: firstAgent }
+    },
+    {
+      key: 'github',
+      label: 'Connect GitHub',
+      expl: 'Subscribe an agent to a repository so pushes, PRs, and issues can trigger it automatically.',
+      done: agents.some((a) => (a.hookKinds ?? []).includes('github')),
+      ctaLabel: 'Connect GitHub',
+      action: { kind: 'github', agentId: firstAgent }
+    },
+    {
+      key: 'conversation',
+      label: 'Finish your first conversation',
+      expl: 'Send an agent a message from the Playground or a connected channel and watch it work end to end.',
+      done: sessions.length > 0,
+      ctaLabel: 'Start a conversation',
+      action: { kind: 'chat', agentId: firstAgent }
+    }
+  ]
+
+  // Members only exist in auth mode; a no-auth deployment has no one to invite.
+  if (authOn) {
+    items.push({
+      key: 'invite',
+      label: 'Invite teammates',
+      expl: 'Add people to this organization so they can share agents, daemons, and channels with you.',
+      done: members.length > 1,
+      ctaLabel: 'Invite teammates',
+      action: { kind: 'members' }
+    })
+  }
+
+  const done = items.filter((i) => i.done).length
+  const total = items.length
+  const fraction = total === 0 ? 1 : done / total
+  return {
+    items,
+    done,
+    total,
+    fraction,
+    ring: `${(fraction * RING_CIRCUMFERENCE).toFixed(2)} ${RING_CIRCUMFERENCE.toFixed(2)}`,
+    allDone: done === total
+  }
+}

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -4,11 +4,13 @@
 // item is incomplete and vanishes for good once the list is complete — there is no
 // manual dismiss, so the only state this module owns is the pure derivation.
 //
-// Seven steps, in the design's order: daemon → runtime signed in → meet your agent →
-// Slack → GitHub+repo (one merged step) → first conversation → invite. "Runtime signed
-// in" is the needs-attention item: it derives from the daemons' probe-reported
-// `authRequired` and turns amber when a daemon is online but no runtime can take a
-// session. Still not derivable client-side (left out rather than faked): the per-item
+// Steps in the design's order: daemon → meet your agent → Slack → GitHub+repo (one
+// merged step) → first conversation → invite. Still not derivable client-side (left
+// out rather than faked, preset-agents.md §6.2): the "Runtime signed in"
+// needs-attention item — neither `authRequired` (absence also means probe
+// pending/failed) nor advertised models (a usable runtime may legitimately have no
+// model selector) encode readiness; add it when the explicit
+// pending|ready|auth_required|failed probe status ships. Same for the per-item
 // "Ask agentconnect" automation (§6.3/§6.4 delegated writes).
 
 import { agentIsPlaced } from './data'
@@ -19,7 +21,6 @@ import type { MemberDto } from './api'
 // (open a modal, route to a page) so this stays pure and testable.
 export type GsAction =
   | { kind: 'daemon' }
-  | { kind: 'runtime'; daemonId: string | null }
   | { kind: 'agent' }
   | { kind: 'slack'; agentId: string | null }
   | { kind: 'github'; agentId: string | null }
@@ -32,8 +33,6 @@ export interface GsItem {
   /** One-line explanation shown when the row is expanded. */
   expl: string
   done: boolean
-  /** Needs-attention: the step is blocking (amber mark + note) rather than merely open. */
-  warn?: boolean
   ctaLabel: string
   action: GsAction
 }
@@ -47,8 +46,6 @@ export interface GettingStarted {
   /** `stroke-dasharray` value for a r=10.5 progress ring (dash then a full-circle gap). */
   ring: string
   allDone: boolean
-  /** Some item is in the needs-attention state (drives the amber banner / pill tint). */
-  hasWarn: boolean
 }
 
 // r=10.5 matches every ring svg in the design (pill, drawer header, rail).
@@ -74,36 +71,14 @@ export function computeGettingStarted(input: {
   // backfills) fall back to "some agent is placed".
   const placedAgent = builtin ? agentIsPlaced(builtin) : agents.some(agentIsPlaced)
 
-  // Runtime sign-in state, from the daemons' probe reports. `authRequired` alone can't
-  // distinguish "signed in" from "probe pending/failed" (absence is stored as false), so
-  // done additionally requires probe evidence — an advertised model list, which empties
-  // on probe failure and is empty before the first probe. Amber only when a daemon is
-  // online yet nothing is provably signed in — with no online daemon the daemon step
-  // already owns the attention.
-  const onlineDaemons = daemons.filter((d) => d.status === 'online')
-  const runtimes = (d: DaemonRow) => d.runtimeModels ?? []
-  const runtimeSignedIn = onlineDaemons.some((d) => runtimes(d).some((r) => !r.authRequired && r.models.length > 0))
-  const runtimeWarn = onlineDaemons.length > 0 && !runtimeSignedIn
-  const signInDaemon =
-    onlineDaemons.find((d) => runtimes(d).some((r) => r.authRequired))?.daemonId ?? onlineDaemons[0]?.daemonId ?? null
-
   const items: GsItem[] = [
     {
       key: 'daemon',
       label: 'Connect a daemon',
       expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
-      done: onlineDaemons.length > 0,
+      done: daemons.some((d) => d.status === 'online'),
       ctaLabel: 'Add a daemon',
       action: { kind: 'daemon' }
-    },
-    {
-      key: 'runtime',
-      label: 'Sign in an AI runtime',
-      expl: 'Agents can’t take a session until a runtime (Claude, Codex, …) is signed in on the daemon host. Open the daemon page for the sign-in command.',
-      done: runtimeSignedIn,
-      warn: runtimeWarn,
-      ctaLabel: 'Sign in',
-      action: { kind: 'runtime', daemonId: signInDaemon }
     },
     {
       key: 'agent',
@@ -162,7 +137,6 @@ export function computeGettingStarted(input: {
     total,
     fraction,
     ring: `${(fraction * RING_CIRCUMFERENCE).toFixed(2)} ${RING_CIRCUMFERENCE.toFixed(2)}`,
-    allDone: done === total,
-    hasWarn: items.some((i) => !i.done && i.warn)
+    allDone: done === total
   }
 }

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -66,20 +66,23 @@ export function computeGettingStarted(input: {
   const { agents, daemons, integrations, sessions, members, authOn } = input
   // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
   // `agentconnect` preset — the canonical agent every org gets — else the first agent.
-  const firstAgent = (agents.find((a) => a.builtin) ?? agents[0])?.id ?? null
-  // Every org is born with the unplaced built-in preset (daemon '—', deferred runtime),
-  // so "an agent exists" is no longer the signal. The step is done once *some* agent is
-  // placed on a daemon with a runtime — i.e. the built-in got configured (onboarding's
-  // agent step) or a user created a real one.
-  const placedAgent = agents.some(agentIsPlaced)
+  const builtin = agents.find((a) => a.builtin)
+  const firstAgent = (builtin ?? agents[0])?.id ?? null
+  // The agent step tracks the BUILT-IN preset when the org has one — the step's card
+  // (MeetYourAgents) renders that preset, so a placed custom agent alone must not tick
+  // the row while the card still shows "Set up". Orgs without the preset (older
+  // backfills) fall back to "some agent is placed".
+  const placedAgent = builtin ? agentIsPlaced(builtin) : agents.some(agentIsPlaced)
 
-  // Runtime sign-in state, from the daemons' probe reports: a runtime whose last probe
-  // was NOT rejected with ACP auth-required can take a session. Amber only when a daemon
-  // is online yet nothing is signed in — with no online daemon the daemon step already
-  // owns the attention.
+  // Runtime sign-in state, from the daemons' probe reports. `authRequired` alone can't
+  // distinguish "signed in" from "probe pending/failed" (absence is stored as false), so
+  // done additionally requires probe evidence — an advertised model list, which empties
+  // on probe failure and is empty before the first probe. Amber only when a daemon is
+  // online yet nothing is provably signed in — with no online daemon the daemon step
+  // already owns the attention.
   const onlineDaemons = daemons.filter((d) => d.status === 'online')
   const runtimes = (d: DaemonRow) => d.runtimeModels ?? []
-  const runtimeSignedIn = onlineDaemons.some((d) => runtimes(d).some((r) => !r.authRequired))
+  const runtimeSignedIn = onlineDaemons.some((d) => runtimes(d).some((r) => !r.authRequired && r.models.length > 0))
   const runtimeWarn = onlineDaemons.length > 0 && !runtimeSignedIn
   const signInDaemon =
     onlineDaemons.find((d) => runtimes(d).some((r) => r.authRequired))?.daemonId ?? onlineDaemons[0]?.daemonId ?? null
@@ -130,7 +133,9 @@ export function computeGettingStarted(input: {
       key: 'conversation',
       label: 'Complete your first conversation',
       expl: 'Send one message and watch the agent work — in a connected channel or in the Playground.',
-      done: sessions.length > 0,
+      // COMPLETED, not merely minted: a running or failed session hasn't finished a
+      // conversation yet ('completed' is the daemon's terminal success status).
+      done: sessions.some((s) => s.statusLabel === 'completed'),
       ctaLabel: 'Start a conversation',
       action: { kind: 'chat' }
     }

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -2,20 +2,21 @@ import { describe, expect, it } from 'vitest'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding } from './onboarding'
 
 describe('needsOnboarding', () => {
-  it('recovers an empty org whose only daemon is offline', () => {
-    expect(needsOnboarding(false, false, 0, false)).toBe(true)
+  it('recovers a fresh org (only the unplaced built-in preset, daemon offline)', () => {
+    expect(needsOnboarding(false, false, false, false)).toBe(true)
   })
 
   it('waits for data and preserves initialized orgs', () => {
-    expect(needsOnboarding(true, false, 0, false)).toBe(false)
-    expect(needsOnboarding(false, false, 1, false)).toBe(false)
-    expect(needsOnboarding(false, false, 0, true)).toBe(false)
+    expect(needsOnboarding(true, false, false, false)).toBe(false)
+    // a placed/configured agent means the org is set up (the built-in preset alone does not)
+    expect(needsOnboarding(false, false, true, false)).toBe(false)
+    expect(needsOnboarding(false, false, false, true)).toBe(false)
   })
 
-  it('keeps an empty org initialized during a planned daemon relaunch', () => {
+  it('keeps a fresh org initialized during a planned daemon relaunch', () => {
     const restarting = { daemonId: 'edge-1', status: 'offline' as const, lifecycleStatus: 'restarting' as const }
     expect(daemonCompletesOnboarding(restarting)).toBe(true)
     expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
-    expect(needsOnboarding(false, false, 0, daemonCompletesOnboarding(restarting))).toBe(false)
+    expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting))).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -19,13 +19,16 @@ export function firstReconnectableDaemonId(daemons: readonly OnboardingDaemon[])
   return daemons.find((daemon) => !daemonCompletesOnboarding(daemon))?.daemonId
 }
 
+// Every org now ships the built-in `agentconnect` preset UNPLACED, so "no agents" no
+// longer marks a fresh org. Initialized = a serving daemon OR a placed/configured agent
+// (agentIsPlaced) exists; otherwise the org is fresh and gets the full-screen wizard.
 export function needsOnboarding(
   agentsLoading: boolean,
   daemonsLoading: boolean,
-  agentCount: number,
+  hasPlacedAgent: boolean,
   hasOnlineDaemon: boolean
 ): boolean {
-  return !agentsLoading && !daemonsLoading && agentCount === 0 && !hasOnlineDaemon
+  return !agentsLoading && !daemonsLoading && !hasPlacedAgent && !hasOnlineDaemon
 }
 
 export function isOnboardingSkipped(org: string): boolean {

--- a/packages/web/src/lib/use-onboarding-redirect.ts
+++ b/packages/web/src/lib/use-onboarding-redirect.ts
@@ -1,0 +1,39 @@
+'use client'
+
+// Fresh-workspace redirect to the full-screen /onboarding route, shared by every
+// console landing surface (Home is the default landing, Agents keeps it for deep
+// links). A fresh org = no placed agent AND no serving daemon (needsOnboarding);
+// the per-tab "Explore the console first" skip flag suppresses the bounce-back.
+//
+// Returns true while the caller should hold a spinner instead of rendering: either
+// the redirect is in flight, or the sessionStorage skip flag hasn't been read yet
+// (it's read in an effect — SSR can't touch sessionStorage).
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useConsoleData } from '@/lib/data-context'
+import { agentIsPlaced } from '@/lib/data'
+import { daemonCompletesOnboarding, isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
+
+export function useOnboardingRedirect(): boolean {
+  const router = useRouter()
+  const params = useParams()
+  const orgKey = typeof params.slug === 'string' ? params.slug : '-'
+  const { agents, daemons, agentsLoading, daemonsLoading } = useConsoleData()
+  const [skipState, setSkipState] = useState<{ orgKey: string; skipped: boolean } | null>(null)
+  const skipped = skipState?.orgKey === orgKey ? skipState.skipped : null
+  useEffect(() => {
+    setSkipState({ orgKey, skipped: isOnboardingSkipped(orgKey) })
+  }, [orgKey])
+  const notInitialized = needsOnboarding(
+    agentsLoading,
+    daemonsLoading,
+    agents.some(agentIsPlaced),
+    daemons.some(daemonCompletesOnboarding)
+  )
+  const redirect = notInitialized && skipped === false
+  useEffect(() => {
+    if (redirect) router.replace(`/${orgKey}/onboarding`)
+  }, [redirect, router, orgKey])
+  return notInitialized && skipped !== true
+}

--- a/packages/web/src/lib/use-slack-platform-install.ts
+++ b/packages/web/src/lib/use-slack-platform-install.ts
@@ -1,0 +1,121 @@
+'use client'
+
+// The one-click "Add to Slack" flow for the built-in AgentConnect Bot (preset-agents.md
+// §5.3): mint a state-bound authorize URL, open it in a popup, then poll the install row
+// until it reaches a terminal state. Extracted so the getting-started "Meet your agents"
+// card runs the SAME logic as the "Add to Slack" button inside AddIntegrationModal —
+// keep the two in sync (the modal keeps its own copy, coupled to its cross-flow busy ref).
+//
+// Unlike the modal (whose whole dialog is the escape hatch), this card is persistent, so
+// it must recover on its own: if the user just CLOSES the Slack popup without approving,
+// the install row stays `pending` forever and polling would hang in `authorizing`. We
+// keep the popup handle and, once it's closed without completing, fall back to idle so
+// the button is clickable again. `cancel()` is the manual escape for when the popup ref
+// is unavailable (pop-up blocked → window.open returns null, or a browser quirk).
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApiError, getSlackPlatformInstall, startSlackPlatformInstall } from '@/lib/api'
+
+// Why a platform install round trip ended without connecting, keyed by the install
+// row's `failureReason`. Mirrors AddIntegrationModal's PLATFORM_INSTALL_FAILURES.
+const FAILURES: Record<string, string> = {
+  denied: 'The install was cancelled in Slack.',
+  expired: 'This install link expired — start again.',
+  workspace_taken: 'That Slack workspace is already connected to another organization.',
+  workspace_mismatch: 'Slack authorized a different workspace. Start again and choose the expected workspace.',
+  agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
+  error: 'Slack could not complete the install. Please try again.'
+}
+
+export interface SlackPlatformInstall {
+  phase: 'idle' | 'authorizing'
+  err: string | null
+  start: () => Promise<void>
+  /** Abandon an in-flight authorize (e.g. the user closed the popup) and return to idle. */
+  cancel: () => void
+}
+
+/** `onCompleted` fires once the install reaches `completed` (refresh lists / close the surface). */
+export function useSlackPlatformInstall(agentId: string, onCompleted: () => void): SlackPlatformInstall {
+  const [phase, setPhase] = useState<'idle' | 'authorizing'>('idle')
+  const [err, setErr] = useState<string | null>(null)
+  const [installId, setInstallId] = useState<string | null>(null)
+  const busy = useRef(false)
+  // The authorize popup. Kept WITHOUT `noopener` so we can observe `.closed` (opener
+  // access to a trusted slack.com auth page is the standard OAuth-popup pattern).
+  const popup = useRef<Window | null>(null)
+
+  const reset = useCallback(() => {
+    setPhase('idle')
+    setInstallId(null)
+    popup.current = null
+  }, [])
+
+  const cancel = useCallback(() => {
+    popup.current?.close()
+    reset()
+  }, [reset])
+
+  const start = useCallback(async () => {
+    if (busy.current) return
+    busy.current = true
+    setErr(null)
+    try {
+      const r = await startSlackPlatformInstall({ agentId })
+      setInstallId(r.id)
+      popup.current = window.open(r.installUrl, '_blank', 'width=680,height=760')
+      setPhase('authorizing')
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      busy.current = false
+    }
+  }, [agentId])
+
+  // While the user approves in the Slack tab, poll the INSTALL ROW for its terminal
+  // state (a re-authorization only rotates the token and creates no integration, so
+  // watching the list would hang). 404 ⇒ the row was TTL-reaped, which is terminal.
+  useEffect(() => {
+    if (phase !== 'authorizing' || !installId) return
+    let alive = true
+    let closeHandled = false
+    const stop = (message: string) => {
+      reset()
+      setErr(message)
+    }
+    // Read the row once and act on its terminal state. `whenPending` runs when it's still
+    // pending — used to decide whether a closed popup means "done" or "abandoned".
+    const check = async (whenPending?: () => void) => {
+      try {
+        const s = await getSlackPlatformInstall(installId)
+        if (!alive) return
+        if (s.status === 'pending') return whenPending?.()
+        if (s.status === 'completed') {
+          reset()
+          onCompleted()
+          return
+        }
+        stop(FAILURES[s.failureReason ?? ''] ?? 'The Slack install did not complete.')
+      } catch (e) {
+        if (alive && e instanceof ApiError && e.status === 404) stop(FAILURES.expired!)
+      }
+    }
+    const poll = setInterval(() => void check(), 2500)
+    // Watch for the user closing the popup. On close, confirm the row's state once more
+    // (it may have completed right as the popup auto-closed); only if it's still pending
+    // do we treat it as abandoned and return to idle — no error, just clickable again.
+    const watch = setInterval(() => {
+      if (!alive || closeHandled || !popup.current?.closed) return
+      closeHandled = true
+      void check(() => alive && reset())
+    }, 600)
+    void check()
+    return () => {
+      alive = false
+      clearInterval(poll)
+      clearInterval(watch)
+    }
+  }, [phase, installId, onCompleted, reset])
+
+  return { phase, err, start, cancel }
+}


### PR DESCRIPTION
## What

Reworks first-run onboarding into the design's **"one blocking step, then a reveal"** and adds the persistent **getting-started checklist** that follows the user into the console. Implements the `AgentConnect Onboarding` and `Getting Started Placement` designs.

### Onboarding (`OnboardingView`)
- The 3-step wizard (daemon → agent → integration) collapses to a **single blocking step**: connect a daemon (mints a real join command, polls for online), which **auto-reveals the same getting-started checklist** once the daemon comes up.
- Rendered **full-screen by the shell** with a slim top bar consistent with the rest of the console: logo · **theme toggle** · **user menu** (profile / settings / sign out).

### Getting Started 1a / 1b (`GettingStarted`)
- Floating **pill** (bottom-right) + **slide-over drawer** — a checklist derived from live state (`lib/getting-started.ts`). Shows on every console page while incomplete; vanishes for good once complete.

### Shared checklist (`GettingStartedChecklist`)
- `computeGettingStarted` (pure derivation) + `useGsActions` (CTA runner) + `GsRows` + the **"Meet your agents"** one-click built-in-agent row — used by **both** the console drawer and the onboarding reveal, so the two surfaces can never disagree.

### Shell
- Extracted `ThemeToggle` + `UserMenu`, now shared by the top bar and the onboarding header; `/onboarding` renders full-screen without the rail (providers stay above the shell so checklist CTAs' modals still work).

## Why

The old wizard left users staring at an empty console and a stack of config decisions. This makes connecting a daemon the only thing that blocks, then hands over a live, derived checklist that's identical in onboarding and the console.

## Reviewer notes

- **Forward-looking UI, per an explicit product call:** preset agents (`agentconnect` / `agentconnect-admin`) and the one-click built-in AgentConnect Bot aren't shipped yet (`preset-agents.md` §3/§5). The "Meet your agents" cards are placeholders — **Connect** falls back to the real create-agent flow, `done` reflects real agent state, and the swap-in points are marked `TODO(preset-agents)`. The "runtime signed in" / "Ask Assistant" checklist items are likewise deferred until their backends land.
- Checklist items derive from existing `useConsoleData` (no new BFF endpoint); the only persisted onboarding bit remains the per-tab skip flag.
- Scope is `packages/web` only. Deliberately excluded two unrelated pre-existing local dev tweaks (`next.config.mjs` dev proxy, generated `next-env.d.ts`).

## Verification

`pnpm --filter @agentconnect.md/web typecheck`, `lint`, `format`, and the unit tests (`getting-started.test.ts` + reworked `OnboardingView.test.ts`, 12 tests) all pass. Both flows exercised in the browser (mock mode): pill → drawer, accordion + CTAs opening real modals, onboarding connect → reveal, theme toggle, and the responsive "Meet your agents" cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)