### PR TITLE
fix(daemon): initialize self-authored channel roots without a model turn

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -526,8 +526,10 @@ Both messages are inbound to agent A. Session 1 is a root, so it has no
 ### 7.2 Case 2a: post to a channel without mentioning another agent
 
 Agent A calls `sendMessage` with only `channel`, no `toUser` or `toAgent`.
-This is a plain channel post. It wakes a new session owned by A, because the
-outbound platform post returns as system input in A's future context.
+This is a plain channel post. It initializes a new idle session owned by A,
+keyed by the returned platform message id, but does **not** run a model turn.
+The post is A's own output rather than a new request, so activating on it would
+allow `sendMessage` to recursively create more roots.
 
 ```text
 --- session 1 ---                    (owner: agentA)
@@ -536,13 +538,21 @@ outbound platform post returns as system input in A's future context.
                                        to={channel: "#channel"},
                                        msg="Please review this.")
 
---- session 2 created ---            (owner: agentA; origin: session 1)
-{type: system, from: agentA}:        Please review this.
+--- session 2 initialized ---        (owner: agentA; origin: session 1; idle)
+{type: agent, from: agentA}:         Please review this.  (recorded, not prompted)
+
+  ... a human replies in the new thread ...
+
+--- session 2 first turn ---
+{type: context, from: agentA}:       Please review this.
+{type: human, from: humanA}:         Here are the details.
 ```
 
-Session 1 records A's outbound tool, while session 2 records inbound system
-input from A. Session 2 can later reply to session 1 through SessionTarget,
-forming a same-agent loop.
+Session 1 records A's outbound tool, while session 2 records the root for
+transcript display and replays it as context with the first real reply. Session
+initialization performs no prompt, tools, memory recall/capture, evaluation turn,
+or usage accounting. Session 2 can later reply to session 1 through SessionTarget
+after a real activation.
 
 ### 7.3 Case 2b: post to a channel and mention another agent
 
@@ -619,13 +629,13 @@ A's session lives on Telegram, but `sendMessage` targets Slack:
                                        to={platform: slack, channel: "#channel"},
                                        msg="Please review this.")
 
