### PR TITLE
fix(daemon): keep Telegram replies anchored to the session thread

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4044,12 +4044,20 @@ export class Daemon {
 
   /** Telegram reply target for a turn/command triggered by `msg`: the triggering
    *  message's own id, so the bot's posts reply to it (req: reply to the last message
-   *  in the session, and keep the reply chain resolvable). Undefined off Telegram or
-   *  when the id can't be recovered as a positive integer. */
+   *  in the session, and keep the reply chain resolvable). An agent-call turn
+   *  (`replyToSession` / a peer wake) synthesizes its msgId (`agentcall:<channel>:<uuid>`)
+   *  so no platform id can be recovered — without a fallback its answer posts to the
+   *  chat root, visually outside the reply chain the session lives in. Those turns
+   *  anchor to the session's thread root instead (`tg:<root>`, see
+   *  {@link canonicalizeTelegramThread}); `dm` and numeric forum-topic threads carry no
+   *  reply anchor. Undefined off Telegram or when neither id resolves. */
   private telegramReplyTarget(msg: NormalizedMessage): number | undefined {
     if (msg.platform !== 'telegram') return undefined
     const n = Number(this.telegramMessageId(msg))
-    return Number.isInteger(n) && n > 0 ? n : undefined
+    if (Number.isInteger(n) && n > 0) return n
+    const root = msg.thread !== undefined ? /^tg:(\d+)$/.exec(msg.thread) : null
+    const r = root ? Number(root[1]) : NaN
+    return Number.isInteger(r) && r > 0 ? r : undefined
   }
 
   // route an inbound Slack message
@@ -5806,6 +5814,12 @@ export class Daemon {
     originThread: string
   }): void {
     const platform = this.narrowPlatform(req.platform)
+    // The post's raw ts is the new thread's root. On Telegram that ts is a bare numeric
+    // message id, but inbound reply-based sessions key `tg:<root>` (see
+    // canonicalizeTelegramThread) — key the spawned session the same way, or a customer
+    // reply to the post can never land in it and opens yet another session. The transcript
+    // seed below still carries the RAW ts (it must stay a real, comparable platform ts).
+    const thread = platform === 'telegram' && /^\d+$/.test(req.thread) ? `tg:${req.thread}` : req.thread
     // The origin session may live on a DIFFERENT platform than this post (e.g. a Telegram
     // turn posting to Slack). Key the origin lookup by the ORIGIN's platform, not the target's,
     // or the caller session is never found and the new session loses its parent lineage.
@@ -5851,7 +5865,7 @@ export class Daemon {
       source: 'agent',
       platform,
       channel: req.channel,
-      thread: req.thread,
+      thread,
       ...(transportScope !== undefined ? { transportScope } : {}),
       // The seed's transcript ts MUST be the post's real ts (the new thread's root), not the
       // random deliveryId — otherwise the session's lastDeliveredTs becomes a non-ts string and
@@ -5864,7 +5878,7 @@ export class Daemon {
       // No model turn runs for this seed; headless is retained as a transport backstop.
       headless: true
     }
-    const targetSession = sessionKey(platform, req.channel, req.thread, req.agentId, transportScope)
+    const targetSession = sessionKey(platform, req.channel, thread, req.agentId, transportScope)
     void this.dispatch(req.agentId, normalized, req.integrationId, undefined, callMeta).catch((err) =>
       this.log.error(`channel-root session spawn failed for agent "${req.agentId}": ${formatErr(err)}`)
     )

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1075,6 +1075,34 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     })
     await daemon.stop()
   })
