### PR TITLE
fix(auth): serialize owner membership transitions

### DIFF
--- a/docs/designs/authorization-policy.md
+++ b/docs/designs/authorization-policy.md
@@ -132,15 +132,16 @@ immutable creation attribution. Removing a member transfers every owned
 visibility carrier to a selected remaining organization owner and prunes every
 share vector before deleting the membership.
 
-Removal locks the departing and recipient memberships exclusively, in stable
-order, before scanning resources. Resource creates and sharing writes hold
-compatible shared membership locks and recheck the actor, initial owner, and
-share targets inside the resource-write transaction. This prevents a queued
-write from persisting a departed stable user ID after the removal scan, and
-prevents a concurrent removal from invalidating the selected recipient.
-
-Concurrent last-owner mutation remains tracked in
-[#271](https://github.com/agentconnect-md/agentconnect/issues/271).
+Owner demotion, removal, and invited-identity role merge first lock the
+organization `FOR NO KEY UPDATE`, then recheck the acting owner and lock the
+affected memberships. This serializes competing last-owner transitions without
+conflicting with ordinary resource writers' parent `FOR KEY SHARE`. Removal
+selects its transfer recipient from an authoritative membership snapshot inside
+that transaction before scanning resources. Resource creates and sharing writes
+hold shared membership locks and recheck the actor, initial owner, and share
+targets inside their own resource-write transaction. A queued write therefore
+cannot persist a departed stable user ID, and a transfer recipient cannot lose
+owner status before the transfer commits.
 
 ## 7. Verification
 

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -6,9 +6,8 @@
 > Resource and session decisions converge through
 > [`authorization-policy.md`](authorization-policy.md). Resource ownership is
 > independent from immutable creation attribution; normal member removal
-> transfers all five visibility carriers atomically. Concurrent last-owner
-> mutation remains tracked in
-> [#271](https://github.com/agentconnect-md/agentconnect/issues/271).
+> transfers all five visibility carriers atomically, and competing last-owner
+> demotions/removals serialize on the organization row.
 > Section 14 (platform conversation gating) is a **proposed** addendum, not yet
 > implemented.
 >
@@ -457,15 +456,19 @@ CronDef, McpProvider, and SkillSource, the transaction:
 3. leaves `createdByUserId` unchanged;
 4. deletes the membership last.
 
-The transaction first locks both the departing membership and the transfer
-recipient `FOR UPDATE`, in stable user-ID order, and verifies that the recipient
-is still a distinct organization owner. Every ownership-bearing resource create
-and dedicated sharing write uses the matching persistence seam: in the same
-transaction as the resource mutation it first protects the parent organization
-`FOR KEY SHARE`, then locks the current actor, initial owner, and requested share
-targets `FOR SHARE`, rechecks membership, and intersects `sharedWith` again. The
-parent-first order remains compatible with organization deletion; the
-shared/exclusive membership lock pair establishes a commit order:
+Owner demotion, removal, and invited-identity role merge first lock the
+organization `FOR NO KEY UPDATE`. That lock serializes owner transitions and
+conflicts with organization deletion, while remaining compatible with the
+parent `FOR KEY SHARE` held by ordinary resource writes. Removal then rechecks
+the acting owner, chooses the transfer recipient from an authoritative
+membership snapshot, and locks the departing and recipient rows inside the same
+transaction. Every ownership-bearing resource create and dedicated sharing
+write uses the matching persistence seam: in the same transaction as the
+resource mutation it first protects the parent organization `FOR KEY SHARE`,
+then locks the current actor, initial owner, and requested share targets `FOR
+SHARE`, rechecks membership, and intersects `sharedWith` again. The parent-first
+order remains compatible with organization deletion; the shared/exclusive
+membership lock pair establishes a commit order:
 
 - if the resource write commits first, removal waits and then transfers or
   prunes that row;
@@ -496,9 +499,12 @@ The HTTP `resolveShareSet` call remains useful early normalization, but it is
 not the correctness boundary because membership can change before the resource
 write commits.
 
-The existing guard continues to reject removal of the final organization
-owner. Serializing competing last-owner removals and demotions remains a
-separate part of [#271](https://github.com/agentconnect-md/agentconnect/issues/271).
+The last-owner check runs under the same organization transition lock and
+rejects before either a demotion or membership deletion commits. No
+post-transaction compensation is used.
+
+This workflow covers managed membership removal only. Direct deletion of an
+`app_user` row is unsupported and does not run ownership transfer.
 
 ## 9. Data-plane isolation: visibility never enters the daemon wire
 

--- a/packages/control-plane/src/http/routes/members.ts
+++ b/packages/control-plane/src/http/routes/members.ts
@@ -101,28 +101,7 @@ export function memberRoutes(deps: HttpDeps) {
         if (denyNonOwner(req, reply)) return
         const orgId = req.orgCtx!.orgId
         const userId = req.params.id
-        const current = (await deps.repos.user.listMembers(orgId)).find((m) => m.userId === userId)
-        if (!current) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'member not found' })
-        }
-        // Demoting the final owner would orphan the org.
-        if (current.role === 'owner' && req.body.role !== 'owner') {
-          const owners = await deps.repos.org.countOwners(orgId)
-          if (owners <= 1) {
-            return reply
-              .code(409)
-              .send({ error: 'Conflict', statusCode: 409, message: 'an organization needs at least one owner' })
-          }
-        }
-        const updated = await deps.repos.user.setMemberRole(orgId, userId, req.body.role)
-        // Compensate the check-then-act window: two concurrent demotes can both
-        // pass the pre-check — if the org just lost its last owner, restore.
-        if (current.role === 'owner' && (await deps.repos.org.countOwners(orgId)) === 0) {
-          await deps.repos.user.setMemberRole(orgId, userId, 'owner')
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'an organization needs at least one owner' })
-        }
+        const updated = await deps.repos.user.setMemberRole(orgId, userId, req.body.role, req.orgCtx!.userId)
         return toDto(updated, deps)
       }
     )
