### PR TITLE
fix(web): let an unplaced agent be placed with its runtime

### DIFF
--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -303,6 +303,40 @@ describe('PUT /agents/:id/daemon', () => {
     expect(control.calls).toEqual([])
   })
 
+  it('places an unplaced runtime-less preset only after its runtime is set', async () => {
+    await seedMoveDaemons()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    // The general preset ships unplaced with deferred exec config
+    // (preset-agents.md §3.2) — no daemon, no runtime.
+    await prisma.agent.update({ where: { id: agentId }, data: { daemonId: null, runtime: null } })
+    const control = new MoveControlSpy()
+    running = buildHttpApp(prisma, undefined, live, control as unknown as ControlSender)
+    const place = () =>
+      running!.app.inject({ method: 'PUT', url: `${ORG}/agents/${agentId}/daemon`, payload: { daemonId: TARGET } })
+
+    // (The 409's wording is pinned by preset-agents.test.ts.)
+    expect((await place()).statusCode).toBe(409)
+    expect(control.calls).toEqual([])
+
+    // The console places by committing the chosen runtime first (the spec PATCH
+    // needs no daemon) and then the placement — the pairing the edit dialog sends
+    // for an initial placement.
+    const patched = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { runtime: 'claude' }
+    })
+    expect(patched.statusCode, patched.body).toBe(200)
+
+    const placed = await place()
+    expect(placed.statusCode, placed.body).toBe(200)
+    expect((await prisma.agent.findUnique({ where: { id: agentId } }))?.daemonId).toBe(TARGET)
+    // No source daemon to drain: the target is staged and activated, nothing detaches
+    // from a machine this agent never ran on.
+    expect(control.calls).toEqual([`detach:${TARGET}`, `activate:${TARGET}`])
+  })
+
   it('treats a cached (hydrated) model list as permissive for the move model gate', async () => {
     await seedMoveDaemons()
     const agentId = randomUUID()

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -263,6 +263,14 @@ export default function EditAgentModal({
   const daemonChanged = daemonId !== initialDaemonId.current
   const initialPlacement = daemonChanged && !initialDaemonId.current
   const placementRequested = daemonChanged || repairPlacement
+  // A cold move or a repair rewrites daemon-local state, so it stays a solo
+  // action — configuration edits must be saved separately. An INITIAL placement
+  // has no source daemon and nothing to drain, and the CP refuses to place an
+  // agent whose runtime is still unset (preset-agents.md §3.2) — the general
+  // preset ships exactly that way — so the exec config rides along with it here,
+  // committed just before the placement (§3.4's "the picker bundles the runtime
+  // choice", on this surface).
+  const soloPlacement = placementRequested && !initialPlacement
   const selectedSandboxRequired = daemonChanged
     ? (daemon?.caps.features.includes('sandbox-required') ?? false)
     : sandboxRequired
@@ -434,10 +442,16 @@ export default function EditAgentModal({
       setErr('The current daemon must be online and upgraded before this agent can be repaired.')
       return
     }
-    if (placementRequested && (hasSpecChanges || hasSharingChanges || hasCallPolicyChanges)) {
+    if (soloPlacement && (hasSpecChanges || hasSharingChanges || hasCallPolicyChanges)) {
       setErr(
         'Move or repair the agent separately from configuration changes. Save those changes first, then reopen it.'
       )
+      return
+    }
+    // Placement is where a deferred runtime becomes mandatory. Say so here rather
+    // than surfacing the CP's 409 after the round trip.
+    if (initialPlacement && !runtime.trim()) {
+      setErr('Choose a runtime before placing this agent on a daemon.')
       return
     }
     setSaving(true)
@@ -447,12 +461,15 @@ export default function EditAgentModal({
       // (workspace dir, launch key) and is immutable in the console — only the
       // display name is renameable.
       // Description is edited on its own card (EditDescriptionModal) — never sent here.
+      // Spec first: an initial placement needs the runtime committed before the
+      // CP will accept the daemon (a solo move/repair carries no spec diff at all
+      // — the guard above rejected one).
+      if (hasSpecChanges && !soloPlacement) await updateAgent(agent.id, patch)
       if (placementRequested) await moveAgent(agent.id, daemonId)
-      else if (hasSpecChanges) await updateAgent(agent.id, patch)
       // Sharing + agent-call visibility ride their own endpoints (canManageSharing
       // gate) — only write when they actually changed, and never during a move.
-      if (!placementRequested && hasSharingChanges) await saveSharing('agents', agent.id, sharing)
-      if (!placementRequested && hasCallPolicyChanges) {
+      if (!soloPlacement && hasSharingChanges) await saveSharing('agents', agent.id, sharing)
+      if (!soloPlacement && hasCallPolicyChanges) {
         const body: AgentCallPolicyInput = {
           callPolicy: inboundMode,
           allowedCallerAgentIds: inboundMode === 'selected' ? normalizeSelected(agent.id, inboundSelected) : [],
@@ -561,11 +578,11 @@ export default function EditAgentModal({
                       className="absolute inset-0 cursor-pointer opacity-0"
                       aria-label="Daemon"
                     >
-                      {!daemonId && (
-                        <option value="" disabled>
-                          No daemon
-                        </option>
-                      )}
+                      {/* An agent that opened unplaced keeps "No daemon" selectable
+                          so a chosen target can be taken back — picking one is what
+                          turns the dialog into a placement. Never offered to a placed
+                          agent: unplacing is not a move. */}
+                      {!initialDaemonId.current && <option value="">No daemon</option>}
                       {daemonId && !daemon && <option value={daemonId}>Current daemon ({daemonId.slice(0, 8)})</option>}
                       {sortedDaemons.map((d) => {
                         const current = d.daemonId === initialDaemonId.current

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -422,6 +422,14 @@ export default function EditAgentModal({
         setErr('Choose an online daemon that supports agent moves.')
         return
       }
+      // Placement is where a deferred runtime becomes mandatory (§3.2). Ahead of
+      // `runtimeUnavailable`, which an unset runtime also trips — a target that
+      // advertises profiles cannot advertise the empty one, and "does not
+      // advertise the — runtime" is not the problem to report.
+      if (initialPlacement && !runtime.trim()) {
+        setErr('Choose a runtime before placing this agent on a daemon.')
+        return
+      }
       if (runtimeUnavailable) {
         setErr(`${daemon.name} does not advertise the ${runtimeLabel(runtime, runtimeMeta?.name)} runtime.`)
         return
@@ -446,12 +454,6 @@ export default function EditAgentModal({
       setErr(
         'Move or repair the agent separately from configuration changes. Save those changes first, then reopen it.'
       )
-      return
-    }
-    // Placement is where a deferred runtime becomes mandatory. Say so here rather
-    // than surfacing the CP's 409 after the round trip.
-    if (initialPlacement && !runtime.trim()) {
-      setErr('Choose a runtime before placing this agent on a daemon.')
       return
     }
     setSaving(true)


### PR DESCRIPTION
## Problem

Placing the `agentconnect` general preset from the console is impossible today.

The preset is created **unplaced with a deferred exec config** (no daemon, no runtime — `preset-agents.md` §3.2), and the CP refuses to place an agent whose runtime is still unset (`agents.ts`, `PUT /agents/:id/daemon` → 409 `agent has no runtime yet`). But the edit dialog rejected *any* spec change made alongside a placement:

```
Move or repair the agent separately from configuration changes. Save those changes first, then reopen it.
```

So choosing the runtime the CP demands always ended in that error — and there was no route to "save those changes first" either: the daemon picker rendered `No daemon` only while `!daemonId` **and** `disabled`, so once a target was selected the dialog could not be walked back. Placing the preset dead-ended; leaving the runtime unset just moved the failure to the CP's 409.

## Change

`packages/web/src/components/console/modals/EditAgentModal.tsx`

- Narrow the solo-action guard from `placementRequested` to `soloPlacement` — a **cold move or a repair**, the two actions that drain daemon-local state. An **initial** placement has no source daemon and nothing to drain, so the exec config rides along with it: the spec PATCH commits **first** (the order the CP requires), then the placement, then the sharing / agent-call writes.
- Report an unset runtime before the round trip (`Choose a runtime before placing this agent on a daemon.`) instead of surfacing the CP conflict.
- An agent that opened unplaced keeps `No daemon` selectable, so a chosen target can be taken back. Never offered to a placed agent — unplacing is not a move.

`packages/control-plane/test/integration/agents.move.route.test.ts`

- New case running the exact sequence the dialog now sends: a runtime-less placement is a clean 409 with **no** control frames emitted; after the runtime PATCH the placement returns 200, the row points at the target, and the control spy sees only `detach:TARGET` + `activate:TARGET` — nothing detaches from a machine the agent never ran on.

No control-plane behavior changes; the CP already supported both halves.

## Reviewer notes

- Cold-move semantics are untouched: a real move (or a repair) still refuses to carry spec, sharing, or agent-call edits.
- `SandboxField` stays disabled during any placement, including the initial one — the PATCH validates `restrictFileAccess` against the agent's *current* daemon, so an unplaced agent has no sandbox policy to satisfy yet. Its value still previews from the target's advertised caps, as before.
- If the spec PATCH lands and the placement then fails, the dialog stays open with the CP's error and a retry re-sends the same idempotent patch.
- This is the manual counterpart of `preset-agents.md` §3.4 ("the picker bundles the runtime choice") on the surface that exists today; the dedicated unplaced-agent CTA is still unbuilt.

## Verification

- `pnpm --filter @agentconnect.md/control-plane test:int` — 60 files / 730 tests pass, new case included.
- Web `tsc --noEmit`, eslint, prettier clean.
- **Not exercised in a live console**: placement requires the target daemon to be READY in the CP's in-memory connection registry, i.e. a real daemon process holding the WS — not reproducible locally here. The client-side change is predicate + request ordering; the server half is covered by the integration test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)