### PR TITLE
feat(auth): let members leave organizations

### DIFF
--- a/docs/designs/authorization-policy.md
+++ b/docs/designs/authorization-policy.md
@@ -66,6 +66,10 @@ The action vocabulary represents the distinct OSS policies that exist today:
 | `session.view`              | tier, owner identity, identity set | org-visible or identity-owned                                 |
 | `session.visibility.change` | tier, owner identity, identity set | identity-owned, or an org owner while the session remains org |
 
+Membership removal uses the target-aware `organization.membership.remove`
+action: every role may remove itself, while removing another member requires
+the owner role.
+
 The vocabulary can gain finer-grained OSS actions when the product adds a new
 role or capability. The principal and resource shapes do not need to change.
 
@@ -130,18 +134,20 @@ already-sized page.
 `ownerUserId` supplies the resource-ownership arm; `createdByUserId` remains
 immutable creation attribution. Removing a member transfers every owned
 visibility carrier to a selected remaining organization owner and prunes every
-share vector before deleting the membership.
+share vector before deleting the membership. Any member may remove their own
+membership; removing another member requires the owner role.
 
 Owner demotion, removal, and invited-identity role merge first lock the
-organization `FOR NO KEY UPDATE`, then recheck the acting owner and lock the
-affected memberships. This serializes competing last-owner transitions without
-conflicting with ordinary resource writers' parent `FOR KEY SHARE`. Removal
-selects its transfer recipient from an authoritative membership snapshot inside
-that transaction before scanning resources. Resource creates and sharing writes
-hold shared membership locks and recheck the actor, initial owner, and share
-targets inside their own resource-write transaction. A queued write therefore
-cannot persist a departed stable user ID, and a transfer recipient cannot lose
-owner status before the transfer commits.
+organization `FOR NO KEY UPDATE`, then recheck the actor's membership and any
+required owner role before locking the affected memberships. This serializes
+competing last-owner transitions without conflicting with ordinary resource
+writers' parent `FOR KEY SHARE`. Removal selects its transfer recipient from an
+authoritative membership snapshot inside that transaction before scanning
+resources. Resource creates and sharing writes hold shared membership locks and
+recheck the actor, initial owner, and share targets inside their own
+resource-write transaction. A queued write therefore cannot persist a departed
+stable user ID, and a transfer recipient cannot lose owner status before the
+transfer commits.
 
 ## 7. Verification
 

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -459,16 +459,18 @@ CronDef, McpProvider, and SkillSource, the transaction:
 Owner demotion, removal, and invited-identity role merge first lock the
 organization `FOR NO KEY UPDATE`. That lock serializes owner transitions and
 conflicts with organization deletion, while remaining compatible with the
-parent `FOR KEY SHARE` held by ordinary resource writes. Removal then rechecks
-the acting owner, chooses the transfer recipient from an authoritative
-membership snapshot, and locks the departing and recipient rows inside the same
-transaction. Every ownership-bearing resource create and dedicated sharing
-write uses the matching persistence seam: in the same transaction as the
-resource mutation it first protects the parent organization `FOR KEY SHARE`,
-then locks the current actor, initial owner, and requested share targets `FOR
-SHARE`, rechecks membership, and intersects `sharedWith` again. The parent-first
-order remains compatible with organization deletion; the shared/exclusive
-membership lock pair establishes a commit order:
+parent `FOR KEY SHARE` held by ordinary resource writes. Any member may remove
+their own membership; removing someone else remains owner-only. Removal then
+rechecks the actor's membership and any required owner role, chooses the
+transfer recipient from an authoritative membership snapshot, and locks the
+departing and recipient rows inside the same transaction. Every
+ownership-bearing resource create and dedicated sharing write uses the matching
+persistence seam: in the same transaction as the resource mutation it first
+protects the parent organization `FOR KEY SHARE`, then locks the current actor,
+initial owner, and requested share targets `FOR SHARE`, rechecks membership, and
+intersects `sharedWith` again. The parent-first order remains compatible with
+organization deletion; the shared/exclusive membership lock pair establishes a
+commit order:
 
 - if the resource write commits first, removal waits and then transfers or
   prunes that row;

