### PR TITLE
fix(lark): align reply menu with footer

### DIFF
--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -60,10 +60,51 @@ export const FEISHU_REPLY_ACTIONS_ELEMENT_ID = 'agentconnect_actions'
 export const FEISHU_REPLY_ACTION_VALUE = 'agentconnect_reply'
 export const FEISHU_REPLY_CANCEL_OPTION = 'cancel'
 
+function cardInlineRow(
+  left: Record<string, unknown> | undefined,
+  right: Record<string, unknown> | undefined,
+  verticalAlign: 'top' | 'center'
+): Record<string, unknown> {
+  return {
+    tag: 'column_set',
+    flex_mode: 'none',
+    horizontal_spacing: '8px',
+    horizontal_align: 'right',
+    columns: [
+      ...(left
+        ? [
+            {
+              tag: 'column',
+              width: 'weighted',
+              weight: 1,
+              vertical_align: verticalAlign,
+              elements: [left]
+            }
+          ]
+        : []),
+      ...(right
+        ? [
+            {
+              tag: 'column',
+              width: 'auto',
+              vertical_align: verticalAlign,
+              elements: [right]
+            }
+          ]
+        : [])
+    ]
+  }
+}
+
 /** Initial CardKit 2.0 reply card. `streaming_mode` makes element updates render
  * incrementally in clients that support CardKit streaming. */
 export function buildStreamingReplyCard(sessionUrl?: string): Record<string, unknown> {
   const menu = cardSessionMenu(sessionUrl, true)
+  const content = {
+    tag: 'markdown',
+    element_id: FEISHU_STREAMING_ELEMENT_ID,
+    content: 'Thinking…'
+  }
   return {
     schema: '2.0',
     config: {
@@ -79,14 +120,7 @@ export function buildStreamingReplyCard(sessionUrl?: string): Record<string, unk
     body: {
       direction: 'vertical',
       padding: '12px 12px 12px 12px',
-      elements: [
-        {
-          tag: 'markdown',
-          element_id: FEISHU_STREAMING_ELEMENT_ID,
-          content: 'Thinking…'
-        },
-        ...(menu ? [menu] : [])
-      ]
+      elements: [menu ? cardInlineRow(content, menu, 'top') : content]
     }
   }
 }
@@ -147,8 +181,7 @@ function cardSessionMenu(sessionUrl: string | undefined, cancellable: boolean): 
     element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
     width: 'default',
     options,
-    value: { action: FEISHU_REPLY_ACTION_VALUE },
-    margin: '8px 0px 0px 0px'
+    value: { action: FEISHU_REPLY_ACTION_VALUE }
   }
 }
 
