### PR TITLE
feat(auth): pick the ownership-transfer recipient by org tenure, and show it first

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -511,10 +511,13 @@ This workflow covers managed membership removal only. Direct deletion of an
 ### 8.2 Choosing the recipient, and showing it before the fact
 
 Transfer keeps a resource inside the organization, but for a **restricted** one
-it also decides who can still see it: visibility follows the ownership arm, and
-no role overrides it (§4). "Which owner inherits" is therefore a
-user-visible outcome, not an implementation detail — an unlucky choice reads as
-data loss to everyone else, including other owners.
+it also decides who can still see it. A restricted resource is reached through
+its ownership arm OR an explicit `sharedWith` grant, and no role overrides
+either (§4); removal preserves every remaining member's grant and prunes only
+the departing one (§8.1). So the ones whose visibility actually rides on this
+decision are those **nobody else was granted** — for them, "which owner
+inherits" is a user-visible outcome, not an implementation detail, and an
+unlucky choice reads as data loss to everyone else, including other owners.
 
 Two cases, one rule each:
 
@@ -539,11 +542,15 @@ whose id is not a cuid fall back to `max(account, organization)` creation.
 
 Because the choice is consequential, it is also **shown before it happens**.
 `GET /members/:id/removal-preview` returns the prospective recipient plus the
-departing member's owned-resource counts per kind, with the restricted subset
-called out, and the console renders it in the leave/remove confirmation. The
-preview takes no locks and is never an authorization input: it shares the
-removal's authorization (§8.1) but the transaction re-derives the recipient
-itself, so a race can only make the dialog stale, never the transfer wrong.
+departing member's owned-resource counts per kind, and the console renders it in
+the leave/remove confirmation. The counts distinguish `restricted` from the
+`recipientOnly` subset of it — restricted rows whose remaining `sharedWith`
+holds no other CURRENT member — because only the latter leaves everyone else's
+console. Claiming otherwise would be the same mistake the preview exists to
+prevent, in the opposite direction. The preview takes no locks and is never an
+authorization input: it shares the removal's authorization (§8.1) but the
+transaction re-derives the recipient itself, so a race can only make the dialog
+stale, never the transfer wrong.
 
 This does not extend visibility to the other owners. A restricted resource stays
 restricted across a transfer; the recipient may widen it afterwards through the

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -451,7 +451,7 @@ restore shared access upon reinvitation.
 CronDef, McpProvider, and SkillSource, the transaction:
 
 1. changes `ownerUserId` from the departing member to the selected remaining
-   organization owner;
+   organization owner (§8.2);
 2. removes the departing ID from `sharedWith`;
 3. leaves `createdByUserId` unchanged;
 4. deletes the membership last.
@@ -507,6 +507,47 @@ post-transaction compensation is used.
 
 This workflow covers managed membership removal only. Direct deletion of an
 `app_user` row is unsupported and does not run ownership transfer.
+
+### 8.2 Choosing the recipient, and showing it before the fact
+
+Transfer keeps a resource inside the organization, but for a **restricted** one
+it also decides who can still see it: visibility follows the ownership arm, and
+no role overrides it (§4). "Which owner inherits" is therefore a
+user-visible outcome, not an implementation detail — an unlucky choice reads as
+data loss to everyone else, including other owners.
+
+Two cases, one rule each:
+
+- **An owner removes someone else** — the acting owner inherits. They made the
+  decision, so they carry what it leaves behind, and they can immediately
+  re-share or re-classify.
+- **A member leaves on their own** — there is no actor to inherit, so the
+  organization's **longest-standing owner** does: `membership.createdAt`
+  ascending, ties broken by `userId` so concurrent joins still resolve
+  deterministically. It is the closest available stand-in for "whoever runs this
+  organization", and unlike a role-order or id-order pick it does not move when
+  someone is promoted or a new owner joins.
+
+`membership.createdAt` exists for this. Before it, the table carried no
+timestamps, so both this choice (`ORDER BY "userId"` over timestamp-prefixed
+cuids) and the console's "joined" column silently ranked **global account signup
+order** — a property of the person's first day on the platform, unrelated to the
+organization they are leaving. Existing rows were backfilled from the cuid in
+`membership.id`, which encodes the row's own creation instant, so the ordering
+is historically accurate rather than merely well-defined going forward; rows
+whose id is not a cuid fall back to `max(account, organization)` creation.
+
+Because the choice is consequential, it is also **shown before it happens**.
+`GET /members/:id/removal-preview` returns the prospective recipient plus the
+departing member's owned-resource counts per kind, with the restricted subset
+called out, and the console renders it in the leave/remove confirmation. The
+preview takes no locks and is never an authorization input: it shares the
+removal's authorization (§8.1) but the transaction re-derives the recipient
+itself, so a race can only make the dialog stale, never the transfer wrong.
+
+This does not extend visibility to the other owners. A restricted resource stays
+restricted across a transfer; the recipient may widen it afterwards through the
+ordinary sharing route.
 
 ## 9. Data-plane isolation: visibility never enters the daemon wire
 

