### PR TITLE
refactor(message): make protocol own wire schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,13 @@ callback endpoint is required; the CP only orchestrates. Concretely:
 
 ## Monorepo (pnpm workspace, `packages/*`)
 
-| Package                          | Stack                              | Role                                                                                                                                                                         |
-| -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@agentconnect.md/message`       | TypeScript + zod                   | Shared message model and pure Slack, Lark, Telegram, and Discord normalization; contains no platform SDKs or I/O.                                                            |
-| `@agentconnect.md/protocol`      | zod                                | Shared wire contract — the daemon↔CP WS frames + fencing fields (`sessionEpoch`/`seq`/`launchId`). Single source of truth, imported by both daemon and CP via `workspace:*`. |
-| `@agentconnect.md/daemon`        | Node CLI (commander)               | The edge unit. Exposes the `agentconnect` CLI bin. Many CLI subcommands are still stubs (`run` and `chat` are the live ones).                                                |
-| `@agentconnect.md/control-plane` | Fastify + Prisma (Postgres)        | One Fastify process co-hosts the C2 BFF REST surface **and** the daemon WS endpoint on one port / one Postgres connection.                                                   |
-| `@agentconnect.md/web`           | Next.js 16 + React 19 + Tailwind 4 | Config / monitoring console.                                                                                                                                                 |
+| Package                          | Stack                              | Role                                                                                                                                                             |
+| -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@agentconnect.md/message`       | TypeScript                         | Pure Slack, Lark, Telegram, and Discord normalization; depends on protocol types and contains no platform SDKs or I/O.                                           |
+| `@agentconnect.md/protocol`      | zod                                | Shared wire contract — frames, normalized message schemas, and fencing fields (`sessionEpoch`/`seq`/`launchId`). Single source of truth for every wire consumer. |
+| `@agentconnect.md/daemon`        | Node CLI (commander)               | The edge unit. Exposes the `agentconnect` CLI bin. Many CLI subcommands are still stubs (`run` and `chat` are the live ones).                                    |
+| `@agentconnect.md/control-plane` | Fastify + Prisma (Postgres)        | One Fastify process co-hosts the C2 BFF REST surface **and** the daemon WS endpoint on one port / one Postgres connection.                                       |
+| `@agentconnect.md/web`           | Next.js 16 + React 19 + Tailwind 4 | Config / monitoring console.                                                                                                                                     |
 
 When you change a frame in `protocol`, both daemon and CP consume it — rebuild
 `protocol` (or rely on its `development` export → `./src/index.ts`) and check both sides.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This repository is a pnpm workspace with nine packages:
 | `@agentconnect.md/control-plane`      | [`packages/control-plane`](packages/control-plane)           | Orchestration, registry, authentication, and Web UI BFF           |
 | `@agentconnect.md/daemon`             | [`packages/daemon`](packages/daemon)                         | Edge message processing and agent execution unit                  |
 | `@agentconnect.md/memory-plugin-mem0` | [`packages/memory-plugin-mem0`](packages/memory-plugin-mem0) | Mem0 Cloud and OSS memory-plugin profiles                         |
-| `@agentconnect.md/message`            | [`packages/message`](packages/message)                       | Shared message model and pure platform normalization              |
+| `@agentconnect.md/message`            | [`packages/message`](packages/message)                       | Pure platform message normalization                               |
 | `@agentconnect.md/protocol`           | [`packages/protocol`](packages/protocol)                     | Shared daemon, relay, and Control Plane wire contracts            |
 | `@agentconnect.md/relay`              | [`packages/relay`](packages/relay)                           | HTTP bot, webhook, GitHub, and webchat ingress                    |
 | `@agentconnect.md/web`                | [`packages/web`](packages/web)                               | Next.js configuration and monitoring console                      |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,10 +65,9 @@ COPY . .
 
 RUN pnpm --filter "@agentconnect.md/control-plane" prisma:generate
 
-# message → protocol → control-plane (topological).
+# protocol → control-plane (topological).
 # Prisma was generated above; skip the control-plane package's prebuild hook.
 RUN pnpm --config.enable-pre-post-scripts=false \
