### PR TITLE
feat(web): name and share a daemon while adding it

### DIFF
--- a/packages/web/src/components/console/ModalProvider.test.tsx
+++ b/packages/web/src/components/console/ModalProvider.test.tsx
@@ -14,11 +14,16 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     daemons: mocks.daemons,
+    members: [],
     provisionDaemon: mocks.provisionDaemon,
     deleteDaemon: mocks.deleteDaemon,
     refresh: mocks.refresh
   })
 }))
+
+// The dialog reads the signed-in user (it pins them in the visibility share set);
+// the real hook fetches /me on mount, which would reach for the CP from a unit test.
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: null, me: null }) }))
 
 import { ModalProvider, useModal } from './ModalProvider'
 

--- a/packages/web/src/components/console/ModalProvider.test.tsx
+++ b/packages/web/src/components/console/ModalProvider.test.tsx
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   daemons: [] as Array<Record<string, unknown>>,
   provisionDaemon: vi.fn(),
   deleteDaemon: vi.fn(),
+  renameDaemon: vi.fn(),
+  saveSharing: vi.fn(),
   refresh: vi.fn()
 }))
 
@@ -17,6 +19,8 @@ vi.mock('@/lib/data-context', () => ({
     members: [],
     provisionDaemon: mocks.provisionDaemon,
     deleteDaemon: mocks.deleteDaemon,
+    renameDaemon: mocks.renameDaemon,
+    saveSharing: mocks.saveSharing,
     refresh: mocks.refresh
   })
 }))
@@ -45,6 +49,8 @@ beforeEach(() => {
   mocks.daemons = []
   mocks.provisionDaemon.mockReset()
   mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
+  mocks.renameDaemon.mockReset().mockResolvedValue(undefined)
+  mocks.saveSharing.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
   host = document.createElement('div')
   document.body.appendChild(host)
@@ -87,5 +93,55 @@ describe('ModalProvider dismissal', () => {
 
     expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_pending')
     expect(host.textContent).not.toContain('Cancelling…')
+  })
+
+  // Once the daemon is connected, Done writes the optional name / visibility. Escape
+  // must not dismiss out from under that write: the dialog owes the operator either
+  // its error banner or the chained follow-up, and a dismissed dialog can deliver
+  // neither.
+  it('ignores Escape while the connected daemon’s name is being saved', async () => {
+    mocks.provisionDaemon.mockResolvedValue({
+      daemonId: 'dmn_live',
+      command: 'npx -y @agentconnect.md/daemon run --api-url https://example.test --api-key test'
+    })
+    mocks.daemons = [{ daemonId: 'dmn_live', name: 'edge-1', status: 'online' }]
+    let settleRename!: () => void
+    mocks.renameDaemon.mockReturnValue(
+      new Promise<void>((resolve) => {
+        settleRename = () => resolve()
+      })
+    )
+
+    await act(async () =>
+      root.render(
+        <ModalProvider>
+          <Harness />
+        </ModalProvider>
+      )
+    )
+    await act(async () => host.querySelector<HTMLButtonElement>('button')?.click())
+    expect(host.textContent).toContain('Daemon connected')
+
+    // Rename it, then commit — React tracks the input's value, so set it through the
+    // native setter and let the synthetic onChange see the new value.
+    const nameInput = host.querySelector('input')!
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!.call(nameInput, 'edge-2')
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const done = [...host.querySelectorAll('button')].find((b) => b.textContent === 'Done')!
+    await act(async () => done.click())
+    expect(mocks.renameDaemon).toHaveBeenCalledWith('dmn_live', 'edge-2')
+
+    await act(async () => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })))
+    expect(host.textContent).toContain('Saving…')
+    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
+
+    // Settling the write is what closes the dialog (the Harness trigger stays).
+    await act(async () => {
+      settleRename()
+      await Promise.resolve()
+    })
+    expect(host.textContent).not.toContain('Daemon connected')
   })
 })

