### PR TITLE
feat(web): link social accounts from profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,10 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # GitHub/Google buttons; unset ⇒ no-auth (the buttons just enter the app). Add
 # the social connectors (target `google`/`github`) inside Logto — the buttons
 # jump straight to them via Logto's direct sign-in.
+# To let signed-in users link another social account from Profile, enable the
+# Account API in Logto Account Center and give Social identities `Edit` access.
+# Also register `https://<logto-endpoint>/account/callback/social/<connector-id>`
+# as an authorized redirect URI with each social provider.
 # NEXT_PUBLIC_LOGTO_ENDPOINT=https://tenant.example.com/
 # NEXT_PUBLIC_LOGTO_APP_ID=
 # Optional: the CP API resource registered in Logto, for a JWT access token. When

--- a/compose.env.example
+++ b/compose.env.example
@@ -27,6 +27,10 @@
 # The issuer is the Logto endpoint with `/oidc`; the audience is the API
 # resource when set, otherwise the app id. Register the Web callback URL:
 #   http://localhost:3000/auth/callback
+# To link additional social accounts from Profile, enable Account API in Logto
+# Account Center with Social identities set to `Edit`, then register this
+# callback with each social provider:
+#   https://<logto-endpoint>/account/callback/social/<connector-id>
 # LOGTO_ENDPOINT=https://tenant.example.com/
 # LOGTO_APP_ID=
 # LOGTO_API_RESOURCE=https://api.example.com

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -14,7 +14,7 @@ import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
 import ApiKeysCard from '@/components/console/ApiKeysCard'
 import SlackConfigCard from '@/components/console/SlackConfigCard'
-import { isAuthConfigured, logout } from '@/lib/auth'
+import { accountSecurityUrl, isAuthConfigured, logout } from '@/lib/auth'
 import { useProfile } from '@/lib/profile'
 import { MOCK_MODE } from '@/lib/data'
 import { useIsMobile } from '@/lib/use-is-mobile'
@@ -40,6 +40,7 @@ export default function ProfileView() {
   // Merged identity (token claims + the CP /me overlay) — repaints live when
   // the edit-profile dialog saves a new name/photo.
   const { user, me: meProfile } = useProfile()
+  const authOn = isAuthConfigured()
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
   // With no match (mock mode / CP down) the fields fall back to the design's
@@ -59,8 +60,13 @@ export default function ProfileView() {
     .join(' · built ')
 
   const signOut = () => {
-    if (isAuthConfigured()) void logout()
+    if (authOn) void logout()
     else router.push('/login')
+  }
+
+  const manageSignIns = () => {
+    const url = accountSecurityUrl(`${window.location.origin}${window.location.pathname}`)
+    if (url) window.location.assign(url)
   }
 
   if (isMobile) {
@@ -109,6 +115,17 @@ export default function ProfileView() {
               <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">Email</span>
               <span className="font-mono text-[12px] font-medium leading-normal">{user.email}</span>
             </div>
+            {authOn && (
+              <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
+                <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">
+                  Sign-in methods
+                </span>
+                <Button variant="secondary" size="xs" onClick={manageSignIns}>
+                  <Icon name="link-2" size={13} />
+                  Link social account
+                </Button>
+              </div>
+            )}
             <div className="flex items-center justify-between gap-4 px-4 py-3">
               <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">
                 Member since
@@ -167,6 +184,14 @@ export default function ProfileView() {
           <KvRow label="Email">
             <span className="mono text-[12.5px]">{user.email}</span>
           </KvRow>
+          {authOn && (
+            <KvRow label="Sign-in methods">
+              <Button variant="secondary" size="xs" onClick={manageSignIns}>
+                <Icon name="link-2" size={13} />
+                Link social account
+              </Button>
+            </KvRow>
+          )}
           <KvRow label="Role">
             <span className={`badge ${roleBadge}`}>{roleLabel}</span>
           </KvRow>

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -82,3 +82,27 @@ describe('getToken', () => {
     expect(logto.replace).toHaveBeenCalledOnce()
   })
 })
+
+describe('accountSecurityUrl', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('window', {
+      __AC_ENV: {
+        LOGTO_ENDPOINT: 'https://login.example.test/',
+        LOGTO_APP_ID: 'web-app'
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns to the current AgentConnect profile after account management', async () => {
+    const { accountSecurityUrl } = await import('./auth')
+
+    expect(accountSecurityUrl('https://console.example.test/acme/profile')).toBe(
+      'https://login.example.test/account/security?redirect=https%3A%2F%2Fconsole.example.test%2Facme%2Fprofile'
+    )
+  })
+})

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -54,6 +54,19 @@ export function isAuthConfigured(): boolean {
   return Boolean(endpoint && appId)
 }
 
+/**
+ * Logto-hosted account security page. It owns the sensitive verification flow
+ * for linking and unlinking social sign-in identities, then returns to the
+ * caller's Profile page.
+ */
+export function accountSecurityUrl(redirectUri: string): string | undefined {
+  const { endpoint, appId } = readConfig()
+  if (!endpoint || !appId) return undefined
+  const url = new URL('/account/security', endpoint)
+  url.searchParams.set('redirect', redirectUri)
+  return url.toString()
+}
+
 let client: LogtoClient | undefined
 
 /** Lazily build the LogtoClient (browser-only — touches window/localStorage). */


### PR DESCRIPTION
## Summary

- add a `Sign-in methods` action to the authenticated Profile page on desktop and mobile
- send users to Logto Account Center to link or unlink another social identity, then return them to the same AgentConnect profile
- document the required Logto Account API permission and per-connector callback URL

## Why

Users can attach another social login, including one with a different email address, to the same Logto user and continue resolving to the same OIDC subject. Logto remains responsible for reauthentication and social-identity ownership verification.

## Validation

- `pnpm --filter @agentconnect.md/web test` (58 files, 416 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web build`

## Deployment note

Enable Account API in Logto Account Center, set Social identities to `Edit`, and register `https://<logto-endpoint>/account/callback/social/<connector-id>` with each social provider.

Created by Codex . GPT-5
