### PR TITLE
fix(integrations): enforce Slack description byte limit

### DIFF
--- a/packages/control-plane/src/http/platform-app-description.ts
+++ b/packages/control-plane/src/http/platform-app-description.ts
@@ -1,19 +1,33 @@
 export const DEFAULT_PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
 export const LARK_APP_DESCRIPTION_MAX_LENGTH = 120
-export const SLACK_APP_DESCRIPTION_MAX_LENGTH = 300
+export const SLACK_APP_DESCRIPTION_MAX_BYTES = 300
 
-/**
- * Platform launchers count JavaScript string length, so keep the result within
- * their UTF-16 limit without cutting a surrogate pair in half.
- */
-export function platformAppDescription(description: string | null | undefined, maxLength: number): string {
+const ELLIPSIS = '…'
+const UTF8_ENCODER = new TextEncoder()
+const utf16Length = (value: string): number => value.length
+
+export function utf8ByteLength(value: string): number {
+  return UTF8_ENCODER.encode(value).byteLength
+}
+
+/** Keep a platform description within its measured limit without splitting a
+ * Unicode code point. Lark uses the default UTF-16 length; Slack's live manifest
+ * validator applies its documented 300-character limit to UTF-8 bytes. */
+export function platformAppDescription(
+  description: string | null | undefined,
+  maxLength: number,
+  lengthOf: (value: string) => number = utf16Length
+): string {
   const value = description?.trim() || DEFAULT_PLATFORM_APP_DESCRIPTION
-  if (value.length <= maxLength) return value
+  if (lengthOf(value) <= maxLength) return value
 
   let head = ''
+  let length = lengthOf(ELLIPSIS)
   for (const character of value) {
-    if (head.length + character.length >= maxLength) break
+    const characterLength = lengthOf(character)
+    if (length + characterLength > maxLength) break
     head += character
+    length += characterLength
   }
-  return `${head.trimEnd()}…`
+  return `${head.trimEnd()}${ELLIPSIS}`
 }

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -8,7 +8,11 @@ import {
   DEFAULT_SLACK_APP_NAME
 } from './slack-manifest.js'
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
-import { DEFAULT_PLATFORM_APP_DESCRIPTION, SLACK_APP_DESCRIPTION_MAX_LENGTH } from './platform-app-description.js'
+import {
+  DEFAULT_PLATFORM_APP_DESCRIPTION,
+  SLACK_APP_DESCRIPTION_MAX_BYTES,
+  utf8ByteLength
+} from './platform-app-description.js'
 
 // The PUBLIC form — `/v1`, not the internal `/api/v1` (see SLACK_OAUTH_CALLBACK_PATH).
 const REDIRECT = 'https://cp.example/v1/integrations/slack/oauth/callback'
@@ -71,7 +75,10 @@ describe('buildInstallManifest', () => {
   })
 
   it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
-    const description = `${'a'.repeat(297)}😀tail`
+    const description = `${'a'.repeat(297)}😀`
+    expect(description.length).toBeLessThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    expect(utf8ByteLength(description)).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+
     const custom = buildInstallManifest('acme-bot', REDIRECT, { description }) as {
       features: { agent_view: { agent_description: string } }
     }
@@ -79,8 +86,8 @@ describe('buildInstallManifest', () => {
       features: { agent_view: { agent_description: string } }
     }
 
-    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}😀…`)
-    expect(custom.features.agent_view.agent_description.length).toBe(SLACK_APP_DESCRIPTION_MAX_LENGTH)
+    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}…`)
+    expect(utf8ByteLength(custom.features.agent_view.agent_description)).toBe(SLACK_APP_DESCRIPTION_MAX_BYTES)
     expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_PLATFORM_APP_DESCRIPTION)
   })
 

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -15,7 +15,7 @@
  * change them here, change them in packages/web/src/lib/slack-manifest.ts too.
  */
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
-import { platformAppDescription, SLACK_APP_DESCRIPTION_MAX_LENGTH } from './platform-app-description.js'
+import { platformAppDescription, SLACK_APP_DESCRIPTION_MAX_BYTES, utf8ByteLength } from './platform-app-description.js'
 
 /**
  * Bot token scopes the Slack app requests. Widening this list later forces every
@@ -125,7 +125,7 @@ function buildManagedManifest(name: string, options: SlackManifestOptions = {}):
       bot_user: { display_name: displayName, always_online: true },
       app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
       agent_view: {
-        agent_description: platformAppDescription(options.description, SLACK_APP_DESCRIPTION_MAX_LENGTH),
+        agent_description: platformAppDescription(options.description, SLACK_APP_DESCRIPTION_MAX_BYTES, utf8ByteLength),
         suggested_prompts: []
       },
       shortcuts: [

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -6,7 +6,7 @@ import {
   SLACK_BOT_EVENTS,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   DEFAULT_SLACK_APP_DESCRIPTION,
-  SLACK_APP_DESCRIPTION_MAX_LENGTH
+  SLACK_APP_DESCRIPTION_MAX_BYTES
 } from './slack-manifest'
 
 // The manual manifest must request exactly what the CP's auto-install manifest does, or
@@ -64,12 +64,16 @@ describe('buildSlackManifest', () => {
   })
 
   it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
-    const description = `${'a'.repeat(297)}😀tail`
+    const description = `${'a'.repeat(297)}😀`
+    const utf8 = new TextEncoder()
+    expect(description.length).toBeLessThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    expect(utf8.encode(description).byteLength).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+
     const custom = buildSlackManifest({ name: 'acme' }, { description })
     const fallback = buildSlackManifest({ name: 'acme' }, { description: '   ' })
 
-    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}😀…`)
-    expect(custom.features.agent_view.agent_description.length).toBe(SLACK_APP_DESCRIPTION_MAX_LENGTH)
+    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}…`)
+    expect(utf8.encode(custom.features.agent_view.agent_description).byteLength).toBe(SLACK_APP_DESCRIPTION_MAX_BYTES)
     expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_SLACK_APP_DESCRIPTION)
   })
 

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -73,7 +73,14 @@ export const SLACK_BOT_EVENTS = [
 /** Fallback name so the manifest / deep link are always valid before the user types one. */
 export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
 export const DEFAULT_SLACK_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
