### PR TITLE
fix(web): clean up pending daemon on Escape

### DIFF
--- a/packages/web/src/components/console/ModalProvider.test.tsx
+++ b/packages/web/src/components/console/ModalProvider.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  daemons: [] as Array<Record<string, unknown>>,
+  provisionDaemon: vi.fn(),
+  deleteDaemon: vi.fn(),
+  refresh: vi.fn()
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    daemons: mocks.daemons,
+    provisionDaemon: mocks.provisionDaemon,
+    deleteDaemon: mocks.deleteDaemon,
+    refresh: mocks.refresh
+  })
+}))
+
+import { ModalProvider, useModal } from './ModalProvider'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLDivElement
+
+function Harness() {
+  const { openModal } = useModal()
+  return (
+    <button type="button" onClick={() => openModal('daemon')}>
+      Add daemon
+    </button>
+  )
+}
+
+beforeEach(() => {
+  mocks.daemons = []
+  mocks.provisionDaemon.mockReset()
+  mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
+  mocks.refresh.mockReset()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('ModalProvider dismissal', () => {
+  it('routes Escape through daemon cancellation, including an in-flight provision', async () => {
+    let resolveProvision!: (value: { daemonId: string; command: string }) => void
+    mocks.provisionDaemon.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProvision = resolve
+      })
+    )
+
+    await act(async () =>
+      root.render(
+        <ModalProvider>
+          <Harness />
+        </ModalProvider>
+      )
+    )
+    await act(async () => host.querySelector<HTMLButtonElement>('button')?.click())
+
+    await act(async () => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })))
+    expect(host.textContent).toContain('Cancelling…')
+
+    await act(async () => {
+      resolveProvision({
+        daemonId: 'dmn_pending',
+        command: 'npx -y @agentconnect.md/daemon run --api-url https://example.test --api-key test'
+      })
+      await Promise.resolve()
+    })
+
+    expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_pending')
+    expect(host.textContent).not.toContain('Cancelling…')
+  })
+})

--- a/packages/web/src/components/console/ModalProvider.tsx
+++ b/packages/web/src/components/console/ModalProvider.tsx
@@ -6,7 +6,7 @@
 // via openModal's 2nd arg — a DaemonRow (reconnect / delete daemon) or an Agent
 // (add integration / delete / edit agent); the kind selects which the render casts it to.
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { Agent, DaemonRow, IntegrationRow } from '@/lib/data'
 import type { CronDto, HookDto } from '@/lib/api'
 import AddAgentModal from './modals/AddAgentModal'
@@ -66,24 +66,40 @@ const Ctx = createContext<ModalData | null>(null)
 
 export function ModalProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState<{ kind: ModalKind; target?: ModalTarget; opts?: ModalOpts } | null>(null)
-  const openModal = useCallback(
-    (kind: ModalKind, target?: ModalTarget, opts?: ModalOpts) => setOpen({ kind, target, opts }),
-    []
-  )
-  const close = useCallback(() => setOpen(null), [])
+  const dismissHandler = useRef<(() => void) | null>(null)
+  const openModal = useCallback((kind: ModalKind, target?: ModalTarget, opts?: ModalOpts) => {
+    dismissHandler.current = null
+    setOpen({ kind, target, opts })
+  }, [])
+  const close = useCallback(() => {
+    dismissHandler.current = null
+    setOpen(null)
+  }, [])
+  const requestClose = useCallback(() => {
+    const dismiss = dismissHandler.current
+    if (dismiss) dismiss()
+    else close()
+  }, [close])
+  const registerDismiss = useCallback((handler: () => void) => {
+    dismissHandler.current = handler
+    return () => {
+      if (dismissHandler.current === handler) dismissHandler.current = null
+    }
+  }, [])
 
   const value = useMemo<ModalData>(() => ({ openModal }), [openModal])
 
   // Dialogs hold in-progress form state, so a stray click on the scrim must not
