### PR TITLE
feat(discord): sync agent icon on bot creation

### DIFF
--- a/docs/designs/icon-uploads.md
+++ b/docs/designs/icon-uploads.md
@@ -108,7 +108,7 @@ the fallback. (Org icons are console-only and need no daemon push.)
 
 **Client UX** (`AgentIconPicker`, reused for org): an _Upload_ button → file input
 (`accept="image/png,image/jpeg,image/webp"`) → **client-side square crop + resize to
-≤256×256** on a `<canvas>` → `canvas.toBlob('image/webp')` → `fetch(url, {method:'PUT',
+≤256×256** on a `<canvas>` → `canvas.toBlob('image/png')` → `fetch(url, {method:'PUT',
 body: blob})`. Resizing client-side means the server never needs `sharp`.
 
 **Server validation / security (client resizing is untrusted).** A caller can POST
@@ -153,5 +153,7 @@ arbitrary bytes straight at the API, so the CP re-validates independently:
 - A stored `image` variant that still carries `url` degrades gracefully to the
   runtime/glyph fallback. `Org.icon` is additive; existing orgs read null → the
   deterministic default.
+- Existing stored WebP agent icons remain displayable but Discord profile sync logs a
+  best-effort compatibility warning. Re-uploading normalizes the image to PNG.
 - The `AGENT_ICON_GLYPHS` / `AGENT_ICON_COLORS` vocab stays hand-mirrored across
   `protocol`, CP `agent-icon.ts`, and web `lib/agent-icon.ts` (unchanged here).

--- a/docs/designs/icon-uploads.md
+++ b/docs/designs/icon-uploads.md
@@ -17,7 +17,7 @@ public origin, and credentials are operator-supplied runtime configuration; the
 CP has no blob store of its own to fall back on. The contract here is:
 
 - **A neutral S3-compatible store.** The CP speaks the plain S3 REST subset
-  (`PutObject` / `DeleteObject`, SigV4 via `aws4fetch`), so any S3-compatible backend
+  (`PutObject` / `GetObject` / `DeleteObject`, SigV4 via `aws4fetch`), so any S3-compatible backend
   (a cloud object store in prod, a local one in dev/CI) works by pointing `S3_ENDPOINT` at
   it. Nothing is vendor-bound.
 - **Config-gated / opt-in.** The store is assembled only when the full `S3_*` group is
@@ -133,6 +133,9 @@ arbitrary bytes straight at the API, so the CP re-validates independently:
   busted by `?v=<lastModified>`); glyph/runtime → rasterized PNG via `@resvg/resvg-js`.
   For an `image` icon the resolved `iconUrl` is the store URL directly, so Slack/browsers
   normally fetch the store and never hit this endpoint; the redirect is the fallback.
+  Registering a new Discord bot also applies these same bytes to both the bot-user
+  avatar and application icon. That external profile sync is cosmetic and best-effort:
+  a Discord or object-store failure is logged without rolling back the integration.
 - **Org** — `GET /v1/orgs/:id/icon`, mirroring the agent endpoint (public, unauth,
   version-root + `/v1` alias — an `<img src>` can't send a bearer, and a logo isn't
   sensitive). `image` → store URL; glyph → rasterized; null → deterministic default glyph.

--- a/packages/control-plane/src/agents/agent-icon-render.ts
+++ b/packages/control-plane/src/agents/agent-icon-render.ts
@@ -105,3 +105,13 @@ export function buildAgentIconSvg(icon: AgentIcon | null, runtime: string | null
   // runtime kind (and null/legacy default): the brand mark on a dark plate.
   return `${open}<rect width="64" height="64" fill="${DARK_PLATE}"/>${centered(runtimeMarkInner(runtime ?? ''), 0.62)}</svg>`
 }
+
+/** Rasterize the console descriptor for consumers that require uploaded image
+ * bytes rather than an SVG or public URL (the icon endpoint and Discord bot setup).
+ * Keep the native module lazy so a load failure degrades only the calling feature,
+ * never Control Plane boot. */
+export async function renderAgentIconPng(icon: AgentIcon | null, runtime: string | null, width = 128): Promise<Buffer> {
+  const { Resvg } = await import('@resvg/resvg-js')
+  const svg = buildAgentIconSvg(icon, runtime)
+  return Buffer.from(new Resvg(svg, { fitTo: { mode: 'width', value: width } }).render().asPng())
+}

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -142,6 +142,7 @@ import { pingDb } from './persistence/prisma.js'
 import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
 import { resolveTelegramBotName } from './http/telegram-identity.js'
 import { verifyDiscordBot } from './http/discord-identity.js'
+import { createDiscordBotIconSyncer } from './http/discord-bot-profile.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
 
@@ -678,6 +679,7 @@ export function buildContainer(
     slackConfigApi,
     resolveTelegramBotName,
     verifyDiscordBot,
+    syncDiscordBotIcon: createDiscordBotIconSyncer(iconStore),
     verifyFeishuBot,
     feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),
     ...(github ? { github } : {}),

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -67,6 +67,7 @@ import type { SlackPlatformAppConfig } from '../config/slack-platform.js'
 import type { SlackConfigApi } from './slack-config-api.js'
 import type { TelegramBotNameResolver } from './telegram-identity.js'
 import type { DiscordBotVerifier } from './discord-identity.js'
+import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
 import type { FeishuBotVerifier } from './feishu-identity.js'
 import type { FeishuAppRegistrationService } from './feishu-registration.js'
 import type { Readiness } from './readiness.js'
@@ -260,6 +261,9 @@ export interface HttpDeps {
    *  name from it when the install omits one). Optional/injectable so tests stay offline
    *  (absent ⇒ no validation, route falls back to the agent name). */
   verifyDiscordBot?: DiscordBotVerifier
+  /** Applies a newly registered Discord bot's Agent icon to its bot-user avatar and
+   *  application icon. Cosmetic and best-effort: install survives a sync failure. */
+  syncDiscordBotIcon?: DiscordBotIconSyncer
   /** Validates a pasted Feishu appId + appSecret via the tenant-access-token exchange
    *  (and derives the bot name from `bot/v3/info` when the install omits one).
    *  Optional/injectable so tests stay offline (absent ⇒ no validation, route falls

--- a/packages/control-plane/src/http/discord-bot-profile.test.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { IconStore } from '../icons/icon-store.js'
+import { createDiscordBotIconSyncer } from './discord-bot-profile.js'
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  vi.restoreAllMocks()
+})
+
+function successfulDiscordFetch(): void {
+  globalThis.fetch = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch
+}
+
+describe('createDiscordBotIconSyncer', () => {
+  it('renders a glyph once and applies it to the bot user and application', async () => {
+    successfulDiscordFetch()
+    const sync = createDiscordBotIconSyncer()
+
+    await sync('discord-secret', {
+      id: '00000000-0000-4000-8000-000000000001',
+      icon: { kind: 'glyph', glyph: 'terminal', color: '#2a6fdb' },
+      runtime: 'claude'
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    const calls = vi.mocked(globalThis.fetch).mock.calls
+    expect(calls.map(([url]) => url)).toEqual([
+      'https://discord.com/api/v10/users/@me',
+      'https://discord.com/api/v10/applications/@me'
+    ])
+    const requests = calls.map(([, init]) => init!)
+    expect(requests.every((init) => init.method === 'PATCH')).toBe(true)
+    expect(requests.every((init) => new Headers(init.headers).get('authorization') === 'Bot discord-secret')).toBe(true)
+    const botBody = JSON.parse(requests[0]!.body as string) as { avatar: string }
+    const appBody = JSON.parse(requests[1]!.body as string) as { icon: string }
+    expect(botBody.avatar).toMatch(/^data:image\/png;base64,/)
+    expect(appBody.icon).toBe(botBody.avatar)
+  })
+
+  it('uses the stored uploaded image bytes without replacing them with a fallback glyph', async () => {
+    successfulDiscordFetch()
+    const bytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xd9])
+    const store: IconStore = {
+      put: vi.fn(async () => undefined),
+      get: vi.fn(async () => ({ bytes, contentType: 'image/jpeg' })),
+      delete: vi.fn(async () => undefined),
+      publicUrl: vi.fn(() => 'https://images.example.test/icon')
+    }
+    const sync = createDiscordBotIconSyncer(store)
+
+    await sync('discord-secret', {
+      id: '00000000-0000-4000-8000-000000000002',
+      icon: { kind: 'image' },
+      runtime: 'codex'
+    })
+
+    expect(store.get).toHaveBeenCalledWith('icon/agents/00000000-0000-4000-8000-000000000002')
+    const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]![1]!.body as string) as { avatar: string }
+    expect(body.avatar).toBe(`data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`)
+  })
+})

--- a/packages/control-plane/src/http/discord-bot-profile.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.ts
@@ -1,0 +1,57 @@
+import type { AgentRecord } from '../persistence/ports.js'
+import { renderAgentIconPng } from '../agents/agent-icon-render.js'
+import { agentIconKey, type IconStore } from '../icons/icon-store.js'
+
+const DISCORD_API = 'https://discord.com/api/v10'
+const DISCORD_TIMEOUT_MS = 5000
+const STORED_ICON_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
+type DiscordIconAgent = Pick<AgentRecord, 'id' | 'icon' | 'runtime'>
+
+export type DiscordBotIconSyncer = (botToken: string, agent: DiscordIconAgent) => Promise<void>
+
+async function iconData(agent: DiscordIconAgent, iconStore?: IconStore): Promise<string> {
+  if (agent.icon?.kind === 'image') {
+    if (!iconStore) throw new Error('uploaded agent icon store is unavailable')
+    const stored = await iconStore.get(agentIconKey(agent.id))
+    if (!stored) throw new Error('uploaded agent icon is missing')
+    if (!STORED_ICON_TYPES.has(stored.contentType)) {
+      throw new Error(`uploaded agent icon has unsupported content type ${stored.contentType}`)
+    }
+    return `data:${stored.contentType};base64,${Buffer.from(stored.bytes).toString('base64')}`
+  }
+
+  const png = await renderAgentIconPng(agent.icon, agent.runtime)
+  return `data:image/png;base64,${png.toString('base64')}`
+}
+
+async function patchIcon(botToken: string, path: string, field: 'avatar' | 'icon', data: string): Promise<void> {
+  const res = await fetch(`${DISCORD_API}${path}`, {
+    method: 'PATCH',
+    headers: {
+      authorization: `Bot ${botToken}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify({ [field]: data }),
+    signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
+  })
+  await res.arrayBuffer()
+  if (!res.ok) throw new Error(`${path} returned ${res.status}`)
+}
+
+/** Apply the Agent icon to both Discord identities: the bot user (messages and
+ * member lists) and the application (install/profile surfaces). Both calls are
+ * attempted; the route treats any failure as cosmetic and keeps the integration. */
+export function createDiscordBotIconSyncer(iconStore?: IconStore): DiscordBotIconSyncer {
+  return async (botToken, agent) => {
+    const data = await iconData(agent, iconStore)
+    const results = await Promise.allSettled([
+      patchIcon(botToken, '/users/@me', 'avatar', data),
+      patchIcon(botToken, '/applications/@me', 'icon', data)
+    ])
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason instanceof Error ? result.reason.message : 'unknown error'] : []
+    )
+    if (failures.length > 0) throw new Error(`Discord icon sync failed: ${failures.join('; ')}`)
+  }
+}

