### PR TITLE
fix(web): offer the built-in Slack app on the preset agent only

### DIFF
--- a/docs/designs/preset-agents.md
+++ b/docs/designs/preset-agents.md
@@ -284,6 +284,15 @@ installed via standard OAuth v2. Verified gaps against current code:
 - **Transport.** Distributed apps are Events-API-only — a socket-mode app token is
   per-app and cannot be demuxed per workspace — so this path hard-depends on the relay
   pool (`PUBLIC_RELAY_URL` + ≥1 connected relay), exactly like `http` transport today.
+- **Console surface: the preset agent only.** Add-integration offers the one-click
+  "Add to Slack" pane on the **`agentconnect` preset** (`AgentDto.builtin`) and on no
+  other agent, even where the platform app is configured: the deployment publishes one
+  Slack app, its workspace install binds to the preset, and a second agent clicking it
+  can only hit `agent_taken` (§5.5). Every other agent opens straight on the custom
+  bot-identity flow — its own app via quick-install (§5.2 machinery), or reuse of a
+  freed / shared bot. The start route still accepts an explicit `agentId` (the API
+  path that widens an already-shared workspace bot); the console never sends one for a
+  non-preset agent.
 
 ### 5.4 The scope contract
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1071,7 +1071,8 @@ export default function AddIntegrationModal({
   } | null>(null)
   // Platform-published "Add to Slack" app (preset-agents.md §5.3): one click, no app
   // to create and no tokens — the CP finishes the install in the OAuth callback, and
-  // the modal polls THAT install row for its terminal state.
+  // the modal polls THAT install row for its terminal state. This is the DEPLOYMENT
+  // probe only; whether THIS agent may use it is `builtinAppOffered` below.
   const [platformAvailable, setPlatformAvailable] = useState(false)
   const [platformPhase, setPlatformPhase] = useState<'idle' | 'authorizing'>('idle')
   const [platformErr, setPlatformErr] = useState<string | null>(null)
@@ -1272,8 +1273,15 @@ export default function AddIntegrationModal({
   // the platform app configured, the DEFAULT pane is the one-click built-in
   // install — the whole custom flow (mode cards, token steps, share toggle, the
   // footer action) hides behind the "Use a custom bot identity" disclosure.
+  // …and it is offered on the BUILT-IN preset agent only (preset-agents.md §5.3):
+  // the platform app is one deployment-level Slack app whose workspace install
+  // binds to the org's `agentconnect` preset. Clicking it from any other agent
+  // is a dead end — the workspace is already taken by the preset, and the
+  // callback answers `agent_taken`. Every other agent gets its own bot identity
+  // (create an app via quick-install, or reuse a freed / shared one).
+  const builtinAppOffered = platformAvailable && agent.builtin === true
   const slackChecking = platform === 'slack' && slackFunnel === null
-  const slackBuiltin = platform === 'slack' && slackFunnel !== null && platformAvailable && slackIdentity === 'builtin'
+  const slackBuiltin = platform === 'slack' && slackFunnel !== null && builtinAppOffered && slackIdentity === 'builtin'
   const hideIdentitySection = slackChecking || slackBuiltin
   const selectedBotId = freeBots.some((b) => b.id === botPick) ? botPick : (freeBots[0]?.id ?? null)
   const selectedBot = freeBots.find((b) => b.id === selectedBotId) ?? null
@@ -2740,8 +2748,9 @@ export default function AddIntegrationModal({
         {platform !== 'webhook' && platform !== 'github' && !hideIdentitySection && (
           <div className="mb-2 flex items-center justify-between gap-3">
             <div className="fldlbl">Bot identity</div>
-            {/* Way back to the simple pane — only meaningful when the platform app exists. */}
-            {platform === 'slack' && platformAvailable && (
+            {/* Way back to the simple pane — only meaningful when the platform app
+                exists AND this agent is the preset it binds to. */}
+            {platform === 'slack' && builtinAppOffered && (
               <button
                 type="button"
                 onClick={() => setSlackIdentity('builtin')}


### PR DESCRIPTION
## What

Add-integration's one-click **Add to Slack** pane is now offered on the `agentconnect` preset agent only. Every other agent opens straight on the custom bot-identity flow.

## Why

The pane was gated on `platformInstallAvailable` alone — a **deployment-level** probe from `GET /slack/config`. Once the platform Slack app is configured for the deployment, that flag is true for every agent in the org, so every agent's Add-integration modal defaulted into the built-in install.

For anything but the preset that is a dead end: the deployment publishes **one** Slack app, its workspace install binds to the org's `agentconnect` preset, and a second agent clicking it can only reach `agent_taken` (preset-agents.md §5.5).

## How

```ts
const builtinAppOffered = platformAvailable && agent.builtin === true
```

Drives both the built-in pane (`slackBuiltin`) and the "Use the built-in Slack app" back-link in the Bot-identity header. `platformAvailable` keeps meaning exactly what its name says — the deployment probe — with the per-agent question answered by the new derived value.

## Notes for the reviewer

- **No server change.** `POST /integrations/slack/platform-install` still accepts an explicit `agentId` for any editable agent — that is the API path §5.5 uses to widen an already-*shared* workspace bot to another agent, and ~15 integration tests exercise it. The console simply never sends one for a non-preset agent. Locking the route down to preset-only targets would retire that path and rewrite those tests; happy to do it as a follow-up if we want the invariant enforced server-side.
- Non-preset agents lose nothing: a dedicated app via the config-token quick-install, or reuse of a freed / shared bot, are both still on the identity flow they now land on directly.
- Design doc updated — preset-agents.md §5.3 gains a "Console surface: the preset agent only" bullet.

## Verification

- Mock console (`NEXT_PUBLIC_MOCK=1`, which reports the platform app as configured): the `builtin`-labeled preset agent still shows **Add to Slack**; `mocked-deploy-bot` opens on **Bot identity → Create a new bot** with no built-in button and no back-link.
- `pnpm --filter @agentconnect.md/web typecheck`, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)