### PR TITLE
feat(telegram): verify privacy mode during setup

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -140,7 +140,7 @@ import { createReadiness, type Readiness } from './http/readiness.js'
 import { McpRateLimiter } from './http/mcp/rate-limit.js'
 import { pingDb } from './persistence/prisma.js'
 import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
-import { resolveTelegramBotName } from './http/telegram-identity.js'
+import { verifyTelegramBot } from './http/telegram-identity.js'
 import { createTelegramBotIconSyncer } from './http/telegram-bot-profile.js'
 import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
 import { createDiscordBotIconSyncer } from './http/discord-bot-profile.js'
@@ -679,7 +679,7 @@ export function buildContainer(
     verifySlackBot,
     verifySlackAppToken,
     slackConfigApi,
-    resolveTelegramBotName,
+    verifyTelegramBot,
     syncTelegramBotIcon: createTelegramBotIconSyncer(iconStore),
     verifyDiscordBot,
     ensureDiscordMessageContentIntent,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -65,7 +65,7 @@ import type { HumanAuthConfig } from './plugins/auth.js'
 import type { SlackBotVerifier, SlackAppTokenVerifier } from './slack-identity.js'
 import type { SlackPlatformAppConfig } from '../config/slack-platform.js'
 import type { SlackConfigApi } from './slack-config-api.js'
-import type { TelegramBotNameResolver } from './telegram-identity.js'
+import type { TelegramBotVerifier } from './telegram-identity.js'
 import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from './discord-identity.js'
 import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
@@ -256,9 +256,9 @@ export interface HttpDeps {
    *  (§Tier B). Optional/injectable; absent (with PUBLIC_CP_URL) ⇒ the funnel routes
    *  404 and the console falls back to the manual manifest flow. */
   slackConfigApi?: SlackConfigApi
-  /** Derives a Telegram integration's name from `getMe` when the install omits one.
-   *  Optional/injectable so tests stay offline (absent ⇒ route falls back to the agent name). */
-  resolveTelegramBotName?: TelegramBotNameResolver
+  /** Validates a Telegram token, derives its bot name, and checks that Group Privacy
+   *  Mode is disabled before the integration is installed. */
+  verifyTelegramBot: TelegramBotVerifier
   /** Applies a newly registered Telegram bot's Agent icon to its profile.
    *  Cosmetic and best-effort: install survives a sync failure. */
   syncTelegramBotIcon?: TelegramBotIconSyncer

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -711,6 +711,13 @@ export const CreateIntegrationBody = z
     }
   })
 
