### PR TITLE
fix(integrations): sync Discord app descriptions

### DIFF
--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -144,7 +144,7 @@ import { verifySlackBot, verifySlackAppToken } from './http/slack-identity.js'
 import { verifyTelegramBot } from './http/telegram-identity.js'
 import { createTelegramBotIconSyncer } from './http/telegram-bot-profile.js'
 import { ensureDiscordMessageContentIntent, verifyDiscordBot } from './http/discord-identity.js'
-import { createDiscordBotIconSyncer } from './http/discord-bot-profile.js'
+import { createDiscordBotProfileSyncer } from './http/discord-bot-profile.js'
 import { verifyFeishuBot } from './http/feishu-identity.js'
 import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
@@ -696,7 +696,7 @@ export function buildContainer(
     syncTelegramBotIcon: createTelegramBotIconSyncer(iconStore),
     verifyDiscordBot,
     ensureDiscordMessageContentIntent,
-    syncDiscordBotIcon: createDiscordBotIconSyncer(iconStore),
+    syncDiscordBotProfile: createDiscordBotProfileSyncer(iconStore),
     verifyFeishuBot,
     configureFeishuHttpApp,
     syncFeishuAppIcon: createFeishuAppIconSyncer(iconStore),

--- a/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.test.ts
@@ -128,7 +128,7 @@ describe('syncAgentBotIcons', () => {
             }
           },
           syncTelegramBotIcon: telegramSync,
-          syncDiscordBotIcon: discordSync,
+          syncDiscordBotProfile: discordSync,
           syncFeishuAppIcon: feishuSync
         },
         agent,
@@ -188,7 +188,7 @@ describe('syncAgentBotIcons', () => {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }
       },
-      syncDiscordBotIcon: discordSync
+      syncDiscordBotProfile: discordSync
     }
     const warn = vi.fn()
 
@@ -243,7 +243,7 @@ describe('syncAgentBotIcons', () => {
           get: async () => ({ botToken: 'discord-token', appToken: null, signingSecret: null })
         }
       },
-      syncDiscordBotIcon: discordSync
+      syncDiscordBotProfile: discordSync
     }
     const warn = vi.fn()
 

--- a/packages/control-plane/src/http/agent-bot-icon-sync.ts
+++ b/packages/control-plane/src/http/agent-bot-icon-sync.ts
@@ -7,7 +7,7 @@ import type {
   IntegrationRepo
 } from '../persistence/ports.js'
 import type { BotProfileIconAgent } from './bot-profile-icon.js'
-import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
+import type { DiscordBotProfileSyncer } from './discord-bot-profile.js'
 import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
 import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 
@@ -19,7 +19,7 @@ interface AgentBotIconSyncDeps {
     botSecret: Pick<BotSecretStore, 'get'>
   }
   syncTelegramBotIcon?: TelegramBotIconSyncer
-  syncDiscordBotIcon?: DiscordBotIconSyncer
+  syncDiscordBotProfile?: DiscordBotProfileSyncer
   syncFeishuAppIcon?: FeishuAppIconSyncer
 }
 
