### PR TITLE
docs(readme): add public project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@
 </p>
 
 <p align="center">
+  <strong><a href="https://docs.agentconnect.md">Documentation</a></strong> ·
+  <strong><a href="https://agentconnect.md">Website</a></strong> ·
+  <strong><a href="https://agentconnect.md/blog">Blog</a></strong> ·
+  <strong><a href="https://app.agentconnect.md/waitlist">Join Cloud waitlist</a></strong>
+</p>
+
+<p align="center">
+  <a href="https://slack.agentconnect.md"><img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" alt="Join AgentConnect on Slack" /></a>
+  <a href="https://x.com/getAgentConnect"><img src="https://img.shields.io/twitter/follow/getAgentConnect?style=social" height="28" alt="Follow @getAgentConnect on X" /></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml"><img src="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml/badge.svg" alt="Test status" /></a>
   <a href="https://www.npmjs.com/package/@agentconnect.md/daemon/v/latest"><img src="https://img.shields.io/npm/v/%40agentconnect.md%2Fdaemon/latest?label=daemon%20latest" alt="Latest daemon version" /></a>
   <a href="https://www.npmjs.com/package/@agentconnect.md/daemon/v/rc"><img src="https://img.shields.io/npm/v/%40agentconnect.md%2Fdaemon/rc?label=daemon%20rc" alt="RC daemon version" /></a>


### PR DESCRIPTION
## Summary

- add prominent links to the official documentation and website in the README header
- add the planned website Blog entry point ahead of the `/blog` page launch
- link to the hosted Cloud waitlist with wording that keeps self-hosted availability distinct
- add externally hosted Slack and X social badges following the Agenta README treatment

## Why

Make the README header a clearer, more polished entry point for people discovering AgentConnect and its community.

## Impact

Documentation only. There is no runtime behavior change and no new badge asset to maintain.

## Related deployment

- agentconnect-md/workflows#69 records the live Slack community shortlink configuration and should merge alongside this PR

## Validation

- `pnpm exec prettier --check README.md`
- `git diff --check`
- both external badge endpoints return HTTP 200 SVG responses
- pre-push `eslint .`
- confirmed the documentation, website, Cloud waitlist, Slack shortlink, and X profile are live
- confirmed `/blog` currently returns 404; the link is intentionally landing ahead of the planned Blog launch

Created by Codex . GPT-5
