### PR TITLE
fix(web): keep repository picker below field

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -3,7 +3,12 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { RepositoryAccessField, WorkspaceModeField } from './WorkspaceFormFields'
+import {
+  GithubRepositoryField,
+  GithubRepositoryOption,
+  RepositoryAccessField,
+  WorkspaceModeField
+} from './WorkspaceFormFields'
 
 let root: Root | undefined
 let container: HTMLDivElement | undefined
@@ -59,5 +64,35 @@ describe('WorkspaceFormFields', () => {
 
     await act(async () => writeButton?.click())
     expect(onChange).toHaveBeenCalledWith('write')
+  })
+
+  it('keeps a portalled repository menu open while its list scrolls', async () => {
+    const onClose = vi.fn()
+    await render(
+      <div className="modalbody">
+        <GithubRepositoryField
+          value="agentconnect-md/agentconnect"
+          loading={false}
+          open
+          query=""
+          onToggle={() => undefined}
+          onClose={onClose}
+          onQueryChange={() => undefined}
+        >
+          <GithubRepositoryOption
+            fullName="agentconnect-md/agentconnect"
+            description="Repository"
+            onSelect={() => undefined}
+          />
+        </GithubRepositoryField>
+      </div>
+    )
+
+    const menu = document.body.querySelector('.fmenu')
+    await act(async () => menu?.dispatchEvent(new Event('scroll')))
+    expect(onClose).not.toHaveBeenCalled()
+
+    await act(async () => container?.querySelector('.modalbody')?.dispatchEvent(new Event('scroll')))
+    expect(onClose).toHaveBeenCalledOnce()
   })
 })

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -1,10 +1,12 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 
 export type WorkspaceMode = 'scratch' | 'github'
 export type WorkspaceRepoAccess = 'read' | 'write'