@@ -144,41 +123,8 @@ export function memberRoutes(deps: HttpDeps) {
         if (denyNonOwner(req, reply)) return
         const orgId = req.orgCtx!.orgId
         const userId = req.params.id
-        const members = await deps.repos.user.listMembers(orgId)
-        const current = members.find((m) => m.userId === userId)
-        if (!current) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'member not found' })
-        }
-        if (current.role === 'owner') {
-          const owners = await deps.repos.org.countOwners(orgId)
-          if (owners <= 1) {
-            return reply
-              .code(409)
-              .send({ error: 'Conflict', statusCode: 409, message: 'an organization needs at least one owner' })
-          }
-        }
         const actingUserId = req.orgCtx!.userId
-        const transferToUserId =
-          userId === actingUserId
-            ? members
-                .filter((member) => member.role === 'owner' && member.userId !== userId)
-                .map((member) => member.userId)
-                .sort()[0]
-            : actingUserId
-        if (!transferToUserId) {
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'an organization needs at least one owner' })
-        }
-        await deps.repos.user.removeMember(orgId, userId, transferToUserId)
-        // Compensate the check-then-act window (see PATCH above): if the org just
-        // lost its last owner to a concurrent removal, put this membership back.
-        if (current.role === 'owner' && (await deps.repos.org.countOwners(orgId)) === 0) {
-          await deps.repos.user.addMember(orgId, userId, 'owner').catch(() => {})
-          return reply
-            .code(409)
-            .send({ error: 'Conflict', statusCode: 409, message: 'an organization needs at least one owner' })
-        }
+        await deps.repos.user.removeMember(orgId, userId, actingUserId)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/http/server.ts
+++ b/packages/control-plane/src/http/server.ts
@@ -137,6 +137,13 @@ export function buildHttpServer(deps: HttpDeps, opts: FastifyServerOptions = {})
     if ((err as { code?: string }).code === 'P2002') {
       return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: 'resource already exists' })
     }
