### PR TITLE
fix(web): prevent agent status column overlap

### DIFF
--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -64,7 +64,7 @@ export default function AgentsView() {
   // its own — a combined "daemon · repo" cell truncated the repo whenever the daemon
   // name ran long.)
   const cols =
-    'grid-cols-[minmax(148px,1.6fr)_72px_minmax(80px,.85fr)_72px_minmax(90px,1.2fr)_minmax(140px,.95fr)_108px_88px_80px_28px]'
+    'grid-cols-[minmax(148px,1.6fr)_92px_minmax(80px,.85fr)_72px_minmax(90px,1.2fr)_minmax(140px,.95fr)_108px_88px_80px_28px]'
   // Resolve an agent's owning daemonId to the daemon's display name (never the raw
   // UUID/host); short id if it's not in the fleet, '—' if unplaced.
   const daemonName = (id: string) =>
@@ -621,9 +621,12 @@ export default function AgentsView() {
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-[7px]">
+                <div className="flex min-w-0 items-center gap-[7px] overflow-hidden">
                   <span className="dot" style={{ background: s.dot }} />
-                  <span className="font-sans text-[12.5px] font-medium leading-normal" style={{ color: s.text }}>
+                  <span
+                    className="truncate font-sans text-[12.5px] font-medium leading-normal"
+                    style={{ color: s.text }}
+                  >
                     {s.label}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- widen the desktop agent status column for planned lifecycle labels
- contain status text so it cannot overlap the daemon column

## Validation
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/AgentsView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/AgentsView.tsx`
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- verified `restarting` at an 864x758 viewport with 0px overlap into the daemon column

Created by Codex . GPT-5