### PR TITLE
fix(web): keep workspace repo picker above footer

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -179,8 +180,25 @@ export function GithubRepositoryField({
   children: ReactNode
   note?: ReactNode
 }) {
+  const fieldRef = useRef<HTMLDivElement>(null)
+  const [menuLayout, setMenuLayout] = useState({ above: false, maxHeight: 340 })
+
+  useLayoutEffect(() => {
+    if (!open) return
+    const field = fieldRef.current
+    const clipRoot = field?.closest('.modalbody, .overflow-y-auto')
+    if (!field || !clipRoot) return
+
+    const fieldRect = field.getBoundingClientRect()
+    const clipRect = clipRoot.getBoundingClientRect()
+    const above = Math.max(0, fieldRect.top - clipRect.top - 5)
+    const below = Math.max(0, clipRect.bottom - fieldRect.bottom - 5)
+    const openAbove = above > below
+    setMenuLayout({ above: openAbove, maxHeight: Math.min(340, openAbove ? above : below) })
+  }, [open])
+
   return (
-    <div className="fld relative min-w-0">
+    <div ref={fieldRef} className="fld relative min-w-0">
       <span className="fldlbl">GitHub repository</span>
       <div className="inp min-w-0 cursor-pointer gap-2" title={value || undefined} onClick={onToggle}>
         <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
@@ -215,7 +233,14 @@ export function GithubRepositoryField({
       {open && (
         <>
           <div className="fscrim" onClick={onClose} />
-          <div className="fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)">
+          <div
+            className={
+              menuLayout.above
+                ? 'fmenu bottom-[calc(100%+5px)] left-0 right-0 top-auto z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)'
+                : 'fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)'
+            }
+            style={{ maxHeight: menuLayout.maxHeight }}
+          >
             <input
               className="fsearch h-10 rounded-md px-3 font-sans text-[13px] font-medium leading-normal"
               value={query}


### PR DESCRIPTION
## Summary

- Place the GitHub repository picker on the side with more visible space.
- Cap the menu to that space so its own scroll area remains usable.

## Root cause

The picker was always positioned below a field near the bottom of a clipped modal scroll region, so the fixed footer hid part of the menu. Forcing it upward caused the same problem at the top edge.

## Impact

Repository search and choices remain visible and scrollable in both the create-agent and edit-workspace dialogs.

## Validation

- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/WorkspaceFormFields.test.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/WorkspaceFormFields.tsx`
- pre-push `eslint .` (no errors; two unrelated existing duplicate-import warnings)

Created by Codex . gpt-5.6-sol
