### PR TITLE
fix(web): stop the Profile sign-in methods card resizing on first load

### DIFF
--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -32,6 +32,14 @@ const byTarget = (account: MySocialAccountDto, target: string): MySocialIdentity
 const workspaceLabel = (workspace: NonNullable<MySocialIdentityDto['workspace']>): string =>
   workspace.name ?? (workspace.domain ? `${workspace.domain}.slack.com` : workspace.teamId)
 
+/**
+ * Height a row's identity cell reserves, so the row is the same height whether it
+ * is still loading, unlinked, or linked — the card used to grow as the first fetch
+ * landed. Two text lines fit inside the avatar; only Slack adds a third, since the
+ * CP populates `workspace` for that target alone.
+ */
+const detailReserve = (provider: SocialLoginProvider): string => (provider.target === 'slack' ? 'min-h-12' : 'min-h-8')
+
 /** The same bare mark the sign-in page uses, at the same size. The box stays
  *  fixed-width so three differently-shaped marks still line the names up; it
  *  carries no plate, which was making one row of a list look like a tile. */
@@ -387,7 +395,9 @@ export default function SocialSignInCard({
                   <ProviderMark provider={provider} />
                   <span className="truncate font-sans text-[13.5px] font-semibold leading-normal">{provider.name}</span>
                 </div>
-                <div className="col-span-2 row-start-2 min-w-0 desktop:col-span-1 desktop:col-start-2 desktop:row-start-1">
+                <div
+                  className={`col-span-2 row-start-2 flex ${detailReserve(provider)} min-w-0 items-center desktop:col-span-1 desktop:col-start-2 desktop:row-start-1`}
+                >
                   {currentAccount ? (
                     details ? (
                       <div className="flex min-w-0 items-center gap-2.5">
@@ -416,6 +426,18 @@ export default function SocialSignInCard({
                         Not linked
                       </span>
                     )
+                  ) : !error ? (
+                    // First-load placeholder shaped like the identity that replaces it.
+                    <div className="flex min-w-0 items-center gap-2.5" aria-hidden="true">
+                      <span className="h-8 w-8 flex-none animate-pulse rounded-full bg-(--surface-active)" />
+                      <span className="min-w-0">
+                        <span className="block h-[11px] w-24 animate-pulse rounded-full bg-(--surface-active)" />
+                        <span className="mt-[7px] block h-[9px] w-40 animate-pulse rounded-full bg-(--surface-active)" />
+                        {provider.target === 'slack' ? (
+                          <span className="mt-[7px] block h-[9px] w-20 animate-pulse rounded-full bg-(--surface-active)" />
+                        ) : null}
+                      </span>
+                    </div>
                   ) : null}
                 </div>
                 <div className="col-start-2 row-start-1 flex items-center justify-end gap-1 desktop:col-start-3">


### PR DESCRIPTION
## What

The **Sign-in methods** card on Profile visibly grew taller a moment after the page loaded.

Each provider row fills its identity column only once the account fetch lands. Until then that column is empty and the row is held up by the 28px provider mark alone. When the data arrives, a 32px avatar plus two or three text lines appear at once and push every row taller.

This reserves the height the identity cell will end up needing, and renders a placeholder shaped like the identity that replaces it (reusing the `animate-pulse` skeleton idiom already in `RecentSessionsCard`).

Two text lines fit inside the avatar, so most rows reserve the avatar's height. Only Slack adds a third line — the CP's schema documents `workspace` as populated for that target alone, so the reserve is per provider rather than uniform.

## Verified

Measured against a local full stack, with the fetcher held in its pending state and then resolved, comparing the two:

| | loading | loaded |
| --- | --- | --- |
| before | rows `[56, 57, 57]`, card 234.5px | rows `[60, 61, 76]`, card 261.5px |
| after | rows `[60, 61, 77]`, card 262.5px | rows `[60, 61, 77]`, card 262.5px |

The card grew 27px in one step before; loading and loaded are now identical. Also checked at 390px, where both states report rows `[96, 97, 113]` and a 351px card, and in the mixed case (one provider linked, the rest not), which is stable at the same heights.

`typecheck`, `eslint` and `prettier` pass.

## For the reviewer

- **Deliberately not** the uniform-row approach (reserving the tallest state on every row). That also removes the shift, but makes the card 33px taller and undoes some of the row rhythm from #280 / #283. Reserving per provider leaves the loaded card as it is today — the residual 1px is `min-h-12` sitting just above the 47px the three-line block actually measures.
- **Trade-off:** an unlinked Slack row is now ~16px taller than an unlinked GitHub or Google row, since it holds space for the workspace line it cannot know about in advance. Happy to drop back to a two-line reserve if that raggedness is worse than a 15px jump for anyone who has Slack linked.
- The skeleton is suppressed once the fetch errors, so the existing error/retry row stays the only thing shown; the reserved height keeps the rows steady in that state too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)