### PR TITLE
feat(lark): sync app icons after agent updates

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -146,6 +146,7 @@ import { createTelegramBotIconSyncer } from './http/telegram-bot-profile.js'
 import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
 import { createDiscordBotIconSyncer } from './http/discord-bot-profile.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
+import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
 import { configureFeishuHttpApp } from './http/feishu-app-config.js'
 
@@ -698,6 +699,7 @@ export function buildContainer(
     syncDiscordBotIcon: createDiscordBotIconSyncer(iconStore),
     verifyFeishuBot,
     configureFeishuHttpApp,
+    syncFeishuAppIcon: createFeishuAppIconSyncer(iconStore),
     feishuAppRegistration: new FeishuAppRegistrationService(repos.feishuAppRegistration),
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -36,7 +36,11 @@ function integration(botId: string, platform: Platform, agentId = AGENT_ID): Int
   }
 }
 
-function bot(id: string, platform: Platform, options: { shareable?: boolean; revoked?: boolean } = {}): BotRecord {
+function bot(
+  id: string,
+  platform: Platform,
+  options: { shareable?: boolean; revoked?: boolean; feishuAppId?: string; feishuRegion?: 'feishu' | 'lark' } = {}
+): BotRecord {
   return {
     id: BotId(id),
     orgId: ORG_ID,
@@ -52,8 +56,8 @@ function bot(id: string, platform: Platform, options: { shareable?: boolean; rev
     credentialRevision: 1,
     credentialInstalledAt: new Date(0),
     discordAppId: null,
-    feishuAppId: null,
-    feishuRegion: null,
+    feishuAppId: options.feishuAppId ?? null,
+    feishuRegion: options.feishuRegion ?? null,
     shareable: options.shareable ?? false,
     transport: 'socket',
     createdBy: null,
@@ -66,18 +70,20 @@ function bot(id: string, platform: Platform, options: { shareable?: boolean; rev
 }
 
 describe('syncAgentBotIcons', () => {
-  it('syncs each dedicated Telegram/Discord bot once and isolates cosmetic failures', async () => {
+  it('syncs each dedicated Telegram/Discord/Feishu bot once and isolates cosmetic failures', async () => {
     const telegramId = '00000000-0000-4000-8000-000000000001'
     const discordId = '00000000-0000-4000-8000-000000000002'
     const sharedId = '00000000-0000-4000-8000-000000000003'
     const revokedId = '00000000-0000-4000-8000-000000000004'
     const slackId = '00000000-0000-4000-8000-000000000005'
+    const feishuId = '00000000-0000-4000-8000-000000000006'
     const bots = new Map([
       [telegramId, bot(telegramId, 'telegram')],
       [discordId, bot(discordId, 'discord')],
       [sharedId, bot(sharedId, 'telegram', { shareable: true })],
       [revokedId, bot(revokedId, 'discord', { revoked: true })],
-      [slackId, bot(slackId, 'slack')]
+      [slackId, bot(slackId, 'slack')],
+      [feishuId, bot(feishuId, 'feishu', { feishuAppId: 'cli_feishu', feishuRegion: 'lark' })]
     ])
     const integrations = [
       integration(telegramId, 'telegram'),
@@ -85,12 +91,14 @@ describe('syncAgentBotIcons', () => {
       integration(discordId, 'discord'),
       integration(sharedId, 'telegram'),
       integration(revokedId, 'discord'),
-      integration(slackId, 'slack')
+      integration(slackId, 'slack'),
+      integration(feishuId, 'feishu')
     ]
     const telegramSync = vi.fn(async () => {
       throw new Error('rate limited')
     })
     const discordSync = vi.fn(async () => {})
+    const feishuSync = vi.fn(async () => {})
     const secretGets: string[] = []
     const warn = vi.fn()
     const currentAgent = agentRecord(agent.icon)
@@ -111,12 +119,17 @@ describe('syncAgentBotIcons', () => {
             botSecret: {
               get: async (id) => {
                 secretGets.push(id)
-                return { botToken: `token-${id}`, appToken: null, signingSecret: null }
+                return {
+                  botToken: `token-${id}`,
+                  appToken: id === feishuId ? 'cli_secret_fallback' : null,
+                  signingSecret: null
+                }
               }
             }
           },
           syncTelegramBotIcon: telegramSync,
-          syncDiscordBotIcon: discordSync
+          syncDiscordBotIcon: discordSync,
+          syncFeishuAppIcon: feishuSync
         },
         agent,
         { warn }
@@ -127,7 +140,14 @@ describe('syncAgentBotIcons', () => {
     expect(telegramSync).toHaveBeenCalledWith(`token-${telegramId}`, expect.objectContaining(agent))
     expect(discordSync).toHaveBeenCalledOnce()
     expect(discordSync).toHaveBeenCalledWith(`token-${discordId}`, expect.objectContaining(agent))
-    expect(secretGets.sort()).toEqual([telegramId, discordId].sort())
+    expect(feishuSync).toHaveBeenCalledOnce()
+    expect(feishuSync).toHaveBeenCalledWith(
+      'cli_secret_fallback',
+      `token-${feishuId}`,
+      'lark',
+      expect.objectContaining(agent)
+    )
+    expect(secretGets.sort()).toEqual([telegramId, discordId, feishuId].sort())
     expect(warn).toHaveBeenCalledOnce()
   })
 

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -8,6 +8,7 @@ import type {
 } from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
 import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
+import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
 import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 
 interface AgentBotIconSyncDeps {
@@ -19,6 +20,7 @@ interface AgentBotIconSyncDeps {
   }
   syncTelegramBotIcon?: TelegramBotIconSyncer
   syncDiscordBotIcon?: DiscordBotIconSyncer
+  syncFeishuAppIcon?: FeishuAppIconSyncer
 }
 
 interface AgentBotIconSyncLogger {
@@ -28,7 +30,6 @@ interface AgentBotIconSyncLogger {
 interface CurrentBotIconState {
   bot: BotRecord
   agent: AgentRecord
-  sync: TelegramBotIconSyncer | DiscordBotIconSyncer
   version: string
 }
 
@@ -53,13 +54,11 @@ async function currentBotIconState(
   const bot = await deps.repos.bot.get(botId)
   if (!bot || bot.shareable || bot.revokedAt) return null
 
-  const sync =
-    bot.platform === 'telegram'
-      ? deps.syncTelegramBotIcon
-      : bot.platform === 'discord'
-        ? deps.syncDiscordBotIcon
-        : undefined
-  if (!sync) return null
+  const supported =
+    (bot.platform === 'telegram' && deps.syncTelegramBotIcon) ||
+    (bot.platform === 'discord' && deps.syncDiscordBotIcon) ||
+    (bot.platform === 'feishu' && deps.syncFeishuAppIcon)
+  if (!supported) return null
 
   const memberships = await deps.repos.integration.listForBot(bot.id)
   if (memberships.length !== 1) return null
@@ -71,7 +70,6 @@ async function currentBotIconState(
   return {
     bot,
     agent,
-    sync,
     version: `${bot.credentialRevision}:${membership.id}:${agent.id}:${agentIconVersion(agent)}`
   }
 }
@@ -93,7 +91,23 @@ async function syncBotIconUntilCurrent(
     }
 
     try {
-      await state.sync(secret.botToken, state.agent)
+      if (state.bot.platform === 'telegram' && deps.syncTelegramBotIcon) {
+        await deps.syncTelegramBotIcon(secret.botToken, state.agent)
+      } else if (state.bot.platform === 'discord' && deps.syncDiscordBotIcon) {
+        await deps.syncDiscordBotIcon(secret.botToken, state.agent)
+      } else if (state.bot.platform === 'feishu' && deps.syncFeishuAppIcon) {
+        // The secret row keeps the credential pair together; public bot
+        // metadata is only the fallback for older rows.
+        const appId = secret.appToken ?? state.bot.feishuAppId
+        if (!appId) {
+          log.warn(
+            { agentId: state.agent.id, botId: state.bot.id, platform: state.bot.platform },
+            'agent bot icon sync skipped: Feishu App ID is missing'
+          )
+          return
+        }
+        await deps.syncFeishuAppIcon(appId, secret.botToken, state.bot.feishuRegion ?? 'feishu', state.agent)
+      }
     } catch (err) {
       log.warn(
         { err, agentId: state.agent.id, botId: state.bot.id },
@@ -107,7 +121,7 @@ async function syncBotIconUntilCurrent(
   }
 }
 
-/** Push one changed Agent icon to each dedicated Telegram/Discord bot currently
+/** Push one changed Agent icon to each dedicated Telegram/Discord/Feishu bot currently
  * installed on it. Shared identities are deliberately excluded: one platform
  * avatar cannot represent several agents. After each provider call, re-read and
  * repair to the latest icon/current owner so detached requests are latest-wins.

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -71,6 +71,7 @@ import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from './discord-identity.js'
 import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
 import type { FeishuBotVerifier } from './feishu-identity.js'
+import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
 import type { FeishuAppRegistrationService } from './feishu-registration.js'
 import type { FeishuHttpAppConfigurator } from './feishu-app-config.js'
 import type { Readiness } from './readiness.js'
@@ -285,6 +286,9 @@ export interface HttpDeps {
   /** Applies the sensitive delivery URL and verification keys that the official
    *  one-click registration deeplink intentionally cannot carry. */
   configureFeishuHttpApp: FeishuHttpAppConfigurator
+  /** Applies an Agent icon to a self-built Feishu/Lark app and submits the
+   *  updated application version. Cosmetic and best-effort. */
+  syncFeishuAppIcon?: FeishuAppIconSyncer
   /** Owns the short-lived official Feishu/Lark device-registration poll. The
    *  browser sees only a deeplink + opaque id; credentials are finalized through
    *  BotSecretStore before the session becomes completed. */

--- a/packages/control-plane/src/http/feishu-app-icon.test.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.test.ts
@@ -22,12 +22,15 @@ describe('createFeishuAppIconSyncer', () => {
           status: 200
         })
       )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, data: { items: [{ status: 1 }] } }), { status: 200 })
+      )
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
 
     await createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'lark', agent)
 
-    expect(fetcher).toHaveBeenCalledTimes(4)
+    expect(fetcher).toHaveBeenCalledTimes(5)
     expect(fetcher.mock.calls[0]?.[0]).toBe('https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal')
     expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual({
       app_id: 'cli_test',
@@ -47,19 +50,25 @@ describe('createFeishuAppIconSyncer', () => {
     })
 
     expect(fetcher.mock.calls[2]?.[0]).toBe(
+      'https://open.larksuite.com/open-apis/application/v6/applications/cli_test/app_versions?lang=en_us&page_size=1&order=0'
+    )
+    expect(fetcher.mock.calls[2]?.[1]?.method).toBe('GET')
+    expect(fetcher.mock.calls[2]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
+
+    expect(fetcher.mock.calls[3]?.[0]).toBe(
       'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/base'
     )
-    expect(fetcher.mock.calls[2]?.[1]?.method).toBe('PATCH')
-    expect(fetcher.mock.calls[2]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
-    expect(JSON.parse(String(fetcher.mock.calls[2]?.[1]?.body))).toEqual({
+    expect(fetcher.mock.calls[3]?.[1]?.method).toBe('PATCH')
+    expect(fetcher.mock.calls[3]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
+    expect(JSON.parse(String(fetcher.mock.calls[3]?.[1]?.body))).toEqual({
       avatar_url: 'https://cdn.example.test/app-icon'
     })
 
-    expect(fetcher.mock.calls[3]?.[0]).toBe(
+    expect(fetcher.mock.calls[4]?.[0]).toBe(
       'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/publish'
     )
-    expect(fetcher.mock.calls[3]?.[1]?.method).toBe('POST')
-    expect(JSON.parse(String(fetcher.mock.calls[3]?.[1]?.body))).toEqual({
+    expect(fetcher.mock.calls[4]?.[1]?.method).toBe('POST')
+    expect(JSON.parse(String(fetcher.mock.calls[4]?.[1]?.body))).toEqual({
       remark: 'Sync the application icon with its AgentConnect agent',
       changelog: 'Updated the application icon'
     })
@@ -77,5 +86,26 @@ describe('createFeishuAppIconSyncer', () => {
       createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'feishu', agent)
     ).rejects.toThrow('Lark/Feishu icon upload returned 200')
     expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not patch or publish an app that already has unpublished changes', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, tenant_access_token: 'tenant-token' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, data: { url: 'https://cdn.example.test/app-icon' } }), {
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, data: { items: [{ status: 4 }] } }), { status: 200 })
+      )
+
+    await expect(
+      createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'feishu', agent)
+    ).rejects.toThrow('Lark/Feishu icon sync skipped: application has unpublished changes')
+    expect(fetcher).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/control-plane/src/http/feishu-app-icon.test.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import sharp from 'sharp'
+import { AgentId } from '../domain/ids.js'
+import type { BotProfileIconAgent } from './bot-profile-icon.js'
+import { createFeishuAppIconSyncer } from './feishu-app-icon.js'
+
+const agent: BotProfileIconAgent = {
+  id: AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+  icon: { kind: 'glyph', glyph: 'bot', color: '#2563eb' },
+  runtime: 'codex'
+}
+
+describe('createFeishuAppIconSyncer', () => {
+  it('uploads, patches, and publishes the Agent icon through the Lark gateway', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, tenant_access_token: 'tenant-token' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, data: { url: 'https://cdn.example.test/app-icon' } }), {
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
+
+    await createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'lark', agent)
+
+    expect(fetcher).toHaveBeenCalledTimes(4)
+    expect(fetcher.mock.calls[0]?.[0]).toBe('https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal')
+    expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual({
+      app_id: 'cli_test',
+      app_secret: 'app-secret'
+    })
+
+    expect(fetcher.mock.calls[1]?.[0]).toBe('https://open.larksuite.com/open-apis/application/v7/app_avatar/upload')
+    const upload = fetcher.mock.calls[1]?.[1]?.body
+    expect(upload).toBeInstanceOf(FormData)
+    const avatar = (upload as FormData).get('avatar')
+    expect(avatar).toBeInstanceOf(Blob)
+    const metadata = await sharp(Buffer.from(await (avatar as Blob).arrayBuffer())).metadata()
+    expect({ width: metadata.width, height: metadata.height, format: metadata.format }).toEqual({
+      width: 512,
+      height: 512,
+      format: 'png'
+    })
+
+    expect(fetcher.mock.calls[2]?.[0]).toBe(
+      'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/base'
+    )
+    expect(fetcher.mock.calls[2]?.[1]?.method).toBe('PATCH')
+    expect(fetcher.mock.calls[2]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
+    expect(JSON.parse(String(fetcher.mock.calls[2]?.[1]?.body))).toEqual({
+      avatar_url: 'https://cdn.example.test/app-icon'
+    })
+
+    expect(fetcher.mock.calls[3]?.[0]).toBe(
+      'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/publish'
+    )
+    expect(fetcher.mock.calls[3]?.[1]?.method).toBe('POST')
+    expect(JSON.parse(String(fetcher.mock.calls[3]?.[1]?.body))).toEqual({
+      remark: 'Sync the application icon with its AgentConnect agent',
+      changelog: 'Updated the application icon'
+    })
+  })
+
+  it('stops before patching when the provider rejects the icon upload', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 0, tenant_access_token: 'tenant-token' }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 999, msg: 'denied' }), { status: 200 }))
+
+    await expect(
+      createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'feishu', agent)
+    ).rejects.toThrow('Lark/Feishu icon upload returned 200')
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/control-plane/src/http/feishu-app-icon.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.ts
@@ -8,10 +8,14 @@ const REGION_ORIGIN: Record<FeishuRegion, string> = {
 }
 const FEISHU_TIMEOUT_MS = 15_000
 const FEISHU_ICON_SIZE = 512
+const FEISHU_AUDITED_APP_VERSION_STATUS = 1
 
 interface FeishuApiResponse {
   code?: number
-  data?: { url?: string }
+  data?: {
+    url?: string
+    items?: Array<{ status?: number }>
+  }
 }
 
 export type FeishuAppIconSyncer = (
@@ -41,10 +45,40 @@ async function iconPng(agent: BotProfileIconAgent, iconStore?: IconStore): Promi
   return sharp(source.bytes).resize(FEISHU_ICON_SIZE, FEISHU_ICON_SIZE, { fit: 'cover' }).png().toBuffer()
 }
 
+async function assertNoUnpublishedVersion(
+  fetcher: typeof fetch,
+  origin: string,
+  encodedAppId: string,
+  token: string
+): Promise<void> {
+  const versionsRes = await request(
+    fetcher,
+    `${origin}/open-apis/application/v6/applications/${encodedAppId}/app_versions?lang=en_us&page_size=1&order=0`,
+    {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+    },
+    'version check'
+  )
+  const versionsBody = await responseBody(versionsRes)
+  if (!versionsRes.ok || versionsBody?.code !== 0) {
+    throw new Error(`Lark/Feishu version check returned ${versionsRes.status}`)
+  }
+
+  // v6 status 1 is audited/published. Every other latest-version state is
+  // ambiguous (unsubmitted, under review, rejected, or unknown), so publishing
+  // could submit unrelated developer changes along with the icon.
+  if (versionsBody.data?.items?.[0]?.status !== FEISHU_AUDITED_APP_VERSION_STATUS) {
+    throw new Error('Lark/Feishu icon sync skipped: application has unpublished changes')
+  }
+}
+
 /**
  * Update a self-built Feishu/Lark application's icon and submit the resulting
  * application version. The app must grant `application:application:patch`;
- * provider review, when required by the tenant, completes asynchronously.
+ * provider review, when required by the tenant, completes asynchronously. A
+ * pre-existing unpublished version makes the sync stop before changing the app.
  */
 export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof fetch = fetch): FeishuAppIconSyncer {
   return async (appId, appSecret, region, agent) => {
@@ -66,6 +100,7 @@ export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof
     }
 
     const token = tokenBody.tenant_access_token
+    const encodedAppId = encodeURIComponent(appId)
     const png = await iconPng(agent, iconStore)
     const form = new FormData()
     form.set('avatar', new Blob([new Uint8Array(png)], { type: 'image/png' }), 'agent-icon.png')
@@ -86,7 +121,8 @@ export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof
       throw new Error(`Lark/Feishu icon upload returned ${uploadRes.status}`)
     }
 
-    const encodedAppId = encodeURIComponent(appId)
+    await assertNoUnpublishedVersion(fetcher, origin, encodedAppId, token)
+
     const patchRes = await request(
       fetcher,
       `${origin}/open-apis/application/v7/applications/${encodedAppId}/base`,

--- a/packages/control-plane/src/http/feishu-app-icon.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.ts
@@ -1,0 +1,131 @@
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+import type { IconStore } from '../icons/icon-store.js'
+import { loadBotProfileIcon, type BotProfileIconAgent } from './bot-profile-icon.js'
+
+const REGION_ORIGIN: Record<FeishuRegion, string> = {
+  feishu: 'https://open.feishu.cn',
+  lark: 'https://open.larksuite.com'
+}
+const FEISHU_TIMEOUT_MS = 15_000
+const FEISHU_ICON_SIZE = 512
+
+interface FeishuApiResponse {
+  code?: number
+  data?: { url?: string }
+}
+
+export type FeishuAppIconSyncer = (
+  appId: string,
+  appSecret: string,
+  region: FeishuRegion,
+  agent: BotProfileIconAgent
+) => Promise<void>
+
+async function request(fetcher: typeof fetch, url: string, init: RequestInit, operation: string): Promise<Response> {
+  try {
+    return await fetcher(url, init)
+  } catch {
+    // Never retain the token exchange body or Authorization header in the
+    // error that the best-effort caller writes to application logs.
+    throw new Error(`Lark/Feishu ${operation} request failed`)
+  }
+}
+
+async function responseBody(res: Response): Promise<FeishuApiResponse | null> {
+  return (await res.json().catch(() => null)) as FeishuApiResponse | null
+}
+
+async function iconPng(agent: BotProfileIconAgent, iconStore?: IconStore): Promise<Buffer> {
+  const source = await loadBotProfileIcon(agent, iconStore, FEISHU_ICON_SIZE)
+  const { default: sharp } = await import('sharp')
+  return sharp(source.bytes).resize(FEISHU_ICON_SIZE, FEISHU_ICON_SIZE, { fit: 'cover' }).png().toBuffer()
+}
+
+/**
+ * Update a self-built Feishu/Lark application's icon and submit the resulting
+ * application version. The app must grant `application:application:patch`;
+ * provider review, when required by the tenant, completes asynchronously.
+ */
+export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof fetch = fetch): FeishuAppIconSyncer {
+  return async (appId, appSecret, region, agent) => {
+    const origin = REGION_ORIGIN[region]
+    const tokenRes = await request(
+      fetcher,
+      `${origin}/open-apis/auth/v3/tenant_access_token/internal`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+        body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+        signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+      },
+      'credential exchange'
+    )
+    const tokenBody = (await responseBody(tokenRes)) as (FeishuApiResponse & { tenant_access_token?: string }) | null
+    if (!tokenRes.ok || tokenBody?.code !== 0 || !tokenBody.tenant_access_token) {
+      throw new Error(`Lark/Feishu credential exchange returned ${tokenRes.status}`)
+    }
+
+    const token = tokenBody.tenant_access_token
+    const png = await iconPng(agent, iconStore)
+    const form = new FormData()
+    form.set('avatar', new Blob([new Uint8Array(png)], { type: 'image/png' }), 'agent-icon.png')
+    const uploadRes = await request(
+      fetcher,
+      `${origin}/open-apis/application/v7/app_avatar/upload`,
+      {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}` },
+        body: form,
+        signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+      },
+      'icon upload'
+    )
+    const uploadBody = await responseBody(uploadRes)
+    const avatarUrl = uploadBody?.data?.url
+    if (!uploadRes.ok || uploadBody?.code !== 0 || !avatarUrl) {
+      throw new Error(`Lark/Feishu icon upload returned ${uploadRes.status}`)
+    }
+
+    const encodedAppId = encodeURIComponent(appId)
+    const patchRes = await request(
+      fetcher,
+      `${origin}/open-apis/application/v7/applications/${encodedAppId}/base`,
+      {
+        method: 'PATCH',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json; charset=utf-8'
+        },
+        body: JSON.stringify({ avatar_url: avatarUrl }),
+        signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+      },
+      'icon patch'
+    )
+    const patchBody = await responseBody(patchRes)
+    if (!patchRes.ok || patchBody?.code !== 0) {
+      throw new Error(`Lark/Feishu icon patch returned ${patchRes.status}`)
+    }
+
+    const publishRes = await request(
+      fetcher,
+      `${origin}/open-apis/application/v7/applications/${encodedAppId}/publish`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json; charset=utf-8'
+        },
+        body: JSON.stringify({
+          remark: 'Sync the application icon with its AgentConnect agent',
+          changelog: 'Updated the application icon'
+        }),
+        signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
+      },
+      'publish'
+    )
+    const publishBody = await responseBody(publishRes)
+    if (!publishRes.ok || publishBody?.code !== 0) {
+      throw new Error(`Lark/Feishu publish returned ${publishRes.status}`)
+    }
+  }
+}

--- a/packages/control-plane/src/http/feishu-app-icon.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.ts
@@ -76,9 +76,11 @@ async function assertNoUnpublishedVersion(
 
 /**
  * Update a self-built Feishu/Lark application's icon and submit the resulting
- * application version. The app must grant `application:application:patch`;
- * provider review, when required by the tenant, completes asynchronously. A
- * pre-existing unpublished version makes the sync stop before changing the app.
+ * application version. The app must grant
+ * `application:application.app_version:readonly` and
+ * `application:application:patch`; provider review, when required by the
+ * tenant, completes asynchronously. A pre-existing unpublished version makes
+ * the sync stop before changing the app.
  */
 export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof fetch = fetch): FeishuAppIconSyncer {
   return async (appId, appSecret, region, agent) => {

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -13,6 +13,7 @@ import {
 } from './platform-app-description.js'
 
 export const AGENTCONNECT_FEISHU_SCOPES = [
+  'application:application.app_version:readonly',
   'application:application:patch',
   'contact:contact.base:readonly',
   'contact:user.base:readonly',

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -13,6 +13,7 @@ import {
 } from './platform-app-description.js'
 
 export const AGENTCONNECT_FEISHU_SCOPES = [
+  'application:application:patch',
   'contact:contact.base:readonly',
   'contact:user.base:readonly',
   'im:chat:read',

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2148,9 +2148,10 @@ export interface AgentRepoAuthorizationRepo {
 // routes, protocol, or the daemon.
 // ───────────────────────────────────────────────────────────────────────────
 
-/** Secret material for one bot. Feishu HTTP callback credentials are optional
- *  for compatibility with every existing platform row and are stored through
- *  the same cipher boundary. */
+/** Secret material for one bot. `appToken` is Slack Socket Mode's app-level token
+ *  or a Feishu/Lark App ID paired with `botToken`'s App Secret. Feishu HTTP callback
+ *  credentials are optional for compatibility with existing platform rows. Every
+ *  value is stored through the same cipher boundary. */
 export interface BotSecretMaterial {
   botToken: string
   appToken: string | null

--- a/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
+++ b/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 })
 
 describe('Agent icon bot profile fan-out', () => {
-  it('syncs dedicated Telegram/Discord bots only when the Agent icon changes', async () => {
+  it('syncs dedicated Telegram/Discord/Feishu bots only when the Agent icon changes', async () => {
     const store: IconStore = {
       put: vi.fn(async () => undefined),
       get: vi.fn(async () => null),
@@ -30,10 +30,14 @@ describe('Agent icon bot profile fan-out', () => {
     }
     const telegramSync = vi.fn(async (_botToken: string, _agent: BotProfileIconAgent) => {})
     const discordSync = vi.fn(async (_botToken: string, _agent: BotProfileIconAgent) => {})
+    const feishuSync = vi.fn(
+      async (_appId: string, _appSecret: string, _region: 'feishu' | 'lark', _agent: BotProfileIconAgent) => {}
+    )
     running = buildHttpApp(prisma, { S3_PUBLIC_BASE_URL: 'https://images.example.test' }, undefined, undefined, {
       iconStore: store,
       syncTelegramBotIcon: telegramSync,
-      syncDiscordBotIcon: discordSync
+      syncDiscordBotIcon: discordSync,
+      syncFeishuAppIcon: feishuSync
     })
 
     const create = await running.app.inject({
@@ -47,11 +51,22 @@ describe('Agent icon bot profile fan-out', () => {
 
     for (const [platform, token] of [
       ['telegram', 'telegram-token'],
-      ['discord', 'discord-token']
+      ['discord', 'discord-token'],
+      ['feishu', 'feishu-secret']
     ] as const) {
       const botId = BotId(randomUUID())
-      await running.deps.repos.bot.create({ id: botId, orgId, platform, name: `${platform}-bot` })
-      await running.deps.repos.botSecret.put(botId, { botToken: token, appToken: null, signingSecret: null })
+      await running.deps.repos.bot.create({
+        id: botId,
+        orgId,
+        platform,
+        name: `${platform}-bot`,
+        ...(platform === 'feishu' ? { feishuAppId: 'cli_feishu', feishuRegion: 'lark' } : {})
+      })
+      await running.deps.repos.botSecret.put(botId, {
+        botToken: token,
+        appToken: platform === 'feishu' ? 'cli_feishu' : null,
+        signingSecret: null
+      })
       await running.deps.repos.integration.create({
         id: IntegrationId(randomUUID()),
         orgId,
@@ -70,6 +85,7 @@ describe('Agent icon bot profile fan-out', () => {
     expect(ordinaryEdit.statusCode).toBe(200)
     expect(telegramSync).not.toHaveBeenCalled()
     expect(discordSync).not.toHaveBeenCalled()
+    expect(feishuSync).not.toHaveBeenCalled()
 
     const glyphEdit = await running.app.inject({
       method: 'PATCH',
@@ -80,6 +96,7 @@ describe('Agent icon bot profile fan-out', () => {
     await vi.waitFor(() => {
       expect(telegramSync).toHaveBeenCalledTimes(1)
       expect(discordSync).toHaveBeenCalledTimes(1)
+      expect(feishuSync).toHaveBeenCalledTimes(1)
     })
 
     const upload = await running.app.inject({
@@ -92,12 +109,17 @@ describe('Agent icon bot profile fan-out', () => {
     await vi.waitFor(() => {
       expect(telegramSync).toHaveBeenCalledTimes(2)
       expect(discordSync).toHaveBeenCalledTimes(2)
+      expect(feishuSync).toHaveBeenCalledTimes(2)
     })
     expect(telegramSync.mock.calls[1]?.[1].icon).toEqual({
       kind: 'image',
       generation: expect.any(String)
     })
     expect(discordSync.mock.calls[1]?.[1].icon).toEqual({
+      kind: 'image',
+      generation: expect.any(String)
+    })
+    expect(feishuSync.mock.calls[1]?.[3].icon).toEqual({
       kind: 'image',
       generation: expect.any(String)
     })
@@ -110,8 +132,11 @@ describe('Agent icon bot profile fan-out', () => {
     await vi.waitFor(() => {
       expect(telegramSync).toHaveBeenCalledTimes(3)
       expect(discordSync).toHaveBeenCalledTimes(3)
+      expect(feishuSync).toHaveBeenCalledTimes(3)
     })
     expect(telegramSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
     expect(discordSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
+    expect(feishuSync.mock.calls[2]?.[3].icon?.kind).toBe('glyph')
+    expect(feishuSync).toHaveBeenCalledWith('cli_feishu', 'feishu-secret', 'lark', expect.any(Object))
   })
 })

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -174,7 +174,12 @@ describe('Feishu/Lark one-click app registration', () => {
       callbacks: { items: [...AGENTCONNECT_FEISHU_CALLBACKS] }
     })
     expect(addons).toMatchObject({
-      scopes: { tenant: expect.arrayContaining(['application:application:patch']) }
+      scopes: {
+        tenant: expect.arrayContaining([
+          'application:application.app_version:readonly',
+          'application:application:patch'
+        ])
+      }
     })
     await first.close()
 

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -166,11 +166,15 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(avatar.statusCode).toBe(200)
     expect(avatar.headers['content-type']).toMatch(/^image\/png/)
     expect(avatar.headers['access-control-allow-origin']).toBe('*')
-    expect(decodeAddons(authorizationUrl.searchParams.get('addons')!)).toMatchObject({
+    const addons = decodeAddons(authorizationUrl.searchParams.get('addons')!)
+    expect(addons).toMatchObject({
       preset: true,
       scopes: { tenant: [...AGENTCONNECT_FEISHU_SCOPES] },
       events: { items: { tenant: [...AGENTCONNECT_FEISHU_EVENTS] } },
       callbacks: { items: [...AGENTCONNECT_FEISHU_CALLBACKS] }
+    })
+    expect(addons).toMatchObject({
+      scopes: { tenant: expect.arrayContaining(['application:application:patch']) }
     })
     await first.close()
 


### PR DESCRIPTION
## Summary

- sync dedicated Feishu/Lark app icons after explicit Agent icon changes
- upload a normalized 512px PNG, patch the application avatar, and publish the updated version
- add `application:application.app_version:readonly` and `application:application:patch` to one-click app scopes and keep synchronization best-effort and latest-wins
- skip before patching when the app already has unpublished or in-review changes, so an icon update cannot submit unrelated configuration

## Notes

- stacked on #242; shared bot identities remain excluded
- existing apps must grant the two new permissions; provider failures do not block the Agent icon update

## Tests

- `pnpm --filter @agentconnect.md/control-plane test:unit`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/agent-icon-sync.route.test.ts test/integration/feishu-registration.route.test.ts`
- pre-push `eslint .`

Created by Codex . GPT-5.6
