### PR TITLE
fix(telegram): refresh privacy status automatically

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -192,8 +192,18 @@ const GUIDE: Record<
 }
 
 type TelegramCheckState = 'idle' | 'checking' | TelegramBotCheckDto['status']
+const TELEGRAM_CHECK_DEBOUNCE_MS = 350
+const TELEGRAM_PRIVACY_RECHECK_MS = 5_000
 
-function TelegramPrivacyStatus({ status, onRetry }: { status: TelegramCheckState; onRetry: () => void }) {
+function TelegramPrivacyStatus({
+  status,
+  refreshing,
+  onRetry
+}: {
+  status: TelegramCheckState
+  refreshing: boolean
+  onRetry: () => void
+}) {
   if (status === 'idle') return null
   const checking = status === 'checking'
   const ready = status === 'ready'
@@ -203,7 +213,7 @@ function TelegramPrivacyStatus({ status, onRetry }: { status: TelegramCheckState
       : status === 'ready'
         ? 'Privacy Mode is off. This bot can receive ordinary group messages.'
         : status === 'privacy_enabled'
-          ? 'Privacy Mode is still on. In @BotFather, send /setprivacy, select this bot and choose Disable.'
+          ? 'Privacy Mode is still on. Disable it in @BotFather. Checking automatically.'
           : status === 'invalid'
             ? 'Telegram rejected this token. Copy it again from @BotFather.'
             : 'AgentConnect could not reach Telegram. Try the check again.'
@@ -211,6 +221,7 @@ function TelegramPrivacyStatus({ status, onRetry }: { status: TelegramCheckState
 
   return (
     <div
+      aria-live="polite"
       className={`mt-2 flex items-start gap-2 rounded-md border px-[10px] py-2 font-sans text-[11.5px] font-normal leading-[1.5] ${
         ready
           ? 'border-(--status-online) bg-(--status-online-soft) text-(--text-secondary)'
@@ -229,11 +240,12 @@ function TelegramPrivacyStatus({ status, onRetry }: { status: TelegramCheckState
       {retryable && (
         <button
           type="button"
-          className="inline-flex flex-none cursor-pointer items-center gap-[5px] border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold leading-[1.5] text-(--text-secondary) hover:text-(--text-primary)"
+          disabled={refreshing}
+          className="inline-flex flex-none cursor-pointer items-center gap-[5px] border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold leading-[1.5] text-(--text-secondary) hover:text-(--text-primary) disabled:cursor-wait"
           onClick={onRetry}
         >
-          <Icon name="refresh-cw" size={12} />
-          Check again
+          <Icon name="refresh-cw" size={12} className={refreshing ? 'animate-spin' : ''} />
+          {refreshing ? 'Checking…' : status === 'privacy_enabled' ? 'Check now' : 'Try again'}
         </button>
       )}
     </div>
@@ -988,11 +1000,12 @@ export default function AddIntegrationModal({
   const [appName, setAppName] = useState(agent.name)
   const [botToken, setBotToken] = useState('')
   const [appToken, setAppToken] = useState('')
-  const [telegramCheckResult, setTelegramCheckResult] = useState<{
+  const [telegramCheckScope] = useState(() => crypto.randomUUID())
+  const telegramCheckSequence = useRef(0)
+  const [telegramCheckRequest, setTelegramCheckRequest] = useState<{
     token: string
-    status: TelegramCheckState
-  }>({ token: '', status: 'idle' })
-  const [telegramCheckRevision, setTelegramCheckRevision] = useState(0)
+    sequence: number
+  } | null>(null)
   // Lark/Feishu gateway: new installs default to international Lark.
   const [feishuRegion, setFeishuRegion] = useState<'feishu' | 'lark'>('lark')
   const [feishuVerificationToken, setFeishuVerificationToken] = useState('')
@@ -1314,34 +1327,50 @@ export default function AddIntegrationModal({
   const botOk = slackBotOk
   const appOk = slackAppOk
   const telegramOk = /^\d+:[A-Za-z0-9_-]{20,}$/.test(tokenTrim)
-  const telegramCheck: TelegramCheckState =
-    mode === 'create' && platform === 'telegram' && telegramOk
-      ? telegramCheckResult.token === tokenTrim
-        ? telegramCheckResult.status
-        : 'checking'
-      : 'idle'
+  const telegramCheckEnabled = mode === 'create' && platform === 'telegram' && telegramOk
   useEffect(() => {
-    if (mode !== 'create' || platform !== 'telegram' || !telegramOk) return
-    if (MOCK_MODE) {
-      setTelegramCheckResult({ token: tokenTrim, status: 'ready' })
+    if (!telegramCheckEnabled || MOCK_MODE) {
+      setTelegramCheckRequest(null)
       return
     }
-    let alive = true
-    setTelegramCheckResult({ token: tokenTrim, status: 'checking' })
     const timer = window.setTimeout(() => {
-      void checkTelegramBot(tokenTrim)
-        .then((result) => {
-          if (alive) setTelegramCheckResult({ token: tokenTrim, status: result.status })
-        })
-        .catch(() => {
-          if (alive) setTelegramCheckResult({ token: tokenTrim, status: 'unreachable' })
-        })
-    }, 350)
-    return () => {
-      alive = false
-      window.clearTimeout(timer)
+      telegramCheckSequence.current += 1
+      setTelegramCheckRequest({ token: tokenTrim, sequence: telegramCheckSequence.current })
+    }, TELEGRAM_CHECK_DEBOUNCE_MS)
+    return () => window.clearTimeout(timer)
+  }, [telegramCheckEnabled, tokenTrim])
+  const telegramCheckKey =
+    telegramCheckEnabled && !MOCK_MODE && telegramCheckRequest?.token === tokenTrim
+      ? ['telegram-bot-check', agent.id, telegramCheckScope, telegramCheckRequest.sequence]
+      : null
+  const {
+    data: telegramCheckData,
+    error: telegramCheckError,
+    isValidating: telegramCheckRefreshing,
+    mutate: refreshTelegramCheck
+  } = useSWR<TelegramBotCheckDto>(telegramCheckKey, () => checkTelegramBot(telegramCheckRequest!.token), {
+    refreshInterval: (result) => (result?.status === 'privacy_enabled' ? TELEGRAM_PRIVACY_RECHECK_MS : 0),
+    refreshWhenHidden: false,
+    revalidateOnFocus: false,
+    shouldRetryOnError: false
+  })
+  const telegramCheck: TelegramCheckState = !telegramCheckEnabled
+    ? 'idle'
+    : MOCK_MODE
+      ? 'ready'
+      : telegramCheckRequest?.token !== tokenTrim
+        ? 'checking'
+        : telegramCheckError
+          ? 'unreachable'
+          : (telegramCheckData?.status ?? 'checking')
+  useEffect(() => {
+    if (telegramCheck !== 'privacy_enabled') return
+    const recheckWhenVisible = () => {
+      if (document.visibilityState === 'visible') void refreshTelegramCheck()
     }
-  }, [mode, platform, telegramCheckRevision, telegramOk, tokenTrim])
+    document.addEventListener('visibilitychange', recheckWhenVisible)
+    return () => document.removeEventListener('visibilitychange', recheckWhenVisible)
+  }, [refreshTelegramCheck, telegramCheck])
   const discordOk = tokenTrim.length >= 24
   // The application (client) id is base64-encoded in the bot token's first segment, so
   // once a token is pasted we can offer a ready-made "Add to Discord" invite link with
@@ -3387,10 +3416,8 @@ export default function AddIntegrationModal({
                 {platform === 'telegram' && (
                   <TelegramPrivacyStatus
                     status={telegramCheck}
-                    onRetry={() => {
-                      setTelegramCheckResult({ token: tokenTrim, status: 'checking' })
-                      setTelegramCheckRevision((revision) => revision + 1)
-                    }}
+                    refreshing={telegramCheck !== 'checking' && telegramCheckRefreshing}
+                    onRetry={() => void refreshTelegramCheck()}
                   />
                 )}
                 {/* Discord: the invite is the fiddly part (right scopes + permissions), so once

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/lib/api'
 import { REPO_ACCESS_BADGE } from '@/components/console/WorkspaceCard'
 import AddAgentRepoModal from './AddAgentRepoModal'
+import { useTelegramPrivacyAutoRefresh } from './telegram-privacy-auto-refresh'
 import {
   GH_DEFAULT_FAMILIES,
   GH_DEFAULT_TRIGGER_MODE,
@@ -193,7 +194,6 @@ const GUIDE: Record<
 
 type TelegramCheckState = 'idle' | 'checking' | TelegramBotCheckDto['status']
 const TELEGRAM_CHECK_DEBOUNCE_MS = 350
-const TELEGRAM_PRIVACY_RECHECK_MS = 5_000
 
 function TelegramPrivacyStatus({
   status,
@@ -1349,8 +1349,6 @@ export default function AddIntegrationModal({
     isValidating: telegramCheckRefreshing,
     mutate: refreshTelegramCheck
   } = useSWR<TelegramBotCheckDto>(telegramCheckKey, () => checkTelegramBot(telegramCheckRequest!.token), {
-    refreshInterval: (result) => (result?.status === 'privacy_enabled' ? TELEGRAM_PRIVACY_RECHECK_MS : 0),
-    refreshWhenHidden: false,
     revalidateOnFocus: false,
     shouldRetryOnError: false
   })
@@ -1363,14 +1361,7 @@ export default function AddIntegrationModal({
         : telegramCheckError
           ? 'unreachable'
           : (telegramCheckData?.status ?? 'checking')
-  useEffect(() => {
-    if (telegramCheck !== 'privacy_enabled') return
-    const recheckWhenVisible = () => {
-      if (document.visibilityState === 'visible') void refreshTelegramCheck()
-    }
-    document.addEventListener('visibilitychange', recheckWhenVisible)
-    return () => document.removeEventListener('visibilitychange', recheckWhenVisible)
-  }, [refreshTelegramCheck, telegramCheck])
+  useTelegramPrivacyAutoRefresh(telegramCheck === 'privacy_enabled', refreshTelegramCheck)
   const discordOk = tokenTrim.length >= 24
   // The application (client) id is base64-encoded in the bot token's first segment, so
   // once a token is pasted we can offer a ready-made "Add to Discord" invite link with
@@ -3417,7 +3408,7 @@ export default function AddIntegrationModal({
                   <TelegramPrivacyStatus
                     status={telegramCheck}
                     refreshing={telegramCheck !== 'checking' && telegramCheckRefreshing}
-                    onRetry={() => void refreshTelegramCheck()}
+                    onRetry={() => void refreshTelegramCheck().catch(() => undefined)}
                   />
                 )}
                 {/* Discord: the invite is the fiddly part (right scopes + permissions), so once

--- a/packages/web/src/components/console/modals/telegram-privacy-auto-refresh.test.tsx
+++ b/packages/web/src/components/console/modals/telegram-privacy-auto-refresh.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TELEGRAM_PRIVACY_RECHECK_MS, useTelegramPrivacyAutoRefresh } from './telegram-privacy-auto-refresh'
+
+let container: HTMLDivElement
+let root: Root
+const refresh = vi.fn()
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function Harness() {
+  const [renderTick, setRenderTick] = useState(0)
+  const [status, setStatus] = useState<'privacy_enabled' | 'ready'>('privacy_enabled')
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setRenderTick((tick) => tick + 1), 25)
+    return () => window.clearInterval(timer)
+  }, [])
+  useTelegramPrivacyAutoRefresh(status === 'privacy_enabled', async () => {
+    refresh()
+    setStatus('ready')
+  })
+
+  return <span data-status={status}>{renderTick}</span>
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+  refresh.mockReset()
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useTelegramPrivacyAutoRefresh', () => {
+  it('keeps polling through unrelated rerenders and stops when privacy mode is ready', async () => {
+    await act(async () => root.render(<Harness />))
+
+    await act(async () => vi.advanceTimersByTimeAsync(TELEGRAM_PRIVACY_RECHECK_MS + 250))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-status]')?.getAttribute('data-status')).toBe('ready')
+
+    await act(async () => vi.advanceTimersByTimeAsync(TELEGRAM_PRIVACY_RECHECK_MS * 2))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web/src/components/console/modals/telegram-privacy-auto-refresh.ts
+++ b/packages/web/src/components/console/modals/telegram-privacy-auto-refresh.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+
+export const TELEGRAM_PRIVACY_RECHECK_MS = 5_000
+
+export function useTelegramPrivacyAutoRefresh(active: boolean, refresh: () => Promise<unknown>): void {
+  const refreshRef = useRef(refresh)
+
+  useEffect(() => {
+    refreshRef.current = refresh
+  }, [refresh])
+
+  useEffect(() => {
+    if (!active) return
+    let inFlight = false
+
+    const refreshWhenVisible = () => {
+      if (document.visibilityState !== 'visible' || inFlight) return
+      inFlight = true
+      void refreshRef
+        .current()
+        .catch(() => undefined)
+        .finally(() => {
+          inFlight = false
+        })
+    }
+
+    const timer = window.setInterval(refreshWhenVisible, TELEGRAM_PRIVACY_RECHECK_MS)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
+    return () => {
+      window.clearInterval(timer)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
+    }
+  }, [active])
+}


### PR DESCRIPTION
## Summary

- recheck Telegram Group Privacy Mode every five seconds while it remains enabled
- pause polling while the page is hidden and check immediately when the user returns
- stop automatically once Telegram reports the bot is ready
- keep a manual check action as a fallback and avoid putting the bot token in the SWR cache key

## Validation

- `pnpm --filter @agentconnect.md/web test` (479 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- changed-file ESLint and Prettier checks
- `git diff --check`
- browser QA observed `privacy_enabled` transition to `ready` without a click
- mobile browser QA at 390×844 confirmed no horizontal overflow

Created by Codex . GPT-5.6