### PR TITLE
fix(web): drop the raw team id from the Slack workspace line

### DIFF
--- a/packages/web/src/lib/slack-identity.test.ts
+++ b/packages/web/src/lib/slack-identity.test.ts
@@ -5,17 +5,17 @@ import { slackWorkspaceLine } from '@/lib/slack-identity'
 const LINKED = { linked: true as const, teamId: 'T0EXAMPLE1', userId: 'U0EXAMPLE1' }
 
 describe('slackWorkspaceLine', () => {
-  it('prefers the workspace name Slack sent, keeping the team id alongside', () => {
-    expect(slackWorkspaceLine({ ...LINKED, teamName: 'Example Workspace' })).toBe('Example Workspace · T0EXAMPLE1')
+  it('shows the workspace name Slack sent, and nothing else', () => {
+    // The raw id is deliberately absent: this line is read by people managing
+    // their own sign-in methods, to whom `T…` is noise.
+    expect(slackWorkspaceLine({ ...LINKED, teamName: 'Example Workspace' })).toBe('Example Workspace')
   })
 
   it('falls back to the workspace domain when there is no name', () => {
-    expect(slackWorkspaceLine({ ...LINKED, teamDomain: 'example-workspace' })).toBe(
-      'example-workspace.slack.com · T0EXAMPLE1'
-    )
+    expect(slackWorkspaceLine({ ...LINKED, teamDomain: 'example-workspace' })).toBe('example-workspace.slack.com')
   })
 
-  it('shows the bare team id when Slack sent neither label', () => {
+  it('shows the bare team id only when Slack sent neither label', () => {
     expect(slackWorkspaceLine(LINKED)).toBe('T0EXAMPLE1')
   })
 

--- a/packages/web/src/lib/slack-identity.ts
+++ b/packages/web/src/lib/slack-identity.ts
@@ -4,10 +4,14 @@
 import type { MySlackIdentityDto } from '@/lib/api'
 
 /**
- * The workspace line for an account's Slack row. Prefers the human label Slack
- * sent, falls back to the workspace domain, and always keeps the `T…` id
- * visible: it is what someone matching this account against a Slack workspace
- * actually needs, and it is the only field Slack always sends.
+ * The workspace line for an account's Slack row: which Slack workspace this
+ * account signs in from, named the way its members would recognize it.
+ *
+ * The raw `T…` id appears ONLY as a last resort. It was previously shown
+ * alongside the name on the grounds that it is the field Slack always sends —
+ * but this line is read by people managing their own sign-in methods, and to
+ * them an opaque id is noise, not information. Anything that needs to match
+ * accounts to workspaces reads the API, which still returns `teamId`.
  *
  * Undefined when there is nothing to say — not linked, or the read failed /
  * this deployment cannot do it. Callers render nothing in that case; the line
@@ -15,6 +19,5 @@ import type { MySlackIdentityDto } from '@/lib/api'
  */
 export function slackWorkspaceLine(slack: MySlackIdentityDto | undefined): string | undefined {
   if (!slack?.linked) return undefined
-  const label = slack.teamName ?? (slack.teamDomain ? `${slack.teamDomain}.slack.com` : undefined)
-  return label ? `${label} · ${slack.teamId}` : slack.teamId
+  return slack.teamName ?? (slack.teamDomain ? `${slack.teamDomain}.slack.com` : slack.teamId)
 }


### PR DESCRIPTION
## What

The Slack row in **Sign-in methods** rendered `<workspace> · T038JQ2G4KX`. Now it renders just the workspace.

## Why

The first question that line got from a reader was *"what is that number?"* — which is the answer to whether it belonged there.

I put it in on the reasoning that `teamId` is the one field Slack always sends, so keeping it visible would help anyone matching an account to a workspace. But this line lives in the panel where people manage **their own** sign-in methods, and to them an opaque `T…` is noise. Anything that genuinely matches accounts to workspaces reads `GET /me/social-identities/slack`, which still returns `teamId` unchanged.

Precedence is now: workspace name → workspace domain → the id, and the id only when Slack sent no label at all.

## Verified

web **471 passing** (66 files), typecheck 0 errors, `format:check` clean. The three precedence cases are covered in `lib/slack-identity.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)