### PR TITLE
fix(discord): normalize bot profile icons

### DIFF
--- a/docs/designs/icon-uploads.md
+++ b/docs/designs/icon-uploads.md
@@ -134,9 +134,12 @@ arbitrary bytes straight at the API, so the CP re-validates independently:
   busted by `?v=<lastModified>`); glyph/runtime → rasterized PNG via `@resvg/resvg-js`.
   For an `image` icon the resolved `iconUrl` is the store URL directly, so Slack/browsers
   normally fetch the store and never hit this endpoint; the redirect is the fallback.
-  Registering a new Discord bot also applies these same bytes to both the bot-user
-  avatar and application icon. That external profile sync is cosmetic and best-effort:
-  a Discord or object-store failure is logged without rolling back the integration.
+  Registering a new Discord bot derives an opaque 512×512 PNG on a neutral white
+  background and applies it to both the bot-user avatar and application icon. This
+  avoids low-resolution scaling and prevents transparent icon regions from exposing
+  Discord's dark avatar backdrop. The derivative stays in memory; the canonical stored
+  icon is unchanged. That external profile sync is cosmetic and best-effort: a Discord,
+  conversion, or object-store failure is logged without rolling back the integration.
   Registering a new Telegram bot similarly converts the icon to the JPG format required
   by Bot API `setMyProfilePhoto` and uploads it as the bot's profile picture. Conversion
   or Telegram API failure is also cosmetic and does not roll back the integration.

--- a/packages/control-plane/src/http/discord-bot-profile.test.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.test.ts
@@ -1,3 +1,4 @@
+import sharp from 'sharp'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IconStore } from '../icons/icon-store.js'
 import { createDiscordBotIconSyncer } from './discord-bot-profile.js'
@@ -13,14 +14,19 @@ function successfulDiscordFetch(): void {
   globalThis.fetch = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch
 }
 
