### PR TITLE
fix(integrations): use agent descriptions for app creation

### DIFF
--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -6,6 +6,11 @@
  * template before creating the app.
  */
 import { gzipSync } from 'node:zlib'
+import {
+  DEFAULT_PLATFORM_APP_DESCRIPTION,
+  LARK_APP_DESCRIPTION_MAX_LENGTH,
+  platformAppDescription
+} from './platform-app-description.js'
 
 export const AGENTCONNECT_FEISHU_SCOPES = [
   'contact:contact.base:readonly',
@@ -24,7 +29,7 @@ export const AGENTCONNECT_FEISHU_CALLBACKS = ['card.action.trigger'] as const
 
 export const AGENTCONNECT_FEISHU_APP_TEMPLATE = {
   archetype: 'PersonalAgent',
-  description: 'Connect this bot to an AgentConnect agent.',
+  description: DEFAULT_PLATFORM_APP_DESCRIPTION,
   addons: {
     preset: true,
     scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
@@ -42,14 +47,23 @@ function encodeAddons(): string {
     .replace(/=+$/, '')
 }
 
-export function buildFeishuAuthorizationUrl(verificationUri: string, appName: string, avatarUrl?: string): string {
+export interface FeishuAppPreset {
+  avatarUrl?: string
+  description?: string | null
+}
+
+export function buildFeishuAuthorizationUrl(
+  verificationUri: string,
+  appName: string,
+  preset: FeishuAppPreset = {}
+): string {
   const url = new URL(verificationUri)
   url.searchParams.set('from', 'sdk')
   url.searchParams.set('source', 'node-sdk/agentconnect')
   url.searchParams.set('tp', 'sdk')
-  if (avatarUrl) url.searchParams.set('avatar', avatarUrl)
+  if (preset.avatarUrl) url.searchParams.set('avatar', preset.avatarUrl)
   url.searchParams.set('name', appName)
-  url.searchParams.set('desc', AGENTCONNECT_FEISHU_APP_TEMPLATE.description)
+  url.searchParams.set('desc', platformAppDescription(preset.description, LARK_APP_DESCRIPTION_MAX_LENGTH))
   url.searchParams.set('addons', encodeAddons())
   url.searchParams.set('createOnly', 'true')
   return url.toString()

--- a/packages/control-plane/src/http/feishu-registration-provider.ts
+++ b/packages/control-plane/src/http/feishu-registration-provider.ts
@@ -7,7 +7,11 @@
  * the encrypted persistence store can resume it after load balancing/restart.
  */
 import type { FeishuRegion } from '@agentconnect.md/protocol'
-import { AGENTCONNECT_FEISHU_APP_TEMPLATE, buildFeishuAuthorizationUrl } from './feishu-app-template.js'
+import {
+  AGENTCONNECT_FEISHU_APP_TEMPLATE,
+  buildFeishuAuthorizationUrl,
+  type FeishuAppPreset
+} from './feishu-app-template.js'
 
 export const FEISHU_REGISTRATION_DOMAIN = 'accounts.feishu.cn'
 export const LARK_REGISTRATION_DOMAIN = 'accounts.larksuite.com'
@@ -45,7 +49,7 @@ export type PollFeishuRegistration =
   | { outcome: 'failed' }
 
 export interface FeishuRegistrationProvider {
-  begin(appName: string, region: FeishuRegion, avatarUrl?: string): Promise<BeginFeishuRegistration>
+  begin(appName: string, region: FeishuRegion, preset?: FeishuAppPreset): Promise<BeginFeishuRegistration>
   poll(providerDomain: string, deviceCode: string): Promise<PollFeishuRegistration>
 }
 
@@ -54,7 +58,7 @@ type RegistrationFetch = typeof fetch
 export class OfficialFeishuRegistrationProvider implements FeishuRegistrationProvider {
   constructor(private readonly fetcher: RegistrationFetch = fetch) {}
 
-  async begin(appName: string, region: FeishuRegion, avatarUrl?: string): Promise<BeginFeishuRegistration> {
+  async begin(appName: string, region: FeishuRegion, preset?: FeishuAppPreset): Promise<BeginFeishuRegistration> {
     const response = await this.request(FEISHU_REGISTRATION_DOMAIN, {
       action: 'begin',
       archetype: AGENTCONNECT_FEISHU_APP_TEMPLATE.archetype,
@@ -67,7 +71,7 @@ export class OfficialFeishuRegistrationProvider implements FeishuRegistrationPro
     const verificationUri = new URL(response.verification_uri_complete)
     if (region === 'lark') verificationUri.hostname = LARK_LAUNCHER_DOMAIN
     return {
-      authorizationUrl: buildFeishuAuthorizationUrl(verificationUri.toString(), appName, avatarUrl),
+      authorizationUrl: buildFeishuAuthorizationUrl(verificationUri.toString(), appName, preset),
       deviceCode: response.device_code,
       providerDomain: FEISHU_REGISTRATION_DOMAIN,
       intervalMs: Math.max(1, response.interval ?? 5) * 1000,

--- a/packages/control-plane/src/http/feishu-registration.ts
+++ b/packages/control-plane/src/http/feishu-registration.ts
@@ -42,6 +42,7 @@ export interface StartFeishuRegistration {
   fallbackRegion: FeishuRegion
   appName: string
   avatarUrl?: string
+  description?: string | null
   requestedName?: string
   createdByUserId: string
 }
@@ -108,7 +109,10 @@ export class FeishuAppRegistrationService {
     const existing = await this.store.getActiveTarget(key)
     if (existing) return this.reuseOrConflict(existing, input.createdByUserId)
 
-    const begun = await this.provider.begin(input.appName, input.fallbackRegion, input.avatarUrl)
+    const begun = await this.provider.begin(input.appName, input.fallbackRegion, {
+      ...(input.avatarUrl ? { avatarUrl: input.avatarUrl } : {}),
+      ...(input.description !== undefined ? { description: input.description } : {})
+    })
     try {
       const row = await this.store.create({
         id: randomUUID(),

--- a/packages/control-plane/src/http/platform-app-description.ts
+++ b/packages/control-plane/src/http/platform-app-description.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+export const LARK_APP_DESCRIPTION_MAX_LENGTH = 120
+export const SLACK_APP_DESCRIPTION_MAX_LENGTH = 300
+
+/**
+ * Platform launchers count JavaScript string length, so keep the result within
+ * their UTF-16 limit without cutting a surrogate pair in half.
+ */
+export function platformAppDescription(description: string | null | undefined, maxLength: number): string {
+  const value = description?.trim() || DEFAULT_PLATFORM_APP_DESCRIPTION
+  if (value.length <= maxLength) return value
+
+  let head = ''
+  for (const character of value) {
+    if (head.length + character.length >= maxLength) break
+    head += character
+  }
+  return `${head.trimEnd()}…`
+}

--- a/packages/control-plane/src/http/routes/feishu-registration.ts
+++ b/packages/control-plane/src/http/routes/feishu-registration.ts
@@ -109,6 +109,7 @@ export function feishuRegistrationRoutes(deps: HttpDeps) {
             fallbackRegion: req.body.region,
             appName,
             ...(avatarUrl ? { avatarUrl } : {}),
+            description: agent.description,
             ...(providedName ? { requestedName: providedName } : {}),
             createdByUserId
           })

--- a/packages/control-plane/src/http/routes/slack-install.ts
+++ b/packages/control-plane/src/http/routes/slack-install.ts
@@ -165,7 +165,11 @@ export function slackInstallRoutes(deps: HttpDeps) {
         // Brand the created app with the agent's icon color (Slack has no API to set
         // the app image itself) — its avatar plate → the manifest background_color.
         const bgColor = agentIconBackgroundColor(agent.icon)
-        const manifest = buildInstallManifest(name, redirectUri, httpBase, bgColor)
+        const manifest = buildInstallManifest(name, redirectUri, {
+          ...(httpBase ? { httpRelayBase: httpBase } : {}),
+          ...(bgColor ? { backgroundColor: bgColor } : {}),
+          description: agent.description
+        })
         let created = await api.createApp(config.accessToken, manifest)
 
         // Slack rejected the config token. resolve() hands back a fresh (unexpired) access

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SLACK_APP_NAME
 } from './slack-manifest.js'
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
+import { DEFAULT_PLATFORM_APP_DESCRIPTION, SLACK_APP_DESCRIPTION_MAX_LENGTH } from './platform-app-description.js'
 
 // The PUBLIC form — `/v1`, not the internal `/api/v1` (see SLACK_OAUTH_CALLBACK_PATH).
 const REDIRECT = 'https://cp.example/v1/integrations/slack/oauth/callback'
@@ -38,7 +39,7 @@ describe('buildInstallManifest', () => {
   })
 
   it('http mode: disables Socket Mode and points the Events API request_urls at the relay', () => {
-    const m = buildInstallManifest('acme-bot', REDIRECT, 'https://relay.example') as {
+    const m = buildInstallManifest('acme-bot', REDIRECT, { httpRelayBase: 'https://relay.example' }) as {
       settings: {
         socket_mode_enabled: boolean
         event_subscriptions: { request_url: string; bot_events: string[] }
@@ -63,10 +64,24 @@ describe('buildInstallManifest', () => {
       display_information: Record<string, unknown>
     }
     expect(plain.display_information.background_color).toBeUndefined()
-    const branded = buildInstallManifest('acme-bot', REDIRECT, undefined, '#c62a78') as {
+    const branded = buildInstallManifest('acme-bot', REDIRECT, { backgroundColor: '#c62a78' }) as {
       display_information: { background_color: string }
     }
     expect(branded.display_information.background_color).toBe('#c62a78')
+  })
+
+  it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
+    const description = `${'a'.repeat(297)}😀tail`
+    const custom = buildInstallManifest('acme-bot', REDIRECT, { description }) as {
+      features: { agent_view: { agent_description: string } }
+    }
+    const fallback = buildInstallManifest('acme-bot', REDIRECT, { description: '   ' }) as {
+      features: { agent_view: { agent_description: string } }
+    }
+
+    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}😀…`)
+    expect(custom.features.agent_view.agent_description.length).toBe(SLACK_APP_DESCRIPTION_MAX_LENGTH)
+    expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_PLATFORM_APP_DESCRIPTION)
   })
 
   // Drift guard: these scopes/events MUST stay in lock-step with the manual manifest
@@ -119,6 +134,7 @@ describe('mergeManagedSlackManifest', () => {
       features: {
         bot_user: { display_name: 'Custom bot', always_online: false },
         app_home: { home_tab_enabled: true },
+        agent_view: { agent_description: 'Keep this agent description' },
         slash_commands: [{ command: '/custom', description: 'Keep me' }],
         shortcuts: [
           { name: 'Keep shortcut', type: 'message', callback_id: 'custom_shortcut' },
@@ -178,7 +194,7 @@ describe('mergeManagedSlackManifest', () => {
     expect(merged.features.app_home.home_tab_enabled).toBe(true)
     expect(merged.features.app_home.messages_tab_enabled).toBe(true)
     expect(merged.features.app_home.messages_tab_read_only_enabled).toBe(false)
-    expect(merged.features.agent_view.agent_description).toContain('AgentConnect agent')
+    expect(merged.features.agent_view.agent_description).toBe('Keep this agent description')
     expect(merged.oauth_config.redirect_urls).toEqual(['https://custom.example/slack/callback', REDIRECT])
     expect(merged.oauth_config.scopes.bot).toEqual(expect.arrayContaining(['bookmarks:read', ...SLACK_BOT_SCOPES]))
     expect(merged.oauth_config.scopes.user).toEqual(['users.profile:read'])

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -15,6 +15,7 @@
  * change them here, change them in packages/web/src/lib/slack-manifest.ts too.
  */
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
+import { platformAppDescription, SLACK_APP_DESCRIPTION_MAX_LENGTH } from './platform-app-description.js'
 
 /**
  * Bot token scopes the Slack app requests. Widening this list later forces every
@@ -99,23 +100,32 @@ export function slackInteractionsRequestUrl(relayHttpBase: string): string {
  *  adds the current CP callback only when one is configured, while create always
  *  supplies it through `buildInstallManifest` below.
  *
- *  `httpRelayBase` set ⇒ HTTP-mode (slack-http-mode): `socket_mode_enabled:false`
+ *  `options.httpRelayBase` set ⇒ HTTP-mode (slack-http-mode): `socket_mode_enabled:false`
  *  and the Events API / interactivity `request_url`s point at the relay pool. Absent
  *  ⇒ classic Socket Mode.
  *
- *  `backgroundColor` (a `#rrggbb`, from the owning agent's icon) sets the app's
+ *  `options.backgroundColor` (a `#rrggbb`, from the owning agent's icon) sets the app's
  *  `display_information.background_color` — Slack has no API to set the app's image
  *  itself, so this is the closest we get to "give the app the agent's icon". */
-function buildManagedManifest(name: string, httpRelayBase?: string, backgroundColor?: string): ManifestRecord {
+export interface SlackManifestOptions {
+  httpRelayBase?: string
+  backgroundColor?: string
+  description?: string | null
+}
+
+function buildManagedManifest(name: string, options: SlackManifestOptions = {}): ManifestRecord {
   const displayName = name.trim() || DEFAULT_SLACK_APP_NAME
-  const http = !!httpRelayBase
+  const http = !!options.httpRelayBase
   return {
-    display_information: { name: displayName, ...(backgroundColor ? { background_color: backgroundColor } : {}) },
+    display_information: {
+      name: displayName,
+      ...(options.backgroundColor ? { background_color: options.backgroundColor } : {})
+    },
     features: {
       bot_user: { display_name: displayName, always_online: true },
       app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
       agent_view: {
-        agent_description: `${displayName} is an AgentConnect agent that responds to Slack conversations and works in threads.`,
+        agent_description: platformAppDescription(options.description, SLACK_APP_DESCRIPTION_MAX_LENGTH),
         suggested_prompts: []
       },
       shortcuts: [
@@ -133,14 +143,14 @@ function buildManagedManifest(name: string, httpRelayBase?: string, backgroundCo
     settings: {
       event_subscriptions: {
         bot_events: [...SLACK_BOT_EVENTS],
-        ...(http ? { request_url: slackEventsRequestUrl(httpRelayBase!) } : {})
+        ...(http ? { request_url: slackEventsRequestUrl(options.httpRelayBase!) } : {})
       },
       interactivity: {
         is_enabled: true,
         ...(http
           ? {
-              request_url: slackInteractionsRequestUrl(httpRelayBase!),
-              message_menu_options_url: slackInteractionsRequestUrl(httpRelayBase!)
+              request_url: slackInteractionsRequestUrl(options.httpRelayBase!),
+              message_menu_options_url: slackInteractionsRequestUrl(options.httpRelayBase!)
             }
           : {})
       },
@@ -156,16 +166,16 @@ function buildManagedManifest(name: string, httpRelayBase?: string, backgroundCo
  * Build the app manifest object for `apps.manifest.create`. `redirectUrl` is the
  * CP's OAuth callback (`<PUBLIC_CP_URL>/api/v1/integrations/slack/oauth/callback`)
  * and is declared as the app's sole redirect URL so the ensuing OAuth install
- * lands back on us. `name` falls back to the default when blank. `httpRelayBase` set
- * ⇒ HTTP-mode (Events API request_urls + Socket Mode off); absent ⇒ Socket Mode.
+ * lands back on us. `name` falls back to the default when blank.
+ * `options.httpRelayBase` set ⇒ HTTP-mode (Events API request_urls + Socket Mode
+ * off); absent ⇒ Socket Mode.
  */
 export function buildInstallManifest(
   name: string,
   redirectUrl: string,
-  httpRelayBase?: string,
-  backgroundColor?: string
+  options: SlackManifestOptions = {}
 ): Record<string, unknown> {
-  const managed = buildManagedManifest(name, httpRelayBase, backgroundColor)
+  const managed = buildManagedManifest(name, options)
   return {
     ...managed,
     oauth_config: {
@@ -189,7 +199,7 @@ export function mergeManagedSlackManifest(
 ): Record<string, unknown> {
   const http = !!httpRelayBase
   const current = asRecord(exported)
-  const managed = buildManagedManifest(name, httpRelayBase)
+  const managed = buildManagedManifest(name, { ...(httpRelayBase ? { httpRelayBase } : {}) })
 
   const currentDisplay = asRecord(current.display_information)
   const managedDisplay = asRecord(managed.display_information)

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -89,21 +89,28 @@ describe('Feishu/Lark one-click app registration', () => {
         })
       )
     })
-    const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin(
-      'AgentConnect Lark',
-      'lark',
-      'https://cdn.example.test/agent.png'
-    )
+    const description = `${'a'.repeat(117)}😀tail`
+    const begun = await new OfficialFeishuRegistrationProvider(fetcher).begin('AgentConnect Lark', 'lark', {
+      avatarUrl: 'https://cdn.example.test/agent.png',
+      description
+    })
 
     expect(new URL(String(fetcher.mock.calls[0]![0])).hostname).toBe(FEISHU_REGISTRATION_DOMAIN)
-    expect(new URL(begun.authorizationUrl).hostname).toBe(LARK_LAUNCHER_DOMAIN)
-    expect(new URL(begun.authorizationUrl).searchParams.get('user_code')).toBe('LARK')
-    expect(new URL(begun.authorizationUrl).searchParams.get('avatar')).toBe('https://cdn.example.test/agent.png')
+    const authorizationUrl = new URL(begun.authorizationUrl)
+    expect(authorizationUrl.hostname).toBe(LARK_LAUNCHER_DOMAIN)
+    expect(authorizationUrl.searchParams.get('user_code')).toBe('LARK')
+    expect(authorizationUrl.searchParams.get('avatar')).toBe('https://cdn.example.test/agent.png')
+    expect(authorizationUrl.searchParams.get('desc')).toBe(`${'a'.repeat(117)}😀…`)
+    expect(authorizationUrl.searchParams.get('desc')!.length).toBe(120)
     expect(begun.providerDomain).toBe(FEISHU_REGISTRATION_DOMAIN)
   })
 
   it('survives a CP restart, installs the full template, and never returns credentials', async () => {
     const agentId = await placedAgent()
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { description: 'Helps teammates solve support requests.' }
+    })
     const requests: URLSearchParams[] = []
     const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
       const form = new URLSearchParams(String(init?.body))
@@ -145,6 +152,7 @@ describe('Feishu/Lark one-click app registration', () => {
     const authorizationUrl = new URL(startDto.authorizationUrl)
     expect(authorizationUrl.searchParams.get('createOnly')).toBe('true')
     expect(authorizationUrl.searchParams.get('name')).toBe('AgentConnect Lark')
+    expect(authorizationUrl.searchParams.get('desc')).toBe('Helps teammates solve support requests.')
     const avatarUrl = new URL(authorizationUrl.searchParams.get('avatar')!)
     expect(avatarUrl.origin).toBe('https://cp.example.test')
     expect(avatarUrl.pathname).toBe(`/v1/agents/${agentId}/icon`)
@@ -272,7 +280,7 @@ describe('Feishu/Lark one-click app registration', () => {
     await expect(coordinator.start({ ...common, createdByUserId: 'user-b' })).rejects.toBeInstanceOf(
       FeishuRegistrationConflictError
     )
-    expect(begin).toHaveBeenCalledWith('AgentConnect', 'lark', undefined)
+    expect(begin).toHaveBeenCalledWith('AgentConnect', 'lark', {})
   })
 
   it('does not expire an authorization while its claimed provider poll is completing', async () => {

--- a/packages/control-plane/test/integration/slack-install.route.test.ts
+++ b/packages/control-plane/test/integration/slack-install.route.test.ts
@@ -179,6 +179,10 @@ async function startAndAuthorize(app: HttpApp): Promise<string> {
 describe('slack auto-install funnel', () => {
   it('POST /app uses the caller’s config token to create the app + a pending row, returns an install URL (no tokens)', async () => {
     const agentId = await placedAgent()
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { description: 'Helps teammates solve support requests.' }
+    })
     await seedUserConfig()
     const { app, stub } = withFunnel()
     const res = await app.app.inject({
@@ -197,8 +201,12 @@ describe('slack auto-install funnel', () => {
     expect(url.searchParams.get('state')).toBe(dto.installId)
     // The PUBLIC `/v1` form — the internal `/api/v1` variant would 404 at the edge.
     expect(url.searchParams.get('redirect_uri')).toBe('https://cp.example/v1/integrations/slack/oauth/callback')
-    const manifest = stub.createCalls[0]!.manifest as { oauth_config: { redirect_urls: string[] } }
+    const manifest = stub.createCalls[0]!.manifest as {
+      features: { agent_view: { agent_description: string } }
+      oauth_config: { redirect_urls: string[] }
+    }
     expect(manifest.oauth_config.redirect_urls).toEqual(['https://cp.example/v1/integrations/slack/oauth/callback'])
+    expect(manifest.features.agent_view.agent_description).toBe('Helps teammates solve support requests.')
     const row = await prisma.slackInstall.findUnique({ where: { id: dto.installId } })
     expect(row).toMatchObject({ appId: 'A1TEST', clientSecret: 'csecret', botToken: null })
     expect(JSON.stringify(dto)).not.toContain('csecret')

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1350,6 +1350,7 @@ export default function AddIntegrationModal({
   // at the relay's public base (omitted ⇒ buildSlackManifest falls back to socket).
   const manifestOpts = {
     mode: effTransport,
+    description: agent.description ?? null,
     // Brand the created app with the agent's icon color (matches the CP auto-install
     // funnel) — Slack has no API to set the app image itself.
     backgroundColor: agentIconBackgroundColor(agent.icon),

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1386,6 +1386,7 @@ export function agentFromDto(d: AgentDto): Agent {
     // daemon '—' coalesce below; display sites render '—' for an empty runtime.
     runtime: d.runtime ?? '',
     desc: d.description ?? PLACEHOLDER,
+    ...(d.description !== null ? { description: d.description } : {}),
     // '—' when the CP has no explicit value: the daemon then falls back to the
     // local agent.json (default 'low'). Session count is derived in the view from
     // the fetched `/sessions` list, so it's not a field here.

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -232,6 +232,8 @@ export interface Agent {
   runtime: string
   /** One-line summary shown on the detail page's General card. */
   desc: string
+  /** Raw description when set; unlike `desc`, never contains the display placeholder. */
+  description?: string
   /** Platform output verbosity: low | medium | high; '—' when unset (daemon default). */
   outputMode: string
   /** Whether platform replies include attribution/session footer chrome. */

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -4,7 +4,9 @@ import {
   slackCreateAppUrl,
   SLACK_BOT_SCOPES,
   SLACK_BOT_EVENTS,
-  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID
+  SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+  DEFAULT_SLACK_APP_DESCRIPTION,
+  SLACK_APP_DESCRIPTION_MAX_LENGTH
 } from './slack-manifest'
 
 // The manual manifest must request exactly what the CP's auto-install manifest does, or
@@ -59,6 +61,16 @@ describe('buildSlackManifest', () => {
     // A color (from the owning agent's icon) ⇒ display_information.background_color.
     const branded = buildSlackManifest({ name: 'acme' }, { backgroundColor: '#c62a78' })
     expect(branded.display_information.background_color).toBe('#c62a78')
+  })
+
+  it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
+    const description = `${'a'.repeat(297)}😀tail`
+    const custom = buildSlackManifest({ name: 'acme' }, { description })
+    const fallback = buildSlackManifest({ name: 'acme' }, { description: '   ' })
+
+    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}😀…`)
+    expect(custom.features.agent_view.agent_description.length).toBe(SLACK_APP_DESCRIPTION_MAX_LENGTH)
+    expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_SLACK_APP_DESCRIPTION)
   })
 
   it('prefills the Slack create-app link with the manifest', () => {

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -72,6 +72,8 @@ export const SLACK_BOT_EVENTS = [
 
 /** Fallback name so the manifest / deep link are always valid before the user types one. */
 export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
+export const DEFAULT_SLACK_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+export const SLACK_APP_DESCRIPTION_MAX_LENGTH = 300
 
 export interface SlackAppManifest {
   display_information: { name: string; background_color?: string }
@@ -102,10 +104,23 @@ export interface SlackAppManifest {
 export interface SlackManifestOpts {
   mode?: 'socket' | 'http'
   relayUrl?: string
+  description?: string | null
   /** `#rrggbb` from the owning agent's icon → `display_information.background_color`,
    *  branding the created app with the agent's avatar color (Slack has no API to set
    *  the app image itself). Mirrors the CP auto-install funnel. */
   backgroundColor?: string
+}
+
+function slackAppDescription(description: string | null | undefined): string {
+  const value = description?.trim() || DEFAULT_SLACK_APP_DESCRIPTION
+  if (value.length <= SLACK_APP_DESCRIPTION_MAX_LENGTH) return value
+
+  let head = ''
+  for (const character of value) {
+    if (head.length + character.length >= SLACK_APP_DESCRIPTION_MAX_LENGTH) break
+    head += character
+  }
+  return `${head.trimEnd()}…`
 }
 
 /** The two names the manifest carries — mirrors the agent's naming model:
@@ -134,7 +149,7 @@ export function buildSlackManifest(names: SlackAppNames, opts?: SlackManifestOpt
       bot_user: { display_name: displayName, always_online: true },
       app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
       agent_view: {
-        agent_description: `${displayName} is an AgentConnect agent that responds to Slack conversations and works in threads.`,
+        agent_description: slackAppDescription(opts?.description),
         suggested_prompts: []
       },
       shortcuts: [


### PR DESCRIPTION
## Summary

- use the current Agent description when creating Lark/Feishu one-click apps and new Slack apps
- fall back to `AI agent powered by AgentConnect.` when the Agent has no description
- truncate safely within the shared Lark/Feishu 120-character limit and Slack's 300-character limit
- preserve an existing Slack app description during Settings refresh

## Why

The app creation templates used fixed AgentConnect setup copy, so the bot profile did not describe the Agent it represented. Agent descriptions can also exceed platform validation limits.

## Impact

New Lark/Feishu and Slack apps now carry the Agent's description without requiring users to edit the app profile manually. Existing Slack app customizations remain untouched when refreshed.

## Validation

- Control Plane Slack manifest unit tests: 11 passed
- Web Slack manifest unit tests: 6 passed
- Feishu/Lark registration integration tests: 7 passed
- Slack auto-install integration tests: 30 passed
- Control Plane and Web typechecks
- ESLint, Prettier, and `git diff --check`
