### PR TITLE
fix(web): open Lark apps at base info

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -63,7 +63,7 @@ function botSubline(b: BotDto): string {
 
 function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu' | 'lark'): string {
   const host = region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
-  return appId ? `${host}/app/${encodeURIComponent(appId)}` : `${host}/page/launcher`
+  return appId ? `${host}/app/${encodeURIComponent(appId)}/baseinfo` : `${host}/page/launcher`
 }
 
 // One rendered member row, precomputed from the wire DTO.


### PR DESCRIPTION
## Summary

- Open Lark and Feishu app configuration links directly on the app's Base Info page.
- Keep the regional developer-console launcher fallback for legacy bots without a stored App ID.

## Why

The existing Settings link stopped at `/app/<app-id>`, which did not reliably land on the requested configuration screen. Appending `/baseinfo` opens the concrete app configuration page directly.

## Validation

- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`
- Pre-push repository lint (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