--- a/packages/control-plane/src/http/routes/agent-icon.ts
+++ b/packages/control-plane/src/http/routes/agent-icon.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId } from '../../domain/ids.js'
-import { buildAgentIconSvg } from '../../agents/agent-icon-render.js'
+import { renderAgentIconPng } from '../../agents/agent-icon-render.js'
 import { agentIconKey, joinPublicUrl } from '../../icons/icon-store.js'
 
 /**
@@ -46,13 +46,9 @@ export function agentIconRoutes(deps: HttpDeps) {
           )
           return reply.redirect(url, 302)
         }
-        const svg = buildAgentIconSvg(agent.icon?.kind === 'image' ? null : agent.icon, agent.runtime)
         let png: Buffer
         try {
-          // Lazy import so a rasterizer load failure degrades this one endpoint
-          // (500) rather than blocking CP boot.
-          const { Resvg } = await import('@resvg/resvg-js')
-          png = new Resvg(svg, { fitTo: { mode: 'width', value: 128 } }).render().asPng()
+          png = await renderAgentIconPng(agent.icon?.kind === 'image' ? null : agent.icon, agent.runtime)
         } catch (err) {
           req.log.error({ err }, 'agent icon render failed')
           return reply.code(500).send()

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -436,6 +436,13 @@ export function integrationRoutes(deps: HttpDeps) {
               ...(req.principal ? { createdByUserId: req.principal.userId } : {})
             })
             await replicateUpsert(integration, daemonId)
+            if (deps.syncDiscordBotIcon && check?.status !== 'unreachable') {
+              try {
+                await deps.syncDiscordBotIcon(discord.botToken, agent)
+              } catch (err) {
+                app.log.warn({ err, agentId: agent.id, botId }, 'discord icon sync failed; integration remains active')
+              }
+            }
             return reply.code(201).send(toDto(integration))
           }
 

--- a/packages/control-plane/src/icons/icon-store.ts
+++ b/packages/control-plane/src/icons/icon-store.ts
@@ -24,6 +24,8 @@ export interface IconStoreConfig {
 export interface IconStore {
   /** Overwrite the object at `key` with `bytes` (path-style PUT). Throws on non-2xx. */
   put(key: string, bytes: Uint8Array, contentType: string): Promise<void>
