### PR TITLE
feat(web): manage social sign-ins in profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,10 +132,13 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # GitHub/Google buttons; unset ⇒ no-auth (the buttons just enter the app). Add
 # the social connectors (target `google`/`github`) inside Logto — the buttons
 # jump straight to them via Logto's direct sign-in.
-# To let signed-in users link another social account from Profile, enable the
-# Account API in Logto Account Center and give Social identities `Edit` access.
-# Also register `https://<logto-endpoint>/account/callback/social/<connector-id>`
-# as an authorized redirect URI with each social provider.
+# To manage social accounts in AgentConnect's own Profile UI, enable Logto's
+# Account API, give Email `ReadOnly` and Social identities `Edit` access, and
+# register `https://<console-origin>/auth/social/callback` with each provider.
+# Google accepts it as an additional authorized redirect URI. A GitHub OAuth App
+# has one callback setting: use a parent URL compatible with both Logto's normal
+# `/callback/<connector-id>` and this console callback (for sibling custom-domain
+# hosts, `https://auth.example.com/` covers both under GitHub's redirect rules).
 # NEXT_PUBLIC_LOGTO_ENDPOINT=https://tenant.example.com/
 # NEXT_PUBLIC_LOGTO_APP_ID=
 # Optional: the CP API resource registered in Logto, for a JWT access token. When

