### PR TITLE
feat(sessions): give every session its own visibility

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -824,15 +824,16 @@ described in this document; integrations, relays, collaboration, hooks, review
 delivery, MCP, memory, git credentials, workspace reads, tool bodies, and usage
 have dedicated schemas under `packages/protocol/src/frames/`.
 
-| Family                                                    | Direction     | Request/reply pattern                             | Purpose                                             |
-| --------------------------------------------------------- | ------------- | ------------------------------------------------- | --------------------------------------------------- |
-| `auth`, `register`                                        | D→C           | correlated replies                                | establish identity and reconcile daemon state       |
-| `heartbeat`, `facts/*`, `event/session`, `agent/activity` | D→C           | events                                            | report health, capabilities, metadata, and activity |
-| `route/*`, `agent/*`, `cron/*`, `daemon/*`, `config/push` | C→D or paired | correlated requests, acknowledgements, and events | mutate fenced daemon control state                  |
-| `secrets/*`                                               | paired        | request/grant plus revoke event                   | manage scoped secret leases                         |
-| `session/*`                                               | paired        | correlated paginated reads                        | fetch daemon-local session data                     |
-| `channel/agents`                                          | D→C           | correlated reply                                  | resolve collaboration directory metadata            |
-| `error`, `ack`                                            | either        | correlated replies                                | provide generic protocol outcomes                   |
+| Family                                                    | Direction     | Request/reply pattern                                 | Purpose                                                                       |
+| --------------------------------------------------------- | ------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `auth`, `register`                                        | D→C           | correlated replies                                    | establish identity and reconcile daemon state                                 |
+| `heartbeat`, `facts/*`, `event/session`, `agent/activity` | D→C           | events                                                | report health, capabilities, metadata, and activity                           |
+| `route/*`, `agent/*`, `cron/*`, `daemon/*`, `config/push` | C→D or paired | correlated requests, acknowledgements, and events     | mutate fenced daemon control state                                            |
+| `secrets/*`                                               | paired        | request/grant plus revoke event                       | manage scoped secret leases                                                   |
+| `session/*`                                               | paired        | correlated paginated reads                            | fetch daemon-local session data                                               |
+| `session/visibility`, `session/visibility/snapshot`       | C→D           | correlated requests (`session/visibility/ok` / `ack`) | push CP-authoritative session privacy gate state (session-visibility.md §5.1) |
+| `channel/agents`                                          | D→C           | correlated reply                                      | resolve collaboration directory metadata                                      |
+| `error`, `ack`                                            | either        | correlated replies                                    | provide generic protocol outcomes                                             |
 
 ---
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -175,6 +175,32 @@ selection. That reply remains governed by the existing origin-only session capab
 a permitted one-way delegation can return its result without requiring a reverse
 visibility grant.
 
+## Session visibility
+
+Every session carries its own visibility, composed with — never widening — the visibility
+of the agent that owns it. Platform direct messages, Playground and webchat conversations,
+and sessions launched through the Web API default to **private**: only their owner and org
+owners can see them. Channel sessions, group direct messages, and automation-originated
+sessions (cron, hook, dream, agent-to-agent) default to **org**, visible to every member
+who can already view the agent. A session's initiator is recorded regardless of tier, so
+the person who started a channel conversation may later pull it private, and an org owner
+may reclassify anything.
+
+An agent-to-agent child inherits its parent's visibility, because a delegation copies the
+parent's prompt into the child's transcript. Tightening a session therefore cascades to its
+descendants; publishing one never does — widening a child stays that child's own decision.
+
+A session the caller may not see is reported as missing, not as forbidden: the console must
+not reveal that it exists.
+
+Making a session private hides its transcript immediately, but agent memory is shared
+across the whole agent, so the guarantee about memory is narrower and must be stated
+plainly wherever the change is offered: capture into shared memory stops once the owning
+daemon acknowledges the change (typically sub-second, surfaced as a pending state until
+then), and anything the agent already distilled while the session was org-visible is not
+retracted. Until a session's daemon has confirmed the current state, that daemon withholds
+capture rather than assuming the session is shareable.
+
 ## Runtime memory-provider compatibility
 
 Memory-provider semantics are part of the support contract for every agent harness, not

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -201,6 +201,19 @@ then), and anything the agent already distilled while the session was org-visibl
 retracted. Until a session's daemon has confirmed the current state, that daemon withholds
 capture rather than assuming the session is shareable.
 
+The block covers both ways a session reaches shared memory: the automatic post-turn
+distillation, and an explicit write by the agent itself. A private session's memory-write
+tools refuse with an explanation rather than failing silently, and reads stay available —
+recalling what the agent already knows is not a disclosure of the current conversation.
+Dream sessions skip private transcripts entirely.
+
+**Agents on native runtime memory are the exception, and the product must say so.** With
+that backend the runtime persists memory inside its own process for the whole agent, with
+no per-session control, so a private session on such an agent gets the transcript
+guarantee but not the memory one. Anywhere an agent is configured for native memory, the
+private tier must be described as "hides the transcript, not what the agent learns from
+it" — silence is not an option.
+
 ## Runtime memory-provider compatibility
 
 Memory-provider semantics are part of the support contract for every agent harness, not

--- a/packages/control-plane/prisma/migrations/20260730090000_session_visibility/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260730090000_session_visibility/migration.sql
@@ -1,0 +1,60 @@
+-- Session visibility (docs/designs/session-visibility.md §3): every session gets
+-- its own visibility tier ('private' | 'org'), a namespaced owner identity, the
+-- A2A reconciliation state marker, and the §5.1 push revision + daemon-ack
+-- watermark. orgId is denormalized from the owning agent so the org-wide list
+-- predicate and its index never join "agent".
+
+-- CreateEnum
+CREATE TYPE "SessionVisibility" AS ENUM ('private', 'org');
+
+-- CreateEnum
+CREATE TYPE "VisibilitySource" AS ENUM ('default', 'inherited_pending', 'inherited', 'explicit');
+
+-- AlterTable ("orgId" is added nullable, backfilled, then made NOT NULL below)
+ALTER TABLE "session_meta"
+  ADD COLUMN "orgId" TEXT,
+  ADD COLUMN "visibility" "SessionVisibility" NOT NULL DEFAULT 'org',
+  ADD COLUMN "ownerIdentity" TEXT,
+  ADD COLUMN "visibilitySource" "VisibilitySource" NOT NULL DEFAULT 'default',
+  ADD COLUMN "visibilityRev" INTEGER NOT NULL DEFAULT 0,
+  -- -1, not 0: rev 0 is a real revision (a session ingested and never changed),
+  -- so the watermark needs a distinct "never acknowledged" value.
+  ADD COLUMN "visibilityAckedRev" INTEGER NOT NULL DEFAULT -1;
+
+-- Backfill orgId from the owning agent. Legacy rows keep visibility='org' — do
+-- NOT retro-classify DMs (the `thread === 'dm'` convention is platform-
+-- inconsistent, and flipping a row private would yank it from members who can
+-- see it today); tightening applies to new sessions only (§3).
+UPDATE "session_meta" AS sm
+SET "orgId" = a."orgId"
+FROM "agent" AS a
+WHERE a."id" = sm."agentId"
+  AND sm."orgId" IS NULL;
+
+-- Rows without a matching agent are unreachable today (agentId has a CASCADE
+-- FK), but a NULL orgId row would fail the NOT NULL flip — drop defensively.
+DELETE FROM "session_meta" WHERE "orgId" IS NULL;
+
+ALTER TABLE "session_meta" ALTER COLUMN "orgId" SET NOT NULL;
+
+-- CreateIndex — org-wide keyset paging under the visibility predicate; the
+-- trailing tuple mirrors the existing page indexes exactly.
+CREATE INDEX "session_meta_org_visibility_page_idx"
+  ON "session_meta"(
+    "orgId",
+    "visibility",
+    "lastActivityAt" DESC,
+    "startedAt" DESC,
+    "id" DESC
+  );
+
+-- Web API launch provenance (session-visibility.md §4.4). correlationId is
+-- minted by the CP and echoed by the daemon on `event/session` — distinct from
+-- the fencing launch id. createdByUserId is a raw scalar (no FK) so a deleted
+-- user never breaks provenance.
+ALTER TABLE "agent_launch"
+  ADD COLUMN "correlationId" UUID,
+  ADD COLUMN "createdByUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_launch_correlationId_key" ON "agent_launch"("correlationId");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -791,41 +791,69 @@ enum ActivityState {
   idle
 }
 