+
+  it('keys a Telegram spawn by the canonical tg:<ts> thread, keeping the raw ts as transcriptTs', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+
+    // A Slack turn posting into a Telegram group: postMessage returned the bare
+    // message id '172'. Inbound replies to that post canonicalize to `tg:172`
+    // (canonicalizeTelegramThread), so the spawned session must key the same way —
+    // pre-fix it was keyed by the raw '172' and a customer reply opened a NEW session.
+    ;(daemon as any).spawnChannelRootSession({
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-1004418558261',
+      thread: '172',
+      text: 'answer relayed to the customer',
+      originPlatform: 'slack',
+      originChannel: 'C1',
+      originThread: '100.1'
+    })
+
+    expect(calls).toHaveLength(1)
+    const { msg } = calls[0]!
+    expect(msg.thread).toBe('tg:172')
+    // The transcript seed keeps the RAW platform ts — it must stay comparable with
+    // later real reply ts values (see the dedup note in spawnChannelRootSession).
+    expect(msg.transcriptTs).toBe('172')
+    await daemon.stop()
+  })
 })
 
 /**

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -409,6 +409,37 @@ describe('reply targeting', () => {
       replyTo: 900
     })
   })
+
+  it('an agent-call turn falls back to the session thread root as its reply anchor', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const replyTarget = (m: NormalizedMessage) => (daemon as any).telegramReplyTarget(m)
+    // A synthesized agent-call delivery (replyToSession / peer wake) — its msgId carries
+    // no platform message id, so pre-fix the turn's answer posted to the chat root,
+    // visually outside the reply chain the session lives in.
+    const agentCall = (thread?: string): NormalizedMessage => ({
+      msgId: 'agentcall:-100:2f1b2c1e-aaaa-bbbb-cccc-121212121212',
+      traceId: 'd1',
+      source: 'agent',
+      platform: 'telegram',
+      channel: '-100',
+      ...(thread !== undefined ? { thread } : {}),
+      sender: { id: 'bot-b', isBot: true },
+      text: 'answer',
+      mentionedBots: [],
+      isDm: false
+    })
+    // Reply-based session → anchor to the thread root (the customer's message).
+    expect(replyTarget(agentCall('tg:170'))).toBe(170)
+    // DM sessions are a single stream — no anchor, plain post as before.
+    expect(replyTarget(agentCall('dm'))).toBeUndefined()
+    // A numeric thread is a forum topic id (drives message_thread_id at post time),
+    // never a reply anchor.
+    expect(replyTarget(agentCall('172'))).toBeUndefined()
+    // A real platform message still replies to ITSELF, not the thread root.
+    expect(replyTarget(tg(456, { thread: 'tg:100' }))).toBe(456)
+    await daemon.stop()
+  })
 })
 
 /** Seed an addressable session in one physical Telegram bot scope. */


### PR DESCRIPTION
## Problem

A Telegram customer question escalated to Slack and answered there ends up broken on the way back (observed live: session `d8464add` / parent `befd0d94` / child `e9065d14` on test):

1. The answer sent back to Telegram is a **top-level post**, not a reply into the customer's thread.
2. That post **spawns a new child session** keyed by the raw message id (`172`), while inbound Telegram replies canonicalize to `tg:<root>` — so a customer reply to the answer can never land in that session and opens yet another one.

## Fixes

- **`telegramReplyTarget`**: agent-call turns (`replyToSession` / peer wakes) synthesize their msgId (`agentcall:<channel>:<uuid>`), so no platform id could be recovered and the turn's answer posted to the chat root. Fall back to the session thread root (`tg:<root>`) as the `replyTo` anchor. `dm` and numeric forum-topic threads keep their existing behavior.
- **`spawnChannelRootSession`**: key a Telegram spawn by the canonical `tg:<ts>` thread instead of the raw numeric ts, so later customer replies meet the spawned session. The transcript seed keeps the RAW ts (it must stay a real, comparable platform ts for dedup).

## Tests

- `telegram-threading.test.ts`: agent-call turns anchor to the thread root; `dm` / forum-topic / real-message targets are unchanged.
- `daemon-message-agent.test.ts`: Telegram spawn keys `tg:172` while `transcriptTs` stays `172`.

Known residual (out of scope here): the `toAgent` + Telegram channel-post peer-wake path still anchors the woken session to the raw ts (`ops.ts` `postedThread`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)