### PR TITLE
fix(lark): route mentioned direct messages

### DIFF
--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -86,12 +86,13 @@ export function routeRules(
   // removed by the daemon before this pure routing boundary.
   if (mention && (!msg.sender.isBot || msg.platform === 'slack')) return pickRule(mention, 'mention')
   if (msg.sender.isBot) return null
-  // A mention that names no bot known to THIS daemon belongs to another bot (or a
-  // human). Do not let local thread affinity claim it: dedicated Slack apps each see
-  // the channel event, and every daemon otherwise believes its own agent is the sole
-  // local thread owner. The addressed bot's daemon will resolve its own mention rule;
-  // this daemon records the message as unrouted for later transcript catch-up.
-  if (msg.mentionedBots.length > 0) return null
+  // An unmatched mention in a channel belongs to another bot (or a human). Do not let
+  // local thread affinity claim it: dedicated Slack apps each see the channel event,
+  // and every daemon otherwise believes its own agent is the sole local thread owner.
+  // A one-to-one DM is already addressed to this bot, though, so mentioning the bot (or
+  // another participant) must not suppress its dm rule. Group DMs are channel-like and
+  // normalize with isDm=false, so they remain mention-gated here.
+  if (!msg.isDm && msg.mentionedBots.length > 0) return null
 
   // 2. thread affinity (§8.2 step 2 — highest after explicit @; bypasses kind filter).
   if (msg.thread) {

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -79,6 +79,32 @@ describe('routeRules ladder', () => {
     expect(routeRules(msg({ isDm: true, text: 'hello' }), rules, noOwner)?.agentId).toBe('dm')
   })
 
+  it('routes a gated Lark DM through its dm rule when the user also @-mentions the bot', () => {
+    const rules = [
+      rule({
+        agentId: 'private-bot',
+        integrationId: 'lark-private',
+        botUserId: 'ou_bot',
+        match: { kind: 'dm' },
+        platform: 'feishu'
+      })
+    ]
+
+    expect(
+      routeRules(
+        msg({
+          platform: 'feishu',
+          channel: 'oc_dm',
+          isDm: true,
+          mentionedBots: ['ou_bot'],
+          text: '@private-bot 中文名是啥?'
+        }),
+        rules,
+        noOwner
+      )
+    ).toEqual({ agentId: 'private-bot', integrationId: 'lark-private', via: 'dm' })
+  })
+
   it('allowedUserIds gate rejects a non-listed sender', () => {
     const rules = [rule({ match: { kind: 'auto' }, allowedUserIds: ['U2'] })]
     expect(routeRules(msg({ sender: { id: 'U1', isBot: false } }), rules, noOwner)).toBeNull()

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -95,7 +95,10 @@ export default function HomeView() {
   // An agent can take a session only when its owning daemon is serving AND that
   // runtime is signed in (its last probe wasn't rejected with ACP auth-required).
   const isOnline = (a: Agent) =>
-    effectiveAgentStatus(a.status, daemons.find((d) => d.daemonId === a.daemon)?.status) === 'online'
+    effectiveAgentStatus(
+      a.status,
+      daemons.find((d) => d.daemonId === a.daemon)
+    ) === 'online'
   const authRequiredFor = (a: Agent) =>
     !!daemons.find((d) => d.daemonId === a.daemon)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
   const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)


### PR DESCRIPTION
## Summary

- keep one-to-one direct messages routable when their text includes an `@` mention
- preserve unmatched-mention suppression for channels and group DMs
- pass the full daemon state from Home so the web production build typechecks and lifecycle states remain accurate
- add a focused regression for a gated Lark DM that mentions its bot

## Root cause

Restricted Lark integrations expose a conversation-scoped `dm` rule. Lark normalization correctly retained the bot mention, but the shared routing ladder treated every mention that did not match a separate `mention` rule as foreign and dropped the message before the `dm` rule could run.

The Home landing page also used the previous `effectiveAgentStatus` call shape and passed only a status string after that helper began requiring the daemon's status and lifecycle state.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/route-rules.test.ts test/feishu-normalize.test.ts` (35 passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/router/routing-table.ts packages/daemon/test/route-rules.test.ts`
- `pnpm --filter @agentconnect.md/web build`
- `pnpm build`
- full daemon suite reached 2302 passed and 2 skipped; Vitest exited nonzero during teardown because the local environment exhausted file watchers (`EMFILE`)

Created by Codex . gpt-5.6-sol
