### PR TITLE
feat(lark): add reply card session menu

### DIFF
--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -20,6 +20,7 @@ export const AGENTCONNECT_FEISHU_SCOPES = [
 ] as const
 
 export const AGENTCONNECT_FEISHU_EVENTS = ['im.message.receive_v1'] as const
+export const AGENTCONNECT_FEISHU_CALLBACKS = ['card.action.trigger'] as const
 
 export const AGENTCONNECT_FEISHU_APP_TEMPLATE = {
   archetype: 'PersonalAgent',
@@ -27,7 +28,8 @@ export const AGENTCONNECT_FEISHU_APP_TEMPLATE = {
   addons: {
     preset: true,
     scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
-    events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
+    events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } },
+    callbacks: { items: [...AGENTCONNECT_FEISHU_CALLBACKS] }
   }
 } as const
 

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -6,7 +6,11 @@ import { prisma } from '../setup.db.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
-import { AGENTCONNECT_FEISHU_EVENTS, AGENTCONNECT_FEISHU_SCOPES } from '../../src/http/feishu-app-template.js'
+import {
+  AGENTCONNECT_FEISHU_CALLBACKS,
+  AGENTCONNECT_FEISHU_EVENTS,
+  AGENTCONNECT_FEISHU_SCOPES
+} from '../../src/http/feishu-app-template.js'
 import {
   OfficialFeishuRegistrationProvider,
   type PollFeishuRegistration,
@@ -118,7 +122,8 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(decodeAddons(authorizationUrl.searchParams.get('addons')!)).toMatchObject({
       preset: true,
       scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
-      events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } }
+      events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } },
+      callbacks: { items: [...AGENTCONNECT_FEISHU_CALLBACKS] }
     })
     await first.close()
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2890,6 +2890,7 @@ export class Daemon {
           this.channelNameResolver?.noteMessage(conn, { ...msg, mentionedUserIds: msg.mentionedBots })
           this.onInbound(msg, this.srcIntegrationIds(conn))
         },
+        onStatusAction: (a) => this.handleStatusAction(a),
         log: this.log
       })
       this.feishuConnecting.add(connectKey)
