### PR TITLE
fix(web): prove account ownership before linking a social identity

### DIFF
--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -46,7 +46,7 @@ export default function SocialAccountCallback() {
     // with, so echo it back alongside the provider's own response params.
     const connectorData = { ...Object.fromEntries(params.entries()), redirectUri: flow.redirectUri }
     verifySocialVerification(flow.verificationRecordId, connectorData)
-      .then(saveSocialIdentity)
+      .then((verified) => saveSocialIdentity(verified, flow.currentVerificationRecordId))
       .then(() => {
         writeAccountNotice({
           kind: 'success',

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -6,7 +6,8 @@ import { SWRConfig, useSWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  fetchAccountProfile: vi.fn()
+  fetchAccountProfile: vi.fn(),
+  requestEmailVerification: vi.fn()
 }))
 
 vi.mock('@/lib/api', () => ({
@@ -26,11 +27,16 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/logto-account', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/logto-account')>()
-  return { ...actual, fetchAccountProfile: mocks.fetchAccountProfile }
+  return {
+    ...actual,
+    fetchAccountProfile: mocks.fetchAccountProfile,
+    requestEmailVerification: mocks.requestEmailVerification
+  }
 })
 
 import SocialSignInCard from './SocialSignInCard'
 import { LogtoAccountError } from '@/lib/logto-account'
+import { resolveMySocialConnectorId } from '@/lib/api'
 
 const ACCOUNT_KEY = 'logto-account-sign-in-methods'
 let root: Root | undefined
@@ -85,6 +91,9 @@ function button(label: string): HTMLButtonElement | undefined {
 
 beforeEach(() => {
   mocks.fetchAccountProfile.mockReset()
+  mocks.requestEmailVerification.mockReset()
+  vi.mocked(resolveMySocialConnectorId).mockReset()
+  vi.mocked(resolveMySocialConnectorId).mockResolvedValue({ connectorId: 'connector' })
 })
 
 afterEach(async () => {
@@ -138,5 +147,39 @@ describe('SocialSignInCard account state', () => {
     expect(container?.textContent).not.toContain('Not linked')
     expect(button('Link')).toBeUndefined()
     expect(button('Unlink')).toBeUndefined()
+  })
+
+  // Logto rejects an identity change the caller has not re-proven (403), and the
+  // proof has to be collected BEFORE leaving for the provider — on return the
+  // identity is saved immediately, with no UI left to ask in.
+  it('proves account ownership before leaving for the provider', async () => {
+    mocks.fetchAccountProfile.mockResolvedValue({
+      identities: {},
+      hasSecurityVerificationMethod: true,
+      primaryEmail: 'phil@example.test'
+    })
+    mocks.requestEmailVerification.mockResolvedValue('current-verification')
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('Not linked') === true)
+
+    await act(async () => button('Link')?.click())
+
+    expect(container?.textContent).toContain('phil@example.test')
+    expect(container?.querySelector('[role="dialog"]')).not.toBeNull()
+    // The provider round trip must not have started yet.
+    expect(resolveMySocialConnectorId).not.toHaveBeenCalled()
+  })
+
+  it('goes straight to the provider when the account has nothing to re-prove', async () => {
+    mocks.fetchAccountProfile.mockResolvedValue({ identities: {}, hasSecurityVerificationMethod: false })
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('Not linked') === true)
+
+    await act(async () => button('Link')?.click())
+
+    expect(container?.querySelector('[role="dialog"]')).toBeNull()
+    expect(resolveMySocialConnectorId).toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -13,6 +13,8 @@ import {
   createSocialState,
   createSocialVerification,
   fetchAccountProfile,
+  requestEmailVerification,
+  verifyEmailCode,
   socialIdentityDetails,
   writeSocialLinkFlow,
   type AccountNotice
@@ -98,6 +100,117 @@ function UnlinkDialog({
   )
 }
 
+/**
+ * Proves the caller still owns THIS account before its sign-in methods change.
+ * Logto requires that proof whenever the account has a security verification
+ * method, and it must be collected BEFORE the provider round trip — on return
+ * the identity is saved straight away, with no UI left to ask in.
+ */
+function VerifyAccountDialog({
+  provider,
+  email,
+  onVerified,
+  onClose
+}: {
+  provider: SocialLoginProvider
+  email?: string
+  onVerified: (currentVerificationRecordId: string) => Promise<void>
+  onClose: () => void
+}) {
+  const titleId = useId()
+  const [verificationId, setVerificationId] = useState<string>()
+  const [code, setCode] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>()
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !busy) onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [busy, onClose])
+
+  const submit = async () => {
+    setBusy(true)
+    setError(undefined)
+    try {
+      if (!email) {
+        throw new LogtoAccountError('This account needs a verified email before sign-in methods can change.', 0)
+      }
+      if (!verificationId) {
+        setVerificationId(await requestEmailVerification(email))
+        return
+      }
+      if (!code.trim()) {
+        setError('Enter the verification code from your email.')
+        return
+      }
+      await onVerified(await verifyEmailCode(email, verificationId, code.trim()))
+    } catch (caught) {
+      setError(accountErrorMessage(caught, { providerName: provider.name, linking: true }))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="scrim">
+      <div className="modal max-w-[480px]" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="modalhead">
+          <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+            <Icon name="shield-check" size={16} color="var(--brand)" />
+          </span>
+          <span id={titleId} className="flex-1 font-sans text-[16px] font-semibold leading-normal">
+            Link {provider.name}
+          </span>
+          <button type="button" className="iconbtn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+        <div className="modalbody">
+          <p className="font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-secondary)">
+            {verificationId
+              ? `Enter the code sent to ${email ?? 'your email'}, then continue to ${provider.name}.`
+              : `To protect your account, verify it's you with a code sent to ${email ?? 'your email'}.`}
+          </p>
+          {verificationId ? (
+            <label className="fld mt-4">
+              <span className="fldlbl">Verification code</span>
+              <input
+                className="inp"
+                value={code}
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                autoFocus
+                placeholder="Enter code"
+                onChange={(event) => setCode(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') void submit()
+                }}
+              />
+            </label>
+          ) : null}
+          {error ? (
+            <div className="mt-3 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)" role="alert">
+              {error}
+            </div>
+          ) : null}
+        </div>
+        <div className="modalfoot">
+          <div className="flex-1" />
+          <Button variant="ghost" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" disabled={busy} onClick={() => void submit()}>
+            {busy ? 'Working…' : verificationId ? `Continue to ${provider.name}` : 'Send code'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function Notice({ notice }: { notice: AccountNotice }) {
   return (
     <div
@@ -138,13 +251,24 @@ export default function SocialSignInCard({
   const { data: slack } = useSWR('me-slack-identity', fetchMySlackIdentity, { shouldRetryOnError: false })
   const workspaceLine = slackWorkspaceLine(slack)
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
+  const [pendingVerify, setPendingVerify] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
   const currentAccount = error ? undefined : account
   const linkedProviderCount = currentAccount
     ? SOCIAL_LOGIN_PROVIDERS.filter((provider) => currentAccount.identities[provider.target]).length
     : 0
 
-  const startLink = async (provider: SocialLoginProvider) => {
+  // Logto refuses an identity change the caller has not re-proven, so accounts
+  // with a security verification method take the code detour first.
+  const beginLink = (provider: SocialLoginProvider) => {
+    if (currentAccount?.hasSecurityVerificationMethod) {
+      setPendingVerify(provider)
+      return
+    }
+    void startLink(provider)
+  }
+
+  const startLink = async (provider: SocialLoginProvider, currentVerificationRecordId?: string) => {
     setBusyProvider(provider.target)
     try {
       const state = createSocialState()
@@ -158,6 +282,7 @@ export default function SocialSignInCard({
         connectorId,
         verificationRecordId,
         redirectUri,
+        ...(currentVerificationRecordId ? { currentVerificationRecordId } : {}),
         providerName: provider.name,
         returnTo: `${window.location.pathname}${window.location.search}`,
         createdAt: Date.now()
@@ -283,7 +408,7 @@ export default function SocialSignInCard({
                         variant="secondary"
                         size="xs"
                         disabled={busyProvider !== undefined}
-                        onClick={() => void startLink(provider)}
+                        onClick={() => beginLink(provider)}
                       >
                         <Icon name="link" size={14} />
                         {busyProvider === provider.target ? 'Linking…' : 'Link'}
@@ -303,6 +428,19 @@ export default function SocialSignInCard({
           provider={pendingUnlink}
           onConfirm={() => unlink(pendingUnlink)}
           onClose={() => setPendingUnlink(undefined)}
+        />
+      ) : null}
+
+      {pendingVerify ? (
+        <VerifyAccountDialog
+          key={pendingVerify.target}
+          provider={pendingVerify}
+          email={currentAccount?.primaryEmail}
+          onVerified={async (currentVerificationRecordId) => {
+            setPendingVerify(undefined)
+            await startLink(pendingVerify, currentVerificationRecordId)
+          }}
+          onClose={() => setPendingVerify(undefined)}
         />
       ) : null}
     </>

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -7,6 +7,11 @@ export interface SocialIdentity {
 
 export interface LogtoAccountProfile {
   identities: Record<string, SocialIdentity>
+  /** Set when the account can prove ownership a second way (a verified email).
+   *  Logto then REQUIRES that proof before identities may change, so the card
+   *  collects an email code first — see `requestEmailVerification`. */
+  hasSecurityVerificationMethod: boolean
+  primaryEmail?: string
 }
 
 export interface SocialIdentityDetails {
@@ -24,6 +29,10 @@ export interface SocialLinkFlow {
   /** Echoed back on verify: Logto exchanges the code against the SAME URI it
    *  authorized with, and the connectors that keep it in session need it too. */
   redirectUri: string
+  /** Proof that the caller owns this account, collected BEFORE leaving for the
+   *  provider — on return the identity is saved immediately, with no UI left to
+   *  ask. Absent when the account has no security verification method. */
+  currentVerificationRecordId?: string
   providerName: string
   returnTo: string
   createdAt: number
@@ -105,7 +114,33 @@ export async function fetchAccountProfile(): Promise<LogtoAccountProfile> {
       ]
     })
   )
-  return { identities }
+  const primaryEmail = stringValue(body.primaryEmail)
+  return {
+    identities,
+    hasSecurityVerificationMethod: body.hasSecurityVerificationMethod === true,
+    ...(primaryEmail ? { primaryEmail } : {})
+  }
+}
+
+/** Send an ownership-proof code to the account's own email. */
+export async function requestEmailVerification(email: string): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/verification-code', {
+    method: 'POST',
+    body: JSON.stringify({
+      identifier: { type: 'email', value: email },
+      templateType: 'UserPermissionValidation'
+    })
+  })
+  return result.verificationRecordId
+}
+
+/** Redeem that code; the returned record is what `logto-verification-id` names. */
+export async function verifyEmailCode(email: string, verificationId: string, code: string): Promise<string> {
+  const result = await accountRequest<{ verificationRecordId: string }>('/api/verifications/verification-code/verify', {
+    method: 'POST',
+    body: JSON.stringify({ identifier: { type: 'email', value: email }, verificationId, code })
+  })
+  return result.verificationRecordId
 }
 
 /**
@@ -140,10 +175,21 @@ export async function verifySocialVerification(
   return result.verificationRecordId
 }
 
-/** Attach the verified identity to this account. */
-export async function saveSocialIdentity(verificationRecordId: string): Promise<void> {
+/**
+ * Attach the verified identity to this account.
+ *
+ * Two different proofs meet here: `verificationRecordId` proves the NEW social
+ * identity, while `currentVerificationRecordId` proves the caller still owns
+ * THIS account. Logto demands the second whenever the account has a security
+ * verification method, and rejects the write with 403 without it.
+ */
+export async function saveSocialIdentity(
+  verificationRecordId: string,
+  currentVerificationRecordId?: string
+): Promise<void> {
   await accountRequest('/api/my-account/identities', {
     method: 'POST',
+    ...(currentVerificationRecordId ? { headers: { 'logto-verification-id': currentVerificationRecordId } } : {}),
     body: JSON.stringify({ newIdentifierVerificationRecordId: verificationRecordId })
   })
 }
@@ -187,6 +233,7 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
       typeof flow.connectorId !== 'string' ||
       typeof flow.verificationRecordId !== 'string' ||
       typeof flow.redirectUri !== 'string' ||
+      (flow.currentVerificationRecordId !== undefined && typeof flow.currentVerificationRecordId !== 'string') ||
       typeof flow.providerName !== 'string' ||
       typeof flow.returnTo !== 'string' ||
       !flow.returnTo.startsWith('/') ||
@@ -240,6 +287,11 @@ export function accountErrorMessage(error: unknown, context?: { providerName?: s
     return `The ${context.providerName ?? 'social'} authorization expired or could not be used. Try again.`
   }
   if (requestError.status === 400) return 'The social authorization response is invalid or expired. Try again.'
+  // 403 while linking is Logto refusing an unproven identity change, not a dead
+  // session — saying "sign in again" sent us chasing the wrong thing once.
+  if (requestError.status === 403 && context?.linking) {
+    return 'Verifying your account timed out. Return to Profile and start again.'
+  }
   if (requestError.status === 401 || requestError.status === 403) {
     return 'Your sign-in session expired. Sign in again and retry.'
   }


### PR DESCRIPTION
## The bug

With #243 deployed, linking Slack now reaches **Slack's consent screen** — then fails on the callback with *"Your sign-in session expired. Sign in again and retry."*

## Root cause

Two different proofs meet at `POST /api/my-account/identities`:

| proof | proves |
|---|---|
| `newIdentifierVerificationRecordId` | the **new** social identity |
| `logto-verification-id` header | the caller still owns **this** account |

Logto requires the second whenever the account has a security verification method, and answers **403** without it. #243 sent neither.

That followed #225's "unlinking does not add a second email-code step" stance — which held only because #225 wrote through the **Management API**, where the M2M credential was the authority. On the **Account API** the user's own token is the authority, so the account has to re-prove itself.

Confirmed against the live account that hit this:

```json
{ "hasSecurityVerificationMethod": true, "identities": ["github", "google"] }
```

## The change

- Collect the ownership proof **before** leaving for the provider, and carry it across in the flow record. It has to be before: on return the identity is saved immediately, with no UI left to ask in.
- Accounts with nothing to re-prove keep going straight out — no new step for them.
- Stop reporting that 403 as an expired sign-in session. That copy sent this investigation chasing the wrong thing; while linking, a 403 means the identity change was not proven.
- Restores `requestEmailVerification` / `verifyEmailCode` and the `hasSecurityVerificationMethod` + `primaryEmail` profile fields that #225 dropped.

## Reviewer notes

- New tests cover both branches: with a security verification method, clicking **Link** opens the dialog and `resolveMySocialConnectorId` is **not** called yet; without one, it goes straight to the provider. The first fails without this change.
- Verified: web **452 passing** (65 files), `lint` 0 errors, `format:check` clean. `typecheck` has one pre-existing failure on `main` (`@agentconnect.md/message` needs a workspace build) — confirmed unrelated by stashing.
- The final hop still needs a real round trip to confirm end to end, since the 403 only appears against a tenant with a security verification method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)