### PR TITLE
feat(auth): support Slack sign-in

### DIFF
--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -78,6 +78,32 @@ interface CachedLogin {
   expiresAt: number
 }
 
+interface CachedSlack {
+  identity: SlackIdentity | null
+  expiresAt: number
+}
+
+/** The Slack workspace identity behind a console account. Both ids are required —
+ *  a `U…` without its `T…` is not addressable, so a partial read is no read. */
+export interface SlackIdentity {
+  /** Slack workspace id (`T…`). */
+  teamId: string
+  /** Slack user id (`U…`) — scoped to that workspace. */
+  userId: string
+  teamName?: string
+  teamDomain?: string
+}
+
+// Slack namespaces its non-standard OIDC claims. `sub` carries the same user id
+// as `https://slack.com/user_id`; team_name/team_domain are best-effort (Slack's
+// published claim list guarantees only the two ids).
+const SLACK_CLAIM = {
+  teamId: 'https://slack.com/team_id',
+  userId: 'https://slack.com/user_id',
+  teamName: 'https://slack.com/team_name',
+  teamDomain: 'https://slack.com/team_domain'
+} as const
+
 /** The Logto user shape we read — identities metadata only. */
 interface LogtoUser {
   identities?: Record<
@@ -85,10 +111,11 @@ interface LogtoUser {
     {
       userId?: string
       details?: {
-        // The connector's raw profile; Logto's github connector stores the
+        // The connector's raw profile. Logto's github connector stores the
         // GitHub /user response under `rawData` (login at `userInfo.login` on
-        // current connectors; older ones kept the flat `login`).
-        rawData?: { userInfo?: { login?: unknown }; login?: unknown }
+        // current connectors; older ones kept the flat `login`); the slack
+        // connector stores the whole decoded OIDC payload there.
+        rawData?: { userInfo?: { login?: unknown }; login?: unknown } & Record<string, unknown>
       }
     }
   >
@@ -99,6 +126,11 @@ export class LogtoIdentityService {
   private tokenInFlight?: Promise<string>
   private readonly logins = new Map<string, CachedLogin>()
   private readonly loginInFlight = new Map<string, Promise<string | null>>()
+  // Kept separate from the login cache on purpose: githubLoginFor sits on a live
+  // authorization gate, and a display-only Slack read must not be able to shift
+  // what that gate sees (or when it re-asks).
+  private readonly slacks = new Map<string, CachedSlack>()
+  private readonly slackInFlight = new Map<string, Promise<SlackIdentity | null>>()
 
   constructor(
     private readonly cfg: LogtoMgmtConfig,
@@ -119,6 +151,22 @@ export class LogtoIdentityService {
     if (!pending) {
       pending = this.lookupLogin(sub).finally(() => this.loginInFlight.delete(sub))
       this.loginInFlight.set(sub, pending)
+    }
+    return pending
+  }
+
+  /**
+   * The Slack workspace identity behind a local user's OIDC subject, or null
+   * when the account never signed in with (or linked) Slack. Read-only
+   * metadata — no caller may treat this as an authorization decision.
+   */
+  async slackIdentityFor(sub: string): Promise<SlackIdentity | null> {
+    const cached = this.slacks.get(sub)
+    if (cached && cached.expiresAt > this.clock.now()) return cached.identity
+    let pending = this.slackInFlight.get(sub)
+    if (!pending) {
+      pending = this.lookupSlack(sub).finally(() => this.slackInFlight.delete(sub))
+      this.slackInFlight.set(sub, pending)
     }
     return pending
   }
@@ -162,7 +210,7 @@ export class LogtoIdentityService {
       body: JSON.stringify({ connectorId, connectorData })
     })
     if (!res.ok) throw await this.responseError('logto social identity link', res)
-    this.logins.delete(sub)
+    this.invalidate(sub)
   }
 
   /** Remove one provider identity from this Logto user. */
@@ -185,8 +233,33 @@ export class LogtoIdentityService {
         method: 'DELETE'
       })
       if (!res.ok) throw await this.responseError('logto social identity unlink', res)
-      this.logins.delete(sub)
+      this.invalidate(sub)
     })