--- a/packages/control-plane/src/authorization/policy.test.ts
+++ b/packages/control-plane/src/authorization/policy.test.ts
@@ -125,6 +125,29 @@ describe('can — organization role actions', () => {
     expect(can(ctx(OTHER, 'collaborator'), { action: AuthorizationAction.OrganizationManage })).toBe(false)
     expect(can(ctx(OTHER, 'owner'), { action: AuthorizationAction.OrganizationManage })).toBe(true)
   })
+
+  it('lets every role leave while keeping removal of another member owner-only', () => {
+    for (const role of ['viewer', 'collaborator', 'owner'] as const) {
+      expect(
+        can(ctx(OTHER, role), {
+          action: AuthorizationAction.OrganizationMembershipRemove,
+          targetUserId: OTHER
+        })
+      ).toBe(true)
+    }
+    expect(
+      can(ctx(OTHER, 'viewer'), {
+        action: AuthorizationAction.OrganizationMembershipRemove,
+        targetUserId: CREATOR
+      })
+    ).toBe(false)
+    expect(
+      can(ctx(OTHER, 'owner'), {
+        action: AuthorizationAction.OrganizationMembershipRemove,
+        targetUserId: CREATOR
+      })
+    ).toBe(true)
+  })
 })
 
 describe('canViewSession (session-visibility.md §5)', () => {

--- a/packages/control-plane/src/authorization/policy.ts
+++ b/packages/control-plane/src/authorization/policy.ts
@@ -19,6 +19,7 @@ export type { Shareable, ViewCtx } from '../persistence/ports.js'
 export const AuthorizationAction = {
   OrganizationWrite: 'organization.write',
   OrganizationManage: 'organization.manage',
+  OrganizationMembershipRemove: 'organization.membership.remove',
   ResourceView: 'resource.view',
   ResourceEdit: 'resource.edit',
   ResourceManageSharing: 'resource.sharing.manage',
@@ -37,6 +38,10 @@ export interface SessionViewable {
 export type AuthorizationRequest =
   | {
       action: typeof AuthorizationAction.OrganizationWrite | typeof AuthorizationAction.OrganizationManage
+    }
+  | {
+      action: typeof AuthorizationAction.OrganizationMembershipRemove
+      targetUserId: string
     }
   | {
       action:
@@ -80,6 +85,8 @@ export function can(principal: ViewCtx, request: AuthorizationRequest): boolean 
       return principal.role !== 'viewer'
     case AuthorizationAction.OrganizationManage:
       return principal.role === 'owner'
+    case AuthorizationAction.OrganizationMembershipRemove:
+      return principal.userId === request.targetUserId || principal.role === 'owner'
     case AuthorizationAction.ResourceView:
       return resourceIsVisible(request.resource, principal)
     case AuthorizationAction.ResourceEdit:

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1570,6 +1570,7 @@ export const MemberDto = z.object({
   name: z.string().nullable(), // displayName
   picture: z.string().nullable(), // OIDC `picture` avatar URL; null until they've signed in with one
   role: MemberRole,
+  isCurrentUser: z.boolean(),
   joinedAt: z.string() // ISO-8601 (user createdAt — memberships carry no timestamps)
 })
 export const MemberListDto = z.array(MemberDto)

--- a/packages/control-plane/src/http/rbac.ts
+++ b/packages/control-plane/src/http/rbac.ts
@@ -4,9 +4,10 @@
  * The org-scope guard (`http/org-scope.ts`) verifies the caller's membership
  * in the PATH org (`/orgs/:orgId/…`) and attaches `req.orgCtx = { orgId,
  * role }`: `owner` edits everything plus members/org info, `collaborator`
- * edits everything except members/org info, `viewer` is read-only. Routes call
- * these tiny guards at the top of a handler; a `true` return means the reply
- * was already sent (403) and the handler must bail.
+ * edits everything except members/org info, `viewer` is read-only. Every role
+ * may remove its own membership. Routes call these tiny guards at the top of a
+ * handler; a `true` return means the reply was already sent (403) and the
+ * handler must bail.
  */
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import type { OrgId } from '../domain/ids.js'
@@ -40,5 +41,19 @@ export function denyViewerWrite(req: FastifyRequest, reply: FastifyReply): boole
 export function denyNonOwner(req: FastifyRequest, reply: FastifyReply): boolean {
   if (can(ctxOf(req), { action: AuthorizationAction.OrganizationManage })) return false
   forbid(reply, 'only an organization owner can do this')
+  return true
+}
+
+/** Every member may leave; removing a different member remains owner-only. */
+export function denyMemberRemoval(req: FastifyRequest, reply: FastifyReply, targetUserId: string): boolean {
+  if (
+    can(ctxOf(req), {
+      action: AuthorizationAction.OrganizationMembershipRemove,
+      targetUserId
+    })
+  ) {
+    return false
+  }
+  forbid(reply, 'only an organization owner can remove another member')
   return true
 }

--- a/packages/control-plane/src/http/routes/members.ts
+++ b/packages/control-plane/src/http/routes/members.ts
@@ -7,18 +7,18 @@
  *                          unknown addresses become invited rows, claimed on
  *                          first SSO sign-in)
  *   PATCH  /members/:id  → change a member's role (owner-only)
- *   DELETE /members/:id  → remove a member (owner-only)
+ *   DELETE /members/:id  → leave the org; owners may remove another member
  *
  * All scoped to `req.principal.orgId` (the console's active org). The
  * last-owner guard keeps an org from orphaning itself: the final owner can't
- * be demoted or removed.
+ * be demoted or leave.
  */
 import type { FastifyInstance } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import type { OrgMemberRecord } from '../../persistence/ports.js'
-import { denyNonOwner } from '../rbac.js'
+import { denyMemberRemoval, denyNonOwner } from '../rbac.js'
 import { Tag } from '../plugins/openapi.js'
 import {
   MemberDto,
@@ -31,13 +31,14 @@ import {
 } from '../dto/index.js'
 import { resolveProfilePictureUrl } from '../../icons/icon-store.js'
 
-function toDto(m: OrgMemberRecord, deps: HttpDeps): MemberDtoT {
+function toDto(m: OrgMemberRecord, currentUserId: string, deps: HttpDeps): MemberDtoT {
   return {
     userId: m.userId,
     email: m.email,
     name: m.displayName,
     picture: resolveProfilePictureUrl(m.userId, m.picture, m.profilePictureUpdatedAt, deps.iconStore),
     role: m.role,
+    isCurrentUser: m.userId === currentUserId,
     joinedAt: m.joinedAt.toISOString()
   }
 }
@@ -59,7 +60,7 @@ export function memberRoutes(deps: HttpDeps) {
       },
       async (req) => {
         const rows = await deps.repos.user.listMembers(req.orgCtx!.orgId)
-        return rows.map((row) => toDto(row, deps))
+        return rows.map((row) => toDto(row, req.orgCtx!.userId, deps))
       }
     )
 
@@ -79,7 +80,7 @@ export function memberRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyNonOwner(req, reply)) return
         const added = await deps.repos.user.addMemberByEmail(req.orgCtx!.orgId, req.body.email, req.body.role)
-        return reply.code(201).send(toDto(added, deps))
+        return reply.code(201).send(toDto(added, req.orgCtx!.userId, deps))
       }
     )
 
@@ -102,7 +103,7 @@ export function memberRoutes(deps: HttpDeps) {
         const orgId = req.orgCtx!.orgId
         const userId = req.params.id
         const updated = await deps.repos.user.setMemberRole(orgId, userId, req.body.role, req.orgCtx!.userId)
-        return toDto(updated, deps)
+        return toDto(updated, req.orgCtx!.userId, deps)
       }
     )
 
@@ -111,19 +112,19 @@ export function memberRoutes(deps: HttpDeps) {
       {
         schema: {
           tags: [Tag.Members],
-          summary: 'Remove a member',
+          summary: 'Leave or remove a member',
           description:
-            'Owner-only. Removes a member from the org; the last owner can’t be removed, which would orphan the org.',
+            'Any member can remove their own membership to leave the org. Only owners can remove another member. The last owner can’t leave, which would orphan the org.',
           operationId: 'removeMember',
           params: IdParam,
           response: { 204: z.null(), 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
         }
       },
       async (req, reply) => {
-        if (denyNonOwner(req, reply)) return
         const orgId = req.orgCtx!.orgId
         const userId = req.params.id
         const actingUserId = req.orgCtx!.userId
+        if (denyMemberRemoval(req, reply, userId)) return
         await deps.repos.user.removeMember(orgId, userId, actingUserId)
         return reply.code(204).send(null)
       }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2973,9 +2973,10 @@ export interface UserRepo {
   addMemberByEmail(orgId: string, email: string, role: OrgMemberRole): Promise<OrgMemberRecord>
 
   /**
-   * Remove a member, choose the transfer recipient, transfer all resource
-   * ownership, and prune share grants atomically. Rechecks the acting owner and
-   * refuses to remove the final owner before committing.
+   * Let a member leave, or let an owner remove another member. Chooses the
+   * transfer recipient, transfers all resource ownership, and prunes share
+   * grants atomically. Rechecks membership and, when removing another member,
+   * the acting owner's role. Refuses to remove the final owner before committing.
    */
   removeMember(orgId: string, userId: string, actingUserId: string): Promise<void>
 

--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -605,12 +605,12 @@ export class PgUserRepo implements UserRepo {
       })
       const actor = membershipSnapshot.find((membership) => membership.userId === actingUserId)
       const departing = membershipSnapshot.find((membership) => membership.userId === userId)
-      if (actor?.role !== 'owner' || !departing) throw new OrgMembershipMissing()
+      const leaving = userId === actingUserId
+      if (!departing || (!leaving && actor?.role !== 'owner')) throw new OrgMembershipMissing()
 
-      const transferToUserId =
-        userId === actingUserId
-          ? membershipSnapshot.find((membership) => membership.role === 'owner' && membership.userId !== userId)?.userId
-          : actingUserId
+      const transferToUserId = leaving
+        ? membershipSnapshot.find((membership) => membership.role === 'owner' && membership.userId !== userId)?.userId
+        : actingUserId
       if (!transferToUserId) throw new OrgOwnerRequired()
 
       // Fence ownership-bearing resource writes on both ends, then recheck the

--- a/packages/control-plane/test/integration/members.route.test.ts
+++ b/packages/control-plane/test/integration/members.route.test.ts
@@ -23,6 +23,7 @@ interface MemberBody {
   email: string | null
   name: string | null
   role: string
+  isCurrentUser: boolean
   joinedAt: string
 }
 
@@ -88,8 +89,10 @@ describe('GET /members', () => {
       const body = res.json() as MemberBody[]
       expect(body.map((m) => m.userId)).toEqual([DEFAULT_OWNER_ID, dana.userId])
       expect(body[0]!.role).toBe('owner')
+      expect(body[0]!.isCurrentUser).toBe(true)
       expect(body[0]!.email).toBe(DEFAULT_OWNER_EMAIL)
       expect(body[1]!.role).toBe('collaborator')
+      expect(body[1]!.isCurrentUser).toBe(false)
     } finally {
       await close()
     }
@@ -191,6 +194,52 @@ describe('PATCH /members/:id — role changes', () => {
 })
 
 describe('DELETE /members/:id — removal', () => {
+  it('lets a collaborator leave and transfers their resources to an owner', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      visibility: 'restricted',
+      createdByUserId: dana.userId,
+      ownerUserId: dana.userId,
+      sharedWith: [DEFAULT_OWNER_ID, dana.userId]
+    })
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'DELETE', url: `${ORG}/members/${dana.userId}` })
+      expect(res.statusCode).toBe(204)
+
+      expect(
+        await prisma.membership.findUnique({
+          where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: dana.userId } }
+        })
+      ).toBeNull()
+      expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
+        ownerUserId: DEFAULT_OWNER_ID,
+        sharedWith: [DEFAULT_OWNER_ID]
+      })
+    } finally {
+      await close()
+    }
+  })
+
+  it('does not let a non-owner remove another member', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'viewer')
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'DELETE', url: `${ORG}/members/${DEFAULT_OWNER_ID}` })
+      expect(res.statusCode).toBe(403)
+      expect(
+        await prisma.membership.findUnique({
+          where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: DEFAULT_OWNER_ID } }
+        })
+      ).not.toBeNull()
+    } finally {
+      await close()
+    }
+  })
+
   it('removes a member for good — the next sign-in does NOT re-add them', async () => {
     const dana = await signup('sub-dana', 'dana@acme.dev')
     await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')

--- a/packages/web/src/components/console/modals/EditMemberModal.tsx
+++ b/packages/web/src/components/console/modals/EditMemberModal.tsx
@@ -1,10 +1,8 @@
 // No 'use client' here: rendered only inside SettingsView (a client component).
 
-// Edit-member dialog (design: `isEditModal`). REAL: Save PATCHes the role
-// (owner grantable — an org can have several owners) and Remove DELETEs the
-// membership; both owner-only server-side (the Settings page only offers the
-// pencil to owners). The CP refuses to demote/remove the LAST owner (409) —
-// the dialog pre-disables those paths via `member.lastOwner`.
+// Edit-member dialog (design: `isEditModal`). Owners can re-role/remove any
+// member; every member can open their own row and leave. The CP refuses to
+// demote/remove the LAST owner (409), and the dialog pre-disables those paths.
 
 import { useState } from 'react'
 import { Avatar, Button, Icon } from '@/components/ui'
@@ -20,6 +18,7 @@ export interface MemberTarget {
   avBg: string
   avText: string
   role: MemberRole
+  isCurrentUser: boolean
   /** True when this member is the org's only owner (demote/remove disabled). */
   lastOwner: boolean
 }
@@ -46,10 +45,14 @@ const dotOff =
 
 export default function EditMemberModal({
   member,
+  canEditRole,
+  onLeave,
   onClose,
   onChanged
 }: {
   member: MemberTarget
+  canEditRole: boolean
+  onLeave?: () => Promise<void>
   onClose: () => void
   onChanged: () => void
 }) {
@@ -66,6 +69,7 @@ export default function EditMemberModal({
 
   const save = async () => {
     if (busy) return
+    if (!canEditRole) return onClose()
     if (role === member.role) return onClose()
     setBusy(true)
     setErr(null)
@@ -84,8 +88,11 @@ export default function EditMemberModal({
     setBusy(true)
     setErr(null)
     try {
-      await removeMember(member.userId)
-      onChanged()
+      if (onLeave) await onLeave()
+      else {
+        await removeMember(member.userId)
+        onChanged()
+      }
       onClose()
     } catch (e) {
       fail(e)
@@ -117,14 +124,20 @@ export default function EditMemberModal({
           {ROLE_TILES.map((t) => {
             const on = role === t.role
             // The last owner can't leave the owner role — the org would orphan.
-            const locked = member.lastOwner && t.role !== 'owner'
+            const locked = !canEditRole || (member.lastOwner && t.role !== 'owner')
             return (
               <div
                 key={t.role}
                 className={`${on ? 'ptile on' : 'ptile'} items-start ${
                   locked ? 'cursor-not-allowed opacity-55' : 'cursor-pointer'
                 }`}
-                title={locked ? 'An organization needs at least one owner' : undefined}
+                title={
+                  !canEditRole
+                    ? 'Only organization owners can change roles'
+                    : locked
+                      ? 'An organization needs at least one owner'
+                      : undefined
+                }
                 onClick={() => !locked && setRole(t.role)}
               >
                 <span
@@ -149,10 +162,12 @@ export default function EditMemberModal({
           <Icon name="user-minus" size={16} color="var(--status-error)" className="flex-none" />
           <div className="flex-1">
             <div className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
-              Remove from organization
+              {onLeave ? 'Leave organization' : 'Remove from organization'}
             </div>
             <div className="font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-              Revokes access immediately. Their sessions stay in history.
+              {onLeave
+                ? 'Resources you own stay with the organization and transfer to an owner.'
+                : 'Removes their membership. Their sessions stay in history.'}
             </div>
           </div>
           <button
@@ -163,12 +178,12 @@ export default function EditMemberModal({
               removeArmed ? 'bg-(--status-error) text-white' : 'bg-(--surface-card) text-(--status-error)'
             } ${member.lastOwner ? 'cursor-not-allowed opacity-55' : 'cursor-pointer'}`}
           >
-            {removeArmed ? 'Confirm remove' : 'Remove'}
+            {removeArmed ? (onLeave ? 'Confirm leave' : 'Confirm remove') : onLeave ? 'Leave' : 'Remove'}
           </button>
         </div>
         {err && (
           <div className="mt-3 font-sans text-[12px] font-normal leading-normal text-(--status-error)">
-            Could not save — {err}
+            Could not complete this change — {err}
           </div>
         )}
       </div>
@@ -177,7 +192,7 @@ export default function EditMemberModal({
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={() => void save()}>{busy ? 'Saving…' : 'Save changes'}</Button>
+        {canEditRole && <Button onClick={() => void save()}>{busy ? 'Saving…' : 'Save changes'}</Button>}
       </div>
     </>
   )

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -2,12 +2,11 @@
 
 // Settings page (design: `isSettings`). Everything here is REAL and scoped to
 // the active org: the Organization card (rename via PATCH /orgs/:id, owners
-// only), Members & roles (GET /members; owners can invite-by-email, re-role
-// and remove members — the CP enforces owner-only writes and the last-owner
-// guard), the Bots card (the org's durable bot identities; free ones can be
-// deleted here — the Add-integration picker only offers them for reuse), and
-// the Roles explainer. In no-auth mode the devAuth principal owns the local
-// default org, so the page is fully editable with no picker.
+// only), self-service organization leave, Members & roles (GET /members;
+// owners can invite-by-email, re-role and remove members — the CP enforces the
+// last-owner guard), the Bots card (the org's durable bot identities; free ones
+// can be deleted here — the Add-integration picker only offers them for reuse),
+// and the Roles explainer.
 
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -82,6 +81,7 @@ interface MemberRowView {
   roleBg: string
   roleText: string
   role: MemberRole
+  isCurrentUser: boolean
 }
 
 function rowFromDto(m: MemberDto): MemberRowView {
@@ -98,7 +98,8 @@ function rowFromDto(m: MemberDto): MemberRowView {
     roleLabel: ROLE_LABELS[m.role],
     roleBg: owner ? 'var(--brand-soft)' : 'var(--surface-active)',
     roleText: owner ? 'var(--brand-soft-text)' : 'var(--text-secondary)',
-    role: m.role
+    role: m.role,
+    isCurrentUser: m.isCurrentUser
   }
 }
 
@@ -471,7 +472,7 @@ function InviteLinksCard({ orgId }: { orgId: string }) {
 export default function SettingsView() {
   const targetBotId = useSearchParams().get('bot')
   const { me } = useProfile()
-  const { activeOrg, myRole, refreshOrgs, error: orgError } = useOrgs()
+  const { activeOrg, myRole, refreshOrgs, leaveOrg, error: orgError } = useOrgs()
   const { openModal } = useModal()
   const isOwner = myRole === 'owner'
   const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
@@ -521,6 +522,7 @@ export default function SettingsView() {
       avBg: r.avBg,
       avText: r.avText,
       role: r.role,
+      isCurrentUser: r.isCurrentUser,
       lastOwner: r.role === 'owner' && ownerCount <= 1
     })
   }
@@ -604,8 +606,12 @@ export default function SettingsView() {
             <span className="badge self-center justify-self-start" style={{ background: p.roleBg, color: p.roleText }}>
               {p.roleLabel}
             </span>
-            {isOwner ? (
-              <button className="iconbtn h-7 w-7 self-center" title="Edit member" onClick={() => edit(p)}>
+            {isOwner || p.isCurrentUser ? (
+              <button
+                className="iconbtn h-7 w-7 self-center"
+                title={isOwner ? 'Edit member' : 'Manage membership'}
+                onClick={() => edit(p)}
+              >
                 <Icon name="pencil" size={14} />
               </button>
             ) : (
@@ -646,7 +652,13 @@ export default function SettingsView() {
       {editing && (
         <div className="scrim" onClick={() => setEditing(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <EditMemberModal member={editing} onClose={() => setEditing(null)} onChanged={onMembersChanged} />
+            <EditMemberModal
+              member={editing}
+              canEditRole={isOwner}
+              onLeave={editing.isCurrentUser ? () => leaveOrg(editing.userId) : undefined}
+              onClose={() => setEditing(null)}
+              onChanged={onMembersChanged}
+            />
           </div>
         </div>
       )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -896,6 +896,7 @@ export interface MemberDto {
   name: string | null // displayName
   picture: string | null // custom uploaded profile photo, or the OIDC `picture` fallback
   role: MemberRole
+  isCurrentUser: boolean
   joinedAt: string // ISO-8601
 }
 
@@ -2849,8 +2850,8 @@ export async function addMember(email: string, role: MemberRole): Promise<Member
   return member
 }
 
-// Remove a member (DELETE /members/:id, owner-only). Removing the last owner is
-// refused (409). Removal sticks — sign-in does not re-add them.
+// Remove a membership. Any member can remove themselves; only owners can remove
+// another member. Removing the last owner is refused (409).
 export async function removeMember(userId: string): Promise<void> {
   await apiDelete<void>(`${orgBase()}/members/${encodeURIComponent(userId)}`)
   track('member_removed', { org_id: apiOrgId, removed_user_id: userId })

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -308,6 +308,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'dana@acme.dev',
     picture: null,
     role: 'owner',
+    isCurrentUser: true,
     joinedAt: '2026-01-01T00:00:00Z'
   },
   {
@@ -316,6 +317,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'sam@acme.dev',
     picture: null,
     role: 'collaborator',
+    isCurrentUser: false,
     joinedAt: '2026-01-02T00:00:00Z'
   },
   {
@@ -324,6 +326,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'ana@acme.dev',
     picture: null,
     role: 'viewer',
+    isCurrentUser: false,
     joinedAt: '2026-01-03T00:00:00Z'
   },
   {
@@ -332,6 +335,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'noah@acme.dev',
     picture: null,
     role: 'collaborator',
+    isCurrentUser: false,
     joinedAt: '2026-01-04T00:00:00Z'
   },
   {
@@ -340,6 +344,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'priya@acme.dev',
     picture: null,
     role: 'viewer',
+    isCurrentUser: false,
     joinedAt: '2026-01-05T00:00:00Z'
   },
   {
@@ -348,6 +353,7 @@ const MOCK_MEMBERS: MemberDto[] = [
     email: 'leo@acme.dev',
     picture: null,
     role: 'collaborator',
+    isCurrentUser: false,
     joinedAt: '2026-01-06T00:00:00Z'
   }
 ]

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -20,6 +20,7 @@ import {
   createOrg as apiCreateOrg,
   updateOrg as apiUpdateOrg,
   deleteOrg as apiDeleteOrg,
+  removeMember as apiRemoveMember,
   type MemberRole,
   type OrgDto
 } from '@/lib/api'
@@ -92,6 +93,9 @@ interface OrgContextValue {
   /** Delete an org (owner-only; 409 while it has daemons). The console then
    *  moves to a remaining org — or the self-healed personal one. */
   deleteOrg: (orgId: string) => Promise<void>
+  /** Leave the active org, immediately dropping its stale local scope before
+   *  re-listing and moving to a remaining or self-healed personal org. */
+  leaveOrg: (userId: string) => Promise<void>
 }
 
 const Ctx = createContext<OrgContextValue | null>(null)
@@ -204,6 +208,20 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     [refreshOrgs]
   )
 
+  const leaveOrg = useCallback(
+    async (userId: string) => {
+      if (!activeOrg) throw new Error('no active organization')
+      const departedOrgId = activeOrg.id
+      await apiRemoveMember(userId)
+      // Authorization is gone once DELETE commits. Drop the stale local row
+      // before the network refresh so a transient list failure cannot keep
+      // issuing requests under an organization the caller no longer belongs to.
+      setOrgs((prev) => prev.filter((org) => org.id !== departedOrgId))
+      await refreshOrgs()
+    },
+    [activeOrg, refreshOrgs]
+  )
+
   const value = useMemo<OrgContextValue>(
     () => ({
       orgs,
@@ -216,9 +234,10 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       refreshOrgs,
       createOrg,
       renameOrg,
-      deleteOrg
+      deleteOrg,
+      leaveOrg
     }),
-    [orgs, activeOrg, loading, error, orgPath, setActiveOrg, refreshOrgs, createOrg, renameOrg, deleteOrg]
+    [orgs, activeOrg, loading, error, orgPath, setActiveOrg, refreshOrgs, createOrg, renameOrg, deleteOrg, leaveOrg]
   )
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>


### PR DESCRIPTION
## Summary

- allow every organization member to remove their own membership while keeping removal of another member owner-only
- reuse the existing Team Settings member modal for self-service leave, with the current member identified by the server
- atomically transfer owned agents, tools, MCP providers, daemons, and crons to a remaining owner and preserve the last-owner guard
- drop the departed organization from local console scope before refreshing the organization list

## Root cause

`DELETE /members/:id` applied an owner-only guard before distinguishing self-removal from removing another member, and Team Settings exposed the existing membership action only to owners.

## Non-goals

- no Session ownership changes
- no account deletion flow
- no change to revocation of already-open long-lived connections

## Validation

- Control Plane and Web typechecks
- authorization policy unit tests: 27 passed
- PostgreSQL members route integration tests: 13 passed
- Web production build
- ESLint, Prettier, and `git diff --check`

Created by Codex . GPT-5
