### PR TITLE
fix: show original activity in Dream session history

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -440,12 +440,15 @@ Observability:
 `memory.dream.started|completed|failed|adopted|skill_accepted|skill_dismissed`
 evaluation events carry correlation, lifecycle, runtime/model, token/cost, and
 bounded byte-count metadata. Every extraction is also represented as a `dream`
-session in the normal Sessions list and usage reports. Its history contains only
-safe lifecycle messages; the memory snapshot, source transcripts, model proposal,
-and skill bodies never enter session history, evaluation events, or logs. The
-Memory Dream list links the execution session and shows that run's model,
-duration, token/cost, and prompt/output byte metrics. Source-session selection is
-input metadata, not the Dream session's history or usage.
+session in the normal Sessions list and usage reports. Its history contains the
+original ACP activity, using the same transcript recorder as an ordinary session:
+the exact extraction prompt, raw reasoning, merged tool call/update bodies, and the
+model's final proposal. Because those bodies can quote the memory snapshot and
+source transcripts, agent session authorization is the privacy boundary. Raw Dream
+activity never enters generic evaluation events, logs, or the triggering chat. The
+Memory Dream list links the execution session and shows that run's model, duration,
+token/cost, and prompt/output byte metrics. Source-session selection is input
+metadata, not the Dream session's usage.
 
 ## 11. Explicitly out of scope (v1)
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -261,10 +261,15 @@ side respectively, so their entire contents are visibly marked as additions or
 removals before adoption.
 
 Each dream model run appears in Sessions with its runtime, model, token/cost usage,
-and a lifecycle-only history. Dream history and evaluation events must never copy
-memory bodies, source transcript text, model proposals, or mined skill bodies. The
-Memory page links the execution session; source-session selection remains input
-metadata and must not displace that run's own usage in the history presentation.
+and its original ACP activity history. Dream history uses the same transcript
+representation as an ordinary session: the exact extraction prompt, raw reasoning,
+merged tool call/update bodies, and the model's final proposal are visible to anyone
+authorized to view that agent's sessions. Those bodies can quote memory and
+source-session content, so the agent's session access boundary is also the privacy
+boundary; the daemon must not publish the Dream activity to the triggering chat,
+generic evaluation events, or logs. The Memory page links the execution session;
+source-session selection remains input metadata and must not displace that run's own
+usage in the history presentation.
 
 ## GitHub informational review checks
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -878,6 +878,15 @@ interface HookCompletionOwner {
   hookTerminalReceipt?: boolean
 }
 
+interface MemoryExtractionCollector {
+  chunks: string[]
+  sessionKey?: string
+  runtimeCostReported?: boolean
+  /** Dream sessions expose the same original reasoning/tool activity as ordinary
+   *  sessions. Background distillation has no transcript and leaves this unset. */
+  transcript?: { channel: string; thread: string; recorder: TranscriptRecorder }
+}
+
 function isSlackStatusBarText(text: string): boolean {
   return text.startsWith(':bar_chart:') || text.startsWith('\uD83D\uDCCA')
 }
@@ -1193,15 +1202,12 @@ export class Daemon {
   )
   /** Provider-neutral serialized post-turn work. Managed distills; external enqueues capture. */
   private memoryPostTurnChains = new Map<string, Promise<void>>()
-  private memoryExtractionCollectors = new Map<
-    string,
-    { chunks: string[]; sessionKey?: string; runtimeCostReported?: boolean }
-  >()
-  /** Sessions whose cancel backstop fired while the runtime prompt is still
-   *  executing. Keep dropping every late update until that exact prompt settles:
-   *  otherwise a delayed Dream proposal can escape into generic evaluation or
-   *  transcript surfaces after its collector has been released. */
-  private memoryExtractionQuarantines = new Set<string>()
+  private memoryExtractionCollectors = new Map<string, MemoryExtractionCollector>()
+  /** Finished/discarded extraction sessions. ACP adapters may emit callbacks even
+   *  after prompt() resolves, so retain this lightweight terminal fence until the
+   *  owning host stops; otherwise late private content can escape into generic
+   *  evaluation or transcript surfaces after its collector has been released. */
+  private memoryExtractionQuarantines = new Map<string, string>()
   /** One isolated extractor session per agent/host lifetime (never shown to users). */
   private memoryExtractionSessions = new Map<string, string>()
   private memoryExtractionDirs = new Map<string, string>()
