### PR TITLE
fix(sessions): show participant identities

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2131,6 +2131,7 @@ export const SessionMessageDto = z.object({
   seq: z.number(),
   sender: z.string(),
   senderName: z.string().optional(), // daemon-resolved display name; absent if unknown
+  trustedAgentBot: z.boolean().optional(), // daemon-verified AgentConnect Slack bot provenance
   ts: z.string(),
   kind: z.string(),
   text: z.string(),

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -576,6 +576,7 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
           {
             seq: 1,
             sender: '@dana',
+            trustedAgentBot: true,
             ts: '1718000000.000100',
             kind: 'text',
             text: 'ship it',
@@ -595,12 +596,13 @@ describe('GET /sessions/:id/messages (history pull via the owning agent)', () =>
     })
     expect(res.statusCode).toBe(200)
     const body = res.json() as {
-      messages: Array<{ text: string; attachments?: Array<{ name: string }> }>
+      messages: Array<{ text: string; trustedAgentBot?: boolean; attachments?: Array<{ name: string }> }>
       nextCursor: string | null
       liveCursor: string | null
       liveMore: boolean
     }
     expect(body.messages[0]!.text).toBe('ship it')
+    expect(body.messages[0]!.trustedAgentBot).toBe(true)
     expect(body.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(body.nextCursor).toBe('c-50')
     expect(body.liveCursor).toBe('77')

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -276,6 +276,7 @@ export function createSessionReader(
           seq: r.seq,
           sender: r.sender,
           ...(senderName ? { senderName } : {}),
+          ...(r.trustedAgentBot ? { trustedAgentBot: true } : {}),
           ts: r.ts,
           kind: r.kind,
           text: substituteUserMentions(withoutAttachmentMention(r.text, attachments), names),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7368,7 +7368,7 @@ export class Daemon {
     threadTs: string,
     cutoffTs?: string,
     afterTs?: string | null
-  ): Promise<{ sender: string; ts: string; text: string }[]> {
+  ): Promise<{ sender: string; ts: string; text: string; trustedAgentBot?: boolean }[]> {
     const conn = this.replyConnFor(agentId) as Partial<SlackConnection> | undefined
     // Only Slack can pull thread history (conversations.replies). Telegram long-poll
     // has no arbitrary-history API, so a cold mid-thread mention just starts fresh.
@@ -7405,7 +7405,8 @@ export class Daemon {
             sender:
               (trustedAgentBot ? r.agentAuthorId : undefined) ?? (r.isBot && ours.has(r.sender) ? agentId : r.sender),
             ts: r.ts,
-            text: mention ? `${r.text}\n${mention}`.trim() : r.text
+            text: mention ? `${r.text}\n${mention}`.trim() : r.text,
+            ...(trustedAgentBot ? { trustedAgentBot: true } : {})
           }
         })
     )

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4438,13 +4438,16 @@ export class Daemon {
    *  conversation history, but are never an activation path. Same-daemon bots use their
    *  resolved Slack identities; cross-daemon bots use the CP collaboration snapshot's
    *  public Slack app ids. Internal `messageAgent` delivery bypasses platform ingress. */
+  private isManagedSlackBotIdentity(channel: string, senderId: string, appId?: string): boolean {
+    const localIdentity = [...this.connByIntegration.values()].some(
+      (conn) => (!!conn.botUserId && senderId === conn.botUserId) || (!!conn.botId && senderId === conn.botId)
+    )
+    return localIdentity || (!!appId && this.cpCollab.isAgentBotApp('slack', channel, appId))
+  }
+
   private isAgentBotMessage(msg: NormalizedMessage): boolean {
     if (msg.source !== 'user' || msg.platform !== 'slack') return false
-    const localIdentity = [...this.connByIntegration.values()].some(
-      (conn) => (!!conn.botUserId && msg.sender.id === conn.botUserId) || (!!conn.botId && msg.sender.id === conn.botId)
-    )
-    if (localIdentity) return true
-    return !!msg.sender.appId && this.cpCollab.isAgentBotApp(msg.platform, msg.channel, msg.sender.appId)
+    return this.isManagedSlackBotIdentity(msg.channel, msg.sender.id, msg.sender.appId)
   }
 
   private onInbound(msg: NormalizedMessage, srcIntegrationIds?: string[]): void {
@@ -7378,19 +7381,29 @@ export class Daemon {
     })
     return (
       replies
+        .map((reply) => ({
+          reply,
+          // Slack metadata event names and payloads are app-defined. Trust AgentConnect
+          // authorship/chrome only when the provider identity belongs to one of our local
+          // bots or to a CP-advertised AgentConnect app in this channel.
+          trustedAgentBot: reply.isBot && this.isManagedSlackBotIdentity(channel, reply.sender, reply.appId)
+        }))
         // Skip daemon CHROME (status bar, progress/plan/reasoning, notices, cards). It is not
-        // conversation and must not be re-ingested as a transcript text row — that leaked, e.g.,
-        // a peer agent's status bar into another agent's session view. New chrome carries the
-        // metadata marker (r.chrome); `isSlackStatusBarText` also catches status bars posted
-        // before the marker existed (transition safety).
-        .filter((r) => !r.chrome && !isSlackStatusBarText(r.text))
-        .map((r) => {
+        // conversation and must not be re-ingested as a transcript text row. The legacy
+        // status-bar text fallback is provenance-gated too, so another app or a human cannot
+        // make ordinary conversation disappear by copying AgentConnect's marker or text.
+        .filter(
+          ({ reply, trustedAgentBot }) => !trustedAgentBot || (!reply.chrome && !isSlackStatusBarText(reply.text))
+        )
+        .map(({ reply: r, trustedAgentBot }) => {
           const mention = attachmentMention(r.attachments)
           return {
             // A shareable Slack app gives every agent-authored message the same bot_id.
-            // Prefer our stable per-message metadata so a remote A is not mistaken for
-            // this local B and then discarded by SessionManager's own-author filter.
-            sender: r.agentAuthorId ?? (r.isBot && ours.has(r.sender) ? agentId : r.sender),
+            // Prefer stable per-message metadata only after verifying the producing app,
+            // so an unrelated app cannot impersonate this or a peer Agent and trip the
+            // SessionManager own-author filter.
+            sender:
+              (trustedAgentBot ? r.agentAuthorId : undefined) ?? (r.isBot && ours.has(r.sender) ? agentId : r.sender),
             ts: r.ts,
             text: mention ? `${r.text}\n${mention}`.trim() : r.text
           }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10182,12 +10182,24 @@ export class Daemon {
     return { username: p.agentName, ...(p.iconUrl ? { icon_url: p.iconUrl } : {}) }
   }
 
-  /** Agent-authored messages use the selected agent identity in both channels and DMs.
-   *  DM system chrome continues through {@link slackPostOptions} without overrides so
-   *  status bars, cards, and notices remain visibly owned by the Slack App. */
-  private slackAgentPostOptions(p: Pick<Pending, 'platform' | 'agentName' | 'iconUrl'>): SlackPostOptions | undefined {
+  /** Visual identity for Slack rows owned by the selected agent. Kept separate from
+   *  conversational authorship because status/chrome rows must retain their chrome
+   *  metadata marker instead of masquerading as transcript messages. */
+  private slackAgentIdentityOptions(
+    p: Pick<Pending, 'platform' | 'agentName' | 'iconUrl'>
+  ): SlackPostOptions | undefined {
     if (p.platform !== 'slack') return undefined
     return { username: p.agentName, ...(p.iconUrl ? { icon_url: p.iconUrl } : {}) }
+  }
+
+  /** Agent-authored conversation messages add a stable author id to Slack metadata.
+   *  Peer daemons use it during thread backfill, so shared/custom bot ids never replace
+   *  the Agent's name and icon in the Console transcript. */
+  private slackAgentPostOptions(
+    p: Pick<Pending, 'platform' | 'agentId' | 'agentName' | 'iconUrl'>
+  ): SlackPostOptions | undefined {
+    const identity = this.slackAgentIdentityOptions(p)
+    return identity ? { ...identity, agentAuthorId: p.agentId } : undefined
   }
 
   /** Opaque routing target attached to daemon-rendered interactive Slack blocks when
@@ -10222,7 +10234,14 @@ export class Daemon {
     const failed: { ts: string; text: string }[] = []
     for (const reply of new Map(pending.map((item) => [item.ts, item])).values()) {
       try {
-        const updated = await conn.updateBlocks(p.channel, reply.ts, [{ type: 'markdown', text: reply.text }])
+        const updated = await conn.updateBlocks(
+          p.channel,
+          reply.ts,
+          [{ type: 'markdown', text: reply.text }],
+          undefined,
+          false,
+          p.agentId
+        )
         if (updated === false) failed.push(reply)
       } catch (err) {
         // Real SlackConnection normalizes API/queue failures to false. Keep this guard
@@ -10286,7 +10305,7 @@ export class Daemon {
     if (!p.liveReplyTs) return
     const attribution = p.attribution
     if (!attribution) {
-      await conn.updateMessage(p.channel, p.liveReplyTs, text)
+      await conn.updateMessage(p.channel, p.liveReplyTs, text, false, p.agentId)
       if (p.lastReply?.ts === p.liveReplyTs) {
         p.lastReply.text = text
         delete p.lastReply.footerKey
@@ -10297,7 +10316,9 @@ export class Daemon {
       p.channel,
       p.liveReplyTs,
       [{ type: 'markdown', text }, ...attribution.blocks],
-      text
+      text,
+      false,
+      p.agentId
     )
     if (updated !== false && p.lastReply?.ts === p.liveReplyTs) {
       p.lastReply.text = text
@@ -10330,7 +10351,7 @@ export class Daemon {
       return
     }
     const postOptions = this.slackPostOptions(p)
-    const statusBarPostOptions = this.slackAgentPostOptions(p)
+    const statusBarPostOptions = this.slackAgentIdentityOptions(p)
     // Chrome variant of the post options: marks status/progress/plan/reasoning/notice/card
     // messages so a peer daemon's thread backfill skips them (they are not conversation).
     const chromeOptions: SlackPostOptions = { ...(postOptions ?? {}), chrome: true }
@@ -10386,7 +10407,9 @@ export class Daemon {
               p.channel,
               p.liveReplyTs,
               [{ type: 'markdown', text: p.liveReplyText }, ...action.blocks],
-              p.liveReplyText
+              p.liveReplyText,
+              false,
+              p.agentId
             )
             if (updated !== false) {
               p.lastReply.text = p.liveReplyText
@@ -14547,6 +14570,7 @@ export class Daemon {
             const options = agent
               ? this.slackAgentPostOptions({
                   platform: msg.platform,
+                  agentId,
                   agentName: agent.displayName?.trim() || agent.name,
                   ...(agent.iconUrl ? { iconUrl: agent.iconUrl } : {})
                 })

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -19,19 +19,21 @@ import type {
  * of the underlying platform SDK response. "channel" is the platform conversation
  * id (Slack channel `C…` / Telegram chat id); "user" is a platform user id.
  */
-/** Optional per-message sender-identity overrides for {@link MessageGateway}. Only
- *  Slack can honor these (via `chat:write.customize`); other platforms have no
- *  per-message identity, so they don't implement the identity-aware send at all. */
+/** Optional per-message sender identity for {@link MessageGateway}. Slack can render
+ *  the name/avatar (via `chat:write.customize`) and persist the stable AgentConnect
+ *  author id in message metadata; other platforms ignore these fields. */
 export interface SendIdentity {
   username?: string
   /** Public https image URL for the message avatar (the agent's icon). */
   icon_url?: string
+  /** Stable AgentConnect author id persisted in Slack message metadata. */
+  agentAuthorId?: string
 }
 
 export interface MessageGateway {
   /** Post a message; returns the resulting message id (`ts` / message_id) so the
-   *  daemon can record it. `identity` carries the agent's sender name/avatar — only
-   *  Slack honors it (`chat:write.customize`); other platforms ignore it. */
+   *  daemon can record it. `identity` carries the agent's stable id and optional
+   *  visual identity; other platforms may ignore it. */
   postMessage(channel: string, text: string, threadTs?: string, identity?: SendIdentity): Promise<string | undefined>
   getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }>
   listMembers(channel: string): Promise<{ id: string; name?: string; isBot?: boolean }[]>
@@ -765,12 +767,10 @@ export async function executeTool(
       }
       const identity: SendIdentity = {
         ...(ctx.agentName ? { username: ctx.agentName } : {}),
-        ...(ctx.iconUrl ? { icon_url: ctx.iconUrl } : {})
+        ...(ctx.iconUrl ? { icon_url: ctx.iconUrl } : {}),
+        agentAuthorId: ctx.agentId
       }
-      const ts =
-        (Object.keys(identity).length > 0
-          ? await gw.postMessage(channel, body, thread, identity)
-          : await gw.postMessage(channel, body, thread)) ?? `local-${deps.now()}`
+      const ts = (await gw.postMessage(channel, body, thread, identity)) ?? `local-${deps.now()}`
       // Whether the target is a DM decides the thread key on the platforms that keep a DM as one
       // continuous conversation, and no id carries that — ask the platform, once, and only where
       // the answer can change the key. A failed lookup falls back to the non-DM conversation

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -223,7 +223,7 @@ export class SessionManager {
         threadTs: string,
         cutoffTs?: string,
         afterTs?: string | null
-      ) => Promise<{ sender: string; ts: string; text: string }[]>
+      ) => Promise<{ sender: string; ts: string; text: string; trustedAgentBot?: boolean }[]>
     }
   ) {}
 
@@ -812,6 +812,7 @@ export class SessionManager {
           thread,
           ts: h.ts,
           sender: h.sender,
+          ...(h.trustedAgentBot ? { trustedAgentBot: true } : {}),
           // Snapshotted thread history is context THIS agent's turn receives.
           recipient: agentId,
           kind: 'text',

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -998,7 +998,9 @@ export class SlackConnection {
               ? m.metadata.event_payload.author_agent_id.trim()
               : ''
           out.push({
-            sender: m.user ?? m.bot_id ?? 'unknown',
+            // Some Slack bot rows expose both `user` and `bot_id`. Keep the stable bot
+            // identity as sender so legacy rows from the same app reconcile consistently.
+            sender: m.bot_id ?? m.user ?? 'unknown',
             ...(metadataAuthor ? { agentAuthorId: metadataAuthor } : {}),
             ...(appId ? { appId } : {}),
             ts: m.ts,

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -280,6 +280,8 @@ type AppLike = {
         messages?: {
           user?: string
           bot_id?: string
+          app_id?: string
+          bot_profile?: { app_id?: string }
           ts?: string
           text?: string
           subtype?: string
@@ -952,6 +954,7 @@ export class SlackConnection {
     {
       sender: string
       agentAuthorId?: string
+      appId?: string
       ts: string
       text: string
       isBot: boolean
@@ -962,6 +965,7 @@ export class SlackConnection {
     const out: {
       sender: string
       agentAuthorId?: string
+      appId?: string
       ts: string
       text: string
       isBot: boolean
@@ -987,6 +991,7 @@ export class SlackConnection {
         })
         for (const m of res.messages ?? []) {
           if (!m.ts) continue
+          const appId = m.app_id ?? m.bot_profile?.app_id
           const metadataAuthor =
             m.metadata?.event_type === 'agentconnect_thread_event' &&
             typeof m.metadata.event_payload?.author_agent_id === 'string'
@@ -995,9 +1000,10 @@ export class SlackConnection {
           out.push({
             sender: m.user ?? m.bot_id ?? 'unknown',
             ...(metadataAuthor ? { agentAuthorId: metadataAuthor } : {}),
+            ...(appId ? { appId } : {}),
             ts: m.ts,
             text: extractSlackMessageText(m),
-            isBot: Boolean(m.bot_id),
+            isBot: Boolean(m.bot_id || appId),
             chrome: m.metadata?.event_type === SLACK_CHROME_EVENT_TYPE,
             attachments: (m.files ?? [])
               .map(toAttachment)

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -30,9 +30,10 @@ export interface ConsolidatedGroup {
   integrations: { agentId: string; integrationId: string }[]
 }
 
-/** Optional per-message rendering controls. The authorship fields both require
- *  Slack's `chat:write.customize` scope; {@link SlackConnection} transparently falls
- *  back to the app identity for older installations that do not have it yet. */
+/** Optional per-message rendering controls. `username` / `icon_url` require Slack's
+ *  `chat:write.customize` scope; {@link SlackConnection} transparently falls back to
+ *  the app identity for older installations that do not have it yet. Stable AgentConnect
+ *  authorship travels separately in message metadata. */
 export interface SlackPostOptions {
   username?: string
   /** Public https image URL for the message avatar (the agent's icon). */
@@ -62,6 +63,19 @@ export interface SlackStatusOptions {
 /** Slack message `metadata.event_type` marking a message as daemon chrome (see
  *  `SlackPostOptions.chrome`). Exported so the backfill can recognize it. */
 export const SLACK_CHROME_EVENT_TYPE = 'agentconnect_chrome'
+
+function slackMessageMetadata(options?: Pick<SlackPostOptions, 'agentAuthorId' | 'chrome'>) {
+  const agentAuthorId = options?.agentAuthorId?.trim()
+  if (agentAuthorId) {
+    return {
+      metadata: {
+        event_type: 'agentconnect_thread_event',
+        event_payload: { author_agent_id: agentAuthorId }
+      }
+    }
+  }
+  return options?.chrome ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } } : {}
+}
 
 /** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. Keep this
  * local fallback for hand-authored direct integrations; CP-pushed shared specs
@@ -797,7 +811,6 @@ export class SlackConnection {
     return this.queue.enqueue(async () => {
       const body = markdownBlock(text)
       const trailing = options?.trailingBlocks
-      const agentAuthorId = options?.agentAuthorId?.trim()
       const res = await this.postChatMessage(
         channel,
         threadTs,
@@ -807,16 +820,7 @@ export class SlackConnection {
           ...body,
           // A conversational agent message carries its author id; chrome carries a distinct
           // marker so a peer daemon's backfill can skip it. The two are mutually exclusive.
-          ...(agentAuthorId
-            ? {
-                metadata: {
-                  event_type: 'agentconnect_thread_event',
-                  event_payload: { author_agent_id: agentAuthorId }
-                }
-              }
-            : options?.chrome
-              ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } }
-              : {}),
+          ...slackMessageMetadata(options),
           ...(trailing?.length
             ? {
                 blocks: [...body.blocks, ...trailing],
@@ -833,16 +837,22 @@ export class SlackConnection {
 
   /** Edit a previously-posted message in place (chat.update) — the §9.1 "in-place update"
    *  primitive for the main progress / plan message. Best-effort: swallows errors.
-   *  `chrome` re-stamps the chrome metadata: chat.update drops metadata that isn't
-   *  re-supplied, so a chrome message updated in place would otherwise lose its marker. */
-  async updateMessage(channel: string, ts: string, text: string, chrome = false): Promise<void> {
+   *  `chrome` / `agentAuthorId` re-stamp metadata: chat.update drops metadata that isn't
+   *  re-supplied, so an updated row would otherwise lose its transcript identity. */
+  async updateMessage(
+    channel: string,
+    ts: string,
+    text: string,
+    chrome = false,
+    agentAuthorId?: string
+  ): Promise<void> {
     await this.queue.enqueue(async () => {
       try {
         await this.app.client.chat.update({
           channel,
           ts,
           ...markdownBlock(text),
-          ...(chrome ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } } : {})
+          ...slackMessageMetadata({ chrome, agentAuthorId })
         })
       } catch (err) {
         this.deps.log?.debug(`slack: chat.update failed (ch=${channel} ts=${ts}): ${(err as Error).message}`)
@@ -873,7 +883,7 @@ export class SlackConnection {
           unfurl_links: false,
           unfurl_media: false,
           // Block Kit chrome (status bar, cards) — mark it so the backfill skips it.
-          ...(options?.chrome ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } } : {})
+          ...slackMessageMetadata(options)
         },
         options
       )
@@ -884,7 +894,14 @@ export class SlackConnection {
   /** Edit a previously-posted Block Kit message in place (chat.update). Best-effort;
    *  returns false after logging so footer migration can retry a failed cleanup. `text`
    *  is optional so callers can preserve the original notification fallback. */
-  async updateBlocks(channel: string, ts: string, blocks: unknown[], text?: string, chrome = false): Promise<boolean> {
+  async updateBlocks(
+    channel: string,
+    ts: string,
+    blocks: unknown[],
+    text?: string,
+    chrome = false,
+    agentAuthorId?: string
+  ): Promise<boolean> {
     try {
       return await this.queue.enqueue(async () => {
         await this.app.client.chat.update({
@@ -894,7 +911,7 @@ export class SlackConnection {
           blocks,
           unfurl_links: false,
           unfurl_media: false,
-          ...(chrome ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } } : {})
+          ...slackMessageMetadata({ chrome, agentAuthorId })
         })
         return true
       })

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -174,6 +174,9 @@ export interface TranscriptEntry {
   // prompt replay still compares the original platform `ts`.
   ts: string
   sender: string
+  /** True only when the daemon verified that this Slack history row came from an
+   *  AgentConnect-managed bot identity. Legacy rows and all other platforms omit it. */
+  trustedAgentBot?: boolean
   kind: TranscriptKind
   text: string
   /** Bounded inline webchat images. Persisted daemon-side; never provider-backed files. */
@@ -501,7 +504,7 @@ export class LocalStore {
         channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT,
         sender TEXT NOT NULL, kind TEXT NOT NULL, text TEXT NOT NULL,
         tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER,
-        attachmentsJson TEXT, revision INTEGER NOT NULL DEFAULT 0
+        attachmentsJson TEXT, trustedAgentBot INTEGER, revision INTEGER NOT NULL DEFAULT 0
       );
       CREATE INDEX IF NOT EXISTS transcript_thread_seq ON transcript (channel, thread, seq);
       -- Dedup conversational rows by platform ts (double-fired inbound / redelivery);
@@ -716,6 +719,7 @@ export class LocalStore {
     this.migrateTranscriptToolBody()
     this.migrateTranscriptAttachments()
     this.migrateTranscriptRecipient()
+    this.migrateTranscriptTrustedAgentBot()
     this.migrateTranscriptEventTime()
     this.migrateTranscriptRevision()
     this.migrateInboxHookContext()
@@ -746,6 +750,14 @@ export class LocalStore {
   private migrateTranscriptRecipient(): void {
     const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
     if (!cols.some((c) => c.name === 'recipient')) this.db.exec('ALTER TABLE transcript ADD COLUMN recipient TEXT')
+  }
+
+  /** Preserve only daemon-verified Slack bot provenance. Existing rows remain NULL so
+   *  readers fail closed instead of inferring trust from a provider-shaped sender id. */
+  private migrateTranscriptTrustedAgentBot(): void {
+    const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
+    if (!cols.some((c) => c.name === 'trustedAgentBot'))
+      this.db.exec('ALTER TABLE transcript ADD COLUMN trustedAgentBot INTEGER')
   }
 
   /**
@@ -2142,23 +2154,37 @@ export class LocalStore {
   }
 
   appendTranscript(e: TranscriptEntry): void {
-    const { attachments, ...entry } = e
+    const { attachments, trustedAgentBot, ...entry } = e
     const revision = this.transcriptRevision + 1
     const inserted = this.db
       .prepare(
         `INSERT OR IGNORE INTO transcript
-           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, revision)
+           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, trustedAgentBot, revision)
          VALUES
-           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @revision)`
+           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @trustedAgentBot, @revision)`
       )
       .run({
         ...entry,
         recipient: e.recipient ?? null,
         eventTimeUs: transcriptEventTimeUs(e.ts),
         attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
+        trustedAgentBot: trustedAgentBot ? 1 : null,
         revision
       } as unknown as SqlParams)
     if (Number(inserted.changes) === 1) this.transcriptRevision = revision
+    // A row may predate this column and later be re-observed in an authoritative Slack
+    // snapshot. Upgrade only toward trusted=true; an untrusted replay can never clear or
+    // manufacture provenance, and the stable text-row coordinates keep this scoped.
+    const provenanceUpgraded =
+      Number(inserted.changes) === 0 && trustedAgentBot
+        ? this.db
+            .prepare(
+              `UPDATE transcript SET trustedAgentBot = 1
+               WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'
+                 AND COALESCE(trustedAgentBot, 0) = 0`
+            )
+            .run(e.channel, e.thread, e.ts)
+        : undefined
     // Record the delivery separately so it survives the text-row dedup above: if this same
     // (channel, thread, ts) was already recorded by another agent, the INSERT OR IGNORE
     // dropped this row and its `recipient`, but the message WAS delivered to this agent too.
@@ -2171,13 +2197,13 @@ export class LocalStore {
 
     if (Number(inserted.changes) === 1) {
       this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], revision)
-    } else if (e.recipient && Number(delivered?.changes ?? 0) === 1) {
+    } else if (Number(provenanceUpgraded?.changes ?? 0) === 1 || Number(delivered?.changes ?? 0) === 1) {
       const deliveryRevision = this.transcriptRevision + 1
       this.db
         .prepare("UPDATE transcript SET revision = ? WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'")
         .run(deliveryRevision, e.channel, e.thread, e.ts)
       this.transcriptRevision = deliveryRevision
-      this.notifyTranscriptMutation(e.channel, e.thread, [e.recipient], deliveryRevision)
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], deliveryRevision)
     }
   }
 

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -305,9 +305,9 @@ export class TelegramConnection {
     threadTs?: string,
     // `replyTo` (a message id) anchors the post as a reply. The cross-platform
     // MessageGateway contract passes a sender-identity object in this 4th slot, which
-    // Telegram can't honor (no per-message identity) — so `username`/`icon_url` are
-    // accepted for structural compatibility and ignored.
-    opts?: { replyTo?: number; username?: string; icon_url?: string }
+    // Telegram can't honor (no per-message identity) — so those fields are accepted
+    // for structural compatibility and ignored.
+    opts?: { replyTo?: number; username?: string; icon_url?: string; agentAuthorId?: string }
   ): Promise<string | undefined> {
     const replyTo = opts?.replyTo
     const thread = threadTs != null && /^\d+$/.test(threadTs) ? Number(threadTs) : undefined

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -262,6 +262,7 @@ describe('SlackConnection.getThreadReplies', () => {
       messages: [
         {
           ts: '100.3',
+          user: 'USHARED',
           bot_id: 'BSHARED',
           app_id: 'AAGENTCONNECT',
           text: '@agent-a → @agent-b: review this',

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -968,6 +968,24 @@ describe('SlackConnection.updateBlocks', () => {
     ])
   })
 
+  it('re-stamps stable agent authorship when an agent reply is edited', async () => {
+    const calls: any[] = []
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () => withUpdate(async (payload) => void calls.push(payload)) as any
+    )
+    const blocks = [{ type: 'markdown', text: 'updated answer' }]
+
+    await expect(conn.updateBlocks('C1', '123.45', blocks, 'updated answer', false, 'agent-a')).resolves.toBe(true)
+
+    expect(calls[0]).toMatchObject({
+      metadata: {
+        event_type: 'agentconnect_thread_event',
+        event_payload: { author_agent_id: 'agent-a' }
+      }
+    })
+  })
+
   it('returns false when the best-effort update fails so callers can retry cleanup', async () => {
     const conn = new SlackConnection(
       { ...deps(), sendIntervalMs: 0 } as any,

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -263,6 +263,7 @@ describe('SlackConnection.getThreadReplies', () => {
         {
           ts: '100.3',
           bot_id: 'BSHARED',
+          app_id: 'AAGENTCONNECT',
           text: '@agent-a → @agent-b: review this',
           metadata: {
             event_type: 'agentconnect_thread_event',
@@ -287,7 +288,12 @@ describe('SlackConnection.getThreadReplies', () => {
     )
 
     await expect(conn.getThreadReplies('C1', '100.1')).resolves.toEqual([
-      expect.objectContaining({ sender: 'BSHARED', agentAuthorId: 'agent-a', isBot: true })
+      expect.objectContaining({
+        sender: 'BSHARED',
+        agentAuthorId: 'agent-a',
+        appId: 'AAGENTCONNECT',
+        isBot: true
+      })
     ])
   })
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1062,6 +1062,42 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('backfill ignores AgentConnect metadata from an unrelated Slack app', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any })
+    await daemon.start()
+    const conn = makeRoutable(daemon) as any
+    conn.botUserId = 'UOWN'
+    conn.botId = 'BOWN'
+    conn.getThreadReplies = vi.fn(async () => [
+      {
+        sender: 'BOTHER',
+        agentAuthorId: 'bot-a',
+        appId: 'AOTHER',
+        ts: '100.2',
+        text: 'unrelated app payload',
+        isBot: true,
+        chrome: false,
+        attachments: []
+      },
+      {
+        sender: 'BOTHER',
+        appId: 'AOTHER',
+        ts: '100.3',
+        text: 'unrelated chrome marker',
+        isBot: true,
+        chrome: true,
+        attachments: []
+      }
+    ])
+
+    await expect((daemon as any).fetchThreadHistory('bot-a', 'C1', 'T1')).resolves.toEqual([
+      { sender: 'BOTHER', ts: '100.2', text: 'unrelated app payload' },
+      { sender: 'BOTHER', ts: '100.3', text: 'unrelated chrome marker' }
+    ])
+
+    await daemon.stop()
+  }, 15_000)
+
   it('records an unrouted message while a long turn is in flight even if the session looks idle-stale', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
@@ -1591,7 +1627,7 @@ describe('Slack interactive status bar', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
-    ;(conn as any).botUserId = 'BOT-A'
+    ;(conn as any).botId = 'B-X'
     ;(conn as any).getThreadReplies = vi.fn(async () => [
       { sender: 'U1', ts: '1.1', text: 'human msg', isBot: false, chrome: false, attachments: [] },
       {

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1027,7 +1027,7 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
     const out = await (daemon as any).fetchThreadHistory('bot-a', 'C1', 'T1')
     expect(out).toEqual([
       { sender: 'U2', ts: '100.1', text: 'human asks' },
-      { sender: 'bot-a', ts: '100.2', text: 'bot replied' }, // own bot frame → agentId
+      { sender: 'bot-a', ts: '100.2', text: 'bot replied', trustedAgentBot: true }, // own bot frame → agentId
       { sender: 'U2', ts: '100.3', text: '[attached: shot.png (image/png)]' } // mention synthesized
     ])
 
@@ -1055,7 +1055,8 @@ describe('Daemon transcript recording (§8.5 unrouted)', () => {
       {
         sender: 'remote-agent-a',
         ts: '100.2',
-        text: '@remote-agent-a → @bot-a: review this'
+        text: '@remote-agent-a → @bot-a: review this',
+        trustedAgentBot: true
       }
     ])
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -1174,7 +1174,7 @@ describe('Daemon rd/msg hook fires', () => {
       'C-alerts',
       '🪝 Webhook delivery d-1',
       undefined,
-      { username: AGENT_ID }
+      { username: AGENT_ID, agentAuthorId: AGENT_ID }
     ])
     const replyCall = conn.postMessage.mock.calls[1] as unknown[] | undefined
     expect(replyCall?.[2]).toBe('ts-1') // threaded under the anchor

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -222,7 +222,8 @@ describe('Daemon session lifecycle (#118)', () => {
 
     expect(postMessage).toHaveBeenCalledWith('C1', '⏰ scheduled', undefined, {
       username: 'Review Bot',
-      icon_url: 'https://console.example.test/icons/review-bot'
+      icon_url: 'https://console.example.test/icons/review-bot',
+      agentAuthorId: 'bot-a'
     })
     const key = sessionKey('slack', 'C1', '100.100000', 'bot-a', TRANSPORT_SCOPE)
     expect((daemon as any).store.getSession(key)?.lastDeliveredTs).toBe('100.100000')

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -750,6 +750,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       expect(answerCall?.[3]).toMatchObject({
         username: 'Release Captain',
         icon_url: 'https://console.example.test/icons/bot-a',
+        agentAuthorId: 'bot-a',
         trailingBlocks: [
           {
             type: 'context',

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -218,9 +218,10 @@ describe('Daemon transcript records the agent reply', () => {
 
     expect(conn.postMessage).toHaveBeenCalledWith('C1', 'the answer', 'T1', {
       username: 'Repo Bot',
+      agentAuthorId: 'bot-a',
       trailingBlocks: [classicFooter('bot-a', 'Claude Code', 'claude-sonnet-4-5')]
     })
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', 'reply-1', expect.any(Array))
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === 'reply-1')).toBe(false)
     // Only the reply, never the footer chrome, is in the transcript.
     const botRows = transcript(daemon).filter((r) => r.sender === 'bot-a')
     expect(botRows.map((r) => r.text)).toEqual(['the answer'])
@@ -245,6 +246,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     expect(conn.postMessage).toHaveBeenCalledWith('C1', 'the answer', 'T1', {
       username: 'bot-a',
+      agentAuthorId: 'bot-a',
       trailingBlocks: [classicFooter('bot-a', 'claude', 'model-after-prompt')]
     })
     await daemon.stop()
@@ -283,6 +285,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     expect(conn.postMessage).toHaveBeenCalledWith('C1', 'early answer', 'T1', {
       username: 'bot-a',
+      agentAuthorId: 'bot-a',
       trailingBlocks: [classicFooter('bot-a', 'claude', 'model-before-prompt')]
     })
     const linkedReplyUpdates = conn.updateBlocks.mock.calls.filter(
@@ -303,9 +306,10 @@ describe('Daemon transcript records the agent reply', () => {
     // The live reply is born with the footer instead of flashing body-only until finalization.
     expect(conn.postMessage).toHaveBeenCalledWith('C1', 'here is my answer', 'T1', {
       username: 'bot-a',
+      agentAuthorId: 'bot-a',
       trailingBlocks: [classicFooter()]
     })
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', 'reply-1', expect.any(Array))
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === 'reply-1')).toBe(false)
     const separateFooter = conn.postBlocks.mock.calls.find((c) => JSON.stringify(c).includes('open in session'))
     expect(separateFooter).toBeUndefined()
     await daemon.stop()
@@ -327,13 +331,15 @@ describe('Daemon transcript records the agent reply', () => {
     expect(postOptions.every((options) => JSON.stringify(options?.trailingBlocks).includes('open in session'))).toBe(
       true
     )
-    expect(conn.updateBlocks).toHaveBeenCalledWith('C1', 'reply-1', [{ type: 'markdown', text: replyPosts[0] }])
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith(
+    expect(conn.updateBlocks).toHaveBeenCalledWith(
       'C1',
-      `reply-${replyPosts.length}`,
-      expect.any(Array),
-      replyPosts.at(-1)
+      'reply-1',
+      [{ type: 'markdown', text: replyPosts[0] }],
+      undefined,
+      false,
+      'bot-a'
     )
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === `reply-${replyPosts.length}`)).toBe(false)
     expect(
       transcript(daemon)
         .filter((row) => row.sender === 'bot-a')
@@ -355,6 +361,7 @@ describe('Daemon transcript records the agent reply', () => {
         await vi.waitFor(() =>
           expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('first part'), 'T1', {
             username: 'bot-a',
+            agentAuthorId: 'bot-a',
             trailingBlocks: [classicFooter()]
           })
         )
@@ -369,6 +376,7 @@ describe('Daemon transcript records the agent reply', () => {
         await vi.waitFor(() =>
           expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('second part'), 'T1', {
             username: 'bot-a',
+            agentAuthorId: 'bot-a',
             trailingBlocks: [classicFooter()]
           })
         )
@@ -394,7 +402,14 @@ describe('Daemon transcript records the agent reply', () => {
     const posts = conn.postMessage.mock.calls.map((c) => String(c[1]))
     expect(posts.some((t) => t.includes('first part'))).toBe(true)
     expect(posts.some((t) => t.includes('second part'))).toBe(true)
-    expect(conn.updateBlocks).toHaveBeenCalledWith('C1', 'reply-1', [{ type: 'markdown', text: 'first part' }])
+    expect(conn.updateBlocks).toHaveBeenCalledWith(
+      'C1',
+      'reply-1',
+      [{ type: 'markdown', text: 'first part' }],
+      undefined,
+      false,
+      'bot-a'
+    )
     // reply-1 (above the card) is never edited to show the post-card segment.
     expect((conn as any).updateMessage).not.toHaveBeenCalledWith(
       'C1',
@@ -450,8 +465,15 @@ describe('Daemon transcript records the agent reply', () => {
       [classicFooter()],
       [classicFooter()]
     ])
-    expect(conn.updateBlocks).toHaveBeenCalledWith('C1', 'reply-1', [{ type: 'markdown', text: 'first section' }])
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', 'reply-2', expect.any(Array))
+    expect(conn.updateBlocks).toHaveBeenCalledWith(
+      'C1',
+      'reply-1',
+      [{ type: 'markdown', text: 'first section' }],
+      undefined,
+      false,
+      'bot-a'
+    )
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === 'reply-2')).toBe(false)
     await daemon.stop()
   }, 15_000)
 
@@ -465,8 +487,8 @@ describe('Daemon transcript records the agent reply', () => {
     await (daemon as any).dispatch('bot-a', dm('100', 'q'), 'int-a')
 
     expect(conn.updateBlocks.mock.calls.filter((call) => call[1] === 'reply-1')).toEqual([
-      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }]],
-      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }]]
+      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }], undefined, false, 'bot-a'],
+      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }], undefined, false, 'bot-a']
     ])
     await daemon.stop()
   }, 15_000)
@@ -481,7 +503,7 @@ describe('Daemon transcript records the agent reply', () => {
     await (daemon as any).dispatch('bot-a', dm('100', 'q'), 'int-a')
 
     expect(conn.postMessage.mock.calls.map((call) => call[1])).toEqual(['first section', 'last section'])
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', 'reply-1', [{ type: 'markdown', text: 'first section' }])
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === 'reply-1')).toBe(false)
     await daemon.stop()
   }, 15_000)
 
@@ -553,8 +575,8 @@ describe('Daemon transcript records the agent reply', () => {
     await expect((daemon as any).dispatch('bot-a', dm('100', 'q'), 'int-a')).rejects.toThrow('runtime exploded')
 
     expect(conn.updateBlocks.mock.calls.filter((call) => call[1] === 'reply-1')).toEqual([
-      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }]],
-      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }]]
+      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }], undefined, false, 'bot-a'],
+      ['C1', 'reply-1', [{ type: 'markdown', text: 'first section' }], undefined, false, 'bot-a']
     ])
     await daemon.stop()
   }, 15_000)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -107,6 +107,18 @@ describe('LocalStore', () => {
       ['text', 'old one'],
       ['text', 'old two']
     ])
+    // A later authoritative Slack snapshot can safely upgrade a pre-column row in
+    // place; absent provenance remains fail-closed until it is re-observed.
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T',
+      ts: '100.1',
+      sender: 'U1',
+      trustedAgentBot: true,
+      kind: 'text',
+      text: 'old one'
+    })
+    expect(s.threadTranscript('C1', 'T').find((row) => row.ts === '100.1')?.trustedAgentBot).toBeTruthy()
     // …and the new kind column is usable afterward.
     s.appendTranscript({ channel: 'C1', thread: 'T', ts: '100.3', sender: 'bot', kind: 'tool', text: 'Edit y' })
     expect(s.transcriptSince('C1', 'T', null).map((e) => e.text)).toEqual(['old one', 'old two'])

--- a/packages/daemon/test/mcp-bridge-e2e.test.ts
+++ b/packages/daemon/test/mcp-bridge-e2e.test.ts
@@ -116,7 +116,7 @@ describe('mcp-bridge end-to-end (real stdio MCP handshake)', () => {
     const out = await client.callTool({ name: 'sendMessage', arguments: { to: { channel: 'C9' }, message: 'e2e hi' } })
     expect(out.isError).toBeFalsy()
     // No `thread` ⇒ post to the channel ROOT (undefined), not the current thread.
-    expect(gw.postMessage).toHaveBeenCalledWith('C9', 'e2e hi', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C9', 'e2e hi', undefined, { agentAuthorId: 'bot-a' })
     expect(recorded).toEqual([{ channel: 'C9', text: 'e2e hi', ts: 'ts-42' }])
   }, 20_000)
 

--- a/packages/daemon/test/mcp-control-server.test.ts
+++ b/packages/daemon/test/mcp-control-server.test.ts
@@ -107,7 +107,7 @@ describe('McpControlServer IPC', () => {
     expect(res.ok).toBe(true)
     // A deliberate sendMessage with no `thread` posts to the channel ROOT (undefined), not the
     // current thread — "reply here" is the agent's normal turn output.
-    expect(gw.postMessage).toHaveBeenCalledWith('C1', 'hello', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C1', 'hello', undefined, { agentAuthorId: 'bot-a' })
     expect(recorded).toEqual([{ channel: 'C1', text: 'hello', ts: 'ts-9' }])
   })
 

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -23,6 +23,7 @@ const ctx: SessionContext = {
   ]),
   integrations: [{ id: 'int-1', platform: 'slack' }]
 }
+const authorIdentity = { agentAuthorId: 'bot-a' }
 
 function fakeGateway(over: Partial<MessageGateway> = {}): MessageGateway {
   return {
@@ -147,7 +148,7 @@ describe('executeTool: sendMessage (channel post)', () => {
       unknown
     >
 
-    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined, authorIdentity)
     expect(res).toMatchObject({
       ok: true,
       post: { platform: 'slack', channel: 'C_CURRENT', thread: null, ts: 'ts-123' }
@@ -161,14 +162,14 @@ describe('executeTool: sendMessage (channel post)', () => {
     const gw = fakeGateway()
     const { deps: d } = deps(gw)
     await executeTool(ctx, 'sendMessage', { to: { channel: 'C_CURRENT', thread: '111.1' }, message: 'hi' }, d)
-    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', '111.1')
+    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', '111.1', authorIdentity)
   })
 
   it('honors an explicit channel and an empty thread (post to channel root)', async () => {
     const gw = fakeGateway()
     const { deps: d } = deps(gw)
     await executeTool(ctx, 'sendMessage', { to: { channel: 'C_OTHER', thread: '' }, message: 'yo' }, d)
-    expect(gw.postMessage).toHaveBeenCalledWith('C_OTHER', 'yo', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_OTHER', 'yo', undefined, authorIdentity)
   })
 
   describe('root post: one canonical thread key for every consumer', () => {
@@ -436,7 +437,7 @@ describe('executeTool: sendMessage (channel post)', () => {
       { to: { platform: 'telegram', channel: '-100123' }, message: 'hi' },
       d
     )) as { post: Record<string, unknown> }
-    expect(gw.postMessage).toHaveBeenCalledWith('-100123', 'hi', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('-100123', 'hi', undefined, authorIdentity)
     expect(res.post).toMatchObject({ platform: 'telegram', integrationId: 'int-tg', channel: '-100123' })
     // Pre-fix this row carried the CALLER's Slack thread under a Telegram channel — coords that
     // belong to no session, and a trap for the reply-owner lookup. It now keys the post's own.
@@ -470,7 +471,7 @@ describe('executeTool: sendMessage (channel post)', () => {
     const res = (await executeTool(multi, 'sendMessage', { to: { channel: 'C_CURRENT' }, message: 'hi' }, d)) as {
       post: Record<string, unknown>
     }
-    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined, authorIdentity)
     expect(res.post).toMatchObject({ integrationId: 'int-b', channel: 'C_CURRENT' })
   })
 
@@ -481,25 +482,26 @@ describe('executeTool: sendMessage (channel post)', () => {
     await executeTool(withIdentity, 'sendMessage', { to: { channel: 'C_CURRENT' }, message: 'hi' }, d)
     expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined, {
       username: 'Bot A',
-      icon_url: 'https://x/y.png'
+      icon_url: 'https://x/y.png',
+      agentAuthorId: 'bot-a'
     })
   })
 
-  it('omits identity (plain 3-arg postMessage) when the session carries none', async () => {
+  it('stamps the stable author id when the session has no visual identity', async () => {
     const gw = fakeGateway()
     const { deps: d } = deps(gw)
     await executeTool(ctx, 'sendMessage', { to: { channel: 'C_CURRENT' }, message: 'hi' }, d)
-    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', 'hi', undefined, authorIdentity)
   })
 
   it('toUser @-mentions a human on Slack (prepends <@id>), and rejects toUser off Slack', async () => {
     const gw = fakeGateway()
     const { deps: d, recorded } = deps(gw)
     await executeTool(ctx, 'sendMessage', { to: { channel: 'C_CURRENT', toUser: 'U9' }, message: 'ping' }, d)
-    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', '<@U9> ping', undefined)
+    expect(gw.postMessage).toHaveBeenCalledWith('C_CURRENT', '<@U9> ping', undefined, authorIdentity)
     // An already-wrapped mention is left as-is.
     await executeTool(ctx, 'sendMessage', { to: { channel: 'C_CURRENT', toUser: '<@U9>' }, message: 'again' }, d)
-    expect(gw.postMessage).toHaveBeenLastCalledWith('C_CURRENT', '<@U9> again', undefined)
+    expect(gw.postMessage).toHaveBeenLastCalledWith('C_CURRENT', '<@U9> again', undefined, authorIdentity)
     expect(recorded).toEqual([
       { channel: 'C_CURRENT', thread: 'ts-123', text: '<@U9> ping', ts: 'ts-123' },
       { channel: 'C_CURRENT', thread: 'ts-123', text: '<@U9> again', ts: 'ts-123' }
@@ -820,8 +822,8 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     }
     expect(res.ok).toBe(true)
     expect(res.wake).toBeDefined()
-    // Visible root post through the gateway (no identity on this ctx → 3-arg call).
-    expect(gw.postMessage).toHaveBeenCalledWith('C_X', 'over to you', undefined)
+    // Visible root post through the gateway, stamped with the calling agent's stable id.
+    expect(gw.postMessage).toHaveBeenCalledWith('C_X', 'over to you', undefined, authorIdentity)
     expect(res.post).toEqual({ platform: 'slack', integrationId: 'int-1', channel: 'C_X', thread: null, ts: 'ts-123' })
     expect(recorded).toEqual([{ channel: 'C_X', thread: 'ts-123', text: 'over to you', ts: 'ts-123' }])
     // The peer is woken INTO the post's ts, and the post ts is carried through as the wake's
@@ -837,7 +839,7 @@ describe('executeTool: sendMessage (wake / reply)', () => {
       { to: { toAgent: 'peer-1', channel: 'C_X', thread: '222.2' }, message: 'ping' },
       d
     )
-    expect(gw.postMessage).toHaveBeenCalledWith('C_X', 'ping', '222.2')
+    expect(gw.postMessage).toHaveBeenCalledWith('C_X', 'ping', '222.2', authorIdentity)
     // Thread reused; transcriptTs = the post's real ts (dedups against the recorded post row).
     expect(calls[0]).toMatchObject({ toAgentId: 'peer-1', channel: 'C_X', thread: '222.2', transcriptTs: 'ts-123' })
   })

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -318,6 +318,26 @@ describe('SessionReader', () => {
     s.close()
   })
 
+  it('carries daemon-verified Slack bot provenance to the session DTO', () => {
+    const s = store()
+    seedHistorySession(s)
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T1',
+      ts: '1',
+      sender: 'UAPPBOT',
+      trustedAgentBot: true,
+      recipient: AGENT,
+      kind: 'text',
+      text: 'legacy agent reply'
+    })
+
+    expect(createSessionReader(s).history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 }).messages).toEqual([
+      expect.objectContaining({ sender: 'UAPPBOT', trustedAgentBot: true })
+    ])
+    s.close()
+  })
+
   it('binds session and tool-body reads to the authorized agent in a shared thread', () => {
     const s = store()
     seedHistorySession(s)

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -775,6 +775,7 @@ describe('session read-back frames (console history pull)', () => {
           {
             seq: 1,
             sender: '@dana',
+            trustedAgentBot: true,
             ts: '1718000000.000100',
             kind: 'text',
             text: 'ship it',
@@ -789,6 +790,7 @@ describe('session read-back frames (console history pull)', () => {
     expect(page.ok).toBe(true)
     if (!page.ok || !isFrame('session/history/page')(page.frame)) throw new Error('expected page')
     expect(page.frame.payload.messages[0]!.text).toBe('ship it')
+    expect(page.frame.payload.messages[0]!.trustedAgentBot).toBe(true)
     expect(page.frame.payload.messages[0]!.attachments?.[0]?.name).toBe('screen.webp')
     expect(page.frame.payload.nextCursor).toBe('c-50')
     expect(page.frame.payload.liveCursor).toBe('42')

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -100,6 +100,9 @@ export const SessionMessage = z.object({
   seq: z.number().int(), // daemon-local insertion order within the session
   sender: z.string(), // platform handle/id of the author
   senderName: z.string().optional(), // display name (daemon-resolved; absent if unknown)
+  // Daemon-verified AgentConnect Slack app/bot provenance. Optional for rolling
+  // compatibility and absent on legacy rows or every non-Slack transport.
+  trustedAgentBot: z.boolean().optional(),
   ts: z.string(), // platform timestamp (daemon-local string form)
   kind: z.string(), // "text" / tool / … (daemon transcript kind)
   text: z.string(),

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -775,13 +775,14 @@ export default function SessionDetailView() {
     return pictures
   }, [members])
   const attributedAgentIdBySender = useMemo(
-    () => sessionAttributionAgentAuthors(msgs ?? [], agentById),
-    [msgs, agentById]
+    () => sessionAttributionAgentAuthors(session?.platform ?? '', msgs ?? [], agentById),
+    [session?.platform, msgs, agentById]
   )
   const participantAgent = (sender: string, text: string): Agent | undefined => {
     const id = agentById.has(sender)
       ? sender
-      : (sessionAttributionAgentId(text, agentById) ?? attributedAgentIdBySender.get(sender))
+      : (sessionAttributionAgentId(session?.platform ?? '', sender, text, agentById) ??
+        attributedAgentIdBySender.get(sender))
     return id ? agentById.get(id) : undefined
   }
   // The viewer's own webchat messages render as "You" (like the live playground) instead

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -53,7 +53,7 @@ import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptTime, parseTranscriptTime } from '@/lib/transcript-time'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
-import { sessionSenderLabel } from '@/lib/session-trigger'
+import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
 import { mergeSessionMessages } from '@/lib/session-transcript'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
@@ -496,6 +496,8 @@ type Turn =
   | {
       kind: 'user'
       sp: ReturnType<typeof speaker>
+      agent: Agent | null
+      avatarUrl?: string | null
       sourceLabel: string
       time: string
       text: string
@@ -504,6 +506,40 @@ type Turn =
       cronId: string | null
     }
   | { kind: 'bot'; agentName: string; model: string; time: string; steps: FmtStep[] }
+
+function ParticipantAvatar({
+  agent,
+  avatarUrl,
+  sp,
+  isCron
+}: {
+  agent: Agent | null
+  avatarUrl?: string | null
+  sp: ReturnType<typeof speaker>
+  isCron: boolean
+}) {
+  return (
+    <span
+      className="av flex h-[26px] w-[26px] flex-none items-center justify-center overflow-hidden rounded-md font-sans text-[9.5px] font-semibold leading-normal"
+      title={sp.name}
+    >
+      {agent ? (
+        <AgentIconView icon={agent.icon} runtime={agent.runtime} size={26} />
+      ) : avatarUrl ? (
+        <img src={avatarUrl} alt="" className="object-cover" style={{ width: '100%', height: '100%' }} />
+      ) : isCron ? (
+        <Icon name="calendar-clock" size={14} color="var(--text-secondary)" />
+      ) : (
+        <span
+          className="flex h-full w-full items-center justify-center rounded-[inherit]"
+          style={{ background: sp.avBg, color: sp.avText }}
+        >
+          {sp.initials || '?'}
+        </span>
+      )}
+    </span>
+  )
+}
 
 function SessionRelationLink({
   relation,
@@ -729,6 +765,25 @@ export default function SessionDetailView() {
     }
     return names
   }, [members])
+  const memberPictureByIdentity = useMemo(() => {
+    const pictures = new Map<string, string>()
+    for (const member of members) {
+      if (!member.picture) continue
+      pictures.set(member.userId, member.picture)
+      if (member.email) pictures.set(member.email, member.picture)
+    }
+    return pictures
+  }, [members])
+  const attributedAgentIdBySender = useMemo(
+    () => sessionAttributionAgentAuthors(msgs ?? [], agentById),
+    [msgs, agentById]
+  )
+  const participantAgent = (sender: string, text: string): Agent | undefined => {
+    const id = agentById.has(sender)
+      ? sender
+      : (sessionAttributionAgentId(text, agentById) ?? attributedAgentIdBySender.get(sender))
+    return id ? agentById.get(id) : undefined
+  }
   // The viewer's own webchat messages render as "You" (like the live playground) instead
   // of a raw id — see isSelfSender. Webchat-only: Slack senders never match /me.
   const isSelf = (sender?: string | null): boolean => isSelfSender(sender, me)
@@ -984,9 +1039,10 @@ export default function SessionDetailView() {
         if (!last.time && step.time) last.time = step.time
       } else {
         // Count participants by stable sender id — two people can share a display name.
-        speakers.add(m.sender)
         const cron = asCron(m.sender)
-        const senderAgentName = agentNameById.get(m.sender)
+        const senderAgent = participantAgent(m.sender, m.text)
+        speakers.add(senderAgent?.id ?? m.sender)
+        const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined
         turns.push({
           kind: 'user',
@@ -996,6 +1052,8 @@ export default function SessionDetailView() {
                 senderAgentName ?? m.sender,
                 cron?.name ?? (cron ? 'Schedule' : senderLabel(m.sender, m.senderName ?? hookFallback))
               ),
+          agent: senderAgent ?? null,
+          avatarUrl: isSelf(m.sender) ? me?.picture : memberPictureByIdentity.get(m.sender),
           sourceLabel: platName(sessionIntegration),
           time: formatTranscriptTime(m.ts),
           text: m.text,
@@ -1010,12 +1068,15 @@ export default function SessionDetailView() {
     session.steps.forEach((stp) => {
       if (stp.kind === 'msg') {
         const who = stp.who ?? session.user
-        speakers.add(who)
         const cron = asCron(who)
-        const senderAgentName = agentNameById.get(who)
+        const senderAgent = participantAgent(who, stp.text)
+        speakers.add(senderAgent?.id ?? who)
+        const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         turns.push({
           kind: 'user',
           sp: speaker(senderAgentName ?? who, cron?.name ?? (cron ? 'Schedule' : senderAgentName)),
+          agent: senderAgent ?? null,
+          avatarUrl: isSelf(who) ? me?.picture : memberPictureByIdentity.get(who),
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? (firstMsg ? session.time : ''),
           text: stp.text,
@@ -1043,11 +1104,14 @@ export default function SessionDetailView() {
     for (const stp of liveSteps) {
       if (stp.kind === 'msg') {
         const who = stp.who ?? session.user
-        speakers.add(who)
-        const senderAgentName = agentNameById.get(who)
+        const senderAgent = participantAgent(who, stp.text)
+        speakers.add(senderAgent?.id ?? who)
+        const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         turns.push({
           kind: 'user',
           sp: speaker(senderAgentName ?? who, senderAgentName),
+          agent: senderAgent ?? null,
+          avatarUrl: isSelf(who) ? me?.picture : memberPictureByIdentity.get(who),
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? '',
           text: stp.text,
@@ -1462,29 +1526,32 @@ export default function SessionDetailView() {
               turn.kind === 'user' ? (
                 // 2b: user turns are right-aligned brand-soft bubbles. A sender label
                 // sits above the bubble only when it isn't you (platform user / cron).
-                <div key={ti} className="flex flex-col items-end gap-[3px]">
-                  {(turn.isCron || turn.sp.handle !== '@you') && (
-                    <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
-                      {turn.isCron && turn.cronId ? (
-                        <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
-                          {turn.sp.name}
-                        </Link>
-                      ) : (
-                        <span>{turn.sp.name}</span>
-                      )}
-                      {turn.time && <span className="mono">{turn.time}</span>}
-                    </span>
-                  )}
-                  <div className="max-w-[86%] rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
-                    {turn.image && (
-                      <img
-                        src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
-                        alt={turn.image.name}
-                        className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
-                      />
+                <div key={ti} className="flex items-start justify-end gap-[9px]">
+                  <div className="flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
+                    {(turn.isCron || turn.sp.handle !== '@you') && (
+                      <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
+                        {turn.isCron && turn.cronId ? (
+                          <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
+                            {turn.sp.name}
+                          </Link>
+                        ) : (
+                          <span>{turn.sp.name}</span>
+                        )}
+                        {turn.time && <span className="mono">{turn.time}</span>}
+                      </span>
                     )}
-                    {turn.text && <MessageText text={turn.text} />}
+                    <div className="max-w-full rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
+                      {turn.image && (
+                        <img
+                          src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                          alt={turn.image.name}
+                          className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
+                        />
+                      )}
+                      {turn.text && <MessageText text={turn.text} />}
+                    </div>
                   </div>
+                  <ParticipantAvatar agent={turn.agent} avatarUrl={turn.avatarUrl} sp={turn.sp} isCron={turn.isCron} />
                 </div>
               ) : (
                 (() => {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -778,10 +778,10 @@ export default function SessionDetailView() {
     () => sessionAttributionAgentAuthors(session?.platform ?? '', msgs ?? [], agentById),
     [session?.platform, msgs, agentById]
   )
-  const participantAgent = (sender: string, text: string): Agent | undefined => {
+  const participantAgent = (sender: string, text: string, trustedAgentBot?: boolean): Agent | undefined => {
     const id = agentById.has(sender)
       ? sender
-      : (sessionAttributionAgentId(session?.platform ?? '', sender, text, agentById) ??
+      : (sessionAttributionAgentId(session?.platform ?? '', { text, trustedAgentBot }, agentById) ??
         attributedAgentIdBySender.get(sender))
     return id ? agentById.get(id) : undefined
   }
@@ -1041,7 +1041,7 @@ export default function SessionDetailView() {
       } else {
         // Count participants by stable sender id — two people can share a display name.
         const cron = asCron(m.sender)
-        const senderAgent = participantAgent(m.sender, m.text)
+        const senderAgent = participantAgent(m.sender, m.text, m.trustedAgentBot)
         speakers.add(senderAgent?.id ?? m.sender)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -395,6 +395,7 @@ export interface SessionMessageDto {
   seq: number
   sender: string
   senderName?: string // daemon-resolved display name; absent if unknown
+  trustedAgentBot?: boolean // daemon-verified AgentConnect Slack bot provenance
   ts: string
   kind: string
   text: string

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -220,22 +220,29 @@ describe('legacy Slack Agent attribution', () => {
     const reviewFooter =
       'done\nsent by <https://test.example.test/team/agents/review-id|review-bot> (Codex) · <https://test.example.test/sessions/1|open in session>'
 
-    expect(sessionAttributionAgentId(reviewFooter, agents)).toBe('review-id')
-    expect(sessionAttributionAgentId('sent by <https://other.test/agents/private-id|private>', agents)).toBeUndefined()
+    expect(sessionAttributionAgentId('slack', 'B0REVIEW', reviewFooter, agents)).toBe('review-id')
+    expect(
+      sessionAttributionAgentId('slack', 'B0REVIEW', 'sent by <https://other.test/agents/private-id|private>', agents)
+    ).toBeUndefined()
+    expect(sessionAttributionAgentId('slack', 'U0HUMAN', reviewFooter, agents)).toBeUndefined()
+    expect(sessionAttributionAgentId('webchat', 'B0REVIEW', reviewFooter, agents)).toBeUndefined()
 
     const authors = sessionAttributionAgentAuthors(
+      'slack',
       [
-        { sender: 'B-REVIEW', text: reviewFooter },
-        { sender: 'B-REVIEW', text: 'an older row without a footer' },
-        { sender: 'B-SHARED', text: reviewFooter },
+        { sender: 'B0REVIEW', text: reviewFooter },
+        { sender: 'B0REVIEW', text: 'an older row without a footer' },
+        { sender: 'B0SHARED', text: reviewFooter },
         {
-          sender: 'B-SHARED',
+          sender: 'B0SHARED',
           text: 'sent by <https://test.example.test/team/agents/test-id|test> (Claude)'
-        }
+        },
+        { sender: 'U0HUMAN', text: reviewFooter }
       ],
       agents
     )
-    expect(authors.get('B-REVIEW')).toBe('review-id')
-    expect(authors.has('B-SHARED')).toBe(false)
+    expect(authors.get('B0REVIEW')).toBe('review-id')
+    expect(authors.has('B0SHARED')).toBe(false)
+    expect(authors.has('U0HUMAN')).toBe(false)
   })
 })

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -220,29 +220,36 @@ describe('legacy Slack Agent attribution', () => {
     const reviewFooter =
       'done\nsent by <https://test.example.test/team/agents/review-id|review-bot> (Codex) · <https://test.example.test/sessions/1|open in session>'
 
-    expect(sessionAttributionAgentId('slack', 'B0REVIEW', reviewFooter, agents)).toBe('review-id')
+    expect(sessionAttributionAgentId('slack', { text: reviewFooter, trustedAgentBot: true }, agents)).toBe('review-id')
     expect(
-      sessionAttributionAgentId('slack', 'B0REVIEW', 'sent by <https://other.test/agents/private-id|private>', agents)
+      sessionAttributionAgentId(
+        'slack',
+        { text: 'sent by <https://other.test/agents/private-id|private>', trustedAgentBot: true },
+        agents
+      )
     ).toBeUndefined()
-    expect(sessionAttributionAgentId('slack', 'U0HUMAN', reviewFooter, agents)).toBeUndefined()
-    expect(sessionAttributionAgentId('webchat', 'B0REVIEW', reviewFooter, agents)).toBeUndefined()
+    expect(sessionAttributionAgentId('slack', { text: reviewFooter }, agents)).toBeUndefined()
+    expect(sessionAttributionAgentId('webchat', { text: reviewFooter, trustedAgentBot: true }, agents)).toBeUndefined()
 
     const authors = sessionAttributionAgentAuthors(
       'slack',
       [
-        { sender: 'B0REVIEW', text: reviewFooter },
+        { sender: 'B0REVIEW', text: reviewFooter, trustedAgentBot: true },
         { sender: 'B0REVIEW', text: 'an older row without a footer' },
-        { sender: 'B0SHARED', text: reviewFooter },
+        { sender: 'U0BOTUSER', text: reviewFooter, trustedAgentBot: true },
+        { sender: 'B0SHARED', text: reviewFooter, trustedAgentBot: true },
         {
           sender: 'B0SHARED',
-          text: 'sent by <https://test.example.test/team/agents/test-id|test> (Claude)'
+          text: 'sent by <https://test.example.test/team/agents/test-id|test> (Claude)',
+          trustedAgentBot: true
         },
-        { sender: 'U0HUMAN', text: reviewFooter }
+        { sender: 'B0UNTRUSTED', text: reviewFooter }
       ],
       agents
     )
     expect(authors.get('B0REVIEW')).toBe('review-id')
+    expect(authors.get('U0BOTUSER')).toBe('review-id')
     expect(authors.has('B0SHARED')).toBe(false)
-    expect(authors.has('U0HUMAN')).toBe(false)
+    expect(authors.has('B0UNTRUSTED')).toBe(false)
   })
 })

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -9,6 +9,8 @@ import {
 import { platName, sessionPlatform } from './data'
 import {
   githubRepoIdFromSessionTriggerFilter,
+  sessionAttributionAgentAuthors,
+  sessionAttributionAgentId,
   sessionSenderLabel,
   sessionTriggerFilterValue,
   sessionTriggerKind
@@ -209,5 +211,31 @@ describe('sessionSenderLabel', () => {
     expect(sessionSenderLabel('agent-id', 'agent-id', agents, members, me)).toBe('Release agent')
     expect(sessionSenderLabel('member-id', 'member-id', agents, members, me)).toBe('Ada')
     expect(sessionSenderLabel('me', 'me', agents, members, me)).toBe('You')
+  })
+})
+
+describe('legacy Slack Agent attribution', () => {
+  it('recovers only visible, unambiguous Agent authors', () => {
+    const agents = new Set(['review-id', 'test-id'])
+    const reviewFooter =
+      'done\nsent by <https://test.example.test/team/agents/review-id|review-bot> (Codex) · <https://test.example.test/sessions/1|open in session>'
+
+    expect(sessionAttributionAgentId(reviewFooter, agents)).toBe('review-id')
+    expect(sessionAttributionAgentId('sent by <https://other.test/agents/private-id|private>', agents)).toBeUndefined()
+
+    const authors = sessionAttributionAgentAuthors(
+      [
+        { sender: 'B-REVIEW', text: reviewFooter },
+        { sender: 'B-REVIEW', text: 'an older row without a footer' },
+        { sender: 'B-SHARED', text: reviewFooter },
+        {
+          sender: 'B-SHARED',
+          text: 'sent by <https://test.example.test/team/agents/test-id|test> (Claude)'
+        }
+      ],
+      agents
+    )
+    expect(authors.get('B-REVIEW')).toBe('review-id')
+    expect(authors.has('B-SHARED')).toBe(false)
   })
 })

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -6,18 +6,17 @@ type IdLookup = { has(id: string): boolean }
 const GITHUB_REPO_TRIGGER_PREFIX = 'github-repo:'
 
 /** Recover the stable author from a pre-metadata Slack bot attribution footer. The
- *  sender is daemon-recorded provider identity: Slack reserves B-prefixed ids for bots,
- *  so human U/W senders and every non-Slack transport are rejected before inspecting
- *  user-controlled text. Only ids visible in the current Agent directory are accepted. */
+ *  daemon sets `trustedAgentBot` only after matching a local bot identity or a
+ *  CP-advertised AgentConnect app id; absent provenance fails closed. Only ids visible
+ *  in the current Agent directory are accepted. */
 export function sessionAttributionAgentId(
   platform: string,
-  sender: string,
-  text: string,
+  message: { text: string; trustedAgentBot?: boolean },
   agentIds: IdLookup
 ): string | undefined {
-  if (platform !== 'slack' || !/^B[A-Z0-9]+$/.test(sender)) return undefined
+  if (platform !== 'slack' || message.trustedAgentBot !== true) return undefined
   const ids = new Set<string>()
-  for (const match of text.matchAll(/(?:^|\n)sent by <https?:\/\/[^<>\s|]+\/agents\/([^/?#|>]+)\|[^>\n]+>/g)) {
+  for (const match of message.text.matchAll(/(?:^|\n)sent by <https?:\/\/[^<>\s|]+\/agents\/([^/?#|>]+)\|[^>\n]+>/g)) {
     try {
       const id = decodeURIComponent(match[1]!)
       if (agentIds.has(id)) ids.add(id)
@@ -33,12 +32,12 @@ export function sessionAttributionAgentId(
  *  deliberately remain unresolved. */
 export function sessionAttributionAgentAuthors(
   platform: string,
-  messages: readonly { sender: string; text: string }[],
+  messages: readonly { sender: string; text: string; trustedAgentBot?: boolean }[],
   agentIds: IdLookup
 ): ReadonlyMap<string, string> {
   const candidates = new Map<string, Set<string>>()
   for (const message of messages) {
-    const id = sessionAttributionAgentId(platform, message.sender, message.text, agentIds)
+    const id = sessionAttributionAgentId(platform, message, agentIds)
     if (!id) continue
     const ids = candidates.get(message.sender) ?? new Set<string>()
     ids.add(id)

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -5,9 +5,17 @@ export type SessionTriggerKind = 'agent' | 'person' | 'github' | 'webhook' | 'sc
 type IdLookup = { has(id: string): boolean }
 const GITHUB_REPO_TRIGGER_PREFIX = 'github-repo:'
 
-/** Recover the stable author from pre-metadata Slack attribution footers. Only ids
- *  that are visible in the current Agent directory are accepted. */
-export function sessionAttributionAgentId(text: string, agentIds: IdLookup): string | undefined {
+/** Recover the stable author from a pre-metadata Slack bot attribution footer. The
+ *  sender is daemon-recorded provider identity: Slack reserves B-prefixed ids for bots,
+ *  so human U/W senders and every non-Slack transport are rejected before inspecting
+ *  user-controlled text. Only ids visible in the current Agent directory are accepted. */
+export function sessionAttributionAgentId(
+  platform: string,
+  sender: string,
+  text: string,
+  agentIds: IdLookup
+): string | undefined {
+  if (platform !== 'slack' || !/^B[A-Z0-9]+$/.test(sender)) return undefined
   const ids = new Set<string>()
   for (const match of text.matchAll(/(?:^|\n)sent by <https?:\/\/[^<>\s|]+\/agents\/([^/?#|>]+)\|[^>\n]+>/g)) {
     try {
@@ -24,12 +32,13 @@ export function sessionAttributionAgentId(text: string, agentIds: IdLookup): str
  *  exactly one attributed Agent elsewhere in this transcript. Shared/ambiguous bot ids
  *  deliberately remain unresolved. */
 export function sessionAttributionAgentAuthors(
+  platform: string,
   messages: readonly { sender: string; text: string }[],
   agentIds: IdLookup
 ): ReadonlyMap<string, string> {
   const candidates = new Map<string, Set<string>>()
   for (const message of messages) {
-    const id = sessionAttributionAgentId(message.text, agentIds)
+    const id = sessionAttributionAgentId(platform, message.sender, message.text, agentIds)
     if (!id) continue
     const ids = candidates.get(message.sender) ?? new Set<string>()
     ids.add(id)

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -5,6 +5,39 @@ export type SessionTriggerKind = 'agent' | 'person' | 'github' | 'webhook' | 'sc
 type IdLookup = { has(id: string): boolean }
 const GITHUB_REPO_TRIGGER_PREFIX = 'github-repo:'
 
+/** Recover the stable author from pre-metadata Slack attribution footers. Only ids
+ *  that are visible in the current Agent directory are accepted. */
+export function sessionAttributionAgentId(text: string, agentIds: IdLookup): string | undefined {
+  const ids = new Set<string>()
+  for (const match of text.matchAll(/(?:^|\n)sent by <https?:\/\/[^<>\s|]+\/agents\/([^/?#|>]+)\|[^>\n]+>/g)) {
+    try {
+      const id = decodeURIComponent(match[1]!)
+      if (agentIds.has(id)) ids.add(id)
+    } catch {
+      // A malformed URL segment is not a trustworthy identity hint.
+    }
+  }
+  return ids.size === 1 ? [...ids][0] : undefined
+}
+
+/** Reconcile older rows without their own footer when the same Slack bot sender has
+ *  exactly one attributed Agent elsewhere in this transcript. Shared/ambiguous bot ids
+ *  deliberately remain unresolved. */
+export function sessionAttributionAgentAuthors(
+  messages: readonly { sender: string; text: string }[],
+  agentIds: IdLookup
+): ReadonlyMap<string, string> {
+  const candidates = new Map<string, Set<string>>()
+  for (const message of messages) {
+    const id = sessionAttributionAgentId(message.text, agentIds)
+    if (!id) continue
+    const ids = candidates.get(message.sender) ?? new Set<string>()
+    ids.add(id)
+    candidates.set(message.sender, ids)
+  }
+  return new Map([...candidates].flatMap(([sender, ids]) => (ids.size === 1 ? [[sender, [...ids][0]!] as const] : [])))
+}
+
 export function sessionTriggerFilterValue(trigger: {
   value: string
   hookKind?: 'webhook' | 'github'


### PR DESCRIPTION
## Summary

- persist stable Agent author IDs in Slack conversation metadata, including MCP sends and edited replies
- recover unambiguous authorship for existing Slack transcript rows from their Agent attribution links
- render peer Agent names/icons and human profile or initials avatars on right-side session messages

## Validation

- pnpm --filter @agentconnect.md/daemon exec vitest run test/mcp-ops.test.ts
- pnpm --filter @agentconnect.md/daemon exec vitest run test/connection.test.ts
- CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-transcript.test.ts
- focused smoke, hook, and lifecycle identity scenarios
- pnpm --filter @agentconnect.md/web exec vitest run src/lib/session-trigger.test.ts
- daemon and web typechecks
- ESLint on all changed files; full pre-push lint

Created by Codex . GPT-5.4
