### PR TITLE
feat(lark): add one-click app registration

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -153,6 +153,16 @@ IntegrationFeishuConfig }`.
   `replicateUpsert(integration, agent.daemonId)`, which sends
   `integrationUpsert(daemonId, integrationToSpec(...))`. This nearly copies the
   Discord branch.
+- Add `POST /integrations/feishu/app` and
+  `GET /integrations/feishu/app/:id` for the default one-click path. The first
+  route starts the official SDK's `registerApp` device flow and returns only a
+  direct authorization URL plus an opaque registration ID. The second polls
+  the short-lived registration status.
+- Configure `registerApp` with `createOnly: true`, the platform
+  `PersonalAgent` preset, AgentConnect's tenant scopes, and
+  `im.message.receive_v1`. After approval, pass the returned App ID and App
+  Secret directly to the same bot-secret installation helper used by the
+  manual route. Never return either credential from the registration routes.
 - In `src/http/dto/index.ts`:
   - Add `'feishu'` to the `platform` `[enum]` in `CreateIntegrationBody`; add
     optional `feishu: z.object({ appId, appSecret })`; and update both
@@ -302,12 +312,14 @@ IntegrationFeishuConfig }`.
 - In `src/components/console/modals/AddIntegrationModal.tsx`:
   - Add `{ key: 'feishu', label: 'Feishu' }` to `BOT_PLATFORMS`; see the scope
     note in section 1.
-  - Add `CREATE_DESC.feishu`, explaining that the user creates a custom app in
-    Feishu Open Platform, enables long-connection event subscriptions, and
-    pastes the App ID and App Secret.
-  - Render **two inputs**, App ID and App Secret, and submit
+  - Make **One-click** the default for a new bot. Open the authorization URL in
+    a new tab, poll the opaque registration ID, and refresh the integration
+    list when setup completes. This is a direct deeplink; the user does not
+    need to scan a QR code.
+  - Keep **Manual** as the advanced fallback. It renders App ID and App Secret
+    inputs and submits
     `{ platform: 'feishu', feishu: { appId, appSecret } }`.
-  - Add `FEISHU_CHECKLIST`, following `DISCORD_CHECKLIST`: enable bot
+  - Show `FEISHU_CHECKLIST` only for manual or existing-app setup: enable bot
     capability, subscribe to `im.message.receive_v1`, select long connection,
     grant required scopes, and add the bot to a group.
   - Optionally derive an "Add to group" link from `feishuAppId`.
@@ -336,13 +348,20 @@ All three must include `'feishu'` for end-to-end selection.
 
 ## 6. Credential flow and security
 
-At installation:
-Console collects `appId` and `appSecret` -> the Control Plane calls
-`verifyFeishuBot` once -> `botSecret.put` stores
+At one-click installation:
+Console starts registration -> the Control Plane returns a provider
+authorization deeplink -> the user confirms the app and requested permissions
+in Feishu/Lark -> the SDK returns `appId` and `appSecret` only to the Control
+Plane -> `verifyFeishuBot` validates them -> `botSecret.put` stores
 `{ botToken: appSecret, appToken: appId }` -> `integrationToSpec` constructs
 `IntegrationSpec.feishu` -> `integration/upsert`, with
 `RegisterOk.integrations[]` as reconciliation fallback, distributes it to the
 daemon -> the daemon persists it in `agent.json` and starts `WSClient`.
+
+The browser receives only the authorization URL, expiry, status, and final
+integration ID. The manual fallback enters at `verifyFeishuBot` with an App ID
+and App Secret supplied by the user and then follows the same installation
+path.
 
 - `appSecret` is a plaintext secret. Wire frames and `agent.json` share the
   existing trust boundary, and the secret **must never be logged**. Preserve the
@@ -417,13 +436,19 @@ flat send.
 
 ### 7.5 Platform setup prerequisites in the web checklist
 
-A custom application must enable bot capability, select **long connection** for
-event subscription, subscribe to `im.message.receive_v1`, request scopes such
-as `im:message`, `im:message:send_as_bot`, `im:resource`, and optionally
-`im:chat` and `contact:user.base:readonly`, and be added to the target group.
-The installation API cannot automate these steps. `FEISHU_CHECKLIST` links to
-[open.feishu.cn](https://open.feishu.cn), parallel to the Discord Developer
-Portal checklist.
+The default one-click flow uses the official `PersonalAgent` app template and
+pre-fills AgentConnect's event and permission additions. They include
+`im.message.receive_v1`, message send/read and resource scopes,
+`im:chat:read`, `im:chat.members:bot_access`,
+`contact:contact.base:readonly`, and `contact:user.base:readonly`. The last
+scope is required for participant names instead of raw `ou_...` IDs. The user
+still reviews and confirms the app, and tenant policy may require administrator
+approval.
+
+Manual setup must configure the same bot capability, long-connection event,
+scopes, and publication state. In both paths, adding the bot to a target group
+remains a user action. `FEISHU_CHECKLIST` documents those manual prerequisites
+and links to [open.feishu.cn](https://open.feishu.cn).
 
 ## 8. Current implementation and remaining scope
 
@@ -432,8 +457,13 @@ Portal checklist.
   capability declaration.
 - **Daemon runtime:** `feishu/{connection,normalize,render}.ts` uses `WSClient`
   for inbound normalization, outbound messages, and reconciliation.
-- **Web:** `AddIntegrationModal` includes Feishu marks, App ID and App Secret
-  fields, a setup checklist, Settings card, and API types.
+- **Web:** `AddIntegrationModal` defaults to the official one-click
+  authorization deeplink and keeps App ID/App Secret entry as an advanced
+  fallback. It also includes Feishu marks, a manual setup checklist, Settings
+  card, and API types.
+- **Control Plane:** a short-lived registration broker owns SDK polling and
+  installs credentials server-side through the same secret-store helper as the
+  manual route. App Secret never enters a browser response.
 - **Attachments and topics:** `downloadFile` uses authenticated
   `im.messageResource.get`; topic replies use
   `im.message.reply(reply_in_thread)` and group sessions keyed by topic root.
@@ -451,6 +481,9 @@ Portal checklist.
 - **Control Plane integration:** apply the migration and exercise the Feishu
   path in `integrations.route.test.ts` with `verifyFeishuBot` stubbed to
   success, invalid, and unreachable.
+- **One-click integration:** stub `registerApp`, verify the complete scope/event
+  preset, complete and denied states, secret persistence, and that registration
+  responses never contain App ID or App Secret.
 - **Live:** use a real custom application with long connection,
   `im.message.receive_v1`, permissions, and group membership. Like Discord, this
   does not block the contract phase.

--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -155,14 +155,20 @@ IntegrationFeishuConfig }`.
   Discord branch.
 - Add `POST /integrations/feishu/app` and
   `GET /integrations/feishu/app/:id` for the default one-click path. The first
-  route starts the official SDK's `registerApp` device flow and returns only a
+  route starts the official app-registration device flow and returns only a
   direct authorization URL plus an opaque registration ID. The second polls
-  the short-lived registration status.
-- Configure `registerApp` with `createOnly: true`, the platform
-  `PersonalAgent` preset, AgentConnect's tenant scopes, and
-  `im.message.receive_v1`. After approval, pass the returned App ID and App
-  Secret directly to the same bot-secret installation helper used by the
-  manual route. Never return either credential from the registration routes.
+  the durable registration status.
+- Keep the reviewable template in `src/http/feishu-app-template.ts`: use
+  `createOnly: true`, the platform `PersonalAgent` preset, AgentConnect's
+  tenant scopes, and `im.message.receive_v1`.
+- Persist the provider device cursor and provisional App Secret through
+  `SecretCipher` in `feishu_app_registration`. A short database claim lets any
+  Control Plane replica resume polling/finalization without duplicate installs;
+  pre-reserved bot/integration IDs make retries idempotent. Clear both secrets
+  on every terminal outcome and TTL-reap old rows.
+- After approval, pass the returned App ID and App Secret directly to the same
+  bot-secret installation helper used by the manual route. Never return either
+  credential from the registration routes.
 - In `src/http/dto/index.ts`:
   - Add `'feishu'` to the `platform` `[enum]` in `CreateIntegrationBody`; add
     optional `feishu: z.object({ appId, appSecret })`; and update both
@@ -461,9 +467,11 @@ and links to [open.feishu.cn](https://open.feishu.cn).
   authorization deeplink and keeps App ID/App Secret entry as an advanced
   fallback. It also includes Feishu marks, a manual setup checklist, Settings
   card, and API types.
-- **Control Plane:** a short-lived registration broker owns SDK polling and
-  installs credentials server-side through the same secret-store helper as the
-  manual route. App Secret never enters a browser response.
+- **Control Plane:** a durable registration coordinator resumes the official
+  device flow across replicas, leases each poll/finalize step, and installs
+  credentials server-side through the same secret-store helper as the manual
+  route. App Secret never enters a browser response and is cleared from the
+  pending row after settlement.
 - **Attachments and topics:** `downloadFile` uses authenticated
   `im.messageResource.get`; topic replies use
   `im.message.reply(reply_in_thread)` and group sessions keyed by topic root.
@@ -481,9 +489,10 @@ and links to [open.feishu.cn](https://open.feishu.cn).
 - **Control Plane integration:** apply the migration and exercise the Feishu
   path in `integrations.route.test.ts` with `verifyFeishuBot` stubbed to
   success, invalid, and unreachable.
-- **One-click integration:** stub `registerApp`, verify the complete scope/event
-  preset, complete and denied states, secret persistence, and that registration
-  responses never contain App ID or App Secret.
+- **One-click integration:** stub the official provider endpoint, verify the
+  complete scope/event preset, completion after reconstructing a second
+  Control Plane instance, denied state, terminal secret clearing, and that
+  registration responses never contain App ID or App Secret.
 - **Live:** use a real custom application with long connection,
   `im.message.receive_v1`, permissions, and group membership. Like Discord, this
   does not block the contract phase.

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -44,7 +44,6 @@
     "@fastify/otel": "^0.20.1",
     "@fastify/swagger": "^9.8.1",
     "@fastify/swagger-ui": "^6.1.0",
-    "@larksuiteoapi/node-sdk": "^1.71.1",
     "@modelcontextprotocol/server": "2.0.0",
     "@octokit/auth-app": "^8.2.0",
     "@opentelemetry/api": "^1.9.1",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -44,6 +44,7 @@
     "@fastify/otel": "^0.20.1",
     "@fastify/swagger": "^9.8.1",
     "@fastify/swagger-ui": "^6.1.0",
+    "@larksuiteoapi/node-sdk": "^1.71.1",
     "@modelcontextprotocol/server": "2.0.0",
     "@octokit/auth-app": "^8.2.0",
     "@opentelemetry/api": "^1.9.1",

--- a/packages/control-plane/prisma/migrations/20260729163000_feishu_app_registration/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260729163000_feishu_app_registration/migration.sql
@@ -1,0 +1,41 @@
+CREATE TYPE "FeishuAppRegistrationStatus" AS ENUM (
+  'pending',
+  'authorized',
+  'completed',
+  'failed'
+);
+
+CREATE TABLE "feishu_app_registration" (
+  "id" UUID NOT NULL,
+  "targetKey" TEXT,
+  "orgId" TEXT NOT NULL,
+  "agentId" UUID NOT NULL,
+  "requestedName" TEXT,
+  "fallbackRegion" TEXT NOT NULL,
+  "authorizationUrl" TEXT NOT NULL,
+  "providerDomain" TEXT NOT NULL,
+  "deviceCode" TEXT,
+  "intervalMs" INTEGER NOT NULL,
+  "nextPollAt" TIMESTAMPTZ(6) NOT NULL,
+  "expiresAt" TIMESTAMPTZ(6) NOT NULL,
+  "status" "FeishuAppRegistrationStatus" NOT NULL DEFAULT 'pending',
+  "failureReason" TEXT,
+  "appId" TEXT,
+  "appSecret" TEXT,
+  "resolvedRegion" TEXT,
+  "botId" UUID NOT NULL,
+  "integrationId" UUID NOT NULL,
+  "createdByUserId" TEXT,
+  "claimToken" UUID,
+  "claimedUntil" TIMESTAMPTZ(6),
+  "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "settledAt" TIMESTAMPTZ(6),
+
+  CONSTRAINT "feishu_app_registration_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "feishu_app_registration_targetKey_key"
+  ON "feishu_app_registration"("targetKey");
+
+CREATE INDEX "feishu_app_registration_status_nextPollAt_idx"
+  ON "feishu_app_registration"("status", "nextPollAt");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1634,6 +1634,52 @@ enum SlackPlatformInstallStatus {
   failed
 }
 
+// Durable Feishu/Lark one-click app registration. The browser polls this row,
+// so any Control Plane replica can continue the provider device flow after a
+// request is load-balanced or a process restarts. `deviceCode` and `appSecret`
+// pass through SecretCipher in PgFeishuAppRegistrationStore and are cleared on
+// every terminal outcome. No FKs: the route re-validates the agent immediately
+// before installation, and abandoned rows are TTL-reaped.
+model FeishuAppRegistration {
+  id               String                      @id @db.Uuid
+  // Non-null only while open. The unique slot prevents two users from creating
+  // two apps for the same target; terminal settlement clears it.
+  targetKey        String?                     @unique
+  orgId            String
+  agentId          String                      @db.Uuid
+  requestedName    String?
+  fallbackRegion   String
+  authorizationUrl String
+  providerDomain   String
+  deviceCode       String? // sensitive — sealed by SecretCipher
+  intervalMs       Int
+  nextPollAt       DateTime                    @db.Timestamptz(6)
+  expiresAt        DateTime                    @db.Timestamptz(6)
+  status           FeishuAppRegistrationStatus @default(pending)
+  failureReason    String?
+  appId            String?
+  appSecret        String? // sensitive — sealed by SecretCipher
+  resolvedRegion   String?
+  // Pre-reserved IDs make finalization restart-idempotent.
+  botId            String                      @db.Uuid
+  integrationId    String                      @db.Uuid
+  createdByUserId  String?
+  claimToken       String?                     @db.Uuid
+  claimedUntil     DateTime?                   @db.Timestamptz(6)
+  createdAt        DateTime                    @default(now()) @db.Timestamptz(6)
+  settledAt        DateTime?                   @db.Timestamptz(6)
+
+  @@index([status, nextPollAt])
+  @@map("feishu_app_registration")
+}
+
+enum FeishuAppRegistrationStatus {
+  pending
+  authorized
+  completed
+  failed
+}
+
 // One user's stored Slack App Configuration Token, scoped to an org (composite key
 // orgId+userId) — docs/designs/slack-install-smoothing.md §Tier B. PER-USER on purpose:
 // the app that `apps.manifest.create` builds is owned by whoever's config token

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -64,6 +64,7 @@ import {
   PgThreadAffinityStore,
   PgSlackInstallStore,
   PgSlackPlatformInstallStore,
+  PgFeishuAppRegistrationStore,
   PgSlackUserConfigStore,
   PgPresetAgentStore,
   PresetAgentBackfill,
@@ -230,6 +231,7 @@ export function buildContainer(
     threadAffinity: new PgThreadAffinityStore(prisma),
     slackInstall: new PgSlackInstallStore(prisma, secretCipher),
     slackPlatformInstall: new PgSlackPlatformInstallStore(prisma),
+    feishuAppRegistration: new PgFeishuAppRegistrationStore(prisma, secretCipher),
     slackUserConfig: new PgSlackUserConfigStore(prisma, secretCipher),
     presetAgent: new PgPresetAgentStore(prisma),
     cron: new PgCronRepo(prisma),
@@ -619,6 +621,7 @@ export function buildContainer(
       externalMemoryGrant: repos.externalMemoryGrant,
       slackInstall: repos.slackInstall,
       slackPlatformInstall: repos.slackPlatformInstall,
+      feishuAppRegistration: repos.feishuAppRegistration,
       slackUserConfig: repos.slackUserConfig,
       presetAgent: repos.presetAgent,
       githubInstallation: repos.githubInstallation,
@@ -656,7 +659,7 @@ export function buildContainer(
     resolveTelegramBotName,
     verifyDiscordBot,
     verifyFeishuBot,
-    feishuAppRegistration: new FeishuAppRegistrationService(),
+    feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(iconStore ? { iconStore } : {}),
@@ -685,7 +688,6 @@ export function buildContainer(
       RELAY_STALE_MS: relayStaleMs
     }
   }
-  const feishuAppRegistration = httpDeps.feishuAppRegistration
   const http = buildHttpServer(httpDeps, opts.fastify)
 
   // Reconciler for orphaned schedule runs: fails `running` cron_run rows whose
@@ -748,7 +750,18 @@ export function buildContainer(
     repos.slackPlatformInstall,
     clock,
     { ttlMs: config.SLACK_INSTALL_TTL_SEC * 1000, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
-    http.log
+    http.log,
+    'slack-platform-install'
+  )
+
+  // Device code/App Secret are encrypted but deliberately short-lived. Retain
+  // a terminal status briefly for the browser, then clear the durable row.
+  const feishuRegistrationReaper = new SlackInstallReaper(
+    repos.feishuAppRegistration,
+    clock,
+    { ttlMs: 10 * 60 * 1000, intervalMs: config.SLACK_INSTALL_REAP_INTERVAL_SEC * 1000 },
+    http.log,
+    'feishu-registration'
   )
 
   // One-time preset backfill (preset-agents.md §3.2): existing orgs receive the
@@ -1126,6 +1139,7 @@ export function buildContainer(
       hookRedeliveryReconciler?.start()
       slackInstallReaper.start()
       slackPlatformInstallReaper.start()
+      feishuRegistrationReaper.start()
       relaySweeper.start()
       slackBotIdentityReconciler.start()
       // One-shot (not a re-arming loop): the worklist empties itself; a partially
@@ -1140,9 +1154,9 @@ export function buildContainer(
       installationDoorbell?.stop()
       slackInstallReaper.stop()
       slackPlatformInstallReaper.stop()
+      feishuRegistrationReaper.stop()
       relaySweeper.stop()
       slackBotIdentityReconciler.stop()
-      feishuAppRegistration.shutdown()
       await Promise.allSettled([...relayRegistrationTasks])
       await prisma.$disconnect()
     }

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -141,6 +141,7 @@ import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
 import { resolveTelegramBotName } from './http/telegram-identity.js'
 import { verifyDiscordBot } from './http/discord-identity.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
+import { FeishuAppRegistrationService } from './http/feishu-registration.js'
 
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from './config/defaults.js'
 
@@ -655,6 +656,7 @@ export function buildContainer(
     resolveTelegramBotName,
     verifyDiscordBot,
     verifyFeishuBot,
+    feishuAppRegistration: new FeishuAppRegistrationService(),
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(iconStore ? { iconStore } : {}),
@@ -683,6 +685,7 @@ export function buildContainer(
       RELAY_STALE_MS: relayStaleMs
     }
   }
+  const feishuAppRegistration = httpDeps.feishuAppRegistration
   const http = buildHttpServer(httpDeps, opts.fastify)
 
   // Reconciler for orphaned schedule runs: fails `running` cron_run rows whose
@@ -1139,6 +1142,7 @@ export function buildContainer(
       slackPlatformInstallReaper.stop()
       relaySweeper.stop()
       slackBotIdentityReconciler.stop()
+      feishuAppRegistration.shutdown()
       await Promise.allSettled([...relayRegistrationTasks])
       await prisma.$disconnect()
     }

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -66,6 +66,7 @@ import type { SlackConfigApi } from './slack-config-api.js'
 import type { TelegramBotNameResolver } from './telegram-identity.js'
 import type { DiscordBotVerifier } from './discord-identity.js'
 import type { FeishuBotVerifier } from './feishu-identity.js'
+import type { FeishuAppRegistrationService } from './feishu-registration.js'
 import type { Readiness } from './readiness.js'
 import type { McpRateLimiter } from './mcp/rate-limit.js'
 import type { SessionKey } from '../domain/sessionKey.js'
@@ -260,6 +261,10 @@ export interface HttpDeps {
    *  Optional/injectable so tests stay offline (absent ⇒ no validation, route falls
    *  back to the agent name). */
   verifyFeishuBot?: FeishuBotVerifier
+  /** Owns the short-lived official Feishu/Lark device-registration poll. The
+   *  browser sees only a deeplink + opaque id; credentials are finalized through
+   *  BotSecretStore before the session becomes completed. */
+  feishuAppRegistration: FeishuAppRegistrationService
   /** github-app workspaces façade; absent ⇒ feature disabled (GITHUB_APP_* unset) and
    *  every github route 404s. */
   github?: GithubService

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -35,6 +35,7 @@ import type {
   ExternalMemoryGrantRepo,
   SlackInstallStore,
   SlackPlatformInstallStore,
+  FeishuAppRegistrationStore,
   SlackUserConfigStore,
   PresetAgentStore,
   GithubInstallationRepo,
@@ -173,6 +174,8 @@ export interface HttpDeps {
     slackInstall: SlackInstallStore
     /** Pending platform-app installs (preset-agents.md §5.3): OAuth state → tenancy, no secrets. */
     slackPlatformInstall: SlackPlatformInstallStore
+    /** Durable, encrypted Feishu/Lark one-click device registrations. */
+    feishuAppRegistration: FeishuAppRegistrationStore
     /** One org's stored Slack App Configuration token (§Tier B); holds secret material, never DTO'd. */
     slackUserConfig: SlackUserConfigStore
     /** Per-org preset provisioning state (preset-agents.md §3.2) — read surface

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1159,6 +1159,29 @@ export const SlackAppStartDto = z.object({
   transport: z.enum(['socket', 'http'])
 })
 
+/** Start Feishu/Lark's one-click self-built app registration. The SDK returns a
+ * deeplink; App ID/Secret stay server-side and are installed when authorization
+ * completes. `region` is only a fallback when the provider omits tenant_brand. */
+export const FeishuAppRegistrationStartBody = z.object({
+  agentId: z.string().uuid(),
+  name: z.string().min(1).optional(),
+  region: FeishuRegion.default('lark')
+})
+
+export const FeishuAppRegistrationStartDto = z.object({
+  id: z.string().uuid(),
+  authorizationUrl: z.string().url(),
+  expiresAt: z.string().datetime()
+})
+
+export const FeishuAppRegistrationStatusDto = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['pending', 'completed', 'failed']),
+  failureReason: z.enum(['denied', 'expired', 'agent_unavailable', 'invalid_credentials', 'setup_failed']).nullable(),
+  integrationId: z.string().uuid().nullable(),
+  expiresAt: z.string().datetime()
+})
+
 /** `POST /integrations/slack/platform-install` (preset-agents.md §5.3) — mint a
  *  pending install of the PLATFORM-published Slack app. The target defaults to
  *  the org's `agentconnect` preset agent; an unplaced target is fine (http

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1159,9 +1159,10 @@ export const SlackAppStartDto = z.object({
   transport: z.enum(['socket', 'http'])
 })
 
-/** Start Feishu/Lark's one-click self-built app registration. The SDK returns a
- * deeplink; App ID/Secret stay server-side and are installed when authorization
- * completes. `region` is only a fallback when the provider omits tenant_brand. */
+/** Start Feishu/Lark's one-click self-built app registration. The provider
+ * returns a deeplink; App ID/Secret stay server-side and are installed when
+ * authorization completes. `region` is only a fallback when tenant_brand is
+ * omitted. */
 export const FeishuAppRegistrationStartBody = z.object({
   agentId: z.string().uuid(),
   name: z.string().min(1).optional(),

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -1,0 +1,53 @@
+/**
+ * The AgentConnect Feishu/Lark one-click app template.
+ *
+ * This is the single reviewable list of capabilities added to Feishu's
+ * official PersonalAgent base. The provider confirmation page shows this
+ * template before creating the app.
+ */
+import { gzipSync } from 'node:zlib'
+
+export const AGENTCONNECT_FEISHU_SCOPES = [
+  'contact:contact.base:readonly',
+  'contact:user.base:readonly',
+  'im:chat:read',
+  'im:chat.members:bot_access',
+  'im:message',
+  'im:message.group_at_msg:readonly',
+  'im:message.p2p_msg:readonly',
+  'im:message:send_as_bot',
+  'im:resource'
+] as const
+
+export const AGENTCONNECT_FEISHU_EVENTS = ['im.message.receive_v1'] as const
+
+export const AGENTCONNECT_FEISHU_APP_TEMPLATE = {
+  archetype: 'PersonalAgent',
+  description: 'Connect this bot to an AgentConnect agent.',
+  addons: {
+    preset: true,
+    scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
+    events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
+  }
+} as const
+
+function encodeAddons(): string {
+  const json = JSON.stringify(AGENTCONNECT_FEISHU_APP_TEMPLATE.addons)
+  return gzipSync(Buffer.from(json, 'utf8'))
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+export function buildFeishuAuthorizationUrl(verificationUri: string, appName: string): string {
+  const url = new URL(verificationUri)
+  url.searchParams.set('from', 'sdk')
+  url.searchParams.set('source', 'node-sdk/agentconnect')
+  url.searchParams.set('tp', 'sdk')
+  url.searchParams.set('name', appName)
+  url.searchParams.set('desc', AGENTCONNECT_FEISHU_APP_TEMPLATE.description)
+  url.searchParams.set('addons', encodeAddons())
+  url.searchParams.set('createOnly', 'true')
+  return url.toString()
+}

--- a/packages/control-plane/src/http/feishu-registration-provider.ts
+++ b/packages/control-plane/src/http/feishu-registration-provider.ts
@@ -1,0 +1,120 @@
+/**
+ * Resumable adapter for Feishu/Lark's official app-registration device flow.
+ *
+ * The public SDK wraps both `begin` and repeated `poll` calls in one Promise,
+ * which cannot be resumed by another Control Plane replica. This adapter uses
+ * the same official endpoint and payload, while exposing the device cursor so
+ * the encrypted persistence store can resume it after load balancing/restart.
+ */
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+import { AGENTCONNECT_FEISHU_APP_TEMPLATE, buildFeishuAuthorizationUrl } from './feishu-app-template.js'
+
+export const FEISHU_REGISTRATION_DOMAIN = 'accounts.feishu.cn'
+export const LARK_REGISTRATION_DOMAIN = 'accounts.larksuite.com'
+
+const REGISTRATION_PATH = '/oauth/v1/app/registration'
+
+interface RegistrationResponse {
+  verification_uri_complete?: string
+  device_code?: string
+  expires_in?: number
+  interval?: number
+  client_id?: string
+  client_secret?: string
+  error?: string
+  error_description?: string
+  user_info?: { tenant_brand?: FeishuRegion }
+}
+
+export interface BeginFeishuRegistration {
+  authorizationUrl: string
+  deviceCode: string
+  providerDomain: string
+  intervalMs: number
+  expiresInMs: number
+}
+
+export type PollFeishuRegistration =
+  | { outcome: 'pending' }
+  | { outcome: 'slow_down' }
+  | { outcome: 'switch_domain'; providerDomain: string }
+  | { outcome: 'authorized'; appId: string; appSecret: string; region?: FeishuRegion }
+  | { outcome: 'denied' }
+  | { outcome: 'expired' }
+  | { outcome: 'failed' }
+
+export interface FeishuRegistrationProvider {
+  begin(appName: string): Promise<BeginFeishuRegistration>
+  poll(providerDomain: string, deviceCode: string): Promise<PollFeishuRegistration>
+}
+
+type RegistrationFetch = typeof fetch
+
+export class OfficialFeishuRegistrationProvider implements FeishuRegistrationProvider {
+  constructor(private readonly fetcher: RegistrationFetch = fetch) {}
+
+  async begin(appName: string): Promise<BeginFeishuRegistration> {
+    const response = await this.request(FEISHU_REGISTRATION_DOMAIN, {
+      action: 'begin',
+      archetype: AGENTCONNECT_FEISHU_APP_TEMPLATE.archetype,
+      auth_method: 'client_secret',
+      request_user_info: 'open_id'
+    })
+    if (!response.verification_uri_complete || !response.device_code) {
+      throw new Error('Feishu app registration did not return a device session')
+    }
+    return {
+      authorizationUrl: buildFeishuAuthorizationUrl(response.verification_uri_complete, appName),
+      deviceCode: response.device_code,
+      providerDomain: FEISHU_REGISTRATION_DOMAIN,
+      intervalMs: Math.max(1, response.interval ?? 5) * 1000,
+      expiresInMs: Math.max(1, response.expires_in ?? 600) * 1000
+    }
+  }
+
+  async poll(providerDomain: string, deviceCode: string): Promise<PollFeishuRegistration> {
+    const response = await this.request(providerDomain, { action: 'poll', device_code: deviceCode })
+    if (response.user_info?.tenant_brand === 'lark' && providerDomain !== LARK_REGISTRATION_DOMAIN) {
+      return { outcome: 'switch_domain', providerDomain: LARK_REGISTRATION_DOMAIN }
+    }
+    if (response.client_id && response.client_secret) {
+      return {
+        outcome: 'authorized',
+        appId: response.client_id,
+        appSecret: response.client_secret,
+        ...(response.user_info?.tenant_brand ? { region: response.user_info.tenant_brand } : {})
+      }
+    }
+    switch (response.error) {
+      case 'authorization_pending':
+        return { outcome: 'pending' }
+      case 'slow_down':
+        return { outcome: 'slow_down' }
+      case 'access_denied':
+        return { outcome: 'denied' }
+      case 'expired_token':
+        return { outcome: 'expired' }
+      case undefined:
+        return { outcome: 'pending' }
+      default:
+        return { outcome: 'failed' }
+    }
+  }
+
+  private async request(providerDomain: string, params: Record<string, string>): Promise<RegistrationResponse> {
+    const response = await this.fetcher(`https://${providerDomain}${REGISTRATION_PATH}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(params).toString(),
+      signal: AbortSignal.timeout(15_000)
+    })
+    const body: unknown = await response.json()
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      throw new Error('Feishu app registration returned an invalid response')
+    }
+    if (!response.ok && typeof Reflect.get(body, 'error') !== 'string') {
+      throw new Error('Feishu app registration request failed')
+    }
+    return body as RegistrationResponse
+  }
+}

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -28,6 +28,14 @@ export class FeishuRegistrationConflictError extends Error {
   }
 }
 