-  --filter "@agentconnect.md/message" \
   --filter "@agentconnect.md/protocol" \
   --filter "@agentconnect.md/control-plane" \
   -r build
@@ -110,9 +109,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 COPY . .
 
-# message → protocol → connection → relay (topological).
-RUN pnpm --filter "@agentconnect.md/message" \
-  --filter "@agentconnect.md/protocol" \
+# protocol → message / connection → relay (topological).
+RUN pnpm --filter "@agentconnect.md/protocol" \
+  --filter "@agentconnect.md/message" \
   --filter "@agentconnect.md/connection" \
   --filter "@agentconnect.md/relay" \
   -r build
@@ -190,16 +189,15 @@ CMD ["node", "server.js"]
 # ───────────────── memory-plugin-mem0 (wrapper): build ───────────────────────
 # The centralized external-memory wrapper (packages/memory-plugin-mem0) served in
 # HTTP mode — an MCP server that forwards to a Mem0 backend. Depends only on
-# message + protocol + external libs (no Prisma, no daemon/connection).
+# protocol + external libs (no Prisma, no daemon/connection/message).
 FROM manifests AS mem0-builder
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
   pnpm install --frozen-lockfile --filter "@agentconnect.md/memory-plugin-mem0..."
 
 COPY . .
 
-# message → protocol → memory-plugin-mem0 (topological).
-RUN pnpm --filter "@agentconnect.md/message" \
-  --filter "@agentconnect.md/protocol" \
+# protocol → memory-plugin-mem0 (topological).
+RUN pnpm --filter "@agentconnect.md/protocol" \
   --filter "@agentconnect.md/memory-plugin-mem0" \
   -r build
 

--- a/docs/designs/daemon-centric-architecture.md
+++ b/docs/designs/daemon-centric-architecture.md
@@ -115,9 +115,11 @@ A daemon is a **self-contained message-processing + agent-execution unit**:
 
 ### 4.3 Platform Adapters (`slack-adapter`, `telegram-adapter`, etc.)
 
-- Pure message schemas and Slack, Lark, Telegram, and Discord normalization live
-  in `@agentconnect.md/message`; direct daemon ingress and optional relay ingress
-  can share them without pulling in SDK clients, routing, or I/O.
+- Wire-level normalized message schemas live in `@agentconnect.md/protocol`.
+  Pure Slack, Lark, Telegram, and Discord normalization lives in
+  `@agentconnect.md/message` and depends on that contract; direct daemon ingress
+  and optional relay ingress can share it without pulling in SDK clients,
+  routing, or I/O.
 - Handle platform connections, authentication, message sending and receiving, rich-text and attachment normalization, and inbound/outbound mapping.
 - Hold platform credentials. See §9, Security.
 - Produce normalized internal messages and pass them through the daemon's local routing layer to the agent.

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'tsdown'
 
 // Ship the CLI as a ~self-contained bundle, exactly like the daemon: alwaysBundle
-// inlines EVERY import (incl. message through the workspace-only protocol, plus
-// connection), and neverBundle keeps ws's OPTIONAL native speedups external
-// (loaded via try/catch require — absent at runtime is fine).
+// inlines EVERY import (incl. the workspace-only protocol and connection), and
+// neverBundle keeps ws's OPTIONAL native speedups external (loaded via try/catch
+// require — absent at runtime is fine).
 // neverBundle wins over alwaysBundle, so the natives stay out. The published
 // manifest is stripped to zero runtime deps at release time (see release.config.js).
 //

