### PR TITLE
fix(relay): scope Slack event dedup by app

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5054,10 +5054,10 @@ export class Daemon {
 
   // Bounded, ephemeral reconnect state keyed by the browser-known turn id.
   private readonly webchatStreams = new Map<string, WebchatTurnStream>()
-  // Idempotency cache for the at-least-once rd/* wire: (sessionKey:msgId) → the ack we
-  // already returned. Bounded like `seenMsgIds`. A relay retransmit replays this instead
-  // of re-dispatching. (design §7.2 RdMsgWebchat: "the daemon drops an already-seen
-  // (sessionKey, msgId)".)
+  // Idempotency cache for the at-least-once rd/* wire. IM deliveries additionally
+  // include the authenticated bot assignment: two Slack apps mentioned in one
+  // platform message share sessionKey + msgId but must wake independently. Bounded
+  // like `seenMsgIds`; a genuine relay retransmit replays the cached ack.
   private readonly relayMsgAcks = new Map<string, RdAck>()
   /** Hook admission crosses an async anchor + durable-inbox barrier. Coalesce a
    * retransmit that arrives before that barrier settles instead of dispatching
@@ -5113,7 +5113,7 @@ export class Daemon {
    * the same replay absorbs a GitHub/manual REDELIVERY of the same deliveryKey.
    */
   private handleRelayMsg(msg: RdMsg, chat: (event: RdChatEvent) => void): RdAck | Promise<RdAck> {
-    const dedupKey = `${msg.sessionKey}:${msg.msgId}`
+    const dedupKey = `${msg.source === 'im' ? `${msg.botId}:` : ''}${msg.sessionKey}:${msg.msgId}`
     const prior = this.relayMsgAcks.get(dedupKey)
     if (prior) {
       this.log.debug(`relay: duplicate rd/msg ${dedupKey} — replaying ack (no re-dispatch)`)

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -273,6 +273,44 @@ describe('Daemon in-conversation commands', () => {
     expect(dispatch).toHaveBeenCalledWith('bot-a', payload, 'int-a')
   })
 
+  it('dedups shared-bot retries per bot while dispatching the same Slack message for two bots', () => {
+    const daemon = new Daemon()
+    const dispatch = vi.fn(async () => {})
+    ;(daemon as any).agents.set('bot-a', {})
+    ;(daemon as any).agents.set('bot-b', {})
+    ;(daemon as any).isSessionMuted = () => false
+    ;(daemon as any).dispatch = dispatch
+    const frame = (agentId: string, botId: string, integrationId: string): RdMsgIm => ({
+      source: 'im',
+      agentId,
+      sessionKey: 'C1/1700000000.000100',
+      msgId: 'slack:C1:1700000000.000100',
+      botId,
+      integrationId,
+      chatId: 'C1',
+      payload: dm('1700000000.000100', 'hello both bots')
+    })
+    const botA = frame('bot-a', '11111111-1111-4111-8111-111111111111', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+    const botB = frame('bot-b', '22222222-2222-4222-8222-222222222222', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+
+    expect((daemon as any).handleRelayMsg(botA, () => {})).toEqual({
+      msgId: botA.msgId,
+      accepted: true
+    })
+    expect((daemon as any).handleRelayMsg(botA, () => {})).toEqual({
+      msgId: botA.msgId,
+      accepted: true
+    })
+    expect((daemon as any).handleRelayMsg(botB, () => {})).toEqual({
+      msgId: botB.msgId,
+      accepted: true
+    })
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toHaveBeenNthCalledWith(1, 'bot-a', botA.payload, botA.integrationId)
+    expect(dispatch).toHaveBeenNthCalledWith(2, 'bot-b', botB.payload, botB.integrationId)
+  })
+
   it('discovers an unroutable gated Feishu callback before the last-hop gate drops it', () => {
     const daemon = new Daemon()
     const discover = vi.fn()

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -142,7 +142,8 @@ export type WireNormalizedMessage = NormalizedPlatformMessage
 // daemon takes the explicit-agent short-circuit into dispatch (no local
 // arbitration — the routing happened in the relay, §10). `msgId` is the platform
 // event id (Slack event_id / TG update_id) — the idempotency key that survives a
-// relay re-assign (§12). Dedup scope is (sessionKey, msgId).
+// relay re-assign (§12). Dedup scope is (botId, sessionKey, msgId): separate bot
+// assignments may receive the same platform event and must wake independently.
 export const RdMsgIm = z.object({
   source: z.literal('im'),
   agentId: z.string().uuid(),

--- a/packages/relay/src/slack-event-dedup.ts
+++ b/packages/relay/src/slack-event-dedup.ts
@@ -1,9 +1,10 @@
 /**
- * `SlackEventDedup` — bounded, TTL'd `event_id` dedup for the shared Slack HTTP
- * ingress. Slack redelivers the same Events API envelope (same `event_id`, an
+ * `SlackEventDedup` — bounded, TTL'd event-identity dedup for the shared Slack HTTP
+ * ingress. Slack redelivers the same Events API envelope (same composite app,
+ * workspace, and `event_id`, with an
  * incremented `X-Slack-Retry-Num`) whenever it doesn't see a fast 200 — a retry a
  * relay pod already ack'd, or one another pod behind the same LB handled. Marking
- * the id on first sight and answering 200 on a repeat keeps one user message from
+ * the identity on first sight and answering 200 on a repeat keeps one user message from
  * fanning out to the daemon twice. State is bounded by a hard-cap flush (the daemon
  * dedup-map precedent) so a hostile/id-churning stream can't grow it without bound.
  */
@@ -29,15 +30,15 @@ export class SlackEventDedup {
     this.maxEntries = opts.maxEntries ?? 50_000
   }
 
-  /** True iff `id` was seen (and not expired); otherwise marks it and returns false.
-   *  An absent id is never deduped (some envelopes carry none) — false. */
-  seen(id: string | undefined): boolean {
-    if (!id) return false
+  /** True iff `identity` was seen (and not expired); otherwise marks it and returns
+   *  false. An absent identity is never deduped (some envelopes carry no event id). */
+  seen(identity: string | undefined): boolean {
+    if (!identity) return false
     const now = this.clock.now()
-    const expiry = this.seenAt.get(id)
+    const expiry = this.seenAt.get(identity)
     if (expiry !== undefined && expiry > now) return true
     if (this.seenAt.size >= this.maxEntries) this.seenAt.clear()
-    this.seenAt.set(id, now + this.ttlMs)
+    this.seenAt.set(identity, now + this.ttlMs)
     return false
   }
 }

--- a/packages/relay/src/slack-http-ingress.test.ts
+++ b/packages/relay/src/slack-http-ingress.test.ts
@@ -132,6 +132,34 @@ describe('slack http ingress', () => {
     expect(h.events).toHaveLength(1)
   })
 
+  it('does not dedup the same event_id across separately mentioned Slack apps', async () => {
+    const event = { type: 'message', channel: 'C1', ts: '1.1', user: 'U1', text: 'hi both apps' }
+    expect(
+      (
+        await postEvent({
+          type: 'event_callback',
+          api_app_id: 'A1',
+          team_id: 'T9',
+          event_id: 'Ev-shared',
+          event
+        })
+      ).statusCode
+    ).toBe(200)
+    expect(
+      (
+        await postEvent({
+          type: 'event_callback',
+          api_app_id: 'A2',
+          team_id: 'T9',
+          event_id: 'Ev-shared',
+          event
+        })
+      ).statusCode
+    ).toBe(200)
+    await flush()
+    expect(h.events).toHaveLength(2)
+  })
+
   it('extracts the urlencoded payload= and returns the block_suggestion options on the 200 body', async () => {
     const res = await postInteraction({
       type: 'block_suggestion',

--- a/packages/relay/src/slack-http-ingress.ts
+++ b/packages/relay/src/slack-http-ingress.ts
@@ -11,7 +11,8 @@
  *  - every other POST is demuxed to a bot AND authenticated in one step by the Slack
  *    request signature (HMAC over the raw bytes, keyed by that bot's signing secret) —
  *    `resolveVerified`; a request that no assigned bot's secret verifies ⇒ 401;
- *  - Events are deduped by `event_id` (Slack redelivers on a slow/again-seen 200),
+ *  - Events are deduped by `(api_app_id, team_id, event_id)` (Slack redelivers on a
+ *    slow/again-seen 200, while separate apps may receive the same underlying event),
  *    then ACK'd 200 and forwarded ASYNC (Slack's 3s window). Interactions run the
  *    handler to completion because `block_suggestion` must return its options on the
  *    200 body; all other interaction side-effects run after the return value.
@@ -55,6 +56,11 @@ export interface SlackHttpIngressDeps {
 
 function headerString(v: string | string[] | undefined): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+function eventDedupKey(body: SlackEventEnvelope): string | undefined {
+  if (!body.event_id) return undefined
+  return `${body.api_app_id ?? ''}\0${body.team_id ?? ''}\0${body.event_id}`
 }
 
 /** The subset of a Slack Events API envelope the route reads for demux + dispatch. */
@@ -114,9 +120,10 @@ export function registerSlackHttpIngress(app: FastifyInstance, deps: SlackHttpIn
       })
       if (!ingest) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
 
-      // Slack redelivers the same event_id (incremented X-Slack-Retry-Num) until it
-      // sees a fast 200 — one already handled here or by a sibling pod. Ack + drop.
-      if (deps.dedup.seen(body.event_id)) return reply.code(200).send()
+      // A retry for one app/install reuses this composite identity. Do not dedup on
+      // event_id alone: one Slack message may be delivered to several explicitly
+      // mentioned apps, and those callbacks must each reach their own agent.
+      if (deps.dedup.seen(eventDedupKey(body))) return reply.code(200).send()
 
       // Ack NOW (Slack's 3s window); forward async. A forward miss is bounded loss.
       // `event_time` is seconds → ms for the CP's revocation fence.


### PR DESCRIPTION
## What changed

- namespace Slack Events API deduplication by `api_app_id`, `team_id`, and `event_id`
- retain retry suppression for repeated delivery to the same Slack app installation
- add a regression test proving two apps with the same `event_id` are both forwarded

## Why

A Slack message that explicitly mentions multiple AgentConnect apps can produce callbacks sharing the same `event_id`. The relay previously deduplicated on `event_id` alone. When callbacks for multiple apps landed on the same relay pod, the first callback populated the pod-local cache and the remaining callbacks were acknowledged and dropped, so only one agent responded. The number of responders varied depending on load-balancer placement across relay pods.

Scoping the identity to the Slack app installation prevents cross-app collisions without weakening retry deduplication.

## Impact

Explicitly mentioning multiple AgentConnect Slack bots now wakes every addressed agent, while Slack retries for one app remain idempotent.

## Validation

- `pnpm --filter @agentconnect.md/relay test:unit -- slack-http-ingress.test.ts` (356 tests passed)
- `pnpm --filter @agentconnect.md/relay^... build`
- `pnpm --filter @agentconnect.md/relay typecheck`
- pre-push `eslint .`