---- session 2 created ---            (platform: slack, owner: agentA; origin: session 1)
-{type: system, from: agentA}:        Please review this.
+--- session 2 initialized ---        (platform: slack, owner: agentA; origin: session 1; idle)
+{type: agent, from: agentA}:         Please review this.  (recorded, not prompted)
 ```
 
 The session platform, Telegram, is where it lives; `to.platform`, Slack, is the
 platform this tool invocation operates. Cross-platform sending does not change
-the caller session's platform. Reply behavior matches case 2a.
+the caller session's platform. Initialization and first-reply replay match case 2a.
 
 ### 7.5 Case 3b: send from Telegram to Slack and mention another agent
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -82,6 +82,18 @@ best-effort edge: a target on another daemon whose call policy terminally reject
 caller can still leave a visible post, because that policy verdict is only known on the
 target's daemon after the post is made.
 
+## Self-authored channel roots
+
+When an agent uses `sendMessage` to publish a new channel-root message without waking
+another agent, the returned platform message creates the agent's session for that new
+thread but does not run a model turn. The root is already the agent's own output, not a
+new request: treating it as an activation can make the agent post it again recursively.
+
+The session starts idle, retains its parent-session lineage, and records the root for
+transcript display. The first real reply in that thread receives the root as preceding
+context before the new message. Session initialization itself produces no agent output,
+tool calls, memory recall or capture, turn evaluation, or token usage.
+
 ## Shared-bot channel ownership
 
 Every active channel served by a shared bot has exactly one default agent. A newly

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -585,10 +585,11 @@ const MAX_BG_TASK_WAKE_REARMS = 15
 const MAX_BG_TASK_WAKES_PER_SESSION = 20
 
 /**
- * DAEMON-PRIVATE trusted metadata for an agent→agent (`messageAgent`) turn. Authoritative
+ * DAEMON-PRIVATE trusted metadata for an agent-originated delivery. Authoritative
  * (never derived from model output or platform text): the caller identity the target can
  * trust, the correlationId to bounce back, and the hop/origin chain for loop protection.
- * A nested `messageAgent` within the turn reads this to auto-increment hopCount (§2.4).
+ * Most deliveries run a turn whose nested `messageAgent` reads this to auto-increment
+ * hopCount (§2.4); a self-authored channel root instead carries `initializeOnly`.
  */
 interface CallMeta {
   /** Trusted caller agentId (the agent that invoked `messageAgent`). */
@@ -599,6 +600,9 @@ interface CallMeta {
   hopCount: number
   /** Stable id of the delivery that started this turn (== the msgId's ts segment). */
   deliveryId: string
+  /** A self-authored channel-root post initializes its new session but is not a model turn.
+   *  Persisted with the inbox row so crash replay cannot accidentally activate the model. */
+  initializeOnly?: boolean
   /** session-concept §5.3: the WAKING (parent/origin) session's stable acpSessionId. This
    *  is the value surfaced to the child as its `Parent session` (§2.3) and the SessionTarget
    *  the child replies into via `sendMessage`. Absent on root turns (human-initiated) and the
@@ -5783,11 +5787,11 @@ export class Daemon {
 
   /**
    * session-concept case 2a: an agent's channel-ROOT post seeds a NEW session owned by the same
-   * agent. The post already happened (ops.ts); here the daemon dispatches a fresh turn into the
-   * new-thread session (keyed by the post's ts) so the top-level message starts its own context,
-   * with `Parent session` = the origin session. Delivered HEADLESS so the agent records it
-   * silently and does NOT auto-reply into the channel (a self-post must not become chatter), and
-   * hop-count-guarded so a self-post chain can't run away.
+   * agent. The post already happened (ops.ts); here the daemon initializes the new-thread session
+   * (keyed by the post's ts) so the top-level message starts its own context,
+   * with `Parent session` = the origin session. This is initialization only: the root is recorded
+   * for replay with the first real reply, but no model turn runs. `headless` remains a transport
+   * backstop, and the hop count remains a defense for replay from an older durable inbox row.
    */
   private spawnChannelRootSession(req: {
     agentId: string
@@ -5827,6 +5831,7 @@ export class Daemon {
       callFrom: req.agentId,
       hopCount,
       deliveryId,
+      initializeOnly: true,
       ...(originSessionId ? { originSessionId } : {}),
       originCoords: {
         platform: originCoordPlatform,
@@ -5856,8 +5861,7 @@ export class Daemon {
       text: req.text,
       mentionedBots: [],
       isDm: false,
-      // Headless: the seed is recorded into the new session, but the turn produces no channel
-      // output — an agent must not visibly answer its own top-level post.
+      // No model turn runs for this seed; headless is retained as a transport backstop.
       headless: true
     }
     const targetSession = sessionKey(platform, req.channel, req.thread, req.agentId, transportScope)
@@ -5865,7 +5869,7 @@ export class Daemon {
       this.log.error(`channel-root session spawn failed for agent "${req.agentId}": ${formatErr(err)}`)
     )
     this.log.info(
-      `channel-root session: "${req.agentId}" seeded new session ${targetSession} (origin ${originSessionId ?? 'none'}, hop ${hopCount})`
+      `channel-root session: "${req.agentId}" initialized new session ${targetSession} (origin ${originSessionId ?? 'none'}, hop ${hopCount})`
     )
   }
 
@@ -8108,7 +8112,7 @@ export class Daemon {
       const settleAdmission = (result: { accepted: boolean; reason?: string; duplicate?: boolean }): void => {
         if (admissionSettled) return
         admissionSettled = true
-        if (result.accepted && !result.duplicate) {
+        if (result.accepted && !result.duplicate && callMeta?.initializeOnly !== true) {
           this.emitEvaluation({
             type: 'turn.accepted',
             agentId,
@@ -8549,10 +8553,11 @@ export class Daemon {
 
   // The whole single-turn body (design §6.9 #377): sessions.handle() is only step one;
   // host.prompt, render/apply, usage/report and finalize all run here before the sessionId
-  // is returned. runLoop awaits this so a queued entry's promise settles only when THAT
-  // message's model turn is actually done — never before.
+  // is returned. The initialization-only channel-root path returns after session metadata,
+  // before Pending/prompt. runLoop awaits either path so queued work cannot overtake it.
   private async dispatchOne(entry: QueueEntry, key: string): Promise<string | null> {
     const { agentId, msg, integrationId, webchat, callMeta, githubReply, hookContext, onSessionReady } = entry
+    const initializeOnly = callMeta?.initializeOnly === true
     const evaluationTurnId = this.evaluationTurnIdFor(agentId, msg)
     let evaluationSessionId: string | undefined = undefined
     let evaluationTerminal = false
@@ -8560,6 +8565,7 @@ export class Daemon {
       type: 'turn.completed' | 'turn.failed' | 'turn.cancelled' | 'turn.timed_out',
       data: Record<string, unknown> = {}
     ): void => {
+      if (initializeOnly) return
       if (evaluationTerminal) return
       evaluationTerminal = true
       this.emitEvaluation({
@@ -8697,6 +8703,7 @@ export class Daemon {
       skipped?: boolean
       captureInput?: string
       turnId?: string
+      initializedOnly?: boolean
     }
     try {
       // A prior provider post-turn operation is serialized. Managed needs this
@@ -8713,7 +8720,8 @@ export class Daemon {
         agent.allowRuntimeChangesInChat ? webchat?.runtime?.effort : undefined,
         // §5.3: the parent asked to be told how this session ends — prompt assembly turns it into
         // a standing directive naming the origin as the reply target.
-        callMeta?.needsReply
+        callMeta?.needsReply,
+        { initializeOnly }
       )
     } catch (err) {
       this.finishSessionInitialization(agentId)
@@ -8856,6 +8864,12 @@ export class Daemon {
       onSessionReady?.(sessionId)
     } catch (err) {
       this.log.warn(`dispatch: session-ready notification failed (${formatErr(err)})`)
+    }
+    if (handled.initializedOnly) {
+      this.showActivity(replyConn, msg.channel, statusThread, '')
+      releaseReplyConn()
+      this.log.info(`dispatch: initialized session ${key} from self-authored channel root without a model turn`)
+      return sessionId
     }
     let resolveDone!: () => void
     const done = new Promise<void>((r) => (resolveDone = r))

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -324,9 +324,10 @@ export interface OpsDeps {
   viewSessionStatus?: (req: SessionStatusReq) => Promise<SessionStatusResult | null>
   /** session-concept case 2a: an agent's channel-ROOT post seeds a NEW session owned by the same
    *  agent (origin = the current session), so a deliberate top-level post starts its own context.
-   *  Only called for a root post (no thread) with no toAgent. Fire-and-forget; the daemon delivers
-   *  it headless (no channel echo) and guards the self-loop via hopCount. Absent in the chat CLI /
-   *  tests (no daemon) — then a root post is a plain post with no session spawn. */
+   *  Only called for a root post (no thread) with no toAgent. Fire-and-forget; the daemon creates
+   *  the session without running a model turn, then replays the root as context on the first real
+   *  reply. Absent in the chat CLI / tests (no daemon) — then a root post is a plain post with no
+   *  session spawn. */
   spawnChannelRootSession?: (req: {
     agentId: string
     platform: string

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -322,12 +322,16 @@ export class SessionManager {
     /** session-concept §5.3: the parent woke this session with `toAgent.needsReply`, so it must
      *  be told to report back into `originSessionId` when it finishes or fails. Persisted on the
      *  session (sticky) so the directive survives resume and later turns. */
-    needsParentReply?: boolean
+    needsParentReply?: boolean,
+    /** A self-authored channel-root post only establishes the new logical/runtime session.
+     *  It is already recorded in the transcript and must not become a model activation. */
+    options: { initializeOnly?: boolean } = {}
   ): Promise<{
     sessionId: string
     blocks: ContentBlock[]
     created: boolean
     skipped?: boolean
+    initializedOnly?: boolean
     /** Bounded normalized text actually delivered this activation, before memory. */
     captureInput?: string
     /** Stable provider-neutral post-turn identity. */
@@ -741,6 +745,17 @@ export class SessionManager {
       }
     }
 
+    // A channel-root message posted by this same agent creates the thread's session cursor
+    // without running the model. Keep lastDeliveredTs at null: the first real reply must replay
+    // this root as context before advancing the cursor. Returning here also avoids thread-history
+    // reads, memory recall, prompt assembly, and the transient `prompting` state for a non-turn.
+    if (options.initializeOnly) {
+      rec.state = 'idle'
+      rec.updatedAt = Date.now()
+      this.deps.store.upsertSession(rec)
+      return { sessionId: rec.acpSessionId!, blocks: [], created, initializedOnly: true }
+    }
+
     // Older anchored cron/hook turns persisted their synthetic UUID as the Slack
     // read cursor. Start one bounded catch-up from scratch instead of passing that
     // non-timestamp through the Slack ordering/dedup path; this turn replaces it
@@ -749,6 +764,7 @@ export class SessionManager {
       msg.platform === 'slack' && rec.lastDeliveredTs !== null && slackTsMicros(rec.lastDeliveredTs) === null
         ? null
         : rec.lastDeliveredTs
+    const firstPromptAfterOwnRootInitialization = markerBefore === null && rec.triggeredBy === agentId
     // §8.4/§8.5 authoritative warm-thread snapshot (#649): Socket Mode is the
     // low-latency trigger, not an ordered/complete unread source. Slack may deliver a
     // minutes-old event only after the current agent turn has ended, while newer plain
@@ -809,7 +825,13 @@ export class SessionManager {
       // SQLite's text order puts UUID-like legacy coordinates after decimal Slack
       // timestamps. Keep those old rows as context, but before the real timeline.
       if (msg.platform === 'slack') gap.sort((a, b) => compareSlackTs(a.ts, b.ts))
-      const participantGap = gap.filter((e) => e.sender !== agentId)
+      // A session initialized from this agent's own channel-root post has never run a model
+      // turn. Replay that one root exactly once, alongside the first real reply, so the new ACP
+      // session understands what the thread is about. Ordinary own-authored rows stay filtered:
+      // after this activation advances the cursor, the root cannot re-enter a later prompt.
+      const participantGap = gap.filter(
+        (e) => e.sender !== agentId || (firstPromptAfterOwnRootInitialization && e.ts === thread)
+      )
       // Own authored rows are not repeated to the model, but they ARE first-class events
       // in the shared log and therefore may advance this agent's read cursor once the
       // surrounding stable window is consumed.
@@ -976,17 +998,20 @@ export class SessionManager {
       }
     }
 
-    // System-side context for a newly-created session: the agent meta object (identity +
+    // System-side context for a newly-created session or the first real prompt after an
+    // initialization-only root: the agent meta object (identity +
     // description + source/channel) and the memory INDEX, both in `sessionContext`. All
     // STANDING context, not a user turn — so they never sit as a leading user block (which
     // a runtime auto-titles from — #398). Claude carries them via `_meta.systemPrompt` (see
     // newSession/claudeSessionMeta), so it adds NOTHING here. Other runtimes have no such
-    // channel: inline sessionContext as one combined first block. Gated on `created`: a
-    // resumed session already carries it from its first turn.
+    // channel: inline sessionContext as one combined first block. A resumed session normally
+    // carries it from its first turn; an initialization-only root deliberately had no such turn.
     const promptPrelude: ContentBlock[] = []
-    if (created) {
+    if (created || firstPromptAfterOwnRootInitialization) {
       // Establish the reminder epoch without redundantly restating the rule that this
-      // new session just received (inline or via `_meta.systemPrompt`).
+      // new session just received (inline or via `_meta.systemPrompt`). A non-Claude
+      // initialization-only session had no first prompt, so defer its inline standing
+      // context to this first real activation.
       this.turnsSinceReminder.set(key, 0)
       if (!usesMeta && sessionContext) promptPrelude.push({ type: 'text', text: sessionContext })
     } else if (restateParentReply) {

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -832,6 +832,22 @@ export class SessionManager {
       const participantGap = gap.filter(
         (e) => e.sender !== agentId || (firstPromptAfterOwnRootInitialization && e.ts === thread)
       )
+      // The initialized root is the only own-authored row admitted above, and it is the
+      // founding context for a runtime session that has never seen a prompt. Keep it outside
+      // the ordinary bounded suffix so a busy thread cannot evict it before first activation.
+      const initializedRoot = firstPromptAfterOwnRootInitialization
+        ? participantGap.find((e) => e.sender === agentId && e.ts === thread)
+        : undefined
+      const boundedReplay = (entries: typeof participantGap) => {
+        const includesInitializedRoot =
+          initializedRoot !== undefined && entries.some((e) => e.ts === initializedRoot.ts)
+        const remainder = includesInitializedRoot ? entries.filter((e) => e.ts !== initializedRoot.ts) : entries
+        const suffix = remainder.slice(-MAX_REPLAY_ENTRIES)
+        return {
+          context: includesInitializedRoot ? [initializedRoot, ...suffix] : suffix,
+          elided: remainder.length - suffix.length
+        }
+      }
       // Own authored rows are not repeated to the model, but they ARE first-class events
       // in the shared log and therefore may advance this agent's read cursor once the
       // surrounding stable window is consumed.
@@ -851,7 +867,7 @@ export class SessionManager {
       const hasMessageAfterTrigger =
         msg.platform === 'slack' && participantGap.some((e) => compareSlackTs(e.ts, ts) > 0)
       if (hasMessageAfterTrigger || triggerWasAlreadyDelivered) {
-        const context = participantGap.slice(-MAX_REPLAY_ENTRIES)
+        const { context, elided } = boundedReplay(participantGap)
         if (context.length === 0) {
           rec.lastDeliveredTs = deliveredThrough
           rec.state = 'idle'
@@ -862,7 +878,6 @@ export class SessionManager {
           this.deps.store.upsertSession(rec)
           return { sessionId: rec.acpSessionId!, blocks: [], created, skipped: true }
         }
-        const elided = participantGap.length - context.length
         const head =
           elided > 0
             ? `(unread thread messages, oldest to newest — ${elided} earlier message(s) elided)`
@@ -872,9 +887,8 @@ export class SessionManager {
         // Normal in-order activation: preserve the established context-prefix + current
         // prompt shape, while never replaying this agent's own recorded messages.
         const allContext = participantGap.filter((e) => e.ts !== ts)
-        const context = allContext.slice(-MAX_REPLAY_ENTRIES)
+        const { context, elided } = boundedReplay(allContext)
         if (context.length > 0) {
-          const elided = allContext.length - context.length
           const head =
             elided > 0
               ? `(thread context you may have missed — ${elided} earlier message(s) elided)`

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -951,12 +951,12 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
 
 /**
  * Case 2a spawn (session-concept §7.2): an agent's channel-ROOT post seeds a NEW session owned
- * by the same agent, keyed by the post's ts, delivered headless with origin lineage — and,
- * critically, with the post's real ts as `transcriptTs` so the new session's delivered-marker is
- * a real Slack ts (a later real reply in that thread must NOT be mis-skipped as already-delivered).
+ * by the same agent, keyed by the post's ts, initialized without a model turn and with origin
+ * lineage. The post's real ts is retained as `transcriptTs` so the transcript row is canonical;
+ * the session cursor deliberately remains null until the first real reply consumes the root.
  */
 describe('spawnChannelRootSession — case 2a new-session seed', () => {
-  it('dispatches a headless, origin-tagged turn keyed by the post ts, with transcriptTs = post ts', async () => {
+  it('dispatches an initialization-only, origin-tagged seed keyed by the post ts', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
     // Seed the origin (current) session so its acpSessionId becomes the child's originSessionId.
@@ -992,12 +992,44 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     expect(msg.transcriptTs).toBe('1784297789.871789')
     expect(msg.headless).toBe(true)
     expect(msg.source).toBe('agent')
+    expect(msg.text).toBe('root spawn 🌿')
     expect(callMeta).toMatchObject({
       callFrom: 'bot-a',
       hopCount: 1,
+      initializeOnly: true,
       originSessionId: 'acp-origin-1',
       originCoords: { platform: 'slack', channel: 'C1', thread: '100.1' }
     })
+    await daemon.stop()
+  })
+
+  it('creates an idle session without prompting the model', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const host = fakeHost()
+    const daemon = new Daemon({ root, hostFactory: () => host as any })
+    await daemon.start()
+    const targetKey = sessionKey('slack', 'C1', '1784297789.871789', 'bot-a')
+
+    ;(daemon as any).spawnChannelRootSession({
+      agentId: 'bot-a',
+      platform: 'slack',
+      integrationId: 'int-a',
+      channel: 'C1',
+      thread: '1784297789.871789',
+      text: 'root spawn 🌿',
+      originChannel: 'C1',
+      originThread: '100.1'
+    })
+
+    await vi.waitFor(() => {
+      expect((daemon as any).store.getSession(targetKey)).toMatchObject({
+        acpSessionId: 'acp-1',
+        state: 'idle',
+        lastDeliveredTs: null
+      })
+    })
+    expect(host.newSession).toHaveBeenCalledOnce()
+    expect(host.prompt).not.toHaveBeenCalled()
     await daemon.stop()
   })
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -71,6 +71,56 @@ describe('SessionManager', () => {
     store.close()
   })
 
+  it('initializes a self-authored root session without a turn and replays the root on the first real reply', async () => {
+    const store = newStore()
+    const host = fakeHost()
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const seed = msg({
+      ts: '200.1',
+      thread: '200.1',
+      source: 'agent',
+      sender: { id: 'bot-a', isBot: true },
+      text: 'Please investigate the deployment failure.'
+    })
+
+    const initialized = await sm.handle('bot-a', seed, undefined, undefined, 'acp-parent-1', undefined, undefined, {
+      initializeOnly: true
+    })
+
+    expect(initialized).toMatchObject({
+      sessionId: 'acp-1',
+      created: true,
+      initializedOnly: true,
+      blocks: []
+    })
+    expect(store.getSession(sessionKey('slack', 'C1', '200.1', 'bot-a'))).toMatchObject({
+      state: 'idle',
+      lastDeliveredTs: null,
+      triggeredBy: 'bot-a',
+      originSessionId: 'acp-parent-1'
+    })
+
+    const firstReply = await sm.handle(
+      'bot-a',
+      msg({
+        ts: '200.2',
+        thread: '200.1',
+        text: 'The failing deployment is production; can you check it now?'
+      })
+    )
+    const prompt = firstReply.blocks.map((block: any) => block.text ?? '').join('\n')
+    expect(prompt).toContain('# Agent')
+    expect(prompt).toContain('Parent session: acp-parent-1')
+    expect(prompt).toContain('Please investigate the deployment failure.')
+    expect(prompt).toContain('The failing deployment is production; can you check it now?')
+    expect(firstReply.blocks.at(-1)).toEqual({
+      type: 'text',
+      text: 'The failing deployment is production; can you check it now?'
+    })
+    expect(host.newSession).toHaveBeenCalledOnce()
+    store.close()
+  })
+
   it('does not replay transcript context from another physical bot with the same channel coordinates', async () => {
     const store = newStore()
     const agentB = { ...agent, id: 'bot-b', name: 'bot-b' }

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -121,6 +121,53 @@ describe('SessionManager', () => {
     store.close()
   })
 
+  it('keeps an initialized self-authored root when first-activation context exceeds the replay cap', async () => {
+    const store = newStore()
+    const host = fakeHost()
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const rootTs = '200.000001'
+    const seed = msg({
+      ts: rootTs,
+      thread: rootTs,
+      source: 'agent',
+      sender: { id: 'bot-a', isBot: true },
+      text: 'ROOT-SUBJECT: investigate the deployment failure.'
+    })
+
+    await sm.handle('bot-a', seed, undefined, undefined, 'acp-parent-1', undefined, undefined, {
+      initializeOnly: true
+    })
+    for (let index = 0; index < 51; index += 1) {
+      store.appendTranscript({
+        channel: 'C1',
+        thread: rootTs,
+        ts: `200.${String(index + 2).padStart(6, '0')}`,
+        sender: 'U1',
+        kind: 'text',
+        text: `missed reply ${index}`
+      })
+    }
+
+    const firstReply = await sm.handle(
+      'bot-a',
+      msg({
+        ts: '200.999999',
+        thread: rootTs,
+        text: 'Please act on the latest thread state.'
+      })
+    )
+    const prompt = firstReply.blocks.map((block: any) => block.text ?? '').join('\n')
+    expect(prompt).toContain('ROOT-SUBJECT: investigate the deployment failure.')
+    expect(prompt).not.toContain('missed reply 0\n')
+    expect(prompt).toContain('missed reply 50')
+    expect(prompt).toContain('1 earlier message(s) elided')
+    expect(firstReply.blocks.at(-1)).toEqual({
+      type: 'text',
+      text: 'Please act on the latest thread state.'
+    })
+    store.close()
+  })
+
   it('does not replay transcript context from another physical bot with the same channel coordinates', async () => {
     const store = newStore()
     const agentB = { ...agent, id: 'bot-b', name: 'bot-b' }


### PR DESCRIPTION
## Summary

- initialize a new idle session when an agent posts a channel-root message without waking another agent
- avoid running a model turn for that self-authored root, removing the recursive `sendMessage` entry point
- replay the root as context with the first real reply, including deferred standing context for runtimes without ACP system-prompt metadata
- document the user-facing invariant and session semantics

## Root cause

`spawnChannelRootSession` dispatched a normal model turn for the agent's own root post. `headless` suppressed ordinary platform output, but it did not suppress model tools, so the model could interpret its post as a new request and call `sendMessage` again. Slack self-echo filtering could not stop the loop because every hop originated inside the daemon.

## Impact

A self-authored channel root now creates the expected session and parent lineage without model execution, tool calls, memory recall/capture, turn evaluation, or token usage. The first actual reply in the new thread still receives the root as preceding context.

## Validation

- daemon test suite: 137 files passed, 1 skipped; 2322 tests passed, 2 skipped
- `pnpm --filter @agentconnect.md/daemon typecheck`
- Prettier check for all changed files
- `git diff --check`
- pre-push `eslint .`