### PR TITLE
fix(web): retain social account notices on mobile

### DIFF
--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -43,6 +43,8 @@ export default function SocialAccountCallback() {
     }
 
     const connectorData = Object.fromEntries(params.entries())
+    // The provider returns code/state; Logto also needs the exact URI used when
+    // it created the authorization request to exchange that code.
     connectorData.redirectUri = flow.redirectUri
     verifySocialVerification(flow.socialVerificationRecordId, connectorData)
       .then((socialVerificationRecordId) =>

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -13,7 +13,6 @@ import {
   removeSocialIdentity,
   requestEmailVerification,
   socialIdentityDetails,
-  takeAccountNotice,
   verifyEmailCode,
   writeSocialLinkFlow,
   type AccountNotice,
@@ -189,14 +188,19 @@ function Notice({ notice }: { notice: AccountNotice }) {
   )
 }
 
-export default function SocialSignInCard({ mobile = false }: { mobile?: boolean }) {
+export default function SocialSignInCard({
+  mobile = false,
+  notice,
+  onNotice
+}: {
+  mobile?: boolean
+  notice?: AccountNotice
+  onNotice: (notice: AccountNotice) => void
+}) {
   const { data, error, isLoading, mutate } = useSWR('logto-account-sign-in-methods', fetchSignInMethods, {
     revalidateOnFocus: true
   })
   const [pending, setPending] = useState<PendingAction>()
-  const [notice, setNotice] = useState<AccountNotice>()
-
-  useEffect(() => setNotice(takeAccountNotice()), [])
 
   const finishAction = async (verificationRecordId?: string) => {
     if (!pending || !data) return
@@ -204,7 +208,7 @@ export default function SocialSignInCard({ mobile = false }: { mobile?: boolean 
       await removeSocialIdentity(pending.connector.target, verificationRecordId)
       await mutate()
       setPending(undefined)
-      setNotice({ kind: 'success', message: `${pending.connector.name} was disconnected.` })
+      onNotice({ kind: 'success', message: `${pending.connector.name} was disconnected.` })
       return
     }
 

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -8,7 +8,7 @@
 // the two must agree). Personal access tokens and "last active" have no backend
 // yet: they render the design's demo values only in mock mode, otherwise empty / '—'.
 
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
@@ -22,6 +22,7 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { useOrgs } from '@/lib/org-context'
 import { fmtDate, ROLE_LABELS } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
+import { takeAccountNotice, type AccountNotice } from '@/lib/logto-account'
 
 function KvRow({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -42,6 +43,10 @@ export default function ProfileView() {
   // the edit-profile dialog saves a new name/photo.
   const { user, me: meProfile } = useProfile()
   const authOn = isAuthConfigured()
+  // ProfileView survives its desktop-first hydration switch to the mobile tree,
+  // so it owns the one-shot callback notice instead of either short-lived card.
+  const [socialNotice, setSocialNotice] = useState<AccountNotice>()
+  useEffect(() => setSocialNotice(takeAccountNotice()), [])
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
   // With no match (mock mode / CP down) the fields fall back to the design's
@@ -119,7 +124,7 @@ export default function ProfileView() {
             </div>
           </div>
 
-          {authOn ? <SocialSignInCard mobile /> : null}
+          {authOn ? <SocialSignInCard mobile notice={socialNotice} onNotice={setSocialNotice} /> : null}
 
           {/* Personal API keys — the caller's own REST credentials */}
           <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} mobile />
@@ -180,7 +185,7 @@ export default function ProfileView() {
         </div>
       </div>
 
-      {authOn ? <SocialSignInCard /> : null}
+      {authOn ? <SocialSignInCard notice={socialNotice} onNotice={setSocialNotice} /> : null}
 
       <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} />
 


### PR DESCRIPTION
## Summary

- keep the one-shot social-account success notice in `ProfileView`, which survives the desktop-first hydration switch
- pass the notice into both responsive `SocialSignInCard` variants so mobile users see the callback result
- clarify why the original OAuth redirect URI is added to Logto's callback verification payload

## Validation

- `pnpm --filter @agentconnect.md/web test` (419 tests)
- `pnpm --filter @agentconnect.md/web lint`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web build`

Created by Codex . GPT-5
