### PR TITLE
docs: add session visibility design

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -58,10 +58,14 @@ The IM form carries a **workspace/tenant segment** from day one: platform uids
 are only unique per tenant (Slack team, Feishu tenant, Telegram bot scope), and
 one org can connect multiple workspaces of the same platform, so a two-segment
 `slack:<uid>` form would allow same-org identity collisions. The workspace
-value is **carried on the wire by the daemon** — the daemon already maintains
-a physical transport scope per platform connection, and `EventSession` gains a
+value is **carried on the wire by the daemon** — `EventSession` gains a
 `transportScope` field (§4.1) that the CP persists verbatim into
-`ownerIdentity`. The CP never reconstructs the scope from `platform` +
+`ownerIdentity`. The reported value must be a **durable tenant identifier**
+(Slack team id, Feishu tenant key): the daemon's existing physical transport
+scope is credential-derived and rotates with tokens, so reusing it would
+orphan historical identity matches on rotation. An adapter whose platform
+exposes no durable tenant id mints a stable per-integration scope once and
+persists it. The CP never reconstructs the scope from `platform` +
 `channel` (ambiguous when an org connects multiple bots/workspaces), and the
 design does not assume every adapter's integration record stores a usable
 tenant key (Feishu's, for example, is not exposed the same way). A milestone
@@ -117,9 +121,11 @@ enum VisibilitySource {
 ```
 
 - `orgId` is denormalized so the list predicate and its index do not join
-  `agent`. All existing paging indexes are `agentId`-prefixed; add
-  `@@index([orgId, visibility, lastActivityAt(sort: Desc), id])` for the
-  org-wide session list, keeping the existing keyset-pagination shape.
+  `agent`. All existing paging indexes are `agentId`-prefixed; add an
+  `(orgId, visibility, …)` index whose trailing columns **mirror the existing
+  keyset tuple exactly** (`lastActivityAt desc, startedAt, id` — whatever the
+  current `agentId`-prefixed page indexes use) so the org-wide session list
+  pages with the same cursor shape.
 - No `sharedWith String[]` on sessions in this iteration. Per-session
   member-sharing can be added later with the same GIN pattern as agents;
   share-by-link (§8) covers the near-term "share this session" ask.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -41,7 +41,7 @@ sender id: `SessionMeta.triggeredBy` is an opaque, platform-namespaced string
 (a Slack/Discord/Telegram/Feishu user id, an agent UUID, `cron:<id>`,
 `hook:<id>`, or — for webchat — the console user's email). There is no
 platform-identity → `app_user` mapping today
-([resource-visibility.md §14.3](resource-visibility.md) lists it as future
+([resource-visibility.md §14.6](resource-visibility.md) lists it as future
 work).
 
 **Decision: the owner is a namespaced identity string, not a `User` FK.**

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -345,8 +345,16 @@ two layers:
    (`isDm`, `platform === 'webchat'`, §4.4 launch correlation) memory capture
    is excluded from the first turn, with no CP round-trip. For an A2A child,
    the delegation command carries the parent session's current privacy flag,
-   so a private parent's children start excluded even across daemons; a
-   delegation whose parent flag is unavailable starts excluded (fail closed).
+   but the flag is **one-directional — it can only tighten**: a `private`
+   hint excludes the child immediately; an `org` hint (or a missing flag)
+   does **not** enable capture. An A2A child always starts excluded and
+   capture enables only once the CP-confirmed gate state for that child
+   (the frame pushed after the child's ingest classification) says `org`.
+   This is what makes the §4.3 cutover causally sound: a stale-`org`
+   delegation already in flight when its parent daemon acks `private`
+   cannot open capture on the receiving daemon, because opening requires a
+   CP confirmation — and by then the CP has classified the child under the
+   post-cascade parent state (§4.5 serialization guarantees `private`).
 2. **CP-pushed effective state.** The CP is the authority on effective
    visibility (§4.3 changes, §4.5 settlements and cascades). On every change
    it sends a `session/visibility` control frame over the existing daemon WS
@@ -363,7 +371,11 @@ two layers:
      visibility change, settlement, and cascade. It is deliberately **not**
      the transcript revision (a daemon-local cursor) nor the WS
      `sessionEpoch`/`seq` fences (connection-scoped); neither advances with
-     visibility. The daemon ignores frames whose rev is ≤ its stored rev.
+     visibility. Delivery is at-least-once, so duplicate handling is
+     explicit: a frame whose rev is ≤ the stored rev is **not reapplied but
+     is still acknowledged** (as already-satisfied/superseded) — "ignore"
+     must never mean "don't ACK", or a lost ACK leaves the CP retrying
+     forever.
    - The daemon **acknowledges** the frame and persists the gate state (with
      its rev) in its local store alongside the session; the CP retries
      unacked frames, per the WS channel's existing command semantics.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -2,10 +2,12 @@
 
 > **Status:** Proposed. Nothing in this document is implemented yet.
 >
-> **Scope:** protocol + control-plane + web. The daemon changes are limited to
-> reporting one extra field on the existing `event/session` telemetry frame;
-> the execution data plane is otherwise unaffected. Sharing is enforced only on
-> Console/BFF read paths — it never crosses the daemon wire, consistent with
+> **Scope:** protocol + control-plane + daemon + web. Daemon changes: three
+> optional fields on the existing `event/session` telemetry frame (§4.1), a
+> memory-capture gate driven by local origin plus a CP-pushed per-session
+> privacy bit (§5.1), and a privacy flag on A2A delegation commands. Console
+> authorization itself is enforced only on CP/BFF read paths; live platform
+> messages and ACP update streams never carry visibility, consistent with
 > [resource-visibility.md](resource-visibility.md).
 
 ## 1. Background and goals
@@ -56,10 +58,16 @@ The IM form carries a **workspace/tenant segment** from day one: platform uids
 are only unique per tenant (Slack team, Feishu tenant, Telegram bot scope), and
 one org can connect multiple workspaces of the same platform, so a two-segment
 `slack:<uid>` form would allow same-org identity collisions. The workspace
-value is the tenant identifier the integration already stores (Slack team id,
-Feishu tenant key); for a platform surface with no tenant concept in DMs
-(e.g. Discord DMs have no guild), use the integration id. Identity linking
-(§7) stores and matches the same three-part tuple.
+value is **carried on the wire by the daemon** — the daemon already maintains
+a physical transport scope per platform connection, and `EventSession` gains a
+`transportScope` field (§4.1) that the CP persists verbatim into
+`ownerIdentity`. The CP never reconstructs the scope from `platform` +
+`channel` (ambiguous when an org connects multiple bots/workspaces), and the
+design does not assume every adapter's integration record stores a usable
+tenant key (Feishu's, for example, is not exposed the same way). A milestone
+arriving **without** `transportScope` records no IM owner (`null`, fail
+closed per §4.2) rather than a guessed one. Identity linking (§7) stores and
+matches the same three-part tuple.
 
 Matching is set membership: at request time the BFF computes the viewer's
 **identity set** — today just `{ user:<userId> }`, later expanded with the
@@ -89,12 +97,22 @@ enum SessionVisibility {
 }
 ```
 
-Three new columns on `SessionMeta`:
+New columns on `SessionMeta`:
 
 ```prisma
-orgId         String            // denormalized from agent.orgId at ingest
-visibility    SessionVisibility @default(org)
-ownerIdentity String?           // §2 format; null for automation/legacy rows
+orgId            String            // denormalized from agent.orgId at ingest
+visibility       SessionVisibility @default(org)
+ownerIdentity    String?           // §2 format; null for automation/legacy rows
+visibilitySource VisibilitySource  @default(default)
+```
+
+```prisma
+enum VisibilitySource {
+  default           // classified by the §4.2 rules
+  inherited_pending // A2A child awaiting parent resolution (§4.5)
+  inherited         // settled from (or cascaded by) its parent
+  explicit          // set by a human via §4.3 — never auto-overwritten
+}
 ```
 
 - `orgId` is denormalized so the list predicate and its index do not join
@@ -113,12 +131,14 @@ Visibility tightening applies to **new sessions only**.
 
 ## 4. Classifying sessions at ingest
 
-### 4.1 Protocol: one new field
+### 4.1 Protocol: new telemetry fields
 
-`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains:
+`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains three
+optional fields:
 
 ```ts
 conversationKind?: 'dm' | 'group_dm' | 'channel'
+transportScope?: string // trusted workspace/tenant scope for ownerIdentity, §2
 launchCorrelationId?: string // Web API launch provenance, §4.4
 ```
 
@@ -127,8 +147,10 @@ The daemon already knows this (`NormalizedMessage.isDm` / `isGroupDm`,
 never reaches the CP. The `thread === 'dm'` heuristic and an
 `IntegrationChannel.kind` join were both considered and rejected: the former is
 platform-inconsistent, the latter does not cover webhook/generic ingress and
-moves a write-time fact to read time. Optional field ⇒ old daemons remain
-compatible (absent = `channel` behavior, i.e. `org`).
+moves a write-time fact to read time. All three fields are optional ⇒ old
+daemons remain compatible (absent `conversationKind` = `channel` behavior,
+i.e. `org`; absent `transportScope`/`launchCorrelationId` = no owner, fail
+closed).
 
 ### 4.2 Default rules
 
@@ -169,10 +191,8 @@ Notes:
   Playground session copies the delegated prompt into the child transcript;
   classifying children `org` would expose that to every viewer of the target
   agent. The child takes the parent's `visibility` + `ownerIdentity` at
-  ingest. `parentSessionId` has no FK and cross-daemon ordering means the
-  parent row may not exist yet — in that case the child is classified
-  `private`/`null` (fail closed) and re-reconciled when the parent's milestone
-  lands.
+  ingest; §4.5 defines the durable reconciliation semantics for out-of-order
+  arrival and later parent changes.
 
 ### 4.3 Changing visibility after the fact
 
@@ -183,6 +203,38 @@ sessions. This is the escape hatch for both directions: publishing a useful DM
 transcript to the org, or pulling a channel/group-DM session private (its
 recorded initiator — once identity linking makes them matchable — or an org
 owner).
+
+An explicit change sets `visibilitySource = 'explicit'`, which pins the row
+against any later automatic reclassification (§4.5). **Tightening cascades to
+descendants** (§4.5); the CP also notifies the owning daemon of the new
+effective state (§5.1). The response/UI must surface the memory caveat from
+§5.1: tightening stops future capture but does not scrub what agent memory
+already distilled while the session was org-visible.
+
+### 4.5 A2A inheritance: durable reconciliation semantics
+
+Inheritance must survive out-of-order arrival and later human changes without
+ever silently overwriting one with the other. `visibilitySource` (§3) is the
+state marker:
+
+- **Out-of-order child.** A child milestone whose parent row does not exist
+  yet is classified `private` + `ownerIdentity = null` with
+  `visibilitySource = 'inherited_pending'`. When the parent's milestone lands,
+  the CP performs a **conditional one-time settlement**: copy the parent's
+  `visibility` + `ownerIdentity` onto the child **iff** the child is still
+  `inherited_pending` (compare-and-set on the source column), then mark it
+  `inherited`. A child that an org owner has meanwhile re-classified is
+  `explicit` and the settlement is a no-op — reconciliation never overwrites
+  a human decision.
+- **Parent tightened later (`org` → `private`).** The child contains content
+  copied from the parent, so leaving it org-visible would defeat the change.
+  Tightening a session **cascades to all its descendants** (transitively,
+  via `parentSessionId`), including `explicit` ones — privacy tightening wins
+  over an earlier widening decision, matching the fail-closed rule of §4.2.
+  Cascaded rows get the parent's owner and `visibilitySource = 'inherited'`.
+- **Parent widened later (`private` → `org`).** Never cascades. Each
+  descendant stays as classified; widening a child remains a per-session §4.3
+  decision by its owner or an org owner.
 
 ### 4.4 Web API launch provenance
 
@@ -227,9 +279,11 @@ session predicate:
 
 Invariants preserved:
 
-- The daemon wire is unaffected: internal reads keep the deliberate
-  fail-open (`visibilityWhere(undefined)` semantics) — visibility is a Console
-  concern, never an execution-plane concern.
+- Console **authorization** stays a CP concern: internal/daemon read paths
+  keep the deliberate fail-open (`visibilityWhere(undefined)` semantics), and
+  no message content ever flows because of visibility. The one daemon-facing
+  addition is the §5.1 privacy bit pushed over the WS control channel — a
+  capture gate, not an authorization check the daemon performs for readers.
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
   authorization boundary; the predicate is applied regardless.
@@ -242,15 +296,38 @@ distilled into agent memory (including by dream sessions) and later surface —
 via memory reads or recall in someone else's session — to any user who can
 view the agent, bypassing every gate in the table above.
 
-Mitigation is **daemon-local**, preserving the invariant that CP visibility
-never crosses the wire: the daemon already knows a turn's origin without any
-CP round-trip (`isDm`, `platform === 'webchat'`, the §4.4 launch correlation).
-By default it must **exclude private-origin turns from agent-scoped memory
-capture** (dream distillation included). Per-owner memory namespaces are a
-possible future relaxation, but exclusion is the shipping requirement — the
-`private` tier's guarantee is dishonest without it. If exclusion is deferred,
-the product docs must explicitly narrow the guarantee ("private hides the
-transcript, not what the agent learned from it"); silence is not an option.
+Origin inference alone cannot carry this: once §4.3 exists, **origin is not
+effective visibility** — a channel session pulled `private` still looks like a
+channel to the daemon, and a cross-daemon A2A child cannot infer its inherited
+privacy from `isDm`/webchat/launch-correlation at all. The gate therefore has
+two layers:
+
+1. **Daemon-local initial state.** For turns the daemon can classify itself
+   (`isDm`, `platform === 'webchat'`, §4.4 launch correlation) memory capture
+   is excluded from the first turn, with no CP round-trip. For an A2A child,
+   the delegation command carries the parent session's current privacy flag,
+   so a private parent's children start excluded even across daemons; a
+   delegation whose parent flag is unavailable starts excluded (fail closed).
+2. **CP-pushed effective state.** The CP is the authority on effective
+   visibility (§4.3 changes, §4.5 settlements and cascades). On every change
+   it sends a `session/visibility` control frame over the existing daemon WS
+   to the owning daemon (and to daemons running affected descendants), and
+   the daemon updates its local capture gate. This is control signaling — the
+   channel's stated purpose — and carries a single privacy bit per session,
+   not message content.
+
+**Already-captured memory is not scrubbed.** Distilled memory cannot be
+reliably attributed back to source turns, so tightening a session stops
+_future_ capture but does not retract what was distilled while it was
+org-visible. This is a stated product caveat, surfaced in the §4.3 flow —
+the guarantee is "private stops the transcript and stops feeding shared
+memory from the moment of tightening", not retroactive amnesia.
+
+Per-owner memory namespaces are a possible future relaxation, but the
+exclusion gate is the shipping requirement — the `private` tier's guarantee
+is dishonest without it. If it is deferred, the product docs must explicitly
+narrow the guarantee ("private hides the transcript, not what the agent
+learned from it"); silence is not an option.
 
 ## 6. Web console
 
@@ -287,8 +364,10 @@ link ends public access without touching the session row.
 - **Unit (`test:unit`):** `canViewSession` truth table (role × visibility ×
   identity match × orphan owner); ingest classification table from §4.2,
   including every fail-closed path (webchat lookup miss, unresolved launch
-  correlation, unresolved parent) and absent `conversationKind`; child
-  inheritance + reconciliation when the parent milestone arrives late.
+  correlation, unresolved parent, missing `transportScope`) and absent
+  `conversationKind`; the §4.5 state machine — pending settlement is
+  one-time and conditional (never overwrites `explicit`), tightening
+  cascades transitively, widening never cascades.
 - **Integration (`test:int`):** list/detail/SSE visibility for a two-member
   org (owner sees all; collaborator sees own private + org sessions only);
   SSE assertion that **neither** `event/session` nor `event/session-activity`

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -111,7 +111,8 @@ enum VisibilitySource {
   default           // classified by the §4.2 rules
   inherited_pending // A2A child awaiting parent resolution (§4.5)
   inherited         // settled from (or cascaded by) its parent
-  explicit          // set by a human via §4.3 — never auto-overwritten
+  explicit          // set by a human via §4.3; only a §4.5 tightening
+                    // cascade may override it (privacy wins)
 }
 ```
 
@@ -255,6 +256,26 @@ state marker:
   descendant stays as classified; widening a child remains a per-session §4.3
   decision by its owner or an org owner.
 
+`explicit` is therefore protected against **settlement** (the automatic
+reconciliation above) but not against a **tightening cascade** — the §3 enum
+semantics are exactly these two rules, and privacy wins on the conflict.
+
+**Serialization.** Child classification and parent tightening race: a child
+milestone that reads its parent's `visibility = 'org'` could otherwise commit
+after the parent has been tightened, retaining stale org visibility. Both
+operations must serialize on the parent row:
+
+- Child ingest classifies inside the same transaction as the child insert and
+  takes a shared row lock on the parent (`SELECT … FOR SHARE`).
+- The §4.3 tightening handler locks the parent `FOR UPDATE` and updates all
+  descendants in the same transaction.
+
+Either the child commits first — and the cascade, which enumerates
+descendants inside its transaction, includes it — or the cascade commits
+first and the child's classification reads `private`. No interleaving can
+produce an org-visible child of a private parent. The integration test plan
+(§9) exercises this with concurrent ingest + tighten.
+
 ## 5. Enforcement points (control-plane)
 
 The authoritative predicate, mirroring `canView`:
@@ -316,6 +337,22 @@ two layers:
    channel's stated purpose — and carries a single privacy bit per session,
    not message content.
 
+   The push must be **durable, not fire-and-forget**, or races and restarts
+   reopen the bypass:
+
+   - Each frame carries a **monotonic revision** per session (the CP already
+     versions session state); the daemon ignores stale revisions.
+   - The daemon **acknowledges** the frame and persists the gate state (with
+     its revision) in its local store alongside the session; the CP retries
+     unacked frames, per the WS channel's existing command semantics.
+   - On daemon **register/reconnect**, the CP replays the current privacy
+     state for the daemon's active sessions (a snapshot, not a diff), closing
+     the window where a change happened while the daemon was offline.
+   - **Fail closed:** a session whose gate state is missing or whose pending
+     update is unconfirmed (e.g. right after a restart, before the snapshot
+     lands) is treated as private for capture purposes until the CP confirms
+     otherwise. A missed or delayed frame can only under-capture, never leak.
+
 **Already-captured memory is not scrubbed.** Distilled memory cannot be
 reliably attributed back to source turns, so tightening a session stops
 _future_ capture but does not retract what was distilled while it was
@@ -375,4 +412,6 @@ link ends public access without touching the session row.
   stability under the new predicate; migration backfill (`org` + `orgId`) on
   seeded legacy rows; visibility PUT authorization matrix (initiator of an
   `org` channel session may pull it private; a non-owner collaborator may
-  not).
+  not); the §4.5 serialization race — concurrent child ingest and parent
+  tightening in either commit order never yields an org-visible child of a
+  private parent.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -48,9 +48,18 @@ work).
 
 ```
 ownerIdentity :=
-  user:<app_user_id>          — console-originated (webchat, Web API launch)
-  <platform>:<platform_uid>   — IM-originated, e.g. slack:U0123ABCD, feishu:ou_...
+  user:<app_user_id>                     — console-originated (webchat, Web API launch)
+  <platform>:<workspace>:<platform_uid>  — IM-originated, e.g. slack:T024BE7LD:U0123ABCD
 ```
+
+The IM form carries a **workspace/tenant segment** from day one: platform uids
+are only unique per tenant (Slack team, Feishu tenant, Telegram bot scope), and
+one org can connect multiple workspaces of the same platform, so a two-segment
+`slack:<uid>` form would allow same-org identity collisions. The workspace
+value is the tenant identifier the integration already stores (Slack team id,
+Feishu tenant key); for a platform surface with no tenant concept in DMs
+(e.g. Discord DMs have no guild), use the integration id. Identity linking
+(§7) stores and matches the same three-part tuple.
 
 Matching is set membership: at request time the BFF computes the viewer's
 **identity set** — today just `{ user:<userId> }`, later expanded with the
@@ -65,12 +74,9 @@ Consequences:
 - When identity linking ships, those sessions become visible to the mapped
   user **automatically**, with no backfill: the stored `ownerIdentity` is
   already correct; only the viewer's identity set grows.
-- Platform uids are scoped per workspace/tenant (a Slack user id is unique per
-  workspace). The predicate is always additionally scoped by `orgId` and by
-  agent visibility, so cross-org collisions are not reachable; a same-org
-  collision across two workspaces of the same platform is theoretical and
-  accepted. If it ever matters, the identity format can grow a tenant segment
-  (`slack:<team>:<uid>`) without a schema change.
+- The predicate is always additionally scoped by `orgId` and by agent
+  visibility, so an identity match can never reach across orgs; the workspace
+  segment above closes the remaining same-org, cross-tenant collision.
 
 ## 3. Data-model changes (`packages/control-plane/prisma/schema.prisma`)
 
@@ -113,6 +119,7 @@ Visibility tightening applies to **new sessions only**.
 
 ```ts
 conversationKind?: 'dm' | 'group_dm' | 'channel'
+launchCorrelationId?: string // Web API launch provenance, §4.4
 ```
 
 The daemon already knows this (`NormalizedMessage.isDm` / `isGroupDm`,
@@ -129,28 +136,43 @@ The CP classifies once, in the `event/session` ingest path
 (`ws/handlers/event-session.ts` → `session.recordMilestone`), first-wins like
 the other origin scalars:
 
-| Origin (how detected)                                                        | `visibility` | `ownerIdentity`                                                            |
-| ---------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------- |
-| Webchat / Playground (`platform === 'webchat'`)                              | `private`    | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup |
-| Web API launch (`launchId` present, launch principal known)                  | `private`    | `user:<launch creator userId>`                                             |
-| IM DM (`conversationKind` = `dm`)                                            | `private`    | `<platform>:<triggeredBy>`                                                 |
-| IM group DM (`conversationKind` = `group_dm`)                                | `org`        | `null`                                                                     |
-| IM channel (`conversationKind` = `channel` or absent)                        | `org`        | `null`                                                                     |
-| Automation: cron / hook / dream / agent-to-agent (`triggeredBy` prefix/UUID) | `org`        | `null`                                                                     |
+| Origin (how detected)                                 | `visibility`    | `ownerIdentity`                                                                                                                       |
+| ----------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Webchat / Playground (`platform === 'webchat'`)       | `private`       | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
+| Web API session launch (§4.4 correlation)             | `private`       | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
+| IM DM (`conversationKind` = `dm`)                     | `private`       | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| IM group DM (`conversationKind` = `group_dm`)         | `org`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| IM channel (`conversationKind` = `channel` or absent) | `org`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| Agent-to-agent child (`triggeredBy` is an agent UUID) | inherits parent | inherits parent's `ownerIdentity`; parent unresolved ⇒ `private`, `null` (fail closed)                                                |
+| Automation: cron / hook / dream                       | `org`           | `null`                                                                                                                                |
 
 Notes:
 
+- **Fail closed on missing ownership metadata.** A classification rule that
+  defaults to `private` must never widen to `org` because a lookup failed —
+  that would turn a metadata inconsistency into disclosure. An unresolvable
+  owner yields `private` + `ownerIdentity = null` (an owner-orphan, visible to
+  org owners only, recoverable via §4.3).
 - Webchat `triggeredBy` is the console user's **email** (set in
   `routes/webchat-token.ts`), which degrades under devAuth and is not a stable
   key — hence the `WebchatConversation` lookup rather than trusting the wire
-  value. Under devAuth the stub principal has no conversation row mismatch
-  concern; if the lookup misses, fall back to `org`.
-- `group_dm` defaults to `org`, like a channel: `ownerIdentity` can only
-  record one person, so treating a multi-party conversation as `private`
-  would hide it from its own participants. Multi-participant conversations
-  are treated as team-visible; a participant who wants it hidden can
-  re-classify it via §4.3 once identity linking makes them the recognizable
-  owner (org owners can always re-classify).
+  value.
+- **`ownerIdentity` is recorded for every human-triggered session regardless
+  of visibility** (DM, group DM, and channel alike). It is orthogonal to the
+  visibility default: for `org` sessions it is provenance and the anchor for
+  §4.3 reclassification rights, not an access gate.
+- `group_dm` defaults to `org`, like a channel: a multi-party conversation
+  treated as `private` would hide it from its own participants, since the
+  predicate can match only one owner. The initiator (or an org owner) can
+  pull it `private` via §4.3.
+- **Agent-to-agent children inherit.** A delegation from a private DM or
+  Playground session copies the delegated prompt into the child transcript;
+  classifying children `org` would expose that to every viewer of the target
+  agent. The child takes the parent's `visibility` + `ownerIdentity` at
+  ingest. `parentSessionId` has no FK and cross-daemon ordering means the
+  parent row may not exist yet — in that case the child is classified
+  `private`/`null` (fail closed) and re-reconciled when the parent's milestone
+  lands.
 
 ### 4.3 Changing visibility after the fact
 
@@ -158,8 +180,28 @@ Notes:
 `{ visibility: 'private' | 'org' }`. Allowed for the session owner (identity
 match) and org owners; collaborators/viewers cannot re-classify other people's
 sessions. This is the escape hatch for both directions: publishing a useful DM
-transcript to the org, or pulling a channel-born session private (org owners
-only, since a channel session has no owner).
+transcript to the org, or pulling a channel/group-DM session private (its
+recorded initiator — once identity linking makes them matchable — or an org
+owner).
+
+### 4.4 Web API launch provenance
+
+The Web API rule in §4.2 is not implementable from what exists today:
+`AgentLaunch` has no creator column, its `launchId` is an agent-runtime
+lifecycle fence (part of the `sessionEpoch`/`seq`/`launchId` fencing tuple),
+and daemon `event/session` telemetry does not populate it. Ownership therefore
+needs explicit provenance:
+
+- The Web API session-launch flow is CP-mediated: the authenticated principal
+  (personal API key → `userId`) is known at the moment the CP issues the
+  launch command. The CP mints a **launch correlation id** and records
+  `correlationId → user:<userId>` (new column or side table on the launch
+  record — distinct from the fencing `launchId`).
+- The daemon echoes the correlation id in the session's `event/session` frame
+  (optional protocol field, added alongside `conversationKind` in §4.1).
+- At ingest, a frame carrying a known correlation id classifies the session
+  `private` with that owner. A Web API launch whose correlation cannot be
+  resolved fails closed per §4.2.
 
 ## 5. Enforcement points (control-plane)
 
@@ -175,13 +217,13 @@ canViewSession(s, ctx, identitySet) =
 All of these already gate on agent visibility; each additionally applies the
 session predicate:
 
-| Surface                       | Where                                                                                     | Change                                                                                                                                                |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, skipped for org owners                                                              |
-| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | apply `canViewSession` after the agent gate; fail as 404                                                                                              |
-| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; invisible parent already renders `null`                                                                                               |
-| SSE                           | `http/routes/stream.ts`                                                                   | today filters per **agent**; must additionally drop `event/session` envelopes for invisible sessions, else private-session live updates leak org-wide |
-| Usage                         | `http/routes/usage.ts`                                                                    | same predicate on session-grained reads; org-aggregate rollups stay org-visible                                                                       |
+| Surface                       | Where                                                                                     | Change                                                                                                                                                                                                                                                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, skipped for org owners                                                                                                                                                                                                           |
+| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | apply `canViewSession` after the agent gate; fail as 404                                                                                                                                                                                                                                           |
+| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; invisible parent already renders `null`                                                                                                                                                                                                                                            |
+| SSE                           | `http/routes/stream.ts`                                                                   | today filters per **agent**; must apply the session predicate to **every session-scoped envelope variant** — both `event/session` milestones and `event/session-activity` invalidations (the latter still expose `sessionId`, revision, and live activity), plus any future session-bearing frames |
+| Usage                         | `http/routes/usage.ts`                                                                    | same predicate on session-grained reads; org-aggregate rollups stay org-visible                                                                                                                                                                                                                    |
 
 Invariants preserved:
 
@@ -191,6 +233,24 @@ Invariants preserved:
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
   authorization boundary; the predicate is applied regardless.
+
+### 5.1 Agent-scoped memory is a bypass — must be plugged
+
+Console read gates alone do not contain private content: **managed memory is
+agent-scoped and shared across users.** A private DM/Playground turn can be
+distilled into agent memory (including by dream sessions) and later surface —
+via memory reads or recall in someone else's session — to any user who can
+view the agent, bypassing every gate in the table above.
+
+Mitigation is **daemon-local**, preserving the invariant that CP visibility
+never crosses the wire: the daemon already knows a turn's origin without any
+CP round-trip (`isDm`, `platform === 'webchat'`, the §4.4 launch correlation).
+By default it must **exclude private-origin turns from agent-scoped memory
+capture** (dream distillation included). Per-owner memory namespaces are a
+possible future relaxation, but exclusion is the shipping requirement — the
+`private` tier's guarantee is dishonest without it. If exclusion is deferred,
+the product docs must explicitly narrow the guarantee ("private hides the
+transcript, not what the agent learned from it"); silence is not an option.
 
 ## 6. Web console
 
@@ -204,8 +264,9 @@ Invariants preserved:
 
 ## 7. Identity linking (future, separate design)
 
-A `UserIdentity` table (`userId`, `platform`, `platformUserId`, verified-at,
-unique on `(platform, platformUserId)` per org or globally) populated by an
+A `UserIdentity` table (`userId`, `platform`, `workspace`, `platformUserId`,
+verified-at, unique on the `(platform, workspace, platformUserId)` tuple —
+matching the three-part identity format of §2) populated by an
 explicit link flow (e.g. the bot DMs a code, the user pastes it in the
 console). Once it exists, the BFF's identity-set computation reads it and
 owner-orphan DM sessions light up for their owners retroactively — no session
@@ -224,10 +285,15 @@ link ends public access without touching the session row.
 ## 9. Test plan
 
 - **Unit (`test:unit`):** `canViewSession` truth table (role × visibility ×
-  identity match × orphan owner); ingest classification table from §4.2
-  including webchat-lookup fallback and absent `conversationKind`.
+  identity match × orphan owner); ingest classification table from §4.2,
+  including every fail-closed path (webchat lookup miss, unresolved launch
+  correlation, unresolved parent) and absent `conversationKind`; child
+  inheritance + reconciliation when the parent milestone arrives late.
 - **Integration (`test:int`):** list/detail/SSE visibility for a two-member
   org (owner sees all; collaborator sees own private + org sessions only);
-  keyset pagination stability under the new predicate; migration backfill
-  (`org` + `orgId`) on seeded legacy rows; visibility PUT authorization
-  matrix.
+  SSE assertion that **neither** `event/session` nor `event/session-activity`
+  for a private session reaches an unauthorized subscriber; keyset pagination
+  stability under the new predicate; migration backfill (`org` + `orgId`) on
+  seeded legacy rows; visibility PUT authorization matrix (initiator of an
+  `org` channel session may pull it private; a non-owner collaborator may
+  not).

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -1,0 +1,233 @@
+# Session Visibility
+
+> **Status:** Proposed. Nothing in this document is implemented yet.
+>
+> **Scope:** protocol + control-plane + web. The daemon changes are limited to
+> reporting one extra field on the existing `event/session` telemetry frame;
+> the execution data plane is otherwise unaffected. Sharing is enforced only on
+> Console/BFF read paths — it never crosses the daemon wire, consistent with
+> [resource-visibility.md](resource-visibility.md).
+
+## 1. Background and goals
+
+Sessions currently have **no visibility of their own** — they derive entirely
+from the owning agent (see the taxonomy in
+[resource-visibility.md §2](resource-visibility.md)). Any org member who can
+view an agent sees **every** session of that agent, including other members'
+platform DMs and other members' Playground conversations. `session_meta` has no
+`orgId`, no owner column, and no `visibility` column; the only tenancy anchor is
+`agentId → agent.orgId`.
+
+This design gives every session its own visibility:
+
+- **`private`** — visible only to the session owner (and org owners, via the
+  governance exception). Default for platform **DM** sessions, **Playground /
+  webchat** sessions, and sessions launched through the **Web API**.
+- **`org`** — visible to every org member who can view the owning agent.
+  Default for IM **channel** sessions and automation-originated sessions
+  (cron, hook, dream, agent-to-agent).
+- **Share-by-link ("public")** — future work; a session with an active share
+  link is readable by anyone holding the link. Deliberately **not** a member of
+  the visibility enum; see §8.
+
+Session visibility **composes with** agent visibility: a session is visible iff
+the viewer can view the owning agent **and** passes the session-level
+predicate. It never widens agent visibility.
+
+## 2. The owner identity problem
+
+The daemon does not know Control-Plane user ids. What it knows is the platform
+sender id: `SessionMeta.triggeredBy` is an opaque, platform-namespaced string
+(a Slack/Discord/Telegram/Feishu user id, an agent UUID, `cron:<id>`,
+`hook:<id>`, or — for webchat — the console user's email). There is no
+platform-identity → `app_user` mapping today
+([resource-visibility.md §14.3](resource-visibility.md) lists it as future
+work).
+
+**Decision: the owner is a namespaced identity string, not a `User` FK.**
+
+```
+ownerIdentity :=
+  user:<app_user_id>          — console-originated (webchat, Web API launch)
+  <platform>:<platform_uid>   — IM-originated, e.g. slack:U0123ABCD, feishu:ou_...
+```
+
+Matching is set membership: at request time the BFF computes the viewer's
+**identity set** — today just `{ user:<userId> }`, later expanded with the
+user's linked platform identities — and a `private` session is visible when
+`ownerIdentity ∈ identitySet`.
+
+Consequences:
+
+- Before the identity mapping exists, a `private` IM DM session is an
+  **owner-orphan**: no console user matches `slack:U…`, so only org owners see
+  it. This is accepted — it errs toward hiding a DM rather than exposing it.
+- When identity linking ships, those sessions become visible to the mapped
+  user **automatically**, with no backfill: the stored `ownerIdentity` is
+  already correct; only the viewer's identity set grows.
+- Platform uids are scoped per workspace/tenant (a Slack user id is unique per
+  workspace). The predicate is always additionally scoped by `orgId` and by
+  agent visibility, so cross-org collisions are not reachable; a same-org
+  collision across two workspaces of the same platform is theoretical and
+  accepted. If it ever matters, the identity format can grow a tenant segment
+  (`slack:<team>:<uid>`) without a schema change.
+
+## 3. Data-model changes (`packages/control-plane/prisma/schema.prisma`)
+
+New enum beside `ResourceVisibility`:
+
+```prisma
+enum SessionVisibility {
+  private
+  org
+}
+```
+
+Three new columns on `SessionMeta`:
+
+```prisma
+orgId         String            // denormalized from agent.orgId at ingest
+visibility    SessionVisibility @default(org)
+ownerIdentity String?           // §2 format; null for automation/legacy rows
+```
+
+- `orgId` is denormalized so the list predicate and its index do not join
+  `agent`. All existing paging indexes are `agentId`-prefixed; add
+  `@@index([orgId, visibility, lastActivityAt(sort: Desc), id])` for the
+  org-wide session list, keeping the existing keyset-pagination shape.
+- No `sharedWith String[]` on sessions in this iteration. Per-session
+  member-sharing can be added later with the same GIN pattern as agents;
+  share-by-link (§8) covers the near-term "share this session" ask.
+
+**Migration / backfill:** existing rows get `orgId` from their agent and
+`visibility = 'org'`. Do **not** retro-classify DMs: the `thread === 'dm'`
+convention is Slack/Discord-only (Feishu writes the chat id), and wrongly
+flipping a session to `private` yanks it from members who can see it today.
+Visibility tightening applies to **new sessions only**.
+
+## 4. Classifying sessions at ingest
+
+### 4.1 Protocol: one new field
+
+`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains:
+
+```ts
+conversationKind?: 'dm' | 'group_dm' | 'channel'
+```
+
+The daemon already knows this (`NormalizedMessage.isDm` / `isGroupDm`,
+`packages/daemon/src/messages/normalized.ts`); it is currently daemon-local and
+never reaches the CP. The `thread === 'dm'` heuristic and an
+`IntegrationChannel.kind` join were both considered and rejected: the former is
+platform-inconsistent, the latter does not cover webhook/generic ingress and
+moves a write-time fact to read time. Optional field ⇒ old daemons remain
+compatible (absent = `channel` behavior, i.e. `org`).
+
+### 4.2 Default rules
+
+The CP classifies once, in the `event/session` ingest path
+(`ws/handlers/event-session.ts` → `session.recordMilestone`), first-wins like
+the other origin scalars:
+
+| Origin (how detected)                                                        | `visibility` | `ownerIdentity`                                                            |
+| ---------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------- |
+| Webchat / Playground (`platform === 'webchat'`)                              | `private`    | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup |
+| Web API launch (`launchId` present, launch principal known)                  | `private`    | `user:<launch creator userId>`                                             |
+| IM DM (`conversationKind` = `dm`)                                            | `private`    | `<platform>:<triggeredBy>`                                                 |
+| IM group DM (`conversationKind` = `group_dm`)                                | `org`        | `null`                                                                     |
+| IM channel (`conversationKind` = `channel` or absent)                        | `org`        | `null`                                                                     |
+| Automation: cron / hook / dream / agent-to-agent (`triggeredBy` prefix/UUID) | `org`        | `null`                                                                     |
+
+Notes:
+
+- Webchat `triggeredBy` is the console user's **email** (set in
+  `routes/webchat-token.ts`), which degrades under devAuth and is not a stable
+  key — hence the `WebchatConversation` lookup rather than trusting the wire
+  value. Under devAuth the stub principal has no conversation row mismatch
+  concern; if the lookup misses, fall back to `org`.
+- `group_dm` defaults to `org`, like a channel: `ownerIdentity` can only
+  record one person, so treating a multi-party conversation as `private`
+  would hide it from its own participants. Multi-participant conversations
+  are treated as team-visible; a participant who wants it hidden can
+  re-classify it via §4.3 once identity linking makes them the recognizable
+  owner (org owners can always re-classify).
+
+### 4.3 Changing visibility after the fact
+
+`PUT /orgs/:orgId/sessions/:id/visibility` with body
+`{ visibility: 'private' | 'org' }`. Allowed for the session owner (identity
+match) and org owners; collaborators/viewers cannot re-classify other people's
+sessions. This is the escape hatch for both directions: publishing a useful DM
+transcript to the org, or pulling a channel-born session private (org owners
+only, since a channel session has no owner).
+
+## 5. Enforcement points (control-plane)
+
+The authoritative predicate, mirroring `canView`:
+
+```ts
+canViewSession(s, ctx, identitySet) =
+  ctx.role === 'owner' || // governance exception
+  s.visibility === 'org' ||
+  (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
+```
+
+All of these already gate on agent visibility; each additionally applies the
+session predicate:
+
+| Surface                       | Where                                                                                     | Change                                                                                                                                                |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, skipped for org owners                                                              |
+| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | apply `canViewSession` after the agent gate; fail as 404                                                                                              |
+| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; invisible parent already renders `null`                                                                                               |
+| SSE                           | `http/routes/stream.ts`                                                                   | today filters per **agent**; must additionally drop `event/session` envelopes for invisible sessions, else private-session live updates leak org-wide |
+| Usage                         | `http/routes/usage.ts`                                                                    | same predicate on session-grained reads; org-aggregate rollups stay org-visible                                                                       |
+
+Invariants preserved:
+
+- The daemon wire is unaffected: internal reads keep the deliberate
+  fail-open (`visibilityWhere(undefined)` semantics) — visibility is a Console
+  concern, never an execution-plane concern.
+- 404, never 403, for invisible sessions (no existence oracle).
+- A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
+  authorization boundary; the predicate is applied regardless.
+
+## 6. Web console
+
+- Session list / homepage: no new affordance needed for correctness — the BFF
+  simply returns fewer rows. Add a visibility badge (lock icon for `private`)
+  and, on the session detail page, the visibility toggle from §4.3 for those
+  allowed to use it.
+- The existing client-side "mine" heuristic
+  (`packages/web/src/lib/session-trigger.ts` email/userId matching) stays as a
+  display concern (the "you" label) but is no longer doing authorization work.
+
+## 7. Identity linking (future, separate design)
+
+A `UserIdentity` table (`userId`, `platform`, `platformUserId`, verified-at,
+unique on `(platform, platformUserId)` per org or globally) populated by an
+explicit link flow (e.g. the bot DMs a code, the user pastes it in the
+console). Once it exists, the BFF's identity-set computation reads it and
+owner-orphan DM sessions light up for their owners retroactively — no session
+backfill, per §2.
+
+## 8. Share-by-link (future, separate design)
+
+Modeled on `OrgInviteLink`: a `SessionShareLink` row with peppered `tokenHash`,
+`displayTail`, `expiresAt`, `revokedAt`, `createdByUserId`. Read path is a
+**separate, org-scope-free, read-only route** (the `/orgs/:orgId` subtree
+404s non-members by design, so public reads cannot live there), proxying the
+same bounded transcript reads the BFF already does. "Public" is therefore a
+property of an active link's existence, not a third enum member — revoking the
+link ends public access without touching the session row.
+
+## 9. Test plan
+
+- **Unit (`test:unit`):** `canViewSession` truth table (role × visibility ×
+  identity match × orphan owner); ingest classification table from §4.2
+  including webchat-lookup fallback and absent `conversationKind`.
+- **Integration (`test:int`):** list/detail/SSE visibility for a two-member
+  org (owner sees all; collaborator sees own private + org sessions only);
+  keyset pagination stability under the new predicate; migration backfill
+  (`org` + `orgId`) on seeded legacy rows; visibility PUT authorization
+  matrix.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -211,6 +211,25 @@ effective state (§5.1). The response/UI must surface the memory caveat from
 §5.1: tightening stops future capture but does not scrub what agent memory
 already distilled while the session was org-visible.
 
+### 4.4 Web API launch provenance
+
+The Web API rule in §4.2 is not implementable from what exists today:
+`AgentLaunch` has no creator column, its `launchId` is an agent-runtime
+lifecycle fence (part of the `sessionEpoch`/`seq`/`launchId` fencing tuple),
+and daemon `event/session` telemetry does not populate it. Ownership therefore
+needs explicit provenance:
+
+- The Web API session-launch flow is CP-mediated: the authenticated principal
+  (personal API key → `userId`) is known at the moment the CP issues the
+  launch command. The CP mints a **launch correlation id** and records
+  `correlationId → user:<userId>` (new column or side table on the launch
+  record — distinct from the fencing `launchId`).
+- The daemon echoes the correlation id in the session's `event/session` frame
+  (optional protocol field, added alongside `conversationKind` in §4.1).
+- At ingest, a frame carrying a known correlation id classifies the session
+  `private` with that owner. A Web API launch whose correlation cannot be
+  resolved fails closed per §4.2.
+
 ### 4.5 A2A inheritance: durable reconciliation semantics
 
 Inheritance must survive out-of-order arrival and later human changes without
@@ -235,25 +254,6 @@ state marker:
 - **Parent widened later (`private` → `org`).** Never cascades. Each
   descendant stays as classified; widening a child remains a per-session §4.3
   decision by its owner or an org owner.
-
-### 4.4 Web API launch provenance
-
-The Web API rule in §4.2 is not implementable from what exists today:
-`AgentLaunch` has no creator column, its `launchId` is an agent-runtime
-lifecycle fence (part of the `sessionEpoch`/`seq`/`launchId` fencing tuple),
-and daemon `event/session` telemetry does not populate it. Ownership therefore
-needs explicit provenance:
-
-- The Web API session-launch flow is CP-mediated: the authenticated principal
-  (personal API key → `userId`) is known at the moment the CP issues the
-  launch command. The CP mints a **launch correlation id** and records
-  `correlationId → user:<userId>` (new column or side table on the launch
-  record — distinct from the fencing `launchId`).
-- The daemon echoes the correlation id in the session's `event/session` frame
-  (optional protocol field, added alongside `conversationKind` in §4.1).
-- At ingest, a frame carrying a known correlation id classifies the session
-  `private` with that owner. A Web API launch whose correlation cannot be
-  resolved fails closed per §4.2.
 
 ## 5. Enforcement points (control-plane)
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -409,8 +409,9 @@ two layers:
 reliably attributed back to source turns, so tightening a session stops
 _future_ capture but does not retract what was distilled while it was
 org-visible. This is a stated product caveat, surfaced in the §4.3 flow —
-the guarantee is "private stops the transcript and stops feeding shared
-memory from the moment of tightening", not retroactive amnesia.
+the guarantee is "private hides the transcript at CP commit and stops
+feeding shared memory once every affected daemon has acked (`applied`)",
+not retroactive amnesia.
 
 Per-owner memory namespaces are a possible future relaxation, but the
 exclusion gate is the shipping requirement — the `private` tier's guarantee
@@ -468,4 +469,11 @@ link ends public access without touching the session row.
   tightening in either commit order never yields an org-visible child of a
   private parent, including the depth-2 interleaving (grandchild insert
   racing an ancestor cascade); tighten-cutover staging — the §4.3 response
-  stays `pending` until daemon ACK and flips to `applied`.
+  stays `pending` until daemon ACK and flips to `applied`; the §5.1 capture
+  gate — an A2A child starts with capture excluded, an `org` child opens
+  capture only after its CP-confirmed gate frame (exercising the initial
+  revision, so local fail-closed state is not mistaken for an
+  already-stored duplicate), and a stale-`org` delegation racing a parent
+  tighten never opens capture; duplicate delivery — losing the first ACK
+  and retrying with an equal revision yields a fresh ACK without
+  reapplying state.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -108,7 +108,13 @@ orgId            String            // denormalized from agent.orgId at ingest
 visibility       SessionVisibility @default(org)
 ownerIdentity    String?           // §2 format; null for automation/legacy rows
 visibilitySource VisibilitySource  @default(default)
+visibilityRev    Int               @default(0) // monotonic, bumped in the same
+                                               // tx as any visibility change (§5.1)
 ```
+
+`visibilityRev` is a **dedicated counter**: the existing transcript revision
+and WS sequence numbers version different things and are not reused for the
+privacy gate.
 
 ```prisma
 enum VisibilitySource {
@@ -272,15 +278,21 @@ after the parent has been tightened, retaining stale org visibility. Both
 operations must serialize on the parent row:
 
 - Child ingest classifies inside the same transaction as the child insert and
-  takes a shared row lock on the parent (`SELECT … FOR SHARE`).
-- The §4.3 tightening handler locks the parent `FOR UPDATE` and updates all
-  descendants in the same transaction.
+  takes a shared row lock on its **immediate parent** (`SELECT … FOR SHARE`).
+- The §4.3 tightening handler cascades **lock-then-scan, level by level, to a
+  fixpoint**: lock the tightened session `FOR UPDATE`; then repeatedly lock
+  the current frontier's children `FOR UPDATE` and update them, re-scanning
+  each level _after_ its parent locks are held, until no new descendants
+  appear. A scan-everything-then-update cascade is **not** sufficient: a
+  grandchild insert holding `FOR SHARE` on its mid-level parent could commit
+  a stale snapshot after a one-shot scan missed it.
 
-Either the child commits first — and the cascade, which enumerates
-descendants inside its transaction, includes it — or the cascade commits
-first and the child's classification reads `private`. No interleaving can
-produce an org-visible child of a private parent. The integration test plan
-(§9) exercises this with concurrent ingest + tighten.
+This closes the race at every depth by induction on the level: for any
+descendant D with parent P, either the cascade acquires `FOR UPDATE` on P
+first — D's `FOR SHARE` waits and D then reads P as `private` — or D's
+insert commits first, and the cascade's post-lock re-scan of P's children
+sees D and updates it. The integration test plan (§9) exercises both commit
+orders, including the depth-2 grandchild interleaving.
 
 ## 5. Enforcement points (control-plane)
 
@@ -346,18 +358,40 @@ two layers:
    The push must be **durable, not fire-and-forget**, or races and restarts
    reopen the bypass:
 
-   - Each frame carries a **monotonic revision** per session (the CP already
-     versions session state); the daemon ignores stale revisions.
+   - Each frame carries the session's **`visibilityRev`** (§3) — a dedicated
+     durable counter bumped atomically in the same transaction as every
+     visibility change, settlement, and cascade. It is deliberately **not**
+     the transcript revision (a daemon-local cursor) nor the WS
+     `sessionEpoch`/`seq` fences (connection-scoped); neither advances with
+     visibility. The daemon ignores frames whose rev is ≤ its stored rev.
    - The daemon **acknowledges** the frame and persists the gate state (with
-     its revision) in its local store alongside the session; the CP retries
+     its rev) in its local store alongside the session; the CP retries
      unacked frames, per the WS channel's existing command semantics.
-   - On daemon **register/reconnect**, the CP replays the current privacy
-     state for the daemon's active sessions (a snapshot, not a diff), closing
-     the window where a change happened while the daemon was offline.
-   - **Fail closed:** a session whose gate state is missing or whose pending
-     update is unconfirmed (e.g. right after a restart, before the snapshot
-     lands) is treated as private for capture purposes until the CP confirms
+   - On daemon **register/reconnect**, the CP replays the current
+     `(sessionId, private?, visibilityRev)` set for the daemon's active
+     sessions (a snapshot, not a diff), closing the window where a change
+     happened while the daemon was offline.
+   - **Fail closed on known-unknown state:** a session whose _locally stored_
+     gate state is missing or pre-snapshot (e.g. right after a daemon
+     restart) is treated as private for capture until the snapshot confirms
      otherwise. A missed or delayed frame can only under-capture, never leak.
+
+   **Tightening cutover is staged, not instantaneous.** A daemon cannot fail
+   closed for an update it has not yet learned exists: between the CP
+   committing `private` and the daemon applying the frame, the daemon
+   legitimately holds confirmed `org` state — a concurrent turn can still be
+   captured, and an A2A delegation can carry the stale bit. The design makes
+   this window explicit rather than pretending it away:
+
+   - **CP-side read gates apply at commit**: list/detail/SSE hide the session
+     immediately.
+   - **The memory boundary takes effect at daemon ACK.** The §4.3 endpoint
+     reports the tighten as `pending` until every affected daemon has acked
+     the new rev, then `applied`; the console shows that state. Turns
+     captured inside the window fall under the existing "already captured is
+     not scrubbed" caveat — the promise is "capture stops at daemon
+     acknowledgement, typically sub-second", not "at the moment of the API
+     call".
 
 **Already-captured memory is not scrubbed.** Distilled memory cannot be
 reliably attributed back to source turns, so tightening a session stops
@@ -420,4 +454,6 @@ link ends public access without touching the session row.
   `org` channel session may pull it private; a non-owner collaborator may
   not); the §4.5 serialization race — concurrent child ingest and parent
   tightening in either commit order never yields an org-visible child of a
-  private parent.
+  private parent, including the depth-2 interleaving (grandchild insert
+  racing an ancestor cascade); tighten-cutover staging — the §4.3 response
+  stays `pending` until daemon ACK and flips to `applied`.


### PR DESCRIPTION
## Summary

Design proposal for per-session visibility (`docs/designs/session-visibility.md`): sessions get their own `private` / `org` tier instead of inheriting everything from the owning agent (today any org member sees every session, including other members' platform DMs and Playground conversations). Share-by-link ("public") is scoped as future work, deliberately outside the visibility enum.

Key decisions (as refined through review):

- **Owner as a namespaced identity string**, not a `User` FK: `user:<app_user_id>` for console origins, `<platform>:<workspace>:<uid>` for IM — the workspace segment is a durable tenant identifier carried on the wire via a new `transportScope` telemetry field, never reconstructed at CP ingest. Private IM DMs work before identity linking exists (owner-orphans, org-owner recovery only) and light up automatically once it ships.
- **Defaults:** 1:1 DMs, Playground/webchat, and Web API launches are `private`; channels, group DMs, and cron/hook/dream automation are `org`. **A2A children inherit the parent's visibility/owner**, failing closed (`private`/orphan, `inherited_pending`) when the parent is unresolved.
- **Classification at ingest** via three optional `EventSession` fields (`conversationKind`, `transportScope`, `launchCorrelationId`); every fail-closed path is specified — missing ownership metadata never widens visibility.
- **Durable reconciliation** (`visibilitySource` state machine): conditional one-time settlement for out-of-order children; parent tightening cascades transitively via lock-then-scan-per-level to a fixpoint (closes the depth-N insert race); widening never cascades; `explicit` blocks settlement but not ancestor tightening.
- **Enforcement** on all CP/BFF read paths (list SQL predicate, detail/messages/tool-body, children, SSE incl. `event/session-activity`, usage).
- **Agent-scoped memory bypass plugged** (§5.1): daemon-local origin exclusion plus a CP-pushed per-session privacy bit over the daemon WS — versioned (`visibilityRev`), ACKed (duplicates re-ACKed without reapplying), snapshot-replayed on reconnect, fail-closed on missing local state. The A2A delegation flag is one-directional (can only tighten). Tighten cutover is staged: transcript hides at CP commit, memory capture stops at daemon ACK (`pending` → `applied`); already-distilled memory is explicitly not scrubbed.
- Existing sessions backfill to `org` with no retro-classification; identity linking and share-by-link are separate future designs.

Doc only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)