-export const SLACK_APP_DESCRIPTION_MAX_LENGTH = 300
+export const SLACK_APP_DESCRIPTION_MAX_BYTES = 300
+
+const ELLIPSIS = '…'
+const UTF8_ENCODER = new TextEncoder()
+
+function utf8ByteLength(value: string): number {
+  return UTF8_ENCODER.encode(value).byteLength
+}
 
 export interface SlackAppManifest {
   display_information: { name: string; background_color?: string }
@@ -113,14 +120,17 @@ export interface SlackManifestOpts {
 
 function slackAppDescription(description: string | null | undefined): string {
   const value = description?.trim() || DEFAULT_SLACK_APP_DESCRIPTION
-  if (value.length <= SLACK_APP_DESCRIPTION_MAX_LENGTH) return value
+  if (utf8ByteLength(value) <= SLACK_APP_DESCRIPTION_MAX_BYTES) return value
 
   let head = ''
+  let bytes = utf8ByteLength(ELLIPSIS)
   for (const character of value) {
-    if (head.length + character.length >= SLACK_APP_DESCRIPTION_MAX_LENGTH) break
+    const characterBytes = utf8ByteLength(character)
+    if (bytes + characterBytes > SLACK_APP_DESCRIPTION_MAX_BYTES) break
     head += character
+    bytes += characterBytes
   }
-  return `${head.trimEnd()}…`
+  return `${head.trimEnd()}${ELLIPSIS}`
 }
 
 /** The two names the manifest carries — mirrors the agent's naming model:


### PR DESCRIPTION
## Summary

- enforce Slack's live 300-byte UTF-8 limit for agent descriptions in both manual and automatic app manifests
- preserve Unicode code points while reserving space for the truncation ellipsis
- keep Lark's existing UTF-16 description limit unchanged
- add regression coverage for descriptions that are under 300 JavaScript characters but over 300 UTF-8 bytes

## Root cause

Slack documents `features.agent_view.agent_description` as a 300-character field, but its live manifest editor validates the value as UTF-8 bytes. The existing truncation measured JavaScript UTF-16 length and could emit a 299-character description that occupied 301 bytes after appending a Unicode ellipsis, causing Slack to reject the manifest.

## Impact

New Slack apps can be created from long or multibyte Agent descriptions without manual manifest edits. Empty-description fallback behavior and existing-app refresh preservation are unchanged.

## Validation

- live Slack manifest editor: 300 ASCII bytes accepted; 301 rejected
- live reproduction: a 299-character / 301-byte value rejected, while its 299-byte ASCII equivalent was accepted
- Web Slack manifest unit tests: 6 passed
- Control Plane Slack manifest unit tests: 11 passed
- Slack auto-install integration tests: 30 passed
- Web and Control Plane typechecks
- changed-file ESLint and Prettier checks
- pre-push repository lint
- `git diff --check`

Closes #289

Created by Codex . GPT-5
