### PR TITLE
docs(sessions): distinguish null-owner rows from unlinked owner-orphans

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -188,8 +188,12 @@ Notes:
 - **Fail closed on missing ownership metadata.** A classification rule that
   defaults to `private` must never widen to `org` because a lookup failed —
   that would turn a metadata inconsistency into disclosure. An unresolvable
-  owner yields `private` + `ownerIdentity = null` (an owner-orphan, visible to
-  no one; identity linking (§7) is what lights it up retroactively).
+  owner yields `private` + `ownerIdentity = null`, a row visible to no one.
+  Note the distinction from the §2 owner-orphan: a stored-but-unmatched
+  platform tuple (`slack:T…:U…`) lights up retroactively when identity
+  linking (§7) grows the viewer's identity set, whereas a `null` owner has
+  nothing to match and stays inaccessible unless a separate repair/backfill
+  populates it.
 - Webchat `triggeredBy` is the console user's **email** (set in
   `routes/webchat-token.ts`), which degrades under devAuth and is not a stable
   key — hence the `WebchatConversation` lookup rather than trusting the wire

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -844,7 +844,7 @@ model SessionMeta {
   // ── session visibility (docs/designs/session-visibility.md §3) ──
   orgId              String // denormalized from agent.orgId at ingest so the org-wide list predicate/index never joins agent
   visibility         SessionVisibility @default(org)
-  ownerIdentity      String? // §2 namespaced identity (`user:<id>` | `<platform>:<scope>:<uid>`); null for automation/legacy/owner-orphan rows
+  ownerIdentity      String? // §2 namespaced identity (`user:<id>` | `<platform>:<scope>:<uid>`); null for automation/legacy/unresolved-owner rows (NOT a §2 owner-orphan, whose tuple is stored but unmatched)
   visibilitySource   VisibilitySource  @default(default)
   visibilityRev      Int               @default(0) // dedicated monotonic counter, bumped in the same tx as any visibility change (§5.1)
   visibilityAckedRev Int               @default(-1) // daemon-ack watermark: 'applied' once >= visibilityRev; -1 = never acked (rev 0 is a real revision)

--- a/packages/control-plane/src/domain/session-visibility.ts
+++ b/packages/control-plane/src/domain/session-visibility.ts
@@ -11,9 +11,11 @@
  *
  *  - **Fail closed.** A rule that defaults to `private` never widens to `org`
  *    because a lookup failed; an unresolvable owner yields `private` +
- *    `ownerIdentity: null` (an owner-orphan, visible to org owners only and
- *    recoverable via the §4.3 endpoint). A metadata inconsistency must never
- *    become a disclosure.
+ *    `ownerIdentity: null` — a row visible to no one. Distinct from a
+ *    stored-but-unmatched platform tuple (a §2 owner-orphan), which identity
+ *    linking (§7) lights up retroactively; a null owner has nothing to match
+ *    and needs a repair/backfill. A metadata inconsistency must never become
+ *    a disclosure.
  *  - **`ownerIdentity` is provenance, not the gate.** It is recorded for every
  *    human-triggered session regardless of tier — for `org` rows it is what
  *    grants its initiator the §4.3 right to pull the session private later.

--- a/packages/control-plane/src/http/visibility.test.ts
+++ b/packages/control-plane/src/http/visibility.test.ts
@@ -145,10 +145,11 @@ describe('canViewSession (session-visibility.md §5)', () => {
     expect(canViewSession(s, c, linked)).toBe(true)
   })
 
-  it('an owner-orphan private session (ownerIdentity null) is visible to no one — fail closed', () => {
-    // Identity linking (§7) is what lights these up retroactively; until then
-    // no role, org owners included, can read a transcript whose owner could
-    // not be resolved.
+  it('a null-owner private session is visible to no one — fail closed', () => {
+    // Unlike a §2 owner-orphan (a stored-but-unmatched platform tuple, which
+    // identity linking §7 lights up retroactively), a null owner has nothing
+    // to match — no role, org owners included, can read it without a
+    // repair/backfill first.
     const s = owned('private', null)
     expect(canViewSession(s, ctx(CREATOR, 'collaborator'), idsOf(ctx(CREATOR, 'collaborator')))).toBe(false)
     expect(canViewSession(s, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')))).toBe(false)

--- a/packages/control-plane/src/http/visibility.ts
+++ b/packages/control-plane/src/http/visibility.ts
@@ -67,10 +67,12 @@ export function identitySetOf(ctx: ViewCtx): Set<string> {
 /** Can this caller SEE the session? Any one arm suffices. Unlike `canView`
  *  there is deliberately NO org-owner governance override: a private session
  *  is a DM-grade transcript, so only its identity-matched owner reads it —
- *  role grants no access. An unowned private session (`ownerIdentity` null —
- *  an owner-orphan) is therefore visible to NO ONE: fail closed, never widen
- *  because ownership could not be resolved (identity linking, §7, is what
- *  lights such rows up retroactively). */
+ *  role grants no access. An unowned private session (`ownerIdentity` null)
+ *  is therefore visible to NO ONE: fail closed, never widen because ownership
+ *  could not be resolved. (Distinct from a stored-but-unmatched platform
+ *  tuple, which identity linking (§7) lights up retroactively by growing the
+ *  viewer's identity set — a null owner has nothing to match and needs a
+ *  repair/backfill instead.) */
 export function canViewSession(s: SessionViewable, ctx: ViewCtx, identitySet: ReadonlySet<string>): boolean {
   return (
     s.visibility === 'org' || // default: visible to whoever can view the agent

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -899,7 +899,7 @@ export interface SessionMetaRecord {
   // ── session visibility (session-visibility.md §3) ──
   orgId: OrgId // denormalized from agent.orgId at ingest
   visibility: SessionVisibility
-  ownerIdentity: string | null // §2 namespaced identity; null for automation/legacy/owner-orphan rows
+  ownerIdentity: string | null // §2 namespaced identity; null for automation/legacy/unresolved-owner rows (NOT a §2 owner-orphan, whose tuple is stored but unmatched)
   visibilitySource: VisibilitySource
   visibilityRev: number // bumped in the same tx as any visibility change (§5.1)
   visibilityAckedRev: number // daemon-ack watermark; 'applied' once >= visibilityRev

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -53,7 +53,8 @@ export interface DaemonWsDeps {
   /** Persists session milestones from the `event/session` EVT (deep-link metadata sync). */
   session: SessionRepo
   /** Resolves a webchat conversation's owning user for session-visibility ingest
-   *  (session-visibility.md §4.2); absent ⇒ webchat sessions stay owner-orphans. */
+   *  (session-visibility.md §4.2); absent ⇒ webchat sessions record no owner
+   *  (null — visible to no one until a repair/backfill). */
   webchatConversation?: WebchatConversationRepo
   /** Resolves Web API launch provenance for the same classification (§4.4). */
   launch?: LaunchRepo

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -58,7 +58,8 @@ describe('session visibility — list & detail', () => {
       visibility: 'private',
       ownerIdentity: `user:${theirs}`
     })
-    // No resolvable owner (§2 owner-orphan): visible to no one — fail closed.
+    // No resolvable owner (ownerIdentity null — nothing for identity linking
+    // to match, unlike a §2 owner-orphan's stored tuple): visible to no one.
     const orphanSession = await seedSessionMeta(prisma, `s-orphan-${randomUUID()}`, agentId, {
       visibility: 'private'
     })


### PR DESCRIPTION
## Summary

Follow-up to #257, addressing the review bot's non-blocking docs correction: identity linking (§7) grows the viewer's identity set, so it can only light up private rows that already **store a platform tuple** (`slack:T…:U…`). A row with `ownerIdentity = null` has nothing to match and stays inaccessible unless a separate repair/backfill populates it.

Clarifies that distinction in three places that conflated the two cases:

- `docs/designs/session-visibility.md` §4.2 fail-closed note
- `canViewSession`'s doc comment (`http/visibility.ts`)
- the classifier's fail-closed invariant (`domain/session-visibility.ts`), which also still claimed org-owner visibility

Comments/docs only — no behavior change.

## Test plan

- [x] `control-plane` typecheck, prettier
- [x] visibility + classifier unit tests (33 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)