### PR TITLE
fix(feishu): resolve channel and participant names

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1842,12 +1842,12 @@ export class Daemon {
       this.store.setDisplayName(id, name, Date.now())
       this.emitSessionMetadataSnapshotsForDisplayName(id)
     }, this.log)
-    // Same cache-then-emit sink for Discord/Telegram channel-name resolution.
+    // Same cache-then-emit sink for Discord/Telegram/Feishu channel and user names.
     this.channelNameResolver = new ChannelNameResolver(
       (id, name) => {
         this.store.setDisplayName(id, name, Date.now())
         this.emitSessionMetadataSnapshotsForDisplayName(id)
-        // A freshly-resolved Telegram/Discord channel name should also refresh that
+        // A freshly-resolved Telegram/Discord/Feishu channel name should also refresh that
         // integration's observed-channel snapshot (approach-A discovery) so the console
         // shows the human name rather than the raw chat/channel id.
         this.refreshObservedChannels()
@@ -2878,7 +2878,7 @@ export class Daemon {
         group,
         newTraceId: () => randomUUID(),
         onMessage: (msg) => {
-          this.channelNameResolver?.noteChannel(conn, msg.channel, msg.sender.id)
+          this.channelNameResolver?.noteMessage(conn, { ...msg, mentionedUserIds: msg.mentionedBots })
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
         log: this.log
@@ -2923,11 +2923,12 @@ export class Daemon {
   }
 
   /**
-   * Resolve display names for the channels of already-stored Discord/Telegram sessions
+   * Resolve display names for the channels and triggering users of already-stored
+   * Discord/Telegram/Feishu sessions
    * so the console labels them without waiting for a new inbound message (the per-message
    * ChannelNameResolver only fires on fresh traffic). The Slack analog is refreshChannels'
-   * bulk membership snapshot; Discord/Telegram have no cheap channel enumeration, so we
-   * resolve each live session's channel individually via its bot connection. Best-effort +
+   * bulk membership snapshot; here we resolve each live session's channel individually
+   * via its bot connection. Best-effort +
    * TTL-guarded by the resolver, so calling it on every reconcile is cheap.
    */
   private backfillChannelNames(): void {
@@ -2943,7 +2944,15 @@ export class Daemon {
           : row.platform === 'telegram'
             ? this.tgConnByIntegration.get(integrationId)
             : this.fsConnByIntegration.get(integrationId)
-      if (conn) resolver.noteChannel(conn, row.channel, row.triggeredBy ?? undefined)
+      if (!conn) continue
+      if (row.triggeredBy) {
+        resolver.noteMessage(conn, {
+          channel: row.channel,
+          sender: { id: row.triggeredBy, isBot: false }
+        })
+      } else {
+        resolver.noteChannel(conn, row.channel)
+      }
     }
     this.refreshObservedChannels()
   }
@@ -2961,11 +2970,10 @@ export class Daemon {
   }
 
   /**
-   * Observed-conversation discovery for Telegram and Discord. These platforms do
-   * not give us an authoritative set of chats the bot is engaged in, so stored
-   * session history is merged with explicitly-addressed Off conversations already
-   * cached for the integration. Reports carry `authoritative:false`: the CP upserts
-   * what we know but never treats an absent row as a leave.
+   * Observed-conversation discovery for Telegram, Discord, and Feishu. Stored session
+   * history is merged with explicitly-addressed Off conversations already cached for
+   * the integration. Reports carry `authoritative:false`: the CP upserts what we know
+   * but never treats an absent row as a leave.
    *
    * Names fill in lazily through ChannelNameResolver. Re-merging the cached rows
    * here is important for Off conversations: they have no session row, so without
@@ -2977,7 +2985,7 @@ export class Daemon {
    */
   private refreshObservedChannels(): void {
     for (const agent of this.agents.values()) {
-      for (const platform of ['telegram', 'discord'] as const) {
+      for (const platform of ['telegram', 'discord', 'feishu'] as const) {
         const integrations = agent.integrations.filter((i) => i.platform === platform)
         if (integrations.length === 0) continue
         // observedChannels is agent+platform-scoped, not per-bot (the sessions table
@@ -3104,7 +3112,7 @@ export class Daemon {
    */
   private collapseObserved(
     observed: { id: string; name?: string }[],
-    platform: 'telegram' | 'discord'
+    platform: 'telegram' | 'discord' | 'feishu'
   ): { id: string; name?: string; spaceId?: string; space?: string }[] {
     if (platform !== 'discord') return observed
     // Two-step: the observed (thread) ids first, then the channels they fold onto —
@@ -8676,9 +8684,12 @@ export class Daemon {
         channel: msg.channel,
         thread: statusThread
       })
-      // A first-seen Telegram/Discord chat widens the observed reachable set (approach-A
-      // discovery) — report the updated membership snapshot so the console lists it.
-      if (msg.platform === 'telegram' || msg.platform === 'discord') this.refreshObservedChannels()
+      // A first-seen Telegram/Discord/Feishu chat widens the observed reachable set
+      // (approach-A discovery) — report it after the session row exists so the console
+      // cannot miss a name lookup that completed during cold session startup.
+      if (msg.platform === 'telegram' || msg.platform === 'discord' || msg.platform === 'feishu') {
+        this.refreshObservedChannels()
+      }
     }
     this.finishSessionInitialization(agentId, sessionId)
     try {

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -483,7 +483,7 @@ describe('Daemon.reconcileSlackConnections', () => {
   })
 })
 
-describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
+describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', () => {
   it('reports observed Telegram chats as a non-authoritative integration/channels update', async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)
@@ -548,6 +548,117 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord discovery)', () => {
     const channels = [{ id: '900123', name: 'general' }, { id: '900456' }]
     expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
     expect((daemon as any).channelSnapshots.get('dc-int')).toEqual({ channels, authoritative: false })
+    await daemon.stop()
+  })
+
+  it('backfills a Feishu participant and reports the resolved chat name', async () => {
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    const conn = {
+      getChannelInfo: vi.fn(),
+      getUserProfile: vi.fn()
+    }
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    ;(daemon as any).agents = new Map([
+      [
+        'bot-fs',
+        {
+          id: 'bot-fs',
+          integrations: [
+            {
+              id: 'fs-int',
+              platform: 'feishu',
+              feishu: { appId: 'cli_fs', appSecret: 'secret', region: 'lark' }
+            }
+          ]
+        }
+      ]
+    ])
+    ;(daemon as any).fsConnByIntegration.set('fs-int', conn)
+    vi.spyOn((daemon as any).store, 'listSessions').mockReturnValue([
+      { agentId: 'bot-fs', platform: 'feishu', channel: 'oc_group', triggeredBy: 'ou_sender' }
+    ])
+    const observed = vi
+      .spyOn((daemon as any).store, 'observedChannels')
+      .mockReturnValue([{ id: 'oc_group', name: 'Product Chat' }])
+    const noteMessage = vi.spyOn((daemon as any).channelNameResolver, 'noteMessage').mockImplementation(() => {})
+
+    ;(daemon as any).backfillChannelNames()
+
+    expect(noteMessage).toHaveBeenCalledWith(conn, {
+      channel: 'oc_group',
+      sender: { id: 'ou_sender', isBot: false }
+    })
+    expect(observed).toHaveBeenCalledWith('bot-fs', 'feishu')
+    const channels = [{ id: 'oc_group', name: 'Product Chat' }]
+    expect(emit).toHaveBeenCalledWith({ integrationId: 'fs-int', channels, authoritative: false })
+    expect((daemon as any).channelSnapshots.get('fs-int')).toEqual({ channels, authoritative: false })
+    await daemon.stop()
+  })
+
+  it('reports a new Feishu chat after its cold session row is committed', async () => {
+    const root = root1()
+    writeAgentJson(root, 'bot-fs', {})
+    let releaseSession!: () => void
+    const sessionGate = new Promise<void>((resolve) => (releaseSession = resolve))
+    const host = {
+      start: vi.fn().mockResolvedValue(undefined),
+      newSession: vi.fn(async () => {
+        await sessionGate
+        return 'acp-fs-1'
+      }),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn().mockResolvedValue('end_turn'),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined)
+    }
+    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    ;(daemon as any).agents.get('bot-fs').integrations = [
+      {
+        id: 'fs-int',
+        platform: 'feishu',
+        feishu: { appId: 'cli_fs', appSecret: 'secret', region: 'lark' }
+      }
+    ]
+    const dispatch = (daemon as any).dispatch(
+      'bot-fs',
+      {
+        msgId: 'feishu:oc_group:om_1',
+        traceId: 'trace-fs-1',
+        source: 'user',
+        platform: 'feishu',
+        channel: 'oc_group',
+        sender: { id: 'ou_sender', isBot: false },
+        text: 'hello',
+        mentionedBots: [],
+        isDm: false,
+        trigger: 'mention'
+      },
+      'fs-int'
+    )
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalledOnce())
+
+    // Model the Lark lookup finishing while cold ACP startup is still blocked: there
+    // is a resolved name, but no session row for discovery to publish yet.
+    ;(daemon as any).store.setDisplayName('oc_group', 'Product Chat', Date.now())
+    ;(daemon as any).refreshObservedChannels()
+    expect(emit).not.toHaveBeenCalled()
+
+    releaseSession()
+    await dispatch
+
+    expect(emit).toHaveBeenCalledWith({
+      integrationId: 'fs-int',
+      channels: [{ id: 'oc_group', name: 'Product Chat' }],
+      authoritative: false
+    })
     await daemon.stop()
   })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1568,6 +1568,7 @@ export function platName(p: string): string {
   if (x.includes('play') || x.includes('web')) return 'Playground'
   if (x.includes('tele')) return 'Telegram'
   if (x.includes('disc')) return 'Discord'
+  if (x.includes('feishu') || x.includes('lark')) return 'Lark'
   return 'Slack'
 }
 

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -6,7 +6,7 @@ import {
   type SessionDetailDto,
   type SessionDto
 } from './api'
-import { sessionPlatform } from './data'
+import { platName, sessionPlatform } from './data'
 import {
   githubRepoIdFromSessionTriggerFilter,
   sessionSenderLabel,
@@ -82,6 +82,7 @@ describe('sessionTriggerKind', () => {
     expect(sessionPlatform(slashNamedWebhook)).toBe('hook')
     expect(sessionPlatform({ platform: 'hook', hookKind: 'github' })).toBe('github')
     expect(sessionPlatform({ platform: 'playground' })).toBe('webchat')
+    expect(platName(sessionPlatform({ platform: 'feishu' }))).toBe('Lark')
   })
 
   it('labels dream execution sessions without exposing their synthetic routing key', () => {


### PR DESCRIPTION
## Summary

- report resolved Lark conversations to the Agent integration list
- resolve Lark sender names for new and existing sessions
- label Feishu-backed sessions as Lark instead of Slack

## Root cause

The daemon resolved Feishu chat names for session metadata, but observed channel snapshots only traversed Telegram and Discord. Feishu ingress also used channel-only resolution, and the web platform label fell through to Slack. A cold-session ordering gap could also let name resolution finish before the first session row existed, leaving the conversation unpublished.

## Validation

- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon exec vitest run test/reconcile-watch.test.ts` (22 tests)
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/name-resolver.test.ts`
- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/session-trigger.test.ts`
- daemon and web typechecks
- changed-file ESLint and Prettier

Created by Codex . GPT-5.6-sol
