### PR TITLE
fix(lark): allow avatar prefill across origins

### DIFF
--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -459,8 +459,11 @@ approval.
 
 The same creation deeplink pre-fills the bot avatar from the Agent's current
 public icon URL. Uploaded icons use their public object-store URL; glyph and
-runtime icons use the public Control Plane PNG endpoint. If neither public base
-is configured, avatar prefill is omitted and app creation continues normally.
+runtime icons use the public Control Plane PNG endpoint. The Control Plane
+response allows anonymous cross-origin reads, and the configured object-store
+origin must do the same, because the Lark launcher rasterizes the avatar
+in-browser. If neither public base is configured, avatar prefill is omitted and
+app creation continues normally.
 
 Manual setup must configure the same bot capability, long-connection event,
 scopes, and publication state. In both paths, adding the bot to a target group

--- a/packages/control-plane/src/http/routes/agent-icon.ts
+++ b/packages/control-plane/src/http/routes/agent-icon.ts
@@ -31,6 +31,9 @@ export function agentIconRoutes(deps: HttpDeps) {
       async (req, reply): Promise<FastifyReply> => {
         const agent = await deps.repos.agent.get(AgentId(req.params.id)).catch(() => null)
         if (!agent) return reply.code(404).send()
+        // Lark's app launcher loads this with `crossOrigin = "anonymous"` before
+        // rasterizing it on a canvas, so the public image response must allow CORS.
+        reply.header('Access-Control-Allow-Origin', '*')
         // `image` icons live in the object store — iconUrl points straight at the
         // store's public URL, so Slack/browsers normally never hit this endpoint for
         // them. Redirect if reached anyway (when a store base is configured); if it

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -149,6 +149,14 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(avatarUrl.origin).toBe('https://cp.example.test')
     expect(avatarUrl.pathname).toBe(`/v1/agents/${agentId}/icon`)
     expect(avatarUrl.searchParams.has('v')).toBe(true)
+    const avatar = await first.app.inject({
+      method: 'GET',
+      url: `${avatarUrl.pathname}${avatarUrl.search}`,
+      headers: { origin: 'https://open.larksuite.com' }
+    })
+    expect(avatar.statusCode).toBe(200)
+    expect(avatar.headers['content-type']).toMatch(/^image\/png/)
+    expect(avatar.headers['access-control-allow-origin']).toBe('*')
     expect(decodeAddons(authorizationUrl.searchParams.get('addons')!)).toMatchObject({
       preset: true,
       scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },


### PR DESCRIPTION
## Summary

- allow anonymous cross-origin reads from the public Agent icon endpoint
- cover the Lark launcher origin in the one-click registration integration test
- document the corresponding requirement for uploaded-icon object storage

## Why

The Lark app launcher loads the supplied avatar with anonymous CORS before
rasterizing it on a canvas. The Control Plane returned a valid PNG but omitted
the required CORS response header, so Lark replaced the prefilled Agent icon
with its broken-image placeholder.

## Validation

- Control Plane typecheck
- Feishu registration integration suite (7 tests)
- changed-file ESLint and Prettier
- diff check