+/** `POST /integrations/telegram/check` — preflight a pasted BotFather token
+ * without storing it. */
+export const TelegramBotCheckBody = z.object({ botToken: z.string().min(1) }).strict()
+export const TelegramBotCheckDto = z.object({
+  status: z.enum(['ready', 'privacy_enabled', 'invalid', 'unreachable'])
+})
+
 /** One conversation the integration's bot is in + how it activates there.
  *  `off` = conversation gating (resource-visibility.md §14): the agent does not
  *  activate there — the default for every conversation of a restricted agent.

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -34,6 +34,8 @@ import { discordAppIdFromBotToken } from '../discord-identity.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
   CreateIntegrationBody,
+  TelegramBotCheckBody,
+  TelegramBotCheckDto,
   UpdateIntegrationChannelBody,
   IntegrationDto,
   IntegrationChannelDto,
@@ -148,6 +150,33 @@ export function integrationRoutes(deps: HttpDeps) {
         app.log.debug({ integrationId, daemonId }, 'integration/remove skipped: daemon offline')
       }
     }
+
+    r.post(
+      '/integrations/telegram/check',
+      {
+        schema: {
+          tags: [Tag.Integrations],
+          summary: 'Check a Telegram bot',
+          description:
+            'Validate a pasted Telegram bot token and report whether Group Privacy Mode is disabled, without storing the token.',
+          operationId: 'checkTelegramBot',
+          body: TelegramBotCheckBody,
+          response: { 200: TelegramBotCheckDto, 403: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const checked = await deps.verifyTelegramBot(req.body.botToken)
+        return {
+          status:
+            checked.status === 'ok'
+              ? checked.privacyModeDisabled
+                ? ('ready' as const)
+                : ('privacy_enabled' as const)
+              : checked.status
+        }
+      }
+    )
 
     r.post(
       '/integrations',
@@ -366,15 +395,39 @@ export function integrationRoutes(deps: HttpDeps) {
             })
           }
 
-          // Telegram: a single BotFather token — no app-level token and no OAuth /
-          // verification funnel. Register the bot + secret + integration inline and push
-          // it live. Name: operator-typed → getMe-derived (best-effort) → owning agent.
+          // Telegram: `getMe` validates the single BotFather token and confirms
+          // Group Privacy Mode is disabled before anything is stored. Telegram exposes
+          // that setting as read-only; the owner still changes it in @BotFather.
           if (req.body.platform === 'telegram') {
             const tg = req.body.telegram! // superRefine guarantees it when botId is absent
+            const checked = await deps.verifyTelegramBot(tg.botToken)
+            if (checked.status === 'invalid') {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                statusCode: 400,
+                code: 'TELEGRAM_BOT_TOKEN_INVALID',
+                message: 'Telegram rejected the bot token — copy it again from @BotFather.'
+              })
+            }
+            if (checked.status === 'unreachable') {
+              return reply.code(503).send({
+                error: 'Service Unavailable',
+                statusCode: 503,
+                code: 'TELEGRAM_BOT_CHECK_UNAVAILABLE',
+                message: 'AgentConnect could not reach Telegram to check this bot. Try again in a moment.'
+              })
+            }
+            if (!checked.privacyModeDisabled) {
+              return reply.code(400).send({
+                error: 'Bad Request',
+                statusCode: 400,
+                code: 'TELEGRAM_PRIVACY_MODE_ENABLED',
+                message:
+                  'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot, choose Disable, then try again.'
+              })
+            }
             const provided = req.body.name?.trim()
-            const derived =
-              !provided && deps.resolveTelegramBotName ? await deps.resolveTelegramBotName(tg.botToken) : null
-            const name = provided || derived || agent.name
+            const name = provided || checked.name || agent.name
             const botId = BotId(randomUUID())
             await deps.repos.bot.create({
               id: botId,

--- a/packages/control-plane/src/http/telegram-identity.test.ts
+++ b/packages/control-plane/src/http/telegram-identity.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { verifyTelegramBot } from './telegram-identity.js'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('verifyTelegramBot', () => {
+  it('returns the bot name and Group Privacy Mode state from getMe', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({
+          ok: true,
+          result: { username: 'agentconnect_bot', can_read_all_group_messages: true }
+        })
+      )
+    )
+
+    await expect(verifyTelegramBot('123:secret')).resolves.toEqual({
+      status: 'ok',
+      name: 'agentconnect_bot',
+      privacyModeDisabled: true
+    })
+  })
+
+  it('reports an enabled Privacy Mode when getMe omits its disabled-only flag', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ ok: true, result: { first_name: 'AgentConnect' } }))
+    )
+
+    await expect(verifyTelegramBot('123:secret')).resolves.toEqual({
+      status: 'ok',
+      name: 'AgentConnect',
+      privacyModeDisabled: false
+    })
+  })
+
+  it('distinguishes rejected tokens from transient Telegram failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response('unauthorized', { status: 401 }))
+        .mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
+    )
+
+    await expect(verifyTelegramBot('123:bad')).resolves.toEqual({ status: 'invalid' })
+    await expect(verifyTelegramBot('123:secret')).resolves.toEqual({ status: 'unreachable' })
+  })
+})

--- a/packages/control-plane/src/http/telegram-identity.ts
+++ b/packages/control-plane/src/http/telegram-identity.ts
@@ -1,27 +1,45 @@
 /**
- * Best-effort Telegram bot-name lookup for the install flow — the Telegram analog
- * of slack-identity.ts.
+ * Telegram bot-token verification for the install flow.
  *
- * When `POST /integrations` omits a name, the CP calls Telegram `getMe` with the
- * BotFather token to derive the bot's @username, so the operator doesn't re-type a
- * name the bot already has. One install-time HTTPS call, short-timeout,
- * best-effort: returns null on ANY failure and the route falls back to the owning
- * agent's name. This is the only spot the CP touches the token to reach Telegram;
- * it NEVER logs it.
+ * `getMe` validates the BotFather token, derives the bot name, and exposes
+ * `can_read_all_group_messages`. The latter is Telegram's read-only signal that
+ * Group Privacy Mode was disabled in @BotFather; the Bot API has no setter for it.
+ * This is the only spot the CP puts the token in a Telegram URL, and it NEVER logs it.
  */