+  }
+
+  /** Drop every cached identity for one user. Called after a link/unlink, so the
+   *  Profile does not keep showing a method the user just changed. */
+  private invalidate(sub: string): void {
+    this.logins.delete(sub)
+    this.slacks.delete(sub)
+  }
+
+  private async lookupSlack(sub: string): Promise<SlackIdentity | null> {
+    const res = await this.request(`/api/users/${encodeURIComponent(sub)}`)
+    if (res.status === 404) {
+      this.slacks.set(sub, { identity: null, expiresAt: this.clock.now() + NEGATIVE_TTL_MS })
+      return null
+    }
+    if (!res.ok) {
+      throw new LogtoApiError(`logto user lookup failed: ${res.status}`, res.status, res.status >= 500)
+    }
+    const user = (await res.json()) as LogtoUser
+    const identity = slackIdentityOf(user)
+    this.slacks.set(sub, {
+      identity,
+      expiresAt: this.clock.now() + (identity ? LOGIN_TTL_MS : NEGATIVE_TTL_MS)
+    })
+    return identity
   }
 
   private async lookupLogin(sub: string): Promise<string | null> {
@@ -283,4 +356,25 @@ export class LogtoIdentityService {
 function firstString(...candidates: unknown[]): string | null {
   for (const c of candidates) if (typeof c === 'string' && c.length > 0) return c
   return null
+}
+
+/** Read the Slack workspace identity out of a Logto user, or null when the
+ *  account has no usable one. */
+function slackIdentityOf(user: LogtoUser): SlackIdentity | null {
+  const identity = user.identities?.slack
+  const raw = identity?.details?.rawData
+  if (!raw) return null
+  const teamId = firstString(raw[SLACK_CLAIM.teamId])
+  // Slack's `sub` IS the user id, so the stored identity key is an equally
+  // authoritative fallback when the namespaced claim is absent.
+  const userId = firstString(raw[SLACK_CLAIM.userId], identity?.userId)
+  if (!teamId || !userId) return null
+  const teamName = firstString(raw[SLACK_CLAIM.teamName])
+  const teamDomain = firstString(raw[SLACK_CLAIM.teamDomain])
+  return {
+    teamId,
+    userId,
+    ...(teamName ? { teamName } : {}),
+    ...(teamDomain ? { teamDomain } : {})
+  }
 }

--- a/packages/control-plane/src/github/slack-identity.test.ts
+++ b/packages/control-plane/src/github/slack-identity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the Slack half of LogtoIdentityService (fake fetch — claim
+ * extraction, per-provider caching, invalidation on link/unlink). No Docker, no
+ * network. The GitHub half and the link/unlink writes are covered by
+ * `user-authz.test.ts`.
+ */
+import { describe, it, expect } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import type { SocialIdentityMutationGate } from '../persistence/ports.js'
+import { LogtoIdentityService } from './logto-identity.js'
+
+const MGMT = { endpoint: 'https://t.logto.app', appId: 'app', appSecret: 'sec', resource: 'https://t.logto.app/api' }
+const MUTATIONS: SocialIdentityMutationGate = {
+  runExclusive: async (_oidcSubject, mutation) => mutation()
+}
+
+type FetchImpl = (url: string, init?: RequestInit) => Promise<Response>
+
+/** Fake Logto: one token endpoint + a mutable user directory. Counts user reads. */
+function fakeLogto(users: Record<string, unknown>) {
+  const calls = { user: 0, deletes: 0 }
+  const fetchImpl: FetchImpl = async (url, init) => {
+    if (url.endsWith('/oidc/token')) return Response.json({ access_token: 'tok', expires_in: 3600 })
+    if (init?.method === 'DELETE') {
+      calls.deletes++
+      return new Response(null, { status: 204 })
+    }
+    if (init?.method === 'POST') return Response.json({})
+    calls.user++
+    const sub = decodeURIComponent(url.split('/').pop()!)
+    const user = users[sub]
+    if (!user) return new Response('{}', { status: 404 })
+    return Response.json(user)
+  }
+  return { fetchImpl, calls }
+}
+
+const svcOf = (fetchImpl: FetchImpl, clock = new FakeClock(0)) =>
+  new LogtoIdentityService(MGMT, clock, MUTATIONS, fetchImpl)
+
+/** A Logto user whose slack identity carries `rawData` — the connector stores the
+ *  decoded OIDC payload whole. Synthetic ids: never a real workspace. */
+function slackUser(rawData: Record<string, unknown>, userId = 'U0EXAMPLE1') {
+  return { identities: { slack: { userId, details: { rawData } } } }
+}
+
+const SLACK_RAW = {
+  sub: 'U0EXAMPLE1',
+  'https://slack.com/team_id': 'T0EXAMPLE1',
+  'https://slack.com/user_id': 'U0EXAMPLE1',
+  'https://slack.com/team_name': 'Example Workspace',
+  'https://slack.com/team_domain': 'example-workspace',
+  email: 'dev@example.test',
+  email_verified: true
+}
+
+describe('LogtoIdentityService.slackIdentityFor', () => {
+  it('resolves the workspace identity from the connector rawData', async () => {
+    const { fetchImpl } = fakeLogto({ 'sub-1': slackUser(SLACK_RAW) })
+    expect(await svcOf(fetchImpl).slackIdentityFor('sub-1')).toEqual({
+      teamId: 'T0EXAMPLE1',
+      userId: 'U0EXAMPLE1',
+      teamName: 'Example Workspace',
+      teamDomain: 'example-workspace'
+    })
+  })
+
+  it('omits the optional workspace labels when Slack did not send them', async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': slackUser({ 'https://slack.com/team_id': 'T0EXAMPLE1', 'https://slack.com/user_id': 'U0EXAMPLE1' })
+    })
+    expect(await svcOf(fetchImpl).slackIdentityFor('sub-1')).toEqual({ teamId: 'T0EXAMPLE1', userId: 'U0EXAMPLE1' })
+  })
+
+  it("falls back to the stored identity key when the user_id claim is absent (it is Slack's sub)", async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': slackUser({ 'https://slack.com/team_id': 'T0EXAMPLE1' }, 'U0FALLBACK')
+    })
+    expect(await svcOf(fetchImpl).slackIdentityFor('sub-1')).toMatchObject({ userId: 'U0FALLBACK' })
+  })
+
+  it('returns null without a team id — a user id alone is not addressable', async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': slackUser({ 'https://slack.com/user_id': 'U0EXAMPLE1' }, '')
+    })
+    expect(await svcOf(fetchImpl).slackIdentityFor('sub-1')).toBeNull()
+  })
+
+  it('returns null for accounts that never connected Slack, and for unknown users', async () => {
+    const { fetchImpl } = fakeLogto({ 'sub-gh': { identities: { github: { details: { rawData: { login: 'x' } } } } } })
+    const svc = svcOf(fetchImpl)
+    expect(await svc.slackIdentityFor('sub-gh')).toBeNull()
+    expect(await svc.slackIdentityFor('sub-missing')).toBeNull()
+  })
+
+  it('surfaces mgmt-API failures rather than reporting "not connected"', async () => {
+    const fetchImpl: FetchImpl = async (url) =>
+      url.endsWith('/oidc/token')
+        ? Response.json({ access_token: 't', expires_in: 3600 })
+        : new Response('boom', { status: 503 })
+    await expect(svcOf(fetchImpl).slackIdentityFor('s')).rejects.toMatchObject({ retryable: true })
+  })
+
+  it('caches per provider — a slack read neither serves nor poisons the github cache', async () => {
+    const { fetchImpl, calls } = fakeLogto({
+      'sub-1': {
+        identities: {
+          github: { details: { rawData: { userInfo: { login: 'octocat' } } } },
+          slack: { userId: 'U0EXAMPLE1', details: { rawData: SLACK_RAW } }
+        }
+      }
+    })
+    const svc = svcOf(fetchImpl)
+
+    expect(await svc.githubLoginFor('sub-1')).toBe('octocat')
+    expect(calls.user).toBe(1)
+    // Separate cache ⇒ its own request, and the github answer is untouched.
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    expect(calls.user).toBe(2)
+
+    // Both now hold their own positive entry.
+    expect(await svc.githubLoginFor('sub-1')).toBe('octocat')
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    expect(calls.user).toBe(2)
+  })
+
+  it('re-asks after the negative TTL, so a just-connected workspace shows up', async () => {
+    const clock = new FakeClock(0)
+    const users: Record<string, unknown> = {}
+    const { fetchImpl, calls } = fakeLogto(users)
+    const svc = svcOf(fetchImpl, clock)
+
+    expect(await svc.slackIdentityFor('sub-1')).toBeNull()
+    expect(await svc.slackIdentityFor('sub-1')).toBeNull() // negative cache
+    expect(calls.user).toBe(1)
+
+    clock.advance(61_000)
+    users['sub-1'] = slackUser(SLACK_RAW)
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    expect(calls.user).toBe(2)
+
+    clock.advance(60_000) // positive cache holds
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    expect(calls.user).toBe(2)
+  })
+
+  it('drops the cached workspace when an identity is unlinked', async () => {
+    // Otherwise Profile keeps showing a workspace the user just disconnected,
+    // for the rest of the positive TTL.
+    const users: Record<string, unknown> = {
+      'sub-1': { identities: { slack: { userId: 'U0EXAMPLE1', details: { rawData: SLACK_RAW } }, github: {} } }
+    }
+    const { fetchImpl, calls } = fakeLogto(users)
+    const svc = svcOf(fetchImpl)
+
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await svc.unlinkSocialIdentity('sub-1', 'slack')
+    expect(calls.deletes).toBe(1)
+
+    users['sub-1'] = { identities: { github: {} } }
+    expect(await svc.slackIdentityFor('sub-1')).toBeNull() // re-read, not the stale hit
+  })
+
+  it('drops the cached workspace when an identity is linked', async () => {
+    const users: Record<string, unknown> = {}
+    const { fetchImpl } = fakeLogto(users)
+    const svc = svcOf(fetchImpl)
+
+    expect(await svc.slackIdentityFor('sub-1')).toBeNull()
+    await svc.linkSocialIdentity('sub-1', 'slack connector', { code: 'c', state: 's' })
+
+    users['sub-1'] = slackUser(SLACK_RAW)
+    expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+  })
+})

