### PR TITLE
feat(web): link social identity rows to the accounts they name

### DIFF
--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useState, type ReactNode } from 'react'
 import useSWR from 'swr'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { SocialLoginMark } from '@/components/marks'
 import { initialsFrom } from '@/lib/auth'
 import { fetchMySlackIdentity, resolveMySocialConnectorId, unlinkMySocialIdentity } from '@/lib/api'
-import { slackWorkspaceLine } from '@/lib/slack-identity'
+import { slackWorkspaceLine, slackWorkspaceUrl } from '@/lib/slack-identity'
 import {
   LogtoAccountError,
   accountErrorMessage,
@@ -211,6 +211,28 @@ function VerifyAccountDialog({
   )
 }
 
+/**
+ * A secondary detail line that becomes a link when we can address the thing it
+ * names. Falls back to plain text rather than a dead link — a provider that
+ * gave us no handle (a GitHub identity with no login, a Slack workspace with no
+ * domain) should still read normally.
+ */
+function ExternalLine({ href, mono = false, children }: { href?: string; mono?: boolean; children: ReactNode }) {
+  const type = mono ? 'font-mono text-[11.5px]' : 'font-sans text-[11.5px]'
+  const base = `block truncate ${type} font-normal leading-normal text-(--text-tertiary)`
+  if (!href) return <div className={base}>{children}</div>
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${base} hover:text-(--text-secondary) hover:underline`}
+    >
+      {children}
+    </a>
+  )
+}
+
 function Notice({ notice }: { notice: AccountNotice }) {
   return (
     <div
@@ -250,6 +272,7 @@ export default function SocialSignInCard({
   // but this one line — never the linking UI it sits in.
   const { data: slack } = useSWR('me-slack-identity', fetchMySlackIdentity, { shouldRetryOnError: false })
   const workspaceLine = slackWorkspaceLine(slack)
+  const workspaceUrl = slackWorkspaceUrl(slack)
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
   const [pendingVerify, setPendingVerify] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
@@ -344,7 +367,7 @@ export default function SocialSignInCard({
         <div aria-busy={isValidating}>
           {SOCIAL_LOGIN_PROVIDERS.map((provider, index) => {
             const identity = currentAccount?.identities[provider.target]
-            const details = identity ? socialIdentityDetails(identity) : undefined
+            const details = identity ? socialIdentityDetails(provider.target, identity) : undefined
             const canUnlink = linkedProviderCount > 1
             return (
               <div
@@ -372,14 +395,12 @@ export default function SocialSignInCard({
                             {details?.name ?? 'Linked'}
                           </div>
                           {details?.email ? (
-                            <div className="truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                            <ExternalLine href={details.profileUrl} mono>
                               {details.email}
-                            </div>
+                            </ExternalLine>
                           ) : null}
                           {provider.target === 'slack' && workspaceLine ? (
-                            <div className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                              {workspaceLine}
-                            </div>
+                            <ExternalLine href={workspaceUrl}>{workspaceLine}</ExternalLine>
                           ) : null}
                         </div>
                       </div>

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -88,3 +88,43 @@ describe('Logto Account API', () => {
     ).toBe('That Google account is already linked to another AgentConnect account.')
   })
 })
+
+describe('socialIdentityDetails profile links', () => {
+  const identity = (details: Record<string, unknown>) => ({ userId: 'x', details })
+
+  it('addresses a GitHub account by the login in the connector rawData', async () => {
+    const { socialIdentityDetails } = await import('./logto-account')
+    expect(socialIdentityDetails('github', identity({ rawData: { userInfo: { login: 'octocat' } } })).profileUrl).toBe(
+      'https://github.com/octocat'
+    )
+  })
+
+  it('addresses a Slack member inside their own workspace', async () => {
+    const { socialIdentityDetails } = await import('./logto-account')
+    expect(
+      socialIdentityDetails(
+        'slack',
+        identity({
+          rawData: {
+            'https://slack.com/team_domain': 'example-workspace',
+            'https://slack.com/user_id': 'U0EXAMPLE1'
+          }
+        })
+      ).profileUrl
+    ).toBe('https://example-workspace.slack.com/team/U0EXAMPLE1')
+  })
+
+  it('sends Google to the account page, the only thing it actually addresses', async () => {
+    const { socialIdentityDetails } = await import('./logto-account')
+    expect(socialIdentityDetails('google', identity({})).profileUrl).toBe('https://myaccount.google.com/profile')
+  })
+
+  it('omits the link when the provider gave no handle, so the row stays plain text', async () => {
+    const { socialIdentityDetails } = await import('./logto-account')
+    // A GitHub identity with no login, and a Slack workspace with no domain.
+    expect(socialIdentityDetails('github', identity({ rawData: {} })).profileUrl).toBeUndefined()
+    expect(
+      socialIdentityDetails('slack', identity({ rawData: { 'https://slack.com/user_id': 'U0EXAMPLE1' } })).profileUrl
+    ).toBeUndefined()
+  })
+})

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -18,6 +18,9 @@ export interface SocialIdentityDetails {
   name?: string
   email?: string
   avatar?: string
+  /** Where this account lives at the provider, when the provider has such a
+   *  place and the connector gave us enough to address it. */
+  profileUrl?: string
 }
 
 export interface SocialLinkFlow {
@@ -194,15 +197,44 @@ export async function saveSocialIdentity(
   })
 }
 
-export function socialIdentityDetails(identity: SocialIdentity): SocialIdentityDetails {
+/**
+ * Where a linked account lives at its provider, so the row can point at the
+ * real thing instead of just naming it. Built from the connector's stored
+ * `rawData`, which is a snapshot from sign-in — a workspace that has since been
+ * renamed yields a stale link, which is why nothing depends on this resolving.
+ *
+ * Google has no per-person public profile, so it points at the account page the
+ * signed-in user can actually act on. Undefined whenever the provider gives us
+ * nothing addressable; callers then render plain text.
+ */
+function providerProfileUrl(target: string, details: Record<string, unknown>): string | undefined {
+  const raw = details.rawData && typeof details.rawData === 'object' ? (details.rawData as Record<string, unknown>) : {}
+  const userInfo = raw.userInfo && typeof raw.userInfo === 'object' ? (raw.userInfo as Record<string, unknown>) : {}
+
+  if (target === 'github') {
+    const login = stringValue(userInfo.login, raw.login, details.login)
+    return login ? `https://github.com/${encodeURIComponent(login)}` : undefined
+  }
+  if (target === 'slack') {
+    const domain = stringValue(raw['https://slack.com/team_domain'])
+    const userId = stringValue(raw['https://slack.com/user_id'], details.id)
+    return domain && userId ? `https://${domain}.slack.com/team/${encodeURIComponent(userId)}` : undefined
+  }
+  if (target === 'google') return 'https://myaccount.google.com/profile'
+  return undefined
+}
+
+export function socialIdentityDetails(target: string, identity: SocialIdentity): SocialIdentityDetails {
   const details = identity.details
   const name = stringValue(details.name, details.displayName, details.login, details.username)
   const email = stringValue(details.email)
   const avatar = stringValue(details.avatar, details.picture, details.avatarUrl, details.avatar_url)
+  const profileUrl = providerProfileUrl(target, details)
   return {
     ...(name ? { name } : {}),
     ...(email ? { email } : {}),
-    ...(avatar ? { avatar } : {})
+    ...(avatar ? { avatar } : {}),
+    ...(profileUrl ? { profileUrl } : {})
   }
 }
 

