### PR TITLE
fix(web): only redirect to onboarding when no org of the user has a daemon

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1665,6 +1665,9 @@ export const OrgDto = z.object({
   /** The CALLER's role in this org. */
   role: MemberRole,
   memberCount: z.number().int(),
+  /** Registered daemons in this org (any status) — lets the console skip the
+   *  onboarding redirect when ANY of the caller's orgs already runs a daemon. */
+  daemonCount: z.number().int(),
   createdAt: z.string() // ISO-8601
 })
 export const OrgListDto = z.array(OrgDto)

--- a/packages/control-plane/src/http/routes/orgs.ts
+++ b/packages/control-plane/src/http/routes/orgs.ts
@@ -44,6 +44,7 @@ function toDto(o: OrgRecord, deps: HttpDeps): OrgDtoT {
     iconUploadEnabled: !!deps.iconStore,
     role: o.role,
     memberCount: o.memberCount,
+    daemonCount: o.daemonCount,
     createdAt: o.createdAt.toISOString()
   }
 }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2898,6 +2898,8 @@ export interface OrgRecord {
   /** The asking user's role in it. */
   role: OrgMemberRole
   memberCount: number
+  /** Registered daemons (any status) — the console's cross-org onboarding signal. */
+  daemonCount: number
   createdAt: Date
   /** Last update — the icon endpoint's `?v=` cache-buster for an uploaded org icon. */
   updatedAt: Date

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -29,7 +29,7 @@ export class PgOrgRepo implements OrgRepo {
   async listForUser(userId: string): Promise<OrgRecord[]> {
     const rows = await this.db.membership.findMany({
       where: { userId },
-      include: { org: { include: { _count: { select: { members: true } } } } },
+      include: { org: { include: { _count: { select: { members: true, daemons: true } } } } },
       orderBy: { id: 'asc' } // cuids are time-sortable ⇒ insertion order (personal org first)
     })
     return rows.map((m) => ({
@@ -39,6 +39,7 @@ export class PgOrgRepo implements OrgRepo {
       icon: parseAgentIcon(m.org.icon),
       role: m.role as OrgMemberRole,
       memberCount: m.org._count.members,
+      daemonCount: m.org._count.daemons,
       createdAt: m.org.createdAt,
       updatedAt: m.org.updatedAt
     }))
@@ -68,6 +69,7 @@ export class PgOrgRepo implements OrgRepo {
       icon: parseAgentIcon(org.icon),
       role: 'owner',
       memberCount: 1,
+      daemonCount: 0,
       createdAt: org.createdAt,
       updatedAt: org.updatedAt
     }

--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -11,7 +11,7 @@ import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
-import { sessionPlatform, type Session } from '@/lib/data'
+import { sessionChannelDisplay, type Session } from '@/lib/data'
 import { useIsMobile } from '@/lib/use-is-mobile'
 
 export function Card({
@@ -103,7 +103,7 @@ export function RecentSessionsCard({
   fillHeight?: boolean
 }) {
   const { orgPath } = useOrgs()
-  const { getAgent } = useConsoleData()
+  const { getAgent, crons } = useConsoleData()
   const cardRef = useRef<HTMLDivElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
   const [fit, setFit] = useState<number | null>(null)
@@ -142,6 +142,7 @@ export function RecentSessionsCard({
         ) : (
           recent.map((s) => {
             const owner = s.agentId ? getAgent(s.agentId) : undefined
+            const ch = sessionChannelDisplay(s, (id) => crons.find((c) => c.id === id)?.name)
             return (
               <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
                 <span className="min-w-0">
@@ -164,9 +165,9 @@ export function RecentSessionsCard({
                     {s.channel && (
                       <>
                         <span className="imark h-4 w-4 rounded-xs">
-                          <PlatformMark platform={sessionPlatform(s)} fillPct={90} />
+                          <PlatformMark platform={ch.platform} fillPct={90} />
                         </span>
-                        <span className="mono truncate text-[11px]">{s.channel}</span>
+                        <span className="mono truncate text-[11px]">{ch.label}</span>
                       </>
                     )}
                   </span>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -21,6 +21,7 @@ import {
   platName,
   preferredModelFor,
   runtimeLabel,
+  sessionChannelDisplay,
   sessionPlatform,
   speaker,
   status,
@@ -910,6 +911,8 @@ export default function SessionDetailView() {
   // it in place. `isLive` gates the composer/typing affordance for both.
   const isWebchat = session.platform === 'webchat'
   const sessionIntegration = sessionPlatform(session)
+  // Header channel chip — resolves a headless `cron:<id>` channel to its schedule.
+  const channelDisplay = sessionChannelDisplay(session, (id) => crons.find((c) => c.id === id)?.name)
   const usesIntegrationAvatar = session.platform === 'hook' && sessionIntegration === 'github'
   const isLive = isPg || isWebchat
   // Composer state is per-session in the provider — bind it to THIS session's id so a
@@ -1247,7 +1250,7 @@ export default function SessionDetailView() {
         )}
         <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
           <span className="imark h-4 w-4 flex-none rounded-xs">
-            <PlatformMark platform={sessionIntegration} fillPct={100} />
+            <PlatformMark platform={channelDisplay.platform} fillPct={100} />
           </span>
           {session.threadUrl ? (
             <a
@@ -1257,10 +1260,10 @@ export default function SessionDetailView() {
               rel="noopener noreferrer"
               title={`Open the ${platName(sessionIntegration)} thread`}
             >
-              {session.channel}
+              {channelDisplay.label}
             </a>
           ) : (
-            <span className="mono truncate text-[12px]">{session.channel}</span>
+            <span className="mono truncate text-[12px]">{channelDisplay.label}</span>
           )}
         </span>
         {headerCron ? (

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -10,6 +10,7 @@ import {
   agentLabel,
   enrichSessionWithAgent,
   platName,
+  sessionChannelDisplay,
   sessionChannelFilterValue,
   sessionPlatform,
   status,
@@ -205,7 +206,9 @@ export default function SessionsView() {
         channel: channel.label,
         channelId: channel.value
       }),
-      { label: channel.label, platform: channel.platform }
+      // Headless-schedule channels keep their raw `cron:<id>` filter value but
+      // render as the schedule's name under the schedule mark.
+      sessionChannelDisplay({ platform: channel.platform, channel: channel.label }, (id) => cronById.get(id)?.name)
     ])
   )
   const triggerSources = new Map(
@@ -547,6 +550,7 @@ export default function SessionsView() {
         )}
         {filtered.map((s, i) => {
           const ss = status(s.status)
+          const ch = sessionChannelDisplay(s, (id) => cronById.get(id)?.name)
           return (
             <Link
               key={s.id}
@@ -587,10 +591,10 @@ export default function SessionsView() {
                 </span>
                 <span className="ml-auto inline-flex min-w-0 flex-1 items-center justify-end gap-[5px]">
                   <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
-                    <PlatformMark platform={sessionPlatform(s)} fillPct={100} />
+                    <PlatformMark platform={ch.platform} fillPct={100} />
                   </span>
                   <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                    {s.channel}
+                    {ch.label}
                   </span>
                 </span>
               </span>
@@ -615,9 +619,9 @@ export default function SessionsView() {
               </div>
               <div className="hidden min-w-0 items-center gap-2 desktop:flex">
                 <span className="imark h-5 w-5 rounded-[5px]">
-                  <PlatformMark platform={sessionPlatform(s)} />
+                  <PlatformMark platform={ch.platform} />
                 </span>
-                <span className="mono truncate text-[12px] text-(--text-secondary)">{s.channel}</span>
+                <span className="mono truncate text-[12px] text-(--text-secondary)">{ch.label}</span>
               </div>
               <div className="hidden items-center gap-[7px] desktop:flex">
                 <span className="dot" style={{ background: ss.dot }} />

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -196,6 +196,14 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   if (x.includes('hook')) {
     return <IconifyIcon icon={webhooksLogoFillIcon} style={s} color="var(--brand)" aria-hidden />
   }
+  // Headless schedule fires — no real platform channel behind them.
+  if (x.includes('sched')) {
+    return (
+      <span style={{ width: s.width, height: s.height }} className="flex items-center justify-center" aria-hidden>
+        <Icon name="calendar-clock" className="h-full w-full" />
+      </span>
+    )
+  }
   if (x.includes('dream')) {
     return (
       <span style={{ width: s.width, height: s.height }} className="flex items-center justify-center" aria-hidden>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -942,6 +942,8 @@ export interface OrgDto {
   /** The signed-in user's role in this org. */
   role: MemberRole
   memberCount: number
+  /** Registered daemons in this org (any status); undefined on older CPs. */
+  daemonCount?: number
   createdAt: string // ISO-8601
 }
 

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -19,6 +19,7 @@ import {
   permissionModeOptions,
   presentedDaemonStatus,
   resolveEffortForModel,
+  sessionChannelDisplay,
   sessionChannelFilterValue,
   status,
   type DaemonRow,
@@ -60,6 +61,30 @@ describe('sessionChannelFilterValue', () => {
 
   it('keeps a normal integration channel addressable by its raw id', () => {
     expect(sessionChannelFilterValue({ platform: 'slack', channel: '#general', channelId: 'C123' })).toBe('C123')
+  })
+})
+
+describe('sessionChannelDisplay', () => {
+  const cronName = (id: string) => (id === 'e23c6ea3-57bd-4bce-b014-81077c865059' ? 'Nightly report' : undefined)
+
+  it('resolves a headless cron channel to its schedule name under the schedule mark', () => {
+    expect(
+      sessionChannelDisplay({ platform: 'slack', channel: 'cron:e23c6ea3-57bd-4bce-b014-81077c865059' }, cronName)
+    ).toEqual({ platform: 'schedule', label: 'Nightly report' })
+  })
+
+  it('falls back to a short schedule id while the crons list is still loading', () => {
+    expect(sessionChannelDisplay({ platform: 'slack', channel: 'cron:0f9b3a10-dead-beef' }, cronName)).toEqual({
+      platform: 'schedule',
+      label: 'Schedule 0f9b3a10'
+    })
+  })
+
+  it('leaves real platform channels untouched', () => {
+    expect(sessionChannelDisplay({ platform: 'slack', channel: '#deploys' }, cronName)).toEqual({
+      platform: 'slack',
+      label: '#deploys'
+    })
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1680,6 +1680,7 @@ export const MEMBERS: Member[] = [
 // platform display name
 export function platName(p: string): string {
   const x = (p || '').toLowerCase()
+  if (x.includes('sched')) return 'Schedule'
   if (x.includes('github')) return 'GitHub'
   if (x.includes('dream')) return 'Memory dream'
   if (x.includes('hook')) return 'Webhook'
@@ -1697,6 +1698,22 @@ export function platName(p: string): string {
 export function sessionPlatform(s: { platform: string; hookKind?: 'webhook' | 'github' }): string {
   if (s.platform === 'playground') return 'webchat'
   return s.platform === 'hook' && s.hookKind === 'github' ? 'github' : s.platform
+}
+
+/** Channel-cell identity (mark + label) for a session row. A headless schedule
+ * fire has no real channel — the daemon keys it `cron:<scheduleId>` on the
+ * legacy 'slack' platform — so resolve it to the schedule's name under a
+ * schedule mark instead of a raw uuid with a Slack icon. `cronName` looks up
+ * the schedule (the crons list may still be loading → short-id fallback). */
+export function sessionChannelDisplay(
+  s: { platform: string; channel: string; hookKind?: 'webhook' | 'github' },
+  cronName: (id: string) => string | null | undefined
+): { platform: string; label: string } {
+  if (s.channel.startsWith('cron:')) {
+    const id = s.channel.slice('cron:'.length)
+    return { platform: 'schedule', label: cronName(id)?.trim() || `Schedule ${id.slice(0, 8)}` }
+  }
+  return { platform: sessionPlatform(s), label: s.channel }
 }
 
 /** Playground conversations have unique internal ids but share one user-facing

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -3,20 +3,24 @@ import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding 
 
 describe('needsOnboarding', () => {
   it('recovers a fresh org (only the unplaced built-in preset, daemon offline)', () => {
-    expect(needsOnboarding(false, false, false, false)).toBe(true)
+    expect(needsOnboarding(false, false, false, false, false)).toBe(true)
   })
 
   it('waits for data and preserves initialized orgs', () => {
-    expect(needsOnboarding(true, false, false, false)).toBe(false)
+    expect(needsOnboarding(true, false, false, false, false)).toBe(false)
     // a placed/configured agent means the org is set up (the built-in preset alone does not)
-    expect(needsOnboarding(false, false, true, false)).toBe(false)
-    expect(needsOnboarding(false, false, false, true)).toBe(false)
+    expect(needsOnboarding(false, false, true, false, false)).toBe(false)
+    expect(needsOnboarding(false, false, false, true, false)).toBe(false)
+  })
+
+  it('skips the wizard when any of the caller orgs already has a daemon', () => {
+    expect(needsOnboarding(false, false, false, false, true)).toBe(false)
   })
 
   it('keeps a fresh org initialized during a planned daemon relaunch', () => {
     const restarting = { daemonId: 'edge-1', status: 'offline' as const, lifecycleStatus: 'restarting' as const }
     expect(daemonCompletesOnboarding(restarting)).toBe(true)
     expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
-    expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting))).toBe(false)
+    expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting), false)).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -22,13 +22,16 @@ export function firstReconnectableDaemonId(daemons: readonly OnboardingDaemon[])
 // Every org now ships the built-in `agentconnect` preset UNPLACED, so "no agents" no
 // longer marks a fresh org. Initialized = a serving daemon OR a placed/configured agent
 // (agentIsPlaced) exists; otherwise the org is fresh and gets the full-screen wizard.
+// A daemon in ANY of the caller's orgs also counts — someone who already runs a daemon
+// elsewhere doesn't need the wizard again in a new empty org.
 export function needsOnboarding(
   agentsLoading: boolean,
   daemonsLoading: boolean,
   hasPlacedAgent: boolean,
-  hasOnlineDaemon: boolean
+  hasOnlineDaemon: boolean,
+  hasDaemonInAnyOrg: boolean
 ): boolean {
-  return !agentsLoading && !daemonsLoading && !hasPlacedAgent && !hasOnlineDaemon
+  return !agentsLoading && !daemonsLoading && !hasPlacedAgent && !hasOnlineDaemon && !hasDaemonInAnyOrg
 }
 
 export function isOnboardingSkipped(org: string): boolean {

--- a/packages/web/src/lib/use-onboarding-redirect.ts
+++ b/packages/web/src/lib/use-onboarding-redirect.ts
@@ -2,8 +2,9 @@
 
 // Fresh-workspace redirect to the full-screen /onboarding route, shared by every
 // console landing surface (Home is the default landing, Agents keeps it for deep
-// links). A fresh org = no placed agent AND no serving daemon (needsOnboarding);
-// the per-tab "Explore the console first" skip flag suppresses the bounce-back.
+// links). A fresh org = no placed agent AND no serving daemon AND no daemon in ANY
+// of the caller's orgs (needsOnboarding); the per-tab "Explore the console first"
+// skip flag suppresses the bounce-back.
 //
 // Returns true while the caller should hold a spinner instead of rendering: either
 // the redirect is in flight, or the sessionStorage skip flag hasn't been read yet
@@ -12,6 +13,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
+import { useOrgs } from '@/lib/org-context'
 import { agentIsPlaced } from '@/lib/data'
 import { daemonCompletesOnboarding, isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
 
@@ -20,6 +22,7 @@ export function useOnboardingRedirect(): boolean {
   const params = useParams()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
   const { agents, daemons, agentsLoading, daemonsLoading } = useConsoleData()
+  const { orgs } = useOrgs()
   const [skipState, setSkipState] = useState<{ orgKey: string; skipped: boolean } | null>(null)
   const skipped = skipState?.orgKey === orgKey ? skipState.skipped : null
   useEffect(() => {
@@ -29,7 +32,8 @@ export function useOnboardingRedirect(): boolean {
     agentsLoading,
     daemonsLoading,
     agents.some(agentIsPlaced),
-    daemons.some(daemonCompletesOnboarding)
+    daemons.some(daemonCompletesOnboarding),
+    orgs.some((org) => (org.daemonCount ?? 0) > 0)
   )
   const redirect = notInitialized && skipped === false
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Onboarding redirect**: `GET /orgs` now returns a per-org `daemonCount` (registered daemons, any status). The console's fresh-workspace redirect to `/onboarding` now additionally requires **every org the caller belongs to** to have zero daemons — a user already running a daemon in another org is no longer bounced into the wizard when landing in a new empty org. Older CPs without the field keep the previous behavior (`daemonCount` is optional on the web side).
- **Schedule session channels**: headless schedule fires are keyed `cron:<scheduleId>` on the legacy slack platform; session lists and detail now resolve them to the schedule's name under a calendar mark instead of a raw uuid with a Slack icon.

## Testing

- `pnpm --filter @agentconnect.md/web test` — 486 passed
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 810 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 787 passed (incl. orgs route)
- typecheck clean on both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)