### PR TITLE
fix(web): load Logto connectors through same-origin route

### DIFF
--- a/packages/web/src/app/api/logto/social-connectors/route.ts
+++ b/packages/web/src/app/api/logto/social-connectors/route.ts
@@ -1,0 +1,32 @@
+export const dynamic = 'force-dynamic'
+
+// Logto's public sign-in-experience endpoint intentionally omits browser CORS
+// headers. Keep the browser request same-origin and forward only the connector
+// metadata it needs; Account API tokens still go directly from browser to Logto.
+function logtoConfig(): { endpoint: string; appId: string } | undefined {
+  const endpoint = process.env.LOGTO_ENDPOINT ?? process.env.NEXT_PUBLIC_LOGTO_ENDPOINT
+  const appId = process.env.LOGTO_APP_ID ?? process.env.NEXT_PUBLIC_LOGTO_APP_ID
+  return endpoint && appId ? { endpoint, appId } : undefined
+}
+
+export async function GET() {
+  const config = logtoConfig()
+  if (!config) {
+    return Response.json({ message: 'Social sign-in methods are not configured.' }, { status: 503 })
+  }
+
+  try {
+    const url = new URL('/api/.well-known/experience', config.endpoint)
+    url.searchParams.set('appId', config.appId)
+    const upstream = await fetch(url, { next: { revalidate: 60 } })
+    if (!upstream.ok) throw new Error(`Logto experience returned ${upstream.status}`)
+
+    const body = (await upstream.json()) as { socialConnectors?: unknown }
+    return Response.json(
+      { socialConnectors: Array.isArray(body.socialConnectors) ? body.socialConnectors : [] },
+      { headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' } }
+    )
+  } catch {
+    return Response.json({ message: 'Social sign-in methods are temporarily unavailable.' }, { status: 502 })
+  }
+}

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -74,6 +74,8 @@ describe('Logto Account API', () => {
     ])
     const accountCall = fetchMock.mock.calls.find(([input]) => String(input).includes('/api/my-account'))
     expect(new Headers(accountCall?.[1]?.headers).get('authorization')).toBe('Bearer opaque-account-token')
+    const connectorsCall = fetchMock.mock.calls.find(([input]) => String(input).includes('social-connectors'))
+    expect(String(connectorsCall?.[0])).toBe('/api/logto/social-connectors')
   })
 
   it('creates and verifies a current-user email verification record', async () => {

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -107,13 +107,9 @@ function connectorName(target: string, value: unknown): string {
   )
 }
 
-/** Enabled social connectors are public sign-in-experience metadata. */
+/** Enabled social connectors, relayed same-origin because Logto's experience endpoint has no CORS headers. */
 export async function fetchSocialConnectors(): Promise<SocialConnector[]> {
-  const config = getLogtoPublicConfig()
-  if (!config) return []
-  const url = new URL('/api/.well-known/experience', config.endpoint)
-  url.searchParams.set('appId', config.appId)
-  const response = await fetch(url)
+  const response = await fetch('/api/logto/social-connectors')
   if (!response.ok) throw await responseError(response)
 
   const body = asRecord(await response.json())

--- a/packages/web/src/lib/logto-social-connectors-route.test.ts
+++ b/packages/web/src/lib/logto-social-connectors-route.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/logto/social-connectors/route'
+
+describe('Logto social connector metadata route', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('loads public connector metadata server-side for the browser', async () => {
+    vi.stubEnv('LOGTO_ENDPOINT', 'https://login.example.test/')
+    vi.stubEnv('LOGTO_APP_ID', 'web-app')
+    const socialConnectors = [{ id: 'github-connector', target: 'github', name: { en: 'GitHub' } }]
+    const fetchMock = vi.fn(async (_input: URL | RequestInfo) =>
+      Response.json({ socialConnectors, customCss: 'not forwarded' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ socialConnectors })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'https://login.example.test/api/.well-known/experience?appId=web-app'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add a same-origin Web route for Logto social connector metadata
- return only the public `socialConnectors` payload from the Logto experience response
- keep Account API tokens flowing directly between the browser and Logto
- add focused regression coverage for both the route and browser fetch target

## Root cause

Logto's public sign-in-experience endpoint returns connector metadata but does not include browser CORS headers. The Profile page fetched it directly from the Logto origin, so the browser rejected the response and the whole sign-in-methods load failed even though the request returned HTTP 200.

## User impact

The native Profile sign-in-methods card can load the configured GitHub and Google connectors without requiring another login or exposing Account API tokens to the Web server.

## Validation

- 420 Web tests
- Web typecheck
- changed-file ESLint and Prettier
- production Web build
- production server smoke test against the test tenant's public connector metadata

Created by Codex . GPT-5