-export type TelegramBotNameResolver = (botToken: string) => Promise<string | null>
+export type TelegramBotVerification =
+  | { status: 'ok'; name: string | null; privacyModeDisabled: boolean }
+  | { status: 'invalid' }
+  | { status: 'unreachable' }
 
-/** The live resolver: `getMe` → the bot's @username, else its first name. */
-export const resolveTelegramBotName: TelegramBotNameResolver = async (botToken) => {
+export type TelegramBotVerifier = (botToken: string) => Promise<TelegramBotVerification>
+
+const TELEGRAM_TIMEOUT_MS = 5000
+
+export const verifyTelegramBot: TelegramBotVerifier = async (botToken) => {
   try {
     const res = await fetch(`https://api.telegram.org/bot${botToken}/getMe`, {
-      signal: AbortSignal.timeout(5000)
+      signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS)
     })
-    if (!res.ok) return null
-    const body = (await res.json()) as { ok?: boolean; result?: { username?: string; first_name?: string } }
-    if (!body.ok || !body.result) return null
-    return body.result.username ?? body.result.first_name ?? null
+    if (res.status === 401 || res.status === 404) return { status: 'invalid' }
+    if (!res.ok) return { status: 'unreachable' }
+    const body = (await res.json()) as {
+      ok?: boolean
+      error_code?: number
+      result?: {
+        username?: string
+        first_name?: string
+        can_read_all_group_messages?: boolean
+      }
+    }
+    if (!body.ok || !body.result) {
+      return body.error_code === 401 || body.error_code === 404 ? { status: 'invalid' } : { status: 'unreachable' }
+    }
+    return {
+      status: 'ok',
+      name: body.result.username ?? body.result.first_name ?? null,
+      privacyModeDisabled: body.result.can_read_all_group_messages === true
+    }
   } catch {
-    return null
+    return { status: 'unreachable' }
   }
 }

--- a/packages/control-plane/test/fakes/build-http.ts
+++ b/packages/control-plane/test/fakes/build-http.ts
@@ -237,6 +237,7 @@ export function buildHttpApp(
     events,
     mcpRateLimit: new McpRateLimiter(clock),
     readiness: createReadiness(() => pingDb(prisma)),
+    verifyTelegramBot: async () => ({ status: 'ok', name: null, privacyModeDisabled: true }),
     ensureDiscordMessageContentIntent: async () => 'ready',
     configureFeishuHttpApp: async () => {},
     feishuAppRegistration: new FeishuAppRegistrationService(feishuAppRegistrationStore),

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -176,6 +176,58 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     })
   })
 