@@ -3578,6 +3584,7 @@ export class Daemon {
     }
     const key = pendingTurnKey(agentId, sessionId)
     const chunks: string[] = []
+    this.memoryExtractionQuarantines.delete(key)
     this.memoryExtractionCollectors.set(key, { chunks })
     try {
       // Extraction runs read-only and shouldn't touch the config files, but keep
@@ -3589,6 +3596,7 @@ export class Daemon {
       if (this.memoryExtractionSessions.get(agentId) === sessionId) this.memoryExtractionSessions.delete(agentId)
       throw err
     } finally {
+      this.memoryExtractionQuarantines.set(key, agentId)
       this.memoryExtractionCollectors.delete(key)
     }
   }
@@ -3705,6 +3713,7 @@ export class Daemon {
     else signal.addEventListener('abort', onAbort, { once: true })
     let promptCompleted = false
     let extractionMode: string | undefined
+    let collector: MemoryExtractionCollector | undefined
     try {
       if (signal.aborted) throw new Error('dream extraction canceled before dispatch')
       // HARD GATE: require a verified non-mutating mode. Fail closed if the
@@ -3721,22 +3730,37 @@ export class Daemon {
 
       const key = pendingTurnKey(agentId, sessionId)
       const chunks: string[] = []
-      const collector = { chunks, sessionKey: executionKey, runtimeCostReported: false }
+      collector = {
+        chunks,
+        sessionKey: executionKey,
+        runtimeCostReported: false,
+        transcript: { channel: 'memory', thread: context.dreamId, recorder: new TranscriptRecorder() }
+      }
+      this.memoryExtractionQuarantines.delete(key)
       this.memoryExtractionCollectors.set(key, collector)
       try {
         this.rematerializeConfigFiles(agentId)
         const text = trusted ? prompt : `${systemPrompt}\n\n${prompt}`
+        this.store.appendTranscript({
+          channel: 'memory',
+          thread: context.dreamId,
+          ts: monotonicTs(),
+          sender: 'memory',
+          recipient: agentId,
+          kind: 'text',
+          text
+        })
         // Bounded backstop: if the runtime ignores `session/cancel` and never
         // yields, stop awaiting after DREAM_CANCEL_FORCE_MS from the abort so the
         // `finally` discards the ACP session instead of leaking it. The runner's
         // own grace window already releases the reservation independently.
         const result = await this.promptWithCancelBackstop(host, sessionId, text, signal, (prompt) => {
           // Release the potentially large proposal chunks once the backstop wins,
-          // but retain a key-only tombstone until the ignored prompt truly ends.
+          // but retain a key-only tombstone until the owning host stops. Some ACP
+          // adapters can still emit callbacks after the prompt promise settles.
           if (this.memoryExtractionCollectors.get(key) === collector) this.memoryExtractionCollectors.delete(key)
-          this.memoryExtractionQuarantines.add(key)
-          const release = () => this.memoryExtractionQuarantines.delete(key)
-          void prompt.then(release, release)
+          this.memoryExtractionQuarantines.set(key, agentId)
+          void prompt.catch(() => {})
         })
         promptCompleted = true
         if (result.usage) {
@@ -3764,10 +3788,26 @@ export class Daemon {
           ...(Object.keys(usage).length ? { usage } : {})
         }
       } finally {
-        if (!this.memoryExtractionQuarantines.has(key)) this.memoryExtractionCollectors.delete(key)
+        this.memoryExtractionQuarantines.set(key, agentId)
+        if (this.memoryExtractionCollectors.get(key) === collector) this.memoryExtractionCollectors.delete(key)
       }
     } finally {
       signal.removeEventListener('abort', onAbort)
+      if (collector?.transcript) {
+        const { channel, thread, recorder } = collector.transcript
+        for (const ev of recorder.onFinal()) this.recordEvent(agentId, channel, thread, ev)
+        const output = collector.chunks.join('')
+        if (output) {
+          this.store.appendTranscript({
+            channel,
+            thread,
+            ts: monotonicTs(),
+            sender: agentId,
+            kind: 'text',
+            text: output
+          })
+        }
+      }
       // Report even on failed/canceled prompts: a runtime may have streamed a
       // native cost/context snapshot before the terminal error. The CP upsert is
       // latest-wins, so the success path and this failure-safe path share one
@@ -3829,9 +3869,9 @@ export class Daemon {
   }
 
   /** Bridge the dream engine's metadata-only lifecycle into evaluation telemetry
-   *  and the safe transcript of its background execution session. Memory bodies,
-   *  source transcript text, prompts, model output, and error prose never enter
-   *  either surface. */
+   *  and the transcript of its background execution session. Raw ACP activity is
+   *  recorded separately by the extraction collector; it never enters evaluation
+   *  events, platform delivery, or logs. */
   private recordDreamLifecycle(event: DreamLifecycleEvent): void {
     const { dream } = event
     this.emitEvaluation({
@@ -11429,10 +11469,16 @@ export class Daemon {
       if (update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text') {
         extraction.chunks.push(String(update.content.text ?? ''))
       }
-      // Distillation uses an unlisted cached extractor and therefore has no
-      // sessionKey. A dream does: retain the native context/cost snapshot while
-      // still suppressing every body-bearing ACP update from ordinary transcript
-      // and evaluation surfaces.
+      if (extraction.transcript) {
+        const { channel, thread, recorder } = extraction.transcript
+        for (const ev of recorder.onUpdate(update)) {
+          this.recordEvent(agentId, channel, thread, ev)
+        }
+      }
+      // Distillation uses an unlisted cached extractor and therefore has neither
+      // sessionKey nor transcript. A Dream has both: retain native usage and the
+      // ordinary raw activity timeline while keeping extraction output out of
+      // platform delivery and evaluation telemetry.
       if (update?.sessionUpdate === 'usage_update' && extraction.sessionKey) {
         if (update.cost?.amount !== undefined) extraction.runtimeCostReported = true
         this.store.setUsageSnapshot(extraction.sessionKey, {
@@ -11445,9 +11491,9 @@ export class Daemon {
       return
     }
     // A runtime can ignore session/cancel and keep streaming after the bounded
-    // Dream await has detached. The collector is gone by then, but the content is
-    // still private extraction output and must never fall through to generic ACP
-    // evaluation, transcript, or delivery handling.
+    // Dream await has detached. The collector is gone by then, so late output no
+    // longer has a trustworthy transcript owner and must not fall through to
+    // generic ACP evaluation, transcript, or delivery handling.
     if (this.memoryExtractionQuarantines.has(extractionKey)) return
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))
     this.emitEvaluation({
@@ -12163,6 +12209,11 @@ export class Daemon {
         if (binding.agentId === agentId) this.sessionDeliveryBindings.delete(key)
       }
     }
+    const clearMemoryExtractionQuarantines = () => {
+      for (const [key, ownerAgentId] of this.memoryExtractionQuarantines) {
+        if (ownerAgentId === agentId) this.memoryExtractionQuarantines.delete(key)
+      }
+    }
     // Once the child (and its process group) is gone, nothing can read the
     // materialized config-file secrets (KUBECONFIG & co.) — remove them so the
     // secret material stops resting on disk between sessions. Safe against the
@@ -12175,6 +12226,7 @@ export class Daemon {
     }
     if (!host) {
       clearDeliveryBindings()
+      clearMemoryExtractionQuarantines()
       removeConfigFiles()
       return
     }
@@ -12190,6 +12242,7 @@ export class Daemon {
       // Keep exact routes alive until the adapter's notification stream has closed;
       // some runtimes flush a final title while session/stop is unwinding.
       clearDeliveryBindings()
+      clearMemoryExtractionQuarantines()
       removeConfigFiles()
     }
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11490,11 +11490,26 @@ export class Daemon {
       }
       return
     }
-    // A runtime can ignore session/cancel and keep streaming after the bounded
-    // Dream await has detached. The collector is gone by then, so late output no
-    // longer has a trustworthy transcript owner and must not fall through to
-    // generic ACP evaluation, transcript, or delivery handling.
-    if (this.memoryExtractionQuarantines.has(extractionKey)) return
+    // A runtime can keep streaming after a Dream collector is released. Body-bearing
+    // updates no longer have a trustworthy transcript owner and stay quarantined,
+    // but a late usage snapshot is safe metadata and must still correct the
+    // session's latest-wins accounting.
+    const extractionQuarantineOwner = this.memoryExtractionQuarantines.get(extractionKey)
+    if (extractionQuarantineOwner) {
+      if (extractionQuarantineOwner === agentId && update?.sessionUpdate === 'usage_update') {
+        const rec = this.store.getSessionByAcpIdForAgent(agentId, sessionId)
+        if (rec?.platform === 'dream') {
+          this.store.setUsageSnapshot(rec.key, {
+            contextUsed: update.used,
+            contextSize: update.size,
+            costAmount: update.cost?.amount ?? undefined,
+            costCurrency: update.cost?.currency ?? undefined
+          })
+          this.emitStoredUsageReport(sessionId, agentId, rec.platform, rec.channel, rec.key, true)
+        }
+      }
+      return
+    }
     const p = this.pending.get(pendingTurnKey(agentId, sessionId))
     this.emitEvaluation({
       type: 'acp.update',

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -139,7 +139,7 @@ describe('Daemon evaluation surface', () => {
     collector.assertValid()
   }, 15_000)
 
-  it('records a dream as a metered session with lifecycle-only history', async () => {
+  it('records a dream as a metered session with its original ACP activity', async () => {
     const collector = new EvaluationEventCollector()
     let onUpdate!: (sessionId: string, update: unknown) => void
     const proposal = JSON.stringify({ index: '# Memory', files: [] })
@@ -152,6 +152,24 @@ describe('Daemon evaluation surface', () => {
       permissionModeOptions: vi.fn(() => ({ modes: ['read-only'] })),
       setSessionPermissionMode: vi.fn(async () => true),
       prompt: vi.fn(async (sessionId: string) => {
+        onUpdate(sessionId, {
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'PRIVATE MEMORY REASONING' }
+        })
+        onUpdate(sessionId, {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'dream-tool-1',
+          title: 'Read PRIVATE /memory/preferences.md',
+          kind: 'read',
+          status: 'in_progress',
+          rawInput: { path: '/memory/preferences.md', secret: 'PRIVATE TOOL INPUT' }
+        })
+        onUpdate(sessionId, {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'dream-tool-1',
+          status: 'completed',
+          rawOutput: { secret: 'PRIVATE TOOL OUTPUT' }
+        })
         onUpdate(sessionId, {
           sessionUpdate: 'usage_update',
           used: 12,
@@ -201,20 +219,53 @@ describe('Daemon evaluation surface', () => {
       costAmount: 0.05,
       costCurrency: 'USD'
     })
-    const history = (daemon as any).store
-      .threadTranscript('memory', started.dreamId)
-      .map((row: { text: string }) => row.text)
-      .join('\n')
+    const transcript = (daemon as any).store.threadTranscript('memory', started.dreamId) as Array<{
+      kind: string
+      text: string
+      body?: string
+      sender: string
+      recipient?: string
+    }>
+    const history = transcript.map((row) => row.text).join('\n')
+    const originalPrompt = host.prompt.mock.calls[0]![1][0]!.text
     expect(history).toContain('Memory dream started.')
-    expect(history).not.toContain('source session')
     expect(history).toContain('Dream completed.')
-    expect(history).not.toContain(proposal)
+    expect(transcript).toContainEqual(
+      expect.objectContaining({ kind: 'text', sender: 'memory', recipient: AGENT_ID, text: originalPrompt })
+    )
+    expect(transcript).toContainEqual(expect.objectContaining({ kind: 'reasoning', text: 'PRIVATE MEMORY REASONING' }))
+    const tool = transcript.find((row) => row.kind === 'tool')
+    expect(tool).toMatchObject({ text: 'Read PRIVATE /memory/preferences.md' })
+    expect(JSON.parse(tool!.body!)).toMatchObject({
+      toolCallId: 'dream-tool-1',
+      kind: 'read',
+      status: 'completed',
+      rawInput: { path: '/memory/preferences.md', secret: 'PRIVATE TOOL INPUT' },
+      rawOutput: { secret: 'PRIVATE TOOL OUTPUT' }
+    })
+    expect(transcript).toContainEqual(expect.objectContaining({ kind: 'text', text: proposal }))
     expect(collector.events().map((event) => event.type)).toEqual([
       'memory.dream.started',
       'memory.dream.completed',
       'memory.dream.adopted'
     ])
+    expect(JSON.stringify(collector.events())).not.toContain('PRIVATE')
+    expect(JSON.stringify(collector.events())).not.toContain(proposal)
     expect(host.discardSession).toHaveBeenCalledWith('dream-session-1')
+
+    const eventCount = collector.events().length
+    onUpdate('dream-session-1', {
+      sessionUpdate: 'agent_thought_chunk',
+      content: { type: 'text', text: 'PRIVATE LATE DREAM UPDATE' }
+    })
+    expect((daemon as any).memoryExtractionQuarantines.size).toBe(1)
+    expect(collector.events()).toHaveLength(eventCount)
+    expect(
+      (daemon as any).store
+        .threadTranscript('memory', started.dreamId)
+        .map((row: { text: string }) => row.text)
+        .join('\n')
+    ).not.toContain('PRIVATE LATE DREAM UPDATE')
 
     ;(daemon as any).recordDreamLifecycle({
       type: 'memory.dream.skill_accepted',
@@ -341,12 +392,13 @@ describe('Daemon evaluation surface', () => {
 
       settlePrompt({ stopReason: 'end_turn' })
       await vi.advanceTimersByTimeAsync(0)
-      expect((daemon as any).memoryExtractionQuarantines.size).toBe(0)
+      expect((daemon as any).memoryExtractionQuarantines.size).toBe(1)
     } finally {
       settlePrompt({ stopReason: 'end_turn' })
       vi.useRealTimers()
       await daemon.stop()
     }
+    expect((daemon as any).memoryExtractionQuarantines.size).toBe(0)
     collector.assertValid()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -195,6 +195,13 @@ describe('Daemon evaluation surface', () => {
       evaluation: { observer: collector, runId: 'eval-run-dream' }
     })
     await daemon.start()
+    const usageReports: any[] = []
+    ;(daemon as any).cpClient = {
+      emitEventSession: vi.fn(),
+      emitSessionActivity: vi.fn(),
+      emitUsageReport: vi.fn((report: unknown) => usageReports.push(report)),
+      stop: vi.fn(async () => {})
+    }
 
     const started = await (daemon as any).dreamRunner().start(AGENT_ID, { trigger: 'manual' })
     let dream
@@ -266,6 +273,34 @@ describe('Daemon evaluation surface', () => {
         .map((row: { text: string }) => row.text)
         .join('\n')
     ).not.toContain('PRIVATE LATE DREAM UPDATE')
+
+    onUpdate('dream-session-1', {
+      sessionUpdate: 'usage_update',
+      used: 99,
+      size: 256_000,
+      cost: { amount: 0.09, currency: 'USD' }
+    })
+    expect((daemon as any).store.getUsage(session.key)).toMatchObject({
+      totalTokens: 12,
+      contextUsed: 99,
+      contextSize: 256_000,
+      costAmount: 0.09,
+      costCurrency: 'USD'
+    })
+    expect(usageReports.at(-1)).toMatchObject({
+      sessionId: 'dream-session-1',
+      agentId: AGENT_ID,
+      platform: 'dream',
+      channel: 'memory',
+      usage: {
+        totalTokens: 12,
+        contextUsed: 99,
+        contextSize: 256_000,
+        costAmount: 0.09,
+        costCurrency: 'USD'
+      }
+    })
+    expect(collector.events()).toHaveLength(eventCount)
 
     ;(daemon as any).recordDreamLifecycle({
       type: 'memory.dream.skill_accepted',


### PR DESCRIPTION
## Summary

- persist the exact Dream extraction prompt as the session's incoming message
- feed Dream reasoning and tool call/update events through the same `TranscriptRecorder` used by ordinary sessions
- persist the model's exact final proposal as the session response
- retain a terminal extraction-session quarantine until the owning ACP host stops, preventing delayed callbacks from escaping into generic evaluation
- keep raw Dream activity out of the triggering chat, generic evaluation events, and logs

## Root cause

Dream ACP updates were diverted into an in-memory proposal collector and returned before the ordinary transcript path. That kept the extraction private, but also meant the Sessions UI only had three lifecycle messages to display.

Dream sessions now use the same agent-session visibility boundary and transcript representation as normal sessions. Anyone authorized to view that agent's sessions can see the original extraction prompt, reasoning, merged tool input/output, and final proposal.

The prior collector lifecycle also had a late-callback gap: an adapter could emit updates after `prompt()` resolved and the collector was removed. The terminal quarantine now remains until host shutdown, covering both normal completion and ignored-cancel paths.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-evaluation.test.ts test/dream-runner.test.ts test/memory-distiller.test.ts --reporter=dot` — 64/64 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- changed-file ESLint — 0 errors
- Prettier and `git diff --check`
- pre-push full-repo ESLint — 0 errors, 2 pre-existing warnings in `packages/control-plane/src/http/routes/icon-upload.ts`
