### PR TITLE
fix(sessions): owner-only private sessions and stuck Applying badge

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -22,8 +22,10 @@ platform DMs and other members' Playground conversations. `session_meta` has no
 
 This design gives every session its own visibility:
 
-- **`private`** — visible only to the session owner (and org owners, via the
-  governance exception). Default for platform **DM** sessions, **Playground /
+- **`private`** — visible only to the session owner (identity match).
+  Deliberately **no org-owner governance override**, unlike resource
+  visibility: a private session is a DM-grade transcript, and role grants no
+  access to it. Default for platform **DM** sessions, **Playground /
   webchat** sessions, and sessions launched through the **Web API**.
 - **`org`** — visible to every org member who can view the owning agent.
   Default for IM **channel** sessions and automation-originated sessions
@@ -81,8 +83,8 @@ user's linked platform identities — and a `private` session is visible when
 Consequences:
 
 - Before the identity mapping exists, a `private` IM DM session is an
-  **owner-orphan**: no console user matches `slack:U…`, so only org owners see
-  it. This is accepted — it errs toward hiding a DM rather than exposing it.
+  **owner-orphan**: no console user matches `slack:U…`, so no one sees it.
+  This is accepted — it errs toward hiding a DM rather than exposing it.
 - When identity linking ships, those sessions become visible to the mapped
   user **automatically**, with no backfill: the stored `ownerIdentity` is
   already correct; only the viewer's identity set grows.
@@ -187,7 +189,7 @@ Notes:
   defaults to `private` must never widen to `org` because a lookup failed —
   that would turn a metadata inconsistency into disclosure. An unresolvable
   owner yields `private` + `ownerIdentity = null` (an owner-orphan, visible to
-  org owners only, recoverable via §4.3).
+  no one; identity linking (§7) is what lights it up retroactively).
 - Webchat `triggeredBy` is the console user's **email** (set in
   `routes/webchat-token.ts`), which degrades under devAuth and is not a stable
   key — hence the `WebchatConversation` lookup rather than trusting the wire
@@ -211,11 +213,13 @@ Notes:
 
 `PUT /orgs/:orgId/sessions/:id/visibility` with body
 `{ visibility: 'private' | 'org' }`. Allowed for the session owner (identity
-match) and org owners; collaborators/viewers cannot re-classify other people's
+match) and org owners — but the route view-gates first and private sessions
+carry no role override, so the org-owner grant effectively reaches only
+org-visible sessions; collaborators/viewers cannot re-classify other people's
 sessions. This is the escape hatch for both directions: publishing a useful DM
-transcript to the org, or pulling a channel/group-DM session private (its
-recorded initiator — once identity linking makes them matchable — or an org
-owner).
+transcript to the org (owner only — no one else can see it to widen it), or
+pulling a channel/group-DM session private (its recorded initiator — once
+identity linking makes them matchable — or an org owner).
 
 An explicit change sets `visibilitySource = 'explicit'`, which pins the row
 against any later automatic reclassification (§4.5). **Tightening cascades to
@@ -255,7 +259,7 @@ state marker:
   the CP performs a **conditional one-time settlement**: copy the parent's
   `visibility` + `ownerIdentity` onto the child **iff** the child is still
   `inherited_pending` (compare-and-set on the source column), then mark it
-  `inherited`. A child that an org owner has meanwhile re-classified is
+  `inherited`. A child that a human has meanwhile re-classified is
   `explicit` and the settlement is a no-op — reconciliation never overwrites
   a human decision.
 - **Parent tightened later (`org` → `private`).** The child contains content
@@ -266,7 +270,8 @@ state marker:
   Cascaded rows get the parent's owner and `visibilitySource = 'inherited'`.
 - **Parent widened later (`private` → `org`).** Never cascades. Each
   descendant stays as classified; widening a child remains a per-session §4.3
