### PR TITLE
feat(discord): enable message content intent on install

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -141,7 +141,7 @@ import { McpRateLimiter } from './http/mcp/rate-limit.js'
 import { pingDb } from './persistence/prisma.js'
 import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
 import { resolveTelegramBotName } from './http/telegram-identity.js'
-import { verifyDiscordBot } from './http/discord-identity.js'
+import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
 import { createDiscordBotIconSyncer } from './http/discord-bot-profile.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
@@ -679,6 +679,7 @@ export function buildContainer(
     slackConfigApi,
     resolveTelegramBotName,
     verifyDiscordBot,
+    ensureDiscordMessageContentIntent,
     syncDiscordBotIcon: createDiscordBotIconSyncer(iconStore),
     verifyFeishuBot,
     feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -66,7 +66,7 @@ import type { SlackBotVerifier, SlackAppTokenVerifier } from './slack-identity.j
 import type { SlackPlatformAppConfig } from '../config/slack-platform.js'
 import type { SlackConfigApi } from './slack-config-api.js'
 import type { TelegramBotNameResolver } from './telegram-identity.js'
-import type { DiscordBotVerifier } from './discord-identity.js'
+import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from './discord-identity.js'
 import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
 import type { FeishuBotVerifier } from './feishu-identity.js'
 import type { FeishuAppRegistrationService } from './feishu-registration.js'
@@ -261,6 +261,9 @@ export interface HttpDeps {
    *  name from it when the install omits one). Optional/injectable so tests stay offline
    *  (absent ⇒ no validation, route falls back to the agent name). */
   verifyDiscordBot?: DiscordBotVerifier
+  /** Ensures the Discord application has Message Content enabled before credentials
+   *  are stored. Test composition injects an offline success stub. */
+  ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer
   /** Applies a newly registered Discord bot's Agent icon to its bot-user avatar and
    *  application icon. Cosmetic and best-effort: install survives a sync failure. */
   syncDiscordBotIcon?: DiscordBotIconSyncer

--- a/packages/control-plane/src/http/discord-identity.test.ts
+++ b/packages/control-plane/src/http/discord-identity.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ensureDiscordMessageContentIntent } from './discord-identity.js'
+
+const DISCORD_APPLICATION = 'https://discord.com/api/v10/applications/@me'
+const PRESENCE_LIMITED = 1 << 13
+const MESSAGE_CONTENT = 1 << 18
+const MESSAGE_CONTENT_LIMITED = 1 << 19
+const APPLICATION_COMMAND_BADGE = 1 << 23
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('ensureDiscordMessageContentIntent', () => {
+  it.each([MESSAGE_CONTENT, MESSAGE_CONTENT_LIMITED])(
+    'leaves an application with message-content flag %i unchanged',
+    async (flags) => {
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({ flags }), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('enables the limited flag while preserving the other editable intent flags', async () => {
+    const currentFlags = PRESENCE_LIMITED | APPLICATION_COMMAND_BADGE
+    const expectedFlags = PRESENCE_LIMITED | MESSAGE_CONTENT_LIMITED
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ flags: currentFlags }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ flags: currentFlags | MESSAGE_CONTENT_LIMITED }), { status: 200 })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(true)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      DISCORD_APPLICATION,
+      expect.objectContaining({ headers: { authorization: 'Bot discord-secret' } })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      DISCORD_APPLICATION,
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: { authorization: 'Bot discord-secret', 'content-type': 'application/json' },
+        body: JSON.stringify({ flags: expectedFlags })
+      })
+    )
+  })
+
+  it('reports failure when Discord rejects the flag update', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ flags: 0 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(false)
+  })
+})

--- a/packages/control-plane/src/http/discord-identity.test.ts
+++ b/packages/control-plane/src/http/discord-identity.test.ts
@@ -16,7 +16,7 @@ describe('ensureDiscordMessageContentIntent', () => {
       const fetchMock = vi.fn(async () => new Response(JSON.stringify({ flags }), { status: 200 }))
       vi.stubGlobal('fetch', fetchMock)
 
-      await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(true)
+      await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe('ready')
       expect(fetchMock).toHaveBeenCalledTimes(1)
     }
   )
