### PR TITLE
refactor(lark): remove icon version guard

### DIFF
--- a/packages/control-plane/src/http/feishu-app-icon.test.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.test.ts
@@ -22,15 +22,12 @@ describe('createFeishuAppIconSyncer', () => {
           status: 200
         })
       )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ code: 0, data: { items: [{ status: 1 }] } }), { status: 200 })
-      )
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0 }), { status: 200 }))
 
     await createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'lark', agent)
 
-    expect(fetcher).toHaveBeenCalledTimes(5)
+    expect(fetcher).toHaveBeenCalledTimes(4)
     expect(fetcher.mock.calls[0]?.[0]).toBe('https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal')
     expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual({
       app_id: 'cli_test',
@@ -50,25 +47,19 @@ describe('createFeishuAppIconSyncer', () => {
     })
 
     expect(fetcher.mock.calls[2]?.[0]).toBe(
-      'https://open.larksuite.com/open-apis/application/v6/applications/cli_test/app_versions?lang=en_us&page_size=1&order=0'
-    )
-    expect(fetcher.mock.calls[2]?.[1]?.method).toBe('GET')
-    expect(fetcher.mock.calls[2]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
-
-    expect(fetcher.mock.calls[3]?.[0]).toBe(
       'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/base'
     )
-    expect(fetcher.mock.calls[3]?.[1]?.method).toBe('PATCH')
-    expect(fetcher.mock.calls[3]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
-    expect(JSON.parse(String(fetcher.mock.calls[3]?.[1]?.body))).toEqual({
+    expect(fetcher.mock.calls[2]?.[1]?.method).toBe('PATCH')
+    expect(fetcher.mock.calls[2]?.[1]?.headers).toMatchObject({ authorization: 'Bearer tenant-token' })
+    expect(JSON.parse(String(fetcher.mock.calls[2]?.[1]?.body))).toEqual({
       avatar_url: 'https://cdn.example.test/app-icon'
     })
 
-    expect(fetcher.mock.calls[4]?.[0]).toBe(
+    expect(fetcher.mock.calls[3]?.[0]).toBe(
       'https://open.larksuite.com/open-apis/application/v7/applications/cli_test/publish'
     )
-    expect(fetcher.mock.calls[4]?.[1]?.method).toBe('POST')
-    expect(JSON.parse(String(fetcher.mock.calls[4]?.[1]?.body))).toEqual({
+    expect(fetcher.mock.calls[3]?.[1]?.method).toBe('POST')
+    expect(JSON.parse(String(fetcher.mock.calls[3]?.[1]?.body))).toEqual({
       remark: 'Sync the application icon with its AgentConnect agent',
       changelog: 'Updated the application icon'
     })
@@ -86,26 +77,5 @@ describe('createFeishuAppIconSyncer', () => {
       createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'feishu', agent)
     ).rejects.toThrow('Lark/Feishu icon upload returned 200')
     expect(fetcher).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not patch or publish an app that already has unpublished changes', async () => {
-    const fetcher = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ code: 0, tenant_access_token: 'tenant-token' }), { status: 200 })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ code: 0, data: { url: 'https://cdn.example.test/app-icon' } }), {
-          status: 200
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ code: 0, data: { items: [{ status: 4 }] } }), { status: 200 })
-      )
-
-    await expect(
-      createFeishuAppIconSyncer(undefined, fetcher)('cli_test', 'app-secret', 'feishu', agent)
-    ).rejects.toThrow('Lark/Feishu icon sync skipped: application has unpublished changes')
-    expect(fetcher).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/control-plane/src/http/feishu-app-icon.ts
+++ b/packages/control-plane/src/http/feishu-app-icon.ts
@@ -8,13 +8,11 @@ const REGION_ORIGIN: Record<FeishuRegion, string> = {
 }
 const FEISHU_TIMEOUT_MS = 15_000
 const FEISHU_ICON_SIZE = 512
-const FEISHU_AUDITED_APP_VERSION_STATUS = 1
 
 interface FeishuApiResponse {
   code?: number
   data?: {
     url?: string
-    items?: Array<{ status?: number }>
   }
 }
 
@@ -45,42 +43,10 @@ async function iconPng(agent: BotProfileIconAgent, iconStore?: IconStore): Promi
   return sharp(source.bytes).resize(FEISHU_ICON_SIZE, FEISHU_ICON_SIZE, { fit: 'cover' }).png().toBuffer()
 }
 