+  it('POST telegram check reports Group Privacy Mode without storing the token', async () => {
+    const { app } = withSpy()
+    app.deps.verifyTelegramBot = async (botToken) => ({
+      status: 'ok',
+      name: 'acme-tg',
+      privacyModeDisabled: botToken.endsWith('ready')
+    })
+
+    const enabled = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/telegram/check`,
+      payload: { botToken: '123456:privacy-on' }
+    })
+    const ready = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations/telegram/check`,
+      payload: { botToken: '123456:ready' }
+    })
+
+    expect(enabled.statusCode).toBe(200)
+    expect(enabled.json()).toEqual({ status: 'privacy_enabled' })
+    expect(ready.statusCode).toBe(200)
+    expect(ready.json()).toEqual({ status: 'ready' })
+    expect(await prisma.botSecret.count()).toBe(0)
+  })
+
+  it('POST telegram refuses an enabled Group Privacy Mode before storing credentials', async () => {
+    const agentId = await placedAgent()
+    const { app, spy } = withSpy()
+    app.deps.verifyTelegramBot = async () => ({
+      status: 'ok',
+      name: 'acme-tg',
+      privacyModeDisabled: false
+    })
+
+    const res = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'telegram', agentId, telegram: { botToken: '123456:AAE-xyz' } }
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json()).toMatchObject({
+      code: 'TELEGRAM_PRIVACY_MODE_ENABLED',
+      message: expect.stringContaining('/setprivacy')
+    })
+    expect(await prisma.integration.count()).toBe(0)
+    expect(await prisma.bot.count()).toBe(0)
+    expect(await prisma.botSecret.count()).toBe(0)
+    expect(spy.upserts).toHaveLength(0)
+  })
+
   it('POST telegram registers a bot + secret with a NULL appToken, pushes a telegram-shaped upsert', async () => {
     const agentId = await placedAgent()
     const { app, spy } = withSpy()

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -31,11 +31,13 @@ import {
   invalidateGithubRepoRosterCache,
   syncGithubInstallations,
   updateAgentRepo,
+  checkTelegramBot,
   type CreateIntegrationInput,
   type CreatedHookDto,
   type GithubInstallationDto,
   type GithubRepoDto,
-  type RepoAccess
+  type RepoAccess,
+  type TelegramBotCheckDto
 } from '@/lib/api'
 import { REPO_ACCESS_BADGE } from '@/components/console/WorkspaceCard'
 import AddAgentRepoModal from './AddAgentRepoModal'
@@ -178,7 +180,7 @@ const GUIDE: Record<
     step1:
       'Open @BotFather → New bot (or send /newbot), give it a display name and a username ending in “bot” — it hands back the token.',
     step1Warning:
-      'disable privacy mode in @BotFather (/setprivacy → Disable) after creation, so it reads every message.',
+      'In @BotFather, send /setprivacy, select this bot and choose Disable. AgentConnect checks it after you paste the token.',
     tokenPlaceholder: '123456789:AAE…'
   },
   discord: {
@@ -187,6 +189,55 @@ const GUIDE: Record<
     step1: 'Name and create the application. In Bot, reset and copy the token.',
     tokenPlaceholder: 'Bot token from the Developer Portal'
   }
+}
+
+type TelegramCheckState = 'idle' | 'checking' | TelegramBotCheckDto['status']
+
+function TelegramPrivacyStatus({ status, onRetry }: { status: TelegramCheckState; onRetry: () => void }) {
+  if (status === 'idle') return null
+  const checking = status === 'checking'
+  const ready = status === 'ready'
+  const message =
+    status === 'checking'
+      ? 'Checking the token and Privacy Mode…'
+      : status === 'ready'
+        ? 'Privacy Mode is off. This bot can receive ordinary group messages.'
+        : status === 'privacy_enabled'
+          ? 'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot and choose Disable.'
+          : status === 'invalid'
+            ? 'Telegram rejected this token. Copy it again from @BotFather.'
+            : 'AgentConnect could not reach Telegram. Try the check again.'
+  const retryable = status === 'privacy_enabled' || status === 'unreachable'
+
+  return (
+    <div
+      className={`mt-2 flex items-start gap-2 rounded-md border px-[10px] py-2 font-sans text-[11.5px] font-normal leading-[1.5] ${
+        ready
+          ? 'border-(--status-online) bg-(--status-online-soft) text-(--text-secondary)'
+          : checking
+            ? 'border-(--border-default) bg-(--status-info-soft) text-(--text-secondary)'
+            : 'border-(--status-error) bg-(--status-error-soft) text-(--status-error)'
+      }`}
+    >
+      <Icon
+        name={checking ? 'loader' : ready ? 'circle-check' : 'triangle-alert'}
+        size={14}
+        color={ready ? 'var(--status-online)' : checking ? 'var(--status-info)' : 'var(--status-error)'}
+        className={`mt-[1px] flex-none ${checking ? 'animate-spin' : ''}`}
+      />
+      <span className="min-w-0 flex-1">{message}</span>
+      {retryable && (
+        <button
+          type="button"
+          className="inline-flex flex-none cursor-pointer items-center gap-[5px] border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold leading-[1.5] text-(--text-secondary) hover:text-(--text-primary)"
+          onClick={onRetry}
+        >
+          <Icon name="refresh-cw" size={12} />
+          Check again
+        </button>
+      )}
+    </div>
+  )
 }
 
 // Feishu needs a few app-level settings beyond the credentials that aren't obvious
