### PR TITLE
fix(web): hide agent info on agent-detail sessions, fit Home Recent to right column

### DIFF
--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -5,27 +5,30 @@
 // name, platform mark + channel, relative time. The small Card/CardLink/EmptyRow
 // primitives live here too — HomeView's other cards reuse them.
 
-import { type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode, type Ref } from 'react'
 import Link from 'next/link'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
 import { sessionPlatform, type Session } from '@/lib/data'
+import { useIsMobile } from '@/lib/use-is-mobile'
 
 export function Card({
   title,
   action,
   className,
-  children
+  children,
+  ref
 }: {
   title: string
   action?: ReactNode
   className?: string
   children: ReactNode
+  ref?: Ref<HTMLDivElement>
 }) {
   return (
-    <div className={`card overflow-hidden ${className ?? ''}`}>
+    <div ref={ref} className={`card overflow-hidden ${className ?? ''}`}>
       <div className="cardhead justify-between">
         <span className="cardtitle">{title}</span>
         {action}
@@ -83,7 +86,9 @@ export function RecentSessionsCard({
   allHref,
   emptyText,
   limit = 6,
-  className
+  className,
+  showAgent = true,
+  fillHeight = false
 }: {
   title?: string
   sessions: Session[]
@@ -92,45 +97,86 @@ export function RecentSessionsCard({
   emptyText: ReactNode
   limit?: number
   className?: string
+  /** Agent detail already scopes to one agent — hide the redundant icon+name there. */
+  showAgent?: boolean
+  /** Card height is set externally (Home: match the right column) — round the fitted row count UP and let the body scroll. */
+  fillHeight?: boolean
 }) {
   const { orgPath } = useOrgs()
   const { getAgent } = useConsoleData()
-  const recent = sessions.slice(0, limit)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const [fit, setFit] = useState<number | null>(null)
+  // Mobile stacks the card in normal flow, so its height is its own content —
+  // measuring there would feed back into itself. Fit rows on desktop only.
+  const isMobile = useIsMobile()
+  const canFill = fillHeight && !isMobile
+  useEffect(() => {
+    if (!canFill) return
+    const el = cardRef.current
+    const body = bodyRef.current
+    if (!el || !body) return
+    const measure = () => {
+      const row = body.querySelector<HTMLElement>('a.row')
+      if (!row || row.offsetHeight === 0) return
+      setFit(Math.max(1, Math.ceil(body.clientHeight / row.offsetHeight)))
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [canFill, sessions.length])
+  const recent = sessions.slice(0, canFill && fit !== null ? fit : limit)
   return (
-    <Card title={title} action={<CardLink href={allHref}>All sessions</CardLink>} className={className}>
-      {loading && recent.length === 0 ? (
-        Array.from({ length: 4 }, (_, i) => <SessionRowSkeleton key={i} i={i} />)
-      ) : recent.length === 0 ? (
-        <EmptyRow>{emptyText}</EmptyRow>
-      ) : (
-        recent.map((s) => {
-          const owner = s.agentId ? getAgent(s.agentId) : undefined
-          return (
-            <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
-              <span className="min-w-0">
-                <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
-                  {s.title}
-                </span>
-                <span className="mt-[3px] flex items-center gap-[6px] text-(--text-tertiary)">
-                  <span className="av h-[15px] w-[15px] rounded-xs">
-                    <AgentIconView icon={owner?.icon} runtime={owner?.runtime ?? s.runtime ?? 'claude'} size={15} />
+    <Card
+      ref={cardRef}
+      title={title}
+      action={<CardLink href={allHref}>All sessions</CardLink>}
+      className={`${fillHeight ? 'desktop:flex desktop:flex-col' : ''} ${className ?? ''}`}
+    >
+      <div ref={bodyRef} className={fillHeight ? 'desktop:min-h-0 desktop:flex-1 desktop:overflow-y-auto' : undefined}>
+        {loading && recent.length === 0 ? (
+          Array.from({ length: 4 }, (_, i) => <SessionRowSkeleton key={i} i={i} />)
+        ) : recent.length === 0 ? (
+          <EmptyRow>{emptyText}</EmptyRow>
+        ) : (
+          recent.map((s) => {
+            const owner = s.agentId ? getAgent(s.agentId) : undefined
+            return (
+              <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
+                <span className="min-w-0">
+                  <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                    {s.title}
                   </span>
-                  <span className="truncate font-sans text-[11.5px] leading-normal">{s.agentName || '—'}</span>
-                  {s.channel && (
-                    <>
-                      <span className="imark h-4 w-4 rounded-xs">
-                        <PlatformMark platform={sessionPlatform(s)} fillPct={90} />
-                      </span>
-                      <span className="mono truncate text-[11px]">{s.channel}</span>
-                    </>
-                  )}
+                  <span className="mt-[3px] flex items-center gap-[6px] text-(--text-tertiary)">
+                    {showAgent && (
+                      <>
+                        <span className="av h-[15px] w-[15px] rounded-xs">
+                          <AgentIconView
+                            icon={owner?.icon}
+                            runtime={owner?.runtime ?? s.runtime ?? 'claude'}
+                            size={15}
+                          />
+                        </span>
+                        <span className="truncate font-sans text-[11.5px] leading-normal">{s.agentName || '—'}</span>
+                      </>
+                    )}
+                    {s.channel && (
+                      <>
+                        <span className="imark h-4 w-4 rounded-xs">
+                          <PlatformMark platform={sessionPlatform(s)} fillPct={90} />
+                        </span>
+                        <span className="mono truncate text-[11px]">{s.channel}</span>
+                      </>
+                    )}
+                  </span>
                 </span>
-              </span>
-              <span className="mono self-start whitespace-nowrap text-[11.5px] text-(--text-tertiary)">{s.time}</span>
-            </Link>
-          )
-        })
-      )}
+                <span className="mono self-start whitespace-nowrap text-[11.5px] text-(--text-tertiary)">{s.time}</span>
+              </Link>
+            )
+          })
+        )}
+      </div>
     </Card>
   )
 }

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1521,6 +1521,7 @@ export default function AgentDetailView() {
             loading={agentSessionsLoading}
             allHref={orgPath(`/sessions?agent=${da.id}`)}
             emptyText="No sessions yet."
+            showAgent={false}
             className="max-desktop:rounded-lg"
           />
         </div>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -370,12 +370,19 @@ export default function HomeView() {
 
       {/* Dashboard grid. */}
       <div className="grid grid-cols-1 gap-4 desktop:grid-cols-[1.5fr_1fr]">
-        <RecentSessionsCard
-          sessions={allSessions}
-          loading={loading}
-          allHref={orgPath('/sessions')}
-          emptyText="No sessions yet — ask an agent above to start one."
-        />
+        {/* On desktop the right column dictates the row height: the card is
+            absolutely positioned (so it never stretches the row itself) and
+            fillHeight fits as many whole session rows as that height allows. */}
+        <div className="desktop:relative">
+          <RecentSessionsCard
+            sessions={allSessions}
+            loading={loading}
+            allHref={orgPath('/sessions')}
+            emptyText="No sessions yet — ask an agent above to start one."
+            fillHeight
+            className="desktop:absolute desktop:inset-0"
+          />
+        </div>
 
         <div className="flex flex-col gap-4">
           <Card title="Agents you use" action={<CardLink href={orgPath('/agents')}>All agents</CardLink>}>


### PR DESCRIPTION
## What changed

**RecentSessionsCard** (shared by Home and Agent detail):
- New `showAgent` prop — Agent detail's "Recent sessions" card no longer repeats the agent icon + name on every row (the page is already scoped to that one agent); rows keep title, platform/channel, and time.
- New `fillHeight` mode — when the card's height is set externally, it measures the body with a `ResizeObserver`, rounds the fitted row count **up** (`Math.ceil`), and lets the row list scroll (`overflow-y-auto`) so the last partial row is reachable instead of leaving dead space.

**HomeView**:
- The dashboard grid's row height is now dictated by the right column (Agents you use / Scheduled runs); the Recent card is absolutely positioned inside its cell (`desktop:relative` wrapper + `desktop:absolute inset-0`) so it always matches that height exactly and fills it with rows.

## Why

On Home, the Recent card was fixed at 6 rows regardless of how tall the right column was, leaving uneven whitespace. On Agent detail, every session row redundantly showed the same agent's icon and name.

## Notes for reviewers

- All fill/scroll behavior is desktop-only (`desktop:` variants + a `useIsMobile()` guard) — mobile keeps the normal-flow, limit-capped list. Measuring on mobile would feed back into the card's own height.
- Session pages fetch 50 rows, so the ceil'd fit always has data to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)