### PR TITLE
feat(settings): organize Slack bots by workspace

### DIFF
--- a/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
@@ -12,6 +12,25 @@ ALTER TABLE "bot"
 ALTER TABLE "slack_platform_install"
   ALTER COLUMN "agentId" DROP NOT NULL;
 
+-- Tie each revoked membership to the credential generation whose uninstall
+-- revoked it. A later Settings reauthorization can then revive only the
+-- memberships from the credential it replaces, while a deliberately freed bot
+-- (whose integration row was deleted) stays free.
+ALTER TABLE "integration"
+  ADD COLUMN "revokedCredentialRevision" INTEGER;
+
+-- Preserve the currently revoked membership set on upgrades. Prisma stamps an
+-- integration's updatedAt when the same revoke transaction flips it, so this
+-- excludes older revoked history (and a later revoke of an already-free bot).
+UPDATE "integration" AS i
+SET "revokedCredentialRevision" = b."credentialRevision"
+FROM "bot" AS b
+WHERE
+  i."botId" = b."id"
+  AND i."status" = 'revoked'
+  AND b."revokedAt" IS NOT NULL
+  AND i."updatedAt" >= b."revokedAt";
+
 -- Existing platform-app rows already have the stable workspace id, and their
 -- generated name carries the OAuth team name. This makes current installations
 -- groupable immediately; custom legacy apps converge through the existing Slack

--- a/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
@@ -6,6 +6,12 @@ ALTER TABLE "bot"
   ADD COLUMN "workspaceId" TEXT,
   ADD COLUMN "workspaceName" TEXT;
 
+-- A Settings reauthorization is bound to an existing bot rather than a target
+-- agent. Keeping agentId nullable lets a freed bot rotate its workspace
+-- credential without silently reattaching it to the default preset agent.
+ALTER TABLE "slack_platform_install"
+  ALTER COLUMN "agentId" DROP NOT NULL;
+
 -- Existing platform-app rows already have the stable workspace id, and their
 -- generated name carries the OAuth team name. This makes current installations
 -- groupable immediately; custom legacy apps converge through the existing Slack