-async function assertNoUnpublishedVersion(
-  fetcher: typeof fetch,
-  origin: string,
-  encodedAppId: string,
-  token: string
-): Promise<void> {
-  const versionsRes = await request(
-    fetcher,
-    `${origin}/open-apis/application/v6/applications/${encodedAppId}/app_versions?lang=en_us&page_size=1&order=0`,
-    {
-      method: 'GET',
-      headers: { authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(FEISHU_TIMEOUT_MS)
-    },
-    'version check'
-  )
-  const versionsBody = await responseBody(versionsRes)
-  if (!versionsRes.ok || versionsBody?.code !== 0) {
-    throw new Error(`Lark/Feishu version check returned ${versionsRes.status}`)
-  }
-
-  // v6 status 1 is audited/published. Every other latest-version state is
-  // ambiguous (unsubmitted, under review, rejected, or unknown), so publishing
-  // could submit unrelated developer changes along with the icon.
-  if (versionsBody.data?.items?.[0]?.status !== FEISHU_AUDITED_APP_VERSION_STATUS) {
-    throw new Error('Lark/Feishu icon sync skipped: application has unpublished changes')
-  }
-}
-
 /**
  * Update a self-built Feishu/Lark application's icon and submit the resulting
- * application version. The app must grant
- * `application:application.app_version:readonly` and
- * `application:application:patch`; provider review, when required by the
- * tenant, completes asynchronously. A pre-existing unpublished version makes
- * the sync stop before changing the app.
+ * application version. The app must grant `application:application:patch`;
+ * provider review, when required by the tenant, completes asynchronously.
  */
 export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof fetch = fetch): FeishuAppIconSyncer {
   return async (appId, appSecret, region, agent) => {
@@ -122,8 +88,6 @@ export function createFeishuAppIconSyncer(iconStore?: IconStore, fetcher: typeof
     if (!uploadRes.ok || uploadBody?.code !== 0 || !avatarUrl) {
       throw new Error(`Lark/Feishu icon upload returned ${uploadRes.status}`)
     }
-
-    await assertNoUnpublishedVersion(fetcher, origin, encodedAppId, token)
 
     const patchRes = await request(
       fetcher,

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -13,7 +13,6 @@ import {
 } from './platform-app-description.js'
 
 export const AGENTCONNECT_FEISHU_SCOPES = [
-  'application:application.app_version:readonly',
   'application:application:patch',
   'contact:contact.base:readonly',
   'contact:user.base:readonly',

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -175,10 +175,7 @@ describe('Feishu/Lark one-click app registration', () => {
     })
     expect(addons).toMatchObject({
       scopes: {
-        tenant: expect.arrayContaining([
-          'application:application.app_version:readonly',
-          'application:application:patch'
-        ])
+        tenant: expect.arrayContaining(['application:application:patch'])
       }
     })
     await first.close()


### PR DESCRIPTION
## Summary

- remove the v6 app-version status lookup from Feishu/Lark icon sync
- keep the icon flow entirely on v7 after credential exchange: upload, patch, then publish
- remove the now-unused `application:application.app_version:readonly` scope from the one-click app template
- delete the obsolete unpublished-version guard test

## Why

The preflight version check added complexity and prevented icon updates whenever the provider had pending application changes. Icon synchronization should directly publish the current application state.

## Impact

Agent icon changes no longer stop on draft, review, or other non-published application states. Publishing the icon may include other pending provider-side changes.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run src/http/feishu-app-icon.test.ts`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run test/integration/feishu-registration.route.test.ts`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm exec prettier --check packages/control-plane/src/http/feishu-app-icon.ts packages/control-plane/src/http/feishu-app-icon.test.ts packages/control-plane/src/http/feishu-app-template.ts packages/control-plane/test/integration/feishu-registration.route.test.ts`
- `pnpm exec eslint packages/control-plane/src/http/feishu-app-icon.ts packages/control-plane/src/http/feishu-app-icon.test.ts packages/control-plane/src/http/feishu-app-template.ts packages/control-plane/test/integration/feishu-registration.route.test.ts`

Created by Codex . GPT-5