+  /** Read the object at `key` for a platform profile sync. Null means absent. */
+  get(key: string): Promise<{ bytes: Uint8Array; contentType: string } | null>
   /** Delete the object at `key`. A 404 is treated as success (idempotent). */
   delete(key: string): Promise<void>
   /** The public URL an `<img>`/Slack fetches. `version` cache-busts (e.g. updatedAt epoch). */
@@ -96,6 +98,18 @@ class S3IconStore implements IconStore {
       const detail = await res.text().catch(() => '')
       throw new Error(`icon store PUT ${key} failed: ${res.status} ${detail.slice(0, 200)}`)
     }
+  }
+
+  async get(key: string): Promise<{ bytes: Uint8Array; contentType: string } | null> {
+    const res = await this.aws.fetch(this.objectUrl(key))
+    if (res.status === 404) return null
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`icon store GET ${key} failed: ${res.status} ${detail.slice(0, 200)}`)
+    }
+    const contentType = res.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase()
+    if (!contentType) throw new Error(`icon store GET ${key} returned no content type`)
+    return { bytes: new Uint8Array(await res.arrayBuffer()), contentType }
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -205,6 +205,11 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST discord registers a bot + secret with a NULL appToken, decodes the app id, pushes a discord-shaped upsert', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
+    let iconSync: { botToken: string; agentId: string } | undefined
+    app.deps.syncDiscordBotIcon = async (botToken, agent) => {
+      iconSync = { botToken, agentId: agent.id }
+      throw new Error('fixture rate limit')
+    }
 
     // A deliberately invalid credential whose first segment still base64url-decodes
     // to the application (client) id we persist for the "Add to Discord" invite.
