### PR TITLE
docs(auth): clarify social OAuth callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,10 +94,11 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 #                         # the resource indicator (= NEXT_PUBLIC_LOGTO_API_RESOURCE).
 #                         # Without one (id-token fallback): the Logto app id
 #                         # (= NEXT_PUBLIC_LOGTO_APP_ID).
-# Logto Management API access for server-side identity metadata and Profile
-# social-account Link/Unlink. Configure an M2M app with Management API access;
-# all three values are required together. For a custom login domain, ENDPOINT
-# and RESOURCE usually use the tenant's canonical Logto host.
+# Logto Management API access for server-side identity metadata, connector
+# lookup, and safe Profile unlinking. Profile linking itself uses Logto's
+# Account API with the current user's token. Configure an M2M app with
+# Management API access; all three values are required together. For a custom
+# login domain, ENDPOINT and RESOURCE usually use the tenant's canonical host.
 # LOGTO_MGMT_ENDPOINT=https://tenant-id.logto.app
 # LOGTO_MGMT_APP_ID=
 # LOGTO_MGMT_APP_SECRET=
@@ -137,17 +138,21 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # Static bearer token (CI/service). Leave unset when the CP runs the devAuth stub.
 # NEXT_PUBLIC_CP_TOKEN=
 # Social login via Logto (opt-in). Login and Profile share one static
-# GitHub/Google provider list. Set ENDPOINT + APP_ID to enable it; unset ⇒
-# no-auth (the login buttons just enter the app). Add the matching social
-# connectors (target `google`/`github`) inside Logto.
-# To show social accounts in AgentConnect's own Profile UI, enable Logto's
-# Account API and give Social identities `ReadOnly` access. Link/Unlink uses the
-# CP-side LOGTO_MGMT_* app above and the current OIDC session, with no email-code
-# step. Register `https://<console-origin>/auth/social/callback` with each provider.
-# Google accepts it as an additional authorized redirect URI. A GitHub OAuth App
-# has one callback setting: use a parent URL compatible with both Logto's normal
-# `/callback/<connector-id>` and this console callback (for sibling custom-domain
-# hosts, `https://auth.example.com/` covers both under GitHub's redirect rules).
+# GitHub/Google/Slack provider list. Set ENDPOINT + APP_ID to enable it; unset ⇒
+# no-auth (the login buttons just enter the app). Add matching `github`, `google`,
+# and `slack` social connectors inside Logto.
+# Register `https://<console-origin>/auth/callback` on the Logto SPA app.
+# To show and link social accounts in AgentConnect's Profile UI, enable Logto's
+# Account API and give Social identities `Edit` access. Linking uses the current
+# user's Account API token and may require an email verification code; unlinking
+# uses the CP-side LOGTO_MGMT_* app to preserve the last sign-in method.
+# For that ownership check, configure a Logto email connector with the
+# `UserPermissionValidation` template. The current Profile UI also requires the
+# account to have a verified primary email before it can send the code.
+# Also register `https://<console-origin>/auth/social/callback` directly with
+# every provider, alongside its Logto connector callback. Google and Slack accept
+# multiple redirect URLs. For GitHub, use a GitHub App (multiple callback URLs);
+# a GitHub OAuth App has only one callback URL.
 # NEXT_PUBLIC_LOGTO_ENDPOINT=https://tenant.example.com/
 # NEXT_PUBLIC_LOGTO_APP_ID=
 # Optional: the CP API resource registered in Logto, for a JWT access token. When

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 // Logto auth for the console (opt-in). When the Logto endpoint + app id are set,
-// "Continue with GitHub/Google" runs a real Authorization-Code + PKCE sign-in
+// "Continue with GitHub/Google/Slack" runs a real Authorization-Code + PKCE sign-in
 // against Logto and the console sends the resulting bearer token to the Control
 // Plane. When UNSET, auth is disabled and the app stays in the CP's zero-config
 // no-auth mode (the buttons just enter the app) — the default for OSS self-hosters.
@@ -9,7 +9,7 @@
 // at any tenant via plain container env — no rebuild. The NEXT_PUBLIC_* statics
 // remain a build-time fallback for local dev (.env.local) and SSR.
 //
-// The supported provider targets (Google/GitHub) are a shared static UI list;
+// The supported provider targets (GitHub/Google/Slack) are a shared static UI list;
 // their credentials and connectors remain configured inside Logto. The buttons
 // use Logto's `direct_sign_in` to jump straight to a connector.
 //


### PR DESCRIPTION
## Summary

- document GitHub, Google, and Slack as the shared sign-in provider set
- distinguish the Logto SPA login callback from the provider callback used by Profile account linking
- correct the Account API permission to `Social identities: Edit` and explain the separate link and unlink authorization paths
- document the email connector, `UserPermissionValidation` template, and verified-primary-email prerequisite for ownership checks
- recommend a GitHub App when multiple exact callback URLs are required

## Why

The environment example predated Slack account linking and still described read-only Account API access plus a GitHub OAuth App parent-URL workaround. Normal sign-in could therefore work while Profile linking remained misconfigured.

## Validation

- `git diff --check`
- `pnpm exec prettier --check packages/web/src/lib/auth.ts`
- pre-push `eslint .`
- cross-checked the documented callback paths and provider allowlists against the current implementation

Created by Codex . GPT-5.6
