### PR TITLE
fix(web): don't redirect to onboarding until every request settled successfully

### DIFF
--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -17,7 +17,7 @@ import type { SocialLoginTarget } from '@/lib/social-login-providers'
 
 const fill = { width: '60%', height: '60%', display: 'block' } as const
 
-export function AgentMark({ model }: { model: string }) {
+export function AgentMark({ model, fillPct = 60 }: { model: string; fillPct?: number }) {
   const registry = useAcpRegistry()
   const registryIcon = acpRuntime(registry, model)?.icon
   if (!registryIcon) return null
@@ -25,7 +25,8 @@ export function AgentMark({ model }: { model: string }) {
     <img
       src={registryIcon}
       alt=""
-      className="block h-[60%] w-[60%] object-contain [html[data-theme='dark']_&]:invert"
+      style={{ width: `${fillPct}%`, height: `${fillPct}%` }}
+      className="block object-contain [html[data-theme='dark']_&]:invert"
     />
   )
 }
@@ -79,20 +80,29 @@ export function modelProviderSlug(model: string): string | null {
 // A model's provider brand mark (lobehub icon set — same CDN the ACP registry's
 // curated runtimes use). Distinct from <AgentMark>, which is the runtime brand:
 // an `opencode` agent running `deepseek/…` shows the deepseek mark here, opencode there.
-export function ModelMark({ model, fallbackRuntime }: { model: string; fallbackRuntime: string }) {
+export function ModelMark({
+  model,
+  fallbackRuntime,
+  fillPct = 80
+}: {
+  model: string
+  fallbackRuntime: string
+  fillPct?: number
+}) {
   const slug = modelProviderSlug(model)
   // Latch the slug whose icon 404s so we fall back to the runtime mark. Keyed by
   // slug (not a boolean) so switching model re-attempts the new provider's icon —
   // no reset effect needed; `key` gives the img a fresh load per slug.
   const [failedSlug, setFailedSlug] = useState<string | null>(null)
-  if (!slug || failedSlug === slug) return <AgentMark model={fallbackRuntime} />
+  if (!slug || failedSlug === slug) return <AgentMark model={fallbackRuntime} fillPct={fillPct} />
   return (
     <img
       key={slug}
       src={`https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/${slug}.svg`}
       alt=""
       onError={() => setFailedSlug(slug)}
-      className="block h-[80%] w-[80%] object-contain [html[data-theme='dark']_&]:invert"
+      style={{ width: `${fillPct}%`, height: `${fillPct}%` }}
+      className="block object-contain [html[data-theme='dark']_&]:invert"
     />
   )
 }

--- a/packages/web/src/lib/use-onboarding-redirect.ts
+++ b/packages/web/src/lib/use-onboarding-redirect.ts
@@ -21,20 +21,27 @@ export function useOnboardingRedirect(): boolean {
   const router = useRouter()
   const params = useParams()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
-  const { agents, daemons, agentsLoading, daemonsLoading } = useConsoleData()
-  const { orgs } = useOrgs()
+  const { agents, daemons, agentsLoading, daemonsLoading, error } = useConsoleData()
+  const { orgs, activeOrg, loading: orgsLoading, error: orgsError } = useOrgs()
   const [skipState, setSkipState] = useState<{ orgKey: string; skipped: boolean } | null>(null)
   const skipped = skipState?.orgKey === orgKey ? skipState.skipped : null
   useEffect(() => {
     setSkipState({ orgKey, skipped: isOnboardingSkipped(orgKey) })
   }, [orgKey])
-  const notInitialized = needsOnboarding(
-    agentsLoading,
-    daemonsLoading,
-    agents.some(agentIsPlaced),
-    daemons.some(daemonCompletesOnboarding),
-    orgs.some((org) => (org.daemonCount ?? 0) > 0)
-  )
+  // Every request must have settled SUCCESSFULLY before judging the org fresh:
+  // a failed or never-issued fetch (org list down, CP error, unresolved slug)
+  // leaves empty rows with the loading flags false — that must not read as
+  // "no agents, no daemons" and bounce the user into the wizard.
+  const settled = !orgsLoading && orgsError == null && activeOrg != null && error == null
+  const notInitialized =
+    settled &&
+    needsOnboarding(
+      agentsLoading,
+      daemonsLoading,
+      agents.some(agentIsPlaced),
+      daemons.some(daemonCompletesOnboarding),
+      orgs.some((org) => (org.daemonCount ?? 0) > 0)
+    )
   const redirect = notInitialized && skipped === false
   useEffect(() => {
     if (redirect) router.replace(`/${orgKey}/onboarding`)


### PR DESCRIPTION
## Summary

- **Onboarding redirect gating**: the fresh-workspace redirect to `/onboarding` previously fired as soon as `agentsLoading`/`daemonsLoading` were false. Two windows produced wrong redirects: a **failed fetch** (CP hiccup, auth 401) drops SWR's `isLoading` to false with data falling back to `[]`, and an **unresolved/empty org list** leaves the SWR keys `null` so `isLoading` is never true — both read as "no agents, no daemons" and bounced the user into the wizard. The redirect now additionally requires every request to have settled **successfully**: org list loaded error-free, the URL's org resolved (`activeOrg != null`), and no console data error.
- **Marks**: `AgentMark`/`ModelMark` accept a `fillPct` prop so call sites can size the brand mark inside its plate (default unchanged: 60/80).

## Reviewer notes

- On any unsettled/failed state the hook returns "not initialized = false", so the console renders normally (with its error surface) instead of holding a spinner or redirecting.
- Follows up on #303 (cross-org `daemonCount` gate), which is already on main.

## Testing

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `pnpm --filter @agentconnect.md/web test` — 489 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)