@@ -56,7 +56,7 @@ async function currentBotIconState(
 
   const supported =
     (bot.platform === 'telegram' && deps.syncTelegramBotIcon) ||
-    (bot.platform === 'discord' && deps.syncDiscordBotIcon) ||
+    (bot.platform === 'discord' && deps.syncDiscordBotProfile) ||
     (bot.platform === 'feishu' && deps.syncFeishuAppIcon)
   if (!supported) return null
 
@@ -93,8 +93,8 @@ async function syncBotIconUntilCurrent(
     try {
       if (state.bot.platform === 'telegram' && deps.syncTelegramBotIcon) {
         await deps.syncTelegramBotIcon(secret.botToken, state.agent)
-      } else if (state.bot.platform === 'discord' && deps.syncDiscordBotIcon) {
-        await deps.syncDiscordBotIcon(secret.botToken, state.agent)
+      } else if (state.bot.platform === 'discord' && deps.syncDiscordBotProfile) {
+        await deps.syncDiscordBotProfile(secret.botToken, state.agent)
       } else if (state.bot.platform === 'feishu' && deps.syncFeishuAppIcon) {
         // The secret row keeps the credential pair together; public bot
         // metadata is only the fallback for older rows.

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -69,7 +69,7 @@ import type { SlackConfigApi } from './slack-config-api.js'
 import type { TelegramBotVerifier } from './telegram-identity.js'
 import type { TelegramBotIconSyncer } from './telegram-bot-profile.js'
 import type { DiscordBotVerifier, DiscordMessageContentIntentEnsurer } from './discord-identity.js'
-import type { DiscordBotIconSyncer } from './discord-bot-profile.js'
+import type { DiscordBotProfileSyncer } from './discord-bot-profile.js'
 import type { FeishuBotVerifier } from './feishu-identity.js'
 import type { FeishuAppIconSyncer } from './feishu-app-icon.js'
 import type { FeishuAppRegistrationService } from './feishu-registration.js'
@@ -275,9 +275,9 @@ export interface HttpDeps {
   /** Ensures the Discord application has Message Content enabled before credentials
    *  are stored. Test composition injects an offline success stub. */
   ensureDiscordMessageContentIntent: DiscordMessageContentIntentEnsurer
-  /** Applies an Agent icon to a Discord bot-user avatar and application icon.
+  /** Applies an Agent icon and description to the Discord bot/application profile.
    *  Cosmetic and best-effort: install/icon updates survive a sync failure. */
-  syncDiscordBotIcon?: DiscordBotIconSyncer
+  syncDiscordBotProfile?: DiscordBotProfileSyncer
   /** Validates a pasted Feishu appId + appSecret via the tenant-access-token exchange
    *  (and derives the bot name from `bot/v3/info` when the install omits one).
    *  Optional/injectable so tests stay offline (absent ⇒ no validation, route falls

--- a/packages/control-plane/src/http/discord-bot-profile.test.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.test.ts
@@ -1,7 +1,8 @@
 import sharp from 'sharp'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IconStore } from '../icons/icon-store.js'
-import { createDiscordBotIconSyncer } from './discord-bot-profile.js'
+import { createDiscordBotProfileSyncer } from './discord-bot-profile.js'
+import { PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS } from './platform-app-description.js'
 
 const realFetch = globalThis.fetch
 
@@ -19,15 +20,16 @@ function dataUriBytes(data: string): Buffer {
   return Buffer.from(data.slice(data.indexOf(',') + 1), 'base64')
 }
 
-describe('createDiscordBotIconSyncer', () => {
-  it('renders the brand glyph as a 512px PNG on a white plate', async () => {
+describe('createDiscordBotProfileSyncer', () => {
+  it('renders the brand glyph and applies a bounded application description', async () => {
     successfulDiscordFetch()
-    const sync = createDiscordBotIconSyncer()
+    const sync = createDiscordBotProfileSyncer()
 
     await sync('discord-secret', {
       id: '00000000-0000-4000-8000-000000000001',
       icon: { kind: 'glyph', glyph: 'agentconnect', color: '#1a212b' },
-      runtime: 'claude'
+      runtime: 'claude',
+      description: `${'😀'.repeat(PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS)}a`
     })
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
@@ -40,8 +42,10 @@ describe('createDiscordBotIconSyncer', () => {
     expect(requests.every((init) => init.method === 'PATCH')).toBe(true)
     expect(requests.every((init) => new Headers(init.headers).get('authorization') === 'Bot discord-secret')).toBe(true)
     const botBody = JSON.parse(requests[0]!.body as string) as { avatar: string }
-    const appBody = JSON.parse(requests[1]!.body as string) as { icon: string }
+    const appBody = JSON.parse(requests[1]!.body as string) as { icon: string; description: string }
     expect(appBody.icon).toBe(botBody.avatar)
+    expect(appBody.description).toBe(`${'😀'.repeat(PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS - 1)}…`)
+    expect([...appBody.description]).toHaveLength(PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS)
     const png = dataUriBytes(botBody.avatar)
     const metadata = await sharp(png).metadata()
     expect(metadata).toMatchObject({ format: 'png', width: 512, height: 512, hasAlpha: false })
@@ -62,12 +66,13 @@ describe('createDiscordBotIconSyncer', () => {
       delete: vi.fn(async () => undefined),
       publicUrl: vi.fn(() => 'https://images.example.test/icon')
     }
-    const sync = createDiscordBotIconSyncer(store)
+    const sync = createDiscordBotProfileSyncer(store)
 
     await sync('discord-secret', {
       id: '00000000-0000-4000-8000-000000000002',
       icon: { kind: 'image' },
-      runtime: 'codex'
+      runtime: 'codex',
+      description: null
     })
 
     expect(store.get).toHaveBeenCalledWith('icon/agents/00000000-0000-4000-8000-000000000002')

--- a/packages/control-plane/src/http/discord-bot-profile.ts
+++ b/packages/control-plane/src/http/discord-bot-profile.ts
@@ -1,12 +1,17 @@
+import type { AgentRecord } from '../persistence/ports.js'
 import type { IconStore } from '../icons/icon-store.js'
 import { loadBotProfileIcon, type BotProfileIconAgent } from './bot-profile-icon.js'
+import { platformAppDescription } from './platform-app-description.js'
 
 const DISCORD_API = 'https://discord.com/api/v10'
 const DISCORD_TIMEOUT_MS = 5000
 const DISCORD_ICON_SIZE = 512
 const DISCORD_ICON_BACKGROUND = '#ffffff'
+const DISCORD_APP_DESCRIPTION_MAX_LENGTH = 400
+const codePointLength = (value: string): number => [...value].length
 
-export type DiscordBotIconSyncer = (botToken: string, agent: BotProfileIconAgent) => Promise<void>
+export type DiscordBotProfileAgent = BotProfileIconAgent & Pick<AgentRecord, 'description'>
+export type DiscordBotProfileSyncer = (botToken: string, agent: DiscordBotProfileAgent) => Promise<void>
 
 async function iconData(agent: BotProfileIconAgent, iconStore?: IconStore): Promise<string> {
   const icon = await loadBotProfileIcon(agent, iconStore, DISCORD_ICON_SIZE)
@@ -19,35 +24,37 @@ async function iconData(agent: BotProfileIconAgent, iconStore?: IconStore): Prom
   return `data:image/png;base64,${png.toString('base64')}`
 }
 
-async function patchIcon(botToken: string, path: string, field: 'avatar' | 'icon', data: string): Promise<void> {
+async function patchProfile(botToken: string, path: string, body: Record<string, string>): Promise<void> {
   const res = await fetch(`${DISCORD_API}${path}`, {
     method: 'PATCH',
     headers: {
       authorization: `Bot ${botToken}`,
       'content-type': 'application/json'
     },
-    body: JSON.stringify({ [field]: data }),
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS)
   })
   await res.arrayBuffer()
   if (!res.ok) throw new Error(`${path} returned ${res.status}`)
 }
 
-/** Apply an opaque high-resolution Agent icon to both Discord identities: the
- * bot user (messages and member lists) and the application (install/profile
- * surfaces). The white plate keeps transparent icons consistent instead of
- * exposing Discord's dark avatar backdrop. Both calls are attempted; the route
- * treats any failure as cosmetic and keeps the integration. */
-export function createDiscordBotIconSyncer(iconStore?: IconStore): DiscordBotIconSyncer {
+/** Apply an Agent profile to both Discord identities: the bot-user avatar used
+ * in messages/member lists, plus the application icon and description shown on
+ * install/profile surfaces. Both calls are attempted; callers treat any failure
+ * as cosmetic and keep the integration. */
+export function createDiscordBotProfileSyncer(iconStore?: IconStore): DiscordBotProfileSyncer {
   return async (botToken, agent) => {
     const data = await iconData(agent, iconStore)
+    // The shared helper applies the 100-character product cap before this
+    // provider-specific 400-character ceiling.
+    const description = platformAppDescription(agent.description, DISCORD_APP_DESCRIPTION_MAX_LENGTH, codePointLength)
     const results = await Promise.allSettled([
-      patchIcon(botToken, '/users/@me', 'avatar', data),
-      patchIcon(botToken, '/applications/@me', 'icon', data)
+      patchProfile(botToken, '/users/@me', { avatar: data }),
+      patchProfile(botToken, '/applications/@me', { icon: data, description })
     ])
     const failures = results.flatMap((result) =>
       result.status === 'rejected' ? [result.reason instanceof Error ? result.reason.message : 'unknown error'] : []
     )
-    if (failures.length > 0) throw new Error(`Discord icon sync failed: ${failures.join('; ')}`)
+    if (failures.length > 0) throw new Error(`Discord profile sync failed: ${failures.join('; ')}`)
   }
 }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -519,11 +519,14 @@ export function integrationRoutes(deps: HttpDeps) {
               ...(req.principal ? { createdByUserId: req.principal.userId } : {})
             })
             await replicateUpsert(integration, daemonId)
-            if (deps.syncDiscordBotIcon && check?.status !== 'unreachable') {
+            if (deps.syncDiscordBotProfile && check?.status !== 'unreachable') {
               try {
-                await deps.syncDiscordBotIcon(discord.botToken, agent)
+                await deps.syncDiscordBotProfile(discord.botToken, agent)
               } catch (err) {
-                app.log.warn({ err, agentId: agent.id, botId }, 'discord icon sync failed; integration remains active')
+                app.log.warn(
+                  { err, agentId: agent.id, botId },
+                  'discord profile sync failed; integration remains active'
+                )
               }
             }
             return reply.code(201).send(toDto(integration))

--- a/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
+++ b/packages/control-plane/test/integration/agent-icon-sync.route.test.ts
@@ -52,7 +52,7 @@ describe('Agent icon bot profile fan-out', () => {
     running = buildHttpApp(prisma, { S3_PUBLIC_BASE_URL: 'https://images.example.test' }, undefined, undefined, {
       iconStore: store,
       syncTelegramBotIcon: telegramSync,
-      syncDiscordBotIcon: discordSync,
+      syncDiscordBotProfile: discordSync,
       syncFeishuAppIcon: feishuSync
     })
 

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -267,15 +267,16 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
 
   it('POST discord registers a bot + secret with a NULL appToken, decodes the app id, pushes a discord-shaped upsert', async () => {
     const agentId = await placedAgent()
+    await prisma.agent.update({ where: { id: agentId }, data: { description: 'Answers support questions.' } })
     const { app, spy } = withSpy()
-    let iconSync: { botToken: string; agentId: string } | undefined
+    let profileSync: { botToken: string; agentId: string; description: string | null } | undefined
     let intentToken: string | undefined
     app.deps.ensureDiscordMessageContentIntent = async (botToken) => {
       intentToken = botToken
       return 'ready'
     }
-    app.deps.syncDiscordBotIcon = async (botToken, agent) => {
-      iconSync = { botToken, agentId: agent.id }
+    app.deps.syncDiscordBotProfile = async (botToken, agent) => {
+      profileSync = { botToken, agentId: agent.id, description: agent.description }
       throw new Error('fixture rate limit')
     }
 
@@ -310,7 +311,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     })
     // Cosmetic profile updates are attempted after the durable install, but a
     // Discord failure never rolls back or blocks the functional integration.
-    expect(iconSync).toEqual({ botToken: DISCORD_TOKEN, agentId })
+    expect(profileSync).toEqual({ botToken: DISCORD_TOKEN, agentId, description: 'Answers support questions.' })
     expect(intentToken).toBe(DISCORD_TOKEN)
   })
 


### PR DESCRIPTION
## Summary

- sync the Agent description into the Discord application profile during integration setup
- send the description with the existing application-icon update, using the shared 100-Unicode-character product cap from #294 while retaining Discord's 400-character provider limit
- rename the Discord sync seam from icon-only to profile sync so its behavior is explicit

## Root cause

The Discord install path synchronized the bot-user avatar and application icon, but never included the application's `description` field. Discord therefore kept the description entered manually in the Developer Portal, often blank.

## Impact

New Discord integrations now receive a concise version of the owning Agent's description without making cosmetic profile updates a prerequisite for installation. The 100-character product cap remains below Discord's 400-character platform limit and counts Unicode code points rather than UTF-16 units. Existing integrations receive it on their next profile sync, such as after an Agent icon update; this change does not run a bulk remote backfill.

## Validation

- 5 focused unit tests
- 43 targeted integration tests
- control-plane typecheck
- changed-file ESLint and Prettier checks
- full repository ESLint in the pre-push hook
- `git diff --check`

Created by Codex . GPT-5