@@ -32,7 +32,7 @@ describe('ensureDiscordMessageContentIntent', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(true)
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe('ready')
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       DISCORD_APPLICATION,
@@ -56,6 +56,24 @@ describe('ensureDiscordMessageContentIntent', () => {
       .mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe(false)
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe('rejected')
+  })
+
+  it.each([429, 500])('reports Discord as unreachable after a transient %i response', async (status) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('unavailable', { status }))
+    )
+
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe('unreachable')
+  })
+
+  it('reports Discord as unreachable when the request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Promise.reject(new Error('network down')))
+    )
+
+    await expect(ensureDiscordMessageContentIntent('discord-secret')).resolves.toBe('unreachable')
   })
 })

--- a/packages/control-plane/src/http/discord-identity.ts
+++ b/packages/control-plane/src/http/discord-identity.ts
@@ -15,7 +15,8 @@ export type DiscordBotVerification =
   | { status: 'unreachable' } // network / timeout / non-401 non-2xx — inconclusive, do not block
 
 export type DiscordBotVerifier = (botToken: string) => Promise<DiscordBotVerification>
-export type DiscordMessageContentIntentEnsurer = (botToken: string) => Promise<boolean>
+export type DiscordMessageContentIntentSetup = 'ready' | 'rejected' | 'unreachable'
+export type DiscordMessageContentIntentEnsurer = (botToken: string) => Promise<DiscordMessageContentIntentSetup>
 
 /** The application (client) id embedded in a bot token's first segment, or undefined
  *  when the shape is unexpected. A Discord bot token is `<base64url(appId)>.<ts>.<hmac>`
@@ -56,6 +57,10 @@ function hasMessageContentIntent(flags: number): boolean {
   return (flags & (GATEWAY_MESSAGE_CONTENT | GATEWAY_MESSAGE_CONTENT_LIMITED)) !== 0
 }
 
+function intentSetupFailure(status: number): DiscordMessageContentIntentSetup {
+  return status >= 400 && status < 500 && status !== 408 && status !== 429 ? 'rejected' : 'unreachable'
+}
+
 /** `GET /users/@me` with the bot token → validity + the derived name (`username`,
  *  with `#discriminator` for legacy bots, else `global_name`). */
 export const verifyDiscordBot: DiscordBotVerifier = async (botToken) => {
@@ -85,11 +90,11 @@ export const ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsur
       headers,
       signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
     })
-    if (!current.ok) return false
+    if (!current.ok) return intentSetupFailure(current.status)
 
     const currentFlags = applicationFlags(await current.json())
-    if (currentFlags === null) return false
-    if (hasMessageContentIntent(currentFlags)) return true
+    if (currentFlags === null) return 'unreachable'
+    if (hasMessageContentIntent(currentFlags)) return 'ready'
 
     const flags = (currentFlags & EDITABLE_LIMITED_INTENTS) | GATEWAY_MESSAGE_CONTENT_LIMITED
     const updated = await fetch(`${DISCORD_API}/applications/@me`, {
@@ -98,11 +103,12 @@ export const ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsur
       body: JSON.stringify({ flags }),
       signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
     })
-    if (!updated.ok) return false
+    if (!updated.ok) return intentSetupFailure(updated.status)
 
     const updatedFlags = applicationFlags(await updated.json())
-    return updatedFlags !== null && hasMessageContentIntent(updatedFlags)
+    if (updatedFlags === null) return 'unreachable'
+    return hasMessageContentIntent(updatedFlags) ? 'ready' : 'rejected'
   } catch {
-    return false
+    return 'unreachable'
   }
 }