@@ -10017,7 +10018,10 @@ export class Daemon {
       case 'card-start':
         if (p.feishuCardAttempted) return
         p.feishuCardAttempted = true
-        p.feishuCard = await conn.startStreamingCard(p.channel, p.thread)
+        p.feishuCard = await conn.startStreamingCard(p.channel, p.thread, {
+          sessionKey: p.sessionKey,
+          sessionUrl: this.sessionLink(p.acpSessionId)
+        })
         return
       case 'card-stream':
         if (p.feishuCard) await conn.updateStreamingCard(p.channel, p.feishuCard, action.text)

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -9,12 +9,15 @@ import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { SlackSendQueue } from '../slack/send-queue.js'
+import type { InteractionActor } from '../slack/connection.js'
 import { normalizeFeishuMessage, type FeishuAttachmentLike, type FeishuMessageLike } from './normalize.js'
 import {
   buildCompletedReplyCard,
   buildPermissionUpdateCard,
   buildStreamingReplyCard,
   chunkForFeishu,
+  FEISHU_REPLY_ACTION_VALUE,
+  FEISHU_REPLY_CANCEL_OPTION,
   FEISHU_STREAMING_ELEMENT_ID
 } from './render.js'
 
@@ -73,12 +76,13 @@ export function consolidateFeishu(agents: Agent[]): Map<string, ConsolidatedFeis
 export interface FeishuDeps {
   group: ConsolidatedFeishuGroup
   onMessage: (msg: NormalizedMessage) => void
+  /** Fired when a user selects Cancel run from an active reply card's overflow menu.
+   * The connection resolves the callback message id to the turn's local session key. */
+  onStatusAction?: (a: { kind: 'cancel'; sessionKey: string; actor?: InteractionActor }) => void
   newTraceId: () => string
   log?: Logger
   /** Min spacing (ms) between outbound writes (serialized send-queue). Tests pass 0. */
   sendIntervalMs?: number
-  // NOTE: no onCallback/onStatusAction/onSelectAction in v1; the permission card's
-  // button is an open-URL behavior and sends no callback.
 }
 
 /** The raw `im.message.receive_v1` event body the WSClient dispatches. `data` IS the
@@ -100,6 +104,36 @@ export interface FeishuRawEvent {
     // per-thread session keying + threaded replies (see normalize + postMessage).
     root_id?: string
     mentions?: { key?: string; id?: { open_id?: string }; name?: string }[]
+  }
+}
+
+/** The raw `card.action.trigger` body delivered by the Lark WSClient. CardKit v2
+ * nests message/chat ids under `context`; root-level fallbacks cover older payloads. */
+export interface FeishuRawCardActionEvent {
+  context?: {
+    open_message_id?: string
+    open_chat_id?: string
+  }
+  open_message_id?: string
+  open_chat_id?: string
+  operator?: {
+    open_id?: string
+    user_id?: string
+    union_id?: string
+    name?: string
+  }
+  action?: {
+    value?: unknown
+    tag?: string
+    name?: string
+    option?: string
+  }
+}
+
+export interface FeishuCardActionResponse {
+  toast?: {
+    type: 'info' | 'success' | 'warning' | 'error'
+    content: string
   }
 }
 
@@ -153,12 +187,20 @@ export interface FeishuStreamingCard {
   messageId?: string
 }
 
+export interface FeishuStreamingCardControls {
+  sessionKey: string
+  sessionUrl: string
+}
+
 /** The handle the connection holds: outbound {@link FeishuApi} + the WSClient lifecycle. */
 export interface FeishuClientHandle {
   api: FeishuApi
-  /** Open the WSClient long-connection, dispatching each `im.message.receive_v1` event
-   *  to `onEvent`. Resolves once the first handshake succeeds. */
-  startWs(onEvent: (event: FeishuRawEvent) => void): Promise<void>
+  /** Open the WSClient long-connection, dispatching inbound messages and CardKit
+   * interactions. Resolves once the first handshake succeeds. */
+  startWs(
+    onEvent: (event: FeishuRawEvent) => void,
+    onCardAction: (event: FeishuRawCardActionEvent) => FeishuCardActionResponse | undefined
+  ): Promise<void>
   /** Close the WSClient (there is NO WSClient.stop()). */
   close(): void
 }
@@ -323,10 +365,13 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
 
   return {
     api,
-    async startWs(onEvent) {
+    async startWs(onEvent, onCardAction) {
       const dispatcher = new Lark.EventDispatcher({}).register({
         'im.message.receive_v1': async (data: FeishuRawEvent) => {
           onEvent(data)
+        },
+        'card.action.trigger': async (data: FeishuRawCardActionEvent) => {
+          return onCardAction(data)
         }
       })
       ws = new Lark.WSClient({ appId, appSecret, domain, loggerLevel: Lark.LoggerLevel.error })
@@ -479,7 +524,13 @@ export class FeishuConnection {
   private queue: SlackSendQueue
   /** CardKit sequence numbers are scoped to a card entity and must increase across
    * element, settings, and full-card updates. */
-  private streamingCards = new Map<string, { sequence: number; lastText: string }>()
+  private streamingCards = new Map<
+    string,
+    { sequence: number; lastText: string; messageId: string; sessionUrl?: string }
+  >()
+  /** Card actions identify their source message, so active reply messages resolve back
+   * to the daemon's local session key without putting that key in client-visible JSON. */
+  private cardSessions = new Map<string, { channel: string; sessionKey: string }>()
   /** App-level permission failures repeat across streamed writes. Announce once per
    * connection, with a bounded retry when the bot currently cannot send the card. */
   private globalPermissionIssues = new Set<Exclude<FeishuPermissionIssue, 'chat-access'>>()
@@ -535,24 +586,55 @@ export class FeishuConnection {
     }
     log?.debug(`feishu: opening WSClient long-connection (app ${this.appId}, bot ${this.botOpenId || '?'})…`)
 
-    await this.handle.startWs((event) => {
-      // The 3s constraint: ONLY normalize + hand off (which enqueues) — never await the
-      // agent turn here.
-      try {
-        const like = this.toLike(event)
-        // Skip our own messages — the agent's replies must not re-trigger a turn.
-        if (like.senderOpenId && like.senderOpenId === this.botOpenId) return
-        const msg = normalizeFeishuMessage(like, { traceId: this.deps.newTraceId() })
-        log?.debug(
-          `feishu: inbound ch=${msg.channel} user=${msg.sender.id} isBot=${msg.sender.isBot} isDm=${msg.isDm} ` +
-            `mentions=[${msg.mentionedBots.join(',')}] text=${JSON.stringify(msg.text.slice(0, 80))}`
-        )
-        this.deps.onMessage(msg)
-      } catch (err) {
-        log?.debug(`feishu: inbound normalize failed: ${(err as Error).message}`)
-      }
-    })
+    await this.handle.startWs(
+      (event) => {
+        // The 3s constraint: ONLY normalize + hand off (which enqueues) — never await the
+        // agent turn here.
+        try {
+          const like = this.toLike(event)
+          // Skip our own messages — the agent's replies must not re-trigger a turn.
+          if (like.senderOpenId && like.senderOpenId === this.botOpenId) return
+          const msg = normalizeFeishuMessage(like, { traceId: this.deps.newTraceId() })
+          log?.debug(
+            `feishu: inbound ch=${msg.channel} user=${msg.sender.id} isBot=${msg.sender.isBot} isDm=${msg.isDm} ` +
+              `mentions=[${msg.mentionedBots.join(',')}] text=${JSON.stringify(msg.text.slice(0, 80))}`
+          )
+          this.deps.onMessage(msg)
+        } catch (err) {
+          log?.debug(`feishu: inbound normalize failed: ${(err as Error).message}`)
+        }
+      },
+      (event) => this.handleCardAction(event)
+    )
     log?.debug('feishu: WSClient long-connection established')
+  }
+
+  /** Resolve an active reply's overflow selection and acknowledge it within Lark's
+   * callback deadline. The daemon owns the actual cancellation and resulting card
+   * lifecycle; removing the mapping first makes redelivered clicks idempotent. */
+  private handleCardAction(event: FeishuRawCardActionEvent): FeishuCardActionResponse | undefined {
+    const messageId = event.context?.open_message_id ?? event.open_message_id
+    const channel = event.context?.open_chat_id ?? event.open_chat_id
+    const actorId = event.operator?.open_id ?? event.operator?.user_id
+    const value = asRecord(event.action?.value)
+    if (
+      !messageId ||
+      !actorId ||
+      event.action?.tag !== 'overflow' ||
+      event.action.option !== FEISHU_REPLY_CANCEL_OPTION ||
+      value?.action !== FEISHU_REPLY_ACTION_VALUE
+    )
+      return undefined
+
+    const target = this.cardSessions.get(messageId)
+    if (!target || (channel && target.channel !== channel) || !this.deps.onStatusAction) return undefined
+    this.cardSessions.delete(messageId)
+    this.deps.onStatusAction({
+      kind: 'cancel',
+      sessionKey: target.sessionKey,
+      actor: { userId: actorId }
+    })
+    return { toast: { type: 'info', content: 'Cancellation requested.' } }
   }
 
   /** Adapt a raw `im.message.receive_v1` event to the pure normalizer's plain-object
@@ -736,14 +818,26 @@ export class FeishuConnection {
 
   /** Create a CardKit entity and publish one IM message that references it. The initial
    * card is visible immediately as `Thinking…`; later updates address the entity id. */
-  async startStreamingCard(channel: string, threadAnchor?: string): Promise<FeishuStreamingCard | undefined> {
+  async startStreamingCard(
+    channel: string,
+    threadAnchor?: string,
+    controls?: FeishuStreamingCardControls
+  ): Promise<FeishuStreamingCard | undefined> {
     return this.queue.enqueue(async () => {
       try {
-        const created = await this.handle.api.createCardEntity(buildStreamingReplyCard())
+        const created = await this.handle.api.createCardEntity(buildStreamingReplyCard(controls?.sessionUrl))
         if (!created.cardId) throw new Error('cardkit.card.create returned no card_id')
         const sent = await this.sendCardEntity(channel, threadAnchor, created.cardId)
         if (!sent.messageId) throw new Error('CardKit IM send returned no message_id')
-        this.streamingCards.set(created.cardId, { sequence: 0, lastText: '' })
+        this.streamingCards.set(created.cardId, {
+          sequence: 0,
+          lastText: '',
+          messageId: sent.messageId,
+          ...(controls ? { sessionUrl: controls.sessionUrl } : {})
+        })
+        if (controls) {
+          this.cardSessions.set(sent.messageId, { channel, sessionKey: controls.sessionKey })
+        }
         await this.postPermissionUpdateCard(channel, threadAnchor)
         return { cardId: created.cardId, messageId: sent.messageId }
       } catch (err) {
@@ -799,12 +893,17 @@ export class FeishuConnection {
       state.sequence += 1
       let updated = false
       try {
-        await this.handle.api.updateCardEntity(card.cardId, buildCompletedReplyCard(text, attribution), state.sequence)
+        await this.handle.api.updateCardEntity(
+          card.cardId,
+          buildCompletedReplyCard(text, attribution, state.sessionUrl),
+          state.sequence
+        )
         updated = true
       } catch (err) {
         this.rememberPermissionIssue(err, channel)
         this.deps.log?.debug(`feishu: streaming card final update failed (${card.cardId}): ${(err as Error).message}`)
       } finally {
+        this.cardSessions.delete(state.messageId)
         this.streamingCards.delete(card.cardId)
       }
       await this.postPermissionUpdateCard(channel)
@@ -814,6 +913,8 @@ export class FeishuConnection {
 
   /** Retract an unfinished Thinking card (silent/no-response or a cancelled turn). */
   async cancelStreamingCard(channel: string, card: FeishuStreamingCard): Promise<void> {
+    const state = this.streamingCards.get(card.cardId)
+    if (state) this.cardSessions.delete(state.messageId)
     this.streamingCards.delete(card.cardId)
     const messageId = card.messageId
     if (!messageId) return
@@ -981,6 +1082,8 @@ export class FeishuConnection {
   }
 
   async stop(): Promise<void> {
+    this.streamingCards.clear()
+    this.cardSessions.clear()
     this.handle.close()
   }
 }

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -12,9 +12,11 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
  * streaming card with a Thinking state, `card-stream` replaces one markdown element
  * with the cumulative answer (CardKit renders the diff with its native typewriter
  * effect), and `card-final` replaces the card with the completed answer + optional
- * linked footer. Transcript rows remain `post` actions with `recordOnly:true`, so card
- * transport and persistence stay independent. Progress / reasoning / plan / tool-output
- * remain short plain-text chrome messages.
+ * linked footer. A compact overflow menu keeps View session available throughout the
+ * card lifecycle and exposes Cancel run only while the turn is active. Transcript rows
+ * remain `post` actions with `recordOnly:true`, so card transport and persistence stay
+ * independent. Progress / reasoning / plan / tool-output remain short plain-text chrome
+ * messages.
  *
  * Kinds otherwise mirror TelegramAction/DiscordAction so dispatch stays parallel:
  *  - `post`        records the agent's reply into the transcript (`recordOnly:true`).
@@ -25,11 +27,11 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
  *  - `plan`        the SINGLE in-place plan-summary message (medium/high).
  *  - `tool-output` a finished tool's output as a fenced code block (high only), not recorded.
  *
- * There is deliberately NO per-turn `status-bar` action (unlike Slack/Discord):
- * Feishu v1 has no interactive session controls, so session state and controls are
- * exposed on demand via typed /commands instead (`/status`, `/stop`, `/cancel`,
- * `/fast` — see commands/commands.ts + daemon.handleCommand). The `/status` reply
- * reuses {@link renderStatusReply}.
+ * There is deliberately NO separate per-turn `status-bar` action (unlike
+ * Slack/Discord). Lark keeps its two compact actions in the reply card's overflow menu;
+ * the fuller session state and controls remain available via typed /commands
+ * (`/status`, `/stop`, `/cancel`, `/fast` — see commands/commands.ts +
+ * daemon.handleCommand). The `/status` reply reuses {@link renderStatusReply}.
  */
 export type FeishuAction =
   | { kind: 'card-start' }
@@ -53,9 +55,15 @@ export const FEISHU_MESSAGE_LIMIT = 4000
 /** Stable CardKit element id targeted by `cardElement.content`. */
 export const FEISHU_STREAMING_ELEMENT_ID = 'agentconnect_reply'
 
+/** Stable CardKit overflow identity returned by `card.action.trigger`. */
+export const FEISHU_REPLY_ACTIONS_ELEMENT_ID = 'agentconnect_actions'
+export const FEISHU_REPLY_ACTION_VALUE = 'agentconnect_reply'
+export const FEISHU_REPLY_CANCEL_OPTION = 'cancel'
+
 /** Initial CardKit 2.0 reply card. `streaming_mode` makes element updates render
  * incrementally in clients that support CardKit streaming. */
-export function buildStreamingReplyCard(): Record<string, unknown> {
+export function buildStreamingReplyCard(sessionUrl?: string): Record<string, unknown> {
+  const menu = cardSessionMenu(sessionUrl, true)
   return {
     schema: '2.0',
     config: {
@@ -76,7 +84,8 @@ export function buildStreamingReplyCard(): Record<string, unknown> {
           tag: 'markdown',
           element_id: FEISHU_STREAMING_ELEMENT_ID,
           content: 'Thinking…'
-        }
+        },
+        ...(menu ? [menu] : [])
       ]
     }
   }
@@ -99,7 +108,7 @@ function escapeFooterText(value: string): string {
     .replace(/([\\`*_[\]~<>])/g, '\\$1')
 }
 
-function footerLink(value: string): string | undefined {
+function cardLink(value: string): string | undefined {
   try {
     const url = new URL(value)
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined
@@ -111,12 +120,44 @@ function footerLink(value: string): string | undefined {
   }
 }
 
+function cardSessionMenu(sessionUrl: string | undefined, cancellable: boolean): Record<string, unknown> | undefined {
+  const url = sessionUrl ? cardLink(sessionUrl) : undefined
+  const options = [
+    ...(cancellable
+      ? [
+          {
+            text: { tag: 'plain_text', content: 'Cancel run' },
+            value: FEISHU_REPLY_CANCEL_OPTION
+          }
+        ]
+      : []),
+    ...(url
+      ? [
+          {
+            text: { tag: 'plain_text', content: 'View session' },
+            value: 'session',
+            multi_url: { url }
+          }
+        ]
+      : [])
+  ]
+  if (options.length === 0) return undefined
+  return {
+    tag: 'overflow',
+    element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+    width: 'default',
+    options,
+    value: { action: FEISHU_REPLY_ACTION_VALUE },
+    margin: '8px 0px 0px 0px'
+  }
+}
+
 /** Reuse the canonical Slack/GitHub attribution sentence while applying CardKit
  * markdown links and escaping at this platform boundary. */
 function attributionFooter(info: ReplyAttributionInfo): string {
   const botName = escapeFooterText(info.botName) || 'unknown agent'
-  const botUrl = footerLink(info.botUrl)
-  const sessionUrl = footerLink(info.sessionUrl)
+  const botUrl = cardLink(info.botUrl)
+  const sessionUrl = cardLink(info.sessionUrl)
   return renderAttributionMessage({
     agent: botUrl ? `[${botName}](${botUrl})` : botName,
     runtime: escapeFooterText(info.runtime),
@@ -127,7 +168,11 @@ function attributionFooter(info: ReplyAttributionInfo): string {
 
 /** Completed CardKit 2.0 reply. The footer is intentionally part of the card rather
  * than a second message, so the answer has one stable visual surface. */
-export function buildCompletedReplyCard(text: string, attribution?: ReplyAttributionInfo): Record<string, unknown> {
+export function buildCompletedReplyCard(
+  text: string,
+  attribution?: ReplyAttributionInfo,
+  sessionUrl = attribution?.sessionUrl
+): Record<string, unknown> {
   const elements: Record<string, unknown>[] = [{ tag: 'markdown', content: text }]
   if (attribution) {
     elements.push({
@@ -136,6 +181,8 @@ export function buildCompletedReplyCard(text: string, attribution?: ReplyAttribu
       content: attributionFooter(attribution)
     })
   }
+  const menu = cardSessionMenu(sessionUrl, false)
+  if (menu) elements.push(menu)
   return {
     schema: '2.0',
     config: {

--- a/packages/daemon/test/feishu-render.test.ts
+++ b/packages/daemon/test/feishu-render.test.ts
@@ -5,6 +5,7 @@ import {
   buildCompletedReplyCard,
   buildStreamingReplyCard,
   FeishuConverger,
+  FEISHU_REPLY_ACTIONS_ELEMENT_ID,
   FEISHU_STREAMING_ELEMENT_ID
 } from '../src/feishu/render.js'
 
@@ -68,18 +69,33 @@ describe('Lark CardKit reply lifecycle', () => {
   })
 
   it('builds a streaming element and the canonical attribution footer', () => {
-    const initial = buildStreamingReplyCard() as {
+    const initial = buildStreamingReplyCard(attribution.sessionUrl) as {
       config: { streaming_mode: boolean }
-      body: { elements: { element_id?: string; content?: string }[] }
+      body: { elements: Record<string, unknown>[] }
     }
     expect(initial.config.streaming_mode).toBe(true)
     expect(initial.body.elements[0]).toMatchObject({
       element_id: FEISHU_STREAMING_ELEMENT_ID,
       content: 'Thinking…'
     })
+    expect(initial.body.elements[1]).toMatchObject({
+      tag: 'overflow',
+      element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+      options: [
+        {
+          text: { tag: 'plain_text', content: 'Cancel run' },
+          value: 'cancel'
+        },
+        {
+          text: { tag: 'plain_text', content: 'View session' },
+          value: 'session',
+          multi_url: { url: attribution.sessionUrl }
+        }
+      ]
+    })
 
     const completed = buildCompletedReplyCard('Done', attribution) as {
-      body: { elements: { tag: string; content?: string; text_size?: string }[] }
+      body: { elements: Record<string, unknown>[] }
     }
     expect(completed.body.elements).toEqual([
       { tag: 'markdown', content: 'Done' },
@@ -88,6 +104,20 @@ describe('Lark CardKit reply lifecycle', () => {
         text_size: 'notation',
         content:
           'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
+      },
+      {
+        tag: 'overflow',
+        element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+        width: 'default',
+        options: [
+          {
+            text: { tag: 'plain_text', content: 'View session' },
+            value: 'session',
+            multi_url: { url: attribution.sessionUrl }
+          }
+        ],
+        value: { action: 'agentconnect_reply' },
+        margin: '8px 0px 0px 0px'
       }
     ])
   })

--- a/packages/daemon/test/feishu-streaming-card.test.ts
+++ b/packages/daemon/test/feishu-streaming-card.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
-import { FeishuConnection, type ConsolidatedFeishuGroup, type FeishuClientHandle } from '../src/feishu/connection.js'
-import { FEISHU_STREAMING_ELEMENT_ID } from '../src/feishu/render.js'
+import {
+  FeishuConnection,
+  type ConsolidatedFeishuGroup,
+  type FeishuCardActionResponse,
+  type FeishuClientHandle,
+  type FeishuRawCardActionEvent
+} from '../src/feishu/connection.js'
+import {
+  FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+  FEISHU_REPLY_ACTION_VALUE,
+  FEISHU_REPLY_CANCEL_OPTION,
+  FEISHU_STREAMING_ELEMENT_ID
+} from '../src/feishu/render.js'
 import type { ReplyAttributionInfo } from '../src/messages/attribution.js'
 
 const attribution: ReplyAttributionInfo = {
@@ -18,6 +29,8 @@ function connection() {
   const setCardEntityStreaming = vi.fn(async () => {})
   const updateCardEntity = vi.fn(async () => {})
   const deleteMessage = vi.fn(async () => {})
+  const onStatusAction = vi.fn()
+  let cardActionHandler: ((event: FeishuRawCardActionEvent) => FeishuCardActionResponse | undefined) | undefined
   const handle: FeishuClientHandle = {
     api: {
       createText: async () => ({}),
@@ -39,7 +52,9 @@ function connection() {
       getUser: async (id) => ({ id }),
       getBotInfo: async () => ({})
     },
-    startWs: async () => {},
+    startWs: async (_onEvent, onCardAction) => {
+      cardActionHandler = onCardAction
+    },
     close: () => {}
   }
   const group: ConsolidatedFeishuGroup = {
@@ -50,7 +65,7 @@ function connection() {
   }
   return {
     conn: new FeishuConnection(
-      { group, onMessage: () => {}, newTraceId: () => 'trace', sendIntervalMs: 0 },
+      { group, onMessage: () => {}, onStatusAction, newTraceId: () => 'trace', sendIntervalMs: 0 },
       () => handle
     ),
     createCardEntity,
@@ -58,7 +73,9 @@ function connection() {
     updateCardEntityElement,
     setCardEntityStreaming,
     updateCardEntity,
-    deleteMessage
+    deleteMessage,
+    onStatusAction,
+    triggerCardAction: (event: FeishuRawCardActionEvent) => cardActionHandler?.(event)
   }
 }
 
@@ -73,11 +90,26 @@ describe('Lark CardKit transport', () => {
       updateCardEntity
     } = connection()
 
-    const card = await conn.startStreamingCard('oc_chat', 'om_root')
+    const card = await conn.startStreamingCard('oc_chat', 'om_root', {
+      sessionKey: 'feishu:oc_chat:om_root:review-bot',
+      sessionUrl: attribution.sessionUrl
+    })
     expect(card).toEqual({ cardId: 'card-1', messageId: 'message-1' })
     expect(createCardEntity.mock.calls[0]![0]).toMatchObject({
       schema: '2.0',
-      config: { streaming_mode: true }
+      config: { streaming_mode: true },
+      body: {
+        elements: [
+          { element_id: FEISHU_STREAMING_ELEMENT_ID, content: 'Thinking…' },
+          {
+            element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+            options: [
+              { value: FEISHU_REPLY_CANCEL_OPTION },
+              { value: 'session', multi_url: { url: attribution.sessionUrl } }
+            ]
+          }
+        ]
+      }
     })
     expect(replyCardEntityMessage).toHaveBeenCalledWith('om_root', 'card-1')
 
@@ -96,9 +128,42 @@ describe('Lark CardKit transport', () => {
             tag: 'markdown',
             content:
               'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
+          },
+          {
+            tag: 'overflow',
+            options: [{ value: 'session', multi_url: { url: attribution.sessionUrl } }]
           }
         ]
       }
+    })
+  })
+
+  it('routes an active reply Cancel run selection once', async () => {
+    const { conn, onStatusAction, triggerCardAction } = connection()
+    await conn.start()
+    await conn.startStreamingCard('oc_chat', 'om_root', {
+      sessionKey: 'feishu:oc_chat:om_root:review-bot',
+      sessionUrl: attribution.sessionUrl
+    })
+
+    const event: FeishuRawCardActionEvent = {
+      context: { open_message_id: 'message-1', open_chat_id: 'oc_chat' },
+      operator: { open_id: 'ou_operator' },
+      action: {
+        tag: 'overflow',
+        option: FEISHU_REPLY_CANCEL_OPTION,
+        value: { action: FEISHU_REPLY_ACTION_VALUE }
+      }
+    }
+    expect(triggerCardAction(event)).toEqual({
+      toast: { type: 'info', content: 'Cancellation requested.' }
+    })
+    expect(triggerCardAction(event)).toBeUndefined()
+    expect(onStatusAction).toHaveBeenCalledOnce()
+    expect(onStatusAction).toHaveBeenCalledWith({
+      kind: 'cancel',
+      sessionKey: 'feishu:oc_chat:om_root:review-bot',
+      actor: { userId: 'ou_operator' }
     })
   })
 


### PR DESCRIPTION
## Summary

- add a compact CardKit overflow menu to Lark reply cards with `Cancel run` and `View session`
- route cancel callbacks through the existing shared session-cancellation path and remove the cancel option after the turn finishes
- include `card.action.trigger` in the one-click Lark bot template so new bots receive the interaction callback

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/feishu-render.test.ts test/feishu-streaming-card.test.ts`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts`
- daemon and control-plane type checks
- daemon production build
- targeted ESLint, Prettier, and `git diff --check`

Created by Codex . GPT-5.6
