### PR TITLE
fix(runtimes): stop leaking probe temp roots when a runtime outlives its adapter

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -487,6 +487,11 @@ const MAX_QUEUED_PER_SESSION = 10
  *  window (DreamRunnerDeps.cancelGraceMs) releases the reservation independently. */
 const DREAM_CANCEL_FORCE_MS = 15_000
 
+/** How often the idle sweep also reclaims abandoned probe temp roots. Much slower than
+ *  the idle cadence: the scan reads the whole OS temp dir, and a leaked root only costs
+ *  disk, so a lazy reclaim is enough. */
+const PROBE_ROOT_SWEEP_INTERVAL_MS = 15 * 60_000
+
 // Last-resort feedback-loop protection. The lower automatic threshold catches
 // agent/system/platform-echo chains; the higher all-turn threshold still stops a
 // platform bug that accidentally labels its own events as ordinary human messages.
@@ -1594,6 +1599,9 @@ export class Daemon {
   private hostStopping = new Map<string, Promise<void>>()
   // Recurring idle sweep (reap idle hosts + TTL-close idle sessions).
   private idleSweepTimer?: TimerHandle
+  // Last probe-temp-root reclaim, so it rides the idle sweep at its own slower
+  // cadence — the OS temp dir can hold thousands of entries to scan.
+  private lastProbeRootSweepAt = 0
   // §7.3 force-cancel backstops, keyed by (agentId, acpSessionId); cleared at turn end.
   private cancelTimers = new Map<string, TimerHandle>()
   // Backstop for an interrupt that lands before a Pending/ACP session id exists
@@ -13411,6 +13419,13 @@ export class Daemon {
 
   private sweepIdle(): void {
     const now = this.clock.now()
+    // Probe temp roots re-created by a runtime that outlived its adapter (see
+    // sweepStaleProbeRoots) must be reclaimed inside THIS process's lifetime — the
+    // startup pass alone would let a long-lived daemon accumulate them indefinitely.
+    if (now - this.lastProbeRootSweepAt >= PROBE_ROOT_SWEEP_INTERVAL_MS) {
+      this.lastProbeRootSweepAt = now
+      sweepStaleProbeRoots({ log: this.log })
+    }
     const ttl = this.cfg.limits.agentIdleTimeoutMs
     const maxLifetime = this.cfg.limits.agentMaxLifetimeMs
     // §7.3 idle→closed: a thread untouched past the TTL stops catching up — UNLESS it

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -160,6 +160,7 @@ import { installedRuntimeCatalog, installedRuntimes } from './runtimes/probe.js'
 import {
   probeAllRuntimes,
   isAuthRequiredError,
+  sweepStaleProbeRoots,
   type ProbeOptions,
   type RuntimeProbeResult
 } from './runtimes/runtime-prober.js'
@@ -1845,6 +1846,10 @@ export class Daemon {
     }
     this.log = makeLogger(cfg.logging.level)
     this.log.info(`starting daemon (root=${root})`)
+    // Reclaim probe temp roots orphaned by an earlier lifetime (a hard kill mid-sweep,
+    // or a runtime that kept writing after its adapter was reaped). Each can hold a
+    // private runtime HOME, so without this they accumulate until the disk fills.
+    sweepStaleProbeRoots({ log: this.log })
     this.log.info(
       `control plane: ${cfg.controlPlane?.enabled ? `enabled (${cfg.controlPlane.url ?? 'no url'})` : 'disabled — running local'}`
     )

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   unlinkSync,
   writeFileSync
@@ -163,6 +164,95 @@ export interface ProbeOptions {
 
 const DEFAULT_TIMEOUT_MS = 30_000
 const DEFAULT_CONCURRENCY = 3
+
+/** Probe temp roots are `ac-probe-<random>` directly under the OS temp dir. */
+const PROBE_ROOT_PREFIX = 'ac-probe-'
+/** Re-check schedule after a probe root's initial removal (see removeProbeRoot). The
+ *  first entry is paid by every sweep; the rest only when the root keeps coming back. */
+const PROBE_ROOT_RECHECK_MS = [250, 1_000, 3_000]
+/** How long a probe root may linger before {@link sweepStaleProbeRoots} treats it as
+ *  abandoned. Comfortably above one sweep's worst case (per-runtime timeout plus the
+ *  AcpHost stop escalation), so a concurrent daemon's live root is never touched. */
+const STALE_PROBE_ROOT_MS = 60 * 60_000
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Remove one probe root, then confirm it STAYS removed.
+ *
+ * A runtime that escapes the adapter's process group can still be mid-write when
+ * `stop()` resolves — omp registers its own daemon under the private HOME, so
+ * `AcpHost.stop()`'s process-group SIGTERM/SIGKILL cannot reach it — and its next
+ * write RE-CREATES the tree we just removed. So a single best-effort `rmSync` loses
+ * the race and leaks the whole root, private runtime HOMEs included (~270MB once omp
+ * has materialized its natives). Crucially, "gone right now" proves nothing either:
+ * the orphan's write may still be seconds out, which is why each pass re-checks after
+ * a delay rather than returning on the first empty stat. Anything still reappearing
+ * after the last pass is left to {@link sweepStaleProbeRoots}.
+ *
+ * Never throws — a cleanup failure must not discard probe results we already have.
+ */
+async function removeProbeRoot(root: string, log?: Logger): Promise<void> {
+  let lastError: unknown
+  const remove = (): void => {
+    try {
+      rmSync(root, { recursive: true, force: true })
+    } catch (err) {
+      lastError = err
+    }
+  }
+
+  remove()
+  for (const delay of PROBE_ROOT_RECHECK_MS) {
+    await sleep(delay)
+    if (!existsSync(root)) return
+    remove()
+  }
+  if (!existsSync(root) && !lastError) return
+  const detail = lastError ? `: ${(lastError as Error).message}` : ' — it kept reappearing'
+  log?.debug(`probe: temp cwd cleanup failed for ${root}${detail}`)
+}
+
+/**
+ * Remove probe roots abandoned by an earlier daemon lifetime. `probeAllRuntimes`
+ * cleans up its own root, but a hard kill mid-sweep — or a runtime that outlives the
+ * retries in {@link removeProbeRoot} — leaves one behind. Each can hold a private
+ * runtime HOME, so an unattended host accumulates them fast (269MB per omp probe),
+ * which is how a single busy hour reached ~57GB of leaked roots.
+ *
+ * Best effort and never throws: a root owned by another user, or removed by a
+ * concurrent daemon between the stat and the unlink, is skipped. Returns the number
+ * of roots actually removed.
+ */
+export function sweepStaleProbeRoots(opts: { log?: Logger; maxAgeMs?: number; tmpRoot?: string } = {}): number {
+  const tmpRoot = opts.tmpRoot ?? tmpdir()
+  const cutoff = Date.now() - (opts.maxAgeMs ?? STALE_PROBE_ROOT_MS)
+  let entries: string[]
+  try {
+    entries = readdirSync(tmpRoot)
+  } catch (err) {
+    opts.log?.debug(`probe: stale-root sweep could not read ${tmpRoot}: ${(err as Error).message}`)
+    return 0
+  }
+
+  let removed = 0
+  for (const name of entries) {
+    if (!name.startsWith(PROBE_ROOT_PREFIX)) continue
+    const path = join(tmpRoot, name)
+    try {
+      // lstat, never stat: the OS temp dir is world-writable, so a symlink planted
+      // under our prefix must be skipped rather than followed out of the temp root.
+      const stat = lstatSync(path)
+      if (!stat.isDirectory() || stat.mtimeMs > cutoff) continue
+      rmSync(path, { recursive: true, force: true })
+      removed++
+    } catch (err) {
+      opts.log?.debug(`probe: could not remove stale probe root ${path}: ${(err as Error).message}`)
+    }
+  }
+  if (removed > 0) opts.log?.info(`probe: removed ${removed} stale probe temp root(s) under ${tmpRoot}`)
+  return removed
+}
 
 function makeHost(
   rt: RuntimeDef,
@@ -463,13 +553,10 @@ export async function probeAllRuntimes(
   try {
     await Promise.all(Array.from({ length: Math.min(limit, ids.length) }, () => worker()))
   } finally {
-    // Best-effort cleanup — a temp-dir removal failure (e.g. Windows EBUSY) must
-    // never discard the probe results we already gathered.
-    try {
-      rmSync(cwd, { recursive: true, force: true })
-    } catch (err) {
-      opts.log?.debug(`probe: temp cwd cleanup failed for ${cwd}: ${(err as Error).message}`)
-    }
+    // Best-effort cleanup — a temp-dir removal failure (e.g. Windows EBUSY, or a
+    // runtime still writing from outside the adapter's process group) must never
+    // discard the probe results we already gathered.
+    await removeProbeRoot(cwd, opts.log)
   }
   return results
 }

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -167,32 +167,48 @@ const DEFAULT_CONCURRENCY = 3
 
 /** Probe temp roots are `ac-probe-<random>` directly under the OS temp dir. */
 const PROBE_ROOT_PREFIX = 'ac-probe-'
-/** Re-check schedule after a probe root's initial removal (see removeProbeRoot). The
- *  first entry is paid by every sweep; the rest only when the root keeps coming back. */
+/** Gaps between the observation points that follow a probe root's initial removal
+ *  (see removeProbeRoot) — cumulatively 250ms, 1.25s and 4.25s after teardown. Every
+ *  point is observed, but in the background, so none of it delays a probe result. */
 const PROBE_ROOT_RECHECK_MS = [250, 1_000, 3_000]
-/** How long a probe root may linger before {@link sweepStaleProbeRoots} treats it as
- *  abandoned. Comfortably above one sweep's worst case (per-runtime timeout plus the
- *  AcpHost stop escalation), so a concurrent daemon's live root is never touched. */
+/** How long a FOREIGN probe root may linger before {@link sweepStaleProbeRoots} treats
+ *  it as abandoned. Comfortably above one sweep's worst case (per-runtime timeout plus
+ *  the AcpHost stop escalation), so another daemon's live root is never touched. Roots
+ *  owned by THIS process are excluded outright via {@link liveProbeRoots}. */
 const STALE_PROBE_ROOT_MS = 60 * 60_000
+
+/** Probe roots this process is actively using. The recurring sweep skips them
+ *  regardless of age, so it can never delete a root out from under a live sweep. */
+const liveProbeRoots = new Set<string>()
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
- * Remove one probe root, then confirm it STAYS removed.
+ * Remove one probe root, then keep watching so it STAYS removed.
  *
  * A runtime that escapes the adapter's process group can still be mid-write when
  * `stop()` resolves — omp registers its own daemon under the private HOME, so
  * `AcpHost.stop()`'s process-group SIGTERM/SIGKILL cannot reach it — and its next
  * write RE-CREATES the tree we just removed. So a single best-effort `rmSync` loses
  * the race and leaks the whole root, private runtime HOMEs included (~270MB once omp
- * has materialized its natives). Crucially, "gone right now" proves nothing either:
- * the orphan's write may still be seconds out, which is why each pass re-checks after
- * a delay rather than returning on the first empty stat. Anything still reappearing
- * after the last pass is left to {@link sweepStaleProbeRoots}.
+ * has materialized its natives).
+ *
+ * "Gone right now" is no better a signal: the orphan's write may land after an earlier
+ * check found the path clean, so stopping at the first empty stat would only move the
+ * race window rather than close it. Every scheduled point is therefore observed, even
+ * once the root looks gone.
+ *
+ * The first removal is synchronous, so a caller sees the root gone on return in the
+ * ordinary case; the returned promise then completes the observation in the BACKGROUND
+ * and is deliberately not awaited by {@link probeAllRuntimes}. Blocking every sweep on
+ * the full window would tax all probing — and every test that probes — for a case that
+ * usually never happens. If the process exits before the watch finishes, the root falls
+ * to {@link sweepStaleProbeRoots}: the next startup, or the recurring idle sweep for a
+ * daemon that keeps running.
  *
  * Never throws — a cleanup failure must not discard probe results we already have.
  */
-async function removeProbeRoot(root: string, log?: Logger): Promise<void> {
+function removeProbeRoot(root: string, log?: Logger): Promise<void> {
   let lastError: unknown
   const remove = (): void => {
     try {
@@ -203,22 +219,28 @@ async function removeProbeRoot(root: string, log?: Logger): Promise<void> {
   }
 
   remove()
-  for (const delay of PROBE_ROOT_RECHECK_MS) {
-    await sleep(delay)
-    if (!existsSync(root)) return
-    remove()
-  }
-  if (!existsSync(root) && !lastError) return
-  const detail = lastError ? `: ${(lastError as Error).message}` : ' — it kept reappearing'
-  log?.debug(`probe: temp cwd cleanup failed for ${root}${detail}`)
+  return (async () => {
+    for (const delay of PROBE_ROOT_RECHECK_MS) {
+      await sleep(delay)
+      if (existsSync(root)) remove()
+    }
+    if (!existsSync(root) && !lastError) return
+    const detail = existsSync(root) ? ' — it kept reappearing' : `: ${(lastError as Error).message}`
+    log?.debug(`probe: temp cwd cleanup failed for ${root}${detail}`)
+  })()
 }
 
 /**
- * Remove probe roots abandoned by an earlier daemon lifetime. `probeAllRuntimes`
- * cleans up its own root, but a hard kill mid-sweep — or a runtime that outlives the
- * retries in {@link removeProbeRoot} — leaves one behind. Each can hold a private
- * runtime HOME, so an unattended host accumulates them fast (269MB per omp probe),
- * which is how a single busy hour reached ~57GB of leaked roots.
+ * Reclaim abandoned probe roots. `probeAllRuntimes` cleans up its own root, but a hard
+ * kill mid-sweep — or a runtime that outlives every observation point in
+ * {@link removeProbeRoot} — leaves one behind. Each can hold a private runtime HOME, so
+ * a host accumulates them fast (269MB per omp probe), which is how a single busy hour
+ * reached ~57GB of leaked roots.
+ *
+ * Called at daemon startup AND on the recurring idle sweep: a root re-created after the
+ * last observation point must be reclaimable within the SAME long-lived process, not
+ * only by the next restart. Roots this process is still using are skipped outright (see
+ * {@link liveProbeRoots}), so the cadence carries no risk to a live sweep.
  *
  * Best effort and never throws: a root owned by another user, or removed by a
  * concurrent daemon between the stat and the unlink, is skipped. Returns the number
@@ -239,6 +261,7 @@ export function sweepStaleProbeRoots(opts: { log?: Logger; maxAgeMs?: number; tm
   for (const name of entries) {
     if (!name.startsWith(PROBE_ROOT_PREFIX)) continue
     const path = join(tmpRoot, name)
+    if (liveProbeRoots.has(path)) continue // a sweep in this process still owns it
     try {
       // lstat, never stat: the OS temp dir is world-writable, so a symlink planted
       // under our prefix must be skipped rather than followed out of the temp root.
@@ -535,7 +558,9 @@ export async function probeAllRuntimes(
   const ids = Object.keys(runtimes)
   if (ids.length === 0) return []
 
-  const cwd = mkdtempSync(join(tmpdir(), 'ac-probe-'))
+  const cwd = mkdtempSync(join(tmpdir(), PROBE_ROOT_PREFIX))
+  // Claim the root so a concurrent recurring sweep cannot reclaim it mid-probe.
+  liveProbeRoots.add(cwd)
   const limit = Math.max(1, opts.concurrency ?? DEFAULT_CONCURRENCY)
   const results: RuntimeProbeResult[] = []
   let next = 0
@@ -555,8 +580,12 @@ export async function probeAllRuntimes(
   } finally {
     // Best-effort cleanup — a temp-dir removal failure (e.g. Windows EBUSY, or a
     // runtime still writing from outside the adapter's process group) must never
-    // discard the probe results we already gathered.
-    await removeProbeRoot(cwd, opts.log)
+    // discard the probe results we already gathered. The initial removal happens
+    // synchronously inside removeProbeRoot; the observation window that follows it is
+    // deliberately NOT awaited, so probe results are never held back by it. The claim
+    // is released only when that watch ends, keeping the recurring sweep off this root
+    // for its whole duration.
+    void removeProbeRoot(cwd, opts.log).finally(() => liveProbeRoots.delete(cwd))
   }
   return results
 }

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -364,34 +364,47 @@ describe('probeAllRuntimes', () => {
     expect(await probeAllRuntimes({})).toEqual([])
   })
 
-  it('removes its temp root even when a runtime re-creates it after teardown', async () => {
-    // Models the real leak: omp's own daemon escapes the adapter's process group, so
-    // it is still writing when stop() resolves and its next write restores the tree
-    // rmSync just deleted. A one-shot cleanup loses that race.
-    let probeRoot = ''
-    const results = await probeAllRuntimes(
-      { a: rt },
-      {
-        hostFactory: (_runtime, _id, cwd) => {
-          probeRoot = dirname(dirname(cwd))
-          return fakeHost({
-            onStop: () => {
-              // Land the write AFTER the first rmSync (cleanup runs as soon as stop()
-              // resolves), so only the retry can reclaim it. 50ms sits inside the first
-              // 250ms backoff step.
-              setTimeout(() => mkdirSync(join(cwd, 'late-write'), { recursive: true }), 50).unref()
-            }
-          })
+  // Models the real leak: omp's own daemon escapes the adapter's process group, so it
+  // is still writing when stop() resolves and its next write restores the tree rmSync
+  // just deleted. Both delays matter: 50ms lands before the first observation point
+  // (250ms), 500ms lands AFTER it — the case an early return on a momentarily-clean
+  // stat would leak, since cleanup would already have declared success.
+  it.each([50, 500])(
+    'removes its temp root when a runtime re-creates it %dms after teardown',
+    async (delayMs) => {
+      let probeRoot = ''
+      const results = await probeAllRuntimes(
+        { a: rt },
+        {
+          hostFactory: (_runtime, _id, cwd) => {
+            probeRoot = dirname(dirname(cwd))
+            return fakeHost({
+              onStop: () => {
+                setTimeout(() => mkdirSync(join(cwd, 'late-write'), { recursive: true }), delayMs).unref()
+              }
+            })
+          }
         }
+      )
+      expect(results.map((r) => r.ok)).toEqual([true])
+      expect(probeRoot).not.toBe('')
+
+      // Wait for the re-creation to actually land first — asserting before it does would
+      // pass against any implementation, including one that never looks again.
+      await new Promise((resolve) => setTimeout(resolve, delayMs + 150))
+      expect(existsSync(probeRoot)).toBe(true)
+
+      // Then let the background watch reclaim it. Polling rather than hardcoding which
+      // observation point catches this delay; a cleanup that stopped early never removes
+      // the root again, so it is still there when the deadline expires.
+      const deadline = Date.now() + 8_000
+      while (existsSync(probeRoot) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50))
       }
-    )
-    expect(results.map((r) => r.ok)).toEqual([true])
-    expect(probeRoot).not.toBe('')
-    // Well past the 50ms re-create and the first retry step, so a root that only a
-    // one-shot rmSync touched is still observable here.
-    await new Promise((resolve) => setTimeout(resolve, 400))
-    expect(existsSync(probeRoot)).toBe(false)
-  })
+      expect(existsSync(probeRoot)).toBe(false)
+    },
+    15_000
+  )
 
   it('uses a disposable protected curated launch and leaves host state unchanged', async () => {
     const hostHome = mkdtempSync(join(tmpdir(), 'ac-probe-host-'))

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  lutimesSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -7,6 +18,7 @@ import {
   curatedProbeEnvironment,
   probeRuntime,
   probeAllRuntimes,
+  sweepStaleProbeRoots,
   type ProbeHostPolicy
 } from '../src/runtimes/runtime-prober.js'
 import { modelOptionsFrom, type AcpHost } from '../src/acp/acp-host.js'
@@ -352,6 +364,35 @@ describe('probeAllRuntimes', () => {
     expect(await probeAllRuntimes({})).toEqual([])
   })
 
+  it('removes its temp root even when a runtime re-creates it after teardown', async () => {
+    // Models the real leak: omp's own daemon escapes the adapter's process group, so
+    // it is still writing when stop() resolves and its next write restores the tree
+    // rmSync just deleted. A one-shot cleanup loses that race.
+    let probeRoot = ''
+    const results = await probeAllRuntimes(
+      { a: rt },
+      {
+        hostFactory: (_runtime, _id, cwd) => {
+          probeRoot = dirname(dirname(cwd))
+          return fakeHost({
+            onStop: () => {
+              // Land the write AFTER the first rmSync (cleanup runs as soon as stop()
+              // resolves), so only the retry can reclaim it. 50ms sits inside the first
+              // 250ms backoff step.
+              setTimeout(() => mkdirSync(join(cwd, 'late-write'), { recursive: true }), 50).unref()
+            }
+          })
+        }
+      }
+    )
+    expect(results.map((r) => r.ok)).toEqual([true])
+    expect(probeRoot).not.toBe('')
+    // Well past the 50ms re-create and the first retry step, so a root that only a
+    // one-shot rmSync touched is still observable here.
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(existsSync(probeRoot)).toBe(false)
+  })
+
   it('uses a disposable protected curated launch and leaves host state unchanged', async () => {
     const hostHome = mkdtempSync(join(tmpdir(), 'ac-probe-host-'))
     const hostHermes = join(hostHome, '.hermes')
@@ -419,5 +460,46 @@ describe('probeAllRuntimes', () => {
 
     expect(results[0]?.ok).toBe(true)
     expect(readFileSync(join(hostConfig, 'mcp.toml'), 'utf8')).toContain('unsafe')
+  })
+})
+
+describe('sweepStaleProbeRoots', () => {
+  const probeRootAged = (tmpRoot: string, name: string, ageMs: number): string => {
+    const path = join(tmpRoot, name)
+    mkdirSync(join(path, 'runtime', 'home'), { recursive: true })
+    writeFileSync(join(path, 'runtime', 'home', 'natives.bin'), 'x')
+    const when = new Date(Date.now() - ageMs)
+    utimesSync(path, when, when)
+    return path
+  }
+
+  it('removes abandoned roots past the age cutoff and keeps fresh ones', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'ac-probe-sweeptest-'))
+    const abandoned = probeRootAged(tmpRoot, 'ac-probe-oldone', 2 * 60 * 60_000)
+    // A live sweep by a concurrent daemon must survive, as must unrelated temp dirs.
+    const fresh = probeRootAged(tmpRoot, 'ac-probe-freshy', 30_000)
+    const unrelated = probeRootAged(tmpRoot, 'ac-sm-something', 2 * 60 * 60_000)
+
+    expect(sweepStaleProbeRoots({ tmpRoot })).toBe(1)
+    expect(existsSync(abandoned)).toBe(false)
+    expect(existsSync(fresh)).toBe(true)
+    expect(existsSync(unrelated)).toBe(true)
+  })
+
+  it('skips a symlink planted under the probe prefix instead of following it', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'ac-probe-sweeptest-'))
+    const victim = mkdtempSync(join(tmpdir(), 'ac-probe-sweepvictim-'))
+    writeFileSync(join(victim, 'keep.txt'), 'keep')
+    const link = join(tmpRoot, 'ac-probe-evilink')
+    symlinkSync(victim, link)
+    const when = new Date(Date.now() - 2 * 60 * 60_000)
+    lutimesSync(link, when, when)
+
+    expect(sweepStaleProbeRoots({ tmpRoot })).toBe(0)
+    expect(existsSync(join(victim, 'keep.txt'))).toBe(true)
+  })
+
+  it('returns 0 when the temp root cannot be read', () => {
+    expect(sweepStaleProbeRoots({ tmpRoot: join(tmpdir(), 'ac-probe-absent-xyz') })).toBe(0)
   })
 })


### PR DESCRIPTION
## Problem

`probeAllRuntimes` removed its temp root with a single best-effort `rmSync`. That loses a race.

A runtime whose process escapes the adapter's process group can still be writing when `AcpHost.stop()` resolves — omp registers its own daemon under the private runtime HOME, so the group-wide SIGTERM/SIGKILL in `stop()` never reaches it — and its next write **re-creates the tree we just deleted**.

Each orphaned root holds a private runtime HOME (~270MB once omp has materialized its natives), so a busy host accumulates them until the disk fills. Observed on a dev host: **213 leaked roots / ~57GB inside a single hour**, filling `/` to 99%.

Evidence that the writer outlives the adapter — probe roots whose last write lands *after* the 30s per-runtime timeout and the stop escalation:

| root | write span |
|---|---|
| `ac-probe-1e1uYy` | 36.4s |
| `ac-probe-1OOFfQ` | 34.3s |

`AcpHost.stop()` itself is not at fault: it does stdin EOF → process-group SIGTERM → SIGKILL after 5s, plus a group sweep on `exit`. A double-forked/`setsid` daemon is simply not in that group.

## Fix

**1. Removal re-checks on a backoff** instead of trusting the first empty stat. "Gone right now" proves nothing when the orphan's write is still seconds out, so each pass looks again after a delay and only escalates while the root keeps coming back. Typical cost is one 250ms re-check per sweep, which probing can afford — it already runs off the connect hot path. Worst case 4.25s.

**2. New `sweepStaleProbeRoots()`, called from daemon startup** — the backstop for anything still reappearing after the last pass, or left behind by a hard kill mid-sweep. Reclaims `ac-probe-*` roots older than an hour, well above one sweep's worst case, so a concurrent daemon's live root is never touched. It `lstat`s rather than `stat`s: the OS temp dir is world-writable, so a symlink planted under the prefix is skipped rather than followed out of the temp root.

## Tests

`test/runtime-prober.test.ts`, +4 (28 pass):

- the re-create-after-teardown case — verified **red/green**, not just green: with the re-check schedule emptied it fails with the root still present, which is the leak itself reproduced
- sweep removes past-cutoff roots, keeps fresh ones and unrelated temp dirs
- sweep skips a symlink planted under the probe prefix
- sweep returns 0 on an unreadable temp root

Full daemon suite: **2493 passed**, 1 failed — `git-injection.test.ts > gitEnvBase > uses a daemon-owned remote name…`, which I confirmed **fails identically on clean `main`** (stashed my changes and re-ran). Unrelated and pre-existing.

`pnpm typecheck`, prettier and eslint all clean.

## Not addressed

omp re-materializes 269MB of natives into every private HOME because `runtime-home.ts` seeding deliberately skips files over `MAX_SEED_FILE_BYTES` (2MB), even though the host already has them at `~/.omp/natives/<ver>/`. So each probe still writes and then deletes that copy — the leak is contained, the churn is not. Fixing it needs omp's natives-cache env var; `RUNTIME_PRIVATE_ENV` has no entry for it, and symlinking is ruled out by `assertNoDestinationSymlink`, which is a deliberate security property of the private HOME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)