-  decision by its owner or an org owner.
+  decision by its owner (a private child is invisible to everyone else,
+  org owners included).
 
 `explicit` is therefore protected against **settlement** (the automatic
 reconciliation above) but not against a **tightening cascade** — the §3 enum
@@ -300,9 +305,8 @@ The authoritative predicate, mirroring `canView`:
 
 ```ts
 canViewSession(s, ctx, identitySet) =
-  ctx.role === 'owner' || // governance exception
-  s.visibility === 'org' ||
-  (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
+  // deliberately NO role-based governance exception — private is owner-only
+  s.visibility === 'org' || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
 ```
 
 All of these already gate on agent visibility; each additionally applies the
@@ -310,7 +314,7 @@ session predicate:
 
 | Surface                       | Where                                                                                     | Change                                                                                                                                                                                                                                                                                             |
 | ----------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, skipped for org owners                                                                                                                                                                                                           |
+| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))`, applied to every viewer (no org-owner bypass)                                                                                                                                                                                    |
 | Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | apply `canViewSession` after the agent gate; fail as 404                                                                                                                                                                                                                                           |
 | Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; invisible parent already renders `null`                                                                                                                                                                                                                                            |
 | SSE                           | `http/routes/stream.ts`                                                                   | today filters per **agent**; must apply the session predicate to **every session-scoped envelope variant** — both `event/session` milestones and `event/session-activity` invalidations (the latter still expose `sessionId`, revision, and live activity), plus any future session-bearing frames |

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -179,12 +179,13 @@ visibility grant.
 
 Every session carries its own visibility, composed with — never widening — the visibility
 of the agent that owns it. Platform direct messages, Playground and webchat conversations,
-and sessions launched through the Web API default to **private**: only their owner and org
-owners can see them. Channel sessions, group direct messages, and automation-originated
-sessions (cron, hook, dream, agent-to-agent) default to **org**, visible to every member
-who can already view the agent. A session's initiator is recorded regardless of tier, so
-the person who started a channel conversation may later pull it private, and an org owner
-may reclassify anything.
+and sessions launched through the Web API default to **private**: only their owner can see
+them — deliberately no role exception, org owners included. Channel sessions, group direct
+messages, and automation-originated sessions (cron, hook, dream, agent-to-agent) default
+to **org**, visible to every member who can already view the agent. A session's initiator
+is recorded regardless of tier, so the person who started a channel conversation may later
+pull it private, and an org owner may reclassify any session they can see — which excludes
+other people's private sessions.
 
 An agent-to-agent child inherits its parent's visibility, because a delegation copies the
 parent's prompt into the child's transcript. Tightening a session therefore cascades to its

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -793,9 +793,9 @@ enum ActivityState {
 
 // Per-session visibility tier (docs/designs/session-visibility.md §1): 'org'
 // (default) = visible to every member who can view the owning agent; 'private'
-// = session owner (identity match) + org owners only. Composes with agent
-// visibility — it never widens it. Share-by-link is deliberately NOT a member
-// of this enum (§8).
+// = session owner (identity match) ONLY — no role override, org owners
+// included. Composes with agent visibility — it never widens it. Share-by-link
+// is deliberately NOT a member of this enum (§8).
 enum SessionVisibility {
   private
   org

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -15,6 +15,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
+import type { SessionVisibility } from '../../persistence/ports.js'
 import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf } from '../rbac.js'
 import { canView, canViewSession, identitySetOf } from '../visibility.js'
@@ -103,20 +104,26 @@ function sessionRelation(s: { id: string; agentId: string; title: string | null 
 
 /**
  * Who may re-classify a session (§4.3): its recorded owner (identity match) and
- * org owners. The route view-gates first and private sessions carry no role
- * override, so the org-owner arm effectively reaches only org-visible sessions
+ * org owners — but the org-owner arm holds only WHILE THE ROW IS ORG-VISIBLE
  * (they may pull a channel session private, never read or widen someone else's
- * private one). Collaborators and viewers cannot re-classify other people's
- * sessions — but note this is deliberately NOT the blanket `denyViewerWrite`
- * guard used elsewhere: the grant follows OWNERSHIP, so a viewer-role member who
- * owns a session keeps control of their own DM's visibility.
+ * private one). The condition cannot lean on the route's view-gate alone:
+ * `setVisibility` re-runs this predicate against the FOR UPDATE-locked row, and
+ * a session tightened (or re-owned by an ancestor cascade) after the unlocked
+ * pre-read must refuse a queued org-owner widen — once private, only an
+ * identity match qualifies. Collaborators and viewers cannot re-classify other
+ * people's sessions — but note this is deliberately NOT the blanket
+ * `denyViewerWrite` guard used elsewhere: the grant follows OWNERSHIP, so a
+ * viewer-role member who owns a session keeps control of their own DM's
+ * visibility.
  */
 function canChangeSessionVisibility(
-  s: { ownerIdentity: string | null },
+  s: { visibility: SessionVisibility; ownerIdentity: string | null },
   ctx: { role: string; userId: string },
   identitySet: ReadonlySet<string>
 ): boolean {
-  return ctx.role === 'owner' || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
+  return (
+    (ctx.role === 'owner' && s.visibility === 'org') || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
+  )
 }
 
 function hookMetadataForSession(metadata: Map<string, HookSessionMetadata>, session: HookSessionRow) {
@@ -642,7 +649,9 @@ export function sessionRoutes(deps: HttpDeps) {
         }
         // The check above read an unlocked row. Re-run it inside the write's
         // transaction: an ancestor cascade committing in between can re-own this
-        // session, and the former owner must not still be able to widen it.
+        // session (the former owner must not still widen it), and a tighten
+        // committing in between flips it private (a queued org-owner widen must
+        // not reopen it — the org-owner arm requires the LOCKED row to be org).
         const { affected, forbidden } = await deps.repos.session.setVisibility(
           SessionId(req.params.id),
           req.body.visibility,

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -103,7 +103,10 @@ function sessionRelation(s: { id: string; agentId: string; title: string | null 
 
 /**
  * Who may re-classify a session (§4.3): its recorded owner (identity match) and
- * org owners. Collaborators and viewers cannot re-classify other people's
+ * org owners. The route view-gates first and private sessions carry no role
+ * override, so the org-owner arm effectively reaches only org-visible sessions
+ * (they may pull a channel session private, never read or widen someone else's
+ * private one). Collaborators and viewers cannot re-classify other people's
  * sessions — but note this is deliberately NOT the blanket `denyViewerWrite`
  * guard used elsewhere: the grant follows OWNERSHIP, so a viewer-role member who
  * owns a session keeps control of their own DM's visibility.
@@ -619,7 +622,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Set session visibility',
           description:
-            'Reclassifies a session as private or org-visible. Allowed for the session owner and org owners. Tightening cascades to descendant sessions and stops future agent-memory capture once the owning daemons acknowledge; memory already distilled is not retracted.',
+            'Reclassifies a session as private or org-visible. Allowed for the session owner, and for org owners on sessions they can view (private sessions are visible only to their owner). Tightening cascades to descendant sessions and stops future agent-memory capture once the owning daemons acknowledge; memory already distilled is not retracted.',
           operationId: 'setSessionVisibility',
           params: IdParam,
           body: SetSessionVisibilityBody,

--- a/packages/control-plane/src/http/visibility.test.ts
+++ b/packages/control-plane/src/http/visibility.test.ts
@@ -126,15 +126,13 @@ describe('canViewSession (session-visibility.md §5)', () => {
     expect(canViewSession(s, ctx(CREATOR, 'viewer'), idsOf(ctx(CREATOR, 'viewer')))).toBe(true)
   })
 
-  it('private session hides from a non-matching non-owner', () => {
+  it('private session hides from every non-matching viewer — org owners included', () => {
+    // Deliberately NO governance override here (unlike `canView` on resources):
+    // a private session is a DM-grade transcript, and role grants no access.
     const s = owned('private', `user:${CREATOR}`)
     expect(canViewSession(s, ctx(OTHER, 'collaborator'), idsOf(ctx(OTHER, 'collaborator')))).toBe(false)
     expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(false)
-  })
-
-  it('private session is visible to any org owner — governance override', () => {
-    const s = owned('private', `user:${CREATOR}`)
-    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(true)
+    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(false)
   })
 
   it('matches a linked platform identity once the identity set carries it', () => {
@@ -147,11 +145,14 @@ describe('canViewSession (session-visibility.md §5)', () => {
     expect(canViewSession(s, c, linked)).toBe(true)
   })
 
-  it('an owner-orphan private session (ownerIdentity null) is owner-role-only — fail closed', () => {
+  it('an owner-orphan private session (ownerIdentity null) is visible to no one — fail closed', () => {
+    // Identity linking (§7) is what lights these up retroactively; until then
+    // no role, org owners included, can read a transcript whose owner could
+    // not be resolved.
     const s = owned('private', null)
     expect(canViewSession(s, ctx(CREATOR, 'collaborator'), idsOf(ctx(CREATOR, 'collaborator')))).toBe(false)
     expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(false)
-    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(true)
+    expect(canViewSession(s, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(false)
   })
 })
 

--- a/packages/control-plane/src/http/visibility.ts
+++ b/packages/control-plane/src/http/visibility.ts
@@ -64,13 +64,16 @@ export function identitySetOf(ctx: ViewCtx): Set<string> {
   return new Set([`user:${ctx.userId}`])
 }
 
-/** Can this caller SEE the session? Any one arm suffices. An unowned private
- *  session (`ownerIdentity` null — an owner-orphan) is visible to org owners
- *  only: fail closed, never widen because ownership could not be resolved. */
+/** Can this caller SEE the session? Any one arm suffices. Unlike `canView`
+ *  there is deliberately NO org-owner governance override: a private session
+ *  is a DM-grade transcript, so only its identity-matched owner reads it —
+ *  role grants no access. An unowned private session (`ownerIdentity` null —
+ *  an owner-orphan) is therefore visible to NO ONE: fail closed, never widen
+ *  because ownership could not be resolved (identity linking, §7, is what
+ *  lights such rows up retroactively). */
 export function canViewSession(s: SessionViewable, ctx: ViewCtx, identitySet: ReadonlySet<string>): boolean {
   return (
-    ctx.role === 'owner' || // governance override — owners see everything
     s.visibility === 'org' || // default: visible to whoever can view the agent
-    (s.ownerIdentity != null && identitySet.has(s.ownerIdentity)) // private: owner match
+    (s.ownerIdentity != null && identitySet.has(s.ownerIdentity)) // private: owner match only
   )
 }

--- a/packages/control-plane/src/orchestrator/visibilityPush.test.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.test.ts
@@ -21,6 +21,7 @@ function session(over: Partial<SessionMetaRecord> = {}): SessionMetaRecord {
     agentId: AGENT,
     visibility: 'private',
     ownerIdentity: 'user:u1',
+    visibilitySource: 'explicit',
     visibilityRev: 2,
     visibilityAckedRev: -1,
     ...over
@@ -435,9 +436,26 @@ describe('isApplied — the §4.3 cutover state', () => {
   })
 
   it('treats revision 0 as needing an ack — -1 means never acknowledged', async () => {
+    // Rev 0 rows that ARE pushed at ingest (A2A children: inherited /
+    // inherited_pending) genuinely wait for their daemon's confirmation.
     const { push } = deps()
-    expect(await push.isApplied([session({ visibilityRev: 0, visibilityAckedRev: -1 })])).toBe(false)
-    expect(await push.isApplied([session({ visibilityRev: 0, visibilityAckedRev: 0 })])).toBe(true)
+    expect(
+      await push.isApplied([session({ visibilitySource: 'inherited', visibilityRev: 0, visibilityAckedRev: -1 })])
+    ).toBe(false)
+    expect(
+      await push.isApplied([session({ visibilitySource: 'inherited', visibilityRev: 0, visibilityAckedRev: 0 })])
+    ).toBe(true)
+  })
+
+  it('is vacuously applied for an initial §4.2 classification — nothing was pushed', async () => {
+    // A default-classified row is never pushed at ingest (the daemon holds the
+    // layer-1 local state already), so its -1 watermark is not a pending
+    // cutover. Without this, every fresh webchat/DM session shows "Applying…"
+    // until its daemon happens to re-register.
+    const { push } = deps()
+    expect(
+      await push.isApplied([session({ visibilitySource: 'default', visibilityRev: 0, visibilityAckedRev: -1 })])
+    ).toBe(true)
   })
 
   it('is vacuously applied ONLY for an unplaced agent — nothing runs it, nothing captures', async () => {

--- a/packages/control-plane/src/orchestrator/visibilityPush.ts
+++ b/packages/control-plane/src/orchestrator/visibilityPush.ts
@@ -244,6 +244,13 @@ export class SessionVisibilityPushService {
    * Has every affected daemon applied this change (§5.1)? The memory boundary
    * takes effect at ACK, so the §4.3 endpoint reports `pending` until then.
    *
+   * A row still on its initial §4.2 classification (`visibilitySource ===
+   * 'default'`) has no cutover in flight: nothing was pushed at ingest (the
+   * daemon classified the turn locally — layer 1 — or fails closed), so its
+   * `-1` watermark is bookkeeping that converges at the next register replay,
+   * not a pending change. Reporting it `pending` would pin "Applying…" on
+   * every freshly ingested session until its daemon happens to reconnect.
+   *
    * Only an UNPLACED agent counts as vacuously applied: nothing is running it,
    * so nothing can capture. A placed daemon that is merely offline is still
    * `pending` — daemons keep serving established sessions while the CP is down
@@ -253,6 +260,7 @@ export class SessionVisibilityPushService {
    */
   async isApplied(sessions: SessionMetaRecord[]): Promise<boolean> {
     for (const s of sessions) {
+      if (s.visibilitySource === 'default') continue // initial classification — nothing staged, nothing to ack
       if (s.visibilityAckedRev >= s.visibilityRev) continue
       const agent = await this.deps.repos.agent.get(s.agentId)
       if (!agent?.daemonId) continue // unplaced: no daemon runs it, nothing to stop

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -193,12 +193,13 @@ function integrationSql(q: SessionFilterQuery): Prisma.Sql | null {
 
 /**
  * The SQL mirror of `http/visibility.ts#canViewSession` (session-visibility.md