--- a/packages/control-plane/src/http/plugins/openapi.test.ts
+++ b/packages/control-plane/src/http/plugins/openapi.test.ts
@@ -55,6 +55,13 @@ describe('openapi plane', () => {
       const agentsPost = doc.paths?.['/api/v1/orgs/{orgId}/agents']?.post
       expect(agentsPost?.requestBody).toBeTruthy()
       expect(agentsPost?.responses?.['201']).toBeTruthy()
+
+      // A discriminated-union response transforms too, and the operation carries
+      // the naming a docs UI needs (without these it renders as a bare path).
+      const slackIdentity = doc.paths?.['/api/v1/me/social-identities/slack']?.get
+      expect(slackIdentity).toMatchObject({ operationId: 'getMySlackIdentity', tags: ['Profile'] })
+      expect(slackIdentity?.summary).toBeTruthy()
+      expect(slackIdentity?.responses?.['200']?.content?.['application/json']?.schema).toBeTruthy()
     } finally {
       await app.close()
     }

--- a/packages/control-plane/src/http/routes/me-social-identities.test.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.test.ts
@@ -76,4 +76,106 @@ describe('my social identities routes', () => {
       await app.close()
     }
   })
+
+  it('accepts slack as a linkable target, matching the console provider list', async () => {
+    // The console offers Slack; a server-side allowlist that omitted it would
+    // turn that Connect button into a 400.
+    const identity = {
+      createSocialAuthorization: vi.fn(async () => ({
+        connectorId: 'slack-connector',
+        redirectTo: 'https://slack.example.test/authorize'
+      }))
+    }
+    const app = await slackApp({ logtoIdentity: identity } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/me/social-identities/authorization-uri',
+        payload: { target: 'slack', state: 's'.repeat(64) }
+      })
+      expect(res.statusCode).toBe(200)
+      expect(identity.createSocialAuthorization).toHaveBeenCalledWith(
+        'slack',
+        'https://app.example.test/auth/social/callback',
+        's'.repeat(64)
+      )
+    } finally {
+      await app.close()
+    }
+  })
+})
+
+/** A routes-only app whose oidcAuth stamps a fixed subject. */
+async function slackApp(partial: Partial<HttpDeps>) {
+  const deps = { ...partial, config: { PUBLIC_WEB_URL: 'https://app.example.test' } } as unknown as HttpDeps
+  const app = Fastify()
+  installZod(app)
+  app.decorate('oidcAuth', async (req) => {
+    req.oidcSubject = 'logto-user'
+  })
+  await app.register(meSocialIdentityRoutes(deps))
+  return app
+}
+
+describe('GET /me/social-identities/slack', () => {
+  it('returns the workspace identity behind the caller’s subject', async () => {
+    const slackIdentityFor = vi.fn(async () => ({
+      teamId: 'T0EXAMPLE1',
+      userId: 'U0EXAMPLE1',
+      teamName: 'Example Workspace'
+    }))
+    const app = await slackApp({ logtoIdentity: { slackIdentityFor } } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/slack' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual({
+        linked: true,
+        teamId: 'T0EXAMPLE1',
+        userId: 'U0EXAMPLE1',
+        teamName: 'Example Workspace'
+      })
+      expect(slackIdentityFor).toHaveBeenCalledWith('logto-user')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('reports "not linked" for an account that never connected Slack', async () => {
+    const app = await slackApp({
+      logtoIdentity: { slackIdentityFor: vi.fn(async () => null) }
+    } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/slack' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual({ linked: false })
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('503s when the deployment cannot resolve identities, like its siblings', async () => {
+    const app = await slackApp({} as unknown as HttpDeps)
+    try {
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/slack' })
+      expect(res.statusCode).toBe(503)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('502s when the provider is unreachable, rather than claiming "not linked"', async () => {
+    const app = await slackApp({
+      logtoIdentity: {
+        slackIdentityFor: vi.fn(async () => {
+          throw new LogtoApiError('logto unreachable', 0, true)
+        })
+      }
+    } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/slack' })
+      expect(res.statusCode).toBe(502)
+    } finally {
+      await app.close()
+    }
+  })
 })

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -16,7 +16,9 @@ import { Tag } from '../plugins/openapi.js'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 
 const ConnectorId = z.string().trim().min(1).max(128)
-const SocialTarget = z.enum(['github', 'google'])
+// Must stay in step with the console's SOCIAL_LOGIN_PROVIDERS: a target the UI
+// offers but this rejects is a Connect button that 400s.
+const SocialTarget = z.enum(['github', 'google', 'slack'])
 const State = z.string().min(32).max(256)
 const ConnectorData = z
   .record(z.string().max(64), z.string().max(4096))
@@ -28,7 +30,24 @@ const LinkBody = z.object({ connectorId: ConnectorId, connectorData: ConnectorDa
 const LinkDto = z.object({ linked: z.literal(true) })
 const TargetParam = z.object({ target: z.string().trim().min(1).max(128) })
 
-type Operation = 'authorize' | 'link' | 'unlink'
+/** The Slack workspace behind the caller's account. `linked: false` is a real
+ *  answer (no Slack identity), not an error — a Logto 404 for the user resolves
+ *  to it too, since an account that is gone has no identity to report. */
+const SlackIdentityDto = z.discriminatedUnion('linked', [
+  z.object({ linked: z.literal(false) }),
+  z.object({
+    linked: z.literal(true),
+    /** Slack workspace id (`T…`). */
+    teamId: z.string(),
+    /** Slack user id (`U…`) — scoped to that workspace. */
+    userId: z.string(),
+    /** Workspace display name / subdomain, when Slack sent them. */
+    teamName: z.string().optional(),
+    teamDomain: z.string().optional()
+  })
+])
+
+type Operation = 'authorize' | 'link' | 'unlink' | 'read'
 
 function socialCallbackUrl(deps: HttpDeps): string | undefined {
   const webUrl = resolveWebAppUrl(deps.config)
@@ -196,6 +215,35 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
           return reply.code(204).send(null)
         } catch (error) {
           return logtoFailure(reply, error, 'unlink')
+        }
+      }
+    )
+
+    // A READ, unlike its siblings: it reports the Slack workspace an account
+    // signed in with — the one server-side path to that pair, since a Logto
+    // access token carries the Logto subject and never the connector identity.
+    // Read-only metadata; nothing may treat it as an authorization statement.
+    r.get(
+      '/me/social-identities/slack',
+      {
+        preHandler: app.oidcAuth,
+        schema: {
+          tags: [Tag.Profile],
+          summary: 'Get your Slack workspace identity',
+          description:
+            'The Slack workspace id and user id behind your account, as recorded by the sign-in provider. Returns `linked: false` when you have not connected Slack.',
+          operationId: 'getMySlackIdentity',
+          response: { 200: SlackIdentityDto, 429: ErrorDto, 502: ErrorDto, 503: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const identity = deps.logtoIdentity
+        if (!identity) return reply.code(503).send(unavailable)
+        try {
+          const slack = await identity.slackIdentityFor(req.oidcSubject!)
+          return slack ? { linked: true as const, ...slack } : { linked: false as const }
+        } catch (error) {
+          return logtoFailure(reply, error, 'read')
         }
       }
     )

--- a/packages/web/src/app/waitlist/Waitlist.tsx
+++ b/packages/web/src/app/waitlist/Waitlist.tsx
@@ -19,13 +19,14 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { FaSlack, FaTelegram, FaDiscord } from 'react-icons/fa'
 import { Icon } from '@/components/ui'
-import { Spinner, Wordmark } from '@/components/marks'
+import { SocialLoginMark, Spinner, Wordmark } from '@/components/marks'
 import { getMyAccess, joinWaitlist, type WaitlistIntake } from '@/lib/api'
 import { getUser, isAuthConfigured, login, logout } from '@/lib/auth'
+import { SOCIAL_LOGIN_PROVIDERS, type SocialLoginTarget } from '@/lib/social-login-providers'
 
 type Phase = 'loading' | 'intake' | 'auth' | 'onlist' | 'error'
 type Platform = 'slack' | 'telegram' | 'discord'
-type Provider = 'github' | 'google'
+type Provider = SocialLoginTarget
 
 const DOCS_URL = 'https://docs.agentconnect.md'
 // Verified sender of the activation email. Deploy-time config, so it comes from the
@@ -35,6 +36,9 @@ const FROM_EMAIL_DEFAULT = 'no-reply@agentconnect.md'
 const INTAKE_KEY = 'ac.wl.intake'
 const PROVIDER_KEY = 'ac.wl.provider'
 const TEAM_SIZES = ['Just me', '2–10', '11–50', '51–200', '200+']
+const PROVIDER_LABELS: Record<string, string> = Object.fromEntries(
+  SOCIAL_LOGIN_PROVIDERS.map((p) => [p.target, `via ${p.name}`])
+)
 const PLATFORMS: { id: Platform; label: string; Mark: typeof FaSlack }[] = [
   { id: 'slack', label: 'Slack', Mark: FaSlack },
   { id: 'telegram', label: 'Telegram', Mark: FaTelegram },
@@ -369,14 +373,19 @@ export default function Waitlist() {
                   typing, no spoofing.
                 </p>
                 <div className="mt-[26px] flex max-w-[380px] flex-col gap-3">
-                  <button type="button" className="sso dark" onClick={() => continueWith('github')}>
-                    <GithubMark />
-                    Continue with GitHub
-                  </button>
-                  <button type="button" className="sso" onClick={() => continueWith('google')}>
-                    <GoogleMark />
-                    Continue with Google
-                  </button>
+                  {SOCIAL_LOGIN_PROVIDERS.map((provider) => (
+                    <button
+                      key={provider.target}
+                      type="button"
+                      // GitHub keeps the design's dark primary treatment; the rest
+                      // are the plain light button.
+                      className={provider.target === 'github' ? 'sso dark' : 'sso'}
+                      onClick={() => continueWith(provider.target)}
+                    >
+                      <SocialLoginMark target={provider.target} />
+                      Continue with {provider.name}
+                    </button>
+                  ))}
                 </div>
               </div>
             )}
@@ -405,7 +414,9 @@ function OnListColumn({
   onSignOut: () => void
   onRefresh: () => void
 }) {
-  const providerLabel = provider === 'github' ? 'via GitHub' : provider === 'google' ? 'via Google' : ''
+  // A stashed provider is unvalidated JSON, so an unknown value degrades to no
+  // label rather than rendering "Verified undefined".
+  const providerLabel = (provider && PROVIDER_LABELS[provider]) || ''
   const lead =
     status === 'approved'
       ? 'You’re approved. Your activation link is on its way — open it to finish setting up your account.'
@@ -662,36 +673,5 @@ function OnListAside() {
         </div>
       </div>
     </aside>
-  )
-}
-
-/* ── Provider marks (verbatim from the design) ────────────────────────────── */
-function GithubMark() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-      <path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 016 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.3.8 1 .8 2.1v3.1c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z" />
-    </svg>
-  )
-}
-function GoogleMark() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden>
-      <path
-        fill="#4285F4"
-        d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.5c-.3 1.5-1.1 2.7-2.4 3.6v3h3.9c2.3-2.1 3.5-5.2 3.5-8.8z"
-      />
-      <path
-        fill="#34A853"
-        d="M12 24c3.2 0 5.9-1.1 7.9-2.9l-3.9-3c-1.1.7-2.5 1.2-4 1.2-3.1 0-5.7-2.1-6.6-4.9H1.4v3.1C3.4 21.4 7.4 24 12 24z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M5.4 14.4c-.2-.7-.4-1.4-.4-2.4s.1-1.6.4-2.4V6.5H1.4C.5 8.2 0 10 0 12s.5 3.8 1.4 5.5l4-3.1z"
-      />
-      <path
-        fill="#EA4335"
-        d="M12 4.8c1.8 0 3.3.6 4.6 1.8l3.4-3.4C17.9 1.2 15.2 0 12 0 7.4 0 3.4 2.6 1.4 6.5l4 3.1C6.3 6.8 8.9 4.8 12 4.8z"
-      />
-    </svg>
   )
 }

--- a/packages/web/src/components/Auth.tsx
+++ b/packages/web/src/components/Auth.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { FcGoogle } from 'react-icons/fc'
-import { SiGithub } from 'react-icons/si'
-import { LogoMark, Wordmark } from '@/components/marks'
+import { LogoMark, SocialLoginMark, Wordmark } from '@/components/marks'
 import { isAuthConfigured, login } from '@/lib/auth'
 import { SOCIAL_LOGIN_PROVIDERS, type SocialLoginTarget } from '@/lib/social-login-providers'
 
@@ -52,7 +50,7 @@ export default function Auth() {
             <div className="mt-[26px] flex flex-col gap-[10px]">
               {SOCIAL_LOGIN_PROVIDERS.map((provider) => (
                 <button key={provider.target} className="sso" onClick={() => sso(provider.target)}>
-                  {provider.target === 'github' ? <SiGithub aria-hidden /> : <FcGoogle aria-hidden />}
+                  <SocialLoginMark target={provider.target} />
                   Continue with {provider.name}
                 </button>
               ))}

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useId, useState } from 'react'
 import useSWR from 'swr'
-import { FcGoogle } from 'react-icons/fc'
-import { SiGithub } from 'react-icons/si'
 import { Avatar, Button, Icon } from '@/components/ui'
+import { SocialLoginMark } from '@/components/marks'
 import { initialsFrom } from '@/lib/auth'
-import { createMySocialIdentityAuthorization, unlinkMySocialIdentity } from '@/lib/api'
+import { createMySocialIdentityAuthorization, fetchMySlackIdentity, unlinkMySocialIdentity } from '@/lib/api'
+import { slackWorkspaceLine } from '@/lib/slack-identity'
 import {
   LogtoAccountError,
   accountErrorMessage,
@@ -21,7 +21,7 @@ import { SOCIAL_LOGIN_PROVIDERS, type SocialLoginProvider } from '@/lib/social-l
 function ProviderMark({ provider }: { provider: SocialLoginProvider }) {
   return (
     <span className="flex h-7 w-7 items-center justify-center rounded-md bg-(--surface-active)">
-      {provider.target === 'github' ? <SiGithub size={19} aria-hidden /> : <FcGoogle size={20} aria-hidden />}
+      <SocialLoginMark target={provider.target} size={19} />
     </span>
   )
 }
@@ -127,6 +127,11 @@ export default function SocialSignInCard({
   } = useSWR('logto-account-sign-in-methods', fetchAccountProfile, {
     revalidateOnFocus: true
   })
+  // The CP's server-side read of the Slack workspace. Deliberately its own key:
+  // an error, or a deployment that cannot resolve identities, must cost nothing
+  // but this one line — never the linking UI it sits in.
+  const { data: slack } = useSWR('me-slack-identity', fetchMySlackIdentity, { shouldRetryOnError: false })
+  const workspaceLine = slackWorkspaceLine(slack)
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
   const linkedProviderCount = account
@@ -236,6 +241,11 @@ export default function SocialSignInCard({
                           {details?.email ? (
                             <div className="truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                               {details.email}
+                            </div>
+                          ) : null}
+                          {provider.target === 'slack' && workspaceLine ? (
+                            <div className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                              {workspaceLine}
                             </div>
                           ) : null}
                         </div>

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -9,8 +9,10 @@ import newLarkIcon from '@iconify-icons/icon-park/new-lark'
 import slackIcon from '@iconify-icons/logos/slack-icon'
 import webhooksLogoFillIcon from '@iconify-icons/ph/webhooks-logo-fill'
 import { Icon as IconifyIcon } from '@iconify/react'
+import { FcGoogle } from 'react-icons/fc'
 import { SiDiscord, SiGithub, SiTelegram } from 'react-icons/si'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
+import type { SocialLoginTarget } from '@/lib/social-login-providers'
 
 const fill = { width: '60%', height: '60%', display: 'block' } as const
 
@@ -169,6 +171,20 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
       <Icon name="plug" className="h-full w-full" />
     </span>
   )
+}
+
+/**
+ * Brand mark for a social sign-in method — shared by the login page and the
+ * Profile "Sign-in methods" card so a provider added to SOCIAL_LOGIN_PROVIDERS
+ * cannot render correctly in one place and wrong in the other.
+ *
+ * `size` is left unset on the login page, where `.sso svg` sizes the mark.
+ */
+export function SocialLoginMark({ target, size }: { target: SocialLoginTarget; size?: number }) {
+  if (target === 'github') return <SiGithub size={size} aria-hidden />
+  if (target === 'slack')
+    return <IconifyIcon icon={slackIcon} {...(size ? { width: size, height: size } : {})} aria-hidden />
+  return <FcGoogle size={size} aria-hidden />
 }
 
 export function Wordmark({ height = 36, inverse = false }: { height?: number; inverse?: boolean }) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2823,6 +2823,17 @@ export async function updateMe(patch: { name: string }): Promise<MeDto> {
   return apiPatch<MeDto>('/me', patch)
 }
 
+// The Slack workspace behind the signed-in account (GET /me/slack-identity),
+// resolved by the CP from the sign-in provider. `linked: false` covers both "not
+// signed in with Slack" and "this deployment can't look it up", so the console
+// renders the same nothing for either.
+export type MySlackIdentityDto =
+  { linked: false } | { linked: true; teamId: string; userId: string; teamName?: string; teamDomain?: string }
+
+export async function fetchMySlackIdentity(): Promise<MySlackIdentityDto> {
+  return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
+}
+
 async function putMyProfilePicture(blob: Blob): Promise<MeDto> {
   const path = '/me/picture'
   const res = await fetch(`${cpBase()}${path}`, {

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -46,7 +46,8 @@ describe('Logto Account API', () => {
     })
     expect(SOCIAL_LOGIN_PROVIDERS).toEqual([
       { target: 'github', name: 'GitHub' },
-      { target: 'google', name: 'Google' }
+      { target: 'google', name: 'Google' },
+      { target: 'slack', name: 'Slack' }
     ])
     expect(fetchMock).toHaveBeenCalledOnce()
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://login.example.test/api/my-account')

--- a/packages/web/src/lib/slack-identity.test.ts
+++ b/packages/web/src/lib/slack-identity.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { slackWorkspaceLine } from '@/lib/slack-identity'
+
+// Synthetic Slack ids throughout — never a real workspace.
+const LINKED = { linked: true as const, teamId: 'T0EXAMPLE1', userId: 'U0EXAMPLE1' }
+
+describe('slackWorkspaceLine', () => {
+  it('prefers the workspace name Slack sent, keeping the team id alongside', () => {
+    expect(slackWorkspaceLine({ ...LINKED, teamName: 'Example Workspace' })).toBe('Example Workspace · T0EXAMPLE1')
+  })
+
+  it('falls back to the workspace domain when there is no name', () => {
+    expect(slackWorkspaceLine({ ...LINKED, teamDomain: 'example-workspace' })).toBe(
+      'example-workspace.slack.com · T0EXAMPLE1'
+    )
+  })
+
+  it('shows the bare team id when Slack sent neither label', () => {
+    expect(slackWorkspaceLine(LINKED)).toBe('T0EXAMPLE1')
+  })
+
+  it('renders nothing when the account has no Slack identity', () => {
+    expect(slackWorkspaceLine({ linked: false })).toBeUndefined()
+  })
+
+  it('renders nothing while the read is pending or has failed', () => {
+    // SWR leaves `data` undefined on both — the row must degrade to today's look
+    // rather than showing a half-resolved workspace.
+    expect(slackWorkspaceLine(undefined)).toBeUndefined()
+  })
+})

--- a/packages/web/src/lib/slack-identity.ts
+++ b/packages/web/src/lib/slack-identity.ts
@@ -1,0 +1,20 @@
+// Presentation of the CP's server-side Slack identity read (GET /me/slack-identity).
+// Kept out of the component so the label precedence is pinned by tests — the live
+// path needs a configured Logto tenant, so this is the only place it can be.
+import type { MySlackIdentityDto } from '@/lib/api'
+
+/**
+ * The workspace line for an account's Slack row. Prefers the human label Slack
+ * sent, falls back to the workspace domain, and always keeps the `T…` id
+ * visible: it is what someone matching this account against a Slack workspace
+ * actually needs, and it is the only field Slack always sends.
+ *
+ * Undefined when there is nothing to say — not linked, or the read failed /
+ * this deployment cannot do it. Callers render nothing in that case; the line
+ * is an addition to the sign-in row, never a prerequisite for it.
+ */
+export function slackWorkspaceLine(slack: MySlackIdentityDto | undefined): string | undefined {
+  if (!slack?.linked) return undefined
+  const label = slack.teamName ?? (slack.teamDomain ? `${slack.teamDomain}.slack.com` : undefined)
+  return label ? `${label} · ${slack.teamId}` : slack.teamId
+}

--- a/packages/web/src/lib/social-login-providers.ts
+++ b/packages/web/src/lib/social-login-providers.ts
@@ -1,6 +1,13 @@
+// The social sign-in methods the console offers, in display order. Each `target`
+// IS a Logto connector target, passed through verbatim by `directSignIn` (login)
+// and by the CP when it resolves the connector to link (Profile). Adding one here
+// lights up BOTH surfaces — but the tenant must have that connector enabled, and
+// the CP's own `SocialTarget` allowlist (routes/me-social-identities.ts) must
+// accept it, or linking is refused server-side.
 export const SOCIAL_LOGIN_PROVIDERS = [
   { target: 'github', name: 'GitHub' },
-  { target: 'google', name: 'Google' }
+  { target: 'google', name: 'Google' },
+  { target: 'slack', name: 'Slack' }
 ] as const
 
 export type SocialLoginProvider = (typeof SOCIAL_LOGIN_PROVIDERS)[number]


### PR DESCRIPTION
## Why

Console sign-in offered only GitHub and Google, so Slack-first teams had to detour through a GitHub account to reach the console. Logto ships a built-in Slack connector (`slack-universal`, target `slack`), so the sign-in half is one entry in the shared provider list.

Slack's OIDC token also carries the **workspace identity** — `https://slack.com/team_id` (`T…`) and `https://slack.com/user_id` (`U…`) — and Logto persists the connector's whole decoded payload under `identities.slack.details.rawData`, the same place the CP already reads a user's GitHub login from. Without a server-side read that identity stays locked inside the identity provider and nothing in our own data could ever match a console user to a Slack sender. So this adds a **read** alongside the link/unlink **writes** from #225.

## What changed

**Sign-in + linking, from one list.** `SOCIAL_LOGIN_PROVIDERS` gains `slack`, which lights up both surfaces it already drives: the login page and the Profile "Sign-in methods" card. The CP's `SocialTarget` allowlist gains it too — offering a Connect button the server refuses would be worse than not offering it at all.

**One brand mark.** A shared `SocialLoginMark` replaces the two-way ternaries the login page and the Profile card each carried, so a fourth provider can't render correctly in one place and wrong in the other. The waitlist verify step now maps the same list instead of hardcoding its own buttons and inline SVG marks.

**`LogtoIdentityService.slackIdentityFor()`** reads the workspace behind an account. Two deliberate choices:
- Its cache is **separate** from the GitHub login cache. That one sits on a live authorization gate and must not shift its behavior (or its re-ask timing) because a display-only read was added.
- Both caches are now dropped **together** on link/unlink. Previously only the login cache was invalidated; without this the Profile would keep showing a workspace the user just disconnected for the rest of the 10-minute TTL.

**`GET /me/social-identities/slack`** exposes it, and the Profile Slack row shows which workspace the account belongs to — degrading to nothing when the read fails or the deployment can't do it.

Read-only metadata throughout. No authorization decision consumes it yet; a reverse `teamId+userId → user` index would need persistence, not a read-through, and is deliberately out of scope.

## Reviewer notes

- **Sign-in stays dark until the Logto tenant enables the Slack connector.** The Slack app needs the `openid`/`email`/`profile` user scopes and `${LOGTO_ENDPOINT}/callback/${connector_id}` as a redirect URL. Worth considering pointing it at the existing platform-published Slack app (`SLACK_PLATFORM_*`) so "Add to Slack" and "Sign in with Slack" are one app to users. `LOGTO_MGMT_*` is already configured, so the read path needs no new env.
- `teamName`/`teamDomain` are best-effort — Slack's published claim list guarantees only the two ids — so the UI falls back to the team id, and a partial read (`U…` with no `T…`) resolves to "not linked" rather than a half identity.
- Two things worth confirming on the tenant before leaning on Slack as a *primary* identity: what Logto does when the same `U…` arrives from a different `T…` (Slack's `sub` is the workspace-scoped user id and is the only value the identity is keyed on), and whether a GitHub user signing in with Slack on the same verified email merges or mints a second account.
- A Slack-only account has no GitHub identity, so binding GitHub repos returns `GITHUB_IDENTITY_REQUIRED` until the user connects GitHub in Profile. That's today's Google behavior, unchanged — but Slack will make it more common.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean. Full suite green: control-plane 720 unit / 744 integration, web 424, and the other packages unchanged.

New coverage: 10 unit tests for the Slack extraction, per-provider cache isolation, and the link/unlink invalidation; 5 route tests (linked, not-linked, 503 unconfigured, 502 upstream, plus `slack` accepted as a linkable target); 5 for the workspace label; and an OpenAPI assertion that the operation is documented with its tag/summary/operationId and that its discriminated-union response transforms.

The login page was checked in the browser — three buttons, Slack mark at the same size as the others. **Not verified:** the real Slack → Logto → console round trip, which needs the tenant config above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)