-  // discard it — only Esc (or the explicit Cancel / ×) closes.
+  // discard it. Esc asks the active dialog to dismiss first, so dialogs that own
+  // cleanup can share the same path as their explicit Cancel button.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close()
+      if (e.key === 'Escape') requestClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open, close])
+  }, [open, requestClose])
 
   return (
     <Ctx.Provider value={value}>
@@ -109,6 +125,7 @@ export function ModalProvider({ children }: { children: ReactNode }) {
               <AddDaemonModal
                 onClose={close}
                 onDone={open.target ? () => openModal('editAgent', open.target, open.opts) : undefined}
+                registerDismiss={registerDismiss}
               />
             )}
             {open.kind === 'integration' && open.target && (

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -1,6 +1,6 @@
 // No 'use client' here: rendered only by ModalProvider (the client boundary).
 
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useConsoleData } from '@/lib/data-context'
 import type { DaemonConnectDto } from '@/lib/api'
 import { daemonCommands } from '@/lib/daemon-commands'
@@ -80,12 +80,21 @@ function CommandBox({ tabs, placeholder }: { tabs: CommandTab[]; placeholder: Re
 // `onDone` (optional) replaces plain close on the connected path's Done button —
 // ModalProvider uses it to chain back into the Edit-agent dialog when this modal
 // was opened from an unplaced agent's "Add daemon" affordance. Cancel never chains.
-export default function AddDaemonModal({ onClose, onDone }: { onClose: () => void; onDone?: () => void }) {
+export default function AddDaemonModal({
+  onClose,
+  onDone,
+  registerDismiss
+}: {
+  onClose: () => void
+  onDone?: () => void
+  registerDismiss: (handler: () => void) => () => void
+}) {
   const { provisionDaemon, daemons, refresh, deleteDaemon } = useConsoleData()
   const [connect, setConnect] = useState<DaemonConnectDto | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [cancelling, setCancelling] = useState(false)
   const provisioned = useRef(false)
+  const provisionPending = useRef<Promise<DaemonConnectDto> | null>(null)
 
   // Mint a daemon + its API key + start command once when the modal opens. The ref
   // guard dedupes StrictMode's double-invoke so only one key is minted; we
@@ -94,9 +103,9 @@ export default function AddDaemonModal({ onClose, onDone }: { onClose: () => voi
   useEffect(() => {
     if (provisioned.current) return
     provisioned.current = true
-    provisionDaemon()
-      .then(setConnect)
-      .catch((e) => setErr(e instanceof Error ? e.message : String(e)))
+    const pending = provisionDaemon()
+    provisionPending.current = pending
+    pending.then(setConnect).catch((e) => setErr(e instanceof Error ? e.message : String(e)))
   }, [provisionDaemon])
 
   // Onboarding writes the daemon row immediately (status `pending`), so presence
@@ -115,18 +124,21 @@ export default function AddDaemonModal({ onClose, onDone }: { onClose: () => voi
   // Bail out before the daemon connects: drop the provisioned-but-never-connected
   // row so it doesn't linger as an offline daemon in the fleet. Once it has
   // connected we keep it (that path shows Done instead of Cancel).
-  const cancel = async () => {
+  const cancel = useCallback(async () => {
     if (cancelling) return
     setCancelling(true)
-    if (connect && !connected) {
+    const pending = connect ?? (await provisionPending.current?.catch(() => null))
+    if (pending && !connected) {
       try {
-        await deleteDaemon(connect.daemonId)
+        await deleteDaemon(pending.daemonId)
       } catch {
         /* best-effort cleanup — an unclaimed provisioned row is harmless */
       }
     }
     onClose()
-  }
+  }, [cancelling, connect, connected, deleteDaemon, onClose])
+
+  useEffect(() => registerDismiss(() => void cancel()), [cancel, registerDismiss])
 
   return (
     <>


### PR DESCRIPTION
## Summary

- route Escape dismissal through the active modal's cleanup handler
- wait for an in-flight daemon provision and delete the unconnected row before closing
- cover immediate Escape cancellation with a focused regression test

## Root cause

`ModalProvider` handled Escape by clearing the modal state directly, bypassing `AddDaemonModal`'s cancel path. That left the newly provisioned pending daemon in the fleet. The cancel path also could not clean up when Escape was pressed before the provision response supplied the daemon ID.

## Impact

Closing Add daemon with Escape now has the same behavior as Cancel: an unconnected placeholder daemon is removed, while a connected daemon is preserved.

## Validation

- `pnpm exec vitest run src/components/console/ModalProvider.test.tsx`
- `pnpm typecheck`
- `pnpm exec eslint src/components/console/ModalProvider.tsx src/components/console/modals/AddDaemonModal.tsx src/components/console/ModalProvider.test.tsx`
- pre-push `eslint .`

Created by Codex . GPT-5