- * §5). Org owners keep the governance override (no arm at all); everyone else
- * sees `org` rows plus `private` rows they own. `= ANY(array)` tolerates an
- * empty identity set, unlike the `IN (…)` list form used for agent ids.
+ * §5). No role bypass — org owners included, every viewer sees `org` rows plus
+ * `private` rows they own; only the internal/daemon-facing callers that pass no
+ * viewer read unfiltered. `= ANY(array)` tolerates an empty identity set,
+ * unlike the `IN (…)` list form used for agent ids.
  */
 function sessionViewerSql(viewer: SessionFilterQuery['viewer']): Prisma.Sql | null {
-  if (!viewer || viewer.role === 'owner') return null
+  if (!viewer) return null
   return Prisma.sql`(
     s."visibility" = 'org'::"SessionVisibility"
     OR (s."ownerIdentity" IS NOT NULL AND s."ownerIdentity" = ANY(${viewer.identitySet}::text[]))
@@ -633,10 +634,9 @@ export class PgSessionRepo implements SessionRepo {
         parentSessionId,
         agentId: { in: agentIds },
         // The Prisma spelling of `sessionViewerSql` — the same predicate as the
-        // list, so a private child never leaks its title through the detail page.
-        ...(viewer && viewer.role !== 'owner'
-          ? { OR: [{ visibility: 'org' as const }, { ownerIdentity: { in: viewer.identitySet } }] }
-          : {})
+        // list (no org-owner bypass), so a private child never leaks its title
+        // through the detail page.
+        ...(viewer ? { OR: [{ visibility: 'org' as const }, { ownerIdentity: { in: viewer.identitySet } }] } : {})
       },
       orderBy: [{ startedAt: 'asc' }, { id: 'asc' }]
     })

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -58,7 +58,7 @@ describe('session visibility — list & detail', () => {
       visibility: 'private',
       ownerIdentity: `user:${theirs}`
     })
-    // No resolvable owner (§2 owner-orphan): org owners only.
+    // No resolvable owner (§2 owner-orphan): visible to no one — fail closed.
     const orphanSession = await seedSessionMeta(prisma, `s-orphan-${randomUUID()}`, agentId, {
       visibility: 'private'
     })
@@ -74,10 +74,15 @@ describe('session visibility — list & detail', () => {
     expect((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${otherSession}` })).statusCode).toBe(404)
     expect((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${orphanSession}` })).statusCode).toBe(404)
 
-    // The governance exception: an org owner sees every session in the org.
+    // No governance override on sessions: an org owner filters exactly like any
+    // other member — a private transcript is its owner's, role grants nothing.
     const ownerApp = appAs(owner)
     const asOwner = sessionIds((await ownerApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json())
-    expect(asOwner).toEqual(expect.arrayContaining([orgSession, ownSession, otherSession, orphanSession]))
+    expect(asOwner).toContain(orgSession)
+    expect(asOwner).not.toContain(ownSession)
+    expect(asOwner).not.toContain(otherSession)
+    expect(asOwner).not.toContain(orphanSession)
+    expect((await ownerApp.app.inject({ method: 'GET', url: `${ORG}/sessions/${otherSession}` })).statusCode).toBe(404)
   })
 
   it('keeps keyset pagination stable under the visibility predicate', async () => {
@@ -140,7 +145,7 @@ describe('session visibility — list & detail', () => {
 })
 
 describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
-  it('lets the recorded owner pull an org session private, and org owners reclassify anything', async () => {
+  it('lets the recorded owner pull an org session private and publish it back', async () => {
     const initiator = await makeUser('sv-put-owner', 'collaborator')
     const orgOwner = await makeUser('sv-put-admin', 'owner')
     const daemonId = await seedDaemon(prisma, randomUUID())
@@ -150,7 +155,8 @@ describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
     })
 
     // The initiator of an `org` channel session may pull it private…
-    const res = await appAs(initiator).app.inject({
+    const initiatorApp = appAs(initiator)
+    const res = await initiatorApp.app.inject({
       method: 'PUT',
       url: `${ORG}/sessions/${session}/visibility`,
       payload: { visibility: 'private' }
@@ -158,8 +164,18 @@ describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
     expect(res.statusCode).toBe(200)
     expect(res.json()).toMatchObject({ id: session, visibility: 'private', visibilityRev: 1 })
 
-    // …and an org owner may publish it back (widening is explicit, never cascaded).
-    const back = await appAs(orgOwner).app.inject({
+    // …after which even an org owner cannot reach it (no view ⇒ no reclassify;
+    // 404, never 403 — no existence oracle)…
+    const denied = await appAs(orgOwner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${session}/visibility`,
+      payload: { visibility: 'org' }
+    })
+    expect(denied.statusCode).toBe(404)
+
+    // …and only the owner themselves may publish it back (widening is explicit,
+    // never cascaded).
+    const back = await initiatorApp.app.inject({
       method: 'PUT',
       url: `${ORG}/sessions/${session}/visibility`,
       payload: { visibility: 'org' }
@@ -323,7 +339,11 @@ describe('session visibility — §4.5 inheritance and cascade', () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
 
-    const root = await seedSessionMeta(prisma, `s-root-${randomUUID()}`, agentId, {})
+    // The root keeps the acting user's identity: once tightened, only its
+    // identity-matched owner can still see it to widen it back.
+    const root = await seedSessionMeta(prisma, `s-root-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${owner}`
+    })
     const child = await seedSessionMeta(prisma, `s-kid-${randomUUID()}`, agentId, { parentSessionId: root })
     const grandchild = await seedSessionMeta(prisma, `s-grandkid-${randomUUID()}`, agentId, {
       parentSessionId: child

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -221,6 +221,62 @@ describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
     ).toBe(404)
   })
 
+  it('refuses an org-owner widen queued behind a concurrent tighten (pre-read passed while org)', async () => {
+    const initiator = await makeUser('sv-queued-init', 'collaborator')
+    const orgOwner = await makeUser('sv-queued-admin', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const session = await seedSessionMeta(prisma, `s-queued-${randomUUID()}`, agentId, {
+      ownerIdentity: `user:${initiator}`
+    })
+
+    // The owner's tighten takes the row lock but does NOT commit yet, so the
+    // org owner's PUT pre-reads the still-committed `org` row, passes the view
+    // gate and the unlocked authorization, and queues on `setVisibility`'s
+    // FOR UPDATE — the exact TOCTOU window for the org-owner arm.
+    let lockTaken!: () => void
+    const lockHeld = new Promise<void>((resolve) => (lockTaken = resolve))
+    let commitTighten!: () => void
+    const tightenHeld = new Promise<void>((resolve) => (commitTighten = resolve))
+    const tighten = prisma.$transaction(
+      async (tx) => {
+        await tx.$executeRaw`
+          UPDATE "session_meta" SET
+            "visibility" = 'private'::"SessionVisibility",
+            "visibilitySource" = 'explicit'::"VisibilitySource",
+            "visibilityRev" = "visibilityRev" + 1
+          WHERE "id" = ${session}`
+        lockTaken()
+        await tightenHeld
+      },
+      { timeout: 20_000 }
+    )
+    await lockHeld
+
+    const queuedWiden = appAs(orgOwner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${session}/visibility`,
+      payload: { visibility: 'org' }
+    })
+    // Only commit the tighten once the PUT is provably parked on the row lock —
+    // i.e. it already passed its unlocked pre-read against the `org` row.
+    for (let i = 0; ; i++) {
+      const waiters = await prisma.$queryRaw<Array<{ n: number }>>`
+        SELECT count(*)::int AS n FROM pg_stat_activity
+        WHERE datname = current_database() AND wait_event_type = 'Lock'`
+      if ((waiters[0]?.n ?? 0) > 0) break
+      if (i > 400) throw new Error('the queued PUT never blocked on the row lock')
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    commitTighten()
+    await tighten
+
+    // The lock-time re-check sees a private row: role grants nothing, 403, and
+    // the session stays private — the queued request cannot reopen it.
+    expect((await queuedWiden).statusCode).toBe(403)
+    expect((await prisma.sessionMeta.findUnique({ where: { id: session } }))?.visibility).toBe('private')
+  })
+
   it('reports `applied` when no daemon can ever ack the change', async () => {
     const owner = await makeUser('sv-state', 'owner')
     const agentId = await seedAgent(prisma, randomUUID()) // unplaced: no daemon

--- a/packages/control-plane/test/integration/stream.route.test.ts
+++ b/packages/control-plane/test/integration/stream.route.test.ts
@@ -65,8 +65,9 @@ describe('session event stream', () => {
     })
     await seedSessionMeta(prisma, 'session-shared', agentId, { daemonId })
 
-    // devAuth's principal is DEFAULT_OWNER_ID, whose org role is `owner` — the
-    // governance exception would see everything, so subscribe as a collaborator.
+    // Subscribe as a collaborator whose identity does not match the session's
+    // ownerIdentity — the only thing that grants private-session reads (there
+    // is no role override on sessions).
     const email = 'stream-collaborator@acme.dev'
     const { userId } = await new PgUserRepo(prisma).provisionOidcUser({
       oidcSubject: 'stream-collaborator',

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -23,7 +23,7 @@ import { Spinner } from '@/components/marks'
 import { ConfirmationDialog } from '@/components/console/ConfirmationDialog'
 import { putSessionVisibility, type SessionVisibility } from '@/lib/api'
 
-export const SESSION_PRIVATE_TITLE = 'Private session — visible only to its owner and org owners'
+export const SESSION_PRIVATE_TITLE = 'Private session — visible only to its owner'
 
 export function SessionVisibilityControl({
   sessionId,

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -562,10 +562,7 @@ export default function SessionsView() {
                 <span className="min-w-0 truncate font-sans text-[14px] font-semibold leading-normal text-(--text-primary)">
                   {s.title}
                 </span>
-                <RestrictedLock
-                  show={s.visibility === 'private'}
-                  title="Private session — visible only to its owner and org owners"
-                />
+                <RestrictedLock show={s.visibility === 'private'} title="Private session — visible only to its owner" />
                 {/* Status as a compact pill — the design's badge, driven by the real
                     status (soft bg + saturated text from STATUS_MAP). */}
                 <span
@@ -605,7 +602,7 @@ export default function SessionsView() {
                   </span>
                   <RestrictedLock
                     show={s.visibility === 'private'}
-                    title="Private session — visible only to its owner and org owners"
+                    title="Private session — visible only to its owner"
                   />
                 </div>
                 <div className="mono text-[11px] text-(--text-tertiary)">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -236,7 +236,7 @@ export interface SessionUsageDto {
 }
 
 // Session-level visibility (docs/designs/session-visibility.md): 'private' rows are
-// visible only to the session owner + org owners; 'org' to every member who can view
+// visible only to the session owner (no role override, org owners included); 'org' to every member who can view
 // the owning agent. Deliberately NOT ResourceVisibility ('org' | 'restricted').
 export type SessionVisibility = 'private' | 'org'
 


### PR DESCRIPTION
## Summary

Two fixes to session visibility (follow-up to #241), found while debugging a private webchat session on the test environment:

1. **Private sessions are now visible only to their identity-matched owner.** The org-owner governance override is removed from every session read path — `canViewSession`, the SQL viewer predicate (`sessionViewerSql`), `listChildren`, and by extension detail/messages/tool-body/SSE. A private session is a DM-grade transcript; role grants no access. Consequences:
   - Owner-orphan private sessions (`ownerIdentity = null`) are now visible to **no one** (fail closed) until identity linking (§7) resolves the owner.
   - Org owners can still pull an org-visible session private, but can no longer read or widen someone else's private session (view-gate 404s first, never 403 — no existence oracle).
   - Resource (agent) visibility keeps its org-owner override — only sessions change.

2. **The "Applying…" badge no longer sticks forever on fresh sessions.** Sessions classified at ingest (`visibilitySource = 'default'`, rev 0) are never pushed to the daemon — the daemon already holds the layer-1 local capture state — so their `-1` ack watermark is bookkeeping, not a pending cutover. `isApplied` now treats such rows as vacuously applied; real §4.3 tightenings and §4.5 cascades (source `explicit`/`inherited`, rev bumped) keep the ack-gated pending state.

Design docs (`session-visibility.md`, `product-conventions.md`), schema comments, OpenAPI description, and console copy updated to match.

## Test plan

- [x] `control-plane` unit tests (789 passed) — including new/updated `visibility.test.ts` and `visibilityPush.test.ts` cases for the owner-only predicate and the default-source applied rule
- [x] `session-visibility.route.test.ts` integration (17 passed) — org owner no longer sees others' private/orphan sessions; 404 on reclassifying an invisible session; owner can still publish their own back
- [x] `stream.route.test.ts` integration — both SSE envelope variants withheld from non-owners
- [x] `control-plane` + `web` typecheck, eslint, prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)