### PR TITLE
fix(control-plane): await GitHub installation wakeups

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -103,7 +103,7 @@ import { WebchatTokenService } from './registry/webchatToken.js'
 import { OrgInviteLinkCodec } from './registry/orgInviteLink.js'
 import { OrgInviteLinkService } from './registry/orgInviteLinkService.js'
 import { WaitlistService } from './registry/waitlistService.js'
-import { AgentId, DaemonId, HookId } from './domain/ids.js'
+import { AgentId, DaemonId, HookId, type OrgId } from './domain/ids.js'
 import { HookService } from './hooks/hook.service.js'
 import { RelayAuthService } from './registry/relayAuthService.js'
 import { DaemonRegistryService } from './registry/registryService.js'
@@ -489,6 +489,26 @@ export function buildContainer(
   // Readiness gate: `/readyz` pings the DB and reports 503 once shutdown begins
   // (issue #240). Owned here (has `prisma` for the ping); the bootstrap flips it.
   const readiness = createReadiness(() => pingDb(prisma))
+  // Best-effort, but never detached: shutdown must not disconnect Prisma while
+  // these projection wakeups are still running.
+  const wakeGithubReviewProjections = async (installationId: bigint, orgId: OrgId): Promise<void> => {
+    const at = new Date(clock.now())
+    const results = await Promise.allSettled([
+      repos.hook.wakeReviewProjectionsForInstallation(installationId, at),
+      repos.hook.wakeReviewProjectionsForOrg(orgId, at)
+    ])
+    for (const [scope, result] of [
+      ['installation', results[0]],
+      ['org', results[1]]
+    ] as const) {
+      if (result.status === 'rejected') {
+        http.log.warn(
+          { err: result.reason, installationId: installationId.toString(), orgId, scope },
+          'github: review projection wake failed'
+        )
+      }
+    }
+  }
   // github-app workspaces (opt-in): assembled only when GITHUB_APP_* is fully
   // configured; absent ⇒ routes 404 and the WS gitcred handler denies.
   const github = githubAppCfg
@@ -499,11 +519,7 @@ export function buildContainer(
         installState: repos.githubInstallState,
         repoAuths: repos.agentRepoAuth,
         agents: repos.agent,
-        onInstallationFactsChanged: (installationId, orgId) => {
-          const at = new Date(clock.now())
-          void repos.hook.wakeReviewProjectionsForInstallation(installationId, at)
-          void repos.hook.wakeReviewProjectionsForOrg(orgId, at)
-        },
+        onInstallationFactsChanged: wakeGithubReviewProjections,
         pepper: config.API_KEY_PEPPER,
         log: { warn: (message) => http.log.warn(message) },
         ...(opts.githubFetch ? { fetchImpl: opts.githubFetch } : {})
@@ -562,11 +578,10 @@ export function buildContainer(
         github,
         installations: repos.githubInstallation,
         recompileOrg: (orgId) => hookService.rebroadcastGithubForOrg(orgId),
-        onFactsChanged: (installationId, orgId) => {
+        onFactsChanged: async (installationId, orgId) => {
           github.tokens.invalidateInstallation(installationId)
           github.invalidateRepositoryRoster(installationId)
-          void repos.hook.wakeReviewProjectionsForInstallation(installationId, new Date(clock.now()))
-          void repos.hook.wakeReviewProjectionsForOrg(orgId, new Date(clock.now()))
+          await wakeGithubReviewProjections(installationId, orgId)
           githubRunReporter?.kick()
         },
         clock,
@@ -1157,7 +1172,10 @@ export function buildContainer(
       feishuRegistrationReaper.stop()
       relaySweeper.stop()
       slackBotIdentityReconciler.stop()
-      await Promise.allSettled([...relayRegistrationTasks])
+      await Promise.allSettled([
+        ...relayRegistrationTasks,
+        ...(installationDoorbell ? [installationDoorbell.settle()] : [])
+      ])
       await prisma.$disconnect()
     }
   }

--- a/packages/control-plane/src/github/installation-doorbell.service.test.ts
+++ b/packages/control-plane/src/github/installation-doorbell.service.test.ts
@@ -38,7 +38,12 @@ function facts(over: Partial<GithubInstallationFacts> = {}): GithubInstallationF
   }
 }
 
-function make(opts: { known?: boolean; pull?: () => Promise<GithubInstallationFacts | null>; cooldownMs?: number }) {
+function make(opts: {
+  known?: boolean
+  pull?: () => Promise<GithubInstallationFacts | null>
+  onFactsChanged?: (installationId: bigint, orgId: OrgId) => void | Promise<void>
+  cooldownMs?: number
+}) {
   const clock = new FakeClock()
   const pullInstallation = vi.fn(opts.pull ?? (async () => facts()))
   const getByInstallationId = vi.fn(async () => ((opts.known ?? true) ? row() : null))
@@ -49,6 +54,7 @@ function make(opts: { known?: boolean; pull?: () => Promise<GithubInstallationFa
     github: { pullInstallation },
     installations: { getByInstallationId, upsertFromGithub, markRevokedByInstallationId },
     recompileOrg,
+    ...(opts.onFactsChanged ? { onFactsChanged: opts.onFactsChanged } : {}),
     clock,
     log: silentLog,
     ...(opts.cooldownMs !== undefined ? { cooldownMs: opts.cooldownMs } : {})
@@ -88,6 +94,24 @@ describe('GithubInstallationDoorbell', () => {
     await h.doorbell.settle()
     expect(h.markRevokedByInstallationId).toHaveBeenCalledWith(INS)
     expect(h.upsertFromGithub).not.toHaveBeenCalled()
+    expect(h.recompileOrg).toHaveBeenCalledWith(OrgId('org-a'))
+  })
+
+  it('settle waits for async fact-change side effects before recompiling', async () => {
+    let release!: () => void
+    const onFactsChanged = vi.fn(() => new Promise<void>((resolve) => (release = resolve)))
+    const h = make({ onFactsChanged })
+    h.doorbell.poke({ installationId: INS.toString(), action: 'repositories_added' })
+    let settled = false
+    const settling = h.doorbell.settle().then(() => {
+      settled = true
+    })
+
+    await vi.waitFor(() => expect(onFactsChanged).toHaveBeenCalledWith(INS, OrgId('org-a')))
+    expect(settled).toBe(false)
+    expect(h.recompileOrg).not.toHaveBeenCalled()
+    release()
+    await settling
     expect(h.recompileOrg).toHaveBeenCalledWith(OrgId('org-a'))
   })
 

--- a/packages/control-plane/src/github/installation-doorbell.service.ts
+++ b/packages/control-plane/src/github/installation-doorbell.service.ts
@@ -44,7 +44,7 @@ export interface InstallationDoorbellDeps {
   recompileOrg: (orgId: OrgId) => Promise<void>
   /** Invalidate purpose-token caches and wake durable reporters after any
    * installation permission/lifecycle fact changes. */
-  onFactsChanged?: (installationId: bigint, orgId: OrgId) => void
+  onFactsChanged?: (installationId: bigint, orgId: OrgId) => void | Promise<void>
   clock: Clock
   log: DoorbellLog
   cooldownMs?: number
@@ -120,7 +120,7 @@ export class GithubInstallationDoorbell {
     this.trailing.clear()
   }
 
-  /** Await quiescence — tests only. */
+  /** Await quiescence — used by tests and graceful shutdown. */
   async settle(): Promise<void> {
     await Promise.all([...this.inflight.values()])
   }
@@ -142,7 +142,7 @@ export class GithubInstallationDoorbell {
       } else {
         await this.deps.installations.markRevokedByInstallationId(installationId)
       }
-      this.deps.onFactsChanged?.(installationId, row.orgId)
+      await this.deps.onFactsChanged?.(installationId, row.orgId)
       await this.deps.recompileOrg(row.orgId)
       this.deps.log.info(
         { installationId: key, action, orgId: row.orgId, revoked: !facts },

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -85,7 +85,7 @@ export interface GithubServiceDeps {
   repoAuths?: AgentRepoAuthorizationRepo
   /** Optional lazy repair of the workspace's rename-proof numeric repo id. */
   agents?: Pick<AgentRepo, 'setWorkspaceRepoId'>
-  onInstallationFactsChanged?: (installationId: bigint, orgId: OrgId) => void
+  onInstallationFactsChanged?: (installationId: bigint, orgId: OrgId) => void | Promise<void>
   pepper: string
   fetchImpl?: FetchLike
   baseUrl?: string
@@ -213,7 +213,7 @@ export class GithubService {
     const row = await this.deps.installations.upsertFromGithub(OrgIdOf(parsed.orgId), toFacts(ins))
     this.tokens.invalidateInstallation(row.installationId)
     this.invalidateRepositoryRoster(row.installationId)
-    this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
+    await this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
     return row
   }
 
@@ -237,7 +237,7 @@ export class GithubService {
       const row = await this.deps.installations.upsertFromGithub(orgId, toFacts(ins))
       this.tokens.invalidateInstallation(BigInt(ins.id))
       this.invalidateRepositoryRoster(row.installationId)
-      this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
+      await this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
     }
     await this.deps.installations.markRevokedExcept(
       orgId,
@@ -247,7 +247,7 @@ export class GithubService {
       this.tokens.invalidateInstallation(row.installationId)
       this.invalidateRepositoryRoster(row.installationId)
     }
-    for (const row of before) this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
+    for (const row of before) await this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
     return this.deps.installations.listForOrg(orgId)
   }
 
@@ -517,7 +517,7 @@ export class GithubService {
     }
     this.tokens.invalidateInstallation(installationId)
     this.invalidateRepositoryRoster(installationId)
-    this.deps.onInstallationFactsChanged?.(installationId, claimed.orgId)
+    await this.deps.onInstallationFactsChanged?.(installationId, claimed.orgId)
     return refreshed
   }
 


### PR DESCRIPTION
## Summary

- await GitHub installation projection wakeups instead of leaving detached Prisma promises
- keep projection wake failures best-effort and logged while waiting for every write to settle
- drain in-flight installation doorbell work before disconnecting Prisma during shutdown
- cover the async callback lifecycle with a focused doorbell regression

## Root cause

The GitHub installation fact-change callbacks launched projection wakeups with `void`. The relay gateway test could finish and disconnect Prisma while one of those writes was still running, producing an unhandled `P2028 Transaction already closed` rejection even though all 348 assertions passed.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/github/installation-doorbell.service.test.ts` (11 passed)
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/github/github.test.ts` (49 passed)
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/relay-gateway.test.ts` (21 passed)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- focused ESLint and Prettier checks
- `git diff --check`
- pre-push ESLint: 0 errors; 2 pre-existing duplicate-import warnings in `icon-upload.ts`

## Related CI

- failing first attempt: https://github.com/agentconnect-md/agentconnect/actions/runs/30475589249/job/90656372534
- successful retry: https://github.com/agentconnect-md/agentconnect/actions/runs/30475589249/job/90657521177

Created by Codex . GPT-5