### PR TITLE
refactor(relay): clarify HTTP ingress naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This repository is a pnpm workspace with eight packages:
 | `@agentconnect.md/daemon`             | [`packages/daemon`](packages/daemon)                         | Edge message processing and agent execution unit                  |
 | `@agentconnect.md/memory-plugin-mem0` | [`packages/memory-plugin-mem0`](packages/memory-plugin-mem0) | Mem0 Cloud and OSS memory-plugin profiles                         |
 | `@agentconnect.md/protocol`           | [`packages/protocol`](packages/protocol)                     | Shared daemon, relay, and Control Plane wire contracts            |
-| `@agentconnect.md/relay`              | [`packages/relay`](packages/relay)                           | Shared bot, webhook, GitHub, and webchat ingress                  |
+| `@agentconnect.md/relay`              | [`packages/relay`](packages/relay)                           | HTTP bot, webhook, GitHub, and webchat ingress                    |
 | `@agentconnect.md/web`                | [`packages/web`](packages/web)                               | Next.js configuration and monitoring console                      |
 
 ## Evaluate AgentConnect add-ons

--- a/docs/designs/loop-breaker-design.md
+++ b/docs/designs/loop-breaker-design.md
@@ -364,7 +364,7 @@ latch is already OPEN, select a target from current agents' Slack integrations
 that actually permits the user, preferring an explicit mention and then stable
 ordering. The same concrete-integration authorization check still runs.
 
-Shared-bot `rd/msg(im)` likewise parses commands before dispatch and uses the
+Relay-managed `rd/msg(im)` likewise parses commands before dispatch and uses the
 target resolved by the relay for the final `allowedUserIds` check. A bot or
 unknown sender cannot resume the scope.
 

--- a/docs/designs/loop-breaker-design.md
+++ b/docs/designs/loop-breaker-design.md
@@ -180,8 +180,8 @@ Implementation entry points:
   durable counter and latch.
 - [`packages/daemon/src/slack/connection.ts`](../../packages/daemon/src/slack/connection.ts):
   direct Slack ingress.
-- [`packages/relay/src/slack-shared-ingest.ts`](../../packages/relay/src/slack-shared-ingest.ts):
-  shared Slack ingress.
+- [`packages/relay/src/slack-http-ingest.ts`](../../packages/relay/src/slack-http-ingest.ts):
+  HTTP Slack ingress.
 
 ### 4.1 Messages Counted
 

--- a/docs/designs/preset-agents.md
+++ b/docs/designs/preset-agents.md
@@ -269,7 +269,7 @@ installed via standard OAuth v2. Verified gaps against current code:
 - **Schema.** `Bot.teamId` (nullable for legacy rows) + unique `(slackAppId, teamId)`;
   multiple `Bot` rows may now share one `slackAppId` across orgs.
 - **Relay demux.** Today demux is a learned `api_app_id → botId` map with a
-  signing-secret brute scan as fallback (`relay/src/shared-bot-manager.ts`). Every
+  signing-secret brute scan as fallback (`relay/src/relay-ingress-manager.ts`). Every
   install of a distributed app shares both the app id **and** the signing secret, so a
   composite `(api_app_id, team_id)` key is a correctness requirement, not an
   optimization. `teamId` is already plumbed into `resolveVerified` and currently

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -2,6 +2,11 @@
 
 > **Status:** Implemented for Slack HTTP ingress, webchat, and webhook ingress.
 > Shared Telegram and Discord ingress are not implemented.
+>
+> **Naming note:** This is a historical filename. “Shared” here describes the
+> relay pool's shared ingress plane, not `Bot.shareable`. `Bot.transport = 'http'`
+> selects relay ingress; `Bot.shareable` separately controls whether one bot may
+> serve multiple agents.
 
 The relay pool is AgentConnect's public content-ingress plane. It accepts
 platform callbacks and browser sessions that cannot terminate at a daemon,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -90,7 +90,7 @@ import { CronRunReaper } from './orchestrator/cronRunReaper.js'
 import { SlackInstallReaper } from './orchestrator/slackInstallReaper.js'
 import { RelaySweeper } from './orchestrator/relaySweeper.js'
 import { RelayRoster } from './orchestrator/relayRoster.js'
-import { SharedBotOrchestrator } from './orchestrator/sharedBot.js'
+import { HttpBotOrchestrator } from './orchestrator/httpBot.js'
 import { SlackBotIdentityReconciler } from './orchestrator/slackBotIdentityReconciler.js'
 import { slackConfigApi } from './http/slack-config-api.js'
 
