### PR TITLE
fix(web): match the sign-in page's provider marks on Profile

### DIFF
--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -32,10 +32,13 @@ const byTarget = (account: MySocialAccountDto, target: string): MySocialIdentity
 const workspaceLabel = (workspace: NonNullable<MySocialIdentityDto['workspace']>): string =>
   workspace.name ?? (workspace.domain ? `${workspace.domain}.slack.com` : workspace.teamId)
 
+/** The same bare mark the sign-in page uses, at the same size. The box stays
+ *  fixed-width so three differently-shaped marks still line the names up; it
+ *  carries no plate, which was making one row of a list look like a tile. */
 function ProviderMark({ provider }: { provider: SocialLoginProvider }) {
   return (
-    <span className="flex h-7 w-7 items-center justify-center rounded-md bg-(--surface-active)">
-      <SocialLoginMark target={provider.target} size={19} />
+    <span className="flex h-7 w-7 items-center justify-center">
+      <SocialLoginMark target={provider.target} size={18} />
     </span>
   )
 }


### PR DESCRIPTION
## What

Drops the grey rounded plate behind each brand mark in Profile → Sign-in methods, and matches the sign-in page's mark size.

## Why

The same three providers are rendered on two surfaces. `/login` shows bare marks; the Profile card wrapped each one in a `bg-(--surface-active)` tile, so every row of a list read like a tile and the two surfaces disagreed about what a provider looks like.

The fixed-width box stays — GitHub, Google and Slack marks differ in width, so without it the provider names no longer line up down the column.

| before | after |
|---|---|
| 28px grey plate, mark at 19px | no plate, mark at 18px (same as `/login`) |

## Notes for the reviewer

- Verified on the live Profile page by stripping the plate from the rendered rows: names stay aligned, and the row reads as a list rather than a grid of tiles.
- **This is a follow-up to #280, not new work.** It was pushed 18 minutes after that PR merged, so it never made it into the squash — the other four fixes in #280 did land, confirmed by checking main for their content rather than their SHAs.
- Verified on top of current `main`: web **481 passing**, typecheck 0 errors, lint and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)