### PR TITLE
fix(lark): preserve valid registration issuer

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -161,9 +161,12 @@ IntegrationFeishuConfig }`.
 - Keep the reviewable template in `src/http/feishu-app-template.ts`: use
   `createOnly: true`, the platform `PersonalAgent` preset, AgentConnect's
   tenant scopes, and `im.message.receive_v1`.
-- Start the device flow on the selected region's accounts domain:
-  `accounts.feishu.cn` for Feishu and `accounts.larksuite.com` for Lark. The
-  returned authorization deeplink must stay on that matching domain.
+- Start every device flow on the canonical `accounts.feishu.cn` issuer. For
+  Lark, preserve the returned `user_code` while changing the user-facing
+  launcher to `open.larksuite.com`; direct issuance from
+  `accounts.larksuite.com` produces launcher codes that are rejected as
+  expired. Keep polling the issuer until the provider reports a Lark tenant,
+  then switch polling to `accounts.larksuite.com`.
 - Persist the provider device cursor and provisional App Secret through
   `SecretCipher` in `feishu_app_registration`. A short database claim lets any
   Control Plane replica resume polling/finalization without duplicate installs;

--- a/packages/control-plane/prisma/migrations/20260729180000_invalidate_bad_lark_registration_sessions/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260729180000_invalidate_bad_lark_registration_sessions/migration.sql
@@ -1,0 +1,17 @@
+-- The previous Lark flow minted device codes directly from accounts.larksuite.com.
+-- Its launcher rejects those codes immediately, so no pending row using that
+-- issuer can complete. Release the short-lived target slot so users can retry
+-- with the canonical issuer after this deployment.
+UPDATE "feishu_app_registration"
+SET
+  "status" = 'failed',
+  "failureReason" = 'expired',
+  "targetKey" = NULL,
+  "deviceCode" = NULL,
+  "appSecret" = NULL,
+  "claimToken" = NULL,
+  "claimedUntil" = NULL,
+  "settledAt" = CURRENT_TIMESTAMP
+WHERE
+  "status" = 'pending'
+  AND "providerDomain" = 'accounts.larksuite.com';

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1161,8 +1161,8 @@ export const SlackAppStartDto = z.object({
 
 /** Start Feishu/Lark's one-click self-built app registration. The provider
  * returns a deeplink; App ID/Secret stay server-side and are installed when
- * authorization completes. `region` is only a fallback when tenant_brand is
- * omitted. */
+ * authorization completes. `region` selects the user-facing launcher and is
+ * the gateway fallback when tenant_brand is omitted. */
 export const FeishuAppRegistrationStartBody = z.object({
   agentId: z.string().uuid(),
   name: z.string().min(1).optional(),

--- a/packages/control-plane/src/http/feishu-registration-provider.ts
+++ b/packages/control-plane/src/http/feishu-registration-provider.ts
@@ -11,6 +11,7 @@ import { AGENTCONNECT_FEISHU_APP_TEMPLATE, buildFeishuAuthorizationUrl } from '.
 
 export const FEISHU_REGISTRATION_DOMAIN = 'accounts.feishu.cn'
 export const LARK_REGISTRATION_DOMAIN = 'accounts.larksuite.com'
+export const LARK_LAUNCHER_DOMAIN = 'open.larksuite.com'
 
 const REGISTRATION_PATH = '/oauth/v1/app/registration'
 
@@ -54,8 +55,7 @@ export class OfficialFeishuRegistrationProvider implements FeishuRegistrationPro
   constructor(private readonly fetcher: RegistrationFetch = fetch) {}
 
   async begin(appName: string, region: FeishuRegion): Promise<BeginFeishuRegistration> {
-    const providerDomain = region === 'lark' ? LARK_REGISTRATION_DOMAIN : FEISHU_REGISTRATION_DOMAIN
-    const response = await this.request(providerDomain, {
+    const response = await this.request(FEISHU_REGISTRATION_DOMAIN, {
       action: 'begin',
       archetype: AGENTCONNECT_FEISHU_APP_TEMPLATE.archetype,
       auth_method: 'client_secret',
@@ -64,10 +64,12 @@ export class OfficialFeishuRegistrationProvider implements FeishuRegistrationPro
     if (!response.verification_uri_complete || !response.device_code) {
       throw new Error('Feishu app registration did not return a device session')
     }
+    const verificationUri = new URL(response.verification_uri_complete)
+    if (region === 'lark') verificationUri.hostname = LARK_LAUNCHER_DOMAIN
     return {
-      authorizationUrl: buildFeishuAuthorizationUrl(response.verification_uri_complete, appName),
+      authorizationUrl: buildFeishuAuthorizationUrl(verificationUri.toString(), appName),
       deviceCode: response.device_code,
-      providerDomain,
+      providerDomain: FEISHU_REGISTRATION_DOMAIN,
       intervalMs: Math.max(1, response.interval ?? 5) * 1000,
       expiresInMs: Math.max(1, response.expires_in ?? 600) * 1000
     }

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -12,7 +12,8 @@ import {
   AGENTCONNECT_FEISHU_SCOPES
 } from '../../src/http/feishu-app-template.js'
 import {
-  LARK_REGISTRATION_DOMAIN,
+  FEISHU_REGISTRATION_DOMAIN,
+  LARK_LAUNCHER_DOMAIN,
   OfficialFeishuRegistrationProvider,
   type PollFeishuRegistration,
   type FeishuRegistrationProvider
@@ -77,11 +78,11 @@ function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
 }
 
 describe('Feishu/Lark one-click app registration', () => {
-  it('starts Lark registration on the Lark accounts domain', async () => {
+  it('uses the canonical issuer for a valid Lark launcher link', async () => {
     const fetcher = vi.fn<typeof fetch>(async () => {
       return new Response(
         JSON.stringify({
-          verification_uri_complete: 'https://accounts.larksuite.com/device?user_code=LARK',
+          verification_uri_complete: 'https://open.feishu.cn/page/launcher?user_code=LARK',
           device_code: 'lark-device-code',
           expires_in: 600,
           interval: 1
@@ -90,9 +91,10 @@ describe('Feishu/Lark one-click app registration', () => {
     })
     const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin('AgentConnect Lark', 'lark')
 
-    expect(new URL(String(fetcher.mock.calls[0]![0])).hostname).toBe(LARK_REGISTRATION_DOMAIN)
-    expect(new URL(begun.authorizationUrl).hostname).toBe(LARK_REGISTRATION_DOMAIN)
-    expect(begun.providerDomain).toBe(LARK_REGISTRATION_DOMAIN)
+    expect(new URL(String(fetcher.mock.calls[0]![0])).hostname).toBe(FEISHU_REGISTRATION_DOMAIN)
+    expect(new URL(begun.authorizationUrl).hostname).toBe(LARK_LAUNCHER_DOMAIN)
+    expect(new URL(begun.authorizationUrl).searchParams.get('user_code')).toBe('LARK')
+    expect(begun.providerDomain).toBe(FEISHU_REGISTRATION_DOMAIN)
   })
 
   it('survives a CP restart, installs the full template, and never returns credentials', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -3370,8 +3370,8 @@ export default function AddIntegrationModal({
               </span>
             </div>
             <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-              {/* Region is used as a fallback; the one-click result normally reports
-                  the authorized tenant brand and the CP stores that exact gateway. */}
+              {/* Region selects the user-facing launcher; the one-click result normally
+                  reports the authorized tenant brand and the CP stores that exact gateway. */}
               <div className="mb-3">
                 <span className="fldlbl mb-[6px] block">Region</span>
                 <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Lark or Feishu region">


### PR DESCRIPTION
## Summary

- mint Feishu/Lark device codes from the canonical `accounts.feishu.cn` issuer
- preserve the returned `user_code` while routing Lark users to `open.larksuite.com`
- keep polling the issuer until the existing tenant-brand handoff switches Lark polling to `accounts.larksuite.com`
- release pending sessions minted by the broken Lark issuer so affected users can retry immediately after deployment
- update the registration contract comments and design documentation

## Root cause

The previous fix started Lark registrations directly against `accounts.larksuite.com`. That endpoint returns a plausible launcher URL and device code, but `open.larksuite.com` immediately rejects that code as expired. The valid provider flow issues the device code on the Feishu accounts domain, then uses the Lark launcher and switches the polling domain after the tenant is identified as Lark.

## Impact

Selecting Lark now opens a valid “Create a Lark app for your agent” page instead of immediately showing “Link expired.” Existing pending sessions produced by the broken issuer are settled during deployment, so users do not have to wait for their one-hour TTL before retrying. Feishu registration remains on its existing launcher, and the App ID/Secret continue to stay server-side.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts` (7/7 passed, including all 44 migrations)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane build`
- focused ESLint and Prettier checks
- live smoke test against the official registration endpoint confirmed the repaired URL loads the Lark app-creation page

Created by Codex . GPT-5
