### PR TITLE
fix(registry): serialize ensurePersonalOrg per user with an app_user row lock

### DIFF
--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -14,7 +14,7 @@
  * lowercase everywhere so invites and sign-ins can't miss on case.
  */
 import type { PrismaClient } from '../../generated/prisma/client.js'
-import { withAmbientTx, type PrismaLike } from '../prisma.js'
+import { Prisma, withAmbientTx, type PrismaLike } from '../prisma.js'
 import {
   type UserRepo,
   type ProvisionOidcUserInput,
@@ -110,6 +110,17 @@ const isP2002 = (err: unknown): boolean => (err as { code?: string }).code === '
  * Postgres ANY failed statement aborts the WHOLE transaction — the caught P2002
  * would poison every following query with 25P02 and surface as a 500. A read-then-insert
  * has the same flaw, since two concurrent allocations can pick the same free candidate.
+ *
+ * PER-USER SERIALIZATION: the first statement locks the `app_user` row
+ * (`SELECT … FOR UPDATE`), making THIS seam the single serialization point for
+ * every personal-org caller — including callers in the external admin app,
+ * which mirrors this seam over the shared database. Without it, two paths that
+ * otherwise lock disjoint rows (e.g. waitlist redeem, which locks only the
+ * `waitlist_entry` row when the user is ALREADY activated and so skips the
+ * `user.update`, racing an admin-side activation repair) can both observe "no
+ * owner membership" and each mint a personal org + preset. The loser of this
+ * lock resumes after the winner commits; READ COMMITTED re-reads then see the
+ * winner's membership and the call degrades to the idempotent no-op.
  */
 export async function ensurePersonalOrg(
   db: PrismaLike,
@@ -119,6 +130,7 @@ export async function ensurePersonalOrg(
   opts?: { presetAgents?: boolean }
 ): Promise<void> {
   await withAmbientTx(db, async (tx) => {
+    await tx.$queryRaw(Prisma.sql`SELECT "id" FROM "app_user" WHERE "id" = ${userId} FOR UPDATE`)
     const already = await tx.membership.findFirst({ where: { userId, role: 'owner' } })
     if (already) return
     const base = personalOrgBase(displayName, email)

--- a/packages/control-plane/test/integration/personal-org-serialization.test.ts
+++ b/packages/control-plane/test/integration/personal-org-serialization.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-user serialization of `ensurePersonalOrg` (the personal-org seam).
+ *
+ * The seam's first statement locks the `app_user` row FOR UPDATE, so callers
+ * that otherwise lock DISJOINT rows still serialize on the user. The regression
+ * this pins down: an ALREADY-activated, org-less user (the external admin app's
+ * activation-repair case) being provisioned concurrently by two transactions —
+ * e.g. a waitlist redeem (which locks only the `waitlist_entry` row and skips
+ * `user.update` for an activated user) racing an admin-side activation. Without
+ * the lock both observe "no owner membership" and each mint a personal org +
+ * preset; with it, exactly one org/membership/preset survives.
+ */
+import { describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { ensurePersonalOrg } from '../../src/persistence/repositories/user.repo.js'
+
+describe('ensurePersonalOrg per-user serialization', () => {
+  it('concurrent calls for one already-activated user mint exactly one org + preset', async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: `cross-${randomUUID()}@example.test`,
+        oidcSubject: `sub-${randomUUID()}`,
+        displayName: 'Cross Race',
+        activatedAt: new Date() // already activated ⇒ no caller takes a user.update lock
+      }
+    })
+
+    // Each call opens its OWN transaction (root-client PrismaLike), modelling
+    // independent callers over the shared database. Same-name slugs force the
+    // colliding candidate chain.
+    await Promise.all(Array.from({ length: 6 }, () => ensurePersonalOrg(prisma, user.id, 'Cross', user.email)))
+
+    const memberships = await prisma.membership.findMany({ where: { userId: user.id } })
+    expect(memberships).toHaveLength(1)
+    expect(memberships[0]!.role).toBe('owner')
+
+    const presets = await prisma.presetAgent.findMany({ where: { orgId: memberships[0]!.orgId } })
+    expect(presets).toHaveLength(1)
+    expect(presets[0]!.status).toBe('created')
+
+    // No orphaned second org slipped through under a suffixed slug.
+    const orgs = await prisma.org.findMany({ where: { slug: { startsWith: 'cross' } } })
+    expect(orgs).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Problem

Two personal-org callers that lock disjoint rows can both observe "no owner membership" for the same user and each mint a personal org + preset. Concrete interleaving (found by review-bot on agentconnect-md/extensions#24, reproduced on Postgres 16 with the full migration chain): a waitlist redeem locks only the `waitlist_entry` row and — for an **already-activated** user — skips `user.update`, so it takes no `app_user` lock; racing the external admin app's activation repair (which locks `app_user`), both transactions commit and the user ends up owning `cross` and `cross-2` with two `preset_agent` rows.

## Fix

Lock the `app_user` row (`SELECT … FOR UPDATE`) as `ensurePersonalOrg`'s first statement, making the seam itself the single per-user serialization point for every caller — CP's redeem / JIT signup / invited-claim paths and the admin app's mirror of this seam over the shared database. The loser resumes after the winner commits; READ COMMITTED re-reads then see the winner's membership and the call degrades to the idempotent no-op. Lock ordering stays acyclic (redeem: `waitlist_entry` → `app_user`; admin: `app_user` only).

## Test plan

- New integration test `personal-org-serialization.test.ts`: provisions one already-activated, org-less user from six concurrent root-client transactions and asserts exactly one org/membership/preset. Verified it **fails** (duplicate org) with the lock line removed.
- `waitlist.route` + `preset-agents` integration suites and full typecheck pass (37 tests).

Companion to agentconnect-md/extensions#24 (admin Activate provisions the personal org); this closes the cross-service half of the race the review bot blocked that PR on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)