### PR TITLE
fix(daemon): scope observed chats to physical bots

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1946,9 +1946,19 @@ export class Daemon {
       setSessionTitle: (req) => this.setSessionTitleFromTool(req),
       gatewayFor: (integrationId) => this.connForIntegration(integrationId),
       // History-backed discovery for platforms whose bot API can't enumerate chats/users
-      // (Telegram): the local session store already records every chat + triggering user.
-      observedChannels: (agentId, platform) => this.store.observedChannels(agentId, platform),
-      observedUsers: (agentId, platform) => this.store.observedUsers(agentId, platform),
+      // (Telegram): only the sole current physical bot's scoped history is reachable.
+      observedChannels: (agentId, platform) => {
+        const integrations = this.agents.get(agentId)?.integrations.filter((i) => i.platform === platform) ?? []
+        return integrations.length === 1
+          ? this.store.observedChannels(agentId, platform, this.transportScopeForIntegration(integrations[0]!))
+          : []
+      },
+      observedUsers: (agentId, platform) => {
+        const integrations = this.agents.get(agentId)?.integrations.filter((i) => i.platform === platform) ?? []
+        return integrations.length === 1
+          ? this.store.observedUsers(agentId, platform, this.transportScopeForIntegration(integrations[0]!))
+          : []
+      },
       // Peer discovery goes to the CP (the only authority for the cross-daemon
       // roster). Resolve the client lazily; fail closed when it isn't connected.
       channelAgents: async (req) => {
@@ -2946,7 +2956,10 @@ export class Daemon {
     if (!resolver) return
     for (const row of this.store.listSessions()) {
       if (row.platform !== 'discord' && row.platform !== 'telegram' && row.platform !== 'feishu') continue
-      const integrationId = this.agents.get(row.agentId)?.integrations.find((i) => i.platform === row.platform)?.id
+      // Legacy unscoped sessions cannot be attributed to the current physical bot.
+      // In particular, never use a replacement bot to look up an old bot's chats.
+      if (!row.transportScope) continue
+      const integrationId = this.integrationIdForTransportScope(row.agentId, row.platform, row.transportScope)
       if (!integrationId) continue
       const conn =
         row.platform === 'discord'
@@ -2998,16 +3011,11 @@ export class Daemon {
       for (const platform of ['telegram', 'discord', 'feishu'] as const) {
         const integrations = agent.integrations.filter((i) => i.platform === platform)
         if (integrations.length === 0) continue
-        // observedChannels is agent+platform-scoped, not per-bot (the sessions table
-        // carries no integrationId). With several bots of the same platform on one
-        // agent we can't tell which bot saw which session. Only merge session history
-        // in the common single-integration case; integration-attributed Off rows can
-        // still be refreshed safely when several bots share the agent.
-        const observed =
-          integrations.length === 1
-            ? this.collapseObserved(this.store.observedChannels(agent.id, platform), platform)
-            : []
         for (const integ of integrations) {
+          const observed = this.collapseObserved(
+            this.store.observedChannels(agent.id, platform, this.transportScopeForIntegration(integ)),
+            platform
+          )
           const prior = this.channelSnapshots.get(integ.id)?.channels ?? []
           if (observed.length === 0 && prior.length === 0) continue
           const priorById = new Map(prior.map((c) => [c.id, c]))

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1105,38 +1105,39 @@ export class LocalStore {
       .all() as unknown as SessionListRow[]
   }
 
-  /** Distinct conversation targets this agent has been triggered in on a platform,
-   *  newest first, joined to their cached display name. Backs the `listChannels`
-   *  fallback for platforms whose bot API can't enumerate chats (Telegram): the
-   *  observed session history IS the reachable set. */
-  observedChannels(agentId: string, platform: string): { id: string; name?: string }[] {
+  /** Distinct conversation targets this agent has been triggered in through one
+   *  physical bot, newest first, joined to their cached display name. Backs the
+   *  `listChannels` fallback for platforms whose bot API can't enumerate chats
+   *  (Telegram): only history from the current bot is reachable through it. */
+  observedChannels(agentId: string, platform: string, transportScope: string): { id: string; name?: string }[] {
     return this.db
       .prepare(
         `SELECT s.channel AS id, d.name AS name
          FROM (SELECT channel, MAX(updatedAt) AS updatedAt FROM sessions
-               WHERE agentId = ? AND platform = ? AND channel IS NOT NULL AND channel <> ''
+               WHERE agentId = ? AND platform = ? AND transportScope = ?
+                 AND channel IS NOT NULL AND channel <> ''
                GROUP BY channel) s
          LEFT JOIN display_names d ON d.id = s.channel
          ORDER BY s.updatedAt DESC`
       )
-      .all(agentId, platform) as { id: string; name?: string }[]
+      .all(agentId, platform, transportScope) as { id: string; name?: string }[]
   }
 
-  /** Distinct users this agent has been triggered by on a platform, newest first,
-   *  joined to their cached display name (present for Slack ids and Telegram DM
-   *  chats where chat id == user id; group senders are id-only). Backs `listKnownUsers`
-   *  so an agent can find a user id to DM on a platform with no user directory. */
-  observedUsers(agentId: string, platform: string): { id: string; name?: string }[] {
+  /** Distinct users this agent has been triggered by through one physical bot,
+   *  newest first, joined to their cached display name (present for Slack ids and
+   *  Telegram DM chats where chat id == user id; group senders are id-only). */
+  observedUsers(agentId: string, platform: string, transportScope: string): { id: string; name?: string }[] {
     return this.db
       .prepare(
         `SELECT s.triggeredBy AS id, d.name AS name
          FROM (SELECT triggeredBy, MAX(updatedAt) AS updatedAt FROM sessions
-               WHERE agentId = ? AND platform = ? AND triggeredBy IS NOT NULL AND triggeredBy <> ''
+               WHERE agentId = ? AND platform = ? AND transportScope = ?
+                 AND triggeredBy IS NOT NULL AND triggeredBy <> ''
                GROUP BY triggeredBy) s
          LEFT JOIN display_names d ON d.id = s.triggeredBy
          ORDER BY s.updatedAt DESC`
       )
-      .all(agentId, platform) as { id: string; name?: string }[]
+      .all(agentId, platform, transportScope) as { id: string; name?: string }[]
   }
 
   /** The most recently active addressable session (has an ACP id) for an agent in a

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -495,15 +495,23 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     s.close()
   })
 
-  it('observedChannels/observedUsers: distinct per agent+platform, newest-first, name-joined', () => {
+  it('observedChannels/observedUsers: distinct per physical bot, newest-first, name-joined', () => {
     const s = store()
-    const sess = (key: string, platform: string, channel: string, triggeredBy: string, updatedAt: number) =>
+    const sess = (
+      key: string,
+      platform: string,
+      channel: string,
+      triggeredBy: string,
+      updatedAt: number,
+      transportScope: string | null = 'bot-scope-a'
+    ) =>
       s.upsertSession({
         key,
         agentId: 'bot-a',
         platform,
         channel,
         thread: 't',
+        transportScope,
         acpSessionId: null,
         state: 'idle',
         lastDeliveredTs: null,
@@ -514,10 +522,12 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     sess('k2', 'telegram', '55', 'U1', 3) // same user, newer; distinct channel
     sess('k3', 'telegram', '-100', 'U2', 2) // same channel as k1, newer than k1
     sess('k4', 'slack', 'C9', 'U9', 5) // different platform — excluded
+    sess('k5', 'telegram', '-999', 'U9', 9, 'bot-scope-b') // different physical bot — excluded
+    sess('k6', 'telegram', '-legacy', 'U8', 8, null) // legacy unknown bot — excluded
     s.setDisplayName('-100', 'team chat', 1)
     s.setDisplayName('55', '@bob', 1)
 
-    const chans = s.observedChannels('bot-a', 'telegram')
+    const chans = s.observedChannels('bot-a', 'telegram', 'bot-scope-a')
     // Distinct channels, newest-first by their latest session (55@3 before -100@2), names joined.
     expect(chans).toEqual([
       { id: '55', name: '@bob' },
@@ -526,12 +536,12 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     // Slack session's channel is not in the Telegram set.
     expect(chans.find((c) => c.id === 'C9')).toBeUndefined()
 
-    const users = s.observedUsers('bot-a', 'telegram')
+    const users = s.observedUsers('bot-a', 'telegram', 'bot-scope-a')
     expect(users).toEqual([
       { id: 'U1', name: null }, // U1's latest session @3 (no display name → null)
       { id: 'U2', name: null }
     ])
-    expect(s.observedUsers('bot-a', 'discord')).toEqual([])
+    expect(s.observedUsers('bot-a', 'discord', 'bot-scope-a')).toEqual([])
     s.close()
   })
 

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -492,13 +492,14 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     // cpClient is wired AFTER start() so any backfill emits during start were no-ops.
     const emit = vi.fn()
     ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const telegramIntegration = { id: 'tg-int', platform: 'telegram', telegram: { botToken: 'tg' } }
     ;(daemon as any).agents = new Map([
       [
         'bot-tg',
         {
           id: 'bot-tg',
           integrations: [
-            { id: 'tg-int', platform: 'telegram', telegram: { botToken: 'tg' } },
+            telegramIntegration,
             { id: 'slack-int', platform: 'slack', slack: { appToken: 'a', botToken: 'x' } }
           ]
         }
@@ -512,7 +513,11 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
 
     // Only the Telegram integration is enumerated — Slack has its own membership snapshot.
     expect(observed).toHaveBeenCalledOnce()
-    expect(observed).toHaveBeenCalledWith('bot-tg', 'telegram')
+    expect(observed).toHaveBeenCalledWith(
+      'bot-tg',
+      'telegram',
+      (daemon as any).transportScopeForIntegration(telegramIntegration)
+    )
     // A named chat carries its name; an unresolved one is id-only (console falls back to the id).
     const channels = [{ id: '-100123', name: 'Team Chat' }, { id: '-100456' }]
     expect(emit).toHaveBeenCalledOnce()
@@ -529,12 +534,13 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
 
     const emit = vi.fn()
     ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const discordIntegration = { id: 'dc-int', platform: 'discord', discord: { botToken: 'dc' } }
     ;(daemon as any).agents = new Map([
       [
         'bot-dc',
         {
           id: 'bot-dc',
-          integrations: [{ id: 'dc-int', platform: 'discord', discord: { botToken: 'dc' } }]
+          integrations: [discordIntegration]
         }
       ]
     ])
@@ -544,7 +550,11 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
 
     ;(daemon as any).refreshObservedChannels()
 
-    expect(observed).toHaveBeenCalledWith('bot-dc', 'discord')
+    expect(observed).toHaveBeenCalledWith(
+      'bot-dc',
+      'discord',
+      (daemon as any).transportScopeForIntegration(discordIntegration)
+    )
     const channels = [{ id: '900123', name: 'general' }, { id: '900456' }]
     expect(emit).toHaveBeenCalledWith({ integrationId: 'dc-int', channels, authoritative: false })
     expect((daemon as any).channelSnapshots.get('dc-int')).toEqual({ channels, authoritative: false })
@@ -562,24 +572,24 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       getUserProfile: vi.fn()
     }
     ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const feishuIntegration = {
+      id: 'fs-int',
+      platform: 'feishu',
+      feishu: { appId: 'cli_fs', appSecret: 'secret', region: 'lark' }
+    }
+    const transportScope = (daemon as any).transportScopeForIntegration(feishuIntegration)
     ;(daemon as any).agents = new Map([
       [
         'bot-fs',
         {
           id: 'bot-fs',
-          integrations: [
-            {
-              id: 'fs-int',
-              platform: 'feishu',
-              feishu: { appId: 'cli_fs', appSecret: 'secret', region: 'lark' }
-            }
-          ]
+          integrations: [feishuIntegration]
         }
       ]
     ])
     ;(daemon as any).fsConnByIntegration.set('fs-int', conn)
     vi.spyOn((daemon as any).store, 'listSessions').mockReturnValue([
-      { agentId: 'bot-fs', platform: 'feishu', channel: 'oc_group', triggeredBy: 'ou_sender' }
+      { agentId: 'bot-fs', platform: 'feishu', channel: 'oc_group', triggeredBy: 'ou_sender', transportScope }
     ])
     const observed = vi
       .spyOn((daemon as any).store, 'observedChannels')
@@ -592,10 +602,74 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
       channel: 'oc_group',
       sender: { id: 'ou_sender', isBot: false }
     })
-    expect(observed).toHaveBeenCalledWith('bot-fs', 'feishu')
+    expect(observed).toHaveBeenCalledWith('bot-fs', 'feishu', transportScope)
     const channels = [{ id: 'oc_group', name: 'Product Chat' }]
     expect(emit).toHaveBeenCalledWith({ integrationId: 'fs-int', channels, authoritative: false })
     expect((daemon as any).channelSnapshots.get('fs-int')).toEqual({ channels, authoritative: false })
+    await daemon.stop()
+  })
+
+  it("does not attach a replaced Feishu app's session history to the new integration", async () => {
+    const root = root1()
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const oldIntegration = {
+      id: 'fs-old',
+      platform: 'feishu',
+      name: 'private-bot',
+      feishu: { appId: 'cli_old', appSecret: 'old-secret', region: 'lark' }
+    }
+    const newIntegration = {
+      id: 'fs-new',
+      platform: 'feishu',
+      name: 'private-bot',
+      feishu: { appId: 'cli_new', appSecret: 'new-secret', region: 'lark' }
+    }
+    ;(daemon as any).agents = new Map([['bot-fs', { id: 'bot-fs', integrations: [newIntegration] }]])
+    const store = (daemon as any).store
+    store.upsertSession({
+      key: 'old-session',
+      agentId: 'bot-fs',
+      platform: 'feishu',
+      channel: 'oc_old',
+      thread: 'old-thread',
+      transportScope: (daemon as any).transportScopeForIntegration(oldIntegration),
+      acpSessionId: 'acp-old',
+      state: 'idle',
+      lastDeliveredTs: null,
+      triggeredBy: 'ou_old',
+      updatedAt: 1
+    })
+    store.setDisplayName('oc_old', 'Old chat', 1)
+
+    ;(daemon as any).refreshObservedChannels()
+    expect(emit).not.toHaveBeenCalled()
+
+    store.upsertSession({
+      key: 'new-session',
+      agentId: 'bot-fs',
+      platform: 'feishu',
+      channel: 'oc_new',
+      thread: 'new-thread',
+      transportScope: (daemon as any).transportScopeForIntegration(newIntegration),
+      acpSessionId: 'acp-new',
+      state: 'idle',
+      lastDeliveredTs: null,
+      triggeredBy: 'ou_new',
+      updatedAt: 2
+    })
+    store.setDisplayName('oc_new', 'New chat', 2)
+
+    ;(daemon as any).refreshObservedChannels()
+    expect(emit).toHaveBeenCalledOnce()
+    expect(emit).toHaveBeenCalledWith({
+      integrationId: 'fs-new',
+      channels: [{ id: 'oc_new', name: 'New chat' }],
+      authoritative: false
+    })
     await daemon.stop()
   })
 
@@ -723,32 +797,47 @@ describe('Daemon.refreshObservedChannels (Telegram/Discord/Feishu discovery)', (
     await daemon.stop()
   })
 
-  it('skips an agent with multiple Telegram bots (observed set is not per-bot)', async () => {
+  it("reports each Telegram bot's own observed chats when an agent has several", async () => {
     const root = root1()
     const { daemon } = makeStubDaemon(root)
     await daemon.start()
 
     const emit = vi.fn()
     ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    const telegramA = { id: 'tg-a', platform: 'telegram', telegram: { botToken: '100:a' } }
+    const telegramB = { id: 'tg-b', platform: 'telegram', telegram: { botToken: '200:b' } }
     ;(daemon as any).agents = new Map([
       [
         'bot-tg2',
         {
           id: 'bot-tg2',
-          integrations: [
-            { id: 'tg-a', platform: 'telegram', telegram: { botToken: 'tg-a' } },
-            { id: 'tg-b', platform: 'telegram', telegram: { botToken: 'tg-b' } }
-          ]
+          integrations: [telegramA, telegramB]
         }
       ]
     ])
-    const observed = vi.spyOn((daemon as any).store, 'observedChannels')
+    const scopeA = (daemon as any).transportScopeForIntegration(telegramA)
+    const scopeB = (daemon as any).transportScopeForIntegration(telegramB)
+    const observed = vi
+      .spyOn((daemon as any).store, 'observedChannels')
+      .mockImplementation((_agentId, _platform, scope) =>
+        scope === scopeA ? [{ id: '-100', name: 'Team A' }] : [{ id: '-200', name: 'Team B' }]
+      )
 
     ;(daemon as any).refreshObservedChannels()
 
-    // Ambiguous which bot saw which chat ⇒ report nothing rather than mis-attribute.
-    expect(observed).not.toHaveBeenCalled()
-    expect(emit).not.toHaveBeenCalled()
+    expect(observed).toHaveBeenCalledWith('bot-tg2', 'telegram', scopeA)
+    expect(observed).toHaveBeenCalledWith('bot-tg2', 'telegram', scopeB)
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenCalledWith({
+      integrationId: 'tg-a',
+      channels: [{ id: '-100', name: 'Team A' }],
+      authoritative: false
+    })
+    expect(emit).toHaveBeenCalledWith({
+      integrationId: 'tg-b',
+      channels: [{ id: '-200', name: 'Team B' }],
+      authoritative: false
+    })
     await daemon.stop()
   })
 


### PR DESCRIPTION
## Summary

- filter observed channel and user history by the existing physical-bot `transportScope`
- resolve historical name lookups only through the integration that owns that scope
- report session-derived conversations separately for each same-platform integration
- add a regression for deleting a Feishu app and creating a same-named bot with a different App ID

## Root cause

Observed conversation discovery pooled daemon sessions by agent and platform even though each session already records an opaque physical-bot scope. When an old Feishu integration was removed and a new one became the agent's only Feishu integration, the daemon republished the old app's sessions under the new integration ID. The Control Plane then correctly persisted those reports, making the new bot appear to retain the old bot's channels and direct messages.

## Impact

A new Feishu/Lark app no longer inherits session-derived conversations from a deleted app just because it is attached to the same agent or has the same display name. Reusing the same physical app still retains its own history because its region and App ID produce the same scope. Telegram and Discord discovery receive the same isolation, and agents with multiple bots on one platform now publish each bot's own observed conversations.

Rows already misattributed before deployment cannot be distinguished safely from legitimate partial observations in the Control Plane. Recreate that affected integration once after this fix is deployed to clear those existing rows; subsequent replacements stay clean.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/local-store.test.ts -t 'observedChannels/observedUsers'`
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/reconcile-watch.test.ts -t "does not attach a replaced Feishu app's session history|reports each Telegram bot's own observed chats"`
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/mcp-ops.test.ts`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- focused ESLint and Prettier checks

Created by Codex . GPT-5
