### PR TITLE
fix(web): four fixes to the Profile sign-in methods card

### DIFF
--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -450,7 +450,11 @@ function summarize(
   const raw = (details.rawData ?? {}) as Record<string, unknown>
   const name = firstString(details.name)
   const email = firstString(details.email)
-  const avatar = firstString(details.avatar)
+  // Not every connector fills the normalized `avatar`: Logto stores it for
+  // github and google but not for slack, whose picture survives only as the
+  // `picture` claim inside the raw payload. Falling back to it costs nothing
+  // and is what any OIDC connector carries.
+  const avatar = firstString(details.avatar, raw.picture)
   const profileUrl = providerProfileUrl(target, raw, slack)
   const workspace = slack
     ? {

--- a/packages/control-plane/src/github/slack-identity.test.ts
+++ b/packages/control-plane/src/github/slack-identity.test.ts
@@ -51,7 +51,10 @@ const SLACK_RAW = {
   'https://slack.com/team_name': 'Example Workspace',
   'https://slack.com/team_domain': 'example-workspace',
   email: 'dev@example.test',
-  email_verified: true
+  email_verified: true,
+  // Slack's avatar reaches us only here: Logto fills the normalized `avatar`
+  // for github and google, but leaves it unset for slack.
+  picture: 'https://avatars.example.test/u0example1.png'
 }
 
 describe('LogtoIdentityService.slackIdentityFor', () => {
@@ -243,6 +246,25 @@ describe('LogtoIdentityService.socialAccountFor', () => {
       identities: [],
       hasSecurityVerificationMethod: false
     })
+  })
+})
+
+describe('LogtoIdentityService.socialAccountFor avatars', () => {
+  it('falls back to the raw picture claim when the connector fills no avatar', async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': {
+        identities: {
+          slack: slackUser(SLACK_RAW).identities.slack,
+          github: { userId: 'g', details: { avatar: 'https://avatars.example.test/gh.png' } }
+        }
+      }
+    })
+    const byTarget = Object.fromEntries(
+      (await svcOf(fetchImpl).socialAccountFor('sub-1')).identities.map((i) => [i.target, i.avatar])
+    )
+    expect(byTarget.slack).toBe('https://avatars.example.test/u0example1.png')
+    // The normalized field still wins where a connector does provide it.
+    expect(byTarget.github).toBe('https://avatars.example.test/gh.png')
   })
 })
 