+function dataUriBytes(data: string): Buffer {
+  expect(data).toMatch(/^data:image\/png;base64,/)
+  return Buffer.from(data.slice(data.indexOf(',') + 1), 'base64')
+}
+
 describe('createDiscordBotIconSyncer', () => {
-  it('renders a glyph once and applies it to the bot user and application', async () => {
+  it('renders the brand glyph as a 512px PNG on a white plate', async () => {
     successfulDiscordFetch()
     const sync = createDiscordBotIconSyncer()
 
     await sync('discord-secret', {
       id: '00000000-0000-4000-8000-000000000001',
-      icon: { kind: 'glyph', glyph: 'terminal', color: '#2a6fdb' },
+      icon: { kind: 'glyph', glyph: 'agentconnect', color: '#1a212b' },
       runtime: 'claude'
     })
 
@@ -35,16 +41,24 @@ describe('createDiscordBotIconSyncer', () => {
     expect(requests.every((init) => new Headers(init.headers).get('authorization') === 'Bot discord-secret')).toBe(true)
     const botBody = JSON.parse(requests[0]!.body as string) as { avatar: string }
     const appBody = JSON.parse(requests[1]!.body as string) as { icon: string }
-    expect(botBody.avatar).toMatch(/^data:image\/png;base64,/)
     expect(appBody.icon).toBe(botBody.avatar)
+    const png = dataUriBytes(botBody.avatar)
+    const metadata = await sharp(png).metadata()
+    expect(metadata).toMatchObject({ format: 'png', width: 512, height: 512, hasAlpha: false })
+    const corner = await sharp(png).extract({ left: 0, top: 0, width: 1, height: 1 }).raw().toBuffer()
+    expect([...corner.subarray(0, 3)]).toEqual([255, 255, 255])
   })
 
-  it('uses the stored uploaded image bytes without replacing them with a fallback glyph', async () => {
+  it('normalizes the stored uploaded image without replacing it with a fallback glyph', async () => {
     successfulDiscordFetch()
-    const bytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xd9])
+    const bytes = await sharp({
+      create: { width: 32, height: 32, channels: 4, background: { r: 12, g: 34, b: 56, alpha: 1 } }
+    })
+      .webp({ lossless: true })
+      .toBuffer()
     const store: IconStore = {
       put: vi.fn(async () => undefined),
-      get: vi.fn(async () => ({ bytes, contentType: 'image/jpeg' })),
+      get: vi.fn(async () => ({ bytes, contentType: 'image/webp' })),
       delete: vi.fn(async () => undefined),
       publicUrl: vi.fn(() => 'https://images.example.test/icon')
     }
@@ -57,7 +71,12 @@ describe('createDiscordBotIconSyncer', () => {
     })
 
     expect(store.get).toHaveBeenCalledWith('icon/agents/00000000-0000-4000-8000-000000000002')
+    expect(store.put).not.toHaveBeenCalled()
     const body = JSON.parse(vi.mocked(globalThis.fetch).mock.calls[0]![1]!.body as string) as { avatar: string }
-    expect(body.avatar).toBe(`data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`)
+    const center = await sharp(dataUriBytes(body.avatar))
+      .extract({ left: 256, top: 256, width: 1, height: 1 })
+      .raw()
+      .toBuffer()
+    expect([...center.subarray(0, 3)]).toEqual([12, 34, 56])
   })
 })

--- a/packages/control-plane/src/http/discord-bot-profile.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.ts
@@ -3,12 +3,20 @@ import { loadBotProfileIcon, type BotProfileIconAgent } from './bot-profile-icon
 
 const DISCORD_API = 'https://discord.com/api/v10'
 const DISCORD_TIMEOUT_MS = 5000
+const DISCORD_ICON_SIZE = 512
+const DISCORD_ICON_BACKGROUND = '#ffffff'
 
 export type DiscordBotIconSyncer = (botToken: string, agent: BotProfileIconAgent) => Promise<void>
 
 async function iconData(agent: BotProfileIconAgent, iconStore?: IconStore): Promise<string> {
-  const icon = await loadBotProfileIcon(agent, iconStore)
-  return `data:${icon.contentType};base64,${Buffer.from(icon.bytes).toString('base64')}`
+  const icon = await loadBotProfileIcon(agent, iconStore, DISCORD_ICON_SIZE)
+  const { default: sharp } = await import('sharp')
+  const png = await sharp(icon.bytes)
+    .resize(DISCORD_ICON_SIZE, DISCORD_ICON_SIZE, { fit: 'cover' })
+    .flatten({ background: DISCORD_ICON_BACKGROUND })
+    .png()
+    .toBuffer()
+  return `data:image/png;base64,${png.toString('base64')}`
 }
 
 async function patchIcon(botToken: string, path: string, field: 'avatar' | 'icon', data: string): Promise<void> {
@@ -25,9 +33,11 @@ async function patchIcon(botToken: string, path: string, field: 'avatar' | 'icon
   if (!res.ok) throw new Error(`${path} returned ${res.status}`)
 }
 
-/** Apply the Agent icon to both Discord identities: the bot user (messages and
- * member lists) and the application (install/profile surfaces). Both calls are
- * attempted; the route treats any failure as cosmetic and keeps the integration. */
+/** Apply an opaque high-resolution Agent icon to both Discord identities: the
+ * bot user (messages and member lists) and the application (install/profile
+ * surfaces). The white plate keeps transparent icons consistent instead of
+ * exposing Discord's dark avatar backdrop. Both calls are attempted; the route
+ * treats any failure as cosmetic and keeps the integration. */
 export function createDiscordBotIconSyncer(iconStore?: IconStore): DiscordBotIconSyncer {
   return async (botToken, agent) => {
     const data = await iconData(agent, iconStore)


### PR DESCRIPTION
## Summary

- generate one opaque 512×512 PNG for both the Discord bot avatar and application icon
- render descriptor-based Agent icons at the target resolution instead of enlarging the 128px endpoint image
- place transparent icon regions on a neutral white background so the AgentConnect mark matches its light Console presentation instead of exposing Discord's dark avatar backdrop
- keep the canonical Agent icon and object-store object unchanged; the Discord derivative exists only in memory

## Root cause

The Discord sync reused the public icon endpoint's default 128px raster and uploaded transparent PNG pixels directly. Discord enlarged that image on profile surfaces, making diagonal edges visibly jagged, and displayed transparent regions against a dark circular backdrop.

## Scope

This is a follow-up stacked on #235 because it reuses that PR's shared target-size icon loader and image conversion dependency. The diff against its base contains only the Discord normalization, tests, and design documentation.

## Validation

- 728 Control Plane unit tests
- Control Plane build
- focused output assertions for PNG format, 512×512 dimensions, opaque white corners, object-store non-mutation, and uploaded-image preservation
- changed-file ESLint and Prettier checks
- visual inspection of the generated 512×512 profile image
- `git diff --check`

Created by Codex . GPT-5