+/** Placement is moving; keep the authorized credentials and retry finalization. */
+export class FeishuRegistrationRetryError extends Error {
+  constructor() {
+    super('agent placement is changing')
+    this.name = 'FeishuRegistrationRetryError'
+  }
+}
+
 export interface StartFeishuRegistration {
   orgId: OrgId
   agentId: AgentId
@@ -171,13 +179,21 @@ export class FeishuAppRegistrationService {
           appSecret: current.appSecret,
           region: current.resolvedRegion
         })
-        await this.store.settle(id, claimToken, { status: 'completed' })
       } catch (error) {
-        await this.store.settle(id, claimToken, {
-          status: 'failed',
-          failureReason: failureReason(error)
-        })
+        if (error instanceof FeishuRegistrationRetryError) {
+          await this.store.releaseAuthorized(id, claimToken)
+        } else {
+          await this.store.settle(id, claimToken, {
+            status: 'failed',
+            failureReason: failureReason(error)
+          })
+        }
+        return publicSnapshot((await this.store.get(id)) ?? current)
       }
+      // Keep settlement outside the finalize catch. If this DB write itself is
+      // transient, the authorized row and reserved IDs remain retryable instead
+      // of reporting failure after the integration was already installed.
+      await this.store.settle(id, claimToken, { status: 'completed' })
     }
     return publicSnapshot((await this.store.get(id)) ?? current)
   }

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -1,0 +1,255 @@
+/**
+ * Short-lived broker for Feishu/Lark's OAuth device registration flow.
+ *
+ * The official SDK owns the device-code polling. The browser receives only the
+ * authorization deeplink plus an opaque registration id; App Secret stays in
+ * this process just long enough for `onRegistered` to persist it through the
+ * normal bot-secret path.
+ *
+ * These sessions are deliberately transient control operations. They are
+ * bounded by the provider's expiry and disappear after a short terminal-state
+ * retention window.
+ */
+import { randomUUID } from 'node:crypto'
+import { registerApp } from '@larksuiteoapi/node-sdk'
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+
+export const AGENTCONNECT_FEISHU_SCOPES = [
+  'contact:contact.base:readonly',
+  'contact:user.base:readonly',
+  'im:chat:read',
+  'im:chat.members:bot_access',
+  'im:message',
+  'im:message.group_at_msg:readonly',
+  'im:message.p2p_msg:readonly',
+  'im:message:send_as_bot',
+  'im:resource'
+] as const
+
+export const AGENTCONNECT_FEISHU_EVENTS = ['im.message.receive_v1'] as const
+
+export type FeishuRegisterApp = typeof registerApp
+export type FeishuRegistrationFailure =
+  'denied' | 'expired' | 'agent_unavailable' | 'invalid_credentials' | 'setup_failed'
+
+export class FeishuRegistrationSetupError extends Error {
+  constructor(readonly reason: Exclude<FeishuRegistrationFailure, 'denied' | 'expired'>) {
+    super(reason)
+    this.name = 'FeishuRegistrationSetupError'
+  }
+}
+
+export interface RegisteredFeishuApp {
+  appId: string
+  appSecret: string
+  region: FeishuRegion
+}
+
+export interface StartFeishuRegistration {
+  orgId: string
+  agentId: string
+  fallbackRegion: FeishuRegion
+  appName: string
+  onRegistered(app: RegisteredFeishuApp): Promise<string>
+}
+
+export interface FeishuRegistrationSnapshot {
+  id: string
+  orgId: string
+  agentId: string
+  authorizationUrl: string
+  expiresAt: Date
+  status: 'pending' | 'completed' | 'failed'
+  failureReason: FeishuRegistrationFailure | null
+  integrationId: string | null
+}
+
+interface InternalSession extends FeishuRegistrationSnapshot {
+  targetKey: string
+  retainUntil: number
+  ready: Promise<FeishuRegistrationSnapshot>
+  resolveReady(snapshot: FeishuRegistrationSnapshot): void
+  rejectReady(error: Error): void
+  abort: AbortController
+}
+
+const DEFAULT_EXPIRES_MS = 10 * 60 * 1000
+const TERMINAL_RETENTION_MS = 10 * 60 * 1000
+
+function registrationErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const code = Reflect.get(error, 'code')
+  return typeof code === 'string' ? code : undefined
+}
+
+function failureReason(error: unknown): FeishuRegistrationFailure {
+  if (error instanceof FeishuRegistrationSetupError) return error.reason
+  switch (registrationErrorCode(error)) {
+    case 'access_denied':
+      return 'denied'
+    case 'expired_token':
+    case 'abort':
+      return 'expired'
+    default:
+      return 'setup_failed'
+  }
+}
+
+function publicSnapshot(session: InternalSession): FeishuRegistrationSnapshot {
+  return {
+    id: session.id,
+    orgId: session.orgId,
+    agentId: session.agentId,
+    authorizationUrl: session.authorizationUrl,
+    expiresAt: session.expiresAt,
+    status: session.status,
+    failureReason: session.failureReason,
+    integrationId: session.integrationId
+  }
+}
+
+export class FeishuAppRegistrationService {
+  private readonly sessions = new Map<string, InternalSession>()
+  private readonly activeByTarget = new Map<string, string>()
+
+  constructor(
+    private readonly register: FeishuRegisterApp = registerApp,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  async start(input: StartFeishuRegistration): Promise<FeishuRegistrationSnapshot> {
+    this.prune()
+    const targetKey = `${input.orgId}:${input.agentId}`
+    const activeId = this.activeByTarget.get(targetKey)
+    const active = activeId ? this.sessions.get(activeId) : undefined
+    if (active?.status === 'pending') return active.ready
+
+    const id = randomUUID()
+    let resolveReady!: (snapshot: FeishuRegistrationSnapshot) => void
+    let rejectReady!: (error: Error) => void
+    const ready = new Promise<FeishuRegistrationSnapshot>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+    const startedAt = this.now()
+    const session: InternalSession = {
+      id,
+      orgId: input.orgId,
+      agentId: input.agentId,
+      targetKey,
+      authorizationUrl: '',
+      expiresAt: new Date(startedAt + DEFAULT_EXPIRES_MS),
+      status: 'pending',
+      failureReason: null,
+      integrationId: null,
+      retainUntil: startedAt + DEFAULT_EXPIRES_MS + TERMINAL_RETENTION_MS,
+      ready,
+      resolveReady,
+      rejectReady,
+      abort: new AbortController()
+    }
+    this.sessions.set(id, session)
+    this.activeByTarget.set(targetKey, id)
+
+    let registration: ReturnType<FeishuRegisterApp>
+    try {
+      registration = this.register({
+        source: 'agentconnect',
+        createOnly: true,
+        signal: session.abort.signal,
+        appPreset: {
+          name: input.appName,
+          desc: 'Connect this bot to an AgentConnect agent.'
+        },
+        addons: {
+          // Keep the official PersonalAgent base and explicitly layer every
+          // capability AgentConnect uses. In particular, the second contact
+          // scope is what lets sessions show a participant name instead of ou_….
+          preset: true,
+          scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
+          events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
+        },
+        onQRCodeReady: ({ url, expireIn }) => {
+          session.authorizationUrl = url
+          session.expiresAt = new Date(this.now() + expireIn * 1000)
+          session.retainUntil = session.expiresAt.getTime() + TERMINAL_RETENTION_MS
+          session.resolveReady(publicSnapshot(session))
+        }
+      })
+    } catch {
+      this.failBeforeReady(session)
+      throw new Error('could not start Feishu app registration')
+    }
+
+    void registration.then(
+      async (result) => {
+        try {
+          const integrationId = await input.onRegistered({
+            appId: result.client_id,
+            appSecret: result.client_secret,
+            region: result.user_info?.tenant_brand ?? input.fallbackRegion
+          })
+          this.complete(session, integrationId)
+        } catch (error) {
+          this.fail(session, failureReason(error))
+        }
+      },
+      (error) => {
+        if (!session.authorizationUrl) session.rejectReady(new Error('could not start Feishu app registration'))
+        this.fail(session, failureReason(error))
+      }
+    )
+
+    return ready
+  }
+
+  get(id: string): FeishuRegistrationSnapshot | null {
+    this.prune()
+    const session = this.sessions.get(id)
+    if (!session) return null
+    if (session.status === 'pending' && session.authorizationUrl && session.expiresAt.getTime() <= this.now()) {
+      session.abort.abort()
+      this.fail(session, 'expired')
+    }
+    return publicSnapshot(session)
+  }
+
+  shutdown(): void {
+    for (const session of this.sessions.values()) {
+      if (session.status === 'pending') session.abort.abort()
+    }
+    this.sessions.clear()
+    this.activeByTarget.clear()
+  }
+
+  private complete(session: InternalSession, integrationId: string): void {
+    if (session.status !== 'pending') return
+    session.status = 'completed'
+    session.integrationId = integrationId
+    session.retainUntil = this.now() + TERMINAL_RETENTION_MS
+    this.activeByTarget.delete(session.targetKey)
+  }
+
+  private fail(session: InternalSession, reason: FeishuRegistrationFailure): void {
+    if (session.status !== 'pending') return
+    session.status = 'failed'
+    session.failureReason = reason
+    session.retainUntil = this.now() + TERMINAL_RETENTION_MS
+    this.activeByTarget.delete(session.targetKey)
+  }
+
+  private failBeforeReady(session: InternalSession): void {
+    this.sessions.delete(session.id)
+    this.activeByTarget.delete(session.targetKey)
+  }
+
+  private prune(): void {
+    const now = this.now()
+    for (const [id, session] of this.sessions) {
+      if (session.retainUntil > now) continue
+      if (session.status === 'pending') session.abort.abort()
+      this.sessions.delete(id)
+      if (this.activeByTarget.get(session.targetKey) === id) this.activeByTarget.delete(session.targetKey)
+    }
+  }
+}

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -1,34 +1,16 @@
 /**
- * Short-lived broker for Feishu/Lark's OAuth device registration flow.
+ * Durable coordinator for Feishu/Lark's one-click app registration.
  *
- * The official SDK owns the device-code polling. The browser receives only the
- * authorization deeplink plus an opaque registration id; App Secret stays in
- * this process just long enough for `onRegistered` to persist it through the
- * normal bot-secret path.
- *
- * These sessions are deliberately transient control operations. They are
- * bounded by the provider's expiry and disappear after a short terminal-state
- * retention window.
+ * Provider cursors and provisional credentials live behind a SecretCipher
+ * persistence seam, so a browser poll can continue on any Control Plane
+ * replica. A short DB claim leases each provider/finalize step to one replica.
  */
 import { randomUUID } from 'node:crypto'
-import { registerApp } from '@larksuiteoapi/node-sdk'
 import type { FeishuRegion } from '@agentconnect.md/protocol'
+import { AgentId, BotId, IntegrationId, type OrgId } from '../domain/ids.js'
+import type { FeishuAppRegistrationRecord, FeishuAppRegistrationStore } from '../persistence/ports.js'
+import { OfficialFeishuRegistrationProvider, type FeishuRegistrationProvider } from './feishu-registration-provider.js'
 
-export const AGENTCONNECT_FEISHU_SCOPES = [
-  'contact:contact.base:readonly',
-  'contact:user.base:readonly',
-  'im:chat:read',
-  'im:chat.members:bot_access',
-  'im:message',
-  'im:message.group_at_msg:readonly',
-  'im:message.p2p_msg:readonly',
-  'im:message:send_as_bot',
-  'im:resource'
-] as const
-
-export const AGENTCONNECT_FEISHU_EVENTS = ['im.message.receive_v1'] as const
-
-export type FeishuRegisterApp = typeof registerApp
 export type FeishuRegistrationFailure =
   'denied' | 'expired' | 'agent_unavailable' | 'invalid_credentials' | 'setup_failed'
 
@@ -39,217 +21,229 @@ export class FeishuRegistrationSetupError extends Error {
   }
 }
 
