### PR TITLE
fix(web): mock fetchMySlackIdentity in the sign-in card suite

### DIFF
--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -11,7 +11,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/api', () => ({
   createMySocialIdentityAuthorization: vi.fn(),
-  unlinkMySocialIdentity: vi.fn()
+  unlinkMySocialIdentity: vi.fn(),
+  // The card reads the Slack workspace through this. An explicit mock factory
+  // must export every name the module under test imports, or the import itself
+  // throws before render. "Not linked" keeps these tests about the linking UI.
+  fetchMySlackIdentity: vi.fn(async () => ({ linked: false }))
 }))
 
 vi.mock('@/lib/auth', () => ({


### PR DESCRIPTION
## What

Adds `fetchMySlackIdentity` to the `@/lib/api` mock factory in `SocialSignInCard.test.tsx`.

## Why

`main` is currently red. #232 gave `SocialSignInCard` a Slack workspace read through `@/lib/api`:

```ts
import { createMySocialIdentityAuthorization, fetchMySlackIdentity, unlinkMySocialIdentity } from '@/lib/api'
```

but that module is mocked in the card's own suite with an **explicit factory**, and a factory must export every name the module under test imports. The new import resolves to `undefined`, so both card tests fail at module init, before anything renders:

```
Error: [vitest] No "fetchMySlackIdentity" export is defined on the "@/lib/api" mock.
Did you forget to return it from "vi.mock"?
```

The card and its test landed through different PRs (#225 added the suite, #232 added the import), so neither side saw the mismatch on its own branch.

## Notes for the reviewer

- The mock returns `{ linked: false }` so these two tests stay about the **linking UI** — the workspace line has its own coverage in `lib/slack-identity.test.ts`.
- Verified on this branch: `pnpm --filter @agentconnect.md/web test` → **64 files / 447 tests passing** (was 2 failing on `main`), plus `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)