--- a/packages/control-plane/prisma/migrations/20260731120000_membership_created_at/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260731120000_membership_created_at/migration.sql
@@ -1,0 +1,43 @@
+-- Membership gains its own join timestamp.
+--
+-- Until now the table carried no timestamps at all, so two surfaces borrowed
+-- `app_user.createdAt` (account signup) as a stand-in: the console's "joined"
+-- column, and — implicitly, through `ORDER BY "userId"` over timestamp-prefixed
+-- cuids — the ownership-transfer recipient chosen when a member leaves. Both
+-- read as "this org's history" while actually ranking global signup order.
+ALTER TABLE "membership" ADD COLUMN "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT now();
+
+-- Backfill, coarse pass. A membership cannot predate its account or its
+-- organization, so max(the two) is a sound lower bound for every row.
+UPDATE "membership" AS m
+SET "createdAt" = GREATEST(u."createdAt", o."createdAt")
+FROM "app_user" AS u, "org" AS o
+WHERE u."id" = m."userId"
+  AND o."id" = m."orgId";
+
+-- Backfill, exact pass. `id` is a cuid v1: the eight characters after the `c`
+-- are the row's creation time as base36 milliseconds, which is precisely the
+-- join time this column wants. Rows with any other id shape (seed fixtures use
+-- readable literals) keep the coarse bound above, as does any value that
+-- decodes to an implausible instant.
+WITH decoded AS (
+  SELECT
+    m."id",
+    to_timestamp(
+      (
+        SUM(
+          (strpos('0123456789abcdefghijklmnopqrstuvwxyz', substr(m."id", 1 + pos, 1)) - 1) *
+            power(36::numeric, 8 - pos)
+        ) / 1000.0
+      )::double precision
+    ) AS "createdAt"
+  FROM "membership" AS m, generate_series(1, 8) AS pos
+  WHERE m."id" ~ '^c[0-9a-z]{24}$'
+  GROUP BY m."id"
+)
+UPDATE "membership" AS m
+SET "createdAt" = decoded."createdAt"
+FROM decoded
+WHERE decoded."id" = m."id"
+  AND decoded."createdAt" > TIMESTAMPTZ '2020-01-01'
+  AND decoded."createdAt" <= now();

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -170,6 +170,11 @@ model Membership {
   orgId  String
   userId String
   role   OrgRole @default(collaborator)
+  // When this user joined THIS org — not their account signup. The console's
+  // "joined" column reads it, and removal picks the ownership-transfer
+  // recipient by it (resource-visibility.md §8.2). Pre-existing rows were
+  // backfilled from the cuid embedded in `id`, which is that same instant.
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
 
   org  Org  @relation(fields: [orgId], references: [id], onDelete: Cascade)
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1585,9 +1585,13 @@ export const MemberRemovalPreviewDto = z.object({
     z.object({
       kind: z.enum(['agent', 'daemon', 'cron', 'mcpProvider', 'skillSource']),
       owned: z.number().int(),
-      // The subset nobody but the owner can see — the part that would otherwise
-      // silently disappear from everyone else's console.
-      restricted: z.number().int()
+      // Not org-visible: reached through ownership or an explicit share.
+      restricted: z.number().int(),
+      // The subset of `restricted` with no OTHER member on its share list, so
+      // after the transfer only `transferTo` could see it. This is the part that
+      // silently disappears from everyone else's console; the rest stay visible
+      // to the members they are already shared with.
+      recipientOnly: z.number().int()
     })
   )
 })

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1571,9 +1571,26 @@ export const MemberDto = z.object({
   picture: z.string().nullable(), // OIDC `picture` avatar URL; null until they've signed in with one
   role: MemberRole,
   isCurrentUser: z.boolean(),
-  joinedAt: z.string() // ISO-8601 (user createdAt — memberships carry no timestamps)
+  joinedAt: z.string() // ISO-8601 — when they joined THIS org
 })
 export const MemberListDto = z.array(MemberDto)
