### PR TITLE
feat(daemon): tell an agent when its root post forked the conversation

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5806,10 +5806,9 @@ export class Daemon {
    * The parent link is read from the CURRENT turn's trusted call metadata when present, else from
    * the DURABLE origin on the session row (§5.3) — the load-bearing half, since relaying an answer
    * happens on a later human-triggered turn with no metadata. Coords come from the parent's own
-   * row, the only place a transport scope is recorded; a CROSS-DAEMON parent has no local row, so
-   * there the live wake's `originCoords` answer instead. Those carry no scope (the parent's scope
-   * belongs to its own daemon and means nothing here), which is why the row is preferred whenever
-   * one exists. This widens nothing — it answers about coordinates the caller itself just named.
+   * row wherever one exists, because only a row records a transport scope; the cross-daemon case
+   * and its deliberate imprecision are spelled out at the branch below. This widens nothing — it
+   * answers about coordinates the caller itself just named.
    */
   private rootPostRelation(req: {
     callerAgentId: string
@@ -5839,15 +5838,23 @@ export class Daemon {
     const inbound = this.activeTurnCallMeta.get(key)
     const parentSessionId = inbound?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
     const parent = parentSessionId ? this.store.getSessionByAcpId(parentSessionId) : undefined
-    const parentCoords = parent
-      ? { platform: parent.platform, channel: parent.channel, scope: parent.transportScope }
-      : inbound?.originSessionId === parentSessionId && inbound?.originCoords
-        ? // Cross-daemon parent: no local row to read, so take the live wake's coords. Scope is
-          // unknowable (it is the source daemon's), so this compares coordinates alone.
-          { platform: inbound.originCoords.platform, channel: inbound.originCoords.channel, scope: targetScope }
-        : undefined
-    if (parentSessionId && parentCoords && isTarget(parentCoords.platform, parentCoords.channel, parentCoords.scope)) {
+    // A LOCAL parent's row records its transport scope, so its identity is exact.
+    if (parentSessionId && parent && isTarget(parent.platform, parent.channel, parent.transportScope)) {
       return { kind: 'parent', sessionId: parentSessionId }
+    }
+    // A CROSS-DAEMON parent has no row here, and its scope cannot be obtained: the value is
+    // derived from the owning daemon's live credential and deliberately never crosses the wire
+    // (see the note on the durable scope in protocol telemetry) — it would also rotate with that
+    // daemon's tokens, so a forwarded copy could not be compared reliably anyway. Identity here is
+    // therefore COORDINATES ONLY, which can over-match where one channel id is reachable through
+    // two bots. That trade is deliberate: the cost of over-matching is a hint naming the caller's
+    // real parent — where a relayed answer belongs regardless — while staying silent would drop
+    // the hint for precisely the escalation shape the relay exists to serve.
+    if (parentSessionId && !parent && inbound?.originCoords) {
+      const { platform, channel } = inbound.originCoords
+      if (platform === req.targetPlatform && channel === req.targetChannel) {
+        return { kind: 'parent', sessionId: parentSessionId }
+      }
     }
     if (isTarget(req.platform, req.callerChannel, req.callerTransportScope)) return { kind: 'self' }
     return undefined

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2008,7 +2008,7 @@ export class Daemon {
       preflightWake: (req) => this.wakeRejectionReason(req),
       replyToSession: (req) => this.replyToSession(req),
       viewSessionStatus: (req) => Promise.resolve(this.viewSessionStatus(req)),
-      parentSession: (req) => this.parentSessionCoords(req),
+      rootPostRelation: (req) => this.rootPostRelation(req),
       spawnChannelRootSession: (req) => this.spawnChannelRootSession(req),
       startOrchestration: (req) => this.startOrchestration(req),
       getOrchestration: (req) => Promise.resolve(this.getOrchestrationForOwner(req)),
@@ -5795,39 +5795,55 @@ export class Daemon {
   }
 
   /**
-   * The caller session's parent (origin): its stable id plus the coords it occupies, or undefined
-   * when the session has no parent. Precedence mirrors {@link replyToSession}'s authorizer — the
-   * CURRENT turn's trusted call metadata first, then the DURABLE link persisted on the session row,
-   * which is all a later human-triggered turn has (§5.3). That later turn is exactly when an agent
-   * relays an answer back, so the persisted fallback is the load-bearing one here.
+   * Whether a channel-ROOT post just made by `caller` landed on a conversation that session is
+   * ALREADY part of — its parent's, its own, or neither. Backs `sendMessage`'s root-post notice.
    *
-   * Backs `sendMessage`'s root-post notice only. It widens nothing: the notice fires solely when
-   * these coords MATCH a channel the caller already named in its own call, so it can never disclose
-   * a parent the caller could not already see.
+   * Conversation identity is the daemon's to decide, which is why this lives here and not in ops:
+   * a channel id is only unique within one physical bot, so two integrations can name the same id
+   * and mean different conversations. The comparison therefore includes the transport scope on
+   * both sides. Likewise the caller's session key uses its platform string verbatim — NOT
+   * {@link narrowPlatform}, whose fallback folds `feishu` onto `slack` and would look up a row
+   * that does not exist.
+   *
+   * The parent link is read from the CURRENT turn's trusted call metadata when present, else from
+   * the DURABLE origin on the session row (§5.3) — the load-bearing half, since relaying an answer
+   * happens on a later human-triggered turn with no metadata. Its coords come from the parent's
+   * own row either way: only the row carries a transport scope. This widens nothing — it answers
+   * about coordinates the caller itself just named.
    */
-  private parentSessionCoords(req: {
+  private rootPostRelation(req: {
     callerAgentId: string
     platform: string
     callerTransportScope?: string
     callerChannel: string
     callerThread: string
-  }): { sessionId: string; platform: string; channel: string } | undefined {
+    targetPlatform: string
+    targetChannel: string
+    targetIntegrationId?: string
+  }): { kind: 'parent'; sessionId: string } | { kind: 'self' } | undefined {
+    const targetScope = this.transportScopeForIntegrationIds(
+      req.targetIntegrationId !== undefined ? [req.targetIntegrationId] : undefined
+    )
+    const isTarget = (platform: string, channel: string, scope?: string | null): boolean =>
+      platform === req.targetPlatform &&
+      channel === req.targetChannel &&
+      (scope ?? undefined) === (targetScope ?? undefined)
+
     const key = sessionKey(
-      this.narrowPlatform(req.platform),
+      req.platform,
       req.callerChannel,
       req.callerThread,
       req.callerAgentId,
       req.callerTransportScope
     )
-    const inbound = this.activeTurnCallMeta.get(key)
-    const sessionId = inbound?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
-    if (!sessionId) return undefined
-    // A live wake carries the origin's coords; a durable link has to read the parent's own row —
-    // which may belong to ANOTHER agent, since a peer's wake is a valid parent.
-    const coords = inbound?.originCoords
-    if (coords) return { sessionId, platform: coords.platform, channel: coords.channel }
-    const rec = this.store.getSessionByAcpId(sessionId)
-    return rec ? { sessionId, platform: rec.platform, channel: rec.channel } : undefined
+    const parentSessionId =
+      this.activeTurnCallMeta.get(key)?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
+    const parent = parentSessionId ? this.store.getSessionByAcpId(parentSessionId) : undefined
+    if (parentSessionId && parent && isTarget(parent.platform, parent.channel, parent.transportScope)) {
+      return { kind: 'parent', sessionId: parentSessionId }
+    }
+    if (isTarget(req.platform, req.callerChannel, req.callerTransportScope)) return { kind: 'self' }
+    return undefined
   }
 
   /**
@@ -5849,7 +5865,7 @@ export class Daemon {
     originTransportScope?: string
     originChannel: string
     originThread: string
-  }): void {
+  }): boolean {
     const platform = this.narrowPlatform(req.platform)
     // The post's raw ts is the new thread's root. On Telegram that ts is a bare numeric
     // message id, but inbound reply-based sessions key `tg:<root>` (see
@@ -5873,7 +5889,7 @@ export class Daemon {
     const hopCount = inbound ? inbound.hopCount + 1 : 1
     if (hopCount > MAX_AGENT_CALL_HOPS) {
       this.log.info(`channel-root session: hop limit reached for agent "${req.agentId}" — not spawning`)
-      return
+      return false
     }
     const originSessionId = this.store.getSession(originKey)?.acpSessionId ?? undefined
     const originCoordPlatform = originPlatform === 'hook' ? 'slack' : originPlatform
@@ -5922,6 +5938,7 @@ export class Daemon {
     this.log.info(
       `channel-root session: "${req.agentId}" initialized new session ${targetSession} (origin ${originSessionId ?? 'none'}, hop ${hopCount})`
     )
+    return true
   }
 
   /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5801,15 +5801,15 @@ export class Daemon {
    * Conversation identity is the daemon's to decide, which is why this lives here and not in ops:
    * a channel id is only unique within one physical bot, so two integrations can name the same id
    * and mean different conversations. The comparison therefore includes the transport scope on
-   * both sides. Likewise the caller's session key uses its platform string verbatim — NOT
-   * {@link narrowPlatform}, whose fallback folds `feishu` onto `slack` and would look up a row
-   * that does not exist.
+   * both sides, and the caller's session key uses its platform string verbatim.
    *
    * The parent link is read from the CURRENT turn's trusted call metadata when present, else from
    * the DURABLE origin on the session row (§5.3) — the load-bearing half, since relaying an answer
-   * happens on a later human-triggered turn with no metadata. Its coords come from the parent's
-   * own row either way: only the row carries a transport scope. This widens nothing — it answers
-   * about coordinates the caller itself just named.
+   * happens on a later human-triggered turn with no metadata. Coords come from the parent's own
+   * row, the only place a transport scope is recorded; a CROSS-DAEMON parent has no local row, so
+   * there the live wake's `originCoords` answer instead. Those carry no scope (the parent's scope
+   * belongs to its own daemon and means nothing here), which is why the row is preferred whenever
+   * one exists. This widens nothing — it answers about coordinates the caller itself just named.
    */
   private rootPostRelation(req: {
     callerAgentId: string
@@ -5836,10 +5836,17 @@ export class Daemon {
       req.callerAgentId,
       req.callerTransportScope
     )
-    const parentSessionId =
-      this.activeTurnCallMeta.get(key)?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
+    const inbound = this.activeTurnCallMeta.get(key)
+    const parentSessionId = inbound?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
     const parent = parentSessionId ? this.store.getSessionByAcpId(parentSessionId) : undefined
-    if (parentSessionId && parent && isTarget(parent.platform, parent.channel, parent.transportScope)) {
+    const parentCoords = parent
+      ? { platform: parent.platform, channel: parent.channel, scope: parent.transportScope }
+      : inbound?.originSessionId === parentSessionId && inbound?.originCoords
+        ? // Cross-daemon parent: no local row to read, so take the live wake's coords. Scope is
+          // unknowable (it is the source daemon's), so this compares coordinates alone.
+          { platform: inbound.originCoords.platform, channel: inbound.originCoords.channel, scope: targetScope }
+        : undefined
+    if (parentSessionId && parentCoords && isTarget(parentCoords.platform, parentCoords.channel, parentCoords.scope)) {
       return { kind: 'parent', sessionId: parentSessionId }
     }
     if (isTarget(req.platform, req.callerChannel, req.callerTransportScope)) return { kind: 'self' }
@@ -6011,7 +6018,11 @@ export class Daemon {
    *  falls back to 'slack' for an unrecognized value (coords still resolve — the union is
    *  a routing/key detail, not the trust basis). */
   private narrowPlatform(p: string): NormalizedMessage['platform'] {
-    return p === 'telegram' || p === 'webchat' || p === 'discord' || p === 'hook' ? p : 'slack'
+    // Every caller turns a platform string off a session/orchestration row back into the union, to
+    // key a session or synthesize a message. `feishu` was missing from the list long after the
+    // platform shipped, so all of them silently produced a `slack:` key for a session ingress
+    // records under `feishu:` — a session nothing could then continue.
+    return p === 'telegram' || p === 'webchat' || p === 'discord' || p === 'feishu' || p === 'hook' ? p : 'slack'
   }
 
   // ══════════════════════════ §3.4/§6.8 main-agent orchestration ══════════════════════════

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2008,6 +2008,7 @@ export class Daemon {
       preflightWake: (req) => this.wakeRejectionReason(req),
       replyToSession: (req) => this.replyToSession(req),
       viewSessionStatus: (req) => Promise.resolve(this.viewSessionStatus(req)),
+      parentSession: (req) => this.parentSessionCoords(req),
       spawnChannelRootSession: (req) => this.spawnChannelRootSession(req),
       startOrchestration: (req) => this.startOrchestration(req),
       getOrchestration: (req) => Promise.resolve(this.getOrchestrationForOwner(req)),
@@ -5791,6 +5792,42 @@ export class Daemon {
   private isAuthorizedChildParent(child: SessionRecord, parentSessionId: string): boolean {
     if (child.originSessionId === parentSessionId) return true
     return this.childSessionLinks.get(child.key)?.parentSessionId === parentSessionId
+  }
+
+  /**
+   * The caller session's parent (origin): its stable id plus the coords it occupies, or undefined
+   * when the session has no parent. Precedence mirrors {@link replyToSession}'s authorizer — the
+   * CURRENT turn's trusted call metadata first, then the DURABLE link persisted on the session row,
+   * which is all a later human-triggered turn has (§5.3). That later turn is exactly when an agent
+   * relays an answer back, so the persisted fallback is the load-bearing one here.
+   *
+   * Backs `sendMessage`'s root-post notice only. It widens nothing: the notice fires solely when
+   * these coords MATCH a channel the caller already named in its own call, so it can never disclose
+   * a parent the caller could not already see.
+   */
+  private parentSessionCoords(req: {
+    callerAgentId: string
+    platform: string
+    callerTransportScope?: string
+    callerChannel: string
+    callerThread: string
+  }): { sessionId: string; platform: string; channel: string } | undefined {
+    const key = sessionKey(
+      this.narrowPlatform(req.platform),
+      req.callerChannel,
+      req.callerThread,
+      req.callerAgentId,
+      req.callerTransportScope
+    )
+    const inbound = this.activeTurnCallMeta.get(key)
+    const sessionId = inbound?.originSessionId ?? this.store.getSession(key)?.originSessionId ?? undefined
+    if (!sessionId) return undefined
+    // A live wake carries the origin's coords; a durable link has to read the parent's own row —
+    // which may belong to ANOTHER agent, since a peer's wake is a valid parent.
+    const coords = inbound?.originCoords
+    if (coords) return { sessionId, platform: coords.platform, channel: coords.channel }
+    const rec = this.store.getSessionByAcpId(sessionId)
+    return rec ? { sessionId, platform: rec.platform, channel: rec.channel } : undefined
   }
 
   /**

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -345,8 +345,10 @@ export interface OpsDeps {
    *  Only called for a root post (no thread) with no toAgent. Fire-and-forget; the daemon creates
    *  the session without running a model turn, then replays the root as context on the first real
    *  reply. Absent in the chat CLI / tests (no daemon) — then a root post is a plain post with no
-   *  session spawn. Returns whether a session was actually seeded: the daemon declines at the
-   *  agent-call hop limit, and nothing downstream may then claim a session opened. */
+   *  session spawn. Returns whether the daemon ACCEPTED the post as a seed — `false` when it
+   *  declines outright (the agent-call hop limit). Acceptance is not completion: the seed itself
+   *  is dispatched fire-and-forget and can still fail later, so nothing downstream may state a
+   *  session as an accomplished fact. */
   spawnChannelRootSession?: (req: {
     agentId: string
     platform: string
@@ -798,13 +800,14 @@ export async function executeTool(
           : undefined
         if (relation?.kind === 'parent') {
           notice =
-            `This posted at the root of the conversation your parent session occupies, which opened a NEW ` +
-            `session on the post — the conversation waiting on you did not receive it. To answer it, call ` +
-            `sendMessage with {"to":{"sessionId":"${relation.sessionId}"}}.`
+            `This posted at the ROOT of the conversation your parent session occupies, so it starts a separate ` +
+            `context there instead of answering — the conversation waiting on you did not receive it. To answer ` +
+            `it, call sendMessage with {"to":{"sessionId":"${relation.sessionId}"}}.`
         } else if (relation?.kind === 'self') {
           notice =
-            `This posted at the root of the conversation this session is already in, which opened a NEW session ` +
-            `on the post. Your ordinary reply for this turn already reaches this conversation — no sendMessage needed.`
+            `This posted at the ROOT of the conversation this session is already in, so it starts a separate ` +
+            `context instead of continuing it. Your ordinary reply for this turn already reaches this conversation ` +
+            `— no sendMessage needed.`
         }
       }
     }

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -315,19 +315,24 @@ export interface OpsDeps {
    *  origin turn's correlationId, and inserts a {type:system, from:<caller>} message —
    *  routing local or cross-daemon. Backs `sendMessage`'s SessionTarget. */
   replyToSession: (req: ReplyToSessionReq) => Promise<ReplyToSessionResult>
-  /** The caller session's parent (origin), when it has one: its stable id plus the coords it
-   *  occupies. Resolved from the CURRENT turn's trusted call metadata when present, else from the
-   *  durable origin link persisted on the caller's session — so it is still answerable on a later
-   *  human-triggered turn, which is exactly when an agent relays an answer back. `sendMessage`
-   *  uses it only to compare against coords the caller itself named, never to disclose anything.
-   *  Absent in the chat CLI / tests with no daemon ⇒ no root-post notice. */
-  parentSession?: (req: {
+  /** How a channel-ROOT post this session just made relates to the conversations the session is
+   *  ALREADY part of: `parent` = the origin session waiting on an answer (named, so the caller can
+   *  address it), `self` = this session's own conversation, undefined = an unrelated destination,
+   *  i.e. the ordinary new-topic post. The daemon answers because it owns the identity rules —
+   *  a channel id means a different conversation under a different transport scope, and the
+   *  parent link may only exist as the durable origin on the session row (a relayed answer runs
+   *  on a human-triggered turn with no call metadata at all). Absent in the chat CLI / tests with
+   *  no daemon ⇒ no notice. */
+  rootPostRelation?: (req: {
     callerAgentId: string
     platform: string
     callerTransportScope?: string
     callerChannel: string
     callerThread: string
-  }) => { sessionId: string; platform: string; channel: string } | undefined
+    targetPlatform: string
+    targetChannel: string
+    targetIntegrationId?: string
+  }) => { kind: 'parent'; sessionId: string } | { kind: 'self' } | undefined
   /** Read the progress of a session the caller started (backs `viewSessionStatus`). The daemon
    *  fills the trusted caller identity from the session context and authorizes `sessionId`
    *  against the caller's own children, fail-closed. Returns null when the id is unknown or is
@@ -340,7 +345,8 @@ export interface OpsDeps {
    *  Only called for a root post (no thread) with no toAgent. Fire-and-forget; the daemon creates
    *  the session without running a model turn, then replays the root as context on the first real
    *  reply. Absent in the chat CLI / tests (no daemon) — then a root post is a plain post with no
-   *  session spawn. */
+   *  session spawn. Returns whether a session was actually seeded: the daemon declines at the
+   *  agent-call hop limit, and nothing downstream may then claim a session opened. */
   spawnChannelRootSession?: (req: {
     agentId: string
     platform: string
@@ -356,7 +362,7 @@ export interface OpsDeps {
     originTransportScope?: string
     originChannel: string
     originThread: string
-  }) => void
+  }) => boolean
   /** Start an orchestration (§3.4/§6.8): record-first, then deliver each subtask, then
    *  schedule the deadline. The daemon fills the trusted main identity + coords from the
    *  session context. Returns null when the caller is not allowed to orchestrate (never today). */
@@ -758,7 +764,7 @@ export async function executeTool(
       // a `toAgent`, the woken peer owns that thread instead (see (B)) — so skip the caller-owned
       // spawn. Also skip when the platform returned no real ts (synthesized `local-*`).
       if (toAgent === undefined && thread === undefined && !ts.startsWith('local-') && deps.spawnChannelRootSession) {
-        deps.spawnChannelRootSession({
+        const seeded = deps.spawnChannelRootSession({
           agentId: ctx.agentId,
           platform: wantPlatform,
           ...(targetId ? { integrationId: targetId } : {}),
@@ -773,25 +779,32 @@ export async function executeTool(
         // A root post is a legitimate way to open a new topic, so this is never blocked — but
         // when it lands on a conversation the agent is ALREADY part of, the intent was almost
         // certainly to answer, not to fork. Two cases, both observed on relay-the-answer-back
-        // agents: posting into the channel of the parent session that is waiting for the answer,
-        // and posting into the channel of the current session, whose ordinary turn reply already
-        // goes there. Say which one happened and name the address that would have replied.
-        const parent = deps.parentSession?.({
-          callerAgentId: ctx.agentId,
-          platform: ctx.platform,
-          ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
-          callerChannel: ctx.channel,
-          callerThread: ctx.thread
-        })
-        if (parent !== undefined && parent.platform === wantPlatform && parent.channel === channel) {
+        // agents: posting into the conversation of the parent session that is waiting for the
+        // answer, and posting into the current session's own conversation, whose ordinary turn
+        // reply already goes there. Say which one happened and name the address that would have
+        // replied — but only when a session really was seeded (`seeded`), since the notice's
+        // whole claim is that one opened.
+        const relation = seeded
+          ? deps.rootPostRelation?.({
+              callerAgentId: ctx.agentId,
+              platform: ctx.platform,
+              ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
+              callerChannel: ctx.channel,
+              callerThread: ctx.thread,
+              targetPlatform: wantPlatform,
+              targetChannel: channel,
+              ...(targetId ? { targetIntegrationId: targetId } : {})
+            })
+          : undefined
+        if (relation?.kind === 'parent') {
           notice =
-            `This posted at the root of the channel your parent session occupies, which opened a NEW session ` +
-            `on the post — the conversation waiting on you did not receive it. To answer it, call sendMessage ` +
-            `with {"to":{"sessionId":"${parent.sessionId}"}}.`
-        } else if (wantPlatform === ctx.platform && channel === ctx.channel) {
+            `This posted at the root of the conversation your parent session occupies, which opened a NEW ` +
+            `session on the post — the conversation waiting on you did not receive it. To answer it, call ` +
+            `sendMessage with {"to":{"sessionId":"${relation.sessionId}"}}.`
+        } else if (relation?.kind === 'self') {
           notice =
-            `This posted at the root of the channel this session is already in, which opened a NEW session on ` +
-            `the post. Your ordinary reply for this turn already reaches this conversation — no sendMessage needed.`
+            `This posted at the root of the conversation this session is already in, which opened a NEW session ` +
+            `on the post. Your ordinary reply for this turn already reaches this conversation — no sendMessage needed.`
         }
       }
     }

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -315,6 +315,19 @@ export interface OpsDeps {
    *  origin turn's correlationId, and inserts a {type:system, from:<caller>} message —
    *  routing local or cross-daemon. Backs `sendMessage`'s SessionTarget. */
   replyToSession: (req: ReplyToSessionReq) => Promise<ReplyToSessionResult>
+  /** The caller session's parent (origin), when it has one: its stable id plus the coords it
+   *  occupies. Resolved from the CURRENT turn's trusted call metadata when present, else from the
+   *  durable origin link persisted on the caller's session — so it is still answerable on a later
+   *  human-triggered turn, which is exactly when an agent relays an answer back. `sendMessage`
+   *  uses it only to compare against coords the caller itself named, never to disclose anything.
+   *  Absent in the chat CLI / tests with no daemon ⇒ no root-post notice. */
+  parentSession?: (req: {
+    callerAgentId: string
+    platform: string
+    callerTransportScope?: string
+    callerChannel: string
+    callerThread: string
+  }) => { sessionId: string; platform: string; channel: string } | undefined
   /** Read the progress of a session the caller started (backs `viewSessionStatus`). The daemon
    *  fills the trusted caller identity from the session context and authorizes `sessionId`
    *  against the caller's own children, fail-closed. Returns null when the id is unknown or is
@@ -708,6 +721,10 @@ export async function executeTool(
     // after the send.
     let post:
       { platform: string; integrationId: string; channel: string; thread: string | null; ts: string } | undefined
+    // Set when the root post just forked a conversation this agent is already part of — see the
+    // notice built below. Surfaced in the tool RESULT, where the agent reads it inside the same
+    // turn it made the call, and can still answer the right way.
+    let notice: string | undefined
     // The thread the peer wake / new session should anchor to when we posted: an explicit
     // `thread` reuses it; a root post anchors to the post's `ts` (undefined if no real ts came
     // back — the peer then falls back to messageAgent's default thread).
@@ -740,8 +757,8 @@ export async function executeTool(
       // owned by this agent, keyed by the post's ts, origin = the current session. When there IS
       // a `toAgent`, the woken peer owns that thread instead (see (B)) — so skip the caller-owned
       // spawn. Also skip when the platform returned no real ts (synthesized `local-*`).
-      if (toAgent === undefined && thread === undefined && !ts.startsWith('local-')) {
-        deps.spawnChannelRootSession?.({
+      if (toAgent === undefined && thread === undefined && !ts.startsWith('local-') && deps.spawnChannelRootSession) {
+        deps.spawnChannelRootSession({
           agentId: ctx.agentId,
           platform: wantPlatform,
           ...(targetId ? { integrationId: targetId } : {}),
@@ -753,6 +770,29 @@ export async function executeTool(
           originChannel: ctx.channel,
           originThread: ctx.thread
         })
+        // A root post is a legitimate way to open a new topic, so this is never blocked — but
+        // when it lands on a conversation the agent is ALREADY part of, the intent was almost
+        // certainly to answer, not to fork. Two cases, both observed on relay-the-answer-back
+        // agents: posting into the channel of the parent session that is waiting for the answer,
+        // and posting into the channel of the current session, whose ordinary turn reply already
+        // goes there. Say which one happened and name the address that would have replied.
+        const parent = deps.parentSession?.({
+          callerAgentId: ctx.agentId,
+          platform: ctx.platform,
+          ...(ctx.transportScope !== undefined ? { callerTransportScope: ctx.transportScope } : {}),
+          callerChannel: ctx.channel,
+          callerThread: ctx.thread
+        })
+        if (parent !== undefined && parent.platform === wantPlatform && parent.channel === channel) {
+          notice =
+            `This posted at the root of the channel your parent session occupies, which opened a NEW session ` +
+            `on the post — the conversation waiting on you did not receive it. To answer it, call sendMessage ` +
+            `with {"to":{"sessionId":"${parent.sessionId}"}}.`
+        } else if (wantPlatform === ctx.platform && channel === ctx.channel) {
+          notice =
+            `This posted at the root of the channel this session is already in, which opened a NEW session on ` +
+            `the post. Your ordinary reply for this turn already reaches this conversation — no sendMessage needed.`
+        }
       }
     }
 
@@ -788,7 +828,8 @@ export async function executeTool(
       ok: true,
       ...(wake !== undefined ? { wake } : {}),
       ...(post !== undefined ? { post } : {}),
-      ...(childSessionId !== undefined ? { childSessionId } : {})
+      ...(childSessionId !== undefined ? { childSessionId } : {}),
+      ...(notice !== undefined ? { notice } : {})
     }
   }
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1106,51 +1106,144 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
 })
 
 /**
- * `parentSessionCoords` — where the parent conversation actually LIVES, which is what lets
- * `sendMessage` notice that a channel-root post just forked it instead of answering it. The
- * durable fallback is the load-bearing half: an agent relays an answer on a human-triggered turn,
- * which carries no CallMeta at all.
+ * `rootPostRelation` — whether a channel-ROOT post landed on a conversation the posting session
+ * is already part of, which is what lets `sendMessage` say it forked one instead of answering it.
+ * The durable parent link is the load-bearing half: an agent relays an answer on a human-triggered
+ * turn, which carries no CallMeta at all.
  */
-describe('parentSessionCoords: the coords a relayed answer should have gone to', () => {
+describe('rootPostRelation: did this post fork a conversation we are already in', () => {
+  const seed = (daemon: any, over: Record<string, unknown>) =>
+    daemon.store.upsertSession({
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      ...over
+    })
   const ask = (daemon: any, over: Record<string, unknown> = {}) =>
-    daemon.parentSessionCoords({
+    daemon.rootPostRelation({
       callerAgentId: 'bot-b',
       platform: 'slack',
       callerChannel: 'C2',
       callerThread: '200.1',
+      targetPlatform: 'telegram',
+      targetChannel: '-100123',
       ...over
     })
 
-  it('reads the parent’s channel off the persisted link when the turn has no CallMeta', async () => {
+  it('finds the parent through the persisted link when the turn has no CallMeta', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
     // The parent conversation — a Telegram customer chat owned by ANOTHER agent, which is the
     // ordinary escalation shape: whoever asked is not whoever answers.
-    ;(daemon as any).store.upsertSession({
+    seed(daemon, {
       key: sessionKey('telegram', '-100123', 'tg:170', 'bot-a'),
       agentId: 'bot-a',
       platform: 'telegram',
       channel: '-100123',
       thread: 'tg:170',
-      acpSessionId: 'acp-parent-1',
-      state: 'idle',
-      lastDeliveredTs: null,
-      updatedAt: Date.now()
+      acpSessionId: 'acp-parent-1'
     })
-    ;(daemon as any).store.upsertSession({
+    seed(daemon, {
       key: sessionKey('slack', 'C2', '200.1', 'bot-b'),
       agentId: 'bot-b',
       platform: 'slack',
       channel: 'C2',
       thread: '200.1',
       acpSessionId: 'acp-child-1',
-      state: 'idle',
-      lastDeliveredTs: null,
-      updatedAt: Date.now(),
       originSessionId: 'acp-parent-1'
     })
 
-    expect(ask(daemon)).toEqual({ sessionId: 'acp-parent-1', platform: 'telegram', channel: '-100123' })
+    expect(ask(daemon)).toEqual({ kind: 'parent', sessionId: 'acp-parent-1' })
+    // A post somewhere else is an ordinary new topic, not a fork.
+    expect(ask(daemon, { targetChannel: '-100999' })).toBeUndefined()
+    // The caller's OWN conversation, which its turn reply already reaches.
+    expect(ask(daemon, { targetPlatform: 'slack', targetChannel: 'C2' })).toEqual({ kind: 'self' })
+    await daemon.stop()
+  })
+
+  it('resolves a Feishu caller, whose platform string is not one narrowPlatform keeps', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    // narrowPlatform folds `feishu` onto `slack`; keying the lookup through it looked up a row
+    // that never existed, so a Feishu session could never resolve its parent.
+    seed(daemon, {
+      key: sessionKey('telegram', '-100123', 'tg:170', 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-100123',
+      thread: 'tg:170',
+      acpSessionId: 'acp-parent-1'
+    })
+    seed(daemon, {
+      key: sessionKey('feishu', 'oc_42', 'om_1', 'bot-b'),
+      agentId: 'bot-b',
+      platform: 'feishu',
+      channel: 'oc_42',
+      thread: 'om_1',
+      acpSessionId: 'acp-child-feishu',
+      originSessionId: 'acp-parent-1'
+    })
+
+    expect(ask(daemon, { platform: 'feishu', callerChannel: 'oc_42', callerThread: 'om_1' })).toEqual({
+      kind: 'parent',
+      sessionId: 'acp-parent-1'
+    })
+    await daemon.stop()
+  })
+
+  it('treats the same channel id under a different bot as a different conversation', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    // Channel ids are only unique within one physical bot (Telegram DMs reuse the user's id
+    // across bots), so identity has to include the transport scope on both sides. The parent
+    // here lives under one bot's scope; the post goes out on a channel id that merely LOOKS the
+    // same, so comparing raw platform+channel would mislabel it as the parent's conversation.
+    seed(daemon, {
+      key: sessionKey('telegram', '-100123', 'tg:170', 'bot-a', 'scope-bot-1'),
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-100123',
+      thread: 'tg:170',
+      transportScope: 'scope-bot-1',
+      acpSessionId: 'acp-parent-scoped'
+    })
+    seed(daemon, {
+      key: sessionKey('slack', 'C2', '200.1', 'bot-b'),
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      originSessionId: 'acp-parent-scoped'
+    })
+    expect(ask(daemon)).toBeUndefined()
+
+    // Control: an unscoped parent on the same coords IS the conversation the post landed on, so
+    // the silence above is the scope doing the work and not a broken lookup.
+    seed(daemon, {
+      key: sessionKey('telegram', '-100123', 'tg:171', 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-100123',
+      thread: 'tg:171',
+      acpSessionId: 'acp-parent-unscoped'
+    })
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('slack', 'C3', '300.1', 'bot-b'),
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C3',
+      thread: '300.1',
+      acpSessionId: 'acp-child-2',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-unscoped'
+    })
+    expect(ask(daemon, { callerChannel: 'C3', callerThread: '300.1' })).toEqual({
+      kind: 'parent',
+      sessionId: 'acp-parent-unscoped'
+    })
     await daemon.stop()
   })
 
@@ -1158,21 +1251,26 @@ describe('parentSessionCoords: the coords a relayed answer should have gone to',
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
     const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
-    ;(daemon as any).store.upsertSession({
+    seed(daemon, {
       key: callerKey,
       agentId: 'bot-b',
       platform: 'slack',
       channel: 'C2',
       thread: '200.1',
-      acpSessionId: 'acp-child-1',
-      state: 'idle',
-      lastDeliveredTs: null,
-      updatedAt: Date.now()
+      acpSessionId: 'acp-child-1'
     })
-    // No parent link anywhere ⇒ nothing to compare a post against.
+    // No parent link anywhere ⇒ a post into an unrelated channel relates to nothing.
     expect(ask(daemon)).toBeUndefined()
 
     // A live wake names its own origin, matching the precedence replyToSession authorizes on.
+    seed(daemon, {
+      key: sessionKey('telegram', '-100999', 'tg:9', 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-100999',
+      thread: 'tg:9',
+      acpSessionId: 'acp-parent-2'
+    })
     ;(daemon as any).activeTurnCallMeta.set(callerKey, {
       callFrom: 'bot-a',
       hopCount: 1,
@@ -1180,7 +1278,7 @@ describe('parentSessionCoords: the coords a relayed answer should have gone to',
       originSessionId: 'acp-parent-2',
       originCoords: { platform: 'telegram', channel: '-100999', thread: 'tg:9' }
     })
-    expect(ask(daemon)).toEqual({ sessionId: 'acp-parent-2', platform: 'telegram', channel: '-100999' })
+    expect(ask(daemon, { targetChannel: '-100999' })).toEqual({ kind: 'parent', sessionId: 'acp-parent-2' })
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1294,6 +1294,14 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
     expect(ask(daemon)).toEqual({ kind: 'parent', sessionId: 'acp-remote-parent' })
     // Still only for the conversation it actually names.
     expect(ask(daemon, { targetChannel: '-100999' })).toBeUndefined()
+    // Matching is coordinates-only here BY DESIGN — the remote scope is credential-derived and
+    // never crosses the wire — so a target integration's own scope does not suppress the match.
+    // Over-matching costs a hint naming the caller's real parent; silence would cost the hint
+    // entirely on the cross-daemon escalation path.
+    expect(ask(daemon, { targetIntegrationId: 'int-tg-1' })).toEqual({
+      kind: 'parent',
+      sessionId: 'acp-remote-parent'
+    })
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1106,6 +1106,86 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
 })
 
 /**
+ * `parentSessionCoords` — where the parent conversation actually LIVES, which is what lets
+ * `sendMessage` notice that a channel-root post just forked it instead of answering it. The
+ * durable fallback is the load-bearing half: an agent relays an answer on a human-triggered turn,
+ * which carries no CallMeta at all.
+ */
+describe('parentSessionCoords: the coords a relayed answer should have gone to', () => {
+  const ask = (daemon: any, over: Record<string, unknown> = {}) =>
+    daemon.parentSessionCoords({
+      callerAgentId: 'bot-b',
+      platform: 'slack',
+      callerChannel: 'C2',
+      callerThread: '200.1',
+      ...over
+    })
+
+  it('reads the parent’s channel off the persisted link when the turn has no CallMeta', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    // The parent conversation — a Telegram customer chat owned by ANOTHER agent, which is the
+    // ordinary escalation shape: whoever asked is not whoever answers.
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('telegram', '-100123', 'tg:170', 'bot-a'),
+      agentId: 'bot-a',
+      platform: 'telegram',
+      channel: '-100123',
+      thread: 'tg:170',
+      acpSessionId: 'acp-parent-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    ;(daemon as any).store.upsertSession({
+      key: sessionKey('slack', 'C2', '200.1', 'bot-b'),
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now(),
+      originSessionId: 'acp-parent-1'
+    })
+
+    expect(ask(daemon)).toEqual({ sessionId: 'acp-parent-1', platform: 'telegram', channel: '-100123' })
+    await daemon.stop()
+  })
+
+  it('prefers the live turn’s origin, and reports nothing for a session with no parent', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    ;(daemon as any).store.upsertSession({
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    // No parent link anywhere ⇒ nothing to compare a post against.
+    expect(ask(daemon)).toBeUndefined()
+
+    // A live wake names its own origin, matching the precedence replyToSession authorizes on.
+    ;(daemon as any).activeTurnCallMeta.set(callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-parent-2',
+      originCoords: { platform: 'telegram', channel: '-100999', thread: 'tg:9' }
+    })
+    expect(ask(daemon)).toEqual({ sessionId: 'acp-parent-2', platform: 'telegram', channel: '-100999' })
+    await daemon.stop()
+  })
+})
+
+/**
  * `viewSessionStatus` (the read counterpart of a SessionTarget reply): a parent may read DOWN its
  * own lineage, a child may reply UP it, and neither can reach sideways. Authorization comes from
  * the child's durable `originSessionId`, with an in-memory link covering the window before the

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1033,6 +1033,28 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     await daemon.stop()
   })
 
+  it('keys a Feishu spawn as feishu, not the narrowPlatform fallback', async () => {
+    const root = scaffold([{ id: 'bot-a' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    // `narrowPlatform` predated Feishu and folded it onto `slack`, so this dispatched a `slack:`
+    // message for a channel Feishu ingress records under `feishu:` — a session nothing could
+    // continue. Every other caller of that helper had the same hole.
+    ;(daemon as any).spawnChannelRootSession({
+      agentId: 'bot-a',
+      platform: 'feishu',
+      channel: 'oc_42',
+      thread: 'om_42',
+      text: 'posted into a Feishu group',
+      originPlatform: 'feishu',
+      originChannel: 'oc_42',
+      originThread: 'om_1'
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.msg.platform).toBe('feishu')
+    await daemon.stop()
+  })
+
   it('resolves the origin session across platforms (Telegram turn → Slack post keeps the parent)', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
@@ -1244,6 +1266,34 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
       kind: 'parent',
       sessionId: 'acp-parent-unscoped'
     })
+    await daemon.stop()
+  })
+
+  it('answers for a CROSS-DAEMON parent, which has no local row to read', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon } = await bootWithDispatchSpy(root)
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    seed(daemon, {
+      key: callerKey,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: 'C2',
+      thread: '200.1',
+      acpSessionId: 'acp-child-1'
+    })
+    // Woken over the relay: the parent session lives on another daemon, so `getSessionByAcpId`
+    // finds nothing and only the trusted wake carries its coords. Requiring a row here made the
+    // notice silent for exactly the escalation shape the relay exists to serve.
+    ;(daemon as any).activeTurnCallMeta.set(callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-remote-parent',
+      originCoords: { platform: 'telegram', channel: '-100123', thread: 'tg:9' }
+    })
+    expect(ask(daemon)).toEqual({ kind: 'parent', sessionId: 'acp-remote-parent' })
+    // Still only for the conversation it actually names.
+    expect(ask(daemon, { targetChannel: '-100999' })).toBeUndefined()
     await daemon.stop()
   })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -188,7 +188,10 @@ describe('executeTool: sendMessage (channel post)', () => {
     it('names the parent session to reply into when the post lands on the parent’s conversation', async () => {
       const d = rootPostDeps({ rootPostRelation: () => parentRelation })
       const res = await send(d, { platform: 'telegram', channel: '-100123' }, dualCtx)
-      expect(res.notice).toContain('opened a NEW session')
+      // The claim is about what a ROOT post does — a separate context, not an answer. The seed
+      // itself is dispatched fire-and-forget, so the notice never states a session as fact.
+      expect(res.notice).toContain('starts a separate context there instead of answering')
+      expect(res.notice).not.toMatch(/opened a (NEW )?session/)
       expect(res.notice).toContain('{"to":{"sessionId":"sess-parent"}}')
     })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -169,6 +169,60 @@ describe('executeTool: sendMessage (channel post)', () => {
     expect(gw.postMessage).toHaveBeenCalledWith('C_OTHER', 'yo', undefined)
   })
 
+  describe('root-post notice: the post forked a conversation this agent is already in', () => {
+    // The spawn is what the notice describes, so it only speaks where a daemon actually seeds
+    // the session (the chat CLI passes no spawn callback and gets no notice).
+    const rootPostDeps = (over: Partial<OpsDeps> = {}) =>
+      makeDeps({ gatewayFor: () => fakeGateway(), spawnChannelRootSession: () => {}, now: () => 1000, ...over })
+    const send = (d: OpsDeps, to: Record<string, unknown>, from: SessionContext = ctx) =>
+      executeTool(from, 'sendMessage', { to, message: 'the answer' }, d) as Promise<{ notice?: string }>
+
+    // A Slack session whose parent is the Telegram conversation that asked — relaying the answer
+    // to that Telegram CHANNEL posts a top-level message and forks; the asker never sees it.
+    const telegramParent = { sessionId: 'sess-parent', platform: 'telegram', channel: '-100123' }
+    const dualCtx: SessionContext = {
+      ...ctx,
+      integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }]
+    }
+
+    it('names the parent session to reply into when the post lands on the parent’s channel', async () => {
+      const d = rootPostDeps({ parentSession: () => telegramParent })
+      const res = await send(d, { platform: 'telegram', channel: '-100123' }, dualCtx)
+      expect(res.notice).toContain('opened a NEW session')
+      expect(res.notice).toContain('{"to":{"sessionId":"sess-parent"}}')
+    })
+
+    it('points a post into its own channel back at the turn’s ordinary reply', async () => {
+      const d = rootPostDeps({ parentSession: () => undefined })
+      const res = await send(d, { channel: 'C_CURRENT' })
+      expect(res.notice).toContain('Your ordinary reply for this turn already reaches this conversation')
+    })
+
+    it('stays quiet for a genuine new topic elsewhere, and for a threaded post', async () => {
+      const d = rootPostDeps({ parentSession: () => telegramParent })
+      // A different channel than either the session's or its parent's: an ordinary top-level post.
+      expect((await send(d, { channel: 'C_OTHER' })).notice).toBeUndefined()
+      // Same channel as the parent, but threaded — it joins a conversation instead of forking,
+      // and no session is spawned at all.
+      expect((await send(d, { platform: 'telegram', channel: '-100123', thread: '9' }, dualCtx)).notice).toBeUndefined()
+    })
+
+    it('says nothing where no session is spawned (no daemon, or a synthesized ts)', async () => {
+      const noSpawn = makeDeps({
+        gatewayFor: () => fakeGateway(),
+        parentSession: () => telegramParent,
+        now: () => 1000
+      })
+      expect((await send(noSpawn, { platform: 'telegram', channel: '-100123' }, dualCtx)).notice).toBeUndefined()
+      // A platform that returned no ts leaves nothing to key a session on, so nothing forked.
+      const noTs = rootPostDeps({
+        gatewayFor: () => fakeGateway({ postMessage: vi.fn(async () => undefined) }),
+        parentSession: () => telegramParent
+      })
+      expect((await send(noTs, { platform: 'telegram', channel: '-100123' }, dualCtx)).notice).toBeUndefined()
+    })
+  })
+
   it('synthesizes a ts when the platform returns none', async () => {
     const gw = fakeGateway({ postMessage: vi.fn(async () => undefined) })
     const { deps: d } = deps(gw)

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -173,53 +173,84 @@ describe('executeTool: sendMessage (channel post)', () => {
     // The spawn is what the notice describes, so it only speaks where a daemon actually seeds
     // the session (the chat CLI passes no spawn callback and gets no notice).
     const rootPostDeps = (over: Partial<OpsDeps> = {}) =>
-      makeDeps({ gatewayFor: () => fakeGateway(), spawnChannelRootSession: () => {}, now: () => 1000, ...over })
+      makeDeps({ gatewayFor: () => fakeGateway(), spawnChannelRootSession: () => true, now: () => 1000, ...over })
     const send = (d: OpsDeps, to: Record<string, unknown>, from: SessionContext = ctx) =>
       executeTool(from, 'sendMessage', { to, message: 'the answer' }, d) as Promise<{ notice?: string }>
 
-    // A Slack session whose parent is the Telegram conversation that asked — relaying the answer
-    // to that Telegram CHANNEL posts a top-level message and forks; the asker never sees it.
-    const telegramParent = { sessionId: 'sess-parent', platform: 'telegram', channel: '-100123' }
+    // Which conversation a post landed on is the DAEMON's verdict (it owns transport-scope
+    // identity and the durable parent link); ops only formats what it is told.
+    const parentRelation = { kind: 'parent', sessionId: 'sess-parent' } as const
     const dualCtx: SessionContext = {
       ...ctx,
       integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }]
     }
 
-    it('names the parent session to reply into when the post lands on the parent’s channel', async () => {
-      const d = rootPostDeps({ parentSession: () => telegramParent })
+    it('names the parent session to reply into when the post lands on the parent’s conversation', async () => {
+      const d = rootPostDeps({ rootPostRelation: () => parentRelation })
       const res = await send(d, { platform: 'telegram', channel: '-100123' }, dualCtx)
       expect(res.notice).toContain('opened a NEW session')
       expect(res.notice).toContain('{"to":{"sessionId":"sess-parent"}}')
     })
 
-    it('points a post into its own channel back at the turn’s ordinary reply', async () => {
-      const d = rootPostDeps({ parentSession: () => undefined })
+    it('points a post into its own conversation back at the turn’s ordinary reply', async () => {
+      const d = rootPostDeps({ rootPostRelation: () => ({ kind: 'self' }) })
       const res = await send(d, { channel: 'C_CURRENT' })
       expect(res.notice).toContain('Your ordinary reply for this turn already reaches this conversation')
     })
 
-    it('stays quiet for a genuine new topic elsewhere, and for a threaded post', async () => {
-      const d = rootPostDeps({ parentSession: () => telegramParent })
-      // A different channel than either the session's or its parent's: an ordinary top-level post.
-      expect((await send(d, { channel: 'C_OTHER' })).notice).toBeUndefined()
-      // Same channel as the parent, but threaded — it joins a conversation instead of forking,
-      // and no session is spawned at all.
-      expect((await send(d, { platform: 'telegram', channel: '-100123', thread: '9' }, dualCtx)).notice).toBeUndefined()
+    it('passes the target coords the daemon needs to judge conversation identity', async () => {
+      const seen: Record<string, unknown>[] = []
+      const d = rootPostDeps({
+        rootPostRelation: (req) => {
+          seen.push(req)
+          return undefined
+        }
+      })
+      await send(d, { platform: 'telegram', channel: '-100123' }, dualCtx)
+      // Including the integration — the daemon resolves it to a transport scope, without which
+      // two bots' identical channel ids would read as the same conversation.
+      expect(seen[0]).toMatchObject({
+        callerAgentId: 'bot-a',
+        platform: 'slack',
+        callerChannel: 'C_CURRENT',
+        callerThread: '111.1',
+        targetPlatform: 'telegram',
+        targetChannel: '-100123',
+        targetIntegrationId: 'int-tg'
+      })
     })
 
-    it('says nothing where no session is spawned (no daemon, or a synthesized ts)', async () => {
+    it('stays quiet for an unrelated destination, and for a threaded post', async () => {
+      const unrelated = rootPostDeps({ rootPostRelation: () => undefined })
+      expect((await send(unrelated, { channel: 'C_OTHER' })).notice).toBeUndefined()
+      // Threaded: it joins a conversation instead of forking, so nothing is spawned or asked.
+      const threaded = rootPostDeps({ rootPostRelation: () => parentRelation })
+      expect(
+        (await send(threaded, { platform: 'telegram', channel: '-100123', thread: '9' }, dualCtx)).notice
+      ).toBeUndefined()
+    })
+
+    it('says nothing when no session was actually seeded', async () => {
+      // No daemon at all (chat CLI).
       const noSpawn = makeDeps({
         gatewayFor: () => fakeGateway(),
-        parentSession: () => telegramParent,
+        rootPostRelation: () => parentRelation,
         now: () => 1000
       })
       expect((await send(noSpawn, { platform: 'telegram', channel: '-100123' }, dualCtx)).notice).toBeUndefined()
       // A platform that returned no ts leaves nothing to key a session on, so nothing forked.
       const noTs = rootPostDeps({
         gatewayFor: () => fakeGateway({ postMessage: vi.fn(async () => undefined) }),
-        parentSession: () => telegramParent
+        rootPostRelation: () => parentRelation
       })
       expect((await send(noTs, { platform: 'telegram', channel: '-100123' }, dualCtx)).notice).toBeUndefined()
+      // The daemon DECLINED the seed (agent-call hop limit): the post happened, but claiming a
+      // session opened would be false.
+      const declined = rootPostDeps({
+        spawnChannelRootSession: () => false,
+        rootPostRelation: () => parentRelation
+      })
+      expect((await send(declined, { platform: 'telegram', channel: '-100123' }, dualCtx)).notice).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Follow-up to #298, independent of it. #298 states the cost in the schema, before the fact; this one states it at the moment it happens.

## Problem

A channel-root post opens a NEW session on that post (`spawnChannelRootSession`, session-concept case 2a). That is correct for a deliberate new topic, and wrong for the shape agents keep hitting: told to relay an answer back to whoever asked, an agent posts to the channel it can see. The asker gets a detached top-level message instead of a reply, and the answer's session forks away from the conversation waiting on it. Nothing told the agent anything — the call returned `ok` with a `post`, and the mistake only showed up later as an orphaned session.

Observed repeatedly on escalate-to-another-platform-and-relay-back agents. Each has had to encode "reply with `sessionId`, never post to their channel" in its own `CLAUDE.md`.

## Change

`sendMessage` returns a `notice` on the result when a root post landed on a conversation this agent is **already part of**, naming the address that would have replied instead:

- **the parent session's channel** ⇒ names the `{"to":{"sessionId":"…"}}` that answers it;
- **the current session's own channel** ⇒ its ordinary turn reply already goes there.

The post is never blocked. A root post elsewhere is a legitimate new topic and stays silent, as does a threaded post (it joins a conversation instead of forking) and a run with no daemon to seed a session. The feedback lands in the same turn as the mistake, where the agent can still answer the right way — which a prompt rule written long beforehand cannot do.

New dep `parentSession` (`Daemon.parentSessionCoords`) resolves the parent from the current turn's trusted CallMeta when present, else the **durable** origin persisted on the session row. The durable half is load-bearing: relaying an answer happens on a later, human-triggered turn that carries no CallMeta at all. Precedence deliberately mirrors what `replyToSession` authorizes on. It widens nothing — the notice fires only when those coords MATCH a channel the caller itself named, so it cannot disclose a parent the caller could not already see.

One incidental tightening: the case-2a block now runs only when a `spawnChannelRootSession` callback exists, so the notice never claims a session was opened where none was (the chat CLI passes none).

## Tests

- `mcp-ops.test.ts`: parent-channel notice names the parent sessionId; own-channel notice points back at the turn's reply; silence for another channel, for a threaded post, for no-daemon, and for a synthesized `local-*` ts.
- `daemon-message-agent.test.ts`: `parentSessionCoords` reads the parent's channel off the persisted link on a turn with no CallMeta (parent owned by another agent — the ordinary escalation shape), prefers a live turn's origin, and reports nothing for a parentless session.

Full daemon suite passes (2331).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
