### PR TITLE
fix(lark): reuse shared attribution footer

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8766,6 +8766,14 @@ export class Daemon {
     })
     if (activeGithub) this.activeGithubTurnMeta.set(key, activeGithub)
     let finalPhase: EventSession['phase'] = 'end'
+    let turnModel: string | undefined
+    const currentAttributionInfo = (): SlackAttributionInfo => ({
+      botName: agent.name,
+      botUrl: this.agentLink(agentId),
+      runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
+      model: this.buildStatusInfo(p).model ?? turnModel ?? 'default',
+      sessionUrl: this.sessionLink(sessionId)
+    })
     try {
       const host = await this.ensureHostAsync(agentId)
       const runtimeAgent = this.agents.get(agentId)
@@ -8842,25 +8850,18 @@ export class Daemon {
       // A runtime-owned "default" is not a public billable model id. Only fall
       // back to config when no selector exists at all; otherwise a failed override
       // could make us price a model that did not actually run.
-      const turnModel =
+      turnModel =
         modelOptions === null
           ? (override ?? agent.runtimeOverrides?.model)
           : advertisedModel === 'default'
             ? undefined
             : advertisedModel
-      const currentSlackAttributionInfo = (): SlackAttributionInfo => ({
-        botName: agent.name,
-        botUrl: this.agentLink(agentId),
-        runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
-        model: this.buildStatusInfo(p).model ?? turnModel ?? 'default',
-        sessionUrl: this.sessionLink(sessionId)
-      })
       // Prepare the linked footer before host.prompt can emit its first chunk. Reply
       // sections then include it in their initial chat.postMessage, where Slack's
       // unfurl controls are supported; onFinal normally observes the same footer and
       // becomes a no-op instead of introducing URLs later through chat.update.
       if (showFooter && p.platform === 'slack') {
-        const attribution = buildAttributionBlocks(currentSlackAttributionInfo())
+        const attribution = buildAttributionBlocks(currentAttributionInfo())
         p.attribution = { blocks: attribution.blocks, key: JSON.stringify(attribution.blocks) }
       }
       // Feishu's answer surface exists before the first ACP token: one CardKit entity
@@ -8979,21 +8980,23 @@ export class Daemon {
         }
       } else {
         const link = showFooter ? this.sessionLink(sessionId) : undefined
-        const finalSlackAttributionInfo = showFooter ? currentSlackAttributionInfo() : undefined
+        const finalAttributionInfo = showFooter ? currentAttributionInfo() : undefined
         // A runtime may only publish its final session-scoped model during prompt.
         // Refresh before enqueueing the final body so any not-yet-sent section is born
         // with the final metadata; an already-sent section is updated in place below.
-        if (showFooter && p.platform === 'slack' && finalSlackAttributionInfo) {
-          const attribution = buildAttributionBlocks(finalSlackAttributionInfo)
+        if (showFooter && p.platform === 'slack' && finalAttributionInfo) {
+          const attribution = buildAttributionBlocks(finalAttributionInfo)
           p.attribution = { blocks: attribution.blocks, key: JSON.stringify(attribution.blocks) }
         }
         // Telegram/Discord keep their existing session-link footer. Slack closes the
         // lifecycle for the compact context already included in the latest reply's
         // initial post and retries any stale-section cleanup.
         const finals =
-          conv instanceof TelegramConverger || conv instanceof DiscordConverger || conv instanceof FeishuConverger
-            ? conv.onFinal(link)
-            : conv.onFinal(finalSlackAttributionInfo)
+          conv instanceof FeishuConverger
+            ? conv.onFinal(finalAttributionInfo)
+            : conv instanceof TelegramConverger || conv instanceof DiscordConverger
+              ? conv.onFinal(link)
+              : conv.onFinal(finalAttributionInfo)
         for (const action of finals) this.enqueueApply(p, action)
       }
       // …and any trailing reasoning the agent emitted after its last reply.
@@ -9094,8 +9097,8 @@ export class Daemon {
         // body and is recorded into the transcript either way.
         const reason = turnFailureReason(err)
         if (p.conv instanceof FeishuConverger) {
-          const link = showFooter ? this.sessionLink(sessionId) : undefined
-          for (const action of p.conv.onFailure(reason, link)) this.enqueueApply(p, action)
+          const attribution = showFooter ? currentAttributionInfo() : undefined
+          for (const action of p.conv.onFailure(reason, attribution)) this.enqueueApply(p, action)
         } else {
           let covered = false
           for (const action of p.conv.flushBuffered()) {
@@ -10021,7 +10024,7 @@ export class Daemon {
         return
       case 'card-final': {
         if (p.feishuCard) {
-          const delivered = await conn.finishStreamingCard(p.channel, p.feishuCard, action.text, action.link)
+          const delivered = await conn.finishStreamingCard(p.channel, p.feishuCard, action.text, action.attribution)
           if (delivered) return
           // A final CardKit update failure must not lose the answer. Remove the stale
           // partial card where possible, then fall back to ordinary text.

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path'
 import * as Lark from '@larksuiteoapi/node-sdk'
 import type { FeishuRegion } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
+import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { SlackSendQueue } from '../slack/send-queue.js'
@@ -778,7 +779,12 @@ export class FeishuConnection {
   /** Close streaming mode and replace the entity with the final answer/footer card.
    * Returns false only when the final full-card update failed, allowing the daemon to
    * fall back to a normal text message instead of losing the reply. */
-  async finishStreamingCard(channel: string, card: FeishuStreamingCard, text: string, link?: string): Promise<boolean> {
+  async finishStreamingCard(
+    channel: string,
+    card: FeishuStreamingCard,
+    text: string,
+    attribution?: ReplyAttributionInfo
+  ): Promise<boolean> {
     return this.queue.enqueue(async () => {
       const state = this.streamingCards.get(card.cardId)
       if (!state) return false
@@ -793,7 +799,7 @@ export class FeishuConnection {
       state.sequence += 1
       let updated = false
       try {
-        await this.handle.api.updateCardEntity(card.cardId, buildCompletedReplyCard(text, link), state.sequence)
+        await this.handle.api.updateCardEntity(card.cardId, buildCompletedReplyCard(text, attribution), state.sequence)
         updated = true
       } catch (err) {
         this.rememberPermissionIssue(err, channel)

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -1,4 +1,5 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
+import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 
 /**
@@ -33,7 +34,7 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 export type FeishuAction =
   | { kind: 'card-start' }
   | { kind: 'card-stream'; text: string }
-  | { kind: 'card-final'; text: string; link?: string }
+  | { kind: 'card-final'; text: string; attribution?: ReplyAttributionInfo }
   | { kind: 'card-cancel' }
   // CardKit owns visible answer delivery. These rows retain the existing transcript
   // segmentation without also posting duplicate text messages into the chat.
@@ -90,23 +91,50 @@ function cardSummary(text: string): string {
   return plain.slice(0, 120) || 'Completed'
 }
 
-function footerLink(link: string): string {
-  return link.replace(/\(/g, '%28').replace(/\)/g, '%29')
+function escapeFooterText(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200)
+    .replace(/([\\`*_[\]~<>])/g, '\\$1')
+}
+
+function footerLink(value: string): string | undefined {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined
+    const normalized = url.toString()
+    if (normalized.length > 2_048) return undefined
+    return normalized.replace(/\(/g, '%28').replace(/\)/g, '%29')
+  } catch {
+    return undefined
+  }
+}
+
+/** Reuse the canonical Slack/GitHub attribution sentence while applying CardKit
+ * markdown links and escaping at this platform boundary. */
+function attributionFooter(info: ReplyAttributionInfo): string {
+  const botName = escapeFooterText(info.botName) || 'unknown agent'
+  const botUrl = footerLink(info.botUrl)
+  const sessionUrl = footerLink(info.sessionUrl)
+  return renderAttributionMessage({
+    agent: botUrl ? `[${botName}](${botUrl})` : botName,
+    runtime: escapeFooterText(info.runtime),
+    model: escapeFooterText(info.model),
+    renderSession: sessionUrl ? (label) => `[${escapeFooterText(label)}](${sessionUrl})` : undefined
+  })
 }
 
 /** Completed CardKit 2.0 reply. The footer is intentionally part of the card rather
  * than a second message, so the answer has one stable visual surface. */
-export function buildCompletedReplyCard(text: string, link?: string): Record<string, unknown> {
+export function buildCompletedReplyCard(text: string, attribution?: ReplyAttributionInfo): Record<string, unknown> {
   const elements: Record<string, unknown>[] = [{ tag: 'markdown', content: text }]
-  if (link) {
-    elements.push(
-      { tag: 'hr' },
-      {
-        tag: 'markdown',
-        text_size: 'notation',
-        content: `AI-generated content is for reference only. [View session](${footerLink(link)})`
-      }
-    )
+  if (attribution) {
+    elements.push({
+      tag: 'markdown',
+      text_size: 'notation',
+      content: attributionFooter(attribution)
+    })
   }
   return {
     schema: '2.0',
@@ -489,8 +517,8 @@ export class FeishuConverger {
   }
 
   /** Turn end: persist the last body window and replace the streaming entity with the
-   * completed answer. The optional footer link is embedded into that same final card. */
-  onFinal(link?: string): FeishuAction[] {
+   * completed answer. Optional shared attribution stays inside that same final card. */
+  onFinal(attribution?: ReplyAttributionInfo): FeishuAction[] {
     const display = this.cardText.trim()
     if (isNoResponseBody(display)) {
       this.buf = ''
@@ -504,12 +532,12 @@ export class FeishuConverger {
     if (!display) return [...actions, { kind: 'card-cancel' }]
     this.cardText = display
     this.lastStreamText = display
-    return [...actions, { kind: 'card-final', text: display, ...(link ? { link } : {}) }]
+    return [...actions, { kind: 'card-final', text: display, ...(attribution ? { attribution } : {}) }]
   }
 
   /** Prompt failure after the card has started: preserve any useful runtime-authored
    * error text, otherwise append one concise failure line, then close the card. */
-  onFailure(reason: string, link?: string): FeishuAction[] {
+  onFailure(reason: string, attribution?: ReplyAttributionInfo): FeishuAction[] {
     const display = this.cardText.trim()
     if (isNoResponseBody(display)) {
       this.buf = ''
@@ -526,7 +554,7 @@ export class FeishuConverger {
     if (this.mode === 'none') return actions
     this.cardText = finalText
     this.lastStreamText = finalText
-    actions.push({ kind: 'card-final', text: finalText, ...(link ? { link } : {}) })
+    actions.push({ kind: 'card-final', text: finalText, ...(attribution ? { attribution } : {}) })
     return actions
   }
 }

--- a/packages/daemon/src/messages/attribution.ts
+++ b/packages/daemon/src/messages/attribution.ts
@@ -10,6 +10,16 @@ export interface AttributionMessageParts {
   renderSession?: (label: string) => string | undefined
 }
 
+/** Raw reply identity shared by platform renderers before each platform applies
+ * its own escaping and link syntax. */
+export interface ReplyAttributionInfo {
+  botName: string
+  botUrl: string
+  runtime: string
+  model: string
+  sessionUrl: string
+}
+
 const OPEN_IN_SESSION_LABEL = 'open in session'
 
 function present(value: string | undefined): value is string {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -14,7 +14,7 @@ export {
   decodePermValue,
   encodePermValue
 } from '@agentconnect.md/protocol'
-import { renderAttributionMessage } from '../messages/attribution.js'
+import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { splitIntoSections } from './formatter.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -82,13 +82,7 @@ export type SlackAction =
 /** Dynamic identity shown under the last reply section. All Slack integration modes use
  *  the same compact `context` footer so shared-bot attribution never looks like body text
  *  or causes its console links to sprout rich previews. */
-export interface SlackAttributionInfo {
-  botName: string
-  botUrl: string
-  runtime: string
-  model: string
-  sessionUrl: string
-}
+export type SlackAttributionInfo = ReplyAttributionInfo
 
 const THINKING = 'is thinking…'
 const WORKING = 'is working…'

--- a/packages/daemon/test/feishu-render.test.ts
+++ b/packages/daemon/test/feishu-render.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
+import type { ReplyAttributionInfo } from '../src/messages/attribution.js'
 import {
   buildCompletedReplyCard,
   buildStreamingReplyCard,
@@ -9,6 +10,14 @@ import {
 
 const chunk = (text: string): SessionUpdate =>
   ({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } }) as unknown as SessionUpdate
+
+const attribution: ReplyAttributionInfo = {
+  botName: 'Review Bot',
+  botUrl: 'https://agentconnect.example/agents/review-bot',
+  runtime: 'Codex',
+  model: 'gpt-5.6',
+  sessionUrl: 'https://agentconnect.example/sessions/123'
+}
 
 describe('FeishuConverger AC_NO_RESPONSE suppression', () => {
   it('retracts the initial card for a bare response-control marker', () => {
@@ -40,25 +49,25 @@ describe('FeishuConverger AC_NO_RESPONSE suppression', () => {
   })
 })
 
-describe('Feishu CardKit reply lifecycle', () => {
-  it('streams cumulative text and finalizes the same reply with a session link', () => {
+describe('Lark CardKit reply lifecycle', () => {
+  it('streams cumulative text and finalizes the same reply with shared attribution', () => {
     const c = new FeishuConverger('low')
     expect(c.onStart()).toEqual([{ kind: 'card-start' }])
 
     c.onUpdate(chunk('Hello'))
     expect(c.streamUpdate()).toEqual([{ kind: 'card-stream', text: 'Hello' }])
     c.onUpdate(chunk(' world'))
-    expect(c.onFinal('https://agentconnect.example/sessions/123')).toEqual([
+    expect(c.onFinal(attribution)).toEqual([
       { kind: 'post', text: 'Hello world', recordOnly: true },
       {
         kind: 'card-final',
         text: 'Hello world',
-        link: 'https://agentconnect.example/sessions/123'
+        attribution
       }
     ])
   })
 
-  it('builds a streaming element and a linked notation footer', () => {
+  it('builds a streaming element and the canonical attribution footer', () => {
     const initial = buildStreamingReplyCard() as {
       config: { streaming_mode: boolean }
       body: { elements: { element_id?: string; content?: string }[] }
@@ -69,16 +78,16 @@ describe('Feishu CardKit reply lifecycle', () => {
       content: 'Thinking…'
     })
 
-    const completed = buildCompletedReplyCard('Done', 'https://agentconnect.example/sessions/123') as {
+    const completed = buildCompletedReplyCard('Done', attribution) as {
       body: { elements: { tag: string; content?: string; text_size?: string }[] }
     }
     expect(completed.body.elements).toEqual([
       { tag: 'markdown', content: 'Done' },
-      { tag: 'hr' },
       {
         tag: 'markdown',
         text_size: 'notation',
-        content: 'AI-generated content is for reference only. [View session](https://agentconnect.example/sessions/123)'
+        content:
+          'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
       }
     ])
   })

--- a/packages/daemon/test/feishu-streaming-card.test.ts
+++ b/packages/daemon/test/feishu-streaming-card.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FeishuConnection, type ConsolidatedFeishuGroup, type FeishuClientHandle } from '../src/feishu/connection.js'
 import { FEISHU_STREAMING_ELEMENT_ID } from '../src/feishu/render.js'
+import type { ReplyAttributionInfo } from '../src/messages/attribution.js'
+
+const attribution: ReplyAttributionInfo = {
+  botName: 'Review Bot',
+  botUrl: 'https://agentconnect.example/agents/review-bot',
+  runtime: 'Codex',
+  model: 'gpt-5.6',
+  sessionUrl: 'https://agentconnect.example/sessions/123'
+}
 
 function connection() {
   const createCardEntity = vi.fn(async () => ({ cardId: 'card-1' }))
@@ -53,7 +62,7 @@ function connection() {
   }
 }
 
-describe('Feishu CardKit transport', () => {
+describe('Lark CardKit transport', () => {
   it('creates, streams, and finalizes one threaded card with monotonic sequences', async () => {
     const {
       conn,
@@ -73,7 +82,7 @@ describe('Feishu CardKit transport', () => {
     expect(replyCardEntityMessage).toHaveBeenCalledWith('om_root', 'card-1')
 
     await conn.updateStreamingCard('oc_chat', card!, 'Hello')
-    await conn.finishStreamingCard('oc_chat', card!, 'Hello world', 'https://agentconnect.example/sessions/123')
+    await conn.finishStreamingCard('oc_chat', card!, 'Hello world', attribution)
 
     expect(updateCardEntityElement).toHaveBeenCalledWith('card-1', FEISHU_STREAMING_ELEMENT_ID, 'Hello', 1)
     expect(setCardEntityStreaming).toHaveBeenCalledWith('card-1', false, 2)
@@ -83,11 +92,10 @@ describe('Feishu CardKit transport', () => {
       body: {
         elements: [
           { tag: 'markdown', content: 'Hello world' },
-          { tag: 'hr' },
           {
             tag: 'markdown',
             content:
-              'AI-generated content is for reference only. [View session](https://agentconnect.example/sessions/123)'
+              'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
           }
         ]
       }


### PR DESCRIPTION
## Summary

- replace the Lark disclaimer and standalone session-link footer with the canonical attribution sentence already used by Slack
- carry the same agent, runtime, model, agent link, and session link into the final CardKit card for successful and failed turns
- share the attribution metadata type while preserving Slack rendering and existing footer visibility settings

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon build`
- focused attribution, Slack renderer, and Lark CardKit suite: 108 tests passed
- targeted ESLint and Prettier checks
- `git diff --check`

Created by Codex . GPT-5.6
