### PR TITLE
feat(integrations): sync bot icons after agent updates

### DIFF
--- a/docs/designs/icon-uploads.md
+++ b/docs/designs/icon-uploads.md
@@ -56,7 +56,8 @@ The blob write and the owner-row `icon` update are two systems, so ordering is c
 transient failure **never leaves a broken avatar** — at worst an orphaned object, which the
 next upload to the same (stable) key overwrites:
 
-- **Upload (PUT):** write the object **first**, then flip the descriptor to `{kind:'image'}`.
+- **Upload (PUT):** write the object **first**, then flip the descriptor to `image`
+  (agent uploads also receive a fresh opaque generation).
   - store OK, DB fails → descriptor unchanged (still the old glyph); the fresh object is
     orphaned but harmless. The user keeps a working icon; a retry re-runs cleanly.
   - store fails → return the error before any DB write; nothing changed.
@@ -73,12 +74,13 @@ next upload to the same (stable) key overwrites:
 
 The wire union stays a discriminated union on `kind`, with two changes:
 
-- `image` **carries no URL**. `{ kind: 'image' }` means "an uploaded icon in the object
-  store". The display/serve URL is resolved separately (the store's public URL for the
-  owner's key) and surfaced as the DTO `iconUrl` / the daemon-facing `AgentSpec.iconUrl`.
-  It is set **only** by the upload route (it carries bytes), never a create/update body —
-  so the create/update DTO (`AgentIconBody`) omits `image`; the output DTO
-  (`AgentIconDto`) includes it.
+- `image` **carries no URL**. It means "an uploaded icon in the object store" and may
+  include an opaque `generation` that distinguishes successive writes to an agent's
+  stable object key (legacy rows omit it). The display/serve URL is resolved separately
+  (the store's public URL for the owner's key) and surfaced as the DTO `iconUrl` / the
+  daemon-facing `AgentSpec.iconUrl`. It is set **only** by the upload route (it carries
+  bytes), never a create/update body — so the create/update DTO (`AgentIconBody`) omits
+  `image`; the output DTO (`AgentIconDto`) includes it.
 - `runtime` **stays in the union and the renderer** as the meaning of a null/legacy icon
   and the render fallback — but it is **removed from the picker**. (Dropping the union
   member would break every legacy agent whose icon is null or `runtime`.)

--- a/packages/control-plane/src/agents/agent-icon.test.ts
+++ b/packages/control-plane/src/agents/agent-icon.test.ts
@@ -55,6 +55,10 @@ describe('parseAgentIcon', () => {
       color: '#c62a78'
     })
     expect(parseAgentIcon({ kind: 'image' })).toEqual({ kind: 'image' })