--- a/packages/control-plane/src/http/discord-identity.ts
+++ b/packages/control-plane/src/http/discord-identity.ts
@@ -1,20 +1,10 @@
 /**
- * Discord bot-token verification for the install flow — the Discord analog of
- * slack-identity.ts / telegram-identity.ts.
+ * Discord bot-token verification and required application setup for the install
+ * flow — the Discord analog of slack-identity.ts / telegram-identity.ts.
  *
- * `POST /integrations` calls this to (a) VALIDATE the pasted bot token against
- * Discord before storing it — so a stale / wrong / swapped token fails the request
- * with a 400 instead of silently producing an integration whose Gateway login never
- * succeeds (and whose only symptom is a daemon-log error nobody sees) — and (b)
- * derive the bot's display name from `GET /users/@me` when the install omits one
- * (one call does both, so we don't re-fetch just to name the bot).
- *
- * Best-effort about *reachability*: a network error / timeout / non-2xx OTHER than a
- * definitive 401 is reported as `unreachable` (inconclusive) and MUST NOT block the
- * install — the CP momentarily failing to reach Discord is not evidence the token is
- * bad. Only a 401 Unauthorized is treated as `invalid`.
- *
- * This is the only spot the CP touches the token to reach Discord; it NEVER logs it.
+ * `verifyDiscordBot` validates the pasted token and derives the bot's display name.
+ * `ensureDiscordMessageContentIntent` idempotently enables the limited Message
+ * Content application flag before the integration is stored. Neither logs the token.
  */
 
 /** `GET /users/@me` outcome: a valid token (with the derived bot name), a token
@@ -25,6 +15,7 @@ export type DiscordBotVerification =
   | { status: 'unreachable' } // network / timeout / non-401 non-2xx — inconclusive, do not block
 
 export type DiscordBotVerifier = (botToken: string) => Promise<DiscordBotVerification>
+export type DiscordMessageContentIntentEnsurer = (botToken: string) => Promise<boolean>
 
 /** The application (client) id embedded in a bot token's first segment, or undefined
  *  when the shape is unexpected. A Discord bot token is `<base64url(appId)>.<ts>.<hmac>`
@@ -47,12 +38,29 @@ export function discordAppIdFromBotToken(botToken: string): string | undefined {
 }
 
 const DISCORD_TIMEOUT_MS = 5000
+const DISCORD_API = 'https://discord.com/api/v10'
+const GATEWAY_PRESENCE_LIMITED = 1 << 13
+const GATEWAY_GUILD_MEMBERS_LIMITED = 1 << 15
+const GATEWAY_MESSAGE_CONTENT = 1 << 18
+const GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
+const EDITABLE_LIMITED_INTENTS =
+  GATEWAY_PRESENCE_LIMITED | GATEWAY_GUILD_MEMBERS_LIMITED | GATEWAY_MESSAGE_CONTENT_LIMITED
+
+function applicationFlags(body: unknown): number | null {
+  if (!body || typeof body !== 'object' || !('flags' in body)) return null
+  const flags = body.flags
+  return typeof flags === 'number' && Number.isSafeInteger(flags) ? flags : null
+}
+
+function hasMessageContentIntent(flags: number): boolean {
+  return (flags & (GATEWAY_MESSAGE_CONTENT | GATEWAY_MESSAGE_CONTENT_LIMITED)) !== 0
+}
 
 /** `GET /users/@me` with the bot token → validity + the derived name (`username`,
  *  with `#discriminator` for legacy bots, else `global_name`). */
 export const verifyDiscordBot: DiscordBotVerifier = async (botToken) => {
   try {
-    const res = await fetch('https://discord.com/api/v10/users/@me', {
+    const res = await fetch(`${DISCORD_API}/users/@me`, {
       headers: { authorization: `Bot ${botToken}` },
       signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
     })
@@ -64,5 +72,37 @@ export const verifyDiscordBot: DiscordBotVerifier = async (botToken) => {
     return { status: 'ok', name }
   } catch {
     return { status: 'unreachable' }
+  }
+}
+
+/** Ensure the app can expose message bodies before its integration goes live.
+ *  Discord lets bot authentication update only the three LIMITED privileged-intent
+ *  flags, so preserve that editable subset and leave Discord-owned flags alone. */
+export const ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer = async (botToken) => {
+  const headers = { authorization: `Bot ${botToken}` }
+  try {
+    const current = await fetch(`${DISCORD_API}/applications/@me`, {
+      headers,
+      signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
+    })
+    if (!current.ok) return false
+
+    const currentFlags = applicationFlags(await current.json())
+    if (currentFlags === null) return false
+    if (hasMessageContentIntent(currentFlags)) return true
+
+    const flags = (currentFlags & EDITABLE_LIMITED_INTENTS) | GATEWAY_MESSAGE_CONTENT_LIMITED
+    const updated = await fetch(`${DISCORD_API}/applications/@me`, {
+      method: 'PATCH',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ flags }),
+      signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
+    })
+    if (!updated.ok) return false
+
+    const updatedFlags = applicationFlags(await updated.json())
+    return updatedFlags !== null && hasMessageContentIntent(updatedFlags)
+  } catch {
+    return false
   }
 }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -389,13 +389,9 @@ export function integrationRoutes(deps: HttpDeps) {
             return reply.code(201).send(toDto(integration))
           }
 
-          // Discord: a single Gateway bot token — no app-level token and no OAuth /
-          // verification funnel. Validate it against Discord BEFORE storing, so a stale /
-          // wrong / reset token fails here (400) instead of silently producing an
-          // integration whose Gateway login never succeeds (its only symptom a daemon-log
-          // error nobody sees). `GET /users/@me` also hands back the bot name, so we don't
-          // re-fetch just to name the bot. Best-effort about reachability: a network blip is
-          // inconclusive (`unreachable`), NOT proof the token is bad — only a 401 blocks it.
+          // Discord: validate the single Gateway bot token, then ensure its application
+          // has Message Content enabled BEFORE storing anything. The flag update is
+          // idempotent; a bot that already has limited or approved access is untouched.
           if (req.body.platform === 'discord') {
             const discord = req.body.discord! // superRefine guarantees it when botId is absent
             const check = deps.verifyDiscordBot ? await deps.verifyDiscordBot(discord.botToken) : null
@@ -405,6 +401,16 @@ export function integrationRoutes(deps: HttpDeps) {
                 statusCode: 400,
                 message:
                   'Discord rejected the bot token — check you pasted the Bot token from the Developer Portal (Bot → Reset Token).'
+              })
+            }
+            const intentReady = await deps.ensureDiscordMessageContentIntent(discord.botToken)
+            if (!intentReady) {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                statusCode: 400,
+                code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
+                message:
+                  'AgentConnect could not enable Message Content Intent automatically. Open the Discord Developer Portal → Bot → Privileged Gateway Intents, turn on Message Content Intent, save, then try again.'
               })
             }
             // Name: operator-typed → users/@me-derived (best-effort) → owning agent. The

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -159,7 +159,7 @@ export function integrationRoutes(deps: HttpDeps) {
             'Install a platform integration on a placed agent, reusing a free bot or registering a new one from pasted tokens, then push it live to the owning daemon.',
           operationId: 'createIntegration',
           body: CreateIntegrationBody,
-          response: { 201: IntegrationDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+          response: { 201: IntegrationDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
         }
       },
       async (req, reply) => {
@@ -403,14 +403,23 @@ export function integrationRoutes(deps: HttpDeps) {
                   'Discord rejected the bot token — check you pasted the Bot token from the Developer Portal (Bot → Reset Token).'
               })
             }