--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui'
+import { Spinner } from '@/components/marks'
+import {
+  accountErrorMessage,
+  saveSocialIdentity,
+  takeSocialLinkFlow,
+  verifySocialVerification,
+  writeAccountNotice
+} from '@/lib/logto-account'
+
+export default function SocialAccountCallback() {
+  const started = useRef(false)
+  const [error, setError] = useState<string>()
+  const [returnTo, setReturnTo] = useState('/')
+
+  useEffect(() => {
+    if (started.current) return
+    started.current = true
+
+    const flow = takeSocialLinkFlow()
+    if (!flow) {
+      setError('This account-linking request expired. Return to Profile and try again.')
+      return
+    }
+    setReturnTo(flow.returnTo)
+
+    const params = new URLSearchParams(window.location.search)
+    const providerError = params.get('error')
+    if (providerError) {
+      setError(
+        providerError === 'access_denied'
+          ? `${flow.providerName} authorization was cancelled.`
+          : `${flow.providerName} could not authorize this account.`
+      )
+      return
+    }
+    if (params.get('state') !== flow.state) {
+      setError('The account-linking response could not be verified. Return to Profile and try again.')
+      return
+    }
+
+    const connectorData = Object.fromEntries(params.entries())
+    connectorData.redirectUri = flow.redirectUri
+    verifySocialVerification(flow.socialVerificationRecordId, connectorData)
+      .then((socialVerificationRecordId) =>
+        saveSocialIdentity(flow.action, socialVerificationRecordId, flow.currentVerificationRecordId)
+      )
+      .then(() => {
+        writeAccountNotice({
+          kind: 'success',
+          message:
+            flow.action === 'add' ? `${flow.providerName} was connected.` : `${flow.providerName} sign-in was changed.`
+        })
+        window.location.replace(flow.returnTo)
+      })
+      .catch((caught) => {
+        setError(accountErrorMessage(caught, { providerName: flow.providerName, linking: true }))
+      })
+  }, [])
+
+  return (
+    <div className="authpage">
+      <div className="m-auto flex max-w-[420px] flex-col items-center gap-[18px] px-6 text-center font-sans text-[14px] font-normal leading-[1.6] text-(--text-secondary)">
+        {!error ? <Spinner size={48} /> : null}
+        <div>{error ?? 'Connecting your sign-in account…'}</div>
+        {error ? (
+          <Button variant="secondary" onClick={() => window.location.replace(returnTo)}>
+            Back to Profile
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import { useEffect, useId, useState } from 'react'
+import useSWR from 'swr'
+import { Avatar, Button, Icon } from '@/components/ui'
+import { initialsFrom } from '@/lib/auth'
+import {
+  LogtoAccountError,
+  accountErrorMessage,
+  createSocialState,
+  createSocialVerification,
+  fetchSignInMethods,
+  removeSocialIdentity,
+  requestEmailVerification,
+  socialIdentityDetails,
+  takeAccountNotice,
+  verifyEmailCode,
+  writeSocialLinkFlow,
+  type AccountNotice,
+  type LogtoAccountProfile,
+  type SocialConnector
+} from '@/lib/logto-account'
+
+type PendingAction = {
+  action: 'add' | 'replace' | 'remove'
+  connector: SocialConnector
+}
+
+function ProviderMark({ connector }: { connector: SocialConnector }) {
+  if (!connector.logo) {
+    return (
+      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-(--surface-active)">
+        <Icon name="link-2" size={15} />
+      </span>
+    )
+  }
+  return (
+    <span className="flex h-7 w-7 items-center justify-center rounded-md bg-white p-1">
+      <img src={connector.logo} alt="" className="max-h-full max-w-full" referrerPolicy="no-referrer" />
+    </span>
+  )
+}
+
+function VerificationDialog({
+  pending,
+  account,
+  onVerified,
+  onClose
+}: {
+  pending: PendingAction
+  account: LogtoAccountProfile
+  onVerified: (verificationRecordId?: string) => Promise<void>
+  onClose: () => void
+}) {
+  const titleId = useId()
+  const [verificationId, setVerificationId] = useState<string>()
+  const [code, setCode] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>()
+  const requiresVerification = account.hasSecurityVerificationMethod
+  const email = account.primaryEmail
+  const isRemove = pending.action === 'remove'
+  const actionLabel =
+    pending.action === 'add'
+      ? `Connect ${pending.connector.name}`
+      : pending.action === 'replace'
+        ? `Change ${pending.connector.name}`
+        : `Remove ${pending.connector.name}`
+  const confirmLabel = isRemove ? `Remove ${pending.connector.name}` : 'Continue'
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !busy) onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [busy, onClose])
+
+  const submit = async () => {
+    setBusy(true)
+    setError(undefined)
+    try {
+      if (!requiresVerification) {
+        await onVerified()
+        return
+      }
+      if (!email) {
+        throw new LogtoAccountError(
+          'This account needs an email verification method before sign-in methods can change.',
+          0
+        )
+      }
+      if (!verificationId) {
+        setVerificationId(await requestEmailVerification(email))
+        return
+      }
+      if (!code.trim()) {
+        setError('Enter the verification code from your email.')
+        return
+      }
+      await onVerified(await verifyEmailCode(email, verificationId, code.trim()))
+    } catch (caught) {
+      setError(
+        accountErrorMessage(caught, {
+          providerName: pending.connector.name,
+          linking: pending.action !== 'remove'
+        })
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="scrim">
+      <div className="modal max-w-[480px]" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="modalhead">
+          <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+            <Icon name={isRemove ? 'unlink' : 'link-2'} size={16} color="var(--brand)" />
+          </span>
+          <span id={titleId} className="flex-1 font-sans text-[16px] font-semibold leading-normal">
+            {actionLabel}
+          </span>
+          <button type="button" className="iconbtn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+        <div className="modalbody">
+          <p className="font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-secondary)">
+            {requiresVerification
+              ? verificationId
+                ? `Enter the code sent to ${email ?? 'your email'} to continue.`
+                : `To protect your account, verify it's you with a code sent to ${email ?? 'your email'}.`
+              : isRemove
+                ? `${pending.connector.name} will no longer be available for signing in to this account.`
+                : `Continue to ${pending.connector.name} to choose the account you want to connect.`}
+          </p>
+          {verificationId ? (
+            <label className="fld mt-4">
+              <span className="fldlbl">Verification code</span>
+              <input
+                className="inp"
+                value={code}
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                autoFocus
+                placeholder="Enter code"
+                onChange={(event) => setCode(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') void submit()
+                }}
+              />
+            </label>
+          ) : null}
+          {error ? (
+            <div className="mt-3 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)" role="alert">
+              {error}
+            </div>
+          ) : null}
+        </div>
+        <div className="modalfoot">
+          <div className="flex-1" />
+          <Button variant="ghost" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant={isRemove && (!requiresVerification || verificationId) ? 'danger' : 'primary'}
+            disabled={busy}
+            onClick={() => void submit()}
+          >
+            {busy ? 'Working…' : requiresVerification && !verificationId ? 'Send code' : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Notice({ notice }: { notice: AccountNotice }) {
+  return (
+    <div
+      className={`border-b border-(--border-subtle) px-4 py-2.5 font-sans text-[12.5px] font-normal leading-normal ${
+        notice.kind === 'success' ? 'text-(--status-online)' : 'text-(--status-error)'
+      }`}
+      role="status"
+    >
+      {notice.message}
+    </div>
+  )
+}
+
+export default function SocialSignInCard({ mobile = false }: { mobile?: boolean }) {
+  const { data, error, isLoading, mutate } = useSWR('logto-account-sign-in-methods', fetchSignInMethods, {
+    revalidateOnFocus: true
+  })
+  const [pending, setPending] = useState<PendingAction>()
+  const [notice, setNotice] = useState<AccountNotice>()
+
+  useEffect(() => setNotice(takeAccountNotice()), [])
+
+  const finishAction = async (verificationRecordId?: string) => {
+    if (!pending || !data) return
+    if (pending.action === 'remove') {
+      await removeSocialIdentity(pending.connector.target, verificationRecordId)
+      await mutate()
+      setPending(undefined)
+      setNotice({ kind: 'success', message: `${pending.connector.name} was disconnected.` })
+      return
+    }
+
+    const state = createSocialState()
+    const redirectUri = `${window.location.origin}/auth/social/callback`
+    const verification = await createSocialVerification(pending.connector.id, redirectUri, state)
+    const stored = writeSocialLinkFlow({
+      state,
+      socialVerificationRecordId: verification.verificationRecordId,
+      ...(verificationRecordId ? { currentVerificationRecordId: verificationRecordId } : {}),
+      action: pending.action,
+      providerName: pending.connector.name,
+      redirectUri,
+      returnTo: `${window.location.pathname}${window.location.search}`,
+      createdAt: Date.now()
+    })
+    if (!stored) {
+      throw new LogtoAccountError('This browser blocked the temporary account-linking state.', 0)
+    }
+    window.location.assign(verification.authorizationUri)
+  }
+
+  const shell = mobile
+    ? 'overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)'
+    : 'card mt-[22px]'
+  const header = mobile ? 'border-b border-(--border-subtle) px-4 py-3' : 'cardhead'
+
+  return (
+    <>
+      <section className={shell} aria-label="Sign-in methods">
+        <div className={header}>
+          <div className={mobile ? '' : 'flex flex-col gap-0.5'}>
+            <div className={mobile ? 'font-sans text-[14px] font-semibold leading-normal' : 'cardtitle'}>
+              Sign-in methods
+            </div>
+            {!mobile ? (
+              <div className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                Connect more than one social account to the same AgentConnect profile.
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {notice ? <Notice notice={notice} /> : null}
+
+        {isLoading ? (
+          <div className="px-4 py-5 font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
+            Loading sign-in methods…
+          </div>
+        ) : error || !data ? (
+          <div className="flex items-center justify-between gap-4 px-4 py-4">
+            <span className="font-sans text-[13px] font-normal leading-normal text-(--status-error)">
+              {accountErrorMessage(error)}
+            </span>
+            <Button variant="secondary" size="xs" onClick={() => void mutate()}>
+              Retry
+            </Button>
+          </div>
+        ) : data.connectors.length === 0 ? (
+          <div className="px-4 py-5 font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
+            No social sign-in methods are configured.
+          </div>
+        ) : (
+          <div>
+            {data.connectors.map((connector, index) => {
+              const identity = data.account.identities[connector.target]
+              const details = identity ? socialIdentityDetails(identity) : undefined
+              return (
+                <div
+                  key={connector.id}
+                  className={`grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 px-4 py-3.5 desktop:grid-cols-[170px_minmax(0,1fr)_auto] ${
+                    index > 0 ? 'border-t border-(--border-subtle)' : ''
+                  }`}
+                >
+                  <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-3">
+                    <ProviderMark connector={connector} />
+                    <span className="truncate font-sans text-[13.5px] font-semibold leading-normal">
+                      {connector.name}
+                    </span>
+                  </div>
+                  <div className="col-span-2 row-start-2 min-w-0 desktop:col-span-1 desktop:col-start-2 desktop:row-start-1">
+                    {identity ? (
+                      <div className="flex min-w-0 items-center gap-2.5">
+                        <Avatar
+                          src={details?.avatar}
+                          initials={initialsFrom(details?.name ?? connector.name, details?.email)}
+                          size={32}
+                          fontSize={11}
+                        />
+                        <div className="min-w-0">
+                          <div className="truncate font-sans text-[13px] font-medium leading-normal">
+                            {details?.name ?? 'Connected'}
+                          </div>
+                          {details?.email ? (
+                            <div className="truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                              {details.email}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
+                        Not connected
+                      </span>
+                    )}
+                  </div>
+                  <div className="col-start-2 row-start-1 flex items-center justify-end gap-1 desktop:col-start-3">
+                    {identity ? (
+                      <>
+                        <Button variant="ghost" size="xs" onClick={() => setPending({ action: 'replace', connector })}>
+                          Change
+                        </Button>
+                        <Button variant="ghost" size="xs" onClick={() => setPending({ action: 'remove', connector })}>
+                          <span className="text-(--status-error)">Remove</span>
+                        </Button>
+                      </>
+                    ) : (
+                      <Button variant="secondary" size="xs" onClick={() => setPending({ action: 'add', connector })}>
+                        <Icon name="plus" size={13} />
+                        Connect
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </section>
+
+      {pending && data ? (
+        <VerificationDialog
+          key={`${pending.action}:${pending.connector.id}`}
+          pending={pending}
+          account={data.account}
+          onVerified={finishAction}
+          onClose={() => setPending(undefined)}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -13,8 +13,9 @@ import { useRouter } from 'next/navigation'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
 import ApiKeysCard from '@/components/console/ApiKeysCard'
+import SocialSignInCard from '@/components/console/SocialSignInCard'
 import SlackConfigCard from '@/components/console/SlackConfigCard'
-import { accountSecurityUrl, isAuthConfigured, logout } from '@/lib/auth'
+import { isAuthConfigured, logout } from '@/lib/auth'
 import { useProfile } from '@/lib/profile'
 import { MOCK_MODE } from '@/lib/data'
 import { useIsMobile } from '@/lib/use-is-mobile'
@@ -64,11 +65,6 @@ export default function ProfileView() {
     else router.push('/login')
   }
 
-  const manageSignIns = () => {
-    const url = accountSecurityUrl(`${window.location.origin}${window.location.pathname}`)
-    if (url) window.location.assign(url)
-  }
-
   if (isMobile) {
     const cardShell =
       'overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)'
@@ -115,17 +111,6 @@ export default function ProfileView() {
               <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">Email</span>
               <span className="font-mono text-[12px] font-medium leading-normal">{user.email}</span>
             </div>
-            {authOn && (
-              <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
-                <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">
-                  Sign-in methods
-                </span>
-                <Button variant="secondary" size="xs" onClick={manageSignIns}>
-                  <Icon name="link-2" size={13} />
-                  Link social account
-                </Button>
-              </div>
-            )}
             <div className="flex items-center justify-between gap-4 px-4 py-3">
               <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary)">
                 Member since
@@ -133,6 +118,8 @@ export default function ProfileView() {
               <span className="font-mono text-[12px] font-medium leading-normal">{memberSince}</span>
             </div>
           </div>
+
+          {authOn ? <SocialSignInCard mobile /> : null}
 
           {/* Personal API keys — the caller's own REST credentials */}
           <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} mobile />
@@ -184,14 +171,6 @@ export default function ProfileView() {
           <KvRow label="Email">
             <span className="mono text-[12.5px]">{user.email}</span>
           </KvRow>
-          {authOn && (
-            <KvRow label="Sign-in methods">
-              <Button variant="secondary" size="xs" onClick={manageSignIns}>
-                <Icon name="link-2" size={13} />
-                Link social account
-              </Button>
-            </KvRow>
-          )}
           <KvRow label="Role">
             <span className={`badge ${roleBadge}`}>{roleLabel}</span>
           </KvRow>
@@ -200,6 +179,8 @@ export default function ProfileView() {
           </KvRow>
         </div>
       </div>
+
+      {authOn ? <SocialSignInCard /> : null}
 
       <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} />
 

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -4,14 +4,23 @@ const logto = vi.hoisted(() => ({
   isAuthenticated: vi.fn(),
   getAccessToken: vi.fn(),
   clearAllTokens: vi.fn(),
-  replace: vi.fn()
+  replace: vi.fn(),
+  clientConfig: undefined as unknown
 }))
 
 vi.mock('@logto/browser', () => ({
   default: class MockLogtoClient {
+    constructor(config: unknown) {
+      logto.clientConfig = config
+    }
     isAuthenticated = logto.isAuthenticated
     getAccessToken = logto.getAccessToken
     clearAllTokens = logto.clearAllTokens
+  },
+  UserScope: {
+    Email: 'email',
+    Profile: 'profile',
+    Identities: 'identities'
   },
   isLogtoRequestError: (error: unknown) => error instanceof Error && error.name === 'LogtoRequestError'
 }))
@@ -27,6 +36,7 @@ describe('getToken', () => {
     logto.getAccessToken.mockReset()
     logto.clearAllTokens.mockReset().mockResolvedValue(undefined)
     logto.replace.mockReset()
+    logto.clientConfig = undefined
     vi.stubGlobal('window', {
       __AC_ENV: {
         LOGTO_ENDPOINT: 'https://login.example.test',
@@ -81,28 +91,14 @@ describe('getToken', () => {
     expect(logto.clearAllTokens).toHaveBeenCalledOnce()
     expect(logto.replace).toHaveBeenCalledOnce()
   })
-})
 
-describe('accountSecurityUrl', () => {
-  beforeEach(() => {
-    vi.resetModules()
-    vi.stubGlobal('window', {
-      __AC_ENV: {
-        LOGTO_ENDPOINT: 'https://login.example.test/',
-        LOGTO_APP_ID: 'web-app'
-      }
-    })
-  })
+  it('mints a resource-less token with the identities scope for the Account API', async () => {
+    logto.getAccessToken.mockResolvedValue('opaque-account-token')
+    const { getAccountToken } = await import('./auth')
 
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
+    await expect(getAccountToken()).resolves.toBe('opaque-account-token')
 
-  it('returns to the current AgentConnect profile after account management', async () => {
-    const { accountSecurityUrl } = await import('./auth')
-
-    expect(accountSecurityUrl('https://console.example.test/acme/profile')).toBe(
-      'https://login.example.test/account/security?redirect=https%3A%2F%2Fconsole.example.test%2Facme%2Fprofile'
-    )
+    expect(logto.getAccessToken).toHaveBeenCalledWith()
+    expect(logto.clientConfig).toMatchObject({ scopes: ['email', 'profile', 'identities'] })
   })
 })

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -18,7 +18,7 @@
 // resource Logto returns an opaque token the CP can't verify, so we fall back to
 // the id token (whose `aud` is the app id — set the CP's OIDC_AUDIENCE to the app
 // id in that case).
-import LogtoClient, { isLogtoRequestError } from '@logto/browser'
+import LogtoClient, { isLogtoRequestError, UserScope } from '@logto/browser'
 import { MOCK_MODE } from '@/lib/data'
 import { identifyUser, resetAnalytics } from '@/lib/analytics'
 
@@ -54,17 +54,11 @@ export function isAuthConfigured(): boolean {
   return Boolean(endpoint && appId)
 }
 
-/**
- * Logto-hosted account security page. It owns the sensitive verification flow
- * for linking and unlinking social sign-in identities, then returns to the
- * caller's Profile page.
- */
-export function accountSecurityUrl(redirectUri: string): string | undefined {
+/** Public tenant values used by the browser-side Logto Account API client. */
+export function getLogtoPublicConfig(): { endpoint: string; appId: string } | undefined {
   const { endpoint, appId } = readConfig()
   if (!endpoint || !appId) return undefined
-  const url = new URL('/account/security', endpoint)
-  url.searchParams.set('redirect', redirectUri)
-  return url.toString()
+  return { endpoint, appId }
 }
 
 let client: LogtoClient | undefined
@@ -79,8 +73,8 @@ function getClient(): LogtoClient | undefined {
       endpoint,
       appId,
       // Request the profile claims so the CP can read email/name (from the token or
-      // its /userinfo endpoint) and show a real creator instead of a placeholder.
-      scopes: ['email', 'profile'],
+      // its /userinfo endpoint), plus identities for the user-facing Account API.
+      scopes: [UserScope.Email, UserScope.Profile, UserScope.Identities],
       ...(apiResource ? { resources: [apiResource] } : {})
     })
   }
@@ -271,17 +265,32 @@ export async function getToken(): Promise<string | undefined> {
   if (!c || !(await c.isAuthenticated())) return undefined
   const { apiResource } = readConfig()
   if (apiResource) {
-    try {
-      return await c.getAccessToken(apiResource)
-    } catch (error) {
-      // A rejected refresh grant cannot recover through retries. Expire only
-      // the local app session and let Logto's SSO session make re-entry cheap.
-      if (!isLogtoRequestError(error) || error.code !== 'oidc.invalid_grant') throw error
-      await clearInvalidGrantSession(c)
-      throw error
-    }
+    return accessToken(c, apiResource)
   }
   return (await c.getIdToken()) ?? undefined
+}
+
+/**
+ * Opaque OP token for Logto's browser-facing Account API. This is deliberately
+ * different from `getToken()`: the Control Plane receives a resource JWT, while
+ * `/api/my-account` requires an access token minted without a resource.
+ */
+export async function getAccountToken(): Promise<string | undefined> {
+  const c = getClient()
+  if (!c || !(await c.isAuthenticated())) return undefined
+  return accessToken(c)
+}
+
+async function accessToken(c: LogtoClient, resource?: string): Promise<string> {
+  try {
+    return resource ? await c.getAccessToken(resource) : await c.getAccessToken()
+  } catch (error) {
+    // A rejected refresh grant cannot recover through retries. Expire only
+    // the local app session and let Logto's SSO session make re-entry cheap.
+    if (!isLogtoRequestError(error) || error.code !== 'oidc.invalid_grant') throw error
+    await clearInvalidGrantSession(c)
+    throw error
+  }
 }
 
 /**

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const auth = vi.hoisted(() => ({
+  getAccountToken: vi.fn(),
+  getLogtoPublicConfig: vi.fn()
+}))
+
+vi.mock('@/lib/auth', () => auth)
+
+describe('Logto Account API', () => {
+  beforeEach(() => {
+    auth.getAccountToken.mockReset().mockResolvedValue('opaque-account-token')
+    auth.getLogtoPublicConfig.mockReset().mockReturnValue({
+      endpoint: 'https://login.example.test/',
+      appId: 'web-app'
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads enabled connectors dynamically and joins them to the current identities', async () => {
+    const fetchMock = vi.fn(async (input: URL | RequestInfo, _init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/api/my-account')) {
+        return new Response(
+          JSON.stringify({
+            primaryEmail: 'person@example.test',
+            hasSecurityVerificationMethod: true,
+            identities: {
+              github: {
+                userId: 'github-user',
+                details: { name: 'Octo Cat', email: 'octo@example.test' }
+              }
+            }
+          }),
+          { status: 200 }
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          socialConnectors: [
+            {
+              id: 'github-connector',
+              target: 'github',
+              name: { en: 'GitHub' },
+              logo: 'data:image/svg+xml,github'
+            },
+            {
+              id: 'google-connector',
+              target: 'google',
+              name: { en: 'Google' },
+              logo: 'data:image/svg+xml,google'
+            }
+          ]
+        }),
+        { status: 200 }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchSignInMethods } = await import('./logto-account')
+    const result = await fetchSignInMethods()
+
+    expect(result.account.primaryEmail).toBe('person@example.test')
+    expect(result.account.identities.github?.details).toEqual({
+      name: 'Octo Cat',
+      email: 'octo@example.test'
+    })
+    expect(result.connectors.map(({ id, target, name }) => ({ id, target, name }))).toEqual([
+      { id: 'github-connector', target: 'github', name: 'GitHub' },
+      { id: 'google-connector', target: 'google', name: 'Google' }
+    ])
+    const accountCall = fetchMock.mock.calls.find(([input]) => String(input).includes('/api/my-account'))
+    expect(new Headers(accountCall?.[1]?.headers).get('authorization')).toBe('Bearer opaque-account-token')
+  })
+
+  it('creates and verifies a current-user email verification record', async () => {
+    const requests: RequestInit[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+        requests.push(init ?? {})
+        return new Response(
+          JSON.stringify({
+            verificationRecordId: requests.length === 1 ? 'pending-verification' : 'verified-user'
+          }),
+          { status: requests.length === 1 ? 201 : 200 }
+        )
+      })
+    )
+
+    const { requestEmailVerification, verifyEmailCode } = await import('./logto-account')
+    await expect(requestEmailVerification('person@example.test')).resolves.toBe('pending-verification')
+    await expect(verifyEmailCode('person@example.test', 'pending-verification', '123456')).resolves.toBe(
+      'verified-user'
+    )
+
+    expect(JSON.parse(String(requests[0]?.body))).toEqual({
+      identifier: { type: 'email', value: 'person@example.test' },
+      templateType: 'UserPermissionValidation'
+    })
+    expect(JSON.parse(String(requests[1]?.body))).toEqual({
+      identifier: { type: 'email', value: 'person@example.test' },
+      verificationId: 'pending-verification',
+      code: '123456'
+    })
+  })
+
+  it('explains identity conflicts without offering account merging', async () => {
+    const { LogtoAccountError, accountErrorMessage } = await import('./logto-account')
+
+    expect(
+      accountErrorMessage(new LogtoAccountError('identity already used', 422, 'user.identity_already_in_use'), {
+        providerName: 'Google',
+        linking: true
+      })
+    ).toBe('That Google account is already connected to another AgentConnect account.')
+  })
+})

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -1,0 +1,333 @@
+import { getAccountToken, getLogtoPublicConfig } from '@/lib/auth'
+
+export interface SocialConnector {
+  id: string
+  target: string
+  name: string
+  logo?: string
+  logoDark?: string
+}
+
+export interface SocialIdentity {
+  userId: string
+  details: Record<string, unknown>
+}
+
+export interface LogtoAccountProfile {
+  primaryEmail?: string
+  identities: Record<string, SocialIdentity>
+  hasSecurityVerificationMethod: boolean
+}
+
+export interface SocialIdentityDetails {
+  name?: string
+  email?: string
+  avatar?: string
+}
+
+export type SocialIdentityAction = 'add' | 'replace'
+
+export interface SocialLinkFlow {
+  state: string
+  socialVerificationRecordId: string
+  currentVerificationRecordId?: string
+  action: SocialIdentityAction
+  providerName: string
+  redirectUri: string
+  returnTo: string
+  createdAt: number
+}
+
+export interface AccountNotice {
+  kind: 'success' | 'error'
+  message: string
+}
+
+const SOCIAL_FLOW_KEY = 'ac.social-link.flow'
+const ACCOUNT_NOTICE_KEY = 'ac.social-link.notice'
+const SOCIAL_FLOW_TTL_MS = 10 * 60 * 1000
+
+export class LogtoAccountError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string
+  ) {
+    super(message)
+    this.name = 'LogtoAccountError'
+  }
+}
+
+function tenantUrl(path: string): URL {
+  const config = getLogtoPublicConfig()
+  if (!config) throw new LogtoAccountError('Logto is not configured.', 0)
+  return new URL(path, config.endpoint)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function stringValue(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+}
+
+async function responseError(response: Response): Promise<LogtoAccountError> {
+  let body: Record<string, unknown> = {}
+  try {
+    body = asRecord(await response.json())
+  } catch {
+    // Some Account API errors have no JSON body. The status-specific UI copy is
+    // still more useful than exposing an empty parse failure.
+  }
+  const code = stringValue(body.code)
+  const message = stringValue(body.message) ?? `Logto Account API returned ${response.status}.`
+  return new LogtoAccountError(message, response.status, code)
+}
+
+async function accountRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = await getAccountToken()
+  if (!token) throw new LogtoAccountError('Your sign-in session has expired.', 401)
+
+  const headers = new Headers(init.headers)
+  headers.set('authorization', `Bearer ${token}`)
+  if (init.body) headers.set('content-type', 'application/json')
+
+  const response = await fetch(tenantUrl(path), { ...init, headers })
+  if (!response.ok) throw await responseError(response)
+  if (response.status === 204) return undefined as T
+  return (await response.json()) as T
+}
+
+function connectorName(target: string, value: unknown): string {
+  if (typeof value === 'string' && value) return value
+  const names = asRecord(value)
+  return (
+    stringValue(names.en, names['en-US'], ...Object.values(names)) ?? target.charAt(0).toUpperCase() + target.slice(1)
+  )
+}
+
+/** Enabled social connectors are public sign-in-experience metadata. */
+export async function fetchSocialConnectors(): Promise<SocialConnector[]> {
+  const config = getLogtoPublicConfig()
+  if (!config) return []
+  const url = new URL('/api/.well-known/experience', config.endpoint)
+  url.searchParams.set('appId', config.appId)
+  const response = await fetch(url)
+  if (!response.ok) throw await responseError(response)
+
+  const body = asRecord(await response.json())
+  const connectors = Array.isArray(body.socialConnectors) ? body.socialConnectors : []
+  return connectors.flatMap((entry) => {
+    const connector = asRecord(entry)
+    const id = stringValue(connector.id)
+    const target = stringValue(connector.target)
+    if (!id || !target) return []
+    const logo = stringValue(connector.logo)
+    const logoDark = stringValue(connector.logoDark)
+    return [
+      {
+        id,
+        target,
+        name: connectorName(target, connector.name),
+        ...(logo ? { logo } : {}),
+        ...(logoDark ? { logoDark } : {})
+      }
+    ]
+  })
+}
+
+export async function fetchAccountProfile(): Promise<LogtoAccountProfile> {
+  const body = asRecord(await accountRequest<unknown>('/api/my-account'))
+  const rawIdentities = asRecord(body.identities)
+  const identities = Object.fromEntries(
+    Object.entries(rawIdentities).map(([target, value]) => {
+      const identity = asRecord(value)
+      return [
+        target,
+        {
+          userId: stringValue(identity.userId) ?? '',
+          details: asRecord(identity.details)
+        } satisfies SocialIdentity
+      ]
+    })
+  )
+  const primaryEmail = stringValue(body.primaryEmail)
+  return {
+    ...(primaryEmail ? { primaryEmail } : {}),
+    identities,
+    hasSecurityVerificationMethod: body.hasSecurityVerificationMethod === true
+  }
+}
+
+export async function fetchSignInMethods(): Promise<{
+  account: LogtoAccountProfile
+  connectors: SocialConnector[]
+}> {
+  const [account, connectors] = await Promise.all([fetchAccountProfile(), fetchSocialConnectors()])
+  return { account, connectors }
+}
+
+export function socialIdentityDetails(identity: SocialIdentity): SocialIdentityDetails {
+  const details = identity.details
+  const name = stringValue(details.name, details.displayName, details.login, details.username)
+  const email = stringValue(details.email)
+  const avatar = stringValue(details.avatar, details.picture, details.avatarUrl, details.avatar_url)
+  return {
+    ...(name ? { name } : {}),
+    ...(email ? { email } : {}),
+    ...(avatar ? { avatar } : {})
+  }
+}
+
+export async function requestEmailVerification(email: string): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/verification-code', {
+    method: 'POST',
+    body: JSON.stringify({
+      identifier: { type: 'email', value: email },
+      templateType: 'UserPermissionValidation'
+    })
+  })
+  return result.verificationRecordId
+}
+
+export async function verifyEmailCode(email: string, verificationId: string, code: string): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/verification-code/verify', {
+    method: 'POST',
+    body: JSON.stringify({
+      identifier: { type: 'email', value: email },
+      verificationId,
+      code
+    })
+  })
+  return result.verificationRecordId
+}
+
+export async function createSocialVerification(
+  connectorId: string,
+  redirectUri: string,
+  state: string
+): Promise<{ verificationRecordId: string; authorizationUri: string }> {
+  return accountRequest('/api/verifications/social', {
+    method: 'POST',
+    body: JSON.stringify({ connectorId, redirectUri, state })
+  })
+}
+
+export async function verifySocialVerification(
+  verificationRecordId: string,
+  connectorData: Record<string, string>
+): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/social/verify', {
+    method: 'POST',
+    body: JSON.stringify({ connectorData, verificationRecordId })
+  })
+  return result.verificationRecordId
+}
+
+function verificationHeaders(currentVerificationRecordId?: string): HeadersInit | undefined {
+  return currentVerificationRecordId ? { 'logto-verification-id': currentVerificationRecordId } : undefined
+}
+
+export async function saveSocialIdentity(
+  action: SocialIdentityAction,
+  socialVerificationRecordId: string,
+  currentVerificationRecordId?: string
+): Promise<void> {
+  await accountRequest('/api/my-account/identities', {
+    method: action === 'add' ? 'POST' : 'PUT',
+    headers: verificationHeaders(currentVerificationRecordId),
+    body: JSON.stringify({ newIdentifierVerificationRecordId: socialVerificationRecordId })
+  })
+}
+
+export async function removeSocialIdentity(target: string, currentVerificationRecordId?: string): Promise<void> {
+  await accountRequest(`/api/my-account/identities/${encodeURIComponent(target)}`, {
+    method: 'DELETE',
+    headers: verificationHeaders(currentVerificationRecordId)
+  })
+}
+
+export function createSocialState(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('')
+}
+
+/** Save only short-lived verification IDs and CSRF state in this tab. */
+export function writeSocialLinkFlow(flow: SocialLinkFlow): boolean {
+  try {
+    const value = JSON.stringify(flow)
+    sessionStorage.setItem(SOCIAL_FLOW_KEY, value)
+    return sessionStorage.getItem(SOCIAL_FLOW_KEY) === value
+  } catch {
+    return false
+  }
+}
+
+export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
+  try {
+    const value = sessionStorage.getItem(SOCIAL_FLOW_KEY)
+    sessionStorage.removeItem(SOCIAL_FLOW_KEY)
+    if (!value) return undefined
+    const flow = asRecord(JSON.parse(value))
+    if (
+      typeof flow.state !== 'string' ||
+      typeof flow.socialVerificationRecordId !== 'string' ||
+      (flow.currentVerificationRecordId !== undefined && typeof flow.currentVerificationRecordId !== 'string') ||
+      (flow.action !== 'add' && flow.action !== 'replace') ||
+      typeof flow.providerName !== 'string' ||
+      typeof flow.redirectUri !== 'string' ||
+      typeof flow.returnTo !== 'string' ||
+      !flow.returnTo.startsWith('/') ||
+      flow.returnTo.startsWith('//') ||
+      typeof flow.createdAt !== 'number' ||
+      Date.now() - flow.createdAt > SOCIAL_FLOW_TTL_MS
+    ) {
+      return undefined
+    }
+    return flow as unknown as SocialLinkFlow
+  } catch {
+    return undefined
+  }
+}
+
+export function writeAccountNotice(notice: AccountNotice): void {
+  try {
+    sessionStorage.setItem(ACCOUNT_NOTICE_KEY, JSON.stringify(notice))
+  } catch {
+    // The profile refresh still shows the new identity; the notice is optional.
+  }
+}
+
+export function takeAccountNotice(): AccountNotice | undefined {
+  try {
+    const value = sessionStorage.getItem(ACCOUNT_NOTICE_KEY)
+    sessionStorage.removeItem(ACCOUNT_NOTICE_KEY)
+    if (!value) return undefined
+    const notice = asRecord(JSON.parse(value))
+    if ((notice.kind !== 'success' && notice.kind !== 'error') || typeof notice.message !== 'string') {
+      return undefined
+    }
+    return notice as unknown as AccountNotice
+  } catch {
+    return undefined
+  }
+}
+
+export function accountErrorMessage(error: unknown, context?: { providerName?: string; linking?: boolean }): string {
+  if (!(error instanceof LogtoAccountError)) return 'Something went wrong. Try again.'
+  if (error.status === 422 && context?.linking) {
+    const reason = `${error.code ?? ''} ${error.message}`.toLowerCase()
+    if (reason.includes('already') && (reason.includes('use') || reason.includes('link'))) {
+      return `That ${context.providerName ?? 'social'} account is already connected to another AgentConnect account.`
+    }
+    return `The ${context.providerName ?? 'social'} authorization expired or could not be used. Try again.`
+  }
+  if (error.status === 400) return 'The verification code or authorization response is invalid. Try again.'
+  if (error.status === 401 || error.status === 403) {
+    return 'Your verification or sign-in session expired. Sign in again and retry.'
+  }
+  if (error.status === 429) return 'Too many attempts. Wait a moment and try again.'
+  if (error.status >= 500) return 'The sign-in provider is temporarily unavailable. Try again.'
+  return error.message
+}


### PR DESCRIPTION
## Summary

- replace the Logto-hosted Account Center handoff with a native responsive Profile card
- load configured social connectors and linked identities directly from Logto's browser-facing Account API
- support Connect, Change, and Remove through AgentConnect-owned email verification and OAuth callback UI
- keep current-user and social verification records tab-local, validate OAuth state, and preserve Logto's identity-in-use conflict instead of merging accounts

## Deployment

- enable Logto Account API with Email set to ReadOnly and Social identities set to Edit
- register `https://<console-origin>/auth/social/callback` with each social provider
- for GitHub's single callback setting, use a parent callback URL compatible with both Logto's normal connector callback and the console callback

## Validation

- `pnpm --filter @agentconnect.md/web test` (419 tests)
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`
- verified the test Logto tenant CORS preflight for Account API reads and sensitive writes from the console origin

Created by Codex . GPT-5
