### PR TITLE
fix(integrations): cap platform app descriptions

### DIFF
--- a/packages/control-plane/src/http/platform-app-description.ts
+++ b/packages/control-plane/src/http/platform-app-description.ts
@@ -1,33 +1,37 @@
 export const DEFAULT_PLATFORM_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+export const PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS = 100
 export const LARK_APP_DESCRIPTION_MAX_LENGTH = 120
 export const SLACK_APP_DESCRIPTION_MAX_BYTES = 300
 
 const ELLIPSIS = '…'
 const UTF8_ENCODER = new TextEncoder()
 const utf16Length = (value: string): number => value.length
+const codePointLength = (value: string): number => [...value].length
 
 export function utf8ByteLength(value: string): number {
   return UTF8_ENCODER.encode(value).byteLength
 }
 
-/** Keep a platform description within its measured limit without splitting a
- * Unicode code point. Lark uses the default UTF-16 length; Slack's live manifest
- * validator applies its documented 300-character limit to UTF-8 bytes. */
+/** Keep a description concise and within its platform-specific measured limit
+ * without splitting a Unicode code point. Lark uses the default UTF-16 length;
+ * Slack's live manifest validator applies its 300-character limit to UTF-8 bytes. */
 export function platformAppDescription(
   description: string | null | undefined,
   maxLength: number,
   lengthOf: (value: string) => number = utf16Length
 ): string {
   const value = description?.trim() || DEFAULT_PLATFORM_APP_DESCRIPTION
-  if (lengthOf(value) <= maxLength) return value
+  if (codePointLength(value) <= PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS && lengthOf(value) <= maxLength) return value
 
   let head = ''
   let length = lengthOf(ELLIPSIS)
+  let characters = 1
   for (const character of value) {
-    const characterLength = lengthOf(character)
-    if (length + characterLength > maxLength) break
+    const measuredLength = lengthOf(character)
+    if (characters + 1 > PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS || length + measuredLength > maxLength) break
     head += character
-    length += characterLength
+    length += measuredLength
+    characters += 1
   }
   return `${head.trimEnd()}${ELLIPSIS}`
 }

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -10,6 +10,7 @@ import {
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
 import {
   DEFAULT_PLATFORM_APP_DESCRIPTION,
+  PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS,
   SLACK_APP_DESCRIPTION_MAX_BYTES,
   utf8ByteLength
 } from './platform-app-description.js'
@@ -75,19 +76,27 @@ describe('buildInstallManifest', () => {
   })
 
   it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
-    const description = `${'a'.repeat(297)}😀`
-    expect(description.length).toBeLessThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
-    expect(utf8ByteLength(description)).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    const longDescription = 'a'.repeat(PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS + 1)
+    const wideDescription = `${'😀'.repeat(75)}a`
+    expect([...wideDescription]).toHaveLength(76)
+    expect(utf8ByteLength(wideDescription)).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
 
-    const custom = buildInstallManifest('acme-bot', REDIRECT, { description }) as {
+    const long = buildInstallManifest('acme-bot', REDIRECT, { description: longDescription }) as {
+      features: { agent_view: { agent_description: string } }
+    }
+    const wide = buildInstallManifest('acme-bot', REDIRECT, { description: wideDescription }) as {
       features: { agent_view: { agent_description: string } }
     }
     const fallback = buildInstallManifest('acme-bot', REDIRECT, { description: '   ' }) as {
       features: { agent_view: { agent_description: string } }
     }
 
-    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}…`)
-    expect(utf8ByteLength(custom.features.agent_view.agent_description)).toBe(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    expect(long.features.agent_view.agent_description).toBe(`${'a'.repeat(99)}…`)
+    expect([...long.features.agent_view.agent_description]).toHaveLength(PLATFORM_APP_DESCRIPTION_MAX_CHARACTERS)
+    expect(wide.features.agent_view.agent_description).toBe(`${'😀'.repeat(74)}…`)
+    expect(utf8ByteLength(wide.features.agent_view.agent_description)).toBeLessThanOrEqual(
+      SLACK_APP_DESCRIPTION_MAX_BYTES
+    )
     expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_PLATFORM_APP_DESCRIPTION)
   })
 

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -101,8 +101,8 @@ describe('Feishu/Lark one-click app registration', () => {
     expect(authorizationUrl.hostname).toBe(LARK_LAUNCHER_DOMAIN)
     expect(authorizationUrl.searchParams.get('user_code')).toBe('LARK')
     expect(authorizationUrl.searchParams.get('avatar')).toBe('https://cdn.example.test/agent.png')
-    expect(authorizationUrl.searchParams.get('desc')).toBe(`${'a'.repeat(117)}😀…`)
-    expect(authorizationUrl.searchParams.get('desc')!.length).toBe(120)
+    expect(authorizationUrl.searchParams.get('desc')).toBe(`${'a'.repeat(99)}…`)
+    expect(authorizationUrl.searchParams.get('desc')!.length).toBe(100)
     expect(begun.providerDomain).toBe(FEISHU_REGISTRATION_DOMAIN)
   })
 

--- a/packages/web/src/lib/slack-manifest.test.ts
+++ b/packages/web/src/lib/slack-manifest.test.ts
@@ -6,6 +6,7 @@ import {
   SLACK_BOT_EVENTS,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   DEFAULT_SLACK_APP_DESCRIPTION,
+  SLACK_APP_DESCRIPTION_MAX_CHARACTERS,
   SLACK_APP_DESCRIPTION_MAX_BYTES
 } from './slack-manifest'
 
@@ -64,16 +65,22 @@ describe('buildSlackManifest', () => {
   })
 
   it('uses the agent description with a fallback and a Unicode-safe platform limit', () => {
-    const description = `${'a'.repeat(297)}😀`
     const utf8 = new TextEncoder()
-    expect(description.length).toBeLessThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
-    expect(utf8.encode(description).byteLength).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    const longDescription = 'a'.repeat(SLACK_APP_DESCRIPTION_MAX_CHARACTERS + 1)
+    const wideDescription = `${'😀'.repeat(75)}a`
+    expect([...wideDescription]).toHaveLength(76)
+    expect(utf8.encode(wideDescription).byteLength).toBeGreaterThan(SLACK_APP_DESCRIPTION_MAX_BYTES)
 
-    const custom = buildSlackManifest({ name: 'acme' }, { description })
+    const long = buildSlackManifest({ name: 'acme' }, { description: longDescription })
+    const wide = buildSlackManifest({ name: 'acme' }, { description: wideDescription })
     const fallback = buildSlackManifest({ name: 'acme' }, { description: '   ' })
 
-    expect(custom.features.agent_view.agent_description).toBe(`${'a'.repeat(297)}…`)
-    expect(utf8.encode(custom.features.agent_view.agent_description).byteLength).toBe(SLACK_APP_DESCRIPTION_MAX_BYTES)
+    expect(long.features.agent_view.agent_description).toBe(`${'a'.repeat(99)}…`)
+    expect([...long.features.agent_view.agent_description]).toHaveLength(SLACK_APP_DESCRIPTION_MAX_CHARACTERS)
+    expect(wide.features.agent_view.agent_description).toBe(`${'😀'.repeat(74)}…`)
+    expect(utf8.encode(wide.features.agent_view.agent_description).byteLength).toBeLessThanOrEqual(
+      SLACK_APP_DESCRIPTION_MAX_BYTES
+    )
     expect(fallback.features.agent_view.agent_description).toBe(DEFAULT_SLACK_APP_DESCRIPTION)
   })
 

--- a/packages/web/src/lib/slack-manifest.ts
+++ b/packages/web/src/lib/slack-manifest.ts
@@ -73,6 +73,7 @@ export const SLACK_BOT_EVENTS = [
 /** Fallback name so the manifest / deep link are always valid before the user types one. */
 export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
 export const DEFAULT_SLACK_APP_DESCRIPTION = 'AI agent powered by AgentConnect.'
+export const SLACK_APP_DESCRIPTION_MAX_CHARACTERS = 100
 export const SLACK_APP_DESCRIPTION_MAX_BYTES = 300
 
 const ELLIPSIS = '…'
@@ -80,6 +81,10 @@ const UTF8_ENCODER = new TextEncoder()
 
 function utf8ByteLength(value: string): number {
   return UTF8_ENCODER.encode(value).byteLength
+}
+
+function codePointLength(value: string): number {
+  return [...value].length
 }
 
 export interface SlackAppManifest {
@@ -120,15 +125,26 @@ export interface SlackManifestOpts {
 
 function slackAppDescription(description: string | null | undefined): string {
   const value = description?.trim() || DEFAULT_SLACK_APP_DESCRIPTION
-  if (utf8ByteLength(value) <= SLACK_APP_DESCRIPTION_MAX_BYTES) return value
+  if (
+    codePointLength(value) <= SLACK_APP_DESCRIPTION_MAX_CHARACTERS &&
+    utf8ByteLength(value) <= SLACK_APP_DESCRIPTION_MAX_BYTES
+  ) {
+    return value
+  }
 
   let head = ''
   let bytes = utf8ByteLength(ELLIPSIS)
+  let characters = 1
   for (const character of value) {
     const characterBytes = utf8ByteLength(character)
-    if (bytes + characterBytes > SLACK_APP_DESCRIPTION_MAX_BYTES) break
+    if (
+      characters + 1 > SLACK_APP_DESCRIPTION_MAX_CHARACTERS ||
+      bytes + characterBytes > SLACK_APP_DESCRIPTION_MAX_BYTES
+    )
+      break
     head += character
     bytes += characterBytes
+    characters += 1
   }
   return `${head.trimEnd()}${ELLIPSIS}`
 }


### PR DESCRIPTION
## Summary

- cap platform application descriptions at 100 Unicode characters, including the truncation ellipsis
- apply the same concise product limit to Slack's manual and automatic manifests and to Lark one-click registration
- continue enforcing each provider's harder constraint: Slack's 300 UTF-8-byte validator and Lark's 120 UTF-16-unit limit

## Root cause

Agent descriptions previously expanded to each provider's full limit. Besides being longer than the intended app-profile copy, a character-only Slack limit could still exceed Slack's effective UTF-8 byte ceiling for multibyte text.

## Impact

Generated platform descriptions are concise and consistent while remaining Unicode-safe. Slack descriptions under 100 characters are still shortened further when their UTF-8 representation would exceed 300 bytes.

## Validation

- 11 control-plane Slack manifest tests
- 6 web Slack manifest tests
- 9 Feishu/Lark registration integration tests
- web and control-plane typechecks
- changed-file ESLint and Prettier checks
- full repository ESLint in the pre-push hook
- `git diff --check`

Created by Codex . GPT-5
