### PR TITLE
fix(web): label shared visibility as Everyone

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -13,6 +13,10 @@ empty states, toasts, or error messages. Rewrite the copy around what the user c
 needs to know; if an implementation detail does not change either, omit it. Technical
 component names belong in logs, developer tooling, and architecture documentation.
 
+Visibility controls use audience language: show **Everyone** for the internal `org`
+value, never **Org** or "org-visible". Keep **Organization** only when the copy is
+actually about organization management, membership, or ownership.
+
 ## Planned daemon lifecycle status
 
 A pending daemon upgrade or restart is a planned transition, not an unexpected outage.

--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
 
 /**
- * The confirmation copy is the product promise (docs/product-conventions.md).
- * An agent on native runtime memory has no per-session capture gate, so the
- * dialog must NOT tell that user their conversation stops feeding shared memory.
+ * The audience label and confirmation copy are product promises
+ * (docs/product-conventions.md). An agent on native runtime memory has no
+ * per-session capture gate, so the dialog must NOT tell that user their
+ * conversation stops feeding shared memory.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -44,6 +45,9 @@ async function openTightenDialog(nativeMemory: boolean): Promise<string> {
       />
     )
   })
+  const everyone = [...container.querySelectorAll('button')].find((button) => button.textContent === 'Everyone')
+  expect(everyone?.title).toBe('Visible to everyone who can view the agent')
+  expect(container.textContent).not.toContain('Org')
   const privateButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('Private'))
   await act(async () => privateButton?.click())
   return document.body.textContent ?? ''

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -111,7 +111,7 @@ export function SessionVisibilityControl({
   return (
     <span className="inline-flex items-center gap-[6px]">
       <span className="inline-flex overflow-hidden rounded-full border border-(--border-default)">
-        {segment('org', 'globe', 'Org', 'Visible to every member who can view the agent')}
+        {segment('org', 'globe', 'Everyone', 'Visible to everyone who can view the agent')}
         {segment('private', 'lock', 'Private', SESSION_PRIVATE_TITLE)}
       </span>
       {state === 'pending' && (
@@ -154,7 +154,8 @@ export function SessionVisibilityControl({
           ) : (
             <>
               Making this session private stops it from feeding shared agent memory once the daemon confirms, and hides
-              the transcript immediately. Anything the agent already learned while it was org-visible is not removed.
+              the transcript immediately. Anything the agent already learned while it was visible to everyone is not
+              removed.
             </>
           )}
         </ConfirmationDialog>

--- a/packages/web/src/components/console/VisibilityField.tsx
+++ b/packages/web/src/components/console/VisibilityField.tsx
@@ -138,7 +138,7 @@ function VisibilityTiles({ restricted, onPick }: { restricted: boolean; onPick: 
   }
   return (
     <div className="grid grid-cols-1 gap-[10px] desktop:grid-cols-2">
-      {tile('org', 'globe', 'Everyone', 'Everyone in your org can see it.')}
+      {tile('org', 'globe', 'Everyone', 'All members can see it.')}
       {tile('restricted', 'lock', 'Selected', 'Only people you choose.')}
     </div>
   )
@@ -272,8 +272,8 @@ function ShareWithList({
           <div className="flex items-start gap-[7px] border-t border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
             <Icon name="info" size={13} className="mt-[2px] flex-none" />
             <span>
-              The creator (pinned above) always has access — you can’t remove them. Org owners can always see restricted
-              resources too.
+              The creator (pinned above) always has access — you can’t remove them. Organization owners can always see
+              restricted resources too.
             </span>
           </div>
         </>
@@ -366,7 +366,8 @@ function ShareWithPills({
       <div className="mt-[10px] flex items-start gap-[6px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
         <Icon name="info" size={13} className="mt-[2px] flex-none" />
         <span>
-          The creator always has access — you can’t remove them. Org owners can always see restricted resources too.
+          The creator always has access — you can’t remove them. Organization owners can always see restricted resources
+          too.
         </span>
       </div>
     </>
@@ -404,7 +405,7 @@ export function VisibilityValue({
   // The chips are the EXPLICIT grant (creator + share set). Org owners can always see
   // a restricted resource on top of that (governance override — the same thing the
   // share editor spells out), so name it here too rather than implying exclusivity.
-  const ownerNote = 'Org owners can always see restricted resources too.'
+  const ownerNote = 'Organization owners can always see restricted resources too.'
   const title = resolved.length > 0 ? `${resolved.map(memberDisplayName).join(', ')} — ${ownerNote}` : ownerNote
   return (
     <span className="inline-flex items-center gap-2" title={title}>


### PR DESCRIPTION
## Summary

- Rename the shared session visibility label from `Org` to `Everyone`.
- Align visibility helper and owner copy with audience-focused language.
- Document the convention while retaining the internal `org` wire and database value.

## Why

The UI exposed the internal `org` enum as an audience label even though it means every eligible member. That was inconsistent with the existing `Everyone` terminology used by other visibility controls.

## Validation

- `pnpm --filter @agentconnect.md/web test` (68 files, 479 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- Focused ESLint and Prettier checks

Created by Codex . gpt-5.6-sol