+
+/** `GET /members/:id/removal-preview` — what leaving/removal would do, for the
+ *  confirmation dialog. Advisory: nothing is locked, and the real decision is
+ *  re-derived inside the DELETE transaction. */
+export const MemberRemovalPreviewDto = z.object({
+  // Null when removal would be refused anyway (the last owner has no successor).
+  transferTo: MemberDto.nullable(),
+  resources: z.array(
+    z.object({
+      kind: z.enum(['agent', 'daemon', 'cron', 'mcpProvider', 'skillSource']),
+      owned: z.number().int(),
+      // The subset nobody but the owner can see — the part that would otherwise
+      // silently disappear from everyone else's console.
+      restricted: z.number().int()
+    })
+  )
+})
 
 /** `PATCH /members/:id` — change a member's role (owner-only; multiple owners OK). */
 export const UpdateMemberBody = z.object({
@@ -2499,6 +2516,7 @@ export type MeDtoT = z.infer<typeof MeDto>
 export type MeAccessDtoT = z.infer<typeof MeAccessDto>
 export type UserApiKeyDtoT = z.infer<typeof UserApiKeyDto>
 export type MemberDtoT = z.infer<typeof MemberDto>
+export type MemberRemovalPreviewDtoT = z.infer<typeof MemberRemovalPreviewDto>
 export type OrgInviteLinkDtoT = z.infer<typeof OrgInviteLinkDto>
 export type AcceptedOrgInviteLinkDtoT = z.infer<typeof AcceptedOrgInviteLinkDto>
 export type OrgDtoT = z.infer<typeof OrgDto>

--- a/packages/control-plane/src/http/routes/members.ts
+++ b/packages/control-plane/src/http/routes/members.ts
@@ -117,7 +117,7 @@ export function memberRoutes(deps: HttpDeps) {
           tags: [Tag.Members],
           summary: 'Preview a leave or removal',
           description:
-            'What DELETE /members/:id would do: which member inherits the departing member’s resources, and how many they own (with the restricted subset — those are visible only through their owner, so the recipient decides whether anyone can still find them). Same authorization as the removal itself. Advisory only: nothing is locked, and the removal re-derives its recipient inside the transaction.',
+            'What DELETE /members/:id would do: which member inherits the departing member’s resources, and how many they own — split into the restricted ones (reached through ownership or an explicit share) and the `recipientOnly` subset of those that no remaining member is shared with, which only the recipient would still be able to see. Same authorization as the removal itself. Advisory only: nothing is locked, and the removal re-derives its recipient inside the transaction.',
           operationId: 'previewMemberRemoval',
           params: IdParam,
           response: { 200: MemberRemovalPreviewDto, 403: ErrorDto, 404: ErrorDto }

--- a/packages/control-plane/src/http/routes/members.ts
+++ b/packages/control-plane/src/http/routes/members.ts
@@ -7,6 +7,8 @@
  *                          unknown addresses become invited rows, claimed on
  *                          first SSO sign-in)
  *   PATCH  /members/:id  → change a member's role (owner-only)
+ *   GET    /members/:id/removal-preview
+ *                        → who would inherit their resources, and how many
  *   DELETE /members/:id  → leave the org; owners may remove another member
  *
  * All scoped to `req.principal.orgId` (the console's active org). The
@@ -23,6 +25,7 @@ import { Tag } from '../plugins/openapi.js'
 import {
   MemberDto,
   MemberListDto,
+  MemberRemovalPreviewDto,
   UpdateMemberBody,
   AddMemberBody,
   IdParam,
@@ -104,6 +107,29 @@ export function memberRoutes(deps: HttpDeps) {
         const userId = req.params.id
         const updated = await deps.repos.user.setMemberRole(orgId, userId, req.body.role, req.orgCtx!.userId)
         return toDto(updated, req.orgCtx!.userId, deps)
+      }
+    )
+
+    r.get(
+      '/members/:id/removal-preview',
+      {
+        schema: {
+          tags: [Tag.Members],
+          summary: 'Preview a leave or removal',
+          description:
+            'What DELETE /members/:id would do: which member inherits the departing member’s resources, and how many they own (with the restricted subset — those are visible only through their owner, so the recipient decides whether anyone can still find them). Same authorization as the removal itself. Advisory only: nothing is locked, and the removal re-derives its recipient inside the transaction.',
+          operationId: 'previewMemberRemoval',
+          params: IdParam,
+          response: { 200: MemberRemovalPreviewDto, 403: ErrorDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyMemberRemoval(req, reply, req.params.id)) return
+        const preview = await deps.repos.user.previewMemberRemoval(req.orgCtx!.orgId, req.params.id, req.orgCtx!.userId)
+        return {
+          transferTo: preview.transferTo ? toDto(preview.transferTo, req.orgCtx!.userId, deps) : null,
+          resources: preview.resources
+        }
       }
     )
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3035,8 +3035,27 @@ export interface OrgMemberRecord {
   /** Set when this member selected an uploaded profile photo. */
   profilePictureUpdatedAt: Date | null
   role: OrgMemberRole
-  /** `membership` carries no timestamps — this is the user row's `createdAt`. */
+  /** When this user joined THIS org (`membership.createdAt`). */
   joinedAt: Date
+}
+
+/** The five resource kinds whose ownership transfers when a member leaves. */
+export type OwnedResourceKind = 'agent' | 'daemon' | 'cron' | 'mcpProvider' | 'skillSource'
+
+/**
+ * What removing one member would do, read before the fact (resource-visibility.md
+ * §8.2). The console shows it in the leave/remove confirmation so the transfer is
+ * predictable rather than discovered afterwards — a restricted resource is
+ * visible ONLY through its ownership arm, so "which owner inherits it" decides
+ * whether anyone can still find it.
+ */
+export interface MemberRemovalPreview {
+  /** The member who inherits ownership; null when removal would be refused
+   *  (the departing member is the last owner). */
+  transferTo: OrgMemberRecord | null
+  /** Per-kind counts of the departing member's owned resources; kinds they own
+   *  nothing of are omitted. `restricted` is the subset only the owner can see. */
+  resources: Array<{ kind: OwnedResourceKind; owned: number; restricted: number }>
 }
 
 /** The caller's own profile (the console `/me` surface). */
@@ -3148,6 +3167,13 @@ export interface UserRepo {
    * the acting owner's role. Refuses to remove the final owner before committing.
    */
   removeMember(orgId: string, userId: string, actingUserId: string): Promise<void>
+
+  /**
+   * Dry-run of `removeMember` for the confirmation dialog: the same recipient
+   * rule, plus what that member currently owns. Racy by nature (nothing is
+   * locked) — advisory display only, never an authorization input.
+   */
+  previewMemberRemoval(orgId: string, userId: string, actingUserId: string): Promise<MemberRemovalPreview>
 
   /** Attach a known user to an org. */
   addMember(orgId: string, userId: string, role: OrgMemberRole): Promise<void>

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3045,17 +3045,28 @@ export type OwnedResourceKind = 'agent' | 'daemon' | 'cron' | 'mcpProvider' | 's
 /**
  * What removing one member would do, read before the fact (resource-visibility.md
  * §8.2). The console shows it in the leave/remove confirmation so the transfer is
- * predictable rather than discovered afterwards — a restricted resource is
- * visible ONLY through its ownership arm, so "which owner inherits it" decides
- * whether anyone can still find it.
+ * predictable rather than discovered afterwards: a restricted resource is reached
+ * through its ownership arm OR an explicit share, so where the arm lands decides
+ * who can still find the ones nobody else was given.
  */
 export interface MemberRemovalPreview {
   /** The member who inherits ownership; null when removal would be refused
    *  (the departing member is the last owner). */
   transferTo: OrgMemberRecord | null
   /** Per-kind counts of the departing member's owned resources; kinds they own
-   *  nothing of are omitted. `restricted` is the subset only the owner can see. */
-  resources: Array<{ kind: OwnedResourceKind; owned: number; restricted: number }>
+   *  nothing of are omitted. */
+  resources: Array<{
+    kind: OwnedResourceKind
+    owned: number
+    /** Not org-visible: reachable only via ownership or `sharedWith`. */
+    restricted: number
+    /** The subset of `restricted` that `transferTo` alone would be able to see —
+     *  no remaining member holds a share. This, not `restricted`, is what
+     *  disappears from everyone else's console, so it is the number the dialog
+     *  warns about. Counted against CURRENT membership: a `sharedWith` id that
+     *  is no longer a member cannot see anything either. */
+    recipientOnly: number
+  }>
 }
 
 /** The caller's own profile (the console `/me` surface). */

--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -20,6 +20,7 @@ import {
   type MemberRemovalPreview,
   type OrgMemberRecord,
   type OrgMemberRole,
+  type OwnedResourceKind,
   type UserProfileRecord,
   SYNTHETIC_EMAIL_SUFFIX,
   isSyntheticEmail
@@ -98,6 +99,65 @@ function mergeResourceAuthoritySql(table: (typeof RESOURCE_AUTHORITY_TABLES)[num
       )
     WHERE resource."ownerUserId" = ${from}
        OR ${from} = ANY(COALESCE(resource."sharedWith", ARRAY[]::TEXT[]))
+  `
+}
+
+/** Kind label (the API's vocabulary) → the table ownership transfers from. */
+const OWNED_RESOURCE_KINDS = [
+  ['agent', 'agent'],
+  ['daemon', 'daemon'],
+  ['cron', 'cron_def'],
+  ['mcpProvider', 'mcp_provider'],
+  ['skillSource', 'skill_source']
+] as const satisfies ReadonlyArray<readonly [OwnedResourceKind, (typeof RESOURCE_AUTHORITY_TABLES)[number]]>
+
+interface OwnedResourceCountRow {
+  kind: OwnedResourceKind
+  owned: number
+  restricted: number
+  recipientOnly: number
+}
+
+/**
+ * One kind's slice of the removal preview: how much of `table` this member owns,
+ * how much of it is restricted, and how much of THAT only `recipient` would be
+ * left able to see.
+ *
+ * The last number is the one worth warning about, and it is not simply
+ * "restricted": `canView` admits the ownership arm OR an explicit share, and
+ * removal prunes only the departing id from `sharedWith` (§8.1), so a resource
+ * shared with anyone still in the organization does not vanish for them. The
+ * share set is intersected with CURRENT membership here for the same reason a
+ * role never widens visibility — an id that is no longer a member cannot see
+ * anything, so counting it as a viewer would suppress a warning that is due.
+ */
+function ownedResourceCountsSql(
+  table: (typeof RESOURCE_AUTHORITY_TABLES)[number],
+  kind: OwnedResourceKind,
+  orgId: string,
+  ownerUserId: string,
+  recipientUserId: string
+) {
+  return Prisma.sql`
+    SELECT
+      ${kind} AS "kind",
+      count(*)::int AS "owned",
+      (count(*) FILTER (WHERE resource."visibility" = 'restricted'))::int AS "restricted",
+      (count(*) FILTER (
+        WHERE resource."visibility" = 'restricted'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM unnest(COALESCE(resource."sharedWith", ARRAY[]::TEXT[])) AS shared(user_id)
+            JOIN "membership" AS other
+              ON other."userId" = shared.user_id
+             AND other."orgId" = resource."orgId"
+            WHERE shared.user_id <> ${ownerUserId}
+              AND shared.user_id <> ${recipientUserId}
+          )
+      ))::int AS "recipientOnly"
+    FROM ${Prisma.raw(`"public"."${table}"`)} AS resource
+    WHERE resource."orgId" = ${orgId}
+      AND resource."ownerUserId" = ${ownerUserId}
   `
 }
 
@@ -669,34 +729,23 @@ export class PgUserRepo implements UserRepo {
     )
     const recipient = rows.find((row) => row.userId === recipientId)
 
-    const owned = { orgId, ownerUserId: userId }
-    const [agent, daemon, cron, mcpProvider, skillSource] = await Promise.all([
-      this.db.agent.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
-      this.db.daemon.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
-      this.db.cronDef.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
-      this.db.mcpProvider.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
-      this.db.skillSource.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } })
-    ])
+    const counts = await this.db.$queryRaw<OwnedResourceCountRow[]>(
+      Prisma.join(
+        OWNED_RESOURCE_KINDS.map(([kind, table]) =>
+          ownedResourceCountsSql(table, kind, orgId, userId, recipientId ?? '')
+        ),
+        ' UNION ALL '
+      )
+    )
+    // UNION ALL has no defined order; re-impose the declared one so the dialog
+    // always lists kinds the same way.
+    const byKind = new Map(counts.map((row) => [row.kind, row]))
 
     return {
       transferTo: recipient ? toMemberRecord(recipient) : null,
-      resources: (
-        [
-          ['agent', agent],
-          ['daemon', daemon],
-          ['cron', cron],
-          ['mcpProvider', mcpProvider],
-          ['skillSource', skillSource]
-        ] as const
-      )
-        .map(([kind, groups]) => ({
-          kind,
-          owned: groups.reduce((total, group) => total + group._count._all, 0),
-          restricted: groups
-            .filter((group) => group.visibility === 'restricted')
-            .reduce((total, group) => total + group._count._all, 0)
-        }))
-        .filter((entry) => entry.owned > 0)
+      resources: OWNED_RESOURCE_KINDS.map(([kind]) => byKind.get(kind)).filter(
+        (row) => row !== undefined && row.owned > 0
+      ) as MemberRemovalPreview['resources']
     }
   }
 

--- a/packages/control-plane/src/persistence/repositories/user.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/user.repo.ts
@@ -17,6 +17,7 @@ import { Prisma, withAmbientTx, type PrismaLike } from '../prisma.js'
 import {
   type UserRepo,
   type ProvisionOidcUserInput,
+  type MemberRemovalPreview,
   type OrgMemberRecord,
   type OrgMemberRole,
   type UserProfileRecord,
@@ -123,12 +124,12 @@ function toProfileRecord(u: {
 function toMemberRecord(m: {
   userId: string
   role: string
+  createdAt: Date
   user: {
     email: string
     displayName: string | null
     picture: string | null
     profilePictureUpdatedAt: Date | null
-    createdAt: Date
   }
 }): OrgMemberRecord {
   return {
@@ -138,8 +139,29 @@ function toMemberRecord(m: {
     picture: m.user.picture,
     profilePictureUpdatedAt: m.user.profilePictureUpdatedAt,
     role: m.role as OrgMemberRole,
-    joinedAt: m.user.createdAt
+    joinedAt: m.createdAt
   }
+}
+
+/**
+ * Who inherits a departing member's resources (resource-visibility.md §8.2).
+ *
+ * Removing someone else hands their resources to the acting owner — they made
+ * the decision, so they carry what it leaves behind. A member leaving on their
+ * own has no such actor, so the org's LONGEST-STANDING owner inherits: the
+ * closest available stand-in for "whoever runs this organization", and stable
+ * against a later join or promotion. `snapshot` must already be ordered by
+ * membership age (ties by `userId`, so the choice is deterministic under
+ * same-instant joins). Null ⇒ nobody qualifies, which only happens when the
+ * departing member is the last owner and the caller must refuse.
+ */
+function chooseTransferRecipient(
+  snapshot: readonly { userId: string; role: OrgMemberRole }[],
+  departingUserId: string,
+  actingUserId: string
+): string | null {
+  if (departingUserId !== actingUserId) return actingUserId
+  return snapshot.find((m) => m.role === 'owner' && m.userId !== departingUserId)?.userId ?? null
 }
 
 /** `Dana Reyes <dana@acme.dev>` → base label `dana` for the personal-org name/slug. */
@@ -545,7 +567,7 @@ export class PgUserRepo implements UserRepo {
     const rows = await this.db.membership.findMany({
       where: { orgId },
       include: { user: true },
-      orderBy: { user: { createdAt: 'asc' } }
+      orderBy: [{ createdAt: 'asc' }, { userId: 'asc' }]
     })
     return rows.map(toMemberRecord)
   }
@@ -601,16 +623,14 @@ export class PgUserRepo implements UserRepo {
       const membershipSnapshot = await tx.membership.findMany({
         where: { orgId },
         select: { userId: true, role: true },
-        orderBy: { userId: 'asc' }
+        orderBy: [{ createdAt: 'asc' }, { userId: 'asc' }]
       })
       const actor = membershipSnapshot.find((membership) => membership.userId === actingUserId)
       const departing = membershipSnapshot.find((membership) => membership.userId === userId)
       const leaving = userId === actingUserId
       if (!departing || (!leaving && actor?.role !== 'owner')) throw new OrgMembershipMissing()
 
-      const transferToUserId = leaving
-        ? membershipSnapshot.find((membership) => membership.role === 'owner' && membership.userId !== userId)?.userId
-        : actingUserId
+      const transferToUserId = chooseTransferRecipient(membershipSnapshot, userId, actingUserId)
       if (!transferToUserId) throw new OrgOwnerRequired()
 
       // Fence ownership-bearing resource writes on both ends, then recheck the
@@ -630,6 +650,54 @@ export class PgUserRepo implements UserRepo {
       // The row is still locked here; deletion completes the same transaction.
       await tx.membership.delete({ where: { orgId_userId: { orgId, userId } } })
     })
+  }
+
+  async previewMemberRemoval(orgId: string, userId: string, actingUserId: string): Promise<MemberRemovalPreview> {
+    // Unlocked and outside any transaction: this only feeds a confirmation
+    // dialog. `removeMember` re-derives everything under the transition lock.
+    const rows = await this.db.membership.findMany({
+      where: { orgId },
+      include: { user: true },
+      orderBy: [{ createdAt: 'asc' }, { userId: 'asc' }]
+    })
+    if (!rows.some((row) => row.userId === userId)) throw new OrgMembershipMissing()
+
+    const recipientId = chooseTransferRecipient(
+      rows.map((row) => ({ userId: row.userId, role: row.role as OrgMemberRole })),
+      userId,
+      actingUserId
+    )
+    const recipient = rows.find((row) => row.userId === recipientId)
+
+    const owned = { orgId, ownerUserId: userId }
+    const [agent, daemon, cron, mcpProvider, skillSource] = await Promise.all([
+      this.db.agent.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
+      this.db.daemon.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
+      this.db.cronDef.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
+      this.db.mcpProvider.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } }),
+      this.db.skillSource.groupBy({ by: ['visibility'], where: owned, _count: { _all: true } })
+    ])
+
+    return {
+      transferTo: recipient ? toMemberRecord(recipient) : null,
+      resources: (
+        [
+          ['agent', agent],
+          ['daemon', daemon],
+          ['cron', cron],
+          ['mcpProvider', mcpProvider],
+          ['skillSource', skillSource]
+        ] as const
+      )
+        .map(([kind, groups]) => ({
+          kind,
+          owned: groups.reduce((total, group) => total + group._count._all, 0),
+          restricted: groups
+            .filter((group) => group.visibility === 'restricted')
+            .reduce((total, group) => total + group._count._all, 0)
+        }))
+        .filter((entry) => entry.owned > 0)
+    }
   }
 
   async addMember(orgId: string, userId: string, role: OrgMemberRole): Promise<void> {

--- a/packages/control-plane/test/integration/members.route.test.ts
+++ b/packages/control-plane/test/integration/members.route.test.ts
@@ -27,6 +27,11 @@ interface MemberBody {
   joinedAt: string
 }
 
+interface PreviewBody {
+  transferTo: MemberBody | null
+  resources: { kind: string; owned: number; restricted: number }[]
+}
+
 const signup = (oidcSubject: string, email: string) =>
   new PgUserRepo(prisma).provisionOidcUser({ oidcSubject, email, emailVerified: true })
 
@@ -93,6 +98,25 @@ describe('GET /members', () => {
       expect(body[0]!.email).toBe(DEFAULT_OWNER_EMAIL)
       expect(body[1]!.role).toBe('collaborator')
       expect(body[1]!.isCurrentUser).toBe(false)
+    } finally {
+      await close()
+    }
+  })
+
+  it('reports joinedAt from the membership, not the account signup', async () => {
+    // The two differ by the milliseconds between provisioning and the invite —
+    // enough for this to catch a regression back to `app_user.createdAt`, which
+    // answered "when did they sign up" for every org they are in.
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    const membership = await prisma.membership.findUniqueOrThrow({
+      where: { orgId_userId: { orgId: DEFAULT_ORG_ID, userId: dana.userId } }
+    })
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members` })
+      const body = res.json() as MemberBody[]
+      expect(body[1]!.joinedAt).toBe(membership.createdAt.toISOString())
     } finally {
       await close()
     }
@@ -223,6 +247,36 @@ describe('DELETE /members/:id — removal', () => {
     }
   })
 
+  it('hands a leaver’s resources to the longest-standing owner, not the oldest account', async () => {
+    // `earlyJoiner` joins the org first but signed up SECOND, so its cuid sorts
+    // after `lateJoiner`'s. Ranking owners by userId — what the schema forced
+    // before `membership.createdAt` existed — would pick `lateJoiner`, i.e. the
+    // oldest ACCOUNT, a fact about the platform rather than this org.
+    const lateJoiner = await signup('sub-late-joiner', 'late-joiner@acme.dev')
+    const earlyJoiner = await signup('sub-early-joiner', 'early-joiner@acme.dev')
+    expect(lateJoiner.userId < earlyJoiner.userId).toBe(true)
+    const repo = new PgUserRepo(prisma)
+    await repo.addMemberByEmail(DEFAULT_ORG_ID, 'early-joiner@acme.dev', 'owner')
+    await repo.addMemberByEmail(DEFAULT_ORG_ID, 'late-joiner@acme.dev', 'owner')
+
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, {
+      visibility: 'restricted',
+      createdByUserId: DEFAULT_OWNER_ID,
+      ownerUserId: DEFAULT_OWNER_ID
+    })
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'DELETE', url: `${ORG}/members/${DEFAULT_OWNER_ID}` })
+      expect(res.statusCode).toBe(204)
+      expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
+        ownerUserId: earlyJoiner.userId
+      })
+    } finally {
+      await close()
+    }
+  })
+
   it('does not let a non-owner remove another member', async () => {
     const dana = await signup('sub-dana', 'dana@acme.dev')
     await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'viewer')
@@ -264,6 +318,77 @@ describe('DELETE /members/:id — removal', () => {
     try {
       const res = await app.inject({ method: 'DELETE', url: `${ORG}/members/${DEFAULT_OWNER_ID}` })
       expect(res.statusCode).toBe(409)
+    } finally {
+      await close()
+    }
+  })
+})
+
+describe('GET /members/:id/removal-preview', () => {
+  it('names the successor and counts what would move, restricted subset included', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    await seedAgent(prisma, randomUUID(), { visibility: 'restricted', ownerUserId: dana.userId })
+    await seedAgent(prisma, randomUUID(), { ownerUserId: dana.userId })
+    // Owned by someone else: never counted against the departing member.
+    await seedAgent(prisma, randomUUID(), { ownerUserId: DEFAULT_OWNER_ID })
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${dana.userId}/removal-preview` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as PreviewBody
+      expect(body.transferTo).toMatchObject({ userId: DEFAULT_OWNER_ID, isCurrentUser: false })
+      // Kinds they own nothing of stay out of the sentence entirely.
+      expect(body.resources).toEqual([{ kind: 'agent', owned: 2, restricted: 1 }])
+    } finally {
+      await close()
+    }
+  })
+
+  it('hands an owner-initiated removal to that owner, and reports an empty estate', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${dana.userId}/removal-preview` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as PreviewBody
+      expect(body.transferTo).toMatchObject({ userId: DEFAULT_OWNER_ID, isCurrentUser: true })
+      expect(body.resources).toEqual([])
+    } finally {
+      await close()
+    }
+  })
+
+  it('reports no successor for the last owner (removal would be refused anyway)', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${DEFAULT_OWNER_ID}/removal-preview` })
+      expect(res.statusCode).toBe(200)
+      expect((res.json() as PreviewBody).transferTo).toBeNull()
+    } finally {
+      await close()
+    }
+  })
+
+  it('shares the removal’s authorization — a non-owner cannot preview another member', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${DEFAULT_OWNER_ID}/removal-preview` })
+      expect(res.statusCode).toBe(403)
+    } finally {
+      await close()
+    }
+  })
+
+  it('404s for a user without a membership in the org', async () => {
+    const stranger = await signup('sub-stranger', 'stranger@acme.dev')
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${stranger.userId}/removal-preview` })
+      expect(res.statusCode).toBe(404)
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/members.route.test.ts
+++ b/packages/control-plane/test/integration/members.route.test.ts
@@ -29,7 +29,7 @@ interface MemberBody {
 
 interface PreviewBody {
   transferTo: MemberBody | null
-  resources: { kind: string; owned: number; restricted: number }[]
+  resources: { kind: string; owned: number; restricted: number; recipientOnly: number }[]
 }
 
 const signup = (oidcSubject: string, email: string) =>
@@ -339,7 +339,64 @@ describe('GET /members/:id/removal-preview', () => {
       const body = res.json() as PreviewBody
       expect(body.transferTo).toMatchObject({ userId: DEFAULT_OWNER_ID, isCurrentUser: false })
       // Kinds they own nothing of stay out of the sentence entirely.
-      expect(body.resources).toEqual([{ kind: 'agent', owned: 2, restricted: 1 }])
+      expect(body.resources).toEqual([{ kind: 'agent', owned: 2, restricted: 1, recipientOnly: 1 }])
+    } finally {
+      await close()
+    }
+  })
+
+  it('counts a restricted resource as recipient-only ONLY when no member keeps a share', async () => {
+    // `canView` admits the ownership arm OR a share, and removal prunes only the
+    // departing id — so a resource someone else is still shared with does not
+    // become invisible, and the dialog must not claim it does.
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    const bob = await signup('sub-bob', 'bob@acme.dev')
+    const repo = new PgUserRepo(prisma)
+    await repo.addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    await repo.addMemberByEmail(DEFAULT_ORG_ID, 'bob@acme.dev', 'collaborator')
+    const departed = await signup('sub-departed', 'departed@acme.dev')
+
+    // Still shared with Bob, a current member ⇒ restricted but NOT recipient-only.
+    await seedAgent(prisma, randomUUID(), {
+      visibility: 'restricted',
+      ownerUserId: dana.userId,
+      sharedWith: [bob.userId]
+    })
+    // Shared only with the departing owner and a stale non-member: nobody who can
+    // still reach the org holds a grant, so it does become recipient-only.
+    await seedAgent(prisma, randomUUID(), {
+      visibility: 'restricted',
+      ownerUserId: dana.userId,
+      sharedWith: [dana.userId, departed.userId]
+    })
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${dana.userId}/removal-preview` })
+      expect(res.statusCode).toBe(200)
+      expect((res.json() as PreviewBody).resources).toEqual([
+        { kind: 'agent', owned: 2, restricted: 2, recipientOnly: 1 }
+      ])
+    } finally {
+      await close()
+    }
+  })
+
+  it('does not count the recipient’s own share against recipient-only', async () => {
+    const dana = await signup('sub-dana', 'dana@acme.dev')
+    await new PgUserRepo(prisma).addMemberByEmail(DEFAULT_ORG_ID, 'dana@acme.dev', 'collaborator')
+    // The successor is already shared in: after the transfer they are still the
+    // only one who can see it, so the warning stands.
+    await seedAgent(prisma, randomUUID(), {
+      visibility: 'restricted',
+      ownerUserId: dana.userId,
+      sharedWith: [DEFAULT_OWNER_ID]
+    })
+    const { app, close } = buildHttpApp(prisma, { DEFAULT_OWNER_ID: dana.userId })
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/members/${dana.userId}/removal-preview` })
+      expect((res.json() as PreviewBody).resources).toEqual([
+        { kind: 'agent', owned: 1, restricted: 1, recipientOnly: 1 }
+      ])
     } finally {
       await close()
     }

--- a/packages/web/src/components/console/modals/EditMemberModal.tsx
+++ b/packages/web/src/components/console/modals/EditMemberModal.tsx
@@ -63,11 +63,35 @@ function countPhrase(resources: MemberRemovalPreviewDto['resources']): string {
 }
 
 /**
+ * The privacy half of the sentence.
+ *
+ * A restricted resource is reached through its owner OR an explicit share, so
+ * only the `recipientOnly` ones actually leave everyone else's console when
+ * ownership moves — the rest stay visible to the members they were shared with.
+ * Saying "only X can see it" about those would be false, and this dialog exists
+ * precisely to stop the transfer from surprising anyone.
+ */
+function privacyClause(recipientOnly: number, alsoShared: number, recipient: string): string {
+  if (recipientOnly === 0 && alsoShared === 0) return ''
+  if (alsoShared === 0) {
+    return recipientOnly === 1
+      ? ` 1 is private — afterwards only ${recipient} can see it.`
+      : ` ${recipientOnly} are private — afterwards only ${recipient} can see them.`
+  }
+  if (recipientOnly === 0) {
+    return alsoShared === 1
+      ? ' 1 is private, and stays visible to the members it is shared with.'
+      : ` ${alsoShared} are private, and stay visible to the members they are shared with.`
+  }
+  return ` ${recipientOnly + alsoShared} are private: ${recipientOnly} will be visible only to ${recipient}, and ${alsoShared} ${alsoShared === 1 ? 'stays' : 'stay'} visible to the members already shared with ${alsoShared === 1 ? 'it' : 'them'}.`
+}
+
+/**
  * The danger card's subtitle: exactly where this member's resources land.
  *
- * Ownership decides who can see a RESTRICTED resource at all, so a transfer the
+ * Ownership decides who can still reach a private resource, so a transfer the
  * departing member can't predict reads as data loss. Named recipient first,
- * private count second — the two facts you can't recover after the fact.
+ * what actually goes private second — the two facts you can't recover after.
  */
 function transferSentence(preview: MemberRemovalPreviewDto, leaving: boolean): string {
   // No successor ⇒ the last owner, which the CP refuses anyway (the button is
@@ -83,13 +107,9 @@ function transferSentence(preview: MemberRemovalPreviewDto, leaving: boolean): s
   const recipient = to.isCurrentUser ? 'you' : (to.name ?? to.email ?? 'the longest-standing owner')
   const total = preview.resources.reduce((count, r) => count + r.owned, 0)
   const moved = `${possessive} ${countPhrase(preview.resources)} ${total === 1 ? 'transfers' : 'transfer'} to ${recipient}.`
+  const recipientOnly = preview.resources.reduce((count, r) => count + r.recipientOnly, 0)
   const restricted = preview.resources.reduce((count, r) => count + r.restricted, 0)
-  if (restricted === 0) return moved
-  // Restricted resources are reachable ONLY through their owner, so this is the
-  // difference between "moved" and "gone" for everyone else in the org.
-  return restricted === 1
-    ? `${moved} 1 is private — afterwards only ${recipient} can see it.`
-    : `${moved} ${restricted} are private — afterwards only ${recipient} can see them.`
+  return `${moved}${privacyClause(recipientOnly, restricted - recipientOnly, recipient)}`
 }
 
 const dotOn = 'mt-[3px] h-[14px] w-[14px] flex-none rounded-full border-4 border-(--brand) bg-(--surface-card)'

--- a/packages/web/src/components/console/modals/EditMemberModal.tsx
+++ b/packages/web/src/components/console/modals/EditMemberModal.tsx
@@ -4,9 +4,17 @@
 // member; every member can open their own row and leave. The CP refuses to
 // demote/remove the LAST owner (409), and the dialog pre-disables those paths.
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Avatar, Button, Icon } from '@/components/ui'
-import { updateMemberRole, removeMember, ApiError, type MemberRole } from '@/lib/api'
+import {
+  updateMemberRole,
+  removeMember,
+  fetchMemberRemovalPreview,
+  ApiError,
+  type MemberRole,
+  type MemberRemovalPreviewDto,
+  type OwnedResourceKind
+} from '@/lib/api'
 
 /** What the member list row hands the dialog (display fields precomputed). */
 export interface MemberTarget {
@@ -39,6 +47,51 @@ const ROLE_TILES: { role: MemberRole; icon: string; title: string; desc: string 
   { role: 'viewer', icon: 'eye', title: 'Viewer', desc: 'Read-only — view agents, sessions and usage.' }
 ]
 
+const KIND_LABEL: Record<OwnedResourceKind, [one: string, many: string]> = {
+  agent: ['agent', 'agents'],
+  daemon: ['daemon', 'daemons'],
+  cron: ['schedule', 'schedules'],
+  mcpProvider: ['MCP provider', 'MCP providers'],
+  skillSource: ['skill source', 'skill sources']
+}
+
+/** `2 agents, 1 daemon and 3 schedules` — omitting kinds they own none of. */
+function countPhrase(resources: MemberRemovalPreviewDto['resources']): string {
+  const parts = resources.map((r) => `${r.owned} ${KIND_LABEL[r.kind][r.owned === 1 ? 0 : 1]}`)
+  if (parts.length <= 1) return parts[0] ?? ''
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+}
+
+/**
+ * The danger card's subtitle: exactly where this member's resources land.
+ *
+ * Ownership decides who can see a RESTRICTED resource at all, so a transfer the
+ * departing member can't predict reads as data loss. Named recipient first,
+ * private count second — the two facts you can't recover after the fact.
+ */
+function transferSentence(preview: MemberRemovalPreviewDto, leaving: boolean): string {
+  // No successor ⇒ the last owner, which the CP refuses anyway (the button is
+  // already disabled); say why rather than describe a transfer that can't run.
+  const to = preview.transferTo
+  if (!to) return 'An organization needs at least one owner — promote another member first.'
+
+  const possessive = leaving ? 'Your' : 'Their'
+  if (preview.resources.length === 0) {
+    return `${leaving ? 'You own' : 'They own'} nothing here, so nothing transfers.`
+  }
+
+  const recipient = to.isCurrentUser ? 'you' : (to.name ?? to.email ?? 'the longest-standing owner')
+  const total = preview.resources.reduce((count, r) => count + r.owned, 0)
+  const moved = `${possessive} ${countPhrase(preview.resources)} ${total === 1 ? 'transfers' : 'transfer'} to ${recipient}.`
+  const restricted = preview.resources.reduce((count, r) => count + r.restricted, 0)
+  if (restricted === 0) return moved
+  // Restricted resources are reachable ONLY through their owner, so this is the
+  // difference between "moved" and "gone" for everyone else in the org.
+  return restricted === 1
+    ? `${moved} 1 is private — afterwards only ${recipient} can see it.`
+    : `${moved} ${restricted} are private — afterwards only ${recipient} can see them.`
+}
+
 const dotOn = 'mt-[3px] h-[14px] w-[14px] flex-none rounded-full border-4 border-(--brand) bg-(--surface-card)'
 const dotOff =
   'mt-[3px] h-[14px] w-[14px] flex-none rounded-full border-[1.5px] border-(--border-strong) bg-(--surface-card)'
@@ -60,6 +113,19 @@ export default function EditMemberModal({
   const [busy, setBusy] = useState(false)
   const [removeArmed, setRemoveArmed] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [preview, setPreview] = useState<MemberRemovalPreviewDto | null>(null)
+
+  // Advisory read — a failure just leaves the generic copy in place rather than
+  // blocking the dialog (the removal itself re-derives all of this server-side).
+  useEffect(() => {
+    let live = true
+    void fetchMemberRemovalPreview(member.userId)
+      .then((p) => live && setPreview(p))
+      .catch(() => {})
+    return () => {
+      live = false
+    }
+  }, [member.userId])
 
   const fail = (e: unknown) => {
     if (e instanceof ApiError && e.status === 409) setErr('An organization needs at least one owner.')
@@ -165,9 +231,11 @@ export default function EditMemberModal({
               {onLeave ? 'Leave organization' : 'Remove from organization'}
             </div>
             <div className="font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-              {onLeave
-                ? 'Resources you own stay with the organization and transfer to an owner.'
-                : 'Removes their membership. Their sessions stay in history.'}
+              {preview
+                ? transferSentence(preview, Boolean(onLeave))
+                : onLeave
+                  ? 'Resources you own stay with the organization and transfer to an owner.'
+                  : 'Removes their membership. Their sessions stay in history.'}
             </div>
           </div>
           <button

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -898,7 +898,18 @@ export interface MemberDto {
   picture: string | null // custom uploaded profile photo, or the OIDC `picture` fallback
   role: MemberRole
   isCurrentUser: boolean
-  joinedAt: string // ISO-8601
+  joinedAt: string // ISO-8601 — when they joined THIS org
+}
+
+// What leaving / removing a member would do, shown in the confirmation dialog.
+// Ownership of everything they own moves to ONE member; anything restricted is
+// visible only through that owner, so this is the difference between "moved" and
+// "gone" for whoever is watching.
+export type OwnedResourceKind = 'agent' | 'daemon' | 'cron' | 'mcpProvider' | 'skillSource'
+
+export interface MemberRemovalPreviewDto {
+  transferTo: MemberDto | null // null only when there is no successor (last owner)
+  resources: { kind: OwnedResourceKind; owned: number; restricted: number }[]
 }
 
 export interface OrgInviteLinkDto {
@@ -2850,6 +2861,12 @@ export async function addMember(email: string, role: MemberRole): Promise<Member
   const member = await apiPost<MemberDto>(`${orgBase()}/members`, { email, role })
   track('member_added', { org_id: apiOrgId, role })
   return member
+}
+
+// What that removal would do, for the confirmation dialog (GET
+// /members/:id/removal-preview). Same authorization as the removal itself.
+export async function fetchMemberRemovalPreview(userId: string): Promise<MemberRemovalPreviewDto> {
+  return apiGet<MemberRemovalPreviewDto>(`${orgBase()}/members/${encodeURIComponent(userId)}/removal-preview`)
 }
 
 // Remove a membership. Any member can remove themselves; only owners can remove

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -902,14 +902,14 @@ export interface MemberDto {
 }
 
 // What leaving / removing a member would do, shown in the confirmation dialog.
-// Ownership of everything they own moves to ONE member; anything restricted is
-// visible only through that owner, so this is the difference between "moved" and
-// "gone" for whoever is watching.
+// Ownership of everything they own moves to ONE member. A restricted resource is
+// reached through ownership OR an explicit share, so only the `recipientOnly`
+// ones — nobody else is shared with them — actually leave everyone's console.
 export type OwnedResourceKind = 'agent' | 'daemon' | 'cron' | 'mcpProvider' | 'skillSource'
 
 export interface MemberRemovalPreviewDto {
   transferTo: MemberDto | null // null only when there is no successor (last owner)
-  resources: { kind: OwnedResourceKind; owned: number; restricted: number }[]
+  resources: { kind: OwnedResourceKind; owned: number; restricted: number; recipientOnly: number }[]
 }
 
 export interface OrgInviteLinkDto {


### PR DESCRIPTION
## Why

A `restricted` resource is reachable only through its ownership arm — no role overrides it. So when a member leaves, **which owner inherits it decides whether anyone can still find it**. Today that outcome is both arbitrary and invisible:

- `membership` carries no timestamps, so the recipient is picked by `ORDER BY "userId"` over timestamp-prefixed cuids. That ranks the **oldest account** among the remaining owners — a fact about the platform, not about the organization being left. Two owners who signed up seconds apart decide it between them, forever.
- The console's "joined" column borrowed `app_user.createdAt` for the same missing-column reason, so it shows account signup, not when that person joined this org.
- Nothing surfaces the transfer, before or after. From every other owner's console, a departing member's private agents simply stop existing.

The first two are the same root cause; the third is why nobody notices.

## What changed

**`membership.createdAt`** (new column + migration). Pre-existing rows are backfilled from the cuid in `membership.id` — its leading base36 milliseconds *are* the row's creation instant — so historical ordering is accurate, not merely well-defined from now on. Rows whose id isn't a cuid (seed fixtures) fall back to `max(account, organization)` creation, a sound lower bound.

**The recipient rule is now stated** (`chooseTransferRecipient`, design §8.2):

- an owner removing someone else inherits their resources — they made the decision, they carry what it leaves behind;
- a member leaving on their own hands them to the organization's **longest-standing owner**, ties broken by `userId` so concurrent joins still resolve deterministically.

A transfer still never widens visibility; the recipient may re-share afterwards.

**`GET /members/:id/removal-preview`** returns the prospective recipient plus the departing member's owned-resource counts per kind, with the restricted subset called out. The leave/remove dialog renders it as a sentence:

| case | copy |
| --- | --- |
| owner removes someone | Their 2 agents transfer to you. 1 is private — afterwards only you can see it. |
| member leaves | Your 1 agent transfers to Dana Reyes. 1 is private — afterwards only Dana Reyes can see it. |
| last owner | An organization needs at least one owner — promote another member first. |

## Reviewer notes

- **The preview is advisory.** It shares the removal's authorization (self, or owner-for-others) but takes no locks and is never an authorization input — `removeMember` re-derives its own recipient inside the transition lock, so a race can only make the dialog stale, never the transfer wrong.
- **The migration reorders existing organizations' recipients.** That is the point: an org whose recipient was "whoever registered first" now resolves to whoever has been in *that org* longest. Worth a look if you disagree with the tenure rule.
- The backfill's base36 decode was checked against known cuids (exact to the millisecond) and against a pre-migration table containing both cuid and literal ids.
- Ownership moves for `org`-visible resources too, and the preview counts them — `restricted` is reported separately because only that subset changes who can *see* anything.

## Verification

- control-plane `test:unit` 1020 passed, `test:int` 898 passed — including 5 new cases: recipient follows org tenure rather than account age, `joinedAt` reads the membership row, and the preview's success / no-successor / 403 / 404 responses.
- `typecheck`, `lint`, `format:check` clean.
- All three dialog states verified in the running console against a live CP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