-            const intentReady = await deps.ensureDiscordMessageContentIntent(discord.botToken)
-            if (!intentReady) {
+            const intentSetup = await deps.ensureDiscordMessageContentIntent(discord.botToken)
+            if (intentSetup === 'rejected') {
               return reply.code(400).send({
                 error: 'Bad Request',
                 statusCode: 400,
                 code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
                 message:
                   'AgentConnect could not enable Message Content Intent automatically. Open the Discord Developer Portal → Bot → Privileged Gateway Intents, turn on Message Content Intent, save, then try again.'
+              })
+            }
+            if (intentSetup === 'unreachable') {
+              return reply.code(503).send({
+                error: 'Service Unavailable',
+                statusCode: 503,
+                code: 'DISCORD_MESSAGE_CONTENT_INTENT_CHECK_UNAVAILABLE',
+                message:
+                  'AgentConnect could not reach Discord to check or enable Message Content Intent. Try installing again in a moment.'
               })
             }
             // Name: operator-typed → users/@me-derived (best-effort) → owning agent. The

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -237,7 +237,7 @@ export function buildHttpApp(
     events,
     mcpRateLimit: new McpRateLimiter(clock),
     readiness: createReadiness(() => pingDb(prisma)),
-    ensureDiscordMessageContentIntent: async () => true,
+    ensureDiscordMessageContentIntent: async () => 'ready',
     feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
     ...depsOverrides

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -237,6 +237,7 @@ export function buildHttpApp(
     events,
     mcpRateLimit: new McpRateLimiter(clock),
     readiness: createReadiness(() => pingDb(prisma)),
+    ensureDiscordMessageContentIntent: async () => true,
     feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),
     config: { DEFAULT_OWNER_ID, ...configOverrides },
     ...depsOverrides

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -212,7 +212,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     let intentToken: string | undefined
     app.deps.ensureDiscordMessageContentIntent = async (botToken) => {
       intentToken = botToken
-      return true
+      return 'ready'
     }
     app.deps.syncDiscordBotIcon = async (botToken, agent) => {
       iconSync = { botToken, agentId: agent.id }
@@ -274,7 +274,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
     app.deps.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix' })
-    app.deps.ensureDiscordMessageContentIntent = async () => false
+    app.deps.ensureDiscordMessageContentIntent = async () => 'rejected'
 
     const res = await app.app.inject({
       method: 'POST',
@@ -286,6 +286,28 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(res.json()).toMatchObject({
       code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
       message: expect.stringContaining('turn on Message Content Intent')
+    })
+    expect(await prisma.integration.count()).toBe(0)
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.botSecret.count()).toBe(0)
+    expect(spy.upserts).toHaveLength(0)
+  })
+
+  it('POST asks the user to retry when Discord intent setup is unreachable', async () => {
+    const agentId = await placedAgent()
+    const { app, spy } = withSpy()
+    app.deps.ensureDiscordMessageContentIntent = async () => 'unreachable'
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'discord', agentId, discord: { botToken: 'MTA1-bot.token.abc' } }
+    })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toMatchObject({
+      code: 'DISCORD_MESSAGE_CONTENT_INTENT_CHECK_UNAVAILABLE',
+      message: expect.stringContaining('Try installing again')
     })
     expect(await prisma.integration.count()).toBe(0)
     expect(await prisma.bot.count()).toBe(0)

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -209,6 +209,11 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     const agentId = await placedAgent()
     const { app, spy } = withSpy()
     let iconSync: { botToken: string; agentId: string } | undefined
+    let intentToken: string | undefined
+    app.deps.ensureDiscordMessageContentIntent = async (botToken) => {
+      intentToken = botToken
+      return true
+    }
     app.deps.syncDiscordBotIcon = async (botToken, agent) => {
       iconSync = { botToken, agentId: agent.id }
       throw new Error('fixture rate limit')
@@ -246,6 +251,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // Cosmetic profile updates are attempted after the durable install, but a
     // Discord failure never rolls back or blocks the functional integration.
     expect(iconSync).toEqual({ botToken: DISCORD_TOKEN, agentId })
+    expect(intentToken).toBe(DISCORD_TOKEN)
   })
 
   it('POST rejects a discord bot token Discord refuses (400) and stores nothing', async () => {
@@ -261,6 +267,29 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(res.statusCode).toBe(400)
     expect(await prisma.integration.count()).toBe(0)
     expect(await prisma.bot.count()).toBe(0)
+    expect(spy.upserts).toHaveLength(0)
+  })
+
+  it('POST stops before storing when Discord cannot enable Message Content Intent', async () => {
+    const agentId = await placedAgent()
+    const { app, spy } = withSpy()
+    app.deps.verifyDiscordBot = async () => ({ status: 'ok', name: 'matrix' })
+    app.deps.ensureDiscordMessageContentIntent = async () => false
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'discord', agentId, discord: { botToken: 'MTA1-bot.token.abc' } }
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json()).toMatchObject({
+      code: 'DISCORD_MESSAGE_CONTENT_INTENT_SETUP_FAILED',
+      message: expect.stringContaining('turn on Message Content Intent')
+    })
+    expect(await prisma.integration.count()).toBe(0)
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.botSecret.count()).toBe(0)
     expect(spy.upserts).toHaveLength(0)
   })
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -184,7 +184,7 @@ const GUIDE: Record<
   discord: {
     linkHref: 'https://discord.com/developers/applications?new_application=true',
     linkLabel: 'Create Discord app',
-    step1: 'Name and create the application. In Bot, reset and copy the token, then enable Message Content Intent.',
+    step1: 'Name and create the application. In Bot, reset and copy the token.',
     tokenPlaceholder: 'Bot token from the Developer Portal'
   }
 }
