### PR TITLE
feat(web): preserve lifecycle transition status

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -13,6 +13,15 @@ empty states, toasts, or error messages. Rewrite the copy around what the user c
 needs to know; if an implementation detail does not change either, omit it. Technical
 component names belong in logs, developer tooling, and architecture documentation.
 
+## Planned daemon lifecycle status
+
+A pending daemon upgrade or restart is a planned transition, not an unexpected outage.
+While that lifecycle operation is pending, the console shows the daemon and its active
+placed agents as `upgrading` or `restarting` with the paused-state color. An agent that
+an operator explicitly paused remains `paused`. Once the operation succeeds, fails, or
+expires, the console returns to the daemon's current connection status; a daemon that
+did not return then reads `offline`.
+
 ## Slack message attribution footer
 
 The attribution footer for an agent response must be attached to the final Slack

--- a/packages/web/src/components/console/AgentReachabilityOverview.tsx
+++ b/packages/web/src/components/console/AgentReachabilityOverview.tsx
@@ -338,7 +338,7 @@ export function AgentReachabilityOverview({
               const agent = agentById.get(agentId)!
               const node = layout.nodes.get(agentId)!
               const owningDaemon = daemons.find((daemon) => daemon.daemonId === agent.daemon)
-              const agentStatus = status(effectiveAgentStatus(agent.status, owningDaemon?.status))
+              const agentStatus = status(effectiveAgentStatus(agent.status, owningDaemon))
               const isFocus = focusAgentId === agentId
               const isFocusedCycleMember = focusedCycleAgentIds?.has(agentId) ?? false
               const dimmed = highlightedAgentIds !== null && !highlightedAgentIds.has(agentId)

--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent a
 import { useRouter } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { agentLabel, effectiveAgentStatus, status } from '@/lib/data'
+import { agentLabel, effectiveAgentStatus, presentedDaemonStatus, status } from '@/lib/data'
 import { cronHuman } from '@/lib/cron'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
@@ -88,7 +88,7 @@ export function GlobalSearch({
       // Gate "online" on the owning daemon being connected (as the Agents view does),
       // and surface the daemon's display NAME — never its host.
       const owning = daemonById.get(a.daemon)
-      const s = status(effectiveAgentStatus(a.status, owning?.status))
+      const s = status(effectiveAgentStatus(a.status, owning))
       return {
         key: `agent:${a.id}`,
         kind: 'agent',
@@ -115,7 +115,7 @@ export function GlobalSearch({
         kind: 'daemon',
         title: d.name,
         meta: [d.version || undefined, `${hosted} agent${hosted === 1 ? '' : 's'}`].filter(Boolean).join(' · '),
-        aux: status(d.status).label,
+        aux: status(presentedDaemonStatus(d)).label,
         href: orgPath(`/daemons/${d.daemonId}`)
       }
     })

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -355,7 +355,7 @@ export default function AgentDetailView() {
   // does (else a blank model reads "Default" here but its resolved default in the
   // editor). Falls back to the static labels when the daemon reports no catalog.
   const modelText = agentModelDisplay(owningDaemon, da.runtime, da.model)
-  const ds = status(effectiveAgentStatus(da.status, owningDaemon?.status))
+  const ds = status(effectiveAgentStatus(da.status, owningDaemon))
   const ws = da.workspace
   // Demo agents have no daemon to read git state from, so the workspace card's
   // live half comes straight from their static mock workspace instead.

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -33,8 +33,9 @@ function initialsOf(label: string): string {
 // with no natural order).
 type SortKey = 'agent' | 'status' | 'daemon' | 'creator' | 'repo' | 'sessions' | 'tokens' | 'cost'
 const NUMERIC_KEYS: SortKey[] = ['sessions', 'tokens', 'cost']
-// Status column sort order: live agents first, then paused, then offline.
-const STATUS_RANK: Record<string, number> = { online: 0, paused: 1, offline: 2 }
+// Status column sort order: live agents first, planned transitions next, then
+// deliberately paused agents and finally unexpected outages.
+const STATUS_RANK: Record<string, number> = { online: 0, upgrading: 1, restarting: 1, paused: 2, offline: 3 }
 
 // Parse a compact/formatted figure ("1.2M", "128K", "$3.40") back to a number so the
 // Tokens/Cost columns can sort by the mock/demo strings when live usage is absent.
@@ -152,7 +153,9 @@ export default function AgentsView() {
     if (scope === 'mine' && (!me?.userId || a.createdBy !== me.userId)) return false
     if (seg === 'all') return true
     const eff = effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status)
-    return eff === seg
+    // A lifecycle transition is a temporary processing pause, not an outage.
+    // Keep it discoverable under Paused while its row names the exact operation.
+    return (eff === 'upgrading' || eff === 'restarting' ? 'paused' : eff) === seg
   })
   // Desktop sort applied on top of the scope/status filter. Mobile has no sort headers,
   // so it keeps `filtered` (natural order). A stable comparator on a copy — never mutate

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -17,7 +17,7 @@ import { useProfile } from '@/lib/profile'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { AgentReachabilityOverview } from '@/components/console/AgentReachabilityOverview'
-import { isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
+import { daemonCompletesOnboarding, isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
 
 // Two-letter avatar initials for a creator name — first letters of the first two
 // words, or the first two chars of a single token.
@@ -94,7 +94,11 @@ export default function AgentsView() {
   const creatorText = (a: Agent) => creatorLabel(a.createdBy || null, me)
   const repoText = (a: Agent) => (a.workspace.mode === 'github' ? a.repo : 'scratch')
   const onlineCount = agents.filter(
-    (a) => effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status) === 'online'
+    (a) =>
+      effectiveAgentStatus(
+        a.status,
+        daemons.find((d) => d.daemonId === a.daemon)
+      ) === 'online'
   ).length
   const currency = usage24h?.totals.costCurrency ?? undefined
   const isMobile = useIsMobile()
@@ -119,7 +123,7 @@ export default function AgentsView() {
     agentsLoading,
     daemonsLoading,
     agents.length,
-    daemons.some((daemon) => daemon.status === 'online')
+    daemons.some(daemonCompletesOnboarding)
   )
   const redirectToOnboarding = notInitialized && onboardingSkipped === false
   useEffect(() => {
@@ -152,7 +156,10 @@ export default function AgentsView() {
   const filtered = agents.filter((a) => {
     if (scope === 'mine' && (!me?.userId || a.createdBy !== me.userId)) return false
     if (seg === 'all') return true
-    const eff = effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status)
+    const eff = effectiveAgentStatus(
+      a.status,
+      daemons.find((d) => d.daemonId === a.daemon)
+    )
     // A lifecycle transition is a temporary processing pause, not an outage.
     // Keep it discoverable under Paused while its row names the exact operation.
     return (eff === 'upgrading' || eff === 'restarting' ? 'paused' : eff) === seg
@@ -161,7 +168,12 @@ export default function AgentsView() {
   // so it keeps `filtered` (natural order). A stable comparator on a copy — never mutate
   // the SWR-backed array.
   const statusRank = (a: Agent) =>
-    STATUS_RANK[effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status)] ?? 3
+    STATUS_RANK[
+      effectiveAgentStatus(
+        a.status,
+        daemons.find((d) => d.daemonId === a.daemon)
+      )
+    ] ?? 3
   const visible = (() => {
     if (!sort) return filtered
     const dir = sort.dir === 'asc' ? 1 : -1
@@ -385,7 +397,7 @@ export default function AgentsView() {
             {filtered.map((a, i) => {
               const owning = daemons.find((d) => d.daemonId === a.daemon)
               const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
-              const s = status(effectiveAgentStatus(a.status, owning?.status))
+              const s = status(effectiveAgentStatus(a.status, owning))
               const agentInts = integrations.filter((int) => int.agentId === a.id)
               const first = agentInts[0]
               const n24 = sessions24h(a.id)
@@ -547,7 +559,7 @@ export default function AgentsView() {
           visible.map((a) => {
             const owning = daemons.find((d) => d.daemonId === a.daemon)
             const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
-            const s = status(effectiveAgentStatus(a.status, owning?.status))
+            const s = status(effectiveAgentStatus(a.status, owning))
             const sessionCount = sessions24h(a.id)
             // Keep the resolved name for sorting, assistive text, and the avatar's hint.
             const creatorName = creatorText(a)

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -9,7 +9,15 @@
 
 import { useState, type ReactNode } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { agentLabel, agentModelDisplay, effectiveAgentStatus, platName, runtimeLabel, status } from '@/lib/data'
+import {
+  agentLabel,
+  agentModelDisplay,
+  effectiveAgentStatus,
+  platName,
+  presentedDaemonStatus,
+  runtimeLabel,
+  status
+} from '@/lib/data'
 import { creatorLabel } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
@@ -79,7 +87,7 @@ export default function DaemonDetailView() {
     )
   }
 
-  const s = status(daemon.status)
+  const s = status(presentedDaemonStatus(daemon))
   const online = daemon.status === 'online'
   // Reconnect + delete are offered for any not-serving daemon. Mid-handshake and
   // reconnect-grace states are normalized to offline by the API mapper, so a dead
@@ -183,7 +191,7 @@ export default function DaemonDetailView() {
         {/* action bar — status-aware: online ⇒ restart/upgrade, offline ⇒ reconnect;
             hidden while a lifecycle op is in flight (the pending badge above shows it). */}
         <div className="flex gap-2 bg-(--surface-card) px-4 pb-4">
-          {offline && (
+          {offline && !pending && (
             <button
               onClick={() => openModal('reconnectDaemon', daemon)}
               className="flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[14px] font-semibold leading-normal text-(--text-primary)"
@@ -333,7 +341,7 @@ export default function DaemonDetailView() {
           {hosted.length > 0 ? (
             hosted.map((a, i) => {
               // Daemon status is known here, so gate the agent's effective online on it.
-              const as = status(effectiveAgentStatus(a.status, daemon.status))
+              const as = status(effectiveAgentStatus(a.status, daemon))
               return (
                 <button
                   key={a.id}
@@ -466,7 +474,7 @@ export default function DaemonDetailView() {
         </div>
 
         {/* delete — offline-only, matching the desktop menu's guard */}
-        {offline && (
+        {offline && !pending && (
           <div className="mx-4 mt-3">
             <button
               onClick={() => openModal('deleteDaemon', daemon)}
@@ -557,7 +565,7 @@ export default function DaemonDetailView() {
                     Restart
                   </button>
                 )}
-                {offline && (
+                {offline && !pending && (
                   <>
                     <button
                       className="dmi"
@@ -767,7 +775,7 @@ export default function DaemonDetailView() {
                 </div>
                 {hosted.map((a) => {
                   // On this page we know the daemon's status, so gate the agent's online.
-                  const as = status(effectiveAgentStatus(a.status, daemon.status))
+                  const as = status(effectiveAgentStatus(a.status, daemon))
                   return (
                     <div
                       key={a.id}

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -153,7 +153,7 @@ export default function DaemonDetailView() {
     ]
     const sysRows: [string, ReactNode, string][] = [
       ['Hostname', daemon.host, 'var(--text-primary)'],
-      ['Status', s.label, online ? 'var(--green-500)' : 'var(--amber-500)'],
+      ['Status', s.label, s.text],
       ['Version', daemon.version, 'var(--text-primary)'],
       ...(pending ? ([['Pending', pendingLabel, 'var(--brand)']] as [string, ReactNode, string][]) : [])
     ]

--- a/packages/web/src/components/console/views/DaemonsView.tsx
+++ b/packages/web/src/components/console/views/DaemonsView.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { status, type DaemonRow } from '@/lib/data'
+import { presentedDaemonStatus, status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { RestrictedLock } from '@/components/console/VisibilityField'
@@ -98,7 +98,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
   const [saving, setSaving] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
 
-  const s = status(m.status)
+  const s = status(presentedDaemonStatus(m))
   const online = m.status === 'online'
   const load = Math.max(m.cpu, m.mem)
   const barColor = loadBarColor(load)
@@ -258,7 +258,7 @@ function DaemonCard({ m, hosted }: { m: DaemonRow; hosted: number }) {
                     Restart
                   </button>
                 )}
-                {offline && (
+                {offline && !pending && (
                   <>
                     <button
                       className="dmi"

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -35,7 +35,10 @@ vi.mock('@/lib/data-context', () => ({
 }))
 vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
 vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
-vi.mock('@/lib/onboarding', () => ({ skipOnboarding: vi.fn() }))
+vi.mock('@/lib/onboarding', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/onboarding')>()
+  return { ...actual, skipOnboarding: vi.fn() }
+})
 vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
 vi.mock('@/lib/data', () => ({ agentLabel: () => 'Agent' }))
 vi.mock('@/components/marks', () => ({

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -8,7 +8,7 @@ import { agentLabel } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { useOrgs } from '@/lib/org-context'
-import { skipOnboarding } from '@/lib/onboarding'
+import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
 import type { DaemonConnectDto } from '@/lib/api'
 
@@ -56,10 +56,10 @@ export default function OnboardingView() {
   const { orgPath } = useOrgs()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
 
-  // Only a serving daemon completes step 1. An offline row may be a provisioned daemon
-  // whose one-time command was lost on reload; the daemon step reconnects it below.
-  const daemonOnline = daemons.some((d) => d.status === 'online')
-  const offlineDaemonId = daemons.find((d) => d.status !== 'online')?.daemonId
+  // A live daemon or a planned relaunch completes step 1. Only an unexpected offline
+  // row is eligible for a replacement connect token.
+  const daemonReady = daemons.some(daemonCompletesOnboarding)
+  const offlineDaemonId = firstReconnectableDaemonId(daemons)
   const hasAgent = agents.length > 0
   const hasIntegration = integrations.length > 0 || agents.some((a) => (a.hookKinds ?? []).length > 0)
 
@@ -75,10 +75,10 @@ export default function OnboardingView() {
   useEffect(() => {
     if (didInit.current || agentsLoading || daemonsLoading) return
     didInit.current = true
-    const s = !daemonOnline ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
+    const s = !daemonReady ? 0 : !hasAgent ? 1 : !hasIntegration ? 2 : 3
     setStep(s)
     setEntered(s > 0)
-  }, [agentsLoading, daemonsLoading, daemonOnline, hasAgent, hasIntegration])
+  }, [agentsLoading, daemonsLoading, daemonReady, hasAgent, hasIntegration])
 
   // --- Daemon provisioning (step 0), mirrors AddDaemonModal --------------------------
   const [connect, setConnect] = useState<DaemonCommand | null>(null)
@@ -88,7 +88,7 @@ export default function OnboardingView() {
   const createdByWizard = useRef(false)
   const connectedOnce = useRef(false)
   useEffect(() => {
-    if (!entered || step !== 0 || daemonOnline || provisioned.current) return
+    if (!entered || step !== 0 || daemonReady || provisioned.current) return
     provisioned.current = true
     setMintErr(null)
     createdByWizard.current = !offlineDaemonId
@@ -100,7 +100,7 @@ export default function OnboardingView() {
       : provisionDaemon()
     commandPending.current = command
     command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
-  }, [entered, step, daemonOnline, offlineDaemonId, provisionDaemon, reconnectDaemon])
+  }, [entered, step, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon])
 
   const provisionedRow = connect ? daemons.find((d) => d.daemonId === connect.daemonId) : undefined
   useEffect(() => {
@@ -220,7 +220,7 @@ export default function OnboardingView() {
                     Back
                   </Button>
                   <div className="flex-1" />
-                  <Button disabled={!daemonOnline} onClick={() => setStep(1)}>
+                  <Button disabled={!daemonReady} onClick={() => setStep(1)}>
                     Create an agent
                     <Icon name="arrow-right" size={15} />
                   </Button>
@@ -233,7 +233,7 @@ export default function OnboardingView() {
                 name={provisionedRow?.name}
                 host={provisionedRow?.host}
                 version={provisionedRow?.version}
-                resumed={daemonOnline && !provisionedRow}
+                resumed={daemonReady && !provisionedRow}
                 resumedName={daemons.find((d) => d.status === 'online')?.name ?? daemons[0]?.name}
               />
               <div className="mt-[14px] flex items-start gap-2 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -7,14 +7,14 @@
 import type {
   Agent,
   AgentCallPolicy,
+  ConnectionStatusKey,
   DaemonRow,
   ResourceVisibility,
   Session,
   SessionImage,
-  StatusKey,
   Workspace
 } from '@/lib/data'
-import { isSelfSender, lifecycleAwareDaemonStatus, MOCK_MODE } from '@/lib/data'
+import { isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import { getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
@@ -1207,9 +1207,8 @@ export function postOAuthConsent(input: OAuthConsentInput): Promise<{ redirectUr
 // ── DTO → UI mappers ────────────────────────────────────────────────────────
 const PLACEHOLDER = '—'
 
-function toStatusKey(raw: string): StatusKey {
+function toStatusKey(raw: string): ConnectionStatusKey {
   const s = (raw || '').toLowerCase()
-  if (s === 'upgrading' || s === 'restarting') return s
   if (['online', 'running', 'active', 'ready', 'live', 'working', 'connected', 'idle', 'completed'].includes(s))
     return 'online'
   if (['paused', 'draining', 'awaiting', 'blocked', 'prompting', 'resuming', 'cancelling'].includes(s)) return 'paused'
@@ -1618,13 +1617,13 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     releaseChannel: d.releaseChannel,
     availableVersions: d.availableVersions ?? [],
     lifecycleOp: d.lifecycleOp ?? null,
+    lifecycleStatus: lifecycleStatus(d.lifecycleOp) ?? null,
     canManageLifecycle: d.canManageLifecycle ?? false,
     // Flag an available upgrade only when both versions parse and latest > running.
     upgradeAvailable: isUpgradeAvailable(d.agentVersion, d.latestVersion),
-    // The durable lifecycle op spans the expected disconnect/reconnect window.
-    // Prefer its explicit transition over the live socket status so the daemon and
-    // its agents do not flash offline while a planned relaunch is still in progress.
-    status: lifecycleAwareDaemonStatus(toStatusKey(d.status), d.lifecycleOp),
+    // Keep connection/readiness operational. Presentation surfaces combine this
+    // with lifecycleStatus without changing onboarding or reconnect decisions.
+    status: toStatusKey(d.status),
     host: d.host ?? PLACEHOLDER,
     // `load.{cpu,mem}` are 0..1 fractions; surface them as percentages.
     cpu: d.load ? Math.round(d.load.cpu * 100) : 0,

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -14,7 +14,7 @@ import type {
   StatusKey,
   Workspace
 } from '@/lib/data'
-import { isSelfSender, MOCK_MODE } from '@/lib/data'
+import { isSelfSender, lifecycleAwareDaemonStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import { getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
@@ -1209,6 +1209,7 @@ const PLACEHOLDER = '—'
 
 function toStatusKey(raw: string): StatusKey {
   const s = (raw || '').toLowerCase()
+  if (s === 'upgrading' || s === 'restarting') return s
   if (['online', 'running', 'active', 'ready', 'live', 'working', 'connected', 'idle', 'completed'].includes(s))
     return 'online'
   if (['paused', 'draining', 'awaiting', 'blocked', 'prompting', 'resuming', 'cancelling'].includes(s)) return 'paused'
@@ -1620,7 +1621,10 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     canManageLifecycle: d.canManageLifecycle ?? false,
     // Flag an available upgrade only when both versions parse and latest > running.
     upgradeAvailable: isUpgradeAvailable(d.agentVersion, d.latestVersion),
-    status: toStatusKey(d.status),
+    // The durable lifecycle op spans the expected disconnect/reconnect window.
+    // Prefer its explicit transition over the live socket status so the daemon and
+    // its agents do not flash offline while a planned relaunch is still in progress.
+    status: lifecycleAwareDaemonStatus(toStatusKey(d.status), d.lifecycleOp),
     host: d.host ?? PLACEHOLDER,
     // `load.{cpu,mem}` are 0..1 fractions; surface them as percentages.
     cpu: d.load ? Math.round(d.load.cpu * 100) : 0,

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -5,9 +5,12 @@ import {
   agentPermissionDisplay,
   displayedEffort,
   enrichSessionWithAgent,
+  effectiveAgentStatus,
   effortChoicesFor,
   effortField,
   fastModeAvailableFor,
+  lifecycleAwareDaemonStatus,
+  lifecycleStatus,
   modelCapability,
   modelLabel,
   permissionModeChoicesFor,
@@ -21,6 +24,21 @@ import {
   type RuntimeModelCatalog,
   type Session
 } from './data'
+
+describe('planned daemon lifecycle status', () => {
+  it('keeps online agents in the explicit restart or upgrade transition', () => {
+    expect(lifecycleStatus({ op: 'upgrade', status: 'pending' })).toBe('upgrading')
+    expect(lifecycleStatus({ op: 'restart', status: 'pending' })).toBe('restarting')
+    expect(lifecycleStatus({ op: 'upgrade', status: 'succeeded' })).toBeUndefined()
+    expect(lifecycleAwareDaemonStatus('offline', { op: 'upgrade', status: 'pending' })).toBe('upgrading')
+    expect(lifecycleAwareDaemonStatus('offline', { op: 'upgrade', status: 'failed' })).toBe('offline')
+
+    expect(effectiveAgentStatus('online', 'upgrading')).toBe('upgrading')
+    expect(effectiveAgentStatus('online', 'restarting')).toBe('restarting')
+    expect(effectiveAgentStatus('online', 'offline')).toBe('offline')
+    expect(effectiveAgentStatus('paused', 'upgrading')).toBe('paused')
+  })
+})
 
 describe('sessionChannelFilterValue', () => {
   it('groups live and persisted Playground conversations under one filter value', () => {

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -20,6 +20,7 @@ import {
   presentedDaemonStatus,
   resolveEffortForModel,
   sessionChannelFilterValue,
+  status,
   type DaemonRow,
   type RuntimeModelCatalog,
   type Session
@@ -35,6 +36,14 @@ describe('planned daemon lifecycle status', () => {
     expect(effectiveAgentStatus('online', upgrading)).toBe('upgrading')
     expect(effectiveAgentStatus('online', { status: 'offline', lifecycleStatus: null })).toBe('offline')
     expect(effectiveAgentStatus('paused', upgrading)).toBe('paused')
+  })
+
+  it('uses the transition tone while a pending daemon is still connected', () => {
+    const restarting = { status: 'online' as const, lifecycleStatus: 'restarting' as const }
+    expect(status(presentedDaemonStatus(restarting))).toMatchObject({
+      label: 'restarting',
+      text: '#9a6500'
+    })
   })
 })
 

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -9,7 +9,6 @@ import {
   effortChoicesFor,
   effortField,
   fastModeAvailableFor,
-  lifecycleAwareDaemonStatus,
   lifecycleStatus,
   modelCapability,
   modelLabel,
@@ -18,6 +17,7 @@ import {
   PLAYGROUND_CHANNEL_FILTER,
   resolvedPermissionMode,
   permissionModeOptions,
+  presentedDaemonStatus,
   resolveEffortForModel,
   sessionChannelFilterValue,
   type DaemonRow,
@@ -30,13 +30,11 @@ describe('planned daemon lifecycle status', () => {
     expect(lifecycleStatus({ op: 'upgrade', status: 'pending' })).toBe('upgrading')
     expect(lifecycleStatus({ op: 'restart', status: 'pending' })).toBe('restarting')
     expect(lifecycleStatus({ op: 'upgrade', status: 'succeeded' })).toBeUndefined()
-    expect(lifecycleAwareDaemonStatus('offline', { op: 'upgrade', status: 'pending' })).toBe('upgrading')
-    expect(lifecycleAwareDaemonStatus('offline', { op: 'upgrade', status: 'failed' })).toBe('offline')
-
-    expect(effectiveAgentStatus('online', 'upgrading')).toBe('upgrading')
-    expect(effectiveAgentStatus('online', 'restarting')).toBe('restarting')
-    expect(effectiveAgentStatus('online', 'offline')).toBe('offline')
-    expect(effectiveAgentStatus('paused', 'upgrading')).toBe('paused')
+    const upgrading = { status: 'offline' as const, lifecycleStatus: 'upgrading' as const }
+    expect(presentedDaemonStatus(upgrading)).toBe('upgrading')
+    expect(effectiveAgentStatus('online', upgrading)).toBe('upgrading')
+    expect(effectiveAgentStatus('online', { status: 'offline', lifecycleStatus: null })).toBe('offline')
+    expect(effectiveAgentStatus('paused', upgrading)).toBe('paused')
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -5,7 +5,8 @@ import type { AgentIcon } from '@/lib/agent-icon'
 import type { MemoryDreamingConfig } from '@/lib/api'
 
 export type LifecycleStatusKey = 'upgrading' | 'restarting'
-export type StatusKey = 'online' | 'paused' | 'offline' | LifecycleStatusKey
+export type ConnectionStatusKey = 'online' | 'paused' | 'offline'
+export type StatusKey = ConnectionStatusKey | LifecycleStatusKey
 
 export interface StatusInfo {
   dot: string
@@ -48,11 +49,8 @@ export function lifecycleStatus(
   return op.op === 'upgrade' ? 'upgrading' : 'restarting'
 }
 
-export function lifecycleAwareDaemonStatus(
-  connectionStatus: StatusKey,
-  op: Pick<DaemonLifecycleOp, 'op' | 'status'> | null | undefined
-): StatusKey {
-  return lifecycleStatus(op) ?? connectionStatus
+export function presentedDaemonStatus(daemon: Pick<DaemonRow, 'status' | 'lifecycleStatus'>): StatusKey {
+  return daemon.lifecycleStatus ?? daemon.status
 }
 
 // An agent runs *inside* its owning daemon, so it can't really be online when that
@@ -60,10 +58,13 @@ export function lifecycleAwareDaemonStatus(
 // remain intact while the daemon drains and relaunches, so carry that explicit amber
 // transition onto the agent instead of flashing it red. When the owning daemon isn't
 // in the fleet (e.g. the demo agents' placeholder daemons), trust the stored status.
-export function effectiveAgentStatus(agentStatus: StatusKey, owningDaemonStatus: StatusKey | undefined): StatusKey {
-  if (agentStatus === 'online' && owningDaemonStatus !== undefined) {
-    if (owningDaemonStatus === 'upgrading' || owningDaemonStatus === 'restarting') return owningDaemonStatus
-    if (owningDaemonStatus !== 'online') return 'offline'
+export function effectiveAgentStatus(
+  agentStatus: StatusKey,
+  owningDaemon: Pick<DaemonRow, 'status' | 'lifecycleStatus'> | undefined
+): StatusKey {
+  if (agentStatus === 'online' && owningDaemon !== undefined) {
+    if (owningDaemon.lifecycleStatus) return owningDaemon.lifecycleStatus
+    if (owningDaemon.status !== 'online') return 'offline'
   }
   return agentStatus
 }
@@ -1552,7 +1553,10 @@ export interface DaemonRow {
   lifecycleOp: DaemonLifecycleOp | null
   /** Whether the caller may command restart/upgrade on this daemon (org owner only). */
   canManageLifecycle: boolean
-  status: StatusKey
+  /** Actual daemon connection/readiness. Never replaced by a presentation-only lifecycle state. */
+  status: ConnectionStatusKey
+  /** Planned lifecycle presentation while the durable operation is pending. */
+  lifecycleStatus: LifecycleStatusKey | null
   host: string
   cpu: number // 0-100 CPU utilization
   mem: number // 0-100 memory utilization

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -4,7 +4,8 @@
 import type { AgentIcon } from '@/lib/agent-icon'
 import type { MemoryDreamingConfig } from '@/lib/api'
 
-export type StatusKey = 'online' | 'paused' | 'offline'
+export type LifecycleStatusKey = 'upgrading' | 'restarting'
+export type StatusKey = 'online' | 'paused' | 'offline' | LifecycleStatusKey
 
 export interface StatusInfo {
   dot: string
@@ -16,21 +17,53 @@ export interface StatusInfo {
 const STATUS_MAP: Record<StatusKey, StatusInfo> = {
   online: { dot: 'var(--status-online)', label: 'online', bg: 'var(--status-online-soft)', text: '#0f7a48' },
   paused: { dot: 'var(--status-paused)', label: 'paused', bg: 'var(--status-paused-soft)', text: '#9a6500' },
-  offline: { dot: 'var(--status-error)', label: 'offline', bg: 'var(--status-error-soft)', text: 'var(--status-error)' }
+  offline: {
+    dot: 'var(--status-error)',
+    label: 'offline',
+    bg: 'var(--status-error-soft)',
+    text: 'var(--status-error)'
+  },
+  upgrading: {
+    dot: 'var(--status-paused)',
+    label: 'upgrading',
+    bg: 'var(--status-paused-soft)',
+    text: '#9a6500'
+  },
+  restarting: {
+    dot: 'var(--status-paused)',
+    label: 'restarting',
+    bg: 'var(--status-paused-soft)',
+    text: '#9a6500'
+  }
 }
 
 export function status(s: string): StatusInfo {
   return STATUS_MAP[s as StatusKey] ?? STATUS_MAP.offline
 }
 
+export function lifecycleStatus(
+  op: Pick<DaemonLifecycleOp, 'op' | 'status'> | null | undefined
+): LifecycleStatusKey | undefined {
+  if (op?.status !== 'pending') return undefined
+  return op.op === 'upgrade' ? 'upgrading' : 'restarting'
+}
+
+export function lifecycleAwareDaemonStatus(
+  connectionStatus: StatusKey,
+  op: Pick<DaemonLifecycleOp, 'op' | 'status'> | null | undefined
+): StatusKey {
+  return lifecycleStatus(op) ?? connectionStatus
+}
+
 // An agent runs *inside* its owning daemon, so it can't really be online when that
-// daemon is offline. The stored agent status ('active' once placed) never tracks
-// daemon liveness — the CP has no reaper that flips it — so the console gates
-// "online" on the owning daemon being connected. When the owning daemon isn't in the
-// fleet (e.g. the demo agents' placeholder daemons), we trust the stored status.
+// daemon is offline. A planned restart/upgrade is different: placement and sessions
+// remain intact while the daemon drains and relaunches, so carry that explicit amber
+// transition onto the agent instead of flashing it red. When the owning daemon isn't
+// in the fleet (e.g. the demo agents' placeholder daemons), trust the stored status.
 export function effectiveAgentStatus(agentStatus: StatusKey, owningDaemonStatus: StatusKey | undefined): StatusKey {
-  if (agentStatus === 'online' && owningDaemonStatus !== undefined && owningDaemonStatus !== 'online') {
-    return 'offline'
+  if (agentStatus === 'online' && owningDaemonStatus !== undefined) {
+    if (owningDaemonStatus === 'upgrading' || owningDaemonStatus === 'restarting') return owningDaemonStatus
+    if (owningDaemonStatus !== 'online') return 'offline'
   }
   return agentStatus
 }

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { needsOnboarding } from './onboarding'
+import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding } from './onboarding'
 
 describe('needsOnboarding', () => {
   it('recovers an empty org whose only daemon is offline', () => {
@@ -10,5 +10,12 @@ describe('needsOnboarding', () => {
     expect(needsOnboarding(true, false, 0, false)).toBe(false)
     expect(needsOnboarding(false, false, 1, false)).toBe(false)
     expect(needsOnboarding(false, false, 0, true)).toBe(false)
+  })
+
+  it('keeps an empty org initialized during a planned daemon relaunch', () => {
+    const restarting = { daemonId: 'edge-1', status: 'offline' as const, lifecycleStatus: 'restarting' as const }
+    expect(daemonCompletesOnboarding(restarting)).toBe(true)
+    expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
+    expect(needsOnboarding(false, false, 0, daemonCompletesOnboarding(restarting))).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -1,9 +1,23 @@
+import type { DaemonRow } from './data'
+
 // Per-tab "skip onboarding" flag. The agents view redirects an uninitialized org to
 // the onboarding route; "Explore the console first" sets this so the very next agents
 // render doesn't bounce straight back (which would be an infinite redirect). Scoped to
 // sessionStorage by org slug, so a fresh tab/session shows onboarding again while the
 // org stays empty.
 const key = (org: string) => `ac:onboarding-skip:${org}`
+
+type OnboardingDaemon = Pick<DaemonRow, 'daemonId' | 'status' | 'lifecycleStatus'>
+
+/** A planned relaunch keeps the daemon established even while its socket reconnects. */
+export function daemonCompletesOnboarding(daemon: OnboardingDaemon): boolean {
+  return daemon.status === 'online' || daemon.lifecycleStatus != null
+}
+
+/** Only an unexpectedly non-serving daemon is eligible for a replacement connect token. */
+export function firstReconnectableDaemonId(daemons: readonly OnboardingDaemon[]): string | undefined {
+  return daemons.find((daemon) => !daemonCompletesOnboarding(daemon))?.daemonId
+}
 
 export function needsOnboarding(
   agentsLoading: boolean,


### PR DESCRIPTION
## Summary

- show pending daemon upgrades and restarts as amber `upgrading` or `restarting` states instead of flashing `offline`
- carry the planned transition onto active placed agents while preserving an explicit operator pause
- keep the daemon's real connection status separate so onboarding and reconnect decisions remain operationally correct
- keep transitional agents discoverable under the Paused filter and document the product behavior

## Why

A planned daemon relaunch temporarily drops its live connection even though placement, sessions, and the lifecycle operation remain intact. The Console previously treated that expected gap as an outage and turned the daemon and all of its agents red.

This is a presentation and lifecycle-read-model change only. It keeps the existing install, drain, durable inbox, session restore, timeout, and failure behavior, and does not claim zero downtime.

## Validation

- `pnpm --filter @agentconnect.md/web test` (59 files, 422 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- targeted ESLint for the changed Web files
- Prettier check and `git diff --check`
- pre-push repository lint completed with two pre-existing import warnings in `packages/control-plane/src/http/routes/icon-upload.ts`

Created by Codex . GPT-5
