### PR TITLE
feat(web): show platform icons for session relations

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2043,6 +2043,7 @@ export const SessionListPageDto = z.object({
 export const SessionRelationDto = z.object({
   id: z.string(),
   agentId: z.string(),
+  platform: z.string(),
   title: z.string().nullable()
 })
 

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -97,8 +97,8 @@ function hookIdForSession(s: HookSessionRow): string | null {
   return HookIdString.safeParse(id).success ? id : null
 }
 
-function sessionRelation(s: { id: string; agentId: string; title: string | null }) {
-  return { id: s.id, agentId: s.agentId, title: s.title }
+function sessionRelation(s: { id: string; agentId: string; platform: string | null; title: string | null }) {
+  return { id: s.id, agentId: s.agentId, platform: s.platform ?? 'slack', title: s.title }
 }
 
 function hookMetadataForSession(metadata: Map<string, HookSessionMetadata>, session: HookSessionRow) {

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -243,6 +243,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       ...base,
       sessionId: firstChild,
       parentSessionId: parent,
+      platform: 'telegram',
       title: 'Check the database',
       ts: '2026-07-05T00:01:00.000Z'
     })
@@ -250,6 +251,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       ...base,
       sessionId: secondChild,
       parentSessionId: parent,
+      platform: 'discord',
       title: 'Check the API',
       ts: '2026-07-05T00:02:00.000Z'
     })
@@ -257,19 +259,27 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     const parentRes = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${parent}` })
     expect(parentRes.statusCode).toBe(200)
     expect(
-      (parentRes.json() as { parentSession: unknown; childSessions: Array<{ id: string; title: string | null }> })
-        .childSessions
+      (
+        parentRes.json() as {
+          parentSession: unknown
+          childSessions: Array<{ id: string; platform: string; title: string | null }>
+        }
+      ).childSessions
     ).toEqual([
-      { id: firstChild, agentId: AGENT, title: 'Check the database' },
-      { id: secondChild, agentId: AGENT, title: 'Check the API' }
+      { id: firstChild, agentId: AGENT, platform: 'telegram', title: 'Check the database' },
+      { id: secondChild, agentId: AGENT, platform: 'discord', title: 'Check the API' }
     ])
     expect((parentRes.json() as { parentSession: unknown }).parentSession).toBeNull()
 
     const childRes = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${firstChild}` })
     expect(childRes.statusCode).toBe(200)
-    expect((childRes.json() as { parentSession: { id: string; title: string | null } | null }).parentSession).toEqual({
+    expect(
+      (childRes.json() as { parentSession: { id: string; platform: string; title: string | null } | null })
+        .parentSession
+    ).toEqual({
       id: parent,
       agentId: AGENT,
+      platform: 'slack',
       title: 'Coordinate the rollout'
     })
     expect((childRes.json() as { childSessions: unknown[] }).childSessions).toEqual([])

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -525,8 +525,8 @@ function SessionRelationLink({
         bordered ? 'border-t border-(--border-subtle)' : ''
       }`}
     >
-      <span className="av h-6 w-6 flex-none rounded-sm">
-        {agent ? <AgentIconView icon={agent.icon} runtime={agent.runtime} size={24} /> : <Icon name="bot" size={14} />}
+      <span className="imark h-6 w-6 flex-none rounded-sm">
+        <PlatformMark platform={relation.platform} />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
         <span className="truncate font-sans text-[12.5px] font-semibold leading-normal">{title}</span>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -334,6 +334,7 @@ export interface SessionListPage {
 export interface SessionRelationDto {
   id: string
   agentId: string
+  platform: string
   title: string | null
 }
 


### PR DESCRIPTION
## Summary

- show each parent and child session’s own platform mark instead of the agent avatar
- include the related session platform in the detail response so cross-platform lineage stays accurate

## Why

Relationship metadata previously exposed only the session, agent, and title, leaving the console without the related session’s source platform. Cross-platform parent/child links therefore showed agent identity instead of Slack, Telegram, Discord, or Lark.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- targeted Prettier and ESLint checks
- Control Plane integration suite: 65 files, 787 tests passed
- pre-push full-repository ESLint

Created by Codex . GPT-5