@@ -194,8 +194,8 @@ const GUIDE: Record<
 const DISCORD_REQS: { icon: string; title: string; desc: string }[] = [
   {
     icon: 'message-square',
-    title: 'Message Content intent',
-    desc: 'Bot → Privileged Gateway Intents. Without it every message arrives with empty text and the bot never replies.'
+    title: 'Message Content Intent',
+    desc: 'AgentConnect checks this during install and turns it on when needed. If it can’t be changed automatically, you’ll be asked to enable it manually.'
   },
   {
     icon: 'terminal',
@@ -575,17 +575,6 @@ function BrowserBar({ url }: { url: string }) {
   )
 }
 
-// Discord's Privileged-Gateway-Intents switch, on or off.
-function DiscordToggle({ on }: { on: boolean }) {
-  return (
-    <span
-      className={`relative flex h-3 w-6 flex-none items-center rounded-full ${on ? 'bg-[#5865f2]' : 'bg-[#c4c9ce]'}`}
-    >
-      <span className={`absolute h-2 w-2 rounded-full bg-white ${on ? 'right-[3px]' : 'left-[3px]'}`} />
-    </span>
-  )
-}
-
 const TG_STEPS: WalkthroughStep[] = [
   {
     label: 'Find the bot',
@@ -712,9 +701,8 @@ const TG_STEPS: WalkthroughStep[] = [
   }
 ]
 
-// Discord's Developer Portal walkthrough, following the same three beats: create the app,
-// reveal + copy the bot token, then turn on the Message Content intent (the one setting whose
-// absence looks like a silently broken bot — see DISCORD_REQS).
+// Discord's Developer Portal walkthrough stops after token copy. AgentConnect handles
+// Message Content Intent during install; the checklist explains the automatic fallback.
 const DISCORD_STEPS: WalkthroughStep[] = [
   {
     label: 'New app',
@@ -810,57 +798,6 @@ const DISCORD_STEPS: WalkthroughStep[] = [
                 Reset Token
               </span>
             </div>
-          </div>
-        </div>
-      </MiniScreen>
-    )
-  },
-  {
-    label: 'Intents',
-    caption: (
-      <>
-        Same page: turn on <span className="font-medium text-(--text-secondary)">Message Content Intent</span>&#32;and
-        Save Changes, or every message arrives empty.
-      </>
-    ),
-    screen: (
-      <MiniScreen
-        frameClass="border-[#e3e5e8] bg-white"
-        bar={<BrowserBar url="discord.com/developers/applications/…/bot" />}
-      >
-        <div className="absolute inset-0 bg-white px-2.5 py-2">
-          <div className="font-sans text-[10px] font-bold leading-normal text-[#313338]">
-            Privileged Gateway Intents
-          </div>
-          <div className="mt-0.5 font-sans text-[8px] leading-snug text-[#5c5e66]">
-            Toggle the intents your bot needs to receive.
-          </div>
-          {[
-            { name: 'Presence Intent', on: false },
-            { name: 'Server Members Intent', on: false },
-            { name: 'Message Content Intent', on: true }
-          ].map((row) => (
-            <div key={row.name} className="relative mt-1.5 flex items-center gap-2 rounded px-1 py-1">
-              {row.on && (
-                <span className="pointer-events-none absolute -inset-0.5 step-blink rounded ring-2 ring-[#5865f2]" />
-              )}
-              <span
-                className={`min-w-0 flex-1 truncate font-sans text-[9px] leading-normal ${
-                  row.on ? 'font-bold text-[#313338]' : 'text-[#5c5e66]'
-                }`}
-              >
-                {row.name}
-              </span>
-              <DiscordToggle on={row.on} />
-            </div>
-          ))}
-          <div className="mt-2 flex items-center gap-2 rounded-md bg-[#313338] px-2 py-1.5">
-            <span className="min-w-0 flex-1 truncate font-sans text-[8.5px] leading-normal text-white">
-              Careful — you have unsaved changes!
-            </span>
-            <span className="flex-none rounded bg-[#248046] px-2 py-[3px] font-sans text-[8.5px] font-semibold leading-normal text-white">
-              Save Changes
-            </span>
           </div>
         </div>
       </MiniScreen>


### PR DESCRIPTION
## Summary

- inspect the Discord application's privileged-intent flags when a bot token is submitted
- leave bots with limited or approved Message Content access unchanged
- otherwise enable the limited Message Content flag while preserving the other editable privileged-intent settings, then verify Discord returned the enabled state
- stop before storing credentials when Discord cannot complete the setup, distinguishing a rejection from a temporary outage
- remove the manual intent step from the Discord walkthrough and explain the automatic behavior

## Why

A Discord bot can authenticate successfully while Message Content Intent is still disabled. That leaves installation looking successful even though the daemon cannot receive normal message bodies. The install flow should ensure this required application setting before the integration goes live.

## User impact

Users now create the Discord app, copy its bot token, and install it. AgentConnect configures Message Content Intent when needed. If Discord rejects the change, the integration is not saved and the user is told exactly where to enable it manually. If Discord is temporarily unreachable, the user is asked to retry instead.

## Validation

- 7 focused Discord intent tests after the review fix
- 39 integration install-route tests
- GitHub Actions Check, Unit Test, and both Integration shards
- Control Plane typecheck
- full workspace production build
- changed-file ESLint
- Prettier check
- `git diff --check`

Created by Codex . GPT-5
