### PR TITLE
fix(auth): simplify sign-in method states

### DIFF
--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -42,7 +42,7 @@ export default function SocialAccountCallback() {
       .then(() => {
         writeAccountNotice({
           kind: 'success',
-          message: `${flow.providerName} was connected.`
+          message: `${flow.providerName} was linked.`
         })
         window.location.replace(flow.returnTo)
       })
@@ -55,7 +55,7 @@ export default function SocialAccountCallback() {
     <div className="authpage">
       <div className="m-auto flex max-w-[420px] flex-col items-center gap-[18px] px-6 text-center font-sans text-[14px] font-normal leading-[1.6] text-(--text-secondary)">
         {!error ? <Spinner size={48} /> : null}
-        <div>{error ?? 'Connecting your sign-in account…'}</div>
+        <div>{error ?? 'Linking your sign-in account…'}</div>
         {error ? (
           <Button variant="secondary" onClick={() => window.location.replace(returnTo)}>
             Back to Profile

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig, useSWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchAccountProfile: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  createMySocialIdentityAuthorization: vi.fn(),
+  unlinkMySocialIdentity: vi.fn()
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getAccountToken: vi.fn(),
+  getLogtoPublicConfig: vi.fn(),
+  initialsFrom: () => 'PZ'
+}))
+
+vi.mock('@/lib/logto-account', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/logto-account')>()
+  return { ...actual, fetchAccountProfile: mocks.fetchAccountProfile }
+})
+
+import SocialSignInCard from './SocialSignInCard'
+import { LogtoAccountError } from '@/lib/logto-account'
+
+const ACCOUNT_KEY = 'logto-account-sign-in-methods'
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function RevalidateAccount() {
+  const { mutate } = useSWRConfig()
+  return (
+    <button type="button" onClick={() => void mutate(ACCOUNT_KEY)}>
+      Revalidate account
+    </button>
+  )
+}
+
+async function renderCard() {
+  const cache = new Map()
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <SWRConfig
+        value={{
+          provider: () => cache,
+          dedupingInterval: 0,
+          errorRetryInterval: 1,
+          shouldRetryOnError: true
+        }}
+      >
+        <SocialSignInCard onNotice={vi.fn()} />
+        <RevalidateAccount />
+      </SWRConfig>
+    )
+  })
+}
+
+async function waitUntil(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (predicate()) return
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+  throw new Error('Timed out waiting for the component state.')
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return Array.from(container?.querySelectorAll('button') ?? []).find((candidate) => candidate.textContent === label)
+}
+
+beforeEach(() => {
+  mocks.fetchAccountProfile.mockReset()
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+describe('SocialSignInCard account state', () => {
+  it('keeps a failed request idle and marks an explicit Retry as busy', async () => {
+    mocks.fetchAccountProfile
+      .mockRejectedValueOnce(new LogtoAccountError('Unavailable', 500))
+      .mockImplementationOnce(() => new Promise(() => {}))
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('temporarily unavailable') === true)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    })
+
+    expect(mocks.fetchAccountProfile).toHaveBeenCalledTimes(1)
+
+    await act(async () => button('Retry')?.click())
+    await waitUntil(() => mocks.fetchAccountProfile.mock.calls.length === 2)
+    expect(container?.querySelector('[aria-busy]')?.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('keeps static providers but hides cached identity details and actions after a refresh fails', async () => {
+    mocks.fetchAccountProfile
+      .mockResolvedValueOnce({
+        identities: {
+          github: {
+            userId: 'github-user',
+            details: { name: 'Phil Z', email: 'zfy0701@gmail.com' }
+          }
+        }
+      })
+      .mockRejectedValueOnce(new LogtoAccountError('Unavailable', 500))
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('Phil Z') === true)
+
+    await act(async () => button('Revalidate account')?.click())
+    await waitUntil(() => container?.textContent?.includes('temporarily unavailable') === true)
+
+    expect(container?.textContent).toContain('GitHub')
+    expect(container?.textContent).toContain('Google')
+    expect(container?.textContent).not.toContain('Phil Z')
+    expect(container?.textContent).not.toContain('zfy0701@gmail.com')
+    expect(container?.textContent).not.toContain('Not linked')
+    expect(button('Link')).toBeUndefined()
+    expect(button('Unlink')).toBeUndefined()
+  })
+})

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -67,7 +67,7 @@ function UnlinkDialog({
             <Icon name="unlink" size={16} color="var(--brand)" />
           </span>
           <span id={titleId} className="flex-1 font-sans text-[16px] font-semibold leading-normal">
-            Remove {provider.name}
+            Unlink {provider.name}
           </span>
           <button type="button" className="iconbtn" aria-label="Close" disabled={busy} onClick={onClose}>
             <Icon name="x" size={16} />
@@ -89,7 +89,7 @@ function UnlinkDialog({
             Cancel
           </Button>
           <Button variant="danger" disabled={busy} onClick={() => void submit()}>
-            {busy ? 'Removing…' : `Remove ${provider.name}`}
+            {busy ? 'Unlinking…' : `Unlink ${provider.name}`}
           </Button>
         </div>
       </div>
@@ -122,15 +122,20 @@ export default function SocialSignInCard({
   const {
     data: account,
     error,
-    isLoading,
+    isValidating,
     mutate
   } = useSWR('logto-account-sign-in-methods', fetchAccountProfile, {
-    revalidateOnFocus: true
+    // Provider rows are static; linked identity details load once per mount
+    // and refresh only after an explicit retry or mutation.
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    shouldRetryOnError: false
   })
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
-  const linkedProviderCount = account
-    ? SOCIAL_LOGIN_PROVIDERS.filter((provider) => account.identities[provider.target]).length
+  const currentAccount = error ? undefined : account
+  const linkedProviderCount = currentAccount
+    ? SOCIAL_LOGIN_PROVIDERS.filter((provider) => currentAccount.identities[provider.target]).length
     : 0
 
   const startLink = async (provider: SocialLoginProvider) => {
@@ -162,7 +167,7 @@ export default function SocialSignInCard({
     await unlinkMySocialIdentity(provider.target)
     await mutate()
     setPendingUnlink(undefined)
-    onNotice({ kind: 'success', message: `${provider.name} was disconnected.` })
+    onNotice({ kind: 'success', message: `${provider.name} was unlinked.` })
   }
 
   const shell = mobile
@@ -180,7 +185,7 @@ export default function SocialSignInCard({
             </div>
             {!mobile ? (
               <div className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                Connect more than one social account to the same AgentConnect profile.
+                Link more than one social account to the same AgentConnect profile.
               </div>
             ) : null}
           </div>
@@ -188,11 +193,7 @@ export default function SocialSignInCard({
 
         {notice ? <Notice notice={notice} /> : null}
 
-        {isLoading ? (
-          <div className="px-4 py-5 font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
-            Loading sign-in methods…
-          </div>
-        ) : error || !account ? (
+        {!isValidating && (error || !account) ? (
           <div className="flex items-center justify-between gap-4 px-4 py-4">
             <span className="font-sans text-[13px] font-normal leading-normal text-(--status-error)">
               {accountErrorMessage(error)}
@@ -201,27 +202,27 @@ export default function SocialSignInCard({
               Retry
             </Button>
           </div>
-        ) : (
-          <div>
-            {SOCIAL_LOGIN_PROVIDERS.map((provider, index) => {
-              const identity = account.identities[provider.target]
-              const details = identity ? socialIdentityDetails(identity) : undefined
-              const canUnlink = linkedProviderCount > 1
-              return (
-                <div
-                  key={provider.target}
-                  className={`grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 px-4 py-3.5 desktop:grid-cols-[170px_minmax(0,1fr)_auto] ${
-                    index > 0 ? 'border-t border-(--border-subtle)' : ''
-                  }`}
-                >
-                  <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-3">
-                    <ProviderMark provider={provider} />
-                    <span className="truncate font-sans text-[13.5px] font-semibold leading-normal">
-                      {provider.name}
-                    </span>
-                  </div>
-                  <div className="col-span-2 row-start-2 min-w-0 desktop:col-span-1 desktop:col-start-2 desktop:row-start-1">
-                    {identity ? (
+        ) : null}
+
+        <div aria-busy={isValidating}>
+          {SOCIAL_LOGIN_PROVIDERS.map((provider, index) => {
+            const identity = currentAccount?.identities[provider.target]
+            const details = identity ? socialIdentityDetails(identity) : undefined
+            const canUnlink = linkedProviderCount > 1
+            return (
+              <div
+                key={provider.target}
+                className={`grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 px-4 py-3.5 desktop:grid-cols-[170px_minmax(0,1fr)_auto] ${
+                  index > 0 ? 'border-t border-(--border-subtle)' : ''
+                }`}
+              >
+                <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-3">
+                  <ProviderMark provider={provider} />
+                  <span className="truncate font-sans text-[13.5px] font-semibold leading-normal">{provider.name}</span>
+                </div>
+                <div className="col-span-2 row-start-2 min-w-0 desktop:col-span-1 desktop:col-start-2 desktop:row-start-1">
+                  {currentAccount ? (
+                    identity ? (
                       <div className="flex min-w-0 items-center gap-2.5">
                         <Avatar
                           src={details?.avatar}
@@ -231,7 +232,7 @@ export default function SocialSignInCard({
                         />
                         <div className="min-w-0">
                           <div className="truncate font-sans text-[13px] font-medium leading-normal">
-                            {details?.name ?? 'Connected'}
+                            {details?.name ?? 'Linked'}
                           </div>
                           {details?.email ? (
                             <div className="truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
@@ -242,22 +243,24 @@ export default function SocialSignInCard({
                       </div>
                     ) : (
                       <span className="font-sans text-[13px] font-normal leading-normal text-(--text-tertiary)">
-                        Not connected
+                        Not linked
                       </span>
-                    )}
-                  </div>
-                  <div className="col-start-2 row-start-1 flex items-center justify-end gap-1 desktop:col-start-3">
-                    {identity ? (
-                      <span title={canUnlink ? undefined : 'Connect another sign-in method before removing this one.'}>
+                    )
+                  ) : null}
+                </div>
+                <div className="col-start-2 row-start-1 flex items-center justify-end gap-1 desktop:col-start-3">
+                  {currentAccount ? (
+                    identity ? (
+                      canUnlink ? (
                         <Button
                           variant="ghost"
                           size="xs"
-                          disabled={busyProvider !== undefined || !canUnlink}
+                          disabled={busyProvider !== undefined}
                           onClick={() => setPendingUnlink(provider)}
                         >
-                          <span className="text-(--status-error)">Remove</span>
+                          <span className="text-(--status-error)">Unlink</span>
                         </Button>
-                      </span>
+                      ) : null
                     ) : (
                       <Button
                         variant="secondary"
@@ -265,16 +268,16 @@ export default function SocialSignInCard({
                         disabled={busyProvider !== undefined}
                         onClick={() => void startLink(provider)}
                       >
-                        <Icon name="plus" size={13} />
-                        {busyProvider === provider.target ? 'Connecting…' : 'Connect'}
+                        <Icon name="link" size={14} />
+                        {busyProvider === provider.target ? 'Linking…' : 'Link'}
                       </Button>
-                    )}
-                  </div>
+                    )
+                  ) : null}
                 </div>
-              )
-            })}
-          </div>
-        )}
+              </div>
+            )
+          })}
+        </div>
       </section>
 
       {pendingUnlink ? (

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -82,6 +82,6 @@ describe('Logto Account API', () => {
         providerName: 'Google',
         linking: true
       })
-    ).toBe('That Google account is already connected to another AgentConnect account.')
+    ).toBe('That Google account is already linked to another AgentConnect account.')
   })
 })

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -187,7 +187,7 @@ export function accountErrorMessage(error: unknown, context?: { providerName?: s
   if ((requestError.status === 409 || requestError.status === 422) && context?.linking) {
     const reason = `${requestError.code ?? ''} ${requestError.message}`.toLowerCase()
     if (reason.includes('already') && (reason.includes('use') || reason.includes('link'))) {
-      return `That ${context.providerName ?? 'social'} account is already connected to another AgentConnect account.`
+      return `That ${context.providerName ?? 'social'} account is already linked to another AgentConnect account.`
     }
     return `The ${context.providerName ?? 'social'} authorization expired or could not be used. Try again.`
   }


### PR DESCRIPTION
## Summary

- hide the Unlink action entirely when it would remove the final social sign-in method
- render the static GitHub and Google provider rows immediately instead of replacing them with a loading message
- load linked identity details once per Profile mount and refresh them only after an explicit retry or mutation
- stop automatic error retries, report explicit retries as busy, and hide cached identity details and actions while the latest account read is in error
- present Link as a bordered action with a chain icon and Unlink as a red text action
- use Link and Unlink consistently across progress, dialog, success, and conflict copy
- keep Retry for genuine identity-read failures because connection status still comes from the signed-in account

## Validation

- `pnpm --filter @agentconnect.md/web test` (60 files, 421 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm exec eslint packages/web/src/components/console/SocialSignInCard.tsx packages/web/src/components/console/SocialSignInCard.test.tsx packages/web/src/app/auth/social/callback/page.tsx packages/web/src/lib/logto-account.ts packages/web/src/lib/logto-account.test.ts`
- `pnpm exec prettier --check packages/web/src/components/console/SocialSignInCard.tsx packages/web/src/components/console/SocialSignInCard.test.tsx packages/web/src/app/auth/social/callback/page.tsx packages/web/src/lib/logto-account.ts packages/web/src/lib/logto-account.test.ts`
- `pnpm --filter @agentconnect.md/web build`
- `git diff --check origin/main...HEAD`

Created by Codex . GPT-5