@@ -937,6 +988,11 @@ export default function AddIntegrationModal({
   const [appName, setAppName] = useState(agent.name)
   const [botToken, setBotToken] = useState('')
   const [appToken, setAppToken] = useState('')
+  const [telegramCheckResult, setTelegramCheckResult] = useState<{
+    token: string
+    status: TelegramCheckState
+  }>({ token: '', status: 'idle' })
+  const [telegramCheckRevision, setTelegramCheckRevision] = useState(0)
   // Lark/Feishu gateway: new installs default to international Lark.
   const [feishuRegion, setFeishuRegion] = useState<'feishu' | 'lark'>('lark')
   const [feishuVerificationToken, setFeishuVerificationToken] = useState('')
@@ -1258,6 +1314,34 @@ export default function AddIntegrationModal({
   const botOk = slackBotOk
   const appOk = slackAppOk
   const telegramOk = /^\d+:[A-Za-z0-9_-]{20,}$/.test(tokenTrim)
+  const telegramCheck: TelegramCheckState =
+    mode === 'create' && platform === 'telegram' && telegramOk
+      ? telegramCheckResult.token === tokenTrim
+        ? telegramCheckResult.status
+        : 'checking'
+      : 'idle'
+  useEffect(() => {
+    if (mode !== 'create' || platform !== 'telegram' || !telegramOk) return
+    if (MOCK_MODE) {
+      setTelegramCheckResult({ token: tokenTrim, status: 'ready' })
+      return
+    }
+    let alive = true
+    setTelegramCheckResult({ token: tokenTrim, status: 'checking' })
+    const timer = window.setTimeout(() => {
+      void checkTelegramBot(tokenTrim)
+        .then((result) => {
+          if (alive) setTelegramCheckResult({ token: tokenTrim, status: result.status })
+        })
+        .catch(() => {
+          if (alive) setTelegramCheckResult({ token: tokenTrim, status: 'unreachable' })
+        })
+    }, 350)
+    return () => {
+      alive = false
+      window.clearTimeout(timer)
+    }
+  }, [mode, platform, telegramCheckRevision, telegramOk, tokenTrim])
   const discordOk = tokenTrim.length >= 24
   // The application (client) id is base64-encoded in the bot token's first segment, so
   // once a token is pasted we can offer a ready-made "Add to Discord" invite link with
@@ -1272,7 +1356,14 @@ export default function AddIntegrationModal({
   const feishuCallbackUrl = relayPublicUrl ? `${relayPublicUrl.replace(/\/+$/, '')}/feishu/events` : null
   // Slack: http needs bot + signing secret; socket needs bot + app-level token.
   const slackCreateOk = effTransport === 'http' ? slackBotOk && slackSigningOk : slackBotOk && slackAppOk
-  const createValid = platform === 'slack' ? slackCreateOk : platform === 'feishu' ? feishuOk : singleTokenOk
+  const createValid =
+    platform === 'slack'
+      ? slackCreateOk
+      : platform === 'telegram'
+        ? telegramOk && telegramCheck === 'ready'
+        : platform === 'feishu'
+          ? feishuOk
+          : singleTokenOk
   const valid = mode === 'existing' ? selectedBotId !== null : createValid
   // The app-level token embeds the app id (xapp-1-{APP_ID}-…); once it's pasted we can
   // deep-link straight to THIS app's Slack pages (Slack funnel only) — chiefly the OAuth
@@ -3260,7 +3351,7 @@ export default function AddIntegrationModal({
                       label={platform === 'telegram' ? 'Telegram bot setup steps' : 'Discord bot setup steps'}
                     />
                   </div>
-                  {GUIDE[platform].step1Warning && (
+                  {GUIDE[platform].step1Warning && !(platform === 'telegram' && telegramCheck === 'ready') && (
                     <div className="mt-2 font-sans text-[12px] font-medium leading-[1.5] text-(--status-error)">
                       {GUIDE[platform].step1Warning}
                     </div>
@@ -3279,12 +3370,29 @@ export default function AddIntegrationModal({
                 <div className="fld">
                   <span className="fldlbl">Bot token</span>
                   <input
-                    className={`inp mn ${showErrors && !singleTokenOk ? 'border-(--status-error)' : ''}`}
+                    className={`inp mn ${
+                      (showErrors && !singleTokenOk) ||
+                      (platform === 'telegram' &&
+                        (telegramCheck === 'privacy_enabled' ||
+                          telegramCheck === 'invalid' ||
+                          telegramCheck === 'unreachable'))
+                        ? 'border-(--status-error)'
+                        : ''
+                    }`}
                     placeholder={GUIDE[platform].tokenPlaceholder}
                     value={botToken}
                     onChange={(e) => setBotToken(e.target.value)}
                   />
                 </div>
+                {platform === 'telegram' && (
+                  <TelegramPrivacyStatus
+                    status={telegramCheck}
+                    onRetry={() => {
+                      setTelegramCheckResult({ token: tokenTrim, status: 'checking' })
+                      setTelegramCheckRevision((revision) => revision + 1)
+                    }}
+                  />
+                )}
                 {/* Discord: the invite is the fiddly part (right scopes + permissions), so once
                   the token decodes to an app id we hand the user a ready-made invite link. */}
                 {platform === 'discord' &&

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -484,6 +484,10 @@ export type CreateIntegrationInput =
       }
     })
 
+export interface TelegramBotCheckDto {
+  status: 'ready' | 'privacy_enabled' | 'invalid' | 'unreachable'
+}
+
 // ── Slack config-token auto-install funnel (docs/designs/slack-install-smoothing.md §Tier B) ──
 // The CP creates the Slack app from a manifest (using the operator's App
 // Configuration Token), the user approves an OAuth install in the browser, and
@@ -2543,6 +2547,11 @@ export async function fetchIntegrations(orgId?: string): Promise<IntegrationDto[
 // (never the tokens); the CP delivers the tokens to the owning agent's daemon.
 export async function createIntegration(input: CreateIntegrationInput): Promise<IntegrationDto> {
   return apiPost<IntegrationDto>(`${orgBase()}/integrations`, input)
+}
+
+/** Validate a pasted Telegram token and its Group Privacy Mode without storing it. */
+export async function checkTelegramBot(botToken: string): Promise<TelegramBotCheckDto> {
+  return apiPost<TelegramBotCheckDto>(`${orgBase()}/integrations/telegram/check`, { botToken })
 }
 
 // ── Feishu/Lark one-click app registration ──


### PR DESCRIPTION
## Summary

- check pasted Telegram bot tokens with `getMe`
- require Group Privacy Mode to be disabled before installation
- show live setup status and retry guidance in the integration modal
- recheck on the server before storing credentials

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/http/telegram-identity.test.ts`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/integrations.route.test.ts`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web typecheck`
- changed-file ESLint and Prettier checks
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- desktop and mobile browser QA with no overflow or console errors

Created by Codex . GPT-5.6