+type RepositoryMenuStyle = { left: number; top: number; width: number; maxHeight: number }
 
 export function WorkspaceModeField({
   value,
@@ -180,27 +182,36 @@ export function GithubRepositoryField({
   children: ReactNode
   note?: ReactNode
 }) {
-  const fieldRef = useRef<HTMLDivElement>(null)
-  const [menuLayout, setMenuLayout] = useState({ above: false, maxHeight: 340 })
+  const triggerRef = useRef<HTMLDivElement>(null)
+  const [menuStyle, setMenuStyle] = useState<RepositoryMenuStyle | null>(null)
 
   useLayoutEffect(() => {
     if (!open) return
-    const field = fieldRef.current
-    const clipRoot = field?.closest('.modalbody, .overflow-y-auto')
-    if (!field || !clipRoot) return
-
-    const fieldRect = field.getBoundingClientRect()
-    const clipRect = clipRoot.getBoundingClientRect()
-    const above = Math.max(0, fieldRect.top - clipRect.top - 5)
-    const below = Math.max(0, clipRect.bottom - fieldRect.bottom - 5)
-    const openAbove = above > below
-    setMenuLayout({ above: openAbove, maxHeight: Math.min(340, openAbove ? above : below) })
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) return
+    setMenuStyle({
+      left: rect.left,
+      top: rect.bottom + 5,
+      width: rect.width,
+      maxHeight: Math.min(340, Math.max(0, window.innerHeight - rect.bottom - 13))
+    })
   }, [open])
 
+  useEffect(() => {
+    if (!open) return
+    const scrollRoot = triggerRef.current?.closest<HTMLElement>('.modalbody, .overflow-y-auto')
+    scrollRoot?.addEventListener('scroll', onClose)
+    window.addEventListener('resize', onClose)
+    return () => {
+      scrollRoot?.removeEventListener('scroll', onClose)
+      window.removeEventListener('resize', onClose)
+    }
+  }, [open, onClose])
+
   return (
-    <div ref={fieldRef} className="fld relative min-w-0">
+    <div className="fld relative min-w-0">
       <span className="fldlbl">GitHub repository</span>
-      <div className="inp min-w-0 cursor-pointer gap-2" title={value || undefined} onClick={onToggle}>
+      <div ref={triggerRef} className="inp min-w-0 cursor-pointer gap-2" title={value || undefined} onClick={onToggle}>
         <span className="inline-flex min-w-0 flex-1 items-center gap-[7px]">
           {value ? (
             <>
@@ -230,39 +241,35 @@ export function GithubRepositoryField({
         </span>
         <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />
       </div>
-      {open && (
-        <>
-          <div className="fscrim" onClick={onClose} />
-          <div
-            className={
-              menuLayout.above
-                ? 'fmenu bottom-[calc(100%+5px)] left-0 right-0 top-auto z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)'
-                : 'fmenu left-0 right-0 z-40 min-w-0 rounded-lg p-2 shadow-(--shadow-xl)'
-            }
-            style={{ maxHeight: menuLayout.maxHeight }}
-          >
-            <input
-              className="fsearch h-10 rounded-md px-3 font-sans text-[13px] font-medium leading-normal"
-              value={query}
-              onChange={(event) => onQueryChange(event.target.value)}
-              onKeyDown={onSearchKeyDown}
-              placeholder="Search or type owner/repo…"
-              autoFocus
-            />
-            {error && (
-              <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
-                <span className="min-w-0 flex-1">{error}</span>
-                {onRetry && (
-                  <button type="button" className="lnk flex-none text-[12px]" onClick={onRetry}>
-                    Retry
-                  </button>
-                )}
-              </div>
-            )}
-            {children}
-          </div>
-        </>
-      )}
+      {open &&
+        menuStyle &&
+        createPortal(
+          <>
+            <div className="fixed inset-0 z-[1090]" onClick={onClose} />
+            <div className="fmenu fixed z-[1100] min-w-0 rounded-lg p-2 shadow-(--shadow-xl)" style={menuStyle}>
+              <input
+                className="fsearch h-10 rounded-md px-3 font-sans text-[13px] font-medium leading-normal"
+                value={query}
+                onChange={(event) => onQueryChange(event.target.value)}
+                onKeyDown={onSearchKeyDown}
+                placeholder="Search or type owner/repo…"
+                autoFocus
+              />
+              {error && (
+                <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                  <span className="min-w-0 flex-1">{error}</span>
+                  {onRetry && (
+                    <button type="button" className="lnk flex-none text-[12px]" onClick={onRetry}>
+                      Retry
+                    </button>
+                  )}
+                </div>
+              )}
+              {children}
+            </div>
+          </>,
+          document.body
+        )}
       {note}
     </div>
   )


### PR DESCRIPTION
## Summary

- portal the GitHub repository picker to `document.body`
- anchor it below the repository field with fixed positioning
- keep long lists internally scrollable and dismiss only when the originating modal scrolls, the viewport resizes, or the user clicks outside

## Why

PR #198 prevented the picker from being clipped by the modal footer, but opening upward covered the workspace controls above it. The first follow-up instead scrolled the modal body to make room, which made the picker inflate the body's scrollable area. A portalled overlay avoids both problems: it stays visually attached to the field without participating in modal layout or clipping.

The overlay intentionally sits above the modal footer while it is open. Treating the footer as the menu's height boundary would leave room for only the search box and roughly one repository in the constrained modal that triggered this fix.

## Impact

Opening the repository picker no longer moves or expands the modal body. The menu floats over the modal and footer, while long repository lists remain internally scrollable within the viewport.

## Validation

- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/WorkspaceFormFields.test.tsx` (3/3, including menu-internal versus modal scrolling)
- `pnpm exec eslint packages/web/src/components/console/WorkspaceFormFields.tsx packages/web/src/components/console/WorkspaceFormFields.test.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/WorkspaceFormFields.tsx packages/web/src/components/console/WorkspaceFormFields.test.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @agentconnect.md/web exec next build`
- browser geometry check at 1280×720: menu parent is `BODY`, position is `fixed`, modal body remains at `scrollTop: 0`, and `scrollHeight === clientHeight`

Created by Codex . gpt-5.6-sol
