### PR TITLE
feat(web): sync the Connect-your-AI modal with the design

### DIFF
--- a/packages/web/src/components/console/ConnectAiModal.tsx
+++ b/packages/web/src/components/console/ConnectAiModal.tsx
@@ -5,8 +5,9 @@
 // Code, any MCP-capable tool) at the AgentConnect MCP endpoint. The endpoint is
 // deployment-wide; the credential is personal — browser OAuth sign-in, or a
 // personal API key from the Profile page — so a connected AI acts with the
-// signed-in user's own permissions. "More" jumps to the external connector docs
-// (the deploy-overridable HELP_MCP_URL target, passed in by the shell).
+// signed-in user's own permissions. The docs link jumps to the external
+// connector docs (the deploy-overridable HELP_MCP_URL target, passed in by the
+// shell) rather than the design's hard-coded modelcontextprotocol.io URL.
 
 import { useEffect, useState } from 'react'
 import { Icon } from '@/components/ui'
@@ -20,10 +21,13 @@ function mcpEndpointUrl(): string {
   return (dedicated || `${cpRestBase()}/mcp`).replace(/\/+$/, '')
 }
 
+const TAGLINE = 'Connects as you — your role, your permissions'
+
 type CopyTarget = 'url' | 'cli'
 
 export default function ConnectAiModal({ onClose, moreUrl }: { onClose: () => void; moreUrl: string }) {
   const [copied, setCopied] = useState<CopyTarget | null>(null)
+  const [keyOpen, setKeyOpen] = useState(false)
   const url = mcpEndpointUrl()
   const cli = `claude mcp add --transport http agentconnect ${url}`
 
@@ -47,72 +51,111 @@ export default function ConnectAiModal({ onClose, moreUrl }: { onClose: () => vo
 
   return (
     <div className="scrim" onClick={onClose}>
-      <div className="modal max-w-[520px]" onClick={(e) => e.stopPropagation()}>
+      <div className="modal max-w-[600px]" onClick={(e) => e.stopPropagation()}>
         <div className="modalhead">
-          <Icon name="plug" size={18} color="var(--text-tertiary)" />
-          <span className="font-sans text-[15px] font-semibold leading-normal">Connect your AI</span>
+          <Icon name="plug" size={20} color="var(--text-secondary)" />
+          <span className="font-sans text-[17px] font-semibold tracking-[-0.012em] leading-normal">
+            Connect your AI
+          </span>
+          {/* The tagline replaces the old intro paragraph, so mobile — where it
+              would never fit beside the title — carries it in the body instead. */}
+          <span className="ml-auto hidden font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:block">
+            {TAGLINE}
+          </span>
+          <button type="button" className="iconbtn ml-auto desktop:ml-[6px]" aria-label="Close" onClick={onClose}>
+            <Icon name="x" size={16} />
+          </button>
         </div>
-        <div className="modalbody flex flex-col gap-[10px]">
-          <p className="m-0 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
-            Give claude.ai, Claude Code or any MCP client a live view of this workspace — agents, sessions, schedules,
-            usage — plus guarded write tools. It connects as <em>you</em>: everything it can see or touch is bounded by
-            your own role and permissions.
+
+        <div className="modalbody flex flex-col">
+          <p className="m-0 pb-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:hidden">
+            {TAGLINE}
           </p>
 
-          <div className="endpoint">
-            <span className="tagpill bg-(--brand-soft) text-(--brand-soft-text)">MCP</span>
-            <span className="mono flex-1 truncate text-[12px] text-(--text-primary) desktop:text-[12.5px]">{url}</span>
-            <button
-              className="iconbtn h-7 w-7"
-              title={copied === 'url' ? 'Copied' : 'Copy MCP endpoint'}
-              aria-label={copied === 'url' ? 'MCP endpoint copied' : 'Copy MCP endpoint'}
-              onClick={() => void copy('url', url)}
-            >
-              <Icon name={copied === 'url' ? 'check' : 'copy'} size={14} />
-            </button>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">claude.ai</span>
-            <p className="m-0 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary)">
-              Settings → Connectors → <span className="font-medium">Add custom connector</span> → paste the URL above.
-              The browser sign-in asks which organization to connect and whether to allow read-only or read + write
-              access.
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
-                Claude Code
+          <div className="flex flex-col gap-[7px] pb-[18px]">
+            <span className="font-mono text-[11px] font-semibold tracking-[0.08em] uppercase leading-normal text-(--text-tertiary)">
+              MCP server URL
+            </span>
+            <div className="flex items-center gap-3 rounded-md border border-(--border-default) bg-(--surface-sunken) py-3 pr-3 pl-[14px]">
+              <span className="mono min-w-0 flex-1 truncate text-[13px] tracking-[-0.01em] text-(--text-primary) desktop:text-[14px]">
+                {url}
               </span>
               <button
-                className="iconbtn h-7 w-7"
-                title={copied === 'cli' ? 'Copied' : 'Copy command'}
-                aria-label={copied === 'cli' ? 'Command copied' : 'Copy command'}
-                onClick={() => void copy('cli', cli)}
+                type="button"
+                className="iconbtn h-[30px] w-auto gap-[6px] px-[10px] font-sans text-[12px] font-medium leading-normal"
+                onClick={() => void copy('url', url)}
               >
-                <Icon name={copied === 'cli' ? 'check' : 'copy'} size={14} />
+                <Icon name={copied === 'url' ? 'check' : 'copy'} size={14} />
+                {copied === 'url' ? 'Copied' : 'Copy'}
               </button>
             </div>
-            <div className="codedark break-all">{cli}</div>
-            <p className="m-0 font-sans text-[12px] font-normal leading-[1.55] text-(--text-tertiary)">
-              Then run <span className="mono">/mcp</span> to sign in via the browser. Headless clients can skip OAuth by
-              sending a personal API key (Profile → API keys) as an{' '}
-              <span className="mono">Authorization: Bearer &lt;key&gt;</span> header — a key carries your full
-              permissions.
-            </p>
           </div>
 
-          <a
-            className="lnk inline-flex items-center gap-[5px] self-start font-sans text-[12.5px] font-medium leading-normal"
-            href={moreUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            More
-            <Icon name="arrow-up-right" size={13} />
-          </a>
+          <div className="grid grid-cols-1 items-start gap-y-[7px] border-t border-(--border-subtle) py-4 desktop:grid-cols-[128px_1fr] desktop:gap-x-4">
+            <span className="font-sans text-[13px] font-semibold leading-[1.4] text-(--text-primary)">
+              Claude Desktop &amp; claude.ai
+            </span>
+            <div className="flex flex-col gap-[7px]">
+              <span className="font-sans text-[13.5px] font-normal leading-normal text-(--text-secondary)">
+                Settings → Connectors →&#32;
+                <strong className="font-semibold text-(--text-primary)">Add custom connector</strong>
+              </span>
+              <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                Sign-in picks the org and access level
+              </span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 items-start gap-y-[7px] border-t border-(--border-subtle) py-4 desktop:grid-cols-[128px_1fr] desktop:gap-x-4">
+            <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary) desktop:pt-[7px]">
+              Claude Code
+            </span>
+            <div className="flex flex-col gap-[7px]">
+              <div className="relative">
+                <div className="codedark pr-11">{cli}</div>
+                <button
+                  type="button"
+                  className="absolute top-2 right-2 flex h-[26px] w-[26px] cursor-pointer items-center justify-center rounded-[5px] border border-white/15 bg-white/5 text-[#c9cfd8] transition-colors hover:bg-white/10"
+                  title={copied === 'cli' ? 'Copied' : 'Copy command'}
+                  aria-label={copied === 'cli' ? 'Command copied' : 'Copy command'}
+                  onClick={() => void copy('cli', cli)}
+                >
+                  <Icon name={copied === 'cli' ? 'check' : 'copy'} size={13} />
+                </button>
+              </div>
+              <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                Then <span className="mono text-[12px] text-(--text-secondary)">/mcp</span> to sign in
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 border-t border-(--border-subtle) pt-[15px]">
+            <button
+              type="button"
+              aria-expanded={keyOpen}
+              className="inline-flex cursor-pointer items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[13px] font-medium leading-normal text-(--text-secondary) transition-colors hover:text-(--text-primary)"
+              onClick={() => setKeyOpen((v) => !v)}
+            >
+              <Icon
+                name="chevron-right"
+                size={14}
+                strokeWidth={2}
+                className={keyOpen ? 'flex-none rotate-90 transition-transform' : 'flex-none transition-transform'}
+              />
+              Headless client? Use an API key
+            </button>
+            <a className="lnk ml-auto text-[13px]" href={moreUrl} target="_blank" rel="noopener noreferrer">
+              MCP docs
+              <Icon name="arrow-up-right" size={13} />
+            </a>
+          </div>
+          {keyOpen ? (
+            <p className="m-0 mt-[10px] ml-5 font-sans text-[12.5px] font-normal leading-[1.6] text-pretty text-(--text-tertiary)">
+              Skip OAuth: send a key from Profile → API keys as&#32;
+              <span className="mono text-[12px] text-(--text-secondary)">Authorization: Bearer &lt;key&gt;</span>. It
+              carries your full permissions.
+            </p>
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/web/src/components/console/ConnectAiModal.tsx
+++ b/packages/web/src/components/console/ConnectAiModal.tsx
@@ -9,8 +9,9 @@
 // connector docs (the deploy-overridable HELP_MCP_URL target, passed in by the
 // shell) rather than the design's hard-coded modelcontextprotocol.io URL.
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
+import { LogoMark } from '@/components/marks'
 import { cpRestBase } from '@/lib/api'
 
 // The public MCP endpoint: a dedicated origin when the deploy sets MCP_URL
@@ -22,6 +23,104 @@ function mcpEndpointUrl(): string {
 }
 
 const TAGLINE = 'Connects as you — your role, your permissions'
+
+// The design fills this column with a screenshot of the claude.ai connector
+// pane. It is drawn from our own tokens rather than shipped as a raster: a
+// captured PNG would be light-mode only under a console that themes, and it
+// would age out the next time that pane is restyled. Three frames — find
+// Connectors, fill the dialog, press Connect — cycle in place, since the last
+// of them is a separate step the sentence above doesn't have room to name.
+const FILM_MS = 2600
+
+function ConnectorFilm({ url }: { url: string }) {
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    // The globals.css reduced-motion block only collapses transitions; a
+    // self-advancing cycle has to stop itself.
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    const t = setInterval(() => setFrame((f) => (f + 1) % 3), FILM_MS)
+    return () => clearInterval(t)
+  }, [])
+
+  return (
+    <div
+      className="relative mt-[2px] h-[140px] w-full overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-sunken)"
+      aria-hidden
+    >
+      <Frame on={frame === 0}>
+        <div className="w-[168px] rounded-sm border border-(--border-subtle) bg-(--surface-card) p-[7px] shadow-(--shadow-xs)">
+          <span className="block px-[7px] pb-[3px] font-sans text-[9px] font-medium leading-normal text-(--text-tertiary)">
+            Customize
+          </span>
+          {NAV.map((item) => (
+            <span
+              key={item.label}
+              className={
+                item.on
+                  ? 'flex items-center gap-[7px] rounded-xs bg-(--surface-active) px-[7px] py-[4px] font-sans text-[10.5px] font-semibold leading-normal text-(--text-primary)'
+                  : 'flex items-center gap-[7px] rounded-xs px-[7px] py-[4px] font-sans text-[10.5px] font-normal leading-normal text-(--text-secondary)'
+              }
+            >
+              <Icon name={item.icon} size={11} />
+              {item.label}
+            </span>
+          ))}
+        </div>
+      </Frame>
+
+      <Frame on={frame === 1}>
+        <div className="w-full rounded-sm border border-(--border-subtle) bg-(--surface-card) p-[10px] shadow-(--shadow-xs)">
+          <span className="block pb-[7px] font-sans text-[11px] font-semibold leading-normal text-(--text-primary)">
+            Add custom connector
+          </span>
+          <span className="mb-[5px] block rounded-xs border border-(--border-default) px-[7px] py-[5px] font-sans text-[9.5px] leading-normal text-(--text-secondary)">
+            AgentConnect
+          </span>
+          <span className="block truncate rounded-xs border border-(--brand) px-[7px] py-[5px] font-mono text-[9.5px] leading-normal text-(--text-primary)">
+            {url}
+          </span>
+          <span className="mt-[8px] ml-auto block w-fit rounded-xs bg-(--surface-active) px-[11px] py-[4px] font-sans text-[9.5px] font-semibold leading-normal text-(--text-secondary)">
+            Add
+          </span>
+        </div>
+      </Frame>
+
+      <Frame on={frame === 2}>
+        <div className="flex flex-col items-center gap-[7px]">
+          <LogoMark size={24} />
+          <span className="font-sans text-[10.5px] font-normal leading-normal text-(--text-tertiary)">
+            You are not connected yet
+          </span>
+          <span className="rounded-sm bg-(--brand) px-[13px] py-[5px] font-sans text-[10.5px] font-semibold leading-normal text-white">
+            Connect
+          </span>
+        </div>
+      </Frame>
+    </div>
+  )
+}
+
+const NAV = [
+  { label: 'Skills', icon: 'scroll-text', on: false },
+  { label: 'Connectors', icon: 'blocks', on: true },
+  { label: 'Plugins', icon: 'unplug', on: false },
+  { label: 'Memory', icon: 'history', on: false }
+]
+
+function Frame({ on, children }: { on: boolean; children: ReactNode }) {
+  return (
+    <div
+      className={
+        on
+          ? 'absolute inset-0 flex items-center justify-center p-2 transition-opacity opacity-100'
+          : 'absolute inset-0 flex items-center justify-center p-2 transition-opacity opacity-0'
+      }
+    >
+      {children}
+    </div>
+  )
+}
 
 type CopyTarget = 'url' | 'cli'
 
@@ -51,24 +150,21 @@ export default function ConnectAiModal({ onClose, moreUrl }: { onClose: () => vo
 
   return (
     <div className="scrim" onClick={onClose}>
-      <div className="modal max-w-[600px]" onClick={(e) => e.stopPropagation()}>
+      <div className="modal max-w-[520px]" onClick={(e) => e.stopPropagation()}>
         <div className="modalhead">
           <Icon name="plug" size={20} color="var(--text-secondary)" />
           <span className="font-sans text-[17px] font-semibold tracking-[-0.012em] leading-normal">
             Connect your AI
           </span>
-          {/* The tagline replaces the old intro paragraph, so mobile — where it
-              would never fit beside the title — carries it in the body instead. */}
-          <span className="ml-auto hidden font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:block">
-            {TAGLINE}
-          </span>
-          <button type="button" className="iconbtn ml-auto desktop:ml-[6px]" aria-label="Close" onClick={onClose}>
+          <button type="button" className="iconbtn ml-auto" aria-label="Close" onClick={onClose}>
             <Icon name="x" size={16} />
           </button>
         </div>
 
         <div className="modalbody flex flex-col">
-          <p className="m-0 pb-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:hidden">
+          {/* The design sits this beside the title; at this width that wraps the
+              header onto two lines, so it leads the body instead. */}
+          <p className="m-0 pb-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
             {TAGLINE}
           </p>
 
@@ -100,9 +196,7 @@ export default function ConnectAiModal({ onClose, moreUrl }: { onClose: () => vo
                 Settings → Connectors →&#32;
                 <strong className="font-semibold text-(--text-primary)">Add custom connector</strong>
               </span>
-              <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-                Sign-in picks the org and access level
-              </span>
+              <ConnectorFilm url={url} />
             </div>
           </div>
 

--- a/packages/web/src/components/console/ConnectAiModal.tsx
+++ b/packages/web/src/components/console/ConnectAiModal.tsx
@@ -28,17 +28,24 @@ const TAGLINE = 'Connects as you — your role, your permissions'
 // pane. It is drawn from our own tokens rather than shipped as a raster: a
 // captured PNG would be light-mode only under a console that themes, and it
 // would age out the next time that pane is restyled. Three frames — find
-// Connectors, fill the dialog, press Connect — cycle in place, since the last
-// of them is a separate step the sentence above doesn't have room to name.
+// Connectors, fill the dialog, press Connect — cycle in place. Every step they
+// show is named in the sentence above, so the film illustrates and never
+// carries instructions on its own: it is aria-hidden, and it holds on one
+// static frame under reduced motion.
 const FILM_MS = 2600
+const DIALOG_FRAME = 1
 
 function ConnectorFilm({ url }: { url: string }) {
   const [frame, setFrame] = useState(0)
 
   useEffect(() => {
     // The globals.css reduced-motion block only collapses transitions; a
-    // self-advancing cycle has to stop itself.
-    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    // self-advancing cycle has to stop itself. Settle on the dialog — the one
+    // frame that shows where the URL goes — rather than whichever came first.
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      setFrame(DIALOG_FRAME)
+      return
+    }
     const t = setInterval(() => setFrame((f) => (f + 1) % 3), FILM_MS)
     return () => clearInterval(t)
   }, [])
@@ -194,7 +201,8 @@ export default function ConnectAiModal({ onClose, moreUrl }: { onClose: () => vo
             <div className="flex flex-col gap-[7px]">
               <span className="font-sans text-[13.5px] font-normal leading-normal text-(--text-secondary)">
                 Settings → Connectors →&#32;
-                <strong className="font-semibold text-(--text-primary)">Add custom connector</strong>
+                <strong className="font-semibold text-(--text-primary)">Add custom connector</strong>, then&#32;
+                <strong className="font-semibold text-(--text-primary)">Connect</strong>
               </span>
               <ConnectorFilm url={url} />
             </div>


### PR DESCRIPTION
Syncs `ConnectAiModal` with `Connect Your AI.dc.html` from the console design project, and fills the screenshot slot the design file left empty.

## What changed

**Layout, per the design.** The modal drops the opening prose paragraph for a short tagline, and turns two stacked heading-plus-paragraph blocks into one labelled row per client. The endpoint field becomes a mono eyebrow label over a sunken box with a *labelled* Copy button, and the header gains a close X it was missing. The API-key note for headless clients moves into a collapsed disclosure in the footer row.

**The claude.ai column** is one sentence plus an animated three-frame shot: find Connectors under Customize → fill the Add-custom-connector dialog → press Connect. The last of those is a genuinely separate step (a freshly added connector sits in a "not connected yet" state until you press Connect, which is what starts the OAuth sign-in), and the design's sentence stopped short of it.

## Notes for review

- **The shot is drawn from our own tokens, not a screenshot.** The design's slot is an unfilled `<image-slot>` placeholder — no image was ever dropped into it. A captured PNG would be light-mode only under a console that themes, and would age out the next time that settings pane is restyled.
- **The dialog frame renders the live MCP endpoint**, the same value as the field above it, so nothing about the URL is hard-coded.
- **The animation stops itself under `prefers-reduced-motion`.** The `globals.css` reduced-motion block collapses transitions, but it can't stop a self-advancing `setInterval`, so the component checks `matchMedia` itself.
- **The modal narrows from 600px to 520px** so the shot fills its column rather than floating in a wide well. At that width the tagline no longer fits beside the title, so it leads the body — which also retires the desktop/mobile dual-render it previously needed.
- **The docs link still points at the deploy-configurable `HELP_MCP_URL`** rather than the design's hard-coded modelcontextprotocol.io, keeping it overridable by an OSS fork. It is relabelled "MCP docs" to match the design.

## Verification

Light and dark × desktop and mobile, all three frames stepped through individually. `typecheck`, `eslint`, `prettier` clean; 481 web tests across 68 files pass.

Verifying gotcha for anyone re-checking the animation: screenshot round-trips alias against the 2.6s frame interval and will keep catching the same frame. Pin one by setting `style.opacity` on the three frame children directly, after confirming via a read of the opacity triple that the cycle is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)