+    expect(parseAgentIcon({ kind: 'image', generation: 'upload-1' })).toEqual({
+      kind: 'image',
+      generation: 'upload-1'
+    })
   })
 
   it('degrades null / invalid to null (⇒ runtime-mark default)', () => {
@@ -88,6 +92,9 @@ describe('resolveAgentIconUrl', () => {
   it('resolves an image icon to the object store URL for the agent key (cache-busted)', () => {
     expect(resolveAgentIconUrl('a1', { kind: 'image' }, { cp, store }, 5)).toBe(
       'https://store.example.com/icon/agents/a1?v=5'
+    )
+    expect(resolveAgentIconUrl('a1', { kind: 'image', generation: 'upload-1' }, { cp, store }, 5)).toBe(
+      'https://store.example.com/icon/agents/a1?v=upload-1'
     )
   })
   it('falls back to the CP endpoint for an image icon when no store base is configured', () => {

--- a/packages/control-plane/src/agents/agent-icon.ts
+++ b/packages/control-plane/src/agents/agent-icon.ts
@@ -104,7 +104,7 @@ export interface IconUrlBases {
  *  - `runtime`/`glyph`/null → the public CP icon endpoint, when `bases.cp`
  *    (PUBLIC_CP_URL) is configured; else null (Slack keeps the app default avatar).
  * `version` (e.g. the agent's lastModified epoch) busts the URL-keyed icon cache
- * (Slack, CDN, browser) whenever the icon changes.
+ * (Slack, CDN, browser); an uploaded image's opaque generation takes precedence.
  */
 export function resolveAgentIconUrl(
   agentId: string,
@@ -112,12 +112,13 @@ export function resolveAgentIconUrl(
   bases: IconUrlBases,
   version?: string | number
 ): string | null {
+  const cacheVersion = icon?.kind === 'image' ? (icon.generation ?? version) : version
   if (icon?.kind === 'image' && bases.store) {
-    return joinPublicUrl(bases.store, agentIconKey(agentId), version)
+    return joinPublicUrl(bases.store, agentIconKey(agentId), cacheVersion)
   }
   if (!bases.cp) return null
   const base = bases.cp.replace(/\/+$/, '')
-  const v = version !== undefined ? `?v=${encodeURIComponent(String(version))}` : ''
+  const v = cacheVersion !== undefined ? `?v=${encodeURIComponent(String(cacheVersion))}` : ''
   return `${base}${agentIconPublicPath(agentId)}${v}`
 }
 
@@ -132,11 +133,12 @@ export function resolveOrgIconUrl(
   bases: IconUrlBases,
   version?: string | number
 ): string | null {
+  const cacheVersion = icon?.kind === 'image' ? (icon.generation ?? version) : version
   if (icon?.kind === 'image' && bases.store) {
-    return joinPublicUrl(bases.store, orgIconKey(orgId), version)
+    return joinPublicUrl(bases.store, orgIconKey(orgId), cacheVersion)
   }
   if (!bases.cp) return null
   const base = bases.cp.replace(/\/+$/, '')
-  const v = version !== undefined ? `?v=${encodeURIComponent(String(version))}` : ''
+  const v = cacheVersion !== undefined ? `?v=${encodeURIComponent(String(cacheVersion))}` : ''
   return `${base}${orgIconPublicPath(orgId)}${v}`
 }

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Platform } from '@agentconnect.md/protocol'
 import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
-import type { BotRecord, IntegrationRecord } from '../persistence/ports.js'
+import type { AgentRecord, BotRecord, IntegrationRecord } from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
 import { syncAgentBotIcons } from './agent-bot-icon-sync.js'
 
@@ -14,11 +14,20 @@ const agent: BotProfileIconAgent = {
   runtime: 'codex'
 }
 
-function integration(botId: string, platform: Platform): IntegrationRecord {
+function agentRecord(icon: AgentRecord['icon'], lastModifiedAt = new Date(1)): AgentRecord {
+  return {
+    ...agent,
+    orgId: ORG_ID,
+    lastModifiedAt,
+    icon
+  } as AgentRecord
+}
+
+function integration(botId: string, platform: Platform, agentId = AGENT_ID): IntegrationRecord {
   return {
     id: IntegrationId(`10000000-0000-4000-8000-${botId.slice(-12)}`),
     orgId: ORG_ID,
-    agentId: AGENT_ID,
+    agentId,
     botId: BotId(botId),
     platform,
     name: platform,
@@ -84,12 +93,20 @@ describe('syncAgentBotIcons', () => {
     const discordSync = vi.fn(async () => {})
     const secretGets: string[] = []
     const warn = vi.fn()
+    const currentAgent = agentRecord(agent.icon)
 
     await expect(
       syncAgentBotIcons(
         {
           repos: {
-            integration: { listForAgent: async () => integrations },
+            agent: { get: async () => currentAgent },
+            integration: {
+              listForAgent: async () => integrations,
+              listForBot: async (id) => {
+                const membership = integrations.find((item) => item.botId === id)
+                return membership ? [membership] : []
+              }
+            },
             bot: { get: async (id) => bots.get(id) ?? null },
             botSecret: {
               get: async (id) => {
@@ -107,10 +124,63 @@ describe('syncAgentBotIcons', () => {
     ).resolves.toBeUndefined()
 
     expect(telegramSync).toHaveBeenCalledOnce()
-    expect(telegramSync).toHaveBeenCalledWith(`token-${telegramId}`, agent)
+    expect(telegramSync).toHaveBeenCalledWith(`token-${telegramId}`, expect.objectContaining(agent))
     expect(discordSync).toHaveBeenCalledOnce()
-    expect(discordSync).toHaveBeenCalledWith(`token-${discordId}`, agent)
+    expect(discordSync).toHaveBeenCalledWith(`token-${discordId}`, expect.objectContaining(agent))
     expect(secretGets.sort()).toEqual([telegramId, discordId].sort())
     expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('repairs a delayed stale write with the latest Agent icon', async () => {
+    const discordId = '00000000-0000-4000-8000-000000000011'
+    const membership = integration(discordId, 'discord')
+    const discordBot = bot(discordId, 'discord')
+    const oldAgent = agentRecord({ kind: 'glyph', glyph: 'bot', color: '#111111' }, new Date(1))
+    const newAgent = agentRecord({ kind: 'glyph', glyph: 'bot', color: '#222222' }, new Date(2))
+    let currentAgent = oldAgent
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let firstStarted!: () => void
+    const firstStartedPromise = new Promise<void>((resolve) => {
+      firstStarted = resolve
+    })
+    const applied: string[] = []
+    let calls = 0
+    const discordSync = vi.fn(async (_token: string, snapshot: BotProfileIconAgent) => {
+      calls += 1
+      if (calls === 1) {
+        firstStarted()
+        await firstBlocked
+      }
+      applied.push(snapshot.icon?.kind === 'glyph' ? snapshot.icon.color : 'other')
+    })
+    const deps = {
+      repos: {
+        agent: { get: async () => currentAgent },
+        integration: {
+          listForAgent: async () => [membership],
+          listForBot: async () => [membership]
+        },
+        bot: { get: async () => discordBot },
+        botSecret: {
+          get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
+        }
+      },
+      syncDiscordBotIcon: discordSync
+    }
+    const warn = vi.fn()
+
+    const stale = syncAgentBotIcons(deps, oldAgent, { warn })
+    await firstStartedPromise
+    currentAgent = newAgent
+    const latest = syncAgentBotIcons(deps, newAgent, { warn })
+    await vi.waitFor(() => expect(applied).toEqual(['#222222']))
+    releaseFirst()
+    await Promise.all([stale, latest])
+
+    expect(applied).toEqual(['#222222', '#111111', '#222222'])
+    expect(warn).not.toHaveBeenCalled()
   })
 })

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -183,4 +183,59 @@ describe('syncAgentBotIcons', () => {
     expect(applied).toEqual(['#222222', '#111111', '#222222'])
     expect(warn).not.toHaveBeenCalled()
   })
+
+  it('repairs delayed image writes when two uploads share a timestamp', async () => {
+    const discordId = '00000000-0000-4000-8000-000000000012'
+    const membership = integration(discordId, 'discord')
+    const discordBot = bot(discordId, 'discord')
+    const timestamp = new Date(1)
+    const oldAgent = agentRecord({ kind: 'image', generation: 'old-upload' }, timestamp)
+    const newAgent = agentRecord({ kind: 'image', generation: 'new-upload' }, timestamp)
+    let currentAgent = oldAgent
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let firstStarted!: () => void
+    const firstStartedPromise = new Promise<void>((resolve) => {
+      firstStarted = resolve
+    })
+    const applied: string[] = []
+    let calls = 0
+    const discordSync = vi.fn(async (_token: string, snapshot: BotProfileIconAgent) => {
+      const generation = snapshot.icon?.kind === 'image' ? snapshot.icon.generation : undefined
+      calls += 1
+      if (calls === 1) {
+        firstStarted()
+        await firstBlocked
+      }
+      applied.push(generation ?? 'legacy')
+    })
+    const deps = {
+      repos: {
+        agent: { get: async () => currentAgent },
+        integration: {
+          listForAgent: async () => [membership],
+          listForBot: async () => [membership]
+        },
+        bot: { get: async () => discordBot },
+        botSecret: {
+          get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
+        }
+      },
+      syncDiscordBotIcon: discordSync
+    }
+    const warn = vi.fn()
+
+    const stale = syncAgentBotIcons(deps, oldAgent, { warn })
+    await firstStartedPromise
+    currentAgent = newAgent
+    const latest = syncAgentBotIcons(deps, newAgent, { warn })
+    await vi.waitFor(() => expect(applied).toEqual(['new-upload']))
+    releaseFirst()
+    await Promise.all([stale, latest])
+
+    expect(applied).toEqual(['new-upload', 'old-upload', 'new-upload'])
+    expect(warn).not.toHaveBeenCalled()
+  })
 })

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Platform } from '@agentconnect.md/protocol'
+import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
+import type { BotRecord, IntegrationRecord } from '../persistence/ports.js'
+import type { BotProfileIconAgent } from './bot-profile-icon.js'
+import { syncAgentBotIcons } from './agent-bot-icon-sync.js'
+
+const ORG_ID = OrgId('org_test')
+const AGENT_ID = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+
+const agent: BotProfileIconAgent = {
+  id: AGENT_ID,
+  icon: { kind: 'glyph', glyph: 'bot', color: '#2563eb' },
+  runtime: 'codex'
+}
+
+function integration(botId: string, platform: Platform): IntegrationRecord {
+  return {
+    id: IntegrationId(`10000000-0000-4000-8000-${botId.slice(-12)}`),
+    orgId: ORG_ID,
+    agentId: AGENT_ID,
+    botId: BotId(botId),
+    platform,
+    name: platform,
+    status: 'active',
+    createdAt: new Date(0)
+  }
+}
+
+function bot(id: string, platform: Platform, options: { shareable?: boolean; revoked?: boolean } = {}): BotRecord {
+  return {
+    id: BotId(id),
+    orgId: ORG_ID,
+    platform,
+    name: platform,
+    prebuilt: false,
+    slackAppId: null,
+    teamId: null,
+    workspaceId: null,
+    workspaceName: null,
+    botUserId: null,
+    revokedAt: options.revoked ? new Date(0) : null,
+    credentialRevision: 1,
+    credentialInstalledAt: new Date(0),
+    discordAppId: null,
+    feishuAppId: null,
+    feishuRegion: null,
+    shareable: options.shareable ?? false,
+    transport: 'socket',
+    createdBy: null,
+    lastUsedAt: null,
+    lastAgentName: null,
+    agentIds: [AGENT_ID],
+    inUseByAgentId: options.shareable ? null : AGENT_ID,
+    createdAt: new Date(0)
+  }
+}
+
+describe('syncAgentBotIcons', () => {
+  it('syncs each dedicated Telegram/Discord bot once and isolates cosmetic failures', async () => {
+    const telegramId = '00000000-0000-4000-8000-000000000001'
+    const discordId = '00000000-0000-4000-8000-000000000002'
+    const sharedId = '00000000-0000-4000-8000-000000000003'
+    const revokedId = '00000000-0000-4000-8000-000000000004'
+    const slackId = '00000000-0000-4000-8000-000000000005'
+    const bots = new Map([
+      [telegramId, bot(telegramId, 'telegram')],
+      [discordId, bot(discordId, 'discord')],
+      [sharedId, bot(sharedId, 'telegram', { shareable: true })],
+      [revokedId, bot(revokedId, 'discord', { revoked: true })],
+      [slackId, bot(slackId, 'slack')]
+    ])
+    const integrations = [
+      integration(telegramId, 'telegram'),
+      integration(telegramId, 'telegram'),
+      integration(discordId, 'discord'),
+      integration(sharedId, 'telegram'),
+      integration(revokedId, 'discord'),
+      integration(slackId, 'slack')
+    ]
+    const telegramSync = vi.fn(async () => {
+      throw new Error('rate limited')
+    })
+    const discordSync = vi.fn(async () => {})
+    const secretGets: string[] = []
+    const warn = vi.fn()
+
+    await expect(
+      syncAgentBotIcons(
+        {
+          repos: {
+            integration: { listForAgent: async () => integrations },
+            bot: { get: async (id) => bots.get(id) ?? null },
+            botSecret: {
+              get: async (id) => {
+                secretGets.push(id)
+                return { botToken: `token-${id}`, appToken: null, signingSecret: null }
+              }
+            }
+          },
+          syncTelegramBotIcon: telegramSync,
+          syncDiscordBotIcon: discordSync
+        },
+        agent,
+        { warn }
+      )
+    ).resolves.toBeUndefined()
+
+    expect(telegramSync).toHaveBeenCalledOnce()
+    expect(telegramSync).toHaveBeenCalledWith(`token-${telegramId}`, agent)
+    expect(discordSync).toHaveBeenCalledOnce()
+    expect(discordSync).toHaveBeenCalledWith(`token-${discordId}`, agent)
+    expect(secretGets.sort()).toEqual([telegramId, discordId].sort())
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -1,11 +1,19 @@
-import type { BotRepo, BotSecretStore, IntegrationRepo } from '../persistence/ports.js'
+import type {
+  AgentRecord,
+  AgentRepo,
+  BotRecord,
+  BotRepo,
+  BotSecretStore,
+  IntegrationRepo
+} from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
 import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
 import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 
 interface AgentBotIconSyncDeps {
   repos: {
-    integration: Pick<IntegrationRepo, 'listForAgent'>
+    agent: Pick<AgentRepo, 'get'>
+    integration: Pick<IntegrationRepo, 'listForAgent' | 'listForBot'>
     bot: Pick<BotRepo, 'get'>
     botSecret: Pick<BotSecretStore, 'get'>
   }
@@ -17,9 +25,89 @@ interface AgentBotIconSyncLogger {
   warn(bindings: Record<string, unknown>, message: string): void
 }
 
+interface CurrentBotIconState {
+  bot: BotRecord
+  agent: AgentRecord
+  sync: TelegramBotIconSyncer | DiscordBotIconSyncer
+  version: string
+}
+
+function agentIconVersion(agent: AgentRecord): string {
+  const icon = agent.icon
+  const iconKey =
+    icon?.kind === 'glyph' ? `${icon.kind}:${icon.glyph}:${icon.color}` : icon?.kind === 'image' ? icon.kind : 'runtime'
+  return `${agent.lastModifiedAt.getTime()}:${agent.runtime ?? ''}:${iconKey}`
+}
+
+/** Re-read both sides of the dedicated-bot ownership edge. This is deliberately
+ * done before and after every provider call: an external write cannot share the
+ * database transaction that changes an Agent icon or bot membership. */
+async function currentBotIconState(
+  deps: AgentBotIconSyncDeps,
+  botId: BotRecord['id']
+): Promise<CurrentBotIconState | null> {
+  const bot = await deps.repos.bot.get(botId)
+  if (!bot || bot.shareable || bot.revokedAt) return null
+
+  const sync =
+    bot.platform === 'telegram'
+      ? deps.syncTelegramBotIcon
+      : bot.platform === 'discord'
+        ? deps.syncDiscordBotIcon
+        : undefined
+  if (!sync) return null
+
+  const memberships = await deps.repos.integration.listForBot(bot.id)
+  if (memberships.length !== 1) return null
+  const membership = memberships[0]!
+  if (membership.platform !== bot.platform) return null
+
+  const agent = await deps.repos.agent.get(membership.agentId)
+  if (!agent || agent.orgId !== bot.orgId) return null
+  return {
+    bot,
+    agent,
+    sync,
+    version: `${bot.credentialRevision}:${membership.id}:${agent.id}:${agentIconVersion(agent)}`
+  }
+}
+
+async function syncBotIconUntilCurrent(
+  deps: AgentBotIconSyncDeps,
+  botId: BotRecord['id'],
+  log: AgentBotIconSyncLogger
+): Promise<void> {
+  let state = await currentBotIconState(deps, botId)
+  while (state) {
+    const secret = await deps.repos.botSecret.get(state.bot.id)
+    if (!secret) {
+      log.warn(
+        { agentId: state.agent.id, botId: state.bot.id, platform: state.bot.platform },
+        'agent bot icon sync skipped: bot credential is missing'
+      )
+      return
+    }
+
+    try {
+      await state.sync(secret.botToken, state.agent)
+    } catch (err) {
+      log.warn(
+        { err, agentId: state.agent.id, botId: state.bot.id },
+        'agent bot icon sync failed; the Agent icon remains updated'
+      )
+    }
+
+    const current = await currentBotIconState(deps, botId)
+    if (!current || current.version === state.version) return
+    state = current
+  }
+}
+
 /** Push one changed Agent icon to each dedicated Telegram/Discord bot currently
  * installed on it. Shared identities are deliberately excluded: one platform
- * avatar cannot represent several agents. Every failure stays cosmetic. */
+ * avatar cannot represent several agents. After each provider call, re-read and
+ * repair to the latest icon/current owner so detached requests are latest-wins.
+ * Every failure stays cosmetic. */
 export async function syncAgentBotIcons(
   deps: AgentBotIconSyncDeps,
   agent: BotProfileIconAgent,
@@ -37,26 +125,7 @@ export async function syncAgentBotIcons(
   await Promise.all(
     botIds.map(async (botId) => {
       try {
-        const bot = await deps.repos.bot.get(botId)
-        if (!bot || bot.shareable || bot.revokedAt) return
-
-        const sync =
-          bot.platform === 'telegram'
-            ? deps.syncTelegramBotIcon
-            : bot.platform === 'discord'
-              ? deps.syncDiscordBotIcon
-              : undefined
-        if (!sync) return
-
-        const secret = await deps.repos.botSecret.get(bot.id)
-        if (!secret) {
-          log.warn(
-            { agentId: agent.id, botId: bot.id, platform: bot.platform },
-            'agent bot icon sync skipped: bot credential is missing'
-          )
-          return
-        }
-        await sync(secret.botToken, agent)
+        await syncBotIconUntilCurrent(deps, botId, log)
       } catch (err) {
         log.warn({ err, agentId: agent.id, botId }, 'agent bot icon sync failed; the Agent icon remains updated')
       }

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -34,9 +34,13 @@ interface CurrentBotIconState {
 
 function agentIconVersion(agent: AgentRecord): string {
   const icon = agent.icon
-  const iconKey =
-    icon?.kind === 'glyph' ? `${icon.kind}:${icon.glyph}:${icon.color}` : icon?.kind === 'image' ? icon.kind : 'runtime'
-  return `${agent.lastModifiedAt.getTime()}:${agent.runtime ?? ''}:${iconKey}`
+  const iconVersion =
+    icon?.kind === 'glyph'
+      ? `${icon.kind}:${icon.glyph}:${icon.color}`
+      : icon?.kind === 'image'
+        ? `${icon.kind}:${icon.generation ?? 'legacy'}`
+        : 'runtime'
+  return `${agent.lastModifiedAt.getTime()}:${agent.runtime ?? ''}:${iconVersion}`
 }
 
 /** Re-read both sides of the dedicated-bot ownership edge. This is deliberately

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -1,0 +1,65 @@
+import type { BotRepo, BotSecretStore, IntegrationRepo } from '../persistence/ports.js'
+import type { BotProfileIconAgent } from './bot-profile-icon.js'
+import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
+import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
+
+interface AgentBotIconSyncDeps {
+  repos: {
+    integration: Pick<IntegrationRepo, 'listForAgent'>
+    bot: Pick<BotRepo, 'get'>
+    botSecret: Pick<BotSecretStore, 'get'>
+  }
+  syncTelegramBotIcon?: TelegramBotIconSyncer
+  syncDiscordBotIcon?: DiscordBotIconSyncer
+}
+
+interface AgentBotIconSyncLogger {
+  warn(bindings: Record<string, unknown>, message: string): void
+}
+
+/** Push one changed Agent icon to each dedicated Telegram/Discord bot currently
+ * installed on it. Shared identities are deliberately excluded: one platform
+ * avatar cannot represent several agents. Every failure stays cosmetic. */
+export async function syncAgentBotIcons(
+  deps: AgentBotIconSyncDeps,
+  agent: BotProfileIconAgent,
+  log: AgentBotIconSyncLogger
+): Promise<void> {
+  let integrations
+  try {
+    integrations = await deps.repos.integration.listForAgent(agent.id)
+  } catch (err) {
+    log.warn({ err, agentId: agent.id }, 'agent bot icon fan-out failed while listing integrations')
+    return
+  }
+
+  const botIds = [...new Set(integrations.map((integration) => integration.botId))]
+  await Promise.all(
+    botIds.map(async (botId) => {
+      try {
+        const bot = await deps.repos.bot.get(botId)
+        if (!bot || bot.shareable || bot.revokedAt) return
+
+        const sync =
+          bot.platform === 'telegram'
+            ? deps.syncTelegramBotIcon
+            : bot.platform === 'discord'
+              ? deps.syncDiscordBotIcon
+              : undefined
+        if (!sync) return
+
+        const secret = await deps.repos.botSecret.get(bot.id)
+        if (!secret) {
+          log.warn(
+            { agentId: agent.id, botId: bot.id, platform: bot.platform },
+            'agent bot icon sync skipped: bot credential is missing'
+          )
+          return
+        }
+        await sync(secret.botToken, agent)
+      } catch (err) {
+        log.warn({ err, agentId: agent.id, botId }, 'agent bot icon sync failed; the Agent icon remains updated')
+      }
+    })
+  )
+}

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -264,8 +264,8 @@ export interface HttpDeps {
   /** Validates a Telegram token, derives its bot name, and checks that Group Privacy
    *  Mode is disabled before the integration is installed. */
   verifyTelegramBot: TelegramBotVerifier
-  /** Applies a newly registered Telegram bot's Agent icon to its profile.
-   *  Cosmetic and best-effort: install survives a sync failure. */
+  /** Applies an Agent icon to a Telegram bot profile.
+   *  Cosmetic and best-effort: install/icon updates survive a sync failure. */
   syncTelegramBotIcon?: TelegramBotIconSyncer
   /** Validates a pasted Discord bot token against `GET /users/@me` (and derives the bot
    *  name from it when the install omits one). Optional/injectable so tests stay offline
@@ -274,8 +274,8 @@ export interface HttpDeps {
   /** Ensures the Discord application has Message Content enabled before credentials
    *  are stored. Test composition injects an offline success stub. */
   ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer
-  /** Applies a newly registered Discord bot's Agent icon to its bot-user avatar and
-   *  application icon. Cosmetic and best-effort: install survives a sync failure. */
+  /** Applies an Agent icon to a Discord bot-user avatar and application icon.
+   *  Cosmetic and best-effort: install/icon updates survive a sync failure. */
   syncDiscordBotIcon?: DiscordBotIconSyncer
   /** Validates a pasted Feishu appId + appSecret via the tenant-access-token exchange
    *  (and derives the bot name from `bot/v3/info` when the install omits one).

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -134,6 +134,7 @@ import { Tag } from '../plugins/openapi.js'
 import { GithubApiError } from '../../github/api.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
+import { syncAgentBotIcons } from '../agent-bot-icon-sync.js'
 
 /** Public bases for resolving an agent's `image` icon URL (cp/store). */
 function iconBasesOf(deps: HttpDeps): IconUrlBases {
@@ -1462,6 +1463,7 @@ export function agentRoutes(deps: HttpDeps) {
           }
           await pushExternalMemoryBeforeAgent(agent)
           await replicateUpsert(agent)
+          if (req.body.icon !== undefined) void syncAgentBotIcons(deps, agent, app.log)
           await removeUnusedExternalMemoryAfterAgent(existing, agent)
           // Provision/drop MCP proxy defs for an enable-list change on a stably-placed
           // agent (a daemon move goes through AgentMoveService + reconcile, not here).

--- a/packages/control-plane/src/http/routes/icon-upload.ts
+++ b/packages/control-plane/src/http/routes/icon-upload.ts
@@ -12,9 +12,11 @@
  * The CP proxies the upload (browser → CP → store): the raw `image/*` body is
  * sniffed here (magic bytes; SVG rejected) so the client `Content-Type` is never
  * trusted, then written to the store under the owner's stable key. The agent/org
- * row keeps just `{kind:'image'}`; the display URL is the store's public URL.
+ * row keeps an image descriptor; each agent upload gets an opaque generation so
+ * detached platform-profile updates can distinguish rapid overwrites.
  */
 import type { FastifyInstance } from 'fastify'
+import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
@@ -106,15 +108,16 @@ export function iconUploadRoutes(deps: HttpDeps) {
         if (!v.ok) return reply.code(v.status).send({ error: 'Unsupported', statusCode: v.status, message: v.message })
 
         await iconStore.put(agentIconKey(agent.id), bytes, v.contentType)
+        const imageIcon = { kind: 'image' as const, generation: randomUUID() }
         const updated = await deps.repos.agent.update(AgentId(agent.id), {
-          icon: { kind: 'image' },
+          icon: imageIcon,
           ...(req.principal?.userId ? { lastModifiedByUserId: req.principal.userId } : {})
         })
         void replicateAgent(agent.id)
         void syncAgentBotIcons(deps, updated, app.log)
         return reply.send({
           icon: { kind: 'image' as const },
-          iconUrl: resolveAgentIconUrl(agent.id, { kind: 'image' }, iconBases, updated.lastModifiedAt.getTime())
+          iconUrl: resolveAgentIconUrl(agent.id, imageIcon, iconBases, updated.lastModifiedAt.getTime())
         })
       }
     )

--- a/packages/control-plane/src/http/routes/icon-upload.ts
+++ b/packages/control-plane/src/http/routes/icon-upload.ts
@@ -25,9 +25,8 @@ import { Tag } from '../plugins/openapi.js'
 import { AgentIconDto, ErrorDto } from '../dto/index.js'
 import { agentIconKey, orgIconKey } from '../../icons/icon-store.js'
 import { validateIconUpload, MAX_ICON_BYTES } from '../../icons/icon-validate.js'
-import { randomGlyphIcon } from '../../agents/agent-icon.js'
-import { resolveAgentIconUrl, resolveOrgIconUrl } from '../../agents/agent-icon.js'
-import type { IconUrlBases } from '../../agents/agent-icon.js'
+import { randomGlyphIcon, resolveAgentIconUrl, resolveOrgIconUrl, type IconUrlBases } from '../../agents/agent-icon.js'
+import { syncAgentBotIcons } from '../agent-bot-icon-sync.js'
 
 const IconResultDto = z.object({
   icon: AgentIconDto,
@@ -112,6 +111,7 @@ export function iconUploadRoutes(deps: HttpDeps) {
           ...(req.principal?.userId ? { lastModifiedByUserId: req.principal.userId } : {})
         })
         void replicateAgent(agent.id)
+        void syncAgentBotIcons(deps, updated, app.log)
         return reply.send({
           icon: { kind: 'image' as const },
           iconUrl: resolveAgentIconUrl(agent.id, { kind: 'image' }, iconBases, updated.lastModifiedAt.getTime())
@@ -146,7 +146,7 @@ export function iconUploadRoutes(deps: HttpDeps) {
             .send({ error: 'Forbidden', statusCode: 403, message: 'built-in agent icon cannot be changed' })
         }
         const glyph = randomGlyphIcon()
-        await deps.repos.agent.update(AgentId(agent.id), {
+        const updated = await deps.repos.agent.update(AgentId(agent.id), {
           icon: glyph,
           ...(req.principal?.userId ? { lastModifiedByUserId: req.principal.userId } : {})
         })
@@ -154,6 +154,7 @@ export function iconUploadRoutes(deps: HttpDeps) {
           app.log.warn({ err, agentId: agent.id }, 'icon store delete failed (row already reset)')
         })
         void replicateAgent(agent.id)
+        void syncAgentBotIcons(deps, updated, app.log)
         return reply.send({ icon: glyph, iconUrl: null })
       }
     )

--- a/packages/control-plane/src/http/telegram-bot-profile.ts
+++ b/packages/control-plane/src/http/telegram-bot-profile.ts
@@ -17,9 +17,9 @@ async function telegramJpeg(agent: BotProfileIconAgent, iconStore?: IconStore): 
     .toBuffer()
 }
 
-/** Apply the Agent icon to a newly registered Telegram bot through Bot API 9.4's
- * `setMyProfilePhoto`. Telegram requires a fresh JPG multipart upload; the route
- * treats conversion or API failure as cosmetic and keeps the integration. */
+/** Apply the Agent icon to a Telegram bot through Bot API 9.4's
+ * `setMyProfilePhoto`. Telegram requires a fresh JPG multipart upload; callers
+ * treat conversion or API failure as cosmetic. */
 export function createTelegramBotIconSyncer(iconStore?: IconStore): TelegramBotIconSyncer {
   return async (botToken, agent) => {
     const jpeg = await telegramJpeg(agent, iconStore)

--- a/packages/control-plane/src/icons/icon-store.ts
+++ b/packages/control-plane/src/icons/icon-store.ts
@@ -4,8 +4,9 @@
  * A neutral S3-compatible client (SigV4 over `aws4fetch`), never bound to a vendor:
  * hosted services and local development stores differ only by the configured
  * `endpoint`. Uploaded icon bytes live here, NOT in Postgres; the
- * agent/org row keeps just the `{kind:'image'}` descriptor, and the display/serve
- * URL is the store's public URL for the owner's key (→ `<img src>` + Slack icon_url).
+ * agent/org row keeps only the image descriptor (plus an optional opaque generation),
+ * and the display/serve URL is the store's public URL for the owner's key
+ * (→ `<img src>` + Slack icon_url).
  *
  * Assembled ONLY when the full `S3_*` config is present (see container.ts). Absent ⇒
  * `undefined`, the upload routes are not mounted, and the console hides Upload.

--- a/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
+++ b/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
@@ -93,8 +93,14 @@ describe('Agent icon bot profile fan-out', () => {
       expect(telegramSync).toHaveBeenCalledTimes(2)
       expect(discordSync).toHaveBeenCalledTimes(2)
     })
-    expect(telegramSync.mock.calls[1]?.[1].icon).toEqual({ kind: 'image' })
-    expect(discordSync.mock.calls[1]?.[1].icon).toEqual({ kind: 'image' })
+    expect(telegramSync.mock.calls[1]?.[1].icon).toEqual({
+      kind: 'image',
+      generation: expect.any(String)
+    })
+    expect(discordSync.mock.calls[1]?.[1].icon).toEqual({
+      kind: 'image',
+      generation: expect.any(String)
+    })
 
     const remove = await running.app.inject({
       method: 'DELETE',

--- a/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
+++ b/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { AgentId, BotId, IntegrationId, OrgId } from '../../src/domain/ids.js'
+import type { IconStore } from '../../src/icons/icon-store.js'
+import type { BotProfileIconAgent } from '../../src/http/bot-profile-icon.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const PNG = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0,
+  0, 0, 0
+])
+
+let running: HttpApp | undefined
+
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+describe('Agent icon bot profile fan-out', () => {
+  it('syncs dedicated Telegram/Discord bots only when the Agent icon changes', async () => {
+    const store: IconStore = {
+      put: vi.fn(async () => undefined),
+      get: vi.fn(async () => null),
+      delete: vi.fn(async () => undefined),
+      publicUrl: vi.fn((key, version) => `https://images.example.test/${key}?v=${version}`)
+    }
+    const telegramSync = vi.fn(async (_botToken: string, _agent: BotProfileIconAgent) => {})
+    const discordSync = vi.fn(async (_botToken: string, _agent: BotProfileIconAgent) => {})
+    running = buildHttpApp(prisma, { S3_PUBLIC_BASE_URL: 'https://images.example.test' }, undefined, undefined, {
+      iconStore: store,
+      syncTelegramBotIcon: telegramSync,
+      syncDiscordBotIcon: discordSync
+    })
+
+    const create = await running.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'profile-sync', runtime: 'codex' }
+    })
+    expect(create.statusCode).toBe(201)
+    const agentId = AgentId((create.json() as { id: string }).id)
+    const orgId = OrgId(DEFAULT_ORG_ID)
+
+    for (const [platform, token] of [
+      ['telegram', 'telegram-token'],
+      ['discord', 'discord-token']
+    ] as const) {
+      const botId = BotId(randomUUID())
+      await running.deps.repos.bot.create({ id: botId, orgId, platform, name: `${platform}-bot` })
+      await running.deps.repos.botSecret.put(botId, { botToken: token, appToken: null, signingSecret: null })
+      await running.deps.repos.integration.create({
+        id: IntegrationId(randomUUID()),
+        orgId,
+        agentId,
+        botId,
+        platform,
+        name: `${platform}-bot`
+      })
+    }
+
+    const ordinaryEdit = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { description: 'ordinary edit' }
+    })
+    expect(ordinaryEdit.statusCode).toBe(200)
+    expect(telegramSync).not.toHaveBeenCalled()
+    expect(discordSync).not.toHaveBeenCalled()
+
+    const glyphEdit = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${agentId}`,
+      payload: { icon: { kind: 'glyph', glyph: 'bot', color: '#2563eb' } }
+    })
+    expect(glyphEdit.statusCode).toBe(200)
+    await vi.waitFor(() => {
+      expect(telegramSync).toHaveBeenCalledTimes(1)
+      expect(discordSync).toHaveBeenCalledTimes(1)
+    })
+
+    const upload = await running.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/icon`,
+      headers: { 'content-type': 'image/png' },
+      payload: PNG
+    })
+    expect(upload.statusCode).toBe(200)
+    await vi.waitFor(() => {
+      expect(telegramSync).toHaveBeenCalledTimes(2)
+      expect(discordSync).toHaveBeenCalledTimes(2)
+    })
+    expect(telegramSync.mock.calls[1]?.[1].icon).toEqual({ kind: 'image' })
+    expect(discordSync.mock.calls[1]?.[1].icon).toEqual({ kind: 'image' })
+
+    const remove = await running.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/agents/${agentId}/icon`
+    })
+    expect(remove.statusCode).toBe(200)
+    await vi.waitFor(() => {
+      expect(telegramSync).toHaveBeenCalledTimes(3)
+      expect(discordSync).toHaveBeenCalledTimes(3)
+    })
+    expect(telegramSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
+    expect(discordSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
+  })
+})

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -103,10 +103,11 @@ export const AGENT_ICON_GLYPHS = [
  *    fails to parse and degrades to the runtime mark on every surface.
  *  - `image`   — a user-uploaded avatar. The bytes live in the CP's configured
  *    object store (S3-compatible; see docs/designs/icon-uploads.md), NOT in this
- *    descriptor — `image` carries no URL, it just marks "an upload exists". The
- *    display/serve URL is resolved separately (the object store's public URL for
- *    the owner's key), surfaced as the DTO `iconUrl` / `AgentSpec.iconUrl`. Set
- *    only via the upload route; never via a create/update body.
+ *    descriptor. Its optional opaque generation distinguishes successive writes
+ *    to the stable object key; legacy rows omit it. The display/serve URL is
+ *    resolved separately (the object store's public URL for the owner's key),
+ *    surfaced as the DTO `iconUrl` / `AgentSpec.iconUrl`. Set only via the upload
+ *    route; never via a create/update body.
  * This descriptor is CP-owned + stored on the agent and surfaced to the web
  * console. The daemon never receives it — it gets only the resolved public
  * `AgentSpec.iconUrl` (for the Slack per-message avatar), so it needs no renderer.
@@ -114,7 +115,7 @@ export const AGENT_ICON_GLYPHS = [
 export const AgentIcon = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('runtime') }),
   z.object({ kind: z.literal('glyph'), glyph: z.enum(AGENT_ICON_GLYPHS), color: z.string() }),
-  z.object({ kind: z.literal('image') })
+  z.object({ kind: z.literal('image'), generation: z.string().min(1).max(128).optional() })
 ])
 export type AgentIcon = z.infer<typeof AgentIcon>
 


### PR DESCRIPTION
## Summary

- sync explicit Agent icon changes to every active dedicated Discord and Telegram bot
- skip shared and revoked bot identities and deduplicate integrations by bot
- keep platform failures cosmetic so the UI update and other bot syncs still succeed

## Validation

- pnpm --filter @agentconnect.md/control-plane test:unit (736 passed)
- pnpm --filter @agentconnect.md/control-plane typecheck
- focused Postgres route test for ordinary edits, glyph changes, uploads, and resets
- eslint on changed files and pre-push repository lint

Created by Codex . GPT-5