### PR TITLE
fix(daemon): name what a channel-root post costs in the sendMessage contract

### DIFF
--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -143,7 +143,9 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
   }
   const channelTarget = {
     title: 'Channel target',
-    description: 'Post one visible message to a platform channel, optionally addressing one human.',
+    description:
+      'Post one visible message to a platform channel, optionally addressing one human. A post at channel root ' +
+      'opens a NEW session of your own on that post; it does not continue the conversation you are in.',
     ...obj(
       {
         channel: {
@@ -160,7 +162,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         thread: {
           type: 'string',
           description:
-            'Optional thread / topic anchor. Omit (or use "") to post at channel root; pass an existing id to post there.'
+            'Optional thread / topic anchor. Omit (or use "") to post at channel root — which opens a new session ' +
+            'on that post; pass an existing id to post into that thread instead.'
         },
         integrationId: {
           type: 'string',
@@ -173,7 +176,9 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
   }
   const sessionTarget = {
     title: 'Parent session target',
-    description: 'Reply directly into the parent/origin session that woke this session.',
+    description:
+      'Reply directly into the parent/origin session that woke this session. This is how an answer reaches the ' +
+      'conversation that asked for it — posting it to that conversation’s channel instead would start a new one.',
     ...obj(
       {
         sessionId: {
@@ -195,7 +200,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
   return {
     name: 'sendMessage',
     description: collaboration
-      ? 'Send one message to exactly one target. Choose one form:\n' +
+      ? 'Send one message to exactly one target. Your own turn reply already reaches the conversation you are in, ' +
+        'so use this tool only to reach a DIFFERENT channel, session, or agent. Choose one form:\n' +
         '- Peer agent (direct wake): `{"to":{"toAgent":"<agent id>"},"message":"..."}` is a postless wake. Add a ' +
         '`channel` (and optional `thread`) to also post a visible message and thread the peer’s reply there. Get the ' +
         'id from listChannelAgents and send one call per peer; never substitute a platform member id. When the wake ' +
@@ -204,13 +210,18 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         '`{"to":{"toAgent":{"agentId":"<agent id>","needsReply":true}},"message":"..."}` to also instruct that ' +
         'session to report back to you when it is done or has failed.\n' +
         '- Channel or human (visible post): `{"to":{"channel":"<channel id>"},"message":"..."}`. Add `toUser` only ' +
-        'to address an actual human, or `platform` to use another connected platform.\n' +
+        'to address an actual human, or `platform` to use another connected platform. Without a `thread` this posts ' +
+        'at channel root, which opens a NEW session of your own on that post — it never continues an existing ' +
+        'conversation.\n' +
         '- Parent session (direct reply): `{"to":{"sessionId":"<Parent session>"},"message":"..."}`. Use the id ' +
-        'from your `# Agent` block.\n' +
+        'from your `# Agent` block. Relay an answer back to whoever asked this way — never by posting it to their ' +
+        'channel.\n' +
         'Write `message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone or wake yourself.'
-      : 'Post one visible message to exactly one platform channel or human. Use ' +
+      : 'Post one visible message to exactly one platform channel or human. Your own turn reply already reaches the ' +
+        'conversation you are in, so use this tool only to reach a DIFFERENT channel. Use ' +
         '`{"to":{"channel":"<channel id>"},"message":"..."}` and add `toUser`, `platform`, `thread`, or ' +
-        '`integrationId` only when needed. Peer-agent and parent-session delivery are disabled for this run. Write ' +
+        '`integrationId` only when needed. Without a `thread` this posts at channel root, which opens a NEW session ' +
+        'of your own on that post. Peer-agent and parent-session delivery are disabled for this run. Write ' +
         '`message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone.',
     inputSchema: obj(
       {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -200,9 +200,10 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
   return {
     name: 'sendMessage',
     description: collaboration
-      ? 'Send one message to exactly one target. Your own turn reply already reaches the conversation you are in, ' +
-        'so use this tool to reach a DIFFERENT conversation — another channel or thread, a session, or a peer ' +
-        'agent. Choose one form:\n' +
+      ? 'Send one message to exactly one target. Your own turn reply already reaches the conversation you are in, so ' +
+        'use this tool for what that reply cannot do: reach a DIFFERENT conversation — another channel or thread, a ' +
+        'session, or a peer agent — or @-mention a specific human with `toUser`, which may be right here. Choose one ' +
+        'form:\n' +
         '- Peer agent (direct wake): `{"to":{"toAgent":"<agent id>"},"message":"..."}` is a postless wake. Add a ' +
         '`channel` (and optional `thread`) to also post a visible message and thread the peer’s reply there. Get the ' +
         'id from listChannelAgents and send one call per peer; never substitute a platform member id. When the wake ' +
@@ -219,8 +220,9 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'channel root.\n' +
         'Write `message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone or wake yourself.'
       : 'Post one visible message to exactly one platform channel or human. Your own turn reply already reaches the ' +
-        'conversation you are in, so use this tool to reach a DIFFERENT conversation — another channel, or another ' +
-        'thread in this one. Use ' +
+        'conversation you are in, so use this tool for what that reply cannot do: reach a DIFFERENT conversation — ' +
+        'another channel, or another thread in this one — or @-mention a specific human with `toUser`, which may be ' +
+        'right here. Use ' +
         '`{"to":{"channel":"<channel id>"},"message":"..."}` and add `toUser`, `platform`, `thread`, or ' +
         '`integrationId` only when needed. Without a `thread` this posts at channel root, which opens a NEW session ' +
         'of your own on that post. Peer-agent and parent-session delivery are disabled for this run. Write ' +

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -145,7 +145,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     title: 'Channel target',
     description:
       'Post one visible message to a platform channel, optionally addressing one human. A post at channel root ' +
-      'opens a NEW session of your own on that post; it does not continue the conversation you are in.',
+      'opens a NEW session of your own on that post; only an explicit `thread` continues an existing conversation.',
     ...obj(
       {
         channel: {
@@ -178,7 +178,7 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     title: 'Parent session target',
     description:
       'Reply directly into the parent/origin session that woke this session. This is how an answer reaches the ' +
-      'conversation that asked for it — posting it to that conversation’s channel instead would start a new one.',
+      'conversation that asked for it — posting it at that conversation’s channel ROOT instead would start a new one.',
     ...obj(
       {
         sessionId: {
@@ -201,7 +201,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     name: 'sendMessage',
     description: collaboration
       ? 'Send one message to exactly one target. Your own turn reply already reaches the conversation you are in, ' +
-        'so use this tool only to reach a DIFFERENT channel, session, or agent. Choose one form:\n' +
+        'so use this tool to reach a DIFFERENT conversation — another channel or thread, a session, or a peer ' +
+        'agent. Choose one form:\n' +
         '- Peer agent (direct wake): `{"to":{"toAgent":"<agent id>"},"message":"..."}` is a postless wake. Add a ' +
         '`channel` (and optional `thread`) to also post a visible message and thread the peer’s reply there. Get the ' +
         'id from listChannelAgents and send one call per peer; never substitute a platform member id. When the wake ' +
@@ -214,11 +215,12 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'at channel root, which opens a NEW session of your own on that post — it never continues an existing ' +
         'conversation.\n' +
         '- Parent session (direct reply): `{"to":{"sessionId":"<Parent session>"},"message":"..."}`. Use the id ' +
-        'from your `# Agent` block. Relay an answer back to whoever asked this way — never by posting it to their ' +
-        'channel.\n' +
+        'from your `# Agent` block. Relay an answer back to whoever asked this way — never by posting it at their ' +
+        'channel root.\n' +
         'Write `message` as CommonMark/GFM. The daemon supplies your identity; you cannot impersonate anyone or wake yourself.'
       : 'Post one visible message to exactly one platform channel or human. Your own turn reply already reaches the ' +
-        'conversation you are in, so use this tool only to reach a DIFFERENT channel. Use ' +
+        'conversation you are in, so use this tool to reach a DIFFERENT conversation — another channel, or another ' +
+        'thread in this one. Use ' +
         '`{"to":{"channel":"<channel id>"},"message":"..."}` and add `toUser`, `platform`, `thread`, or ' +
         '`integrationId` only when needed. Without a `thread` this posts at channel root, which opens a NEW session ' +
         'of your own on that post. Peer-agent and parent-session delivery are disabled for this run. Write ' +

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -132,7 +132,7 @@ describe('toolsForIntegrations', () => {
     // instead of a reply in the conversation that asked. The consequence has to be ON the
     // branch that carries it, and the tool has to say the turn's own reply already lands here.
     const description = sendTool([slackInt])!.description
-    expect(description).toContain('use this tool to reach a DIFFERENT conversation')
+    expect(description).toContain('reach a DIFFERENT conversation')
     expect(description).toContain('opens a NEW session')
     expect(description).toContain('never by posting it at their channel root')
 
@@ -144,12 +144,16 @@ describe('toolsForIntegrations', () => {
       'channel ROOT instead would start a new one'
     )
 
-    // The cost is ROOT-only: an explicit thread joins a conversation, and same-channel sends
-    // (another thread, or `toUser` addressing a human) stay legitimate — so the guidance says
-    // "a different conversation", never "a different channel".
+    // The cost is ROOT-only: an explicit thread joins a conversation rather than forking one, so
+    // the guidance says "a different conversation", never "a different channel".
     expect(description).not.toContain('DIFFERENT channel,')
     for (const text of [description, sendTargetBranch([slackInt], 'channel').description!])
       expect(text).toMatch(/(at )?channel root/i)
+
+    // …and "different conversation" is not the whole rule either: `toUser` exists to @-mention a
+    // human, which is a legitimate reason to send into the conversation the agent is already in.
+    // Excluding it would make the preamble contradict the branch it introduces.
+    expect(description).toContain('@-mention a specific human with `toUser`, which may be right here')
 
     // Collaboration off ⇒ only the channel branch exists, and it is then the ONLY way to send —
     // so the root-post cost must be stated there too (spawnChannelRootSession runs either way).
@@ -157,7 +161,8 @@ describe('toolsForIntegrations', () => {
       (t) => t.name === 'sendMessage'
     )!.description
     expect(soloDescription).toContain('opens a NEW session')
-    expect(soloDescription).toContain('use this tool to reach a DIFFERENT conversation')
+    expect(soloDescription).toContain('use this tool for what that reply cannot do')
+    expect(soloDescription).toContain('@-mention a specific human with `toUser`, which may be right here')
   })
 
   it('`toAgent` accepts the bare agent id OR an {agentId, needsReply} object', () => {

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -18,7 +18,8 @@ describe('toolsForIntegrations', () => {
   const sendTool = (ints: Integration[]) => toolsForIntegrations(ints).find((t) => t.name === 'sendMessage')
   type ObjectSchema = {
     type?: string
-    properties: Record<string, { enum?: string[] }>
+    description?: string
+    properties: Record<string, { enum?: string[]; description?: string }>
     required?: string[]
     additionalProperties?: boolean
     oneOf?: ObjectSchema[]
@@ -122,6 +123,32 @@ describe('toolsForIntegrations', () => {
     expect(tool.description).toContain('{"to":{"toAgent":"<agent id>"},"message":"..."}')
     expect(tool.description).toContain('{"to":{"channel":"<channel id>"},"message":"..."}')
     expect(tool.description).toContain('{"to":{"sessionId":"<Parent session>"},"message":"..."}')
+  })
+
+  it('states what a channel-root post costs, and points a relayed answer at the parent session', () => {
+    // A coordinate-only description leaves the three branches reading as equivalent ways to
+    // "send somewhere", so an agent asked to relay an answer back to a customer picks the
+    // channel it can see and posts at its root — a top-level message plus a NEW session,
+    // instead of a reply in the conversation that asked. The consequence has to be ON the
+    // branch that carries it, and the tool has to say the turn's own reply already lands here.
+    const description = sendTool([slackInt])!.description
+    expect(description).toContain('use this tool only to reach a DIFFERENT channel, session, or agent')
+    expect(description).toContain('opens a NEW session')
+    expect(description).toContain('never by posting it to their channel')
+
+    expect(sendTargetBranch([slackInt], 'channel').description).toContain(
+      'does not continue the conversation you are in'
+    )
+    expect(sendTargetBranch([slackInt], 'channel').properties.thread!.description).toContain('opens a new session')
+    expect(sendTargetBranch([slackInt], 'sessionId').description).toContain('would start a new one')
+
+    // Collaboration off ⇒ only the channel branch exists, and it is then the ONLY way to send —
+    // so the root-post cost must be stated there too (spawnChannelRootSession runs either way).
+    const soloDescription = toolsForIntegrations([slackInt], { collaboration: false }).find(
+      (t) => t.name === 'sendMessage'
+    )!.description
+    expect(soloDescription).toContain('opens a NEW session')
+    expect(soloDescription).toContain('use this tool only to reach a DIFFERENT channel')
   })
 
   it('`toAgent` accepts the bare agent id OR an {agentId, needsReply} object', () => {

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -132,15 +132,24 @@ describe('toolsForIntegrations', () => {
     // instead of a reply in the conversation that asked. The consequence has to be ON the
     // branch that carries it, and the tool has to say the turn's own reply already lands here.
     const description = sendTool([slackInt])!.description
-    expect(description).toContain('use this tool only to reach a DIFFERENT channel, session, or agent')
+    expect(description).toContain('use this tool to reach a DIFFERENT conversation')
     expect(description).toContain('opens a NEW session')
-    expect(description).toContain('never by posting it to their channel')
+    expect(description).toContain('never by posting it at their channel root')
 
     expect(sendTargetBranch([slackInt], 'channel').description).toContain(
-      'does not continue the conversation you are in'
+      'only an explicit `thread` continues an existing conversation'
     )
     expect(sendTargetBranch([slackInt], 'channel').properties.thread!.description).toContain('opens a new session')
-    expect(sendTargetBranch([slackInt], 'sessionId').description).toContain('would start a new one')
+    expect(sendTargetBranch([slackInt], 'sessionId').description).toContain(
+      'channel ROOT instead would start a new one'
+    )
+
+    // The cost is ROOT-only: an explicit thread joins a conversation, and same-channel sends
+    // (another thread, or `toUser` addressing a human) stay legitimate — so the guidance says
+    // "a different conversation", never "a different channel".
+    expect(description).not.toContain('DIFFERENT channel,')
+    for (const text of [description, sendTargetBranch([slackInt], 'channel').description!])
+      expect(text).toMatch(/(at )?channel root/i)
 
     // Collaboration off ⇒ only the channel branch exists, and it is then the ONLY way to send —
     // so the root-post cost must be stated there too (spawnChannelRootSession runs either way).
@@ -148,7 +157,7 @@ describe('toolsForIntegrations', () => {
       (t) => t.name === 'sendMessage'
     )!.description
     expect(soloDescription).toContain('opens a NEW session')
-    expect(soloDescription).toContain('use this tool only to reach a DIFFERENT channel')
+    expect(soloDescription).toContain('use this tool to reach a DIFFERENT conversation')
   })
 
   it('`toAgent` accepts the bare agent id OR an {agentId, needsReply} object', () => {


### PR DESCRIPTION
## Problem

`sendMessage`'s three `to` branches are described as equivalent coordinate forms — peer agent, channel, parent session — as if they were three ways to "send a message somewhere". Only one of them continues the conversation the agent is currently in, and nothing in the schema said so:

- The channel branch says "Post one visible message to a platform channel"; `thread` says "Omit (or use "") to post at channel root". Purely mechanical — **no mention that a root post opens a NEW session** keyed to that post (`spawnChannelRootSession`, session-concept case 2a).
- The parent-session branch says how to address it, but not that it is *the* way to return an answer to whoever asked.
- Nothing says the turn's own reply already reaches the current conversation.

So an agent instructed to "relay the answer back to the customer" picks the channel id it can see and posts at its root. The asker gets a detached top-level message instead of a reply in their thread, and the answer's session forks away from the conversation it belongs to. Observed on an escalate-to-another-platform-and-relay-back agent; every such agent has had to re-derive the rule in its own `CLAUDE.md`.

Interestingly the `toAgent` branch *does* explain this ("anchor the peer to the new root message") — the plain channel branch, which is the one ordinary agents use every day, does not.

## Change

Contract prose only, no behavior change:

- **Channel target** (branch + `thread`): a root post opens a new session of your own on that post; it does not continue the conversation you are in.
- **Parent session target**: this is how an answer reaches the conversation that asked for it — posting it to that conversation's channel instead would start a new one.
- **Tool description** (both the collaboration and collaboration-off variants): your own turn reply already reaches the conversation you are in, so use this tool only to reach a DIFFERENT channel, session, or agent. The collaboration-off descriptor needs it too — the channel branch is then the only way to send, and a root post spawns a session either way.

## Tests

`mcp-tools.test.ts`: a new case pins each sentence to the branch that carries it, plus the collaboration-off descriptor. Full daemon suite passes (2326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
