### PR TITLE
fix(auth): link social identities through the Account API

### DIFF
--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -171,12 +171,19 @@ export class LogtoIdentityService {
     return pending
   }
 
-  /** Resolve a statically supported provider target and build its link URL. */
-  async createSocialAuthorization(
-    target: string,
-    redirectUri: string,
-    state: string
-  ): Promise<{ connectorId: string; redirectTo: string }> {
+  /**
+   * The tenant's Social connector id for a provider target.
+   *
+   * Resolution only — building the authorization URI is deliberately NOT done
+   * here. Logto's `POST /api/connectors/:id/authorization-uri` runs the
+   * connector with no session context (it passes `notImplemented` as the
+   * session store), so any connector whose `getAuthorizationUri` persists state
+   * — Slack stores `redirectUri` there, and Apple / standard OIDC / OAuth 2.0
+   * do the same — fails inside Logto with a 500. The browser drives the
+   * authorization through the Account API instead, where the verification
+   * record carries that session; it only needs this id to start.
+   */
+  async socialConnectorIdFor(target: string): Promise<string> {
     const connectorsRes = await this.request(`/api/connectors?target=${encodeURIComponent(target)}`)
     if (!connectorsRes.ok) throw await this.responseError('logto social connector lookup', connectorsRes)
     const connectors: unknown = await connectorsRes.json()
@@ -190,27 +197,7 @@ export class LogtoIdentityService {
     const connectorId =
       connector && typeof (connector as { id?: unknown }).id === 'string' ? (connector as { id: string }).id : undefined
     if (!connectorId) throw new LogtoApiError('social connector not found', 404, false)
-
-    const res = await this.request(`/api/connectors/${encodeURIComponent(connectorId)}/authorization-uri`, {
-      method: 'POST',
-      body: JSON.stringify({ redirectUri, state })
-    })
-    if (!res.ok) throw await this.responseError('logto social authorization', res)
-    const body = (await res.json()) as { redirectTo?: unknown }
-    if (typeof body.redirectTo !== 'string' || body.redirectTo.length === 0) {
-      throw new LogtoApiError('logto social authorization response missing redirectTo', 502, false)
-    }
-    return { connectorId, redirectTo: body.redirectTo }
-  }
-
-  /** Link the provider identity proved by `connectorData` to this Logto user. */
-  async linkSocialIdentity(sub: string, connectorId: string, connectorData: Record<string, string>): Promise<void> {
-    const res = await this.request(`/api/users/${encodeURIComponent(sub)}/identities`, {
-      method: 'POST',
-      body: JSON.stringify({ connectorId, connectorData })
-    })
-    if (!res.ok) throw await this.responseError('logto social identity link', res)
-    this.invalidate(sub)
+    return connectorId
   }
 
   /** Remove one provider identity from this Logto user. */

--- a/packages/control-plane/src/github/slack-identity.test.ts
+++ b/packages/control-plane/src/github/slack-identity.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the Slack half of LogtoIdentityService (fake fetch — claim
- * extraction, per-provider caching, invalidation on link/unlink). No Docker, no
- * network. The GitHub half and the link/unlink writes are covered by
+ * extraction, per-provider caching, invalidation on unlink). No Docker, no
+ * network. The GitHub half and the connector-id/unlink writes are covered by
  * `user-authz.test.ts`.
  */
 import { describe, it, expect } from 'vitest'
@@ -161,15 +161,20 @@ describe('LogtoIdentityService.slackIdentityFor', () => {
     expect(await svc.slackIdentityFor('sub-1')).toBeNull() // re-read, not the stale hit
   })
 
-  it('drops the cached workspace when an identity is linked', async () => {
-    const users: Record<string, unknown> = {}
+  it('drops the cached workspace when the identity is unlinked', async () => {
+    // Two identities, so the last-sign-in-method guard lets the unlink through.
+    const users: Record<string, unknown> = {
+      'sub-1': { identities: { slack: slackUser(SLACK_RAW).identities.slack, github: { userId: 'g' } } }
+    }
     const { fetchImpl } = fakeLogto(users)
     const svc = svcOf(fetchImpl)
 
-    expect(await svc.slackIdentityFor('sub-1')).toBeNull()
-    await svc.linkSocialIdentity('sub-1', 'slack connector', { code: 'c', state: 's' })
-
-    users['sub-1'] = slackUser(SLACK_RAW)
     expect(await svc.slackIdentityFor('sub-1')).toMatchObject({ teamId: 'T0EXAMPLE1' })
+    await svc.unlinkSocialIdentity('sub-1', 'slack')
+
+    // Without invalidation the 10-minute positive cache would keep reporting a
+    // workspace the user just disconnected.
+    users['sub-1'] = { identities: { github: { userId: 'g' } } }
+    expect(await svc.slackIdentityFor('sub-1')).toBeNull()
   })
 })

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -125,7 +125,7 @@ describe('LogtoIdentityService', () => {
     await expect(svc.githubLoginFor('s')).rejects.toMatchObject({ retryable: true })
   })
 
-  it('builds a provider authorization URI, then links and unlinks through the same M2M token', async () => {
+  it('resolves a connector id and unlinks through the same M2M token', async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = []
     const fetchImpl = async (url: string, init?: RequestInit): Promise<Response> => {
       if (url.endsWith('/oidc/token')) {
@@ -135,9 +135,6 @@ describe('LogtoIdentityService', () => {
       if (url.endsWith('/api/connectors?target=google')) {
         return Response.json([{ id: 'google connector', target: 'google', type: 'Social' }])
       }
-      if (url.endsWith('/authorization-uri')) {
-        return Response.json({ redirectTo: 'https://accounts.example.test/authorize' })
-      }
       if (url.endsWith('/api/users/logto%20user') && !init?.method) {
         return Response.json({ identities: { google: {}, github: {} } })
       }
@@ -146,33 +143,29 @@ describe('LogtoIdentityService', () => {
     }
     const svc = new LogtoIdentityService(MGMT, new FakeClock(0), MUTATIONS, fetchImpl)
 
-    await expect(
-      svc.createSocialAuthorization('google', 'https://app.example.test/auth/social/callback', 'state')
-    ).resolves.toEqual({
-      connectorId: 'google connector',
-      redirectTo: 'https://accounts.example.test/authorize'
-    })
-    await svc.linkSocialIdentity('logto user', 'google connector', { code: 'provider-code', state: 'state' })
+    await expect(svc.socialConnectorIdFor('google')).resolves.toBe('google connector')
     await svc.unlinkSocialIdentity('logto user', 'google')
 
+    // Notably absent: /authorization-uri and POST …/identities. Both run the
+    // connector without a session, so linking is the browser's job now.
     expect(requests.map(({ url, init }) => [url, init?.method])).toEqual([
       ['https://t.logto.app/api/connectors?target=google', undefined],
-      ['https://t.logto.app/api/connectors/google%20connector/authorization-uri', 'POST'],
-      ['https://t.logto.app/api/users/logto%20user/identities', 'POST'],
       ['https://t.logto.app/api/users/logto%20user', undefined],
       ['https://t.logto.app/api/users/logto%20user/identities/google', 'DELETE']
     ])
-    expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
-      redirectUri: 'https://app.example.test/auth/social/callback',
-      state: 'state'
-    })
-    expect(JSON.parse(String(requests[2]?.init?.body))).toEqual({
-      connectorId: 'google connector',
-      connectorData: { code: 'provider-code', state: 'state' }
-    })
     expect(requests.every(({ init }) => new Headers(init?.headers).get('authorization') === 'Bearer mgmt-token')).toBe(
       true
     )
+  })
+
+  it('rejects a target with no Social connector in the tenant', async () => {
+    const fetchImpl = async (url: string): Promise<Response> =>
+      url.endsWith('/oidc/token')
+        ? Response.json({ access_token: 'mgmt-token', expires_in: 3600 })
+        : Response.json(url.includes('target=slack') ? [] : [{ id: 'x', target: 'google', type: 'Social' }])
+    const svc = new LogtoIdentityService(MGMT, new FakeClock(0), MUTATIONS, fetchImpl)
+
+    await expect(svc.socialConnectorIdFor('slack')).rejects.toMatchObject({ status: 404 })
   })
 
   it('refuses to unlink the last social sign-in method', async () => {

--- a/packages/control-plane/src/http/routes/me-social-identities.test.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.test.ts
@@ -6,13 +6,9 @@ import { installZod } from '../plugins/zod.js'
 import { meSocialIdentityRoutes } from './me-social-identities.js'
 
 describe('my social identities routes', () => {
-  it('uses the OIDC subject and server-owned callback for link and unlink', async () => {
+  it('resolves a connector id and unlinks under the OIDC subject', async () => {
     const identity = {
-      createSocialAuthorization: vi.fn(async () => ({
-        connectorId: 'google-connector',
-        redirectTo: 'https://accounts.example.test/authorize'
-      })),
-      linkSocialIdentity: vi.fn(async () => undefined),
+      socialConnectorIdFor: vi.fn(async () => 'google-connector'),
       unlinkSocialIdentity: vi.fn(async () => undefined)
     }
     const deps = {
@@ -27,37 +23,19 @@ describe('my social identities routes', () => {
     await app.register(meSocialIdentityRoutes(deps))
 
     try {
-      const state = 's'.repeat(64)
-      const authorization = await app.inject({
-        method: 'POST',
-        url: '/me/social-identities/authorization-uri',
-        payload: { target: 'google', state }
-      })
-      expect(authorization.statusCode).toBe(200)
-      expect(authorization.json()).toEqual({
-        authorizationUri: 'https://accounts.example.test/authorize',
-        connectorId: 'google-connector'
-      })
-      expect(identity.createSocialAuthorization).toHaveBeenCalledWith(
-        'google',
-        'https://app.example.test/auth/social/callback',
-        state
-      )
+      const connector = await app.inject({ method: 'GET', url: '/me/social-identities/connectors/google' })
+      expect(connector.statusCode).toBe(200)
+      expect(connector.json()).toEqual({ connectorId: 'google-connector' })
+      expect(identity.socialConnectorIdFor).toHaveBeenCalledWith('google')
 
-      const linked = await app.inject({
+      // Linking is not a CP operation any more: the browser drives it against
+      // the Account API, which is the only side with a connector session.
+      const removedLinkRoute = await app.inject({
         method: 'POST',
         url: '/me/social-identities',
-        payload: {
-          connectorId: 'google-connector',
-          connectorData: { code: 'provider-code', state, redirectUri: 'https://attacker.example.test/callback' }
-        }
+        payload: { connectorId: 'google-connector', connectorData: { code: 'c' } }
       })
-      expect(linked.statusCode).toBe(200)
-      expect(identity.linkSocialIdentity).toHaveBeenCalledWith('logto-user', 'google-connector', {
-        code: 'provider-code',
-        state,
-        redirectUri: 'https://app.example.test/auth/social/callback'
-      })
+      expect(removedLinkRoute.statusCode).toBe(404)
 
       const unlinked = await app.inject({ method: 'DELETE', url: '/me/social-identities/google' })
       expect(unlinked.statusCode).toBe(204)
@@ -79,26 +57,26 @@ describe('my social identities routes', () => {
 
   it('accepts slack as a linkable target, matching the console provider list', async () => {
     // The console offers Slack; a server-side allowlist that omitted it would
-    // turn that Connect button into a 400.
-    const identity = {
-      createSocialAuthorization: vi.fn(async () => ({
-        connectorId: 'slack-connector',
-        redirectTo: 'https://slack.example.test/authorize'
-      }))
-    }
+    // turn that Link button into a 400.
+    const identity = { socialConnectorIdFor: vi.fn(async () => 'slack-connector') }
     const app = await slackApp({ logtoIdentity: identity } as unknown as HttpDeps)
     try {
-      const res = await app.inject({
-        method: 'POST',
-        url: '/me/social-identities/authorization-uri',
-        payload: { target: 'slack', state: 's'.repeat(64) }
-      })
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/connectors/slack' })
       expect(res.statusCode).toBe(200)
-      expect(identity.createSocialAuthorization).toHaveBeenCalledWith(
-        'slack',
-        'https://app.example.test/auth/social/callback',
-        's'.repeat(64)
-      )
+      expect(res.json()).toEqual({ connectorId: 'slack-connector' })
+      expect(identity.socialConnectorIdFor).toHaveBeenCalledWith('slack')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('rejects a target the console does not offer', async () => {
+    const identity = { socialConnectorIdFor: vi.fn(async () => 'nope') }
+    const app = await slackApp({ logtoIdentity: identity } as unknown as HttpDeps)
+    try {
+      const res = await app.inject({ method: 'GET', url: '/me/social-identities/connectors/facebook' })
+      expect(res.statusCode).toBe(400)
+      expect(identity.socialConnectorIdFor).not.toHaveBeenCalled()
     } finally {
       await app.close()
     }

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -1,14 +1,25 @@
 /**
  * The signed-in user's social sign-in methods. These routes deliberately use
- * `oidcAuth` (never devAuth or API keys) and proxy the narrow operation through
- * Logto's Management API, so its M2M credential stays server-side.
+ * `oidcAuth` (never devAuth or API keys). The current OIDC session is the
+ * authorization boundary; unlinking does not add a second email-code step.
  *
- * The current OIDC session is the authorization boundary. Provider OAuth proves
- * the identity being linked; unlinking does not add a second email-code step.
+ * Linking and unlinking deliberately run over DIFFERENT Logto surfaces:
+ *
+ *  - **Unlink** stays here, on the Management API, because it enforces a
+ *    server-side invariant the browser cannot be trusted with: the last social
+ *    sign-in method may not be removed, serialized per user by
+ *    `SocialIdentityMutationGate`. It needs no connector session.
+ *  - **Link** is driven by the browser against Logto's Account API, with the
+ *    user's OWN token — the Management API has no session context, so any
+ *    connector that persists state in `getAuthorizationUri` (Slack, Apple,
+ *    standard OIDC/OAuth 2.0) fails inside Logto with a 500. That path needs
+ *    nothing from the M2M credential, so it never reaches the browser either.
+ *
+ * What the browser still cannot do is discover the connector id, so this
+ * module resolves target → connector id and stops there.
  */
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
-import { resolveWebAppUrl } from '../../config/env.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import type { HttpDeps } from '../deps.js'
 import { ErrorDto } from '../dto/index.js'
@@ -19,15 +30,8 @@ const ConnectorId = z.string().trim().min(1).max(128)
 // Must stay in step with the console's SOCIAL_LOGIN_PROVIDERS: a target the UI
 // offers but this rejects is a Connect button that 400s.
 const SocialTarget = z.enum(['github', 'google', 'slack'])
-const State = z.string().min(32).max(256)
-const ConnectorData = z
-  .record(z.string().max(64), z.string().max(4096))
-  .refine((value) => Object.keys(value).length <= 32, 'too many connector response fields')
-
-const AuthorizationBody = z.object({ target: SocialTarget, state: State }).strict()
-const AuthorizationDto = z.object({ authorizationUri: z.url(), connectorId: ConnectorId })
-const LinkBody = z.object({ connectorId: ConnectorId, connectorData: ConnectorData }).strict()
-const LinkDto = z.object({ linked: z.literal(true) })
+const TargetParamStrict = z.object({ target: SocialTarget })
+const ConnectorDto = z.object({ connectorId: ConnectorId })
 const TargetParam = z.object({ target: z.string().trim().min(1).max(128) })
 
 /** The Slack workspace behind the caller's account. `linked: false` is a real
@@ -47,29 +51,25 @@ const SlackIdentityDto = z.discriminatedUnion('linked', [
   })
 ])
 
-type Operation = 'authorize' | 'link' | 'unlink' | 'read'
-
-function socialCallbackUrl(deps: HttpDeps): string | undefined {
-  const webUrl = resolveWebAppUrl(deps.config)
-  return webUrl ? new URL('/auth/social/callback', webUrl).toString() : undefined
-}
+// No 'link': that runs in the browser against the Account API, so its provider
+// errors (422 "already in use" and friends) are mapped there, not here.
+type Operation = 'authorize' | 'unlink' | 'read'
 
 function logtoFailure(reply: FastifyReply, error: unknown, operation: Operation) {
   if (!(error instanceof LogtoApiError)) throw error
+  // The upstream reason never reaches the caller — the mapping below flattens it
+  // to a generic status — so record it once here. Without this an operator has
+  // nothing to go on when Logto starts refusing.
+  reply.log.warn(
+    { operation, upstreamStatus: error.status, upstreamCode: error.code, retryable: error.retryable },
+    'logto request failed'
+  )
   if (operation === 'unlink' && error.status === 409 && error.code === 'LAST_SOCIAL_IDENTITY') {
     return reply.code(409).send({
       error: 'Conflict',
       statusCode: 409,
       code: error.code,
       message: 'connect another sign-in method before removing this one'
-    })
-  }
-  if (operation === 'link' && error.status === 422) {
-    return reply.code(409).send({
-      error: 'Conflict',
-      statusCode: 409,
-      code: 'SOCIAL_IDENTITY_IN_USE',
-      message: 'this social account is already connected to another account'
     })
   }
   if (error.status === 400) {
@@ -110,19 +110,19 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       message: 'social sign-in management is not configured'
     } as const
 
-    r.post(
-      '/me/social-identities/authorization-uri',
+    r.get(
+      '/me/social-identities/connectors/:target',
       {
         preHandler: app.oidcAuth,
         schema: {
           tags: [Tag.Profile],
-          summary: 'Start linking a social sign-in method',
+          summary: 'Resolve a social connector id',
           description:
-            'Resolve a statically supported provider target and build its authorization URI. The current OIDC session authorizes the operation; the provider flow proves the new identity.',
-          operationId: 'createMySocialIdentityAuthorization',
-          body: AuthorizationBody,
+            "The tenant's connector id for a supported provider target, so the console can start the Account API link flow. Resolution only — the authorization URI is built by the browser, which is the only side with the connector session Logto needs.",
+          operationId: 'getMySocialConnectorId',
+          params: TargetParamStrict,
           response: {
-            200: AuthorizationDto,
+            200: ConnectorDto,
             400: ErrorDto,
             404: ErrorDto,
             429: ErrorDto,
@@ -133,54 +133,11 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       },
       async (req, reply) => {
         const identity = deps.logtoIdentity
-        const redirectUri = socialCallbackUrl(deps)
-        if (!identity || !redirectUri) return reply.code(503).send(unavailable)
+        if (!identity) return reply.code(503).send(unavailable)
         try {
-          const authorization = await identity.createSocialAuthorization(req.body.target, redirectUri, req.body.state)
-          return {
-            authorizationUri: authorization.redirectTo,
-            connectorId: authorization.connectorId
-          }
+          return { connectorId: await identity.socialConnectorIdFor(req.params.target) }
         } catch (error) {
           return logtoFailure(reply, error, 'authorize')
-        }
-      }
-    )
-
-    r.post(
-      '/me/social-identities',
-      {
-        preHandler: app.oidcAuth,
-        schema: {
-          tags: [Tag.Profile],
-          summary: 'Link a social sign-in method',
-          description:
-            'Link the social identity authenticated by the provider to the signed-in user. Existing accounts are not merged.',
-          operationId: 'linkMySocialIdentity',
-          body: LinkBody,
-          response: {
-            200: LinkDto,
-            400: ErrorDto,
-            404: ErrorDto,
-            409: ErrorDto,
-            429: ErrorDto,
-            502: ErrorDto,
-            503: ErrorDto
-          }
-        }
-      },
-      async (req, reply) => {
-        const identity = deps.logtoIdentity
-        const redirectUri = socialCallbackUrl(deps)
-        if (!identity || !redirectUri) return reply.code(503).send(unavailable)
-        try {
-          await identity.linkSocialIdentity(req.oidcSubject!, req.body.connectorId, {
-            ...req.body.connectorData,
-            redirectUri
-          })
-          return { linked: true as const }
-        } catch (error) {
-          return logtoFailure(reply, error, 'link')
         }
       }
     )

--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -3,8 +3,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui'
 import { Spinner } from '@/components/marks'
-import { linkMySocialIdentity } from '@/lib/api'
-import { accountErrorMessage, takeSocialLinkFlow, writeAccountNotice } from '@/lib/logto-account'
+import {
+  accountErrorMessage,
+  saveSocialIdentity,
+  takeSocialLinkFlow,
+  verifySocialVerification,
+  writeAccountNotice
+} from '@/lib/logto-account'
 
 export default function SocialAccountCallback() {
   const started = useRef(false)
@@ -37,8 +42,11 @@ export default function SocialAccountCallback() {
       return
     }
 
-    const connectorData = Object.fromEntries(params.entries())
-    linkMySocialIdentity(flow.connectorId, connectorData)
+    // Logto exchanges the provider code against the exact URI it authorized
+    // with, so echo it back alongside the provider's own response params.
+    const connectorData = { ...Object.fromEntries(params.entries()), redirectUri: flow.redirectUri }
+    verifySocialVerification(flow.verificationRecordId, connectorData)
+      .then(saveSocialIdentity)
       .then(() => {
         writeAccountNotice({
           kind: 'success',

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/lib/api', () => ({
-  createMySocialIdentityAuthorization: vi.fn(),
+  resolveMySocialConnectorId: vi.fn(),
   unlinkMySocialIdentity: vi.fn(),
   // The card reads the Slack workspace through this. An explicit mock factory
   // must export every name the module under test imports, or the import itself

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -5,12 +5,13 @@ import useSWR from 'swr'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { SocialLoginMark } from '@/components/marks'
 import { initialsFrom } from '@/lib/auth'
-import { createMySocialIdentityAuthorization, fetchMySlackIdentity, unlinkMySocialIdentity } from '@/lib/api'
+import { fetchMySlackIdentity, resolveMySocialConnectorId, unlinkMySocialIdentity } from '@/lib/api'
 import { slackWorkspaceLine } from '@/lib/slack-identity'
 import {
   LogtoAccountError,
   accountErrorMessage,
   createSocialState,
+  createSocialVerification,
   fetchAccountProfile,
   socialIdentityDetails,
   writeSocialLinkFlow,
@@ -147,10 +148,16 @@ export default function SocialSignInCard({
     setBusyProvider(provider.target)
     try {
       const state = createSocialState()
-      const { authorizationUri, connectorId } = await createMySocialIdentityAuthorization(provider.target, state)
+      // Two hops on purpose: only the CP can name the connector, and only the
+      // browser can authorize it (the Account API is the side with a session).
+      const { connectorId } = await resolveMySocialConnectorId(provider.target)
+      const redirectUri = `${window.location.origin}/auth/social/callback`
+      const { authorizationUri, verificationRecordId } = await createSocialVerification(connectorId, redirectUri, state)
       const stored = writeSocialLinkFlow({
         state,
         connectorId,
+        verificationRecordId,
+        redirectUri,
         providerName: provider.name,
         returnTo: `${window.location.pathname}${window.location.search}`,
         createdAt: Date.now()

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2861,18 +2861,13 @@ export async function deleteMyProfilePicture(): Promise<MeDto> {
 }
 
 // ── my social sign-in methods ────────────────────────────────────────────────
-// The CP uses the verified OIDC subject plus its server-side Logto Management
-// credential. The browser sees only the provider authorization URL and callback
-// data; it never receives that M2M credential.
-export function createMySocialIdentityAuthorization(
-  target: SocialLoginTarget,
-  state: string
-): Promise<{ authorizationUri: string; connectorId: string }> {
-  return apiPost('/me/social-identities/authorization-uri', { target, state })
-}
-
-export async function linkMySocialIdentity(connectorId: string, connectorData: Record<string, string>): Promise<void> {
-  await apiPost('/me/social-identities', { connectorId, connectorData })
+// The tenant's connector id for a provider target. Only the CP can resolve this
+// (it holds the Logto Management credential, which never reaches the browser);
+// the authorization itself is then driven browser-side against the Account API,
+// because the Management API gives the connector no session — see
+// lib/logto-account.ts#createSocialVerification.
+export function resolveMySocialConnectorId(target: SocialLoginTarget): Promise<{ connectorId: string }> {
+  return apiGet(`/me/social-identities/connectors/${encodeURIComponent(target)}`)
 }
 
 export async function unlinkMySocialIdentity(target: string): Promise<void> {

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -66,6 +66,8 @@ describe('Logto Account API', () => {
     const flow = {
       state: 'state-123',
       connectorId: 'google-connector',
+      verificationRecordId: 'verification-123',
+      redirectUri: 'https://console.example.test/auth/social/callback',
       providerName: 'Google',
       returnTo: '/agentconnect/profile',
       createdAt: Date.now()

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -18,6 +18,12 @@ export interface SocialIdentityDetails {
 export interface SocialLinkFlow {
   state: string
   connectorId: string
+  /** The Account API verification this flow is completing. The provider's
+   *  response is only meaningful against the record that started it. */
+  verificationRecordId: string
+  /** Echoed back on verify: Logto exchanges the code against the SAME URI it
+   *  authorized with, and the connectors that keep it in session need it too. */
+  redirectUri: string
   providerName: string
   returnTo: string
   createdAt: number
@@ -102,6 +108,46 @@ export async function fetchAccountProfile(): Promise<LogtoAccountProfile> {
   return { identities }
 }
 
+/**
+ * Start a social link against Logto's Account API, with the user's OWN token.
+ *
+ * This runs in the browser on purpose. The equivalent Management API endpoint
+ * gives the connector no session, so every connector that persists state while
+ * building its authorization URI (Slack keeps `redirectUri` there) fails
+ * upstream with a 500. The Account API's verification record carries that
+ * session, so the same connectors work here.
+ */
+export async function createSocialVerification(
+  connectorId: string,
+  redirectUri: string,
+  state: string
+): Promise<{ verificationRecordId: string; authorizationUri: string }> {
+  return accountRequest('/api/verifications/social', {
+    method: 'POST',
+    body: JSON.stringify({ connectorId, redirectUri, state })
+  })
+}
+
+/** Exchange the provider's response for a verified identity, still unlinked. */
+export async function verifySocialVerification(
+  verificationRecordId: string,
+  connectorData: Record<string, string>
+): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/social/verify', {
+    method: 'POST',
+    body: JSON.stringify({ connectorData, verificationRecordId })
+  })
+  return result.verificationRecordId
+}
+
+/** Attach the verified identity to this account. */
+export async function saveSocialIdentity(verificationRecordId: string): Promise<void> {
+  await accountRequest('/api/my-account/identities', {
+    method: 'POST',
+    body: JSON.stringify({ newIdentifierVerificationRecordId: verificationRecordId })
+  })
+}
+
 export function socialIdentityDetails(identity: SocialIdentity): SocialIdentityDetails {
   const details = identity.details
   const name = stringValue(details.name, details.displayName, details.login, details.username)
@@ -139,6 +185,8 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
     if (
       typeof flow.state !== 'string' ||
       typeof flow.connectorId !== 'string' ||
+      typeof flow.verificationRecordId !== 'string' ||
+      typeof flow.redirectUri !== 'string' ||
       typeof flow.providerName !== 'string' ||
       typeof flow.returnTo !== 'string' ||
       !flow.returnTo.startsWith('/') ||


### PR DESCRIPTION
## The bug

Linking Slack from Profile always fails: the CP returns 502, the card shows *"Something went wrong. Try again."*

## Root cause (upstream, not config)

Logto's `POST /api/connectors/{id}/authorization-uri` runs the connector **with no session context** — it passes `notImplemented` as the session store. Any connector whose `getAuthorizationUri` persists state therefore fails *inside Logto* with a 500. Slack's connector does exactly that:

```js
await setSession({ redirectUri })   // read back by getUserInfo for the token exchange
```

Logto documents this as a **Management-API-specific** limitation ("Management API does not have any session context…") and names apple / standard OIDC / standard OAuth 2.0. Slack belongs in that set too. The Account API page carries no such caveat.

Both legs are affected, so moving only the first call would not have helped — the session is what carries `redirectUri` between authorize and verify.

**Verified against a live tenant, same connector:**

| path | result |
|---|---|
| Management API `POST /api/connectors/{id}/authorization-uri` | **500** → CP 502 |
| Account API `POST /api/verifications/social` | **201**, real `slack.com/openid/connect/authorize` URI |

## The change

Link and unlink now run over different Logto surfaces, split by whether they need a connector session:

- **Link** → browser, Account API, the user's **own** token. This restores the pre-#225 flow. It does *not* weaken #225's rationale: that path never involves the M2M credential at all, so the credential still never reaches the browser.
- **Unlink** → stays on the CP. It enforces an invariant the browser cannot be trusted with — the last sign-in method may not be removed, serialized per user by `SocialIdentityMutationGate` — and needs no session.

The browser still cannot discover a connector id, so the CP keeps that half:

- `POST /me/social-identities/authorization-uri` + `POST /me/social-identities` → **`GET /me/social-identities/connectors/:target`**
- `createSocialAuthorization` + `linkSocialIdentity` → **`socialConnectorIdFor`**

Also logs the upstream status/code in `logtoFailure`. Diagnosing this took far longer than it should have: the 502 fallback recorded **nothing** — the CP swallowed Logto's 500 without a single log line.

## Reviewer notes

- This partially reverts #225's linking architecture, deliberately and only for the half that cannot work.
- `POST /api/my-account/identities` is called without a `logto-verification-id` header, matching #225's "no second email-code step" stance. If a tenant has a security verification method configured, Logto may demand one — that surfaces as a clear 403 message rather than a silent failure.
- Verified: control-plane unit **737 passing**, web **447 passing**, `typecheck` / `lint` / `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)