--- a/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260730090000_bot_workspace_metadata/migration.sql
@@ -1,0 +1,21 @@
+-- Display-only external workspace metadata for grouping bot identities in the
+-- Console. Keep it separate from bot.teamId: teamId is also a platform-app
+-- admission/demux marker, while custom Slack apps need workspace labels without
+-- changing those semantics.
+ALTER TABLE "bot"
+  ADD COLUMN "workspaceId" TEXT,
+  ADD COLUMN "workspaceName" TEXT;
+
+-- Existing platform-app rows already have the stable workspace id, and their
+-- generated name carries the OAuth team name. This makes current installations
+-- groupable immediately; custom legacy apps converge through the existing Slack
+-- identity reconciliation loop.
+UPDATE "bot"
+SET
+  "workspaceId" = "teamId",
+  "workspaceName" = CASE
+    WHEN "prebuilt" = TRUE AND "name" LIKE 'AgentConnect (%)'
+      THEN substring("name" FROM 15 FOR char_length("name") - 15)
+    ELSE NULL
+  END
+WHERE "teamId" IS NOT NULL;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1486,20 +1486,23 @@ enum IntegrationStatus {
 }
 
 model Integration {
-  id              String            @id @db.Uuid // IntegrationSpec.integrationId
-  orgId           String
-  agentId         String            @db.Uuid // owner ⇒ delivery daemon (agent.daemonId)
+  id                        String            @id @db.Uuid // IntegrationSpec.integrationId
+  orgId                     String
+  agentId                   String            @db.Uuid // owner ⇒ delivery daemon (agent.daemonId)
   // The identity this install runs as. NO @unique: a shareable bot fans out to
   // one Integration row per agent (shared-bot-relay.md §4.1). A classic
   // (non-shareable) bot is still capped at ≤1 install by the create route.
-  botId           String            @db.Uuid
-  platform        Platform          @default(slack)
-  name            String // Slack app / display name (mirrors bot.name at install time)
-  status          IntegrationStatus @default(active)
-  feishuRegion    String? // Feishu/Lark open-platform gateway: 'feishu' (open.feishu.cn) | 'lark' (open.larksuite.com). NULL ⇒ 'feishu' (default / non-feishu integrations). Public config, NOT secret.
-  createdByUserId String? // WebUI user who installed it (audit)
-  createdAt       DateTime          @default(now()) @db.Timestamptz(6)
-  updatedAt       DateTime          @updatedAt @db.Timestamptz(6)
+  botId                     String            @db.Uuid
+  platform                  Platform          @default(slack)
+  name                      String // Slack app / display name (mirrors bot.name at install time)
+  status                    IntegrationStatus @default(active)
+  // Credential generation whose uninstall/token-revocation flipped this row.
+  // Null for active rows and user-freed rows (which are deleted, not revoked).
+  revokedCredentialRevision Int?
+  feishuRegion              String? // Feishu/Lark open-platform gateway: 'feishu' (open.feishu.cn) | 'lark' (open.larksuite.com). NULL ⇒ 'feishu' (default / non-feishu integrations). Public config, NOT secret.
+  createdByUserId           String? // WebUI user who installed it (audit)
+  createdAt                 DateTime          @default(now()) @db.Timestamptz(6)
+  updatedAt                 DateTime          @updatedAt @db.Timestamptz(6)
 
   org             Org                  @relation(fields: [orgId], references: [id], onDelete: Cascade)
   agent           Agent                @relation(fields: [agentId], references: [id], onDelete: Cascade)

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1379,6 +1379,12 @@ model Bot {
   // (slackAppId, teamId) identifies a workspace's Bot. NULL for legacy /
   // single-workspace bots. Public metadata, NOT secret material.
   teamId                String?
+  // External workspace identity used only to label/group bot rows in the Console.
+  // Slack fills this from auth.test/OAuth for every bot kind. It is deliberately
+  // separate from teamId, whose non-null value marks a distributed platform-app
+  // install and participates in relay demux/admission behavior.
+  workspaceId           String?
+  workspaceName         String?
   // Slack bot user id ("U…"/"B…"), from the OAuth exchange (`bot_user_id`). Saves
   // the relay an auth.test round-trip and backs echo suppression. Public metadata.
   botUserId             String?

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1607,14 +1607,17 @@ model SlackInstall {
 // Pending install of the PLATFORM-published (distributed) Slack app
 // (preset-agents.md §5.3). Unlike SlackInstall, no per-app credentials live here —
 // the app id / client secret / signing secret are deployment env config
-// (SLACK_PLATFORM_*). The row only binds the OAuth `state` to tenancy:
-// {org, target agent, initiating user}. The `id` doubles as the unforgeable
-// OAuth `state`; rows are TTL-reaped alongside slack_install. No FKs (mirrors
-// slack_install): a dangling row after an org/agent delete is harmless.
+// (SLACK_PLATFORM_*). The row binds the OAuth `state` to either {org, target
+// agent, initiating user} or {org, expected bot, initiating user}. The `id`
+// doubles as the unforgeable OAuth `state`; rows are TTL-reaped alongside
+// slack_install. No FKs (mirrors slack_install): a dangling row after an
+// org/agent/bot delete is harmless.
 model SlackPlatformInstall {
   id              String                     @id @db.Uuid // == OAuth state
   orgId           String
-  agentId         String                     @db.Uuid // bind target (defaults to the org's `agentconnect` preset)
+  // Generic installs bind a target agent. A bot-bound Settings reauthorization
+  // leaves this null so a freed bot stays free.
+  agentId         String?                    @db.Uuid
   // Terminal state of the OAuth round trip — the row IS the console's completion
   // signal. It must survive the callback (not be deleted) because a successful
   // RE-authorization of a workspace this agent already has need not create any
@@ -1623,7 +1626,10 @@ model SlackPlatformInstall {
   // callback's close page shows, so the console can report WHY it failed.
   status          SlackPlatformInstallStatus @default(pending)
   failureReason   String?
-  botId           String?                    @db.Uuid // the workspace's Bot once completed (console deep-link)
+  // For a Settings reauthorization this is populated while pending and fences
+  // the OAuth callback to that exact Bot/workspace. Generic installs fill it on
+  // completion for the console deep-link.
+  botId           String?                    @db.Uuid
   createdByUserId String?
   createdAt       DateTime                   @default(now()) @db.Timestamptz(6)
   settledAt       DateTime?                  @db.Timestamptz(6)

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -820,16 +820,17 @@ export function buildContainer(
     http.log
   )
 
-  // Older HTTP Slack installs discarded the public app id even though the OAuth
-  // funnel / bot-token verification knew it. Repair those rows off the request
-  // path so the Settings roster can render app-specific links immediately after
-  // convergence. Unresolved rows remain null and retry every 15 minutes.
+  // Older Slack installs discarded some public app/workspace identity metadata.
+  // Repair those rows off the request path so Settings can render links and
+  // workspace groups without turning GET /bots into a Slack API fan-out.
   const slackBotIdentityReconciler = new SlackBotIdentityReconciler(
     repos.bot,
     repos.botSecret,
     async (botToken) => {
       const result = await verifySlackBot(botToken)
-      return result.status === 'ok' ? result.appId : null
+      return result.status === 'ok'
+        ? { appId: result.appId, workspaceId: result.teamId, workspaceName: result.teamName }
+        : null
     },
     clock,
     { intervalMs: 15 * 60 * 1000 },

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1282,6 +1282,9 @@ export const BotDto = z.object({
   freedFromAgent: z.string().nullable(),
   /** Slack workspace id (T…) — set for platform-app installs (preset-agents.md §5.3). */
   teamId: z.string().nullable(),
+  /** External workspace metadata used only to label/group bots in the Console. */
+  workspaceId: z.string().nullable(),
+  workspaceName: z.string().nullable(),
   /** The workspace uninstalled the app / revoked its tokens (`rc/bot-revoked`);
    *  a platform-app re-install clears it. ISO-8601, null ⇒ live. */
   revokedAt: z.string().nullable(),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1184,12 +1184,18 @@ export const FeishuAppRegistrationStatusDto = z.object({
 })
 
 /** `POST /integrations/slack/platform-install` (preset-agents.md §5.3) — mint a
- *  pending install of the PLATFORM-published Slack app. The target defaults to
- *  the org's `agentconnect` preset agent; an unplaced target is fine (http
- *  delivery converges at placement). */
-export const SlackPlatformInstallStartBody = z.object({
-  agentId: z.string().uuid().optional()
-})
+ *  pending install of the PLATFORM-published Slack app. A generic install may
+ *  target an agent (or default to the org preset); Settings reauthorization
+ *  supplies a botId so OAuth is fenced to that existing workspace without
+ *  changing its agent memberships. */
+export const SlackPlatformInstallStartBody = z
+  .object({
+    agentId: z.string().uuid().optional(),
+    botId: z.string().uuid().optional()
+  })
+  .refine((body) => !(body.agentId && body.botId), {
+    message: 'agentId and botId are mutually exclusive'
+  })
 
 /** The pending platform install: its state id + the slack.com authorize URL. */
 export const SlackPlatformInstallStartDto = z.object({
@@ -1207,10 +1213,12 @@ export const SlackPlatformInstallStartDto = z.object({
 export const SlackPlatformInstallStatusDto = z.object({
   id: z.string(),
   status: z.enum(['pending', 'completed', 'failed']),
-  /** Short code identifying the failure ('denied' | 'expired' | 'workspace_taken' |
-   *  'error') — the console renders a message from it. Null unless `failed`. */
+  /** Short code identifying the failure ('denied' | 'expired' |
+   *  'workspace_taken' | 'workspace_mismatch' | 'agent_taken' | 'error') —
+   *  the console renders a message from it. Null unless `failed`. */
   failureReason: z.string().nullable(),
-  /** The workspace's bot once completed (console deep-link); null otherwise. */
+  /** The expected workspace bot during a Settings reauthorization, or the
+   *  installed bot after a generic install; null otherwise. */
   botId: z.string().nullable()
 })
 

--- a/packages/control-plane/src/http/install-slack.ts
+++ b/packages/control-plane/src/http/install-slack.ts
@@ -44,6 +44,9 @@ export interface InstallSlackBotArgs {
   /** Slack workspace id ("T…") — platform-app installs persist it as the composite
    *  relay demux key (Bot.teamId). Public metadata. */
   teamId?: string
+  /** Display-only workspace identity/name learned from OAuth or auth.test. */
+  workspaceId?: string
+  workspaceName?: string
   /** Slack bot user id from the OAuth exchange. Public metadata. */
   botUserId?: string
   /** Provisioned by AgentConnect (the platform app), not a console user. */
@@ -89,6 +92,8 @@ export async function installNewSlackBot(
     transport,
     ...(slackAppId ? { slackAppId } : {}),
     ...(args.teamId ? { teamId: args.teamId } : {}),
+    ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
+    ...(args.workspaceName ? { workspaceName: args.workspaceName } : {}),
     ...(args.botUserId ? { botUserId: args.botUserId } : {}),
     ...(args.prebuilt ? { prebuilt: true } : {}),
     ...(shareable ? { shareable: true } : {}),

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -51,6 +51,8 @@ function toDto(b: BotRecord): BotDtoT {
     lastUsedAt: b.lastUsedAt?.toISOString() ?? null,
     freedFromAgent: b.lastAgentName,
     teamId: b.teamId,
+    workspaceId: b.workspaceId,
+    workspaceName: b.workspaceName,
     revokedAt: b.revokedAt?.toISOString() ?? null,
     createdAt: b.createdAt.toISOString()
   }
@@ -95,7 +97,7 @@ export function botRoutes(deps: HttpDeps) {
           tags: [Tag.Bots],
           summary: 'List bots',
           description:
-            "The org's durable platform bot identities, including freed and prebuilt bots offered for reuse.",
+            "The org's durable platform bot identities, including freed and built-in bots offered for reuse.",
           operationId: 'listBots',
           response: { 200: BotListDto }
         }
@@ -151,11 +153,6 @@ export function botRoutes(deps: HttpDeps) {
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'only Slack apps can be refreshed' })
         }
-        if (bot.prebuilt) {
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'prebuilt Slack apps are managed by AgentConnect' })
-        }
         if (!bot.slackAppId) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -176,13 +173,19 @@ export function botRoutes(deps: HttpDeps) {
         // modify the wrong Slack app.
         const checked = await deps.verifySlackBot?.(secret.botToken)
         const appIdentityMatches = checked?.status === 'ok' && checked.appId === bot.slackAppId
-        let manifest: SlackBotRefreshDtoT['manifest'] = 'manual_update_required'
+        if (appIdentityMatches && checked.teamId) {
+          await deps.repos.bot.setWorkspaceMetadata(bot.id, checked.teamId, checked.teamName)
+        }
+        // A built-in app's manifest is deployment-managed rather than owned by
+        // the signed-in user's Slack config token. Refresh still verifies its
+        // installed scopes so the Console can offer the platform OAuth reinstall.
+        let manifest: SlackBotRefreshDtoT['manifest'] = bot.prebuilt ? 'synced' : 'manual_update_required'
         const api = deps.slackConfigApi
         // Manifest sync needs a config token that owns THIS app — i.e. the caller's
         // own (per-user). If they don't own it (or stored none), Slack rejects the
         // export/update and `manifest` stays `manual_update_required` — the graceful
         // fallback the DTO already surfaces via the Slack settings links.
-        if (api && appIdentityMatches && req.principal) {
+        if (!bot.prebuilt && api && appIdentityMatches && req.principal) {
           const config = await resolveUserConfigAccessToken(deps, bot.orgId, req.principal.userId, new Date())
           if (config.ok) {
             const exported = await api.exportApp(config.accessToken, bot.slackAppId)

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -533,6 +533,8 @@ export function integrationRoutes(deps: HttpDeps) {
             botToken: slack.botToken,
             transport,
             ...(botCheck?.status === 'ok' && botCheck.appId ? { slackAppId: botCheck.appId } : {}),
+            ...(botCheck?.status === 'ok' && botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
+            ...(botCheck?.status === 'ok' && botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
             ...(slack.appToken ? { appToken: slack.appToken } : {}),
             ...(slack.signingSecret ? { signingSecret: slack.signingSecret } : {}),
             ...(req.body.shareable === true ? { shareable: true } : {}),

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -357,13 +357,10 @@ export function slackInstallRoutes(deps: HttpDeps) {
           })
         }
 
-        // Name: operator-chosen at start, else the bot user name Slack derives, else the agent's.
-        let name = row.name
-        if (!name && deps.verifySlackBot) {
-          const check = await deps.verifySlackBot(row.botToken)
-          if (check.status === 'ok') name = check.name
-        }
-        name = name || agent.name
+        // auth.test supplies display-only workspace metadata for the Settings
+        // grouping. It also remains the fallback source for an omitted app name.
+        const botCheck = deps.verifySlackBot ? await deps.verifySlackBot(row.botToken) : null
+        const name = row.name || (botCheck?.status === 'ok' ? botCheck.name : null) || agent.name
         const release = deps.agentMutations.tryBeginMutation(agent.id)
         if (!release) {
           return reply.code(409).send({
@@ -396,6 +393,8 @@ export function slackInstallRoutes(deps: HttpDeps) {
             botToken: row.botToken,
             transport: row.transport,
             slackAppId: row.appId,
+            ...(botCheck?.status === 'ok' && botCheck.teamId ? { workspaceId: botCheck.teamId } : {}),
+            ...(botCheck?.status === 'ok' && botCheck.teamName ? { workspaceName: botCheck.teamName } : {}),
             // socket: the pasted xapp; http: the signing secret captured at create. The
             // shareable choice rides the finalize body (installNewSlackBot coerces it off
             // for socket regardless).

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -564,7 +564,8 @@ export function slackConfigRoutes(deps: HttpDeps) {
   }
 }
 
-export type SlackCallbackNote = 'connected' | 'denied' | 'expired' | 'error' | 'workspace_taken' | 'agent_taken'
+export type SlackCallbackNote =
+  'connected' | 'denied' | 'expired' | 'error' | 'workspace_taken' | 'workspace_mismatch' | 'agent_taken'
 
 /**
  * The callback tab is a THROWAWAY — the real flow continues in the ORIGINAL
@@ -575,8 +576,8 @@ export type SlackCallbackNote = 'connected' | 'denied' | 'expired' | 'error' | '
  * link origin comes from config), so there's nothing to escape.
  *
  * Exported for the platform-app callback (slack-platform-install.ts), which
- * shares the throwaway-tab UX (and adds the `workspace_taken` / `agent_taken`
- * outcomes — the platform bot is non-shareable, so a workspace backs one agent).
+ * shares the throwaway-tab UX (and adds workspace/admission outcomes — the
+ * platform bot is non-shareable, so a workspace backs one agent).
  */
 export function closePageHtml(note: SlackCallbackNote, consoleUrl?: string): string {
   const ok = note === 'connected'
@@ -590,9 +591,11 @@ export function closePageHtml(note: SlackCallbackNote, consoleUrl?: string): str
           ? 'The install was cancelled. Close this tab and try again in AgentConnect.'
           : note === 'workspace_taken'
             ? 'This Slack workspace is already connected to a different AgentConnect organization. Remove that connection first, then try again.'
-            : note === 'agent_taken'
-              ? 'This Slack workspace is already connected to another agent in your organization. Remove that integration first, then try again.'
-              : 'Something went wrong finishing the install. Close this tab and try again in AgentConnect.'
+            : note === 'workspace_mismatch'
+              ? 'Slack authorized a different workspace. Close this tab and try again, choosing the workspace shown in AgentConnect.'
+              : note === 'agent_taken'
+                ? 'This Slack workspace is already connected to another agent in your organization. Remove that integration first, then try again.'
+                : 'Something went wrong finishing the install. Close this tab and try again in AgentConnect.'
   // Auto-close only on success (a failure needs reading). window.close() is allowed
   // for script-opened tabs (this one was window.open'd); the text is the fallback.
   const autoClose = ok ? '<script>setTimeout(function(){try{window.close()}catch(e){}},1500)</script>' : ''

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -312,7 +312,12 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
           const revision = await deps.repos.botCredential.install(
             BotId(existing.id),
             { botToken: result.botToken, appToken: null, signingSecret: platform.signingSecret },
-            new Date()
+            new Date(),
+            // A row-level Settings reinstall has no target agent. Restore only
+            // memberships tagged with the revoked credential generation; if the
+            // user deliberately freed the bot, those rows were deleted and
+            // nothing is reattached.
+            { restoreRevokedMemberships: !!expectedBot }
           )
           req.log.info({ botId: existing.id, revision }, 'slack platform re-install: credential generation advanced')
           if (agent) {

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -6,14 +6,17 @@
  * always **http + NON-shareable** — Events-API-only because a distributed app has
  * no per-workspace xapp token, and one-agent because a workspace install keeps the
  * classic 1-install cap — and auto-binds to the org's `agentconnect` preset agent
- * (or an explicitly chosen one). Serving several agents from one Slack identity
- * remains the quick-install upgrade (a dedicated app per agent).
+ * (or an explicitly chosen one). A Settings reauthorization instead binds the
+ * OAuth state to an existing Bot/workspace and preserves its memberships.
+ * Serving several agents from one Slack identity remains the quick-install
+ * upgrade (a dedicated app per agent).
  *
  * TWO plugins, mirroring the quick-install funnel's split:
  *  - `slackPlatformInstallRoutes` mounts inside `/orgs/:orgId` (humanAuth +
  *    org-scope): mint a pending-install row whose id doubles as the OAuth
- *    `state` — binding {org, target agent, user} — and return the authorize URL.
- *    A bare share URL cannot carry tenancy, so installs always start here.
+ *    `state` — binding either {org, target agent, user} or {org, expected bot,
+ *    user} — and return the authorize URL. A bare share URL cannot carry
+ *    tenancy, so installs always start here.
  *  - `slackPlatformCallbackRoutes` mounts at the version root, UNAUTHENTICATED
  *    (Slack redirects the installer's browser). The exchange runs server-side
  *    with the env credentials; the browser gets only a self-closing page.
@@ -60,7 +63,7 @@ export function slackPlatformInstallRoutes(deps: HttpDeps) {
           tags: [Tag.Integrations],
           summary: 'Start platform Slack app install',
           description:
-            'Mint a pending install of the platform-published Slack app — the OAuth `state` binds {org, target agent, user} — and return the slack.com authorize URL to open. The target defaults to the org’s `agentconnect` preset agent. Requires the relay pool (the distributed app is Events-API-only).',
+            'Mint a pending install of the platform-published Slack app and return the slack.com authorize URL. A generic install binds the OAuth state to an org, target agent, and user; a Settings reauthorization binds it to an existing bot/workspace and preserves that bot’s current agent memberships. Requires the relay pool (the distributed app is Events-API-only).',
           operationId: 'startSlackPlatformInstall',
           body: SlackPlatformInstallStartBody,
           response: { 201: SlackPlatformInstallStartDto, 401: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
@@ -80,32 +83,54 @@ export function slackPlatformInstallRoutes(deps: HttpDeps) {
             message: 'HTTP-mode Slack requires a connected relay (PUBLIC_RELAY_URL + a running relay)'
           })
         }
-        // Explicit target, else the org's general preset (the design's default
-        // bind target). No placement requirement — http delivery converges later.
-        let agentId = req.body.agentId
-        if (!agentId) {
-          const preset = await deps.repos.presetAgent.get(orgId, 'general')
-          agentId = preset?.agentId ?? undefined
-        }
-        if (!agentId) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'no target agent: pass agentId (the agentconnect preset is absent in this org)'
-          })
-        }
-        const agent = await deps.repos.agent.get(AgentId(agentId))
-        if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
-        }
-        if (!canEdit(agent, ctxOf(req))) {
-          return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
+        let agentId: AgentId | undefined
+        let expectedBotId: BotId | undefined
+        if (req.body.botId) {
+          // Settings reauthorization: fence the callback to this exact
+          // platform-app workspace. No target agent is stored, so a freed bot
+          // remains free and an active bot keeps its existing memberships.
+          const bot = await deps.repos.bot.get(BotId(req.body.botId))
+          if (!bot || bot.orgId !== orgId) {
+            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
+          }
+          if (bot.platform !== 'slack' || !bot.prebuilt || bot.slackAppId !== platform.appId || !bot.teamId) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: 'only an installed built-in Slack workspace can be reauthorized'
+            })
+          }
+          expectedBotId = bot.id
+        } else {
+          // Explicit target, else the org's general preset (the design's default
+          // bind target). No placement requirement — http delivery converges later.
+          let requestedAgentId = req.body.agentId
+          if (!requestedAgentId) {
+            const preset = await deps.repos.presetAgent.get(orgId, 'general')
+            requestedAgentId = preset?.agentId ?? undefined
+          }
+          if (!requestedAgentId) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: 'no target agent: pass agentId (the agentconnect preset is absent in this org)'
+            })
+          }
+          const agent = await deps.repos.agent.get(AgentId(requestedAgentId))
+          if (!agent || agent.orgId !== orgId || !canView(agent, ctxOf(req))) {
+            return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+          }
+          if (!canEdit(agent, ctxOf(req))) {
+            return reply.code(403).send({ error: 'Forbidden', statusCode: 403, message: 'cannot edit this agent' })
+          }
+          agentId = agent.id
         }
 
         const install = await deps.repos.slackPlatformInstall.create({
           id: randomUUID(),
           orgId,
-          agentId: agent.id,
+          ...(agentId ? { agentId } : {}),
+          ...(expectedBotId ? { botId: expectedBotId } : {}),
           createdByUserId: req.principal.userId
         })
         const url = new URL(SLACK_AUTHORIZE_URL)
@@ -225,13 +250,45 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
           return fail('error')
         }
 
-        const agent = await deps.repos.agent.get(row.agentId)
-        if (!agent || agent.orgId !== row.orgId) {
+        // A Settings refresh puts its expected Bot id in the pending state. Its
+        // durable platform-app teamId is the workspace fence: authorizing any
+        // other workspace must fail before credentials or memberships change.
+        const expectedBot = row.botId ? await deps.repos.bot.get(BotId(row.botId)) : null
+        if (
+          row.botId &&
+          (!expectedBot ||
+            expectedBot.orgId !== row.orgId ||
+            expectedBot.platform !== 'slack' ||
+            !expectedBot.prebuilt ||
+            expectedBot.slackAppId !== platform.appId ||
+            !expectedBot.teamId)
+        ) {
+          req.log.warn({ installId: row.id, botId: row.botId }, 'slack platform reauthorization: invalid bot fence')
+          return fail('error')
+        }
+        if (expectedBot && result.teamId !== expectedBot.teamId) {
+          req.log.warn(
+            { installId: row.id, botId: expectedBot.id, expectedTeamId: expectedBot.teamId },
+            'slack platform reauthorization: different workspace authorized'
+          )
+          return fail('workspace_mismatch')
+        }
+
+        const agent = row.agentId ? await deps.repos.agent.get(row.agentId) : null
+        if (row.agentId && (!agent || agent.orgId !== row.orgId)) {
           // Target deleted while the tab was open — nothing sane to bind to.
           return fail('error')
         }
+        if (!expectedBot && !agent) return fail('error')
 
         const existing = await deps.repos.bot.getBySlackAppTeam(platform.appId, result.teamId)
+        if (expectedBot && existing?.id !== expectedBot.id) {
+          req.log.warn(
+            { installId: row.id, botId: expectedBot.id },
+            'slack platform reauthorization: workspace bot changed'
+          )
+          return fail('workspace_mismatch')
+        }
         if (existing && existing.orgId !== row.orgId) {
           // A workspace binds to exactly one org (the demux key is global).
           // Don't leak WHICH org holds it.
@@ -258,53 +315,46 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
             new Date()
           )
           req.log.info({ botId: existing.id, revision }, 'slack platform re-install: credential generation advanced')
-          // Membership admission is ATOMIC with the bot row (addBotMembership
-          // locks it): `shareable` and the active membership set are re-read in
-          // the same transaction as the insert, so a concurrent sharing toggle
-          // or a duplicate concurrent callback serializes there instead of
-          // racing this handler's earlier `existing` snapshot. One (bot, agent)
-          // can gain at most one active install ('exists' = idempotent success).
-          const admission = await deps.repos.integration.addBotMembership({
-            id: IntegrationId(randomUUID()),
-            orgId: OrgId(row.orgId),
-            agentId: agent.id,
-            botId: existing.id,
-            platform: 'slack',
-            name: existing.name,
-            ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
-          })
-          if (admission.outcome === 'revoked') {
-            // Exotic: the workspace uninstalled again between this callback's
-            // fresh credential install and the admission — the revoke won the
-            // row lock and flipped every install, so admitting now would mint a
-            // live membership on the dead credential. Settle as a plain error;
-            // the next "Add to Slack" round trip re-installs cleanly.
-            req.log.warn(
-              { installId: row.id, botId: existing.id, targetAgentId: agent.id },
-              'slack platform re-install: bot revoked mid-callback'
-            )
-            await deps.httpBot.syncBot(existing.id)
-            return fail('error')
-          }
-          if (admission.outcome === 'not_shareable') {
-            // The platform bot installs NON-shareable: one workspace install
-            // serves exactly one agent, so a re-install aimed at a DIFFERENT
-            // agent cannot just add a second row (that is the cap the classic
-            // reuse path enforces with a 409). The credential above still
-            // rotated — the workspace's existing binding keeps working, it just
-            // did not move. Moving it is a deliberate console action, not a
-            // side effect of clicking "Add to Slack" with another agent
-            // selected. If the user flips the bot SHAREABLE (Settings → Bots),
-            // the admission simply adds the agent instead.
-            req.log.warn(
-              { installId: row.id, botId: existing.id, targetAgentId: agent.id },
-              'slack platform re-install: workspace already bound to another agent'
-            )
-            await deps.httpBot.syncBot(existing.id)
-            return fail('agent_taken')
+          if (agent) {
+            // Generic install/re-install only: membership admission is ATOMIC
+            // with the bot row. A bot-bound Settings reauthorization has no
+            // agent target and deliberately preserves the current set instead.
+            const admission = await deps.repos.integration.addBotMembership({
+              id: IntegrationId(randomUUID()),
+              orgId: OrgId(row.orgId),
+              agentId: agent.id,
+              botId: existing.id,
+              platform: 'slack',
+              name: existing.name,
+              ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})
+            })
+            if (admission.outcome === 'revoked') {
+              // Exotic: the workspace uninstalled again between this callback's
+              // fresh credential install and the admission — the revoke won the
+              // row lock and flipped every install, so admitting now would mint a
+              // live membership on the dead credential.
+              req.log.warn(
+                { installId: row.id, botId: existing.id, targetAgentId: agent.id },
+                'slack platform re-install: bot revoked mid-callback'
+              )
+              await deps.httpBot.syncBot(existing.id)
+              return fail('error')
+            }
+            if (admission.outcome === 'not_shareable') {
+              // A generic re-install aimed at a different agent must not widen a
+              // non-shareable workspace bot. The credential still rotated, so
+              // its existing binding keeps working.
+              req.log.warn(
+                { installId: row.id, botId: existing.id, targetAgentId: agent.id },
+                'slack platform re-install: workspace already bound to another agent'
+              )
+              await deps.httpBot.syncBot(existing.id)
+              return fail('agent_taken')
+            }
           }
           await deps.httpBot.syncBot(existing.id)
         } else {
+          if (!agent || expectedBot) return fail('error')
           const created = await installNewSlackBot(deps, req.log, {
             orgId: OrgId(row.orgId),
             agent,

--- a/packages/control-plane/src/http/routes/slack-platform-install.ts
+++ b/packages/control-plane/src/http/routes/slack-platform-install.ts
@@ -245,6 +245,7 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
           // rotate to the fresh token, clear any uninstall marker, and make sure
           // the target agent has an active install; then reconverge the pool.
           botId = existing.id
+          await deps.repos.bot.setWorkspaceMetadata(existing.id, result.teamId, result.teamName)
           // ONE transition: the fresh token and the generation it belongs to
           // commit together, so no reader (notably restart reconciliation, which
           // does not filter on `revokedAt`) can broadcast the new credential
@@ -319,6 +320,8 @@ export function slackPlatformCallbackRoutes(deps: HttpDeps) {
             prebuilt: true,
             slackAppId: platform.appId,
             teamId: result.teamId,
+            workspaceId: result.teamId,
+            ...(result.teamName ? { workspaceName: result.teamName } : {}),
             ...(result.botUserId ? { botUserId: result.botUserId } : {}),
             signingSecret: platform.signingSecret,
             ...(row.createdByUserId ? { createdByUserId: row.createdByUserId } : {})

--- a/packages/control-plane/src/http/slack-identity.test.ts
+++ b/packages/control-plane/src/http/slack-identity.test.ts
@@ -28,6 +28,7 @@ describe('verifySlackBot (auth.test)', () => {
       name: 'matrix_test',
       appId: 'A0123',
       teamId: 'T0123',
+      teamName: 'Acme',
       scopes: ['chat:write', 'channels:read', 'assistant:write']
     })
   })
@@ -39,6 +40,7 @@ describe('verifySlackBot (auth.test)', () => {
       name: 'Acme',
       appId: null,
       teamId: null,
+      teamName: 'Acme',
       scopes: null
     })
   })
@@ -56,6 +58,7 @@ describe('verifySlackBot (auth.test)', () => {
       name: 'matrix_test',
       appId: 'A0123',
       teamId: null,
+      teamName: null,
       scopes: null
     })
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
@@ -72,6 +75,7 @@ describe('verifySlackBot (auth.test)', () => {
       name: null,
       appId: null,
       teamId: null,
+      teamName: null,
       scopes: null
     })
   })

--- a/packages/control-plane/src/http/slack-identity.ts
+++ b/packages/control-plane/src/http/slack-identity.ts
@@ -26,6 +26,7 @@ export type SlackBotVerification =
       name: string | null
       appId: string | null
       teamId: string | null
+      teamName: string | null
       scopes: string[] | null
     } // valid; scopes from x-oauth-scopes
   | { status: 'invalid' } // Slack definitively rejected the credential
@@ -109,7 +110,14 @@ export const verifySlackBot: SlackBotVerifier = async (botToken) => {
           .filter(Boolean)
       : null
     const appId = body.app_id ?? (body.bot_id ? await resolveBotAppId(botToken, body.bot_id) : null)
-    return { status: 'ok', name: body.user ?? body.team ?? null, appId, teamId: body.team_id ?? null, scopes }
+    return {
+      status: 'ok',
+      name: body.user ?? body.team ?? null,
+      appId,
+      teamId: body.team_id ?? null,
+      teamName: body.team ?? null,
+      scopes
+    }
   } catch {
     return { status: 'unreachable' }
   }

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -252,7 +252,10 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       revoke: async (id, at, fence) => {
         const applied = await bots.revokeIfCurrent!(id, at, fence)
         if (!applied) return { applied: false, integrationIds: [] }
-        return { applied: true, integrationIds: await intRepo.markRevokedForBot!(id) }
+        return {
+          applied: true,
+          integrationIds: await intRepo.markRevokedForBot!(id, botRow.credentialRevision)
+        }
       }
     }
     return new HttpBotOrchestrator(

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.test.ts
@@ -14,7 +14,16 @@ function bot(): BotRecord {
     name: 'legacy-http',
     prebuilt: false,
     slackAppId: null,
+    teamId: null,
+    workspaceId: null,
+    workspaceName: null,
+    botUserId: null,
+    revokedAt: null,
+    credentialRevision: 1,
+    credentialInstalledAt: null,
     discordAppId: null,
+    feishuAppId: null,
+    feishuRegion: null,
     shareable: false,
     transport: 'http',
     createdBy: null,
@@ -27,16 +36,22 @@ function bot(): BotRecord {
 }
 
 describe('SlackBotIdentityReconciler', () => {
-  it('resolves and backfills a missing HTTP Slack app id without exposing the token', async () => {
+  it('resolves and backfills missing Slack app/workspace identity without exposing the token', async () => {
     const setSlackAppIdIfMissing = vi.fn(async () => true)
+    const setWorkspaceMetadata = vi.fn(async () => {})
     const bots = {
-      listHttpMissingSlackAppId: async () => [bot()],
-      setSlackAppIdIfMissing
+      listSlackMissingIdentity: async () => [bot()],
+      setSlackAppIdIfMissing,
+      setWorkspaceMetadata
     } as unknown as BotRepo
     const secrets = {
       get: async () => ({ botToken: 'xoxb-secret', appToken: null, signingSecret: 'signing-secret' })
     } as unknown as BotSecretStore
-    const resolve = vi.fn(async () => 'AHTTPBOT')
+    const resolve = vi.fn(async () => ({
+      appId: 'AHTTPBOT',
+      workspaceId: 'TWORKSPACE',
+      workspaceName: 'Acme'
+    }))
     const info = vi.fn()
 
     await new SlackBotIdentityReconciler(
@@ -54,31 +69,39 @@ describe('SlackBotIdentityReconciler', () => {
 
     expect(resolve).toHaveBeenCalledWith('xoxb-secret')
     expect(setSlackAppIdIfMissing).toHaveBeenCalledWith(BOT, 'AHTTPBOT')
+    expect(setWorkspaceMetadata).toHaveBeenCalledWith(BOT, 'TWORKSPACE', 'Acme')
     expect(JSON.stringify(info.mock.calls)).not.toContain('xoxb-secret')
   })
 
   it('keeps unresolved rows retryable and never stores a malformed id', async () => {
     const setSlackAppIdIfMissing = vi.fn(async () => true)
+    const setWorkspaceMetadata = vi.fn(async () => {})
     const bots = {
-      listHttpMissingSlackAppId: async () => [bot()],
-      setSlackAppIdIfMissing
+      listSlackMissingIdentity: async () => [bot()],
+      setSlackAppIdIfMissing,
+      setWorkspaceMetadata
     } as unknown as BotRepo
     const secrets = {
       get: async () => ({ botToken: 'xoxb-secret', appToken: null, signingSecret: 'signing-secret' })
     } as unknown as BotSecretStore
 
-    await new SlackBotIdentityReconciler(bots, secrets, async () => 'not-an-app-id', new FakeClock(), {
-      intervalMs: 60_000
-    }).tick()
+    await new SlackBotIdentityReconciler(
+      bots,
+      secrets,
+      async () => ({ appId: 'not-an-app-id', workspaceId: 'not-a-workspace', workspaceName: 'Nope' }),
+      new FakeClock(),
+      { intervalMs: 60_000 }
+    ).tick()
 
     expect(setSlackAppIdIfMissing).not.toHaveBeenCalled()
+    expect(setWorkspaceMetadata).not.toHaveBeenCalled()
   })
 
   it('runs immediately on start and re-arms the retry interval', async () => {
     const clock = new FakeClock()
     const list = vi.fn(async () => [])
     const reconciler = new SlackBotIdentityReconciler(
-      { listHttpMissingSlackAppId: list } as unknown as BotRepo,
+      { listSlackMissingIdentity: list } as unknown as BotRepo,
       {} as BotSecretStore,
       async () => null,
       clock,

--- a/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
+++ b/packages/control-plane/src/orchestrator/slackBotIdentityReconciler.ts
@@ -1,8 +1,7 @@
 /**
- * Repairs HTTP Slack bot rows created before their public Slack app id was
- * persisted. The id is resolved from the already-stored bot token and written
- * only when the column is still null, so an established identity is never
- * replaced by a delayed or stale lookup.
+ * Repairs Slack bot rows created before public app/workspace identity was
+ * persisted. Values are resolved from the already-stored bot token. The app id
+ * is written only while missing; workspace metadata is display-only.
  *
  * This is a background convergence loop, not part of GET /bots: opening the
  * Settings page must not fan out to Slack or turn a metadata read into a write.
@@ -20,9 +19,16 @@ export interface SlackBotIdentityReconcilerLog {
   error(obj: unknown, msg?: string): void
 }
 
-export type ResolveSlackAppId = (botToken: string) => Promise<string | null>
+export interface ResolvedSlackIdentity {
+  appId: string | null
+  workspaceId: string | null
+  workspaceName: string | null
+}
+
+export type ResolveSlackIdentity = (botToken: string) => Promise<ResolvedSlackIdentity | null>
 
 const SLACK_APP_ID = /^A[A-Z0-9]+$/
+const SLACK_WORKSPACE_ID = /^T[A-Z0-9]+$/
 
 export class SlackBotIdentityReconciler {
   private timer: TimerHandle | undefined
@@ -32,7 +38,7 @@ export class SlackBotIdentityReconciler {
   constructor(
     private readonly bots: BotRepo,
     private readonly secrets: BotSecretStore,
-    private readonly resolveAppId: ResolveSlackAppId,
+    private readonly resolveIdentity: ResolveSlackIdentity,
     private readonly clock: Clock,
     private readonly cfg: SlackBotIdentityReconcilerConfig,
     private readonly log?: SlackBotIdentityReconcilerLog
@@ -68,14 +74,23 @@ export class SlackBotIdentityReconciler {
     }
     this.running = true
     try {
-      for (const bot of await this.bots.listHttpMissingSlackAppId()) {
+      for (const bot of await this.bots.listSlackMissingIdentity()) {
         try {
           const secret = await this.secrets.get(bot.id)
           if (!secret) continue
-          const appId = await this.resolveAppId(secret.botToken)
-          if (!appId || !SLACK_APP_ID.test(appId)) continue
-          if (await this.bots.setSlackAppIdIfMissing(bot.id, appId)) {
-            this.log?.info({ botId: bot.id, slackAppId: appId }, 'slack-bot-identity: backfilled app id')
+          const identity = await this.resolveIdentity(secret.botToken)
+          if (!identity) continue
+          if (identity.appId && SLACK_APP_ID.test(identity.appId)) {
+            if (await this.bots.setSlackAppIdIfMissing(bot.id, identity.appId)) {
+              this.log?.info({ botId: bot.id, slackAppId: identity.appId }, 'slack-bot-identity: backfilled app id')
+            }
+          }
+          if (identity.workspaceId && SLACK_WORKSPACE_ID.test(identity.workspaceId)) {
+            await this.bots.setWorkspaceMetadata(bot.id, identity.workspaceId, identity.workspaceName)
+            this.log?.info(
+              { botId: bot.id, workspaceId: identity.workspaceId },
+              'slack-bot-identity: refreshed workspace metadata'
+            )
           }
         } catch (err) {
           this.log?.warn({ err, botId: bot.id }, 'slack-bot-identity: bot lookup failed')

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2074,8 +2074,15 @@ export interface RevokeBotResult {
  */
 export interface BotCredentialWriter {
   /** A fresh credential landed (platform re-install / rotation): store it and
-   *  advance the generation as one step. Returns the new revision. */
-  install(botId: BotId, material: BotSecretMaterial, at: Date): Promise<number>
+   *  advance the generation as one step. A bot-bound Settings reinstall may
+   *  also restore only memberships revoked with the credential being replaced;
+   *  all three writes remain one transaction. Returns the new revision. */
+  install(
+    botId: BotId,
+    material: BotSecretMaterial,
+    at: Date,
+    options?: { restoreRevokedMemberships?: boolean }
+  ): Promise<number>
   /** Apply `rc/bot-revoked` behind its generation fence, flipping the bot and
    *  its active installs together. */
   revoke(botId: BotId, at: Date, fence: { revision?: number; eventAt?: Date }): Promise<RevokeBotResult>
@@ -2470,8 +2477,12 @@ export interface IntegrationRepo {
    *  earliest is the group's default agent). */
   listForBot(botId: BotId): Promise<IntegrationRecord[]>
   /** Flip every ACTIVE integration of `botId` to `revoked` (workspace uninstall /
-   *  token revocation). Returns the affected integration ids. */
-  markRevokedForBot(botId: BotId): Promise<IntegrationId[]>
+   *  token revocation), recording the credential generation that owned it.
+   *  Returns the affected integration ids. */
+  markRevokedForBot(botId: BotId, credentialRevision: number): Promise<IntegrationId[]>
+  /** Restore memberships revoked with exactly `credentialRevision`. Historical
+   *  revoked rows and deliberately deleted/free memberships stay untouched. */
+  restoreRevokedForBot(botId: BotId, credentialRevision: number): Promise<number>
   delete(id: IntegrationId): Promise<void>
 }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2199,12 +2199,15 @@ export type SlackPlatformInstallStatus = 'pending' | 'completed' | 'failed'
 export interface SlackPlatformInstallRecord {
   id: string // == OAuth state (random uuid)
   orgId: OrgId
-  agentId: AgentId // bind target (defaults to the org's `agentconnect` preset)
+  /** Generic-install bind target. Null for bot-bound Settings reauthorization,
+   *  which preserves the bot's current (possibly empty) membership set. */
+  agentId: AgentId | null
   /** Terminal state of the OAuth round trip — the console's completion signal. */
   status: SlackPlatformInstallStatus
   /** Short code (same note the callback's close page shows) when `failed`. */
   failureReason: string | null
-  /** The workspace's Bot once `completed`. */
+  /** Expected Bot fence for Settings reauthorization, or the resulting Bot once
+   *  a generic install completes. */
   botId: string | null
   createdByUserId: string | null
   createdAt: Date
@@ -2215,7 +2218,9 @@ export interface SlackPlatformInstallStore {
   create(input: {
     id: string
     orgId: OrgId
-    agentId: AgentId
+    agentId?: AgentId
+    /** Bind OAuth to an existing platform Bot/workspace without changing membership. */
+    botId?: BotId
     createdByUserId?: string
   }): Promise<SlackPlatformInstallRecord>
   get(id: string): Promise<SlackPlatformInstallRecord | null>

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1790,6 +1790,9 @@ export interface CreateBotInput {
   /** Slack workspace id (T…), from the platform app's OAuth exchange. Together with
    *  `slackAppId` it is the relay demux key for a distributed app. Public metadata. */
   teamId?: string
+  /** Display-only external workspace metadata; never used for routing/admission. */
+  workspaceId?: string
+  workspaceName?: string
   /** Slack bot user id, from the OAuth exchange (`bot_user_id`). Public metadata. */
   botUserId?: string
   /** Discord application (client) id, decoded from the bot token. Public metadata, NOT a secret. */
@@ -1818,6 +1821,10 @@ export interface BotRecord {
   /** Slack workspace id (T…); non-null only for platform-app installs, where
    *  (slackAppId, teamId) is the relay demux key. */
   teamId: string | null
+  /** Display-only external workspace metadata; unlike teamId, this never changes
+   *  routing or install admission. */
+  workspaceId: string | null
+  workspaceName: string | null
   /** Slack bot user id, persisted from the OAuth exchange; null for legacy bots. */
   botUserId: string | null
   /** Stamped when the workspace uninstalled the app / revoked its tokens
@@ -1863,8 +1870,11 @@ export interface BotRepo {
   create(input: CreateBotInput): Promise<BotRecord>
   get(id: BotId): Promise<BotRecord | null>
   listForOrg(orgId: OrgId): Promise<BotRecord[]>
-  /** Legacy HTTP Slack bots created before app-id persistence was wired. */
-  listHttpMissingSlackAppId(): Promise<BotRecord[]>
+  /** Record workspace metadata learned from OAuth/auth.test. A missing name
+   *  preserves the last known label. */
+  setWorkspaceMetadata(id: BotId, workspaceId: string, workspaceName: string | null): Promise<void>
+  /** Slack bots missing public app/workspace identity metadata. */
+  listSlackMissingIdentity(): Promise<BotRecord[]>
   /** Backfill only a missing id; never replace an established Slack app identity. */
   setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean>
   /** Stamp the freed-bot display hints when its LAST integration is removed. */

--- a/packages/control-plane/src/persistence/repositories/bot-credential.writer.ts
+++ b/packages/control-plane/src/persistence/repositories/bot-credential.writer.ts
@@ -2,9 +2,10 @@
  * `PgBotCredentialWriter` — the two lifecycle transitions of a shared bot's
  * credential, each as ONE atomic, serialized step (preset-agents.md §5.3).
  *
- * Both transitions span two tables (`bot_secret` + `bot`, or `bot` +
- * `integration`), and both are fenced by `bot.credentialRevision`. Split across
- * separate commits they interleave in ways the fence cannot catch:
+ * Both transitions span two or three tables (`bot_secret` + `bot` + optionally
+ * `integration`, or `bot` + `integration`), and both are fenced by
+ * `bot.credentialRevision`. Split across separate commits they interleave in
+ * ways the fence cannot catch:
  *
  *  - install: the fresh token committing before the generation bump leaves a
  *    window where the bot carries the NEW secret under the OLD revision. A
@@ -39,7 +40,12 @@ export class PgBotCredentialWriter implements BotCredentialWriter {
     private readonly cipher: SecretCipher
   ) {}
 
-  async install(botId: BotId, material: BotSecretMaterial, at: Date): Promise<number> {
+  async install(
+    botId: BotId,
+    material: BotSecretMaterial,
+    at: Date,
+    options: { restoreRevokedMemberships?: boolean } = {}
+  ): Promise<number> {
     // Seal first: cipher calls may be remote (Vault Transit), and holding a
     // transaction open across them would pin a connection for that round trip.
     const sealed = {
@@ -48,10 +54,21 @@ export class PgBotCredentialWriter implements BotCredentialWriter {
       signingSecret: material.signingSecret === null ? null : await this.cipher.seal(material.signingSecret)
     }
     return withTx(this.prisma, async (tx) => {
+      // Read the generation being replaced while taking the same bot-row lock as
+      // revoke. This makes the optional membership restore part of the credential
+      // transition rather than a follow-up that a concurrent revoke could flip.
+      const locked = await tx.$queryRaw<
+        { credentialRevision: number; revokedAt: Date | null }[]
+      >`SELECT "credentialRevision", "revokedAt" FROM bot WHERE id = ${botId} FOR UPDATE`
+      if (!locked[0]) throw new Error(`bot ${botId} not found`)
       await tx.botSecret.upsert({ where: { botId }, create: { botId, ...sealed }, update: sealed })
       // Same transaction: no reader can ever observe the new secret under the
       // old generation, so the fence always describes the credential in place.
-      return new PgBotRepo(tx).bumpCredential(botId, at)
+      const revision = await new PgBotRepo(tx).bumpCredential(botId, at)
+      if (options.restoreRevokedMemberships && locked[0].revokedAt) {
+        await new PgIntegrationRepo(tx).restoreRevokedForBot(botId, locked[0].credentialRevision)
+      }
+      return revision
     })
   }
 
@@ -63,7 +80,8 @@ export class PgBotCredentialWriter implements BotCredentialWriter {
       // slipping a fresh generation between the decision and the flip below.
       const applied = await bots.revokeIfCurrent(botId, at, fence)
       if (!applied) return { applied: false, integrationIds: [] }
-      const integrationIds = await new PgIntegrationRepo(tx).markRevokedForBot(botId)
+      const bot = await tx.bot.findUniqueOrThrow({ where: { id: botId }, select: { credentialRevision: true } })
+      const integrationIds = await new PgIntegrationRepo(tx).markRevokedForBot(botId, bot.credentialRevision)
       return { applied: true, integrationIds }
     })
   }

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -488,7 +488,7 @@ export class PgIntegrationRepo implements IntegrationRepo {
     return rows.map(toRecord)
   }
 
-  async markRevokedForBot(botId: BotId): Promise<IntegrationId[]> {
+  async markRevokedForBot(botId: BotId, credentialRevision: number): Promise<IntegrationId[]> {
     // Read-then-flip inside one statement pair: the ids are needed by the caller
     // (spec removal per daemon), and updateMany returns only a count.
     const rows = await this.db.integration.findMany({
@@ -498,9 +498,17 @@ export class PgIntegrationRepo implements IntegrationRepo {
     if (rows.length === 0) return []
     await this.db.integration.updateMany({
       where: { id: { in: rows.map((r) => r.id) } },
-      data: { status: 'revoked' }
+      data: { status: 'revoked', revokedCredentialRevision: credentialRevision }
     })
     return rows.map((r) => IntegrationId(r.id))
+  }
+
+  async restoreRevokedForBot(botId: BotId, credentialRevision: number): Promise<number> {
+    const { count } = await this.db.integration.updateMany({
+      where: { botId, status: 'revoked', revokedCredentialRevision: credentialRevision },
+      data: { status: 'active', revokedCredentialRevision: null }
+    })
+    return count
   }
 
   async delete(id: IntegrationId): Promise<void> {

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -59,6 +59,8 @@ function toBotRecord(b: BotJoined): BotRecord {
     prebuilt: b.prebuilt,
     slackAppId: b.slackAppId,
     teamId: b.teamId,
+    workspaceId: b.workspaceId,
+    workspaceName: b.workspaceName,
     botUserId: b.botUserId,
     revokedAt: b.revokedAt,
     credentialRevision: b.credentialRevision,
@@ -94,6 +96,8 @@ export class PgBotRepo implements BotRepo {
         ...(input.prebuilt !== undefined ? { prebuilt: input.prebuilt } : {}),
         ...(input.slackAppId ? { slackAppId: input.slackAppId } : {}),
         ...(input.teamId ? { teamId: input.teamId } : {}),
+        ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+        ...(input.workspaceName ? { workspaceName: input.workspaceName } : {}),
         ...(input.botUserId ? { botUserId: input.botUserId } : {}),
         ...(input.discordAppId ? { discordAppId: input.discordAppId } : {}),
         ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
@@ -121,9 +125,22 @@ export class PgBotRepo implements BotRepo {
     return rows.map(toBotRecord)
   }
 
-  async listHttpMissingSlackAppId(): Promise<BotRecord[]> {
+  async setWorkspaceMetadata(id: BotId, workspaceId: string, workspaceName: string | null): Promise<void> {
+    await this.db.bot.update({
+      where: { id },
+      data: {
+        workspaceId,
+        ...(workspaceName ? { workspaceName } : {})
+      }
+    })
+  }
+
+  async listSlackMissingIdentity(): Promise<BotRecord[]> {
     const rows = await this.db.bot.findMany({
-      where: { platform: 'slack', transport: 'http', slackAppId: null },
+      where: {
+        platform: 'slack',
+        OR: [{ transport: 'http', slackAppId: null }, { workspaceId: null }, { workspaceName: null }]
+      },
       include: botInclude,
       orderBy: { createdAt: 'asc' }
     })

--- a/packages/control-plane/src/persistence/repositories/slack-platform-install.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/slack-platform-install.repo.ts
@@ -1,20 +1,21 @@
 /**
  * PgSlackPlatformInstallStore (preset-agents.md §5.3) — pending installs of the
  * platform-published (distributed) Slack app. No secret material: the app's
- * credentials are deployment env config; a row only binds the OAuth `state` to
- * {org, target agent, user}. No FKs (mirrors slack_install): a dangling row
- * after an org/agent delete is harmless and TTL-reaped.
+ * credentials are deployment env config; a row binds the OAuth `state` to
+ * either {org, target agent, user} or {org, expected bot, user}. No FKs
+ * (mirrors slack_install): a dangling row after an org/agent/bot delete is
+ * harmless and TTL-reaped.
  */
 import type { SlackPlatformInstall } from '../../generated/prisma/client.js'
 import type { PrismaLike } from '../prisma.js'
 import type { SlackPlatformInstallRecord, SlackPlatformInstallStore } from '../ports.js'
-import { OrgId, AgentId } from '../../domain/ids.js'
+import { OrgId, AgentId, BotId } from '../../domain/ids.js'
 
 function toRecord(r: SlackPlatformInstall): SlackPlatformInstallRecord {
   return {
     id: r.id,
     orgId: OrgId(r.orgId),
-    agentId: AgentId(r.agentId),
+    agentId: r.agentId ? AgentId(r.agentId) : null,
     status: r.status,
     failureReason: r.failureReason,
     botId: r.botId,
@@ -30,14 +31,16 @@ export class PgSlackPlatformInstallStore implements SlackPlatformInstallStore {
   async create(input: {
     id: string
     orgId: OrgId
-    agentId: AgentId
+    agentId?: AgentId
+    botId?: BotId
     createdByUserId?: string
   }): Promise<SlackPlatformInstallRecord> {
     const row = await this.prisma.slackPlatformInstall.create({
       data: {
         id: input.id,
         orgId: input.orgId,
-        agentId: input.agentId,
+        ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+        ...(input.botId !== undefined ? { botId: input.botId } : {}),
         ...(input.createdByUserId !== undefined ? { createdByUserId: input.createdByUserId } : {})
       }
     })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -151,6 +151,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       name: 'http-bot',
       appId: 'AHTTPBOT',
       teamId: 'T1',
+      teamName: 'Acme',
       scopes: []
     })
 
@@ -169,7 +170,9 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const dto = res.json() as { botId: string }
     expect(await prisma.bot.findUnique({ where: { id: dto.botId } })).toMatchObject({
       transport: 'http',
-      slackAppId: 'AHTTPBOT'
+      slackAppId: 'AHTTPBOT',
+      workspaceId: 'T1',
+      workspaceName: 'Acme'
     })
   })
 
@@ -446,7 +449,14 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects an app-level token Slack refuses (400) and stores nothing', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({ status: 'ok', name: null, appId: null, teamId: null, scopes: [] })
+    app.deps.verifySlackBot = async () => ({
+      status: 'ok',
+      name: null,
+      appId: null,
+      teamId: null,
+      teamName: null,
+      scopes: []
+    })
     app.deps.verifySlackAppToken = async () => 'invalid'
 
     const res = await app.app.inject({
@@ -462,7 +472,14 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST rejects valid Slack tokens that belong to different apps', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy()
-    app.deps.verifySlackBot = async () => ({ status: 'ok', name: null, appId: 'AOTHER', teamId: null, scopes: [] })
+    app.deps.verifySlackBot = async () => ({
+      status: 'ok',
+      name: null,
+      appId: 'AOTHER',
+      teamId: null,
+      teamName: null,
+      scopes: []
+    })
     app.deps.verifySlackAppToken = async () => 'ok'
 
     const res = await app.app.inject({
@@ -488,6 +505,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       name: 'matrix_test',
       appId: null,
       teamId: null,
+      teamName: null,
       scopes: []
     })
 
@@ -734,7 +752,11 @@ describe('bot roster (GET/DELETE /bots)', () => {
     const reconciler = new SlackBotIdentityReconciler(
       app.deps.repos.bot,
       app.deps.repos.botSecret,
-      async () => 'ALEGACYHTTP',
+      async () => ({
+        appId: 'ALEGACYHTTP',
+        workspaceId: 'TLEGACY',
+        workspaceName: 'Legacy workspace'
+      }),
       systemClock,
       { intervalMs: 60_000 }
     )
@@ -743,7 +765,14 @@ describe('bot roster (GET/DELETE /bots)', () => {
 
     const res = await app.app.inject({ method: 'GET', url: `${ORG}/bots` })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual([expect.objectContaining({ id: botId, slackAppId: 'ALEGACYHTTP' })])
+    expect(res.json()).toEqual([
+      expect.objectContaining({
+        id: botId,
+        slackAppId: 'ALEGACYHTTP',
+        workspaceId: 'TLEGACY',
+        workspaceName: 'Legacy workspace'
+      })
+    ])
   })
 
   it('GET /bots surfaces free vs in-use, freed-from hints, and never tokens', async () => {
@@ -855,6 +884,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       name: 'refresh-me',
       appId: 'A0TESTAPP1',
       teamId: 'T0TESTTEAM1',
+      teamName: 'Acme',
       scopes: [...SLACK_BOT_SCOPES]
     })
 
@@ -900,6 +930,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       name: 'manual-app',
       appId: 'A0MANUAL01',
       teamId: 'T0MANUAL01',
+      teamName: 'Acme',
       scopes: [...SLACK_BOT_SCOPES]
     })
 
@@ -953,6 +984,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       name: 'mismatched-app',
       appId: 'A0DIFFERENT',
       teamId: 'T0OTHERTEAM',
+      teamName: 'Other',
       scopes: [...SLACK_BOT_SCOPES]
     })
 
@@ -965,6 +997,10 @@ describe('bot roster (GET/DELETE /bots)', () => {
       manifestUrl: 'https://api.slack.com/apps/A0EXPECTED1'
     })
     expect(exportCalls).toBe(0)
+    expect(await prisma.bot.findUnique({ where: { id: created.botId } })).toMatchObject({
+      workspaceId: null,
+      workspaceName: null
+    })
   })
 
   it.each(['assistant:write', 'chat:write.customize'] as const)(
@@ -989,6 +1025,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
         name: 'old-app',
         appId: 'A0OLDAPP01',
         teamId: 'T0OLDTEAM01',
+        teamName: 'Legacy',
         scopes: SLACK_BOT_SCOPES.filter((scope) => scope !== missingScope)
       })
 

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -379,6 +379,7 @@ describe('GET /integrations/slack/platform/callback', () => {
     })
     const before = await prisma.bot.findFirstOrThrow({ where: { slackAppId: PLATFORM.appId } })
     await prisma.integration.deleteMany({ where: { botId: before.id } })
+    await app.deps.httpBot.revokeBot(before.id, 'app_uninstalled')
 
     stub.exchangeResult = {
       ok: true,
@@ -404,7 +405,56 @@ describe('GET /integrations/slack/platform/callback', () => {
     const after = await prisma.bot.findUniqueOrThrow({ where: { id: before.id }, include: { secret: true } })
     expect(after.credentialRevision).toBe(before.credentialRevision + 1)
     expect(after.secret?.botToken).toBe('xoxb-refreshed')
+    expect(after.revokedAt).toBeNull()
     expect(await prisma.integration.count({ where: { botId: before.id } })).toBe(0)
+  })
+
+  it('a Settings reauthorization restores memberships revoked with the old credential', async () => {
+    const { app, stub } = withPlatform()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const first = await startInstall(app, agentId)
+    await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c1&state=${first.id}`
+    })
+    const before = await prisma.bot.findFirstOrThrow({ where: { slackAppId: PLATFORM.appId } })
+    const integration = await prisma.integration.findFirstOrThrow({ where: { botId: before.id } })
+    await app.deps.httpBot.revokeBot(before.id, 'app_uninstalled')
+    expect(await prisma.integration.findUniqueOrThrow({ where: { id: integration.id } })).toMatchObject({
+      status: 'revoked',
+      revokedCredentialRevision: before.credentialRevision
+    })
+
+    stub.exchangeResult = {
+      ok: true,
+      result: {
+        botToken: 'xoxb-restored',
+        appId: PLATFORM.appId,
+        teamId: 'T0WORKSPACE',
+        teamName: 'Acme',
+        botUserId: 'U0BOT'
+      }
+    }
+    const reauthorization = await startReauthorization(app, before.id)
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c2&state=${reauthorization.id}`
+    })
+
+    expect(cb.body).toContain('Connected to Slack')
+    const after = await prisma.bot.findUniqueOrThrow({ where: { id: before.id }, include: { secret: true } })
+    expect(after).toMatchObject({
+      credentialRevision: before.credentialRevision + 1,
+      revokedAt: null
+    })
+    expect(after.secret?.botToken).toBe('xoxb-restored')
+    expect(await prisma.integration.findUniqueOrThrow({ where: { id: integration.id } })).toMatchObject({
+      agentId,
+      status: 'active',
+      revokedCredentialRevision: null
+    })
+    expect(await prisma.integration.count({ where: { botId: before.id, status: 'active' } })).toBe(1)
   })
 
   // Slack does not order `app_uninstalled` / `tokens_revoked`: an event from the

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -105,6 +105,16 @@ async function startInstall(app: HttpApp, agentId?: string): Promise<{ id: strin
   return res.json() as { id: string; installUrl: string }
 }
 
+async function startReauthorization(app: HttpApp, botId: string): Promise<{ id: string; installUrl: string }> {
+  const res = await app.app.inject({
+    method: 'POST',
+    url: `${ORG}/integrations/slack/platform-install`,
+    payload: { botId }
+  })
+  expect(res.statusCode).toBe(201)
+  return res.json() as { id: string; installUrl: string }
+}
+
 /** Poll one install's terminal state — the console's completion signal. */
 async function status(app: HttpApp, id: string) {
   return app.app.inject({ method: 'GET', url: `${ORG}/integrations/slack/platform-install/${id}` })
@@ -308,6 +318,93 @@ describe('GET /integrations/slack/platform/callback', () => {
     expect(revived.revokedAt).toBeNull()
     expect(revived.secret?.botToken).toBe('xoxb-workspace-token')
     expect(await prisma.integration.count({ where: { botId: bot.id, status: 'active', agentId } })).toBe(1)
+  })
+
+  it('a Settings reauthorization refuses a different workspace before mutating the bot', async () => {
+    const { app, stub } = withPlatform()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const first = await startInstall(app, agentId)
+    await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c1&state=${first.id}`
+    })
+    const before = await prisma.bot.findFirstOrThrow({
+      where: { slackAppId: PLATFORM.appId },
+      include: { secret: true }
+    })
+
+    const reauthorization = await startReauthorization(app, before.id)
+    expect(await prisma.slackPlatformInstall.findUniqueOrThrow({ where: { id: reauthorization.id } })).toMatchObject({
+      agentId: null,
+      botId: before.id
+    })
+    stub.exchangeResult = {
+      ok: true,
+      result: {
+        botToken: 'xoxb-wrong-workspace',
+        appId: PLATFORM.appId,
+        teamId: 'T0OTHER',
+        teamName: 'Other',
+        botUserId: 'U0OTHER'
+      }
+    }
+
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c2&state=${reauthorization.id}`
+    })
+
+    expect(cb.body).toContain('authorized a different workspace')
+    expect((await status(app, reauthorization.id)).json()).toMatchObject({
+      status: 'failed',
+      failureReason: 'workspace_mismatch',
+      botId: before.id
+    })
+    const after = await prisma.bot.findUniqueOrThrow({ where: { id: before.id }, include: { secret: true } })
+    expect(after.credentialRevision).toBe(before.credentialRevision)
+    expect(after.secret?.botToken).toBe(before.secret?.botToken)
+    expect(await prisma.bot.count({ where: { slackAppId: PLATFORM.appId } })).toBe(1)
+    expect(await prisma.integration.count({ where: { botId: before.id, status: 'active' } })).toBe(1)
+  })
+
+  it('reauthorizing a free Settings bot rotates its token without attaching an agent', async () => {
+    const { app, stub } = withPlatform()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const first = await startInstall(app, agentId)
+    await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c1&state=${first.id}`
+    })
+    const before = await prisma.bot.findFirstOrThrow({ where: { slackAppId: PLATFORM.appId } })
+    await prisma.integration.deleteMany({ where: { botId: before.id } })
+
+    stub.exchangeResult = {
+      ok: true,
+      result: {
+        botToken: 'xoxb-refreshed',
+        appId: PLATFORM.appId,
+        teamId: 'T0WORKSPACE',
+        teamName: 'Acme',
+        botUserId: 'U0BOT'
+      }
+    }
+    const reauthorization = await startReauthorization(app, before.id)
+    const cb = await app.app.inject({
+      method: 'GET',
+      url: `/api/v1/integrations/slack/platform/callback?code=c2&state=${reauthorization.id}`
+    })
+
+    expect(cb.body).toContain('Connected to Slack')
+    expect((await status(app, reauthorization.id)).json()).toMatchObject({
+      status: 'completed',
+      botId: before.id
+    })
+    const after = await prisma.bot.findUniqueOrThrow({ where: { id: before.id }, include: { secret: true } })
+    expect(after.credentialRevision).toBe(before.credentialRevision + 1)
+    expect(after.secret?.botToken).toBe('xoxb-refreshed')
+    expect(await prisma.integration.count({ where: { botId: before.id } })).toBe(0)
   })
 
   // Slack does not order `app_uninstalled` / `tokens_revoked`: an event from the

--- a/packages/control-plane/test/integration/slack-platform-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-platform-install.route.test.ts
@@ -11,6 +11,7 @@ import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { provisionPresetAgents } from '../../src/persistence/index.js'
+import { SLACK_BOT_SCOPES } from '../../src/http/slack-manifest.js'
 import type { RelayChannel } from '../../src/ws/relay-registry.js'
 import type {
   SlackConfigApi,
@@ -188,6 +189,8 @@ describe('GET /integrations/slack/platform/callback', () => {
       prebuilt: true,
       botUserId: 'U0BOT',
       name: 'AgentConnect (Acme)',
+      workspaceId: 'T0WORKSPACE',
+      workspaceName: 'Acme',
       revokedAt: null
     })
     expect(bot!.secret).toMatchObject({ botToken: 'xoxb-workspace-token', signingSecret: PLATFORM.signingSecret })
@@ -196,6 +199,25 @@ describe('GET /integrations/slack/platform/callback', () => {
     })
     expect(bot!.integrations).toHaveLength(1)
     expect(bot!.integrations[0]).toMatchObject({ agentId: preset!.id, status: 'active' })
+
+    app.deps.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'agentconnect',
+      appId: PLATFORM.appId,
+      teamId: 'T0WORKSPACE',
+      teamName: 'Acme',
+      scopes: [...SLACK_BOT_SCOPES]
+    })
+    const refreshed = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/bots/${bot!.id}/slack/refresh`
+    })
+    expect(refreshed.statusCode).toBe(200)
+    expect(refreshed.json()).toMatchObject({
+      manifest: 'synced',
+      authorization: 'current',
+      missingScopes: []
+    })
 
     // The row SURVIVES as the console's completion signal, but the state is still
     // single-use: a replayed callback is refused rather than re-running the install.

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -2763,7 +2763,7 @@ export default function AddIntegrationModal({
           </div>
         )}
         {/* A bot is installed on one agent at a time and OUTLIVES its integration:
-            reuse a freed / prebuilt one, or create a new bot for this platform.
+            reuse a freed / builtin one, or create a new bot for this platform.
             (Webhook and GitHub are bot-less — their bodies render above instead.) */}
         {platform !== 'webhook' && platform !== 'github' && !hideIdentitySection && (
           <div className="mb-3 grid grid-cols-1 gap-[10px] desktop:grid-cols-2">
@@ -2845,7 +2845,7 @@ export default function AddIntegrationModal({
                         </span>
                       )}
                       {b.prebuilt && (
-                        <span className="badge bg-(--surface-active) text-(--text-tertiary)">prebuilt</span>
+                        <span className="badge bg-(--surface-active) text-(--text-tertiary)">builtin</span>
                       )}
                     </div>
                     <div className="mt-[2px] font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -107,6 +107,7 @@ const PLATFORM_INSTALL_FAILURES: Record<string, string> = {
   denied: 'The install was cancelled in Slack.',
   expired: 'This install link expired — start again.',
   workspace_taken: 'That Slack workspace is already connected to another organization.',
+  workspace_mismatch: 'Slack authorized a different workspace. Start again and choose the expected workspace.',
   agent_taken: 'That Slack workspace is already connected to another agent here. Remove that integration first.',
   error: 'Slack could not complete the install. Please try again.'
 }
@@ -1960,7 +1961,7 @@ export default function AddIntegrationModal({
     if (busyRef.current) return
     setPlatformErr(null)
     try {
-      const r = await startSlackPlatformInstall(agent.id)
+      const r = await startSlackPlatformInstall({ agentId: agent.id })
       setPlatformInstallId(r.id)
       window.open(r.installUrl, '_blank', 'noopener,width=680,height=760')
       setPlatformPhase('authorizing')

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -739,7 +739,7 @@ function BotsCard({
       return { ...current, [b.id]: result ? { result } : {} }
     })
     try {
-      const started = await startSlackPlatformInstall(b.agentIds[0])
+      const started = await startSlackPlatformInstall({ botId: b.id })
       setSlackReinstall({ botId: b.id, installId: started.id })
       window.open(started.installUrl, '_blank', 'noopener,width=680,height=760')
     } catch (e) {
@@ -776,8 +776,14 @@ function BotsCard({
           fail(
             status.failureReason === 'denied'
               ? 'The reinstall was cancelled in Slack.'
-              : 'Slack could not complete the reinstall. Please try again.'
+              : status.failureReason === 'workspace_mismatch'
+                ? 'Slack authorized a different workspace. Try again and choose this bot’s workspace.'
+                : 'Slack could not complete the reinstall. Please try again.'
           )
+          return
+        }
+        if (status.botId !== botId) {
+          fail('Slack reauthorized a different bot. Please try again.')
           return
         }
 

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -23,6 +23,7 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import { initialsFrom } from '@/lib/auth'
 import {
+  ApiError,
   createOrgInviteLink,
   creatorLabel,
   fetchGithubInstallUrl,
@@ -31,9 +32,11 @@ import {
   fetchOrgInviteLink,
   memberDisplayName,
   refreshSlackBot,
+  getSlackPlatformInstall,
   revokeOrgInviteLink,
   ROLE_LABELS,
   syncGithubInstallations,
+  startSlackPlatformInstall,
   updateOrg,
   uploadOrgIcon,
   type BotDto,
@@ -58,7 +61,7 @@ import UninstallGithubInstallationModal from '@/components/console/modals/Uninst
 // The free-bot sub-line shows where the bot came from without repeating
 // historical usage metadata in the list row.
 function botSubline(b: BotDto): string {
-  return b.freedFromAgent ? `freed from ${b.freedFromAgent}` : b.prebuilt ? 'prebuilt' : ''
+  return b.freedFromAgent ? `freed from ${b.freedFromAgent}` : b.prebuilt ? 'builtin' : ''
 }
 
 function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu' | 'lark'): string {
@@ -103,7 +106,7 @@ const MEMBER_GRID = 'grid-cols-[2fr_1.4fr_auto]'
 // Design grid (`isSettings` Bots card): Bot | Sharable | Agents | Created by |
 // actions. The 100px action track fits refresh + platform link + delete and stays
 // identical across rows; below 480px "Created by" is dropped to preserve space.
-const BOT_GRID = 'grid-cols-[2fr_0.9fr_1.5fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
+const BOT_GRID = 'grid-cols-[3fr_1.1fr_1fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
 const BOT_PLATFORMS = [
   { platform: 'slack', label: 'Slack', noun: 'app' },
   { platform: 'discord', label: 'Discord', noun: 'bot' },
@@ -111,6 +114,35 @@ const BOT_PLATFORMS = [
   { platform: 'feishu', label: 'Lark', noun: 'bot' }
 ] as const
 type BotPlatform = (typeof BOT_PLATFORMS)[number]['platform']
+
+type BotRosterRow = { kind: 'workspace'; key: string; label: string } | { kind: 'bot'; key: string; bot: BotDto }
+
+// Preserve the server's bot order within each workspace. The heading is rendered
+// only when this produces several groups, so single-workspace organizations keep
+// the compact flat list.
+function botRosterRows(bots: BotDto[]): BotRosterRow[] {
+  const groups = new Map<string, { label: string; bots: BotDto[] }>()
+  for (const bot of bots) {
+    const workspaceId = bot.workspaceId?.trim() || null
+    const workspaceName = bot.workspaceName?.trim() || null
+    const key = workspaceId ? `id:${workspaceId}` : workspaceName ? `name:${workspaceName.toLowerCase()}` : 'unknown'
+    const current = groups.get(key)
+    if (current) {
+      if (workspaceName && current.label === workspaceId) current.label = workspaceName
+      current.bots.push(bot)
+      continue
+    }
+    groups.set(key, {
+      label: workspaceName ?? workspaceId ?? 'Workspace unavailable',
+      bots: [bot]
+    })
+  }
+  if (groups.size <= 1) return bots.map((bot) => ({ kind: 'bot', key: bot.id, bot }))
+  return [...groups].flatMap(([workspaceKey, group]) => [
+    { kind: 'workspace', key: `workspace:${workspaceKey}`, label: group.label },
+    ...group.bots.map((bot) => ({ kind: 'bot' as const, key: bot.id, bot }))
+  ])
+}
 
 // One merged channel row for a bot's expandable roster.
 interface BotChannelView {
@@ -231,8 +263,22 @@ function DefaultDispatchPicker({
   )
 }
 
-function SlackRefreshNotice({ result }: { result: SlackBotRefreshDto }) {
-  const { needsAttention, message, action } = slackRefreshNoticeState(result)
+function SlackRefreshNotice({
+  result,
+  builtin,
+  reinstalling,
+  onReinstall
+}: {
+  result: SlackBotRefreshDto
+  builtin?: boolean
+  reinstalling?: boolean
+  onReinstall?: () => void
+}) {
+  const { needsAttention, message: defaultMessage, action } = slackRefreshNoticeState(result)
+  const message =
+    builtin && result.authorization === 'invalid'
+      ? 'Slack rejected this workspace authorization. Reinstall the app to reconnect it.'
+      : defaultMessage
 
   return (
     <div
@@ -248,11 +294,20 @@ function SlackRefreshNotice({ result }: { result: SlackBotRefreshDto }) {
           <span className="mono ml-1 text-[11px]">Missing: {result.missingScopes.join(', ')}</span>
         )}
       </span>
-      {action && (
+      {action?.label === 'Reinstall workspace' && onReinstall ? (
+        <button
+          type="button"
+          className="lnk flex-none border-0 bg-transparent p-0"
+          disabled={reinstalling}
+          onClick={onReinstall}
+        >
+          {reinstalling ? 'Reinstalling…' : action.label}
+        </button>
+      ) : action ? (
         <a href={action.href} target="_blank" rel="noopener noreferrer" className="lnk flex-none">
           {action.label}
         </a>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -608,7 +663,15 @@ function BotsCard({
   targetBotId: string | null
   onDelete: (b: BotDto) => void
 }) {
-  const { bots, integrations, getAgent, setBotShareable, setChannelAgent, loading: dataLoading } = useConsoleData()
+  const {
+    bots,
+    integrations,
+    getAgent,
+    setBotShareable,
+    setChannelAgent,
+    refresh,
+    loading: dataLoading
+  } = useConsoleData()
   const [platform, setPlatform] = useState<BotPlatform>('slack')
   // Bot row expanded to its channel roster (one at a time), the bot whose
   // shareable PATCH is in flight, and the last toggle denial to surface (the CP
@@ -618,12 +681,14 @@ function BotsCard({
   const [botErr, setBotErr] = useState<{ id: string; msg: string } | null>(null)
   const [slackRefreshBusyId, setSlackRefreshBusyId] = useState<string | null>(null)
   const [slackRefresh, setSlackRefresh] = useState<Record<string, { result?: SlackBotRefreshDto; error?: string }>>({})
+  const [slackReinstall, setSlackReinstall] = useState<{ botId: string; installId: string } | null>(null)
 
   const targetBotPlatform = BOT_PLATFORMS.find(
     (item) => item.platform === bots.find((bot) => bot.id === targetBotId)?.platform
   )?.platform
   const { label, noun } = BOT_PLATFORMS.find((item) => item.platform === platform)!
   const platformBots = bots.filter((b) => b.platform === platform)
+  const rosterRows = botRosterRows(platformBots)
 
   useEffect(() => {
     if (!targetBotId || !targetBotPlatform) return
@@ -656,6 +721,7 @@ function BotsCard({
     try {
       const result = await refreshSlackBot(b.id)
       setSlackRefresh((current) => ({ ...current, [b.id]: { result } }))
+      refresh()
     } catch (e) {
       setSlackRefresh((current) => ({
         ...current,
@@ -665,6 +731,82 @@ function BotsCard({
       setSlackRefreshBusyId(null)
     }
   }
+
+  const reinstallBuiltinSlackApp = async (b: BotDto) => {
+    if (slackReinstall || slackRefreshBusyId) return
+    setSlackRefresh((current) => {
+      const result = current[b.id]?.result
+      return { ...current, [b.id]: result ? { result } : {} }
+    })
+    try {
+      const started = await startSlackPlatformInstall(b.agentIds[0])
+      setSlackReinstall({ botId: b.id, installId: started.id })
+      window.open(started.installUrl, '_blank', 'noopener,width=680,height=760')
+    } catch (e) {
+      setSlackRefresh((current) => {
+        const result = current[b.id]?.result
+        const error = e instanceof Error ? e.message : String(e)
+        return { ...current, [b.id]: result ? { result, error } : { error } }
+      })
+    }
+  }
+
+  useEffect(() => {
+    if (!slackReinstall) return
+    const { botId, installId } = slackReinstall
+    let stopped = false
+
+    const stop = () => {
+      stopped = true
+      clearInterval(timer)
+    }
+    const fail = (message: string) => {
+      stop()
+      setSlackReinstall(null)
+      setSlackRefresh((current) => {
+        const result = current[botId]?.result
+        return { ...current, [botId]: result ? { result, error: message } : { error: message } }
+      })
+    }
+    const tick = async () => {
+      try {
+        const status = await getSlackPlatformInstall(installId)
+        if (stopped || status.status === 'pending') return
+        if (status.status === 'failed') {
+          fail(
+            status.failureReason === 'denied'
+              ? 'The reinstall was cancelled in Slack.'
+              : 'Slack could not complete the reinstall. Please try again.'
+          )
+          return
+        }
+
+        stop()
+        setSlackReinstall(null)
+        setSlackRefreshBusyId(botId)
+        try {
+          const result = await refreshSlackBot(botId)
+          setSlackRefresh((current) => ({ ...current, [botId]: { result } }))
+          refresh()
+        } catch (e) {
+          setSlackRefresh((current) => ({
+            ...current,
+            [botId]: { error: e instanceof Error ? e.message : String(e) }
+          }))
+        } finally {
+          setSlackRefreshBusyId(null)
+        }
+      } catch (e) {
+        if (!stopped && e instanceof ApiError && e.status === 404) {
+          fail('This reinstall link expired. Please try again.')
+        }
+      }
+    }
+
+    const timer = setInterval(() => void tick(), 2500)
+    void tick()
+    return stop
+  }, [refresh, slackReinstall])
 
   return (
     <div className="card mt-[18px]">
@@ -703,13 +845,28 @@ function BotsCard({
         <span className="whitespace-nowrap max-[479px]:hidden">Created by</span>
         <span />
       </div>
-      {platformBots.map((b) => {
+      {rosterRows.map((row) => {
+        if (row.kind === 'workspace') {
+          return (
+            <div
+              key={row.key}
+              className="flex items-center gap-2 border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-2"
+            >
+              <span className="font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                Workspace
+              </span>
+              <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">{row.label}</span>
+            </div>
+          )
+        }
+        const b = row.bot
         const free = b.agentIds.length === 0
         const open = openBotId === b.id
         const channels = open ? botChannels(b, integrations) : []
         const hasChannelRows = channels.some((c) => c.kind === 'channel')
         const slackState = slackRefresh[b.id]
-        const refreshingSlack = slackRefreshBusyId === b.id
+        const reinstallingSlack = slackReinstall?.botId === b.id
+        const refreshingSlack = slackRefreshBusyId === b.id || reinstallingSlack
         const slackNeedsAttention = slackState?.result
           ? slackRefreshNoticeState(slackState.result).needsAttention
           : false
@@ -746,8 +903,8 @@ function BotsCard({
                     <PlatformMark platform={b.platform} fillPct={100} />
                   </span>
                 </span>
-                <span className="mono truncate text-[12.5px]">{b.name}</span>
-                {b.prebuilt && <span className="badge bg-(--surface-active) text-(--text-tertiary)">prebuilt</span>}
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px]">{b.name}</span>
+                {b.prebuilt && <span className="badge bg-(--surface-active) text-(--text-tertiary)">builtin</span>}
                 {/* Workspace uninstalled the app / revoked its tokens (rc/bot-revoked):
                     the credential is dead until a re-install refreshes it. */}
                 {b.revokedAt && (
@@ -761,7 +918,9 @@ function BotsCard({
                 {/* Transport tag (Slack) — makes the Sharable column's disabled state
                     self-explanatory: only an http bot may be shared. */}
                 {platform === 'slack' && (
-                  <span className="badge bg-(--surface-active) text-(--text-tertiary)">{b.transport ?? 'socket'}</span>
+                  <span className="badge bg-(--surface-active) text-(--text-tertiary) max-[479px]:hidden">
+                    {b.transport ?? 'socket'}
+                  </span>
                 )}
               </div>
               <span
@@ -805,7 +964,7 @@ function BotsCard({
                 {b.createdBy ? creatorLabel(b.createdBy, me) : b.prebuilt ? 'AgentConnect' : '—'}
               </span>
               <span className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
-                {platform === 'slack' && !b.prebuilt && b.slackAppId && canWrite && (
+                {platform === 'slack' && b.slackAppId && canWrite && (
                   <button
                     className={`iconbtn h-7 w-7 flex-none ${
                       slackNeedsAttention ? 'border-(--amber-500) bg-(--status-paused-soft) text-(--amber-500)' : ''
@@ -890,7 +1049,14 @@ function BotsCard({
                 Couldn&apos;t refresh this Slack app — {slackState.error}
               </div>
             )}
-            {slackState?.result && <SlackRefreshNotice result={slackState.result} />}
+            {slackState?.result && (
+              <SlackRefreshNotice
+                result={slackState.result}
+                builtin={b.prebuilt}
+                reinstalling={reinstallingSlack}
+                onReinstall={b.prebuilt ? () => void reinstallBuiltinSlackApp(b) : undefined}
+              />
+            )}
             {open && (
               <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 pb-[14px] pl-10 pt-3">
                 {channels.length > 0 ? (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2576,13 +2576,14 @@ export async function finalizeSlackInstall(
 
 // ── Platform-published "Add to Slack" app (preset-agents.md §5.3) ──
 // Mint a pending install of the deployment's distributed Slack app and get the
-// slack.com authorize URL to open. `agentId` optional — the CP defaults to the
-// org's `agentconnect` preset agent. The callback finishes the install
-// server-side; the console polls the row below to learn when it landed.
-export async function startSlackPlatformInstall(agentId?: string): Promise<SlackPlatformInstallDto> {
-  return apiPost<SlackPlatformInstallDto>(`${orgBase()}/integrations/slack/platform-install`, {
-    ...(agentId ? { agentId } : {})
-  })
+// slack.com authorize URL to open. A generic install may select an agent (the CP
+// otherwise defaults to the org preset); Settings supplies `botId` to fence a
+// reauthorization to the bot's existing workspace. The callback finishes the
+// install server-side; the console polls the row below to learn when it landed.
+export async function startSlackPlatformInstall(
+  input: { agentId?: string; botId?: string } = {}
+): Promise<SlackPlatformInstallDto> {
+  return apiPost<SlackPlatformInstallDto>(`${orgBase()}/integrations/slack/platform-install`, input)
 }
 
 // Poll one platform-app install to completion. The ROW's terminal state is the

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -622,6 +622,8 @@ export interface BotDto {
   lastUsedAt: string | null // ISO-8601; stamped when last freed; null ⇒ never used
   freedFromAgent: string | null // agent it was last freed from ("freed from support-bot")
   teamId?: string | null // Slack workspace id (T…) — platform-app installs only
+  workspaceId?: string | null // external workspace identity used only for Console grouping
+  workspaceName?: string | null // human-readable external workspace label
   revokedAt?: string | null // workspace uninstalled the app / revoked tokens; null ⇒ live
   createdAt: string // ISO-8601
 }

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -340,6 +340,8 @@ const MOCK_MEMBERS: MemberDto[] = [
 
 // Demo bot roster (MOCK_MODE only) — one per platform so the Settings platform
 // cards + the Add-integration reuse picker render populated with no CP running.
+// The two Slack rows sit in distinct workspaces so the conditional grouping is
+// visible in design/dev mode.
 // Discord rows carry a real-shaped application id so the "Add to Discord" invite
 // link is exercised. `createdBy` ids resolve to MOCK_MEMBERS names via creatorLabel.
 const MOCK_BOTS: BotDto[] = [
@@ -349,6 +351,8 @@ const MOCK_BOTS: BotDto[] = [
     platform: 'slack',
     prebuilt: false,
     slackAppId: 'A0DEPLOYBOT',
+    workspaceId: 'T0ENGINEERING',
+    workspaceName: 'Engineering',
     discordAppId: null,
     createdBy: 'u_dana',
     transport: 'socket',
@@ -361,18 +365,20 @@ const MOCK_BOTS: BotDto[] = [
   },
   {
     id: 'bot_slack_free',
-    name: 'support-bot',
+    name: 'AgentConnect',
     platform: 'slack',
-    prebuilt: false,
+    prebuilt: true,
     slackAppId: 'A0SUPPORTBT',
+    workspaceId: 'T0SUPPORT',
+    workspaceName: 'Support',
     discordAppId: null,
-    createdBy: 'u_sam',
+    createdBy: null,
     transport: 'http',
     shareable: false,
     inUseByAgentId: null,
     agentIds: [],
     lastUsedAt: '2026-06-28T00:00:00Z',
-    freedFromAgent: 'review',
+    freedFromAgent: null,
     createdAt: '2026-01-20T00:00:00Z'
   },
   {


### PR DESCRIPTION
## Summary

- persist Slack workspace identity and display names across built-in, custom, and legacy bot installs
- group Settings bot rows by workspace only when more than one workspace is present, and use `builtin` in user-facing labels
- allow built-in Slack apps to run Refresh and complete a bot/workspace-bound OAuth reinstall when scopes or authorization need attention
- reject a different Slack workspace before rotating credentials and keep a deliberately freed bot free
- restore memberships revoked by the credential being replaced, so reinstalling an uninstalled app reconnects its prior agents
- keep workspace display metadata separate from the existing platform-app routing identity

## Validation

- control-plane and web TypeScript checks
- 18 focused control-plane unit tests
- 6 Slack refresh notice tests
- 67 focused control-plane integration tests with all 45 Prisma migrations applied
- focused platform-install suite: 30 tests, including workspace mismatch, freed-bot, and revoked-membership restoration regressions
- Prisma schema validation
- production Next.js build in mock mode plus desktop/mobile Settings visual checks
- GitHub Build, Check, Unit Test, and both Integration shards

Created by Codex . GPT-5