@@ -235,6 +240,9 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       platform: 'discord',
       discord: { botToken: DISCORD_TOKEN }
     })
+    // Cosmetic profile updates are attempted after the durable install, but a
+    // Discord failure never rolls back or blocks the functional integration.
+    expect(iconSync).toEqual({ botToken: DISCORD_TOKEN, agentId })
   })
 
   it('POST rejects a discord bot token Discord refuses (400) and stores nothing', async () => {

--- a/packages/control-plane/test/integration/me.route.test.ts
+++ b/packages/control-plane/test/integration/me.route.test.ts
@@ -101,6 +101,7 @@ describe('PATCH /me', () => {
   it('uploads and removes a custom profile photo without losing the OIDC fallback', async () => {
     const store: IconStore = {
       put: vi.fn(async () => undefined),
+      get: vi.fn(async () => null),
       delete: vi.fn(async () => undefined),
       publicUrl: vi.fn((key, version) => `https://images.example.test/${key}?v=${version}`)
     }

--- a/packages/control-plane/test/integration/preset-agents.test.ts
+++ b/packages/control-plane/test/integration/preset-agents.test.ts
@@ -105,6 +105,7 @@ describe('org-creation seam (POST /orgs)', () => {
     ])
     const store: IconStore = {
       put: vi.fn(async () => undefined),
+      get: vi.fn(async () => null),
       delete: vi.fn(async () => undefined),
       publicUrl: vi.fn(() => 'https://images.example.test/x')
     }

--- a/packages/web/src/lib/icon-upload.test.ts
+++ b/packages/web/src/lib/icon-upload.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resizeImageToIconBlob } from './icon-upload'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('resizeImageToIconBlob', () => {
+  it('normalizes a WebP upload to a Discord-compatible PNG', async () => {
+    const bitmap = { width: 512, height: 256, close: vi.fn() }
+    const drawImage = vi.fn()
+    const toBlob = vi.fn((callback: BlobCallback, type?: string) => {
+      callback(new Blob(['png'], { type }))
+    })
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage })),
+      toBlob
+    }
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => bitmap)
+    )
+    vi.stubGlobal('document', { createElement: vi.fn(() => canvas) })
+
+    const source = new File(['webp'], 'agent.webp', { type: 'image/webp' })
+    const result = await resizeImageToIconBlob(source)
+
+    expect(createImageBitmap).toHaveBeenCalledWith(source)
+    expect(canvas.width).toBe(256)
+    expect(canvas.height).toBe(256)
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 128, 0, 256, 256, 0, 0, 256, 256)
+    expect(toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png')
+    expect(result.type).toBe('image/png')
+    expect(bitmap.close).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/web/src/lib/icon-upload.ts
+++ b/packages/web/src/lib/icon-upload.ts
@@ -1,11 +1,11 @@
 // Client-side icon normalization (docs/designs/icon-uploads.md): crop the picked
-// file to a centered square and resize to <=256x256, then encode WebP. Doing this in
+// file to a centered square and resize to <=256x256, then encode PNG. Doing this in
 // the browser means the CP never needs a raster decoder (sharp) — it just sniffs +
 // stores the bytes. Browser-only (uses <canvas>); call from event handlers, not SSR.
 
 const ICON_SIZE = 256
 
-/** Resize/crop `file` to a 256x256 WebP blob for upload. Throws on decode failure. */
+/** Resize/crop `file` to a 256x256 PNG blob for upload. Throws on decode failure. */
 export async function resizeImageToIconBlob(file: File, size = ICON_SIZE): Promise<Blob> {
   const bitmap = await createImageBitmap(file)
   try {
@@ -20,7 +20,7 @@ export async function resizeImageToIconBlob(file: File, size = ICON_SIZE): Promi
     const sy = (bitmap.height - s) / 2
     ctx.drawImage(bitmap, sx, sy, s, s, 0, 0, size, size)
     return await new Promise<Blob>((resolve, reject) =>
-      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('canvas.toBlob failed'))), 'image/webp', 0.9)
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('canvas.toBlob failed'))), 'image/png')
     )
   } finally {
     bitmap.close()


### PR DESCRIPTION
## Summary

- sync a newly registered Discord bot user's avatar and application icon from the Agent icon
- reuse the existing icon renderer and object store for glyph, runtime, and uploaded images
- normalize new console icon uploads to PNG so WebP source images reach Discord in a supported format
- keep icon sync best-effort so a cosmetic Discord failure does not block integration creation

## Why

AgentConnect previously stored the token and connected the bot without applying the Agent icon, even though Discord supports updating both identities.

## Validation

- 707 Control Plane unit tests
- 425 Web tests
- focused Discord integration tests (3 passed)
- Control Plane and Web typechecks
- protocol and Control Plane builds
- exact-head GitHub Build, Check, Unit, and both Integration jobs
- exact-head review bot approval

Created by Codex . GPT-5