@@ -174,15 +207,18 @@ export function buildCompletedReplyCard(
   sessionUrl = attribution?.sessionUrl
 ): Record<string, unknown> {
   const elements: Record<string, unknown>[] = [{ tag: 'markdown', content: text }]
-  if (attribution) {
-    elements.push({
-      tag: 'markdown',
-      text_size: 'notation',
-      content: attributionFooter(attribution)
-    })
-  }
+  const footer = attribution
+    ? {
+        tag: 'markdown',
+        text_size: 'notation',
+        content: attributionFooter(attribution)
+      }
+    : undefined
   const menu = cardSessionMenu(sessionUrl, false)
-  if (menu) elements.push(menu)
+  if (footer || menu) {
+    elements.push({ tag: 'hr' })
+    elements.push(cardInlineRow(footer, menu, 'center'))
+  }
   return {
     schema: '2.0',
     config: {

--- a/packages/daemon/test/feishu-render.test.ts
+++ b/packages/daemon/test/feishu-render.test.ts
@@ -75,21 +75,36 @@ describe('Lark CardKit reply lifecycle', () => {
     }
     expect(initial.config.streaming_mode).toBe(true)
     expect(initial.body.elements[0]).toMatchObject({
-      element_id: FEISHU_STREAMING_ELEMENT_ID,
-      content: 'Thinking…'
-    })
-    expect(initial.body.elements[1]).toMatchObject({
-      tag: 'overflow',
-      element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
-      options: [
+      tag: 'column_set',
+      columns: [
         {
-          text: { tag: 'plain_text', content: 'Cancel run' },
-          value: 'cancel'
+          width: 'weighted',
+          elements: [
+            {
+              element_id: FEISHU_STREAMING_ELEMENT_ID,
+              content: 'Thinking…'
+            }
+          ]
         },
         {
-          text: { tag: 'plain_text', content: 'View session' },
-          value: 'session',
-          multi_url: { url: attribution.sessionUrl }
+          width: 'auto',
+          elements: [
+            {
+              tag: 'overflow',
+              element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+              options: [
+                {
+                  text: { tag: 'plain_text', content: 'Cancel run' },
+                  value: 'cancel'
+                },
+                {
+                  text: { tag: 'plain_text', content: 'View session' },
+                  value: 'session',
+                  multi_url: { url: attribution.sessionUrl }
+                }
+              ]
+            }
+          ]
         }
       ]
     })
@@ -100,24 +115,49 @@ describe('Lark CardKit reply lifecycle', () => {
     expect(completed.body.elements).toEqual([
       { tag: 'markdown', content: 'Done' },
       {
-        tag: 'markdown',
-        text_size: 'notation',
-        content:
-          'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
+        tag: 'hr'
       },
       {
-        tag: 'overflow',
-        element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
-        width: 'default',
-        options: [
+        tag: 'column_set',
+        flex_mode: 'none',
+        horizontal_spacing: '8px',
+        horizontal_align: 'right',
+        columns: [
           {
-            text: { tag: 'plain_text', content: 'View session' },
-            value: 'session',
-            multi_url: { url: attribution.sessionUrl }
+            tag: 'column',
+            width: 'weighted',
+            weight: 1,
+            vertical_align: 'center',
+            elements: [
+              {
+                tag: 'markdown',
+                text_size: 'notation',
+                content:
+                  'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
+              }
+            ]
+          },
+          {
+            tag: 'column',
+            width: 'auto',
+            vertical_align: 'center',
+            elements: [
+              {
+                tag: 'overflow',
+                element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+                width: 'default',
+                options: [
+                  {
+                    text: { tag: 'plain_text', content: 'View session' },
+                    value: 'session',
+                    multi_url: { url: attribution.sessionUrl }
+                  }
+                ],
+                value: { action: 'agentconnect_reply' }
+              }
+            ]
           }
-        ],
-        value: { action: 'agentconnect_reply' },
-        margin: '8px 0px 0px 0px'
+        ]
       }
     ])
   })

--- a/packages/daemon/test/feishu-streaming-card.test.ts
+++ b/packages/daemon/test/feishu-streaming-card.test.ts
@@ -100,12 +100,23 @@ describe('Lark CardKit transport', () => {
       config: { streaming_mode: true },
       body: {
         elements: [
-          { element_id: FEISHU_STREAMING_ELEMENT_ID, content: 'Thinking…' },
           {
-            element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
-            options: [
-              { value: FEISHU_REPLY_CANCEL_OPTION },
-              { value: 'session', multi_url: { url: attribution.sessionUrl } }
+            tag: 'column_set',
+            columns: [
+              {
+                elements: [{ element_id: FEISHU_STREAMING_ELEMENT_ID, content: 'Thinking…' }]
+              },
+              {
+                elements: [
+                  {
+                    element_id: FEISHU_REPLY_ACTIONS_ELEMENT_ID,
+                    options: [
+                      { value: FEISHU_REPLY_CANCEL_OPTION },
+                      { value: 'session', multi_url: { url: attribution.sessionUrl } }
+                    ]
+                  }
+                ]
+              }
             ]
           }
         ]
@@ -124,14 +135,28 @@ describe('Lark CardKit transport', () => {
       body: {
         elements: [
           { tag: 'markdown', content: 'Hello world' },
+          { tag: 'hr' },
           {
-            tag: 'markdown',
-            content:
-              'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
-          },
-          {
-            tag: 'overflow',
-            options: [{ value: 'session', multi_url: { url: attribution.sessionUrl } }]
+            tag: 'column_set',
+            columns: [
+              {
+                elements: [
+                  {
+                    tag: 'markdown',
+                    content:
+                      'sent by [Review Bot](https://agentconnect.example/agents/review-bot) (Codex · gpt-5.6) · [open in session](https://agentconnect.example/sessions/123)'
+                  }
+                ]
+              },
+              {
+                elements: [
+                  {
+                    tag: 'overflow',
+                    options: [{ value: 'session', multi_url: { url: attribution.sessionUrl } }]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Summary

- restore the divider between the Lark reply body and attribution footer
- place the completed-card footer and overflow menu in one CardKit column row
- keep the active streaming content and overflow control on one row

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/feishu-render.test.ts test/feishu-streaming-card.test.ts`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon build`
- targeted ESLint and Prettier checks
- `git diff --check`

Created by Codex . GPT-5.6