--- a/packages/web/src/components/console/ModalProvider.test.tsx
+++ b/packages/web/src/components/console/ModalProvider.test.tsx
@@ -99,16 +99,18 @@ describe('ModalProvider dismissal', () => {
   // must not dismiss out from under that write: the dialog owes the operator either
   // its error banner or the chained follow-up, and a dismissed dialog can deliver
   // neither.
-  it('ignores Escape while the connected daemon’s name is being saved', async () => {
+  it('ignores Escape while the connected daemon’s name and visibility are being saved', async () => {
     mocks.provisionDaemon.mockResolvedValue({
       daemonId: 'dmn_live',
       command: 'npx -y @agentconnect.md/daemon run --api-url https://example.test --api-key test'
     })
     mocks.daemons = [{ daemonId: 'dmn_live', name: 'edge-1', status: 'online' }]
-    let settleRename!: () => void
-    mocks.renameDaemon.mockReturnValue(
+    // Defer the SECOND write, so the dialog is mid-save with one request already
+    // settled — the state a dismissal used to tear down.
+    let settleSharing!: () => void
+    mocks.saveSharing.mockReturnValue(
       new Promise<void>((resolve) => {
-        settleRename = () => resolve()
+        settleSharing = () => resolve()
       })
     )
 
@@ -122,16 +124,19 @@ describe('ModalProvider dismissal', () => {
     await act(async () => host.querySelector<HTMLButtonElement>('button')?.click())
     expect(host.textContent).toContain('Daemon connected')
 
-    // Rename it, then commit — React tracks the input's value, so set it through the
-    // native setter and let the synthetic onChange see the new value.
+    // Rename it — React tracks the input's value, so set it through the native
+    // setter and let the synthetic onChange see the new value.
     const nameInput = host.querySelector('input')!
     await act(async () => {
       Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!.call(nameInput, 'edge-2')
       nameInput.dispatchEvent(new Event('input', { bubbles: true }))
     })
+    // …and restrict it, so Done issues both writes.
+    await act(async () => host.querySelectorAll<HTMLElement>('.ptile')[1]?.click())
     const done = [...host.querySelectorAll('button')].find((b) => b.textContent === 'Done')!
     await act(async () => done.click())
     expect(mocks.renameDaemon).toHaveBeenCalledWith('dmn_live', 'edge-2')
+    expect(mocks.saveSharing).toHaveBeenCalledWith('daemons', 'dmn_live', { visibility: 'restricted', sharedWith: [] })
 
     await act(async () => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })))
     expect(host.textContent).toContain('Saving…')
@@ -139,7 +144,7 @@ describe('ModalProvider dismissal', () => {
 
     // Settling the write is what closes the dialog (the Harness trigger stays).
     await act(async () => {
-      settleRename()
+      settleSharing()
       await Promise.resolve()
     })
     expect(host.textContent).not.toContain('Daemon connected')

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -108,6 +108,9 @@ export default function AddDaemonModal({
   const [saveErr, setSaveErr] = useState<string | null>(null)
   const provisioned = useRef(false)
   const provisionPending = useRef<Promise<DaemonConnectDto> | null>(null)
+  // Set the moment a dismissal is honoured, so an in-flight save can't act on a
+  // dialog the operator has already left.
+  const dismissed = useRef(false)
 
   // Mint a daemon + its API key + start command once when the modal opens. The ref
   // guard dedupes StrictMode's double-invoke so only one key is minted; we
@@ -138,8 +141,13 @@ export default function AddDaemonModal({
   // row so it doesn't linger as an offline daemon in the fleet. Once it has
   // connected we keep it (that path shows Done instead of Cancel).
   const cancel = useCallback(async () => {
-    if (cancelling) return
+    // Mid-save the write owns the dialog: dismissing now would strand the error
+    // banner a failure needs to render, and let a success chain into Edit agent
+    // after the operator asked to leave. The save settles in a moment and closes
+    // (or reports) on its own, so Escape is a no-op until then.
+    if (cancelling || saving) return
     setCancelling(true)
+    dismissed.current = true
     const pending = connect ?? (await provisionPending.current?.catch(() => null))
     if (pending && !connected) {
       try {
@@ -149,7 +157,7 @@ export default function AddDaemonModal({
       }
     }
     onClose()
-  }, [cancelling, connect, connected, deleteDaemon, onClose])
+  }, [cancelling, saving, connect, connected, deleteDaemon, onClose])
 
   useEffect(() => registerDismiss(() => void cancel()), [cancel, registerDismiss])
 
@@ -165,8 +173,14 @@ export default function AddDaemonModal({
       const next = name.trim()
       if (next && next !== row?.name) await renameDaemon(connect.daemonId, next)
       if (!sameSharing(sharing, DEFAULT_SHARING)) await saveSharing('daemons', connect.daemonId, sharing)
+      // A dialog dismissed while this was in flight must stay dismissed — closing
+      // again is harmless, but chaining into Edit agent would reopen a surface the
+      // operator already left. (`cancel` fences on `saving`, so this only catches a
+      // dismissal that raced the flag; the guard makes the ordering irrelevant.)
+      if (dismissed.current) return
       ;(onDone ?? onClose)()
     } catch (e) {
+      if (dismissed.current) return
       setSaveErr(e instanceof Error ? e.message : String(e))
       setSaving(false)
     }

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -2,10 +2,16 @@
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useConsoleData } from '@/lib/data-context'
+import { useProfile } from '@/lib/profile'
 import type { DaemonConnectDto } from '@/lib/api'
 import { daemonCommands } from '@/lib/daemon-commands'
 import { Button, Icon } from '@/components/ui'
 import { Spinner } from '@/components/marks'
+import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
+
+/** What the CP already gave the provisioned row — skip the /sharing write when the
+ *  operator leaves it alone. */
+const DEFAULT_SHARING: SharingValue = { visibility: 'org', sharedWith: [] }
 
 interface CommandTab {
   key: string
@@ -89,10 +95,17 @@ export default function AddDaemonModal({
   onDone?: () => void
   registerDismiss: (handler: () => void) => () => void
 }) {
-  const { provisionDaemon, daemons, refresh, deleteDaemon } = useConsoleData()
+  const { provisionDaemon, daemons, refresh, deleteDaemon, renameDaemon, saveSharing } = useConsoleData()
+  const { me } = useProfile()
   const [connect, setConnect] = useState<DaemonConnectDto | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [cancelling, setCancelling] = useState(false)
+  // Optional overrides applied on Done: an empty name keeps the daemon's own
+  // reported one, and the default sharing skips the /sharing write entirely.
+  const [name, setName] = useState('')
+  const [sharing, setSharing] = useState<SharingValue>(DEFAULT_SHARING)
+  const [saving, setSaving] = useState(false)
+  const [saveErr, setSaveErr] = useState<string | null>(null)
   const provisioned = useRef(false)
   const provisionPending = useRef<Promise<DaemonConnectDto> | null>(null)
 
@@ -139,6 +152,25 @@ export default function AddDaemonModal({
   }, [cancelling, connect, connected, deleteDaemon, onClose])
 
   useEffect(() => registerDismiss(() => void cancel()), [cancel, registerDismiss])
+
+  // Finish: apply the optional name + visibility to the row the daemon just claimed,
+  // then close (or chain on). Both writes are skipped when untouched, so the plain
+  // "connect and go" path stays a single click. A failure keeps the dialog open —
+  // the daemon IS connected either way, so nothing here is worth rolling back.
+  const finish = async () => {
+    if (saving || !connect) return
+    setSaving(true)
+    setSaveErr(null)
+    try {
+      const next = name.trim()
+      if (next && next !== row?.name) await renameDaemon(connect.daemonId, next)
+      if (!sameSharing(sharing, DEFAULT_SHARING)) await saveSharing('daemons', connect.daemonId, sharing)
+      ;(onDone ?? onClose)()
+    } catch (e) {
+      setSaveErr(e instanceof Error ? e.message : String(e))
+      setSaving(false)
+    }
+  }
 
   return (
     <>
@@ -190,6 +222,33 @@ export default function AddDaemonModal({
             </>
           )}
         </div>
+        {/* Both are optional overrides on the row the daemon claims: leave the name
+            blank to keep the one it reports (the placeholder, once it has connected),
+            and the visibility on Everyone to keep the org-wide default. Written on
+            Done (see `finish`). */}
+        <div className="fld mt-[14px]">
+          <span className="fldlbl">
+            Name <span className="font-normal text-(--text-tertiary)">· optional</span>
+          </span>
+          <input
+            className="inp"
+            value={name}
+            maxLength={64}
+            spellCheck={false}
+            placeholder={(connected && row?.name) || 'edge-1'}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && connected) void finish()
+            }}
+          />
+        </div>
+        <VisibilityField value={sharing} onChange={setSharing} creatorUserId={me?.userId} />
+        {saveErr && (
+          <div className="mt-[14px] flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[11px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--status-error)">
+            <Icon name="triangle-alert" size={15} />
+            {saveErr}
+          </div>
+        )}
       </div>
       <div className="modalfoot">
         <span className="mono text-[11px] text-(--text-tertiary)">
@@ -197,8 +256,12 @@ export default function AddDaemonModal({
         </span>
         <div className="flex-1" />
         {connected ? (
-          <Button variant="primary" onClick={onDone ?? onClose}>
-            {onDone ? 'Continue' : 'Done'}
+          <Button
+            variant="primary"
+            onClick={() => void finish()}
+            className={saving ? 'cursor-default opacity-60' : undefined}
+          >
+            {saving ? 'Saving…' : onDone ? 'Continue' : 'Done'}
           </Button>
         ) : (
           // Can't finish until the daemon connects — offer a Cancel that cleans up


### PR DESCRIPTION
## What

The Add-daemon dialog now carries two optional controls under the connect
command, applied on **Done** to the row the daemon just claimed:

- **Name · optional** — the standard `.fld`/`.inp` field. Leave it blank to keep
  the name the daemon reports; once it connects, that reported name becomes the
  placeholder, so the field reads as an override.
- **Visibility** — the shared `VisibilityField` (Everyone / Selected + member
  picker, creator pinned), the same control Add/Edit agent, Edit daemon, and Add
  cron already use. Mobile gets its pill variant for free.

## Why

Onboarding handed you a command and nothing else: a fresh daemon kept its
hostname-seeded name and the org-wide default until you found it in the fleet
and opened Edit. Naming it and restricting it belong to the moment you add it.

## Notes for review

- Both writes (`PATCH /daemons/:id`, then `PUT /daemons/:id/sharing`) are skipped
  when untouched — connect-and-go stays one click with zero extra requests.
- A failed write keeps the dialog open and shows the standard error banner; there
  is nothing to roll back, since the daemon is connected either way.
- Cancel-before-connect still deletes the unclaimed provisioned row, unchanged.
- The fields render while the dialog is still waiting for the daemon rather than
  appearing on connect — no layout jump, and you can fill them in while the
  install runs. Easy to gate on `connected` if reviewers prefer that.
- No CP changes: both endpoints already exist and are gated by `canEdit` /
  `canManageSharing`.

## Verification

Local stack (scratch Postgres + CP + a daemon run from source): the dialog moved
to "Daemon connected", entering a name plus **Selected** and pressing Done
persisted `name` + `visibility=restricted` on the CP, and the fleet card
re-rendered with the new name and the restricted lock. Also checked the mobile
bottom-sheet layout and that Cancel still cleans up. `typecheck`, eslint,
prettier, and the 478 web unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)