+// Per-session visibility tier (docs/designs/session-visibility.md §1): 'org'
+// (default) = visible to every member who can view the owning agent; 'private'
+// = session owner (identity match) + org owners only. Composes with agent
+// visibility — it never widens it. Share-by-link is deliberately NOT a member
+// of this enum (§8).
+enum SessionVisibility {
+  private
+  org
+}
+
+// How a session's visibility was determined (session-visibility.md §3, §4.5).
+// The A2A reconciliation state machine: settlement flips inherited_pending →
+// inherited iff the row is still pending (CAS on this column); 'explicit' pins
+// the row against settlement but NOT against a tightening cascade (privacy wins).
+enum VisibilitySource {
+  default // classified by the §4.2 ingest rules
+  inherited_pending // A2A child awaiting parent resolution (§4.5)
+  inherited // settled from (or cascaded by) its parent
+  explicit // set by a human via §4.3
+}
+
 model SessionMeta {
-  id              String        @id // EventSession.sessionId = ACP session id (agent-assigned string, NOT a UUID)
-  parentSessionId String? // Parent ACP session id reported by the daemon; no FK because parent metadata may arrive later or live on another daemon
-  agentId         String        @db.Uuid
-  launchId        String?       @db.Uuid // CP launch fence; null for Slack/Discord-created sessions (no CP launch)
-  platform        String? // denormalized sessionKey echo for dashboard filters (free string so webchat can be listed)
-  channel         String?
-  thread          String?
-  phase           SessionPhase  @default(start)
-  link            String? // deep-link (NOT a body)
-  summary         String?       @db.Text // short milestone text (NOT the stream)
-  title           String?       @db.Text // daemon-derived display title (NOT a body)
-  status          String?
-  triggeredBy     String?
-  channelName     String?
-  triggeredByName String?
-  threadUrl       String?       @db.Text
+  id                 String            @id // EventSession.sessionId = ACP session id (agent-assigned string, NOT a UUID)
+  parentSessionId    String? // Parent ACP session id reported by the daemon; no FK because parent metadata may arrive later or live on another daemon
+  agentId            String            @db.Uuid
+  launchId           String?           @db.Uuid // CP launch fence; null for Slack/Discord-created sessions (no CP launch)
+  platform           String? // denormalized sessionKey echo for dashboard filters (free string so webchat can be listed)
+  channel            String?
+  thread             String?
+  phase              SessionPhase      @default(start)
+  link               String? // deep-link (NOT a body)
+  summary            String?           @db.Text // short milestone text (NOT the stream)
+  title              String?           @db.Text // daemon-derived display title (NOT a body)
+  status             String?
+  triggeredBy        String?
+  channelName        String?
+  triggeredByName    String?
+  threadUrl          String?           @db.Text
   // ── execution-config snapshot (what the session actually ran with) ──
   // Daemon-reported via event/session (session override ?? agent config at run
   // time); null ⇒ never reported / the runtime's own default. Recorded so the
   // console shows what a session USED, not the agent's config at view time.
-  runtime         String?
-  model           String?
-  effort          String? // reasoning effort level (runtime-owned vocabulary)
-  fastMode        Boolean?
-  permissionMode  String? // runtime permission/approval mode
-  outputMode      String? // daemon-side output verbosity (low/medium/high)
-  daemonId        String?       @db.Uuid // daemon that reported the session — stamped by the CP from the authenticated WS conn, never daemon-echoed
-  activityState   ActivityState @default(idle)
+  runtime            String?
+  model              String?
+  effort             String? // reasoning effort level (runtime-owned vocabulary)
+  fastMode           Boolean?
+  permissionMode     String? // runtime permission/approval mode
+  outputMode         String? // daemon-side output verbosity (low/medium/high)
+  daemonId           String?           @db.Uuid // daemon that reported the session — stamped by the CP from the authenticated WS conn, never daemon-echoed
+  activityState      ActivityState     @default(idle)
+  // ── session visibility (docs/designs/session-visibility.md §3) ──
+  orgId              String // denormalized from agent.orgId at ingest so the org-wide list predicate/index never joins agent
+  visibility         SessionVisibility @default(org)
+  ownerIdentity      String? // §2 namespaced identity (`user:<id>` | `<platform>:<scope>:<uid>`); null for automation/legacy/owner-orphan rows
+  visibilitySource   VisibilitySource  @default(default)
+  visibilityRev      Int               @default(0) // dedicated monotonic counter, bumped in the same tx as any visibility change (§5.1)
+  visibilityAckedRev Int               @default(-1) // daemon-ack watermark: 'applied' once >= visibilityRev; -1 = never acked (rev 0 is a real revision)
   // Cursor tokens pass through JavaScript Date (millisecond precision), so the
   // complete keyset tuple must use the same precision in Postgres.
-  lastActivityAt  DateTime      @db.Timestamptz(3)
-  startedAt       DateTime      @default(now()) @db.Timestamptz(3)
-  endedAt         DateTime?     @db.Timestamptz(6)
-  updatedAt       DateTime      @updatedAt @db.Timestamptz(6)
+  lastActivityAt     DateTime          @db.Timestamptz(3)
+  startedAt          DateTime          @default(now()) @db.Timestamptz(3)
+  endedAt            DateTime?         @db.Timestamptz(6)
+  updatedAt          DateTime          @updatedAt @db.Timestamptz(6)
 
   agent  Agent        @relation(fields: [agentId], references: [id], onDelete: Cascade)
   launch AgentLaunch? @relation(fields: [launchId], references: [id], onDelete: SetNull)
@@ -837,6 +865,7 @@ model SessionMeta {
   @@index([agentId, platform, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_agent_platform_page_idx")
   @@index([agentId, channel, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_agent_channel_page_idx")
   @@index([agentId, triggeredBy, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_agent_trigger_page_idx")
+  @@index([orgId, visibility, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_org_visibility_page_idx")
   @@index([parentSessionId])
   @@index([platform, channel])
   @@index([launchId])
@@ -948,6 +977,11 @@ model AgentLaunch {
   runtime            String
   mode               LaunchMode   @default(long_lived)
   acpSessionId       String? // set iff long-lived ACP session
+  // Web API launch provenance (session-visibility.md §4.4) — DISTINCT from the
+  // fencing `id`: the CP mints it, the daemon echoes it on the session's
+  // `event/session` frame, and ingest resolves it back to the launching user.
+  correlationId      String?      @unique @db.Uuid
+  createdByUserId    String? // launching principal; raw scalar (no FK) so a deleted user never breaks provenance
   activeCapabilities String[]     @default([]) // capability pin (AgentCapabilities.active)
   status             LaunchStatus @default(launching)
   launchEpoch        BigInt       @db.BigInt // sessionEpoch the launch was issued under

--- a/packages/control-plane/prisma/seed-example.sql
+++ b/packages/control-plane/prisma/seed-example.sql
@@ -77,11 +77,14 @@ VALUES
 ON CONFLICT ("id") DO NOTHING;
 
 -- ── A converged session milestone (metadata only — NO message bodies) ───────
+-- orgId is denormalized from the agent; visibility columns keep their defaults
+-- ('org' / 'default' / rev 0 — a channel session, visible org-wide).
 INSERT INTO "session_meta"
-  ("id","agentId","launchId","platform","channel","thread","phase","link","summary",
+  ("id","agentId","orgId","launchId","platform","channel","thread","phase","link","summary",
    "activityState","lastActivityAt","startedAt","updatedAt")
 VALUES
   ('55555555-5555-4555-8555-555555555555','22222222-2222-4222-8222-222222222222',
+   'org_default00000000000000000',
    '44444444-4444-4444-8444-444444444444','slack','C0DEMO0001','1718000000.000100',
    'plan','https://app.example/sessions/55555555','Reviewing PR #3: drafted a plan',
    'thinking', now(), now(), now())

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -85,6 +85,7 @@ import {
 
 import { EpochService } from './orchestrator/epoch.js'
 import { ControlSender, NoConnection } from './orchestrator/outbound.js'
+import { SessionVisibilityPushService } from './orchestrator/visibilityPush.js'
 import { AgentSpecAssembler } from './orchestrator/agentSpecAssembler.js'
 import { Placement } from './orchestrator/placement.js'
 import { Watchdog } from './orchestrator/watchdog.js'
@@ -394,6 +395,16 @@ export function buildContainer(
   // The single fencing site (allocates seq, stamps epoch/launchId on C→D frames).
   const sender = new ControlSender(connReg, repos.launch)
 
+  // Per-session memory-capture gate convergence (session-visibility.md §5.1):
+  // the CP is the authority on effective visibility; daemons only enforce it.
+  const visibilityPush = new SessionVisibilityPushService({
+    repos: { session: repos.session, agent: repos.agent },
+    control: sender,
+    connReg,
+    // Lazy over `http.log` (assigned below; only ever called at push time).
+    log: { warn: (o, m) => http.log.warn(o, m) }
+  })
+
   // Bot-agnostic collaboration routing snapshot fan-out (agent-collaboration
   // §2.3/§6.2): relays get the all-org table; daemons get their org-scoped copy.
   const collabRoutes = new CollabRoutesService(repos.daemon, repos.integration, relayControl, sender)
@@ -656,6 +667,7 @@ export function buildContainer(
     // (structurally a `DaemonLiveness`): it knows who is connected RIGHT NOW.
     liveness: connReg,
     control: sender,
+    visibilityPush,
     relayControl,
     httpBot,
     collabRoutes,
@@ -843,6 +855,9 @@ export function buildContainer(
     orchestrator,
     connReg,
     session: repos.session,
+    webchatConversation: repos.webchatConversation,
+    launch: repos.launch,
+    visibilityPush,
     events,
     sessionUsage: repos.sessionUsage,
     integration: repos.integration,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1196,6 +1196,7 @@ export function buildContainer(
       visibilityPush.stop()
       await Promise.allSettled([
         ...relayRegistrationTasks,
+        visibilityPush.settle(),
         ...(installationDoorbell ? [installationDoorbell.settle()] : [])
       ])
       await prisma.$disconnect()

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1193,6 +1193,7 @@ export function buildContainer(
       feishuRegistrationReaper.stop()
       relaySweeper.stop()
       slackBotIdentityReconciler.stop()
+      visibilityPush.stop()
       await Promise.allSettled([
         ...relayRegistrationTasks,
         ...(installationDoorbell ? [installationDoorbell.settle()] : [])

--- a/packages/control-plane/src/domain/session-visibility.test.ts
+++ b/packages/control-plane/src/domain/session-visibility.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { classifySession } from './session-visibility.js'
+
+describe('classifySession — the §4.2 default rules', () => {
+  it('inherits for an A2A child before any other rule', () => {
+    expect(classifySession({ parentSessionId: 'parent-1', platform: 'webchat' })).toEqual({ inherit: true })
+    expect(classifySession({ parentSessionId: 'parent-1', platform: 'slack', conversationKind: 'channel' })).toEqual({
+      inherit: true
+    })
+  })
+
+  it('classifies webchat private and owns it via the resolved binding', () => {
+    expect(classifySession({ platform: 'webchat', triggeredBy: 'dev@example.com', webchatOwnerUserId: 'u1' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: 'user:u1',
+      source: 'default'
+    })
+  })
+
+  it('classifies a Web API launch private and owns it via the correlation principal', () => {
+    expect(classifySession({ platform: 'slack', launchCorrelationId: 'c1', launchOwnerUserId: 'u2' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: 'user:u2',
+      source: 'default'
+    })
+  })
+
+  it('classifies automation org with no owner', () => {
+    for (const triggeredBy of ['cron:abc', 'hook:def', 'dream:ghi']) {
+      expect(classifySession({ platform: 'slack', triggeredBy, transportScope: 'T1' })).toEqual({
+        visibility: 'org',
+        ownerIdentity: null,
+        source: 'default'
+      })
+    }
+    expect(classifySession({ platform: 'hook' })).toEqual({
+      visibility: 'org',
+      ownerIdentity: null,
+      source: 'default'
+    })
+  })
+
+  it('classifies an IM DM private with the three-part identity tuple', () => {
+    expect(
+      classifySession({ platform: 'slack', conversationKind: 'dm', transportScope: 'T024BE7LD', triggeredBy: 'U0123' })
+    ).toEqual({ visibility: 'private', ownerIdentity: 'slack:T024BE7LD:U0123', source: 'default' })
+  })
+
+  it('classifies group DMs and channels org but still records the initiator', () => {
+    const base = { platform: 'slack' as const, transportScope: 'T1', triggeredBy: 'U9' }
+    for (const conversationKind of ['group_dm', 'channel'] as const) {
+      expect(classifySession({ ...base, conversationKind })).toEqual({
+        visibility: 'org',
+        ownerIdentity: 'slack:T1:U9',
+        source: 'default'
+      })
+    }
+  })
+
+  it('treats an absent conversationKind as a channel (old daemons stay org-visible)', () => {
+    expect(classifySession({ platform: 'slack', transportScope: 'T1', triggeredBy: 'U9' })).toEqual({
+      visibility: 'org',
+      ownerIdentity: 'slack:T1:U9',
+      source: 'default'
+    })
+  })
+})
+
+describe('classifySession — fail-closed paths', () => {
+  it('keeps webchat private with no owner when the binding lookup misses', () => {
+    expect(classifySession({ platform: 'webchat', webchatOwnerUserId: null })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+    // Lookup not even attempted (no channel on the frame) ⇒ same outcome.
+    expect(classifySession({ platform: 'webchat' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+  })
+
+  it('keeps a launch-correlated session private with no owner when the correlation is unknown', () => {
+    expect(classifySession({ platform: 'slack', launchCorrelationId: 'c1', launchOwnerUserId: null })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+  })
+
+  it('records no IM owner when transportScope is missing — never a guessed one', () => {
+    expect(classifySession({ platform: 'slack', conversationKind: 'dm', triggeredBy: 'U0123' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+    expect(classifySession({ platform: 'slack', conversationKind: 'channel', triggeredBy: 'U0123' })).toEqual({
+      visibility: 'org',
+      ownerIdentity: null,
+      source: 'default'
+    })
+  })
+
+  it('records no IM owner when the sender or platform is missing', () => {
+    expect(classifySession({ platform: 'slack', conversationKind: 'dm', transportScope: 'T1' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+    expect(classifySession({ conversationKind: 'dm', transportScope: 'T1', triggeredBy: 'U1' })).toEqual({
+      visibility: 'private',
+      ownerIdentity: null,
+      source: 'default'
+    })
+  })
+
+  it('never widens a private default because a lookup failed', () => {
+    // Every private-defaulting origin, with its ownership lookup failed.
+    const failedLookups = [
+      classifySession({ platform: 'webchat', webchatOwnerUserId: null }),
+      classifySession({ launchCorrelationId: 'c1', launchOwnerUserId: null }),
+      classifySession({ platform: 'slack', conversationKind: 'dm' })
+    ]
+    for (const c of failedLookups) expect(c).toMatchObject({ visibility: 'private' })
+  })
+})

--- a/packages/control-plane/src/domain/session-visibility.ts
+++ b/packages/control-plane/src/domain/session-visibility.ts
@@ -1,0 +1,111 @@
+/**
+ * Session-visibility classification (docs/designs/session-visibility.md §4.2).
+ *
+ * Pure decision function: given what an `event/session` milestone reports plus
+ * the ownership lookups the handler already resolved, decide the session's
+ * visibility tier and its namespaced owner identity (§2). Zero I/O — the
+ * handler performs the lookups, this module only decides, so the whole §4.2
+ * table (including every fail-closed path) is unit-testable without a database.
+ *
+ * Two invariants the rules encode:
+ *
+ *  - **Fail closed.** A rule that defaults to `private` never widens to `org`
+ *    because a lookup failed; an unresolvable owner yields `private` +
+ *    `ownerIdentity: null` (an owner-orphan, visible to org owners only and
+ *    recoverable via the §4.3 endpoint). A metadata inconsistency must never
+ *    become a disclosure.
+ *  - **`ownerIdentity` is provenance, not the gate.** It is recorded for every
+ *    human-triggered session regardless of tier — for `org` rows it is what
+ *    grants its initiator the §4.3 right to pull the session private later.
+ */
+import type { SessionConversationKind, SessionVisibility, VisibilitySource } from '../persistence/ports.js'
+
+/** Automation `triggeredBy` prefixes (`cron:<id>` / `hook:<id>`) — already
+ *  load-bearing in the session list filters. Dream sessions report neither a
+ *  platform sender nor a conversation, so they fall through to the same arm. */
+const AUTOMATION_TRIGGER_PREFIXES = ['cron:', 'hook:', 'dream:'] as const
+
+/** Everything the classifier needs, with the CP-side lookups already resolved. */
+export interface SessionClassificationInput {
+  /** Daemon-reported platform echo (`webchat`, `slack`, `hook`, …). */
+  platform?: string
+  /** Daemon-reported conversation shape (§4.1); absent ⇒ channel behavior. */
+  conversationKind?: SessionConversationKind
+  /** Durable tenant scope for the IM identity tuple (§2); absent ⇒ no IM owner. */
+  transportScope?: string
+  /** Platform sender id (webchat reports an unstable email — never used as a key). */
+  triggeredBy?: string
+  /** Present ⇒ an A2A child: it inherits from its parent under a row lock (§4.5). */
+  parentSessionId?: string
+  /** Resolved `WebchatConversation.userId`, or null when the lookup missed. */
+  webchatOwnerUserId?: string | null
+  /** Present ⇒ a Web API launch (§4.4); the value is its resolved principal or null. */
+  launchCorrelationId?: string
+  /** Resolved launching-principal user id, or null when the correlation is unknown. */
+  launchOwnerUserId?: string | null
+}
+
+/** A settled classification, or the marker that the row must inherit (§4.5). */
+export type SessionClassification =
+  | { inherit: true }
+  | { inherit?: false; visibility: SessionVisibility; ownerIdentity: string | null; source: VisibilitySource }
+
+function isAutomationTrigger(triggeredBy: string | undefined): boolean {
+  return triggeredBy != null && AUTOMATION_TRIGGER_PREFIXES.some((prefix) => triggeredBy.startsWith(prefix))
+}
+
+/** The IM identity tuple `<platform>:<workspace>:<uid>` (§2). Every segment must
+ *  be present: platform uids are unique only per tenant, so a two-segment form
+ *  would let two workspaces of one org collide. Missing scope ⇒ no owner. */
+function imOwnerIdentity(input: SessionClassificationInput): string | null {
+  const { platform, transportScope, triggeredBy } = input
+  if (!platform || !transportScope || !triggeredBy) return null
+  return `${platform}:${transportScope}:${triggeredBy}`
+}
+
+/**
+ * Classify a session at ingest. First match wins, mirroring the §4.2 table:
+ *
+ * | origin                        | visibility      | ownerIdentity                    |
+ * | ----------------------------- | --------------- | -------------------------------- |
+ * | A2A child (`parentSessionId`) | inherits parent | inherits parent                  |
+ * | webchat / Playground          | `private`       | `user:<WebchatConversation.userId>` |
+ * | Web API launch (§4.4)         | `private`       | `user:<launch principal>`        |
+ * | cron / hook / dream           | `org`           | null                             |
+ * | IM DM                         | `private`       | `<platform>:<scope>:<uid>`       |
+ * | IM group DM / channel / absent| `org`           | `<platform>:<scope>:<uid>`       |
+ */
+export function classifySession(input: SessionClassificationInput): SessionClassification {
+  // A2A children copy the parent's tier and owner: a delegation from a private
+  // DM or Playground session copies the delegated prompt into the child
+  // transcript, so classifying children `org` would expose it to every viewer
+  // of the target agent. Resolution needs the parent row under a lock (§4.5).
+  if (input.parentSessionId) return { inherit: true }
+
+  // Webchat/Playground. `triggeredBy` here is the console user's email, which
+  // degrades under devAuth and is not a stable key — the binding lookup is the
+  // authority, and a miss stays private with no owner.
+  if (input.platform === 'webchat') {
+    const userId = input.webchatOwnerUserId ?? null
+    return { visibility: 'private', ownerIdentity: userId ? `user:${userId}` : null, source: 'default' }
+  }
+
+  // Web API launch provenance (§4.4): an unresolvable correlation fails closed.
+  if (input.launchCorrelationId) {
+    const userId = input.launchOwnerUserId ?? null
+    return { visibility: 'private', ownerIdentity: userId ? `user:${userId}` : null, source: 'default' }
+  }
+
+  // Automation has no human owner; its output is org-visible by default.
+  if (input.platform === 'hook' || isAutomationTrigger(input.triggeredBy)) {
+    return { visibility: 'org', ownerIdentity: null, source: 'default' }
+  }
+
+  // IM. A group DM defaults to `org` like a channel: the predicate can match
+  // only one owner, so treating a multi-party conversation as `private` would
+  // hide it from its own participants. Its initiator can still pull it private
+  // via §4.3 — which is why the owner is recorded for `org` rows too.
+  const ownerIdentity = imOwnerIdentity(input)
+  const visibility: SessionVisibility = input.conversationKind === 'dm' ? 'private' : 'org'
+  return { visibility, ownerIdentity, source: 'default' }
+}

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -54,6 +54,7 @@ import type { WebchatTokenService } from '../registry/webchatToken.js'
 import type { OrgInviteLinkService } from '../registry/orgInviteLinkService.js'
 import type { WaitlistService } from '../registry/waitlistService.js'
 import type { ControlSender } from '../orchestrator/outbound.js'
+import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { AgentSpecAssembler } from '../orchestrator/agentSpecAssembler.js'
 import type { RelayControlSender } from '../orchestrator/relayControl.js'
 import type { HttpBotOrchestrator } from '../orchestrator/httpBot.js'
@@ -204,6 +205,10 @@ export interface HttpDeps {
   /** The fencing site for C→D control. REST agent CRUD pushes `agent/upsert`/
    *  `agent/remove` through it to replicate config to the owning daemon. */
   control: ControlSender
+  /** Pushes the per-session memory-capture gate to the owning daemons after a
+   *  §4.3 visibility change, and answers the pending/applied cutover state
+   *  (session-visibility.md §5.1). Absent ⇒ changes converge on register. */
+  visibilityPush?: SessionVisibilityPushService
   /** CP→relay control fan-out — pushes `rc/daemon-revoke` to connected relays when a
    *  daemon key is revoked / a daemon is removed (shared-bot-relay.md §9). */
   relayControl: RelayControlSender

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -31,6 +31,12 @@ import { HEX_COLOR_RE, AGENT_ICON_GLYPHS } from '../../agents/agent-icon.js'
 /** 'org' = visible to every org member (default); 'restricted' = creator + org
  *  owners + the `sharedWith` set. */
 export const ResourceVisibilityEnum = z.enum(['org', 'restricted'])
+/** Per-SESSION visibility (docs/designs/session-visibility.md §1) — a different
+ *  tier vocabulary from `ResourceVisibilityEnum`: sessions have no share set,
+ *  their owner is a namespaced identity string (§2). */
+export const SessionVisibilityEnum = z.enum(['private', 'org'])
+/** Whether a visibility change has reached the daemons that enforce it (§5.1). */
+export const SessionVisibilityStateEnum = z.enum(['pending', 'applied'])
 /** `PUT /{agents|daemons|crons}/:id/sharing` — set a resource's visibility + share
  *  set. Gated exactly like a content edit (`canEdit`, decision §13.3). */
 export const SetSharingBody = z
@@ -1958,7 +1964,8 @@ export const SessionDto = z.object({
   fastMode: z.boolean().nullable(),
   permissionMode: z.string().nullable(),
   outputMode: z.string().nullable(),
-  daemonId: z.string().nullable()
+  daemonId: z.string().nullable(),
+  visibility: SessionVisibilityEnum
 })
 export const SessionListDto = z.array(SessionDto)
 export const SessionFacetsDto = z.object({
@@ -2026,8 +2033,29 @@ export const SessionDetailDto = z.object({
   outputMode: z.string().nullable(),
   daemonId: z.string().nullable(),
   activityState: z.string(),
+  // ── session visibility (docs/designs/session-visibility.md) ──
+  visibility: SessionVisibilityEnum,
+  /** §5.1 cutover: `pending` until every affected daemon has acked the change —
+   *  CP read gates apply at commit, the memory boundary at acknowledgement. */
+  visibilityState: SessionVisibilityStateEnum,
+  /** Whether THIS caller may use `PUT /sessions/:id/visibility` (§4.3). Computed
+   *  server-side; the console never re-derives permissions from identity. */
+  canChangeVisibility: z.boolean(),
   startedAt: z.string(), // ISO-8601
   endedAt: z.string().nullable()
+})
+
+/** `PUT /sessions/:id/visibility` (session-visibility.md §4.3). */
+export const SetSessionVisibilityBody = z.object({ visibility: SessionVisibilityEnum }).strict()
+export type SetSessionVisibilityBodyT = z.infer<typeof SetSessionVisibilityBody>
+
+export const SessionVisibilityDto = z.object({
+  id: z.string(),
+  visibility: SessionVisibilityEnum,
+  visibilityRev: z.number().int().nonnegative(),
+  /** Descendants a tightening cascade rewrote (§4.5); empty when widening. */
+  cascadedSessionIds: z.array(z.string()),
+  state: SessionVisibilityStateEnum
 })
 
 /** One message page returned by `GET /sessions/:id/messages` (proxied from the daemon).

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -17,9 +17,10 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf } from '../rbac.js'
-import { canView } from '../visibility.js'
+import { canView, canViewSession, identitySetOf } from '../visibility.js'
 import { Tag } from '../plugins/openapi.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
+import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
 import {
   SessionListPageDto,
   SessionFacetsDto,
@@ -28,7 +29,9 @@ import {
   SessionToolBodyQueryDto,
   SessionToolBodyChunkDto,
   ErrorDto,
-  IdParam
+  IdParam,
+  SetSessionVisibilityBody,
+  SessionVisibilityDto
 } from '../dto/index.js'
 
 const SessionFilterQueryDto = z.object({
@@ -96,6 +99,21 @@ function hookIdForSession(s: HookSessionRow): string | null {
 
 function sessionRelation(s: { id: string; agentId: string; title: string | null }) {
   return { id: s.id, agentId: s.agentId, title: s.title }
+}
+
+/**
+ * Who may re-classify a session (§4.3): its recorded owner (identity match) and
+ * org owners. Collaborators and viewers cannot re-classify other people's
+ * sessions — but note this is deliberately NOT the blanket `denyViewerWrite`
+ * guard used elsewhere: the grant follows OWNERSHIP, so a viewer-role member who
+ * owns a session keeps control of their own DM's visibility.
+ */
+function canChangeSessionVisibility(
+  s: { ownerIdentity: string | null },
+  ctx: { role: string; userId: string },
+  identitySet: ReadonlySet<string>
+): boolean {
+  return ctx.role === 'owner' || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
 }
 
 function hookMetadataForSession(metadata: Map<string, HookSessionMetadata>, session: HookSessionRow) {
@@ -253,7 +271,8 @@ function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMeta
     fastMode: s.fastMode ?? null,
     permissionMode: s.permissionMode ?? null,
     outputMode: s.outputMode ?? null,
-    daemonId: s.daemonId ?? null
+    daemonId: s.daemonId ?? null,
+    visibility: s.visibility
   }
 }
 
@@ -284,9 +303,20 @@ export function sessionRoutes(deps: HttpDeps) {
       return canView(agent, ctxOf(req)) ? agent : null
     }
 
+    // Session visibility (session-visibility.md §5) COMPOSES with the agent gate
+    // above: a session is visible iff its agent is visible AND the caller passes
+    // the session predicate. The repo arm and this in-app check must stay two
+    // spellings of one rule — both come from `canViewSession`.
+    const viewerOf = (req: FastifyRequest) => {
+      const ctx = ctxOf(req)
+      return { role: ctx.role, identitySet: [...identitySetOf(ctx)] }
+    }
+
     const getOrgViewableSession = async (req: FastifyRequest, sessionId: string) => {
       const session = await deps.repos.session.get(SessionId(sessionId))
       if (!session) return null
+      const ctx = ctxOf(req)
+      if (!canViewSession(session, ctx, identitySetOf(ctx))) return null
       const agent = await getOrgViewableAgent(req, session.agentId)
       return agent ? { session, agent } : null
     }
@@ -312,6 +342,7 @@ export function sessionRoutes(deps: HttpDeps) {
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, true)
         const index = await deps.repos.session.listFacets({
           agentIds: visibleAgentIds,
+          viewer: viewerOf(req),
           ...(req.query.agentId ? { agentId: AgentId(req.query.agentId) } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
@@ -368,6 +399,7 @@ export function sessionRoutes(deps: HttpDeps) {
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, false)
         const page = await deps.repos.session.listPage({
           agentIds: selectedAgentIds,
+          viewer: viewerOf(req),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
@@ -417,14 +449,18 @@ export function sessionRoutes(deps: HttpDeps) {
         // is indistinguishable from no parent; hidden children are omitted.
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((a) => a.id)
         const visibleAgentIdSet = new Set<string>(visibleAgentIds)
+        const ctx = ctxOf(req)
+        const identitySet = identitySetOf(ctx)
         const [parent, children, usage] = await Promise.all([
           s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
-          deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds),
+          deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds, viewerOf(req)),
           deps.repos.sessionUsage.get(s.agentId, s.id)
         ])
+        const parentVisible =
+          parent !== null && visibleAgentIdSet.has(parent.agentId) && canViewSession(parent, ctx, identitySet)
         return {
           id: s.id,
-          parentSession: parent && visibleAgentIdSet.has(parent.agentId) ? sessionRelation(parent) : null,
+          parentSession: parentVisible ? sessionRelation(parent) : null,
           childSessions: children.map(sessionRelation),
           agentId: s.agentId,
           launchId: s.launchId,
@@ -450,6 +486,11 @@ export function sessionRoutes(deps: HttpDeps) {
           outputMode: s.outputMode,
           daemonId: s.daemonId,
           activityState: s.activityState,
+          visibility: s.visibility,
+          // The §5.1 cutover state: CP read gates apply at commit, but the memory
+          // boundary only takes effect once every affected daemon has acked.
+          visibilityState: await visibilityStateOf(deps.visibilityPush, deps.repos, [s.id]),
+          canChangeVisibility: canChangeSessionVisibility(s, ctx, identitySet),
           startedAt: s.startedAt.toISOString(),
           endedAt: s.endedAt ? s.endedAt.toISOString() : null
         }
@@ -562,6 +603,54 @@ export function sessionRoutes(deps: HttpDeps) {
               .send({ error: 'Service Unavailable', statusCode: 503, message: 'owning daemon is offline' })
           }
           throw err
+        }
+      }
+    )
+
+    // §4.3 reclassification — the escape hatch in both directions: publish a
+    // useful DM transcript to the org, or pull a channel/group-DM session
+    // private. Tightening cascades to descendants and stops future memory
+    // capture once every affected daemon acks (§5.1); it does NOT scrub what the
+    // agent already distilled while the session was org-visible.
+    r.put(
+      '/sessions/:id/visibility',
+      {
+        schema: {
+          tags: [Tag.Sessions],
+          summary: 'Set session visibility',
+          description:
+            'Reclassifies a session as private or org-visible. Allowed for the session owner and org owners. Tightening cascades to descendant sessions and stops future agent-memory capture once the owning daemons acknowledge; memory already distilled is not retracted.',
+          operationId: 'setSessionVisibility',
+          params: IdParam,
+          body: SetSessionVisibilityBody,
+          response: { 200: SessionVisibilityDto, 403: ErrorDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const owned = await getOrgViewableSession(req, req.params.id)
+        if (!owned) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'session not found' })
+        }
+        const ctx = ctxOf(req)
+        if (!canChangeSessionVisibility(owned.session, ctx, identitySetOf(ctx))) {
+          return reply
+            .code(403)
+            .send({ error: 'Forbidden', statusCode: 403, message: 'not allowed to change this session visibility' })
+        }
+        const { affected } = await deps.repos.session.setVisibility(SessionId(req.params.id), req.body.visibility)
+        // Read gates apply at commit; the daemons learn asynchronously.
+        if (affected.length > 0) void deps.visibilityPush?.notifySessions(affected)
+        const current = affected.find((s) => s.id === owned.session.id) ?? owned.session
+        return {
+          id: current.id,
+          visibility: current.visibility,
+          visibilityRev: current.visibilityRev,
+          cascadedSessionIds: affected.filter((s) => s.id !== current.id).map((s) => s.id),
+          state: await visibilityStateOf(
+            deps.visibilityPush,
+            deps.repos,
+            affected.length > 0 ? affected.map((s) => s.id) : [current.id]
+          )
         }
       }
     )

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -637,7 +637,19 @@ export function sessionRoutes(deps: HttpDeps) {
             .code(403)
             .send({ error: 'Forbidden', statusCode: 403, message: 'not allowed to change this session visibility' })
         }
-        const { affected } = await deps.repos.session.setVisibility(SessionId(req.params.id), req.body.visibility)
+        // The check above read an unlocked row. Re-run it inside the write's
+        // transaction: an ancestor cascade committing in between can re-own this
+        // session, and the former owner must not still be able to widen it.
+        const { affected, forbidden } = await deps.repos.session.setVisibility(
+          SessionId(req.params.id),
+          req.body.visibility,
+          (row) => canChangeSessionVisibility(row, ctx, identitySetOf(ctx))
+        )
+        if (forbidden) {
+          return reply
+            .code(403)
+            .send({ error: 'Forbidden', statusCode: 403, message: 'not allowed to change this session visibility' })
+        }
         // Read gates apply at commit; the daemons learn asynchronously.
         if (affected.length > 0) void deps.visibilityPush?.notifySessions(affected)
         const current = affected.find((s) => s.id === owned.session.id) ?? owned.session

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -13,8 +13,15 @@ import type { HttpDeps } from '../deps.js'
 import type { SessionEventEnvelope } from '../../events/sink.js'
 import { Tag } from '../plugins/openapi.js'
 import { ctxOf } from '../rbac.js'
-import { canView, type Shareable, type ViewCtx } from '../visibility.js'
-import { AgentId, DaemonId, type OrgId } from '../../domain/ids.js'
+import {
+  canView,
+  canViewSession,
+  identitySetOf,
+  type SessionViewable,
+  type Shareable,
+  type ViewCtx
+} from '../visibility.js'
+import { AgentId, DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
 
 const KEEPALIVE_MS = 25_000
 
@@ -22,6 +29,23 @@ export function canStreamAgent(agent: (Shareable & { orgId: OrgId }) | null, org
   // `canView` assumes its caller already selected the current tenant. This org
   // check applies even to owners: their governance override is path-org scoped.
   return !!agent && agent.orgId === orgId && canView(agent, ctx)
+}
+
+/**
+ * Session-level gate for the live feed (session-visibility.md §5). BOTH envelope
+ * variants are session-scoped and both must pass it: the milestone carries a
+ * content-derived `summary`, and the activity invalidation still exposes the
+ * session's existence, revision, and live activity.
+ *
+ * A row that cannot be read is dropped — an activity event whose milestone never
+ * committed has no visibility to check, so fail closed like the agent arm does.
+ */
+export function canStreamSession(
+  session: SessionViewable | null,
+  ctx: ViewCtx,
+  identitySet: ReadonlySet<string>
+): boolean {
+  return !!session && canViewSession(session, ctx, identitySet)
 }
 
 function writeEvent(reply: FastifyReply, envelope: SessionEventEnvelope): void {
@@ -87,11 +111,23 @@ export function streamRoutes(deps: HttpDeps) {
           return ok
         }
 
+        // Session visibility is deliberately NOT memoized: a §4.3 tightening must
+        // hide the session from a live subscriber at commit, and a long-lived SSE
+        // connection holding a cached verdict would keep leaking it. Sessions are
+        // per-event unique anyway, so a cache would rarely hit.
+        const identitySet = identitySetOf(ctx)
+        const canSeeSession = async (sessionId: string): Promise<boolean> => {
+          const session = await deps.repos.session.get(SessionId(sessionId)).catch(() => null)
+          return canStreamSession(session, ctx, identitySet)
+        }
+
         const unsubscribe = deps.events.subscribe((envelope) => {
           void (async () => {
             if (!(await inOrg(envelope.daemonId))) return
             const agentId = envelope.activity?.agentId ?? envelope.event?.agentId
             if (!agentId || !(await canSeeAgent(agentId))) return
+            const sessionId = envelope.activity?.sessionId ?? envelope.event?.sessionId
+            if (!sessionId || !(await canSeeSession(sessionId))) return
             writeEvent(reply, envelope)
           })()
         })

--- a/packages/control-plane/src/http/visibility.test.ts
+++ b/packages/control-plane/src/http/visibility.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { canView, canEdit, canManageSharing, visibilityWhere, type Shareable, type ViewCtx } from './visibility.js'
+import {
+  canView,
+  canEdit,
+  canManageSharing,
+  canViewSession,
+  identitySetOf,
+  visibilityWhere,
+  type SessionViewable,
+  type Shareable,
+  type ViewCtx
+} from './visibility.js'
 import type { OrgMemberRole } from '../persistence/ports.js'
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -83,6 +93,65 @@ describe('canManageSharing (relaxed to === canEdit, §13.3)', () => {
     expect(canManageSharing(restricted, ctx(GRANTEE, 'collaborator'))).toBe(true)
     expect(canManageSharing(restricted, ctx(GRANTEE, 'viewer'))).toBe(false)
     expect(canManageSharing(orgVisible, ctx(OTHER, 'collaborator'))).toBe(true)
+  })
+})
+
+describe('identitySetOf', () => {
+  it('is exactly the console identity today (identity linking grows it later)', () => {
+    expect(identitySetOf(ctx(OTHER, 'collaborator'))).toEqual(new Set([`user:${OTHER}`]))
+  })
+})
+
+describe('canViewSession (session-visibility.md §5)', () => {
+  const owned = (visibility: SessionViewable['visibility'], ownerIdentity: string | null): SessionViewable => ({
+    visibility,
+    ownerIdentity
+  })
+  const idsOf = (c: ViewCtx) => identitySetOf(c)
+
+  it('org session is visible to every role, owner-match or not', () => {
+    const s = owned('org', `user:${CREATOR}`)
+    expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(true)
+    expect(canViewSession(s, ctx(OTHER, 'collaborator'), idsOf(ctx(OTHER, 'collaborator')))).toBe(true)
+    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(true)
+  })
+
+  it('org session with no recorded owner (automation) stays org-visible', () => {
+    expect(canViewSession(owned('org', null), ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(true)
+  })
+
+  it('private session is visible to its identity-matched owner, any role', () => {
+    const s = owned('private', `user:${CREATOR}`)
+    expect(canViewSession(s, ctx(CREATOR, 'collaborator'), idsOf(ctx(CREATOR, 'collaborator')))).toBe(true)
+    expect(canViewSession(s, ctx(CREATOR, 'viewer'), idsOf(ctx(CREATOR, 'viewer')))).toBe(true)
+  })
+
+  it('private session hides from a non-matching non-owner', () => {
+    const s = owned('private', `user:${CREATOR}`)
+    expect(canViewSession(s, ctx(OTHER, 'collaborator'), idsOf(ctx(OTHER, 'collaborator')))).toBe(false)
+    expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(false)
+  })
+
+  it('private session is visible to any org owner — governance override', () => {
+    const s = owned('private', `user:${CREATOR}`)
+    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(true)
+  })
+
+  it('matches a linked platform identity once the identity set carries it', () => {
+    const s = owned('private', 'slack:T024BE7LD:U0123ABCD')
+    const c = ctx(OTHER, 'collaborator')
+    // Pre-linking: the platform owner is an owner-orphan for this viewer.
+    expect(canViewSession(s, c, idsOf(c))).toBe(false)
+    // Post-linking (§7): the set grows; the stored ownerIdentity already matches.
+    const linked = new Set([...idsOf(c), 'slack:T024BE7LD:U0123ABCD'])
+    expect(canViewSession(s, c, linked)).toBe(true)
+  })
+
+  it('an owner-orphan private session (ownerIdentity null) is owner-role-only — fail closed', () => {
+    const s = owned('private', null)
+    expect(canViewSession(s, ctx(CREATOR, 'collaborator'), idsOf(ctx(CREATOR, 'collaborator')))).toBe(false)
+    expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(false)
+    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(true)
   })
 })
 

--- a/packages/control-plane/src/http/visibility.ts
+++ b/packages/control-plane/src/http/visibility.ts
@@ -15,7 +15,7 @@
  * everything). `canManageSharing` is relaxed to `=== canEdit` (decision §13.3):
  * anyone who can edit a resource can also change who it is shared with.
  */
-import type { Shareable, ViewCtx } from '../persistence/ports.js'
+import type { SessionVisibility, Shareable, ViewCtx } from '../persistence/ports.js'
 
 // Re-export the shared visibility primitives so route code has a single import
 // site (`http/visibility.js`) while the repo layer imports them from `ports.js`.
@@ -43,3 +43,34 @@ export function canEdit(r: Shareable, c: ViewCtx): boolean {
  *  `sharedWith`)? Relaxed (§13.3) to exactly the content-edit gate: if you can
  *  edit it, you can re-share it. Only viewers (read-only) are excluded. */
 export const canManageSharing = canEdit
+
+// ── session visibility (docs/designs/session-visibility.md §5) ──────────────
+// Sessions are deliberately NOT `Shareable`: their owner is a namespaced
+// identity string (`user:<id>` | `<platform>:<scope>:<uid>`, §2) matched
+// against the viewer's identity set — not a creator FK — and they carry no
+// `sharedWith`. The repo WHERE arm (session.repo.ts `pageWhereSql` viewer
+// predicate) must stay the SQL mirror of `canViewSession`.
+
+/** The visibility-bearing fields of a session row the predicate needs. */
+export interface SessionViewable {
+  visibility: SessionVisibility
+  ownerIdentity: string | null
+}
+
+/** The viewer's identity set (§2): today just their console identity; identity
+ *  linking (§7) will add verified platform identities, lighting owner-orphan DM
+ *  sessions up retroactively — the stored `ownerIdentity` is already correct. */
+export function identitySetOf(ctx: ViewCtx): Set<string> {
+  return new Set([`user:${ctx.userId}`])
+}
+
+/** Can this caller SEE the session? Any one arm suffices. An unowned private
+ *  session (`ownerIdentity` null — an owner-orphan) is visible to org owners
+ *  only: fail closed, never widen because ownership could not be resolved. */
+export function canViewSession(s: SessionViewable, ctx: ViewCtx, identitySet: ReadonlySet<string>): boolean {
+  return (
+    ctx.role === 'owner' || // governance override — owners see everything
+    s.visibility === 'org' || // default: visible to whoever can view the agent
+    (s.ownerIdentity != null && identitySet.has(s.ownerIdentity)) // private: owner match
+  )
+}

--- a/packages/control-plane/src/orchestrator/outbound.ts
+++ b/packages/control-plane/src/orchestrator/outbound.ts
@@ -91,7 +91,9 @@ import type {
   CollabRoutesSnapshot,
   AgentPermissionRequestList,
   AgentPermissionRequestPage,
-  AgentPermissionDecision
+  AgentPermissionDecision,
+  SessionVisibilityPush,
+  SessionVisibilityOk
 } from '@agentconnect.md/protocol'
 import type { LaunchRepo } from '../persistence/ports.js'
 import { ConnectionClosed, type ConnectionRegistry, type DaemonConnState } from '../ws/registry.js'
@@ -358,6 +360,27 @@ export class ControlSender {
   async memoryConnectionRemove(daemonId: string, connectionId: string): Promise<void> {
     const c = this.must(daemonId)
     c.conn.send('memoryconnection/remove', { connectionId }, { epoch: c.sessionEpoch })
+  }
+
+  /**
+   * Push one session's effective capture gate (session-visibility.md §5.1).
+   *
+   * A single privacy bit + its revision — control signaling, never content. The
+   * revision (not the epoch) is what orders competing pushes, so retransmits and
+   * out-of-order delivery are safe: the daemon acks a stale revision
+   * `superseded` rather than erroring, and the register-time snapshot converges
+   * anything this connection never delivered.
+   */
+  async sessionVisibility(daemonId: string, p: SessionVisibilityPush): Promise<SessionVisibilityOk> {
+    const c = this.must(daemonId)
+    return c.conn.request<SessionVisibilityOk>('session/visibility', p, { epoch: c.sessionEpoch })
+  }
+
+  /** Replay the whole gate set to a (re)connecting daemon (§5.1) — a snapshot,
+   *  not a diff, so a change made while it was offline cannot stay unapplied. */
+  async sessionVisibilitySnapshot(daemonId: string, entries: SessionVisibilityPush[]): Promise<Ack> {
+    const c = this.must(daemonId)
+    return c.conn.request<Ack>('session/visibility/snapshot', { entries }, { epoch: c.sessionEpoch })
   }
 
   /** Sink a cron def to a running daemon (live CRUD, epoch-fenced REQ → ack, §5.4). */

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -5,7 +5,10 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { SESSION_VISIBILITY_FEATURE } from '@agentconnect.md/protocol'
-import { SessionVisibilityPushService } from './visibilityPush.js'
+import { SessionVisibilityPushService, visibilityStateOf } from './visibilityPush.js'
+
+/** One past the cutover-state read cap (SUBTREE_LIMIT = 500). */
+const SUBTREE_OVERFLOW = 501
 import { NoConnection } from './outbound.js'
 import type { SessionMetaRecord } from '../persistence/ports.js'
 
@@ -35,7 +38,16 @@ function connReg(opts: { connected?: boolean; feature?: boolean } = {}) {
   } as never
 }
 
-function deps(over: { connReg?: never; sessionVisibility?: unknown; daemonId?: string | null } = {}) {
+function deps(
+  over: {
+    connReg?: never
+    sessionVisibility?: unknown
+    daemonId?: string | null
+    /** Successive snapshot pages the repo hands back, newest call first. */
+    snapshotPages?: Array<Array<{ sessionId: string; visibility: 'private' | 'org'; visibilityRev: number }>>
+    unackedAfter?: number[]
+  } = {}
+) {
   const recordVisibilityAck = vi.fn(async () => {})
   const sessionVisibility =
     over.sessionVisibility ??
@@ -45,19 +57,27 @@ function deps(over: { connReg?: never; sessionVisibility?: unknown; daemonId?: s
       status: 'applied' as const
     }))
   const daemonId = over.daemonId === undefined ? DAEMON : over.daemonId
+  const pages = [...(over.snapshotPages ?? [[]])]
+  const unacked = [...(over.unackedAfter ?? [0])]
+  const visibilitySnapshotForDaemon = vi.fn(async () => pages.shift() ?? [])
+  const countUnackedVisibility = vi.fn(async () => unacked.shift() ?? 0)
+  const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
   return {
     recordVisibilityAck,
     sessionVisibility,
+    visibilitySnapshotForDaemon,
+    sessionVisibilitySnapshot,
     push: new SessionVisibilityPushService({
       repos: {
         session: {
           recordVisibilityAck,
-          visibilitySnapshotForDaemon: vi.fn(async () => []),
+          visibilitySnapshotForDaemon,
+          countUnackedVisibility,
           get: vi.fn(async () => null)
         } as never,
         agent: { get: vi.fn(async () => (daemonId ? { id: AGENT, daemonId } : { id: AGENT })) } as never
       },
-      control: { sessionVisibility, sessionVisibilitySnapshot: vi.fn(async () => ({ ok: true })) } as never,
+      control: { sessionVisibility, sessionVisibilitySnapshot } as never,
       connReg: over.connReg ?? connReg(),
       log: { warn: vi.fn() }
     })
@@ -115,6 +135,82 @@ describe('notifySessions', () => {
     const { push, recordVisibilityAck } = deps({ sessionVisibility })
     await push.notifySessions([session({ id: 'acp-bad' }), session({ id: 'acp-good' })])
     expect(recordVisibilityAck).toHaveBeenCalledWith('acp-good', 2)
+  })
+})
+
+describe('replayTo — register-time convergence', () => {
+  const page = (n: number, from = 0) =>
+    Array.from({ length: n }, (_, i) => ({
+      sessionId: `acp-${from + i}`,
+      visibility: 'private' as const,
+      visibilityRev: 1
+    }))
+
+  it('keeps paging until nothing is left unacknowledged', async () => {
+    // A full page means there may be more behind it; ordering alone would ack
+    // the first page and leave the rest carrying a stale gate until some later
+    // register — which for a daemon that stays connected may never come.
+    const d = deps({ snapshotPages: [page(500), page(2, 500), []], unackedAfter: [2, 0] })
+    await d.push.replayTo(DAEMON as never)
+    expect(d.sessionVisibilitySnapshot).toHaveBeenCalledTimes(2)
+    expect(d.recordVisibilityAck).toHaveBeenCalledTimes(502)
+  })
+
+  it('stops after a partial page — nothing is behind it', async () => {
+    const d = deps({ snapshotPages: [page(3)] })
+    await d.push.replayTo(DAEMON as never)
+    expect(d.sessionVisibilitySnapshot).toHaveBeenCalledTimes(1)
+    expect(d.visibilitySnapshotForDaemon).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops paging when the daemon drops mid-replay — the next register retries', async () => {
+    const d = deps({ snapshotPages: [page(500), page(500, 500)], unackedAfter: [500, 0] })
+    d.sessionVisibilitySnapshot.mockImplementationOnce(async () => {
+      throw new NoConnection(DAEMON)
+    })
+    await d.push.replayTo(DAEMON as never)
+    expect(d.sessionVisibilitySnapshot).toHaveBeenCalledTimes(1)
+    expect(d.recordVisibilityAck).not.toHaveBeenCalled()
+  })
+
+  it('sends nothing to a daemon that does not advertise the feature', async () => {
+    const d = deps({ snapshotPages: [page(3)], connReg: connReg({ feature: false }) as never })
+    await d.push.replayTo(DAEMON as never)
+    expect(d.visibilitySnapshotForDaemon).not.toHaveBeenCalled()
+  })
+})
+
+describe('visibilityStateOf — subtree scope', () => {
+  const subtreeDeps = (rows: SessionMetaRecord[]) => {
+    const d = deps()
+    return {
+      push: d.push,
+      repos: { session: { visibilitySubtree: vi.fn(async (_id: string, limit: number) => rows.slice(0, limit)) } }
+    }
+  }
+
+  it('covers descendants, so an acked root with a behind child is still pending', async () => {
+    const { push, repos } = subtreeDeps([
+      session({ id: 'root', visibilityRev: 1, visibilityAckedRev: 1 }),
+      session({ id: 'child', visibilityRev: 1, visibilityAckedRev: -1 })
+    ])
+    expect(await visibilityStateOf(push, repos as never, ['root' as never])).toBe('pending')
+  })
+
+  it('reports pending when the subtree is larger than one read evaluates', async () => {
+    // All 501 rows are fully acked: the ONLY reason to report pending is that we
+    // could not see the whole subtree, and claiming a verified cutover from a
+    // partial read would be a false promise.
+    const rows = Array.from({ length: SUBTREE_OVERFLOW }, (_, i) =>
+      session({ id: `s-${i}`, visibilityRev: 1, visibilityAckedRev: 1 })
+    )
+    const { push, repos } = subtreeDeps(rows)
+    expect(await visibilityStateOf(push, repos as never, ['root' as never])).toBe('pending')
+  })
+
+  it('reports applied for a fully acked subtree within the cap', async () => {
+    const { push, repos } = subtreeDeps([session({ id: 'root', visibilityRev: 1, visibilityAckedRev: 1 })])
+    expect(await visibilityStateOf(push, repos as never, ['root' as never])).toBe('applied')
   })
 })
 

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -135,13 +135,20 @@ describe('isApplied — the §4.3 cutover state', () => {
     expect(await push.isApplied([session({ visibilityRev: 0, visibilityAckedRev: 0 })])).toBe(true)
   })
 
-  it('is vacuously applied when nothing can ever ack (unplaced / offline / pre-upgrade)', async () => {
+  it('is vacuously applied ONLY for an unplaced agent — nothing runs it, nothing captures', async () => {
+    const unplaced = deps({ daemonId: null })
+    expect(await unplaced.push.isApplied([session({ visibilityRev: 1, visibilityAckedRev: -1 })])).toBe(true)
+  })
+
+  it('stays pending for a placed daemon that is merely offline or pre-upgrade', async () => {
+    // A daemon keeps serving established sessions while the CP is down, so its
+    // gate may genuinely still be `org`. Claiming `applied` would promise a
+    // memory boundary that is not in force.
     for (const d of [
-      deps({ daemonId: null }),
       deps({ connReg: connReg({ connected: false }) as never }),
       deps({ connReg: connReg({ feature: false }) as never })
     ]) {
-      expect(await d.push.isApplied([session({ visibilityRev: 1, visibilityAckedRev: -1 })])).toBe(true)
+      expect(await d.push.isApplied([session({ visibilityRev: 1, visibilityAckedRev: -1 })])).toBe(false)
     }
   })
 

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -285,6 +285,103 @@ describe('replayTo — register-time convergence', () => {
     }
   })
 
+  it('resumes after a retryable send failure — the daemon is still connected', async () => {
+    vi.useFakeTimers()
+    try {
+      // A correlator timeout surfaces as an ordinary rejection, NOT NoConnection:
+      // the daemon is still there, so no register is coming to converge the tail.
+      const sessionVisibilitySnapshot = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('INTERNAL: ack timeout'))
+        .mockResolvedValue({ ok: true })
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck: vi.fn(async () => {}),
+            visibilitySnapshotForDaemon: vi.fn(async () => page(2)),
+            countUnackedVisibility: vi.fn(async () => 0),
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
+        connReg: connReg(),
+        log: { warn: vi.fn() }
+      })
+
+      await push.replayTo(DAEMON as never)
+      await vi.advanceTimersByTimeAsync(30_000)
+      await push.settle()
+      expect(sessionVisibilitySnapshot).toHaveBeenCalledTimes(2) // it came back
+      push.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resumes when recording the acks fails, so the CP does not lose the tail', async () => {
+    vi.useFakeTimers()
+    try {
+      const recordVisibilityAck = vi.fn().mockRejectedValueOnce(new Error('db down')).mockResolvedValue(undefined)
+      const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck,
+            visibilitySnapshotForDaemon: vi.fn(async () => page(2)),
+            countUnackedVisibility: vi.fn(async () => 0),
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
+        connReg: connReg(),
+        log: { warn: vi.fn() }
+      })
+
+      await push.replayTo(DAEMON as never)
+      await vi.advanceTimersByTimeAsync(30_000)
+      await push.settle()
+      // Re-sent and recorded: the daemon answers `superseded`, nothing double-applies.
+      expect(sessionVisibilitySnapshot).toHaveBeenCalledTimes(2)
+      push.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does NOT arm a timer when the daemon simply disconnected — register converges', async () => {
+    vi.useFakeTimers()
+    try {
+      const sessionVisibilitySnapshot = vi.fn(async () => {
+        throw new NoConnection(DAEMON)
+      })
+      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck: vi.fn(async () => {}),
+            visibilitySnapshotForDaemon,
+            countUnackedVisibility: vi.fn(async () => 10),
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
+        connReg: connReg(),
+        log: { warn: vi.fn() }
+      })
+
+      await push.replayTo(DAEMON as never)
+      await vi.advanceTimersByTimeAsync(60_000)
+      await push.settle()
+      expect(visibilitySnapshotForDaemon).toHaveBeenCalledTimes(1)
+      push.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends nothing to a daemon that does not advertise the feature', async () => {
     const d = deps({ snapshotPages: [page(3)], connReg: connReg({ feature: false }) as never })
     await d.push.replayTo(DAEMON as never)

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -173,6 +173,49 @@ describe('replayTo — register-time convergence', () => {
     expect(d.recordVisibilityAck).not.toHaveBeenCalled()
   })
 
+  it('pauses and resumes instead of abandoning a set it knows is stale', async () => {
+    vi.useFakeTimers()
+    try {
+      // Pages stay full and the unacked count never drops: changes are landing
+      // as fast as we ack. A round cap would walk away from gates we KNOW are
+      // stale; the loop must yield and come back instead.
+      const warn = vi.fn()
+      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
+      const countUnackedVisibility = vi.fn(async () => 5_000)
+      const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck: vi.fn(async () => {}),
+            visibilitySnapshotForDaemon,
+            countUnackedVisibility,
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
+        connReg: connReg(),
+        log: { warn }
+      })
+
+      await push.replayTo(DAEMON as never)
+      // It stopped (no spin) …
+      expect(sessionVisibilitySnapshot).toHaveBeenCalledTimes(2)
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({ unacked: 5_000 }),
+        expect.stringContaining('resuming')
+      )
+
+      // … and it comes back on its own, rather than waiting for a register that
+      // a still-connected daemon may never perform again.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(sessionVisibilitySnapshot.mock.calls.length).toBeGreaterThan(2)
+      push.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends nothing to a daemon that does not advertise the feature', async () => {
     const d = deps({ snapshotPages: [page(3)], connReg: connReg({ feature: false }) as never })
     await d.push.replayTo(DAEMON as never)

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -216,6 +216,75 @@ describe('replayTo — register-time convergence', () => {
     }
   })
 
+  it('resumes after a repo failure instead of abandoning the stale tail', async () => {
+    vi.useFakeTimers()
+    try {
+      const warn = vi.fn()
+      // A repo read rejects OUTSIDE sendSnapshotChunk's catch. Left unhandled it
+      // would both surface as an unhandled rejection and strand the gates we
+      // already know are stale.
+      const visibilitySnapshotForDaemon = vi.fn().mockRejectedValueOnce(new Error('db down')).mockResolvedValue(page(2))
+      const sessionVisibilitySnapshot = vi.fn(async () => ({ ok: true }))
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck: vi.fn(async () => {}),
+            visibilitySnapshotForDaemon,
+            countUnackedVisibility: vi.fn(async () => 0),
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot } as never,
+        connReg: connReg(),
+        log: { warn }
+      })
+
+      await expect(push.replayTo(DAEMON as never)).resolves.toBeUndefined()
+      expect(sessionVisibilitySnapshot).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      await push.settle()
+      expect(sessionVisibilitySnapshot).toHaveBeenCalledTimes(1) // the tail went out
+      push.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops scheduling once shut down, and settles a resume that already fired', async () => {
+    vi.useFakeTimers()
+    try {
+      const visibilitySnapshotForDaemon = vi.fn(async () => page(500))
+      const push = new SessionVisibilityPushService({
+        repos: {
+          session: {
+            recordVisibilityAck: vi.fn(async () => {}),
+            visibilitySnapshotForDaemon,
+            countUnackedVisibility: vi.fn(async () => 5_000),
+            get: vi.fn(async () => null)
+          } as never,
+          agent: { get: vi.fn(async () => ({ id: AGENT, daemonId: DAEMON })) } as never
+        },
+        control: { sessionVisibility: vi.fn(), sessionVisibilitySnapshot: vi.fn(async () => ({ ok: true })) } as never,
+        connReg: connReg(),
+        log: { warn: vi.fn() }
+      })
+
+      await push.replayTo(DAEMON as never) // stalls, arms a resume
+      push.stop()
+      const callsAtShutdown = visibilitySnapshotForDaemon.mock.calls.length
+      await vi.advanceTimersByTimeAsync(60_000)
+      await push.settle()
+      // Nothing re-armed and nothing touched the database after shutdown.
+      expect(visibilitySnapshotForDaemon.mock.calls.length).toBe(callsAtShutdown)
+      await expect(push.replayTo(DAEMON as never)).resolves.toBeUndefined()
+      expect(visibilitySnapshotForDaemon.mock.calls.length).toBe(callsAtShutdown)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends nothing to a daemon that does not advertise the feature', async () => {
     const d = deps({ snapshotPages: [page(3)], connReg: connReg({ feature: false }) as never })
     await d.push.replayTo(DAEMON as never)

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The §5.1 gate-push service: who gets pushed to, what an ack records, and when
+ * the §4.3 endpoint may call a tighten `applied`. Pure unit test — the registry,
+ * the sender, and the repos are all fakes, so no Docker and no socket.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { SESSION_VISIBILITY_FEATURE } from '@agentconnect.md/protocol'
+import { SessionVisibilityPushService } from './visibilityPush.js'
+import { NoConnection } from './outbound.js'
+import type { SessionMetaRecord } from '../persistence/ports.js'
+
+const DAEMON = 'd0d0d0d0-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+function session(over: Partial<SessionMetaRecord> = {}): SessionMetaRecord {
+  return {
+    id: 'acp-1',
+    agentId: AGENT,
+    visibility: 'private',
+    ownerIdentity: 'user:u1',
+    visibilityRev: 2,
+    visibilityAckedRev: -1,
+    ...over
+  } as SessionMetaRecord
+}
+
+/** A registry holding one daemon, optionally advertising the feature. */
+function connReg(opts: { connected?: boolean; feature?: boolean } = {}) {
+  const { connected = true, feature = true } = opts
+  return {
+    get: (id: string) =>
+      connected && id === DAEMON
+        ? { capabilities: { features: feature ? [SESSION_VISIBILITY_FEATURE] : [] } }
+        : undefined
+  } as never
+}
+
+function deps(over: { connReg?: never; sessionVisibility?: unknown; daemonId?: string | null } = {}) {
+  const recordVisibilityAck = vi.fn(async () => {})
+  const sessionVisibility =
+    over.sessionVisibility ??
+    vi.fn(async (_d: string, p: { sessionId: string; visibilityRev: number }) => ({
+      sessionId: p.sessionId,
+      visibilityRev: p.visibilityRev,
+      status: 'applied' as const
+    }))
+  const daemonId = over.daemonId === undefined ? DAEMON : over.daemonId
+  return {
+    recordVisibilityAck,
+    sessionVisibility,
+    push: new SessionVisibilityPushService({
+      repos: {
+        session: {
+          recordVisibilityAck,
+          visibilitySnapshotForDaemon: vi.fn(async () => []),
+          get: vi.fn(async () => null)
+        } as never,
+        agent: { get: vi.fn(async () => (daemonId ? { id: AGENT, daemonId } : { id: AGENT })) } as never
+      },
+      control: { sessionVisibility, sessionVisibilitySnapshot: vi.fn(async () => ({ ok: true })) } as never,
+      connReg: over.connReg ?? connReg(),
+      log: { warn: vi.fn() }
+    })
+  }
+}
+
+describe('notifySessions', () => {
+  it('pushes the current gate state and records the daemon’s ack', async () => {
+    const { push, sessionVisibility, recordVisibilityAck } = deps()
+    await push.notifySessions([session()])
+
+    expect(sessionVisibility).toHaveBeenCalledWith(DAEMON, {
+      sessionId: 'acp-1',
+      visibility: 'private',
+      visibilityRev: 2
+    })
+    expect(recordVisibilityAck).toHaveBeenCalledWith('acp-1', 2)
+  })
+
+  it('records the ack for a `superseded` reply too — the daemon already holds it', async () => {
+    const sessionVisibility = vi.fn(async () => ({ sessionId: 'acp-1', visibilityRev: 2, status: 'superseded' }))
+    const { push, recordVisibilityAck } = deps({ sessionVisibility })
+    await push.notifySessions([session()])
+    expect(recordVisibilityAck).toHaveBeenCalledWith('acp-1', 2)
+  })
+
+  it('skips an unplaced agent, an offline daemon, and one too old to know the frame', async () => {
+    const unplaced = deps({ daemonId: null })
+    await unplaced.push.notifySessions([session()])
+    expect(unplaced.sessionVisibility).not.toHaveBeenCalled()
+
+    const offline = deps({ connReg: connReg({ connected: false }) as never })
+    await offline.push.notifySessions([session()])
+    expect(offline.sessionVisibility).not.toHaveBeenCalled()
+
+    const old = deps({ connReg: connReg({ feature: false }) as never })
+    await old.push.notifySessions([session()])
+    expect(old.sessionVisibility).not.toHaveBeenCalled()
+  })
+
+  it('swallows a mid-flight disconnect — the register snapshot carries it', async () => {
+    const sessionVisibility = vi.fn(async () => {
+      throw new NoConnection(DAEMON)
+    })
+    const { push, recordVisibilityAck } = deps({ sessionVisibility })
+    await expect(push.notifySessions([session()])).resolves.toBeUndefined()
+    expect(recordVisibilityAck).not.toHaveBeenCalled()
+  })
+
+  it('keeps going after one session fails, so a cascade is not truncated', async () => {
+    const sessionVisibility = vi.fn(async (_d: string, p: { sessionId: string; visibilityRev: number }) => {
+      if (p.sessionId === 'acp-bad') throw new Error('boom')
+      return { sessionId: p.sessionId, visibilityRev: p.visibilityRev, status: 'applied' as const }
+    })
+    const { push, recordVisibilityAck } = deps({ sessionVisibility })
+    await push.notifySessions([session({ id: 'acp-bad' }), session({ id: 'acp-good' })])
+    expect(recordVisibilityAck).toHaveBeenCalledWith('acp-good', 2)
+  })
+})
+
+describe('isApplied — the §4.3 cutover state', () => {
+  it('is pending while a reachable daemon has not acked the current revision', async () => {
+    const { push } = deps()
+    expect(await push.isApplied([session({ visibilityRev: 3, visibilityAckedRev: 2 })])).toBe(false)
+  })
+
+  it('is applied once the ack watermark reaches the revision', async () => {
+    const { push } = deps()
+    expect(await push.isApplied([session({ visibilityRev: 3, visibilityAckedRev: 3 })])).toBe(true)
+  })
+
+  it('treats revision 0 as needing an ack — -1 means never acknowledged', async () => {
+    const { push } = deps()
+    expect(await push.isApplied([session({ visibilityRev: 0, visibilityAckedRev: -1 })])).toBe(false)
+    expect(await push.isApplied([session({ visibilityRev: 0, visibilityAckedRev: 0 })])).toBe(true)
+  })
+
+  it('is vacuously applied when nothing can ever ack (unplaced / offline / pre-upgrade)', async () => {
+    for (const d of [
+      deps({ daemonId: null }),
+      deps({ connReg: connReg({ connected: false }) as never }),
+      deps({ connReg: connReg({ feature: false }) as never })
+    ]) {
+      expect(await d.push.isApplied([session({ visibilityRev: 1, visibilityAckedRev: -1 })])).toBe(true)
+    }
+  })
+
+  it('is pending if ANY affected session of a cascade is still unacked', async () => {
+    const { push } = deps()
+    const acked = session({ id: 'acp-1', visibilityRev: 1, visibilityAckedRev: 1 })
+    const unacked = session({ id: 'acp-2', visibilityRev: 1, visibilityAckedRev: 0 })
+    expect(await push.isApplied([acked, unacked])).toBe(false)
+  })
+})

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -1,0 +1,157 @@
+/**
+ * Session-visibility gate push (docs/designs/session-visibility.md §5.1).
+ *
+ * Console read gates alone do not contain private content: managed memory is
+ * agent-scoped and shared across users, so a private turn distilled into agent
+ * memory would resurface to anyone who can view the agent. The daemon therefore
+ * runs a per-session capture gate, and the CP — the authority on effective
+ * visibility (§4.3 changes, §4.5 settlements and cascades) — pushes the single
+ * privacy bit that drives it. This is control signaling, not content.
+ *
+ * Durability is the whole design problem. The WS correlator retransmits only
+ * within one live connection and rejects everything on socket close, so a live
+ * push alone would leave a change unapplied across a reconnect. Two mechanisms
+ * close that:
+ *
+ *  - **`visibilityRev`** — a durable per-session counter bumped in the same
+ *    transaction as every visibility change. It orders competing deliveries, so
+ *    at-least-once is safe: the daemon acks a stale revision `superseded`
+ *    instead of erroring, and `visibilityAckedRev` records what actually landed.
+ *  - **The register-time snapshot** (`replayTo`) — the full current gate set for
+ *    a (re)connecting daemon's sessions. This is load-bearing, not a nicety: it
+ *    is what makes a push lost to a dropped socket eventually converge.
+ *
+ * Both are best-effort at the moment of the call. A daemon that is offline,
+ * unplaced, or too old to know the frame simply does not ack — the §4.3 endpoint
+ * reports the tighten as `pending` until it does, and the daemon meanwhile fails
+ * closed (unknown gate state ⇒ capture excluded).
+ */
+import { SESSION_VISIBILITY_FEATURE, type SessionVisibilityPush } from '@agentconnect.md/protocol'
+import type { AgentRepo, SessionMetaRecord, SessionRepo } from '../persistence/ports.js'
+import { SessionId, type DaemonId } from '../domain/ids.js'
+import type { ConnectionRegistry } from '../ws/registry.js'
+import { NoConnection, type ControlSender } from './outbound.js'
+
+/** How many sessions one register-time snapshot covers, newest-active first.
+ *  Older rows converge to the daemon's fail-closed default (capture excluded),
+ *  which under-captures rather than leaking. */
+const SNAPSHOT_LIMIT = 2000
+/** Entries per snapshot frame. The schema caps at 1000; stay well under the
+ *  256 KiB frame ceiling. */
+const SNAPSHOT_CHUNK = 500
+
+export interface VisibilityPushDeps {
+  repos: { session: SessionRepo; agent: AgentRepo }
+  control: ControlSender
+  connReg: ConnectionRegistry
+  log?: { warn(obj: unknown, msg?: string): void }
+}
+
+function toPush(s: SessionMetaRecord): SessionVisibilityPush {
+  return { sessionId: s.id, visibility: s.visibility, visibilityRev: s.visibilityRev }
+}
+
+export class SessionVisibilityPushService {
+  constructor(private readonly deps: VisibilityPushDeps) {}
+
+  /**
+   * A daemon can only be pushed to if it is connected AND advertises the
+   * feature. An older daemon would fail to decode the frame and NAK
+   * `UNKNOWN_FRAME`, which the correlator surfaces as a rejection — feature
+   * gating keeps that off the §4.3 endpoint's pending/applied bookkeeping.
+   */
+  private supports(daemonId: string): boolean {
+    const c = this.deps.connReg.get(daemonId)
+    return c?.capabilities?.features?.includes(SESSION_VISIBILITY_FEATURE) ?? false
+  }
+
+  /**
+   * Push the current gate state for these sessions to whichever daemons run
+   * them, recording each ack. Descendants of a cascade legitimately live on
+   * different daemons, so placement is resolved per row — via the AGENT (1 agent
+   * : 1 machine), not `SessionMeta.daemonId`, which is provenance and may lag a
+   * move.
+   */
+  async notifySessions(sessions: SessionMetaRecord[]): Promise<void> {
+    const byAgent = new Map<string, string | null>()
+    for (const s of sessions) {
+      if (!byAgent.has(s.agentId)) {
+        const agent = await this.deps.repos.agent.get(s.agentId)
+        byAgent.set(s.agentId, agent?.daemonId ?? null)
+      }
+      const daemonId = byAgent.get(s.agentId)
+      if (!daemonId || !this.supports(daemonId)) continue
+      try {
+        const ok = await this.deps.control.sessionVisibility(daemonId, toPush(s))
+        await this.deps.repos.session.recordVisibilityAck(SessionId(ok.sessionId), ok.visibilityRev)
+      } catch (err) {
+        if (err instanceof NoConnection) continue // offline → the register snapshot carries it
+        this.deps.log?.warn(
+          { sessionId: s.id, daemonId, err: (err as Error).message },
+          'session visibility push failed'
+        )
+      }
+    }
+  }
+
+  /**
+   * Replay the whole gate set to a (re)connecting daemon. Idempotent by
+   * revision, so it runs on EVERY register: reconnect is convergence, not
+   * replay. Failure is swallowed — the next register tries again.
+   */
+  async replayTo(daemonId: DaemonId): Promise<void> {
+    if (!this.supports(daemonId)) return
+    const snapshot = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_LIMIT)
+    if (snapshot.length === 0) return
+    for (let i = 0; i < snapshot.length; i += SNAPSHOT_CHUNK) {
+      const chunk = snapshot.slice(i, i + SNAPSHOT_CHUNK)
+      try {
+        const ack = await this.deps.control.sessionVisibilitySnapshot(daemonId, chunk)
+        if (!ack.ok) {
+          this.deps.log?.warn({ daemonId, reason: ack.reason }, 'session visibility snapshot rejected')
+          return
+        }
+        for (const entry of chunk) {
+          await this.deps.repos.session.recordVisibilityAck(entry.sessionId, entry.visibilityRev)
+        }
+      } catch (err) {
+        if (err instanceof NoConnection) return
+        this.deps.log?.warn({ daemonId, err: (err as Error).message }, 'session visibility snapshot failed')
+        return
+      }
+    }
+  }
+
+  /**
+   * Has every affected daemon applied this change (§5.1)? The memory boundary
+   * takes effect at ACK, so the §4.3 endpoint reports `pending` until then.
+   * Vacuously applied when nothing can ever ack — an unplaced agent, an offline
+   * or pre-upgrade daemon — otherwise the console would spin forever on a state
+   * that will only converge on the daemon's next register.
+   */
+  async isApplied(sessions: SessionMetaRecord[]): Promise<boolean> {
+    for (const s of sessions) {
+      if (s.visibilityAckedRev >= s.visibilityRev) continue
+      const agent = await this.deps.repos.agent.get(s.agentId)
+      const daemonId = agent?.daemonId
+      if (!daemonId || !this.supports(daemonId)) continue
+      return false
+    }
+    return true
+  }
+}
+
+/** Re-read the affected rows and answer the §4.3 endpoint's cutover state. */
+export async function visibilityStateOf(
+  push: SessionVisibilityPushService | undefined,
+  repos: { session: SessionRepo },
+  sessionIds: SessionId[]
+): Promise<'pending' | 'applied'> {
+  if (!push) return 'applied'
+  const rows: SessionMetaRecord[] = []
+  for (const id of sessionIds) {
+    const row = await repos.session.get(id)
+    if (row) rows.push(row)
+  }
+  return (await push.isApplied(rows)) ? 'applied' : 'pending'
+}

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -56,13 +56,25 @@ function toPush(s: SessionMetaRecord): SessionVisibilityPush {
 export class SessionVisibilityPushService {
   /** daemonId → pending resume of a replay that stalled (see `scheduleRetry`). */
   private readonly retries = new Map<string, ReturnType<typeof setTimeout>>()
+  /** Resumed replays already running — awaited by `settle()` so shutdown cannot
+   *  disconnect the database underneath one that has already fired. */
+  private readonly inFlight = new Set<Promise<void>>()
+  private stopped = false
 
   constructor(private readonly deps: VisibilityPushDeps) {}
 
-  /** Drop pending resumes (process shutdown / test teardown). */
+  /** Stop scheduling and drop pending resumes (shutdown / test teardown). A run
+   *  already in progress observes the flag at its next page boundary. */
   stop(): void {
+    this.stopped = true
     for (const timer of this.retries.values()) clearTimeout(timer)
     this.retries.clear()
+  }
+
+  /** Wait for any already-fired resume to finish — the shutdown counterpart to
+   *  `stop()`, so Prisma is not disconnected mid-query. */
+  async settle(): Promise<void> {
+    await Promise.allSettled([...this.inFlight])
   }
 
   /**
@@ -112,18 +124,33 @@ export class SessionVisibilityPushService {
    */
   async replayTo(daemonId: DaemonId): Promise<void> {
     this.cancelRetry(daemonId)
-    if (!this.supports(daemonId)) return
-    // Page until nothing is left unacknowledged. Ordering alone is not enough:
-    // with more unacked rows than one page holds, a single pass would ack the
-    // first page and leave the rest carrying a stale gate until some LATER
-    // register — which, for a daemon that stays connected, may never come.
-    //
-    // The loop is bounded by PROGRESS, not by a round count: each page acks its
-    // entries, so the unacknowledged set strictly shrinks and the loop ends. A
-    // fixed cap would instead walk away from gates we KNOW are stale, which is
-    // the privacy gap this replay exists to close.
+    if (this.stopped || !this.supports(daemonId)) return
+    try {
+      await this.replayPages(daemonId)
+    } catch (err) {
+      // A repo read can reject outside `sendSnapshotChunk`'s catch. Abandoning
+      // here would strand exactly the gates we know are stale, so treat it like
+      // any other non-convergence: resume shortly.
+      this.deps.log?.warn({ daemonId, err: (err as Error).message }, 'session visibility replay failed')
+      this.scheduleRetry(daemonId, 'failed')
+    }
+  }
+
+  /**
+   * Page until nothing is left unacknowledged. Ordering alone is not enough:
+   * with more unacked rows than one page holds, a single pass would ack the
+   * first page and leave the rest carrying a stale gate until some LATER
+   * register — which, for a daemon that stays connected, may never come.
+   *
+   * Bounded by PROGRESS, not by a round count: each page acks its entries, so
+   * the unacknowledged set strictly shrinks and the loop ends. A fixed cap would
+   * instead walk away from gates we KNOW are stale, which is the privacy gap
+   * this replay exists to close.
+   */
+  private async replayPages(daemonId: DaemonId): Promise<void> {
     let previousUnacked = Number.POSITIVE_INFINITY
     for (;;) {
+      if (this.stopped) return // shutdown: the next process converges on register
       const page = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK)
       if (page.length === 0) return
       if (!(await this.sendSnapshotChunk(daemonId, page))) return // offline / rejected: next register retries
@@ -140,17 +167,25 @@ export class SessionVisibilityPushService {
     }
   }
 
-  /** Resume a stalled replay later. One outstanding timer per daemon; unref'd so
-   *  it never holds the process open, and cancelled by the next `replayTo`. */
-  private scheduleRetry(daemonId: DaemonId, unacked: number): void {
+  /** Resume a stalled or failed replay later. One outstanding timer per daemon;
+   *  unref'd so it never holds the process open, cancelled by the next
+   *  `replayTo`, and never armed once `stop()` has run. The resumed run is
+   *  tracked so `settle()` can await it during shutdown. */
+  private scheduleRetry(daemonId: DaemonId, unacked: number | 'failed'): void {
+    if (this.stopped) return
     this.deps.log?.warn(
       { daemonId, unacked, retryMs: REPLAY_RETRY_MS },
-      'session visibility replay not converging — resuming shortly'
+      'session visibility replay incomplete — resuming shortly'
     )
     if (this.retries.has(daemonId)) return
     const timer = setTimeout(() => {
       this.retries.delete(daemonId)
-      void this.replayTo(daemonId)
+      // `replayTo` handles its own failures, but keep the promise observed and
+      // tracked: an unhandled rejection here would be invisible, and shutdown
+      // must be able to wait for a run that has already fired.
+      const run = this.replayTo(daemonId).catch(() => {})
+      this.inFlight.add(run)
+      void run.finally(() => this.inFlight.delete(run))
     }, REPLAY_RETRY_MS)
     timer.unref?.()
     this.retries.set(daemonId, timer)

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -27,18 +27,18 @@
  * closed (unknown gate state ⇒ capture excluded).
  */
 import { SESSION_VISIBILITY_FEATURE, type SessionVisibilityPush } from '@agentconnect.md/protocol'
-import type { AgentRepo, SessionMetaRecord, SessionRepo } from '../persistence/ports.js'
+import type { AgentRepo, SessionMetaRecord, SessionRepo, SessionVisibilityState } from '../persistence/ports.js'
 import { SessionId, type DaemonId } from '../domain/ids.js'
 import type { ConnectionRegistry } from '../ws/registry.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 
-/** How many sessions one register-time snapshot covers, newest-active first.
- *  Older rows converge to the daemon's fail-closed default (capture excluded),
- *  which under-captures rather than leaking. */
-const SNAPSHOT_LIMIT = 2000
 /** Entries per snapshot frame. The schema caps at 1000; stay well under the
  *  256 KiB frame ceiling. */
 const SNAPSHOT_CHUNK = 500
+/** Runaway guard on the paging loop below. Each round acks its page, so the
+ *  unacknowledged set shrinks by up to SNAPSHOT_CHUNK per round; this bounds a
+ *  pathological daemon at 100k gates per register rather than looping forever. */
+const MAX_SNAPSHOT_ROUNDS = 200
 
 export interface VisibilityPushDeps {
   repos: { session: SessionRepo; agent: AgentRepo }
@@ -101,36 +101,41 @@ export class SessionVisibilityPushService {
    */
   async replayTo(daemonId: DaemonId): Promise<void> {
     if (!this.supports(daemonId)) return
-    const snapshot = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_LIMIT)
-    if (snapshot.length === 0) return
-    // The snapshot is bounded, but ordered unacknowledged-first, so a change made
-    // while this daemon was offline is always in it. If the cap still bit, say so
-    // rather than let a truncated replay read as full convergence.
-    if (snapshot.length === SNAPSHOT_LIMIT) {
-      const unacked = await this.deps.repos.session.countUnackedVisibility(daemonId)
-      if (unacked > SNAPSHOT_LIMIT) {
-        this.deps.log?.warn(
-          { daemonId, unacked, limit: SNAPSHOT_LIMIT },
-          'session visibility snapshot truncated: unacknowledged gates exceed the replay cap'
-        )
-      }
+    // Page until nothing is left unacknowledged. Ordering alone is not enough:
+    // with more unacked rows than one page holds, a single pass would ack the
+    // first page and leave the rest carrying a stale gate until some LATER
+    // register happened to run — which, for a daemon that stays connected, may
+    // be never. Each round acks its page, so the unacked set strictly shrinks.
+    for (let round = 0; round < MAX_SNAPSHOT_ROUNDS; round++) {
+      const snapshot = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK)
+      if (snapshot.length === 0) return
+      if (!(await this.sendSnapshotChunk(daemonId, snapshot))) return // offline / rejected: next register retries
+      if (snapshot.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
+      if ((await this.deps.repos.session.countUnackedVisibility(daemonId)) === 0) return
     }
-    for (let i = 0; i < snapshot.length; i += SNAPSHOT_CHUNK) {
-      const chunk = snapshot.slice(i, i + SNAPSHOT_CHUNK)
-      try {
-        const ack = await this.deps.control.sessionVisibilitySnapshot(daemonId, chunk)
-        if (!ack.ok) {
-          this.deps.log?.warn({ daemonId, reason: ack.reason }, 'session visibility snapshot rejected')
-          return
-        }
-        for (const entry of chunk) {
-          await this.deps.repos.session.recordVisibilityAck(entry.sessionId, entry.visibilityRev)
-        }
-      } catch (err) {
-        if (err instanceof NoConnection) return
-        this.deps.log?.warn({ daemonId, err: (err as Error).message }, 'session visibility snapshot failed')
-        return
+    this.deps.log?.warn(
+      { daemonId, rounds: MAX_SNAPSHOT_ROUNDS },
+      'session visibility replay hit the round cap with gates still unacknowledged'
+    )
+  }
+
+  /** One snapshot frame + its acks. False ⇒ stop replaying (the daemon is gone
+   *  or refused); the next register converges. */
+  private async sendSnapshotChunk(daemonId: DaemonId, chunk: SessionVisibilityState[]): Promise<boolean> {
+    try {
+      const ack = await this.deps.control.sessionVisibilitySnapshot(daemonId, chunk)
+      if (!ack.ok) {
+        this.deps.log?.warn({ daemonId, reason: ack.reason }, 'session visibility snapshot rejected')
+        return false
       }
+      for (const entry of chunk) {
+        await this.deps.repos.session.recordVisibilityAck(entry.sessionId, entry.visibilityRev)
+      }
+      return true
+    } catch (err) {
+      if (err instanceof NoConnection) return false
+      this.deps.log?.warn({ daemonId, err: (err as Error).message }, 'session visibility snapshot failed')
+      return false
     }
   }
 
@@ -156,8 +161,8 @@ export class SessionVisibilityPushService {
   }
 }
 
-/** How much of a subtree one cutover-state read will consider. Beyond this the
- *  answer stays `pending` rather than silently ignoring the tail. */
+/** How much of a subtree one cutover-state read evaluates. A subtree larger than
+ *  this reports `pending` rather than claiming a cutover it did not verify. */
 const SUBTREE_LIMIT = 500
 
 /**
@@ -174,7 +179,12 @@ export async function visibilityStateOf(
   if (!push) return 'applied'
   const rows = new Map<string, SessionMetaRecord>()
   for (const id of sessionIds) {
-    for (const row of await repos.session.visibilitySubtree(id, SUBTREE_LIMIT)) rows.set(row.id, row)
+    // One over the cap: if the extra row exists the subtree is larger than we
+    // will evaluate, and an unseen descendant may still be behind — so the
+    // honest answer is `pending`, not an `applied` based on a partial read.
+    const page = await repos.session.visibilitySubtree(id, SUBTREE_LIMIT + 1)
+    if (page.length > SUBTREE_LIMIT) return 'pending'
+    for (const row of page) rows.set(row.id, row)
   }
   return (await push.isApplied([...rows.values()])) ? 'applied' : 'pending'
 }

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -103,6 +103,18 @@ export class SessionVisibilityPushService {
     if (!this.supports(daemonId)) return
     const snapshot = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_LIMIT)
     if (snapshot.length === 0) return
+    // The snapshot is bounded, but ordered unacknowledged-first, so a change made
+    // while this daemon was offline is always in it. If the cap still bit, say so
+    // rather than let a truncated replay read as full convergence.
+    if (snapshot.length === SNAPSHOT_LIMIT) {
+      const unacked = await this.deps.repos.session.countUnackedVisibility(daemonId)
+      if (unacked > SNAPSHOT_LIMIT) {
+        this.deps.log?.warn(
+          { daemonId, unacked, limit: SNAPSHOT_LIMIT },
+          'session visibility snapshot truncated: unacknowledged gates exceed the replay cap'
+        )
+      }
+    }
     for (let i = 0; i < snapshot.length; i += SNAPSHOT_CHUNK) {
       const chunk = snapshot.slice(i, i + SNAPSHOT_CHUNK)
       try {
@@ -125,33 +137,44 @@ export class SessionVisibilityPushService {
   /**
    * Has every affected daemon applied this change (§5.1)? The memory boundary
    * takes effect at ACK, so the §4.3 endpoint reports `pending` until then.
-   * Vacuously applied when nothing can ever ack — an unplaced agent, an offline
-   * or pre-upgrade daemon — otherwise the console would spin forever on a state
-   * that will only converge on the daemon's next register.
+   *
+   * Only an UNPLACED agent counts as vacuously applied: nothing is running it,
+   * so nothing can capture. A placed daemon that is merely offline is still
+   * `pending` — daemons keep serving established sessions while the CP is down
+   * (that graceful degradation is the whole point of the edge), so its gate may
+   * genuinely still be `org`. Claiming `applied` there would promise a boundary
+   * that is not in force; it converges when the daemon reconnects and replays.
    */
   async isApplied(sessions: SessionMetaRecord[]): Promise<boolean> {
     for (const s of sessions) {
       if (s.visibilityAckedRev >= s.visibilityRev) continue
       const agent = await this.deps.repos.agent.get(s.agentId)
-      const daemonId = agent?.daemonId
-      if (!daemonId || !this.supports(daemonId)) continue
+      if (!agent?.daemonId) continue // unplaced: no daemon runs it, nothing to stop
       return false
     }
     return true
   }
 }
 
-/** Re-read the affected rows and answer the §4.3 endpoint's cutover state. */
+/** How much of a subtree one cutover-state read will consider. Beyond this the
+ *  answer stays `pending` rather than silently ignoring the tail. */
+const SUBTREE_LIMIT = 500
+
+/**
+ * The §4.3 cutover state for a session AND everything a tightening cascade would
+ * have rewritten under it. The root's daemon acking first must not flip the UI to
+ * `applied` while a descendant's daemon is still behind — the descendant holds
+ * text copied from the root, and its capture is exactly what the change was for.
+ */
 export async function visibilityStateOf(
   push: SessionVisibilityPushService | undefined,
   repos: { session: SessionRepo },
   sessionIds: SessionId[]
 ): Promise<'pending' | 'applied'> {
   if (!push) return 'applied'
-  const rows: SessionMetaRecord[] = []
+  const rows = new Map<string, SessionMetaRecord>()
   for (const id of sessionIds) {
-    const row = await repos.session.get(id)
-    if (row) rows.push(row)
+    for (const row of await repos.session.visibilitySubtree(id, SUBTREE_LIMIT)) rows.set(row.id, row)
   }
-  return (await push.isApplied(rows)) ? 'applied' : 'pending'
+  return (await push.isApplied([...rows.values()])) ? 'applied' : 'pending'
 }

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -35,10 +35,12 @@ import { NoConnection, type ControlSender } from './outbound.js'
 /** Entries per snapshot frame. The schema caps at 1000; stay well under the
  *  256 KiB frame ceiling. */
 const SNAPSHOT_CHUNK = 500
-/** Runaway guard on the paging loop below. Each round acks its page, so the
- *  unacknowledged set shrinks by up to SNAPSHOT_CHUNK per round; this bounds a
- *  pathological daemon at 100k gates per register rather than looping forever. */
-const MAX_SNAPSHOT_ROUNDS = 200
+/** How long to wait before resuming a replay that stalled — i.e. one where the
+ *  unacknowledged set stopped shrinking because new changes are landing as fast
+ *  as we ack them. A pause, never an abandonment: the remaining gates are known
+ *  to be stale, and `replayTo` otherwise only runs on register, which a daemon
+ *  that stays connected may not do again for a long time. */
+const REPLAY_RETRY_MS = 30_000
 
 export interface VisibilityPushDeps {
   repos: { session: SessionRepo; agent: AgentRepo }
@@ -52,7 +54,16 @@ function toPush(s: SessionMetaRecord): SessionVisibilityPush {
 }
 
 export class SessionVisibilityPushService {
+  /** daemonId → pending resume of a replay that stalled (see `scheduleRetry`). */
+  private readonly retries = new Map<string, ReturnType<typeof setTimeout>>()
+
   constructor(private readonly deps: VisibilityPushDeps) {}
+
+  /** Drop pending resumes (process shutdown / test teardown). */
+  stop(): void {
+    for (const timer of this.retries.values()) clearTimeout(timer)
+    this.retries.clear()
+  }
 
   /**
    * A daemon can only be pushed to if it is connected AND advertises the
@@ -100,23 +111,57 @@ export class SessionVisibilityPushService {
    * replay. Failure is swallowed — the next register tries again.
    */
   async replayTo(daemonId: DaemonId): Promise<void> {
+    this.cancelRetry(daemonId)
     if (!this.supports(daemonId)) return
     // Page until nothing is left unacknowledged. Ordering alone is not enough:
     // with more unacked rows than one page holds, a single pass would ack the
     // first page and leave the rest carrying a stale gate until some LATER
-    // register happened to run — which, for a daemon that stays connected, may
-    // be never. Each round acks its page, so the unacked set strictly shrinks.
-    for (let round = 0; round < MAX_SNAPSHOT_ROUNDS; round++) {
-      const snapshot = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK)
-      if (snapshot.length === 0) return
-      if (!(await this.sendSnapshotChunk(daemonId, snapshot))) return // offline / rejected: next register retries
-      if (snapshot.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
-      if ((await this.deps.repos.session.countUnackedVisibility(daemonId)) === 0) return
+    // register — which, for a daemon that stays connected, may never come.
+    //
+    // The loop is bounded by PROGRESS, not by a round count: each page acks its
+    // entries, so the unacknowledged set strictly shrinks and the loop ends. A
+    // fixed cap would instead walk away from gates we KNOW are stale, which is
+    // the privacy gap this replay exists to close.
+    let previousUnacked = Number.POSITIVE_INFINITY
+    for (;;) {
+      const page = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK)
+      if (page.length === 0) return
+      if (!(await this.sendSnapshotChunk(daemonId, page))) return // offline / rejected: next register retries
+      if (page.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
+      const unacked = await this.deps.repos.session.countUnackedVisibility(daemonId)
+      if (unacked === 0) return
+      if (unacked >= previousUnacked) {
+        // Not converging — new changes are arriving at least as fast as we ack.
+        // Yield and resume rather than spin, and rather than leave it to chance.
+        this.scheduleRetry(daemonId, unacked)
+        return
+      }
+      previousUnacked = unacked
     }
+  }
+
+  /** Resume a stalled replay later. One outstanding timer per daemon; unref'd so
+   *  it never holds the process open, and cancelled by the next `replayTo`. */
+  private scheduleRetry(daemonId: DaemonId, unacked: number): void {
     this.deps.log?.warn(
-      { daemonId, rounds: MAX_SNAPSHOT_ROUNDS },
-      'session visibility replay hit the round cap with gates still unacknowledged'
+      { daemonId, unacked, retryMs: REPLAY_RETRY_MS },
+      'session visibility replay not converging — resuming shortly'
     )
+    if (this.retries.has(daemonId)) return
+    const timer = setTimeout(() => {
+      this.retries.delete(daemonId)
+      void this.replayTo(daemonId)
+    }, REPLAY_RETRY_MS)
+    timer.unref?.()
+    this.retries.set(daemonId, timer)
+  }
+
+  private cancelRetry(daemonId: DaemonId): void {
+    const timer = this.retries.get(daemonId)
+    if (timer) {
+      clearTimeout(timer)
+      this.retries.delete(daemonId)
+    }
   }
 
   /** One snapshot frame + its acks. False ⇒ stop replaying (the daemon is gone

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -29,7 +29,7 @@
 import { SESSION_VISIBILITY_FEATURE, type SessionVisibilityPush } from '@agentconnect.md/protocol'
 import type { AgentRepo, SessionMetaRecord, SessionRepo, SessionVisibilityState } from '../persistence/ports.js'
 import { SessionId, type DaemonId } from '../domain/ids.js'
-import type { ConnectionRegistry } from '../ws/registry.js'
+import { ConnectionClosed, type ConnectionRegistry } from '../ws/registry.js'
 import { NoConnection, type ControlSender } from './outbound.js'
 
 /** Entries per snapshot frame. The schema caps at 1000; stay well under the
@@ -153,7 +153,14 @@ export class SessionVisibilityPushService {
       if (this.stopped) return // shutdown: the next process converges on register
       const page = await this.deps.repos.session.visibilitySnapshotForDaemon(daemonId, SNAPSHOT_CHUNK)
       if (page.length === 0) return
-      if (!(await this.sendSnapshotChunk(daemonId, page))) return // offline / rejected: next register retries
+      const outcome = await this.sendSnapshotChunk(daemonId, page)
+      if (outcome === 'gone') return // disconnected: its next register replays
+      if (outcome === 'retry') {
+        // Still connected, but this page did not land. Nothing else is coming
+        // back for the tail on its own, so resume it ourselves.
+        this.scheduleRetry(daemonId, 'failed')
+        return
+      }
       if (page.length < SNAPSHOT_CHUNK) return // the page was not full: nothing behind it
       const unacked = await this.deps.repos.session.countUnackedVisibility(daemonId)
       if (unacked === 0) return
@@ -199,23 +206,37 @@ export class SessionVisibilityPushService {
     }
   }
 
-  /** One snapshot frame + its acks. False ⇒ stop replaying (the daemon is gone
-   *  or refused); the next register converges. */
-  private async sendSnapshotChunk(daemonId: DaemonId, chunk: SessionVisibilityState[]): Promise<boolean> {
+  /**
+   * One snapshot frame + its acks.
+   *
+   *  - `sent` — delivered and recorded; keep paging.
+   *  - `gone` — the daemon disconnected. Its next register replays from scratch,
+   *    so a timer here would be redundant.
+   *  - `retry` — anything else: a correlator timeout, a refused ack, or a
+   *    failure recording the acks. The daemon is still connected, so nothing
+   *    else will come back for the tail — the caller must schedule a resume.
+   *    Collapsing these into `gone` was how a known-stale tail got stranded.
+   */
+  private async sendSnapshotChunk(
+    daemonId: DaemonId,
+    chunk: SessionVisibilityState[]
+  ): Promise<'sent' | 'gone' | 'retry'> {
     try {
       const ack = await this.deps.control.sessionVisibilitySnapshot(daemonId, chunk)
       if (!ack.ok) {
         this.deps.log?.warn({ daemonId, reason: ack.reason }, 'session visibility snapshot rejected')
-        return false
+        return 'retry'
       }
+      // A failure here leaves the rows unacked, so the next page re-sends them;
+      // the daemon answers `superseded` and nothing is applied twice.
       for (const entry of chunk) {
         await this.deps.repos.session.recordVisibilityAck(entry.sessionId, entry.visibilityRev)
       }
-      return true
+      return 'sent'
     } catch (err) {
-      if (err instanceof NoConnection) return false
+      if (err instanceof NoConnection || err instanceof ConnectionClosed) return 'gone'
       this.deps.log?.warn({ daemonId, err: (err as Error).message }, 'session visibility snapshot failed')
-      return false
+      return 'retry'
     }
   }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -859,6 +859,8 @@ export interface SessionMilestoneResult {
  *  tightening cascade rewrote. Empty `affected` ⇒ the request was a no-op. */
 export interface SessionVisibilityChange {
   affected: SessionMetaRecord[]
+  /** The lock-time re-authorization refused the change (§4.3 ownership moved). */
+  forbidden?: boolean
 }
 
 /** One entry of the §5.1 register-time gate snapshot. */
@@ -990,7 +992,14 @@ export interface SessionRepo {
    *  cascades to every descendant (transitively, `explicit` ones included —
    *  privacy wins) under the lock-then-scan-to-fixpoint protocol of §4.5. Every
    *  rewritten row's `visibilityRev` is bumped in the same transaction. */
-  setVisibility(sessionId: SessionId, visibility: SessionVisibility): Promise<SessionVisibilityChange>
+  setVisibility(
+    sessionId: SessionId,
+    visibility: SessionVisibility,
+    /** Re-checked against the LOCKED row, closing the gap between the route's
+     *  authorization read and this write: a concurrent ancestor cascade can
+     *  re-own the session in between. Denied ⇒ `forbidden`, nothing written. */
+    authorize?: (row: { visibility: SessionVisibility; ownerIdentity: string | null }) => boolean
+  ): Promise<SessionVisibilityChange>
   /** Raise the daemon-ack watermark (§5.1). Monotonic: a late ack for an older
    *  revision never lowers it, so the tighten stays `applied`. */
   recordVisibilityAck(sessionId: SessionId, visibilityRev: number): Promise<void>
@@ -998,6 +1007,12 @@ export interface SessionRepo {
    *  `(sessionId, visibility, visibilityRev)` set for the sessions it reported,
    *  newest first and bounded. A snapshot, not a diff. */
   visibilitySnapshotForDaemon(daemonId: DaemonId, limit: number): Promise<SessionVisibilityState[]>
+  /** How many of a daemon's sessions still owe an ack — used to report when a
+   *  bounded snapshot could not carry them all (never a silent truncation). */
+  countUnackedVisibility(daemonId: DaemonId): Promise<number>
+  /** A session plus every descendant — the set a tightening cascade rewrote, so
+   *  the detail view's cutover state covers the whole subtree, not just the root. */
+  visibilitySubtree(sessionId: SessionId, limit: number): Promise<SessionMetaRecord[]>
   /** Resolve the agent that owns a bot's `(channel, thread)` — the most-recently-active session
    *  keyed there whose agent still has an active integration for that bot and a current daemon
    *  placement. Backstop for shared-bot thread-affinity lookup: a daemon-created session (e.g.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -93,6 +93,16 @@ export function visibilityWhere(v?: ViewCtx) {
 export type AssignmentState = 'active' | 'draining' | 'released' | 'frozen'
 export type SessionPhase = 'start' | 'plan' | 'problem' | 'end'
 export type ActivityState = 'thinking' | 'tool_call' | 'awaiting_permission' | 'idle'
+/** Per-session visibility tier (session-visibility.md §1). Distinct from
+ *  `ResourceVisibility` — sessions have no `restricted`/`sharedWith` tier. */
+export type SessionVisibility = 'private' | 'org'
+/** How a session's visibility was determined — the §4.5 A2A reconciliation
+ *  state marker; `explicit` pins the row against settlement (not cascades). */
+export type VisibilitySource = 'default' | 'inherited_pending' | 'inherited' | 'explicit'
+/** Daemon-reported conversation shape (session-visibility.md §4.1) — the
+ *  ingest classification input. NOT the Slack-flavored `ConversationKind`
+ *  ('channel'|'im'|'mpim') used by integration-channel rows. */
+export type SessionConversationKind = 'dm' | 'group_dm' | 'channel'
 export type LaunchMode = 'long_lived' | 'per_turn'
 export type LaunchStatus = 'launching' | 'running' | 'stopped' | 'crashed'
 export type LeaseStatus = 'active' | 'expired' | 'revoked'
@@ -813,7 +823,49 @@ export interface EventSessionInput {
   platform?: Platform
   channel?: string
   thread?: string
+  // ── visibility classification inputs (session-visibility.md §4.1) ──
+  // All optional ⇒ old daemons stay compatible: absent conversationKind means
+  // channel behavior ('org'); absent transportScope/launchCorrelationId means
+  // no owner is recorded (fail closed).
+  conversationKind?: SessionConversationKind
+  transportScope?: string // durable tenant scope for ownerIdentity (§2), NOT the credential-derived hash
+  launchCorrelationId?: string // Web API launch provenance (§4.4)
+  /** The §4.2 verdict the ingest handler computed (its ownership lookups are
+   *  already resolved). Absent ⇒ the row is classified `org` with no owner —
+   *  the pre-visibility behavior, kept for internal callers and fixtures. */
+  classification?: SessionClassification
   at: Date
+}
+
+/** A settled §4.2 classification, or the marker that the row inherits from its
+ *  parent — which the repo resolves under a row lock (§4.5). Structurally
+ *  identical to `domain/session-visibility.ts#SessionClassification`; declared
+ *  here so the port layer does not depend on the domain module. */
+export type SessionClassification =
+  | { inherit: true }
+  | { inherit?: false; visibility: SessionVisibility; ownerIdentity: string | null; source: VisibilitySource }
+
+/** What one `event/session` upsert changed. `recorded: false` means the session
+ *  id is already bound to a different agent (nothing was written). `settled`
+ *  carries the A2A children this milestone resolved out of `inherited_pending`
+ *  (§4.5) — the CP owes each of them a §5.1 gate push. */
+export interface SessionMilestoneResult {
+  recorded: boolean
+  session: SessionMetaRecord | null
+  settled: SessionMetaRecord[]
+}
+
+/** Outcome of a §4.3 visibility change: the target row plus every descendant a
+ *  tightening cascade rewrote. Empty `affected` ⇒ the request was a no-op. */
+export interface SessionVisibilityChange {
+  affected: SessionMetaRecord[]
+}
+
+/** One entry of the §5.1 register-time gate snapshot. */
+export interface SessionVisibilityState {
+  sessionId: SessionId
+  visibility: SessionVisibility
+  visibilityRev: number
 }
 
 export interface SessionMetaRecord {
@@ -842,6 +894,13 @@ export interface SessionMetaRecord {
   outputMode: string | null
   daemonId: DaemonId | null
   activityState: ActivityState
+  // ── session visibility (session-visibility.md §3) ──
+  orgId: OrgId // denormalized from agent.orgId at ingest
+  visibility: SessionVisibility
+  ownerIdentity: string | null // §2 namespaced identity; null for automation/legacy/owner-orphan rows
+  visibilitySource: VisibilitySource
+  visibilityRev: number // bumped in the same tx as any visibility change (§5.1)
+  visibilityAckedRev: number // daemon-ack watermark; 'applied' once >= visibilityRev
   startedAt: Date
   endedAt: Date | null
 }
@@ -864,6 +923,11 @@ export interface SessionFilterQuery extends SessionQuery {
   triggeredBy?: string
   githubHookIds?: HookId[]
   hookTriggerIds?: HookId[]
+  /** Session-visibility predicate inputs (session-visibility.md §5): non-owner
+   *  viewers see `org` rows plus `private` rows whose ownerIdentity is in their
+   *  identity set. Absent ⇒ no session predicate — the internal fail-open,
+   *  mirroring `visibilityWhere(undefined)`. */
+  viewer?: { role: OrgMemberRole; identitySet: string[] }
 }
 
 export interface SessionPageQuery extends SessionFilterQuery {
@@ -900,8 +964,11 @@ export interface SessionFacetIndex {
 
 export interface SessionRepo {
   /** Upsert the converged milestone for a session (advance `phase`; NO message body).
-   *  False means the global session id is already bound to a different agent. */
-  recordMilestone(ev: EventSessionInput): Promise<boolean>
+   *  `recorded: false` means the global session id is already bound to a different
+   *  agent. Classification is first-wins: an existing row keeps the visibility it
+   *  was ingested with (§4.2), and an A2A child resolves its parent under a shared
+   *  row lock, settling any `inherited_pending` children of its own (§4.5). */
+  recordMilestone(ev: EventSessionInput): Promise<SessionMilestoneResult>
   /** Filter, keyset-page, and order in Postgres; usage is hydrated only for the
    *  returned page. `total` is computed only when explicitly requested. */
   listPage(q: SessionPageQuery): Promise<SessionPageRecord>
@@ -912,8 +979,25 @@ export interface SessionRepo {
   list(q: SessionQuery): Promise<SessionListRecord[]>
   get(id: SessionId): Promise<SessionMetaRecord | null>
   /** Visible-child lookup for the session detail page. Parent ids are opaque and
-   *  deliberately not foreign-keyed, so this remains a metadata query. */
-  listChildren(parentSessionId: SessionId, agentIds: AgentId[]): Promise<SessionMetaRecord[]>
+   *  deliberately not foreign-keyed, so this remains a metadata query. `viewer`
+   *  applies the same session predicate as the list (absent ⇒ internal fail-open). */
+  listChildren(
+    parentSessionId: SessionId,
+    agentIds: AgentId[],
+    viewer?: { role: OrgMemberRole; identitySet: string[] }
+  ): Promise<SessionMetaRecord[]>
+  /** §4.3 reclassification. Widening touches only the target row; tightening
+   *  cascades to every descendant (transitively, `explicit` ones included —
+   *  privacy wins) under the lock-then-scan-to-fixpoint protocol of §4.5. Every
+   *  rewritten row's `visibilityRev` is bumped in the same transaction. */
+  setVisibility(sessionId: SessionId, visibility: SessionVisibility): Promise<SessionVisibilityChange>
+  /** Raise the daemon-ack watermark (§5.1). Monotonic: a late ack for an older
+   *  revision never lowers it, so the tighten stays `applied`. */
+  recordVisibilityAck(sessionId: SessionId, visibilityRev: number): Promise<void>
+  /** The §5.1 register-time gate snapshot for one daemon: the current
+   *  `(sessionId, visibility, visibilityRev)` set for the sessions it reported,
+   *  newest first and bounded. A snapshot, not a diff. */
+  visibilitySnapshotForDaemon(daemonId: DaemonId, limit: number): Promise<SessionVisibilityState[]>
   /** Resolve the agent that owns a bot's `(channel, thread)` — the most-recently-active session
    *  keyed there whose agent still has an active integration for that bot and a current daemon
    *  placement. Backstop for shared-bot thread-affinity lookup: a daemon-created session (e.g.
@@ -937,6 +1021,10 @@ export interface WebchatConversationBinding {
 export interface WebchatConversationRepo {
   /** Register a server-allocated conversation before its first relay dial. */
   create(binding: WebchatConversationBinding): Promise<void>
+  /** The owning console user of a conversation, for session-visibility ingest
+   *  (§4.2). Scoped to the agent the conversation was minted against; unknown
+   *  and foreign bindings both return null (the caller fails closed). */
+  findOwner(conversationId: string, agentId: AgentId): Promise<string | null>
   /** Exact owner check for resume. Unknown and foreign bindings both return false. */
   owns(binding: WebchatConversationBinding): Promise<boolean>
 }
@@ -1030,6 +1118,12 @@ export interface RecordLaunchInput {
   mode?: LaunchMode
   epoch: bigint
   startedAt?: Date
+  /** Web API launch provenance (session-visibility.md §4.4): the CP-minted
+   *  correlation id the daemon echoes on the session's `event/session` frame,
+   *  and the principal that requested the launch. Distinct from `launchId`,
+   *  which is the agent-runtime fence. */
+  correlationId?: string
+  createdByUserId?: string
 }
 
 export interface LaunchRecord {
@@ -1047,6 +1141,9 @@ export interface LaunchRepo {
   record(input: RecordLaunchInput): Promise<LaunchRecord>
   /** The current (most recent running/launching) launch for an agent — the fence (§4.8). */
   currentLaunch(agentId: AgentId): Promise<LaunchId | undefined>
+  /** The user a launch correlation belongs to (session-visibility.md §4.4);
+   *  null when the correlation is unknown, so ingest fails closed. */
+  ownerByCorrelationId(correlationId: string): Promise<string | null>
   markStopped(launchId: LaunchId, status: 'stopped' | 'crashed', at: Date): Promise<void>
 }
 

--- a/packages/control-plane/src/persistence/repositories/launch.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/launch.repo.ts
@@ -39,10 +39,20 @@ export class PgLaunchRepo implements LaunchRepo {
         mode: input.mode ?? 'long_lived',
         launchEpoch: input.epoch,
         status: 'running',
-        startedAt: input.startedAt ?? new Date()
+        startedAt: input.startedAt ?? new Date(),
+        ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
+        ...(input.createdByUserId !== undefined ? { createdByUserId: input.createdByUserId } : {})
       }
     })
     return toRecord(l)
+  }
+
+  async ownerByCorrelationId(correlationId: string): Promise<string | null> {
+    const l = await this.db.agentLaunch.findUnique({
+      where: { correlationId },
+      select: { createdByUserId: true }
+    })
+    return l?.createdByUserId ?? null
   }
 
   async currentLaunch(agentId: AgentId): Promise<LaunchId | undefined> {

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -7,9 +7,12 @@
  */
 import type { Platform } from '@agentconnect.md/protocol'
 import { Prisma, type SessionMeta } from '../../generated/prisma/client.js'
-import type { PrismaLike } from '../prisma.js'
+import { withAmbientTx, type PrismaLike } from '../prisma.js'
 import type {
   SessionRepo,
+  SessionMilestoneResult,
+  SessionVisibilityChange,
+  SessionVisibilityState,
   SessionMetaRecord,
   SessionListRecord,
   SessionFilterQuery,
@@ -22,9 +25,11 @@ import type {
   SessionUsageCounts,
   SessionQuery,
   SessionPhase,
-  ActivityState
+  ActivityState,
+  SessionVisibility,
+  VisibilitySource
 } from '../ports.js'
-import { AgentId, BotId, DaemonId, LaunchId, SessionId } from '../../domain/ids.js'
+import { AgentId, BotId, DaemonId, LaunchId, OrgId, SessionId } from '../../domain/ids.js'
 
 function toRecord(s: SessionMeta): SessionMetaRecord {
   return {
@@ -53,6 +58,12 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     outputMode: s.outputMode,
     daemonId: s.daemonId ? DaemonId(s.daemonId) : null,
     activityState: s.activityState as ActivityState,
+    orgId: OrgId(s.orgId),
+    visibility: s.visibility as SessionVisibility,
+    ownerIdentity: s.ownerIdentity,
+    visibilitySource: s.visibilitySource as VisibilitySource,
+    visibilityRev: s.visibilityRev,
+    visibilityAckedRev: s.visibilityAckedRev,
     startedAt: s.startedAt,
     endedAt: s.endedAt
   }
@@ -180,8 +191,24 @@ function integrationSql(q: SessionFilterQuery): Prisma.Sql | null {
   return platformSql(q.integration)
 }
 
+/**
+ * The SQL mirror of `http/visibility.ts#canViewSession` (session-visibility.md
+ * §5). Org owners keep the governance override (no arm at all); everyone else
+ * sees `org` rows plus `private` rows they own. `= ANY(array)` tolerates an
+ * empty identity set, unlike the `IN (…)` list form used for agent ids.
+ */
+function sessionViewerSql(viewer: SessionFilterQuery['viewer']): Prisma.Sql | null {
+  if (!viewer || viewer.role === 'owner') return null
+  return Prisma.sql`(
+    s."visibility" = 'org'::"SessionVisibility"
+    OR (s."ownerIdentity" IS NOT NULL AND s."ownerIdentity" = ANY(${viewer.identitySet}::text[]))
+  )`
+}
+
 function pageWhereSql(q: SessionFilterQuery, includeCursor: boolean): Prisma.Sql {
   const filters: Prisma.Sql[] = [Prisma.sql`s."agentId" IN (${Prisma.join(queryAgentIds(q))})`]
+  const viewerArm = sessionViewerSql(q.viewer)
+  if (viewerArm) filters.push(viewerArm)
   if (q.platform) filters.push(platformSql(q.platform))
   const integration = integrationSql(q)
   if (integration) filters.push(integration)
@@ -255,16 +282,109 @@ export class PgSessionRepo implements SessionRepo {
     })
   }
 
-  async recordMilestone(ev: EventSessionInput): Promise<boolean> {
+  /**
+   * Resolve the row's §4.2 classification, taking the shared parent lock when it
+   * inherits (§4.5). `FOR SHARE` is what serializes a child insert against a
+   * concurrent §4.3 tightening cascade (which holds `FOR UPDATE` on the same
+   * parent): either we wait and then read the parent as already-private, or we
+   * commit first and the cascade's post-lock re-scan finds us.
+   *
+   * The lookup is by session id ALONE — an A2A parent legitimately belongs to a
+   * different agent, and often to a different daemon.
+   */
+  private async resolveClassification(
+    tx: PrismaLike,
+    ev: EventSessionInput
+  ): Promise<{ visibility: SessionVisibility; ownerIdentity: string | null; source: VisibilitySource }> {
+    const classification = ev.classification
+    if (!classification) return { visibility: 'org', ownerIdentity: null, source: 'default' }
+    if (classification.inherit !== true) return classification
+    const parent = ev.parentSessionId
+      ? await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
+          SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${ev.parentSessionId} FOR SHARE
+        `)
+      : []
+    // Parent not here yet (it may live on another daemon, or simply arrive
+    // later): start private + unowned and mark the row for one-time settlement.
+    if (parent.length !== 1) return { visibility: 'private', ownerIdentity: null, source: 'inherited_pending' }
+    return {
+      visibility: parent[0]!.visibility as SessionVisibility,
+      ownerIdentity: parent[0]!.ownerIdentity,
+      source: 'inherited'
+    }
+  }
+
+  /**
+   * §4.5 settlement: copy this session's visibility onto the children that
+   * arrived before it. Conditional and one-time — the CAS on `visibilitySource`
+   * means a child an org owner has meanwhile re-classified (`explicit`) is left
+   * alone: reconciliation never overwrites a human decision.
+   */
+  private async settlePendingChildren(tx: PrismaLike, parent: SessionMetaRecord): Promise<SessionMetaRecord[]> {
+    const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+      UPDATE "session_meta" SET
+        "visibility" = ${parent.visibility}::"SessionVisibility",
+        "ownerIdentity" = ${parent.ownerIdentity},
+        "visibilitySource" = 'inherited'::"VisibilitySource",
+        "visibilityRev" = "visibilityRev" + 1,
+        "updatedAt" = CURRENT_TIMESTAMP
+      WHERE "parentSessionId" = ${parent.id}
+        AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
+      RETURNING *
+    `)
+    return rows.map(toRecord)
+  }
+
+  /**
+   * The other half of settlement: a child whose parent commits between our own
+   * classification read and our commit stays `inherited_pending` forever unless
+   * we re-check. Same CAS, so it is a no-op once anything else has settled the
+   * row. Runs in its own transaction after the milestone commits.
+   */
+  private async settleFromParent(sessionId: SessionId, parentSessionId: SessionId): Promise<SessionMetaRecord[]> {
+    return withAmbientTx(this.db, async (tx) => {
+      const parent = await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
+        SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${parentSessionId} FOR SHARE
+      `)
+      if (parent.length !== 1) return []
+      const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+        UPDATE "session_meta" SET
+          "visibility" = ${parent[0]!.visibility}::"SessionVisibility",
+          "ownerIdentity" = ${parent[0]!.ownerIdentity},
+          "visibilitySource" = 'inherited'::"VisibilitySource",
+          "visibilityRev" = "visibilityRev" + 1,
+          "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "id" = ${sessionId}
+          AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
+        RETURNING *
+      `)
+      return rows.map(toRecord)
+    })
+  }
+
+  async recordMilestone(ev: EventSessionInput): Promise<SessionMilestoneResult> {
+    const result = await withAmbientTx(this.db, async (tx) => this.upsertMilestone(tx, ev))
+    if (!result.recorded || !result.session) return result
+    // Out-of-order arrival: our parent may have landed while we were writing.
+    if (result.session.visibilitySource === 'inherited_pending' && result.session.parentSessionId) {
+      const settled = await this.settleFromParent(result.session.id, result.session.parentSessionId)
+      if (settled[0]) return { ...result, session: settled[0] }
+    }
+    return result
+  }
+
+  private async upsertMilestone(tx: PrismaLike, ev: EventSessionInput): Promise<SessionMilestoneResult> {
     const endedAt = ev.phase === 'end' ? ev.at : undefined
     const lastActivityAt = ev.lastActivityAt ?? ev.at
-    const rows = await this.db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    const cls = await this.resolveClassification(tx, ev)
+    const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
       INSERT INTO "session_meta" (
         "id", "parentSessionId", "agentId", "launchId", "platform", "channel",
         "thread", "phase", "link", "summary", "title", "status",
         "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
         "threadUrl", "runtime", "model", "effort", "fastMode",
-        "permissionMode", "outputMode", "daemonId", "startedAt", "endedAt",
+        "permissionMode", "outputMode", "daemonId", "orgId", "visibility",
+        "ownerIdentity", "visibilitySource", "startedAt", "endedAt",
         "updatedAt"
       ) VALUES (
         ${ev.sessionId}, ${ev.parentSessionId ?? null}, ${ev.agentId},
@@ -275,9 +395,18 @@ export class PgSessionRepo implements SessionRepo {
         ${ev.triggeredByName ?? null}, ${ev.threadUrl ?? null},
         ${ev.runtime ?? null}, ${ev.model ?? null}, ${ev.effort ?? null},
         ${ev.fastMode ?? null}, ${ev.permissionMode ?? null},
-        ${ev.outputMode ?? null}, ${ev.daemonId ?? null}, ${ev.at},
+        ${ev.outputMode ?? null}, ${ev.daemonId ?? null},
+        -- Denormalized from the owning agent (§3) so the org-wide list predicate
+        -- never joins "agent". The agentId FK guarantees the subquery resolves.
+        (SELECT a."orgId" FROM "agent" a WHERE a."id" = ${ev.agentId}),
+        ${cls.visibility}::"SessionVisibility", ${cls.ownerIdentity},
+        ${cls.source}::"VisibilitySource", ${ev.at},
         ${endedAt ?? null}, CURRENT_TIMESTAMP
       )
+      -- NOTE: the visibility columns are deliberately absent from this SET list.
+      -- Classification is FIRST-WINS (§4.2): a later milestone for the same
+      -- session must never re-classify it — that would undo a §4.3 decision and,
+      -- for a re-emit that lost its conversationKind, silently widen a private DM.
       ON CONFLICT ("id") DO UPDATE SET
         "parentSessionId" = COALESCE(
           "session_meta"."parentSessionId",
@@ -318,9 +447,11 @@ export class PgSessionRepo implements SessionRepo {
         "endedAt" = COALESCE(EXCLUDED."endedAt", "session_meta"."endedAt"),
         "updatedAt" = CURRENT_TIMESTAMP
       WHERE "session_meta"."agentId" = EXCLUDED."agentId"
-      RETURNING "id"
+      RETURNING *
     `)
-    return rows.length === 1
+    if (rows.length !== 1) return { recorded: false, session: null, settled: [] }
+    const session = toRecord(rows[0]!)
+    return { recorded: true, session, settled: await this.settlePendingChildren(tx, session) }
   }
 
   async listPage(q: SessionPageQuery): Promise<SessionPageRecord> {
@@ -451,13 +582,113 @@ export class PgSessionRepo implements SessionRepo {
     return s ? toRecord(s) : null
   }
 
-  async listChildren(parentSessionId: SessionId, agentIds: AgentId[]): Promise<SessionMetaRecord[]> {
+  async listChildren(
+    parentSessionId: SessionId,
+    agentIds: AgentId[],
+    viewer?: SessionFilterQuery['viewer']
+  ): Promise<SessionMetaRecord[]> {
     if (agentIds.length === 0) return []
     const rows = await this.db.sessionMeta.findMany({
-      where: { parentSessionId, agentId: { in: agentIds } },
+      where: {
+        parentSessionId,
+        agentId: { in: agentIds },
+        // The Prisma spelling of `sessionViewerSql` — the same predicate as the
+        // list, so a private child never leaks its title through the detail page.
+        ...(viewer && viewer.role !== 'owner'
+          ? { OR: [{ visibility: 'org' as const }, { ownerIdentity: { in: viewer.identitySet } }] }
+          : {})
+      },
       orderBy: [{ startedAt: 'asc' }, { id: 'asc' }]
     })
     return rows.map(toRecord)
+  }
+
+  /**
+   * §4.3 reclassification, with the §4.5 cascade semantics:
+   *
+   *  - **Widening** (`private → org`) never cascades — each descendant stays as
+   *    classified; widening a child remains its owner's own decision.
+   *  - **Tightening** (`org → private`) cascades to every descendant, including
+   *    `explicit` ones: the child holds prompt text copied from the parent, so
+   *    leaving it org-visible would defeat the change. Privacy wins.
+   *
+   * The cascade is lock-then-scan to a fixpoint: each level is re-scanned only
+   * AFTER its parents are locked `FOR UPDATE`. A one-shot "scan everything, then
+   * update" is not sufficient — a grandchild insert holding `FOR SHARE` on its
+   * mid-level parent could commit a stale `org` snapshot after the scan passed.
+   */
+  async setVisibility(sessionId: SessionId, visibility: SessionVisibility): Promise<SessionVisibilityChange> {
+    return withAmbientTx(this.db, async (tx) => {
+      const locked = await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
+        SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${sessionId} FOR UPDATE
+      `)
+      if (locked.length !== 1) return { affected: [] }
+      if (locked[0]!.visibility === visibility) return { affected: [] } // no-op: no rev bump, no push
+      const ownerIdentity = locked[0]!.ownerIdentity
+      const target = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+        UPDATE "session_meta" SET
+          "visibility" = ${visibility}::"SessionVisibility",
+          "visibilitySource" = 'explicit'::"VisibilitySource",
+          "visibilityRev" = "visibilityRev" + 1,
+          "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "id" = ${sessionId}
+        RETURNING *
+      `)
+      const affected = target.map(toRecord)
+      if (visibility === 'org') return { affected }
+
+      const seen = new Set<string>([sessionId])
+      let frontier: string[] = [sessionId]
+      while (frontier.length > 0) {
+        // Lock this level's children BEFORE reading them as a set to update: a
+        // concurrent child insert either waits here or is caught by the re-scan.
+        const children = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+          SELECT "id" FROM "session_meta"
+          WHERE "parentSessionId" = ANY(${frontier}::text[])
+          ORDER BY "id"
+          FOR UPDATE
+        `)
+        const next = children.map((c) => c.id).filter((id) => !seen.has(id))
+        if (next.length === 0) break
+        for (const id of next) seen.add(id)
+        const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+          UPDATE "session_meta" SET
+            "visibility" = 'private'::"SessionVisibility",
+            "ownerIdentity" = ${ownerIdentity},
+            "visibilitySource" = 'inherited'::"VisibilitySource",
+            "visibilityRev" = "visibilityRev" + 1,
+            "updatedAt" = CURRENT_TIMESTAMP
+          WHERE "id" = ANY(${next}::text[])
+            AND "visibility" <> 'private'::"SessionVisibility"
+          RETURNING *
+        `)
+        affected.push(...rows.map(toRecord))
+        frontier = next
+      }
+      return { affected }
+    })
+  }
+
+  async recordVisibilityAck(sessionId: SessionId, visibilityRev: number): Promise<void> {
+    await this.db.$executeRaw(Prisma.sql`
+      UPDATE "session_meta"
+      SET "visibilityAckedRev" = GREATEST("visibilityAckedRev", ${visibilityRev})
+      WHERE "id" = ${sessionId}
+    `)
+  }
+
+  async visibilitySnapshotForDaemon(daemonId: DaemonId, limit: number): Promise<SessionVisibilityState[]> {
+    const rows = await this.db.sessionMeta.findMany({
+      where: { daemonId },
+      orderBy: SESSION_ORDER,
+      take: limit,
+      select: { id: true, visibility: true, visibilityRev: true }
+    })
+    return rows.map((r) => ({
+      sessionId: SessionId(r.id),
+      visibility: r.visibility as SessionVisibility,
+      visibilityRev: r.visibilityRev
+    }))
   }
 
   async findThreadOwner(

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -657,14 +657,26 @@ export class PgSessionRepo implements SessionRepo {
    * update" is not sufficient — a grandchild insert holding `FOR SHARE` on its
    * mid-level parent could commit a stale `org` snapshot after the scan passed.
    */
-  async setVisibility(sessionId: SessionId, visibility: SessionVisibility): Promise<SessionVisibilityChange> {
+  async setVisibility(
+    sessionId: SessionId,
+    visibility: SessionVisibility,
+    authorize?: (row: { visibility: SessionVisibility; ownerIdentity: string | null }) => boolean
+  ): Promise<SessionVisibilityChange> {
     return withAmbientTx(this.db, async (tx) => {
       const locked = await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
         SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${sessionId} FOR UPDATE
       `)
       if (locked.length !== 1) return { affected: [] }
-      if (locked[0]!.visibility === visibility) return { affected: [] } // no-op: no rev bump, no push
-      const ownerIdentity = locked[0]!.ownerIdentity
+      const current = {
+        visibility: locked[0]!.visibility as SessionVisibility,
+        ownerIdentity: locked[0]!.ownerIdentity
+      }
+      // Re-authorize against the LOCKED row, not the one the route read. An
+      // ancestor cascade committing in between can re-own this session, and the
+      // former owner's in-flight request must not still widen it.
+      if (authorize && !authorize(current)) return { affected: [], forbidden: true }
+      if (current.visibility === visibility) return { affected: [] } // no-op: no rev bump, no push
+      const ownerIdentity = current.ownerIdentity
       const target = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
         UPDATE "session_meta" SET
           "visibility" = ${visibility}::"SessionVisibility",
@@ -691,6 +703,10 @@ export class PgSessionRepo implements SessionRepo {
         const next = children.map((c) => c.id).filter((id) => !seen.has(id))
         if (next.length === 0) break
         for (const id of next) seen.add(id)
+        // Every descendant is rewritten, including ones ALREADY private: their
+        // transcripts hold text copied from this session, so they must inherit
+        // ITS owner. Leaving a private-but-differently-owned child alone would
+        // keep that other owner's access to the tightened session's content.
         const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
           UPDATE "session_meta" SET
             "visibility" = 'private'::"SessionVisibility",
@@ -699,7 +715,11 @@ export class PgSessionRepo implements SessionRepo {
             "visibilityRev" = "visibilityRev" + 1,
             "updatedAt" = CURRENT_TIMESTAMP
           WHERE "id" = ANY(${next}::text[])
-            AND "visibility" <> 'private'::"SessionVisibility"
+            AND (
+              "visibility" <> 'private'::"SessionVisibility"
+              OR "ownerIdentity" IS DISTINCT FROM ${ownerIdentity}
+              OR "visibilitySource" <> 'inherited'::"VisibilitySource"
+            )
           RETURNING *
         `)
         affected.push(...rows.map(toRecord))
@@ -718,17 +738,45 @@ export class PgSessionRepo implements SessionRepo {
   }
 
   async visibilitySnapshotForDaemon(daemonId: DaemonId, limit: number): Promise<SessionVisibilityState[]> {
-    const rows = await this.db.sessionMeta.findMany({
-      where: { daemonId },
-      orderBy: SESSION_ORDER,
-      take: limit,
-      select: { id: true, visibility: true, visibilityRev: true }
-    })
+    // Unacknowledged revisions FIRST, newest-active after. A session tightened
+    // while this daemon was offline is by definition unacked, so it replays no
+    // matter how old it is — a plain newest-first window would drop it past the
+    // cap and leave the daemon capturing with a stale `org` gate forever.
+    const rows = await this.db.$queryRaw<Array<{ id: string; visibility: string; visibilityRev: number }>>(Prisma.sql`
+      SELECT "id", "visibility", "visibilityRev"
+      FROM "session_meta"
+      WHERE "daemonId" = ${daemonId}::uuid
+      ORDER BY ("visibilityAckedRev" < "visibilityRev") DESC,
+               "lastActivityAt" DESC, "startedAt" DESC, "id" DESC
+      LIMIT ${limit}
+    `)
     return rows.map((r) => ({
       sessionId: SessionId(r.id),
       visibility: r.visibility as SessionVisibility,
       visibilityRev: r.visibilityRev
     }))
+  }
+
+  async countUnackedVisibility(daemonId: DaemonId): Promise<number> {
+    const rows = await this.db.$queryRaw<Array<{ n: bigint }>>(Prisma.sql`
+      SELECT COUNT(*)::bigint AS n FROM "session_meta"
+      WHERE "daemonId" = ${daemonId}::uuid AND "visibilityAckedRev" < "visibilityRev"
+    `)
+    return Number(rows[0]?.n ?? 0)
+  }
+
+  /** The session plus every descendant, for the §5.1 cutover state of a cascade. */
+  async visibilitySubtree(sessionId: SessionId, limit: number): Promise<SessionMetaRecord[]> {
+    const rows = await this.db.$queryRaw<SessionMeta[]>(Prisma.sql`
+      WITH RECURSIVE subtree AS (
+        SELECT * FROM "session_meta" WHERE "id" = ${sessionId}
+        UNION
+        SELECT child.* FROM "session_meta" child
+        JOIN subtree ON child."parentSessionId" = subtree."id"
+      )
+      SELECT * FROM subtree LIMIT ${limit}
+    `)
+    return rows.map(toRecord)
   }
 
   async findThreadOwner(

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -300,13 +300,23 @@ export class PgSessionRepo implements SessionRepo {
     if (!classification) return { visibility: 'org', ownerIdentity: null, source: 'default' }
     if (classification.inherit !== true) return classification
     const parent = ev.parentSessionId
-      ? await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
-          SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${ev.parentSessionId} FOR SHARE
-        `)
+      ? await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null; visibilitySource: string }>>(
+          Prisma.sql`
+            SELECT "visibility", "ownerIdentity", "visibilitySource"
+            FROM "session_meta" WHERE "id" = ${ev.parentSessionId} FOR SHARE
+          `
+        )
       : []
     // Parent not here yet (it may live on another daemon, or simply arrive
     // later): start private + unowned and mark the row for one-time settlement.
-    if (parent.length !== 1) return { visibility: 'private', ownerIdentity: null, source: 'inherited_pending' }
+    //
+    // A parent that IS here but is itself `inherited_pending` only holds the same
+    // placeholder, so copying it as `inherited` would look settled and drop this
+    // row out of the settlement scan — leaving a deep chain that arrives
+    // root-last stuck private forever. Stay pending; the recursive settlement
+    // below reaches us when the real ancestor lands.
+    const unsettledParent = parent.length !== 1 || parent[0]!.visibilitySource === 'inherited_pending'
+    if (unsettledParent) return { visibility: 'private', ownerIdentity: null, source: 'inherited_pending' }
     return {
       visibility: parent[0]!.visibility as SessionVisibility,
       ownerIdentity: parent[0]!.ownerIdentity,
@@ -315,24 +325,38 @@ export class PgSessionRepo implements SessionRepo {
   }
 
   /**
-   * §4.5 settlement: copy this session's visibility onto the children that
-   * arrived before it. Conditional and one-time — the CAS on `visibilitySource`
-   * means a child an org owner has meanwhile re-classified (`explicit`) is left
+   * §4.5 settlement: copy a settled session's visibility onto the descendants
+   * that arrived before it.
+   *
+   * Recursive by level, because a whole chain can be waiting: a grandchild whose
+   * own parent was still `inherited_pending` when it arrived is pending too, so
+   * settling one level unblocks the next. Every level is the same CAS on
+   * `visibilitySource`, which is what keeps it conditional and one-time — a
+   * descendant an org owner has meanwhile re-classified is `explicit` and left
    * alone: reconciliation never overwrites a human decision.
    */
   private async settlePendingChildren(tx: PrismaLike, parent: SessionMetaRecord): Promise<SessionMetaRecord[]> {
-    const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
-      UPDATE "session_meta" SET
-        "visibility" = ${parent.visibility}::"SessionVisibility",
-        "ownerIdentity" = ${parent.ownerIdentity},
-        "visibilitySource" = 'inherited'::"VisibilitySource",
-        "visibilityRev" = "visibilityRev" + 1,
-        "updatedAt" = CURRENT_TIMESTAMP
-      WHERE "parentSessionId" = ${parent.id}
-        AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
-      RETURNING *
-    `)
-    return rows.map(toRecord)
+    const settled: SessionMetaRecord[] = []
+    const seen = new Set<string>([parent.id])
+    let frontier: string[] = [parent.id]
+    while (frontier.length > 0) {
+      const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+        UPDATE "session_meta" SET
+          "visibility" = ${parent.visibility}::"SessionVisibility",
+          "ownerIdentity" = ${parent.ownerIdentity},
+          "visibilitySource" = 'inherited'::"VisibilitySource",
+          "visibilityRev" = "visibilityRev" + 1,
+          "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "parentSessionId" = ANY(${frontier}::text[])
+          AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
+        RETURNING *
+      `)
+      const next = rows.map((row) => row.id).filter((id) => !seen.has(id))
+      for (const id of next) seen.add(id)
+      settled.push(...rows.map(toRecord))
+      frontier = next
+    }
+    return settled
   }
 
   /**
@@ -343,10 +367,16 @@ export class PgSessionRepo implements SessionRepo {
    */
   private async settleFromParent(sessionId: SessionId, parentSessionId: SessionId): Promise<SessionMetaRecord[]> {
     return withAmbientTx(this.db, async (tx) => {
-      const parent = await tx.$queryRaw<Array<{ visibility: string; ownerIdentity: string | null }>>(Prisma.sql`
-        SELECT "visibility", "ownerIdentity" FROM "session_meta" WHERE "id" = ${parentSessionId} FOR SHARE
-      `)
-      if (parent.length !== 1) return []
+      const parent = await tx.$queryRaw<
+        Array<{ visibility: string; ownerIdentity: string | null; visibilitySource: string }>
+      >(
+        Prisma.sql`
+          SELECT "visibility", "ownerIdentity", "visibilitySource"
+          FROM "session_meta" WHERE "id" = ${parentSessionId} FOR SHARE
+        `
+      )
+      // Nothing to settle from a parent that is itself still waiting.
+      if (parent.length !== 1 || parent[0]!.visibilitySource === 'inherited_pending') return []
       const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
         UPDATE "session_meta" SET
           "visibility" = ${parent[0]!.visibility}::"SessionVisibility",
@@ -358,7 +388,10 @@ export class PgSessionRepo implements SessionRepo {
           AND "visibilitySource" = 'inherited_pending'::"VisibilitySource"
         RETURNING *
       `)
-      return rows.map(toRecord)
+      if (rows.length !== 1) return []
+      const self = toRecord(rows[0]!)
+      // We just settled — anything that was waiting on US can settle now too.
+      return [self, ...(await this.settlePendingChildren(tx, self))]
     })
   }
 
@@ -366,9 +399,11 @@ export class PgSessionRepo implements SessionRepo {
     const result = await withAmbientTx(this.db, async (tx) => this.upsertMilestone(tx, ev))
     if (!result.recorded || !result.session) return result
     // Out-of-order arrival: our parent may have landed while we were writing.
+    // Settling ourselves can in turn settle descendants that were waiting on us,
+    // so they join the set the caller owes a §5.1 gate push.
     if (result.session.visibilitySource === 'inherited_pending' && result.session.parentSessionId) {
-      const settled = await this.settleFromParent(result.session.id, result.session.parentSessionId)
-      if (settled[0]) return { ...result, session: settled[0] }
+      const [self, ...descendants] = await this.settleFromParent(result.session.id, result.session.parentSessionId)
+      if (self) return { ...result, session: self, settled: [...result.settled, ...descendants] }
     }
     return result
   }
@@ -451,7 +486,12 @@ export class PgSessionRepo implements SessionRepo {
     `)
     if (rows.length !== 1) return { recorded: false, session: null, settled: [] }
     const session = toRecord(rows[0]!)
-    return { recorded: true, session, settled: await this.settlePendingChildren(tx, session) }
+    // A row that is itself waiting has only placeholder values, so it must not
+    // settle anything: stamping a descendant `inherited` from a pending parent
+    // would drop it out of the scan when the real ancestor finally lands.
+    const settled =
+      session.visibilitySource === 'inherited_pending' ? [] : await this.settlePendingChildren(tx, session)
+    return { recorded: true, session, settled }
   }
 
   async listPage(q: SessionPageQuery): Promise<SessionPageRecord> {

--- a/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/webchat-conversation.repo.ts
@@ -5,6 +5,7 @@
  */
 import type { PrismaLike } from '../prisma.js'
 import type { WebchatConversationBinding, WebchatConversationRepo } from '../ports.js'
+import type { AgentId } from '../../domain/ids.js'
 
 export class PgWebchatConversationRepo implements WebchatConversationRepo {
   constructor(private readonly db: PrismaLike) {}
@@ -18,6 +19,14 @@ export class PgWebchatConversationRepo implements WebchatConversationRepo {
         userId: binding.userId
       }
     })
+  }
+
+  async findOwner(conversationId: string, agentId: AgentId): Promise<string | null> {
+    const row = await this.db.webchatConversation.findFirst({
+      where: { id: conversationId, agentId },
+      select: { userId: true }
+    })
+    return row?.userId ?? null
   }
 
   async owns(binding: WebchatConversationBinding): Promise<boolean> {

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -18,8 +18,11 @@ import type {
   CronRepo,
   HookRepo,
   AgentRepo,
-  ExternalMemoryConnectionRepo
+  ExternalMemoryConnectionRepo,
+  WebchatConversationRepo,
+  LaunchRepo
 } from '../persistence/ports.js'
+import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { RelayRosterEntry } from '@agentconnect.md/protocol'
 import type { GithubService } from '../github/service.js'
 import type { GithubReviewBrokerService } from '../github/review-broker.service.js'
@@ -49,6 +52,14 @@ export interface DaemonWsDeps {
   sessionUsage: SessionUsageRepo
   /** Persists session milestones from the `event/session` EVT (deep-link metadata sync). */
   session: SessionRepo
+  /** Resolves a webchat conversation's owning user for session-visibility ingest
+   *  (session-visibility.md §4.2); absent ⇒ webchat sessions stay owner-orphans. */
+  webchatConversation?: WebchatConversationRepo
+  /** Resolves Web API launch provenance for the same classification (§4.4). */
+  launch?: LaunchRepo
+  /** Pushes the CP-confirmed capture gate to the owning daemon (§5.1); absent ⇒
+   *  daemons converge on their next register snapshot instead. */
+  visibilityPush?: SessionVisibilityPushService
   /** Publishes persisted session milestones to the WebUI SSE feed. */
   events: SessionEventSink
   /** Ownership check for the `integration/channels` EVT (integration → daemon scope). */

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AnyFrame } from '@agentconnect.md/protocol'
 import type { DaemonConnection } from '../connection.js'
 import type { DaemonWsDeps } from '../deps.js'
+import type { SessionMetaRecord, SessionMilestoneResult } from '../../persistence/ports.js'
 import { handleEventSession } from './event-session.js'
 
 const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const SESSION_ID = 'session-407'
 
 function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
   return {
@@ -33,16 +35,25 @@ function eventSessionFrame(): AnyFrame {
   }
 }
 
+/** A minimal `recorded` result: the upsert landed and settled no A2A children. */
+function recorded(session: Partial<SessionMetaRecord> = {}): SessionMilestoneResult {
+  return {
+    recorded: true,
+    session: { id: SESSION_ID, agentId: AGENT_ID, parentSessionId: null, ...session } as SessionMetaRecord,
+    settled: []
+  }
+}
+
 describe('handleEventSession', () => {
   it('publishes the milestone only after it has been persisted', async () => {
     const order: string[] = []
     let finishPersist!: () => void
     const recordMilestone = vi.fn(() => {
       order.push('persist:start')
-      return new Promise<boolean>((resolve) => {
+      return new Promise<SessionMilestoneResult>((resolve) => {
         finishPersist = () => {
           order.push('persist:finish')
-          resolve(true)
+          resolve(recorded())
         }
       })
     })
@@ -70,7 +81,7 @@ describe('handleEventSession', () => {
   })
 
   it('passes the execution-config snapshot through and stamps daemonId from the connection', async () => {
-    const recordMilestone = vi.fn().mockResolvedValue(true)
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({
       session: { recordMilestone },
       events: { publish: vi.fn() }
@@ -119,7 +130,7 @@ describe('handleEventSession', () => {
   it('does not publish a milestone rejected by the session ownership fence', async () => {
     const publish = vi.fn()
     const deps = scopedDeps({
-      session: { recordMilestone: vi.fn().mockResolvedValue(false) },
+      session: { recordMilestone: vi.fn().mockResolvedValue({ recorded: false, session: null, settled: [] }) },
       events: { publish }
     })
 

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -12,10 +12,41 @@
  * Trust boundary: the reported agent must still be placed on the authenticated
  * daemon, and an existing sessionId remains bound to its first agent.
  */
-import { isFrame } from '@agentconnect.md/protocol'
+import { isFrame, type EventSession } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, LaunchId, SessionId } from '../../domain/ids.js'
+import { classifySession } from '../../domain/session-visibility.js'
+import type { DaemonWsDeps } from '../deps.js'
 import type { Handler } from './index.js'
 import { runForReportingAgent } from './reporting-agent.js'
+
+/**
+ * Resolve the ownership lookups the §4.2 classification needs, then classify.
+ *
+ * Both lookups fail closed by construction: they return `null` on a miss and
+ * `classifySession` keeps the row `private` with no owner rather than widening
+ * it (session-visibility.md §4.2). The webchat lookup is additionally scoped to
+ * the reporting agent — a conversation id is only an owner claim for the agent
+ * it was minted against.
+ */
+async function classifyMilestone(p: EventSession, agentId: AgentId, deps: DaemonWsDeps) {
+  const webchatOwnerUserId =
+    p.platform === 'webchat' && p.channel
+      ? ((await deps.webchatConversation?.findOwner(p.channel, agentId)) ?? null)
+      : null
+  const launchOwnerUserId = p.launchCorrelationId
+    ? ((await deps.launch?.ownerByCorrelationId(p.launchCorrelationId)) ?? null)
+    : null
+  return classifySession({
+    ...(p.platform !== undefined ? { platform: p.platform } : {}),
+    ...(p.conversationKind !== undefined ? { conversationKind: p.conversationKind } : {}),
+    ...(p.transportScope !== undefined ? { transportScope: p.transportScope } : {}),
+    ...(p.triggeredBy !== undefined ? { triggeredBy: p.triggeredBy } : {}),
+    ...(p.parentSessionId !== undefined ? { parentSessionId: p.parentSessionId } : {}),
+    ...(p.launchCorrelationId !== undefined ? { launchCorrelationId: p.launchCorrelationId } : {}),
+    webchatOwnerUserId,
+    launchOwnerUserId
+  })
+}
 
 export const handleEventSession: Handler = async (frame, conn, deps) => {
   if (!isFrame('event/session')(frame)) return
@@ -23,7 +54,8 @@ export const handleEventSession: Handler = async (frame, conn, deps) => {
   const agentId = AgentId(p.agentId)
   const daemonId = DaemonId(conn.daemonId)
   await runForReportingAgent(agentId, daemonId, deps, async () => {
-    const recorded = await deps.session.recordMilestone({
+    const classification = await classifyMilestone(p, agentId, deps)
+    const { recorded, session, settled } = await deps.session.recordMilestone({
       sessionId: SessionId(p.sessionId),
       ...(p.parentSessionId !== undefined ? { parentSessionId: SessionId(p.parentSessionId) } : {}),
       agentId,
@@ -47,12 +79,25 @@ export const handleEventSession: Handler = async (frame, conn, deps) => {
       ...(p.fastMode !== undefined ? { fastMode: p.fastMode } : {}),
       ...(p.permissionMode !== undefined ? { permissionMode: p.permissionMode } : {}),
       ...(p.outputMode !== undefined ? { outputMode: p.outputMode } : {}),
+      ...(p.conversationKind !== undefined ? { conversationKind: p.conversationKind } : {}),
+      ...(p.transportScope !== undefined ? { transportScope: p.transportScope } : {}),
+      ...(p.launchCorrelationId !== undefined ? { launchCorrelationId: p.launchCorrelationId } : {}),
+      classification,
       // The reporting daemon comes from the AUTHENTICATED connection, not the
       // frame payload.
       daemonId,
       at: new Date(p.ts)
     })
     if (!recorded) return
+    // Confirm the capture gate for the rows whose privacy the daemon cannot
+    // infer locally (§5.1): an A2A child always starts excluded and only a
+    // CP-confirmed `org` state may open it, and a settled child's tier is by
+    // definition news to the daemon that runs it. The ack watermark keeps this
+    // to one push per revision — later milestones of the same session are silent.
+    const confirm = [...settled, ...(session?.parentSessionId ? [session] : [])].filter(
+      (s) => s.visibilityAckedRev < s.visibilityRev
+    )
+    if (confirm.length > 0) void deps.visibilityPush?.notifySessions(confirm)
     // Publish only after the metadata commit. Browser subscribers use this as an
     // invalidation signal and immediately re-read `/sessions`; publishing first
     // would race that GET against the upsert and leave the new row invisible.

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -10,7 +10,7 @@
  * Idempotent: re-sending `register` re-runs reconcile and yields the same
  * snapshot (CP wins all conflicts) — reconnect is convergence, not replay.
  */
-import { isFrame, SESSION_LIVE_TAIL_FEATURE } from '@agentconnect.md/protocol'
+import { isFrame, SESSION_LIVE_TAIL_FEATURE, SESSION_VISIBILITY_FEATURE } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
 
@@ -42,9 +42,17 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
     ...snap,
     relays,
     ...(gitCommitIdentity ? { gitCommitIdentity } : {}),
-    serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1', SESSION_LIVE_TAIL_FEATURE]
+    serverFeatures: ['hook-report-ack-v1', 'gitcred-actions-v1', SESSION_LIVE_TAIL_FEATURE, SESSION_VISIBILITY_FEATURE]
   })
   deps.connReg.markReady(conn.daemonId, conn)
+
+  // Converge the per-session memory-capture gates (session-visibility.md §5.1).
+  // A visibility change committed while this daemon was offline was never
+  // delivered — the live push is connection-scoped — so the snapshot, not the
+  // push, is what ultimately closes the bypass. Best-effort: the daemon fails
+  // closed (unknown gate ⇒ capture excluded) until it lands, and the next
+  // register retries.
+  await deps.visibilityPush?.replayTo(did).catch(() => {})
 
   // Now that this connection has actually reached READY (reconcile succeeded above),
   // close any CP-commanded restart/upgrade op it was relaunching for (§7). Best-effort

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -83,6 +83,40 @@ export async function seedAgent(
   return AgentId(id)
 }
 
+/** A converged session milestone row. `visibility`/`ownerIdentity` default to
+ *  what ingest records for a channel session (session-visibility.md §4.2). */
+export async function seedSessionMeta(
+  prisma: PrismaClient,
+  id: string,
+  agentId: string,
+  opts: {
+    visibility?: 'org' | 'private'
+    ownerIdentity?: string
+    daemonId?: string
+    platform?: string
+    channel?: string
+    parentSessionId?: string
+    lastActivityAt?: Date
+  } = {}
+): Promise<string> {
+  await prisma.sessionMeta.create({
+    data: {
+      id,
+      agentId,
+      orgId: DEFAULT_ORG_ID,
+      platform: opts.platform ?? 'slack',
+      channel: opts.channel ?? '#general',
+      phase: 'start',
+      lastActivityAt: opts.lastActivityAt ?? new Date(),
+      ...(opts.visibility ? { visibility: opts.visibility } : {}),
+      ...(opts.ownerIdentity ? { ownerIdentity: opts.ownerIdentity } : {}),
+      ...(opts.daemonId ? { daemonId: opts.daemonId } : {}),
+      ...(opts.parentSessionId ? { parentSessionId: opts.parentSessionId } : {})
+    }
+  })
+  return id
+}
+
 export async function seedLaunch(
   prisma: PrismaClient,
   id: string,

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -353,6 +353,51 @@ describe('session visibility — §4.5 inheritance and cascade', () => {
     expect(untouched).toMatchObject({ visibility: 'org', visibilitySource: 'explicit' })
   })
 
+  it('settles a whole chain that arrived root-last, not just its first level', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const rootId = `s-chain-root-${randomUUID()}`
+    const childId = `s-chain-child-${randomUUID()}`
+    const grandchildId = `s-chain-grandchild-${randomUUID()}`
+
+    // Deepest first: each arrival's parent is missing, or present but itself
+    // still pending — either way the row must stay pending, or the settlement
+    // scan (which matches only `inherited_pending`) would skip it forever.
+    for (const [id, parent] of [
+      [grandchildId, childId],
+      [childId, rootId]
+    ] as const) {
+      const r = await repo.recordMilestone({
+        sessionId: SessionId(id),
+        parentSessionId: SessionId(parent),
+        agentId,
+        phase: 'start',
+        classification: { inherit: true },
+        at: new Date()
+      })
+      expect(r.session).toMatchObject({ visibility: 'private', visibilitySource: 'inherited_pending' })
+    }
+
+    const root = await repo.recordMilestone({
+      sessionId: SessionId(rootId),
+      agentId,
+      phase: 'start',
+      classification: { visibility: 'org', ownerIdentity: 'slack:T1:U7', source: 'default' },
+      at: new Date()
+    })
+
+    // Both levels settle, and both are reported so each gets a §5.1 gate push.
+    expect(root.settled.map((s) => s.id).sort()).toEqual([childId, grandchildId].sort())
+    for (const id of [childId, grandchildId]) {
+      expect(await prisma.sessionMeta.findUnique({ where: { id } })).toMatchObject({
+        visibility: 'org',
+        ownerIdentity: 'slack:T1:U7',
+        visibilitySource: 'inherited'
+      })
+    }
+  })
+
   it('inherits a private parent at ingest, so a delegated prompt is never org-visible', async () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -248,6 +248,52 @@ describe('session visibility — §5.1 daemon-ack cutover', () => {
     expect((await repo.get(SessionId(session)))?.visibilityRev).toBe(1)
   })
 
+  it('replays an unacknowledged gate ahead of newer acknowledged ones', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+
+    // An OLD session tightened while the daemon was offline: it must ride the
+    // snapshot no matter how far past a newest-first cap it sits, or the daemon
+    // keeps capturing against a stale `org` gate forever.
+    const stale = await seedSessionMeta(prisma, `s-stale-${randomUUID()}`, agentId, {
+      daemonId,
+      lastActivityAt: new Date(Date.now() - 86_400_000)
+    })
+    await repo.setVisibility(SessionId(stale), 'private')
+    const fresh = await seedSessionMeta(prisma, `s-fresh-${randomUUID()}`, agentId, {
+      daemonId,
+      lastActivityAt: new Date()
+    })
+    await repo.recordVisibilityAck(SessionId(fresh), 0)
+
+    expect(await repo.countUnackedVisibility(daemonId)).toBe(1)
+    const capped = await repo.visibilitySnapshotForDaemon(daemonId, 1)
+    expect(capped).toEqual([{ sessionId: stale, visibility: 'private', visibilityRev: 1 }])
+  })
+
+  it('reports the cutover as pending while a DESCENDANT daemon is still behind', async () => {
+    const owner = await makeUser('sv-subtree', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+
+    const root = await seedSessionMeta(prisma, `s-sub-root-${randomUUID()}`, agentId, { daemonId })
+    const child = await seedSessionMeta(prisma, `s-sub-child-${randomUUID()}`, agentId, {
+      daemonId,
+      parentSessionId: root
+    })
+    const { affected } = await repo.setVisibility(SessionId(root), 'private')
+    expect(affected.map((a) => a.id).sort()).toEqual([child, root].sort())
+
+    // Only the root's daemon acks. The child holds text copied from the root, so
+    // the cutover is NOT complete — the detail view must keep saying pending.
+    await repo.recordVisibilityAck(SessionId(root), 1)
+    const subtree = await repo.visibilitySubtree(SessionId(root), 100)
+    expect(subtree.map((r) => r.id).sort()).toEqual([child, root].sort())
+    expect(subtree.find((r) => r.id === child)).toMatchObject({ visibilityAckedRev: -1, visibilityRev: 1 })
+  })
+
   it('snapshots the gate state for one daemon, newest first', async () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const otherDaemonId = await seedDaemon(prisma, randomUUID())
@@ -305,6 +351,69 @@ describe('session visibility — §4.5 inheritance and cascade', () => {
     for (const id of [child, grandchild]) {
       expect((await prisma.sessionMeta.findUnique({ where: { id } }))?.visibility).toBe('private')
     }
+  })
+
+  it('re-owns an already-private descendant, so its old owner loses the copied content', async () => {
+    const owner = await makeUser('sv-reown', 'owner')
+    const other = await makeUser('sv-reown-other', 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+
+    const root = await seedSessionMeta(prisma, `s-reown-root-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${owner}`
+    })
+    // A child that is ALREADY private but owned by someone else. Its transcript
+    // holds text delegated from the root, so tightening the root must hand it
+    // the root's owner — leaving `other` on it keeps their access to that text.
+    const child = await seedSessionMeta(prisma, `s-reown-child-${randomUUID()}`, agentId, {
+      parentSessionId: root,
+      visibility: 'private',
+      ownerIdentity: `user:${other}`
+    })
+
+    await appAs(owner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${root}/visibility`,
+      payload: { visibility: 'private' }
+    })
+
+    expect(await prisma.sessionMeta.findUnique({ where: { id: child } })).toMatchObject({
+      visibility: 'private',
+      ownerIdentity: `user:${owner}`,
+      visibilitySource: 'inherited'
+    })
+    // …and the former owner can no longer read it.
+    expect((await appAs(other).app.inject({ method: 'GET', url: `${ORG}/sessions/${child}` })).statusCode).toBe(404)
+  })
+
+  it('re-authorizes against the locked row, so a revoked owner cannot still widen', async () => {
+    const owner = await makeUser('sv-toctou', 'owner')
+    const child_owner = await makeUser('sv-toctou-child', 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+
+    const root = await seedSessionMeta(prisma, `s-toctou-root-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${owner}`
+    })
+    const child = await seedSessionMeta(prisma, `s-toctou-child-${randomUUID()}`, agentId, {
+      parentSessionId: root,
+      visibility: 'private',
+      ownerIdentity: `user:${child_owner}`
+    })
+
+    // The ancestor cascade re-owns the child to the root's owner.
+    await repo.setVisibility(SessionId(root), 'private')
+
+    // The child's FORMER owner now tries to publish it. The route's own check
+    // could have passed on a pre-cascade read; the lock-time re-check refuses.
+    const denied = await repo.setVisibility(
+      SessionId(child),
+      'org',
+      (row) => row.ownerIdentity === `user:${child_owner}`
+    )
+    expect(denied).toMatchObject({ forbidden: true, affected: [] })
+    expect((await repo.get(SessionId(child)))?.visibility).toBe('private')
   })
 
   it('settles an out-of-order child once, and never over a human decision', async () => {

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Session visibility end-to-end (docs/designs/session-visibility.md §9).
+ *
+ * Exercises the CP read gates, the §4.3 reclassification endpoint, and the §4.5
+ * cascade semantics against real Postgres and the real HTTP stack. Under devAuth
+ * the principal is fixed, so a second app built with `{ DEFAULT_OWNER_ID }` is
+ * how we "act as" another member — same idiom as visibility.route.test.ts.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { SessionId } from '../../src/domain/ids.js'
+import type { OrgMemberRole } from '../../src/persistence/ports.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const users = () => new PgUserRepo(prisma)
+const opened: HttpApp[] = []
+
+afterEach(async () => {
+  await Promise.all(opened.splice(0).map((a) => a.close()))
+})
+
+async function makeUser(sub: string, role: OrgMemberRole): Promise<string> {
+  const email = `${sub}@acme.dev`
+  const { userId } = await users().provisionOidcUser({ oidcSubject: sub, email, emailVerified: true })
+  await users().addMemberByEmail(DEFAULT_ORG_ID, email, role)
+  return userId
+}
+
+function appAs(userId: string): HttpApp {
+  const app = buildHttpApp(prisma, { DEFAULT_OWNER_ID: userId })
+  opened.push(app)
+  return app
+}
+
+const sessionIds = (body: unknown): string[] =>
+  (body as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)
+
+describe('session visibility — list & detail', () => {
+  it('a collaborator sees org sessions and their own private ones, never another member’s', async () => {
+    const mine = await makeUser('sv-mine', 'collaborator')
+    const theirs = await makeUser('sv-theirs', 'collaborator')
+    const owner = await makeUser('sv-owner', 'owner')
+
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const orgSession = await seedSessionMeta(prisma, `s-org-${randomUUID()}`, agentId, {})
+    const ownSession = await seedSessionMeta(prisma, `s-own-${randomUUID()}`, agentId, {
+      visibility: 'private',
+      ownerIdentity: `user:${mine}`
+    })
+    const otherSession = await seedSessionMeta(prisma, `s-other-${randomUUID()}`, agentId, {
+      visibility: 'private',
+      ownerIdentity: `user:${theirs}`
+    })
+    // No resolvable owner (§2 owner-orphan): org owners only.
+    const orphanSession = await seedSessionMeta(prisma, `s-orphan-${randomUUID()}`, agentId, {
+      visibility: 'private'
+    })
+
+    const mineApp = appAs(mine)
+    const listed = sessionIds((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json())
+    expect(listed).toEqual(expect.arrayContaining([orgSession, ownSession]))
+    expect(listed).not.toContain(otherSession)
+    expect(listed).not.toContain(orphanSession)
+
+    // Detail is 404 (never 403) for a session the caller cannot see.
+    expect((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${ownSession}` })).statusCode).toBe(200)
+    expect((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${otherSession}` })).statusCode).toBe(404)
+    expect((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${orphanSession}` })).statusCode).toBe(404)
+
+    // The governance exception: an org owner sees every session in the org.
+    const ownerApp = appAs(owner)
+    const asOwner = sessionIds((await ownerApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json())
+    expect(asOwner).toEqual(expect.arrayContaining([orgSession, ownSession, otherSession, orphanSession]))
+  })
+
+  it('keeps keyset pagination stable under the visibility predicate', async () => {
+    const viewer = await makeUser('sv-page', 'collaborator')
+    const other = await makeUser('sv-page-other', 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+
+    // Interleave visible and hidden rows so a page boundary lands mid-run.
+    const visible: string[] = []
+    for (let i = 0; i < 6; i++) {
+      const at = new Date(Date.now() - i * 1000)
+      const isHidden = i % 2 === 1
+      const id = await seedSessionMeta(prisma, `s-page-${i}-${randomUUID()}`, agentId, {
+        lastActivityAt: at,
+        ...(isHidden ? { visibility: 'private' as const, ownerIdentity: `user:${other}` } : {})
+      })
+      if (!isHidden) visible.push(id)
+    }
+
+    const app = appAs(viewer)
+    const collected: string[] = []
+    let cursor: string | null = null
+    for (let page = 0; page < 5; page++) {
+      const url = `${ORG}/sessions?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+      const body = (await app.app.inject({ method: 'GET', url })).json() as {
+        sessions: Array<{ sessionId: string }>
+        nextCursor: string | null
+      }
+      collected.push(...body.sessions.map((s) => s.sessionId))
+      cursor = body.nextCursor
+      if (!cursor) break
+    }
+    // Every visible row exactly once, newest-first, with no hidden row leaking.
+    expect(collected).toEqual(visible)
+  })
+
+  it('hides a private child and parent from the detail relationship links', async () => {
+    const viewer = await makeUser('sv-rel', 'collaborator')
+    const other = await makeUser('sv-rel-other', 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+
+    const parent = await seedSessionMeta(prisma, `s-parent-${randomUUID()}`, agentId, {})
+    const visibleChild = await seedSessionMeta(prisma, `s-child-ok-${randomUUID()}`, agentId, {
+      parentSessionId: parent
+    })
+    const hiddenChild = await seedSessionMeta(prisma, `s-child-hidden-${randomUUID()}`, agentId, {
+      parentSessionId: parent,
+      visibility: 'private',
+      ownerIdentity: `user:${other}`
+    })
+
+    const body = (await appAs(viewer).app.inject({ method: 'GET', url: `${ORG}/sessions/${parent}` })).json() as {
+      childSessions: Array<{ id: string }>
+    }
+    expect(body.childSessions.map((c) => c.id)).toEqual([visibleChild])
+    expect(body.childSessions.map((c) => c.id)).not.toContain(hiddenChild)
+  })
+})
+
+describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
+  it('lets the recorded owner pull an org session private, and org owners reclassify anything', async () => {
+    const initiator = await makeUser('sv-put-owner', 'collaborator')
+    const orgOwner = await makeUser('sv-put-admin', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const session = await seedSessionMeta(prisma, `s-put-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${initiator}`
+    })
+
+    // The initiator of an `org` channel session may pull it private…
+    const res = await appAs(initiator).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${session}/visibility`,
+      payload: { visibility: 'private' }
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ id: session, visibility: 'private', visibilityRev: 1 })
+
+    // …and an org owner may publish it back (widening is explicit, never cascaded).
+    const back = await appAs(orgOwner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${session}/visibility`,
+      payload: { visibility: 'org' }
+    })
+    expect(back.statusCode).toBe(200)
+    expect(back.json()).toMatchObject({ visibility: 'org', visibilityRev: 2 })
+  })
+
+  it('403s a member who can see the session but does not own it, and 404s one who cannot', async () => {
+    const initiator = await makeUser('sv-put-init', 'collaborator')
+    const bystander = await makeUser('sv-put-bystander', 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+
+    const orgSession = await seedSessionMeta(prisma, `s-put-org-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${initiator}`
+    })
+    const privateSession = await seedSessionMeta(prisma, `s-put-priv-${randomUUID()}`, agentId, {
+      visibility: 'private',
+      ownerIdentity: `user:${initiator}`
+    })
+
+    const app = appAs(bystander)
+    // Visible but not theirs ⇒ 403.
+    expect(
+      (
+        await app.app.inject({
+          method: 'PUT',
+          url: `${ORG}/sessions/${orgSession}/visibility`,
+          payload: { visibility: 'private' }
+        })
+      ).statusCode
+    ).toBe(403)
+    // Invisible ⇒ 404, never 403: no existence oracle.
+    expect(
+      (
+        await app.app.inject({
+          method: 'PUT',
+          url: `${ORG}/sessions/${privateSession}/visibility`,
+          payload: { visibility: 'org' }
+        })
+      ).statusCode
+    ).toBe(404)
+  })
+
+  it('reports `applied` when no daemon can ever ack the change', async () => {
+    const owner = await makeUser('sv-state', 'owner')
+    const agentId = await seedAgent(prisma, randomUUID()) // unplaced: no daemon
+    const session = await seedSessionMeta(prisma, `s-state-${randomUUID()}`, agentId, {})
+
+    const res = await appAs(owner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${session}/visibility`,
+      payload: { visibility: 'private' }
+    })
+    expect(res.json()).toMatchObject({ state: 'applied' })
+  })
+})
+
+describe('session visibility — §5.1 daemon-ack cutover', () => {
+  // The pending→applied decision itself (which needs a live, feature-advertising
+  // daemon connection) is unit-tested in src/orchestrator/visibilityPush.test.ts;
+  // here we pin the durable half: the revision it compares against.
+  it('bumps the revision on every change and never lowers the ack watermark', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const session = await seedSessionMeta(prisma, `s-ack-${randomUUID()}`, agentId, { daemonId })
+    const repo = new PgSessionRepo(prisma)
+
+    // -1 is "never acknowledged" — distinct from an ack of revision 0, which is
+    // a real revision for a session ingested and never re-classified.
+    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(-1)
+    const { affected } = await repo.setVisibility(SessionId(session), 'private')
+    expect(affected[0]).toMatchObject({ visibilityRev: 1, visibilityAckedRev: -1 })
+
+    // At-least-once delivery means acks can arrive out of order; the watermark
+    // is monotonic so a late one for an older revision cannot un-apply a change.
+    await repo.recordVisibilityAck(SessionId(session), 0)
+    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(0)
+    await repo.recordVisibilityAck(SessionId(session), 1)
+    await repo.recordVisibilityAck(SessionId(session), 0)
+    expect((await repo.get(SessionId(session)))?.visibilityAckedRev).toBe(1)
+
+    // A no-op re-set neither bumps the revision nor re-opens the cutover.
+    expect((await repo.setVisibility(SessionId(session), 'private')).affected).toEqual([])
+    expect((await repo.get(SessionId(session)))?.visibilityRev).toBe(1)
+  })
+
+  it('snapshots the gate state for one daemon, newest first', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const otherDaemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const older = await seedSessionMeta(prisma, `s-snap-old-${randomUUID()}`, agentId, {
+      daemonId,
+      lastActivityAt: new Date(Date.now() - 60_000)
+    })
+    const newer = await seedSessionMeta(prisma, `s-snap-new-${randomUUID()}`, agentId, {
+      daemonId,
+      visibility: 'private',
+      lastActivityAt: new Date()
+    })
+    await seedSessionMeta(prisma, `s-snap-elsewhere-${randomUUID()}`, agentId, { daemonId: otherDaemonId })
+
+    const snapshot = await new PgSessionRepo(prisma).visibilitySnapshotForDaemon(daemonId, 10)
+    expect(snapshot).toEqual([
+      { sessionId: newer, visibility: 'private', visibilityRev: 0 },
+      { sessionId: older, visibility: 'org', visibilityRev: 0 }
+    ])
+  })
+})
+
+describe('session visibility — §4.5 inheritance and cascade', () => {
+  it('tightening cascades transitively (explicit descendants included); widening never does', async () => {
+    const owner = await makeUser('sv-cascade', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+
+    const root = await seedSessionMeta(prisma, `s-root-${randomUUID()}`, agentId, {})
+    const child = await seedSessionMeta(prisma, `s-kid-${randomUUID()}`, agentId, { parentSessionId: root })
+    const grandchild = await seedSessionMeta(prisma, `s-grandkid-${randomUUID()}`, agentId, {
+      parentSessionId: child
+    })
+    // A descendant a human already re-classified: privacy still wins over it.
+    await prisma.sessionMeta.update({ where: { id: grandchild }, data: { visibilitySource: 'explicit' } })
+
+    const app = appAs(owner)
+    await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${root}/visibility`,
+      payload: { visibility: 'private' }
+    })
+    for (const id of [root, child, grandchild]) {
+      expect((await prisma.sessionMeta.findUnique({ where: { id } }))?.visibility).toBe('private')
+    }
+
+    // Widening the root leaves every descendant private — each is its own decision.
+    await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${root}/visibility`,
+      payload: { visibility: 'org' }
+    })
+    expect((await prisma.sessionMeta.findUnique({ where: { id: root } }))?.visibility).toBe('org')
+    for (const id of [child, grandchild]) {
+      expect((await prisma.sessionMeta.findUnique({ where: { id } }))?.visibility).toBe('private')
+    }
+  })
+
+  it('settles an out-of-order child once, and never over a human decision', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-late-parent-${randomUUID()}`
+
+    // The child's milestone arrives first: no parent row to inherit from yet.
+    const child = await repo.recordMilestone({
+      sessionId: SessionId(`s-early-child-${randomUUID()}`),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      classification: { inherit: true },
+      at: new Date()
+    })
+    expect(child.session).toMatchObject({ visibility: 'private', visibilitySource: 'inherited_pending' })
+
+    // A second pending child that an org owner re-classifies before settlement.
+    const pinned = await repo.recordMilestone({
+      sessionId: SessionId(`s-pinned-child-${randomUUID()}`),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      classification: { inherit: true },
+      at: new Date()
+    })
+    await repo.setVisibility(pinned.session!.id, 'org')
+
+    // Now the parent lands as an org channel session.
+    const parent = await repo.recordMilestone({
+      sessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      classification: { visibility: 'org', ownerIdentity: 'slack:T1:U1', source: 'default' },
+      at: new Date()
+    })
+
+    // The still-pending child settles from the parent, exactly once…
+    expect(parent.settled.map((s) => s.id)).toEqual([child.session!.id])
+    const settled = await prisma.sessionMeta.findUnique({ where: { id: child.session!.id } })
+    expect(settled).toMatchObject({ visibility: 'org', ownerIdentity: 'slack:T1:U1', visibilitySource: 'inherited' })
+    // …and the human decision is untouched (still `explicit`, not re-settled).
+    const untouched = await prisma.sessionMeta.findUnique({ where: { id: pinned.session!.id } })
+    expect(untouched).toMatchObject({ visibility: 'org', visibilitySource: 'explicit' })
+  })
+
+  it('inherits a private parent at ingest, so a delegated prompt is never org-visible', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+
+    const parentId = `s-dm-parent-${randomUUID()}`
+    await repo.recordMilestone({
+      sessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      classification: { visibility: 'private', ownerIdentity: 'user:u-1', source: 'default' },
+      at: new Date()
+    })
+    const child = await repo.recordMilestone({
+      sessionId: SessionId(`s-dm-child-${randomUUID()}`),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      classification: { inherit: true },
+      at: new Date()
+    })
+    expect(child.session).toMatchObject({
+      visibility: 'private',
+      ownerIdentity: 'user:u-1',
+      visibilitySource: 'inherited'
+    })
+  })
+
+  it('never leaves an org-visible descendant of a private parent, in either commit order', async () => {
+    const owner = await makeUser('sv-race', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const app = appAs(owner)
+
+    for (const childFirst of [true, false]) {
+      const rootId = `s-race-root-${randomUUID()}`
+      await repo.recordMilestone({
+        sessionId: SessionId(rootId),
+        agentId,
+        phase: 'start',
+        classification: { visibility: 'org', ownerIdentity: 'slack:T1:U9', source: 'default' },
+        at: new Date()
+      })
+      const childId = `s-race-child-${randomUUID()}`
+      const grandchildId = `s-race-grandchild-${randomUUID()}`
+      await repo.recordMilestone({
+        sessionId: SessionId(childId),
+        parentSessionId: SessionId(rootId),
+        agentId,
+        phase: 'start',
+        classification: { inherit: true },
+        at: new Date()
+      })
+
+      // A grandchild ingest racing the ancestor's tighten — the depth-2 case the
+      // lock-then-scan-to-fixpoint cascade exists for.
+      const tighten = app.app.inject({
+        method: 'PUT',
+        url: `${ORG}/sessions/${rootId}/visibility`,
+        payload: { visibility: 'private' }
+      })
+      const insertGrandchild = repo.recordMilestone({
+        sessionId: SessionId(grandchildId),
+        parentSessionId: SessionId(childId),
+        agentId,
+        phase: 'start',
+        classification: { inherit: true },
+        at: new Date()
+      })
+      await (childFirst ? Promise.all([insertGrandchild, tighten]) : Promise.all([tighten, insertGrandchild]))
+
+      for (const id of [rootId, childId, grandchildId]) {
+        const row = await prisma.sessionMeta.findUnique({ where: { id } })
+        expect({ id, visibility: row?.visibility }).toEqual({ id, visibility: 'private' })
+      }
+    }
+  })
+})

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -64,6 +64,7 @@ async function seedSession(agentId = AGENT): Promise<void> {
     data: {
       id: SESSION,
       agentId,
+      orgId: DEFAULT_ORG_ID,
       platform: 'slack',
       channel: '#deploys',
       phase: 'start',
@@ -80,6 +81,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
       data: {
         id: SESSION,
         agentId: AGENT,
+        orgId: DEFAULT_ORG_ID,
         platform: 'slack',
         channel: '#deploys',
         thread: 'T1',
@@ -147,6 +149,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
       data: {
         id: SESSION,
         agentId: AGENT,
+        orgId: DEFAULT_ORG_ID,
         platform: 'slack',
         channel: '#deploys',
         phase: 'start',
@@ -172,6 +175,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: older,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -180,6 +184,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: newer,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -208,6 +213,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: oldest,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -216,6 +222,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: tieA,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -225,6 +232,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: tieM,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -234,6 +242,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: tieZ,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',
@@ -275,6 +284,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: older,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: 'C-OLDER',
           channelName: 'older',
@@ -286,6 +296,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: newer,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: 'C-NEWER',
           channelName: 'newer',
@@ -341,6 +352,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: randomUUID(),
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: 'C-A-SLACK',
           triggeredBy: 'U-A-SLACK',
@@ -350,6 +362,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: randomUUID(),
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'discord',
           channel: 'C-A-DISCORD',
           triggeredBy: 'U-A-DISCORD',
@@ -359,6 +372,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: randomUUID(),
           agentId: secondAgent,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: 'C-B-SLACK',
           triggeredBy: 'U-B-SLACK',
@@ -450,6 +464,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: firstSession,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: 'C-FIRST',
           triggeredBy: `hook:${firstHook}`,
@@ -460,6 +475,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: secondSession,
           agentId: secondAgent,
+          orgId: DEFAULT_ORG_ID,
           platform: 'hook',
           channel: secondHook,
           triggeredBy: `hook:${secondHook}`,
@@ -470,6 +486,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: otherSession,
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'hook',
           channel: otherHook,
           triggeredBy: `hook:${otherHook}`,
@@ -514,6 +531,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: randomUUID(),
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#deploys',
           phase: 'start',
@@ -522,6 +540,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
         {
           id: randomUUID(),
           agentId: AGENT,
+          orgId: DEFAULT_ORG_ID,
           platform: 'slack',
           channel: '#ops',
           phase: 'start',

--- a/packages/control-plane/test/integration/stream.route.test.ts
+++ b/packages/control-plane/test/integration/stream.route.test.ts
@@ -9,7 +9,8 @@ import { randomUUID } from 'node:crypto'
 
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { seedAgent, seedDaemon, seedSessionMeta } from '../fixtures/seed.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { prisma } from '../setup.db.js'
 
 const ORIGIN = 'https://app.example.com'
@@ -51,6 +52,74 @@ describe('session event stream', () => {
     }
   })
 
+  // session-visibility.md §5: BOTH session-scoped envelope variants are gated —
+  // the milestone carries a content-derived summary, and the activity event
+  // still exposes the session's existence, revision, and live activity.
+  it('withholds both envelope variants of a private session from a non-owner', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    await seedSessionMeta(prisma, 'session-private', agentId, {
+      daemonId,
+      visibility: 'private',
+      ownerIdentity: 'user:someone-else'
+    })
+    await seedSessionMeta(prisma, 'session-shared', agentId, { daemonId })
+
+    // devAuth's principal is DEFAULT_OWNER_ID, whose org role is `owner` — the
+    // governance exception would see everything, so subscribe as a collaborator.
+    const email = 'stream-collaborator@acme.dev'
+    const { userId } = await new PgUserRepo(prisma).provisionOidcUser({
+      oidcSubject: 'stream-collaborator',
+      email,
+      emailVerified: true
+    })
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+
+    const app = buildHttpApp(prisma, { DEFAULT_OWNER_ID: userId })
+    opened.push(app)
+    const base = await app.app.listen({ port: 0, host: '127.0.0.1' })
+    const { request, response } = await openStream(`${base}/api/v1/orgs/${DEFAULT_ORG_ID}/stream`)
+    const chunks: string[] = []
+    response.setEncoding('utf8')
+    response.on('data', (chunk: string) => chunks.push(chunk))
+
+    try {
+      app.events.publishActivity(daemonId, {
+        sessionId: 'session-private',
+        agentId,
+        revision: '3',
+        ts: '2026-07-30T00:00:00.000Z'
+      })
+      app.events.publish(daemonId, {
+        sessionId: 'session-private',
+        agentId,
+        phase: 'plan',
+        summary: 'secret plan',
+        ts: '2026-07-30T00:00:01.000Z'
+      })
+      // A visible session's event is the ordering barrier: once it has arrived,
+      // the two above were definitively dropped rather than merely pending.
+      app.events.publishActivity(daemonId, {
+        sessionId: 'session-shared',
+        agentId,
+        revision: '4',
+        ts: '2026-07-30T00:00:02.000Z'
+      })
+
+      await vi.waitFor(() => expect(chunks.join('')).toContain('"sessionId":"session-shared"'))
+      const body = chunks.join('')
+      expect(body).not.toContain('session-private')
+      expect(body).not.toContain('secret plan')
+    } finally {
+      await new Promise<void>((resolve) => {
+        if (response.destroyed) return resolve()
+        response.once('close', resolve)
+        response.destroy()
+        request.destroy()
+      })
+    }
+  })
+
   it('relays a body-free session activity event for a visible agent', async () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
@@ -61,6 +130,10 @@ describe('session event stream', () => {
     const chunks: string[] = []
     response.setEncoding('utf8')
     response.on('data', (chunk: string) => chunks.push(chunk))
+
+    // The activity gate reads the session row (session-visibility.md §5), so seed
+    // the milestone the daemon would have reported before any turn activity.
+    await seedSessionMeta(prisma, 'session-live', agentId, { daemonId })
 
     try {
       app.events.publishActivity(daemonId, {

--- a/packages/control-plane/test/integration/visibility.route.test.ts
+++ b/packages/control-plane/test/integration/visibility.route.test.ts
@@ -518,6 +518,7 @@ describe('derived visibility — session bodies, usage', () => {
       data: {
         id: session,
         agentId: R,
+        orgId: DEFAULT_ORG_ID,
         platform: 'slack',
         channel: 'C-HR',
         phase: 'start',

--- a/packages/control-plane/test/repo/session.repo.test.ts
+++ b/packages/control-plane/test/repo/session.repo.test.ts
@@ -137,16 +137,20 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
     await seedAgent(prisma, OTHER_AGENT, { daemonId: DAEMON })
     const repo = new PgSessionRepo(prisma)
 
-    expect(await repo.recordMilestone(ev('start', { title: 'Original', daemonId: DaemonId(DAEMON) }))).toBe(true)
+    expect((await repo.recordMilestone(ev('start', { title: 'Original', daemonId: DaemonId(DAEMON) }))).recorded).toBe(
+      true
+    )
     expect(
-      await repo.recordMilestone(
-        ev('end', {
-          agentId: AgentId(OTHER_AGENT),
-          launchId: undefined,
-          title: 'Forged',
-          daemonId: DaemonId(DAEMON)
-        })
-      )
+      (
+        await repo.recordMilestone(
+          ev('end', {
+            agentId: AgentId(OTHER_AGENT),
+            launchId: undefined,
+            title: 'Forged',
+            daemonId: DaemonId(DAEMON)
+          })
+        )
+      ).recorded
     ).toBe(false)
 
     const got = await repo.get(SessionId(SESSION))
@@ -172,9 +176,9 @@ describe('SessionRepo.recordMilestone — milestone-only (real Postgres)', () =>
       )
     ])
 
-    expect(accepted.filter(Boolean)).toHaveLength(1)
+    expect(accepted.filter((result) => result.recorded)).toHaveLength(1)
     const got = await repo.get(SessionId(SESSION))
-    if (accepted[0]) {
+    if (accepted[0]!.recorded) {
       expect(got).toMatchObject({ agentId: AGENT, title: 'Agent A', phase: 'start' })
     } else {
       expect(got).toMatchObject({ agentId: OTHER_AGENT, title: 'Agent B', phase: 'end' })

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -77,6 +77,8 @@ export interface DreamStorePort {
     agentId: string,
     limit: number
   ): { sessionId: string; channel: string; thread: string; transportScope?: string | null }[]
+  /** Is this session excluded from agent-memory capture (session-visibility.md §5.1)? */
+  isCaptureExcluded(acpSessionId: string | undefined): boolean
   /** Chronological text rows of one session thread, scoped to the agent. */
   dreamTranscriptText(
     channel: string,
@@ -286,7 +288,13 @@ export class DreamRunner {
       }
       const sessionWindow = opts.sessionWindow ?? policy.sessionWindow ?? DEFAULT_SESSION_WINDOW
       const instructions = opts.instructions ?? policy.instructions
-      const sources = this.deps.store.dreamSessionSources(agentId, sessionWindow)
+      // Dreams distill transcripts straight from the store, bypassing the
+      // per-turn capture path — so the session-visibility gate has to be applied
+      // here too, or a private session's content reaches shared agent memory by
+      // the back door (session-visibility.md §5.1).
+      const sources = this.deps.store
+        .dreamSessionSources(agentId, sessionWindow)
+        .filter((source) => !this.deps.store.isCaptureExcluded(source.sessionId))
 
       // Snapshot the live store — the digest is the adoption fence. Taken under
       // the shared memory-dir lock so it cannot tear against a concurrent

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -67,7 +67,8 @@ import type {
   DreamFilesReq,
   DreamFileReadReq,
   DreamSkillReviewReq,
-  DreamSkillReadReq
+  DreamSkillReadReq,
+  SessionVisibilityPush
 } from '@agentconnect.md/protocol'
 import {
   buildEnvelope,
@@ -673,6 +674,27 @@ export class CpClient {
       case 'cron/run':
         this.reply(frame, 'ack', this.deps.configApply.runCron((frame.payload as { cronId: string }).cronId))
         return
+      case 'session/visibility': {
+        // session-visibility.md §5.1. ALWAYS reply: a stale revision is answered
+        // `superseded`, never an error frame — an error would reject the CP's
+        // promise and drive its retransmit budget to exhaustion.
+        const p = frame.payload as SessionVisibilityPush
+        const status = this.deps.configApply.applySessionVisibility(p)
+        this.reply(frame, 'session/visibility/ok', {
+          sessionId: p.sessionId,
+          visibilityRev: p.visibilityRev,
+          status
+        })
+        return
+      }
+      case 'session/visibility/snapshot': {
+        // Register-time convergence: the full gate set, applied entry by entry
+        // under the same revision rule. One ack for the whole chunk.
+        const { entries } = frame.payload as { entries: SessionVisibilityPush[] }
+        for (const entry of entries) this.deps.configApply.applySessionVisibility(entry)
+        this.reply(frame, 'ack', { ok: true })
+        return
+      }
       case 'route/assign': {
         const a = frame.payload as Parameters<ConfigApply['applyRouteAssign']>[0]
         this.deps.configApply.applyRouteAssign(a)

--- a/packages/daemon/src/cp/config-apply.ts
+++ b/packages/daemon/src/cp/config-apply.ts
@@ -29,7 +29,8 @@ import type {
   DaemonControlAck,
   AgentPermissionRequestList,
   AgentPermissionRequestPage,
-  AgentPermissionDecision
+  AgentPermissionDecision,
+  SessionVisibilityPush
 } from '@agentconnect.md/protocol'
 import type { Config } from '../config/config-schema.js'
 
@@ -90,6 +91,13 @@ export interface ConfigApply {
   applyDaemonRestart(req: DaemonRestart): DaemonControlAck
   /** Drain + exit for a version bump (daemon/upgrade REQ). */
   applyDaemonUpgrade(req: DaemonUpgrade): DaemonControlAck
+  /**
+   * Apply the CP's effective session visibility to the local memory-capture gate
+   * (session-visibility.md §5.1). Idempotent by `visibilityRev`: a revision at or
+   * below the stored one is reported `superseded` and NOT reapplied — but it is
+   * still acknowledged, so a lost ack cannot make the CP retry forever.
+   */
+  applySessionVisibility(p: SessionVisibilityPush): 'applied' | 'superseded'
 }
 
 const LOG_LEVELS = new Set(['trace', 'debug', 'info', 'warn', 'error'])

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -161,6 +161,7 @@ import {
   RELAY_DAEMON_SUBPROTOCOL,
   RELAY_DAEMON_WS_PATH,
   RESERVED_RESTART_CODE,
+  SESSION_VISIBILITY_FEATURE,
   effectiveMemoryDreamingPolicy,
   gitRepoLabel
 } from '@agentconnect.md/protocol'
@@ -265,7 +266,8 @@ import type {
   FeishuRegion,
   MemoryDreamingPolicy,
   ChildSessionStatus,
-  ChildSessionStatusProbe
+  ChildSessionStatusProbe,
+  SessionVisibilityPush
 } from '@agentconnect.md/protocol'
 
 /** Format an error for logs, surfacing a JSON-RPC/ACP RequestError's `code` and
@@ -617,6 +619,14 @@ interface CallMeta {
    *  Like `deliverHeadless` it does NOT cascade — a grandchild is only obliged if its own parent
    *  asks. Absent ⇒ an ordinary fire-and-forget wake. */
   needsReply?: boolean
+  /** session-visibility.md §5.1: the WAKING session is private, so this child's
+   *  transcript holds prompt text copied out of it and must not feed shared agent
+   *  memory. Strictly ONE-DIRECTIONAL — it can only tighten. A `false`/absent
+   *  value never opens capture: an A2A child always starts excluded, and only a
+   *  CP-confirmed `org` state (which the CP derives from the post-cascade parent)
+   *  may open it. That is what makes a stale hint in flight during a §4.3
+   *  tightening harmless. */
+  parentPrivate?: boolean
 }
 
 type TurnInterruptReason = 'pause' | 'loop protection' | 'stop' | 'cancel' | 'shutdown'
@@ -1087,6 +1097,12 @@ interface WebchatTurnContext {
   sink: WebchatSink
   runtime?: WebchatRuntimeConfig
   doneSent?: boolean
+  /** This turn is driven by the local evaluation harness, not a browser. Its
+   *  webchat shape is synthetic, so the session-visibility capture gate does NOT
+   *  treat it as a private Playground conversation — measuring memory capture is
+   *  the harness's whole purpose (session-visibility.md §4.2 applies to real
+   *  user conversations). */
+  evaluation?: boolean
 }
 
 /** One daemon-owned turn stream. `sink` is stable for the turn engine; `transport`
@@ -1617,7 +1633,8 @@ export class Daemon {
     const sessionId = await this.dispatch(input.agentId, message, undefined, {
       conversationId: input.conversationId,
       turnId,
-      sink
+      sink,
+      evaluation: true
     })
     // Product turns intentionally enqueue post-turn memory work. Evaluation waits
     // for this agent's chain so the returned artifact has a terminal capture event.
@@ -3486,6 +3503,11 @@ export class Daemon {
   ): void {
     if (this.evaluationProfile.memory === 'off') return
     if (!output.trim()) return
+    // Agent memory is agent-scoped and shared across users, so a private
+    // session's turn must never be distilled into it (session-visibility.md
+    // §5.1). The gate is checked HERE — before both the managed distillation and
+    // the external capture outbox — and fails closed on unknown state.
+    if (this.store.isCaptureExcluded(sessionId)) return
     const provider = binding?.provider ?? 'managed'
     const observableCapture = provider === 'managed' || provider === 'external'
     const record = async () => {
@@ -5002,7 +5024,11 @@ export class Daemon {
       ...(msg.originCoords !== undefined ? { originCoords: msg.originCoords } : {}),
       // §5.4: the remote caller asked this child to report its outcome back. Same gate as the
       // local path — the directive names `originSessionId`, so it is meaningless without one.
-      ...(msg.needsReply === true && msg.originSessionId !== undefined ? { needsReply: true } : {})
+      ...(msg.needsReply === true && msg.originSessionId !== undefined ? { needsReply: true } : {}),
+      // §5.1: tighten-only. A `true` seals the child's capture gate immediately;
+      // a `false`/absent value changes nothing, because the child starts excluded
+      // and only the CP may open it.
+      ...(msg.parentPrivate === true ? { parentPrivate: true } : {})
     }
     const narrowed = this.narrowPlatform(platform)
     const resolved = this.resolveCpAgent(msg.toAgentId)
@@ -5337,7 +5363,10 @@ export class Daemon {
       originCoords,
       // §5.3: `toAgent.needsReply` — tell the child to report its outcome back to that origin.
       // Meaningless without an origin to reply into, so it rides the same condition.
-      ...(req.needsReply === true && originSessionId !== undefined ? { needsReply: true } : {})
+      ...(req.needsReply === true && originSessionId !== undefined ? { needsReply: true } : {}),
+      // §5.1: seal the child's capture gate when the waking session is private.
+      // Tighten-only — see CallMeta.parentPrivate.
+      ...(originSessionId !== undefined && this.store.isCaptureExcluded(originSessionId) ? { parentPrivate: true } : {})
     }
 
     const normalized: NormalizedMessage = {
@@ -5445,7 +5474,12 @@ export class Daemon {
       hopCount: sourceHopCount + 1,
       deliveryId,
       ...(replierSessionId !== undefined ? { originSessionId: replierSessionId } : {}),
-      originCoords: replyOriginCoords
+      originCoords: replyOriginCoords,
+      // §5.1: seal the child's capture gate when the waking session is private.
+      // Tighten-only — see CallMeta.parentPrivate.
+      ...(replierSessionId !== undefined && this.store.isCaptureExcluded(replierSessionId)
+        ? { parentPrivate: true }
+        : {})
     }
 
     // Resolve where the origin session lives. Local ⇒ dispatch straight into it through the
@@ -5743,7 +5777,10 @@ export class Daemon {
         platform: originCoordPlatform,
         channel: req.originChannel,
         ...(req.originThread ? { thread: req.originThread } : {})
-      }
+      },
+      // §5.1: seal the child's capture gate when the waking session is private.
+      // Tighten-only — see CallMeta.parentPrivate.
+      ...(originSessionId && this.store.isCaptureExcluded(originSessionId) ? { parentPrivate: true } : {})
     }
     const transportScope = this.transportScopeForIntegrationIds(
       req.integrationId !== undefined ? [req.integrationId] : undefined
@@ -5806,6 +5843,10 @@ export class Daemon {
     try {
       const ack = await this.relays.sendAgentMsg({
         claimedFromAgentId: req.callerAgentId,
+        // Tighten-only privacy hint for the remote child's capture gate (§5.1).
+        ...(ctx.originSessionId !== undefined && this.store.isCaptureExcluded(ctx.originSessionId)
+          ? { parentPrivate: true }
+          : {}),
         toAgentId: req.toAgentId,
         text: req.text,
         coords: {
@@ -8734,6 +8775,12 @@ export class Daemon {
     // First metadata snapshot: enough for the CP's DB-backed session list/detail to
     // resolve this daemon-local session without pulling `session/list` on every view.
     if (created) {
+      // Classify for session visibility BEFORE the first milestone: the CP's
+      // ingest is first-wins, and the daemon's own capture gate must be closed
+      // from turn one for anything that could be private (session-visibility.md
+      // §4.1/§5.1). Persisted on the session row so later re-emits — including
+      // after a restart, when `msg` is long gone — still carry the same facts.
+      this.classifyNewSession(agentId, key, sessionId, msg, callMeta !== undefined, webchat?.evaluation === true)
       this.emitSessionMetadataSnapshot({
         sessionId,
         agentId,
@@ -10222,6 +10269,17 @@ export class Daemon {
       ts: now
     }
     if (row?.parentSessionId !== undefined) event.parentSessionId = row.parentSessionId
+    // Visibility-classification inputs (session-visibility.md §4.1), read from
+    // the session row so every re-emit carries them. Absent fields make the CP
+    // fail closed (no owner) rather than guess — never send a placeholder.
+    const classification = this.store.getSessionClassification(input.agentId, input.sessionId)
+    if (classification?.conversationKind !== undefined) {
+      event.conversationKind = classification.conversationKind as EventSession['conversationKind']
+    }
+    if (classification?.tenantScope !== undefined) event.transportScope = classification.tenantScope
+    if (classification?.launchCorrelationId !== undefined) {
+      event.launchCorrelationId = classification.launchCorrelationId
+    }
     const thread = key?.thread ?? input.thread
     if (thread !== undefined) event.thread = thread
     if (row?.title !== undefined) event.title = row.title
@@ -11861,6 +11919,12 @@ export class Daemon {
    *  lifetime (§14.7 open question 2: a restart re-notices, which is acceptable). */
   private readonly gatedNoticesSent = new Set<string>()
 
+  /** agentId → the CP launch correlation awaiting the next session this agent
+   *  creates (session-visibility.md §4.4). `agent/launch` only warm-starts a
+   *  host — the session arrives later, from the daemon's own ingress — so the
+   *  provenance has to be parked here and consumed once. */
+  private readonly pendingLaunchCorrelation = new Map<string, string>()
+
   /** The integration config backing `integrationId`, across all local agents. */
   private integrationConfigById(integrationId: string): Integration | undefined {
     for (const a of this.agents.values()) {
@@ -11902,6 +11966,103 @@ export class Daemon {
       .digest('hex')
       .slice(0, 24)
     return `${integration.platform}:${digest}`
+  }
+
+  /**
+   * The DURABLE tenant scope for an integration (session-visibility.md §2) — the
+   * middle segment of an IM owner identity `<platform>:<scope>:<uid>`.
+   *
+   * Deliberately NOT `transportScopeForIntegration`: that one hashes the live
+   * credential, so it rotates with tokens and would orphan every historical
+   * identity match. This returns a value that survives rotation — the platform's
+   * own tenant id where one exists, otherwise a scope minted once per
+   * integration and persisted. Undefined ⇒ the CP records no owner (fail closed),
+   * never a guessed one.
+   */
+  private tenantScopeForIntegration(integration: Integration): string | undefined {
+    switch (integration.platform) {
+      case 'slack': {
+        // The workspace id from auth.test, surfaced by the live connection.
+        // Optional-call: the connection map holds live SlackConnections in
+        // production, but a not-yet-authenticated (or test-substituted) one may
+        // not expose the accessor — fall back to a minted scope rather than throw.
+        const teamId = this.connByIntegration.get(integration.id)?.workspaceId?.()
+        return teamId || this.mintedTenantScope(integration.id)
+      }
+      case 'telegram': {
+        // The public bot id prefix survives a BotFather token rotation.
+        const botId = integration.telegram.botToken.split(':', 1)[0]
+        return /^\d+$/.test(botId ?? '') ? `bot${botId}` : this.mintedTenantScope(integration.id)
+      }
+      case 'feishu':
+        // App id + region is the tenant anchor Feishu/Lark exposes to us.
+        return `${integration.feishu.region}:${integration.feishu.appId}`
+      default:
+        // Discord (and anything new) exposes no durable tenant id here.
+        return this.mintedTenantScope(integration.id)
+    }
+  }
+
+  /**
+   * Seed a new session's visibility facts and its local capture gate (§4.1/§5.1).
+   *
+   * The gate's first layer is what the daemon can decide alone, with no CP
+   * round-trip. It is deliberately conservative: an A2A child ALWAYS starts
+   * excluded regardless of any hint it carried, because a delegated prompt may
+   * be copied from a private parent and only a CP-confirmed `org` state may open
+   * capture. Everything else the CP later confirms or overrides.
+   */
+  private classifyNewSession(
+    agentId: string,
+    key: string,
+    acpSessionId: string,
+    msg: NormalizedMessage,
+    isA2aChild: boolean,
+    isEvaluation = false
+  ): void {
+    try {
+      this.classifyNewSessionOrThrow(agentId, key, acpSessionId, msg, isA2aChild, isEvaluation)
+    } catch (err) {
+      // Never let classification break a turn — but fail CLOSED: an unclassified
+      // session keeps memory capture excluded until the CP confirms otherwise.
+      this.log.warn(`session visibility: classification failed for ${acpSessionId} (${formatErr(err)})`)
+      this.store.setLocalCaptureGate(acpSessionId, true)
+    }
+  }
+
+  private classifyNewSessionOrThrow(
+    agentId: string,
+    key: string,
+    acpSessionId: string,
+    msg: NormalizedMessage,
+    isA2aChild: boolean,
+    isEvaluation: boolean
+  ): void {
+    const conversationKind = msg.isDm ? 'dm' : msg.isGroupDm ? 'group_dm' : 'channel'
+    const integrationId =
+      msg.platform === 'webchat'
+        ? undefined
+        : this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
+    const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
+    const tenantScope = integration ? this.tenantScopeForIntegration(integration) : undefined
+    const launchCorrelationId = this.pendingLaunchCorrelation.get(agentId)
+    if (launchCorrelationId) this.pendingLaunchCorrelation.delete(agentId)
+    this.store.setSessionClassification(key, {
+      conversationKind,
+      ...(tenantScope ? { tenantScope } : {}),
+      ...(launchCorrelationId ? { launchCorrelationId } : {})
+    })
+    const locallyPrivate =
+      !isEvaluation && (isA2aChild || msg.isDm || msg.platform === 'webchat' || launchCorrelationId !== undefined)
+    this.store.setLocalCaptureGate(acpSessionId, locallyPrivate)
+  }
+
+  /** Mint-once, persisted: stable across restarts and credential rotations. */
+  private mintedTenantScope(integrationId: string): string {
+    return (
+      this.store.getMintedTenantScope(integrationId) ??
+      this.store.mintTenantScope(integrationId, `mint:${randomUUID().replace(/-/g, '').slice(0, 24)}`)
+    )
   }
 
   /** Source integrations on one live ingress share a physical connection. The
@@ -13618,6 +13779,11 @@ export class Daemon {
         // launchId is a fresh fence value; per-turn mode + launchId-scoped prompt
         // fencing are out of scope (the daemon prompts from its own ingress).
         this.drainingAgents.delete(launch.agentId)
+        // Park the CP's launch provenance for the next session this agent
+        // creates, so ingest can attribute it to the launching user (§4.4).
+        if (launch.launchCorrelationId) {
+          this.pendingLaunchCorrelation.set(launch.agentId, launch.launchCorrelationId)
+        }
         await this.ensureHostAsync(launch.agentId)
         return {
           agentId: launch.agentId,
@@ -13633,7 +13799,14 @@ export class Daemon {
       applyDaemonDrain: (drain: Drain, onProgress: (p: DrainProgress) => void): Promise<DrainDone> =>
         this.runDrain(drain, onProgress),
       applyDaemonRestart: (_req: DaemonRestart): DaemonControlAck => this.scheduleFleetExit('restart'),
-      applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck => this.scheduleFleetExit('upgrade', req.targetVersion)
+      applyDaemonUpgrade: (req: DaemonUpgrade): DaemonControlAck =>
+        this.scheduleFleetExit('upgrade', req.targetVersion),
+      // The CP is the authority on effective visibility (§4.3 changes, §4.5
+      // settlements and cascades); the daemon only enforces the resulting
+      // capture gate. Ordering is by the CP's durable revision, so retransmits
+      // and out-of-order delivery are safe.
+      applySessionVisibility: (p: SessionVisibilityPush): 'applied' | 'superseded' =>
+        this.store.applyCpCaptureGate(p.sessionId, p.visibility === 'private', p.visibilityRev)
     }
   }
 
@@ -14003,7 +14176,11 @@ export class Daemon {
           // with a clear "not supported by this agent's version" instead of
           // sending a frame that daemon would silently drop (and hanging until
           // the request times out), and the console hides the panel.
-          'memory-dreaming-v1'
+          'memory-dreaming-v1',
+          // Per-session memory-capture gate (session-visibility.md §5.1). The CP
+          // only pushes `session/visibility` to daemons that advertise this — an
+          // older daemon would NAK the unknown frame, not ignore it.
+          SESSION_VISIBILITY_FEATURE
         ]
       }),
       // Observed runtime profiles, sent as one `facts/daemon-runtimes` snapshot on

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2008,6 +2008,12 @@ export class Daemon {
       cancelOrchestration: (req) => Promise.resolve(this.cancelOrchestrationForOwner(req)),
       submitGithubReview: (req) => this.submitGithubReview(req),
       memory: this.memory,
+      // session-visibility.md §5.1: the same capture gate that blocks automatic
+      // distillation also blocks an EXPLICIT write from a private session —
+      // agent memory is shared across users, so the tool path would otherwise
+      // be a way around it. Resolved from the caller's trusted session coords
+      // at call time, so a session tightened mid-life is covered.
+      memoryWriteAllowed: (ctx) => !this.store.isCaptureExcluded(this.acpSessionIdForToolCall(ctx)),
       recordOutbound: (ctx, channel, thread, text, ts, integrationId) =>
         this.store.appendTranscript({
           channel: transcriptChannelKey(channel, this.transportScopeForIntegrationIds([integrationId])),
@@ -12055,6 +12061,20 @@ export class Daemon {
     const locallyPrivate =
       !isEvaluation && (isA2aChild || msg.isDm || msg.platform === 'webchat' || launchCorrelationId !== undefined)
     this.store.setLocalCaptureGate(acpSessionId, locallyPrivate)
+  }
+
+  /** The ACP session id behind an MCP tool call, from the caller's trusted
+   *  session coords. Undefined when no local row matches — the capture gate
+   *  treats that as unknown, i.e. excluded. */
+  private acpSessionIdForToolCall(ctx: {
+    agentId: string
+    platform: string
+    channel: string
+    thread: string
+    transportScope?: string
+  }): string | undefined {
+    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+    return this.store.getSession(key)?.acpSessionId ?? undefined
   }
 
   /** Mint-once, persisted: stable across restarts and credential rotations. */

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -269,6 +269,13 @@ export interface SubmitGithubReviewReq extends SubmitGithubReviewInput {
   transportScope?: string
 }
 
+/** Refusal surfaced to the model when a private session tries to write shared
+ *  agent memory (session-visibility.md §5.1). Phrased so the agent stops
+ *  retrying and does not paraphrase the content into its reply instead. */
+export const MEMORY_WRITE_BLOCKED =
+  'This session is private, so it cannot write to the agent memory shared with other users. Keep the information in ' +
+  'this conversation instead; do not retry.'
+
 export interface OpsDeps {
   /** Fail-closed turn gate checked before every daemon bridge tool. Used to make
    *  pause/cancel/loop interrupts terminal even while the runtime is still unwinding. */
@@ -352,6 +359,13 @@ export interface OpsDeps {
   /** The agent memory provider — backs the `readMemory`/`writeMemory` tools.
    *  Universal (every agent has memory), independent of the platform. */
   memory: MemoryProvider
+  /** Session-visibility capture gate (session-visibility.md §5.1) for the tool
+   *  path. Automatic post-turn distillation is gated in the daemon, but an agent
+   *  can also write agent-scoped memory EXPLICITLY — and agent memory is shared
+   *  across users, so a private session must not be able to. Checked at CALL
+   *  time, not session/new, so a session tightened mid-life is covered too.
+   *  Absent ⇒ allowed (no gate wired, e.g. in unit fixtures). */
+  memoryWriteAllowed?: (ctx: SessionContext) => boolean
   /** Record an agent-sent message into the session transcript. */
   recordOutbound: (
     ctx: SessionContext,
@@ -482,6 +496,7 @@ export async function executeTool(
   // them before the platform-gateway gate so an agent with no platform integration works.
   if (name === 'readMemory' || name === 'writeMemory') {
     const scope = { agentId: ctx.agentId }
+    if (name === 'writeMemory' && deps.memoryWriteAllowed?.(ctx) === false) throw new Error(MEMORY_WRITE_BLOCKED)
     try {
       if (name === 'readMemory') {
         const path = optionalString(args, 'path') ?? 'MEMORY.md'
@@ -539,6 +554,11 @@ export async function executeTool(
     const scope = { agentId: ctx.agentId }
     const requireCapability = (operation: 'recall' | 'create' | 'get' | 'update' | 'delete'): void => {
       if (!surface.capabilities.has(operation)) throw new Error(`record memory does not support ${operation}`)
+      // Record memory is agent-scoped and shared just like the file kind, so the
+      // same gate applies to every MUTATION (reads stay available — recalling
+      // what the agent already knows is not a disclosure of THIS session).
+      const mutates = operation === 'create' || operation === 'update' || operation === 'delete'
+      if (mutates && deps.memoryWriteAllowed?.(ctx) === false) throw new Error(MEMORY_WRITE_BLOCKED)
     }
     if (name === 'searchMemory') {
       requireCapability('recall')

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -706,6 +706,14 @@ export class SlackConnection {
     if (added.length > 0) this.deps.log?.warn(`slack: bot token missing OAuth scope(s): ${added.join(', ')}`)
   }
 
+  /** The Slack workspace (team) id this connection authenticated into, or ''
+   *  before `auth.test` resolves. A DURABLE tenant id — unlike the bot token it
+   *  survives credential rotation, which is what session-visibility.md §2
+   *  requires of the middle segment of an owner identity. */
+  workspaceId(): string {
+    return this.teamId
+  }
+
   private permissionUpdateUrl(): string | undefined {
     if (!/^A[A-Z0-9]+$/.test(this.appId)) return undefined
     const appId = encodeURIComponent(this.appId)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -446,6 +446,27 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS session_mutes (
         key TEXT PRIMARY KEY
       );
+      -- Per-session memory-capture gate (session-visibility.md §5.1). Keyed by ACP
+      -- session id, NOT the logical session key: the CP addresses sessions by the
+      -- id it knows, and its push can arrive before (or after a resume recreates)
+      -- the sessions row — so this table stands alone, like session_mutes.
+      --   localExcluded: the daemon-local initial verdict (DM/webchat/launch/A2A).
+      --   cpPrivate    : the CP-confirmed bit; authoritative once it is set.
+      --   cpRev        : the CP's durable visibilityRev — the dedup/order key.
+      -- (localExcluded, not "excluded": SQLite's upsert pseudo-table owns that name.)
+      CREATE TABLE IF NOT EXISTS session_gates (
+        acpSessionId TEXT PRIMARY KEY,
+        localExcluded INTEGER NOT NULL DEFAULT 1,
+        cpPrivate INTEGER,
+        cpRev INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER
+      );
+      -- Minted durable tenant scopes for platforms that expose none (§2).
+      CREATE TABLE IF NOT EXISTS tenant_scopes (
+        integrationId TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        createdAt INTEGER
+      );
       -- Platform id → human display name (Slack channel/user names, daemon-resolved
       -- and cached here so session read-back can label ids without a Slack call).
       CREATE TABLE IF NOT EXISTS display_names (
@@ -690,6 +711,7 @@ export class LocalStore {
     this.migrateDreamObservability()
     this.migrateSessionUsage()
     this.migrateSessionMutes()
+    this.migrateSessionGates()
     this.migrateInboxLoopGuardCounted()
     this.migrateTranscriptToolBody()
     this.migrateTranscriptAttachments()
@@ -958,6 +980,33 @@ export class LocalStore {
       this.db.exec('ALTER TABLE sessions ADD COLUMN needsParentReply INTEGER')
     if (!cols.some((c) => c.name === 'transportScope'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN transportScope TEXT')
+    // session-visibility.md §4.1: persisted so EVERY event/session re-emit
+    // carries them, not just the one dispatch that knew the message.
+    if (!cols.some((c) => c.name === 'conversationKind'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN conversationKind TEXT')
+    if (!cols.some((c) => c.name === 'tenantScope')) this.db.exec('ALTER TABLE sessions ADD COLUMN tenantScope TEXT')
+    if (!cols.some((c) => c.name === 'launchCorrelationId'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN launchCorrelationId TEXT')
+  }
+
+  /** Pre-visibility databases have no gate table; the CREATE above only runs on
+   *  a fresh DB. Missing gate state fails closed (capture excluded) until the
+   *  CP's register-time snapshot lands. */
+  private migrateSessionGates(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS session_gates (
+        acpSessionId TEXT PRIMARY KEY,
+        localExcluded INTEGER NOT NULL DEFAULT 1,
+        cpPrivate INTEGER,
+        cpRev INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER
+      );
+      CREATE TABLE IF NOT EXISTS tenant_scopes (
+        integrationId TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        createdAt INTEGER
+      );
+    `)
   }
 
   /**
@@ -1501,6 +1550,120 @@ export class LocalStore {
     } catch (err) {
       this.db.exec('ROLLBACK')
       throw err
+    }
+  }
+
+  // ── memory-capture gate (session-visibility.md §5.1) ──────────────────────
+  // Two layers: the daemon-local verdict it can reach without a CP round-trip
+  // (DM / webchat / launch-correlated / A2A ⇒ excluded), and the CP-confirmed
+  // effective state, which supersedes it once it arrives. Unknown ⇒ excluded:
+  // a missed or delayed frame may only under-capture, never leak.
+
+  /** Seed the local verdict for a session the daemon just created. Never lowers
+   *  `cpRev`: a CP push that arrived first stays authoritative. */
+  setLocalCaptureGate(acpSessionId: string, localExcluded: boolean): void {
+    this.db
+      .prepare(
+        `INSERT INTO session_gates (acpSessionId, localExcluded, cpRev, updatedAt)
+         VALUES (?, ?, 0, ?)
+         ON CONFLICT(acpSessionId) DO UPDATE SET
+           localExcluded = excluded.localExcluded, updatedAt = excluded.updatedAt`
+      )
+      .run(acpSessionId, localExcluded ? 1 : 0, Date.now())
+  }
+
+  /**
+   * Apply a CP `session/visibility` push. Idempotent by revision: a frame whose
+   * rev is at or below what we hold is NOT reapplied but IS still acknowledged
+   * (`superseded`) — "ignore" must never mean "don't ACK", or a lost ack leaves
+   * the CP retrying forever.
+   */
+  applyCpCaptureGate(acpSessionId: string, isPrivate: boolean, rev: number): 'applied' | 'superseded' {
+    const row = this.db.prepare('SELECT cpRev FROM session_gates WHERE acpSessionId = ?').get(acpSessionId) as
+      { cpRev: number } | undefined
+    // rev 0 is a legitimate first revision (a session ingested and never
+    // changed), so it applies once — but only while we hold nothing newer.
+    if (row && (rev > 0 ? row.cpRev >= rev : row.cpRev > 0)) return 'superseded'
+    this.db
+      .prepare(
+        `INSERT INTO session_gates (acpSessionId, localExcluded, cpPrivate, cpRev, updatedAt)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(acpSessionId) DO UPDATE SET
+           cpPrivate = excluded.cpPrivate, cpRev = excluded.cpRev, updatedAt = excluded.updatedAt`
+      )
+      .run(acpSessionId, isPrivate ? 1 : 0, isPrivate ? 1 : 0, rev, Date.now())
+    return 'applied'
+  }
+
+  /**
+   * Is memory capture excluded for this session? The CP-confirmed bit wins once
+   * we have one; otherwise the local verdict; otherwise excluded. An A2A child
+   * therefore starts closed and only a CP-confirmed `org` state opens it.
+   */
+  isCaptureExcluded(acpSessionId: string | undefined): boolean {
+    if (!acpSessionId) return true
+    const row = this.db
+      .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE acpSessionId = ?')
+      .get(acpSessionId) as { localExcluded: number; cpPrivate: number | null } | undefined
+    if (!row) return true
+    if (row.cpPrivate !== null) return row.cpPrivate === 1
+    return row.localExcluded === 1
+  }
+
+  // ── durable tenant scopes (session-visibility.md §2) ──────────────────────
+  // A platform with no durable tenant id of its own (Discord today) mints one
+  // per integration ONCE and keeps it: the credential-derived transportScope
+  // rotates with tokens, which would orphan historical identity matches.
+
+  /** The minted tenant scope for an integration, or undefined if never minted. */
+  getMintedTenantScope(integrationId: string): string | undefined {
+    const row = this.db.prepare('SELECT value FROM tenant_scopes WHERE integrationId = ?').get(integrationId) as
+      { value: string } | undefined
+    return row?.value
+  }
+
+  /** Mint-once: concurrent callers converge on the first stored value. */
+  mintTenantScope(integrationId: string, value: string): string {
+    this.db
+      .prepare('INSERT OR IGNORE INTO tenant_scopes (integrationId, value, createdAt) VALUES (?, ?, ?)')
+      .run(integrationId, value, Date.now())
+    return this.getMintedTenantScope(integrationId) ?? value
+  }
+
+  /** Persist a session's visibility-classification inputs so EVERY later
+   *  `event/session` re-emit carries them, not just the dispatch that knew the
+   *  originating message (session-visibility.md §4.1). First non-null wins. */
+  setSessionClassification(
+    key: string,
+    c: { conversationKind?: string; tenantScope?: string; launchCorrelationId?: string }
+  ): void {
+    this.db
+      .prepare(
+        `UPDATE sessions SET
+           conversationKind = COALESCE(conversationKind, ?),
+           tenantScope = COALESCE(tenantScope, ?),
+           launchCorrelationId = COALESCE(launchCorrelationId, ?)
+         WHERE key = ?`
+      )
+      .run(c.conversationKind ?? null, c.tenantScope ?? null, c.launchCorrelationId ?? null, key)
+  }
+
+  /** Read them back by ACP session id, the key the telemetry emitter holds. */
+  getSessionClassification(
+    agentId: string,
+    acpSessionId: string
+  ): { conversationKind?: string; tenantScope?: string; launchCorrelationId?: string } | undefined {
+    const row = this.db
+      .prepare(
+        'SELECT conversationKind, tenantScope, launchCorrelationId FROM sessions WHERE agentId = ? AND acpSessionId = ?'
+      )
+      .get(agentId, acpSessionId) as
+      { conversationKind: string | null; tenantScope: string | null; launchCorrelationId: string | null } | undefined
+    if (!row) return undefined
+    return {
+      ...(row.conversationKind ? { conversationKind: row.conversationKind } : {}),
+      ...(row.tenantScope ? { tenantScope: row.tenantScope } : {}),
+      ...(row.launchCorrelationId ? { launchCorrelationId: row.launchCorrelationId } : {})
     }
   }
 

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -106,6 +106,10 @@ const dm = (ts: string, text: string) => ({
   trigger: 'dm' as const
 })
 
+/** Same conversation, but a CHANNEL: org-visible, so agent-memory capture stays
+ *  enabled (a DM is private and excluded — session-visibility.md §4.2/§5.1). */
+const channelMsg = (ts: string, text: string) => ({ ...dm(ts, text), isDm: false, trigger: 'mention' as const })
+
 function transcript(daemon: Daemon): TranscriptEntry[] {
   return (daemon as any).store.transcriptSince(TRANSCRIPT_CHANNEL, 'T1', null)
 }
@@ -162,7 +166,7 @@ describe('Daemon transcript records the agent reply', () => {
     ;(daemon as any).memory.recordTurnForBinding = recordTurn
     const capturedBinding = (daemon as any).agents.get('bot-a').memory
 
-    const turn = (daemon as any).dispatch('bot-a', dm('100', 'question?'), 'int-a')
+    const turn = (daemon as any).dispatch('bot-a', channelMsg('100', 'question?'), 'int-a')
     await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalled())
     expect(recordTurn).not.toHaveBeenCalled()
 
@@ -172,7 +176,7 @@ describe('Daemon transcript records the agent reply', () => {
     expect(recordTurn).toHaveBeenCalledWith(
       { agentId: 'bot-a', sessionId: 'acp-1' },
       {
-        turnId: stableTurnId('bot-a', dm('100', 'question?')),
+        turnId: stableTurnId('bot-a', channelMsg('100', 'question?')),
         sessionId: 'acp-1',
         input: 'question?',
         output: 'here is my answer'
@@ -180,6 +184,24 @@ describe('Daemon transcript records the agent reply', () => {
       capturedBinding,
       undefined
     )
+    await daemon.stop()
+  }, 15_000)
+
+  // session-visibility.md §5.1: managed memory is agent-scoped and shared across
+  // users, so a private conversation must never be distilled into it. A DM is
+  // private from its first turn, with no CP round-trip.
+  it('never captures post-turn memory from a private DM session', async () => {
+    const { factory } = replyingHost('here is my answer')
+    const daemon = new Daemon({ root: scaffold('medium'), hostFactory: factory })
+    await daemon.start()
+    makeRoutable(daemon)
+    const recordTurn = vi.fn(async () => {})
+    ;(daemon as any).memory.recordTurnForBinding = recordTurn
+
+    await (daemon as any).dispatch('bot-a', dm('100', 'question?'), 'int-a')
+
+    expect((daemon as any).store.isCaptureExcluded('acp-1')).toBe(true)
+    expect(recordTurn).not.toHaveBeenCalled()
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -58,6 +58,12 @@ class FakeStore implements DreamStorePort {
   dreamSessionSources(): { sessionId: string; channel: string; thread: string }[] {
     return this.sources
   }
+  /** Sessions excluded from agent-memory capture (session-visibility.md §5.1).
+   *  Empty by default; a test adds an id to assert dreams skip private sources. */
+  captureExcluded = new Set<string>()
+  isCaptureExcluded(acpSessionId: string | undefined): boolean {
+    return acpSessionId !== undefined && this.captureExcluded.has(acpSessionId)
+  }
   toolRows: { sender: string; text: string; kind?: string }[] = []
   dreamTranscriptText(
     _c: string,

--- a/packages/daemon/test/memory-write-gate.test.ts
+++ b/packages/daemon/test/memory-write-gate.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The tool half of the memory-capture gate (session-visibility.md §5.1).
+ *
+ * Automatic post-turn distillation is gated in the daemon, but agent memory is
+ * shared across users and the agent can also write it EXPLICITLY — the session
+ * prompt actively encourages recording durable facts. A private session must not
+ * be able to reach shared memory by either route.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { executeTool, MEMORY_WRITE_BLOCKED, type OpsDeps, type SessionContext } from '../src/mcp/ops.js'
+
+const ctx = (): SessionContext => ({
+  agentId: 'bot-a',
+  platform: 'slack',
+  channel: 'C1',
+  thread: 'T1',
+  isDm: true,
+  tools: []
+})
+
+function deps(allowed: boolean, over: Partial<OpsDeps> = {}): OpsDeps {
+  return {
+    memory: {
+      read: vi.fn(async () => ({ content: 'existing' })),
+      write: vi.fn(async () => ({ ok: true }))
+    },
+    memoryWriteAllowed: () => allowed,
+    ...over
+  } as unknown as OpsDeps
+}
+
+describe('writeMemory under the session-visibility gate', () => {
+  it('refuses a write from a private session, without touching the provider', async () => {
+    const d = deps(false)
+    await expect(executeTool(ctx(), 'writeMemory', { content: 'secret' }, d)).rejects.toThrow(MEMORY_WRITE_BLOCKED)
+    expect(d.memory.write).not.toHaveBeenCalled()
+  })
+
+  it('still allows READS — recalling what the agent already knows is not a disclosure', async () => {
+    const d = deps(false)
+    await expect(executeTool(ctx(), 'readMemory', {}, d)).resolves.toEqual({ content: 'existing' })
+  })
+
+  it('allows the write when the session is org-visible', async () => {
+    const d = deps(true)
+    await executeTool(ctx(), 'writeMemory', { content: 'shared fact' }, d)
+    expect(d.memory.write).toHaveBeenCalled()
+  })
+
+  it('allows the write when no gate is wired at all (unit fixtures)', async () => {
+    const d = deps(true, { memoryWriteAllowed: undefined })
+    await executeTool(ctx(), 'writeMemory', { content: 'shared fact' }, d)
+    expect(d.memory.write).toHaveBeenCalled()
+  })
+})
+
+describe('record-memory mutations under the same gate', () => {
+  const recordDeps = (allowed: boolean): OpsDeps => {
+    const surface = {
+      shape: 'records' as const,
+      capabilities: new Set(['recall', 'create', 'update', 'delete', 'get']),
+      search: vi.fn(async () => []),
+      create: vi.fn(async () => ({ id: 'r1' })),
+      update: vi.fn(async () => ({ id: 'r1' })),
+      delete: vi.fn(async () => true)
+    }
+    return {
+      memory: { adminSurface: () => surface, adminSurfaceForAgent: () => surface },
+      memoryWriteAllowed: () => allowed
+    } as unknown as OpsDeps
+  }
+
+  it('refuses saveMemory from a private session', async () => {
+    await expect(
+      executeTool(ctx(), 'saveMemory', { content: 'secret', metadata: {} }, recordDeps(false))
+    ).rejects.toThrow(MEMORY_WRITE_BLOCKED)
+  })
+
+  it('still allows searchMemory from a private session', async () => {
+    await expect(executeTool(ctx(), 'searchMemory', { query: 'deploys' }, recordDeps(false))).resolves.toBeTruthy()
+  })
+})

--- a/packages/daemon/test/session-capture-gate.test.ts
+++ b/packages/daemon/test/session-capture-gate.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The daemon side of the memory-capture gate (docs/designs/session-visibility.md
+ * §5.1): the local fail-closed default, the CP-confirmed override, and the
+ * revision rule that makes at-least-once delivery safe.
+ */
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { LocalStore } from '../src/store/local-store.js'
+
+function newStore(): LocalStore {
+  return new LocalStore(join(mkdtempSync(join(tmpdir(), 'ac-gate-')), 'daemon.db'))
+}
+
+describe('capture gate — local state', () => {
+  it('fails closed for a session it has never heard of', () => {
+    const store = newStore()
+    expect(store.isCaptureExcluded('unknown-session')).toBe(true)
+    expect(store.isCaptureExcluded(undefined)).toBe(true)
+  })
+
+  it('honors the daemon-local verdict until the CP confirms otherwise', () => {
+    const store = newStore()
+    store.setLocalCaptureGate('acp-dm', true)
+    store.setLocalCaptureGate('acp-channel', false)
+    expect(store.isCaptureExcluded('acp-dm')).toBe(true)
+    expect(store.isCaptureExcluded('acp-channel')).toBe(false)
+  })
+
+  it('lets the CP-confirmed state win over the local verdict, in both directions', () => {
+    const store = newStore()
+    // A channel session the CP later pulls private (§4.3 tightening).
+    store.setLocalCaptureGate('acp-1', false)
+    expect(store.applyCpCaptureGate('acp-1', true, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+    // An A2A child that starts excluded and is confirmed org-visible.
+    store.setLocalCaptureGate('acp-2', true)
+    expect(store.applyCpCaptureGate('acp-2', false, 1)).toBe('applied')
+    expect(store.isCaptureExcluded('acp-2')).toBe(false)
+  })
+
+  it('applies a gate that arrives before the session exists locally', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('acp-early', false, 3)).toBe('applied')
+    expect(store.isCaptureExcluded('acp-early')).toBe(false)
+    // A later local verdict must not clobber the CP's authoritative state.
+    store.setLocalCaptureGate('acp-early', true)
+    expect(store.isCaptureExcluded('acp-early')).toBe(false)
+  })
+})
+
+describe('capture gate — revision rule (§5.1 at-least-once)', () => {
+  it('applies the initial revision, so fail-closed state is not mistaken for a duplicate', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('acp-1', false, 0)).toBe('applied')
+    expect(store.isCaptureExcluded('acp-1')).toBe(false)
+  })
+
+  it('reports a duplicate delivery as superseded WITHOUT reapplying it', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('acp-1', true, 4)).toBe('applied')
+    // The CP lost the first ack and retransmits the identical frame: still an
+    // answer (never an error), just not a second application.
+    expect(store.applyCpCaptureGate('acp-1', true, 4)).toBe('superseded')
+    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+  })
+
+  it('ignores an out-of-order older revision but keeps the newer state', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('acp-1', true, 7)).toBe('applied')
+    expect(store.applyCpCaptureGate('acp-1', false, 6)).toBe('superseded')
+    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+    expect(store.applyCpCaptureGate('acp-1', false, 8)).toBe('applied')
+    expect(store.isCaptureExcluded('acp-1')).toBe(false)
+  })
+
+  it('treats a rev-0 push as superseded once a real revision is stored', () => {
+    const store = newStore()
+    expect(store.applyCpCaptureGate('acp-1', true, 2)).toBe('applied')
+    expect(store.applyCpCaptureGate('acp-1', false, 0)).toBe('superseded')
+    expect(store.isCaptureExcluded('acp-1')).toBe(true)
+  })
+})

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -18,6 +18,14 @@ export const CP_WS_PATH = '/daemon/ws'
 export const SESSION_LIVE_TAIL_FEATURE = 'session-live-tail-v1'
 
 /**
+ * Daemon understands the `session/visibility` gate pushes + register-time
+ * snapshot replay (session-visibility.md §5.1). Advertised by the daemon in
+ * `RegisterReq.capabilities.features`; the CP gates all visibility pushes on
+ * it so older daemons never see the frames.
+ */
+export const SESSION_VISIBILITY_FEATURE = 'session-visibility-v1'
+
+/**
  * Exit code a daemon uses for a PLANNED lifecycle exit (drain-then-exit on a
  * `daemon/restart` or `daemon/upgrade`, cli-daemon-split.md §6). It must be
  * non-zero: launchd's `KeepAlive.SuccessfulExit=false` only relaunches on a

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -42,7 +42,10 @@ import {
   SessionToolBodyChunk,
   ChildSessionStatus,
   ChildSessionStatusReq,
-  ChildSessionStatusProbe
+  ChildSessionStatusProbe,
+  SessionVisibilityPush,
+  SessionVisibilityOk,
+  SessionVisibilitySnapshot
 } from './frames/session.js'
 import { ChannelAgentsReq, ChannelAgentsOk } from './frames/channel.js'
 import {
@@ -215,6 +218,13 @@ export const FRAME_SCHEMAS = {
   'session/child-status/ok': ChildSessionStatus,
   'session/child-status/probe': ChildSessionStatusProbe,
   'session/child-status/probe/ok': ChildSessionStatus,
+  // ── session visibility gate push (session-visibility.md §5.1). C→D REQs: a single
+  // per-session push (reply: typed `session/visibility/ok`) and the register-time
+  // snapshot replay (reply: generic `ack`). Rev-fenced in the payload — a stale rev
+  // is acked `superseded`, never answered with an error frame.
+  'session/visibility': SessionVisibilityPush,
+  'session/visibility/ok': SessionVisibilityOk,
+  'session/visibility/snapshot': SessionVisibilitySnapshot,
   // ── channel agent directory (agent collaboration; D→C REQ → REP) ──
   'channel/agents': ChannelAgentsReq,
   'channel/agents/ok': ChannelAgentsOk,
@@ -392,6 +402,9 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('session/child-status/ok', FRAME_SCHEMAS['session/child-status/ok']),
   frame('session/child-status/probe', FRAME_SCHEMAS['session/child-status/probe']),
   frame('session/child-status/probe/ok', FRAME_SCHEMAS['session/child-status/probe/ok']),
+  frame('session/visibility', FRAME_SCHEMAS['session/visibility']),
+  frame('session/visibility/ok', FRAME_SCHEMAS['session/visibility/ok']),
+  frame('session/visibility/snapshot', FRAME_SCHEMAS['session/visibility/snapshot']),
   frame('channel/agents', FRAME_SCHEMAS['channel/agents']),
   frame('channel/agents/ok', FRAME_SCHEMAS['channel/agents/ok']),
   frame('workspace/list', FRAME_SCHEMAS['workspace/list']),

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -262,7 +262,13 @@ export const AgentLaunch = z.object({
   workspaceId: z.string().uuid(),
   capabilities: z.array(z.string()), // the active-capability pin (§8.1)
   spec: AgentSpec, // prompt/model/env — arrives at start, no separate CRUD needed
-  mode: z.enum(['long_lived', 'per_turn']).default('long_lived') // 🅰️ decision #2 knob
+  mode: z.enum(['long_lived', 'per_turn']).default('long_lived'), // 🅰️ decision #2 knob
+  // Web API launch provenance (session-visibility.md §4.4): CP-minted when the
+  // launch was requested by a console user, echoed back by the daemon on the
+  // resulting session's `event/session` so ingest can classify it `private`
+  // with that user as owner. Optional — CLI/orchestration launches and older
+  // CPs omit it. NOT the launchId fence (which is per-launch, not per-user).
+  launchCorrelationId: z.string().uuid().optional()
 })
 export type AgentLaunch = z.infer<typeof AgentLaunch>
 

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -3,6 +3,7 @@ import {
   RdMsg,
   RdAck,
   RdChat,
+  RdAgentMsg,
   RdAgentMsgFwd,
   RdSlackAction,
   RelayWebchatOp,
@@ -317,6 +318,33 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
         deliveryId: 'delivery-1'
       }).success
     ).toBe(true)
+  })
+
+  it('rd/agentmsg + rd/agentmsg/fwd carry the tighten-only parentPrivate hint (session-visibility.md §5.1)', () => {
+    const msg = {
+      claimedFromAgentId: AGENT_ID,
+      toAgentId: '44444444-4444-4444-8444-444444444444',
+      text: 'delegate this',
+      coords: { platform: 'slack' as const, channel: 'C123' },
+      hopCount: 0,
+      deliveryId: 'delivery-1'
+    }
+    // an old daemon omits the hint — still decodable (absent must never open capture)
+    expect(RdAgentMsg.parse(msg).parentPrivate).toBeUndefined()
+    expect(RdAgentMsg.parse({ ...msg, parentPrivate: true }).parentPrivate).toBe(true)
+
+    const fwd = {
+      trustedFromAgentId: AGENT_ID,
+      orgId: ORG_ID,
+      toAgentId: '44444444-4444-4444-8444-444444444444',
+      text: 'delegate this',
+      coords: { platform: 'slack' as const, channel: 'C123' },
+      hopCount: 1,
+      deliveryId: 'delivery-1'
+    }
+    // the relay forwards the hint verbatim — same optional field on the fwd leg
+    expect(RdAgentMsgFwd.parse(fwd).parentPrivate).toBeUndefined()
+    expect(RdAgentMsgFwd.parse({ ...fwd, parentPrivate: true }).parentPrivate).toBe(true)
   })
 
   it('rd/chat streams webchat output and done events verbatim', () => {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -319,7 +319,13 @@ export const RdAgentMsg = z.object({
   // standing directive on the child; it is never part of the delivered `text`. Meaningless without
   // an origin to report to, so the target ignores it when `originSessionId` is absent. Optional —
   // an ordinary fire-and-forget wake and any older daemon omit it.
-  needsReply: z.boolean().optional()
+  needsReply: z.boolean().optional(),
+  // session-visibility.md §5.1: the ORIGIN session's current privacy bit, so the
+  // target daemon can seed the woken child's memory-capture gate without a CP
+  // round-trip. TIGHTEN-ONLY: `true` excludes the child immediately; `false` or
+  // absent must NEVER enable capture — an A2A child always starts excluded and
+  // opens only on CP confirmation. Optional — old daemons omit it.
+  parentPrivate: z.boolean().optional()
 })
 export type RdAgentMsg = z.infer<typeof RdAgentMsg>
 
@@ -364,7 +370,12 @@ export const RdAgentMsgFwd = z.object({
   // Forwarded verbatim from RdAgentMsg (session-concept §5.4): the caller's request that the woken
   // session report its outcome back into `originSessionId`. Opaque to the relay — it is the
   // caller's own instruction about its own lineage, not a claim the relay mints or validates.
-  needsReply: z.boolean().optional()
+  needsReply: z.boolean().optional(),
+  // Forwarded verbatim from RdAgentMsg (session-visibility.md §5.1): the origin session's
+  // privacy bit, a TIGHTEN-ONLY hint for the target's memory-capture gate. Opaque to the
+  // relay — the caller's own statement about its own session, not a claim the relay mints
+  // or validates; an `org`/absent value never opens capture on the target.
+  parentPrivate: z.boolean().optional()
 })
 export type RdAgentMsgFwd = z.infer<typeof RdAgentMsgFwd>
 

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AgentLaunch,
+  EventSession,
+  FRAME_SCHEMAS,
+  SESSION_VISIBILITY_FEATURE,
+  SessionVisibilityOk,
+  SessionVisibilityPush,
+  SessionVisibilitySnapshot,
+  decodeEnvelope,
+  isFrame
+} from '../index.js'
+
+const ID = '11111111-1111-4111-8111-111111111111'
+const AGENT_ID = '33333333-3333-4333-8333-333333333333'
+const WORKSPACE_ID = '55555555-5555-4555-8555-555555555555'
+const CORRELATION_ID = '99999999-9999-4999-8999-999999999999'
+const TS = '2026-07-30T00:00:00.000Z'
+
+function envelope(type: string, payload: unknown, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({ v: 1, id: ID, ts: TS, type, payload, ...extra })
+}
+
+describe('session/visibility frames (session-visibility.md §5.1)', () => {
+  const push = { sessionId: 'acp-sess-01H9', visibility: 'private', visibilityRev: 3 }
+
+  it('SessionVisibilityPush parses a literal wire push and rejects malformed ones', () => {
+    expect(SessionVisibilityPush.parse(push)).toEqual(push)
+    expect(SessionVisibilityPush.safeParse({ ...push, visibility: 'org' }).success).toBe(true)
+    // the vocabulary is closed and the rev is a nonnegative durable counter
+    expect(SessionVisibilityPush.safeParse({ ...push, visibility: 'hidden' }).success).toBe(false)
+    expect(SessionVisibilityPush.safeParse({ ...push, visibilityRev: -1 }).success).toBe(false)
+    expect(SessionVisibilityPush.safeParse({ ...push, visibilityRev: 1.5 }).success).toBe(false)
+    expect(SessionVisibilityPush.safeParse({ ...push, sessionId: '' }).success).toBe(false)
+  })
+
+  it('SessionVisibilityOk carries both settlement statuses — superseded is an ACK, not an error', () => {
+    const ok = { sessionId: 'acp-sess-01H9', visibilityRev: 3, status: 'applied' }
+    expect(SessionVisibilityOk.parse(ok).status).toBe('applied')
+    // a stale rev is acknowledged as superseded (never answered with an error frame)
+    expect(SessionVisibilityOk.safeParse({ ...ok, status: 'superseded' }).success).toBe(true)
+    expect(SessionVisibilityOk.safeParse({ ...ok, status: 'rejected' }).success).toBe(false)
+  })
+
+  it('SessionVisibilitySnapshot bounds the register-time replay at 1000 entries', () => {
+    expect(SessionVisibilitySnapshot.safeParse({ entries: [] }).success).toBe(true)
+    expect(SessionVisibilitySnapshot.parse({ entries: [push] }).entries).toHaveLength(1)
+    const tooMany = Array.from({ length: 1001 }, (_, i) => ({ ...push, sessionId: `s-${i}` }))
+    expect(SessionVisibilitySnapshot.safeParse({ entries: tooMany }).success).toBe(false)
+  })
+
+  it('all three frames are registered on the daemon↔CP wire and decode', () => {
+    const req = decodeEnvelope(envelope('session/visibility', push))
+    expect(req.ok).toBe(true)
+    if (!req.ok || !isFrame('session/visibility')(req.frame)) throw new Error('expected session/visibility')
+    expect(req.frame.payload.visibility).toBe('private')
+    expect(req.frame.payload.visibilityRev).toBe(3)
+
+    const rep = decodeEnvelope(
+      envelope(
+        'session/visibility/ok',
+        { sessionId: push.sessionId, visibilityRev: 3, status: 'superseded' },
+        { corr: ID }
+      )
+    )
+    expect(rep.ok).toBe(true)
+    if (!rep.ok || !isFrame('session/visibility/ok')(rep.frame)) throw new Error('expected session/visibility/ok')
+    expect(rep.frame.corr).toBe(ID)
+    expect(rep.frame.payload.status).toBe('superseded')
+
+    const snap = decodeEnvelope(envelope('session/visibility/snapshot', { entries: [push] }))
+    expect(snap.ok).toBe(true)
+    if (!snap.ok || !isFrame('session/visibility/snapshot')(snap.frame)) {
+      throw new Error('expected session/visibility/snapshot')
+    }
+    expect(snap.frame.payload.entries[0]!.sessionId).toBe(push.sessionId)
+
+    expect(FRAME_SCHEMAS['session/visibility']).toBe(SessionVisibilityPush)
+    expect(FRAME_SCHEMAS['session/visibility/ok']).toBe(SessionVisibilityOk)
+    expect(FRAME_SCHEMAS['session/visibility/snapshot']).toBe(SessionVisibilitySnapshot)
+  })
+
+  it('exports the feature flag the daemon advertises and the CP gates pushes on', () => {
+    expect(SESSION_VISIBILITY_FEATURE).toBe('session-visibility-v1')
+  })
+})
+
+describe('EventSession visibility-classification fields (session-visibility.md §4.1)', () => {
+  const legacyMilestone = {
+    sessionId: 'acp-sess-01H9',
+    agentId: AGENT_ID,
+    phase: 'start',
+    platform: 'slack',
+    channel: 'D0ALICE',
+    triggeredBy: 'U-DANA',
+    ts: TS
+  }
+
+  it('a milestone from an old daemon (no new fields) still parses', () => {
+    const parsed = EventSession.parse(legacyMilestone)
+    expect(parsed.conversationKind).toBeUndefined()
+    expect(parsed.transportScope).toBeUndefined()
+    expect(parsed.launchCorrelationId).toBeUndefined()
+  })
+
+  it('carries conversationKind + durable transportScope + launchCorrelationId', () => {
+    const parsed = EventSession.parse({
+      ...legacyMilestone,
+      conversationKind: 'dm',
+      transportScope: 'T024BE7LD',
+      launchCorrelationId: CORRELATION_ID
+    })
+    expect(parsed.conversationKind).toBe('dm')
+    expect(parsed.transportScope).toBe('T024BE7LD')
+    expect(parsed.launchCorrelationId).toBe(CORRELATION_ID)
+    expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'group_dm' }).success).toBe(true)
+    expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'channel' }).success).toBe(true)
+  })
+
+  it('rejects an unknown conversationKind, an empty scope, and a non-uuid correlation id', () => {
+    expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'thread' }).success).toBe(false)
+    expect(EventSession.safeParse({ ...legacyMilestone, transportScope: '' }).success).toBe(false)
+    expect(EventSession.safeParse({ ...legacyMilestone, transportScope: 'x'.repeat(201) }).success).toBe(false)
+    expect(EventSession.safeParse({ ...legacyMilestone, launchCorrelationId: 'not-a-uuid' }).success).toBe(false)
+  })
+})
+
+describe('agent/launch launchCorrelationId (session-visibility.md §4.4)', () => {
+  const launch = {
+    agentId: AGENT_ID,
+    runtime: 'claude',
+    workspaceId: WORKSPACE_ID,
+    capabilities: [],
+    spec: { name: 'helper' }
+  }
+
+  it('remains optional (an older CP omits it) and rides as a uuid when present', () => {
+    expect(AgentLaunch.parse(launch).launchCorrelationId).toBeUndefined()
+    expect(AgentLaunch.parse({ ...launch, launchCorrelationId: CORRELATION_ID }).launchCorrelationId).toBe(
+      CORRELATION_ID
+    )
+    expect(AgentLaunch.safeParse({ ...launch, launchCorrelationId: 'not-a-uuid' }).success).toBe(false)
+  })
+})

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -229,3 +229,52 @@ export const ChildSessionStatusProbe = z.object({
   childSessionId: z.string().min(1)
 })
 export type ChildSessionStatusProbe = z.infer<typeof ChildSessionStatusProbe>
+
+/**
+ * C→D REQ → `session/visibility/ok` (session-visibility.md §5.1): the CP pushes
+ * a session's authoritative effective visibility so the owning daemon updates
+ * its local memory-capture gate. Control signaling only — one privacy bit per
+ * session, never content.
+ *
+ * `visibilityRev` is the session's dedicated durable visibility counter
+ * (bumped in the same CP transaction as every visibility change, settlement,
+ * and cascade). It is deliberately NOT the transcript revision nor the WS
+ * `sessionEpoch`/`seq` fences — those are connection/launch-scoped and do not
+ * advance with visibility. Delivery is at-least-once; the rev makes duplicate
+ * and out-of-order application safe on the daemon.
+ */
+export const SessionVisibilityPush = z.object({
+  sessionId: z.string().min(1), // opaque ACP session id (agent-assigned; NOT a wire UUID)
+  visibility: z.enum(['private', 'org']),
+  visibilityRev: z.number().int().nonnegative()
+})
+export type SessionVisibilityPush = z.infer<typeof SessionVisibilityPush>
+
+/**
+ * D→C REP (corr = the push's id). `status` reports how the daemon settled the
+ * push: `applied` = the rev advanced its stored gate state; `superseded` = the
+ * rev is ≤ the stored one, so nothing was reapplied — but the frame is STILL
+ * acknowledged (never answered with an `error` frame): "ignore" must never
+ * mean "don't ACK", or a lost ACK leaves the CP retrying forever. The CP
+ * records the ack watermark on either status.
+ */
+export const SessionVisibilityOk = z.object({
+  sessionId: z.string().min(1),
+  visibilityRev: z.number().int().nonnegative(),
+  status: z.enum(['applied', 'superseded'])
+})
+export type SessionVisibilityOk = z.infer<typeof SessionVisibilityOk>
+
+/**
+ * C→D REQ → generic `ack` (session-visibility.md §5.1): the register-time
+ * replay of the current `(sessionId, visibility, visibilityRev)` set for the
+ * daemon's active sessions — a snapshot, not a diff — closing the window
+ * where a visibility change happened while the daemon was offline. Each entry
+ * applies with the same rev semantics as a single push; a stale entry is
+ * skipped, never an error. Chunked by the CP; ≤ 1000 entries per frame keeps
+ * it far under the frame-size cap.
+ */
+export const SessionVisibilitySnapshot = z.object({
+  entries: z.array(SessionVisibilityPush).max(1000)
+})
+export type SessionVisibilitySnapshot = z.infer<typeof SessionVisibilitySnapshot>

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -47,6 +47,20 @@ export const EventSession = z.object({
   channelName: z.string().optional(),
   triggeredByName: z.string().optional(),
   threadUrl: z.string().optional(),
+  // ── visibility classification inputs (session-visibility.md §4.1) ──
+  // What kind of conversation the session lives in, from the daemon's own
+  // NormalizedMessage.isDm/isGroupDm. Absent (old daemon) ⇒ 'channel' behavior,
+  // i.e. the CP classifies the session `org`.
+  conversationKind: z.enum(['dm', 'group_dm', 'channel']).optional(),
+  // DURABLE workspace/tenant scope for ownerIdentity (§2) — a Slack team id,
+  // Feishu tenant key, or a minted stable per-integration scope. NOT the
+  // daemon's credential-derived transport scope (that rotates with tokens).
+  // Absent ⇒ the CP records no IM owner (fail closed).
+  transportScope: z.string().min(1).max(200).optional(),
+  // Web API launch provenance (§4.4): the correlation id the CP minted on
+  // `agent/launch`, echoed back so ingest can attribute the session to the
+  // launching console user. NOT the launchId fence above.
+  launchCorrelationId: z.string().uuid().optional(),
   // Effective execution-config snapshot: what the session actually ran with
   // (per-session sticky override, else the agent's config at run time; absent ⇒
   // the runtime's own default). Recorded so the console shows what a session

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,7 +9,13 @@
  */
 
 // ── cross-package wire + lifecycle constants ──
-export { CP_SUBPROTOCOL, CP_WS_PATH, RESERVED_RESTART_CODE, SESSION_LIVE_TAIL_FEATURE } from './consts.js'
+export {
+  CP_SUBPROTOCOL,
+  CP_WS_PATH,
+  RESERVED_RESTART_CODE,
+  SESSION_LIVE_TAIL_FEATURE,
+  SESSION_VISIBILITY_FEATURE
+} from './consts.js'
 
 // ── envelope + control extension ──
 export { Envelope, ControlExt, NIL_UUID } from './envelope.js'

--- a/packages/relay/src/agent-msg-router.ts
+++ b/packages/relay/src/agent-msg-router.ts
@@ -124,7 +124,10 @@ export function createAgentMsgRouter(deps: AgentMsgRouterDeps) {
         ...(msg.originCoords !== undefined ? { originCoords: msg.originCoords } : {}),
         // §5.4 report-back request, forwarded opaquely for the same reason: it is an instruction
         // about the caller's OWN lineage, so the relay carries it without minting or validating it.
-        ...(msg.needsReply !== undefined ? { needsReply: msg.needsReply } : {})
+        ...(msg.needsReply !== undefined ? { needsReply: msg.needsReply } : {}),
+        // session-visibility.md §5.1 privacy hint — again the caller's own fact
+        // about its own lineage, forwarded verbatim. The relay stores nothing.
+        ...(msg.parentPrivate !== undefined ? { parentPrivate: msg.parentPrivate } : {})
       })
     } catch (err) {
       // Forward timed out / socket dropped mid-flight → treat as offline (retransmit is

--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+/**
+ * The confirmation copy is the product promise (docs/product-conventions.md).
+ * An agent on native runtime memory has no per-session capture gate, so the
+ * dialog must NOT tell that user their conversation stops feeding shared memory.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/marks', () => ({ Spinner: () => <span data-testid="spinner" /> }))
+vi.mock('@/components/ui', () => ({
+  Icon: () => <span data-testid="icon" />,
+  Button: ({ children, ...rest }: { children?: React.ReactNode }) => <button {...rest}>{children}</button>
+}))
+
+import { SessionVisibilityControl } from './SessionVisibilityControl'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+async function openTightenDialog(nativeMemory: boolean): Promise<string> {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <SessionVisibilityControl
+        sessionId="acp-1"
+        visibility="org"
+        canChange
+        nativeMemory={nativeMemory}
+        onChanged={() => {}}
+      />
+    )
+  })
+  const privateButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('Private'))
+  await act(async () => privateButton?.click())
+  return document.body.textContent ?? ''
+}
+
+describe('SessionVisibilityControl — tighten confirmation', () => {
+  it('promises the memory boundary on an ordinary (gated) agent', async () => {
+    const text = await openTightenDialog(false)
+    expect(text).toContain('stops it from feeding shared agent memory')
+    // …and still states the caveat that past distillation is not retracted.
+    expect(text).toContain('already learned')
+  })
+
+  it('withholds that promise on a native-memory agent and says why', async () => {
+    const text = await openTightenDialog(true)
+    expect(text).not.toContain('stops it from feeding shared agent memory')
+    expect(text).toContain('hides the transcript')
+    expect(text).toContain('no per-session control')
+  })
+})

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -30,6 +30,7 @@ export function SessionVisibilityControl({
   visibility,
   state,
   canChange,
+  nativeMemory = false,
   onChanged
 }: {
   sessionId: string
@@ -38,6 +39,10 @@ export function SessionVisibilityControl({
   /** §5.1 tighten cutover state; 'pending' renders the spinner pill. */
   state?: 'pending' | 'applied' | null
   canChange: boolean
+  /** The owning agent persists memory inside its runtime (provider `native`),
+   *  which has no per-session gate — so the copy must NOT promise that going
+   *  private stops what the agent learns. See docs/product-conventions.md. */
+  nativeMemory?: boolean
   /** Reflect the PUT response into the caller's caches (detail SWR + lists). */
   onChanged: (next: { visibility: SessionVisibility; state: 'pending' | 'applied' }) => void
 }) {
@@ -111,7 +116,11 @@ export function SessionVisibilityControl({
       </span>
       {state === 'pending' && (
         <span
-          title="Waiting for the owning daemon to confirm the change — capture stops at daemon acknowledgement"
+          title={
+            nativeMemory
+              ? 'Waiting for the owning daemon to confirm the change'
+              : 'Waiting for the owning daemon to confirm the change — capture stops at daemon acknowledgement'
+          }
           className="inline-flex flex-none items-center gap-1 rounded-full border border-(--brand) bg-(--surface-sunken) py-[1px] pr-[7px] pl-[5px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand)"
         >
           <Spinner size={10} />
@@ -135,8 +144,19 @@ export function SessionVisibilityControl({
             setError(null)
           }}
         >
-          Making this session private stops it from feeding shared agent memory once the daemon confirms, and hides the
-          transcript immediately. Anything the agent already learned while it was org-visible is not removed.
+          {nativeMemory ? (
+            <>
+              Making this session private hides the transcript from other members immediately. It does{' '}
+              <strong>not</strong> affect this agent&rsquo;s memory: it runs on its runtime&rsquo;s own memory, which
+              has no per-session control, so what the agent learns here can still surface in other people&rsquo;s
+              sessions.
+            </>
+          ) : (
+            <>
+              Making this session private stops it from feeding shared agent memory once the daemon confirms, and hides
+              the transcript immediately. Anything the agent already learned while it was org-visible is not removed.
+            </>
+          )}
         </ConfirmationDialog>
       )}
     </span>

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -1,0 +1,144 @@
+// No 'use client' here: this module is imported only by client components
+// (SessionDetailView), so it's already in the client bundle — and keeping the
+// directive off avoids Next's "props must be serializable" entry-file check on
+// the onChanged callback.
+
+/**
+ * Session-level visibility badge + toggle (docs/designs/session-visibility.md
+ * §4.3/§5.1/§6). Sessions use their OWN two-state enum ('org' | 'private') — this
+ * deliberately mirrors VisibilityField's look without reusing its
+ * ResourceVisibility ('org' | 'restricted') types or share-set machinery.
+ *
+ * - Read-only viewers see a lock badge on private sessions and nothing on org
+ *   sessions (org is the unmarked default).
+ * - `canChange` (server-computed: org owner or the identity-matched session
+ *   owner) renders the two-option control instead. Tightening (org → private)
+ *   confirms through a dialog carrying the memory caveat; widening is immediate.
+ * - `state === 'pending'` renders the spinner pill (DaemonLifecycleBadge
+ *   pattern) until every affected daemon acks the change.
+ */
+import { useState } from 'react'
+import { Icon } from '@/components/ui'
+import { Spinner } from '@/components/marks'
+import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
+import { putSessionVisibility, type SessionVisibility } from '@/lib/api'
+
+export const SESSION_PRIVATE_TITLE = 'Private session — visible only to its owner and org owners'
+
+export function SessionVisibilityControl({
+  sessionId,
+  visibility,
+  state,
+  canChange,
+  onChanged
+}: {
+  sessionId: string
+  /** Effective visibility; undefined (legacy/mock rows) is treated as 'org'. */
+  visibility: SessionVisibility | undefined
+  /** §5.1 tighten cutover state; 'pending' renders the spinner pill. */
+  state?: 'pending' | 'applied' | null
+  canChange: boolean
+  /** Reflect the PUT response into the caller's caches (detail SWR + lists). */
+  onChanged: (next: { visibility: SessionVisibility; state: 'pending' | 'applied' }) => void
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const effective: SessionVisibility = visibility ?? 'org'
+
+  const apply = async (next: SessionVisibility) => {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await putSessionVisibility(sessionId, next)
+      setConfirming(false)
+      onChanged({ visibility: result.visibility, state: result.state })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const pick = (next: SessionVisibility) => {
+    if (busy || next === effective) return
+    setError(null)
+    // Tightening surfaces the memory caveat first; widening never cascades and
+    // applies immediately.
+    if (next === 'private') setConfirming(true)
+    else void apply('org')
+  }
+
+  if (!canChange) {
+    // Org sessions carry no badge — org is the unmarked default.
+    if (effective !== 'private') return null
+    return (
+      <span
+        title={SESSION_PRIVATE_TITLE}
+        className="inline-flex items-center gap-[5px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
+      >
+        <Icon name="lock" size={13} color="var(--text-tertiary)" />
+        Private
+      </span>
+    )
+  }
+
+  const segment = (v: SessionVisibility, icon: string, label: string, title: string) => {
+    const on = effective === v
+    return (
+      <button
+        type="button"
+        title={title}
+        disabled={busy}
+        onClick={() => pick(v)}
+        className={
+          on
+            ? 'inline-flex items-center gap-1 border-0 bg-(--brand-soft) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--brand)'
+            : 'inline-flex cursor-pointer items-center gap-1 border-0 bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) transition-[background-color,color] hover:bg-(--surface-hover) hover:text-(--text-primary)'
+        }
+      >
+        <Icon name={icon} size={11} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
+        {label}
+      </button>
+    )
+  }
+
+  return (
+    <span className="inline-flex items-center gap-[6px]">
+      <span className="inline-flex overflow-hidden rounded-full border border-(--border-default)">
+        {segment('org', 'globe', 'Org', 'Visible to every member who can view the agent')}
+        {segment('private', 'lock', 'Private', SESSION_PRIVATE_TITLE)}
+      </span>
+      {state === 'pending' && (
+        <span
+          title="Waiting for the owning daemon to confirm the change — capture stops at daemon acknowledgement"
+          className="inline-flex flex-none items-center gap-1 rounded-full border border-(--brand) bg-(--surface-sunken) py-[1px] pr-[7px] pl-[5px] font-sans text-[10.5px] font-semibold leading-normal text-(--brand)"
+        >
+          <Spinner size={10} />
+          Applying…
+        </span>
+      )}
+      {error && !confirming && (
+        <span role="alert" className="font-sans text-[11.5px] font-normal leading-normal text-(--status-error)">
+          {error}
+        </span>
+      )}
+      {confirming && (
+        <ConfirmationDialog
+          title="Make this session private?"
+          confirmLabel="Make private"
+          busy={busy}
+          error={error}
+          onConfirm={() => void apply('private')}
+          onClose={() => {
+            setConfirming(false)
+            setError(null)
+          }}
+        >
+          Making this session private stops it from feeding shared agent memory once the daemon confirms, and hides the
+          transcript immediately. Anything the agent already learned while it was org-visible is not removed.
+        </ConfirmationDialog>
+      )}
+    </span>
+  )
+}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -58,6 +58,7 @@ import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
+import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import {
   sessionEffortAfterModelChange,
   sessionEffortChoicesForSelection,
@@ -558,7 +559,8 @@ export default function SessionDetailView() {
     daemons,
     members,
     sessionActivityVersionById,
-    sessionStreamGeneration
+    sessionStreamGeneration,
+    revalidateSessionLists
   } = useConsoleData()
   const {
     getPgSession,
@@ -610,7 +612,11 @@ export default function SessionDetailView() {
     !syntheticPlayground && (!localSession || localSession.steps.length === 0 || localSession.platform === 'playground')
       ? id
       : null
-  const { data: sessionDetail, isLoading: sessionDetailLoading } = useSWR<SessionDetailDto>(
+  const {
+    data: sessionDetail,
+    isLoading: sessionDetailLoading,
+    mutate: mutateSessionDetail
+  } = useSWR<SessionDetailDto>(
     consoleKeys.sessionDetail(activeOrg?.id, detailId),
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
     { refreshInterval: 30_000 }
@@ -819,6 +825,28 @@ export default function SessionDetailView() {
   }
 
   const ss = status(session.status)
+  // Session visibility (session-visibility.md §4.3/§6). Rendered in the desktop
+  // header and the mobile meta strip; null when there is nothing to show (an org
+  // session the caller cannot re-classify, or a mock/legacy row).
+  const visibilityControl =
+    sessionDetail && detailId ? (
+      <SessionVisibilityControl
+        sessionId={detailId}
+        visibility={sessionDetail.visibility ?? undefined}
+        state={sessionDetail.visibilityState}
+        canChange={sessionDetail.canChangeVisibility === true}
+        onChanged={({ visibility, state }) => {
+          // Reflect the new tier locally, then re-read: the detail row also
+          // carries the authoritative pending/applied state, and the lists must
+          // drop (or regain) the row for other members.
+          void mutateSessionDetail(
+            (current) => (current ? { ...current, visibility, visibilityState: state } : current),
+            { revalidate: true }
+          )
+          void revalidateSessionLists()
+        }}
+      />
+    ) : null
   const isPg = session.platform === 'playground'
   // A persisted webchat session is the same surface as the live playground — continue
   // it in place. `isLive` gates the composer/typing affordance for both.
@@ -1254,6 +1282,7 @@ export default function SessionDetailView() {
               <span className="dot h-[6px] w-[6px]" style={{ background: ss.dot }} />
               {session.statusLabel || ss.label}
             </span>
+            {visibilityControl}
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-x-[14px] gap-y-2">
             {agentHref ? (
@@ -1360,6 +1389,14 @@ export default function SessionDetailView() {
           </div>
         ))}
       </div>
+
+      {/* MOBILE VISIBILITY ROW — the desktop header is `hidden desktop:flex`, so
+          the badge/toggle needs its own place in the mobile meta strip. */}
+      {visibilityControl && (
+        <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
+          {visibilityControl}
+        </div>
+      )}
 
       {/* MOBILE AGENT CONFIG ROW — taps through to the owning agent. */}
       {agentHref ? (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -835,6 +835,9 @@ export default function SessionDetailView() {
         visibility={sessionDetail.visibility ?? undefined}
         state={sessionDetail.visibilityState}
         canChange={sessionDetail.canChangeVisibility === true}
+        // Native runtime memory has no per-session gate, so the copy must not
+        // promise a memory boundary this tier cannot deliver.
+        nativeMemory={owner?.memoryProvider === 'native'}
         onChanged={({ visibility, state }) => {
           // Reflect the new tier locally, then re-read: the detail row also
           // carries the authoritative pending/applied state, and the lists must

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -30,6 +30,7 @@ import { useProfile } from '@/lib/profile'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { useMobileFilterSlot } from '@/components/console/Shell'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
+import { RestrictedLock } from '@/components/console/VisibilityField'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 
@@ -561,6 +562,10 @@ export default function SessionsView() {
                 <span className="min-w-0 truncate font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
                   {s.title}
                 </span>
+                <RestrictedLock
+                  show={s.visibility === 'private'}
+                  title="Private session — visible only to its owner and org owners"
+                />
                 {/* Status as a compact pill — the design's badge, driven by the real
                     status (soft bg + saturated text from STATUS_MAP). */}
                 <span
@@ -594,8 +599,14 @@ export default function SessionsView() {
               </span>
               {/* ── desktop arrangement (≥769px): the 6 grid cells ────────────── */}
               <div className="hidden min-w-0 desktop:block">
-                <div className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                  {s.title}
+                <div className="flex min-w-0 items-center gap-[6px]">
+                  <span className="truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                    {s.title}
+                  </span>
+                  <RestrictedLock
+                    show={s.visibility === 'private'}
+                    title="Private session — visible only to its owner and org owners"
+                  />
                 </div>
                 <div className="mono text-[11px] text-(--text-tertiary)">
                   {s.time} · {renderTrigger(s)}

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -12,6 +12,7 @@ import {
   fetchMemoryAdminSurface,
   fmtCountCompact,
   invalidateGithubRepoRosterCache,
+  putSessionVisibility,
   listMemoryRecordHistory,
   listMemoryFileHistory,
   listMemoryRecords,
@@ -171,6 +172,41 @@ describe('raw-blob helper errors', () => {
       status: 502,
       code: undefined
     })
+  })
+})
+
+describe('putSessionVisibility', () => {
+  afterEach(() => {
+    setApiOrgId(null)
+    vi.unstubAllGlobals()
+  })
+
+  it('PUTs the tier to the org-scoped session route and returns the cutover state', async () => {
+    setApiOrgId('org-1')
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            id: 'acp-1',
+            visibility: 'private',
+            visibilityRev: 3,
+            cascadedSessionIds: ['acp-child'],
+            state: 'pending'
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await putSessionVisibility('acp-1', 'private')
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toContain('/orgs/org-1/sessions/acp-1/visibility')
+    expect(init?.method).toBe('PUT')
+    expect(JSON.parse(String(init?.body))).toEqual({ visibility: 'private' })
+    // `state: 'pending'` is what the detail view renders as "Applying…": the CP
+    // read gates already apply, but no daemon has acked the capture change yet.
+    expect(result).toMatchObject({ visibility: 'private', visibilityRev: 3, state: 'pending' })
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -235,6 +235,11 @@ export interface SessionUsageDto {
   costCurrency?: string
 }
 
+// Session-level visibility (docs/designs/session-visibility.md): 'private' rows are
+// visible only to the session owner + org owners; 'org' to every member who can view
+// the owning agent. Deliberately NOT ResourceVisibility ('org' | 'restricted').
+export type SessionVisibility = 'private' | 'org'
+
 export interface SessionDto {
   sessionId: string
   sessionKey: { platform: string; channel: string; thread?: string }
@@ -243,6 +248,9 @@ export interface SessionDto {
   status: string | null
   lastActivityAt: string | null
   usage: SessionUsageDto | null
+  // Absent/null on a CP that predates session visibility — treated as 'org'
+  // (matching the server-side backfill of legacy rows).
+  visibility?: SessionVisibility | null
   triggeredBy: string | null
   hookKind?: 'webhook' | 'github' | null
   // Daemon-resolved display names; null until the daemon has resolved them.
@@ -346,6 +354,14 @@ export interface SessionDetailDto {
   permissionMode: string | null
   outputMode: string | null
   daemonId: string | null
+  // Session visibility (docs/designs/session-visibility.md §5/§6). All three are
+  // absent on a CP that predates the feature. `visibilityState` is the §5.1
+  // tighten cutover: 'pending' until every affected daemon acked the change,
+  // then 'applied'. `canChangeVisibility` is server-computed (org owner or the
+  // identity-matched session owner) — the client never re-derives it.
+  visibility?: SessionVisibility | null
+  visibilityState?: 'pending' | 'applied' | null
+  canChangeVisibility?: boolean | null
 }
 
 // The full ACP tool body (protocol `ToolBody`), transported as a JSON STRING in
@@ -1529,6 +1545,8 @@ export function sessionFromDto(d: SessionDto): Session {
     user,
     ...(d.triggeredBy ? { triggeredBy: d.triggeredBy } : {}),
     ...(d.hookKind ? { hookKind: d.hookKind } : {}),
+    // Absent on legacy/pre-feature rows — the views treat undefined as 'org'.
+    ...(d.visibility != null ? { visibility: d.visibility } : {}),
     duration: PLACEHOLDER,
     tokens: fmtCountCompact(usage?.totalTokens),
     cost: fmtCost(usage?.costAmount, usage?.costCurrency),
@@ -1573,6 +1591,7 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
     channelName: d.channelName,
     triggeredByName: d.triggeredByName,
     threadUrl: d.threadUrl,
+    ...(d.visibility != null ? { visibility: d.visibility } : {}),
     runtime: d.runtime,
     model: d.model,
     effort: d.effort,
@@ -1719,6 +1738,27 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
  *  rows are already filtered by the caller's agent visibility on the server. */
 export function fetchSessionDetail(sessionId: string, orgId?: string): Promise<SessionDetailDto> {
   return apiGet<SessionDetailDto>(`${orgBase(orgId)}/sessions/${encodeURIComponent(sessionId)}`)
+}
+
+// PUT /sessions/:id/visibility response. `state` is the §5.1 cutover: 'pending'
+// until every affected daemon has acked the new `visibilityRev`, then 'applied'.
+export interface SessionVisibilityResultDto {
+  id: string
+  visibility: SessionVisibility
+  visibilityRev: number
+  state: 'pending' | 'applied'
+}
+
+// Set a session's visibility (PUT /sessions/:id/visibility). Gated server-side:
+// org owners or the identity-matched session owner (`canChangeVisibility` in the
+// detail DTO); invisible sessions 404 — never 403 (no existence oracle).
+export async function putSessionVisibility(
+  sessionId: string,
+  visibility: SessionVisibility
+): Promise<SessionVisibilityResultDto> {
+  return apiPut<SessionVisibilityResultDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/visibility`, {
+    visibility
+  })
 }
 
 // One page of a session's transcript, proxied live from the owning daemon. The

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -117,6 +117,9 @@ interface ConsoleData {
   sessionActivityVersionById: Record<string, number>
   /** Advances on every SSE (re)connect so views close any disconnect gap. */
   sessionStreamGeneration: number
+  /** Re-fetch every session list/facet page — used after a mutation that can
+   *  change which sessions a caller may see (e.g. a visibility change). */
+  revalidateSessionLists: () => Promise<unknown>
   crons: CronDto[]
   integrations: IntegrationRow[]
   /** Durable bot identities (freed + in-use) — Add-integration picker + Settings Bots card. */
@@ -1220,6 +1223,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       sessionsNextCursor,
       sessionActivityVersionById,
       sessionStreamGeneration,
+      revalidateSessionLists,
       crons,
       integrations,
       bots,
@@ -1282,6 +1286,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       sessionsNextCursor,
       sessionActivityVersionById,
       sessionStreamGeneration,
+      revalidateSessionLists,
       crons,
       integrations,
       bots,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -783,6 +783,9 @@ export interface Session {
   triggeredBy?: string
   /** Stable source kind for a `hook:<id>` trigger, enriched by the Control Plane. */
   hookKind?: 'webhook' | 'github'
+  /** Session-level visibility (lock badge / detail toggle). Absent on mock and
+   *  pre-feature CP rows — treated as 'org', matching the server-side backfill. */
+  visibility?: 'private' | 'org'
   duration: string
   tokens: string
   cost: string


### PR DESCRIPTION
Implements [`docs/designs/session-visibility.md`](https://github.com/agentconnect-md/agentconnect/blob/main/docs/designs/session-visibility.md). Closes #211.

## Why

Sessions have no visibility of their own — they derive it entirely from the owning agent. Any org member who can view an agent sees **every** session of that agent, including other members' platform DMs and Playground conversations.

## What

Every session now carries its own tier, which **composes with** agent visibility and never widens it:

- **`private`** — the session owner (identity match) + org owners. Default for IM **DMs**, **webchat/Playground**, and **Web API** launches.
- **`org`** — every member who can already view the agent. Default for **channels**, **group DMs**, and automation (cron / hook / dream / agent-to-agent).

The owner is a namespaced identity string (`user:<id>` or `<platform>:<tenant>:<uid>`), not a user FK — the daemon knows only platform sender ids. Until identity linking (§7) ships, an IM DM is an *owner-orphan* visible to org owners only: it errs toward hiding a DM rather than exposing it, and lights up for its owner automatically once linking lands (no backfill needed).

### By package

| Package | Change |
| --- | --- |
| `protocol` | `EventSession` gains `conversationKind` / `transportScope` / `launchCorrelationId`; new `session/visibility{,/ok,/snapshot}` frames; tighten-only `parentPrivate` on the A2A relay frames; `session-visibility-v1` feature flag |
| `control-plane` | visibility columns + keyset index on `session_meta`; pure §4.2 classifier; first-wins classification in the milestone upsert with parent locking and CAS settlement; predicate on list/facets/detail/children/SSE; `PUT /sessions/:id/visibility` with a tightening cascade |
| `daemon` | per-session memory-capture gate (per-turn path **and** dream sources), durable tenant scopes, CP push handler + register-time snapshot |
| `web` | lock badge on private rows, detail-page toggle with the memory caveat, pending→applied state |

## Points worth reviewing

**The memory bypass is the load-bearing part.** Console read gates alone do not contain private content: managed memory is agent-scoped and shared across users, so a private DM turn could be distilled into agent memory and resurface to anyone who can view the agent. The daemon now runs a per-session capture gate that fails closed on unknown state, blocks both the per-turn path and dream source selection, and is driven by a CP-pushed privacy bit. Because the WS correlator only retransmits within one live connection, the **register-time snapshot replay is load-bearing for correctness**, not just for offline windows.

**Stated caveat, not a silent gap:** tightening stops *future* capture once the owning daemon acks (surfaced as a pending state, typically sub-second) and does **not** retract what the agent already distilled. This is spelled out in the confirmation dialog and in `docs/product-conventions.md`.

**The cascade race.** Child ingest takes `FOR SHARE` on its parent; the tightening cascade locks `FOR UPDATE` and re-scans each level *after* its parents are locked, to a fixpoint. A one-shot scan is not sufficient — a grandchild insert could commit a stale `org` snapshot after the scan passed. Both commit orders, including the depth-2 grandchild interleaving, are covered by integration tests.

**Behavior change in the daemon suite:** a DM no longer feeds agent memory, so two existing tests that asserted the capture-ordering invariant over a DM now use a channel message, and a new test pins the DM exclusion. The local evaluation harness is explicitly exempt — its synthetic webchat shape exists precisely to measure capture.

**Backfill is deliberately conservative:** legacy rows get `orgId` + `visibility = 'org'`. DMs are **not** retro-classified — the `thread === 'dm'` convention is platform-inconsistent, and wrongly flipping a row private would yank it from members who can see it today.

## Verification

- `pnpm typecheck` (9/9 packages), `pnpm lint`, `pnpm format:check` — clean.
- **control-plane 735 unit + 758 integration** — includes 12 new integration tests (visibility list/detail/SSE for a two-member org, PUT authz matrix, keyset stability under the predicate, cascade race in both commit orders, settlement CAS) and 10 new push-service unit tests.
- **protocol 204**, **relay 339**, **web 425** — pass.
- **daemon**: every touched file passes. The full daemon suite is flaky under parallel load on this machine — clean `main` fails 2 (one deterministic and pre-existing: `git-injection.test.ts`), this branch fails a varying 2–3 that all pass in isolation.

## Not in scope

§4.4's Web API session-launch flow **does not exist yet** — `ControlSender.agentLaunch` has no production caller and no REST route creates sessions. The provenance plumbing is in place (correlation id minted and recorded, daemon echo, ingest resolution), but that path is unexercised until the launch route is built. Identity linking (§7) and share-by-link (§8) remain separate designs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)