--- a/packages/web/src/lib/slack-identity.test.ts
+++ b/packages/web/src/lib/slack-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { slackWorkspaceLine } from '@/lib/slack-identity'
+import { slackWorkspaceLine, slackWorkspaceUrl } from '@/lib/slack-identity'
 
 // Synthetic Slack ids throughout — never a real workspace.
 const LINKED = { linked: true as const, teamId: 'T0EXAMPLE1', userId: 'U0EXAMPLE1' }
@@ -27,5 +27,24 @@ describe('slackWorkspaceLine', () => {
     // SWR leaves `data` undefined on both — the row must degrade to today's look
     // rather than showing a half-resolved workspace.
     expect(slackWorkspaceLine(undefined)).toBeUndefined()
+  })
+})
+
+describe('slackWorkspaceUrl', () => {
+  it('addresses the workspace by its domain', () => {
+    expect(slackWorkspaceUrl({ ...LINKED, teamDomain: 'example-workspace' })).toBe(
+      'https://example-workspace.slack.com'
+    )
+  })
+
+  it('stays undefined without a domain, since the team id does not address one', () => {
+    // The label still renders — it just renders as plain text rather than a
+    // link that would 404.
+    expect(slackWorkspaceUrl({ ...LINKED, teamName: 'Example Workspace' })).toBeUndefined()
+  })
+
+  it('stays undefined when there is no Slack identity at all', () => {
+    expect(slackWorkspaceUrl({ linked: false })).toBeUndefined()
+    expect(slackWorkspaceUrl(undefined)).toBeUndefined()
   })
 })

--- a/packages/web/src/lib/slack-identity.ts
+++ b/packages/web/src/lib/slack-identity.ts
@@ -21,3 +21,13 @@ export function slackWorkspaceLine(slack: MySlackIdentityDto | undefined): strin
   if (!slack?.linked) return undefined
   return slack.teamName ?? (slack.teamDomain ? `${slack.teamDomain}.slack.com` : slack.teamId)
 }
+
+/**
+ * The workspace's own Slack URL, so the label can open the place it names.
+ * Only the domain addresses a workspace on the web — the `T…` id does not — so
+ * this is undefined when Slack sent no domain, and the label stays plain text.
+ */
+export function slackWorkspaceUrl(slack: MySlackIdentityDto | undefined): string | undefined {
+  if (!slack?.linked || !slack.teamDomain) return undefined
+  return `https://${slack.teamDomain}.slack.com`
+}


### PR DESCRIPTION
## What

In **Sign-in methods**, each identity's secondary line becomes a link to the account it names.

| row | links to |
|---|---|
| GitHub | `github.com/<login>` |
| Slack (email) | that member inside their own workspace |
| Slack (workspace label) | the workspace itself |
| Google | the Google account page |

## Why

The card named three accounts but pointed at none of them — confirming *"is that the right Slack workspace? the right GitHub user?"* meant looking it up by hand.

Google is the odd one: it has no per-person public profile, so it points at the account page, which is the only thing genuinely addressable for the signed-in user.

## Notes

- **No endpoint changes.** Everything needed is already in the identity Logto stores: the workspace URL comes from the CP read that already backs that label, the rest from the connector `rawData` the browser already fetches.
- A line with **no handle behind it** — a GitHub identity with no login, a Slack workspace with no domain — stays plain text rather than becoming a link that would 404. These addresses come from a sign-in-time snapshot (a renamed workspace yields a stale link), so nothing depends on one resolving.
- Links are `target="_blank"` + `rel="noopener noreferrer"`.

## Verified

web **478 passing** (66 files), typecheck 0 errors, lint 0 errors, `format:check` clean. New tests cover each provider's URL shape plus both no-handle fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)