--- a/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
+++ b/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
@@ -33,6 +33,22 @@ describe('Agent icon bot profile fan-out', () => {
     const feishuSync = vi.fn(
       async (_appId: string, _appSecret: string, _region: 'feishu' | 'lark', _agent: BotProfileIconAgent) => {}
     )
+    const waitForSyncedIcon = async (icon: unknown) => {
+      let previousCallCounts: number[] | undefined
+      await vi.waitFor(() => {
+        const callCounts = [telegramSync.mock.calls.length, discordSync.mock.calls.length, feishuSync.mock.calls.length]
+        const lastCallCounts = previousCallCounts
+        previousCallCounts = callCounts
+        expect(telegramSync.mock.calls.at(-1)?.[1].icon).toEqual(icon)
+        expect(discordSync.mock.calls.at(-1)?.[1].icon).toEqual(icon)
+        expect(feishuSync.mock.calls.at(-1)?.[3].icon).toEqual(icon)
+
+        // Each route starts a detached latest-wins sync. A preceding sync may
+        // observe the newer icon and retry, so wait for a quiet window instead
+        // of treating those valid repair calls as duplicates.
+        expect(callCounts).toEqual(lastCallCounts)
+      })
+    }
     running = buildHttpApp(prisma, { S3_PUBLIC_BASE_URL: 'https://images.example.test' }, undefined, undefined, {
       iconStore: store,
       syncTelegramBotIcon: telegramSync,
@@ -93,10 +109,10 @@ describe('Agent icon bot profile fan-out', () => {
       payload: { icon: { kind: 'glyph', glyph: 'bot', color: '#2563eb' } }
     })
     expect(glyphEdit.statusCode).toBe(200)
-    await vi.waitFor(() => {
-      expect(telegramSync).toHaveBeenCalledTimes(1)
-      expect(discordSync).toHaveBeenCalledTimes(1)
-      expect(feishuSync).toHaveBeenCalledTimes(1)
+    await waitForSyncedIcon({
+      kind: 'glyph',
+      glyph: 'bot',
+      color: '#2563eb'
     })
 
     const upload = await running.app.inject({
@@ -106,20 +122,7 @@ describe('Agent icon bot profile fan-out', () => {
       payload: PNG
     })
     expect(upload.statusCode).toBe(200)
-    await vi.waitFor(() => {
-      expect(telegramSync).toHaveBeenCalledTimes(2)
-      expect(discordSync).toHaveBeenCalledTimes(2)
-      expect(feishuSync).toHaveBeenCalledTimes(2)
-    })
-    expect(telegramSync.mock.calls[1]?.[1].icon).toEqual({
-      kind: 'image',
-      generation: expect.any(String)
-    })
-    expect(discordSync.mock.calls[1]?.[1].icon).toEqual({
-      kind: 'image',
-      generation: expect.any(String)
-    })
-    expect(feishuSync.mock.calls[1]?.[3].icon).toEqual({
+    await waitForSyncedIcon({
       kind: 'image',
       generation: expect.any(String)
     })
@@ -129,14 +132,11 @@ describe('Agent icon bot profile fan-out', () => {
       url: `${ORG}/agents/${agentId}/icon`
     })
     expect(remove.statusCode).toBe(200)
-    await vi.waitFor(() => {
-      expect(telegramSync).toHaveBeenCalledTimes(3)
-      expect(discordSync).toHaveBeenCalledTimes(3)
-      expect(feishuSync).toHaveBeenCalledTimes(3)
+    await waitForSyncedIcon({
+      kind: 'glyph',
+      glyph: expect.any(String),
+      color: expect.any(String)
     })
-    expect(telegramSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
-    expect(discordSync.mock.calls[2]?.[1].icon?.kind).toBe('glyph')
-    expect(feishuSync.mock.calls[2]?.[3].icon?.kind).toBe('glyph')
     expect(feishuSync).toHaveBeenCalledWith('cli_feishu', 'feishu-secret', 'lark', expect.any(Object))
   })
 })

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -1,4 +1,4 @@
-import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/message'
+import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
 
 /**
  * A file shared alongside a message. Platform ingresses carry metadata + a

--- a/packages/memory-plugin-mem0/Dockerfile
+++ b/packages/memory-plugin-mem0/Dockerfile
@@ -3,8 +3,6 @@ FROM node:24-bookworm-slim AS build
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json .npmrc .pnpmfile.mjs ./
-COPY packages/message/package.json packages/message/tsconfig.json ./packages/message/
-COPY packages/message/src ./packages/message/src
 COPY packages/protocol/package.json packages/protocol/tsconfig.json ./packages/protocol/
 COPY packages/protocol/src ./packages/protocol/src
 COPY packages/memory-plugin-mem0/package.json packages/memory-plugin-mem0/tsconfig.json ./packages/memory-plugin-mem0/
@@ -17,11 +15,9 @@ ENV NODE_ENV=production HOST=0.0.0.0 PORT=8788 MEM0_DIALECT=cloud MCP_TRANSPORT=
 WORKDIR /app
 RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc .pnpmfile.mjs ./
-COPY packages/message/package.json ./packages/message/package.json
 COPY packages/protocol/package.json ./packages/protocol/package.json
 COPY packages/memory-plugin-mem0/package.json ./packages/memory-plugin-mem0/package.json
 RUN pnpm install --prod --frozen-lockfile --ignore-scripts --filter @agentconnect.md/memory-plugin-mem0...
-COPY --from=build /app/packages/message/dist ./packages/message/dist
 COPY --from=build /app/packages/protocol/dist ./packages/protocol/dist
 COPY --from=build /app/packages/memory-plugin-mem0/dist ./packages/memory-plugin-mem0/dist
 USER node

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentconnect.md/message",
   "version": "1.0.0-dev",
-  "description": "AgentConnect shared message model and pure platform normalization for daemon and relay ingress",
+  "description": "AgentConnect pure platform message normalization for daemon and relay ingress",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -30,7 +30,7 @@
   "sideEffects": false,
   "types": "dist/index.d.ts",
   "dependencies": {
-    "zod": "^4.4.3"
+    "@agentconnect.md/protocol": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/message/src/attachment-mention.ts
+++ b/packages/message/src/attachment-mention.ts
@@ -1,0 +1,10 @@
+import type { PlatformAttachment } from '@agentconnect.md/protocol'
+
+type AttachmentSummary = Pick<PlatformAttachment, 'name' | 'mimeType'>
+
+/** One-line human summary used when a platform reply quotes attached media. */
+export function attachmentMention(attachments: readonly AttachmentSummary[] | undefined): string {
+  if (!attachments?.length) return ''
+  const list = attachments.map((attachment) => `${attachment.name} (${attachment.mimeType})`).join(', ')
+  return `[attached: ${list}]`
+}

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -1,4 +1,4 @@
-import type { NormalizedPlatformMessage, PlatformAttachment } from './normalized-message.js'
+import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
 
 /**
  * Minimal plain-object Discord view accepted by pure normalization. The daemon

--- a/packages/message/src/feishu-message.ts
+++ b/packages/message/src/feishu-message.ts
@@ -1,4 +1,4 @@
-import type { NormalizedPlatformMessage, PlatformAttachment } from './normalized-message.js'
+import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
 
 /**
  * Minimal plain-object view of a Lark `im.message.receive_v1` event. Both the

--- a/packages/message/src/index.ts
+++ b/packages/message/src/index.ts
@@ -1,4 +1,4 @@
-export * from './normalized-message.js'
+export * from './attachment-mention.js'
 export * from './discord-message.js'
 export * from './telegram-message.js'
 export * from './slack-message.js'

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -1,4 +1,4 @@
-import type { NormalizedPlatformMessage, PlatformAttachment } from './normalized-message.js'
+import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnect.md/protocol'
 import { extractSlackMessageText } from './slack-message-text.js'
 
 /** The subset of a Slack file element carried through normalization. */

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -1,9 +1,5 @@
-import {
-  attachmentMention,
-  type NormalizedPlatformMessage,
-  type PlatformAttachment,
-  type QuotedMessage
-} from './normalized-message.js'
+import type { NormalizedPlatformMessage, PlatformAttachment, QuotedMessage } from '@agentconnect.md/protocol'
+import { attachmentMention } from './attachment-mention.js'
 
 /**
  * Minimal plain-object Telegram Bot API views used by pure normalization. The

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentconnect.md/protocol",
   "version": "1.0.0-dev",
-  "description": "AgentConnect shared wire contract — daemon ↔ control-plane WebSocket protocol (zod, 29 frames)",
+  "description": "AgentConnect shared wire contracts and normalized message schemas",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -30,7 +30,6 @@
   "sideEffects": false,
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@agentconnect.md/message": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -4,7 +4,7 @@ import {
   PlatformAttachmentSchema,
   type NormalizedPlatformMessage,
   type PlatformAttachment
-} from '@agentconnect.md/message'
+} from '../normalized-message.js'
 import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
 import { WebchatDone, WebchatImageAttachment, WebchatOutput } from './webchat.js'

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,8 +1,7 @@
 /**
- * `@agentconnect.md/protocol` — the shared wire contract for the daemon ↔ CP
- * WebSocket protocol (daemon-cp-ws-protocol.md). Single source of truth for all
- * frames and the `sessionEpoch`/`seq`/`launchId` fencing fields, imported by
- * both the control-plane and the daemon.
+ * `@agentconnect.md/protocol` — shared daemon, relay, and Control Plane wire
+ * contracts. Single source of truth for normalized message schemas, frames,
+ * and the `sessionEpoch`/`seq`/`launchId` fencing fields.
  *
  * This barrel re-exports the zod schemas, their inferred types, and the
  * `isFrameType` guard.
@@ -16,6 +15,9 @@ export {
   SESSION_LIVE_TAIL_FEATURE,
   SESSION_VISIBILITY_FEATURE
 } from './consts.js'
+
+// ── normalized platform-message wire contract ──
+export * from './normalized-message.js'
 
 // ── envelope + control extension ──
 export { Envelope, ControlExt, NIL_UUID } from './envelope.js'

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 
 /**
- * Provider-backed attachment metadata shared by direct daemon ingress and
- * relay HTTP ingress. The relay never downloads or forwards the bytes; the
- * daemon fetches them directly from the provider using its assigned token.
+ * Provider-backed attachment metadata shared by direct daemon ingress and relay
+ * HTTP ingress. The relay never downloads or forwards the bytes; the daemon
+ * fetches them directly from the provider using its assigned token.
  */
 export const PlatformAttachmentSchema = z.object({
   id: z.string(),
@@ -13,15 +13,6 @@ export const PlatformAttachmentSchema = z.object({
   sourceUrl: z.string()
 })
 export type PlatformAttachment = z.infer<typeof PlatformAttachmentSchema>
-
-type AttachmentSummary = Pick<PlatformAttachment, 'name' | 'mimeType'>
-
-/** One-line human summary used when a platform reply quotes attached media. */
-export function attachmentMention(attachments: readonly AttachmentSummary[] | undefined): string {
-  if (!attachments?.length) return ''
-  const list = attachments.map((attachment) => `${attachment.name} (${attachment.mimeType})`).join(', ')
-  return `[attached: ${list}]`
-}
 
 export const QuotedMessageSchema = z.object({
   messageId: z.string().optional(),
@@ -33,11 +24,11 @@ export const QuotedMessageSchema = z.object({
 export type QuotedMessage = z.infer<typeof QuotedMessageSchema>
 
 /**
- * The transport-neutral platform message produced by pure normalizers.
+ * The transport-neutral platform message contract used by pure normalizers.
  *
  * This is deliberately narrower than the daemon's runtime message: daemon-only
  * transcript, session, and inline-content fields are added after ingress. It is
- * also the exact payload carried by relay `rd/msg` IM frames.
+ * the exact payload carried by relay `rd/msg` IM frames.
  */
 export const NormalizedPlatformMessageSchema = z.object({
   msgId: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,9 +397,9 @@ importers:
 
   packages/message:
     dependencies:
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+      '@agentconnect.md/protocol':
+        specifier: workspace:*
+        version: link:../protocol
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -410,9 +410,6 @@ importers:
 
   packages/protocol:
     dependencies:
-      '@agentconnect.md/message':
-        specifier: workspace:*
-        version: link:../message
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/release.config.js
+++ b/release.config.js
@@ -64,8 +64,7 @@ export default {
     [
       // Publish the CLI (@agentconnect.md/cli) to npm the same way as the daemon:
       // a self-contained tsdown bundle stripped to zero runtime deps. Same
-      // build-then-strip ordering (its build inlines message + protocol +
-      // connection), and
+      // build-then-strip ordering (its build inlines protocol + connection), and
       // the same conditional skip — the CLI is the thin, stable bin and changes
       // far less often than the daemon, so most releases skip its publish. Its
       // change detector additionally tracks packages/connection (the login auth

--- a/scripts/component-versions.sh
+++ b/scripts/component-versions.sh
@@ -47,10 +47,10 @@ esac
 # .npmrc), the build-context filter (.dockerignore), and the shared tsconfig
 # every package build extends.
 COMMON="docker/Dockerfile docker-bake.hcl .dockerignore .npmrc .pnpmfile.mjs pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json scripts"
-CP_PATHS="packages/control-plane packages/message packages/protocol $COMMON"
+CP_PATHS="packages/control-plane packages/protocol $COMMON"
 WEB_PATHS="packages/web $COMMON"
 RELAY_PATHS="packages/relay packages/message packages/protocol packages/connection $COMMON"
-MEM0_PATHS="packages/memory-plugin-mem0 packages/message packages/protocol $COMMON"
+MEM0_PATHS="packages/memory-plugin-mem0 packages/protocol $COMMON"
 # The backend's application source is the immutable external context declared in
 # docker-bake.hcl. Changes to that pin, its owned Dockerfile, or this resolver
 # rebuild the image; unrelated app/package changes leave it on its effective tag.

--- a/scripts/lockfile-closure-changed.test.mjs
+++ b/scripts/lockfile-closure-changed.test.mjs
@@ -6,6 +6,7 @@ import { stringify } from 'yaml'
 import { lockfileClosureChanged } from './lockfile-closure-changed.mjs'
 
 const DAEMON_IMPORTERS = ['packages/daemon', 'packages/message', 'packages/protocol', 'packages/connection']
+const CLI_IMPORTERS = ['packages/cli', 'packages/protocol', 'packages/connection']
 
 // A miniature v9 lockfile shaped like the real one: root + web importers that
 // the daemon check must ignore, workspace links, a peer-suffixed dep path,
@@ -18,7 +19,19 @@ const baseLock = () => ({
       devDependencies: { 'semantic-release': { specifier: '^25.0.5', version: '25.0.5' } }
     },
     'packages/connection': {
-      dependencies: { ws: { specifier: '^8.21.0', version: '8.21.0' } }
+      dependencies: {
+        '@agentconnect.md/protocol': { specifier: 'workspace:*', version: 'link:../protocol' },
+        ws: { specifier: '^8.21.0', version: '8.21.0' }
+      }
+    },
+    'packages/cli': {
+      dependencies: {
+        '@agentconnect.md/connection': { specifier: 'workspace:*', version: 'link:../connection' },
+        '@agentconnect.md/protocol': { specifier: 'workspace:*', version: 'link:../protocol' }
+      },
+      devDependencies: {
+        tsdown: { specifier: '^0.22.3', version: '0.22.3(typescript@6.0.3)' }
+      }
     },
     'packages/daemon': {
       dependencies: {
@@ -32,13 +45,15 @@ const baseLock = () => ({
       }
     },
     'packages/message': {
-      dependencies: { zod: { specifier: '^4.4.3', version: '4.4.3' } }
+      dependencies: {
+        '@agentconnect.md/protocol': { specifier: 'workspace:*', version: 'link:../protocol' }
+      },
+      devDependencies: {
+        typescript: { specifier: '^6.0.3', version: '6.0.3' }
+      }
     },
     'packages/protocol': {
-      dependencies: {
-        '@agentconnect.md/message': { specifier: 'workspace:*', version: 'link:../message' },
-        zod: { specifier: '^4.4.3', version: '4.4.3' }
-      }
+      dependencies: { zod: { specifier: '^4.4.3', version: '4.4.3' } }
     },
     'packages/web': {
       dependencies: {
@@ -66,10 +81,10 @@ const baseLock = () => ({
   }
 })
 
-const changed = (mutate) => {
+const changed = (mutate, importerDirs = DAEMON_IMPORTERS) => {
   const head = baseLock()
   mutate(head)
-  return lockfileClosureChanged(stringify(baseLock()), stringify(head), DAEMON_IMPORTERS)
+  return lockfileClosureChanged(stringify(baseLock()), stringify(head), importerDirs)
 }
 
 test('identical lockfiles are unchanged', () => {
@@ -99,6 +114,17 @@ test('root devDependency bump does not affect the daemon closure', () => {
       lock.packages['semantic-release@25.0.6'] = { resolution: { integrity: 'sha512-semrel2' } }
       lock.snapshots['semantic-release@25.0.6'] = {}
     }),
+    false
+  )
+})
+
+test('message-only dependency bump does not affect the CLI closure', () => {
+  assert.equal(
+    changed((lock) => {
+      lock.importers['packages/message'].devDependencies.typescript.version = '6.0.4'
+      lock.packages['typescript@6.0.4'] = { resolution: { integrity: 'sha512-message-ts2' } }
+      lock.snapshots['typescript@6.0.4'] = {}
+    }, CLI_IMPORTERS),
     false
   )
 })

--- a/scripts/publish-cli-if-changed.sh
+++ b/scripts/publish-cli-if-changed.sh
@@ -40,13 +40,12 @@ case "$MODE" in
     ;;
 esac
 
-# Everything tsdown inlines into the CLI bundle: the CLI itself, its workspace
-# deps (message through protocol, plus connection — the login auth probe uses
-# connection's ClientTransport, so a connection-layer change must retrigger a
-# CLI publish), and tsconfig.base.json (shapes the emitted JS). The lockfile is
-# checked separately below, scoped to the CLI's importers.
-CLI_PATHS="packages/cli packages/message packages/protocol packages/connection tsconfig.base.json"
-CLI_IMPORTERS="packages/cli packages/message packages/protocol packages/connection"
+# Everything tsdown inlines into the CLI bundle: the CLI itself, protocol,
+# connection (the login auth probe uses connection's ClientTransport), and
+# tsconfig.base.json (shapes the emitted JS). The lockfile is checked separately
+# below, scoped to the CLI's importers.
+CLI_PATHS="packages/cli packages/protocol packages/connection tsconfig.base.json"
+CLI_IMPORTERS="packages/cli packages/protocol packages/connection"
 
 if [ -n "$LAST_TAG" ] && git rev-parse -q --verify "${LAST_TAG}^{commit}" > /dev/null; then
   # Word-splitting CLI_PATHS is deliberate: it is a list of pathspecs.


### PR DESCRIPTION
## Summary

- move normalized platform-message, attachment, and quoted-reply wire schemas into `@agentconnect.md/protocol`
- make `@agentconnect.md/message` a pure Slack, Lark, Telegram, and Discord normalization package that depends on protocol types
- preserve the Telegram and Discord normalizers merged in #253 while removing the Control Plane, CLI, and Mem0 transitive dependency on `message`
- update Docker build ordering plus npm/image change detection for the new dependency direction
- make the pre-existing Agent icon integration test assert the eventual latest icon instead of rejecting valid latest-wins repair calls

## Impact

The Control Plane remains outside platform normalization and no longer rebuilds for message source changes. Daemon and relay continue to consume the shared normalizers, with no production message or icon-sync behavior changes.

## Validation

- `pnpm typecheck`
- affected workspace build excluding web
- protocol: 206 tests passed
- message: 1 test passed
- focused Discord, Telegram, Feishu, and attachment normalization: 100 tests passed
- lockfile closure detection: 12 tests passed
- Agent icon integration test against PostgreSQL after all 48 migrations: passed before and after rebase
- `pnpm lint`
- `pnpm format:check`

Created by Codex . GPT-5