--- a/packages/web/src/app/auth/social/callback/page.tsx
+++ b/packages/web/src/app/auth/social/callback/page.tsx
@@ -8,8 +8,7 @@ import {
   accountErrorMessage,
   saveSocialIdentity,
   takeSocialLinkFlow,
-  verifySocialVerification,
-  writeAccountNotice
+  verifySocialVerification
 } from '@/lib/logto-account'
 
 export default function SocialAccountCallback() {
@@ -51,13 +50,9 @@ export default function SocialAccountCallback() {
       // Best-effort: the link already succeeded, so a failure here must not be
       // reported as one. It only costs a stale row until the cache expires.
       .then(() => refreshMySocialIdentities().catch(() => undefined))
-      .then(() => {
-        writeAccountNotice({
-          kind: 'success',
-          message: `${flow.providerName} was linked.`
-        })
-        window.location.replace(flow.returnTo)
-      })
+      // Straight back to Profile: the row now shows the linked account, which
+      // says it better than a banner that outlives the action.
+      .then(() => window.location.replace(flow.returnTo))
       .catch((caught) => {
         setError(accountErrorMessage(caught, { providerName: flow.providerName, linking: true }))
       })

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -247,9 +247,7 @@ function ExternalLine({ href, mono = false, children }: { href?: string; mono?: 
 function Notice({ notice }: { notice: AccountNotice }) {
   return (
     <div
-      className={`border-b border-(--border-subtle) px-4 py-2.5 font-sans text-[12.5px] font-normal leading-normal ${
-        notice.kind === 'success' ? 'text-(--status-online)' : 'text-(--status-error)'
-      }`}
+      className="border-b border-(--border-subtle) px-4 py-2.5 font-sans text-[12.5px] font-normal leading-normal text-(--status-error)"
       role="status"
     >
       {notice.message}
@@ -321,7 +319,6 @@ export default function SocialSignInCard({
       window.location.assign(authorizationUri)
     } catch (caught) {
       onNotice({
-        kind: 'error',
         message: accountErrorMessage(caught, { providerName: provider.name, linking: true })
       })
       setBusyProvider(undefined)
@@ -332,7 +329,6 @@ export default function SocialSignInCard({
     await unlinkMySocialIdentity(provider.target)
     await mutate()
     setPendingUnlink(undefined)
-    onNotice({ kind: 'success', message: `${provider.name} was unlinked.` })
   }
 
   const shell = mobile

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -186,21 +186,24 @@ function VerifyAccountDialog({
               : `To protect your account, verify it's you with a code sent to ${email ?? 'your email'}.`}
           </p>
           {verificationId ? (
-            <label className="fld mt-4">
-              <span className="fldlbl">Verification code</span>
+            // A short code, not prose: centred, spaced and monospaced so the
+            // digits read as a group. `.inp` is the wrong shape here — it spans
+            // the dialog for a handful of characters, and it defines no focus
+            // style, so it falls back to the browser's own ring.
+            <div className="mt-4 flex justify-center">
               <input
-                className="inp"
+                aria-label="Verification code"
+                className="w-[190px] rounded-lg border border-(--border-default) bg-(--surface-card) px-3 py-2.5 text-center indent-[0.32em] font-mono text-[19px] font-medium tracking-[0.32em] text-(--text-primary) outline-none transition-[border-color,box-shadow] focus:border-(--brand) focus:shadow-[0_0_0_3px_var(--brand-soft)]"
                 value={code}
                 inputMode="numeric"
                 autoComplete="one-time-code"
                 autoFocus
-                placeholder="Enter code"
                 onChange={(event) => setCode(event.target.value)}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter') void submit()
                 }}
               />
-            </label>
+            </div>
           ) : null}
           {error ? (
             <div className="mt-3 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)" role="alert">

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -193,7 +193,7 @@ function VerifyAccountDialog({
             <div className="mt-4 flex justify-center">
               <input
                 aria-label="Verification code"
-                className="w-[190px] rounded-lg border border-(--border-default) bg-(--surface-card) px-3 py-2.5 text-center indent-[0.32em] font-mono text-[19px] font-medium tracking-[0.32em] text-(--text-primary) outline-none transition-[border-color,box-shadow] focus:border-(--brand) focus:shadow-[0_0_0_3px_var(--brand-soft)]"
+                className="w-[190px] rounded-lg border border-(--border-default) bg-(--surface-card) px-3 py-2.5 text-center indent-[0.32em] font-mono text-[19px] font-medium tracking-[0.32em] text-(--text-primary) outline-none focus:border-(--border-focus) focus:ring-[3px] focus:ring-(--brand-ring)"
                 value={code}
                 inputMode="numeric"
                 autoComplete="one-time-code"

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -8,7 +8,7 @@
 // the two must agree). Personal access tokens and "last active" have no backend
 // yet: they render the design's demo values only in mock mode, otherwise empty / '—'.
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
@@ -22,7 +22,7 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { useOrgs } from '@/lib/org-context'
 import { fmtDate, ROLE_LABELS } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
-import { takeAccountNotice, type AccountNotice } from '@/lib/logto-account'
+import { type AccountNotice } from '@/lib/logto-account'
 
 function KvRow({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -46,7 +46,6 @@ export default function ProfileView() {
   // ProfileView survives its desktop-first hydration switch to the mobile tree,
   // so it owns the one-shot callback notice instead of either short-lived card.
   const [socialNotice, setSocialNotice] = useState<AccountNotice>()
-  useEffect(() => setSocialNotice(takeAccountNotice()), [])
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
   // With no match (mock mode / CP down) the fields fall back to the design's

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -44,7 +44,7 @@ export default function ProfileView() {
   const { user, me: meProfile } = useProfile()
   const authOn = isAuthConfigured()
   // ProfileView survives its desktop-first hydration switch to the mobile tree,
-  // so it owns the one-shot callback notice instead of either short-lived card.
+  // so it holds the card's failure notice instead of either short-lived card.
   const [socialNotice, setSocialNotice] = useState<AccountNotice>()
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.

--- a/packages/web/src/lib/logto-account.test.ts
+++ b/packages/web/src/lib/logto-account.test.ts
@@ -53,4 +53,18 @@ describe('Logto Account API', () => {
       })
     ).toBe('That Google account is already linked to another AgentConnect account.')
   })
+
+  // Measured against a live tenant: a session opened before the deployment
+  // granted the identities scope keeps working everywhere else, so "expired"
+  // sends people to retry the same broken thing. Only a fresh sign-in helps.
+  it('tells a scope-stale session to sign out rather than calling it expired', async () => {
+    const { LogtoAccountError, accountErrorMessage } = await import('./logto-account')
+    const unauthorized = new LogtoAccountError('unauthorized', 401)
+
+    expect(accountErrorMessage(unauthorized, { providerName: 'Google', linking: true })).toBe(
+      'This sign-in session cannot change sign-in methods. Sign out, sign in again, and retry.'
+    )
+    // Outside linking a 401 really is a dead session.
+    expect(accountErrorMessage(unauthorized)).toBe('Your sign-in session expired. Sign in again and retry.')
+  })
 })

--- a/packages/web/src/lib/logto-account.ts
+++ b/packages/web/src/lib/logto-account.ts
@@ -18,13 +18,13 @@ export interface SocialLinkFlow {
   createdAt: number
 }
 
+/** Something the user has to be told, which is only ever a failure: the card
+ *  renders the linked accounts, so a success needs no words. */
 export interface AccountNotice {
-  kind: 'success' | 'error'
   message: string
 }
 
 const SOCIAL_FLOW_KEY = 'ac.social-link.flow'
-const ACCOUNT_NOTICE_KEY = 'ac.social-link.notice'
 const SOCIAL_FLOW_TTL_MS = 10 * 60 * 1000
 
 export class LogtoAccountError extends Error {
@@ -194,29 +194,6 @@ export function takeSocialLinkFlow(): SocialLinkFlow | undefined {
   }
 }
 
-export function writeAccountNotice(notice: AccountNotice): void {
-  try {
-    sessionStorage.setItem(ACCOUNT_NOTICE_KEY, JSON.stringify(notice))
-  } catch {
-    // The profile refresh still shows the new identity; the notice is optional.
-  }
-}
-
-export function takeAccountNotice(): AccountNotice | undefined {
-  try {
-    const value = sessionStorage.getItem(ACCOUNT_NOTICE_KEY)
-    sessionStorage.removeItem(ACCOUNT_NOTICE_KEY)
-    if (!value) return undefined
-    const notice = asRecord(JSON.parse(value))
-    if ((notice.kind !== 'success' && notice.kind !== 'error') || typeof notice.message !== 'string') {
-      return undefined
-    }
-    return notice as unknown as AccountNotice
-  } catch {
-    return undefined
-  }
-}
-
 export function accountErrorMessage(error: unknown, context?: { providerName?: string; linking?: boolean }): string {
   const requestError =
     error instanceof LogtoAccountError ||
@@ -236,6 +213,13 @@ export function accountErrorMessage(error: unknown, context?: { providerName?: s
   // session — saying "sign in again" sent us chasing the wrong thing once.
   if (requestError.status === 403 && context?.linking) {
     return 'Verifying your account timed out. Return to Profile and start again.'
+  }
+  // A 401 on the link path is usually not an expired session: the identity
+  // endpoints are scope-gated, and a session opened before the deployment
+  // granted that scope keeps working everywhere else while these calls refuse.
+  // Only a fresh sign-in re-issues the token, so say that rather than "expired".
+  if (requestError.status === 401 && context?.linking) {
+    return 'This sign-in session cannot change sign-in methods. Sign out, sign in again, and retry.'
   }
   if (requestError.status === 401 || requestError.status === 403) {
     return 'Your sign-in session expired. Sign in again and retry.'


### PR DESCRIPTION
Four reported problems on the Profile sign-in methods card. Each was measured against a live tenant rather than reasoned about.

## 1. "Google was linked." — removed

Said nothing the row below it wasn't already saying, and its timing was wrong **by construction**: it was stashed in `sessionStorage` so it could survive the provider redirect, so it surfaced on the next Profile *mount*, not at the moment of the action.

Removing the message removes the only reason that hand-off existed, so `writeAccountNotice` / `takeAccountNotice` and the `ProfileView` effect that drained them go with it. The unlink banner goes too. `AccountNotice` is now failure-only — the honest shape: **the card renders state, only failures need words.**

## 2. The Slack avatar was missing

The Slack row fell back to initials while GitHub and Google showed photos. Probed on a live tenant:

| target | `details.avatar` | `rawData.picture` |
|---|---|---|
| **slack** | **absent** | present |
| github | present | absent |
| google | present | present |

Logto fills the normalized `avatar` for those two connectors but not for slack. `summarize()` read `details.avatar` alone, so it found nothing; it now falls back to the `picture` claim, which any OIDC connector carries.

## 3. The verification-code field

A generic `.inp` — full dialog width for six characters — and `.inp` defines **no focus style**, so it fell through to the browser's own ring, a heavy blue belonging to no palette here. Replaced with a field shaped like what it holds: fixed width, centred, monospaced, letter-spaced, brand focus ring. The redundant label is gone (the sentence above already says what to enter) and survives as the accessible name.

Compared side by side against the real design tokens in a live console before committing.

## 4. The 401 message was actively misleading

Reported as "linking Google shows *Your sign-in session expired*". **Not a code bug** — but the message sends people to retry the same broken thing. After a deployment enables Logto's account center, a session opened *before* that keeps working almost everywhere, because its token predates the scope gating the identity endpoints:

| call | staging |
|---|---|
| `GET /api/my-account` | **200**, but `identities` is *absent*, not empty |
| `POST /api/verifications/social` | **201** — different resource |
| `POST /api/my-account/identities` | **401** — needs the missing scope |

Same code and user on the test tenant returns `identities` populated; the only difference is when the token was issued. A **linking** 401 now says to sign out first; non-linking 401s keep the old wording, where it's accurate.

## Reviewer notes

- Anyone already signed in to staging/prod must sign out and back in once — a one-time artifact of enabling the account center, and it will hit any deployment that enables it later.
- `.inp` having no focus style is a console-wide gap this PR does not close.
- Verified: web **480 passing** (68 files), control-plane **804 passing** (93 files), both typechecks 0 errors, `eslint` and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)