-export interface RegisteredFeishuApp {
+export class FeishuRegistrationConflictError extends Error {
+  constructor() {
+    super('another user is already setting up a Feishu/Lark app for this agent')
+    this.name = 'FeishuRegistrationConflictError'
+  }
+}
+
+export interface StartFeishuRegistration {
+  orgId: OrgId
+  agentId: AgentId
+  fallbackRegion: FeishuRegion
+  appName: string
+  requestedName?: string
+  createdByUserId: string
+}
+
+export interface FinalizeFeishuRegistration {
+  orgId: OrgId
+  agentId: AgentId
+  requestedName: string | null
+  createdByUserId: string
+  botId: BotId
+  integrationId: IntegrationId
   appId: string
   appSecret: string
   region: FeishuRegion
 }
 
-export interface StartFeishuRegistration {
-  orgId: string
-  agentId: string
-  fallbackRegion: FeishuRegion
-  appName: string
-  onRegistered(app: RegisteredFeishuApp): Promise<string>
-}
-
 export interface FeishuRegistrationSnapshot {
   id: string
-  orgId: string
-  agentId: string
+  orgId: OrgId
+  agentId: AgentId
   authorizationUrl: string
   expiresAt: Date
   status: 'pending' | 'completed' | 'failed'
   failureReason: FeishuRegistrationFailure | null
-  integrationId: string | null
+  integrationId: IntegrationId | null
 }
 
-interface InternalSession extends FeishuRegistrationSnapshot {
-  targetKey: string
-  retainUntil: number
-  ready: Promise<FeishuRegistrationSnapshot>
-  resolveReady(snapshot: FeishuRegistrationSnapshot): void
-  rejectReady(error: Error): void
-  abort: AbortController
-}
+const CLAIM_MS = 2 * 60 * 1000
 
-const DEFAULT_EXPIRES_MS = 10 * 60 * 1000
-const TERMINAL_RETENTION_MS = 10 * 60 * 1000
-
-function registrationErrorCode(error: unknown): string | undefined {
-  if (typeof error !== 'object' || error === null) return undefined
-  const code = Reflect.get(error, 'code')
-  return typeof code === 'string' ? code : undefined
+function targetKey(orgId: OrgId, agentId: AgentId): string {
+  return `${orgId}:${agentId}`
 }
 
 function failureReason(error: unknown): FeishuRegistrationFailure {
-  if (error instanceof FeishuRegistrationSetupError) return error.reason
-  switch (registrationErrorCode(error)) {
-    case 'access_denied':
-      return 'denied'
-    case 'expired_token':
-    case 'abort':
-      return 'expired'
-    default:
-      return 'setup_failed'
+  return error instanceof FeishuRegistrationSetupError ? error.reason : 'setup_failed'
+}
+
+function publicSnapshot(row: FeishuAppRegistrationRecord): FeishuRegistrationSnapshot {
+  const status = row.status === 'authorized' ? 'pending' : row.status
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    agentId: row.agentId,
+    authorizationUrl: row.authorizationUrl,
+    expiresAt: row.expiresAt,
+    status,
+    failureReason:
+      status === 'failed' ? ((row.failureReason as FeishuRegistrationFailure | null) ?? 'setup_failed') : null,
+    integrationId: status === 'completed' ? row.integrationId : null
   }
 }
 
-function publicSnapshot(session: InternalSession): FeishuRegistrationSnapshot {
-  return {
-    id: session.id,
-    orgId: session.orgId,
-    agentId: session.agentId,
-    authorizationUrl: session.authorizationUrl,
-    expiresAt: session.expiresAt,
-    status: session.status,
-    failureReason: session.failureReason,
-    integrationId: session.integrationId
-  }
+function isUniqueConstraint(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && Reflect.get(error, 'code') === 'P2002'
 }
 
 export class FeishuAppRegistrationService {
-  private readonly sessions = new Map<string, InternalSession>()
-  private readonly activeByTarget = new Map<string, string>()
-
   constructor(
-    private readonly register: FeishuRegisterApp = registerApp,
+    private readonly store: FeishuAppRegistrationStore,
+    private readonly provider: FeishuRegistrationProvider = new OfficialFeishuRegistrationProvider(),
     private readonly now: () => number = Date.now
   ) {}
 
   async start(input: StartFeishuRegistration): Promise<FeishuRegistrationSnapshot> {
-    this.prune()
-    const targetKey = `${input.orgId}:${input.agentId}`
-    const activeId = this.activeByTarget.get(targetKey)
-    const active = activeId ? this.sessions.get(activeId) : undefined
-    if (active?.status === 'pending') return active.ready
+    const key = targetKey(input.orgId, input.agentId)
+    const now = new Date(this.now())
+    await this.store.expireTarget(key, now)
+    const existing = await this.store.getActiveTarget(key)
+    if (existing) return this.reuseOrConflict(existing, input.createdByUserId)
 
-    const id = randomUUID()
-    let resolveReady!: (snapshot: FeishuRegistrationSnapshot) => void
-    let rejectReady!: (error: Error) => void
-    const ready = new Promise<FeishuRegistrationSnapshot>((resolve, reject) => {
-      resolveReady = resolve
-      rejectReady = reject
-    })
-    const startedAt = this.now()
-    const session: InternalSession = {
-      id,
-      orgId: input.orgId,
-      agentId: input.agentId,
-      targetKey,
-      authorizationUrl: '',
-      expiresAt: new Date(startedAt + DEFAULT_EXPIRES_MS),
-      status: 'pending',
-      failureReason: null,
-      integrationId: null,
-      retainUntil: startedAt + DEFAULT_EXPIRES_MS + TERMINAL_RETENTION_MS,
-      ready,
-      resolveReady,
-      rejectReady,
-      abort: new AbortController()
-    }
-    this.sessions.set(id, session)
-    this.activeByTarget.set(targetKey, id)
-
-    let registration: ReturnType<FeishuRegisterApp>
+    const begun = await this.provider.begin(input.appName)
     try {
-      registration = this.register({
-        source: 'agentconnect',
-        createOnly: true,
-        signal: session.abort.signal,
-        appPreset: {
-          name: input.appName,
-          desc: 'Connect this bot to an AgentConnect agent.'
-        },
-        addons: {
-          // Keep the official PersonalAgent base and explicitly layer every
-          // capability AgentConnect uses. In particular, the second contact
-          // scope is what lets sessions show a participant name instead of ou_….
-          preset: true,
-          scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
-          events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
-        },
-        onQRCodeReady: ({ url, expireIn }) => {
-          session.authorizationUrl = url
-          session.expiresAt = new Date(this.now() + expireIn * 1000)
-          session.retainUntil = session.expiresAt.getTime() + TERMINAL_RETENTION_MS
-          session.resolveReady(publicSnapshot(session))
-        }
+      const row = await this.store.create({
+        id: randomUUID(),
+        targetKey: key,
+        orgId: input.orgId,
+        agentId: input.agentId,
+        ...(input.requestedName ? { requestedName: input.requestedName } : {}),
+        fallbackRegion: input.fallbackRegion,
+        authorizationUrl: begun.authorizationUrl,
+        providerDomain: begun.providerDomain,
+        deviceCode: begun.deviceCode,
+        intervalMs: begun.intervalMs,
+        nextPollAt: now,
+        expiresAt: new Date(now.getTime() + begun.expiresInMs),
+        botId: BotId(randomUUID()),
+        integrationId: IntegrationId(randomUUID()),
+        createdByUserId: input.createdByUserId
       })
-    } catch {
-      this.failBeforeReady(session)
-      throw new Error('could not start Feishu app registration')
+      return publicSnapshot(row)
+    } catch (error) {
+      if (!isUniqueConstraint(error)) throw error
+      const winner = await this.store.getActiveTarget(key)
+      if (!winner) throw error
+      return this.reuseOrConflict(winner, input.createdByUserId)
+    }
+  }
+
+  async get(
+    id: string,
+    orgId: OrgId,
+    finalize: (input: FinalizeFeishuRegistration) => Promise<void>
+  ): Promise<FeishuRegistrationSnapshot | null> {
+    let row = await this.store.get(id)
+    if (!row || row.orgId !== orgId) return null
+
+    const now = new Date(this.now())
+    if (row.status === 'pending' && row.expiresAt <= now) {
+      await this.store.expire(id, now)
+      row = (await this.store.get(id)) ?? row
+    }
+    if (row.status === 'completed' || row.status === 'failed') return publicSnapshot(row)
+
+    const claimToken = randomUUID()
+    const claimed = await this.store.claim(id, claimToken, now, new Date(now.getTime() + CLAIM_MS))
+    if (!claimed) return publicSnapshot((await this.store.get(id)) ?? row)
+
+    let current = claimed
+    if (current.status === 'pending') {
+      current = await this.poll(current, claimToken)
+      if (current.status !== 'authorized') return publicSnapshot(current)
     }
 
-    void registration.then(
-      async (result) => {
-        try {
-          const integrationId = await input.onRegistered({
-            appId: result.client_id,
-            appSecret: result.client_secret,
-            region: result.user_info?.tenant_brand ?? input.fallbackRegion
-          })
-          this.complete(session, integrationId)
-        } catch (error) {
-          this.fail(session, failureReason(error))
-        }
-      },
-      (error) => {
-        if (!session.authorizationUrl) session.rejectReady(new Error('could not start Feishu app registration'))
-        this.fail(session, failureReason(error))
+    if (!current.appId || !current.appSecret || !current.resolvedRegion || !current.createdByUserId) {
+      await this.store.settle(id, claimToken, { status: 'failed', failureReason: 'setup_failed' })
+    } else {
+      try {
+        await finalize({
+          orgId: current.orgId,
+          agentId: current.agentId,
+          requestedName: current.requestedName,
+          createdByUserId: current.createdByUserId,
+          botId: current.botId,
+          integrationId: current.integrationId,
+          appId: current.appId,
+          appSecret: current.appSecret,
+          region: current.resolvedRegion
+        })
+        await this.store.settle(id, claimToken, { status: 'completed' })
+      } catch (error) {
+        await this.store.settle(id, claimToken, {
+          status: 'failed',
+          failureReason: failureReason(error)
+        })
       }
-    )
-
-    return ready
-  }
-
-  get(id: string): FeishuRegistrationSnapshot | null {
-    this.prune()
-    const session = this.sessions.get(id)
-    if (!session) return null
-    if (session.status === 'pending' && session.authorizationUrl && session.expiresAt.getTime() <= this.now()) {
-      session.abort.abort()
-      this.fail(session, 'expired')
     }
-    return publicSnapshot(session)
+    return publicSnapshot((await this.store.get(id)) ?? current)
   }
 
-  shutdown(): void {
-    for (const session of this.sessions.values()) {
-      if (session.status === 'pending') session.abort.abort()
+  private async poll(row: FeishuAppRegistrationRecord, claimToken: string): Promise<FeishuAppRegistrationRecord> {
+    if (!row.deviceCode) {
+      await this.store.settle(row.id, claimToken, { status: 'failed', failureReason: 'setup_failed' })
+      return (await this.store.get(row.id)) ?? row
     }
-    this.sessions.clear()
-    this.activeByTarget.clear()
-  }
 
-  private complete(session: InternalSession, integrationId: string): void {
-    if (session.status !== 'pending') return
-    session.status = 'completed'
-    session.integrationId = integrationId
-    session.retainUntil = this.now() + TERMINAL_RETENTION_MS
-    this.activeByTarget.delete(session.targetKey)
-  }
-
-  private fail(session: InternalSession, reason: FeishuRegistrationFailure): void {
-    if (session.status !== 'pending') return
-    session.status = 'failed'
-    session.failureReason = reason
-    session.retainUntil = this.now() + TERMINAL_RETENTION_MS
-    this.activeByTarget.delete(session.targetKey)
-  }
-
-  private failBeforeReady(session: InternalSession): void {
-    this.sessions.delete(session.id)
-    this.activeByTarget.delete(session.targetKey)
-  }
-
-  private prune(): void {
-    const now = this.now()
-    for (const [id, session] of this.sessions) {
-      if (session.retainUntil > now) continue
-      if (session.status === 'pending') session.abort.abort()
-      this.sessions.delete(id)
-      if (this.activeByTarget.get(session.targetKey) === id) this.activeByTarget.delete(session.targetKey)
+    let result
+    try {
+      result = await this.provider.poll(row.providerDomain, row.deviceCode)
+    } catch {
+      await this.release(row, claimToken, row.intervalMs)
+      return (await this.store.get(row.id)) ?? row
     }
+
+    switch (result.outcome) {
+      case 'pending':
+        await this.release(row, claimToken, row.intervalMs)
+        break
+      case 'slow_down':
+        await this.release(row, claimToken, row.intervalMs + 5000)
+        break
+      case 'switch_domain':
+        await this.release(row, claimToken, row.intervalMs, result.providerDomain, 0)
+        break
+      case 'authorized': {
+        const authorized = await this.store.authorize(row.id, claimToken, {
+          appId: result.appId,
+          appSecret: result.appSecret,
+          region: result.region ?? row.fallbackRegion
+        })
+        if (authorized) return authorized
+        break
+      }
+      case 'denied':
+        await this.store.settle(row.id, claimToken, { status: 'failed', failureReason: 'denied' })
+        break
+      case 'expired':
+        await this.store.settle(row.id, claimToken, { status: 'failed', failureReason: 'expired' })
+        break
+      case 'failed':
+        await this.store.settle(row.id, claimToken, { status: 'failed', failureReason: 'setup_failed' })
+        break
+    }
+    return (await this.store.get(row.id)) ?? row
+  }
+
+  private async release(
+    row: FeishuAppRegistrationRecord,
+    claimToken: string,
+    intervalMs: number,
+    providerDomain?: string,
+    delayMs = intervalMs
+  ): Promise<void> {
+    await this.store.release(row.id, claimToken, {
+      ...(providerDomain ? { providerDomain } : {}),
+      intervalMs,
+      nextPollAt: new Date(this.now() + delayMs)
+    })
+  }
+
+  private reuseOrConflict(existing: FeishuAppRegistrationRecord, createdByUserId: string): FeishuRegistrationSnapshot {
+    if (existing.createdByUserId !== createdByUserId) throw new FeishuRegistrationConflictError()
+    return publicSnapshot(existing)
   }
 }

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -74,10 +74,6 @@ function targetKey(orgId: OrgId, agentId: AgentId): string {
   return `${orgId}:${agentId}`
 }
 
-function failureReason(error: unknown): FeishuRegistrationFailure {
-  return error instanceof FeishuRegistrationSetupError ? error.reason : 'setup_failed'
-}
-
 function publicSnapshot(row: FeishuAppRegistrationRecord): FeishuRegistrationSnapshot {
   const status = row.status === 'authorized' ? 'pending' : row.status
   return {
@@ -180,13 +176,16 @@ export class FeishuAppRegistrationService {
           region: current.resolvedRegion
         })
       } catch (error) {
-        if (error instanceof FeishuRegistrationRetryError) {
-          await this.store.releaseAuthorized(id, claimToken)
-        } else {
+        if (error instanceof FeishuRegistrationSetupError) {
           await this.store.settle(id, claimToken, {
             status: 'failed',
-            failureReason: failureReason(error)
+            failureReason: error.reason
           })
+        } else {
+          // DB/control delivery may fail after the reserved bot/integration was
+          // already persisted. Keep credentials retryable; the idempotent
+          // finalizer will reuse those rows on the next browser poll.
+          await this.store.releaseAuthorized(id, claimToken)
         }
         return publicSnapshot((await this.store.get(id)) ?? current)
       }

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -1,0 +1,82 @@
+/**
+ * Register a Feishu/Lark bot from an app credential pair and push it live.
+ *
+ * Both the manual credential form and the one-click registration flow land
+ * here. Secret material is written through BotSecretStore and is never
+ * returned to the browser or included in logs.
+ */
+import { randomUUID } from 'node:crypto'
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+import type { HttpDeps } from './deps.js'
+import type { AgentRecord, IntegrationRecord } from '../persistence/ports.js'
+import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
+import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
+import { NoConnection } from '../orchestrator/outbound.js'
+
+export interface InstallFeishuBotArgs {
+  orgId: OrgId
+  agent: AgentRecord
+  name: string
+  appId: string
+  appSecret: string
+  region: FeishuRegion
+  createdByUserId?: string
+}
+
+interface DebugLog {
+  debug(obj: unknown, msg?: string): void
+}
+
+export async function installNewFeishuBot(
+  deps: HttpDeps,
+  log: DebugLog,
+  args: InstallFeishuBotArgs
+): Promise<IntegrationRecord> {
+  const { orgId, agent, name, appId, appSecret, region, createdByUserId } = args
+  const botId = BotId(randomUUID())
+  await deps.repos.bot.create({
+    id: botId,
+    orgId,
+    platform: 'feishu',
+    name,
+    feishuAppId: appId,
+    feishuRegion: region,
+    ...(createdByUserId ? { createdByUserId } : {})
+  })
+  // Feishu reuses the established two-slot secret shape:
+  // botToken = appSecret (secret), appToken = appId (identifier).
+  await deps.repos.botSecret.put(botId, {
+    botToken: appSecret,
+    appToken: appId,
+    signingSecret: null
+  })
+
+  const id = IntegrationId(randomUUID())
+  const integration = await deps.repos.integration.create({
+    id,
+    orgId,
+    agentId: agent.id,
+    botId,
+    platform: 'feishu',
+    name,
+    feishuRegion: region,
+    ...(createdByUserId ? { createdByUserId } : {})
+  })
+
+  const [secret, channels] = await Promise.all([
+    deps.repos.botSecret.get(botId),
+    deps.repos.integrationChannel.listForIntegration(id)
+  ])
+  if (secret) {
+    try {
+      await deps.control.integrationUpsert(
+        agent.daemonId!,
+        integrationToSpec(integration, secret, channels, isGatedAgent(agent))
+      )
+    } catch (err) {
+      if (!(err instanceof NoConnection)) throw err
+      log.debug({ integrationId: id, daemonId: agent.daemonId }, 'integration/upsert skipped: daemon offline')
+    }
+  }
+  return integration
+}

--- a/packages/control-plane/src/http/install-feishu.ts
+++ b/packages/control-plane/src/http/install-feishu.ts
@@ -16,6 +16,10 @@ import { NoConnection } from '../orchestrator/outbound.js'
 export interface InstallFeishuBotArgs {
   orgId: OrgId
   agent: AgentRecord
+  /** Pre-reserved by durable one-click registration for restart-idempotency. */
+  botId?: BotId
+  /** Pre-reserved by durable one-click registration for restart-idempotency. */
+  integrationId?: IntegrationId
   name: string
   appId: string
   appSecret: string
@@ -33,16 +37,34 @@ export async function installNewFeishuBot(
   args: InstallFeishuBotArgs
 ): Promise<IntegrationRecord> {
   const { orgId, agent, name, appId, appSecret, region, createdByUserId } = args
-  const botId = BotId(randomUUID())
-  await deps.repos.bot.create({
-    id: botId,
-    orgId,
-    platform: 'feishu',
-    name,
-    feishuAppId: appId,
-    feishuRegion: region,
-    ...(createdByUserId ? { createdByUserId } : {})
-  })
+  const botId = args.botId ?? BotId(randomUUID())
+  const id = args.integrationId ?? IntegrationId(randomUUID())
+  let integration = await deps.repos.integration.get(id)
+  if (
+    integration &&
+    (integration.orgId !== orgId ||
+      integration.agentId !== agent.id ||
+      integration.botId !== botId ||
+      integration.platform !== 'feishu')
+  ) {
+    throw new Error('reserved Feishu integration id is already in use')
+  }
+  if (!integration) {
+    const bot = await deps.repos.bot.get(botId)
+    if (!bot) {
+      await deps.repos.bot.create({
+        id: botId,
+        orgId,
+        platform: 'feishu',
+        name,
+        feishuAppId: appId,
+        feishuRegion: region,
+        ...(createdByUserId ? { createdByUserId } : {})
+      })
+    } else if (bot.orgId !== orgId || bot.platform !== 'feishu' || bot.feishuAppId !== appId) {
+      throw new Error('reserved Feishu bot id is already in use')
+    }
+  }
   // Feishu reuses the established two-slot secret shape:
   // botToken = appSecret (secret), appToken = appId (identifier).
   await deps.repos.botSecret.put(botId, {
@@ -51,17 +73,18 @@ export async function installNewFeishuBot(
     signingSecret: null
   })
 
-  const id = IntegrationId(randomUUID())
-  const integration = await deps.repos.integration.create({
-    id,
-    orgId,
-    agentId: agent.id,
-    botId,
-    platform: 'feishu',
-    name,
-    feishuRegion: region,
-    ...(createdByUserId ? { createdByUserId } : {})
-  })
+  if (!integration) {
+    integration = await deps.repos.integration.create({
+      id,
+      orgId,
+      agentId: agent.id,
+      botId,
+      platform: 'feishu',
+      name,
+      feishuRegion: region,
+      ...(createdByUserId ? { createdByUserId } : {})
+    })
+  }
 
   const [secret, channels] = await Promise.all([
     deps.repos.botSecret.get(botId),

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -1,10 +1,9 @@
 /**
  * One-click Feishu/Lark self-built app registration.
  *
- * The official SDK gives the Console a deeplink and polls the provider's OAuth
- * device flow inside the Control Plane. When the user confirms, credentials go
- * directly into the existing bot-secret install seam; neither endpoint returns
- * App Secret.
+ * The provider gives the Console a deeplink. Its device cursor and provisional
+ * credentials are encrypted in Postgres so any Control Plane replica can
+ * continue the poll and install; neither endpoint returns App Secret.
  */
 import type { FastifyInstance } from 'fastify'
 import type { ZodTypeProvider } from '../plugins/zod.js'
@@ -14,7 +13,7 @@ import { AgentId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canEdit, canView } from '../visibility.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
-import { FeishuRegistrationSetupError } from '../feishu-registration.js'
+import { FeishuRegistrationConflictError, FeishuRegistrationSetupError } from '../feishu-registration.js'
 import { installNewFeishuBot } from '../install-feishu.js'
 import {
   ErrorDto,
@@ -95,36 +94,22 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
             agentId: targetAgentId,
             fallbackRegion: req.body.region,
             appName,
-            onRegistered: async ({ appId, appSecret, region }) => {
-              // Authorization may take minutes. Re-read the target before writing:
-              // deletion/unplacement during the other-tab flow must fail closed.
-              const current = await deps.repos.agent.get(targetAgentId)
-              if (!current || current.orgId !== orgId || !current.daemonId) {
-                throw new FeishuRegistrationSetupError('agent_unavailable')
-              }
-              const check = deps.verifyFeishuBot ? await deps.verifyFeishuBot(appId, appSecret, region) : null
-              if (check?.status === 'invalid') {
-                throw new FeishuRegistrationSetupError('invalid_credentials')
-              }
-              const name = providedName || (check?.status === 'ok' ? check.name : null) || current.name
-              const integration = await installNewFeishuBot(deps, app.log, {
-                orgId,
-                agent: current,
-                name,
-                appId,
-                appSecret,
-                region,
-                createdByUserId
-              })
-              return integration.id
-            }
+            ...(providedName ? { requestedName: providedName } : {}),
+            createdByUserId
           })
           return reply.code(201).send({
             id: started.id,
             authorizationUrl: started.authorizationUrl,
             expiresAt: started.expiresAt.toISOString()
           })
-        } catch {
+        } catch (error) {
+          if (error instanceof FeishuRegistrationConflictError) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: error.message
+            })
+          }
           return reply.code(502).send({
             error: 'Bad Gateway',
             statusCode: 502,
@@ -148,8 +133,34 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
         }
       },
       async (req, reply) => {
-        const session = deps.feishuAppRegistration.get(req.params.id)
-        if (!session || session.orgId !== orgIdOf(req)) {
+        const orgId = orgIdOf(req)
+        const session = await deps.feishuAppRegistration.get(req.params.id, orgId, async (registration) => {
+          // Authorization may take minutes or cross a CP restart. Re-read the
+          // target before the idempotent write so deletion/unplacement fails closed.
+          const current = await deps.repos.agent.get(registration.agentId)
+          if (!current || current.orgId !== registration.orgId || !current.daemonId) {
+            throw new FeishuRegistrationSetupError('agent_unavailable')
+          }
+          const check = deps.verifyFeishuBot
+            ? await deps.verifyFeishuBot(registration.appId, registration.appSecret, registration.region)
+            : null
+          if (check?.status === 'invalid') {
+            throw new FeishuRegistrationSetupError('invalid_credentials')
+          }
+          const name = registration.requestedName || (check?.status === 'ok' ? check.name : null) || current.name
+          await installNewFeishuBot(deps, app.log, {
+            orgId: registration.orgId,
+            agent: current,
+            botId: registration.botId,
+            integrationId: registration.integrationId,
+            name,
+            appId: registration.appId,
+            appSecret: registration.appSecret,
+            region: registration.region,
+            createdByUserId: registration.createdByUserId
+          })
+        })
+        if (!session) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'registration not found' })
         }
         return {

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -13,7 +13,11 @@ import { AgentId, OrgId } from '../../domain/ids.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canEdit, canView } from '../visibility.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
-import { FeishuRegistrationConflictError, FeishuRegistrationSetupError } from '../feishu-registration.js'
+import {
+  FeishuRegistrationConflictError,
+  FeishuRegistrationRetryError,
+  FeishuRegistrationSetupError
+} from '../feishu-registration.js'
 import { installNewFeishuBot } from '../install-feishu.js'
 import {
   ErrorDto,
@@ -135,30 +139,53 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
       async (req, reply) => {
         const orgId = orgIdOf(req)
         const session = await deps.feishuAppRegistration.get(req.params.id, orgId, async (registration) => {
-          // Authorization may take minutes or cross a CP restart. Re-read the
-          // target before the idempotent write so deletion/unplacement fails closed.
-          const current = await deps.repos.agent.get(registration.agentId)
-          if (!current || current.orgId !== registration.orgId || !current.daemonId) {
-            throw new FeishuRegistrationSetupError('agent_unavailable')
-          }
           const check = deps.verifyFeishuBot
             ? await deps.verifyFeishuBot(registration.appId, registration.appSecret, registration.region)
             : null
           if (check?.status === 'invalid') {
             throw new FeishuRegistrationSetupError('invalid_credentials')
           }
-          const name = registration.requestedName || (check?.status === 'ok' ? check.name : null) || current.name
-          await installNewFeishuBot(deps, app.log, {
-            orgId: registration.orgId,
-            agent: current,
-            botId: registration.botId,
-            integrationId: registration.integrationId,
-            name,
-            appId: registration.appId,
-            appSecret: registration.appSecret,
-            region: registration.region,
-            createdByUserId: registration.createdByUserId
-          })
+
+          // Authorization can outlive the original placement. Take the mutation
+          // side of the move fence, then resolve both placement and capability
+          // under it so a concurrent move cannot omit this new integration.
+          const release = deps.agentMutations.tryBeginMutation(registration.agentId)
+          if (!release) throw new FeishuRegistrationRetryError()
+          try {
+            const current = await deps.repos.agent.get(registration.agentId)
+            if (
+              !current ||
+              current.orgId !== registration.orgId ||
+              !current.daemonId ||
+              !canView(current, ctxOf(req)) ||
+              !canEdit(current, ctxOf(req))
+            ) {
+              throw new FeishuRegistrationSetupError('agent_unavailable')
+            }
+            const availability = await integrationPlatformAvailability(deps, {
+              daemonId: current.daemonId,
+              orgId: registration.orgId,
+              viewer: ctxOf(req),
+              platform: 'feishu'
+            })
+            if (availability !== 'available') {
+              throw new FeishuRegistrationSetupError('agent_unavailable')
+            }
+            const name = registration.requestedName || (check?.status === 'ok' ? check.name : null) || current.name
+            await installNewFeishuBot(deps, app.log, {
+              orgId: registration.orgId,
+              agent: current,
+              botId: registration.botId,
+              integrationId: registration.integrationId,
+              name,
+              appId: registration.appId,
+              appSecret: registration.appSecret,
+              region: registration.region,
+              createdByUserId: registration.createdByUserId
+            })
+          } finally {
+            release()
+          }
         })
         if (!session) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'registration not found' })

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -1,0 +1,165 @@
+/**
+ * One-click Feishu/Lark self-built app registration.
+ *
+ * The official SDK gives the Console a deeplink and polls the provider's OAuth
+ * device flow inside the Control Plane. When the user confirms, credentials go
+ * directly into the existing bot-secret install seam; neither endpoint returns
+ * App Secret.
+ */
+import type { FastifyInstance } from 'fastify'
+import type { ZodTypeProvider } from '../plugins/zod.js'
+import { Tag } from '../plugins/openapi.js'
+import type { HttpDeps } from '../deps.js'
+import { AgentId, OrgId } from '../../domain/ids.js'
+import { denyViewerWrite, ctxOf } from '../rbac.js'
+import { canEdit, canView } from '../visibility.js'
+import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
+import { FeishuRegistrationSetupError } from '../feishu-registration.js'
+import { installNewFeishuBot } from '../install-feishu.js'
+import {
+  ErrorDto,
+  FeishuAppRegistrationStartBody,
+  FeishuAppRegistrationStartDto,
+  FeishuAppRegistrationStatusDto,
+  IdParam
+} from '../dto/index.js'
+
+export function feishuRegistrationRoutes(deps: HttpDeps) {
+  return async function feishuRegistrationRoutesPlugin(app: FastifyInstance): Promise<void> {
+    const r = app.withTypeProvider<ZodTypeProvider>()
+    const orgIdOf = (req: { orgCtx?: { orgId: OrgId } }) => req.orgCtx!.orgId
+
+    r.post(
+      '/integrations/feishu/app',
+      {
+        schema: {
+          tags: [Tag.Integrations],
+          summary: 'Start Feishu app registration',
+          description:
+            'Create an AgentConnect-ready Feishu/Lark self-built app through the official device authorization flow. Returns only the authorization deeplink; credentials are installed server-side after approval.',
+          operationId: 'startFeishuAppRegistration',
+          body: FeishuAppRegistrationStartBody,
+          response: {
+            201: FeishuAppRegistrationStartDto,
+            400: ErrorDto,
+            401: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            502: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        if (!req.principal) {
+          return reply.code(401).send({ error: 'Unauthorized', statusCode: 401, message: 'authentication required' })
+        }
+        const orgId = orgIdOf(req)
+        const agent = await deps.repos.agent.get(AgentId(req.body.agentId))
+        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        }
+        if (!canEdit(agent, ctxOf(req))) {
+          return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
+        }
+        if (!agent.daemonId) {
+          return reply
+            .code(409)
+            .send({ error: 'Conflict', statusCode: 409, message: 'agent must be placed on a daemon first' })
+        }
+        const availability = await integrationPlatformAvailability(deps, {
+          daemonId: agent.daemonId,
+          orgId,
+          viewer: ctxOf(req),
+          platform: 'feishu'
+        })
+        if (availability === 'not_found') {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
+        }
+        if (availability === 'unsupported') {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message: 'daemon does not support feishu integrations'
+          })
+        }
+
+        const providedName = req.body.name?.trim()
+        const appName = providedName || agent.name
+        const createdByUserId = req.principal.userId
+        const targetAgentId = agent.id
+        try {
+          const started = await deps.feishuAppRegistration.start({
+            orgId,
+            agentId: targetAgentId,
+            fallbackRegion: req.body.region,
+            appName,
+            onRegistered: async ({ appId, appSecret, region }) => {
+              // Authorization may take minutes. Re-read the target before writing:
+              // deletion/unplacement during the other-tab flow must fail closed.
+              const current = await deps.repos.agent.get(targetAgentId)
+              if (!current || current.orgId !== orgId || !current.daemonId) {
+                throw new FeishuRegistrationSetupError('agent_unavailable')
+              }
+              const check = deps.verifyFeishuBot ? await deps.verifyFeishuBot(appId, appSecret, region) : null
+              if (check?.status === 'invalid') {
+                throw new FeishuRegistrationSetupError('invalid_credentials')
+              }
+              const name = providedName || (check?.status === 'ok' ? check.name : null) || current.name
+              const integration = await installNewFeishuBot(deps, app.log, {
+                orgId,
+                agent: current,
+                name,
+                appId,
+                appSecret,
+                region,
+                createdByUserId
+              })
+              return integration.id
+            }
+          })
+          return reply.code(201).send({
+            id: started.id,
+            authorizationUrl: started.authorizationUrl,
+            expiresAt: started.expiresAt.toISOString()
+          })
+        } catch {
+          return reply.code(502).send({
+            error: 'Bad Gateway',
+            statusCode: 502,
+            message: 'Could not start Feishu app setup. Please try again.'
+          })
+        }
+      }
+    )
+
+    r.get(
+      '/integrations/feishu/app/:id',
+      {
+        schema: {
+          tags: [Tag.Integrations],
+          summary: 'Poll Feishu app registration',
+          description:
+            'Read one Feishu/Lark device-registration session until it completes or fails. Credentials are never returned.',
+          operationId: 'getFeishuAppRegistration',
+          params: IdParam,
+          response: { 200: FeishuAppRegistrationStatusDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const session = deps.feishuAppRegistration.get(req.params.id)
+        if (!session || session.orgId !== orgIdOf(req)) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'registration not found' })
+        }
+        return {
+          id: session.id,
+          status: session.status,
+          failureReason: session.failureReason,
+          integrationId: session.integrationId,
+          expiresAt: session.expiresAt.toISOString()
+        }
+      }
+    )
+  }
+}

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -29,6 +29,7 @@ import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js
 import { pickChannelOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
+import { installNewFeishuBot } from '../install-feishu.js'
 import { discordAppIdFromBotToken } from '../discord-identity.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
@@ -464,35 +465,15 @@ export function integrationRoutes(deps: HttpDeps) {
             const provided = req.body.name?.trim()
             const derived = check?.status === 'ok' ? check.name : null
             const name = provided || derived || agent.name
-            const botId = BotId(randomUUID())
-            await deps.repos.bot.create({
-              id: botId,
+            const integration = await installNewFeishuBot(deps, app.log, {
               orgId,
-              platform: 'feishu',
+              agent,
               name,
-              // Durable home for the region so a later reinstall of this freed bot
-              // reconstructs the right gateway (the integration row is deleted on uninstall).
-              feishuAppId: feishu.appId,
-              feishuRegion: region,
+              appId: feishu.appId,
+              appSecret: feishu.appSecret,
+              region,
               ...(req.principal ? { createdByUserId: req.principal.userId } : {})
             })
-            // botToken = appSecret (secret), appToken = appId (identifier).
-            await deps.repos.botSecret.put(botId, {
-              botToken: feishu.appSecret,
-              appToken: feishu.appId,
-              signingSecret: null
-            })
-            const integration = await deps.repos.integration.create({
-              id: IntegrationId(randomUUID()),
-              orgId,
-              agentId: agent.id,
-              botId,
-              platform: 'feishu',
-              name,
-              feishuRegion: region,
-              ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-            })
-            await replicateUpsert(integration, daemonId)
             return reply.code(201).send(toDto(integration))
           }
 

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -23,6 +23,7 @@ import { agentRoutes } from './routes/agents.js'
 import { agentRepoRoutes } from './routes/agent-repos.js'
 import { webchatTokenRoutes } from './routes/webchat-token.js'
 import { integrationRoutes } from './routes/integrations.js'
+import { feishuRegistrationRoutes } from './routes/feishu-registration.js'
 import { slackInstallRoutes, slackConfigRoutes, slackOauthCallbackRoutes } from './routes/slack-install.js'
 import { slackPlatformInstallRoutes, slackPlatformCallbackRoutes } from './routes/slack-platform-install.js'
 import { botRoutes } from './routes/bots.js'
@@ -206,6 +207,7 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
           await scope.register(agentRepoRoutes(deps))
           await scope.register(webchatTokenRoutes(deps))
           await scope.register(integrationRoutes(deps))
+          await scope.register(feishuRegistrationRoutes(deps))
           await scope.register(slackInstallRoutes(deps))
           await scope.register(slackPlatformInstallRoutes(deps))
           await scope.register(slackConfigRoutes(deps))

--- a/packages/control-plane/src/orchestrator/slackInstallReaper.ts
+++ b/packages/control-plane/src/orchestrator/slackInstallReaper.ts
@@ -41,7 +41,8 @@ export class SlackInstallReaper {
     private readonly repo: SlackInstallReaperRepo,
     private readonly clock: Clock,
     private readonly cfg: SlackInstallReaperConfig,
-    private readonly log?: ReaperLog
+    private readonly log?: ReaperLog,
+    private readonly label = 'slack-install'
   ) {}
 
   /** Arm the periodic sweep. Idempotent — a second call re-arms from now. */
@@ -78,10 +79,10 @@ export class SlackInstallReaper {
       if (reaped > 0)
         this.log?.info(
           { reaped, staleBefore: staleBefore.toISOString() },
-          'slack-install-reaper: deleted abandoned pending installs'
+          `${this.label}-reaper: deleted abandoned pending installs`
         )
     } catch (err) {
-      this.log?.error({ err }, 'slack-install-reaper: sweep failed')
+      this.log?.error({ err }, `${this.label}-reaper: sweep failed`)
     } finally {
       this.arm()
     }

--- a/packages/control-plane/src/persistence/index.ts
+++ b/packages/control-plane/src/persistence/index.ts
@@ -43,6 +43,7 @@ export {
 export { PgThreadAffinityStore } from './repositories/thread-affinity.repo.js'
 export { PgSlackInstallStore } from './repositories/slack-install.repo.js'
 export { PgSlackPlatformInstallStore } from './repositories/slack-platform-install.repo.js'
+export { PgFeishuAppRegistrationStore } from './repositories/feishu-app-registration.repo.js'
 export { PgSlackUserConfigStore } from './repositories/slack-user-config.repo.js'
 export { GENERAL_PRESET, RESERVED_AGENT_SLUGS, PgPresetAgentStore, provisionPresetAgents } from './preset-agents.js'
 export { PresetAgentBackfill } from './preset-agent-backfill.js'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2222,6 +2222,89 @@ export interface SlackPlatformInstallStore {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// FeishuAppRegistrationStore — resumable one-click app registration. Device
+// cursor and provisional App Secret are encrypted behind the implementation;
+// terminal settlement clears both. A short claim leases provider/finalize work
+// to one CP replica at a time.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type FeishuAppRegistrationStatus = 'pending' | 'authorized' | 'completed' | 'failed'
+
+export interface FeishuAppRegistrationRecord {
+  id: string
+  targetKey: string | null
+  orgId: OrgId
+  agentId: AgentId
+  requestedName: string | null
+  fallbackRegion: FeishuRegion
+  authorizationUrl: string
+  providerDomain: string
+  deviceCode: string | null
+  intervalMs: number
+  nextPollAt: Date
+  expiresAt: Date
+  status: FeishuAppRegistrationStatus
+  failureReason: string | null
+  appId: string | null
+  appSecret: string | null
+  resolvedRegion: FeishuRegion | null
+  botId: BotId
+  integrationId: IntegrationId
+  createdByUserId: string | null
+  claimToken: string | null
+  claimedUntil: Date | null
+  createdAt: Date
+  settledAt: Date | null
+}
+
+export interface CreateFeishuAppRegistrationInput {
+  id: string
+  targetKey: string
+  orgId: OrgId
+  agentId: AgentId
+  requestedName?: string
+  fallbackRegion: FeishuRegion
+  authorizationUrl: string
+  providerDomain: string
+  deviceCode: string
+  intervalMs: number
+  nextPollAt: Date
+  expiresAt: Date
+  botId: BotId
+  integrationId: IntegrationId
+  createdByUserId: string
+}
+
+export interface FeishuAppRegistrationStore {
+  create(input: CreateFeishuAppRegistrationInput): Promise<FeishuAppRegistrationRecord>
+  get(id: string): Promise<FeishuAppRegistrationRecord | null>
+  getActiveTarget(targetKey: string): Promise<FeishuAppRegistrationRecord | null>
+  /** Atomically fail an expired open row and release its target reservation. */
+  expire(id: string, now: Date): Promise<void>
+  /** Clear an expired target reservation before a new begin call. */
+  expireTarget(targetKey: string, now: Date): Promise<void>
+  /** Lease due provider/finalization work to one replica. */
+  claim(id: string, claimToken: string, now: Date, claimedUntil: Date): Promise<FeishuAppRegistrationRecord | null>
+  release(
+    id: string,
+    claimToken: string,
+    update: { providerDomain?: string; intervalMs: number; nextPollAt: Date }
+  ): Promise<void>
+  authorize(
+    id: string,
+    claimToken: string,
+    input: { appId: string; appSecret: string; region: FeishuRegion }
+  ): Promise<FeishuAppRegistrationRecord | null>
+  settle(
+    id: string,
+    claimToken: string,
+    outcome: { status: 'completed' } | { status: 'failed'; failureReason: string }
+  ): Promise<void>
+  /** Delete terminal/expired rows whose secret-bearing window is over. */
+  reapExpired(staleBefore: Date): Promise<number>
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // PresetAgentStore — per-org preset provisioning state (preset-agents.md §3.2).
 // Rows are WRITTEN by the org-creation seam / the one-time backfill / the
 // settle-stamp anchors (persistence-internal); this port is the READ surface for

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2295,6 +2295,8 @@ export interface FeishuAppRegistrationStore {
     claimToken: string,
     input: { appId: string; appSecret: string; region: FeishuRegion }
   ): Promise<FeishuAppRegistrationRecord | null>
+  /** Release a finalized-credential claim for a short-lived placement retry. */
+  releaseAuthorized(id: string, claimToken: string): Promise<void>
   settle(
     id: string,
     claimToken: string,

--- a/packages/control-plane/src/persistence/repositories/feishu-app-registration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/feishu-app-registration.repo.ts
@@ -90,7 +90,12 @@ export class PgFeishuAppRegistrationStore implements FeishuAppRegistrationStore 
 
   async expire(id: string, now: Date): Promise<void> {
     await this.prisma.feishuAppRegistration.updateMany({
-      where: { id, status: 'pending', expiresAt: { lte: now } },
+      where: {
+        id,
+        status: 'pending',
+        expiresAt: { lte: now },
+        OR: [{ claimedUntil: null }, { claimedUntil: { lte: now } }]
+      },
       data: {
         status: 'failed',
         failureReason: 'expired',
@@ -106,7 +111,12 @@ export class PgFeishuAppRegistrationStore implements FeishuAppRegistrationStore 
 
   async expireTarget(targetKey: string, now: Date): Promise<void> {
     await this.prisma.feishuAppRegistration.updateMany({
-      where: { targetKey, status: 'pending', expiresAt: { lte: now } },
+      where: {
+        targetKey,
+        status: 'pending',
+        expiresAt: { lte: now },
+        OR: [{ claimedUntil: null }, { claimedUntil: { lte: now } }]
+      },
       data: {
         status: 'failed',
         failureReason: 'expired',
@@ -174,6 +184,13 @@ export class PgFeishuAppRegistrationStore implements FeishuAppRegistrationStore 
       }
     })
     return updated.count === 1 ? this.get(id) : null
+  }
+
+  async releaseAuthorized(id: string, claimToken: string): Promise<void> {
+    await this.prisma.feishuAppRegistration.updateMany({
+      where: { id, status: 'authorized', claimToken },
+      data: { claimToken: null, claimedUntil: null }
+    })
   }
 
   async settle(

--- a/packages/control-plane/src/persistence/repositories/feishu-app-registration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/feishu-app-registration.repo.ts
@@ -1,0 +1,207 @@
+/**
+ * Durable Feishu/Lark device-registration state.
+ *
+ * Device codes and provisional App Secrets are sealed with the deployment's
+ * SecretCipher. Claim tokens make provider polling and finalization
+ * single-writer across Control Plane replicas.
+ */
+import type { FeishuAppRegistration } from '../../generated/prisma/client.js'
+import type { PrismaLike } from '../prisma.js'
+import type {
+  CreateFeishuAppRegistrationInput,
+  FeishuAppRegistrationRecord,
+  FeishuAppRegistrationStore
+} from '../ports.js'
+import type { SecretCipher } from '../../secrets/cipher.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+
+function region(value: string | null): FeishuRegion | null {
+  return value === 'feishu' || value === 'lark' ? value : null
+}
+
+export class PgFeishuAppRegistrationStore implements FeishuAppRegistrationStore {
+  constructor(
+    private readonly prisma: PrismaLike,
+    private readonly cipher: SecretCipher
+  ) {}
+
+  private async toRecord(row: FeishuAppRegistration): Promise<FeishuAppRegistrationRecord> {
+    return {
+      id: row.id,
+      targetKey: row.targetKey,
+      orgId: OrgId(row.orgId),
+      agentId: AgentId(row.agentId),
+      requestedName: row.requestedName,
+      fallbackRegion: region(row.fallbackRegion) ?? 'lark',
+      authorizationUrl: row.authorizationUrl,
+      providerDomain: row.providerDomain,
+      deviceCode: row.deviceCode === null ? null : await this.cipher.open(row.deviceCode),
+      intervalMs: row.intervalMs,
+      nextPollAt: row.nextPollAt,
+      expiresAt: row.expiresAt,
+      status: row.status,
+      failureReason: row.failureReason,
+      appId: row.appId,
+      appSecret: row.appSecret === null ? null : await this.cipher.open(row.appSecret),
+      resolvedRegion: region(row.resolvedRegion),
+      botId: BotId(row.botId),
+      integrationId: IntegrationId(row.integrationId),
+      createdByUserId: row.createdByUserId,
+      claimToken: row.claimToken,
+      claimedUntil: row.claimedUntil,
+      createdAt: row.createdAt,
+      settledAt: row.settledAt
+    }
+  }
+
+  async create(input: CreateFeishuAppRegistrationInput): Promise<FeishuAppRegistrationRecord> {
+    const row = await this.prisma.feishuAppRegistration.create({
+      data: {
+        id: input.id,
+        targetKey: input.targetKey,
+        orgId: input.orgId,
+        agentId: input.agentId,
+        ...(input.requestedName !== undefined ? { requestedName: input.requestedName } : {}),
+        fallbackRegion: input.fallbackRegion,
+        authorizationUrl: input.authorizationUrl,
+        providerDomain: input.providerDomain,
+        deviceCode: await this.cipher.seal(input.deviceCode),
+        intervalMs: input.intervalMs,
+        nextPollAt: input.nextPollAt,
+        expiresAt: input.expiresAt,
+        botId: input.botId,
+        integrationId: input.integrationId,
+        createdByUserId: input.createdByUserId
+      }
+    })
+    return this.toRecord(row)
+  }
+
+  async get(id: string): Promise<FeishuAppRegistrationRecord | null> {
+    const row = await this.prisma.feishuAppRegistration.findUnique({ where: { id } })
+    return row ? this.toRecord(row) : null
+  }
+
+  async getActiveTarget(targetKey: string): Promise<FeishuAppRegistrationRecord | null> {
+    const row = await this.prisma.feishuAppRegistration.findUnique({ where: { targetKey } })
+    return row ? this.toRecord(row) : null
+  }
+
+  async expire(id: string, now: Date): Promise<void> {
+    await this.prisma.feishuAppRegistration.updateMany({
+      where: { id, status: 'pending', expiresAt: { lte: now } },
+      data: {
+        status: 'failed',
+        failureReason: 'expired',
+        targetKey: null,
+        deviceCode: null,
+        appSecret: null,
+        claimToken: null,
+        claimedUntil: null,
+        settledAt: now
+      }
+    })
+  }
+
+  async expireTarget(targetKey: string, now: Date): Promise<void> {
+    await this.prisma.feishuAppRegistration.updateMany({
+      where: { targetKey, status: 'pending', expiresAt: { lte: now } },
+      data: {
+        status: 'failed',
+        failureReason: 'expired',
+        targetKey: null,
+        deviceCode: null,
+        appSecret: null,
+        claimToken: null,
+        claimedUntil: null,
+        settledAt: now
+      }
+    })
+  }
+
+  async claim(
+    id: string,
+    claimToken: string,
+    now: Date,
+    claimedUntil: Date
+  ): Promise<FeishuAppRegistrationRecord | null> {
+    const claimed = await this.prisma.feishuAppRegistration.updateMany({
+      where: {
+        id,
+        AND: [
+          { OR: [{ claimedUntil: null }, { claimedUntil: { lte: now } }] },
+          {
+            OR: [{ status: 'authorized' }, { status: 'pending', expiresAt: { gt: now }, nextPollAt: { lte: now } }]
+          }
+        ]
+      },
+      data: { claimToken, claimedUntil }
+    })
+    return claimed.count === 1 ? this.get(id) : null
+  }
+
+  async release(
+    id: string,
+    claimToken: string,
+    update: { providerDomain?: string; intervalMs: number; nextPollAt: Date }
+  ): Promise<void> {
+    await this.prisma.feishuAppRegistration.updateMany({
+      where: { id, status: 'pending', claimToken },
+      data: {
+        ...(update.providerDomain ? { providerDomain: update.providerDomain } : {}),
+        intervalMs: update.intervalMs,
+        nextPollAt: update.nextPollAt,
+        claimToken: null,
+        claimedUntil: null
+      }
+    })
+  }
+
+  async authorize(
+    id: string,
+    claimToken: string,
+    input: { appId: string; appSecret: string; region: FeishuRegion }
+  ): Promise<FeishuAppRegistrationRecord | null> {
+    const updated = await this.prisma.feishuAppRegistration.updateMany({
+      where: { id, status: 'pending', claimToken },
+      data: {
+        status: 'authorized',
+        appId: input.appId,
+        appSecret: await this.cipher.seal(input.appSecret),
+        resolvedRegion: input.region,
+        deviceCode: null
+      }
+    })
+    return updated.count === 1 ? this.get(id) : null
+  }
+
+  async settle(
+    id: string,
+    claimToken: string,
+    outcome: { status: 'completed' } | { status: 'failed'; failureReason: string }
+  ): Promise<void> {
+    await this.prisma.feishuAppRegistration.updateMany({
+      where: { id, status: { in: ['pending', 'authorized'] }, claimToken },
+      data: {
+        status: outcome.status,
+        ...(outcome.status === 'failed' ? { failureReason: outcome.failureReason } : {}),
+        targetKey: null,
+        deviceCode: null,
+        appSecret: null,
+        claimToken: null,
+        claimedUntil: null,
+        settledAt: new Date()
+      }
+    })
+  }
+
+  async reapExpired(staleBefore: Date): Promise<number> {
+    const deleted = await this.prisma.feishuAppRegistration.deleteMany({
+      where: {
+        OR: [{ settledAt: { lt: staleBefore } }, { expiresAt: { lt: staleBefore } }]
+      }
+    })
+    return deleted.count
+  }
+}

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -48,6 +48,7 @@ import {
   PgExternalMemoryGrantRepo,
   PgSlackInstallStore,
   PgSlackPlatformInstallStore,
+  PgFeishuAppRegistrationStore,
   PgThreadAffinityStore,
   PgSlackUserConfigStore,
   PgPresetAgentStore,
@@ -145,6 +146,7 @@ export function buildHttpApp(
   const botRepo = new PgBotRepo(prisma)
   const botSecretStore = new PgBotSecretStore(prisma, cipher)
   const botCredentialWriter = new PgBotCredentialWriter(prisma, cipher)
+  const feishuAppRegistrationStore = new PgFeishuAppRegistrationStore(prisma, cipher)
   const integrationChannelRepo = new PgIntegrationChannelRepo(prisma)
   const agentRepo = new PgAgentRepo(prisma)
   const hookRepo = new PgHookRepo(prisma)
@@ -188,6 +190,7 @@ export function buildHttpApp(
       externalMemoryGrant: new PgExternalMemoryGrantRepo(prisma, cipher),
       slackInstall: new PgSlackInstallStore(prisma, cipher),
       slackPlatformInstall: new PgSlackPlatformInstallStore(prisma),
+      feishuAppRegistration: feishuAppRegistrationStore,
       slackUserConfig: new PgSlackUserConfigStore(prisma, cipher),
       presetAgent: new PgPresetAgentStore(prisma),
       integrationChannel: integrationChannelRepo,
@@ -234,7 +237,7 @@ export function buildHttpApp(
     events,
     mcpRateLimit: new McpRateLimiter(clock),
     readiness: createReadiness(() => pingDb(prisma)),
-    feishuAppRegistration: new FeishuAppRegistrationService(),
+    feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
     ...depsOverrides
   }
@@ -247,7 +250,6 @@ export function buildHttpApp(
     events,
     relayReg,
     close: async () => {
-      deps.feishuAppRegistration.shutdown()
       await app.close()
     }
   }

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -83,6 +83,7 @@ import { pingDb } from '../../src/persistence/prisma.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import { systemClock } from '../../src/domain/clock.js'
 import { DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import { FeishuAppRegistrationService } from '../../src/http/feishu-registration.js'
 
 export const TEST_API_KEY_PEPPER = 'test-api-key-pepper-0123456789abcdef'
 
@@ -233,6 +234,7 @@ export function buildHttpApp(
     events,
     mcpRateLimit: new McpRateLimiter(clock),
     readiness: createReadiness(() => pingDb(prisma)),
+    feishuAppRegistration: new FeishuAppRegistrationService(),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
     ...depsOverrides
   }
@@ -245,6 +247,7 @@ export function buildHttpApp(
     events,
     relayReg,
     close: async () => {
+      deps.feishuAppRegistration.shutdown()
       await app.close()
     }
   }

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -9,6 +9,7 @@ import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { AGENTCONNECT_FEISHU_EVENTS, AGENTCONNECT_FEISHU_SCOPES } from '../../src/http/feishu-app-template.js'
 import {
   OfficialFeishuRegistrationProvider,
+  type PollFeishuRegistration,
   type FeishuRegistrationProvider
 } from '../../src/http/feishu-registration-provider.js'
 import { FeishuAppRegistrationService, FeishuRegistrationConflictError } from '../../src/http/feishu-registration.js'
@@ -19,6 +20,7 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const UNSUPPORTED_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
 
 let running: HttpApp | undefined
 
@@ -52,6 +54,14 @@ function service(fetcher: typeof fetch): FeishuAppRegistrationService {
 
 function decodeAddons(encoded: string): unknown {
   return JSON.parse(gunzipSync(Buffer.from(encoded, 'base64url')).toString('utf8'))
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
 }
 
 describe('Feishu/Lark one-click app registration', () => {
@@ -213,5 +223,99 @@ describe('Feishu/Lark one-click app registration', () => {
       FeishuRegistrationConflictError
     )
     expect(begin).toHaveBeenCalledOnce()
+  })
+
+  it('does not expire an authorization while its claimed provider poll is completing', async () => {
+    let now = 0
+    const providerResult = deferred<PollFeishuRegistration>()
+    const poll = vi.fn(() => providerResult.promise)
+    const coordinator = new FeishuAppRegistrationService(
+      new PgFeishuAppRegistrationStore(prisma, new PlaintextSecretCipher()),
+      {
+        begin: async () => ({
+          authorizationUrl: 'https://accounts.feishu.cn/device?user_code=LEASED',
+          deviceCode: 'leased-device-code',
+          providerDomain: 'accounts.feishu.cn',
+          intervalMs: 1000,
+          expiresInMs: 1000
+        }),
+        poll
+      },
+      () => now
+    )
+    const started = await coordinator.start({
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId: AgentId(randomUUID()),
+      fallbackRegion: 'feishu',
+      appName: 'AgentConnect',
+      createdByUserId: 'user-a'
+    })
+    const finalize = vi.fn(async () => {})
+    const completing = coordinator.get(started.id, OrgId(DEFAULT_ORG_ID), finalize)
+    await vi.waitFor(() => expect(poll).toHaveBeenCalledOnce())
+
+    now = 2000
+    await expect(coordinator.get(started.id, OrgId(DEFAULT_ORG_ID), finalize)).resolves.toMatchObject({
+      status: 'pending'
+    })
+    providerResult.resolve({
+      outcome: 'authorized',
+      appId: 'cli_lease',
+      appSecret: 'lease-secret',
+      region: 'feishu'
+    })
+    await expect(completing).resolves.toMatchObject({ status: 'completed' })
+    expect(finalize).toHaveBeenCalledOnce()
+  })
+
+  it('retries across an active move, then rejects a destination without Feishu capability', async () => {
+    const agentId = await placedAgent()
+    await seedDaemon(prisma, UNSUPPORTED_DAEMON, {
+      capabilities: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] }
+    })
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      const form = new URLSearchParams(String(init?.body))
+      if (form.get('action') === 'begin') {
+        return new Response(
+          JSON.stringify({
+            verification_uri_complete: 'https://accounts.feishu.cn/device?user_code=MOVING',
+            device_code: 'moving-device-code',
+            expires_in: 600,
+            interval: 1
+          })
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          client_id: 'cli_moving',
+          client_secret: 'moving-secret',
+          user_info: { tenant_brand: 'feishu' }
+        })
+      )
+    })
+    const app = buildHttpApp(prisma, undefined, undefined, undefined, {
+      feishuAppRegistration: service(fetcher)
+    })
+    running = app
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/feishu/app`,
+      payload: { agentId }
+    })
+    const { id } = started.json() as { id: string }
+    const releaseMove = app.deps.agentMutations.tryBeginMove(agentId)
+    expect(releaseMove).not.toBeNull()
+
+    const moving = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+    expect(moving.json()).toMatchObject({ status: 'pending' })
+    expect(await prisma.integration.count()).toBe(0)
+
+    await prisma.agent.update({ where: { id: agentId }, data: { daemonId: UNSUPPORTED_DAEMON } })
+    releaseMove!()
+    const unsupported = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+    expect(unsupported.json()).toMatchObject({ status: 'failed', failureReason: 'agent_unavailable' })
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.integration.count()).toBe(0)
   })
 })

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -36,6 +36,13 @@ class SpyControl {
   }
 }
 
+class FlakyControl extends SpyControl {
+  override async integrationUpsert(daemonId: string, spec: IntegrationUpsert): Promise<void> {
+    await super.integrationUpsert(daemonId, spec)
+    if (this.upserts.length === 1) throw new Error('simulated integration push failure')
+  }
+}
+
 async function placedAgent(): Promise<string> {
   await seedDaemon(prisma, DAEMON, {
     capabilities: { platforms: ['feishu'], runtimes: ['claude'], acp: true, features: [] }
@@ -317,5 +324,60 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(unsupported.json()).toMatchObject({ status: 'failed', failureReason: 'agent_unavailable' })
     expect(await prisma.bot.count()).toBe(0)
     expect(await prisma.integration.count()).toBe(0)
+  })
+
+  it('retries a failed daemon push without duplicating the persisted integration', async () => {
+    const agentId = await placedAgent()
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      const form = new URLSearchParams(String(init?.body))
+      if (form.get('action') === 'begin') {
+        return new Response(
+          JSON.stringify({
+            verification_uri_complete: 'https://accounts.feishu.cn/device?user_code=RETRY',
+            device_code: 'retry-device-code',
+            expires_in: 600,
+            interval: 1
+          })
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          client_id: 'cli_retry',
+          client_secret: 'retry-secret',
+          user_info: { tenant_brand: 'feishu' }
+        })
+      )
+    })
+    const control = new FlakyControl()
+    const app = buildHttpApp(prisma, undefined, undefined, control as unknown as ControlSender, {
+      feishuAppRegistration: service(fetcher)
+    })
+    running = app
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/feishu/app`,
+      payload: { agentId }
+    })
+    const { id } = started.json() as { id: string }
+    const first = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+    expect(first.json()).toMatchObject({ status: 'pending', integrationId: null })
+    const persisted = await prisma.integration.findFirstOrThrow({ where: { agentId, platform: 'feishu' } })
+    expect(await prisma.integration.count()).toBe(1)
+    expect(await prisma.feishuAppRegistration.findUnique({ where: { id } })).toMatchObject({
+      status: 'authorized',
+      integrationId: persisted.id,
+      appSecret: 'retry-secret'
+    })
+
+    const retried = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+    expect(retried.json()).toMatchObject({ status: 'completed', integrationId: persisted.id })
+    expect(await prisma.integration.count()).toBe(1)
+    expect(control.upserts).toHaveLength(2)
+    expect(await prisma.feishuAppRegistration.findUnique({ where: { id } })).toMatchObject({
+      status: 'completed',
+      appSecret: null,
+      targetKey: null
+    })
   })
 })

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type { IntegrationUpsert } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { ControlSender } from '../../src/orchestrator/outbound.js'
+import {
+  AGENTCONNECT_FEISHU_EVENTS,
+  AGENTCONNECT_FEISHU_SCOPES,
+  FeishuAppRegistrationService,
+  type FeishuRegisterApp
+} from '../../src/http/feishu-registration.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+
+let running: HttpApp | undefined
+
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+class SpyControl {
+  readonly upserts: Array<{ daemonId: string; spec: IntegrationUpsert }> = []
+  async integrationUpsert(daemonId: string, spec: IntegrationUpsert): Promise<void> {
+    this.upserts.push({ daemonId, spec })
+  }
+}
+
+async function placedAgent(): Promise<string> {
+  await seedDaemon(prisma, DAEMON, {
+    capabilities: { platforms: ['feishu'], runtimes: ['claude'], acp: true, features: [] }
+  })
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON, name: 'support-agent' })
+  return agentId
+}
+
+describe('Feishu/Lark one-click app registration', () => {
+  it('opens the official deeplink with AgentConnect scopes, then installs credentials without returning them', async () => {
+    const agentId = await placedAgent()
+    let options: Parameters<FeishuRegisterApp>[0] | undefined
+    const register: FeishuRegisterApp = async (input) => {
+      options = input
+      input.onQRCodeReady({
+        url: 'https://accounts.feishu.cn/device?user_code=SAFE-CODE',
+        expireIn: 600
+      })
+      return {
+        client_id: 'cli_oneclick',
+        client_secret: 'one-click-secret',
+        user_info: { tenant_brand: 'lark' }
+      }
+    }
+    const service = new FeishuAppRegistrationService(register)
+    const spy = new SpyControl()
+    const app = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender, {
+      feishuAppRegistration: service,
+      verifyFeishuBot: async () => ({ status: 'ok', name: 'One-click Bot' })
+    })
+    running = app
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/feishu/app`,
+      // The provider-reported tenant brand must win over this UI fallback.
+      payload: { agentId, name: 'AgentConnect Lark', region: 'feishu' }
+    })
+    expect(started.statusCode).toBe(201)
+    const startDto = started.json() as { id: string; authorizationUrl: string }
+    expect(startDto.authorizationUrl).toBe('https://accounts.feishu.cn/device?user_code=SAFE-CODE')
+    expect(JSON.stringify(startDto)).not.toContain('one-click-secret')
+    expect(JSON.stringify(startDto)).not.toContain('cli_oneclick')
+    expect(options).toMatchObject({
+      source: 'agentconnect',
+      createOnly: true,
+      appPreset: { name: 'AgentConnect Lark' },
+      addons: {
+        preset: true,
+        scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
+        events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
+      }
+    })
+    expect(options?.addons?.scopes?.tenant).toEqual(
+      expect.arrayContaining(['contact:user.base:readonly', 'im:chat:read'])
+    )
+
+    await vi.waitFor(async () => {
+      const polled = await app.app.inject({
+        method: 'GET',
+        url: `${ORG}/integrations/feishu/app/${startDto.id}`
+      })
+      expect(polled.statusCode).toBe(200)
+      expect(polled.json()).toMatchObject({ status: 'completed', failureReason: null })
+      expect(JSON.stringify(polled.json())).not.toContain('one-click-secret')
+      expect(JSON.stringify(polled.json())).not.toContain('cli_oneclick')
+    })
+
+    const bot = await prisma.bot.findFirst({ where: { feishuAppId: 'cli_oneclick' } })
+    expect(bot).toMatchObject({ name: 'AgentConnect Lark', feishuRegion: 'lark' })
+    expect(await prisma.botSecret.findUnique({ where: { botId: bot!.id } })).toMatchObject({
+      botToken: 'one-click-secret',
+      appToken: 'cli_oneclick'
+    })
+    expect(spy.upserts).toHaveLength(1)
+    expect(spy.upserts[0]).toMatchObject({
+      daemonId: DAEMON,
+      spec: {
+        agentId,
+        platform: 'feishu',
+        feishu: { appId: 'cli_oneclick', appSecret: 'one-click-secret', region: 'lark' }
+      }
+    })
+  })
+
+  it('reports a denied authorization without creating a bot', async () => {
+    const agentId = await placedAgent()
+    const register: FeishuRegisterApp = async (input) => {
+      input.onQRCodeReady({ url: 'https://accounts.feishu.cn/device?user_code=DENIED', expireIn: 600 })
+      throw { code: 'access_denied', description: 'denied' }
+    }
+    const app = buildHttpApp(prisma, undefined, undefined, undefined, {
+      feishuAppRegistration: new FeishuAppRegistrationService(register)
+    })
+    running = app
+
+    const started = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/feishu/app`,
+      payload: { agentId }
+    })
+    expect(started.statusCode).toBe(201)
+    const { id } = started.json() as { id: string }
+
+    await vi.waitFor(async () => {
+      const polled = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+      expect(polled.json()).toMatchObject({ status: 'failed', failureReason: 'denied', integrationId: null })
+    })
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.integration.count()).toBe(0)
+  })
+})

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -1,16 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { gunzipSync } from 'node:zlib'
 import { randomUUID } from 'node:crypto'
 import type { IntegrationUpsert } from '@agentconnect.md/protocol'
 import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
+import { AGENTCONNECT_FEISHU_EVENTS, AGENTCONNECT_FEISHU_SCOPES } from '../../src/http/feishu-app-template.js'
 import {
-  AGENTCONNECT_FEISHU_EVENTS,
-  AGENTCONNECT_FEISHU_SCOPES,
-  FeishuAppRegistrationService,
-  type FeishuRegisterApp
-} from '../../src/http/feishu-registration.js'
+  OfficialFeishuRegistrationProvider,
+  type FeishuRegistrationProvider
+} from '../../src/http/feishu-registration-provider.js'
+import { FeishuAppRegistrationService, FeishuRegistrationConflictError } from '../../src/http/feishu-registration.js'
+import { PgFeishuAppRegistrationStore } from '../../src/persistence/index.js'
+import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -39,31 +43,48 @@ async function placedAgent(): Promise<string> {
   return agentId
 }
 
-describe('Feishu/Lark one-click app registration', () => {
-  it('opens the official deeplink with AgentConnect scopes, then installs credentials without returning them', async () => {
-    const agentId = await placedAgent()
-    let options: Parameters<FeishuRegisterApp>[0] | undefined
-    const register: FeishuRegisterApp = async (input) => {
-      options = input
-      input.onQRCodeReady({
-        url: 'https://accounts.feishu.cn/device?user_code=SAFE-CODE',
-        expireIn: 600
-      })
-      return {
-        client_id: 'cli_oneclick',
-        client_secret: 'one-click-secret',
-        user_info: { tenant_brand: 'lark' }
-      }
-    }
-    const service = new FeishuAppRegistrationService(register)
-    const spy = new SpyControl()
-    const app = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender, {
-      feishuAppRegistration: service,
-      verifyFeishuBot: async () => ({ status: 'ok', name: 'One-click Bot' })
-    })
-    running = app
+function service(fetcher: typeof fetch): FeishuAppRegistrationService {
+  return new FeishuAppRegistrationService(
+    new PgFeishuAppRegistrationStore(prisma, new PlaintextSecretCipher()),
+    new OfficialFeishuRegistrationProvider(fetcher)
+  )
+}
 
-    const started = await app.app.inject({
+function decodeAddons(encoded: string): unknown {
+  return JSON.parse(gunzipSync(Buffer.from(encoded, 'base64url')).toString('utf8'))
+}
+
+describe('Feishu/Lark one-click app registration', () => {
+  it('survives a CP restart, installs the full template, and never returns credentials', async () => {
+    const agentId = await placedAgent()
+    const requests: URLSearchParams[] = []
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      const form = new URLSearchParams(String(init?.body))
+      requests.push(form)
+      if (form.get('action') === 'begin') {
+        return new Response(
+          JSON.stringify({
+            verification_uri_complete: 'https://accounts.feishu.cn/device?user_code=SAFE-CODE',
+            device_code: 'encrypted-device-code',
+            expires_in: 600,
+            interval: 1
+          })
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          client_id: 'cli_oneclick',
+          client_secret: 'one-click-secret',
+          user_info: { tenant_brand: 'lark' }
+        })
+      )
+    })
+
+    // Replica A begins the flow, then disappears before the browser's first poll.
+    const first = buildHttpApp(prisma, undefined, undefined, undefined, {
+      feishuAppRegistration: service(fetcher)
+    })
+    const started = await first.app.inject({
       method: 'POST',
       url: `${ORG}/integrations/feishu/app`,
       // The provider-reported tenant brand must win over this UI fallback.
@@ -71,25 +92,29 @@ describe('Feishu/Lark one-click app registration', () => {
     })
     expect(started.statusCode).toBe(201)
     const startDto = started.json() as { id: string; authorizationUrl: string }
-    expect(startDto.authorizationUrl).toBe('https://accounts.feishu.cn/device?user_code=SAFE-CODE')
     expect(JSON.stringify(startDto)).not.toContain('one-click-secret')
     expect(JSON.stringify(startDto)).not.toContain('cli_oneclick')
-    expect(options).toMatchObject({
-      source: 'agentconnect',
-      createOnly: true,
-      appPreset: { name: 'AgentConnect Lark' },
-      addons: {
-        preset: true,
-        scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
-        events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
-      }
+
+    const authorizationUrl = new URL(startDto.authorizationUrl)
+    expect(authorizationUrl.searchParams.get('createOnly')).toBe('true')
+    expect(authorizationUrl.searchParams.get('name')).toBe('AgentConnect Lark')
+    expect(decodeAddons(authorizationUrl.searchParams.get('addons')!)).toMatchObject({
+      preset: true,
+      scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
+      events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
     })
-    expect(options?.addons?.scopes?.tenant).toEqual(
-      expect.arrayContaining(['contact:user.base:readonly', 'im:chat:read'])
-    )
+    await first.close()
+
+    // Replica B reconstructs the coordinator from the shared row and completes.
+    const spy = new SpyControl()
+    const second = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender, {
+      feishuAppRegistration: service(fetcher),
+      verifyFeishuBot: async () => ({ status: 'ok', name: 'One-click Bot' })
+    })
+    running = second
 
     await vi.waitFor(async () => {
-      const polled = await app.app.inject({
+      const polled = await second.app.inject({
         method: 'GET',
         url: `${ORG}/integrations/feishu/app/${startDto.id}`
       })
@@ -99,11 +124,20 @@ describe('Feishu/Lark one-click app registration', () => {
       expect(JSON.stringify(polled.json())).not.toContain('cli_oneclick')
     })
 
+    // The first successful Feishu-domain response identifies a Lark tenant;
+    // the durable cursor switches domains, then a later browser poll resumes it.
+    expect(requests.map((request) => request.get('action'))).toEqual(['begin', 'poll', 'poll'])
     const bot = await prisma.bot.findFirst({ where: { feishuAppId: 'cli_oneclick' } })
     expect(bot).toMatchObject({ name: 'AgentConnect Lark', feishuRegion: 'lark' })
     expect(await prisma.botSecret.findUnique({ where: { botId: bot!.id } })).toMatchObject({
       botToken: 'one-click-secret',
       appToken: 'cli_oneclick'
+    })
+    expect(await prisma.feishuAppRegistration.findUnique({ where: { id: startDto.id } })).toMatchObject({
+      status: 'completed',
+      deviceCode: null,
+      appSecret: null,
+      targetKey: null
     })
     expect(spy.upserts).toHaveLength(1)
     expect(spy.upserts[0]).toMatchObject({
@@ -116,14 +150,24 @@ describe('Feishu/Lark one-click app registration', () => {
     })
   })
 
-  it('reports a denied authorization without creating a bot', async () => {
+  it('persists a denied authorization as a terminal status without creating a bot', async () => {
     const agentId = await placedAgent()
-    const register: FeishuRegisterApp = async (input) => {
-      input.onQRCodeReady({ url: 'https://accounts.feishu.cn/device?user_code=DENIED', expireIn: 600 })
-      throw { code: 'access_denied', description: 'denied' }
-    }
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      const form = new URLSearchParams(String(init?.body))
+      if (form.get('action') === 'begin') {
+        return new Response(
+          JSON.stringify({
+            verification_uri_complete: 'https://accounts.feishu.cn/device?user_code=DENIED',
+            device_code: 'denied-device-code',
+            expires_in: 600,
+            interval: 1
+          })
+        )
+      }
+      return new Response(JSON.stringify({ error: 'access_denied', error_description: 'denied' }), { status: 400 })
+    })
     const app = buildHttpApp(prisma, undefined, undefined, undefined, {
-      feishuAppRegistration: new FeishuAppRegistrationService(register)
+      feishuAppRegistration: service(fetcher)
     })
     running = app
 
@@ -135,11 +179,39 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(started.statusCode).toBe(201)
     const { id } = started.json() as { id: string }
 
-    await vi.waitFor(async () => {
-      const polled = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
-      expect(polled.json()).toMatchObject({ status: 'failed', failureReason: 'denied', integrationId: null })
-    })
+    const polled = await app.app.inject({ method: 'GET', url: `${ORG}/integrations/feishu/app/${id}` })
+    expect(polled.json()).toMatchObject({ status: 'failed', failureReason: 'denied', integrationId: null })
     expect(await prisma.bot.count()).toBe(0)
     expect(await prisma.integration.count()).toBe(0)
+  })
+
+  it('does not reuse one user’s pending setup for a different requester', async () => {
+    const begin = vi.fn(async () => ({
+      authorizationUrl: 'https://accounts.feishu.cn/device?user_code=ONE',
+      deviceCode: 'one-device-code',
+      providerDomain: 'accounts.feishu.cn',
+      intervalMs: 1000,
+      expiresInMs: 600_000
+    }))
+    const provider: FeishuRegistrationProvider = {
+      begin,
+      poll: async () => ({ outcome: 'pending' })
+    }
+    const coordinator = new FeishuAppRegistrationService(
+      new PgFeishuAppRegistrationStore(prisma, new PlaintextSecretCipher()),
+      provider
+    )
+    const common = {
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId: AgentId(randomUUID()),
+      fallbackRegion: 'lark' as const,
+      appName: 'AgentConnect'
+    }
+
+    await coordinator.start({ ...common, createdByUserId: 'user-a' })
+    await expect(coordinator.start({ ...common, createdByUserId: 'user-b' })).rejects.toBeInstanceOf(
+      FeishuRegistrationConflictError
+    )
+    expect(begin).toHaveBeenCalledOnce()
   })
 })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -14,6 +14,8 @@ import { consoleKeys } from '@/lib/swr-keys'
 import {
   ApiError,
   creatorLabel,
+  startFeishuRegistration,
+  getFeishuRegistration,
   startSlackInstall,
   startSlackPlatformInstall,
   getSlackPlatformInstall,
@@ -107,6 +109,14 @@ const PLATFORM_INSTALL_FAILURES: Record<string, string> = {
   workspace_taken: 'That Slack workspace is already connected to another organization.',
   agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
   error: 'Slack could not complete the install. Please try again.'
+}
+
+const FEISHU_REGISTRATION_FAILURES: Record<string, string> = {
+  denied: 'The Feishu/Lark app setup was cancelled.',
+  expired: 'This setup link expired — start again.',
+  agent_unavailable: 'This agent moved or was removed during setup. Check its daemon, then try again.',
+  invalid_credentials: 'The app was created, but its credentials could not be verified.',
+  setup_failed: 'Feishu/Lark could not complete the app setup. Please try again.'
 }
 
 const GH_TRIGGER_TILES: { mode: GhTriggerMode; label: string; desc: string }[] = [
@@ -213,8 +223,8 @@ const FEISHU_REQS: { icon: string; title: string; desc: string }[] = [
   },
   {
     icon: 'shield-check',
-    title: 'Grant the message scopes',
-    desc: 'Request im:message, im:message:send_as_bot and im:resource (add im:chat as needed), then create a version and publish.'
+    title: 'Grant message and name scopes',
+    desc: 'Request the message, chat and resource scopes plus contact:contact.base:readonly and contact:user.base:readonly so channels and participants have readable names, then publish.'
   },
   {
     icon: 'users',
@@ -987,6 +997,7 @@ export default function AddIntegrationModal({
     createGithubHook,
     daemons,
     daemonsLoading,
+    refresh,
     updateAgent
   } = useConsoleData()
   const { me } = useProfile()
@@ -999,11 +1010,18 @@ export default function AddIntegrationModal({
   // Feishu/Lark gateway: new installs default to international Lark.
   const [feishuRegion, setFeishuRegion] = useState<'feishu' | 'lark'>('lark')
   const feishuBrand = feishuRegion === 'lark' ? 'Lark' : 'Feishu'
+  const [feishuMethod, setFeishuMethod] = useState<'deeplink' | 'manual'>('deeplink')
+  const [feishuPhase, setFeishuPhase] = useState<'idle' | 'authorizing'>('idle')
+  const [feishuRegistration, setFeishuRegistration] = useState<{
+    id: string
+    authorizationUrl: string
+    expiresAt: string
+  } | null>(null)
   const botIdentityCopy: Record<BotPlatform, { create: string; existing: string }> = {
     slack: { create: 'Create with a Slack manifest', existing: 'An unused Slack app' },
     telegram: { create: 'Create a bot with @BotFather', existing: 'An unused Telegram bot' },
     discord: { create: 'Create a bot in Discord', existing: 'An unused Discord bot' },
-    feishu: { create: `Create a bot in ${feishuBrand}`, existing: `An unused ${feishuBrand} bot` }
+    feishu: { create: `Create with one-click ${feishuBrand} setup`, existing: `An unused ${feishuBrand} bot` }
   }
   const [saving, setSaving] = useState(false)
   const [showErrors, setShowErrors] = useState(false)
@@ -1204,6 +1222,9 @@ export default function AddIntegrationModal({
     setBotToken('')
     setAppToken('')
     setCreateMethod(null)
+    setFeishuMethod('deeplink')
+    setFeishuPhase('idle')
+    setFeishuRegistration(null)
     setCfgAccess('')
     setCfgRefresh('')
     setShowErrors(false)
@@ -1225,6 +1246,9 @@ export default function AddIntegrationModal({
     setAppName(agent.name)
     setBotToken('')
     setAppToken('')
+    setFeishuMethod('deeplink')
+    setFeishuPhase('idle')
+    setFeishuRegistration(null)
     setShowErrors(false)
     setErr(null)
   }, [agent.name, createdHook, daemonsLoading, firstSupportedBotPlatform, selectedBotPlatformSupported])
@@ -1792,6 +1816,79 @@ export default function AddIntegrationModal({
     setErr(null)
   }
 
+  // Feishu/Lark's official device flow returns a normal authorization deeplink.
+  // Open a blank tab synchronously so popup blockers preserve the user's click
+  // while the CP asks the provider for that URL.
+  const startFeishuAuto = async () => {
+    if (busyRef.current || feishuRegistration) return
+    busyRef.current = true
+    setSaving(true)
+    setErr(null)
+    const authorizationTab = window.open('about:blank', '_blank')
+    if (authorizationTab) authorizationTab.opener = null
+    try {
+      const started = await startFeishuRegistration({
+        agentId: agent.id,
+        region: feishuRegion,
+        ...(appName.trim() ? { name: appName.trim() } : {})
+      })
+      setFeishuRegistration(started)
+      setFeishuPhase('authorizing')
+      if (authorizationTab) authorizationTab.location.replace(started.authorizationUrl)
+      else window.open(started.authorizationUrl, '_blank', 'noopener,noreferrer')
+    } catch (e) {
+      authorizationTab?.close()
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+      busyRef.current = false
+    }
+  }
+
+  // The App Secret never reaches the browser. Poll only the short-lived session:
+  // once the CP has installed the credentials and pushed the integration, refresh
+  // the two console projections and close.
+  useEffect(() => {
+    if (
+      mode !== 'create' ||
+      platform !== 'feishu' ||
+      feishuMethod !== 'deeplink' ||
+      feishuPhase !== 'authorizing' ||
+      !feishuRegistration
+    )
+      return
+    let alive = true
+    const stop = (message: string) => {
+      setFeishuPhase('idle')
+      setFeishuRegistration(null)
+      setErr(message)
+    }
+    const tick = async () => {
+      try {
+        const status = await getFeishuRegistration(feishuRegistration.id)
+        if (!alive || status.status === 'pending') return
+        if (status.status === 'completed') {
+          refresh()
+          return onClose()
+        }
+        stop(
+          FEISHU_REGISTRATION_FAILURES[status.failureReason ?? ''] ??
+            'Feishu/Lark could not complete the app setup. Please try again.'
+        )
+      } catch (e) {
+        // A missing short-lived session is terminal; ordinary network failures
+        // remain retryable and the next poll keeps the setup moving.
+        if (alive && e instanceof ApiError && e.status === 404) stop(FEISHU_REGISTRATION_FAILURES.expired!)
+      }
+    }
+    const timer = setInterval(() => void tick(), 2000)
+    void tick()
+    return () => {
+      alive = false
+      clearInterval(timer)
+    }
+  }, [feishuMethod, feishuPhase, feishuRegistration, mode, onClose, platform, refresh])
+
   // Auto flow — final step. Socket: hand the CP the pasted app-level token; it
   // combines it with the OAuth-obtained bot token to create the bot + integration.
   // Http: no token — the CP reads the signing secret via the caller's config token,
@@ -1943,6 +2040,7 @@ export default function AddIntegrationModal({
   // is shown and the footer commits it (save + create the app).
   const isConfigSetup =
     mode === 'create' && platform === 'slack' && slackFunnel === true && slackMethod === 'config' && !autoUsable
+  const isFeishuDeeplink = mode === 'create' && platform === 'feishu' && feishuMethod === 'deeplink'
   const footer =
     platform === 'webhook'
       ? createdHook
@@ -3228,112 +3326,208 @@ export default function AddIntegrationModal({
               </div>
             </div>
           )}
-        {/* Feishu needs TWO credentials (App ID + App Secret), so it gets its own create
-            block instead of the single-token generic one above — mirroring Slack. */}
+        {/* Feishu/Lark defaults to the official device-registration deeplink. The
+            manual credential pair remains available as an advanced fallback. */}
         {mode === 'create' && platform === 'feishu' && (
-          <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-            {/* Region picks the open-platform gateway: Feishu (China, open.feishu.cn) vs
-                Lark (international, open.larksuite.com). Same app model, different console
-                + host — an app is registered in one region, so the operator chooses first. */}
-            <div className="mb-3">
-              <span className="fldlbl mb-[6px] block">Region</span>
-              <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Lark or Feishu region">
-                {(
-                  [
-                    { key: 'lark', label: 'Lark', sub: 'International' },
-                    { key: 'feishu', label: 'Feishu', sub: '飞书 · China' }
-                  ] as const
-                ).map((r) => (
-                  <button
-                    key={r.key}
-                    type="button"
-                    role="radio"
-                    aria-checked={feishuRegion === r.key}
-                    onClick={() => setFeishuRegion(r.key)}
-                    className={`flex flex-col items-start gap-[1px] rounded-md border px-[11px] py-[7px] text-left ${
-                      feishuRegion === r.key
-                        ? 'border-(--brand) bg-(--surface-active)'
-                        : 'border-(--border-default) bg-(--surface-app)'
-                    }`}
-                  >
-                    <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                      {r.label}
-                    </span>
-                    <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                      {r.sub}
-                    </span>
-                  </button>
-                ))}
+          <>
+            <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-[6px]">
+              <div className="inline-flex flex-none rounded-lg border border-(--border-default) bg-(--surface-card) p-[3px]">
+                {(['deeplink', 'manual'] as const).map((method) => {
+                  const on = feishuMethod === method
+                  return (
+                    <button
+                      key={method}
+                      type="button"
+                      disabled={feishuPhase === 'authorizing'}
+                      onClick={() => {
+                        setFeishuMethod(method)
+                        setShowErrors(false)
+                        setErr(null)
+                      }}
+                      title={feishuPhase === 'authorizing' ? 'App setup is in progress' : undefined}
+                      className={`rounded-[6px] px-[11px] py-[5px] font-sans text-[12px] font-semibold leading-normal ${
+                        on ? 'bg-(--brand-soft) text-(--brand)' : 'bg-transparent text-(--text-tertiary)'
+                      } ${feishuPhase === 'authorizing' ? 'cursor-not-allowed opacity-50' : ''}`}
+                    >
+                      {method === 'deeplink' ? 'One-click' : 'Manual'}
+                    </button>
+                  )
+                })}
               </div>
-            </div>
-            <div className="mb-3 flex gap-[10px]">
-              <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
-                1
+              <span className="min-w-0 flex-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                {feishuMethod === 'deeplink'
+                  ? `Recommended — approve in ${feishuBrand}; permissions, events and credentials are connected automatically.`
+                  : 'Advanced — configure a self-built app yourself and paste its credentials.'}
               </span>
-              <div className="min-w-0 flex-1">
-                <div className="mb-2 font-sans text-[12.5px] font-medium leading-[1.45] text-(--text-secondary)">
-                  Create a self-built app in the {feishuBrand}&#32;console, enable the bot, then copy its App ID and App
-                  Secret from Credentials &amp; Basic Info.
-                </div>
-                <div className="group relative">
-                  <a
-                    href={
-                      feishuRegion === 'lark'
-                        ? 'https://open.larksuite.com/page/launcher'
-                        : 'https://open.feishu.cn/page/launcher'
-                    }
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
-                  >
-                    <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
-                      <PlatformMark platform="feishu" />
-                    </span>
-                    Create {feishuBrand} bot
-                    <Icon name="external-link" size={14} />
-                  </a>
-                  <BotSetupWalkthrough
-                    steps={
-                      feishuRegion === 'lark'
-                        ? feishuWalkthroughSteps('Lark', 'open.larksuite.com')
-                        : feishuWalkthroughSteps('Feishu', 'open.feishu.cn')
-                    }
-                    label={feishuRegion === 'lark' ? 'Lark bot setup steps' : 'Feishu bot setup steps'}
-                  />
+            </div>
+            <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+              {/* Region is used as a fallback; the one-click result normally reports
+                  the authorized tenant brand and the CP stores that exact gateway. */}
+              <div className="mb-3">
+                <span className="fldlbl mb-[6px] block">Region</span>
+                <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Lark or Feishu region">
+                  {(
+                    [
+                      { key: 'lark', label: 'Lark', sub: 'International' },
+                      { key: 'feishu', label: 'Feishu', sub: '飞书 · China' }
+                    ] as const
+                  ).map((region) => (
+                    <button
+                      key={region.key}
+                      type="button"
+                      role="radio"
+                      disabled={feishuPhase === 'authorizing'}
+                      aria-checked={feishuRegion === region.key}
+                      onClick={() => setFeishuRegion(region.key)}
+                      className={`flex flex-col items-start gap-[1px] rounded-md border px-[11px] py-[7px] text-left ${
+                        feishuRegion === region.key
+                          ? 'border-(--brand) bg-(--surface-active)'
+                          : 'border-(--border-default) bg-(--surface-app)'
+                      } ${feishuPhase === 'authorizing' ? 'cursor-not-allowed opacity-50' : ''}`}
+                    >
+                      <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                        {region.label}
+                      </span>
+                      <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                        {region.sub}
+                      </span>
+                    </button>
+                  ))}
                 </div>
               </div>
+
+              {feishuMethod === 'deeplink' ? (
+                feishuPhase === 'authorizing' && feishuRegistration ? (
+                  <div className="flex gap-[10px]">
+                    <span className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--brand-soft)">
+                      <Icon name="loader" size={12} color="var(--brand)" className="animate-spin" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                        Approve the app setup in {feishuBrand}
+                      </div>
+                      <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                        We opened the authorization page in a new tab. Confirm the app and permissions; this dialog
+                        updates automatically.
+                      </div>
+                      <a
+                        href={feishuRegistration.authorizationUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="lnk mt-2 inline-flex items-center gap-[5px]"
+                      >
+                        Reopen {feishuBrand} setup
+                        <Icon name="external-link" size={12} />
+                      </a>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="mb-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                      Name and create the bot
+                    </div>
+                    <div className="flex flex-col gap-2 desktop:flex-row">
+                      <div className="fld flex-1">
+                        <input
+                          className="inp mn"
+                          placeholder="Bot name"
+                          value={appName}
+                          onChange={(e) => setAppName(e.target.value)}
+                        />
+                      </div>
+                      <Button
+                        disabled={saving}
+                        onClick={() => void startFeishuAuto()}
+                        className={saving ? 'flex-none cursor-default opacity-50' : 'flex-none'}
+                      >
+                        <span className="imark h-4 w-4 border-0 bg-transparent">
+                          <PlatformMark platform="feishu" />
+                        </span>
+                        {saving ? 'Creating…' : `Create ${feishuBrand} bot`}
+                      </Button>
+                    </div>
+                    <div className="mt-[9px] flex items-start gap-[6px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                      <Icon name="shield-check" size={13} className="mt-[1px] flex-none" />
+                      <span>
+                        You review the requested message, chat, resource and basic-contact permissions before the app is
+                        created. No App ID or Secret is shown here.
+                      </span>
+                    </div>
+                  </>
+                )
+              ) : (
+                <>
+                  <div className="mb-3 flex gap-[10px]">
+                    <span className="mono mt-[1px] flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                      1
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-2 font-sans text-[12.5px] font-medium leading-[1.45] text-(--text-secondary)">
+                        Create a self-built app in the {feishuBrand}&#32;console, enable the bot, then copy its App ID
+                        and App Secret.
+                      </div>
+                      <div className="group relative">
+                        <a
+                          href={
+                            feishuRegion === 'lark'
+                              ? 'https://open.larksuite.com/page/launcher'
+                              : 'https://open.feishu.cn/page/launcher'
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex h-[38px] items-center justify-center gap-2 rounded-md bg-(--surface-inverse) font-sans text-[13px] font-semibold leading-normal text-white no-underline"
+                        >
+                          <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
+                            <PlatformMark platform="feishu" />
+                          </span>
+                          Create {feishuBrand} bot
+                          <Icon name="external-link" size={14} />
+                        </a>
+                        <BotSetupWalkthrough
+                          steps={
+                            feishuRegion === 'lark'
+                              ? feishuWalkthroughSteps('Lark', 'open.larksuite.com')
+                              : feishuWalkthroughSteps('Feishu', 'open.feishu.cn')
+                          }
+                          label={feishuRegion === 'lark' ? 'Lark bot setup steps' : 'Feishu bot setup steps'}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-[14px] mb-[11px] flex items-center gap-[10px] border-t border-dashed border-(--border-default) pt-[13px]">
+                    <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
+                      2
+                    </span>
+                    <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                      Paste the App ID &amp; App Secret
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-1 gap-[10px] pl-[30px] min-[440px]:grid-cols-2">
+                    <div className="fld">
+                      <span className="fldlbl">App ID</span>
+                      <input
+                        className={`inp mn ${showErrors && !feishuAppIdOk ? 'border-(--status-error)' : ''}`}
+                        placeholder="cli_…"
+                        value={botToken}
+                        onChange={(e) => setBotToken(e.target.value)}
+                      />
+                    </div>
+                    <div className="fld">
+                      <span className="fldlbl">App Secret</span>
+                      <input
+                        className={`inp mn ${showErrors && !feishuSecretOk ? 'border-(--status-error)' : ''}`}
+                        placeholder="App Secret"
+                        value={appToken}
+                        onChange={(e) => setAppToken(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
-            <div className="mt-[14px] mb-[11px] flex items-center gap-[10px] border-t border-dashed border-(--border-default) pt-[13px]">
-              <span className="mono flex h-5 w-5 flex-none items-center justify-center rounded-full bg-(--surface-active) text-[11px] text-(--text-secondary)">
-                2
-              </span>
-              <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                Paste the App ID &amp; App Secret — both required to connect
-              </span>
-            </div>
-            <div className="grid grid-cols-1 gap-[10px] pl-[30px] min-[440px]:grid-cols-2">
-              <div className="fld">
-                <span className="fldlbl">App ID</span>
-                <input
-                  className={`inp mn ${showErrors && !feishuAppIdOk ? 'border-(--status-error)' : ''}`}
-                  placeholder="cli_…"
-                  value={botToken}
-                  onChange={(e) => setBotToken(e.target.value)}
-                />
-              </div>
-              <div className="fld">
-                <span className="fldlbl">App Secret</span>
-                <input
-                  className={`inp mn ${showErrors && !feishuSecretOk ? 'border-(--status-error)' : ''}`}
-                  placeholder="App Secret"
-                  value={appToken}
-                  onChange={(e) => setAppToken(e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
+          </>
         )}
-        {platform === 'feishu' && (
+        {platform === 'feishu' && (mode === 'existing' || feishuMethod === 'manual') && (
           <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
             <div className="mb-[11px] flex items-center gap-2 font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary)">
               <Icon name="shield-check" size={14} color="var(--brand)" className="flex-none" />
@@ -3412,7 +3606,7 @@ export default function AddIntegrationModal({
         </Button>
         {/* The built-in pane's action is its own Add-to-Slack button (the modal closes
             itself when the install lands), so the custom flow's footer action hides. */}
-        {!hideIdentitySection && (
+        {!hideIdentitySection && !isFeishuDeeplink && (
           <Button onClick={footer.act} className={footer.enabled && !saving ? undefined : 'cursor-default opacity-50'}>
             <Icon name={platform === 'webhook' && createdHook ? 'check' : 'plug'} size={15} />
             {saving ? (isAuto && autoPhase === 'config' ? 'Creating…' : 'Connecting…') : footer.label}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -509,6 +509,26 @@ export interface SlackInstallStatusDto {
   status: 'awaiting_oauth' | 'bot_ready'
 }
 
+/** Feishu/Lark one-click self-built app registration. The browser receives only
+ * the provider authorization URL; App ID/Secret are finalized server-side. */
+export interface StartFeishuRegistrationInput {
+  agentId: string
+  name?: string
+  region?: 'feishu' | 'lark'
+}
+export interface FeishuRegistrationStartDto {
+  id: string
+  authorizationUrl: string
+  expiresAt: string
+}
+export interface FeishuRegistrationStatusDto {
+  id: string
+  status: 'pending' | 'completed' | 'failed'
+  failureReason: 'denied' | 'expired' | 'agent_unavailable' | 'invalid_credentials' | 'setup_failed' | null
+  integrationId: string | null
+  expiresAt: string
+}
+
 /** `GET /slack/config` — the CALLER's own stored-config status (drives the create
  *  modal's forced auto/manual mode). Per-user. NEVER carries the token. */
 export interface SlackConfigDto {
@@ -2509,6 +2529,18 @@ export async function fetchIntegrations(orgId?: string): Promise<IntegrationDto[
 // (never the tokens); the CP delivers the tokens to the owning agent's daemon.
 export async function createIntegration(input: CreateIntegrationInput): Promise<IntegrationDto> {
   return apiPost<IntegrationDto>(`${orgBase()}/integrations`, input)
+}
+
+// ── Feishu/Lark one-click app registration ──
+// Start the official device flow and receive a normal browser deeplink. The CP
+// keeps polling and installs the returned credentials without exposing them here.
+export async function startFeishuRegistration(
+  input: StartFeishuRegistrationInput
+): Promise<FeishuRegistrationStartDto> {
+  return apiPost<FeishuRegistrationStartDto>(`${orgBase()}/integrations/feishu/app`, input)
+}
+export async function getFeishuRegistration(id: string): Promise<FeishuRegistrationStatusDto> {
+  return apiGet<FeishuRegistrationStatusDto>(`${orgBase()}/integrations/feishu/app/${encodeURIComponent(id)}`)
 }
 
 // ── Slack auto-install funnel ──

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^6.1.0
         version: 6.1.0
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.71.1
+        version: 1.71.1
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,9 +151,6 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^6.1.0
         version: 6.1.0
-      '@larksuiteoapi/node-sdk':
-        specifier: ^1.71.1
-        version: 1.71.1
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Summary

- make official Feishu/Lark one-click app registration the default new-bot flow, opening a direct authorization deeplink with manual credentials retained as an advanced fallback
- keep the reviewable PersonalAgent template in `feishu-app-template.ts`, including message, chat, resource, event, and basic-contact scopes so channel and participant names can be resolved
- persist encrypted device-flow state in Postgres so polling and finalization survive Control Plane restarts and load balancing; reserve bot/integration IDs for idempotent retry
- keep App ID and App Secret server-side, clear provisional secrets on settlement, and push the completed integration to the owning daemon
- fence finalization against agent moves, revalidate the destination daemon's Feishu capability, and keep expiry or post-persistence push failures safely retryable

## Impact

Users only need to open the Feishu/Lark authorization page and confirm the requested app permissions. No QR scan, developer-console app creation, or credential copy/paste is required for the default path. Tenant admin approval may still apply under the tenant's own policy, and adding the bot to a group remains a user action.

## Validation

- `pnpm --filter @agentconnect.md/protocol build`
- `pnpm --filter @agentconnect.md/control-plane build`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web build`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts` (6 passed)
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/integrations.route.test.ts -t feishu` (4 passed)
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/orchestrator/slackInstallReaper.test.ts` (3 passed)
- focused ESLint and Prettier checks; pre-push ESLint has 0 errors and 2 pre-existing duplicate-import warnings in `icon-upload.ts`

Created by Codex . GPT-5.6
