### PR TITLE
feat(lark): prefill bot avatar from agent icon

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -457,6 +457,11 @@ scope is required for participant names instead of raw `ou_...` IDs. The user
 still reviews and confirms the app, and tenant policy may require administrator
 approval.
 
+The same creation deeplink pre-fills the bot avatar from the Agent's current
+public icon URL. Uploaded icons use their public object-store URL; glyph and
+runtime icons use the public Control Plane PNG endpoint. If neither public base
+is configured, avatar prefill is omitted and app creation continues normally.
+
 Manual setup must configure the same bot capability, long-connection event,
 scopes, and publication state. In both paths, adding the bot to a target group
 remains a user action. `FEISHU_CHECKLIST` documents those manual prerequisites

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -42,11 +42,12 @@ function encodeAddons(): string {
     .replace(/=+$/, '')
 }
 
-export function buildFeishuAuthorizationUrl(verificationUri: string, appName: string): string {
+export function buildFeishuAuthorizationUrl(verificationUri: string, appName: string, avatarUrl?: string): string {
   const url = new URL(verificationUri)
   url.searchParams.set('from', 'sdk')
   url.searchParams.set('source', 'node-sdk/agentconnect')
   url.searchParams.set('tp', 'sdk')
+  if (avatarUrl) url.searchParams.set('avatar', avatarUrl)
   url.searchParams.set('name', appName)
   url.searchParams.set('desc', AGENTCONNECT_FEISHU_APP_TEMPLATE.description)
   url.searchParams.set('addons', encodeAddons())

--- a/packages/control-plane/src/http/feishu-registration-provider.ts
+++ b/packages/control-plane/src/http/feishu-registration-provider.ts
@@ -45,7 +45,7 @@ export type PollFeishuRegistration =
   | { outcome: 'failed' }
 
 export interface FeishuRegistrationProvider {
-  begin(appName: string, region: FeishuRegion): Promise<BeginFeishuRegistration>
+  begin(appName: string, region: FeishuRegion, avatarUrl?: string): Promise<BeginFeishuRegistration>
   poll(providerDomain: string, deviceCode: string): Promise<PollFeishuRegistration>
 }
 
@@ -54,7 +54,7 @@ type RegistrationFetch = typeof fetch
 export class OfficialFeishuRegistrationProvider implements FeishuRegistrationProvider {
   constructor(private readonly fetcher: RegistrationFetch = fetch) {}
 
-  async begin(appName: string, region: FeishuRegion): Promise<BeginFeishuRegistration> {
+  async begin(appName: string, region: FeishuRegion, avatarUrl?: string): Promise<BeginFeishuRegistration> {
     const response = await this.request(FEISHU_REGISTRATION_DOMAIN, {
       action: 'begin',
       archetype: AGENTCONNECT_FEISHU_APP_TEMPLATE.archetype,
@@ -67,7 +67,7 @@ export class OfficialFeishuRegistrationProvider implements FeishuRegistrationPro
     const verificationUri = new URL(response.verification_uri_complete)
     if (region === 'lark') verificationUri.hostname = LARK_LAUNCHER_DOMAIN
     return {
-      authorizationUrl: buildFeishuAuthorizationUrl(verificationUri.toString(), appName),
+      authorizationUrl: buildFeishuAuthorizationUrl(verificationUri.toString(), appName, avatarUrl),
       deviceCode: response.device_code,
       providerDomain: FEISHU_REGISTRATION_DOMAIN,
       intervalMs: Math.max(1, response.interval ?? 5) * 1000,

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -41,6 +41,7 @@ export interface StartFeishuRegistration {
   agentId: AgentId
   fallbackRegion: FeishuRegion
   appName: string
+  avatarUrl?: string
   requestedName?: string
   createdByUserId: string
 }
@@ -107,7 +108,7 @@ export class FeishuAppRegistrationService {
     const existing = await this.store.getActiveTarget(key)
     if (existing) return this.reuseOrConflict(existing, input.createdByUserId)
 
-    const begun = await this.provider.begin(input.appName, input.fallbackRegion)
+    const begun = await this.provider.begin(input.appName, input.fallbackRegion, input.avatarUrl)
     try {
       const row = await this.store.create({
         id: randomUUID(),

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -10,6 +10,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
+import { resolveAgentIconUrl } from '../../agents/agent-icon.js'
 import { denyViewerWrite, ctxOf } from '../rbac.js'
 import { canEdit, canView } from '../visibility.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
@@ -90,6 +91,15 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
 
         const providedName = req.body.name?.trim()
         const appName = providedName || agent.name
+        const avatarUrl = resolveAgentIconUrl(
+          agent.id,
+          agent.icon,
+          {
+            ...(deps.config.PUBLIC_CP_URL ? { cp: deps.config.PUBLIC_CP_URL } : {}),
+            ...(deps.config.S3_PUBLIC_BASE_URL ? { store: deps.config.S3_PUBLIC_BASE_URL } : {})
+          },
+          agent.lastModifiedAt.getTime()
+        )
         const createdByUserId = req.principal.userId
         const targetAgentId = agent.id
         try {
@@ -98,6 +108,7 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
             agentId: targetAgentId,
             fallbackRegion: req.body.region,
             appName,
+            ...(avatarUrl ? { avatarUrl } : {}),
             ...(providedName ? { requestedName: providedName } : {}),
             createdByUserId
           })

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -89,11 +89,16 @@ describe('Feishu/Lark one-click app registration', () => {
         })
       )
     })
-    const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin('AgentConnect Lark', 'lark')
+    const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin(
+      'AgentConnect Lark',
+      'lark',
+      'https://cdn.example.test/agent.png'
+    )
 
     expect(new URL(String(fetcher.mock.calls[0]![0])).hostname).toBe(FEISHU_REGISTRATION_DOMAIN)
     expect(new URL(begun.authorizationUrl).hostname).toBe(LARK_LAUNCHER_DOMAIN)
     expect(new URL(begun.authorizationUrl).searchParams.get('user_code')).toBe('LARK')
+    expect(new URL(begun.authorizationUrl).searchParams.get('avatar')).toBe('https://cdn.example.test/agent.png')
     expect(begun.providerDomain).toBe(FEISHU_REGISTRATION_DOMAIN)
   })
 
@@ -123,7 +128,7 @@ describe('Feishu/Lark one-click app registration', () => {
     })
 
     // Replica A begins the flow, then disappears before the browser's first poll.
-    const first = buildHttpApp(prisma, undefined, undefined, undefined, {
+    const first = buildHttpApp(prisma, { PUBLIC_CP_URL: 'https://cp.example.test' }, undefined, undefined, {
       feishuAppRegistration: service(fetcher)
     })
     const started = await first.app.inject({
@@ -140,6 +145,10 @@ describe('Feishu/Lark one-click app registration', () => {
     const authorizationUrl = new URL(startDto.authorizationUrl)
     expect(authorizationUrl.searchParams.get('createOnly')).toBe('true')
     expect(authorizationUrl.searchParams.get('name')).toBe('AgentConnect Lark')
+    const avatarUrl = new URL(authorizationUrl.searchParams.get('avatar')!)
+    expect(avatarUrl.origin).toBe('https://cp.example.test')
+    expect(avatarUrl.pathname).toBe(`/v1/agents/${agentId}/icon`)
+    expect(avatarUrl.searchParams.has('v')).toBe(true)
     expect(decodeAddons(authorizationUrl.searchParams.get('addons')!)).toMatchObject({
       preset: true,
       scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
@@ -255,7 +264,7 @@ describe('Feishu/Lark one-click app registration', () => {
     await expect(coordinator.start({ ...common, createdByUserId: 'user-b' })).rejects.toBeInstanceOf(
       FeishuRegistrationConflictError
     )
-    expect(begin).toHaveBeenCalledWith('AgentConnect', 'lark')
+    expect(begin).toHaveBeenCalledWith('AgentConnect', 'lark', undefined)
   })
 
   it('does not expire an authorization while its claimed provider poll is completing', async () => {


### PR DESCRIPTION
## Summary

- resolve the target Agent's current public icon URL when starting Feishu/Lark one-click app creation
- prefill that URL through the official `avatar` deeplink parameter
- preserve app creation when no public icon URL is configured
- document the avatar behavior and cover it in the existing registration integration suite

## Why

The resumable registration adapter mirrored the official SDK's name, description, addons, and create-only parameters, but omitted `appPreset.avatar`. As a result, one-click-created bots used the provider's default avatar instead of the Agent's configured identity.

## Impact

New Feishu/Lark bots created through the one-click flow default to the current Agent icon. Uploaded images use the public object-store URL; glyph and runtime icons use the public Control Plane PNG endpoint. The provider confirmation page can still edit the avatar. Manual setup and deployments without a public icon base are unchanged. No API or database migration is required.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts` (7/7 passed)
- ESLint on the changed TypeScript files
- Prettier check on all changed files
- repository pre-commit and pre-push hooks
