### PR TITLE
fix(feishu): recover legacy app ids

### DIFF
--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1362,8 +1362,9 @@ model Relay {
 //   read/write path for tokens. `none` stores plaintext; an encrypting provider
 //   stores ciphertext. `integration` is the install: it binds ONE bot to
 //   ONE agent (`botId` unique ⇒ a bot serves at most one agent at a time) and
-//   is what the owning daemon opens the socket from. The metadata read paths
-//   (GET /bots, GET /integrations) never select the secret table.
+//   is what the owning daemon opens the socket from. Metadata reads never join
+//   the secret table. GET /bots may recover a legacy Feishu/Lark public App ID
+//   through BotSecretStore, then persist it on bot for subsequent reads.
 // ───────────────────────────────────────────────────────────────────────────
 
 model Bot {

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -5,8 +5,9 @@
  * A bot outlives the integration installing it: the console's "Add integration"
  * picker reads this list to offer freed / prebuilt bots for reuse instead of
  * forcing a re-create. Metadata only — token material never leaves the
- * `BotSecretStore`. Deleting is refused while the bot is installed (the
- * integration's Restrict FK backstops).
+ * `BotSecretStore`. Legacy Feishu/Lark rows may recover their public App ID
+ * through that store and persist it back onto `bot`. Deleting is refused while
+ * the bot is installed (the integration's Restrict FK backstops).
  */
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
@@ -31,7 +32,7 @@ import { resolveUserConfigAccessToken } from '../slack-user-config.js'
 import { mergeManagedSlackManifest, slackOAuthRedirectUri, SLACK_BOT_SCOPES } from '../slack-manifest.js'
 import { relayHttpBase } from './slack-install.js'
 
-function toDto(b: BotRecord): BotDtoT {
+function toDto(b: BotRecord, feishuAppId: string | null = b.feishuAppId): BotDtoT {
   return {
     id: b.id,
     name: b.name,
@@ -39,7 +40,7 @@ function toDto(b: BotRecord): BotDtoT {
     prebuilt: b.prebuilt,
     slackAppId: b.slackAppId,
     discordAppId: b.discordAppId,
-    feishuAppId: b.feishuAppId,
+    feishuAppId,
     feishuRegion: b.feishuRegion,
     // Creator's userId (web resolves to a name / "You"); synthetic-email placeholder ⇒
     // non-human creator ⇒ null (the console shows the prebuilt/"—" fallback).
@@ -87,6 +88,27 @@ export function slackAppLinks(
 export function botRoutes(deps: HttpDeps) {
   return async function botRoutesPlugin(app: FastifyInstance): Promise<void> {
     const r = app.withTypeProvider<ZodTypeProvider>()
+    const toRecoveredDto = async (bot: BotRecord): Promise<BotDtoT> => {
+      if (bot.platform !== 'feishu' || bot.feishuAppId) return toDto(bot)
+
+      let appId: string | null = null
+      try {
+        appId = (await deps.repos.botSecret.get(bot.id))?.appToken ?? null
+      } catch (err) {
+        app.log.warn({ err, botId: bot.id }, 'failed to recover legacy Feishu app id')
+        return toDto(bot)
+      }
+      if (!appId || !/^cli_[A-Za-z0-9]+$/.test(appId)) return toDto(bot)
+
+      try {
+        await deps.repos.bot.setFeishuAppIdIfMissing(bot.id, appId)
+      } catch (err) {
+        // The recovered public id is still safe and useful for this response;
+        // a later roster read can retry the durable metadata backfill.
+        app.log.warn({ err, botId: bot.id }, 'failed to backfill legacy Feishu app id')
+      }
+      return toDto(bot, appId)
+    }
 
     r.get(
       '/bots',
@@ -102,7 +124,7 @@ export function botRoutes(deps: HttpDeps) {
       },
       async (req) => {
         const rows = await deps.repos.bot.listForOrg(orgOf(req))
-        return rows.map(toDto)
+        return Promise.all(rows.map(toRecoveredDto))
       }
     )
 
@@ -123,7 +145,7 @@ export function botRoutes(deps: HttpDeps) {
         if (!bot || bot.orgId !== req.orgCtx!.orgId) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
-        return toDto(bot)
+        return toRecoveredDto(bot)
       }
     )
 
@@ -287,7 +309,7 @@ export function botRoutes(deps: HttpDeps) {
         if (!bot || bot.orgId !== req.orgCtx!.orgId) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
         }
-        if (req.body.shareable === bot.shareable) return toDto(bot) // no-op
+        if (req.body.shareable === bot.shareable) return toRecoveredDto(bot) // no-op
         const observedAgentIds = [...bot.agentIds].sort()
         const release = deps.agentMutations.tryBeginMutation(observedAgentIds)
         if (!release) {
@@ -350,7 +372,7 @@ export function botRoutes(deps: HttpDeps) {
           // ingest re-open; the transport, hence the ingest, is unchanged).
           await deps.httpBot.syncRoutes(bot.id)
           const updated = await deps.repos.bot.get(bot.id)
-          return toDto(updated!)
+          return toRecoveredDto(updated!)
         } finally {
           release()
         }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1862,6 +1862,8 @@ export interface BotRepo {
   listHttpMissingSlackAppId(): Promise<BotRecord[]>
   /** Backfill only a missing id; never replace an established Slack app identity. */
   setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean>
+  /** Recover a legacy Feishu/Lark public App ID without replacing established metadata. */
+  setFeishuAppIdIfMissing(id: BotId, feishuAppId: string): Promise<boolean>
   /** Stamp the freed-bot display hints when its LAST integration is removed. */
   markFreed(id: BotId, at: Date, lastAgentName: string | null): Promise<void>
   /** Flip the shared-bot (multi-agent) opt-in (console toggle). Serialized on the
@@ -2022,9 +2024,10 @@ export interface AgentRepoAuthorizationRepo {
 // routes, protocol, or the daemon.
 // ───────────────────────────────────────────────────────────────────────────
 
-/** Token material for one bot. `appToken` is Slack Socket Mode's app-level token
- *  (null for Telegram / http transport). `signingSecret` is Slack's Events API
- *  request-verification key (http transport; null for socket / Telegram). */
+/** Token material for one bot. `appToken` is Slack Socket Mode's app-level token,
+ *  or Feishu/Lark's public App ID (null for Telegram / http transport).
+ *  `signingSecret` is Slack's Events API request-verification key (http transport;
+ *  null for socket / Telegram). */
 export interface BotSecretMaterial {
   botToken: string
   appToken: string | null

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -135,6 +135,14 @@ export class PgBotRepo implements BotRepo {
     return result.count === 1
   }
 
+  async setFeishuAppIdIfMissing(id: BotId, feishuAppId: string): Promise<boolean> {
+    const result = await this.db.bot.updateMany({
+      where: { id, platform: 'feishu', feishuAppId: null },
+      data: { feishuAppId }
+    })
+    return result.count === 1
+  }
+
   async markFreed(id: BotId, at: Date, lastAgentName: string | null): Promise<void> {
     await this.db.bot.update({ where: { id }, data: { lastUsedAt: at, lastAgentName } })
   }

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -19,7 +19,7 @@ import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import type { IntegrationUpsert, IntegrationRemove } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
-import { OrgId } from '../../src/domain/ids.js'
+import { BotId, OrgId } from '../../src/domain/ids.js'
 import type { SlackConfigApi } from '../../src/http/slack-config-api.js'
 import { SLACK_BOT_EVENTS, SLACK_BOT_SCOPES } from '../../src/http/slack-manifest.js'
 import type { RelayChannel } from '../../src/ws/relay-registry.js'
@@ -787,6 +787,34 @@ describe('bot roster (GET/DELETE /bots)', () => {
     // Slack's app settings); an unexpected token shape leaves it null.
     expect(freed.slackAppId).toBe('A0TESTAPP1')
     expect(busy.slackAppId).toBeNull()
+  })
+
+  it('GET /bots recovers and backfills a legacy Feishu app id through the secret store', async () => {
+    const { app } = withSpy()
+    const botId = BotId(randomUUID())
+    const appId = 'cli_legacylark123'
+    const appSecret = 'legacy-lark-secret'
+    await prisma.bot.create({
+      data: {
+        id: botId,
+        orgId: DEFAULT_ORG_ID,
+        platform: 'feishu',
+        name: 'legacy-lark',
+        feishuRegion: 'lark'
+      }
+    })
+    await app.deps.repos.botSecret.put(botId, {
+      botToken: appSecret,
+      appToken: appId,
+      signingSecret: null
+    })
+
+    const res = await app.app.inject({ method: 'GET', url: `${ORG}/bots` })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual([expect.objectContaining({ id: botId, feishuAppId: appId, feishuRegion: 'lark' })])
+    expect(res.body).not.toContain(appSecret)
+    expect(await prisma.bot.findUnique({ where: { id: botId } })).toMatchObject({ feishuAppId: appId })
   })
 
   it('DELETE /bots refuses while installed (409), succeeds once freed, and drops the secret', async () => {


### PR DESCRIPTION
## Summary

- Recover missing legacy Lark/Feishu App IDs through the existing `BotSecretStore` decryption seam when bot metadata is read.
- Persist the recovered public `cli_…` ID with a compare-and-set backfill so later roster reads stay metadata-only.
- Keep App Secrets out of every DTO while allowing the existing Settings link to open `/app/<app-id>/baseinfo`.

## Root cause

The original SQL migration could backfill only plaintext `bot_secret.appToken` values. Deployments using at-rest encryption retained the App ID inside the encrypted secret row, leaving `bot.feishuAppId` null and forcing the web console onto `/page/launcher`.

## Validation

- Prisma format, generate, and validate
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- Changed-file ESLint and Prettier
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/integrations.route.test.ts` (38 tests)
- Pre-push repository lint (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