@@ -401,10 +401,10 @@ export function buildContainer(
   // daemons on register/sweep via the `relay/roster` EVT (sender is the broadcaster).
   const relayRoster = new RelayRoster(repos.relay, sender, clock, relayStaleMs)
 
-  // Shared-bot placement + attributed-route compilation (shared-bot-relay.md §4.2/§10).
+  // HTTP-bot assignment + attributed-route compilation (shared-bot-relay.md §4.2/§10).
   // Its logger is lazy (a wrapper over `http.log`, which is created below) — only ever
   // invoked at request/sweep time, well after `http` is assigned, so no TDZ hazard.
-  const sharedBot = new SharedBotOrchestrator(
+  const httpBot = new HttpBotOrchestrator(
     repos.bot,
     repos.botSecret,
     repos.botCredential,
@@ -432,7 +432,7 @@ export function buildContainer(
     crons: repos.cron,
     control: sender,
     hooks: hookService,
-    sharedBot,
+    httpBot,
     collabRoutes,
     mutations: agentMutations,
     sessionOwners: connReg,
@@ -552,7 +552,7 @@ export function buildContainer(
   // org-level model (installation coverage) as before.
   // Installation doorbell (webhook-triggers decision 11): the relay's verified
   // `installation*` pokes trigger an App-JWT re-pull + github-hook recompile.
-  // Logger is lazy over `http.log` (SharedBotOrchestrator precedent — pokes only
+  // Logger is lazy over `http.log` (HttpBotOrchestrator precedent — pokes only
   // arrive over the relay WS, long after `http` exists).
   const installationDoorbell = github
     ? new GithubInstallationDoorbell({
@@ -633,7 +633,7 @@ export function buildContainer(
     liveness: connReg,
     control: sender,
     relayControl,
-    sharedBot,
+    httpBot,
     collabRoutes,
     agentMutations,
     memoryConnectionMutations,
@@ -762,11 +762,11 @@ export function buildContainer(
     { staleMs: relayStaleMs, intervalMs: config.RELAY_REAP_INTERVAL_SEC * 1000 },
     // On a reap: re-fan the shrunk roster to daemons. Whole-pool ingress means a dead
     // relay strands no bot (the manifest request_url is a stable LB; the CP broadcasts
-    // to whoever is connected), so no shared-bot re-placement is needed here.
+    // to whoever is connected), so no per-bot re-placement is needed here.
     async () => {
       await relayRoster.broadcast()
       // §14.3: a reaped relay may have held notice authorities — re-stamp survivors.
-      await sharedBot.reconcileAll().catch((err) => http.log.error({ err }, 'relay sweep: shared-bot reconcile failed'))
+      await httpBot.reconcileAll().catch((err) => http.log.error({ err }, 'relay sweep: HTTP-bot reconcile failed'))
       const selected = (await relayRoster.entries())[0]
       if (selected) {
         await syncMemoryConnectionsToDaemons(relayHttpOrigin(selected.url), {
@@ -874,7 +874,7 @@ export function buildContainer(
     authorizeGithubComment: async (req) => (githubCommentAuthz ? githubCommentAuthz.allowed(req) : false),
     authorizeGithubRerequest: async (req) => (githubRerequest ? githubRerequest.resolve(req) : { allowed: false }),
     // A relay just (re)registered — refresh every daemon's roster, (re)assign every
-    // shared bot's ingest + routes (§5, idempotent), AND replay the compiled hook
+    // HTTP bots' ingress + routes (§5, idempotent), AND replay the compiled hook
     // rules to the fresh connection (its table is a memory copy). All fire-and-forget,
     // so the DB reads MUST NOT reject unhandled (that would crash the CP under Node's
     // throw-on-unhandled-rejection): swallow + log, mirroring the sweeper's guarded
@@ -886,15 +886,13 @@ export function buildContainer(
       // Seed ONLY the fresh relay with every http bot's assign + persisted thread
       // affinity (per-relay replay — no re-broadcast to the whole pool)…
       trackRelayRegistrationTask(
-        sharedBot.replayTo(ch).catch((err) => http.log.error({ err }, 'relay: shared-bot replay on register failed'))
+        httpBot.replayTo(ch).catch((err) => http.log.error({ err }, 'relay: HTTP-bot replay on register failed'))
       )
       // …then converge the WHOLE pool: a joined relay changes the connected roster,
       // which moves §14.3 notice authorities — existing relays must learn the new
       // assignment or two pods could both (or neither) believe they hold it.
       trackRelayRegistrationTask(
-        sharedBot
-          .reconcileAll()
-          .catch((err) => http.log.error({ err }, 'relay: shared-bot reconcile on register failed'))
+        httpBot.reconcileAll().catch((err) => http.log.error({ err }, 'relay: HTTP-bot reconcile on register failed'))
       )
       trackRelayRegistrationTask(
         hookService.replayTo(ch).catch((err) => http.log.error({ err }, 'relay: hook-rule replay on register failed'))
@@ -1035,7 +1033,7 @@ export function buildContainer(
     // the bot's routes. Swallow+log: a store error must not close the shared relay link.
     onSetChannelAgent: async (m) => {
       try {
-        await sharedBot.setChannelAgent(m.botId, m.channelId, m.agentId)
+        await httpBot.setChannelAgent(m.botId, m.channelId, m.agentId)
       } catch (err) {
         http.log.error({ err, botId: m.botId }, 'relay: set-channel-agent failed')
       }
@@ -1044,7 +1042,7 @@ export function buildContainer(
     // its complete membership. Persist across every install and refresh relay routes.
     onBotChannels: async (m) => {
       try {
-        await sharedBot.replaceChannels(m.botId, m.channels)
+        await httpBot.replaceChannels(m.botId, m.channels)
       } catch (err) {
         http.log.error({ err, botId: m.botId }, 'relay: bot-channels snapshot failed')
       }
@@ -1052,9 +1050,9 @@ export function buildContainer(
     // A closed relay socket shrinks the connected roster — re-stamp §14.3 notice
     // authorities on the survivors (fire-and-forget; errors logged).
     onRelayGone: () => {
-      void sharedBot
+      void httpBot
         .reconcileAll()
-        .catch((err) => http.log.error({ err }, 'relay: shared-bot reconcile on disconnect failed'))
+        .catch((err) => http.log.error({ err }, 'relay: HTTP-bot reconcile on disconnect failed'))
     },
     // A workspace uninstalled the app / revoked its tokens — mark the Bot + its
     // installs revoked and release the bot from the pool, unless the report is
@@ -1064,7 +1062,7 @@ export function buildContainer(
     // swallowed — swallowing would look like success and lose the only signal a
     // dead credential ever produces.
     onBotRevoked: async (m) =>
-      sharedBot.revokeBot(m.botId, m.reason, {
+      httpBot.revokeBot(m.botId, m.reason, {
         ...(m.credentialRevision !== undefined ? { revision: m.credentialRevision } : {}),
         ...(m.eventAtMs !== undefined ? { eventAtMs: m.eventAtMs } : {})
       }),
@@ -1072,7 +1070,7 @@ export function buildContainer(
     // latch. Swallow+log.
     onNoticePosted: async (m) => {
       try {
-        await sharedBot.recordNoticePosted(m)
+        await httpBot.recordNoticePosted(m)
       } catch (err) {
         http.log.error({ err, botId: m.botId }, 'relay: notice-posted record failed')
       }
@@ -1081,7 +1079,7 @@ export function buildContainer(
     // the bot's gated installs so console editors can enable the DM. Swallow+log.
     onBotConversation: async (m) => {
       try {
-        await sharedBot.reportConversation(m.botId, m.conversation)
+        await httpBot.reportConversation(m.botId, m.conversation)
       } catch (err) {
         http.log.error({ err, botId: m.botId }, 'relay: bot-conversation report failed')
       }
@@ -1090,13 +1088,13 @@ export function buildContainer(
     // a store error must not close the shared relay link.
     onThreadAssign: async (m) => {
       try {
-        await sharedBot.recordThreadAssign(m)
+        await httpBot.recordThreadAssign(m)
       } catch (err) {
         http.log.error({ err, botId: m.botId }, 'relay: thread-assign failed')
       }
     },
     // Pull-on-miss BACKSTOP leg — may throw → the handler answers a retryable error.
-    threadLookup: (m) => sharedBot.lookupThread(m),
+    threadLookup: (m) => httpBot.lookupThread(m),
     // Installation doorbell poke — fire-and-forget into the throttled re-pull
     // (the doorbell owns single-flight/cooldown and swallows its own errors).
     onGithubInstallation: async (m) => {

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -54,7 +54,7 @@ import type { WaitlistService } from '../registry/waitlistService.js'
 import type { ControlSender } from '../orchestrator/outbound.js'
 import type { AgentSpecAssembler } from '../orchestrator/agentSpecAssembler.js'
 import type { RelayControlSender } from '../orchestrator/relayControl.js'
-import type { SharedBotOrchestrator } from '../orchestrator/sharedBot.js'
+import type { HttpBotOrchestrator } from '../orchestrator/httpBot.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
 import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { ExclusiveMutationGate } from '../orchestrator/exclusiveMutationGate.js'
@@ -202,10 +202,10 @@ export interface HttpDeps {
   /** CP→relay control fan-out — pushes `rc/daemon-revoke` to connected relays when a
    *  daemon key is revoked / a daemon is removed (shared-bot-relay.md §9). */
   relayControl: RelayControlSender
-  /** Shared-bot placement + attributed-route compilation (shared-bot-relay.md §4.2/§10).
+  /** HTTP-bot assignment + attributed-route compilation (shared-bot-relay.md §4.2/§10).
    *  Install / uninstall / toggle / channel-owner changes call it to (re)assign a
-   *  shared bot's ingest to a relay and push its routes + send-only daemon specs. */
-  sharedBot: SharedBotOrchestrator
+   *  HTTP bot's ingest to the relay pool and push its routes + send-only daemon specs. */
+  httpBot: HttpBotOrchestrator
   /** Rebuilds placement-dependent collaboration routes after an agent cold move. */
   collabRoutes: CollabRoutesService
   /** Process-local exclusive move vs shared CRUD gate; valid with one active CP writer. */

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -32,7 +32,7 @@ export interface InstallSlackBotArgs {
   /** The owning agent. For SOCKET transport it MUST already be placed (`daemonId`
    *  non-null; the daemon owns the socket) — caller checks. An http-transport
    *  install tolerates an unplaced agent: the relay assignment simply defers until
-   *  placement re-converges the shared bot (preset-agents.md §5.3). */
+   *  placement re-converges the HTTP bot (preset-agents.md §5.3). */
   agent: AgentRecord
   name: string
   botToken: string // xoxb-…
@@ -52,7 +52,7 @@ export interface InstallSlackBotArgs {
   appToken?: string
   /** Slack signing secret — required for http transport (Events API verification). */
   signingSecret?: string
-  /** Multi-agent shared mode (http transport only). Caller has checked a relay is connected. */
+  /** Multi-agent sharing (http transport only). Caller has checked a relay is connected. */
   shareable?: boolean
   createdByUserId?: string
 }
@@ -115,10 +115,10 @@ export async function installNewSlackBot(
   })
 
   // HTTP transport: the relay pool owns the ingest — broadcast the bot assign and push
-  // the send-only spec to the daemon (SharedBotOrchestrator does both). No Socket Mode
+  // the send-only spec to the daemon (HttpBotOrchestrator does both). No Socket Mode
   // socket opens on the daemon.
   if (transport === 'http') {
-    await deps.sharedBot.syncBot(botId)
+    await deps.httpBot.syncBot(botId)
     return integration
   }
 

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -803,7 +803,7 @@ export function agentRoutes(deps: HttpDeps) {
       crons: deps.repos.cron,
       control: deps.control,
       hooks: deps.hooks,
-      sharedBot: deps.sharedBot,
+      httpBot: deps.httpBot,
       collabRoutes: deps.collabRoutes,
       mutations: deps.agentMutations,
       sessionOwners: deps.sessionOwners,
@@ -1869,7 +1869,7 @@ export function agentRoutes(deps: HttpDeps) {
     // collaborator who can't even view a restricted agent 404s. Identities never
     // ride the wire, but the DERIVED conversation-gating flag does (§14/§9): a
     // visibility flip re-converges every integration of the agent — direct installs
-    // get a fresh spec push, shared bots a route recompile — best-effort, with the
+    // get a fresh spec push, HTTP bots a route recompile — best-effort, with the
     // reconcile roster as the durable backstop.
     r.put(
       '/agents/:id/sharing',

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -262,19 +262,16 @@ export function botRoutes(deps: HttpDeps) {
       }
     )
 
-    // Flip the shared-bot opt-in (shared-bot-relay.md §4.1). Enabling migrates the
-    // bot's inbound onto a relay (needs a connected relay — 409 otherwise) and
-    // re-specs its daemons send-only. Disabling is refused while >1 agent shares it
-    // (that would orphan the others); with ≤1 it reverts the bot to a classic
-    // daemon-owned socket.
+    // Flip the HTTP bot's multi-agent capacity (`Bot.shareable`,
+    // shared-bot-relay.md §4.1). Transport is immutable: relay ingress remains in
+    // place either way. Disabling is refused while >1 agent uses the bot.
     r.patch(
       '/bots/:id',
       {
         schema: {
           tags: [Tag.Bots],
           summary: 'Update a bot',
-          description:
-            "Toggle the bot's shared-bot opt-in. Enabling moves its inbound onto a relay (many agents may then share it); disabling reverts it to a classic single-agent socket.",
+          description: 'Allow or disallow this HTTP bot from serving multiple agents. Relay ingress is unchanged.',
           operationId: 'updateBot',
           params: IdParam,
           body: UpdateBotBody,
@@ -335,7 +332,7 @@ export function botRoutes(deps: HttpDeps) {
           await deps.repos.bot.setShareable(bot.id, req.body.shareable)
           // Multi-agent capacity change only — recompile the relay pool's routes (no
           // ingest re-open; the transport, hence the ingest, is unchanged).
-          await deps.sharedBot.syncRoutes(bot.id)
+          await deps.httpBot.syncRoutes(bot.id)
           const updated = await deps.repos.bot.get(bot.id)
           return toDto(updated!)
         } finally {

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -26,7 +26,7 @@ import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit } from '../visibility.js'
 import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
-import { pickChannelOwner } from '../../orchestrator/sharedBot.js'
+import { pickChannelOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { discordAppIdFromBotToken } from '../discord-identity.js'
@@ -108,10 +108,10 @@ export function integrationRoutes(deps: HttpDeps) {
       }
     }
 
-    // Shared-install preconditions (shared-bot-relay.md §6): Slack-only for now, a
+    // Shareable-install preconditions (shared-bot-relay.md §6): Slack-only for now, a
     // relay must be connected to host the ingest, and one agent installs a bot once.
     // Returns an error envelope to send, or null when the install may proceed.
-    const validateSharedInstall = async (
+    const validateShareableInstall = async (
       bot: { agentIds: string[] },
       agentId: string,
       platform: 'slack' | 'telegram' | 'discord' | 'feishu'
@@ -119,16 +119,16 @@ export function integrationRoutes(deps: HttpDeps) {
       if (platform !== 'slack') {
         return {
           code: 400,
-          body: { error: 'Bad Request', statusCode: 400, message: 'shared bots currently support Slack only' }
+          body: { error: 'Bad Request', statusCode: 400, message: 'multi-agent bots currently support Slack only' }
         }
       }
-      if (!deps.sharedBot.hasConnectedRelay()) {
+      if (!deps.httpBot.hasConnectedRelay()) {
         return {
           code: 409,
           body: {
             error: 'Conflict',
             statusCode: 409,
-            message: 'no relay is connected — shared bots need a relay to receive messages'
+            message: 'no relay is connected — HTTP bots need a relay to receive messages'
           }
         }
       }
@@ -277,11 +277,11 @@ export function integrationRoutes(deps: HttpDeps) {
               })
             }
             // Reuse keeps the bot's existing transport (immutable post-create). An
-            // http bot routes via the relay pool; adding a 2nd agent makes it shared.
+            // An HTTP bot routes via the relay pool; adding a second agent makes it shareable.
             const wantHttp = bot.transport === 'http'
             if (wantHttp) {
-              const sharedErr = await validateSharedInstall(bot, agent.id, req.body.platform)
-              if (sharedErr) return reply.code(sharedErr.code).send(sharedErr.body)
+              const shareableErr = await validateShareableInstall(bot, agent.id, req.body.platform)
+              if (shareableErr) return reply.code(shareableErr.code).send(shareableErr.body)
               if (!bot.shareable) await deps.repos.bot.setShareable(bot.id, true)
               const integration = await deps.repos.integration.create({
                 id: IntegrationId(randomUUID()),
@@ -297,7 +297,7 @@ export function integrationRoutes(deps: HttpDeps) {
               })
               // Relay owns the ingest — (re)assign the bot + push send-only specs to
               // every member daemon (including any that were direct before promotion).
-              await deps.sharedBot.syncBot(bot.id)
+              await deps.httpBot.syncBot(bot.id)
               return reply.code(201).send(toDto(integration))
             }
             // Classic reuse: 1 bot : ≤1 install.
@@ -507,7 +507,7 @@ export function integrationRoutes(deps: HttpDeps) {
             }
           } else {
             // HTTP mode: inbound arrives at the relay pool — a relay must be connected.
-            if (!deps.sharedBot.hasConnectedRelay()) {
+            if (!deps.httpBot.hasConnectedRelay()) {
               return reply.code(409).send({
                 error: 'Conflict',
                 statusCode: 409,
@@ -559,7 +559,7 @@ export function integrationRoutes(deps: HttpDeps) {
             channels: await deps.repos.integrationChannel.listForIntegration(integration.id)
           }))
         )
-        // Membership is repeated per shared-bot integration, while only the
+        // Membership is repeated per shareable-bot integration, while only the
         // canonical owner row persists agentId. Read effective state from every
         // active install of each visible bot — not only viewer-visible integrations
         // — so a sibling never disagrees with the relay's route table.
@@ -730,7 +730,7 @@ export function integrationRoutes(deps: HttpDeps) {
           let updated: IntegrationChannelRecord | null = null
           let routesSynced = false
           if (botScopedChannel) {
-            updated = await deps.sharedBot.updateChannel(
+            updated = await deps.httpBot.updateChannel(
               bot.id,
               req.params.channelId,
               {
@@ -766,10 +766,10 @@ export function integrationRoutes(deps: HttpDeps) {
           }
           if (!updated)
             return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'channel not found' })
-          // Push the change: a shared bot's routes hot-update on the relay; a classic
+          // Push the change: an HTTP bot's routes hot-update on the relay; a classic
           // bot re-pushes its recomputed bindRules to the owning daemon.
           if (bot.transport === 'http') {
-            if (!routesSynced) await deps.sharedBot.syncRoutes(bot.id)
+            if (!routesSynced) await deps.httpBot.syncRoutes(bot.id)
           } else if (agent.daemonId) {
             await replicateUpsert(integration, agent.daemonId)
           }
@@ -831,10 +831,10 @@ export function integrationRoutes(deps: HttpDeps) {
           agent = current
           const botBefore = await deps.repos.bot.get(existing.botId)
           if (botBefore?.transport === 'http') {
-            await deps.sharedBot.prepareIntegrationRemoval(existing.botId)
+            await deps.httpBot.prepareIntegrationRemoval(existing.botId)
           }
           await deps.repos.integration.delete(existing.id)
-          // "Freed" now means NO active integration remains (a shared bot may still
+          // "Freed" now means NO active integration remains (a shareable bot may still
           // serve other agents — don't stamp it freed while it does, §6).
           const remaining = await deps.repos.integration.listForBot(existing.botId)
           if (remaining.length === 0) {
@@ -842,9 +842,9 @@ export function integrationRoutes(deps: HttpDeps) {
           }
           // Tell the removed agent's daemon to drop the spec either way.
           await replicateRemove(existing.id, agent.daemonId ?? null)
-          // Shared bot: recompute the relay's routes + members (or release it if this
+          // HTTP bot: recompute the relay's routes + members (or release it if this
           // was the last install).
-          if (botBefore?.transport === 'http') await deps.sharedBot.syncBot(existing.botId)
+          if (botBefore?.transport === 'http') await deps.httpBot.syncBot(existing.botId)
           return reply.code(204).send(null)
         } finally {
           release()

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -151,7 +151,7 @@ export function slackInstallRoutes(deps: HttpDeps) {
         // manual paste. http requires a connected relay to receive the POSTs.
         const transport = req.body.transport ?? 'socket'
         const httpBase = transport === 'http' ? (relayHttpBase(deps.config.PUBLIC_RELAY_URL) ?? undefined) : undefined
-        if (transport === 'http' && (!httpBase || !deps.sharedBot.hasConnectedRelay())) {
+        if (transport === 'http' && (!httpBase || !deps.httpBot.hasConnectedRelay())) {
           return reply.code(409).send({
             error: 'Conflict',
             statusCode: 409,
@@ -453,7 +453,7 @@ export function slackConfigRoutes(deps: HttpDeps) {
       const durable = !!row?.refreshToken
       // HTTP mode is offerable here: a public relay origin is configured AND ≥1 relay
       // is connected to receive the Events API POSTs.
-      const relayAvailable = !!relayPublicUrl && deps.sharedBot.hasConnectedRelay()
+      const relayAvailable = !!relayPublicUrl && deps.httpBot.hasConnectedRelay()
       return {
         configured: !!row,
         durable,

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -73,7 +73,7 @@ export function slackPlatformInstallRoutes(deps: HttpDeps) {
         }
         const orgId = req.orgCtx!.orgId
         // Events-API-only: same relay precondition as an http quick-install.
-        if (!relayHttpBase(deps.config.PUBLIC_RELAY_URL) || !deps.sharedBot.hasConnectedRelay()) {
+        if (!relayHttpBase(deps.config.PUBLIC_RELAY_URL) || !deps.httpBot.hasConnectedRelay()) {
           return reply.code(409).send({
             error: 'Conflict',
             statusCode: 409,
@@ -271,7 +271,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
               { installId: row.id, botId: existing.id, boundAgentId: otherAgent.agentId, targetAgentId: agent.id },
               'slack platform re-install: workspace already bound to another agent'
             )
-            await deps.sharedBot.syncBot(existing.id)
+            await deps.httpBot.syncBot(existing.id)
             return fail('agent_taken')
           }
           if (installs.length === 0) {
@@ -285,7 +285,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
               ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
             })
           }
-          await deps.sharedBot.syncBot(existing.id)
+          await deps.httpBot.syncBot(existing.id)
         } else {
           const created = await installNewSlackBot(deps, req.log, {
             orgId: OrgId(row.orgId),

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -12,7 +12,7 @@ import type {
 } from '../persistence/ports.js'
 import type { ControlSender } from './outbound.js'
 import type { HookService } from '../hooks/hook.service.js'
-import type { SharedBotOrchestrator } from './sharedBot.js'
+import type { HttpBotOrchestrator } from './httpBot.js'
 import type { CollabRoutesService } from './collabRoutes.service.js'
 import { AgentMoveConflict, AgentMoveFailed, AgentMoveService } from './agentMove.js'
 import { AgentSpecAssembler } from './agentSpecAssembler.js'
@@ -248,7 +248,7 @@ function make(
     } as unknown as ConstructorParameters<typeof AgentMoveService>[0]['assignments'],
     control,
     hooks: { rebroadcastForAgent: async () => void calls.push('hooks') } as unknown as HookService,
-    sharedBot: { syncBot: async () => void calls.push('shared') } as unknown as SharedBotOrchestrator,
+    httpBot: { syncBot: async () => void calls.push('http') } as unknown as HttpBotOrchestrator,
     collabRoutes: { broadcast: async () => void calls.push('collab') } as unknown as CollabRoutesService,
     mutations,
     sessionOwners: { releaseSession: (key) => void releasedLive.push(key as typeof SESSION_KEY) }

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -33,11 +33,11 @@ import type {
 } from '../persistence/ports.js'
 import { AgentWorkspaceIntegrationConflict } from '../persistence/errors.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
-import { cronToUpsert, integrationToSpec, isGatedAgent, sharedIntegrationToSpec } from './placement.js'
+import { cronToUpsert, integrationToSpec, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import type { AgentSpecAssembler } from './agentSpecAssembler.js'
 import type { ControlSender } from './outbound.js'
 import type { HookService } from '../hooks/hook.service.js'
-import type { SharedBotOrchestrator } from './sharedBot.js'
+import type { HttpBotOrchestrator } from './httpBot.js'
 import type { CollabRoutesService } from './collabRoutes.service.js'
 import type { AgentMutationGate } from './agentMutationGate.js'
 import type { SessionKey } from '../domain/sessionKey.js'
@@ -78,7 +78,7 @@ export interface AgentMoveDeps {
   crons: CronRepo
   control: ControlSender
   hooks: HookService
-  sharedBot: SharedBotOrchestrator
+  httpBot: HttpBotOrchestrator
   collabRoutes: CollabRoutesService
   mutations: AgentMutationGate
   sessionOwners: { releaseSession(key: SessionKey): void }
@@ -86,9 +86,9 @@ export interface AgentMoveDeps {
 }
 
 interface MoveBundle {
-  integrations: Array<{ spec: IntegrationSpec; botId: string; shared: boolean }>
+  integrations: Array<{ spec: IntegrationSpec; botId: string; http: boolean }>
   crons: CronUpsert[]
-  sharedBotIds: string[]
+  httpBotIds: string[]
   /** The agent's write-only secret env vars (AgentSecretStore) — part of the wire
    *  definition, so a mid-move secret edit trips the fingerprint stability check. */
   secrets: Record<string, string>
@@ -231,7 +231,7 @@ export class AgentMoveService {
           reconcileWorkspace: true
         })
       }
-      await this.convergeDerived(stable.agent, stable.bundle.sharedBotIds)
+      await this.convergeDerived(stable.agent, stable.bundle.httpBotIds)
     } finally {
       release()
     }
@@ -248,7 +248,7 @@ export class AgentMoveService {
       if (err instanceof AgentMoveFailed) throw err
       throw new AgentMoveFailed('target daemon repair failed', err)
     }
-    await this.convergeDerived(stable.agent, stable.bundle.sharedBotIds)
+    await this.convergeDerived(stable.agent, stable.bundle.httpBotIds)
     return stable.agent
   }
 
@@ -271,7 +271,7 @@ export class AgentMoveService {
       const stable = await this.activateUntilStable(agent.id, agent.daemonId, 'workspace edit repair', {
         reconcileWorkspace: true
       })
-      await this.finalizeWorkspaceChange(stable.agent, workspaceRepoId, stable.bundle.sharedBotIds)
+      await this.finalizeWorkspaceChange(stable.agent, workspaceRepoId, stable.bundle.httpBotIds)
       return stable.agent
     }
 
@@ -387,7 +387,7 @@ export class AgentMoveService {
       await this.rollbackWorkspaceChange(agent, converted, bundle, moveId, activated.reason)
     }
 
-    await this.finalizeWorkspaceChange(converted, workspaceRepoId, bundle.sharedBotIds)
+    await this.finalizeWorkspaceChange(converted, workspaceRepoId, bundle.httpBotIds)
     return converted
   }
 
@@ -450,7 +450,7 @@ export class AgentMoveService {
       throw new AgentMoveFailed('target daemon bootstrap failed', err)
     }
 
-    await this.convergeDerived(stable.agent, stable.bundle.sharedBotIds)
+    await this.convergeDerived(stable.agent, stable.bundle.httpBotIds)
     return stable.agent
   }
 
@@ -501,17 +501,17 @@ export class AgentMoveService {
       )
     }
     await this.restoreDetachedWorkspace(converted.daemonId!, original, bundle, moveId, 'workspace activation rejection')
-    await this.convergeDerived(restored, bundle.sharedBotIds)
+    await this.convergeDerived(restored, bundle.httpBotIds)
     throw new AgentMoveFailed(`workspace edit rejected${reason ? `: ${reason}` : ''}`)
   }
 
   private async finalizeWorkspaceChange(
     agent: AgentRecord,
     workspaceRepoId: bigint | undefined,
-    sharedBotIds: string[]
+    httpBotIds: string[]
   ): Promise<void> {
     if (agent.workspace.mode !== 'github' || workspaceRepoId === undefined) {
-      await this.convergeDerived(agent, sharedBotIds)
+      await this.convergeDerived(agent, httpBotIds)
       return
     }
     try {
@@ -528,7 +528,7 @@ export class AgentMoveService {
       // lazy workspace-id repair and must not turn a committed edit into 5xx.
       this.deps.log?.warn({ err, agentId: agent.id }, 'workspace edit: repository grant cleanup deferred')
     }
-    await this.convergeDerived(agent, sharedBotIds)
+    await this.convergeDerived(agent, httpBotIds)
   }
 
   /** Read every placement-dependent wire definition. */
@@ -552,9 +552,9 @@ export class AgentMoveService {
         const gated = isGatedAgent(agent)
         return {
           botId: String(bot.id),
-          shared: isHttp,
+          http: isHttp,
           spec: isHttp
-            ? sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
+            ? httpIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
             : integrationToSpec(integration, secret, channels, gated)
         }
       })
@@ -567,7 +567,7 @@ export class AgentMoveService {
     return {
       integrations: specs,
       crons,
-      sharedBotIds: [...new Set(specs.filter((s) => s.shared).map((s) => s.botId))].sort(),
+      httpBotIds: [...new Set(specs.filter((s) => s.http).map((s) => s.botId))].sort(),
       secrets,
       skills
     }
@@ -727,11 +727,11 @@ export class AgentMoveService {
     }
   }
 
-  private async convergeDerived(agent: AgentRecord, sharedBotIds: string[]): Promise<void> {
+  private async convergeDerived(agent: AgentRecord, httpBotIds: string[]): Promise<void> {
     const jobs: Array<{ label: string; run: () => Promise<void> }> = [
       { label: 'hook routes', run: () => this.deps.hooks.rebroadcastForAgent(agent.id) },
       { label: 'collaboration routes', run: () => this.deps.collabRoutes.broadcast(agent.orgId) },
-      ...sharedBotIds.map((botId) => ({ label: `shared bot ${botId}`, run: () => this.deps.sharedBot.syncBot(botId) }))
+      ...httpBotIds.map((botId) => ({ label: `HTTP bot ${botId}`, run: () => this.deps.httpBot.syncBot(botId) }))
     ]
     for (const job of jobs) {
       try {

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { SharedBotOrchestrator } from './sharedBot.js'
+import { HttpBotOrchestrator } from './httpBot.js'
 import { RelayRegistry, type RelayChannel } from '../ws/relay-registry.js'
 import type { RcBotAssign, RelayCpFrameType } from '@agentconnect.md/protocol'
 import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -96,7 +96,7 @@ function channel(over: Partial<IntegrationChannelRecord>): IntegrationChannelRec
   }
 }
 
-describe('SharedBotOrchestrator — attributed route compilation (§10)', () => {
+describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   let relayReg: RelayRegistry
   let ch: FakeChannel
   let botRow: BotRecord
@@ -119,7 +119,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
   // a re-install landing between revokeBot's commit and its external effects.
   let bumpRevisionAfterFirstGet: boolean
 
-  function makeOrch(): SharedBotOrchestrator {
+  function makeOrch(): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
       [ALICE]: agent(ALICE, 'alice', D1),
       [BOB]: agent(BOB, 'bob', D2)
@@ -255,7 +255,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
         return { applied: true, integrationIds: await intRepo.markRevokedForBot!(id) }
       }
     }
-    return new SharedBotOrchestrator(
+    return new HttpBotOrchestrator(
       bots as BotRepo,
       botSecret as BotSecretStore,
       botCredential,
@@ -404,7 +404,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
       expect(assign.gatedAgentIds).toEqual([ALICE, BOB])
     })
 
-    it("a gated install's shared spec carries its scoped bindRules + gated for the daemon backstop", async () => {
+    it("a gated install's send-only spec carries its scoped bindRules + gated for the daemon backstop", async () => {
       gatedAgents = new Set([ALICE])
       channels = [
         channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'mention' }),
@@ -474,7 +474,7 @@ describe('SharedBotOrchestrator — attributed route compilation (§10)', () => 
     })
 
     // One Slack identity cannot say WHICH agent a group-DM mention meant, and the slug
-    // that disambiguates a shared DM does not apply (the mention rung outranks keyword).
+    // that disambiguates a multi-agent DM does not apply (the mention rung outranks keyword).
     // Two identical scoped mention routes would let relay order decide silently, so the
     // conversation converges on the earliest install instead.
     it('converges a group DM enabled by TWO gated agents onto the earliest install', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -1,12 +1,12 @@
 /**
- * `SharedBotOrchestrator` (shared-bot-relay.md §4.2 / §5 / §10) — the CP side of
- * shared bots: it places each shareable bot's INBOUND onto exactly one relay,
- * compiles the ATTRIBUTED routing table (channel ownership → keyword → default
- * agent), pushes it via `rc/bot-assign` / `rc/routes`, and delivers the SHARED
- * (send-only) integration spec to each member agent's daemon.
+ * `HttpBotOrchestrator` (shared-bot-relay.md §4.2 / §5 / §10) — the CP convergence
+ * seam for HTTP-transport bots. It broadcasts each bot's ingress assignment to the
+ * relay pool, compiles the ATTRIBUTED routing table (channel ownership → keyword →
+ * default agent), and delivers the send-only integration spec (wire mode `shared`)
+ * to each member agent's daemon.
  *
- * It is the convergence seam invoked on every event that can change a shared
- * bot's placement or routes: an install / uninstall, the shareable toggle, a
+ * It is invoked on every event that can change an HTTP bot's assignment or routes:
+ * an install / uninstall, a transport or shareable toggle, a
  * per-channel default-agent change, and — for failover — a relay (re)register or
  * sweep. Every method is idempotent: it recomputes from the DB and pushes the
  * result, so a missed push self-heals on the next call.
@@ -43,16 +43,16 @@ import type {
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isDirectConversationKind } from '../persistence/ports.js'
-import { isGatedAgent, sharedIntegrationToSpec } from './placement.js'
+import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import { AgentId, BotId, DaemonId } from '../domain/ids.js'
 
-export interface SharedBotLog {
+export interface HttpBotLog {
   info(obj: unknown, msg?: string): void
   warn(obj: unknown, msg?: string): void
   debug?(obj: unknown, msg?: string): void
 }
 
-/** The compiled routing table for one shared bot (relay-agnostic). */
+/** The compiled routing table for one HTTP bot (relay-agnostic). */
 interface Compiled {
   platform: 'slack' | 'telegram' | 'discord'
   members: { daemonId: string; agentIds: string[] }[]
@@ -81,7 +81,7 @@ export function pickChannelOwner(
   return installs.find((integration) => assigned.has(integration.agentId)) ?? installs[0]
 }
 
-export class SharedBotOrchestrator {
+export class HttpBotOrchestrator {
   private readonly channelMutationChains = new Map<string, Promise<unknown>>()
 
   constructor(
@@ -95,13 +95,13 @@ export class SharedBotOrchestrator {
     private readonly control: ControlSender,
     private readonly threads: ThreadAffinityStore,
     private readonly sessions: SessionRepo,
-    private readonly log: SharedBotLog
+    private readonly log: HttpBotLog
   ) {}
 
   /**
    * Converge one bot: BROADCAST `rc/bot-assign` to every connected relay (whole-pool
    * ingress — any pod may receive an inbound Events API POST via the stable
-   * PUBLIC_RELAY_URL LB) + deliver the shared spec to each member daemon. A
+   * PUBLIC_RELAY_URL LB) + deliver the send-only spec to each member daemon. A
    * non-http / empty bot is released. Safe to call for a socket bot (no-op after
    * the release check).
    */
@@ -119,19 +119,19 @@ export class SharedBotOrchestrator {
     }
     const secret = await this.botSecret.get(bot.id)
     if (!secret) {
-      this.log.warn({ botId }, 'shared-bot: no secret for http bot — cannot assign')
+      this.log.warn({ botId }, 'http-bot: no secret for http bot — cannot assign')
       return
     }
     if (bot.platform === 'slack' && !secret.signingSecret) {
       // An http-mode Slack bot with no signing secret can't be verified by the relay.
-      this.log.warn({ botId }, 'shared-bot: no signing secret for http Slack bot — cannot assign')
+      this.log.warn({ botId }, 'http-bot: no signing secret for http Slack bot — cannot assign')
       return
     }
 
     if (this.relayReg.all().length === 0) {
       // No connected relay to host the ingest — the register replay re-fans when one
       // (re)connects (reconcileAll / replayTo).
-      this.log.warn({ botId }, 'shared-bot: no connected relay available — deferring placement')
+      this.log.warn({ botId }, 'http-bot: no connected relay available — deferring placement')
       return
     }
 
@@ -139,7 +139,7 @@ export class SharedBotOrchestrator {
     this.broadcast((ch) => ch.send('rc/bot-assign', assign))
     this.log.info(
       { botId: bot.id, members: compiled.members.length, routes: compiled.routes.length },
-      'shared-bot: broadcast assign to relay pool'
+      'http-bot: broadcast assign to relay pool'
     )
     await this.pushSpecs(compiled, secret, bot)
   }
@@ -228,7 +228,7 @@ export class SharedBotOrchestrator {
     if (!applied) {
       this.log.info(
         { botId: bot.id, reason, reportedRevision: fence.revision, currentRevision: bot.credentialRevision },
-        'shared-bot: stale revoke ignored — credential was replaced since the event'
+        'http-bot: stale revoke ignored — credential was replaced since the event'
       )
       return { applied: false }
     }
@@ -240,7 +240,7 @@ export class SharedBotOrchestrator {
     if (after && after.credentialRevision !== bot.credentialRevision) {
       this.log.info(
         { botId: bot.id, reason, from: bot.credentialRevision, to: after.credentialRevision },
-        'shared-bot: revoke committed but the credential was replaced — skipping teardown effects'
+        'http-bot: revoke committed but the credential was replaced — skipping teardown effects'
       )
       // The revocation itself DID commit, so the report is settled.
       return { applied: true }
@@ -258,10 +258,10 @@ export class SharedBotOrchestrator {
         await this.control.integrationRemove(agent.daemonId, { integrationId: integration.id })
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
-        this.log.debug?.({ integrationId: integration.id }, 'shared-bot: revoke spec removal skipped — daemon offline')
+        this.log.debug?.({ integrationId: integration.id }, 'http-bot: revoke spec removal skipped — daemon offline')
       }
     }
-    this.log.info({ botId: bot.id, reason, installs: installs.length }, 'shared-bot: bot revoked by workspace')
+    this.log.info({ botId: bot.id, reason, installs: installs.length }, 'http-bot: bot revoked by workspace')
     return { applied: true }
   }
 
@@ -362,7 +362,7 @@ export class SharedBotOrchestrator {
     return !!row && row.trigger !== 'off'
   }
 
-  /** Is at least one relay connected right now? The install-time gate: a shared
+  /** Is at least one relay connected right now? The install-time gate: an HTTP
    *  install with no relay to host the ingest is a deployment misconfig (§6 409). */
   hasConnectedRelay(): boolean {
     return this.relayReg.all().length > 0
@@ -373,14 +373,14 @@ export class SharedBotOrchestrator {
    *  app membership, so fan the snapshot across them, preserving per-install
    *  trigger/owner fields in the repository, then hot-refresh relay routes.
    *
-   *  For a shared bot, route compilation converges every reported channel to
+   *  For an HTTP bot, route compilation converges every reported channel to
    *  exactly one owner. A new or ownerless channel is assigned to the bot's
    *  creating (earliest active) agent, while an existing owner is preserved.
    */
   async replaceChannels(botId: string, channels: ReportedChannel[]): Promise<void> {
     const bot = await this.bots.get(BotId(botId))
     if (!bot || bot.platform !== 'slack' || bot.transport !== 'http') {
-      this.log.warn({ botId }, 'shared-bot: channel snapshot for a non-http/unknown Slack bot — ignored')
+      this.log.warn({ botId }, 'http-bot: channel snapshot for a non-http/unknown Slack bot — ignored')
       return
     }
     const installs = await this.integrations.listForBot(bot.id)
@@ -438,7 +438,7 @@ export class SharedBotOrchestrator {
   async reportConversation(botId: string, conversation: ReportedChannel): Promise<void> {
     const bot = await this.bots.get(BotId(botId))
     if (!bot || bot.platform !== 'slack' || bot.transport !== 'http') {
-      this.log.warn({ botId }, 'shared-bot: conversation report for a non-http/unknown Slack bot — ignored')
+      this.log.warn({ botId }, 'http-bot: conversation report for a non-http/unknown Slack bot — ignored')
       return
     }
     const installs = await this.integrations.listForBot(bot.id)
@@ -458,7 +458,7 @@ export class SharedBotOrchestrator {
   }
 
   /**
-   * Update a shared channel through its bot-level ownership boundary. The selected
+   * Update a multi-agent channel through its bot-level ownership boundary. The selected
    * agent becomes the sole owner, and the channel trigger follows the channel when
    * ownership changes instead of reverting to a stale per-install value.
    */
@@ -471,7 +471,7 @@ export class SharedBotOrchestrator {
     return this.serializeChannelMutation(botId, channelId, async () => {
       const bot = await this.bots.get(BotId(botId))
       if (bot?.transport !== 'http') {
-        this.log.warn({ botId }, 'shared-bot: update-channel for a non-http/unknown bot — ignored')
+        this.log.warn({ botId }, 'http-bot: update-channel for a non-http/unknown bot — ignored')
         return null
       }
       const installs = await this.integrations.listForBot(bot.id)
@@ -483,13 +483,13 @@ export class SharedBotOrchestrator {
       if (options.expectedOwnerAgentId && currentOwner?.agentId !== options.expectedOwnerAgentId) {
         this.log.warn(
           { botId, channelId, expectedOwnerAgentId: options.expectedOwnerAgentId },
-          'shared-bot: channel owner changed before update — ignored'
+          'http-bot: channel owner changed before update — ignored'
         )
         return null
       }
       const owner = patch.agentId ? installs.find((i) => i.agentId === patch.agentId) : currentOwner
       if (!owner) {
-        this.log.warn({ botId, agentId: patch.agentId }, 'shared-bot: update-channel for a non-member agent — ignored')
+        this.log.warn({ botId, agentId: patch.agentId }, 'http-bot: update-channel for a non-member agent — ignored')
         return null
       }
 
@@ -716,7 +716,7 @@ export class SharedBotOrchestrator {
         match
       })
       if (c.kind === 'im' && p.gated) {
-        // Slug disambiguation inside a shared DM enabled for SEVERAL gated agents
+        // Slug disambiguation inside a multi-agent DM enabled for SEVERAL gated agents
         // (§14.3): a conversation-scoped keyword outranks the scoped auto in the
         // relay's arbitration, so "<slug> …" names this agent while an unslugged
         // DM falls to the first enabled auto route. (Unscoped keyword stays
@@ -755,7 +755,7 @@ export class SharedBotOrchestrator {
     //    a bare @bot + DMs. Delivered as `defaultAgentId` (the relay's fallback
     //    rung), not a route, so it never pre-empts keyword/channel arbitration. A
     //    gated agent must never be the fallback (§14: the bare-@bot/DM rungs are
-    //    what make a shared bot fail-open); a group of only gated agents has none.
+    //    what make an HTTP bot fail-open); a group of only gated agents has none.
     const first = placed.find((p) => !p.gated)
     const agents = placed.map((p) => {
       const a = agentById.get(p.integration.agentId)
@@ -781,7 +781,7 @@ export class SharedBotOrchestrator {
     }
   }
 
-  /** Deliver the shared (send-only) spec to each member agent's daemon (best-effort).
+  /** Deliver the HTTP-transport send-only spec to each member agent's daemon (best-effort).
    *  `shareable` rides each spec so the daemon knows whether to expose "Switch agent". */
   private async pushSpecs(
     compiled: Compiled,
@@ -799,11 +799,11 @@ export class SharedBotOrchestrator {
         const channels = gated ? botChannels.filter((c) => c.integrationId === integration.id) : []
         await this.control.integrationUpsert(
           daemonId,
-          sharedIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
+          httpIntegrationToSpec(integration, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
         )
       } catch (err) {
         if (!(err instanceof NoConnection)) throw err
-        this.log.debug?.({ integrationId: integration.id, daemonId }, 'shared-bot: spec push skipped — daemon offline')
+        this.log.debug?.({ integrationId: integration.id, daemonId }, 'http-bot: spec push skipped — daemon offline')
       }
     }
   }

--- a/packages/control-plane/src/orchestrator/integrationPush.ts
+++ b/packages/control-plane/src/orchestrator/integrationPush.ts
@@ -1,8 +1,8 @@
 /**
  * Integration-gating convergence (resource-visibility.md §14.4): when an agent's
  * visibility flips, its derived conversation-gating flag changes, so every
- * integration of the agent must be re-converged — a shared (http) bot recompiles
- * its relay routes + re-pushes shared specs (`syncBot` covers both), a direct
+ * integration of the agent must be re-converged — an HTTP bot recompiles
+ * its relay routes + re-pushes send-only specs (`syncBot` covers both), a direct
  * install gets a fresh token-bearing spec push. Best-effort per integration: a
  * missed push self-heals from the reconcile roster on the daemon's next connect.
  */
@@ -25,7 +25,7 @@ export interface GatingPushDeps {
     integrationChannel: IntegrationChannelRepo
   }
   control: ControlSender
-  sharedBot: { syncBot(botId: string): Promise<void> }
+  httpBot: { syncBot(botId: string): Promise<void> }
 }
 
 export async function convergeIntegrationGating(
@@ -41,7 +41,7 @@ export async function convergeIntegrationGating(
       if (bot?.transport === 'http') {
         if (!syncedBots.has(String(bot.id))) {
           syncedBots.add(String(bot.id))
-          await deps.sharedBot.syncBot(String(bot.id))
+          await deps.httpBot.syncBot(String(bot.id))
         }
         continue
       }

--- a/packages/control-plane/src/orchestrator/mcpReplay.ts
+++ b/packages/control-plane/src/orchestrator/mcpReplay.ts
@@ -5,7 +5,7 @@
  * mutation time — so a relay that connects or reconnects later holds nothing, yet the
  * daemon's relay roster can still pick it (`desiredMcpServers`), and requests through it
  * would 401. On every relay (re)register we replay the full persisted set to just that
- * relay — the exact analog of `HookService.replayTo` / `SharedBotManager.replayTo`.
+ * relay — the exact analog of `HookService.replayTo` / `RelayIngressManager.replayTo`.
  *
  * The frame carries the upstream credential (headers) — NEVER logged. Per-provider
  * failures are swallowed + logged so one bad row can't starve the rest of the pool.

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -264,8 +264,8 @@ export function integrationToSpec(
     agentId: i.agentId,
     platform: 'slack',
     // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
-    // The 'shared' variant (transport==='http', xoxb-only, no appToken/bindRules) is
-    // assembled by the shared-bot path, which reads the bot's `transport`; this mapper
+    // The 'shared' wire variant (transport==='http', xoxb-only, no appToken/bindRules)
+    // is assembled by the HTTP-bot path, which reads the bot's `transport`; this mapper
     // is always direct. A socket bot is single-agent, so it is never shareable. Slack
     // always stores an app-level token (Socket Mode).
     slack: {
@@ -281,19 +281,20 @@ export function integrationToSpec(
 }
 
 /**
- * Assemble the SHARED-mode {@link IntegrationSpec} for a member agent of a shared
- * bot (shared-bot-relay.md §7.3). The daemon gets xoxb ONLY (send path) — no
+ * Assemble the send-only {@link IntegrationSpec} for a member agent of an HTTP bot
+ * (shared-bot-relay.md §7.3). The wire keeps `mode: 'shared'` for compatibility.
+ * The daemon gets xoxb ONLY (send path) — no
  * appToken (the relay owns the event stream) and no bindRules (the relay
  * arbitrates inbound and delivers it pre-addressed). Slack-only for now; a
  * shareable Telegram/Discord bot lands in milestone C. Token-bearing — NEVER log.
  *
  * GATED exception (resource-visibility.md §14.3): a restricted agent's install
- * ships its conversation-scoped rules + `gated: true` even in shared mode — the
+ * ships its conversation-scoped rules + `gated: true` even in relay-managed mode — the
  * relay is still the arbiter, but the daemon uses these for its last-hop
  * admission backstop in `handleRelayIm` (it must not trust a stale relay route
  * snapshot to keep a private agent fail-closed).
  */
-export function sharedIntegrationToSpec(
+export function httpIntegrationToSpec(
   i: IntegrationRecord,
   secret: BotSecretMaterial,
   shareable: boolean,
@@ -305,7 +306,7 @@ export function sharedIntegrationToSpec(
     integrationId: i.id,
     agentId: i.agentId,
     platform: 'slack',
-    // `shareable` gates the daemon's in-thread "Switch agent" control: a shared bot
+    // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
     // routes through the relay either way, but only a multi-agent (shareable) bot has
     // something to switch to.
     slack: {
@@ -390,7 +391,7 @@ export class Placement implements ReconcileService {
           // reconciles it send-only (no Socket Mode). Socket bots reconcile as direct.
           const gated = gatedAgentIds.has(i.agentId)
           return bot?.transport === 'http'
-            ? sharedIntegrationToSpec(i, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
+            ? httpIntegrationToSpec(i, secret, bot.shareable, channels, gated, bot.slackAppId ?? undefined)
             : integrationToSpec(i, secret, channels, gated)
         })
       )

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -67,7 +67,7 @@ import { WaitlistService } from '../../src/registry/waitlistService.js'
 import { EpochService } from '../../src/orchestrator/epoch.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { RelayControlSender } from '../../src/orchestrator/relayControl.js'
-import { SharedBotOrchestrator } from '../../src/orchestrator/sharedBot.js'
+import { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import { CollabRoutesService } from '../../src/orchestrator/collabRoutes.service.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { ExclusiveMutationGate } from '../../src/orchestrator/exclusiveMutationGate.js'
@@ -149,7 +149,7 @@ export function buildHttpApp(
   const hookRepo = new PgHookRepo(prisma)
   const hookSecretStore = new PgHookSecretStore(prisma, cipher)
   const githubInstallationRepo = new PgGithubInstallationRepo(prisma)
-  // An empty relay registry ⇒ shared installs 409 (no relay) and hook broadcasts are
+  // An empty relay registry ⇒ multi-agent installs 409 (no relay) and hook broadcasts are
   // no-ops — exactly the prod graph with no relay dialed in, unless a test wires one up.
   const relayReg = new RelayRegistry()
   const relayControl = new RelayControlSender(relayReg)
@@ -198,7 +198,7 @@ export function buildHttpApp(
     liveness,
     control: sender,
     relayControl,
-    sharedBot: new SharedBotOrchestrator(
+    httpBot: new HttpBotOrchestrator(
       botRepo,
       botSecretStore,
       botCredentialWriter,

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -7,7 +7,7 @@ import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import type { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { HookService } from '../../src/hooks/hook.service.js'
-import type { SharedBotOrchestrator } from '../../src/orchestrator/sharedBot.js'
+import type { HttpBotOrchestrator } from '../../src/orchestrator/httpBot.js'
 import type { CollabRoutesService } from '../../src/orchestrator/collabRoutes.service.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { OrgId } from '../../src/domain/ids.js'
@@ -68,20 +68,20 @@ describe('PUT /agents/:id/daemon', () => {
     const agentId = randomUUID()
     await seedAgent(prisma, agentId, { daemonId: SOURCE })
     const classicBot = randomUUID()
-    const sharedBot = randomUUID()
+    const httpBot = randomUUID()
     const classicIntegration = randomUUID()
     const sharedIntegration = randomUUID()
     const cronId = randomUUID()
     await prisma.bot.createMany({
       data: [
         { id: classicBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'classic' },
-        { id: sharedBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'shared', shareable: true, transport: 'http' }
+        { id: httpBot, orgId: DEFAULT_ORG_ID, platform: 'slack', name: 'shared', shareable: true, transport: 'http' }
       ]
     })
     await prisma.botSecret.createMany({
       data: [
         { botId: classicBot, botToken: 'xoxb-classic', appToken: 'xapp-classic' },
-        { botId: sharedBot, botToken: 'xoxb-shared', appToken: 'xapp-shared' }
+        { botId: httpBot, botToken: 'xoxb-shared', appToken: 'xapp-shared' }
       ]
     })
     await prisma.integration.createMany({
@@ -98,7 +98,7 @@ describe('PUT /agents/:id/daemon', () => {
           id: sharedIntegration,
           orgId: DEFAULT_ORG_ID,
           agentId,
-          botId: sharedBot,
+          botId: httpBot,
           platform: 'slack',
           name: 'shared'
         }
@@ -123,9 +123,9 @@ describe('PUT /agents/:id/daemon', () => {
     const derived: string[] = []
     running = buildHttpApp(prisma, undefined, live, control as unknown as ControlSender, {
       hooks: { rebroadcastForAgent: async () => void derived.push('hooks') } as unknown as HookService,
-      sharedBot: {
-        syncBot: async (id: string) => void derived.push(`shared:${id}`)
-      } as unknown as SharedBotOrchestrator,
+      httpBot: {
+        syncBot: async (id: string) => void derived.push(`http:${id}`)
+      } as unknown as HttpBotOrchestrator,
       collabRoutes: { broadcast: async () => void derived.push('collab') } as unknown as CollabRoutesService
     })
 
@@ -146,7 +146,7 @@ describe('PUT /agents/:id/daemon', () => {
         .sort()
     ).toEqual(['direct', 'shared'])
     expect(control.activations[0]?.crons.map((cron) => cron.cronId)).toEqual([cronId])
-    expect(derived).toEqual(['hooks', 'collab', `shared:${sharedBot}`])
+    expect(derived).toEqual(['hooks', 'collab', `http:${httpBot}`])
 
     // A lost-response retry repairs the full target bundle and activates again,
     // and first arms the idempotent target staging gate.

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -269,7 +269,7 @@ describe('GET /integrations/slack/platform/callback', () => {
     const bot = await prisma.bot.findUniqueOrThrow({
       where: { slackAppId_teamId: { slackAppId: PLATFORM.appId, teamId: 'T0WORKSPACE' } }
     })
-    await app.deps.sharedBot.revokeBot(bot.id, 'app_uninstalled')
+    await app.deps.httpBot.revokeBot(bot.id, 'app_uninstalled')
     const revoked = await prisma.bot.findUniqueOrThrow({ where: { id: bot.id } })
     expect(revoked.revokedAt).toBeInstanceOf(Date)
     expect(await prisma.integration.count({ where: { botId: bot.id, status: 'revoked' } })).toBe(1)
@@ -321,15 +321,15 @@ describe('GET /integrations/slack/platform/callback', () => {
     // NOW the stale event lands. A relay that missed the re-assign echoes revision 1;
     // one that already applied it echoes revision 2 with the OLD occurrence time.
     // Both must be refused.
-    await app.deps.sharedBot.revokeBot(bot.id, 'app_uninstalled', { revision: 1, eventAtMs: uninstalledAt })
-    await app.deps.sharedBot.revokeBot(bot.id, 'app_uninstalled', { revision: 2, eventAtMs: uninstalledAt })
+    await app.deps.httpBot.revokeBot(bot.id, 'app_uninstalled', { revision: 1, eventAtMs: uninstalledAt })
+    await app.deps.httpBot.revokeBot(bot.id, 'app_uninstalled', { revision: 2, eventAtMs: uninstalledAt })
 
     const after = await prisma.bot.findUniqueOrThrow({ where: { id: bot.id } })
     expect(after.revokedAt).toBeNull()
     expect(await prisma.integration.count({ where: { botId: bot.id, status: 'active' } })).toBe(1)
 
     // A genuine LATER uninstall of the current generation still works.
-    await app.deps.sharedBot.revokeBot(bot.id, 'app_uninstalled', {
+    await app.deps.httpBot.revokeBot(bot.id, 'app_uninstalled', {
       revision: 2,
       eventAtMs: after.credentialInstalledAt!.getTime() + 1000
     })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -903,7 +903,7 @@ interface Pending {
   /** Trusted sender id for the message that started this turn. Approval audit rows use
    *  this actor, not the session's historical first trigger. */
   requesterId?: string
-  /** Exact integration that owns the reply path. Shared Slack turns encode it into the
+  /** Exact integration that owns the reply path. HTTP Slack turns encode it into the
    *  status controls so the relay can route each button to the right owner. */
   integrationId?: string
   /** Public avatar URL for this turn's Slack channel messages (icon_url), if the CP resolved one. */
@@ -1307,13 +1307,13 @@ export class Daemon {
   private dreamScheduler!: DreamScheduler
   private sessions!: SessionManager
   // integrationId -> the SlackConnection that owns it (for replies). Holds BOTH
-  // socket-mode (direct) and send-only (shared-bot) connections — a shared bot's
+  // socket-mode (direct) and send-only (HTTP-bot) connections — an HTTP bot's
   // send-only client is registered here too so replies/attachments/MCP reuse it.
   private connByIntegration = new Map<string, SlackConnection>()
-  // Shared-bot send-only Slack clients, keyed by xoxb (one per bot token; the relay
+  // HTTP-bot send-only Slack clients, keyed by xoxb (one per bot token; the relay
   // owns their inbound). Separate from the direct sockets so reconcile can dedup +
-  // tear down a bot's old direct socket when it flips to shared.
-  private sharedSlackConns = new Map<string, SlackConnection>()
+  // tear down a bot's old direct socket when it flips to HTTP transport.
+  private httpSlackConns = new Map<string, SlackConnection>()
   // integrationId -> the TelegramConnection that owns it (for replies). Separate from
   // connByIntegration so Slack reconcile (which reads `.appToken`) never sees a Telegram conn.
   private tgConnByIntegration = new Map<string, TelegramConnection>()
@@ -2148,8 +2148,8 @@ export class Daemon {
       }
     }
 
-    // open send-only Slack clients for shared bots (inbound lives on the relay).
-    await this.openSharedSlackConnections(agents)
+    // Open send-only Slack clients for HTTP bots (inbound lives on the relay).
+    await this.openHttpSlackConnections(agents)
     // Long-poll / gateway / WS platform connects (Telegram/Discord/Feishu) must NOT gate
     // boot: their start() awaits a bot-identity handshake (e.g. Telegram getMe) that can
     // HANG indefinitely when the platform API is unreachable — which would otherwise stall
@@ -2418,7 +2418,7 @@ export class Daemon {
    * Close platform clients whose credential key has no reference in the FINAL
    * active-agent roster, and evict every derived index that points at a removed
    * or re-keyed integration. Consolidation maps are the reference counts: direct
-   * Slack is keyed by appToken; shared Slack, Telegram and Discord by botToken.
+   * Slack is keyed by appToken; HTTP Slack, Telegram and Discord by botToken.
    *
    * A captured connection on a live turn is a temporary reference too. Detach
    * drains its own dispatch leases before reaching this method; the guard also
@@ -2525,11 +2525,11 @@ export class Daemon {
       await conn.stop()
       this.connections = this.connections.filter((candidate) => candidate !== conn)
     }
-    for (const [botToken, conn] of [...this.sharedSlackConns]) {
+    for (const [botToken, conn] of [...this.httpSlackConns]) {
       if (shared.has(botToken)) continue
       await this.waitForConnectionUses(conn)
       await conn.stop()
-      this.sharedSlackConns.delete(botToken)
+      this.httpSlackConns.delete(botToken)
     }
     for (const conn of [...this.telegramConns]) {
       if (telegram.has(conn.botToken)) continue
@@ -2638,24 +2638,24 @@ export class Daemon {
         )
       }
     }
-    // Shared-bot send-only clients (mode:'shared') — reconciled alongside the sockets.
-    await this.openSharedSlackConnections([...this.agents.values()])
+    // HTTP-bot send-only clients (wire mode `shared`) — reconciled alongside the sockets.
+    await this.openHttpSlackConnections([...this.agents.values()])
   }
 
   /**
-   * Open (or reuse) a SEND-ONLY Slack Web-API client per shared bot token and bind
+   * Open (or reuse) a SEND-ONLY Slack Web-API client per HTTP bot token and bind
    * it into `connByIntegration`, so replies / attachment fetches / MCP platform
    * tools / cron anchors resolve a connection for a `mode:'shared'` integration
    * (shared-bot-relay.md §11). No Socket Mode socket is opened — the bot's inbound
    * arrives from the relay as `rd/msg(im)`. Idempotent: an already-open client for
-   * the same xoxb is reused; when a bot flips direct→shared its old direct socket
+   * the same xoxb is reused; when a bot flips direct→HTTP transport its old direct socket
    * (same botToken) is stopped so it stops competing with the relay for the single
    * Socket Mode consumer.
    */
-  private async openSharedSlackConnections(agents: LoadedAgent[]): Promise<void> {
+  private async openHttpSlackConnections(agents: LoadedAgent[]): Promise<void> {
     const groups = consolidateShared(agents)
     for (const group of groups.values()) {
-      let conn = this.sharedSlackConns.get(group.botToken)
+      let conn = this.httpSlackConns.get(group.botToken)
       let bound = false
       if (!conn) {
         conn = new SlackConnection({
@@ -2671,10 +2671,10 @@ export class Daemon {
         })
         try {
           await conn.start()
-          this.sharedSlackConns.set(group.botToken, conn)
-          this.log.info(`slack: send-only (shared) client ready as bot user ${conn.botUserId}`)
+          this.httpSlackConns.set(group.botToken, conn)
+          this.log.info(`slack: send-only (HTTP) client ready as bot user ${conn.botUserId}`)
         } catch (err) {
-          this.log.warn(`slack: shared send-only client failed — retry on next reconcile: ${formatErr(err)}`)
+          this.log.warn(`slack: HTTP send-only client failed — retry on next reconcile: ${formatErr(err)}`)
           continue
         }
       }
@@ -2683,7 +2683,7 @@ export class Daemon {
         this.botUserIds[integrationId] = conn.botUserId
         this.connByIntegration.set(integrationId, conn)
       }
-      // Shared integrations still have the same xoxb Web API surface as direct
+      // HTTP integrations still have the same xoxb Web API surface as direct
       // sockets. Once a send-only client is bound, use it to seed the membership
       // snapshot too; otherwise rows created by shared routing know only the raw
       // channel id and the console can never render Slack's channel name.
@@ -4675,7 +4675,7 @@ export class Daemon {
   }
 
   /**
-   * A shared-bot inbound (`rd/msg` `im`): the relay already arbitrated the target
+   * An HTTP-bot inbound (`rd/msg` `im`): the relay already arbitrated the target
    * agent + integration, so this is the explicit-agent path — no local routing. The
    * reply flows out-of-band through the agent's send-only Slack connection
    * (`replyConnFor`), NOT `rd/chat` (that is webchat-only). The `rd/ack` is a plain
@@ -4694,22 +4694,22 @@ export class Daemon {
     // API. Mirror the lookup here so session metadata/history can label the sender.
     const conn = this.connByIntegration.get(msg.integrationId)
     if (conn) this.nameResolver?.noteMessage(conn, normalized)
-    // Shared-bot ingress is pre-addressed and bypasses onInbound(), so repeat the
+    // HTTP-bot ingress is pre-addressed and bypasses onInbound(), so repeat the
     // terminal agent-bot suppression here before commands or model admission.
     if (this.isAgentBotMessage(normalized)) {
       this.log.debug(`relay: consumed AgentConnect bot message ${msg.msgId} without waking ${msg.agentId}`)
       return { msgId: msg.msgId, accepted: true }
     }
-    // Conversation gating (§14) last-hop backstop: the relay arbitrates shared-bot
+    // Conversation gating (§14) last-hop backstop: the relay arbitrates HTTP-bot
     // routing, but a stale relay route snapshot must not activate a private agent in
     // an Off conversation. Admission = a bindRule scoped to this conversation (the
-    // CP ships a gated install's enabled set even in shared mode).
+    // CP ships a gated install's enabled set even in relay-managed mode).
     if (!this.gatedAdmission(msg.integrationId, normalized)) {
       this.maybeGatedNotice(normalized, [msg.integrationId])
       this.log.debug(`relay: dropped ${msg.msgId} for gated integration ${msg.integrationId} (conversation off)`)
       return { msgId: msg.msgId, accepted: true }
     }
-    // Shared-bot IM bypasses onInbound() because the relay already arbitrated the
+    // HTTP-bot IM bypasses onInbound() because the relay already arbitrated the
     // target. It must still intercept control commands before dispatch — especially
     // `!resume`, otherwise an open loop circuit drops the only recovery message.
     const command = parseCommand(normalized.text)
@@ -4726,7 +4726,7 @@ export class Daemon {
       this.handleCommand(command, normalized, target)
       return { msgId: msg.msgId, accepted: true }
     }
-    // Shared-bot ingress bypasses onInbound(), so repeat its `!stop` thread-mute gate:
+    // HTTP-bot ingress bypasses onInbound(), so repeat its `!stop` thread-mute gate:
     // while muted, implicit routing (thread affinity / keyword / auto / dm) never
     // dispatches — only an explicit @mention does, and it clears the mute. Muted traffic
     // still enters the transcript so the agent catches up when re-activated (§8.5).
@@ -4752,8 +4752,8 @@ export class Daemon {
     return { msgId: msg.msgId, accepted: true }
   }
 
-  /** Apply one shared-bot interaction after relay routing. Re-check every daemon-owned
-   *  boundary before opening or mutating anything: the agent, shared Slack integration,
+  /** Apply one HTTP-bot interaction after relay routing. Re-check every daemon-owned
+   *  boundary before opening or mutating anything: the agent, HTTP Slack integration,
    *  local connection, session owner, and (when retained) exact delivery binding must all
    *  still agree. Message shortcuts resolve their channel/thread coordinates here. */
   private handleRelaySlackAction(msg: RdMsgSlackAction): RdAck {
@@ -6743,7 +6743,7 @@ export class Daemon {
         .map((r) => {
           const mention = attachmentMention(r.attachments)
           return {
-            // A shared Slack app gives every agent-authored message the same bot_id.
+            // A shareable Slack app gives every agent-authored message the same bot_id.
             // Prefer our stable per-message metadata so a remote A is not mistaken for
             // this local B and then discarded by SessionManager's own-author filter.
             sender: r.agentAuthorId ?? (r.isBot && ours.has(r.sender) ? agentId : r.sender),
@@ -9420,8 +9420,8 @@ export class Daemon {
 
   /** Opaque routing target attached to daemon-rendered interactive Slack blocks when
    * inbound actions belong to the relay instead of this process's Socket Mode edge. */
-  private sharedSlackSessionTarget(p: Pick<Pending, 'agentId' | 'integrationId' | 'sessionKey'>): string | undefined {
-    return p.integrationId && this.isSharedSlackIntegration(p.agentId, p.integrationId)
+  private httpSlackSessionTarget(p: Pick<Pending, 'agentId' | 'integrationId' | 'sessionKey'>): string | undefined {
+    return p.integrationId && this.isHttpSlackIntegration(p.agentId, p.integrationId)
       ? encodeSharedSlackStatusTarget({
           agentId: p.agentId,
           integrationId: p.integrationId,
@@ -10065,9 +10065,9 @@ export class Daemon {
     return `${this.webAppBase()}${orgSeg}/agents/${encodeURIComponent(agentId)}`
   }
 
-  /** Whether this turn's reply rides a shared Slack integration. The relay owns that
-   *  app's Socket Mode connection, so interactive actions must use relay-recognized ids. */
-  private isSharedSlackIntegration(agentId: string, integrationId?: string): boolean {
+  /** Whether this turn's reply rides an HTTP Slack integration. The relay owns that
+   *  app's inbound edge, so interactive actions must use relay-recognized ids. */
+  private isHttpSlackIntegration(agentId: string, integrationId?: string): boolean {
     if (!integrationId) return false
     const agent = this.agents.get(agentId)
     const int = agent?.integrations.find((i) => i.id === integrationId)
@@ -10076,7 +10076,7 @@ export class Daemon {
 
   /** Whether this turn's Slack bot is SHAREABLE (multi-agent). Only a shareable bot
    *  has another agent to switch to, so the in-thread "Switch agent" control is gated
-   *  on this — a single-agent shared bot routes the same way but omits the option. */
+   *  on this — a single-agent HTTP bot routes the same way but omits the option. */
   private isShareableSlackIntegration(agentId: string, integrationId?: string): boolean {
     if (!integrationId) return false
     const agent = this.agents.get(agentId)
@@ -10346,7 +10346,7 @@ export class Daemon {
       // as usage_update / turn-end land.
       p.lastStatusBar = key
       const link = this.sessionLink(p.acpSessionId)
-      const sessionTarget = this.sharedSlackSessionTarget(p)
+      const sessionTarget = this.httpSlackSessionTarget(p)
       const shared =
         sessionTarget && p.integrationId
           ? {
@@ -10674,7 +10674,7 @@ export class Daemon {
       channel: p.channel,
       resolve: resolveResult
     })
-    const blocks = buildPermissionCard(requestId, params, this.sharedSlackSessionTarget(p))
+    const blocks = buildPermissionCard(requestId, params, this.httpSlackSessionTarget(p))
     const fallback = `Permission requested: ${params.toolCall?.title ?? 'a tool call'}`
     const ts = await this.postCardSerialized(p, (slack) =>
       slack.postBlocks(p.channel, blocks, fallback, p.statusThread, {
@@ -11094,7 +11094,7 @@ export class Daemon {
     const target = elicitTarget(params)
     if (!target) return undefined
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
-    const blocks = buildElicitationCard(requestId, params, this.sharedSlackSessionTarget(p))
+    const blocks = buildElicitationCard(requestId, params, this.httpSlackSessionTarget(p))
     if (!blocks) return undefined
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
@@ -14367,7 +14367,7 @@ export class Daemon {
     await Promise.resolve(this.relays?.stop()).catch((e) => errors.push(e))
     for (const run of [...this.slackRetryRuns.values()]) await Promise.resolve(run.promise).catch((e) => errors.push(e))
     for (const c of this.connections) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
-    for (const c of this.sharedSlackConns.values()) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
+    for (const c of this.httpSlackConns.values()) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
     for (const c of this.telegramConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
     for (const c of this.discordConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
     for (const c of this.feishuConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -277,7 +277,7 @@ describe('Daemon in-conversation commands', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
     await daemon.start()
     makeRoutable(daemon)
-    // The session the shared bot's inbound keys to (sessionKey(platform, channel, thread, agent)).
+    // The session the HTTP bot's inbound keys to (sessionKey(platform, channel, thread, agent)).
     const muteKey = SESSION_KEY
     ;(daemon as any).store.setSessionMuted(muteKey, true)
 
@@ -957,7 +957,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('backfill preserves a remote agent author carried by a shared Slack bot', async () => {
+  it('backfill preserves a remote agent author carried by an HTTP Slack bot', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
     await daemon.start()
     const conn = makeRoutable(daemon) as any
@@ -1218,7 +1218,7 @@ describe('Slack interactive status bar', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('drops Switch agent for a non-shareable shared bot while keeping agent identity + relay routing', async () => {
+  it('drops Switch agent for a non-shareable HTTP bot while keeping agent identity + relay routing', async () => {
     const { host, release } = modelHost()
     const daemon = new Daemon({ root: scaffold(AGENT_IDENTITY), hostFactory: () => host as any })
     await daemon.start()
@@ -1252,7 +1252,7 @@ describe('Slack interactive status bar', () => {
       integrationId: 'int-a',
       sessionKey: SESSION_KEY
     })
-    // Agent identity is preserved in shared mode, and the message remains marked as chrome.
+    // Agent identity is preserved in HTTP mode, and the message remains marked as chrome.
     expect(call[4]).toEqual(STATUS_BAR_POST_OPTIONS)
 
     release()

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -295,13 +295,13 @@ describe('Daemon watcher resilience: corrupt agent.json', () => {
 })
 
 describe('Daemon.reconcileSlackConnections', () => {
-  it('refreshes channel metadata when a shared send-only client is first bound', async () => {
+  it('refreshes channel metadata when an HTTP send-only client is first bound', async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)
     await daemon.start()
 
     const shared = { botToken: 'xoxb-shared', botUserId: 'U_SHARED', stop: vi.fn().mockResolvedValue(undefined) }
-    ;(daemon as any).sharedSlackConns = new Map([['xoxb-shared', shared]])
+    ;(daemon as any).httpSlackConns = new Map([['xoxb-shared', shared]])
     ;(daemon as any).agents = new Map([
       [
         'bot-shared',
@@ -313,14 +313,14 @@ describe('Daemon.reconcileSlackConnections', () => {
     ])
     const refresh = vi.spyOn(daemon as any, 'refreshChannels').mockResolvedValue(undefined)
 
-    await (daemon as any).openSharedSlackConnections([...(daemon as any).agents.values()])
+    await (daemon as any).openHttpSlackConnections([...(daemon as any).agents.values()])
 
     expect((daemon as any).connByIntegration.get('int-shared')).toBe(shared)
     expect(refresh).toHaveBeenCalledOnce()
     expect(refresh).toHaveBeenCalledWith(shared)
 
     // A normal reconcile of an unchanged binding should not re-list Slack channels.
-    await (daemon as any).openSharedSlackConnections([...(daemon as any).agents.values()])
+    await (daemon as any).openHttpSlackConnections([...(daemon as any).agents.values()])
     expect(refresh).toHaveBeenCalledOnce()
     await daemon.stop()
   })
@@ -420,7 +420,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     const telegramOld = conn('tg-old')
     const discordLive = conn('dc-live')
     const discordOld = conn('dc-old')
-    ;(daemon as any).sharedSlackConns = new Map([
+    ;(daemon as any).httpSlackConns = new Map([
       ['xoxb-live', sharedLive],
       ['xoxb-old', sharedOld]
     ])

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentconnect.md/relay",
   "version": "1.0.0-dev",
-  "description": "AgentConnect relay — the unified ingress plane (shared bot / webhook / webchat) that dials the control-plane and forwards to daemons",
+  "description": "AgentConnect relay — the unified ingress plane (HTTP bot / webhook / webchat) that dials the control-plane and forwards to daemons",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { SharedBotRouter, arbitrate, type BotAssignment, type RouteTarget } from './shared-bot-router.js'
+import { BotArbitrationRouter, arbitrate, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
 import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
 
 const D1 = 'd1'
@@ -47,7 +47,7 @@ const msg = (over: Partial<WireNormalizedMessage>): WireNormalizedMessage => ({
   ...over
 })
 
-describe('shared-bot arbitration (§10)', () => {
+describe('HTTP-bot arbitration (§10)', () => {
   const empty = () => new Map<string, RouteTarget>()
 
   it('channel ownership with a mention trigger routes a mentioned message to the owner', () => {
@@ -170,9 +170,9 @@ describe('shared-bot arbitration (§10)', () => {
   })
 })
 
-describe('SharedBotRouter — table + live affinity', () => {
+describe('BotArbitrationRouter — table + live affinity', () => {
   it('records live affinity so a follow-up continues to the same agent', () => {
-    const r = new SharedBotRouter()
+    const r = new BotArbitrationRouter()
     r.upsert(assignment())
     // First turn: "@bot bob" → bob, recorded.
     const first = r.route(
@@ -186,7 +186,7 @@ describe('SharedBotRouter — table + live affinity', () => {
   })
 
   it('updateRoutes swaps the table but keeps the resolved botUserId', () => {
-    const r = new SharedBotRouter()
+    const r = new BotArbitrationRouter()
     r.upsert(assignment())
     r.setBotUserId('bot-1', BOTUSER)
     r.updateRoutes('bot-1', {
@@ -201,7 +201,7 @@ describe('SharedBotRouter — table + live affinity', () => {
   })
 
   it('remove drops the assignment', () => {
-    const r = new SharedBotRouter()
+    const r = new BotArbitrationRouter()
     r.upsert(assignment())
     r.remove('bot-1')
     expect(r.get('bot-1')).toBeUndefined()
@@ -209,7 +209,7 @@ describe('SharedBotRouter — table + live affinity', () => {
   })
 
   it('resolves status actions only for the exact current agent + integration', () => {
-    const r = new SharedBotRouter()
+    const r = new BotArbitrationRouter()
     r.upsert(assignment())
     expect(r.targetForAgent('bot-1', ALICE, 'iA')).toEqual({
       agentId: ALICE,
@@ -230,7 +230,7 @@ describe('SharedBotRouter — table + live affinity', () => {
       integrationId: 'iA',
       match: { kind: 'keyword', value: 'alice-elsewhere' }
     })
-    const r = new SharedBotRouter()
+    const r = new BotArbitrationRouter()
     r.upsert(ambiguous)
     expect(r.targetForAgent('bot-1', ALICE, 'iA')).toBeUndefined()
 

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -1,11 +1,11 @@
 /**
- * `SharedBotRouter` (shared-bot-relay.md §10) — the relay-side arbitration table
- * for shared bots. Holds each assigned bot's attributed routing table (pushed by
+ * `BotArbitrationRouter` (shared-bot-relay.md §10) — the relay-side arbitration table
+ * for HTTP bots. Holds each assigned bot's attributed routing table (pushed by
  * the CP via `rc/bot-assign` / `rc/routes`) plus live thread affinity, and
  * resolves one inbound message to its target `{ agentId, daemonId, integrationId }`.
  *
  * The ladder mirrors the daemon's local arbitration (routing-table.ts) but over
- * ALREADY-ATTRIBUTED routes, and adapted for the shared-bot ambiguity (all agents
+ * ALREADY-ATTRIBUTED routes, and adapted for the multi-agent ambiguity (all agents
  * answer as one bot user id): channel ownership → thread continuity → keyword
  * (agent slug) → the group's default agent for a bare @bot / DM. There is NO
  * unscoped mention rule (it would starve keyword disambiguation, §10.4); the bare
@@ -114,7 +114,7 @@ export function arbitrate(
   //    rule fires on any message — the operator's trigger choice).
   const ownedMention = scoped.find((r) => r.match.kind === 'mention' && kindMatches(r, msg, a.botUserId))
   if (ownedMention) return target(ownedMention)
-  // Conversation-scoped keyword (§14.3): slug disambiguation inside a shared DM
+  // Conversation-scoped keyword (§14.3): slug disambiguation inside a multi-agent DM
   // enabled for several gated agents — outranks the scoped auto so "<slug> …"
   // names its agent; an unslugged message falls through to the first auto route.
   const ownedKeyword = scoped.find((r) => r.match.kind === 'keyword' && kindMatches(r, msg, a.botUserId))
@@ -158,7 +158,7 @@ export function arbitrate(
 /** Cap on a bot's negative-affinity set before it is flushed (bounds CP lookups). */
 const MAX_NEGATIVE_AFFINITY = 10_000
 
-export class SharedBotRouter {
+export class BotArbitrationRouter {
   private readonly bots = new Map<string, BotAssignment>()
   /** Per-bot thread affinity: botId → (sessionKey → target). */
   private readonly affinity = new Map<string, Map<string, RouteTarget>>()
@@ -213,7 +213,7 @@ export class SharedBotRouter {
     return this.bots.get(botId)
   }
 
-  /** Resolve an opaque shared-status target to the current canonical daemon route.
+  /** Resolve an opaque relay-status target to the current canonical daemon route.
    *  Both agentId and integrationId must still belong to this bot; stale/tampered
    *  buttons are rejected instead of falling through to a channel's current owner. */
   targetForAgent(botId: string, agentId: string, integrationId: string): RouteTarget | undefined {
@@ -230,7 +230,7 @@ export class SharedBotRouter {
     return target(route)
   }
 
-  /** Resolve an agent picker value to one canonical route for this shared bot.
+  /** Resolve an agent picker value to one canonical route for this HTTP bot.
    *  Repeated scoped/keyword rules are fine when they point at the same integration;
    *  conflicting placements fail closed instead of choosing by array order. */
   targetForAgentId(botId: string, agentId: string): RouteTarget | undefined {

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -1,6 +1,6 @@
 /**
  * `CollaborationRouter` — the relay's bot-AGNOSTIC agent-collaboration routing table
- * (agent-collaboration §2.3 / §6.2). Unlike {@link SharedBotRouter} (keyed by botId,
+ * (agent-collaboration §2.3 / §6.2). Unlike {@link BotArbitrationRouter} (keyed by botId,
  * so two agents in the same channel on DIFFERENT bots aren't co-resolvable), this is
  * keyed by `(orgId, platform, channelId)` and holds every agent's placement + call
  * directional policy in that channel — which is what a cross-daemon `rd/agentmsg` needs to

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -17,12 +17,12 @@ import { buildRelayServer } from './server.js'
 import { createRelayDaemonServer, type RelayDaemonServer } from './relay-daemon-server.js'
 import { createRelayBrowserServer } from './relay-browser-server.js'
 import { WebchatRouter } from './webchat-router.js'
-import { SharedBotManager } from './shared-bot-manager.js'
+import { RelayIngressManager } from './relay-ingress-manager.js'
 import { SlackEventDedup } from './slack-event-dedup.js'
 import { registerSlackHttpIngress } from './slack-http-ingress.js'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
-import type { BotAssignment } from './shared-bot-router.js'
+import type { BotAssignment } from './bot-arbitration.js'
 import { HookTable } from './hooks/hook-table.js'
 import { HookRateLimiter } from './hooks/rate-limit.js'
 import { registerHookIngress } from './hooks/ingress.js'
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
   // Build the server first so the CP client can log through its pino instance. The
   // health probes and the CP-revoke callback read the client / rd server through a
   // holder (both are constructed below, once the logger exists).
-  const held: { client?: RelayCpClient; rdServer?: RelayDaemonServer; sharedBot?: SharedBotManager } = {}
+  const held: { client?: RelayCpClient; rdServer?: RelayDaemonServer; relayIngress?: RelayIngressManager } = {}
 
   // The bot-agnostic collaboration routing snapshot (agent-collaboration §2.3/§6.2).
   // The CP ships it over `rc/collab-routes`; the cross-daemon `rd/agentmsg` router
@@ -132,22 +132,22 @@ async function main(): Promise<void> {
       // revoked grants cannot survive a reconnect while a CP outage still leaves
       // the last verified bindings available.
       memoryBindings.clear()
-      held.sharedBot?.flushPendingReports()
+      held.relayIngress?.flushPendingReports()
     },
     // CP revoked a daemon's credential/membership — drop its rd/* connection now (§9).
     onRevoke: (daemonId) => held.rdServer?.revoke(daemonId),
-    // Shared-bot control (§10): the manager is constructed below (after rdServer);
-    // these callbacks only fire once the relay is READY, so `held.sharedBot` is set.
+    // HTTP-bot control (§10): the manager is constructed below (after rdServer);
+    // these callbacks only fire once the relay is READY, so `held.relayIngress` is set.
     onBotAssign: (a) =>
-      void held.sharedBot
+      void held.relayIngress
         ?.assign(toBotAssignment(a))
         .catch((err) => log.error(`relay: bot-assign failed: ${String(err)}`)),
     onBotUnassign: (a) =>
-      void held.sharedBot
+      void held.relayIngress
         ?.unassign(a.botId, a.credentialRevision)
         .catch((err) => log.error(`relay: bot-unassign failed: ${String(err)}`)),
     onRoutes: (r) =>
-      held.sharedBot?.updateRoutes(r.botId, {
+      held.relayIngress?.updateRoutes(r.botId, {
         members: r.members,
         agents: r.agents.map((x) => ({ agentId: x.agentId, name: x.name })),
         routes: r.routes,
@@ -158,7 +158,7 @@ async function main(): Promise<void> {
         noticedDmConversations: r.noticedDmConversations
       }),
     onAssign: (a) =>
-      held.sharedBot?.setAffinity(a.botId, a.sessionKey, {
+      held.relayIngress?.setAffinity(a.botId, a.sessionKey, {
         agentId: a.agentId,
         daemonId: a.daemonId,
         integrationId: ''
@@ -176,11 +176,11 @@ async function main(): Promise<void> {
   })
   held.client = client
 
-  // Shared-bot manager (§10): loads each `rc/bot-assign`'s inbound routing + creds and
-  // arbitrates/forwards inbound. Constructed before `listen()` so the shared Slack HTTP
+  // Relay ingress manager (§10): loads each `rc/bot-assign`'s inbound routing + creds and
+  // arbitrates/forwards inbound. Constructed before `listen()` so the Slack HTTP
   // ingress can register its routes; `getDaemon` late-binds the rd/* server (created
   // after listen). Inbound arrives on `/slack/events` + `/slack/interactions` below.
-  const sharedBot = new SharedBotManager({
+  const relayIngress = new RelayIngressManager({
     getDaemon: (daemonId) => held.rdServer?.get(daemonId),
     setChannelAgent: (botId, channelId, agentId) => client.emitSetChannelAgent({ botId, channelId, agentId }),
     reportBotChannels: (m) => client.emitBotChannels(m),
@@ -195,12 +195,12 @@ async function main(): Promise<void> {
     clock: systemClock,
     log
   })
-  held.sharedBot = sharedBot
+  held.relayIngress = relayIngress
 
-  // Shared Slack HTTP ingress (POST /slack/events + /slack/interactions) — the pool's
+  // Slack HTTP ingress (POST /slack/events + /slack/interactions) — the pool's
   // ONE inbound Events API surface. Each POST is demuxed+HMAC-verified to a bot, deduped
   // by event_id, then arbitrated + forwarded. Routes must register before listen.
-  registerSlackHttpIngress(server, { manager: () => held.sharedBot, dedup: new SlackEventDedup(systemClock), log })
+  registerSlackHttpIngress(server, { manager: () => held.relayIngress, dedup: new SlackEventDedup(systemClock), log })
 
   // Public webhook ingress (POST /webhooks/in/:token). Routes must register
   // before listen; the rd/* server only exists after it — hence the late bind.
@@ -303,7 +303,7 @@ async function main(): Promise<void> {
     // stop the CP client, then close the http server.
     for (const ws of rdServer.wss.clients) ws.close(1012, 'relay restarting')
     for (const ws of browserServer.clients) ws.close(1012, 'relay restarting')
-    await held.sharedBot?.stopAll()
+    await held.relayIngress?.stopAll()
     await client.stop()
     await server.close()
     process.exit(0)

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -10,13 +10,13 @@ import type {
 } from '@agentconnect.md/protocol'
 import { FakeClock } from '@agentconnect.md/connection'
 import {
-  SharedBotManager,
-  type SharedBotManagerDeps,
-  sharedSlackActionMsgId,
-  sharedSlackShortcutMsgId
-} from './shared-bot-manager.js'
-import { SharedBotRouter, type BotAssignment } from './shared-bot-router.js'
-import type { SharedSlackSessionAction, SharedSlackSessionShortcut } from './slack-shared-ingest.js'
+  RelayIngressManager,
+  type RelayIngressManagerDeps,
+  httpSlackActionMsgId,
+  httpSlackShortcutMsgId
+} from './relay-ingress-manager.js'
+import { BotArbitrationRouter, type BotAssignment } from './bot-arbitration.js'
+import type { HttpSlackSessionAction, HttpSlackSessionShortcut } from './slack-http-ingest.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 import type { Logger } from './log.js'
 
@@ -33,7 +33,7 @@ const PEER_RELAY = '88888888-8888-4888-8888-888888888882'
 const silentLog: Logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
 
 /** Manager deps with the required affinity + clock stubs, overridable per test. */
-const deps = (over: Partial<SharedBotManagerDeps> = {}): SharedBotManagerDeps => ({
+const deps = (over: Partial<RelayIngressManagerDeps> = {}): RelayIngressManagerDeps => ({
   getDaemon: () => undefined,
   setChannelAgent: vi.fn(),
   reportBotChannels: vi.fn(() => true),
@@ -65,17 +65,17 @@ const assignment = (): BotAssignment => ({
   ]
 })
 
-const action = (over: Partial<SharedSlackSessionAction> = {}): SharedSlackSessionAction =>
+const action = (over: Partial<HttpSlackSessionAction> = {}): HttpSlackSessionAction =>
   ({
     target: { v: 1, agentId: AGENT_ID, integrationId: INTEGRATION_ID, sessionKey: SESSION_KEY },
     interactionId: JSON.stringify(['ac_set_model', '1720000000.000200']),
     kind: 'set-model',
     model: 'opus-4.8',
     ...over
-  }) as SharedSlackSessionAction
+  }) as HttpSlackSessionAction
 
 interface ManagerInternals {
-  router: SharedBotRouter
+  router: BotArbitrationRouter
   ingests: Map<
     string,
     {
@@ -86,16 +86,16 @@ interface ManagerInternals {
   reportChannels(snapshot: RcBotChannels): void
   reportRevoked(m: { botId: string; reason: 'app_uninstalled' | 'tokens_revoked'; credentialRevision?: number }): void
   selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void
-  forwardSessionAction(botId: string, action: SharedSlackSessionAction): void
-  forwardSessionShortcut(botId: string, shortcut: SharedSlackSessionShortcut): boolean
+  forwardSessionAction(botId: string, action: HttpSlackSessionAction): void
+  forwardSessionShortcut(botId: string, shortcut: HttpSlackSessionShortcut): boolean
   forward(botId: string, msg: WireNormalizedMessage): Promise<void>
 }
 
-describe('SharedBotManager shared Slack session actions', () => {
+describe('RelayIngressManager HTTP Slack session actions', () => {
   it('rebinds the current thread immediately when the inline selector changes agent', () => {
     const setChannelAgent = vi.fn()
     const reportThreadAssign = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ setChannelAgent, reportThreadAssign }))
+    const manager = new RelayIngressManager(deps({ setChannelAgent, reportThreadAssign }))
     const internals = manager as unknown as ManagerInternals
     const assigned = assignment()
     assigned.members.push({ daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] })
@@ -146,7 +146,7 @@ describe('SharedBotManager shared Slack session actions', () => {
   it('forwards to the exact current agent+integration with a stable redelivery msgId', () => {
     const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
-    const manager = new SharedBotManager(
+    const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
     const internals = manager as unknown as ManagerInternals
@@ -164,7 +164,7 @@ describe('SharedBotManager shared Slack session actions', () => {
       agentId: AGENT_ID,
       integrationId: INTEGRATION_ID,
       sessionKey: SESSION_KEY,
-      msgId: sharedSlackActionMsgId(BOT_ID, delivered),
+      msgId: httpSlackActionMsgId(BOT_ID, delivered),
       botId: BOT_ID,
       payload: { kind: 'set-model', model: 'opus-4.8' }
     })
@@ -175,7 +175,7 @@ describe('SharedBotManager shared Slack session actions', () => {
   it('forwards a message shortcut through the current thread affinity', () => {
     const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
-    const manager = new SharedBotManager(
+    const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
     const internals = manager as unknown as ManagerInternals
@@ -185,7 +185,7 @@ describe('SharedBotManager shared Slack session actions', () => {
       daemonId: DAEMON_ID,
       integrationId: INTEGRATION_ID
     })
-    const shortcut: SharedSlackSessionShortcut = {
+    const shortcut: HttpSlackSessionShortcut = {
       triggerId: 'trigger-shortcut',
       channelId: 'C123',
       threadTs: 'T1',
@@ -199,7 +199,7 @@ describe('SharedBotManager shared Slack session actions', () => {
       agentId: AGENT_ID,
       integrationId: INTEGRATION_ID,
       sessionKey: 'C123/T1',
-      msgId: sharedSlackShortcutMsgId(BOT_ID, shortcut),
+      msgId: httpSlackShortcutMsgId(BOT_ID, shortcut),
       botId: BOT_ID,
       userId: 'U-ALICE',
       payload: {
@@ -214,7 +214,7 @@ describe('SharedBotManager shared Slack session actions', () => {
   it('forwards the tapping user, and omits it entirely when the interaction named none', () => {
     const sendMsg = vi.fn(async (msg: RdMsgSlackAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
     const daemon = { sendMsg } as unknown as RelayDaemonConnection
-    const manager = new SharedBotManager(
+    const manager = new RelayIngressManager(
       deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
     )
     const internals = manager as unknown as ManagerInternals
@@ -235,23 +235,23 @@ describe('SharedBotManager shared Slack session actions', () => {
   })
 
   it('uses distinct ids for distinct selected values even if receipt metadata is reused', () => {
-    expect(sharedSlackActionMsgId(BOT_ID, action({ model: 'opus-4.8' }))).not.toBe(
-      sharedSlackActionMsgId(BOT_ID, action({ model: 'sonnet-5' }))
+    expect(httpSlackActionMsgId(BOT_ID, action({ model: 'opus-4.8' }))).not.toBe(
+      httpSlackActionMsgId(BOT_ID, action({ model: 'sonnet-5' }))
     )
   })
 
   it('uses distinct ids for two real clicks with different Slack action timestamps', () => {
     expect(
-      sharedSlackActionMsgId(BOT_ID, action({ interactionId: JSON.stringify(['ac_set_model', '1720000000.000200']) }))
+      httpSlackActionMsgId(BOT_ID, action({ interactionId: JSON.stringify(['ac_set_model', '1720000000.000200']) }))
     ).not.toBe(
-      sharedSlackActionMsgId(BOT_ID, action({ interactionId: JSON.stringify(['ac_set_model', '1720000000.000201']) }))
+      httpSlackActionMsgId(BOT_ID, action({ interactionId: JSON.stringify(['ac_set_model', '1720000000.000201']) }))
     )
   })
 
   it('rejects a tampered/stale target instead of falling back to the channel owner', () => {
     const sendMsg = vi.fn()
     const warn = vi.fn()
-    const manager = new SharedBotManager(
+    const manager = new RelayIngressManager(
       deps({ getDaemon: () => ({ sendMsg }) as unknown as RelayDaemonConnection, log: { ...silentLog, warn } })
     )
     const internals = manager as unknown as ManagerInternals
@@ -274,7 +274,7 @@ describe('SharedBotManager shared Slack session actions', () => {
   })
 })
 
-describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
+describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
   const online = (
     sendMsg = vi.fn(async (m: { msgId: string }): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
   ) => ({
@@ -322,7 +322,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
   it('reports the first route of a thread once, not on every message', async () => {
     const reportThreadAssign = vi.fn(() => true)
     const { daemon, sendMsg } = online()
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelOwned())
 
@@ -344,7 +344,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
   it('does NOT report for an `auto`-owned channel (every message re-resolves locally)', async () => {
     const reportThreadAssign = vi.fn(() => true)
     const { daemon, sendMsg } = online()
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelAutoOwned())
 
@@ -361,7 +361,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     const isAgentBotApp = vi.fn((_agentId: string, _platform: string, _channel: string, appId: string) => {
       return appId === 'AMANAGED'
     })
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, reportThreadAssign, isAgentBotApp }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign, isAgentBotApp }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelAutoOwned())
 
@@ -393,7 +393,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     let ready = false
     const reportThreadAssign = vi.fn(() => ready) // false ⇒ "link not READY, dropped"
     const { daemon } = online()
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, reportThreadAssign }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelOwned())
 
@@ -412,7 +412,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
   it('retries the latest channel snapshot dropped while the CP link was down', () => {
     let ready = false
     const reportBotChannels = vi.fn(() => ready)
-    const manager = new SharedBotManager(deps({ reportBotChannels }))
+    const manager = new RelayIngressManager(deps({ reportBotChannels }))
     const internals = manager as unknown as ManagerInternals
     const first = { botId: BOT_ID, channels: [{ id: 'C123', name: 'first' }] } satisfies RcBotChannels
     const latest = { botId: BOT_ID, channels: [{ id: 'C456', name: 'latest' }] } satisfies RcBotChannels
@@ -439,7 +439,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     try {
       let committed = false
       const reportBotRevoked = vi.fn(async () => committed)
-      const manager = new SharedBotManager(deps({ reportBotRevoked }))
+      const manager = new RelayIngressManager(deps({ reportBotRevoked }))
       const internals = manager as unknown as ManagerInternals
       const report = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 3 }
 
@@ -473,7 +473,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
         calls.push(m)
         return commitNext
       })
-      const manager = new SharedBotManager(deps({ reportBotRevoked }))
+      const manager = new RelayIngressManager(deps({ reportBotRevoked }))
       const internals = manager as unknown as ManagerInternals
       const current = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 2 }
       const delayed = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 1 }
@@ -508,7 +508,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     try {
       let commitNext = false
       const reportBotRevoked = vi.fn(async () => commitNext)
-      const manager = new SharedBotManager(deps({ reportBotRevoked }))
+      const manager = new RelayIngressManager(deps({ reportBotRevoked }))
       const internals = manager as unknown as ManagerInternals
       // The auth.test dead-credential backstop: exact current revision, NO
       // eventAtMs — "dead NOW", unconditional on the CP's time arm.
@@ -547,7 +547,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     vi.useFakeTimers()
     try {
       const reportBotRevoked = vi.fn(async () => false) // keep everything queued
-      const manager = new SharedBotManager(deps({ reportBotRevoked }))
+      const manager = new RelayIngressManager(deps({ reportBotRevoked }))
       const internals = manager as unknown as ManagerInternals
       const newer = { botId: BOT_ID, reason: 'tokens_revoked' as const, credentialRevision: 2, eventAtMs: 2_000 }
       const older = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 2, eventAtMs: 1_000 }
@@ -571,7 +571,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
     try {
       const resolvers: Array<(v: boolean) => void> = []
       const reportBotRevoked = vi.fn(() => new Promise<boolean>((resolve) => resolvers.push(resolve)))
-      const manager = new SharedBotManager(deps({ reportBotRevoked }))
+      const manager = new RelayIngressManager(deps({ reportBotRevoked }))
       const internals = manager as unknown as ManagerInternals
       const first = { botId: BOT_ID, reason: 'app_uninstalled' as const, credentialRevision: 1 }
       // A reinstall bumped the generation and a SECOND revoke observed it — this
@@ -610,7 +610,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
       target: { agentId: AGENT_ID, daemonId: DAEMON_ID }
     }))
     const reportThreadAssign = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, lookupThread, reportThreadAssign }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread, reportThreadAssign }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelOwned())
     // Remove the channel-owner rule so an un-mentioned follow-up misses local arbitration.
@@ -642,7 +642,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
       target: null
     }))
     const { daemon, sendMsg } = online()
-    const manager = new SharedBotManager(deps({ getDaemon: () => daemon, lookupThread }))
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(channelOwned())
     internals.router.updateRoutes(BOT_ID, {
@@ -666,7 +666,7 @@ describe('SharedBotManager thread affinity (report + pull-on-miss)', () => {
   })
 })
 
-describe('SharedBotManager conversation gating (resource-visibility §14.3)', () => {
+describe('RelayIngressManager conversation gating (resource-visibility §14.3)', () => {
   const fakeIngest = () => ({
     lookupUserName: vi.fn(async () => '@Alice'),
     postText: vi.fn(async () => {})
@@ -697,7 +697,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('reports an unrouted gated DM as a kind:im conversation and notices once per conversation', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
@@ -718,7 +718,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
   })
 
   it('a first gated DM on a NON-authority pod still posts (single event copy, receiving pod owns it)', async () => {
-    const manager = new SharedBotManager(deps({ selfRelayId: () => PEER_RELAY }))
+    const manager = new RelayIngressManager(deps({ selfRelayId: () => PEER_RELAY }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY, not this pod
     const ingest = fakeIngest()
@@ -729,7 +729,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
   })
 
   it('a DM whose notice was already DELIVERED (noticedDmConversations) is latched on EVERY pod', async () => {
-    const manager = new SharedBotManager(deps())
+    const manager = new RelayIngressManager(deps())
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     a.noticedDmConversations = ['D42'] // delivery reported + re-stamped by the CP
@@ -744,7 +744,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
   it('a DM discovered while a public default routed it STILL gets its notice once unroutable', async () => {
     const reportNoticePosted = vi.fn(() => true)
     const daemon = { sendMsg: vi.fn(async (m: { msgId: string }) => ({ msgId: m.msgId, accepted: true })) }
-    const manager = new SharedBotManager(
+    const manager = new RelayIngressManager(
       deps({ reportNoticePosted, getDaemon: () => daemon as unknown as RelayDaemonConnection })
     )
     const internals = manager as unknown as ManagerInternals
@@ -791,7 +791,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('reports a gated DM even when a non-gated default agent WINS the routing (mixed bot)', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     // OTHER is org-visible and catches every unslugged DM as the group default.
@@ -829,7 +829,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('resets the DM-report latch when the gated member set changes (new install needs its row)', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     internals.router.upsert(a)
@@ -863,7 +863,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
   it('retries the DM report on the next DM when the CP link was down', async () => {
     let ready = false
     const reportBotConversation = vi.fn(() => ready)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
     internals.ingests.set(BOT_ID, fakeIngest())
@@ -879,7 +879,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('an unrouted @mention in a channel gets the notice but NO conversation report', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     internals.router.upsert(gatedAssignment())
     const ingest = fakeIngest()
@@ -896,7 +896,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   /** Two manager instances = two relay pods; only the authority pod may post. */
   const pod = (authority: boolean) => {
-    const manager = new SharedBotManager(deps({ selfRelayId: () => (authority ? SELF_RELAY : PEER_RELAY) }))
+    const manager = new RelayIngressManager(deps({ selfRelayId: () => (authority ? SELF_RELAY : PEER_RELAY) }))
     const internals = manager as unknown as ManagerInternals
     const ingest = fakeIngest()
     internals.router.upsert(gatedAssignment()) // noticeAuthority = SELF_RELAY
@@ -952,7 +952,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('no authority stamped (old CP / empty roster): no pod posts; DM discovery still reports', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation, selfRelayId: () => SELF_RELAY }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation, selfRelayId: () => SELF_RELAY }))
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     delete a.noticeAuthority
@@ -969,7 +969,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 
   it('does nothing gated-related for a bot with no gated members', async () => {
     const reportBotConversation = vi.fn(() => true)
-    const manager = new SharedBotManager(deps({ reportBotConversation }))
+    const manager = new RelayIngressManager(deps({ reportBotConversation }))
     const internals = manager as unknown as ManagerInternals
     const a = gatedAssignment()
     a.gatedAgentIds = []
@@ -989,7 +989,7 @@ describe('SharedBotManager conversation gating (resource-visibility §14.3)', ()
 // one signing secret, so the HMAC can authenticate but cannot discriminate —
 // only the composite key may route, and the verify-scan must never hand one
 // workspace's events to a sibling install (a cross-tenant leak, not a miss).
-describe('SharedBotManager.resolveVerified composite demux', () => {
+describe('RelayIngressManager.resolveVerified composite demux', () => {
   const BOT_T1 = 'aaaaaaaa-1111-4111-8111-111111111111'
   const BOT_T2 = 'aaaaaaaa-2222-4222-8222-222222222222'
   const BOT_LEGACY = 'aaaaaaaa-3333-4333-8333-333333333333'
@@ -1001,7 +1001,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   const sig = (secret: string) => `v0=${createHmac('sha256', secret).update(`v0:${ts}:${body}`).digest('hex')}`
 
   interface DemuxInternals {
-    router: SharedBotRouter
+    router: BotArbitrationRouter
     ingests: Map<string, { signingSecret: string; stop(): Promise<void> }>
     demuxByApiApp: Map<string, string>
     demuxByAppTeam: Map<string, string>
@@ -1012,7 +1012,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
    *  start: router assignment + a secret-bearing ingest stand-in + (for a
    *  team-scoped bot) the assign-derived composite index entries. */
   const addBot = (
-    manager: SharedBotManager,
+    manager: RelayIngressManager,
     botId: string,
     signingSecret: string,
     opts: { apiAppId?: string; teamId?: string; indexed?: boolean } = {}
@@ -1033,7 +1033,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
     if (opts.apiAppId && !opts.teamId) internals.demuxByApiApp.set(opts.apiAppId, botId)
   }
 
-  const resolve = (manager: SharedBotManager, over: { apiAppId?: string; teamId?: string; secret?: string }) =>
+  const resolve = (manager: RelayIngressManager, over: { apiAppId?: string; teamId?: string; secret?: string }) =>
     manager.resolveVerified({
       ...(over.apiAppId ? { apiAppId: over.apiAppId } : {}),
       ...(over.teamId ? { teamId: over.teamId } : {}),
@@ -1043,7 +1043,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
     })
 
   it('demuxes sibling installs of one distributed app by (api_app_id, team_id)', () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
@@ -1053,7 +1053,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   })
 
   it('never serves a team-scoped bot to another workspace via the signature scan', () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     // Composite index deliberately EMPTY (indexed:false) — only the router knows
     // the team ids, so resolution falls through to the verify-scan, where the
     // same-secret sibling MUST be skipped on the team-id guard.
@@ -1067,7 +1067,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   })
 
   it('fails closed when a distributed-app envelope carries no team id', () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
     addBot(manager, BOT_T2, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T2' })
 
@@ -1076,7 +1076,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   })
 
   it('keeps the legacy app-only fast path and scan learning for team-less bots', () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_LEGACY, 'legacy-secret', {}) // no app id stamped — scan learns it
 
     const internals = manager as unknown as DemuxInternals
@@ -1093,7 +1093,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   // that gap, commit N+1, and broadcast its assign FIRST. Applying the stale
   // release would tear down the ingest of a credential it never described.
   it('unassign carrying an OLDER generation than the held assignment is ignored', async () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     const internals = manager as unknown as DemuxInternals
     internals.ingests.set(BOT_T1, { signingSecret: SHARED_SECRET, stop: async () => {} })
     internals.router.upsert({
@@ -1120,7 +1120,7 @@ describe('SharedBotManager.resolveVerified composite demux', () => {
   })
 
   it('unassign drops the composite index entries', async () => {
-    const manager = new SharedBotManager(deps({ clock: new FakeClock(NOW) }))
+    const manager = new RelayIngressManager(deps({ clock: new FakeClock(NOW) }))
     addBot(manager, BOT_T1, SHARED_SECRET, { apiAppId: PLATFORM_APP, teamId: 'T1' })
 
     await manager.unassign(BOT_T1)

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -1,12 +1,12 @@
 /**
- * `SharedBotManager` (shared-bot-relay.md §10 / §12) — glues the CP's shared-bot
+ * `RelayIngressManager` (shared-bot-relay.md §10 / §12) — glues the CP's HTTP-bot
  * control frames (`rc/bot-assign` / `rc/bot-unassign` / `rc/routes` / `rc/assign`)
- * to the ingest lifecycle, arbitration ({@link SharedBotRouter}), and forwarding
+ * to the ingest lifecycle, arbitration ({@link BotArbitrationRouter}), and forwarding
  * onto the target daemon (`rd/msg` `im`).
  *
  * Flow: `rc/bot-assign` loads the bot's inbound routing + credentials; inbound
- * arrives via the shared HTTP `/slack/events` + `/slack/interactions` routes, which
- * demux to a bot via {@link SharedBotManager.resolveVerified} (Slack HMAC is the
+ * arrives via the public HTTP `/slack/events` + `/slack/interactions` routes, which
+ * demux to a bot via {@link RelayIngressManager.resolveVerified} (Slack HMAC is the
  * authenticator), normalize, arbitrate, and forward to the resolved daemon as a
  * pre-addressed `rd/msg(im)`. A daemon that is offline / has no connection here is a
  * TYPED delivery miss → bounded-loss drop + count (never a silent success, §17).
@@ -29,12 +29,8 @@ import type {
 } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from './log.js'
-import { SharedBotRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './shared-bot-router.js'
-import {
-  SlackSharedIngest,
-  type SharedSlackSessionAction,
-  type SharedSlackSessionShortcut
-} from './slack-shared-ingest.js'
+import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
+import { SlackHttpIngest, type HttpSlackSessionAction, type HttpSlackSessionShortcut } from './slack-http-ingest.js'
 import { verifySlackSignature } from './hooks/signature.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 
@@ -81,7 +77,7 @@ function isOlderRevokeReport(incoming: RcBotRevoked, queued: RcBotRevoked): bool
   return incoming.eventAtMs < queued.eventAtMs
 }
 
-export interface SharedBotManagerDeps {
+export interface RelayIngressManagerDeps {
   /** A live `rd/*` connection to a daemon on THIS relay, or undefined if none. */
   getDaemon: (daemonId: string) => RelayDaemonConnection | undefined
   /** Persist a channel's default agent chosen in the config modal (→ CP `rc/set-channel-agent`). */
@@ -99,13 +95,13 @@ export interface SharedBotManagerDeps {
   /** Report a workspace uninstall / token revocation (→ `rc/bot-revoked`) so the CP
    *  marks the Bot + its installs revoked. Returns `false` when the CP link wasn't
    *  READY, so the manager can retry on reconnect ({@link
-   *  SharedBotManager.flushPendingReports}) — this report is NOT droppable: Slack
+   *  RelayIngressManager.flushPendingReports}) — this report is NOT droppable: Slack
    *  acked the HTTP event before this ran and never redelivers it, and a dead token
    *  gives the CP nothing to observe. */
   reportBotRevoked: (m: RcBotRevoked) => Promise<boolean>
   /** Report the thread's now-resolved owner to the CP (→ `rc/thread-assign`). Returns
    *  `false` if the CP link was not READY and the frame was dropped, so the manager can
-   *  retry it when the link recovers ({@link SharedBotManager.flushPendingReports}). */
+   *  retry it when the link recovers ({@link RelayIngressManager.flushPendingReports}). */
   reportThreadAssign: (m: RcThreadAssign) => boolean
   /** Pull a thread's persisted owner from the CP on an affinity miss (→ `rc/thread-lookup`). */
   lookupThread: (m: RcThreadLookup) => Promise<import('@agentconnect.md/protocol').RcThreadLookupOk>
@@ -123,7 +119,7 @@ export interface SharedBotManagerDeps {
 /** Stable daemon-side dedup id for one Slack interaction. The hash deliberately omits
  *  open-config's one-shot triggerId (interactionId already identifies that click), so
  *  sensitive trigger material never leaks into logs or dedup keys. */
-export function sharedSlackActionMsgId(botId: string, action: SharedSlackSessionAction): string {
+export function httpSlackActionMsgId(botId: string, action: HttpSlackSessionAction): string {
   const { target, interactionId, kind } = action
   let value: string | boolean | undefined
   switch (action.kind) {
@@ -167,7 +163,7 @@ export function sharedSlackActionMsgId(botId: string, action: SharedSlackSession
   return `slack-action:${digest}`
 }
 
-export function sharedSlackShortcutMsgId(botId: string, shortcut: SharedSlackSessionShortcut): string {
+export function httpSlackShortcutMsgId(botId: string, shortcut: HttpSlackSessionShortcut): string {
   const digest = createHash('sha256')
     .update(
       JSON.stringify({
@@ -182,9 +178,9 @@ export function sharedSlackShortcutMsgId(botId: string, shortcut: SharedSlackSes
   return `slack-action:${digest}`
 }
 
-export class SharedBotManager {
-  private readonly router = new SharedBotRouter()
-  private readonly ingests = new Map<string, SlackSharedIngest>()
+export class RelayIngressManager {
+  private readonly router = new BotArbitrationRouter()
+  private readonly ingests = new Map<string, SlackHttpIngest>()
   /** Learned/assigned `api_app_id → botId` index — O(1) HTTP demux (self-populates on
    *  first verified delivery when the CP didn't stamp `apiAppId`). Bounded flush.
    *  Team-scoped bots (a distributed app's installs) NEVER enter this map — they
@@ -225,7 +221,7 @@ export class SharedBotManager {
     for (const k of [...this.gatedDmReported]) if (k.startsWith(prefix)) this.gatedDmReported.delete(k)
   }
 
-  constructor(private readonly deps: SharedBotManagerDeps) {}
+  constructor(private readonly deps: RelayIngressManagerDeps) {}
 
   /** Emit a thread-assign report; on a non-READY CP link stash it for retry. */
   private report(m: RcThreadAssign): void {
@@ -262,7 +258,7 @@ export class SharedBotManager {
     const queued = this.pendingRevokedReports.get(m.botId)
     if (queued && isOlderRevokeReport(m, queued)) {
       this.deps.log.warn(
-        `shared-bot(${m.botId}): dropping out-of-order revoke report (an at-least-as-new one is queued)`
+        `relay-ingress(${m.botId}): dropping out-of-order revoke report (an at-least-as-new one is queued)`
       )
       return
     }
@@ -328,7 +324,7 @@ export class SharedBotManager {
     this.clearGatedDmLatches(a.botId)
     this.router.upsert(a)
     if (a.platform !== 'slack') {
-      this.deps.log.warn(`shared-bot(${a.botId}): platform '${a.platform}' ingest not yet supported (milestone C)`)
+      this.deps.log.warn(`relay-ingress(${a.botId}): platform '${a.platform}' ingest not yet supported (milestone C)`)
       return
     }
     // Rebuild the ingest (secrets may have rotated). Idempotent: stop any existing.
@@ -346,7 +342,7 @@ export class SharedBotManager {
     } else if (a.apiAppId) {
       this.rememberApiApp(a.apiAppId, a.botId)
     }
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       a.botId,
       { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret },
       {
@@ -361,7 +357,7 @@ export class SharedBotManager {
         onSessionAction: (action) => this.forwardSessionAction(a.botId, action),
         onSessionShortcut: (shortcut) => this.forwardSessionShortcut(a.botId, shortcut),
         onBotRevoked: (reason, eventAtMs) => {
-          this.deps.log.warn(`shared-bot(${a.botId}): workspace revoked the app (${reason})`)
+          this.deps.log.warn(`relay-ingress(${a.botId}): workspace revoked the app (${reason})`)
           // Echo the generation this assignment carries + when Slack says the
           // event happened: the CP refuses the report if a re-install has since
           // replaced the credential (lifecycle events are not ordered).
@@ -408,11 +404,11 @@ export class SharedBotManager {
     // NEWER assignment, the release describes a credential that has since been
     // replaced — the CP decided and broadcast in that order, and a re-install's
     // assign can overtake it. Dropping the stale release here is what keeps a
-    // live ingest alive; an unstamped release (transport flip, un-share, last
+    // live ingest alive; an unstamped release (transport flip, uninstall, last
     // install removed) is unconditional as before.
     const held = this.router.get(botId)?.credentialRevision
     if (credentialRevision !== undefined && held !== undefined && held > credentialRevision) {
-      this.deps.log.warn(`shared-bot(${botId}): ignoring stale unassign (rev ${credentialRevision} < held ${held})`)
+      this.deps.log.warn(`relay-ingress(${botId}): ignoring stale unassign (rev ${credentialRevision} < held ${held})`)
       return
     }
     this.clearGatedDmLatches(botId)
@@ -451,7 +447,7 @@ export class SharedBotManager {
     timestamp: string | undefined
     rawBody: Buffer
     signature: string | undefined
-  }): SlackSharedIngest | undefined {
+  }): SlackHttpIngest | undefined {
     const now = this.deps.clock.now()
     const { apiAppId, teamId, timestamp, rawBody, signature } = args
     // Composite fast path — assign-derived, so a hit is exact (still HMAC-verified).
@@ -495,7 +491,7 @@ export class SharedBotManager {
   private selectThreadAgent(botId: string, channelId: string, threadTs: string, agentId: string): void {
     const route = this.router.targetForAgentId(botId, agentId)
     if (!route) {
-      this.deps.log.warn(`shared-bot(${botId}): ignored stale thread-agent selection for agent ${agentId}`)
+      this.deps.log.warn(`relay-ingress(${botId}): ignored stale thread-agent selection for agent ${agentId}`)
       return
     }
     const sessionKey = sessionKeyOf({ channel: channelId, thread: threadTs })
@@ -540,7 +536,7 @@ export class SharedBotManager {
     // Filter before arbitration so a managed agent's platform copy cannot mutate
     // thread affinity or produce a CP assignment report.
     if (this.isAgentBotMessage(botId, msg)) {
-      this.deps.log.debug(`shared-bot(${botId}): ignored AgentConnect bot message ${msg.msgId}`)
+      this.deps.log.debug(`relay-ingress(${botId}): ignored AgentConnect bot message ${msg.msgId}`)
       return
     }
     const sessionKey = sessionKeyOf(msg)
@@ -601,7 +597,7 @@ export class SharedBotManager {
     if (!daemon) {
       const n = (this.dropped.get(botId) ?? 0) + 1
       this.dropped.set(botId, n)
-      this.deps.log.warn(`shared-bot(${botId}): daemon ${tgt.daemonId} offline — dropped (total ${n})`)
+      this.deps.log.warn(`relay-ingress(${botId}): daemon ${tgt.daemonId} offline — dropped (total ${n})`)
       return
     }
     const rd: RdMsgIm = {
@@ -620,7 +616,7 @@ export class SharedBotManager {
       const n = (this.dropped.get(botId) ?? 0) + 1
       this.dropped.set(botId, n)
       this.deps.log.warn(
-        `shared-bot(${botId}): forward to ${tgt.daemonId} failed: ${(err as Error).message} (dropped ${n})`
+        `relay-ingress(${botId}): forward to ${tgt.daemonId} failed: ${(err as Error).message} (dropped ${n})`
       )
     }
   }
@@ -687,23 +683,25 @@ export class SharedBotManager {
       // Pool-wide DM latch = DELIVERY, reported after the post succeeds.
       if (msg.isDm) this.deps.reportNoticePosted({ botId, channel: msg.channel })
     } catch (err) {
-      this.deps.log.warn(`shared-bot(${botId}): gating notice failed in ch=${msg.channel}: ${(err as Error).message}`)
+      this.deps.log.warn(
+        `relay-ingress(${botId}): gating notice failed in ch=${msg.channel}: ${(err as Error).message}`
+      )
     }
   }
 
-  /** Forward a shared Slack status-modal action to the exact agent that rendered
+  /** Forward an HTTP Slack status-modal action to the exact agent that rendered
    *  the button. This intentionally does not use channel ownership: the operator may
    *  click an older Bob session after switching the channel default to Alice. */
-  private forwardSessionAction(botId: string, action: SharedSlackSessionAction): void {
+  private forwardSessionAction(botId: string, action: HttpSlackSessionAction): void {
     const { target, interactionId: _interactionId, userId, ...payload } = action
     const route = this.router.targetForAgent(botId, target.agentId, target.integrationId)
     if (!route) {
-      this.deps.log.warn(`shared-bot(${botId}): ignored stale session action for agent ${target.agentId}`)
+      this.deps.log.warn(`relay-ingress(${botId}): ignored stale session action for agent ${target.agentId}`)
       return
     }
     const daemon = this.deps.getDaemon(route.daemonId)
     if (!daemon) {
-      this.deps.log.warn(`shared-bot(${botId}): daemon ${route.daemonId} offline — session action dropped`)
+      this.deps.log.warn(`relay-ingress(${botId}): daemon ${route.daemonId} offline — session action dropped`)
       return
     }
     const rd: RdMsgSlackAction = {
@@ -711,7 +709,7 @@ export class SharedBotManager {
       agentId: route.agentId,
       integrationId: route.integrationId,
       sessionKey: target.sessionKey,
-      msgId: sharedSlackActionMsgId(botId, action),
+      msgId: httpSlackActionMsgId(botId, action),
       botId,
       ...(userId ? { userId } : {}),
       payload
@@ -720,16 +718,16 @@ export class SharedBotManager {
       .sendMsg(rd)
       .then((ack) => {
         if (!ack.accepted)
-          this.deps.log.warn(`shared-bot(${botId}): daemon rejected session action (${ack.reason ?? 'unknown'})`)
+          this.deps.log.warn(`relay-ingress(${botId}): daemon rejected session action (${ack.reason ?? 'unknown'})`)
       })
       .catch((err) =>
-        this.deps.log.warn(`shared-bot(${botId}): session action forward failed: ${(err as Error).message}`)
+        this.deps.log.warn(`relay-ingress(${botId}): session action forward failed: ${(err as Error).message}`)
       )
   }
 
   /** Resolve a message shortcut from live conversation ownership, then let the
    *  daemon resolve the exact bot-scoped session before it opens the modal. */
-  private forwardSessionShortcut(botId: string, shortcut: SharedSlackSessionShortcut): boolean {
+  private forwardSessionShortcut(botId: string, shortcut: HttpSlackSessionShortcut): boolean {
     const sessionKey = sessionKeyOf({ channel: shortcut.channelId, thread: shortcut.threadTs })
     const assignment = this.router.get(botId)
     if (!assignment) return false
@@ -758,7 +756,7 @@ export class SharedBotManager {
       agentId: route.agentId,
       integrationId: route.integrationId,
       sessionKey,
-      msgId: sharedSlackShortcutMsgId(botId, shortcut),
+      msgId: httpSlackShortcutMsgId(botId, shortcut),
       botId,
       ...(shortcut.userId ? { userId: shortcut.userId } : {}),
       payload: {
@@ -772,10 +770,10 @@ export class SharedBotManager {
       .sendMsg(rd)
       .then((ack) => {
         if (!ack.accepted)
-          this.deps.log.warn(`shared-bot(${botId}): daemon rejected session shortcut (${ack.reason ?? 'unknown'})`)
+          this.deps.log.warn(`relay-ingress(${botId}): daemon rejected session shortcut (${ack.reason ?? 'unknown'})`)
       })
       .catch((err) =>
-        this.deps.log.warn(`shared-bot(${botId}): session shortcut forward failed: ${(err as Error).message}`)
+        this.deps.log.warn(`relay-ingress(${botId}): session shortcut forward failed: ${(err as Error).message}`)
       )
     return true
   }

--- a/packages/relay/src/slack-http-ingest.test.ts
+++ b/packages/relay/src/slack-http-ingest.test.ts
@@ -13,14 +13,14 @@ import {
 } from '@agentconnect.md/protocol'
 import {
   normalizeSlackMessage,
-  parseSharedSlackAgentSelection,
-  parseSharedSlackAgentSwitch,
-  parseSharedSlackSessionAction,
-  sharedSlackAgentOptions,
-  SlackSharedIngest,
-  type SlackSharedIngestDeps,
+  parseHttpSlackAgentSelection,
+  parseHttpSlackAgentSwitch,
+  parseHttpSlackSessionAction,
+  httpSlackAgentOptions,
+  SlackHttpIngest,
+  type SlackHttpIngestDeps,
   type SlackInteractiveBody
-} from './slack-shared-ingest.js'
+} from './slack-http-ingest.js'
 import { verifySlackSignature } from './hooks/signature.js'
 
 const AGENT_ID = '11111111-1111-4111-8111-111111111111'
@@ -39,9 +39,9 @@ function body(actionId: string, over: Partial<SlackInteractiveBody> = {}): Slack
   }
 }
 
-describe('parseSharedSlackSessionAction', () => {
+describe('parseHttpSlackSessionAction', () => {
   it('parses the status gear from action.value and keeps a stable interaction receipt', () => {
-    const parsed = parseSharedSlackSessionAction(
+    const parsed = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.manage, {
         actions: [
           {
@@ -61,7 +61,7 @@ describe('parseSharedSlackSessionAction', () => {
   })
 
   it('carries the tapping user through, and leaves it absent when the payload has none', () => {
-    const withUser = parseSharedSlackSessionAction(
+    const withUser = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.setModel, {
         user: { id: 'U-ALICE' },
         actions: [
@@ -76,7 +76,7 @@ describe('parseSharedSlackSessionAction', () => {
     expect(withUser).toMatchObject({ kind: 'set-model', model: 'opus', userId: 'U-ALICE' })
 
     // A payload without `user` yields no key at all — never an empty or invented id.
-    const withoutUser = parseSharedSlackSessionAction(
+    const withoutUser = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.setModel, {
         actions: [
           {
@@ -92,7 +92,7 @@ describe('parseSharedSlackSessionAction', () => {
   })
 
   it('parses Session options and Cancel from the compact overflow', () => {
-    const manage = parseSharedSlackSessionAction(
+    const manage = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.more, {
         actions: [
           {
@@ -106,7 +106,7 @@ describe('parseSharedSlackSessionAction', () => {
     )
     expect(manage).toMatchObject({ target: TARGET, kind: 'open-config', triggerId: 'trigger-1' })
 
-    const cancel = parseSharedSlackSessionAction(
+    const cancel = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.more, {
         actions: [
           {
@@ -120,7 +120,7 @@ describe('parseSharedSlackSessionAction', () => {
     )
     expect(cancel).toMatchObject({ target: TARGET, kind: 'cancel' })
 
-    const legacyCancel = parseSharedSlackSessionAction(
+    const legacyCancel = parseHttpSlackSessionAction(
       body(SLACK_STATUS_ACTION.more, {
         actions: [
           {
@@ -143,7 +143,7 @@ describe('parseSharedSlackSessionAction', () => {
     [SLACK_STATUS_ACTION.setFast, 'on', { kind: 'set-fast', fastMode: true }],
     [SLACK_STATUS_ACTION.setOutput, 'medium', { kind: 'set-output', outputMode: 'medium' }]
   ])('parses modal action %s from private_metadata', (actionId, selected, expected) => {
-    const parsed = parseSharedSlackSessionAction(
+    const parsed = parseHttpSlackSessionAction(
       body(actionId, {
         actions: [{ action_id: actionId, action_ts: '1720000000.000300', selected_option: { value: selected } }]
       })
@@ -157,7 +157,7 @@ describe('parseSharedSlackSessionAction', () => {
 
   it('parses cancel and falls back to trigger_id when action_ts is absent', () => {
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(SLACK_STATUS_ACTION.cancel, { actions: [{ action_id: SLACK_STATUS_ACTION.cancel }] })
       )
     ).toEqual({
@@ -167,9 +167,9 @@ describe('parseSharedSlackSessionAction', () => {
     })
   })
 
-  it('routes permission and elicitation message buttons from their shared block target', () => {
+  it('routes permission and elicitation message buttons from their relay block target', () => {
     const parseCard = (action_id: string, value: string) =>
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(action_id, {
           actions: [{ action_id, action_ts: '1720000000.000500', block_id: ENCODED_TARGET, value }],
           view: undefined
@@ -195,7 +195,7 @@ describe('parseSharedSlackSessionAction', () => {
       value: null
     })
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(`${PERMISSION_ACTION_PREFIX}:0`, {
           actions: [{ action_id: `${PERMISSION_ACTION_PREFIX}:0`, action_ts: '1', value: 'perm-1|allow_once' }]
         })
@@ -205,7 +205,7 @@ describe('parseSharedSlackSessionAction', () => {
 
   it('parses an inline Cancel target from action.value', () => {
     expect(
-      parseSharedSlackSessionAction({
+      parseHttpSlackSessionAction({
         type: 'block_actions',
         actions: [{ action_id: SLACK_STATUS_ACTION.cancel, action_ts: '1', value: ENCODED_TARGET }]
       })
@@ -214,7 +214,7 @@ describe('parseSharedSlackSessionAction', () => {
 
   it('never turns the relay-local person/default-agent control into a daemon action', () => {
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(SHARED_CONFIG_ACTION_ID, {
           actions: [{ action_id: SHARED_CONFIG_ACTION_ID, action_ts: '1720000000.000400', value: ENCODED_TARGET }]
         })
@@ -224,7 +224,7 @@ describe('parseSharedSlackSessionAction', () => {
 
   it('rejects malformed/tampered targets, unknown values, and receipts with no stable id', () => {
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(SLACK_STATUS_ACTION.manage, {
           actions: [{ action_id: SLACK_STATUS_ACTION.manage, action_ts: '1', value: '{bad-json' }]
         })
@@ -232,21 +232,21 @@ describe('parseSharedSlackSessionAction', () => {
     ).toBeNull()
     const extraField = JSON.stringify({ ...TARGET, daemonId: 'attacker-chosen-daemon' })
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(SLACK_STATUS_ACTION.manage, {
           actions: [{ action_id: SLACK_STATUS_ACTION.manage, action_ts: '1', value: extraField }]
         })
       )
     ).toBeNull()
     expect(
-      parseSharedSlackSessionAction(
+      parseHttpSlackSessionAction(
         body(SLACK_STATUS_ACTION.setFast, {
           actions: [{ action_id: SLACK_STATUS_ACTION.setFast, action_ts: '1', selected_option: { value: 'maybe' } }]
         })
       )
     ).toBeNull()
     expect(
-      parseSharedSlackSessionAction({
+      parseHttpSlackSessionAction({
         type: 'block_actions',
         actions: [{ action_id: SLACK_STATUS_ACTION.cancel }],
         view: { private_metadata: ENCODED_TARGET }
@@ -255,18 +255,18 @@ describe('parseSharedSlackSessionAction', () => {
   })
 })
 
-describe('shared Slack agent selector', () => {
+describe('HTTP Slack agent selector', () => {
   const agents = [
     { agentId: AGENT_ID, name: 'Deploy Agent' },
     { agentId: '33333333-3333-4333-8333-333333333333', name: 'Review Agent' }
   ]
 
-  it('serves matching options and accepts only a current shared-bot member', () => {
-    expect(sharedSlackAgentOptions(agents, 'deploy')).toEqual([
+  it('serves matching options and accepts only a current HTTP-bot member', () => {
+    expect(httpSlackAgentOptions(agents, 'deploy')).toEqual([
       { text: { type: 'plain_text', text: 'Deploy Agent' }, value: AGENT_ID }
     ])
     expect(
-      parseSharedSlackAgentSelection(
+      parseHttpSlackAgentSelection(
         {
           type: 'block_actions',
           channel: { id: 'C123' },
@@ -291,12 +291,12 @@ describe('shared Slack agent selector', () => {
         }
       ]
     })
-    expect(parseSharedSlackAgentSwitch(interaction)).toEqual({
+    expect(parseHttpSlackAgentSwitch(interaction)).toEqual({
       channelId: 'C123',
       threadTs: '1720000000.000100',
       currentAgentId: AGENT_ID
     })
-    expect(parseSharedSlackSessionAction(interaction)).toBeNull()
+    expect(parseHttpSlackSessionAction(interaction)).toBeNull()
 
     const legacyInteraction = {
       ...interaction,
@@ -310,7 +310,7 @@ describe('shared Slack agent selector', () => {
         }
       ]
     }
-    expect(parseSharedSlackAgentSwitch(legacyInteraction)).toEqual({
+    expect(parseHttpSlackAgentSwitch(legacyInteraction)).toEqual({
       channelId: 'C123',
       threadTs: '1720000000.000100',
       currentAgentId: AGENT_ID
@@ -318,9 +318,9 @@ describe('shared Slack agent selector', () => {
   })
 })
 
-describe('SlackSharedIngest.handleInteraction', () => {
+describe('SlackHttpIngest.handleInteraction', () => {
   const silentLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
-  const ingestDeps = (over: Partial<SlackSharedIngestDeps> = {}): SlackSharedIngestDeps => ({
+  const ingestDeps = (over: Partial<SlackHttpIngestDeps> = {}): SlackHttpIngestDeps => ({
     onMessage: vi.fn(async () => {}),
     onBotUserId: vi.fn(),
     onChannelsChanged: vi.fn(),
@@ -338,7 +338,7 @@ describe('SlackSharedIngest.handleInteraction', () => {
   })
 
   it('returns the external-select options on the 200 body for a block_suggestion', async () => {
-    const ingest = new SlackSharedIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, ingestDeps())
+    const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, ingestDeps())
     const result = await ingest.handleInteraction({
       type: 'block_suggestion',
       action_id: SHARED_AGENT_SELECT_ACTION_ID,
@@ -349,7 +349,7 @@ describe('SlackSharedIngest.handleInteraction', () => {
 
   it('fires the thread-agent selection and returns an empty 200 body', async () => {
     const onSelectThreadAgent = vi.fn()
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       ingestDeps({ onSelectThreadAgent })
@@ -366,7 +366,7 @@ describe('SlackSharedIngest.handleInteraction', () => {
 
   it('forwards a message shortcut with the selected conversation coordinates', async () => {
     const onSessionShortcut = vi.fn(() => true)
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       ingestDeps({ onSessionShortcut })
@@ -391,9 +391,9 @@ describe('SlackSharedIngest.handleInteraction', () => {
   })
 })
 
-describe('SlackSharedIngest channel membership events', () => {
+describe('SlackHttpIngest channel membership events', () => {
   const silentLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
-  const deps = (web: object, over: Partial<SlackSharedIngestDeps> = {}): SlackSharedIngestDeps => ({
+  const deps = (web: object, over: Partial<SlackHttpIngestDeps> = {}): SlackHttpIngestDeps => ({
     onMessage: vi.fn(async () => {}),
     onBotUserId: vi.fn(),
     onChannelsChanged: vi.fn(),
@@ -423,7 +423,7 @@ describe('SlackSharedIngest channel membership events', () => {
     )
     const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) }, users: { conversations } }
     const onChannelsChanged = vi.fn()
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       deps(web, { onChannelsChanged })
@@ -446,7 +446,7 @@ describe('SlackSharedIngest channel membership events', () => {
     const conversations = vi.fn(async () => ({ channels: [{ id: 'C1', name: 'remaining' }] }))
     const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) }, users: { conversations } }
     const onChannelsChanged = vi.fn()
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       deps(web, { onChannelsChanged })
@@ -465,7 +465,7 @@ describe('SlackSharedIngest channel membership events', () => {
     const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) } }
     const onBotRevoked = vi.fn()
     const onMessage = vi.fn(async () => {})
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       deps(web, { onBotRevoked, onMessage })
@@ -491,7 +491,7 @@ describe('SlackSharedIngest channel membership events', () => {
         auth: { test: vi.fn(async () => Promise.reject(Object.assign(new Error(code), { data: { error: code } }))) }
       }
       const onBotRevoked = vi.fn()
-      const ingest = new SlackSharedIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
+      const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
 
       await ingest.start()
 
@@ -510,7 +510,7 @@ describe('SlackSharedIngest channel membership events', () => {
         auth: { test: vi.fn(async () => Promise.reject(Object.assign(new Error(code), { data: { error: code } }))) }
       }
       const onBotRevoked = vi.fn()
-      const ingest = new SlackSharedIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
+      const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
 
       await ingest.start()
 
@@ -521,7 +521,7 @@ describe('SlackSharedIngest channel membership events', () => {
   it('does NOT report a revocation for a network error with no Slack error code', async () => {
     const web = { auth: { test: vi.fn(async () => Promise.reject(new Error('ECONNRESET'))) } }
     const onBotRevoked = vi.fn()
-    const ingest = new SlackSharedIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
+    const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
 
     await ingest.start()
 
@@ -531,7 +531,7 @@ describe('SlackSharedIngest channel membership events', () => {
   it('reports a revocation with no occurrence time when the envelope omitted event_time', async () => {
     const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) } }
     const onBotRevoked = vi.fn()
-    const ingest = new SlackSharedIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
+    const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onBotRevoked }))
     await ingest.start()
 
     await ingest.handleEvent({ type: 'app_uninstalled' })
@@ -571,12 +571,12 @@ describe('normalizeSlackMessage conversation kinds', () => {
   })
 })
 
-describe('SlackSharedIngest message events', () => {
+describe('SlackHttpIngest message events', () => {
   it('drops self and Slack system messages while forwarding peer app text', async () => {
     const onMessage = vi.fn(async () => {})
     const botIds = [undefined, 'BSELF']
     const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT', bot_id: botIds.shift() })) } }
-    const ingest = new SlackSharedIngest(
+    const ingest = new SlackHttpIngest(
       'bot',
       { botToken: 'xoxb', signingSecret: 's' },
       {

--- a/packages/relay/src/slack-http-ingest.ts
+++ b/packages/relay/src/slack-http-ingest.ts
@@ -1,10 +1,10 @@
 /**
- * `SlackSharedIngest` (shared-bot-relay.md §12) — per-shared-bot inbound handler,
+ * `SlackHttpIngest` (shared-bot-relay.md §12) — per-HTTP-bot inbound handler,
  * held by the relay. Inbound no longer rides a Socket Mode websocket: the relay
  * exposes ONE shared HTTP Events API surface (`/slack/events` + `/slack/interactions`,
  * see `slack-http-ingress.ts`) behind the pool's stable public URL, and after the
  * POST is demuxed to a bot + its signing secret verified, the route calls
- * {@link SlackSharedIngest.handleEvent} / {@link SlackSharedIngest.handleInteraction}.
+ * {@link SlackHttpIngest.handleEvent} / {@link SlackHttpIngest.handleInteraction}.
  * There is no MANUAL-ack seam anymore: Slack's HTTP 200 IS the ack. We answer 200
  * immediately (Slack's 3s window) and forward asynchronously — a forward miss is
  * still counted as bounded loss by the forwarder, honestly declared.
@@ -69,30 +69,30 @@ export interface SlackInteractiveBody {
   }
 }
 
-interface SharedSlackInteractionReceipt {
+interface HttpSlackInteractionReceipt {
   /** Stable across Slack redelivery of the same interaction. The manager hashes this
    *  with the target + operation before placing it on rd/msg, so trigger ids never
    *  appear in logs while daemon-side (sessionKey,msgId) dedup remains effective. */
   interactionId: string
 }
 
-export type SharedSlackSessionAction = SharedSlackInteractionReceipt & {
+export type HttpSlackSessionAction = HttpSlackInteractionReceipt & {
   target: SharedSlackStatusTarget
   /** Who tapped it (Slack `body.user`), forwarded so the daemon can attribute the
    *  session change. Absent when the payload names no user. */
   userId?: string
 } & Exclude<RdSlackAction, { kind: 'open-config-for-thread' }>
 
-export interface SharedSlackSessionShortcut extends SharedSlackInteractionReceipt {
+export interface HttpSlackSessionShortcut extends HttpSlackInteractionReceipt {
   channelId: string
   threadTs: string
   triggerId: string
   userId?: string
 }
 
-type SharedSlackAgent = { agentId: string; name: string }
+type HttpSlackAgent = { agentId: string; name: string }
 
-function sharedSlackAgentOption(agent: SharedSlackAgent) {
+function httpSlackAgentOption(agent: HttpSlackAgent) {
   const label = agent.name.trim() || agent.agentId
   return {
     text: { type: 'plain_text' as const, text: label.length > 75 ? `${label.slice(0, 74)}…` : label },
@@ -100,23 +100,23 @@ function sharedSlackAgentOption(agent: SharedSlackAgent) {
   }
 }
 
-/** Build one external-select response from the relay's current shared-bot member
+/** Build one external-select response from the relay's current HTTP-bot member
  *  directory. Slack caps a suggestion response at 100 options. Matching both name
  *  and id keeps a pasted agent id useful without changing the visible label. */
-export function sharedSlackAgentOptions(agents: SharedSlackAgent[], query = '') {
+export function httpSlackAgentOptions(agents: HttpSlackAgent[], query = '') {
   const needle = query.trim().toLocaleLowerCase()
   return agents
     .filter((agent) => !needle || agent.name.toLocaleLowerCase().includes(needle) || agent.agentId.includes(needle))
     .slice(0, 100)
-    .map(sharedSlackAgentOption)
+    .map(httpSlackAgentOption)
 }
 
-/** Decode and locally validate the shared status bar's agent selection. The CP
+/** Decode and locally validate the relay-managed status bar's agent selection. The CP
  *  validates membership again when it persists the channel owner; this edge check
  *  avoids forwarding stale/tampered option values in the common case. */
-export function parseSharedSlackAgentSelection(
+export function parseHttpSlackAgentSelection(
   body: SlackInteractiveBody,
-  agents: SharedSlackAgent[]
+  agents: HttpSlackAgent[]
 ): { channelId: string; threadTs?: string; agentId: string } | null {
   if (body.type !== 'block_actions') return null
   const action = body.actions?.find((candidate) => candidate.action_id === SHARED_AGENT_SELECT_ACTION_ID)
@@ -127,9 +127,9 @@ export function parseSharedSlackAgentSelection(
   return { channelId, ...(threadTs ? { threadTs } : {}), agentId }
 }
 
-/** Decode the shared status overflow's Switch agent choice. Slack has no nested
+/** Decode the relay-managed status overflow's Switch agent choice. Slack has no nested
  *  overflow menus, so this choice opens the relay-owned picker modal instead. */
-export function parseSharedSlackAgentSwitch(
+export function parseHttpSlackAgentSwitch(
   body: SlackInteractiveBody
 ): { channelId: string; threadTs?: string; currentAgentId: string } | null {
   if (body.type !== 'block_actions') return null
@@ -144,13 +144,13 @@ export function parseSharedSlackAgentSwitch(
   return { channelId, ...(threadTs ? { threadTs } : {}), currentAgentId: target.agentId }
 }
 
-type SharedSlackAgentModalContext = { channelId: string; threadTs?: string }
+type HttpSlackAgentModalContext = { channelId: string; threadTs?: string }
 
-function encodeAgentModalContext(context: SharedSlackAgentModalContext): string {
+function encodeAgentModalContext(context: HttpSlackAgentModalContext): string {
   return context.threadTs ? JSON.stringify({ v: 1, ...context }) : context.channelId
 }
 
-function decodeAgentModalContext(value: string): SharedSlackAgentModalContext | null {
+function decodeAgentModalContext(value: string): HttpSlackAgentModalContext | null {
   if (!value) return null
   try {
     const parsed = JSON.parse(value) as { v?: unknown; channelId?: unknown; threadTs?: unknown }
@@ -163,17 +163,17 @@ function decodeAgentModalContext(value: string): SharedSlackAgentModalContext | 
   }
 }
 
-/** Decode one daemon-owned session control from the shared app's Slack interaction.
- *  The target is opaque user-interface state at this edge; SharedBotManager validates
+/** Decode one daemon-owned session control from an HTTP app's Slack interaction.
+ *  The target is opaque user-interface state at this edge; RelayIngressManager validates
  *  its agent against the current bot assignment before choosing a daemon/integration. */
-export function parseSharedSlackSessionAction(body: SlackInteractiveBody): SharedSlackSessionAction | null {
-  const parsed = decodeSharedSlackSessionAction(body)
+export function parseHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSessionAction | null {
+  const parsed = decodeHttpSlackSessionAction(body)
   if (!parsed) return null
   // Attach the actor at the single exit so every decoded verb carries it.
   return body.user?.id ? { ...parsed, userId: body.user.id } : parsed
 }
 
-function decodeSharedSlackSessionAction(body: SlackInteractiveBody): SharedSlackSessionAction | null {
+function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSessionAction | null {
   if (body.type !== 'block_actions') return null
   const action = body.actions?.[0]
   if (!action?.action_id) return null
@@ -305,7 +305,7 @@ interface SlackFile {
   url_private_download?: string
 }
 
-/** The Slack Events API fields used by shared HTTP ingest. Message events use the
+/** The Slack Events API fields used by relay-managed HTTP ingest. Message events use the
  *  chat fields; membership events use type/user/channel to trigger a full refresh. */
 export interface SlackMessageEvent {
   type: string
@@ -392,7 +392,7 @@ function isRoutableEvent(event: SlackMessageEvent): boolean {
   )
 }
 
-export interface SlackSharedIngestDeps {
+export interface SlackHttpIngestDeps {
   /** Hand a normalized message to the router/forwarder; resolves once the delivery
    *  outcome is known (delivered or dropped). NEVER throws — runs after the HTTP 200. */
   onMessage: (msg: WireNormalizedMessage) => Promise<void>
@@ -411,10 +411,10 @@ export interface SlackSharedIngestDeps {
    *  channel default. The thread timestamp comes from the source status message. */
   onSelectThreadAgent: (channelId: string, threadTs: string, agentId: string) => void
   /** Forward the current agent/session controls to its owning daemon. */
-  onSessionAction: (action: SharedSlackSessionAction) => void
+  onSessionAction: (action: HttpSlackSessionAction) => void
   /** Resolve and forward the app-level message shortcut. False opens a local
    *  unavailable modal while the one-shot trigger id is still valid. */
-  onSessionShortcut: (shortcut: SharedSlackSessionShortcut) => boolean
+  onSessionShortcut: (shortcut: HttpSlackSessionShortcut) => boolean
   /** The workspace uninstalled the app / revoked its tokens — the bot's credential
    *  is dead; report upstream so the CP marks it revoked. */
   /** `eventAtMs` = Slack's envelope `event_time` (when the uninstall HAPPENED),
@@ -426,7 +426,7 @@ export interface SlackSharedIngestDeps {
   log: Logger
 }
 
-export class SlackSharedIngest {
+export class SlackHttpIngest {
   private web?: WebClient // bot-token Web API client (auth.test + views.open for the modal)
   private botUserId = ''
   private slackBotId = ''
@@ -438,7 +438,7 @@ export class SlackSharedIngest {
   constructor(
     readonly botId: string,
     private readonly secrets: { botToken: string; signingSecret: string },
-    private readonly deps: SlackSharedIngestDeps
+    private readonly deps: SlackHttpIngestDeps
   ) {}
 
   /** The Slack signing secret — the HTTP ingress HMACs inbound POSTs with it to
@@ -477,7 +477,7 @@ export class SlackSharedIngest {
   }
 
   /** Best-effort setup: resolve the bot user id for arbitration. No socket to open —
-   *  inbound arrives on the shared HTTP routes and is dispatched via `handle*`. */
+   *  inbound arrives on the pool-wide HTTP routes and is dispatched via `handle*`. */
   async start(): Promise<void> {
     const dispatcher = proxyDispatcher()
     const options: WebClientOptions = dispatcher ? { fetch: fetchWithDispatcher(dispatcher) } : {}
@@ -494,7 +494,7 @@ export class SlackSharedIngest {
         this.deps.onBotUserId(auth.user_id)
       }
     } catch (err) {
-      this.deps.log.warn(`shared-ingest(${this.botId}): auth.test failed: ${(err as Error).message}`)
+      this.deps.log.warn(`slack-http-ingest(${this.botId}): auth.test failed: ${(err as Error).message}`)
       // A DEAD-credential answer is positive evidence, not a transient miss: it
       // says the token this very assignment carries no longer works. Report it as
       // a revocation so the CP converges even when the `app_uninstalled` event
@@ -508,7 +508,7 @@ export class SlackSharedIngest {
       // revision arm alone is the correct fence here anyway — it identifies the
       // exact credential this probe just found dead.
       if (isDeadCredentialError(err)) {
-        this.deps.log.warn(`shared-ingest(${this.botId}): credential is dead — reporting revocation`)
+        this.deps.log.warn(`slack-http-ingest(${this.botId}): credential is dead — reporting revocation`)
         this.deps.onBotRevoked?.('tokens_revoked')
       }
     }
@@ -538,7 +538,7 @@ export class SlackSharedIngest {
       const msg = normalizeSlackMessage(event)
       if (msg) await this.deps.onMessage(msg)
     } catch (err) {
-      this.deps.log.warn(`shared-ingest(${this.botId}): event handler error: ${(err as Error).message}`)
+      this.deps.log.warn(`slack-http-ingest(${this.botId}): event handler error: ${(err as Error).message}`)
     }
   }
 
@@ -608,7 +608,7 @@ export class SlackSharedIngest {
     try {
       if (body.type === 'block_suggestion' && body.action_id === SHARED_AGENT_SELECT_ACTION_ID) {
         // The one branch whose result rides the 200 body (replaces `ack({ options })`).
-        return { options: sharedSlackAgentOptions(this.deps.agents(), body.value) }
+        return { options: httpSlackAgentOptions(this.deps.agents(), body.value) }
       }
       if (body.type === 'message_action' && body.callback_id === SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID) {
         const triggerId = body.trigger_id
@@ -632,12 +632,12 @@ export class SlackSharedIngest {
         body.type === 'block_actions' &&
         body.actions?.some((action) => action.action_id === SHARED_AGENT_SELECT_ACTION_ID)
       ) {
-        const selected = parseSharedSlackAgentSelection(body, this.deps.agents())
+        const selected = parseHttpSlackAgentSelection(body, this.deps.agents())
         if (selected?.threadTs) this.deps.onSelectThreadAgent(selected.channelId, selected.threadTs, selected.agentId)
         else if (selected) this.deps.onSetChannelAgent(selected.channelId, selected.agentId)
         return ''
       }
-      const agentSwitch = parseSharedSlackAgentSwitch(body)
+      const agentSwitch = parseHttpSlackAgentSwitch(body)
       if (agentSwitch && body.trigger_id) {
         // trigger_id is valid ~3s — fire promptly, don't block the 200.
         void this.openConfigModal(
@@ -665,14 +665,14 @@ export class SlackSharedIngest {
         else if (context && picked) this.deps.onSetChannelAgent(context.channelId, picked)
         return '' // empty 200 closes the modal (same as the old empty ack)
       }
-      const sessionAction = parseSharedSlackSessionAction(body)
+      const sessionAction = parseHttpSlackSessionAction(body)
       if (sessionAction) {
         this.deps.onSessionAction(sessionAction)
         return ''
       }
       return ''
     } catch (err) {
-      this.deps.log.warn(`shared-ingest(${this.botId}): interactive error: ${(err as Error).message}`)
+      this.deps.log.warn(`slack-http-ingest(${this.botId}): interactive error: ${(err as Error).message}`)
       return ''
     }
   }
@@ -697,7 +697,7 @@ export class SlackSharedIngest {
         }
       } as never)
     } catch (err) {
-      this.deps.log.warn(`shared-ingest(${this.botId}): views.open failed: ${(err as Error).message}`)
+      this.deps.log.warn(`slack-http-ingest(${this.botId}): views.open failed: ${(err as Error).message}`)
     }
   }
 
@@ -746,7 +746,7 @@ export class SlackSharedIngest {
   }
 
   async stop(): Promise<void> {
-    // No socket to close — inbound is the shared HTTP surface. Drop the WebClient so a
+    // No socket to close — inbound is the pool-wide HTTP surface. Drop the WebClient so a
     // re-assign rebuilds it with (possibly rotated) credentials.
     this.web = undefined
   }

--- a/packages/relay/src/slack-http-ingress.ts
+++ b/packages/relay/src/slack-http-ingress.ts
@@ -1,6 +1,6 @@
 /**
- * Shared Slack HTTP ingress — `POST /slack/events` + `POST /slack/interactions`,
- * the relay pool's ONE inbound Events API surface for every shared Slack bot (the
+ * Slack HTTP ingress — `POST /slack/events` + `POST /slack/interactions`,
+ * the relay pool's ONE inbound Events API surface for every HTTP Slack bot (the
  * successor to the per-bot Socket Mode consumer). One stable public URL behind the
  * LB; any pod may receive any bot's delivery, so this endpoint is stateless demux:
  *
@@ -24,18 +24,18 @@
 import type { FastifyInstance } from 'fastify'
 import type { Logger } from './log.js'
 import type { SlackEventDedup } from './slack-event-dedup.js'
-import type { SlackInteractiveBody, SlackMessageEvent } from './slack-shared-ingest.js'
+import type { SlackInteractiveBody, SlackMessageEvent } from './slack-http-ingest.js'
 
 /** Raw-body cap for the Slack endpoints (Slack payloads are well under 1 MiB). */
 export const SLACK_BODY_LIMIT = 1024 * 1024
 
-/** The minimum an ingest must expose to the route (satisfied by `SlackSharedIngest`). */
+/** The minimum an ingest must expose to the route (satisfied by `SlackHttpIngest`). */
 export interface SlackIngestHandlers {
   handleEvent(event: SlackMessageEvent | undefined, eventAtMs?: number): Promise<void>
   handleInteraction(body: SlackInteractiveBody): Promise<unknown>
 }
 
-/** Demux + authenticate an inbound POST to a bot's ingest (satisfied by `SharedBotManager`). */
+/** Demux + authenticate an inbound POST to a bot's ingest (satisfied by `RelayIngressManager`). */
 export interface SlackIngestResolver {
   resolveVerified(args: {
     apiAppId?: string

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -227,7 +227,7 @@ export function placePopover(
  * names the owner. The CP already resolves this bot-wide (GET /integrations
  * stamps the effective owner onto every install, from ALL installs including
  * ones the viewer can't see, and PATCH …/channels/:id routes ownership through
- * `sharedBot.updateChannel`), so this is the client-side safety net for a row
+ * `httpBot.updateChannel`), so this is the client-side safety net for a row
  * whose owner the CP couldn't resolve — never the only thing keeping the two
  * pages agreeing. Mirrors `botChannels` in SettingsView.
  */
@@ -409,7 +409,7 @@ export function IntegrationChannelList({
   // The agents that share this bot. A channel's default is its explicit owner —
   // this row's when the CP stamped it, else whichever sibling install of the bot
   // persists it — falling back to the earliest install, the same ordering
-  // sharedBot.ts's compiler uses for a channel nobody has ever claimed.
+  // httpBot.ts's compiler uses for a channel nobody has ever claimed.
   const members = memberIds.map(member)
   const owners = shareable && botId ? channelOwners(botId, integrations) : undefined
   const viewer = agentId && memberIds.includes(agentId) ? member(agentId) : undefined
@@ -448,7 +448,7 @@ export function IntegrationChannelList({
                   ownership of a shared (http) channel is bot-scoped server-side —
                   the route resolves the effective owner across every install,
                   fences on it (`expectedOwnerAgentId`) and hands the write to
-                  `sharedBot.updateChannel`, so exactly one row stays canonical no
+                  `httpBot.updateChannel`, so exactly one row stays canonical no
                   matter which install the console patched. */}
               <DefaultAgentPicker
                 current={def}


### PR DESCRIPTION
## Summary

- rename relay infrastructure to `RelayIngressManager`, `BotArbitrationRouter`, and `SlackHttpIngest`, including files, helpers, logs, and tests
- rename the control-plane convergence seam to `HttpBotOrchestrator` and `sharedIntegrationToSpec` to `httpIntegrationToSpec`
- align daemon-local HTTP Slack helper names while preserving the existing `mode: 'shared'` wire value
- clarify docs and API descriptions so relay ingress (`transport: 'http'`) is distinct from multi-agent capacity (`shareable`)

## Root cause

The code used “shared bot” for both the relay pool’s shared ingress plane and the separate `Bot.shareable` product flag. Since every HTTP bot uses relay ingress—including non-shareable platform-app installs—the shared-bot infrastructure names suggested behavior that was not actually required.

## Impact

This is a terminology-only refactor. Protocol frames, persisted schema, migration history, and the `mode: 'shared'` compatibility value are unchanged.

## Validation

- `pnpm --filter @agentconnect.md/relay typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/relay test:unit` (339 tests)
- `pnpm --filter @agentconnect.md/control-plane test:unit` (698 tests)
- focused daemon HTTP Slack reconciliation and non-shareable status-control tests with Chokidar polling
- `pnpm format:check`
- `pnpm lint` (passes with two pre-existing warnings in `icon-upload.ts`)

Closes #188

Created by Codex . GPT-5