+    if ((err as { code?: string }).code === 'ORG_OWNER_REQUIRED') {
+      return reply.code(409).send({
+        error: 'Conflict',
+        statusCode: 409,
+        message: 'an organization needs at least one owner'
+      })
+    }
     if ((err as { code?: string }).code === 'RESOURCE_OWNER_MISSING') {
       return reply.code(409).send({
         error: 'Conflict',

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -98,6 +98,20 @@ export class OrgMembershipMissing extends Error {
 }
 
 /**
+ * An owner transition would leave an organization without any owner. The
+ * repository checks this under the organization transition lock, before the
+ * role update or membership deletion commits.
+ */
+export class OrgOwnerRequired extends Error {
+  readonly code = 'ORG_OWNER_REQUIRED' as const
+
+  constructor() {
+    super('an organization needs at least one owner')
+    this.name = 'OrgOwnerRequired'
+  }
+}
+
+/**
  * Restricted visibility requires a durable owner. Ownerless org-visible rows
  * remain editable, but cannot be made restricted until an explicit,
  * provenance-aware ownership workflow assigns one.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2958,11 +2958,11 @@ export interface UserRepo {
   listMembers(orgId: string): Promise<OrgMemberRecord[]>
 
   /**
-   * Change one member's role. Callers enforce owner-only access and the
-   * last-owner guard. Rejects with Prisma P2025 (→ 404) when the membership
-   * doesn't exist.
+   * Change one member's role under the organization owner-transition lock.
+   * Rechecks that the actor is still an owner and refuses to demote the final
+   * owner before committing.
    */
-  setMemberRole(orgId: string, userId: string, role: OrgMemberRole): Promise<OrgMemberRecord>
+  setMemberRole(orgId: string, userId: string, role: OrgMemberRole, actingUserId: string): Promise<OrgMemberRecord>
 
   /**
    * Add a member directly by email (no email is sent). An existing user gains a
@@ -2972,13 +2972,14 @@ export interface UserRepo {
    */
   addMemberByEmail(orgId: string, email: string, role: OrgMemberRole): Promise<OrgMemberRecord>
 
-  /** Remove a member, transfer all of their resource ownership, and prune their
-   *  share grants atomically. Rejects with a not-found-shaped error when the
-   *  target or transfer recipient is no longer eligible. Callers enforce
-   *  owner-only access and the last-owner guard. */
-  removeMember(orgId: string, userId: string, transferToUserId: string): Promise<void>
+  /**
+   * Remove a member, choose the transfer recipient, transfer all resource
+   * ownership, and prune share grants atomically. Rechecks the acting owner and
+   * refuses to remove the final owner before committing.
+   */
+  removeMember(orgId: string, userId: string, actingUserId: string): Promise<void>
 
-  /** Re-attach a known user to an org (the last-owner compensation path). */
+  /** Attach a known user to an org. */
   addMember(orgId: string, userId: string, role: OrgMemberRole): Promise<void>
 
   /** The caller's own profile (`GET /me`); null when the row is gone. */
@@ -3034,8 +3035,6 @@ export interface OrgRepo {
    * the org still has daemons. Throws P2025 when absent.
    */
   delete(orgId: string): Promise<OrgDeleteResult>
-  /** How many owners the org has (the last-owner guard reads this). */
-  countOwners(orgId: string): Promise<number>
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -113,10 +113,6 @@ export class PgOrgRepo implements OrgRepo {
     return org?.slug ?? null
   }
 
-  async countOwners(orgId: string): Promise<number> {
-    return this.db.membership.count({ where: { orgId, role: 'owner' } })
-  }
-
   async delete(orgId: string): ReturnType<OrgRepo['delete']> {
     // R2a HookRun/projection rows intentionally have no owner FK so ordinary
     // HookDef/Agent deletion can finish GitHub cleanup. Organization deletion

--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -13,7 +13,6 @@
  * placeholder, or be stored as the user's address. Emails are normalized to
  * lowercase everywhere so invites and sign-ins can't miss on case.
  */
-import type { PrismaClient } from '../../generated/prisma/client.js'
 import { Prisma, withAmbientTx, type PrismaLike } from '../prisma.js'
 import {
   type UserRepo,
@@ -25,9 +24,49 @@ import {
   isSyntheticEmail
 } from '../ports.js'
 import { provisionPresetAgents } from '../preset-agents.js'
-import { OrgMembershipMissing } from '../errors.js'
+import { OrgMembershipMissing, OrgOwnerRequired } from '../errors.js'
 
 const RESOURCE_AUTHORITY_TABLES = ['agent', 'daemon', 'cron_def', 'mcp_provider', 'skill_source'] as const
+const ORG_ROLE_RANK: Record<OrgMemberRole, number> = { viewer: 0, collaborator: 1, owner: 2 }
+
+interface LockedOrgMembership {
+  userId: string
+  role: OrgMemberRole
+}
+
+/**
+ * One transaction-scoped mutex for every owner demotion/removal in an
+ * organization. NO KEY UPDATE conflicts with another transition and org
+ * deletion, but remains compatible with the KEY SHARE lock held by ordinary
+ * resource writes.
+ *
+ * The parent row is always locked before child memberships.
+ */
+async function lockOrgOwnerTransition(tx: Prisma.TransactionClient, orgId: string): Promise<void> {
+  const org = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT "id"
+    FROM "org"
+    WHERE "id" = ${orgId}
+    FOR NO KEY UPDATE
+  `)
+  if (org.length === 0) throw new OrgMembershipMissing()
+}
+
+async function lockOrgMemberships(
+  tx: Prisma.TransactionClient,
+  orgId: string,
+  userIds: readonly string[]
+): Promise<LockedOrgMembership[]> {
+  const ids = [...new Set(userIds)].sort()
+  return tx.$queryRaw<LockedOrgMembership[]>(Prisma.sql`
+    SELECT "userId", "role"::text AS "role"
+    FROM "membership"
+    WHERE "orgId" = ${orgId}
+      AND "userId" IN (${Prisma.join(ids)})
+    ORDER BY "userId"
+    FOR UPDATE
+  `)
+}
 
 /**
  * Replace one local user identity with another in a resource's effective
@@ -315,17 +354,20 @@ export class PgUserRepo implements UserRepo {
       const expectedOrgIds = [...new Set(holder.memberships.map((membership) => membership.orgId))].sort()
       const userIds = [holder.id, userId].sort()
       const outcome = await withAmbientTx(this.db, async (tx) => {
-        // Parent before child, matching lockResourceWriteMemberships. KEY SHARE
-        // keeps an org deletion from cascading through memberships while this
-        // identity merge is moving their authority.
-        if (expectedOrgIds.length > 0) {
-          await tx.$queryRaw(Prisma.sql`
+        // Parent before child, matching every membership transition. NO KEY
+        // UPDATE serializes owner-role merges with demotion/removal while
+        // remaining compatible with ordinary resource writers' KEY SHARE.
+        // Lock multiple parents one statement at a time in sorted order; ORDER
+        // BY on one multi-row SELECT does not guarantee row-lock acquisition
+        // order.
+        for (const orgId of expectedOrgIds) {
+          const lockedOrg = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
             SELECT "id"
             FROM "org"
-            WHERE "id" IN (${Prisma.join(expectedOrgIds)})
-            ORDER BY "id"
-            FOR KEY SHARE
+            WHERE "id" = ${orgId}
+            FOR NO KEY UPDATE
           `)
+          if (lockedOrg.length === 0) return 'retry' as const
         }
 
         // Fence both the invited identity and the canonical recipient across all
@@ -385,15 +427,36 @@ export class PgUserRepo implements UserRepo {
         }
 
         const holderMemberships = currentMemberships.filter((membership) => membership.userId === holder.id)
-        if (holderMemberships.length > 0) {
+        const canonicalByOrg = new Map(
+          currentMemberships
+            .filter((membership) => membership.userId === userId)
+            .map((membership) => [membership.orgId, membership])
+        )
+        const missingMemberships = holderMemberships.filter((membership) => !canonicalByOrg.has(membership.orgId))
+        if (missingMemberships.length > 0) {
           await tx.membership.createMany({
-            data: holderMemberships.map((membership) => ({
+            data: missingMemberships.map((membership) => ({
               orgId: membership.orgId,
               userId,
               role: membership.role
             })),
             skipDuplicates: true
           })
+        }
+        // A duplicate membership keeps the stronger role. Otherwise merging an
+        // invited owner into a canonical collaborator could delete the org's
+        // final owner along with the invited placeholder.
+        for (const membership of holderMemberships) {
+          const canonicalMembership = canonicalByOrg.get(membership.orgId)
+          if (
+            canonicalMembership &&
+            ORG_ROLE_RANK[membership.role as OrgMemberRole] > ORG_ROLE_RANK[canonicalMembership.role as OrgMemberRole]
+          ) {
+            await tx.membership.update({
+              where: { id: canonicalMembership.id },
+              data: { role: membership.role }
+            })
+          }
         }
 
         // Resource-table order matches removeMember. Translate grants as well as
@@ -487,13 +550,33 @@ export class PgUserRepo implements UserRepo {
     return rows.map(toMemberRecord)
   }
 
-  async setMemberRole(orgId: string, userId: string, role: OrgMemberRole): Promise<OrgMemberRecord> {
-    const row = await this.db.membership.update({
-      where: { orgId_userId: { orgId, userId } },
-      data: { role },
-      include: { user: true }
+  async setMemberRole(
+    orgId: string,
+    userId: string,
+    role: OrgMemberRole,
+    actingUserId: string
+  ): Promise<OrgMemberRecord> {
+    return withAmbientTx(this.db, async (tx) => {
+      await lockOrgOwnerTransition(tx, orgId)
+      const memberships = await lockOrgMemberships(tx, orgId, [actingUserId, userId])
+      const actor = memberships.find((membership) => membership.userId === actingUserId)
+      const current = memberships.find((membership) => membership.userId === userId)
+      if (actor?.role !== 'owner' || !current) throw new OrgMembershipMissing()
+      if (
+        current.role === 'owner' &&
+        role !== 'owner' &&
+        (await tx.membership.count({ where: { orgId, role: 'owner' } })) === 1
+      ) {
+        throw new OrgOwnerRequired()
+      }
+
+      const row = await tx.membership.update({
+        where: { orgId_userId: { orgId, userId } },
+        data: { role },
+        include: { user: true }
+      })
+      return toMemberRecord(row)
     })
-    return toMemberRecord(row)
   }
 
   async addMemberByEmail(orgId: string, email: string, role: OrgMemberRole): Promise<OrgMemberRecord> {
@@ -509,31 +592,36 @@ export class PgUserRepo implements UserRepo {
     return toMemberRecord(row)
   }
 
-  async removeMember(orgId: string, userId: string, transferToUserId: string): Promise<void> {
+  async removeMember(orgId: string, userId: string, actingUserId: string): Promise<void> {
     // Transfer ownership, prune the departing user's grants, then remove the
     // membership in ONE transaction (docs/designs/resource-visibility.md §8).
     // createdByUserId is immutable audit attribution and is deliberately untouched.
-    const run = async (tx: PrismaLike): Promise<void> => {
-      // Common serialization point with resource create/sharing writes. Lock both
-      // ends in stable order: the departing membership fences its writes, while
-      // the recipient lock prevents another removal from invalidating the transfer
-      // target. Resource writes hold FOR SHARE on every membership whose authority
-      // they persist, so these locks close the scan→delete window.
-      const memberIds = [...new Set([userId, transferToUserId])].sort()
-      const locked = await tx.$queryRaw<Array<{ userId: string; role: string }>>(Prisma.sql`
-        SELECT "userId", "role"::text AS "role"
-        FROM "membership"
-        WHERE "orgId" = ${orgId}
-          AND "userId" IN (${Prisma.join(memberIds)})
-        ORDER BY "userId"
-        FOR UPDATE
-      `)
-      const byUserId = new Map(locked.map((member) => [member.userId, member]))
-      // The target must still exist and the distinct recipient must still own the
-      // organization at this transaction's serialization point.
-      if (userId === transferToUserId || !byUserId.has(userId) || byUserId.get(transferToUserId)?.role !== 'owner') {
+    await withAmbientTx(this.db, async (tx) => {
+      await lockOrgOwnerTransition(tx, orgId)
+      const membershipSnapshot = await tx.membership.findMany({
+        where: { orgId },
+        select: { userId: true, role: true },
+        orderBy: { userId: 'asc' }
+      })
+      const actor = membershipSnapshot.find((membership) => membership.userId === actingUserId)
+      const departing = membershipSnapshot.find((membership) => membership.userId === userId)
+      if (actor?.role !== 'owner' || !departing) throw new OrgMembershipMissing()
+
+      const transferToUserId =
+        userId === actingUserId
+          ? membershipSnapshot.find((membership) => membership.role === 'owner' && membership.userId !== userId)?.userId
+          : actingUserId
+      if (!transferToUserId) throw new OrgOwnerRequired()
+
+      // Fence ownership-bearing resource writes on both ends, then recheck the
+      // snapshot used above. The org transition lock keeps every competing
+      // demotion/removal out until this transaction commits.
+      const locked = await lockOrgMemberships(tx, orgId, [userId, transferToUserId])
+      const byUserId = new Map(locked.map((membership) => [membership.userId, membership]))
+      if (!byUserId.has(userId) || byUserId.get(transferToUserId)?.role !== 'owner') {
         throw new OrgMembershipMissing()
       }
+
       await tx.$executeRaw`UPDATE "agent" SET "ownerUserId" = CASE WHEN "ownerUserId" = ${userId} THEN ${transferToUserId} ELSE "ownerUserId" END, "sharedWith" = array_remove("sharedWith", ${userId}) WHERE "orgId" = ${orgId} AND ("ownerUserId" = ${userId} OR ${userId} = ANY("sharedWith"))`
       await tx.$executeRaw`UPDATE "daemon" SET "ownerUserId" = CASE WHEN "ownerUserId" = ${userId} THEN ${transferToUserId} ELSE "ownerUserId" END, "sharedWith" = array_remove("sharedWith", ${userId}) WHERE "orgId" = ${orgId} AND ("ownerUserId" = ${userId} OR ${userId} = ANY("sharedWith"))`
       await tx.$executeRaw`UPDATE "cron_def" SET "ownerUserId" = CASE WHEN "ownerUserId" = ${userId} THEN ${transferToUserId} ELSE "ownerUserId" END, "sharedWith" = array_remove("sharedWith", ${userId}) WHERE "orgId" = ${orgId} AND ("ownerUserId" = ${userId} OR ${userId} = ANY("sharedWith"))`
@@ -541,11 +629,7 @@ export class PgUserRepo implements UserRepo {
       await tx.$executeRaw`UPDATE "skill_source" SET "ownerUserId" = CASE WHEN "ownerUserId" = ${userId} THEN ${transferToUserId} ELSE "ownerUserId" END, "sharedWith" = array_remove("sharedWith", ${userId}) WHERE "orgId" = ${orgId} AND ("ownerUserId" = ${userId} OR ${userId} = ANY("sharedWith"))`
       // The row is still locked here; deletion completes the same transaction.
       await tx.membership.delete({ where: { orgId_userId: { orgId, userId } } })
-    }
-    // Compose under an ambient transaction when given one (TransactionClient has no
-    // $transaction); open our own interactive transaction otherwise.
-    if ('$transaction' in this.db) await (this.db as PrismaClient).$transaction((tx) => run(tx))
-    else await run(this.db)
+    })
   }
 
   async addMember(orgId: string, userId: string, role: OrgMemberRole): Promise<void> {

--- a/packages/control-plane/test/integration/members.route.test.ts
+++ b/packages/control-plane/test/integration/members.route.test.ts
@@ -7,9 +7,11 @@
  * invited rows claimed at first SSO sign-in), re-roled (`PATCH`), and removed
  * (`DELETE`), with the last-owner guard keeping the org from orphaning itself.
  */
-import { describe, it, expect } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { describe, it, expect, vi } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { buildHttpApp } from '../fakes/build-http.js'
+import { seedAgent } from '../fixtures/seed.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID, DEFAULT_OWNER_EMAIL } from '../../prisma/seed.js'
 
@@ -26,6 +28,54 @@ interface MemberBody {
 
 const signup = (oidcSubject: string, email: string) =>
   new PgUserRepo(prisma).provisionOidcUser({ oidcSubject, email, emailVerified: true })
+
+async function makeOwner(label: string): Promise<string> {
+  const suffix = randomUUID()
+  const email = `${label}-${suffix}@acme.dev`
+  const { userId } = await signup(`${label}-${suffix}`, email)
+  await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, email, 'owner')
+  return userId
+}
+
+async function holdOwnerTransitions(): Promise<{ release(): void; blocker: Promise<void> }> {
+  let releaseLock!: () => void
+  let markLocked!: () => void
+  const release = new Promise<void>((resolve) => (releaseLock = resolve))
+  const locked = new Promise<void>((resolve) => (markLocked = resolve))
+  const blocker = prisma.$transaction(
+    async (tx) => {
+      await tx.$queryRaw`
+        SELECT "id"
+        FROM "org"
+        WHERE "id" = ${DEFAULT_ORG_ID}
+        FOR UPDATE
+      `
+      markLocked()
+      await release
+    },
+    { timeout: 20_000 }
+  )
+  await locked
+
+  let released = false
+  return {
+    release() {
+      if (released) return
+      released = true
+      releaseLock()
+    },
+    blocker
+  }
+}
+
+async function waitingLocks(): Promise<number> {
+  const rows = await prisma.$queryRaw<Array<{ waiting: bigint }>>`
+    SELECT count(*)::bigint AS "waiting"
+    FROM pg_stat_activity
+    WHERE datname = current_database() AND wait_event_type = 'Lock'
+  `
+  return Number(rows[0]?.waiting ?? 0n)
+}
 
 describe('GET /members', () => {
   it('lists the seeded owner plus members added to the default org', async () => {
@@ -167,6 +217,138 @@ describe('DELETE /members/:id — removal', () => {
       expect(res.statusCode).toBe(409)
     } finally {
       await close()
+    }
+  })
+})
+
+describe('concurrent owner transitions', () => {
+  it('allows only one of two owners to leave and transfers both resources to the survivor', async () => {
+    const otherOwnerId = await makeOwner('concurrent-leave')
+    const firstAgentId = randomUUID()
+    const secondAgentId = randomUUID()
+    await seedAgent(prisma, firstAgentId, {
+      createdByUserId: DEFAULT_OWNER_ID,
+      ownerUserId: DEFAULT_OWNER_ID
+    })
+    await seedAgent(prisma, secondAgentId, {
+      createdByUserId: otherOwnerId,
+      ownerUserId: otherOwnerId
+    })
+    const firstApp = buildHttpApp(prisma)
+    const secondApp = buildHttpApp(prisma, { DEFAULT_OWNER_ID: otherOwnerId })
+    const transitionBlocker = await holdOwnerTransitions()
+    const pending: Promise<unknown>[] = []
+
+    try {
+      const firstLeave = firstApp.app.inject({
+        method: 'DELETE',
+        url: `${ORG}/members/${DEFAULT_OWNER_ID}`
+      })
+      const secondLeave = secondApp.app.inject({
+        method: 'DELETE',
+        url: `${ORG}/members/${otherOwnerId}`
+      })
+      pending.push(firstLeave, secondLeave)
+      await vi.waitFor(async () => expect(await waitingLocks()).toBeGreaterThanOrEqual(2), { timeout: 5_000 })
+
+      transitionBlocker.release()
+      const responses = await Promise.all([firstLeave, secondLeave])
+      expect(responses.map((response) => response.statusCode).sort()).toEqual([204, 409])
+
+      const members = await prisma.membership.findMany({ where: { orgId: DEFAULT_ORG_ID } })
+      expect(members).toHaveLength(1)
+      expect(members[0]!.role).toBe('owner')
+      const resources = await prisma.agent.findMany({
+        where: { id: { in: [firstAgentId, secondAgentId] } },
+        select: { ownerUserId: true }
+      })
+      expect(resources).toHaveLength(2)
+      expect(resources.every((resource) => resource.ownerUserId === members[0]!.userId)).toBe(true)
+    } finally {
+      transitionBlocker.release()
+      await Promise.allSettled([transitionBlocker.blocker, ...pending])
+      await Promise.all([firstApp.close(), secondApp.close()])
+    }
+  })
+
+  it('allows only one of two owners to demote themselves', async () => {
+    const otherOwnerId = await makeOwner('concurrent-demote')
+    const firstApp = buildHttpApp(prisma)
+    const secondApp = buildHttpApp(prisma, { DEFAULT_OWNER_ID: otherOwnerId })
+    const transitionBlocker = await holdOwnerTransitions()
+    const pending: Promise<unknown>[] = []
+
+    try {
+      const firstDemote = firstApp.app.inject({
+        method: 'PATCH',
+        url: `${ORG}/members/${DEFAULT_OWNER_ID}`,
+        payload: { role: 'viewer' }
+      })
+      const secondDemote = secondApp.app.inject({
+        method: 'PATCH',
+        url: `${ORG}/members/${otherOwnerId}`,
+        payload: { role: 'viewer' }
+      })
+      pending.push(firstDemote, secondDemote)
+      await vi.waitFor(async () => expect(await waitingLocks()).toBeGreaterThanOrEqual(2), { timeout: 5_000 })
+
+      transitionBlocker.release()
+      const responses = await Promise.all([firstDemote, secondDemote])
+      expect(responses.map((response) => response.statusCode).sort()).toEqual([200, 409])
+
+      const members = await prisma.membership.findMany({
+        where: { orgId: DEFAULT_ORG_ID },
+        orderBy: { userId: 'asc' }
+      })
+      expect(members.map((member) => member.role).sort()).toEqual(['owner', 'viewer'])
+    } finally {
+      transitionBlocker.release()
+      await Promise.allSettled([transitionBlocker.blocker, ...pending])
+      await Promise.all([firstApp.close(), secondApp.close()])
+    }
+  })
+
+  it('keeps the transfer recipient owned when leave races with demotion', async () => {
+    const otherOwnerId = await makeOwner('leave-demote')
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      createdByUserId: DEFAULT_OWNER_ID,
+      ownerUserId: DEFAULT_OWNER_ID
+    })
+    const leavingApp = buildHttpApp(prisma)
+    const demotingApp = buildHttpApp(prisma, { DEFAULT_OWNER_ID: otherOwnerId })
+    const transitionBlocker = await holdOwnerTransitions()
+    const pending: Promise<unknown>[] = []
+
+    try {
+      const leave = leavingApp.app.inject({
+        method: 'DELETE',
+        url: `${ORG}/members/${DEFAULT_OWNER_ID}`
+      })
+      const demote = demotingApp.app.inject({
+        method: 'PATCH',
+        url: `${ORG}/members/${otherOwnerId}`,
+        payload: { role: 'viewer' }
+      })
+      pending.push(leave, demote)
+      await vi.waitFor(async () => expect(await waitingLocks()).toBeGreaterThanOrEqual(2), { timeout: 5_000 })
+
+      transitionBlocker.release()
+      const responses = await Promise.all([leave, demote])
+      const statuses = responses.map((response) => response.statusCode)
+      expect(statuses.filter((status) => status === 409)).toHaveLength(1)
+      expect(statuses.some((status) => status === 200 || status === 204)).toBe(true)
+
+      const owners = await prisma.membership.findMany({
+        where: { orgId: DEFAULT_ORG_ID, role: 'owner' },
+        select: { userId: true }
+      })
+      expect(owners).toHaveLength(1)
+      expect((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).ownerUserId).toBe(owners[0]!.userId)
+    } finally {
+      transitionBlocker.release()
+      await Promise.allSettled([transitionBlocker.blocker, ...pending])
+      await Promise.all([leavingApp.close(), demotingApp.close()])
     }
   })
 })

--- a/packages/control-plane/test/repo/user.repo.test.ts
+++ b/packages/control-plane/test/repo/user.repo.test.ts
@@ -177,6 +177,13 @@ describe('PgUserRepo.provisionOidcUser — signup creates the personal org', () 
     expect(upgraded.userId).toBe(canonicalUserId)
     expect(await prisma.user.findUnique({ where: { id: invited.userId } })).toBeNull()
     expect((await prisma.user.findUniqueOrThrow({ where: { id: canonicalUserId } })).email).toBe(email)
+    expect(
+      (
+        await prisma.membership.findUniqueOrThrow({
+          where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: canonicalUserId } }
+        })
+      ).role
+    ).toBe('owner')
 
     const select = { ownerUserId: true, sharedWith: true, createdByUserId: true } as const
     const resources = await Promise.all([


### PR DESCRIPTION
## Summary

- serialize owner demotion, member removal, and invited-identity role merge per organization with a `FOR NO KEY UPDATE` transition lock
- move acting-owner revalidation, final-owner refusal, deterministic transfer-target selection, ownership transfer, share pruning, and membership deletion into the same transaction
- remove the old post-commit owner-count compensation path, so no committed zero-owner interval is possible
- preserve the stronger membership role when an invited placeholder identity merges into an existing canonical user
- add deterministic PostgreSQL regressions for concurrent self-leave, concurrent self-demotion, and leave-versus-recipient-demotion

## Why

The remaining part of #271 still checked and compensated the final-owner invariant outside the membership mutation transaction. Competing owner transitions could therefore commit a zero-owner state before a later repair, and a crash in that interval could make the orphan permanent. A stale acting-owner snapshot could also authorize a queued role mutation after that actor lost ownership.

The organization row is now the common transition mutex. `FOR NO KEY UPDATE` serializes competing owner transitions and organization deletion while remaining compatible with ordinary resource writers' parent `FOR KEY SHARE`; the existing membership shared/exclusive locks still order resource writes against transfer and pruning.

## Scope

This completes managed organization membership transitions only. It does not add account deletion or Session ownership. Direct deletion of `app_user` remains unsupported.

`POST /members` is unchanged: it can add an owner but cannot reduce the owner count. Commit-time revalidation for every owner-management write can be considered separately if that broader authorization guarantee is desired.

## Deployment

There is no database migration. The invariant depends on every Control Plane membership-transition writer taking the new organization lock, so drain older Control Plane writers (or temporarily disable member mutations) before serving the new version across all instances.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` (93 files / 809 tests)
- PostgreSQL member, visibility, ownership-transfer, and identity-merge suites (53 tests; all 50 migrations applied from empty PostgreSQL)
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
- two independent read-only reviews found no P0-P2

Closes #271
