### PR TITLE
feat(web): chat-first Home landing + session chat restyle

### DIFF
--- a/packages/web/src/app/(app)/[slug]/home/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/home/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import HomeView from '@/components/console/views/HomeView'
+import { LoadingState } from '@/components/marks'
+
+export const metadata: Metadata = { title: 'Home · AgentConnect' }
+
+export default function Page() {
+  return (
+    <Suspense fallback={<LoadingState fill />}>
+      <HomeView />
+    </Suspense>
+  )
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -441,7 +441,7 @@
     border-left-color: var(--brand);
   }
   .navitem.on i {
-    color: var(--brand);
+    color: #fff;
   }
   .navitem i {
     width: 18px;

--- a/packages/web/src/app/home/page.tsx
+++ b/packages/web/src/app/home/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+// The literal top-level `/home`. The console is org-scoped (`/{slug}/home`), so
+// resolve the last-used org from the `ac.org` cookie (default: the seeded org
+// `-`) and bounce into its Home. OrgProvider then reconciles an unknown/stale
+// slug to a real org exactly as it does for any other console URL.
+export default async function HomeRedirect() {
+  const slug = (await cookies()).get('ac.org')?.value || '-'
+  redirect(`/${slug}/home`)
+}

--- a/packages/web/src/app/join/[token]/JoinOrganization.tsx
+++ b/packages/web/src/app/join/[token]/JoinOrganization.tsx
@@ -26,7 +26,7 @@ export default function JoinOrganization({ token }: { token: string }) {
         }
 
         const result = await acceptOrgInviteLink(token)
-        if (!cancelled) router.replace(`/${encodeURIComponent(result.org.slug)}/agents`)
+        if (!cancelled) router.replace(`/${encodeURIComponent(result.org.slug)}/home`)
       } catch (e) {
         if (cancelled) return
         setError(

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -4,8 +4,8 @@ import { NotFound } from '@/components/console/NotFound'
 // first segment like `/xxx` (the org-slug position), which the in-shell
 // `[slug]/[...notFound]` catch-all can't reach. Rendered by the root layout, so
 // there's no shell/org context: no rail, and global search isn't mounted (hence
-// `showSearch={false}`). "Go to agents" heads to `/`, which resolves to the
-// active org's agents list.
+// `showSearch={false}`). "Go home" heads to `/`, which resolves to the active
+// org's Home.
 export default function NotFoundPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-(--surface-app) p-6">
@@ -14,8 +14,8 @@ export default function NotFoundPage() {
           icon="compass"
           kind="PAGE"
           title="Page not found"
-          post="This page doesn’t exist. Check the address, or head back to your agents."
-          actionLabel="Go to agents"
+          post="This page doesn’t exist. Check the address, or head back home."
+          actionLabel="Go home"
           actionHref="/"
           showSearch={false}
         />

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -1,9 +1,22 @@
 'use client'
 
-import { useId, useRef, type KeyboardEvent } from 'react'
+import { useId, useRef, type KeyboardEvent, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
 
-type ComposerMenuChoice = { value: string; label: string; description?: string }
+// Default trigger look — the minimal inline chip used by the session composer.
+// Callers (e.g. the Home composer's design-pill selectors) can replace it via
+// `triggerClassName` and prepend an icon via `leading`.
+const DEFAULT_TRIGGER =
+  'inline-flex h-6 items-center gap-1 rounded-sm px-1 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover)'
+
+type ComposerMenuChoice = {
+  value: string
+  label: string
+  description?: string
+  leading?: ReactNode
+  /** Render the option dimmed (still selectable) — e.g. an offline agent. */
+  dimmed?: boolean
+}
 
 export function ComposerMenu({
   title,
@@ -11,6 +24,10 @@ export function ComposerMenu({
   options,
   open,
   align = 'right',
+  placement = 'up',
+  leading,
+  triggerClassName,
+  tooltips = true,
   onOpenChange,
   onChange
 }: {
@@ -19,6 +36,16 @@ export function ComposerMenu({
   options: ComposerMenuChoice[]
   open: boolean
   align?: 'left' | 'right'
+  /** Which way the menu opens. Default 'up' suits a bottom-docked composer; use
+   *  'down' when the trigger sits near the top of its scroll container (Home). */
+  placement?: 'up' | 'down'
+  /** Optional node rendered before the label (e.g. an agent avatar / model mark). */
+  leading?: ReactNode
+  /** Overrides the default trigger look (e.g. the Home composer's design pills). */
+  triggerClassName?: string
+  /** Hover-tooltip the trigger + options (via the console Tooltip layer). Turn off
+   *  for self-explanatory menus (model / effort / permission) where the popover is noise. */
+  tooltips?: boolean
   onOpenChange: (open: boolean) => void
   onChange: (value: string) => void
 }) {
@@ -27,7 +54,7 @@ export function ComposerMenu({
   const headingId = useId()
   const selected = options.find((choice) => choice.value === value) ?? options[0]
   const tooltipFor = (choice: ComposerMenuChoice | undefined) =>
-    choice?.description ?? (choice ? `${title}: ${choice.label}` : title)
+    tooltips ? (choice?.description ?? (choice ? `${title}: ${choice.label}` : title)) : undefined
 
   const closeAndFocus = () => {
     onOpenChange(false)
@@ -65,7 +92,7 @@ export function ComposerMenu({
       <button
         ref={triggerRef}
         type="button"
-        className="inline-flex h-6 items-center gap-1 rounded-sm px-1 font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover)"
+        className={triggerClassName ?? DEFAULT_TRIGGER}
         aria-label={`${title}: ${selected?.label ?? value}`}
         aria-haspopup="menu"
         aria-expanded={open}
@@ -78,6 +105,7 @@ export function ComposerMenu({
           onOpenChange(true)
         }}
       >
+        {leading}
         <span>{selected?.label ?? value}</span>
         <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
       </button>
@@ -88,9 +116,9 @@ export function ComposerMenu({
             id={menuId}
             role="menu"
             aria-labelledby={headingId}
-            className={`absolute bottom-[calc(100%+8px)] z-50 min-w-[148px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
-              align === 'left' ? 'left-0' : 'right-0'
-            }`}
+            className={`absolute z-50 min-w-[148px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
+              placement === 'down' ? 'top-[calc(100%+8px)]' : 'bottom-[calc(100%+8px)]'
+            } ${align === 'left' ? 'left-0' : 'right-0'}`}
             onKeyDown={moveFocus}
           >
             <div
@@ -99,26 +127,31 @@ export function ComposerMenu({
             >
               {title}
             </div>
-            {options.map((choice) => {
-              const selectedChoice = choice.value === selected?.value
-              return (
-                <button
-                  key={choice.value}
-                  type="button"
-                  role="menuitemradio"
-                  aria-checked={selectedChoice}
-                  autoFocus={selectedChoice}
-                  title={tooltipFor(choice)}
-                  className={`fopt min-h-8 gap-2 rounded-md px-2 py-[5px] text-[12px] ${
-                    selectedChoice ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
-                  }`}
-                  onClick={() => pick(choice.value)}
-                >
-                  <span className="min-w-0 flex-1 truncate text-left">{choice.label}</span>
-                  {selectedChoice && <Icon name="check" size={14} color="var(--brand)" className="flex-none" />}
-                </button>
-              )
-            })}
+            {/* Options scroll within a capped height so a long list (e.g. dozens of
+                models) never runs off-screen; the heading above stays put. */}
+            <div className="max-h-[300px] overflow-y-auto overflow-x-hidden">
+              {options.map((choice) => {
+                const selectedChoice = choice.value === selected?.value
+                return (
+                  <button
+                    key={choice.value}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={selectedChoice}
+                    autoFocus={selectedChoice}
+                    title={tooltipFor(choice)}
+                    className={`fopt min-h-8 gap-2 rounded-md px-2 py-[5px] text-[12px] ${
+                      selectedChoice ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
+                    } ${choice.dimmed ? 'opacity-55' : ''}`}
+                    onClick={() => pick(choice.value)}
+                  >
+                    {choice.leading}
+                    <span className="min-w-0 flex-1 truncate text-left">{choice.label}</span>
+                    {selectedChoice && <Icon name="check" size={14} color="var(--brand)" className="flex-none" />}
+                  </button>
+                )
+              })}
+            </div>
           </div>
         </>
       )}

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -34,6 +34,7 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
+  { href: '/home', label: 'Home', icon: 'house' },
   { href: '/agents', label: 'Agents', icon: 'bot' },
   { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
   { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
@@ -81,6 +82,7 @@ const ADD_KIND: Record<string, 'agent' | 'cron' | 'daemon'> = {
 
 // Section label for the header breadcrumb, matched by path prefix.
 const SECTIONS: { prefix: string; label: string }[] = [
+  { prefix: '/home', label: 'Home' },
   { prefix: '/agents', label: 'Agents' },
   { prefix: '/sessions', label: 'Sessions' },
   { prefix: '/crons', label: 'Schedules' },
@@ -387,10 +389,10 @@ function ShellChrome({ children }: { children: ReactNode }) {
   }, [barePath])
 
   // No-auth mode has no identity and a single implicit org, so Profile / Settings
-  // don't exist — bounce any direct navigation to those routes back to the agents list.
+  // don't exist — bounce any direct navigation to those routes back to the home landing.
   useEffect(() => {
     if (!isAuthConfigured() && (barePath === '/profile' || barePath === '/settings')) {
-      router.replace(orgPath('/agents'))
+      router.replace(orgPath('/home'))
     }
   }, [barePath, router, orgPath])
 
@@ -438,7 +440,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // Back from a push screen: pop in-app history when there is any, else (deep-link /
   // hard refresh — no history) route to the parent list so "back" never leaves the app.
   const hasParentList = LIST_ROUTES.includes(`/${seg[0] ?? ''}`)
-  const parentList = hasParentList ? `/${seg[0]}` : '/agents'
+  const parentList = hasParentList ? `/${seg[0]}` : '/home'
   const parentListHref = orgPath(parentList + (seg[0] === 'sessions' ? sessionFilterSearch(locationSearch) : ''))
   const showDetailCrumb = hasParentList && seg.length >= 2 && crumb !== '' && pushTitle !== crumb
   const goBack = () => {
@@ -469,11 +471,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
           label already sitting next to the icon. */}
         <aside data-no-tooltip className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
           <div className="railbrand">
-            <Link
-              href={orgPath('/agents')}
-              className="railbrand-logo cursor-pointer select-none"
-              aria-label="Go to Agents"
-            >
+            <Link href={orgPath('/home')} className="railbrand-logo cursor-pointer select-none" aria-label="Go to Home">
               <LogoMark />
               <span className="brandword font-sans text-[17px] font-semibold leading-normal tracking-[-.02em] text-white">
                 Agent<span className="text-(--magenta-300)">Connect</span>
@@ -509,7 +507,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 title={item.label}
                 className={on ? 'navitem on' : 'navitem'}
               >
-                <Icon name={item.icon} size={18} color={on ? 'var(--brand)' : undefined} />
+                <Icon name={item.icon} size={18} color={on ? '#fff' : undefined} />
                 <span>{item.label}</span>
               </Link>
             )
@@ -679,7 +677,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
           <header className="mtop">
             {isListRoute ? (
               <>
-                <Link href={orgPath('/agents')} className="mtop-logo select-none" aria-label="Go to Agents">
+                <Link href={orgPath('/home')} className="mtop-logo select-none" aria-label="Go to Home">
                   <LogoMark />
                 </Link>
                 <span className="mtop-title">{crumb}</span>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -47,10 +47,10 @@ const NAV_ITEMS: NavItem[] = [
 // destinations as equal columns plus a "More" slot that opens a bottom sheet.
 // (Schedules uses `alarm-clock` per the design, not `calendar-clock`.)
 const MOBILE_NAV: NavItem[] = [
+  { href: '/home', label: 'Home', icon: 'house' },
   { href: '/agents', label: 'Agents', icon: 'bot' },
   { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
-  { href: '/crons', label: 'Schedules', icon: 'alarm-clock' },
-  { href: '/daemons', label: 'Daemons', icon: 'server' }
+  { href: '/crons', label: 'Schedules', icon: 'alarm-clock' }
 ]
 
 // The "More" sheet's destinations — Analytics / Tools & Skills / Settings (the desktop rail
@@ -58,14 +58,16 @@ const MOBILE_NAV: NavItem[] = [
 // bar as a top-right avatar (mirroring the desktop top bar). The org switcher is
 // prepended separately, in the sheet itself.
 const MORE_ROWS: NavItem[] = [
+  { href: '/daemons', label: 'Daemons', icon: 'server' },
   { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
 
-// List routes own the tab-bar + list app bar; every other route is a "push" screen
-// (back-button app bar, no bottom nav) on mobile.
-const LIST_ROUTES = ['/agents', '/sessions', '/crons', '/daemons']
+// Top-level routes own the tab-bar + list app bar (no back button, bottom nav shown);
+// every other route is a "push" screen (back-button app bar, no bottom nav) on mobile.
+// Home is a top-level surface (the default landing), not a push screen.
+const LIST_ROUTES = ['/home', '/agents', '/sessions', '/crons', '/daemons']
 const SESSION_FILTER_KEYS = ['agent', 'integration', 'channel', 'trigger']
 const CONSOLE_SWR_CONFIG = {
   dedupingInterval: 2_000,

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import { workSummary } from './session-work'
+import { workCounts, workSummary } from './session-work'
+
+const step = (lane: string, files: string[] = []) => ({ lane, files: files.map((path) => ({ path })) })
+
+describe('workCounts', () => {
+  it('counts edited FILES by path, not EDIT-step count (one EDIT row, two files → 2)', () => {
+    expect(workCounts([step('THINK'), step('EDIT', ['a.ts', 'b.ts'])])).toEqual({
+      thinkCount: 1,
+      toolCount: 0,
+      editCount: 2
+    })
+  })
+
+  it('dedupes repeated paths and counts a metadata-less EDIT row as one file', () => {
+    expect(workCounts([step('EDIT', ['a.ts']), step('EDIT', ['a.ts']), step('EDIT', [])])).toEqual({
+      thinkCount: 0,
+      toolCount: 0,
+      editCount: 2 // {a.ts} + one bare edit
+    })
+  })
+
+  it('counts TOOL as command steps and treats the remainder (THINK/PLAN) as reasoning', () => {
+    expect(workCounts([step('THINK'), step('PLAN'), step('TOOL'), step('TOOL')])).toEqual({
+      thinkCount: 2,
+      toolCount: 2,
+      editCount: 0
+    })
+  })
+
+  it('feeds the summary so one EDIT row with two files reads "edited 2 files"', () => {
+    const { thinkCount, toolCount, editCount } = workCounts([step('THINK'), step('EDIT', ['a.ts', 'b.ts'])])
+    expect(workSummary(thinkCount, toolCount, editCount)).toBe('Thought through 1 step, edited 2 files')
+  })
+})
 
 describe('workSummary', () => {
   it('counts reasoning, tool commands, and file edits separately', () => {

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { workSummary } from './session-work'
+
+describe('workSummary', () => {
+  it('counts reasoning, tool commands, and file edits separately', () => {
+    // The bug: edits were folded into the "thought through" step count.
+    expect(workSummary(1, 0, 2)).toBe('Thought through 1 step, edited 2 files')
+    expect(workSummary(1, 2, 3)).toBe('Thought through 1 step, ran 2 commands, edited 3 files')
+  })
+
+  it('capitalizes only the first clause and pluralizes each count', () => {
+    expect(workSummary(0, 1, 0)).toBe('Ran 1 command')
+    expect(workSummary(0, 0, 1)).toBe('Edited 1 file')
+    expect(workSummary(2, 0, 0)).toBe('Thought through 2 steps')
+  })
+
+  it('is empty when there is no work', () => {
+    expect(workSummary(0, 0, 0)).toBe('')
+  })
+})

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -1,0 +1,17 @@
+// 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
+// text and collapses its "work" — reasoning (THINK/PLAN), tool calls (TOOL), and
+// file edits (EDIT) — behind a per-turn "Thought through…" toggle.
+export const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
+
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`
+
+/** One-line label for the collapsed work: reasoning steps, tool commands, and file
+ *  edits are counted SEPARATELY so edits are credited as edits (not folded into the
+ *  "thought through" step count). First clause capitalized, the rest lowercased. */
+export function workSummary(thinkCount: number, toolCount: number, editCount: number): string {
+  const parts: string[] = []
+  if (thinkCount > 0) parts.push(`Thought through ${plural(thinkCount, 'step')}`)
+  if (toolCount > 0) parts.push(`${parts.length ? 'ran' : 'Ran'} ${plural(toolCount, 'command')}`)
+  if (editCount > 0) parts.push(`${parts.length ? 'edited' : 'Edited'} ${plural(editCount, 'file')}`)
+  return parts.join(', ')
+}

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -3,6 +3,31 @@
 // file edits (EDIT) — behind a per-turn "Thought through…" toggle.
 export const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
 
+/** Split an agent turn's collapsed work steps into the counts the summary reports:
+ *  reasoning STEPS (THINK/PLAN), tool-command STEPS (TOOL), and edited FILES — the
+ *  DISTINCT file paths across all EDIT steps (a single EDIT row can touch several
+ *  files), with a metadata-less EDIT row counting as one file. Files are counted by
+ *  path, not by EDIT-row count, so "1 EDIT step touching a.ts + b.ts" reads "2 files". */
+export function workCounts(steps: { lane: string; files: { path: string }[] }[]): {
+  thinkCount: number
+  toolCount: number
+  editCount: number
+} {
+  let toolCount = 0
+  let editStepCount = 0
+  let bareEdits = 0
+  const editPaths = new Set<string>()
+  for (const s of steps) {
+    if (s.lane === 'TOOL') toolCount += 1
+    else if (s.lane === 'EDIT') {
+      editStepCount += 1
+      if (s.files.length === 0) bareEdits += 1
+      else for (const f of s.files) editPaths.add(f.path)
+    }
+  }
+  return { thinkCount: steps.length - toolCount - editStepCount, toolCount, editCount: editPaths.size + bareEdits }
+}
+
 const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`
 
 /** One-line label for the collapsed work: reasoning steps, tool commands, and file

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -771,7 +771,7 @@ export default function AgentDetailView() {
                     <span className="inline-flex h-4 w-4 desktop:hidden">
                       <AgentMark model={da.runtime} />
                     </span>
-                    <span className="imark hidden h-4 w-4 desktop:flex">
+                    <span className="imark hidden h-6 w-6 desktop:flex">
                       <AgentMark model={da.runtime} />
                     </span>
                     {runtimeLabel(da.runtime, runtimeMeta?.name)}

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -180,6 +180,45 @@ describe('HomeView run-selectors (catalog-aware)', () => {
     expect(mocks.pgSend).toHaveBeenCalled()
   })
 
+  it('stages an offered level for blank reasoning when the catalog entry has no defaultEffort', async () => {
+    // Phase-2 shape: efforts present, defaultEffort intentionally absent.
+    const noDefault = {
+      models: [
+        {
+          id: 'm-nodef',
+          efforts: [
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' }
+          ]
+        }
+      ],
+      permissionModes: [{ value: 'default', name: 'Default' }],
+      defaultModel: 'm-nodef',
+      source: 'acp',
+      observedAt: ''
+    }
+    mocks.agents = [agent({ model: 'm-nodef', reasoning: '' })] // blank stored effort
+    mocks.daemons = [
+      daemon({
+        runtimeModels: [{ runtime: 'claude', models: ['m-nodef'], modelCatalog: noDefault, authRequired: false }]
+      })
+    ]
+    await render()
+    // Not blank: falls back to the first offered level, so the pill can't claim a level the turn won't run.
+    expect(menu('Effort')?.value).toBe('low')
+    const ta = host.querySelector('textarea')!
+    const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!
+    await act(async () => {
+      setValue.call(ta, 'hi')
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('button.sendbtn')!.click()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(mocks.pgSetEffort).toHaveBeenCalledWith('pg_1', 'a1', 'low') // displayed == staged
+  })
+
   it('hides Effort/Permission for a runtime with no such vocabulary (opencode)', async () => {
     mocks.agents = [agent({ id: 'a2', runtime: 'opencode', daemon: 'd2' })]
     mocks.daemons = [

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Uses the REAL lib/data catalog helpers (modelCapability / effortChoicesFor /
+// permissionModeChoicesFor / preferredModelFor) so the P1 logic actually runs;
+// only the providers + heavy child components are stubbed. Each ComposerMenu
+// records its props so tests can assert which run-selectors render and with what.
+const mocks = vi.hoisted(() => ({
+  agents: [] as Array<Record<string, unknown>>,
+  daemons: [] as Array<Record<string, unknown>>,
+  menus: [] as Array<{ title: string; value: string; options: string[] }>,
+  openPlayground: vi.fn(() => 'pg_1'),
+  push: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }))
+vi.mock('next/link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <a>{children}</a>
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (p: string) => `/acme${p}` }) }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: mocks.agents,
+    daemons: mocks.daemons,
+    crons: [],
+    allSessions: [],
+    usage24h: null,
+    getAgent: () => undefined,
+    loading: false
+  })
+}))
+vi.mock('@/components/console/PlaygroundProvider', () => ({
+  usePlayground: () => ({
+    openPlayground: mocks.openPlayground,
+    pgSend: vi.fn(),
+    pgSetModel: vi.fn(),
+    pgSetEffort: vi.fn(),
+    pgSetPermissionMode: vi.fn()
+  })
+}))
+vi.mock('@/components/console/ComposerMenu', () => ({
+  ComposerMenu: (props: { title: string; value: string; options: { value: string }[] }) => {
+    mocks.menus.push({ title: props.title, value: props.value, options: props.options.map((o) => o.value) })
+    return <div data-menu={props.title} />
+  }
+}))
+vi.mock('@/components/marks', () => ({
+  AgentIconView: () => <span />,
+  ModelMark: () => <span />,
+  PlatformMark: () => <span />,
+  LoadingState: () => <span>loading</span>
+}))
+vi.mock('@/components/ui', () => ({ Icon: () => <span /> }))
+
+import HomeView from './HomeView'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLDivElement
+
+const claudeCatalog = {
+  models: [
+    {
+      id: 'claude-sonnet-4-5',
+      efforts: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' }
+      ],
+      defaultEffort: 'high'
+    }
+  ],
+  permissionModes: [
+    { value: 'default', name: 'Default' },
+    { value: 'plan', name: 'Plan' }
+  ],
+  defaultModel: 'claude-sonnet-4-5',
+  source: 'acp',
+  observedAt: ''
+}
+const agent = (over: Record<string, unknown> = {}) => ({
+  id: 'a1',
+  name: 'bot',
+  runtime: 'claude',
+  model: '',
+  reasoning: '',
+  permissionMode: '',
+  daemon: 'd1',
+  status: 'online',
+  icon: null,
+  ...over
+})
+const daemon = (over: Record<string, unknown> = {}) => ({
+  daemonId: 'd1',
+  status: 'online',
+  runtimeModels: [
+    { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: false }
+  ],
+  ...over
+})
+
+const render = async () => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => root.render(<HomeView />))
+}
+
+beforeEach(() => {
+  mocks.menus = []
+  mocks.openPlayground.mockClear()
+  mocks.push.mockClear()
+})
+afterEach(() => {
+  act(() => root.unmount())
+  document.body.innerHTML = ''
+})
+
+const menu = (title: string) => mocks.menus.find((m) => m.title === title)
+
+describe('HomeView run-selectors (catalog-aware)', () => {
+  it('resolves a blank stored model to the daemon default (shown == what runs)', async () => {
+    mocks.agents = [agent({ model: '' })]
+    mocks.daemons = [daemon()]
+    await render()
+    expect(menu('Model')?.value).toBe('claude-sonnet-4-5')
+    expect(menu('Effort')?.value).toBe('high') // catalog defaultEffort
+    expect(menu('Permission')?.value).toBe('default')
+  })
+
+  it('hides Effort/Permission for a runtime with no such vocabulary (opencode)', async () => {
+    mocks.agents = [agent({ id: 'a2', runtime: 'opencode', daemon: 'd2' })]
+    mocks.daemons = [
+      daemon({
+        daemonId: 'd2',
+        runtimeModels: [
+          { runtime: 'opencode', models: ['deepseek/deepseek-v4'], modelCatalog: undefined, authRequired: false }
+        ]
+      })
+    ]
+    await render()
+    expect(menu('Model')).toBeTruthy()
+    expect(menu('Effort')).toBeUndefined()
+    expect(menu('Permission')).toBeUndefined()
+  })
+})
+
+describe('HomeView readiness gate', () => {
+  it('shows the offline banner when the selected agent’s daemon is not serving', async () => {
+    mocks.agents = [agent()]
+    mocks.daemons = [daemon({ status: 'offline' })]
+    await render()
+    expect(host.textContent).toContain('is offline')
+  })
+
+  it('shows the no-runtime banner when the daemon runtime requires auth', async () => {
+    mocks.agents = [agent()]
+    mocks.daemons = [
+      daemon({
+        runtimeModels: [
+          { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: true }
+        ]
+      })
+    ]
+    await render()
+    expect(host.textContent).toContain('No AI runtime is signed in')
+  })
+})

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => ({
   daemons: [] as Array<Record<string, unknown>>,
   menus: [] as Array<{ title: string; value: string; options: string[] }>,
   openPlayground: vi.fn(() => 'pg_1'),
+  pgSend: vi.fn(),
+  pgSetModel: vi.fn(),
+  pgSetEffort: vi.fn(),
+  pgSetPermissionMode: vi.fn(),
   push: vi.fn()
 }))
 
@@ -34,10 +38,10 @@ vi.mock('@/lib/data-context', () => ({
 vi.mock('@/components/console/PlaygroundProvider', () => ({
   usePlayground: () => ({
     openPlayground: mocks.openPlayground,
-    pgSend: vi.fn(),
-    pgSetModel: vi.fn(),
-    pgSetEffort: vi.fn(),
-    pgSetPermissionMode: vi.fn()
+    pgSend: mocks.pgSend,
+    pgSetModel: mocks.pgSetModel,
+    pgSetEffort: mocks.pgSetEffort,
+    pgSetPermissionMode: mocks.pgSetPermissionMode
   })
 }))
 vi.mock('@/components/console/ComposerMenu', () => ({
@@ -111,6 +115,10 @@ const render = async () => {
 beforeEach(() => {
   mocks.menus = []
   mocks.openPlayground.mockClear()
+  mocks.pgSend.mockClear()
+  mocks.pgSetModel.mockClear()
+  mocks.pgSetEffort.mockClear()
+  mocks.pgSetPermissionMode.mockClear()
   mocks.push.mockClear()
 })
 afterEach(() => {
@@ -128,6 +136,48 @@ describe('HomeView run-selectors (catalog-aware)', () => {
     expect(menu('Model')?.value).toBe('claude-sonnet-4-5')
     expect(menu('Effort')?.value).toBe('high') // catalog defaultEffort
     expect(menu('Permission')?.value).toBe('default')
+  })
+
+  it('resolves a stored effort the selected model does not offer, and STAGES the resolved value on send', async () => {
+    const lowMed = {
+      models: [
+        {
+          id: 'm-lowmed',
+          efforts: [
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' }
+          ],
+          defaultEffort: 'medium'
+        }
+      ],
+      permissionModes: [{ value: 'default', name: 'Default' }],
+      defaultModel: 'm-lowmed',
+      source: 'acp',
+      observedAt: ''
+    }
+    mocks.agents = [agent({ model: 'm-lowmed', reasoning: 'xhigh' })] // stored xhigh not offered by m-lowmed
+    mocks.daemons = [
+      daemon({
+        runtimeModels: [{ runtime: 'claude', models: ['m-lowmed'], modelCatalog: lowMed, authRequired: false }]
+      })
+    ]
+    await render()
+    // Displayed effort is resolved to an offered level, not the phantom `xhigh`.
+    expect(menu('Effort')?.value).toBe('medium')
+    // …and send stages exactly that (never `xhigh`).
+    const ta = host.querySelector('textarea')!
+    const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!
+    await act(async () => {
+      setValue.call(ta, 'hi')
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('button.sendbtn')!.click()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(mocks.pgSetModel).toHaveBeenCalledWith('pg_1', 'a1', 'm-lowmed')
+    expect(mocks.pgSetEffort).toHaveBeenCalledWith('pg_1', 'a1', 'medium')
+    expect(mocks.pgSend).toHaveBeenCalled()
   })
 
   it('hides Effort/Permission for a runtime with no such vocabulary (opencode)', async () => {

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -146,13 +146,18 @@ export default function HomeView() {
   // Resolve the raw effort (override → agent default) against the SELECTED model's
   // offered levels, so the shown value is always one send can stage — never a phantom
   // the new model doesn't offer (e.g. keeping `xhigh` after switching to a low/medium
-  // model). Blank resolves to the model's own default level. This also makes a model
-  // change auto-correct effort without a special reset.
+  // model), and never a blank that displays as `options[0]` while send skips staging.
+  // Precedence: resolved raw value → the vocabulary's Default sentinel / model default
+  // → the first offered level. So the pill's level is ALWAYS exactly what send stages,
+  // even for phase-2 catalog entries that carry efforts but no `defaultEffort`. Also
+  // makes a model change auto-correct effort without a special reset.
   const rawEffort = runtime.effort ?? agent?.reasoning ?? ''
   const effort =
     agent && showEffort
       ? resolveEffortForModel(agent.runtime, capability, rawEffort) ||
-        displayedEffort('', effortList, capability?.defaultEffort)
+        displayedEffort('', effortList, capability?.defaultEffort) ||
+        effortList[0]?.value ||
+        ''
       : ''
   const effortChoices = effortList.map((o) => ({ value: o.value, label: o.label, description: o.description }))
 

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -20,9 +20,14 @@ import {
   agentLabel,
   modelLabel,
   runtimeLabel,
-  effortField,
-  permissionModeOptions,
   effectiveAgentStatus,
+  preferredModelFor,
+  modelCapability,
+  effortChoicesFor,
+  displayedEffort,
+  permissionModeChoicesFor,
+  resolvedPermissionMode,
+  supportsModes,
   type Agent
 } from '@/lib/data'
 import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
@@ -86,14 +91,18 @@ export default function HomeView() {
   const { agents, daemons, crons, allSessions, usage24h, getAgent, loading } = useConsoleData()
   const { openPlayground, pgSend, pgSetModel, pgSetEffort, pgSetPermissionMode } = usePlayground()
 
-  // An agent can only take a session when its owning daemon is serving.
+  // An agent can take a session only when its owning daemon is serving AND that
+  // runtime is signed in (its last probe wasn't rejected with ACP auth-required).
   const isOnline = (a: Agent) =>
     effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status) === 'online'
+  const authRequiredFor = (a: Agent) =>
+    !!daemons.find((d) => d.daemonId === a.daemon)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
+  const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)
 
   // Preferred default agent: the "agentconnect" preset if present, else the first
-  // ONLINE agent, else the first (so the composer defaults to something startable).
+  // READY one, else the first (so the composer defaults to something startable).
   const preferred = useMemo(
-    () => agents.find((a) => a.name === 'agentconnect') ?? agents.find(isOnline) ?? agents[0],
+    () => agents.find((a) => a.name === 'agentconnect') ?? agents.find(agentReady) ?? agents[0],
     [agents, daemons]
   )
   const [agentId, setAgentId] = useState<string | undefined>(undefined)
@@ -111,54 +120,73 @@ export default function HomeView() {
 
   // The selected agent's owning daemon supplies the model catalog + defaults.
   const owningDaemon = agent ? daemons.find((d) => d.daemonId === agent.daemon) : undefined
-  const runtimeModels = owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)?.models ?? []
-  const modelChoices = (runtimeModels.length ? runtimeModels : agent?.model ? [agent.model] : []).map((m) => ({
-    value: m,
-    label: modelLabel(m)
-  }))
-  const effortChoices = agent ? effortField(agent.runtime).options.map((o) => ({ value: o.v, label: o.l })) : []
-  const permissionChoices = agent ? permissionModeOptions(agent.runtime).map((o) => ({ value: o.v, label: o.l })) : []
+  const runtimeProfile = owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)
+  const models = runtimeProfile?.models ?? []
+  const modelCatalog = runtimeProfile?.modelCatalog ?? undefined
 
-  // Selected-agent readiness. Starting a session needs the agent's owning daemon
-  // serving AND its runtime signed in — the daemon's last probe of that runtime
-  // wasn't rejected with the ACP "authentication required" error (authRequired).
-  const runtimeAuthRequired =
-    agentOnline && !!owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)?.authRequired
+  // Effective model = explicit override, else the agent's stored model when the daemon
+  // still advertises it, else the daemon's RESOLVED default (preferredModelFor). We stage
+  // this on send, so the pill's label is exactly the model the turn runs — not a display
+  // that silently differs from the daemon default for a blank/stale stored model.
+  const defaultModel =
+    agent && models.includes(agent.model)
+      ? agent.model
+      : preferredModelFor(owningDaemon, agent?.runtime ?? '') || agent?.model || ''
+  const model = runtime.model ?? defaultModel
+  const modelChoices = (models.length ? models : model ? [model] : []).map((m) => ({ value: m, label: modelLabel(m) }))
+
+  // Effort + permission come from the SELECTED model's discovered capability / the
+  // runtime catalog — the same catalog-aware helpers the session and add/edit controls
+  // use — not the static tables. So a runtime with no such vocabulary (e.g. opencode)
+  // shows no effort/permission control instead of Claude-style values it doesn't accept.
+  const capability = agent ? modelCapability(owningDaemon, agent.runtime, model) : undefined
+  const effortList = agent ? effortChoicesFor(agent.runtime, capability) : []
+  const showEffort = capability?.efforts ? effortList.length > 0 : agent ? supportsModes(agent.runtime) : false
+  const effort = showEffort
+    ? displayedEffort(runtime.effort ?? agent?.reasoning ?? '', effortList, capability?.defaultEffort)
+    : ''
+  const effortChoices = effortList.map((o) => ({ value: o.value, label: o.label, description: o.description }))
+
+  const permissionList = agent ? permissionModeChoicesFor(agent.runtime, modelCatalog) : []
+  const showPermission = agent ? !!modelCatalog?.permissionModes?.length || supportsModes(agent.runtime) : false
+  const permission = showPermission
+    ? resolvedPermissionMode(runtime.permission ?? agent?.permissionMode ?? '', permissionList, modelCatalog)
+    : ''
+  const permissionChoices = permissionList.map((o) => ({ value: o.v, label: o.l, description: o.description }))
+
   // Why the composer can't start a session for the selected agent (null ⇒ it can).
   const blocked: 'offline' | 'auth' | null = !agent
     ? null
     : !agentOnline
       ? 'offline'
-      : runtimeAuthRequired
+      : authRequiredFor(agent)
         ? 'auth'
         : null
   const canSend = !!agent && blocked === null
   const daemonHref = owningDaemon ? orgPath(`/daemons/${owningDaemon.daemonId}`) : null
 
-  // Effective run runtime = override, else the agent's own config. Resolve the model
-  // against the available choices the SAME way ComposerMenu does (value ?? options[0]),
-  // so the pill's icon matches the label shown even when the agent's stored model isn't
-  // in the daemon's advertised list (else ModelMark gets an unmatched value → wrong icon).
-  const rawModel = runtime.model ?? agent?.model ?? ''
-  const model = modelChoices.find((c) => c.value === rawModel)?.value ?? modelChoices[0]?.value ?? rawModel
-  const effort = runtime.effort ?? agent?.reasoning ?? ''
-  const permission = runtime.permission ?? agent?.permissionMode ?? ''
-
   const send = () => {
     const text = input.trim()
     if (!text || !agent || !canSend) return // offline / unsigned-in agents can't take a session
     const id = openPlayground(agent) // pg_ session; pgSend awaits the socket, so no race
-    // Apply run-runtime overrides before the turn — stageRuntimeChange is a synchronous
-    // ref write, so pgSend's payload picks them up (PlaygroundProvider).
-    if (runtime.model) pgSetModel(id, agent.id, runtime.model)
-    if (runtime.effort) pgSetEffort(id, agent.id, runtime.effort)
-    if (runtime.permission) pgSetPermissionMode(id, agent.id, runtime.permission)
+    // Stage the EFFECTIVE (displayed) runtime before the turn — not just explicit
+    // overrides — so the session runs exactly what the composer showed. stageRuntimeChange
+    // is a synchronous ref write, so pgSend's payload picks it up (PlaygroundProvider).
+    if (model) pgSetModel(id, agent.id, model)
+    if (effort) pgSetEffort(id, agent.id, effort)
+    if (permission) pgSetPermissionMode(id, agent.id, permission)
     pgSend(id, agent.id, text)
     setInput('')
     router.push(orgPath(`/sessions/${id}`))
   }
 
+  // Same readiness gate as the composer: starting a chat with a not-ready agent would
+  // open a dead session, so select it in Home instead and let the banner explain why.
   const startChat = (a: Agent) => {
+    if (!agentReady(a)) {
+      setAgentId(a.id)
+      return
+    }
     const id = openPlayground(a)
     router.push(orgPath(`/sessions/${id}`))
   }
@@ -179,18 +207,21 @@ export default function HomeView() {
   if (loading && agents.length === 0 && allSessions.length === 0) return <LoadingState fill />
 
   const agentOptions = agents.map((a) => {
-    const online = isOnline(a)
+    const ready = agentReady(a)
+    const reason = !isOnline(a)
+      ? `${agentLabel(a)} is offline — its daemon isn't serving`
+      : `${agentLabel(a)} has no AI runtime signed in`
     return {
       value: a.id,
       label: agentLabel(a),
-      dimmed: !online,
-      description: online ? 'Pick the agent to ask' : `${agentLabel(a)} is offline — its daemon isn't serving`,
+      dimmed: !ready,
+      description: ready ? 'Pick the agent to ask' : reason,
       leading: (
         <span className="relative flex-none">
           <span className="av h-[18px] w-[18px] rounded-xs">
             <AgentIconView icon={a.icon} runtime={a.runtime} size={18} />
           </span>
-          {!online && (
+          {!ready && (
             <span
               className="dot absolute -right-[2px] -bottom-[2px] h-[7px] w-[7px] ring-2 ring-(--surface-card)"
               style={{ background: 'var(--status-error)' }}
@@ -224,81 +255,86 @@ export default function HomeView() {
           placeholder="Ask agentconnect to connect a workspace, deploy an agent, or check on a run"
           className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-4 pt-[14px] pb-2 font-sans text-[14px] leading-normal text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
         />
-        <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
-          {agent ? (
-            <>
-              <ComposerMenu
-                title="Agent"
-                value={agent.id}
-                options={agentOptions}
-                open={menu === 'agent'}
-                align="left"
-                placement="down"
-                triggerClassName="inline-flex h-7 items-center gap-[7px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
-                leading={
-                  <span className="av h-4 w-4 rounded-xs">
-                    <AgentIconView icon={agent.icon} runtime={agent.runtime} size={16} />
-                  </span>
-                }
-                onOpenChange={(o) => setMenu(o ? 'agent' : null)}
-                onChange={setAgentId}
-              />
-              {modelChoices.length > 0 && (
+        {/* items-start + a wrapping selector group so the controls reflow onto a second
+            row at phone widths instead of overflowing (mobile .content clips overflow-x);
+            the send button stays pinned top-right. */}
+        <div className="flex items-start gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            {agent ? (
+              <>
                 <ComposerMenu
-                  title="Model"
-                  value={model}
-                  options={modelChoices}
-                  open={menu === 'model'}
+                  title="Agent"
+                  value={agent.id}
+                  options={agentOptions}
+                  open={menu === 'agent'}
                   align="left"
                   placement="down"
-                  triggerClassName="inline-flex h-7 items-center gap-[3px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
-                  tooltips={false}
+                  triggerClassName="inline-flex h-7 items-center gap-[7px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
                   leading={
-                    <span className="inline-flex h-4 w-4 flex-none items-center justify-center">
-                      <ModelMark model={model} fallbackRuntime={agent.runtime} />
+                    <span className="av h-4 w-4 rounded-xs">
+                      <AgentIconView icon={agent.icon} runtime={agent.runtime} size={16} />
                     </span>
                   }
-                  onOpenChange={(o) => setMenu(o ? 'model' : null)}
-                  onChange={(m) => setRuntime((r) => ({ ...r, model: m }))}
+                  onOpenChange={(o) => setMenu(o ? 'agent' : null)}
+                  onChange={setAgentId}
                 />
-              )}
-              {effortChoices.length > 0 && (
-                <ComposerMenu
-                  title="Effort"
-                  value={effort}
-                  options={effortChoices}
-                  open={menu === 'effort'}
-                  align="left"
-                  placement="down"
-                  triggerClassName={CHIP}
-                  tooltips={false}
-                  onOpenChange={(o) => setMenu(o ? 'effort' : null)}
-                  onChange={(v) => setRuntime((r) => ({ ...r, effort: v }))}
-                />
-              )}
-              {permissionChoices.length > 0 && (
-                <ComposerMenu
-                  title="Permission"
-                  value={permission}
-                  options={permissionChoices}
-                  open={menu === 'permission'}
-                  align="left"
-                  placement="down"
-                  triggerClassName={CHIP}
-                  tooltips={false}
-                  onOpenChange={(o) => setMenu(o ? 'permission' : null)}
-                  onChange={(v) => setRuntime((r) => ({ ...r, permission: v }))}
-                />
-              )}
-            </>
-          ) : (
-            <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
-              No agents yet
-            </span>
-          )}
+                {modelChoices.length > 0 && (
+                  <ComposerMenu
+                    title="Model"
+                    value={model}
+                    options={modelChoices}
+                    open={menu === 'model'}
+                    align="left"
+                    placement="down"
+                    triggerClassName="inline-flex h-7 items-center gap-[3px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
+                    tooltips={false}
+                    leading={
+                      <span className="inline-flex h-4 w-4 flex-none items-center justify-center">
+                        <ModelMark model={model} fallbackRuntime={agent.runtime} />
+                      </span>
+                    }
+                    onOpenChange={(o) => setMenu(o ? 'model' : null)}
+                    onChange={(m) => setRuntime((r) => ({ ...r, model: m, effort: undefined }))}
+                  />
+                )}
+                {showEffort && effortChoices.length > 0 && (
+                  <ComposerMenu
+                    title="Effort"
+                    value={effort}
+                    options={effortChoices}
+                    open={menu === 'effort'}
+                    align="left"
+                    placement="down"
+                    triggerClassName={CHIP}
+                    tooltips={false}
+                    onOpenChange={(o) => setMenu(o ? 'effort' : null)}
+                    onChange={(v) => setRuntime((r) => ({ ...r, effort: v }))}
+                  />
+                )}
+                {showPermission && permissionChoices.length > 0 && (
+                  <ComposerMenu
+                    title="Permission"
+                    value={permission}
+                    options={permissionChoices}
+                    open={menu === 'permission'}
+                    align="left"
+                    placement="down"
+                    triggerClassName={CHIP}
+                    tooltips={false}
+                    onOpenChange={(o) => setMenu(o ? 'permission' : null)}
+                    onChange={(v) => setRuntime((r) => ({ ...r, permission: v }))}
+                  />
+                )}
+              </>
+            ) : (
+              <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+                No agents yet
+              </span>
+            )}
+          </div>
           <button
             type="button"
-            className="sendbtn ml-auto h-7 w-7 rounded-[7px]"
+            className="sendbtn h-7 w-7 flex-none rounded-[7px]"
             disabled={!input.trim() || !canSend}
             onClick={send}
             title={
@@ -394,30 +430,37 @@ export default function HomeView() {
             {rankedAgents.length === 0 ? (
               <EmptyRow>No agents yet.</EmptyRow>
             ) : (
-              rankedAgents.map((a) => (
-                <button
-                  key={a.id}
-                  type="button"
-                  onClick={() => startChat(a)}
-                  title={`Start a chat with ${agentLabel(a)}`}
-                  className="row click w-full grid-cols-[auto_1fr_auto] gap-3 text-left"
-                >
-                  <span className="av h-7 w-7 rounded-md">
-                    <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
-                      {agentLabel(a)}
+              rankedAgents.map((a) => {
+                const ready = agentReady(a)
+                return (
+                  <button
+                    key={a.id}
+                    type="button"
+                    onClick={() => startChat(a)}
+                    title={
+                      ready
+                        ? `Start a chat with ${agentLabel(a)}`
+                        : `${agentLabel(a)} isn't ready — select it to see why`
+                    }
+                    className={`row click w-full grid-cols-[auto_1fr_auto] gap-3 text-left ${ready ? '' : 'opacity-60'}`}
+                  >
+                    <span className="av h-7 w-7 rounded-md">
+                      <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
                     </span>
-                    <span className="mono block truncate text-[11px] text-(--text-tertiary)">
-                      {runtimeLabel(a.runtime)} · {modelLabel(a.model)}
+                    <span className="min-w-0">
+                      <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                        {agentLabel(a)}
+                      </span>
+                      <span className="mono block truncate text-[11px] text-(--text-tertiary)">
+                        {runtimeLabel(a.runtime)} · {modelLabel(a.model)}
+                      </span>
                     </span>
-                  </span>
-                  <span className="mono whitespace-nowrap text-[12px] text-(--text-secondary)">
-                    {sessionsByAgent.get(a.id) ?? 0}
-                  </span>
-                </button>
-              ))
+                    <span className="mono whitespace-nowrap text-[12px] text-(--text-secondary)">
+                      {sessionsByAgent.get(a.id) ?? 0}
+                    </span>
+                  </button>
+                )
+              })
             )}
           </Card>
 

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -1,0 +1,452 @@
+'use client'
+
+// The chat-first console landing. A composer ("Ask an agent") is the primary
+// posture; sending hands off to a live session (openPlayground → pgSend →
+// /sessions/{id}), which IS the design's "the same page becomes the
+// conversation". Below it the page answers "what happened / what's next / who
+// do I ask": Recent sessions, Agents you use (ranked by 24h session count),
+// and Scheduled runs.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useOrgs } from '@/lib/org-context'
+import { useConsoleData } from '@/lib/data-context'
+import { usePlayground } from '@/components/console/PlaygroundProvider'
+import { ComposerMenu } from '@/components/console/ComposerMenu'
+import { Icon } from '@/components/ui'
+import { AgentIconView, ModelMark, PlatformMark, LoadingState } from '@/components/marks'
+import {
+  agentLabel,
+  modelLabel,
+  runtimeLabel,
+  effortField,
+  permissionModeOptions,
+  effectiveAgentStatus,
+  type Agent
+} from '@/lib/data'
+import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
+
+// Design composer selectors: agent/model are "pills" (rounded, with a leading
+// mark), effort/permission are plain "chips". Full literal strings so Tailwind's
+// scanner sees them (STYLE.md §8).
+const CHIP =
+  'inline-flex h-7 items-center gap-[6px] rounded-md px-[9px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
+
+// Relative "…ago" for a cron's last run. fmtNextRun covers the future side;
+// this is the (missing) past side. Coarse buckets are all a dashboard needs.
+function fmtAgo(iso: string | null): string {
+  if (!iso) return 'never'
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return 'never'
+  const s = Math.max(0, Math.round((Date.now() - t) / 1000))
+  if (s < 60) return 'just now'
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.round(h / 24)}d ago`
+}
+
+function Card({ title, action, children }: { title: string; action?: ReactNode; children: ReactNode }) {
+  return (
+    <div className="card overflow-hidden">
+      <div className="cardhead justify-between">
+        <span className="cardtitle">{title}</span>
+        {action}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function CardLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1 font-sans text-[12px] font-medium leading-normal text-(--text-brand) hover:underline"
+    >
+      {children}
+      <Icon name="arrow-right" size={12} color="var(--text-brand)" />
+    </Link>
+  )
+}
+
+function EmptyRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="px-4 py-5 text-center font-sans text-[12.5px] leading-normal text-(--text-tertiary)">
+      {children}
+    </div>
+  )
+}
+
+export default function HomeView() {
+  const router = useRouter()
+  const { orgPath } = useOrgs()
+  const { agents, daemons, crons, allSessions, usage24h, getAgent, loading } = useConsoleData()
+  const { openPlayground, pgSend, pgSetModel, pgSetEffort, pgSetPermissionMode } = usePlayground()
+
+  // An agent can only take a session when its owning daemon is serving.
+  const isOnline = (a: Agent) =>
+    effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status) === 'online'
+
+  // Preferred default agent: the "agentconnect" preset if present, else the first
+  // ONLINE agent, else the first (so the composer defaults to something startable).
+  const preferred = useMemo(
+    () => agents.find((a) => a.name === 'agentconnect') ?? agents.find(isOnline) ?? agents[0],
+    [agents, daemons]
+  )
+  const [agentId, setAgentId] = useState<string | undefined>(undefined)
+  const agent = agents.find((a) => a.id === agentId) ?? preferred
+  const agentOnline = agent ? isOnline(agent) : false
+
+  const [input, setInput] = useState('')
+  // Which selector menu is open (only one at a time), and the run-runtime overrides.
+  const [menu, setMenu] = useState<'agent' | 'model' | 'effort' | 'permission' | null>(null)
+  const [runtime, setRuntime] = useState<{ model?: string; effort?: string; permission?: string }>({})
+
+  // Overrides are per-agent; drop them when the agent changes so the new agent's
+  // own defaults show through.
+  useEffect(() => setRuntime({}), [agent?.id])
+
+  // The selected agent's owning daemon supplies the model catalog + defaults.
+  const owningDaemon = agent ? daemons.find((d) => d.daemonId === agent.daemon) : undefined
+  const runtimeModels = owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)?.models ?? []
+  const modelChoices = (runtimeModels.length ? runtimeModels : agent?.model ? [agent.model] : []).map((m) => ({
+    value: m,
+    label: modelLabel(m)
+  }))
+  const effortChoices = agent ? effortField(agent.runtime).options.map((o) => ({ value: o.v, label: o.l })) : []
+  const permissionChoices = agent ? permissionModeOptions(agent.runtime).map((o) => ({ value: o.v, label: o.l })) : []
+
+  // Selected-agent readiness. Starting a session needs the agent's owning daemon
+  // serving AND its runtime signed in — the daemon's last probe of that runtime
+  // wasn't rejected with the ACP "authentication required" error (authRequired).
+  const runtimeAuthRequired =
+    agentOnline && !!owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)?.authRequired
+  // Why the composer can't start a session for the selected agent (null ⇒ it can).
+  const blocked: 'offline' | 'auth' | null = !agent
+    ? null
+    : !agentOnline
+      ? 'offline'
+      : runtimeAuthRequired
+        ? 'auth'
+        : null
+  const canSend = !!agent && blocked === null
+  const daemonHref = owningDaemon ? orgPath(`/daemons/${owningDaemon.daemonId}`) : null
+
+  // Effective run runtime = override, else the agent's own config. Resolve the model
+  // against the available choices the SAME way ComposerMenu does (value ?? options[0]),
+  // so the pill's icon matches the label shown even when the agent's stored model isn't
+  // in the daemon's advertised list (else ModelMark gets an unmatched value → wrong icon).
+  const rawModel = runtime.model ?? agent?.model ?? ''
+  const model = modelChoices.find((c) => c.value === rawModel)?.value ?? modelChoices[0]?.value ?? rawModel
+  const effort = runtime.effort ?? agent?.reasoning ?? ''
+  const permission = runtime.permission ?? agent?.permissionMode ?? ''
+
+  const send = () => {
+    const text = input.trim()
+    if (!text || !agent || !canSend) return // offline / unsigned-in agents can't take a session
+    const id = openPlayground(agent) // pg_ session; pgSend awaits the socket, so no race
+    // Apply run-runtime overrides before the turn — stageRuntimeChange is a synchronous
+    // ref write, so pgSend's payload picks them up (PlaygroundProvider).
+    if (runtime.model) pgSetModel(id, agent.id, runtime.model)
+    if (runtime.effort) pgSetEffort(id, agent.id, runtime.effort)
+    if (runtime.permission) pgSetPermissionMode(id, agent.id, runtime.permission)
+    pgSend(id, agent.id, text)
+    setInput('')
+    router.push(orgPath(`/sessions/${id}`))
+  }
+
+  const startChat = (a: Agent) => {
+    const id = openPlayground(a)
+    router.push(orgPath(`/sessions/${id}`))
+  }
+
+  const recent = allSessions.slice(0, 6)
+
+  const sessionsByAgent = useMemo(
+    () => new Map((usage24h?.agents ?? []).map((u) => [u.agentId, u.sessions])),
+    [usage24h]
+  )
+  const rankedAgents = useMemo(
+    () => [...agents].sort((a, b) => (sessionsByAgent.get(b.id) ?? 0) - (sessionsByAgent.get(a.id) ?? 0)).slice(0, 4),
+    [agents, sessionsByAgent]
+  )
+
+  const scheduled = crons.slice(0, 3)
+
+  if (loading && agents.length === 0 && allSessions.length === 0) return <LoadingState fill />
+
+  const agentOptions = agents.map((a) => {
+    const online = isOnline(a)
+    return {
+      value: a.id,
+      label: agentLabel(a),
+      dimmed: !online,
+      description: online ? 'Pick the agent to ask' : `${agentLabel(a)} is offline — its daemon isn't serving`,
+      leading: (
+        <span className="relative flex-none">
+          <span className="av h-[18px] w-[18px] rounded-xs">
+            <AgentIconView icon={a.icon} runtime={a.runtime} size={18} />
+          </span>
+          {!online && (
+            <span
+              className="dot absolute -right-[2px] -bottom-[2px] h-[7px] w-[7px] ring-2 ring-(--surface-card)"
+              style={{ background: 'var(--status-error)' }}
+            />
+          )}
+        </span>
+      )
+    }
+  })
+
+  return (
+    <div className="wrap max-w-[1000px] max-desktop:px-4 max-desktop:pt-4 max-desktop:pb-24">
+      <h1 className="ptitle mb-4">Ask an agent</h1>
+
+      {/* Composer — hands off to a live session on send. The footer selectors mirror
+          the design: agent + model as pills (leading mark), effort + permission as
+          chips. Each picks the run's runtime; the choice is applied on send. */}
+      <div className="card mb-3 overflow-visible">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            // Enter sends, except during IME composition (candidate-confirming Enter)
+            // or with Shift (newline).
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+              e.preventDefault()
+              send()
+            }
+          }}
+          rows={2}
+          placeholder="Ask agentconnect to connect a workspace, deploy an agent, or check on a run"
+          className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-4 pt-[14px] pb-2 font-sans text-[14px] leading-normal text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+        />
+        <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
+          {agent ? (
+            <>
+              <ComposerMenu
+                title="Agent"
+                value={agent.id}
+                options={agentOptions}
+                open={menu === 'agent'}
+                align="left"
+                placement="down"
+                triggerClassName="inline-flex h-7 items-center gap-[7px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
+                leading={
+                  <span className="av h-4 w-4 rounded-xs">
+                    <AgentIconView icon={agent.icon} runtime={agent.runtime} size={16} />
+                  </span>
+                }
+                onOpenChange={(o) => setMenu(o ? 'agent' : null)}
+                onChange={setAgentId}
+              />
+              {modelChoices.length > 0 && (
+                <ComposerMenu
+                  title="Model"
+                  value={model}
+                  options={modelChoices}
+                  open={menu === 'model'}
+                  align="left"
+                  placement="down"
+                  triggerClassName="inline-flex h-7 items-center gap-[3px] rounded-full px-[10px] font-sans text-[12.5px] font-medium leading-normal text-(--text-primary) hover:bg-(--surface-hover)"
+                  tooltips={false}
+                  leading={
+                    <span className="inline-flex h-4 w-4 flex-none items-center justify-center">
+                      <ModelMark model={model} fallbackRuntime={agent.runtime} />
+                    </span>
+                  }
+                  onOpenChange={(o) => setMenu(o ? 'model' : null)}
+                  onChange={(m) => setRuntime((r) => ({ ...r, model: m }))}
+                />
+              )}
+              {effortChoices.length > 0 && (
+                <ComposerMenu
+                  title="Effort"
+                  value={effort}
+                  options={effortChoices}
+                  open={menu === 'effort'}
+                  align="left"
+                  placement="down"
+                  triggerClassName={CHIP}
+                  tooltips={false}
+                  onOpenChange={(o) => setMenu(o ? 'effort' : null)}
+                  onChange={(v) => setRuntime((r) => ({ ...r, effort: v }))}
+                />
+              )}
+              {permissionChoices.length > 0 && (
+                <ComposerMenu
+                  title="Permission"
+                  value={permission}
+                  options={permissionChoices}
+                  open={menu === 'permission'}
+                  align="left"
+                  placement="down"
+                  triggerClassName={CHIP}
+                  tooltips={false}
+                  onOpenChange={(o) => setMenu(o ? 'permission' : null)}
+                  onChange={(v) => setRuntime((r) => ({ ...r, permission: v }))}
+                />
+              )}
+            </>
+          ) : (
+            <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+              No agents yet
+            </span>
+          )}
+          <button
+            type="button"
+            className="sendbtn ml-auto h-7 w-7 rounded-[7px]"
+            disabled={!input.trim() || !canSend}
+            onClick={send}
+            title={
+              blocked === 'offline'
+                ? `${agentLabel(agent!)} is offline — can't start a session`
+                : blocked === 'auth'
+                  ? `No AI runtime is signed in on ${owningDaemon?.name ?? 'the daemon'} — can't start a session`
+                  : 'Send'
+            }
+          >
+            <Icon name="arrow-up" size={15} color="#fff" />
+          </button>
+        </div>
+      </div>
+
+      {/* Why the selected agent can't take a session (state-driven, per agent):
+          offline ⇒ its daemon isn't serving; auth ⇒ online but the daemon's runtime
+          reported "sign-in required" (no active AI subscription/login). */}
+      {!loading && blocked && (
+        <div className="mb-3 flex items-center gap-3 rounded-lg border border-(--status-paused-soft) bg-(--status-paused-soft) px-4 py-[10px]">
+          <Icon name="triangle-alert" size={16} color="var(--status-paused)" />
+          <span className="min-w-0 flex-1 font-sans text-[13px] leading-normal text-(--text-secondary)">
+            {blocked === 'offline' ? (
+              <>
+                <span className="font-semibold">{agentLabel(agent!)}</span>
+                {' is offline — you can’t start a session until its daemon reconnects.'}
+              </>
+            ) : (
+              <>
+                {'No AI runtime is signed in'}
+                {owningDaemon ? (
+                  <>
+                    {' on '}
+                    <span className="font-semibold">{owningDaemon.name}</span>
+                  </>
+                ) : null}
+                {', so agents can’t take a session.'}
+              </>
+            )}
+          </span>
+          {daemonHref && (
+            <button
+              type="button"
+              className="flex-none font-sans text-[13px] font-semibold leading-normal text-(--text-brand) hover:underline"
+              onClick={() => router.push(daemonHref)}
+            >
+              {blocked === 'auth' ? 'Fix' : 'View daemon'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Dashboard grid. */}
+      <div className="grid grid-cols-1 gap-4 desktop:grid-cols-[1.5fr_1fr]">
+        <Card title="Recent" action={<CardLink href={orgPath('/sessions')}>All sessions</CardLink>}>
+          {recent.length === 0 ? (
+            <EmptyRow>No sessions yet — ask an agent above to start one.</EmptyRow>
+          ) : (
+            recent.map((s) => {
+              const owner = s.agentId ? getAgent(s.agentId) : undefined
+              return (
+                <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
+                  <span className="min-w-0">
+                    <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                      {s.title}
+                    </span>
+                    <span className="mt-[3px] flex items-center gap-[6px] text-(--text-tertiary)">
+                      <span className="av h-[15px] w-[15px] rounded-xs">
+                        <AgentIconView icon={owner?.icon} runtime={owner?.runtime ?? s.runtime ?? 'claude'} size={15} />
+                      </span>
+                      <span className="truncate font-sans text-[11.5px] leading-normal">{s.agentName || '—'}</span>
+                      {s.channel && (
+                        <>
+                          <span className="imark h-[13px] w-[13px] rounded-xs">
+                            <PlatformMark platform={s.platform} />
+                          </span>
+                          <span className="mono truncate text-[11px]">{s.channel}</span>
+                        </>
+                      )}
+                    </span>
+                  </span>
+                  <span className="mono self-start whitespace-nowrap text-[11.5px] text-(--text-tertiary)">
+                    {s.time}
+                  </span>
+                </Link>
+              )
+            })
+          )}
+        </Card>
+
+        <div className="flex flex-col gap-4">
+          <Card title="Agents you use" action={<CardLink href={orgPath('/agents')}>All agents</CardLink>}>
+            {rankedAgents.length === 0 ? (
+              <EmptyRow>No agents yet.</EmptyRow>
+            ) : (
+              rankedAgents.map((a) => (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => startChat(a)}
+                  title={`Start a chat with ${agentLabel(a)}`}
+                  className="row click w-full grid-cols-[auto_1fr_auto] gap-3 text-left"
+                >
+                  <span className="av h-7 w-7 rounded-md">
+                    <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                      {agentLabel(a)}
+                    </span>
+                    <span className="mono block truncate text-[11px] text-(--text-tertiary)">
+                      {runtimeLabel(a.runtime)} · {modelLabel(a.model)}
+                    </span>
+                  </span>
+                  <span className="mono whitespace-nowrap text-[12px] text-(--text-secondary)">
+                    {sessionsByAgent.get(a.id) ?? 0}
+                  </span>
+                </button>
+              ))
+            )}
+          </Card>
+
+          <Card title="Scheduled runs" action={<CardLink href={orgPath('/crons')}>All schedules</CardLink>}>
+            {scheduled.length === 0 ? (
+              <EmptyRow>No schedules yet.</EmptyRow>
+            ) : (
+              scheduled.map((c) => {
+                const owner = c.agentId ? getAgent(c.agentId) : undefined
+                return (
+                  <Link key={c.id} href={orgPath(`/crons/${c.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
+                    <span className="min-w-0">
+                      <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                        {c.name || cronHuman(c.schedule) || c.schedule}
+                      </span>
+                      <span className="mono mt-[3px] block truncate text-[11px] text-(--text-tertiary)">
+                        {owner ? agentLabel(owner) : '—'} · ran {fmtAgo(c.lastRunAt)}
+                      </span>
+                    </span>
+                    <span className="mono self-start whitespace-nowrap text-[11.5px] text-(--text-secondary)">
+                      {c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone)) : 'paused'}
+                    </span>
+                  </Link>
+                )
+              })
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -25,6 +25,7 @@ import {
   modelCapability,
   effortChoicesFor,
   displayedEffort,
+  resolveEffortForModel,
   permissionModeChoicesFor,
   resolvedPermissionMode,
   supportsModes,
@@ -142,9 +143,17 @@ export default function HomeView() {
   const capability = agent ? modelCapability(owningDaemon, agent.runtime, model) : undefined
   const effortList = agent ? effortChoicesFor(agent.runtime, capability) : []
   const showEffort = capability?.efforts ? effortList.length > 0 : agent ? supportsModes(agent.runtime) : false
-  const effort = showEffort
-    ? displayedEffort(runtime.effort ?? agent?.reasoning ?? '', effortList, capability?.defaultEffort)
-    : ''
+  // Resolve the raw effort (override → agent default) against the SELECTED model's
+  // offered levels, so the shown value is always one send can stage — never a phantom
+  // the new model doesn't offer (e.g. keeping `xhigh` after switching to a low/medium
+  // model). Blank resolves to the model's own default level. This also makes a model
+  // change auto-correct effort without a special reset.
+  const rawEffort = runtime.effort ?? agent?.reasoning ?? ''
+  const effort =
+    agent && showEffort
+      ? resolveEffortForModel(agent.runtime, capability, rawEffort) ||
+        displayedEffort('', effortList, capability?.defaultEffort)
+      : ''
   const effortChoices = effortList.map((o) => ({ value: o.value, label: o.label, description: o.description }))
 
   const permissionList = agent ? permissionModeChoicesFor(agent.runtime, modelCatalog) : []
@@ -294,7 +303,7 @@ export default function HomeView() {
                       </span>
                     }
                     onOpenChange={(o) => setMenu(o ? 'model' : null)}
-                    onChange={(m) => setRuntime((r) => ({ ...r, model: m, effort: undefined }))}
+                    onChange={(m) => setRuntime((r) => ({ ...r, model: m }))}
                   />
                 )}
                 {showEffort && effortChoices.length > 0 && (

--- a/packages/web/src/components/console/views/NotFoundView.tsx
+++ b/packages/web/src/components/console/views/NotFoundView.tsx
@@ -17,9 +17,9 @@ export default function NotFoundView() {
         kind="PAGE"
         title="Page not found"
         chip={pathname}
-        post=" doesn’t exist. Check the address, or head back to your agents."
-        actionLabel="Go to agents"
-        actionHref={orgPath('/agents')}
+        post=" doesn’t exist. Check the address, or head back home."
+        actionLabel="Go to home"
+        actionHref={orgPath('/home')}
         searchLabel="Search"
       />
     </div>

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -141,7 +141,7 @@ export default function OnboardingView() {
   const goConsole = () => {
     void cleanupPending()
     skipOnboarding(orgKey)
-    router.push(orgPath('/agents'))
+    router.push(orgPath('/home'))
   }
 
   if (loading) return <LoadingState fill />

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -57,6 +57,7 @@ import { mergeSessionMessages } from '@/lib/session-transcript'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
+import { WORK_LANES, workSummary } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import {
   sessionEffortAfterModelChange,
@@ -130,17 +131,6 @@ interface FmtStep {
   time?: string
   // Present only on real-transcript tool rows that carry a captured body.
   msg?: SessionMessageDto
-}
-
-// 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
-// text and collapses its "work" (reasoning / plan / tool / edit lanes) behind a
-// per-turn "Thought through…" toggle.
-const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
-function workSummary(thinkCount: number, toolCount: number): string {
-  const parts: string[] = []
-  if (thinkCount > 0) parts.push(`Thought through ${thinkCount} step${thinkCount > 1 ? 's' : ''}`)
-  if (toolCount > 0) parts.push(`${parts.length ? 'ran' : 'Ran'} ${toolCount} command${toolCount > 1 ? 's' : ''}`)
-  return parts.join(', ')
 }
 
 // A step's non-text extras (code block, file chips, captured tool body) — rendered
@@ -1527,7 +1517,9 @@ export default function SessionDetailView() {
                   const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
                   const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
                   const toolCount = workSteps.filter((s) => s.lane === 'TOOL').length
-                  const summary = workSummary(workSteps.length - toolCount, toolCount)
+                  const editCount = workSteps.filter((s) => s.lane === 'EDIT').length
+                  // Reasoning = everything that isn't a tool call or a file edit (THINK/PLAN).
+                  const summary = workSummary(workSteps.length - toolCount - editCount, toolCount, editCount)
                   // Auto-open while a turn has produced only work (mid-stream), so the
                   // live agent isn't hidden; collapse once its answer text lands.
                   const openWork = expandedWork.has(ti) || textSteps.length === 0

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -57,7 +57,7 @@ import { mergeSessionMessages } from '@/lib/session-transcript'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
-import { WORK_LANES, workSummary } from '@/components/console/session-work'
+import { WORK_LANES, workCounts, workSummary } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import {
   sessionEffortAfterModelChange,
@@ -1516,10 +1516,10 @@ export default function SessionDetailView() {
                   // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
                   const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
                   const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
-                  const toolCount = workSteps.filter((s) => s.lane === 'TOOL').length
-                  const editCount = workSteps.filter((s) => s.lane === 'EDIT').length
-                  // Reasoning = everything that isn't a tool call or a file edit (THINK/PLAN).
-                  const summary = workSummary(workSteps.length - toolCount - editCount, toolCount, editCount)
+                  // Reasoning steps / tool commands / edited FILES (distinct paths across
+                  // EDIT rows, since one EDIT row can touch several files).
+                  const { thinkCount, toolCount, editCount } = workCounts(workSteps)
+                  const summary = workSummary(thinkCount, toolCount, editCount)
                   // Auto-open while a turn has produced only work (mid-stream), so the
                   // live agent isn't hidden; collapse once its answer text lands.
                   const openWork = expandedWork.has(ti) || textSteps.length === 0

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -132,6 +132,41 @@ interface FmtStep {
   msg?: SessionMessageDto
 }
 
+// 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
+// text and collapses its "work" (reasoning / plan / tool / edit lanes) behind a
+// per-turn "Thought through…" toggle.
+const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
+function workSummary(thinkCount: number, toolCount: number): string {
+  const parts: string[] = []
+  if (thinkCount > 0) parts.push(`Thought through ${thinkCount} step${thinkCount > 1 ? 's' : ''}`)
+  if (toolCount > 0) parts.push(`${parts.length ? 'ran' : 'Ran'} ${toolCount} command${toolCount > 1 ? 's' : ''}`)
+  return parts.join(', ')
+}
+
+// A step's non-text extras (code block, file chips, captured tool body) — rendered
+// identically in a turn's plain answer and in its collapsed "work" rows.
+function StepExtras({ step, sessionId }: { step: FmtStep; sessionId?: string }) {
+  return (
+    <>
+      {step.code && (
+        <div className="codeblk mt-[7px]" style={{ color: step.codeColor }}>
+          {step.code}
+        </div>
+      )}
+      {step.files.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-[6px]">
+          {step.files.map((f, fi) => (
+            <span key={fi} className="scope">
+              <span style={{ color: f.color }}>{f.tag}</span> {f.path}
+            </span>
+          ))}
+        </div>
+      )}
+      {step.msg && sessionId && <ToolBodyDetail msg={step.msg} sessionId={sessionId} />}
+    </>
+  )
+}
+
 function fmtTranscriptDuration(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return '—'
   const totalSeconds = Math.round(ms / 1000)
@@ -584,8 +619,15 @@ export default function SessionDetailView() {
   const [msgErr, setMsgErr] = useState<string | null>(null)
   const [tailReady, setTailReady] = useState(false)
   const [nowMs, setNowMs] = useState(() => Date.now())
-  const [showThinking, setShowThinking] = useState(true)
-  const [showTools, setShowTools] = useState(true)
+  // Which bot turns have their collapsed "work" expanded (keyed by turn index).
+  const [expandedWork, setExpandedWork] = useState<Set<number>>(() => new Set())
+  const toggleWork = (ti: number) =>
+    setExpandedWork((prev) => {
+      const next = new Set(prev)
+      if (next.has(ti)) next.delete(ti)
+      else next.add(ti)
+      return next
+    })
   const [imagePreparing, setImagePreparing] = useState(false)
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
@@ -982,19 +1024,6 @@ export default function SessionDetailView() {
   // Transcript visibility is presentation-only: keep the complete turn list for
   // usage/duration accounting, and derive a filtered tree for rendering. Live PLAN
   // steps are the playground equivalent of persisted THINK messages.
-  const isThinkingStep = (step: FmtStep): boolean => step.lane === 'THINK' || step.lane === 'PLAN'
-  const isToolStep = (step: FmtStep): boolean => step.lane === 'TOOL'
-  const hasThinkingSteps = turns.some((turn) => turn.kind === 'bot' && turn.steps.some((step) => isThinkingStep(step)))
-  const hasToolSteps = turns.some((turn) => turn.kind === 'bot' && turn.steps.some((step) => isToolStep(step)))
-  const hasActivityFilters = hasThinkingSteps || hasToolSteps
-  const visibleTurns: Turn[] = turns.flatMap((turn): Turn[] => {
-    if (turn.kind === 'user') return [turn]
-    const steps = turn.steps.filter(
-      (step) => (showThinking || !isThinkingStep(step)) && (showTools || !isToolStep(step))
-    )
-    return steps.length > 0 ? [{ ...turn, steps }] : []
-  })
-
   // Sole author reads as "You" when it's the viewer (webchat) — checked on the raw
   // triggeredBy id, not the display `user`, since a resolved name would mask the match.
   const soleAuthor = senderLabel(session.triggeredBy, session.user)
@@ -1273,7 +1302,7 @@ export default function SessionDetailView() {
             )}
             <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
               <span className="imark h-4 w-4 rounded-xs">
-                <PlatformMark platform={sessionIntegration} />
+                <PlatformMark platform={sessionIntegration} fillPct={100} />
               </span>
               {session.threadUrl ? (
                 <a
@@ -1461,198 +1490,127 @@ export default function SessionDetailView() {
           turns + live tail; on desktop the gutter div is a plain block so turns and
           the composer sit in the page flow exactly as before. */}
       <div className="flex flex-col gap-4 p-4 desktop:block desktop:p-0">
-        {hasActivityFilters && (
-          <div
-            className="flex flex-wrap items-center gap-[10px] desktop:mb-[14px]"
-            role="group"
-            aria-label="Transcript activity filters"
-          >
-            <span className="font-mono text-[11px] font-semibold uppercase leading-normal tracking-[.04em] text-(--text-tertiary)">
-              Show
-            </span>
-            <span className="inline-flex items-center gap-3">
-              {hasThinkingSteps && (
-                <label
-                  className="inline-flex cursor-pointer items-center gap-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)"
-                  title={showThinking ? 'Hide thinking' : 'Show thinking'}
-                >
-                  <input
-                    type="checkbox"
-                    checked={showThinking}
-                    onChange={(event) => setShowThinking(event.target.checked)}
-                    className="h-4 w-4 cursor-pointer accent-(--brand)"
-                  />
-                  thinking
-                </label>
-              )}
-              {hasToolSteps && (
-                <label
-                  className="inline-flex cursor-pointer items-center gap-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)"
-                  title={showTools ? 'Hide tool calls' : 'Show tool calls'}
-                >
-                  <input
-                    type="checkbox"
-                    checked={showTools}
-                    onChange={(event) => setShowTools(event.target.checked)}
-                    className="h-4 w-4 cursor-pointer accent-(--brand)"
-                  />
-                  tools
-                </label>
-              )}
-            </span>
-          </div>
-        )}
-        {visibleTurns.length > 0 && (
-          <div className="flex flex-col gap-4 desktop:gap-[14px]">
-            {visibleTurns.map((turn, ti) =>
+        {turns.length > 0 && (
+          <div className="flex flex-col gap-4 desktop:gap-[15px]">
+            {turns.map((turn, ti) =>
               turn.kind === 'user' ? (
-                <div key={ti} className="flex items-start gap-[10px] desktop:gap-[11px]">
-                  {turn.sp.handle === '@you' ? (
-                    <Avatar
-                      src={user.picture}
-                      initials={turn.sp.initials}
-                      size={30}
-                      fontSize={11}
-                      bg={turn.sp.avBg}
-                      fg={turn.sp.avText}
-                    />
-                  ) : (
-                    <span
-                      className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-full font-sans text-[11px] font-semibold leading-normal"
-                      style={{ background: turn.sp.avBg, color: turn.sp.avText }}
-                    >
-                      {turn.isCron ? (
-                        <Icon name="calendar-clock" size={15} />
-                      ) : usesIntegrationAvatar ? (
-                        <PlatformMark platform={sessionIntegration} />
-                      ) : (
-                        turn.sp.initials
-                      )}
-                    </span>
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-[5px] flex items-baseline gap-[7px]">
+                // 2b: user turns are right-aligned brand-soft bubbles. A sender label
+                // sits above the bubble only when it isn't you (platform user / cron).
+                <div key={ti} className="flex flex-col items-end gap-[3px]">
+                  {(turn.isCron || turn.sp.handle !== '@you') && (
+                    <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
                       {turn.isCron && turn.cronId ? (
-                        <Link
-                          className="lnk font-sans text-[13px] font-semibold leading-normal text-inherit"
-                          href={orgPath(`/crons/${turn.cronId}`)}
-                        >
+                        <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
                           {turn.sp.name}
                         </Link>
                       ) : (
-                        <span className="font-sans text-[13px] font-semibold leading-normal">{turn.sp.name}</span>
+                        <span>{turn.sp.name}</span>
                       )}
-                      {!turn.isCron && turn.sp.handle !== turn.sp.name && (
-                        <span className="mono text-[11px] text-(--text-tertiary)">{turn.sp.handle}</span>
-                      )}
-                      {/* Source-label chip is desktop-only chrome. */}
-                      <span className="hidden rounded-[3px] border border-(--border-strong) px-1 py-[1px] font-sans text-[9px] font-medium uppercase leading-normal tracking-[.06em] text-(--text-tertiary) desktop:inline">
-                        {turn.sourceLabel}
-                      </span>
-                      {turn.time && (
-                        <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
-                          {turn.time}
-                        </span>
-                      )}
-                    </div>
-                    <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-card) px-[13px] py-[10px] font-sans text-[13.5px] font-normal leading-[1.5] text-(--text-primary) desktop:px-[14px] desktop:py-[11px] desktop:leading-[1.55]">
-                      {turn.image && (
-                        <img
-                          src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
-                          alt={turn.image.name}
-                          className={`max-h-[360px] max-w-full rounded-md object-contain ${
-                            turn.text ? 'mb-[10px]' : ''
-                          }`}
-                        />
-                      )}
-                      {turn.text && <MessageText text={turn.text} />}
-                    </div>
+                      {turn.time && <span className="mono">{turn.time}</span>}
+                    </span>
+                  )}
+                  <div className="max-w-[86%] rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
+                    {turn.image && (
+                      <img
+                        src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                        alt={turn.image.name}
+                        className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
+                      />
+                    )}
+                    {turn.text && <MessageText text={turn.text} />}
                   </div>
                 </div>
               ) : (
-                <div key={ti} className="flex items-start gap-[10px] desktop:gap-[11px]">
-                  <span className="av h-[30px] w-[30px] flex-none rounded-md">
-                    <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={30} />
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-2 flex items-center gap-[7px]">
-                      <span className="font-sans text-[13px] font-semibold leading-normal">{turn.agentName}</span>
-                      {/* APP chip is desktop-only chrome. */}
-                      <span className="hidden rounded-[3px] border border-(--border-strong) px-1 py-[1px] font-sans text-[9px] font-semibold leading-normal tracking-[.06em] text-(--text-tertiary) desktop:inline">
-                        APP
+                (() => {
+                  // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
+                  // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
+                  const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
+                  const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
+                  const toolCount = workSteps.filter((s) => s.lane === 'TOOL').length
+                  const summary = workSummary(workSteps.length - toolCount, toolCount)
+                  // Auto-open while a turn has produced only work (mid-stream), so the
+                  // live agent isn't hidden; collapse once its answer text lands.
+                  const openWork = expandedWork.has(ti) || textSteps.length === 0
+                  return (
+                    <div key={ti} className="flex items-start gap-[9px]">
+                      <span className="av h-[26px] w-[26px] flex-none rounded-md">
+                        <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={26} />
                       </span>
-                      {turn.time && (
-                        <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
-                          {turn.time}
-                        </span>
-                      )}
-                    </div>
-                    {/* Step card: `card` chrome on both widths (mobile radius 11); the inner
-                    padding gutter + per-row bottom rules are desktop, edge-to-edge rows
-                    with top rules are mobile. */}
-                    <div className="card overflow-hidden max-desktop:rounded-[11px]">
-                      <div className="desktop:px-[18px] desktop:pt-[6px] desktop:pb-3">
-                        {turn.steps.map((st, si) => (
-                          <div
-                            key={si}
-                            className={`grid grid-cols-[72px_1fr] gap-[11px] border-(--border-subtle) px-[14px] py-[11px] desktop:grid-cols-[90px_1fr] desktop:gap-[13px] desktop:border-b desktop:px-0 ${
-                              si > 0 ? 'border-t desktop:border-t-0' : ''
-                            }`}
-                          >
-                            <div className="flex flex-col items-end gap-[3px] self-start desktop:gap-1 desktop:pt-[1px]">
-                              <div className="flex items-center justify-end gap-[6px] desktop:gap-[7px]">
-                                <span
-                                  className="mono text-[10px] font-semibold tracking-[.02em]"
-                                  style={{ color: st.laneColor }}
-                                >
-                                  {st.lane}
-                                </span>
-                                <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-[5px] flex items-center gap-[7px]">
+                          <span className="font-sans text-[13px] font-semibold leading-normal">{turn.agentName}</span>
+                          {turn.time && (
+                            <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
+                              {turn.time}
+                            </span>
+                          )}
+                        </div>
+                        {textSteps.map((st, si) => (
+                          <div key={si} className={si > 0 ? 'mt-2' : ''}>
+                            {st.text && (
+                              <div className="font-sans text-[13.5px] leading-[1.6] whitespace-pre-wrap text-(--text-primary)">
+                                <MessageText text={st.text} />
                               </div>
-                              {st.time && (
-                                <span className="mono whitespace-nowrap text-[10.5px] text-(--text-tertiary)">
-                                  {st.time}
-                                </span>
-                              )}
-                            </div>
-                            <div className="min-w-0">
-                              {st.text && (
-                                <div
-                                  className="font-sans text-[13px] leading-[1.5]"
-                                  style={{ fontWeight: st.weight, color: st.textColor }}
-                                >
-                                  <MessageText text={st.text} />
-                                </div>
-                              )}
-                              {st.code && (
-                                <div className="codeblk mt-[7px]" style={{ color: st.codeColor }}>
-                                  {st.code}
-                                </div>
-                              )}
-                              {st.files.length > 0 && (
-                                <div className="mt-2 flex flex-wrap gap-[6px]">
-                                  {st.files.map((f, fi) => (
-                                    <span key={fi} className="scope">
-                                      <span style={{ color: f.color }}>{f.tag}</span> {f.path}
-                                    </span>
-                                  ))}
-                                </div>
-                              )}
-                              {st.msg && sid && <ToolBodyDetail msg={st.msg} sessionId={sid} />}
-                            </div>
+                            )}
+                            <StepExtras step={st} sessionId={sid} />
                           </div>
                         ))}
+                        {workSteps.length > 0 && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => toggleWork(ti)}
+                              className="mt-2 inline-flex items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+                              title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
+                            >
+                              <Icon
+                                name={openWork ? 'chevron-down' : 'chevron-right'}
+                                size={13}
+                                color="var(--text-tertiary)"
+                              />
+                              {summary || 'Details'}
+                            </button>
+                            {openWork && (
+                              <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+                                {workSteps.map((st, si) => (
+                                  <div
+                                    key={si}
+                                    className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
+                                      si > 0 ? 'border-t border-(--border-subtle)' : ''
+                                    }`}
+                                  >
+                                    <div className="flex w-[52px] flex-none items-center gap-[6px] pt-[1px]">
+                                      <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
+                                      <span
+                                        className="mono text-[10px] font-semibold tracking-[.02em]"
+                                        style={{ color: st.laneColor }}
+                                      >
+                                        {st.lane}
+                                      </span>
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                      {st.text && (
+                                        <div
+                                          className="font-sans text-[13px] leading-[1.5]"
+                                          style={{ fontWeight: st.weight, color: st.textColor }}
+                                        >
+                                          <MessageText text={st.text} />
+                                        </div>
+                                      )}
+                                      <StepExtras step={st} sessionId={sid} />
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </>
+                        )}
                       </div>
                     </div>
-                  </div>
-                </div>
+                  )
+                })()
               )
             )}
-          </div>
-        )}
-        {turns.length > 0 && visibleTurns.length === 0 && (
-          <div className="card px-4 py-5 text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-            All transcript activity is hidden by the current filters.
           </div>
         )}
 
@@ -1698,116 +1656,130 @@ export default function SessionDetailView() {
             {imageError && (
               <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
             )}
-            <div className="flex items-start gap-[10px] desktop:mt-4 desktop:gap-[11px]">
-              <Avatar src={user.picture} initials={user.initials} size={30} fontSize={11} />
+            {/* Sticky-to-bottom composer: pinned to the bottom of the scroll area so it's
+                always reachable while scrolling the transcript. Its opaque page-colour
+                background covers earlier turns scrolling behind it; the negative `bottom`
+                + matching bottom padding pull it flush past `.content`'s bottom padding
+                (else turns would show through that strip). A top gradient softens the
+                seam where the transcript slides underneath. */}
+            <div className="sticky z-10 bg-(--surface-app) bottom-[calc(-24px-env(safe-area-inset-bottom,0px))] pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-2 desktop:mt-4 desktop:bottom-[-26px] desktop:pb-[26px] desktop:pt-3">
               <div
-                className="pgcomposer relative min-w-0 flex-1 flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default)"
-                onKeyDown={(event) => {
-                  if (event.key !== 'Escape') return
-                  setAttachMenuOpen(false)
-                  setComposerMenuOpen(null)
-                }}
-              >
-                <input
-                  ref={imageInputRef}
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(event) => void onImageFile(event.target.files?.[0])}
-                />
-                <div className="flex min-w-0 flex-col">
-                  {pgImage && (
-                    <div className="relative mb-2 w-fit">
-                      <img
-                        src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
-                        alt={pgImage.name}
-                        title={pgImage.name}
-                        className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
-                      />
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
+              />
+              <div className="flex items-start gap-[10px] desktop:gap-[11px]">
+                <Avatar src={user.picture} initials={user.initials} size={30} fontSize={11} />
+                <div
+                  className="pgcomposer relative min-w-0 flex-1 flex-col items-stretch gap-2 rounded-[11px] border border-(--border-default)"
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Escape') return
+                    setAttachMenuOpen(false)
+                    setComposerMenuOpen(null)
+                  }}
+                >
+                  <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    onChange={(event) => void onImageFile(event.target.files?.[0])}
+                  />
+                  <div className="flex min-w-0 flex-col">
+                    {pgImage && (
+                      <div className="relative mb-2 w-fit">
+                        <img
+                          src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
+                          alt={pgImage.name}
+                          title={pgImage.name}
+                          className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                        />
+                        <button
+                          type="button"
+                          className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+                          title="Remove image"
+                          aria-label="Remove image"
+                          onClick={() => setPgImage(session.id)}
+                        >
+                          <Icon name="x" size={14} />
+                        </button>
+                      </div>
+                    )}
+                    <textarea
+                      className="pgin w-full border-0 px-1 py-2 focus:shadow-none"
+                      placeholder={`Message ${session.agentName}…`}
+                      value={pgInput}
+                      onChange={(e) => setPgInput(e.target.value)}
+                      onPaste={(event) => {
+                        const image = clipboardImageFile(event.clipboardData)
+                        if (!image) return
+                        event.preventDefault()
+                        void onImageFile(image)
+                      }}
+                      onKeyDown={(e) => {
+                        // Enter sends — but NOT while an IME is composing (that Enter
+                        // just confirms the candidate), and Shift+Enter is a newline.
+                        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                          e.preventDefault()
+                          onPgSend()
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <div className="relative flex-none">
                       <button
                         type="button"
-                        className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
-                        title="Remove image"
-                        aria-label="Remove image"
-                        onClick={() => setPgImage(session.id)}
+                        className="iconbtn h-7 w-7 rounded-sm"
+                        aria-label="Add"
+                        aria-haspopup="menu"
+                        aria-expanded={attachMenuOpen}
+                        disabled={imagePreparing}
+                        onClick={() => {
+                          setComposerMenuOpen(null)
+                          setAttachMenuOpen((open) => !open)
+                        }}
                       >
-                        <Icon name="x" size={14} />
+                        {imagePreparing ? <Spinner size={14} /> : <Icon name="plus" size={17} />}
                       </button>
-                    </div>
-                  )}
-                  <textarea
-                    className="pgin w-full border-0 px-1 py-2 focus:shadow-none"
-                    placeholder={`Message ${session.agentName}…`}
-                    value={pgInput}
-                    onChange={(e) => setPgInput(e.target.value)}
-                    onPaste={(event) => {
-                      const image = clipboardImageFile(event.clipboardData)
-                      if (!image) return
-                      event.preventDefault()
-                      void onImageFile(image)
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault()
-                        onPgSend()
-                      }
-                    }}
-                  />
-                </div>
-                <div className="flex min-w-0 items-center gap-2">
-                  <div className="relative flex-none">
-                    <button
-                      type="button"
-                      className="iconbtn h-7 w-7 rounded-sm"
-                      aria-label="Add"
-                      aria-haspopup="menu"
-                      aria-expanded={attachMenuOpen}
-                      disabled={imagePreparing}
-                      onClick={() => {
-                        setComposerMenuOpen(null)
-                        setAttachMenuOpen((open) => !open)
-                      }}
-                    >
-                      {imagePreparing ? <Spinner size={14} /> : <Icon name="plus" size={17} />}
-                    </button>
-                    {attachMenuOpen && (
-                      <>
-                        <div
-                          aria-hidden="true"
-                          className="fixed inset-0 z-40"
-                          onClick={() => setAttachMenuOpen(false)}
-                        ></div>
-                        <div
-                          role="menu"
-                          className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-                        >
-                          <button
-                            type="button"
-                            role="menuitem"
-                            className="fopt"
-                            onClick={() => {
-                              setAttachMenuOpen(false)
-                              imageInputRef.current?.click()
-                            }}
+                      {attachMenuOpen && (
+                        <>
+                          <div
+                            aria-hidden="true"
+                            className="fixed inset-0 z-40"
+                            onClick={() => setAttachMenuOpen(false)}
+                          ></div>
+                          <div
+                            role="menu"
+                            className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
                           >
-                            <Icon name="image" size={16} color="var(--text-secondary)" />
-                            Add photos
-                          </button>
-                        </div>
-                      </>
-                    )}
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="fopt"
+                              onClick={() => {
+                                setAttachMenuOpen(false)
+                                imageInputRef.current?.click()
+                              }}
+                            >
+                              <Icon name="image" size={16} color="var(--text-secondary)" />
+                              Add photos
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    {pgStatusBar}
+                    <button
+                      className="sendbtn h-7 w-7 rounded-sm"
+                      aria-label={pgBusy ? 'Stop response' : 'Send message'}
+                      onClick={() =>
+                        pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
+                      }
+                      disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
+                    >
+                      <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
+                    </button>
                   </div>
-                  {pgStatusBar}
-                  <button
-                    className="sendbtn h-7 w-7 rounded-sm"
-                    aria-label={pgBusy ? 'Stop response' : 'Send message'}
-                    onClick={() =>
-                      pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
-                    }
-                    disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
-                  >
-                    <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
-                  </button>
                 </div>
               </div>
             </div>

--- a/packages/web/src/components/marks.test.tsx
+++ b/packages/web/src/components/marks.test.tsx
@@ -1,6 +1,24 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { AgentIconView, OrgIconView, PlatformMark } from './marks'
+import { AgentIconView, OrgIconView, PlatformMark, modelProviderSlug } from './marks'
+
+describe('modelProviderSlug', () => {
+  it('reads the provider prefix from provider/model ids', () => {
+    expect(modelProviderSlug('deepseek/deepseek-v4-flash')).toBe('deepseek')
+    expect(modelProviderSlug('anthropic/claude-sonnet-4-5')).toBe('claude')
+    expect(modelProviderSlug('x-ai/grok-4')).toBe('grok')
+  })
+  it('infers the family from a bare model id', () => {
+    expect(modelProviderSlug('claude-sonnet-4-5')).toBe('claude')
+    expect(modelProviderSlug('gpt-5-mini')).toBe('openai')
+    expect(modelProviderSlug('deepseek-v4-flash')).toBe('deepseek')
+  })
+  it('falls back to the raw prefix for an unknown provider/model, else null', () => {
+    expect(modelProviderSlug('acme/whatever-1')).toBe('acme')
+    expect(modelProviderSlug('mystery-model')).toBeNull()
+    expect(modelProviderSlug('')).toBeNull()
+  })
+})
 
 describe('icon views', () => {
   it('identifies glyph icons so their parent does not show a dark edge', () => {

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -3,6 +3,7 @@
 // Agent-type + IM-platform brand marks.
 // Sized to 60% of their container to match the .av / .imark CSS.
 
+import { useState } from 'react'
 import { Icon } from './ui'
 import { withIconUrl, type AgentIcon } from '@/lib/agent-icon'
 import newLarkIcon from '@iconify-icons/icon-park/new-lark'
@@ -23,6 +24,73 @@ export function AgentMark({ model }: { model: string }) {
       src={registryIcon}
       alt=""
       className="block h-[60%] w-[60%] object-contain [html[data-theme='dark']_&]:invert"
+    />
+  )
+}
+
+// Map a model id to an AI-provider brand slug in the lobehub icon set. Handles the
+// `provider/model` form (opencode / openrouter, e.g. `deepseek/deepseek-v4-flash`)
+// first, then falls back to inferring the family from a bare model id. Returns null
+// when it can't tell (⇒ caller shows the runtime mark instead).
+// ponytail: substring/prefix heuristic; a wrong guess degrades gracefully because
+// <ModelMark> falls back on the icon's onError. Add a mapping when a provider recurs.
+const MODEL_PROVIDER_PREFIX: Record<string, string> = {
+  deepseek: 'deepseek',
+  openai: 'openai',
+  anthropic: 'claude',
+  google: 'gemini',
+  'google-vertex': 'gemini',
+  meta: 'meta',
+  'meta-llama': 'meta',
+  mistral: 'mistral',
+  mistralai: 'mistral',
+  qwen: 'qwen',
+  alibaba: 'qwen',
+  moonshot: 'moonshot',
+  moonshotai: 'moonshot',
+  xai: 'grok',
+  'x-ai': 'grok',
+  cohere: 'cohere',
+  groq: 'groq',
+  perplexity: 'perplexity',
+  ollama: 'ollama',
+  openrouter: 'openrouter'
+}
+export function modelProviderSlug(model: string): string | null {
+  const m = model.toLowerCase().trim()
+  if (!m) return null
+  const prefix = m.includes('/') ? m.slice(0, m.indexOf('/')) : ''
+  if (prefix && MODEL_PROVIDER_PREFIX[prefix]) return MODEL_PROVIDER_PREFIX[prefix]
+  if (/deepseek/.test(m)) return 'deepseek'
+  if (/claude|sonnet|opus|haiku/.test(m)) return 'claude'
+  if (/gpt|codex|(?:^|[^a-z])o[134]\b/.test(m)) return 'openai'
+  if (/gemini/.test(m)) return 'gemini'
+  if (/mistral|mixtral|codestral/.test(m)) return 'mistral'
+  if (/qwen/.test(m)) return 'qwen'
+  if (/llama/.test(m)) return 'meta'
+  if (/grok/.test(m)) return 'grok'
+  if (/kimi|moonshot/.test(m)) return 'moonshot'
+  // Unknown `provider/model`: try the raw prefix as a lobehub slug; onError falls back.
+  return prefix || null
+}
+
+// A model's provider brand mark (lobehub icon set — same CDN the ACP registry's
+// curated runtimes use). Distinct from <AgentMark>, which is the runtime brand:
+// an `opencode` agent running `deepseek/…` shows the deepseek mark here, opencode there.
+export function ModelMark({ model, fallbackRuntime }: { model: string; fallbackRuntime: string }) {
+  const slug = modelProviderSlug(model)
+  // Latch the slug whose icon 404s so we fall back to the runtime mark. Keyed by
+  // slug (not a boolean) so switching model re-attempts the new provider's icon —
+  // no reset effect needed; `key` gives the img a fresh load per slug.
+  const [failedSlug, setFailedSlug] = useState<string | null>(null)
+  if (!slug || failedSlug === slug) return <AgentMark model={fallbackRuntime} />
+  return (
+    <img
+      key={slug}
+      src={`https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/${slug}.svg`}
+      alt=""
+      onError={() => setFailedSlug(slug)}
+      className="block h-[80%] w-[80%] object-contain [html[data-theme='dark']_&]:invert"
     />
   )
 }

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -48,8 +48,8 @@ function writeLastSlug(slug: string): void {
  *  is the current slug param. */
 export function subPath(pathname: string, slug: string): string {
   const [, first, ...rest] = pathname.split('/')
-  if (first === slug) return `/${rest.join('/') || 'agents'}`
-  return pathname === '/' ? '/agents' : pathname
+  if (first === slug) return `/${rest.join('/') || 'home'}`
+  return pathname === '/' ? '/home' : pathname
 }
 
 /** The URL prefix shown next to the org slug ("appears in the URL") — THIS

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -15,7 +15,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 //     org and replaces it in one step.
 // A stale cookie (renamed/removed org) is fine: the org context's
 // reconciliation replaces an unknown slug with the caller's real org.
-const CONSOLE_ROOTS = ['agents', 'sessions', 'daemons', 'crons', 'tools', 'usage', 'settings', 'profile']
+const CONSOLE_ROOTS = ['home', 'agents', 'sessions', 'daemons', 'crons', 'tools', 'usage', 'settings', 'profile']
 
 // A real slug or the reserved `-` — anything else in the cookie is ignored
 // (it goes straight into a redirect path, so validate strictly).
@@ -32,7 +32,7 @@ export function proxy(req: NextRequest) {
   const isEntry = pathname === '/' || CONSOLE_ROOTS.includes(first)
   if (!isEntry) return NextResponse.next()
 
-  const consolePath = pathname === '/' ? '/agents' : pathname
+  const consolePath = pathname === '/' ? '/home' : pathname
   const url = req.nextUrl.clone()
   const slug = lastOrgSlug(req)
   if (slug) {


### PR DESCRIPTION
## What

Adds a chat-first **Home** (`/home`) console landing and makes it the default destination (replacing `/agents`), plus a session-transcript restyle and composer polish.

### Home (`/home`)
- **"Ask an agent" composer** that hands off to a live session (`openPlayground → pgSend → /sessions/{id}`). Agent / model / effort / permission selectors rendered as design pills/chips; the run-runtime choice is applied on send.
- Dashboard cards: **Recent** sessions, **Agents you use** (ranked by 24h session count, click to start a chat), **Scheduled runs**.
- **Per-agent readiness banner**: `offline` (daemon not serving) vs "**No AI runtime is signed in**" (daemon runtime `authRequired`); send is gated on the same state.

### Default landing → `/home`
`proxy.ts` + `org-context.subPath` + logo links + no-auth bounce + onboarding-complete + 404 now default to `/home` instead of `/agents` (the Agents nav item and "All agents" links are unchanged).

### Session detail — "2b" chat style
- User turns are right-aligned neutral bubbles; agent answers render as plain text with reasoning/tool **work collapsed** behind a per-turn "Thought through… / ran … commands" toggle.
- **Sticky-to-bottom composer** (always reachable while scrolling) with a gradient seam.
- **IME-safe Enter** — Enter no longer sends while an IME is composing.

### Shared bits
- `ComposerMenu`: leading icon, design-pill trigger, downward placement, per-option dim (offline agents), optional tooltips, and a scrollable capped-height option list.
- `marks.ModelMark`: renders a model's **provider** brand icon (lobehub set) derived from the model id (handles `provider/model`), falling back to the runtime mark on unknown/404.

## Test
- `pnpm --filter @agentconnect.md/web test` — 415 passing (incl. new `modelProviderSlug` unit tests).
- typecheck + lint clean; verified in mock mode: default `/` → Home, composer→session handoff, offline/auth banners, transcript collapse, sticky composer, model provider icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)