### PR TITLE
fix(lark): use Lark registration domain

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -161,6 +161,9 @@ IntegrationFeishuConfig }`.
 - Keep the reviewable template in `src/http/feishu-app-template.ts`: use
   `createOnly: true`, the platform `PersonalAgent` preset, AgentConnect's
   tenant scopes, and `im.message.receive_v1`.
+- Start the device flow on the selected region's accounts domain:
+  `accounts.feishu.cn` for Feishu and `accounts.larksuite.com` for Lark. The
+  returned authorization deeplink must stay on that matching domain.
 - Persist the provider device cursor and provisional App Secret through
   `SecretCipher` in `feishu_app_registration`. A short database claim lets any
   Control Plane replica resume polling/finalization without duplicate installs;

--- a/packages/control-plane/src/http/feishu-registration-provider.ts
+++ b/packages/control-plane/src/http/feishu-registration-provider.ts
@@ -44,7 +44,7 @@ export type PollFeishuRegistration =
   | { outcome: 'failed' }
 
 export interface FeishuRegistrationProvider {
-  begin(appName: string): Promise<BeginFeishuRegistration>
+  begin(appName: string, region: FeishuRegion): Promise<BeginFeishuRegistration>
   poll(providerDomain: string, deviceCode: string): Promise<PollFeishuRegistration>
 }
 
@@ -53,8 +53,9 @@ type RegistrationFetch = typeof fetch
 export class OfficialFeishuRegistrationProvider implements FeishuRegistrationProvider {
   constructor(private readonly fetcher: RegistrationFetch = fetch) {}
 
-  async begin(appName: string): Promise<BeginFeishuRegistration> {
-    const response = await this.request(FEISHU_REGISTRATION_DOMAIN, {
+  async begin(appName: string, region: FeishuRegion): Promise<BeginFeishuRegistration> {
+    const providerDomain = region === 'lark' ? LARK_REGISTRATION_DOMAIN : FEISHU_REGISTRATION_DOMAIN
+    const response = await this.request(providerDomain, {
       action: 'begin',
       archetype: AGENTCONNECT_FEISHU_APP_TEMPLATE.archetype,
       auth_method: 'client_secret',
@@ -66,7 +67,7 @@ export class OfficialFeishuRegistrationProvider implements FeishuRegistrationPro
     return {
       authorizationUrl: buildFeishuAuthorizationUrl(response.verification_uri_complete, appName),
       deviceCode: response.device_code,
-      providerDomain: FEISHU_REGISTRATION_DOMAIN,
+      providerDomain,
       intervalMs: Math.max(1, response.interval ?? 5) * 1000,
       expiresInMs: Math.max(1, response.expires_in ?? 600) * 1000
     }

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -107,7 +107,7 @@ export class FeishuAppRegistrationService {
     const existing = await this.store.getActiveTarget(key)
     if (existing) return this.reuseOrConflict(existing, input.createdByUserId)
 
-    const begun = await this.provider.begin(input.appName)
+    const begun = await this.provider.begin(input.appName, input.fallbackRegion)
     try {
       const row = await this.store.create({
         id: randomUUID(),

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -8,6 +8,7 @@ import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
 import { AGENTCONNECT_FEISHU_EVENTS, AGENTCONNECT_FEISHU_SCOPES } from '../../src/http/feishu-app-template.js'
 import {
+  LARK_REGISTRATION_DOMAIN,
   OfficialFeishuRegistrationProvider,
   type PollFeishuRegistration,
   type FeishuRegistrationProvider
@@ -72,6 +73,24 @@ function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
 }
 
 describe('Feishu/Lark one-click app registration', () => {
+  it('starts Lark registration on the Lark accounts domain', async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => {
+      return new Response(
+        JSON.stringify({
+          verification_uri_complete: 'https://accounts.larksuite.com/device?user_code=LARK',
+          device_code: 'lark-device-code',
+          expires_in: 600,
+          interval: 1
+        })
+      )
+    })
+    const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin('AgentConnect Lark', 'lark')
+
+    expect(new URL(String(fetcher.mock.calls[0]![0])).hostname).toBe(LARK_REGISTRATION_DOMAIN)
+    expect(new URL(begun.authorizationUrl).hostname).toBe(LARK_REGISTRATION_DOMAIN)
+    expect(begun.providerDomain).toBe(LARK_REGISTRATION_DOMAIN)
+  })
+
   it('survives a CP restart, installs the full template, and never returns credentials', async () => {
     const agentId = await placedAgent()
     const requests: URLSearchParams[] = []
@@ -229,7 +248,7 @@ describe('Feishu/Lark one-click app registration', () => {
     await expect(coordinator.start({ ...common, createdByUserId: 'user-b' })).rejects.toBeInstanceOf(
       FeishuRegistrationConflictError
     )
-    expect(begin).toHaveBeenCalledOnce()
+    expect(begin).toHaveBeenCalledWith('AgentConnect', 'lark')
   })
 
   it('does not expire an authorization while its claimed provider poll is completing', async () => {


### PR DESCRIPTION
## Summary

- pass the selected Feishu/Lark region into the resumable app-registration provider
- start Lark device authorization on `accounts.larksuite.com` while keeping Feishu on `accounts.feishu.cn`
- persist the matching provider domain for subsequent polling and document the invariant

## Root cause

The one-click provider hardcoded `accounts.feishu.cn` for every `begin` request. The selected region was only used later as a credential-region fallback, so choosing Lark could never produce a Lark authorization deeplink.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane build`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts` (7 passed)
- focused ESLint and Prettier checks
- `git diff --check`
- pre-push ESLint: 0 errors; 2 pre-existing duplicate-import warnings in `icon-upload.ts`

Created by Codex . GPT-5
