### PR TITLE
fix(web): fall back to app list

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -63,7 +63,7 @@ function botSubline(b: BotDto): string {
 
 function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu' | 'lark'): string {
   const host = region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
-  return appId ? `${host}/app/${encodeURIComponent(appId)}/baseinfo` : `${host}/page/launcher`
+  return appId ? `${host}/app/${encodeURIComponent(appId)}/baseinfo` : `${host}/app`
 }
 
 // One rendered member row, precomputed from the wire DTO.


### PR DESCRIPTION
## Summary

- Keep bots with a stored App ID linked directly to `/app/<app-id>/baseinfo`.
- Send legacy bots without an App ID to the regional developer-console App list (`/app`) instead of the generic launcher.

## Why

The launcher is too broad for a Configure action. The App list is the closest useful destination when the concrete App ID is unavailable.

## Validation

- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`
- Pre-push repository lint (0 errors; 2 pre-existing duplicate-import warnings)

Created by Codex . GPT-5
