### PR TITLE
fix(web): don't default Home composer to a not-ready agentconnect preset

### DIFF
--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -258,4 +258,36 @@ describe('HomeView readiness gate', () => {
     await render()
     expect(host.textContent).toContain('No AI runtime is signed in')
   })
+
+  it('shows no banner when the selected agent’s daemon is healthy but ANOTHER daemon is not', async () => {
+    mocks.agents = [agent()]
+    mocks.daemons = [
+      daemon(),
+      daemon({
+        daemonId: 'd2',
+        status: 'offline',
+        runtimeModels: [
+          { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: true }
+        ]
+      })
+    ]
+    await render()
+    expect(host.textContent).not.toContain('is offline')
+    expect(host.textContent).not.toContain('No AI runtime is signed in')
+  })
+
+  it('defaults past a NOT-ready agentconnect preset to a ready agent (no banner for an unused daemon)', async () => {
+    mocks.agents = [agent({ id: 'a-pre', name: 'agentconnect', daemon: 'd2' }), agent({ id: 'a1', name: 'bot' })]
+    mocks.daemons = [daemon(), daemon({ daemonId: 'd2', status: 'offline' })]
+    await render()
+    expect(mocks.menus.find((m) => m.title === 'Agent')?.value).toBe('a1')
+    expect(host.textContent).not.toContain('is offline')
+  })
+
+  it('still prefers the agentconnect preset when it is ready', async () => {
+    mocks.agents = [agent({ id: 'a1', name: 'bot' }), agent({ id: 'a-pre', name: 'agentconnect' })]
+    mocks.daemons = [daemon()]
+    await render()
+    expect(mocks.menus.find((m) => m.title === 'Agent')?.value).toBe('a-pre')
+  })
 })

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -76,12 +76,15 @@ export default function HomeView() {
     !!daemons.find((d) => d.daemonId === a.daemon)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
   const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)
 
-  // Preferred default agent: the "agentconnect" preset if present, else the first
-  // READY one, else the first (so the composer defaults to something startable).
-  const preferred = useMemo(
-    () => agents.find((a) => a.name === 'agentconnect') ?? agents.find(agentReady) ?? agents[0],
-    [agents, daemons]
-  )
+  // Preferred default agent: the "agentconnect" preset when it's READY, else the
+  // first READY one, else the preset, else the first. Readiness outranks the preset:
+  // if the preset's daemon is offline/unsigned-in while another daemon serves ready
+  // agents, defaulting to the preset would flash the blocked banner for a daemon the
+  // user isn't even using (composer must default to something startable).
+  const preferred = useMemo(() => {
+    const preset = agents.find((a) => a.name === 'agentconnect')
+    return preset && agentReady(preset) ? preset : (agents.find(agentReady) ?? preset ?? agents[0])
+  }, [agents, daemons])
   const [agentId, setAgentId] = useState<string | undefined>(undefined)
   const agent = agents.find((a) => a.id === agentId) ?? preferred
   const agentOnline = agent ? isOnline(agent) : false


### PR DESCRIPTION
## What

The Home composer's default-agent pick (`preferred` in `HomeView.tsx`) unconditionally preferred the `agentconnect` preset:

```ts
agents.find((a) => a.name === 'agentconnect') ?? agents.find(agentReady) ?? agents[0]
```

Now the preset wins only when it is READY (its daemon serving + runtime signed in); otherwise the pick falls to the first ready agent, then the preset, then the first agent.

## Why

In a multi-daemon org where the preset happens to sit on an offline / unsigned-in daemon, Home auto-selected it and showed the "is offline / No AI runtime is signed in" blocked banner — even though perfectly usable agents exist on a healthy daemon. This read as a false alarm: the daemon the user actually works with is fine, yet Home warns about another daemon's problem.

The per-agent `blocked` derivation itself was verified correct (it is scoped to the selected agent's owning daemon); only the default selection was at fault.

## Notes for reviewers

- New regression tests in `HomeView.test.tsx`:
  - healthy selected agent + a different broken daemon ⇒ no banner
  - preset on a broken daemon ⇒ composer defaults to the ready agent, no banner
  - preset still wins when ready
- Explicit user selection is unaffected — this only changes the initial default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)