### PR TITLE
feat(daemon): adopt Linux sandbox runtime

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,10 +257,10 @@ jobs:
           if sysctl kernel.unprivileged_userns_clone >/dev/null 2>&1; then
             sudo sysctl -w kernel.unprivileged_userns_clone=1
           fi
-      - name: Install bubblewrap
+      - name: Install SRT Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes bubblewrap ripgrep socat
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Generate Prisma client
@@ -278,6 +278,8 @@ jobs:
         env:
           pnpm_config_enable_pre_post_scripts: false
         run: pnpm --filter @agentconnect.md/daemon build
+      - name: Ordinary ACP SRT smoke
+        run: node packages/daemon/scripts/srt-linux-smoke.mjs packages/daemon/dist/index.js
       - name: Real daemon namespace and fixture tests
         env:
           AGENTCONNECT_RUN_BWRAP_E2E: '1'

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -134,7 +134,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--agents-dir <dir>`    | `agentsDir`                    | Override agent discovery root. Daemon/`chat` recursively collect `agent.json`, skipping `node_modules`, `.git`, dot directories, depth about four. |
 | `--agent <name>`        | Selector                       | Select by `agent.id`: single-agent `run` ignoring status, or disambiguate `chat`.                                                                  |
 | `--max-agents <n>`      | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
-| `--require-sandbox`     | `security.requireSandbox=true` | Require every agent to run in an OS sandbox; refuse daemon startup if unsupported.                                                                 |
+| `--require-sandbox`     | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
 | `--dry-run`             | n/a                            | Load and validate all configuration and print the reconcile plan without opening connections/processes.                                            |
 
 All environment equivalents use the `AGENTCONNECT_` prefix, such as `AGENTCONNECT_CP_URL`, `AGENTCONNECT_CP_KEY`, and `AGENTCONNECT_ROOT`, for containers and system services.
@@ -268,8 +268,8 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
     // Set false to permit inheritance; restart daemon, affecting future ACP children only.
     "isolateAccountApps": true,
 
-    // Default false. true / --require-sandbox requires every agent to run in an OS sandbox.
-    // If bwrap (Linux) or sandbox-exec (macOS) is unavailable, daemon refuses to start.
+    // Default false. true / --require-sandbox requires every agent to run in the
+    // Linux SRT/bwrap sandbox. macOS and Windows are not supported in this rollout.
     "requireSandbox": false,
 
     // Exact origins that daemon-managed workspace clone/pull may target.
@@ -301,6 +301,38 @@ On POSIX hosts, AgentConnect removes group/other access from existing
 `config.json` and `agent.json` files; newly created or rewritten files use mode
 `0600`. Agent directories created by the daemon use `0700`; existing custom
 agent directories and higher custom parents are left unchanged.
+
+### Linux ACP runtime sandbox
+
+AgentConnect currently enables runtime sandboxing on Linux only. The daemon uses
+the exact-pinned `@anthropic-ai/sandbox-runtime` package, backed by `bubblewrap`,
+and launches a separate SRT provider process for each ordinary ACP host so policy
+state is never shared between agents. The host must provide working `bwrap`,
+`socat`, and `rg` executables and permit unprivileged user namespaces. Startup
+performs a live probe rather than treating installed binaries as sufficient.
+
+An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
+metadata and the host source from which that runtime state was seeded, and
+re-allows reads only for the workspace, private HOME, managed memory,
+`run/config-files`, and `.agentconnect/runtime-policy`. Writes are limited to the
+workspace, private HOME, managed memory, and SRT temporary storage. Outbound
+domains are approved by a provider callback and Unix sockets remain
+compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
+egress, but SRT's isolated Linux network namespace means host access to an
+agent-started local server and clients that ignore the proxy environment are not
+yet compatibility guarantees; issue #312 tracks those boundaries. SRT's
+temporary directory is redirected below the private HOME and its shared
+`/tmp/claude` fallback is hidden.
+
+Read access outside the explicitly denied agent/runtime-state roots remains
+unchanged in this rollout. This is not yet a whole-host read allowlist: unrelated
+host files and another runtime's credential source require a separate policy.
+
+When sandboxing is only an agent preference and the live probe fails, the daemon
+logs a warning and runs that agent without confinement. With
+`security.requireSandbox=true` or `--require-sandbox`, the same failure refuses
+daemon startup. macOS and Windows always follow this unsupported-host behavior;
+this rollout intentionally adds no runtime-specific Keychain integration.
 
 `security.workspaceGitAllowedOrigins` is a daemon-local remote-origin policy. Tenant
 workspace configuration cannot widen it, and the control plane intentionally

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -41,6 +41,7 @@
     "@agentconnect.md/connection": "workspace:*",
     "@agentconnect.md/message": "workspace:*",
     "@agentconnect.md/protocol": "workspace:*",
+    "@anthropic-ai/sandbox-runtime": "0.0.67",
     "@larksuiteoapi/node-sdk": "^1.71.1",
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",

--- a/packages/daemon/scripts/srt-linux-smoke.mjs
+++ b/packages/daemon/scripts/srt-linux-smoke.mjs
@@ -25,6 +25,8 @@ try {
   const settingsPath = join(settingsDir, 'settings.json')
 
   for (const path of [workspace, home, memory, hostState, settingsDir]) mkdirSync(path, { recursive: true })
+  mkdirSync(join(workspace, '.git', 'hooks'), { recursive: true })
+  writeFileSync(join(workspace, '.git', 'config'), '[core]\n\trepositoryformatversion = 0\n')
   writeFileSync(join(agentDir, 'agent.json'), '{"secret":"hidden"}\n')
   writeFileSync(join(hostState, '.credentials.json'), '{"secret":"host"}\n')
   writeFileSync(
@@ -37,7 +39,7 @@ try {
           allowRead: [workspace, home, memory],
           allowWrite: [workspace, home, memory],
           denyWrite: ['/tmp/claude', '/private/tmp/claude'],
-          allowGitConfig: true
+          allowGitConfig: false
         },
         git: { safeDirectories: [workspace] }
       },
@@ -63,6 +65,8 @@ try {
     assert(denied(() => readFileSync(hostState + '/.credentials.json')), 'host runtime state remained readable')
     writeFileSync(workspace + '/ok.txt', 'ok')
     assert(readFileSync(workspace + '/ok.txt', 'utf8') === 'ok', 'workspace was not writable')
+    assert(denied(() => writeFileSync(workspace + '/.git/hooks/post-merge', 'escape')), 'git hooks remained writable')
+    assert(denied(() => writeFileSync(workspace + '/.git/config', 'escape')), 'git config remained writable')
     assert(denied(() => writeFileSync(outside, 'escape')), 'outside path was writable')
 
     const socketPath = home + '/compat.sock'
@@ -97,6 +101,7 @@ try {
       '__sandbox-runtime',
       settingsPath,
       String(process.pid),
+      workspace,
       '--',
       process.execPath,
       '--input-type=module',
@@ -109,7 +114,9 @@ try {
       outside
     ],
     {
-      cwd: workspace,
+      // Production providers inherit the daemon's cwd. The explicit trusted
+      // workspace argument must anchor SRT's mandatory-deny discovery itself.
+      cwd: root,
       env: { ...process.env, HOME: home },
       input: 'SRT_STDIN',
       encoding: 'utf8',
@@ -126,8 +133,8 @@ try {
   const orphanLauncher = `
     import { spawn } from 'node:child_process'
     const [entry, settingsPath, cwd] = process.argv.slice(1)
-    const child = spawn(process.execPath, [entry, '__sandbox-runtime', settingsPath, String(process.pid), '--', 'sleep', '30'], {
-      cwd,
+    const child = spawn(process.execPath, [entry, '__sandbox-runtime', settingsPath, String(process.pid), cwd, '--', 'sleep', '30'], {
+      cwd: ${JSON.stringify(root)},
       env: process.env,
       stdio: 'ignore'
     })

--- a/packages/daemon/scripts/srt-linux-smoke.mjs
+++ b/packages/daemon/scripts/srt-linux-smoke.mjs
@@ -1,0 +1,171 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+if (process.platform !== 'linux') throw new Error('SRT smoke test requires Linux')
+
+const entry = resolve(process.argv[2] ?? fileURLToPath(new URL('../dist/index.js', import.meta.url)))
+if (!isAbsolute(entry)) throw new Error('daemon entry must be absolute')
+
+const base = resolve(process.env.AGENTCONNECT_SRT_SMOKE_BASE ?? tmpdir())
+mkdirSync(base, { recursive: true })
+const root = mkdtempSync(join(base, 'agentconnect-srt-smoke-'))
+let orphanProviderPid
+
+try {
+  const agentDir = join(root, 'agent')
+  const workspace = join(agentDir, 'workspace')
+  const home = join(agentDir, 'home')
+  const memory = join(agentDir, 'memory')
+  const hostState = join(root, 'host', '.claude')
+  const outside = join(root, 'outside.txt')
+  const settingsDir = join(agentDir, '.agentconnect', 'sandbox')
+  const settingsPath = join(settingsDir, 'settings.json')
+
+  for (const path of [workspace, home, memory, hostState, settingsDir]) mkdirSync(path, { recursive: true })
+  writeFileSync(join(agentDir, 'agent.json'), '{"secret":"hidden"}\n')
+  writeFileSync(join(hostState, '.credentials.json'), '{"secret":"host"}\n')
+  writeFileSync(
+    settingsPath,
+    `${JSON.stringify(
+      {
+        network: { allowedDomains: [], deniedDomains: [], allowAllUnixSockets: true },
+        filesystem: {
+          denyRead: [agentDir, hostState, '/tmp/claude', '/private/tmp/claude'],
+          allowRead: [workspace, home, memory],
+          allowWrite: [workspace, home, memory],
+          denyWrite: ['/tmp/claude', '/private/tmp/claude'],
+          allowGitConfig: true
+        },
+        git: { safeDirectories: [workspace] }
+      },
+      null,
+      2
+    )}\n`,
+    { mode: 0o600 }
+  )
+
+  const probe = `
+    import { spawnSync } from 'node:child_process'
+    import { readFileSync, writeFileSync } from 'node:fs'
+    import { createServer } from 'node:net'
+
+    const [agentDir, workspace, home, hostState, outside] = process.argv.slice(1)
+    const assert = (condition, message) => { if (!condition) throw new Error(message) }
+    const denied = (operation) => { try { operation(); return false } catch { return true } }
+
+    assert(readFileSync(0, 'utf8') === 'SRT_STDIN', 'provider did not preserve ACP stdin')
+    assert(process.env.HOME === home, 'private HOME was not preserved')
+    assert(process.env.TMPDIR === home + '/.tmp', 'temporary files were not redirected into private HOME')
+    assert(denied(() => readFileSync(agentDir + '/agent.json')), 'agent metadata remained readable')
+    assert(denied(() => readFileSync(hostState + '/.credentials.json')), 'host runtime state remained readable')
+    writeFileSync(workspace + '/ok.txt', 'ok')
+    assert(readFileSync(workspace + '/ok.txt', 'utf8') === 'ok', 'workspace was not writable')
+    assert(denied(() => writeFileSync(outside, 'escape')), 'outside path was writable')
+
+    const socketPath = home + '/compat.sock'
+    const server = createServer()
+    await new Promise((resolve, reject) => server.once('error', reject).listen(socketPath, resolve))
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+
+    const curl = spawnSync('curl', ['-fsS', 'https://example.com'], { stdio: 'ignore' })
+    assert(curl.status === 0, 'allow-all network compatibility failed')
+    console.log('SRT_LINUX_SMOKE_OK')
+  `
+
+  // Keep an intermediate launcher alive between the daemon owner and the SRT
+  // provider. Source builds use the same shape because tsx launches the entry
+  // script in a child process.
+  const providerLauncher = `
+    import { spawnSync } from 'node:child_process'
+    const result = spawnSync(process.execPath, process.argv.slice(1), {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: 'inherit'
+    })
+    process.exit(result.status ?? 1)
+  `
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      providerLauncher,
+      entry,
+      '__sandbox-runtime',
+      settingsPath,
+      String(process.pid),
+      '--',
+      process.execPath,
+      '--input-type=module',
+      '-e',
+      probe,
+      agentDir,
+      workspace,
+      home,
+      hostState,
+      outside
+    ],
+    {
+      cwd: workspace,
+      env: { ...process.env, HOME: home },
+      input: 'SRT_STDIN',
+      encoding: 'utf8',
+      timeout: 30_000
+    }
+  )
+
+  if (result.status !== 0 || !result.stdout.includes('SRT_LINUX_SMOKE_OK')) {
+    if (result.stdout) process.stderr.write(result.stdout)
+    if (result.stderr) process.stderr.write(result.stderr)
+    throw new Error(`SRT smoke test failed with status ${result.status ?? 'null'}`)
+  }
+
+  const orphanLauncher = `
+    import { spawn } from 'node:child_process'
+    const [entry, settingsPath, cwd] = process.argv.slice(1)
+    const child = spawn(process.execPath, [entry, '__sandbox-runtime', settingsPath, String(process.pid), '--', 'sleep', '30'], {
+      cwd,
+      env: process.env,
+      stdio: 'ignore'
+    })
+    if (!child.pid) process.exit(2)
+    process.stdout.write(String(child.pid))
+    child.unref()
+  `
+  const orphanOwner = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', orphanLauncher, entry, settingsPath, workspace],
+    { env: { ...process.env, HOME: home }, encoding: 'utf8', timeout: 5_000 }
+  )
+  orphanProviderPid = Number(orphanOwner.stdout.trim())
+  if (orphanOwner.status !== 0 || !Number.isSafeInteger(orphanProviderPid)) {
+    throw new Error(`failed to launch orphan-cleanup probe: ${orphanOwner.stderr}`)
+  }
+  const providerAlive = () => {
+    try {
+      const state = /\)\s+([A-Z])\s/.exec(readFileSync(`/proc/${orphanProviderPid}/stat`, 'utf8'))?.[1]
+      return state !== undefined && state !== 'Z'
+    } catch {
+      return false
+    }
+  }
+  const cleanupDeadline = Date.now() + 5_000
+  while (providerAlive() && Date.now() < cleanupDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  if (providerAlive()) throw new Error('SRT provider survived its daemon owner')
+  orphanProviderPid = undefined
+  process.stdout.write('SRT Linux smoke test passed\n')
+} finally {
+  if (orphanProviderPid) {
+    try {
+      process.kill(orphanProviderPid, 'SIGKILL')
+    } catch {
+      // Already gone.
+    }
+  }
+  rmSync(root, { recursive: true, force: true })
+}

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -147,6 +147,8 @@ export interface AcpSandboxLaunch {
   /** Trusted SRT policy for ordinary ACP hosts. Delegated bwrap cells retain
    * their existing source-to-target mount launch and do not consume it. */
   settingsPath?: string
+  /** Trusted working directory used to anchor SRT's Linux mandatory-deny scan. */
+  cwd?: string
   /** Daemon-owned private broker roots hidden from every untrusted bwrap host. */
   maskedReadRoots?: string[]
   /** Present only for an entitled host and already tied to its broker cell. */

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -144,6 +144,9 @@ export interface SessionConfigPrefs {
 export interface AcpSandboxLaunch {
   mechanism: SandboxMechanism
   writable: string[]
+  /** Trusted SRT policy for ordinary ACP hosts. Delegated bwrap cells retain
+   * their existing source-to-target mount launch and do not consume it. */
+  settingsPath?: string
   /** Daemon-owned private broker roots hidden from every untrusted bwrap host. */
   maskedReadRoots?: string[]
   /** Present only for an entitled host and already tied to its broker cell. */
@@ -511,10 +514,10 @@ export class AcpHost {
       /** Whether to suppress account-bound cloud apps/connectors at spawn. Defaults
        *  to true; daemon config may explicitly opt out for all runtimes on the host. */
       isolateAccountApps?: boolean
-      /** OS sandbox for the agent process (issue #642). Set by ensureHost when the
+      /** OS sandbox for the agent process (issue #312). Set by ensureHost when the
        *  the agent's effective Run in sandbox policy is on. `writable` is
-       *  the workspace, private runtime HOME, memory, and daemon socket dirs; tmp is
-       *  added by sandboxWrap.
+       *  the workspace, private runtime HOME, and managed memory; SRT supplies
+       *  private temporary storage.
        *  Absent ⇒ run unconfined (fail-open). */
       sandbox?: AcpSandboxLaunch
       /** Called once when the owned adapter process reaches terminal exit. The
@@ -585,9 +588,9 @@ export class AcpHost {
     // appendArgs carries any account-app-isolation flags (e.g. Copilot's
     // --disable-builtin-mcps) that must reach the adapter as CLI args.
     const spawnArgs = [...this.runtime.args, ...(isolateAccountApps ? appIsolation.appendArgs : [])]
-    // OS sandbox (issue #642): wrap the launcher so the agent process can only write
-    // inside its agent dir + tmp. Fail-open — ensureHost only sets opts.sandbox when a
-    // mechanism exists, so no mechanism ⇒ this is a no-op and the agent runs unconfined.
+    // Linux SRT sandbox (issue #312). Fail-open — ensureHost only sets
+    // opts.sandbox after a live probe, so no mechanism means the adapter runs
+    // unconfined unless daemon policy required sandboxing and refused startup.
     const delegatedCell = this.opts.sandbox?.delegatedCellMount
     const delegatedHome = this.opts.sandbox?.delegatedRuntimeHomeMount
     if ((delegatedCell && !delegatedHome) || (!delegatedCell && delegatedHome)) {

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -8,7 +8,13 @@ export interface PreparedRuntimeLaunch {
   /** Sandboxed launches carry a sanitized environment; unsandboxed launches inherit the daemon environment. */
   inheritProcessEnv: boolean
   runtimeHome?: string
-  sandbox?: { mechanism: SandboxMechanism; writable: string[]; settingsPath: string; maskedReadRoots?: string[] }
+  sandbox?: {
+    mechanism: SandboxMechanism
+    writable: string[]
+    settingsPath: string
+    cwd: string
+    maskedReadRoots?: string[]
+  }
 }
 
 /** Daemon policy overrides the per-agent preference. Without an available host
@@ -87,6 +93,7 @@ export function prepareRuntimeLaunch(opts: {
       mechanism: opts.sandboxMechanism!,
       writable: boundary.writable,
       settingsPath,
+      cwd: boundary.gitSafeDirectories[0]!,
       ...(opts.maskedReadRoots?.length ? { maskedReadRoots: opts.maskedReadRoots } : {})
     }
   }

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -1,13 +1,14 @@
 import { mkdirSync } from 'node:fs'
-import { sandboxBoundary, type SandboxMechanism } from './sandbox.js'
+import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from './sandbox.js'
 import { prepareRuntimeHome, runtimeHomeEnvironment } from '../runtimes/runtime-home.js'
+import { runtimeStateLocations } from '../runtimes/probe.js'
 
 export interface PreparedRuntimeLaunch {
   env: Record<string, string>
   /** Sandboxed launches carry a sanitized environment; unsandboxed launches inherit the daemon environment. */
   inheritProcessEnv: boolean
   runtimeHome?: string
-  sandbox?: { mechanism: SandboxMechanism; writable: string[]; maskedReadRoots?: string[] }
+  sandbox?: { mechanism: SandboxMechanism; writable: string[]; settingsPath: string; maskedReadRoots?: string[] }
 }
 
 /** Daemon policy overrides the per-agent preference. Without an available host
@@ -46,32 +47,46 @@ export function prepareRuntimeLaunch(opts: {
     return { env: opts.explicitEnv ?? {}, inheritProcessEnv: true }
   }
   if (opts.runInSandbox && !opts.sandboxMechanism) {
-    throw new Error('OS sandbox requested but this host has no bwrap/sandbox-exec')
+    throw new Error('OS sandbox requested but this host has no supported Linux SRT/bwrap mechanism')
   }
 
-  const runtimeHome = prepareRuntimeHome(opts.runtimeId, opts.scopeDir, opts.stateSourceEnv ?? opts.hostEnv)
+  const stateSourceEnv = opts.stateSourceEnv ?? opts.hostEnv ?? process.env
+  const runtimeHome = prepareRuntimeHome(opts.runtimeId, opts.scopeDir, stateSourceEnv)
   const env = runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, opts.hostEnv)
 
   if (!opts.runInSandbox) {
     return { env, inheritProcessEnv: false, runtimeHome }
   }
 
-  const { writable } = sandboxBoundary({
+  const boundary = sandboxBoundary({
     agentDir: opts.scopeDir,
     cwd: opts.cwd,
     runtimeHome,
     mcpSocketPath: opts.mcpSocketPath
   })
-  // Bubblewrap bind sources must exist before spawn. This also initializes the
-  // workspace/memory directories for a newly-created agent.
-  for (const path of writable) mkdirSync(path, { recursive: true })
+  // SRT write roots (and delegated bwrap bind sources) must exist before spawn.
+  // This also initializes workspace/memory for a newly-created agent.
+  for (const path of boundary.writable) mkdirSync(path, { recursive: true })
+  const settingsPath = writeSandboxSettings(opts.scopeDir, {
+    writable: boundary.writable,
+    // The reviewed runtime state was copied into the private HOME above. Hide
+    // its host source so the child cannot bypass isolation or read later edits.
+    denyRead: [
+      ...boundary.denyRead,
+      ...(opts.maskedReadRoots ?? []),
+      ...runtimeStateLocations(opts.runtimeId, stateSourceEnv).map((location) => location.source)
+    ],
+    allowRead: boundary.allowRead,
+    gitSafeDirectories: boundary.gitSafeDirectories
+  })
   return {
     env,
     inheritProcessEnv: false,
     runtimeHome,
     sandbox: {
       mechanism: opts.sandboxMechanism!,
-      writable,
+      writable: boundary.writable,
+      settingsPath,
       ...(opts.maskedReadRoots?.length ? { maskedReadRoots: opts.maskedReadRoots } : {})
     }
   }

--- a/packages/daemon/src/acp/sandbox-runtime-provider.ts
+++ b/packages/daemon/src/acp/sandbox-runtime-provider.ts
@@ -1,0 +1,123 @@
+import { spawn } from 'node:child_process'
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
+import { isAbsolute, join, resolve } from 'node:path'
+import { SandboxManager, SandboxRuntimeConfigSchema } from '@anthropic-ai/sandbox-runtime'
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function isAncestorProcess(ownerPid: number): boolean {
+  let pid = process.pid
+  const visited = new Set<number>()
+
+  while (pid > 0 && !visited.has(pid)) {
+    if (pid === ownerPid) return true
+    visited.add(pid)
+
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+      const fields = stat
+        .slice(stat.lastIndexOf(') ') + 2)
+        .trim()
+        .split(/\s+/)
+      const parentPid = Number(fields[1])
+      if (!Number.isSafeInteger(parentPid) || parentPid < 0) return false
+      pid = parentPid
+    } catch {
+      return false
+    }
+  }
+
+  return false
+}
+
+/**
+ * Run one command through an isolated Sandbox Runtime manager. This helper is
+ * launched in its own process for every ACP host: SRT's manager is global to a
+ * process, while AgentConnect needs a different filesystem/socket policy per
+ * agent and may run many hosts concurrently.
+ */
+export async function runSandboxRuntimeProvider(argv: string[]): Promise<number> {
+  if (process.platform !== 'linux') {
+    console.error('agentconnect sandbox-runtime: Linux is the only supported platform')
+    return 1
+  }
+  const separator = argv.indexOf('--')
+  const ownerPid = Number(argv[1])
+  if (separator !== 2 || argv.length < 4 || !Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
+    console.error('agentconnect sandbox-runtime: expected <settings> <owner-pid> -- <command> [args...]')
+    return 2
+  }
+
+  try {
+    const config = SandboxRuntimeConfigSchema.parse(JSON.parse(readFileSync(argv[0]!, 'utf8')))
+    const requestedHome = process.env.HOME
+    const privateHome = requestedHome && isAbsolute(requestedHome) ? realpathSync(requestedHome) : undefined
+    if (!privateHome || !config.filesystem.allowWrite.map((path) => resolve(path)).includes(resolve(privateHome))) {
+      throw new Error('private HOME must be an explicit SRT write root')
+    }
+    const privateTmp = join(resolve(privateHome), '.tmp')
+    if (existsSync(privateTmp)) {
+      const stat = lstatSync(privateTmp)
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error('private SRT temp path must be a real directory')
+      }
+    }
+    mkdirSync(privateTmp, { recursive: true, mode: 0o700 })
+    chmodSync(privateTmp, 0o700)
+    // SRT otherwise defaults TMPDIR to the shared host /tmp/claude path. Keep
+    // temporary state inside this agent's private HOME instead.
+    process.env.HOME = privateHome
+    process.env.TMPDIR = privateTmp
+    process.env.CLAUDE_CODE_TMPDIR = privateTmp
+    process.env.CLAUDE_TMPDIR = privateTmp
+    // Network policy is intentionally not part of this filesystem-sandbox
+    // rollout. SRT requires an allow-only network config, so approve every
+    // domain through its callback. This preserves proxy-aware web egress; SRT's
+    // network namespace still has documented local-port/client compatibility
+    // gaps tracked in issue #312.
+    await SandboxManager.initialize(config, async () => true)
+
+    const command = argv.slice(3).map(shellQuote).join(' ')
+    const wrapped = await SandboxManager.wrapWithSandboxArgv(command, undefined, undefined, undefined, process.cwd())
+    const child = spawn(wrapped.argv[0]!, wrapped.argv.slice(1), {
+      env: wrapped.env,
+      shell: false,
+      stdio: 'inherit'
+    })
+
+    // bwrap dies with this provider, but the provider also needs to die with the
+    // daemon. The source launcher adds a tsx process between them, so poll the
+    // Linux process ancestry rather than requiring the daemon to be our direct
+    // parent. This covers abrupt daemon death where no shutdown signal reaches
+    // the detached ACP process group.
+    let escalation: NodeJS.Timeout | undefined
+    const ownerWatch = setInterval(() => {
+      if (isAncestorProcess(ownerPid)) return
+      clearInterval(ownerWatch)
+      child.kill('SIGTERM')
+      escalation = setTimeout(() => child.kill('SIGKILL'), 2_000)
+    }, 250)
+    ownerWatch.unref()
+
+    const code = await new Promise<number>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', (exitCode, signal) => resolve(signal ? 1 : (exitCode ?? 1)))
+    })
+    clearInterval(ownerWatch)
+    clearTimeout(escalation)
+    SandboxManager.cleanupAfterCommand()
+    await SandboxManager.reset()
+    return code
+  } catch (error) {
+    console.error(`agentconnect sandbox-runtime: ${error instanceof Error ? error.message : String(error)}`)
+    try {
+      SandboxManager.cleanupAfterCommand()
+    } catch {
+      // Initialization may have failed before per-command state existed.
+    }
+    await SandboxManager.reset().catch(() => undefined)
+    return 1
+  }
+}

--- a/packages/daemon/src/acp/sandbox-runtime-provider.ts
+++ b/packages/daemon/src/acp/sandbox-runtime-provider.ts
@@ -45,16 +45,36 @@ export async function runSandboxRuntimeProvider(argv: string[]): Promise<number>
   }
   const separator = argv.indexOf('--')
   const ownerPid = Number(argv[1])
-  if (separator !== 2 || argv.length < 4 || !Number.isSafeInteger(ownerPid) || ownerPid <= 0) {
-    console.error('agentconnect sandbox-runtime: expected <settings> <owner-pid> -- <command> [args...]')
+  const requestedCwd = argv[2]
+  if (
+    separator !== 3 ||
+    argv.length < 5 ||
+    !Number.isSafeInteger(ownerPid) ||
+    ownerPid <= 0 ||
+    !requestedCwd ||
+    !isAbsolute(requestedCwd)
+  ) {
+    console.error('agentconnect sandbox-runtime: expected <settings> <owner-pid> <cwd> -- <command> [args...]')
     return 2
   }
 
   try {
     const config = SandboxRuntimeConfigSchema.parse(JSON.parse(readFileSync(argv[0]!, 'utf8')))
+    const sandboxCwd = realpathSync(requestedCwd)
+    const writeRoots = config.filesystem.allowWrite.map((path) => resolve(path))
+    const safeDirectories = config.git?.safeDirectories?.map((path) => resolve(path)) ?? []
+    if (!writeRoots.includes(resolve(sandboxCwd)) || !safeDirectories.includes(resolve(sandboxCwd))) {
+      throw new Error('sandbox cwd must be an explicit SRT write root and Git safe directory')
+    }
+    // SRT discovers mandatory deny paths from its own process.cwd() on Linux;
+    // the cwd argument to wrapWithSandboxArgv is not used for that scan. Anchor
+    // discovery to the trusted workspace before the manager initializes so
+    // .git/hooks, .git/config, and the other mandatory paths are protected in
+    // production as well as in smoke tests.
+    process.chdir(sandboxCwd)
     const requestedHome = process.env.HOME
     const privateHome = requestedHome && isAbsolute(requestedHome) ? realpathSync(requestedHome) : undefined
-    if (!privateHome || !config.filesystem.allowWrite.map((path) => resolve(path)).includes(resolve(privateHome))) {
+    if (!privateHome || !writeRoots.includes(resolve(privateHome))) {
       throw new Error('private HOME must be an explicit SRT write root')
     }
     const privateTmp = join(resolve(privateHome), '.tmp')
@@ -79,7 +99,10 @@ export async function runSandboxRuntimeProvider(argv: string[]): Promise<number>
     // gaps tracked in issue #312.
     await SandboxManager.initialize(config, async () => true)
 
-    const command = argv.slice(3).map(shellQuote).join(' ')
+    const command = argv
+      .slice(separator + 1)
+      .map(shellQuote)
+      .join(' ')
     const wrapped = await SandboxManager.wrapWithSandboxArgv(command, undefined, undefined, undefined, process.cwd())
     const child = spawn(wrapped.argv[0]!, wrapped.argv.slice(1), {
       env: wrapped.env,

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -124,9 +124,15 @@ function probeSandbox(env: NodeJS.ProcessEnv): SandboxMechanism | undefined {
     const settingsPath = writeSandboxSettings(agentDir, {
       writable: [writable, privateHome],
       denyRead: [],
-      allowRead: []
+      allowRead: [],
+      gitSafeDirectories: [writable]
     })
-    const launch = sandboxWrap('true', [], { mechanism: 'bwrap', writable: [writable, privateHome], settingsPath })
+    const launch = sandboxWrap('true', [], {
+      mechanism: 'bwrap',
+      writable: [writable, privateHome],
+      settingsPath,
+      cwd: writable
+    })
     const probe = spawnSync(launch.cmd, launch.args, {
       env: { ...env, HOME: privateHome },
       stdio: 'ignore',
@@ -285,9 +291,10 @@ export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy)
       allowRead: canonical(policy.allowRead),
       allowWrite: canonical(policy.writable),
       denyWrite: canonical(['/tmp/claude', '/private/tmp/claude']),
-      // Agents must be able to update repo-local git config; SRT still protects
-      // hooks and the other mandatory code-execution paths.
-      allowGitConfig: true
+      // Daemon-managed Git writes the credential-helper entries outside the
+      // sandbox. A confined runtime must not redirect later host-side Git via
+      // core.hooksPath, core.fsmonitor, filter.*, or similar settings.
+      allowGitConfig: false
     },
     ...(policy.gitSafeDirectories?.length ? { git: { safeDirectories: canonical(policy.gitSafeDirectories) } } : {})
   }
@@ -314,15 +321,24 @@ export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy)
 export function sandboxWrap(
   cmd: string,
   args: string[],
-  opts: { mechanism: SandboxMechanism; writable: string[]; settingsPath?: string; maskedReadRoots?: string[] }
+  opts: {
+    mechanism: SandboxMechanism
+    writable: string[]
+    settingsPath?: string
+    cwd?: string
+    maskedReadRoots?: string[]
+  }
 ): { cmd: string; args: string[] } {
   if (!opts.settingsPath || !isAbsolute(opts.settingsPath)) {
     throw new SandboxError('sandbox settings path is required')
   }
+  if (!opts.cwd || !isAbsolute(opts.cwd)) {
+    throw new SandboxError('sandbox cwd is required')
+  }
   const provider = sandboxProviderLauncher()
   return {
     cmd: provider.cmd,
-    args: [...provider.args, '__sandbox-runtime', opts.settingsPath, String(process.pid), '--', cmd, ...args]
+    args: [...provider.args, '__sandbox-runtime', opts.settingsPath, String(process.pid), opts.cwd, '--', cmd, ...args]
   }
 }
 

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -1,30 +1,53 @@
-import { realpathSync, statSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { spawnSync } from 'node:child_process'
-import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path'
-import { resolveCommandPath } from '../runtimes/probe.js'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime'
 
 /**
- * OS-level process sandbox for agent runtimes (issue #642).
+ * OS-level process sandbox for agent runtimes (issue #312).
  *
  * The agent subprocess reads/writes the disk with its OWN tools (ACP fs is not a
  * chokepoint), so the only enforceable boundary is the kernel. We wrap the spawn
- * command in the platform's native sandbox launcher and confine WRITES to a small
- * allow-list. Reads stay open — locking reads breaks interpreters/libs/configs for
- * little threat reduction, and the goal is "the agent can't modify anything outside
- * its workspace", not secrecy.
+ * command through @anthropic-ai/sandbox-runtime (SRT). Each ACP host gets its own
+ * provider process because SRT's manager is process-global, while AgentConnect runs
+ * many differently-scoped agents concurrently.
  *
  * SECURITY — the writable set is derived from the TRUSTED agent directory (the
  * daemon's filesystem-scan result), never from mutable `agent.json` fields. The
- * agent-dir root that holds `agent.json` and agent-local state is intentionally NOT writable (only
- * its subdirs are), so a confined runtime cannot rewrite the very config that decides
- * sandboxing (e.g. point `workspace.path` at `/`) and escape on the next respawn.
+ * agent-dir root that holds `agent.json` and agent-local state is intentionally
+ * hidden; only reviewed subdirectories are re-exposed. A confined runtime cannot
+ * rewrite the config that decides sandboxing (e.g. point `workspace.path` at `/`)
+ * and escape on the next respawn.
  *
- * Fail-open: `detectSandbox()` returns undefined when no mechanism is installed and
- * the caller runs the agent unconfined. `sandboxBoundary()` instead THROWS on an
- * unsafe layout — an un-sandboxable config must not silently run unconfined.
+ * Fail-open: `detectSandbox()` returns undefined when SRT cannot establish a live
+ * Linux sandbox and the caller runs the agent unconfined. `sandboxBoundary()`
+ * instead THROWS on an unsafe layout — an un-sandboxable config must not silently
+ * run unconfined.
  */
-export type SandboxMechanism = 'bwrap' | 'sandbox-exec'
+export type SandboxMechanism = 'bwrap'
+
+export interface SrtSandboxPolicy {
+  writable: string[]
+  denyRead: string[]
+  allowRead: string[]
+  gitSafeDirectories?: string[]
+}
 
 export interface DelegatedCellMount {
   maskedRoot: string
@@ -61,38 +84,61 @@ export function supportsDelegatedMcpIsolation(input: {
   return input.platform === 'linux' && input.mechanism === 'bwrap' && input.requireSandbox && input.bwrapProbePassed
 }
 
-/** The sandbox launcher available on this host, or undefined (⇒ fail-open). */
-export function detectSandbox(env: NodeJS.ProcessEnv = process.env): SandboxMechanism | undefined {
-  if (process.platform === 'linux') {
-    const bwrap = resolveCommandPath('bwrap', env)
-    if (!bwrap) return undefined
-    const probe = spawnSync(
-      bwrap,
-      [
-        '--unshare-pid',
-        '--die-with-parent',
-        '--ro-bind',
-        '/',
-        '/',
-        '--dev',
-        '/dev',
-        '--proc',
-        '/proc',
-        '--tmpfs',
-        tmpdir(),
-        'true'
-      ],
-      {
-        env,
-        stdio: 'ignore',
-        timeout: 2_000,
-        windowsHide: true
-      }
-    )
-    return probe.status === 0 ? 'bwrap' : undefined
+function sandboxProviderLauncher(): { cmd: string; args: string[] } {
+  // Source/dev/tests run through tsx. A published daemon is the bundled
+  // dist/index.js and can execute its hidden provider command directly.
+  const sourceEntry = fileURLToPath(new URL('../index.ts', import.meta.url))
+  if (existsSync(sourceEntry)) {
+    const req = createRequire(import.meta.url)
+    return { cmd: process.execPath, args: [req.resolve('tsx/cli'), sourceEntry] }
   }
-  if (process.platform === 'darwin') return resolveCommandPath('sandbox-exec', env) ? 'sandbox-exec' : undefined
-  return undefined
+  const entry = process.argv[1]
+  if (!entry) throw new SandboxError('cannot locate the AgentConnect sandbox provider entry')
+  return { cmd: process.execPath, args: [entry] }
+}
+
+let cachedHostSandbox: { value: SandboxMechanism | undefined } | undefined
+
+/** Live Linux SRT/bwrap support on this host, or undefined (⇒ fail-open). */
+export function detectSandbox(env: NodeJS.ProcessEnv = process.env): SandboxMechanism | undefined {
+  if (env === process.env && cachedHostSandbox) return cachedHostSandbox.value
+  const value = probeSandbox(env)
+  if (env === process.env) cachedHostSandbox = { value }
+  return value
+}
+
+/** Keep the live SRT launch out of every Daemon constructor after the first one.
+ * Production has one daemon, while a Linux test process may construct hundreds. */
+function probeSandbox(env: NodeJS.ProcessEnv): SandboxMechanism | undefined {
+  // This rollout is intentionally Linux-only. macOS needs a runtime-neutral
+  // credential strategy before private HOME + Seatbelt can be enabled safely.
+  if (process.platform !== 'linux') return undefined
+
+  const root = mkdtempSync(join(tmpdir(), 'agentconnect-srt-probe-'))
+  try {
+    const agentDir = join(root, 'agent')
+    const writable = join(agentDir, 'workspace')
+    const privateHome = join(agentDir, 'home')
+    mkdirSync(writable, { recursive: true })
+    mkdirSync(privateHome)
+    const settingsPath = writeSandboxSettings(agentDir, {
+      writable: [writable, privateHome],
+      denyRead: [],
+      allowRead: []
+    })
+    const launch = sandboxWrap('true', [], { mechanism: 'bwrap', writable: [writable, privateHome], settingsPath })
+    const probe = spawnSync(launch.cmd, launch.args, {
+      env: { ...env, HOME: privateHome },
+      stdio: 'ignore',
+      timeout: 10_000,
+      windowsHide: true
+    })
+    return probe.status === 0 ? 'bwrap' : undefined
+  } catch {
+    return undefined
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 }
 
 /** True when `p` resolves to a strict descendant of `root` (never `root` itself). */
@@ -145,11 +191,16 @@ function existingDelegatedMountDirectory(path: string): string {
  * it — else we throw rather than bind an ancestor (which would expose `agent.json`).
  * The agent-dir root itself is never returned, so config stays read-only.
  *
- * Writable set: the cwd, one private runtime HOME, the managed-memory dir, and the
- * daemon's MCP bridge socket dir (the child connects to it for platform tools).
+ * Writable set: the cwd, one private runtime HOME, and the managed-memory dir.
+ * Unix-socket policy deliberately remains compatibility-open during the SRT
+ * migration; connecting to an existing MCP socket does not make its directory a
+ * writable filesystem surface.
  */
 export function sandboxBoundary(opts: { agentDir: string; cwd: string; runtimeHome: string; mcpSocketPath?: string }): {
   writable: string[]
+  denyRead: string[]
+  allowRead: string[]
+  gitSafeDirectories: string[]
 } {
   const requestedAgentDir = resolve(opts.agentDir)
   if (!isAbsolute(requestedAgentDir) || requestedAgentDir === sep) {
@@ -169,12 +220,22 @@ export function sandboxBoundary(opts: { agentDir: string; cwd: string; runtimeHo
     throw new SandboxError(`managed memory dir is not inside the agent dir "${agentDir}"`)
   }
   const writable = new Set<string>([cwd, runtimeHome, managedMemory])
-  if (opts.mcpSocketPath) writable.add(canonicalTarget(dirname(opts.mcpSocketPath)))
-  return { writable: [...writable] }
+  const allowRead = new Set<string>([
+    ...writable,
+    canonicalTarget(join(agentDir, 'run', 'config-files')),
+    canonicalTarget(join(agentDir, '.agentconnect', 'runtime-policy'))
+  ])
+  return {
+    writable: [...writable],
+    // Hide agent.json (including persisted runtime secrets) and every other
+    // daemon-owned sibling, then carve back only the runtime's data surfaces.
+    denyRead: [agentDir],
+    allowRead: [...allowRead],
+    gitSafeDirectories: [cwd]
+  }
 }
 
-/** Resolve symlinks so subpath rules match the kernel's canonical path (macOS /tmp
- *  → /private/tmp). */
+/** Resolve symlinks so SRT rules match the kernel's canonical path. */
 function canonical(paths: string[]): string[] {
   const out = new Set<string>()
   for (const p of paths) {
@@ -185,50 +246,111 @@ function canonical(paths: string[]): string[] {
 }
 
 /**
- * Wrap `cmd`/`args` so the process runs under `mechanism`, everything readable but
- * writes confined to `writable` (plus tmp, added here so callers can't forget it).
+ * Atomically publish the trusted SRT policy outside every agent-writable path.
  */
+export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy): string {
+  const root = canonicalTarget(agentDir)
+  const settingsDir = join(root, '.agentconnect', 'sandbox')
+  let current = root
+  for (const part of relative(root, settingsDir).split(sep).filter(Boolean)) {
+    current = join(current, part)
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) {
+      throw new SandboxError(`sandbox settings path contains a symlink: ${current}`)
+    }
+  }
+  mkdirSync(settingsDir, { recursive: true, mode: 0o700 })
+  chmodSync(settingsDir, 0o700)
+  if (!strictlyInside(root, realpathSync(settingsDir))) {
+    throw new SandboxError('sandbox settings path escapes the trusted agent dir')
+  }
+
+  const config: SandboxRuntimeConfig = {
+    // Preserve common proxy-aware outbound web access while SRT isolates the
+    // network namespace. The provider approves unmatched domains until a
+    // separate network policy is designed; SRT intentionally rejects a bare
+    // wildcard in allowedDomains. Host-local ports and clients that ignore the
+    // proxy environment remain explicit compatibility gaps in issue #312.
+    network: {
+      allowedDomains: [],
+      deniedDomains: [],
+      // Socket restrictions are a separate policy project. Preserve all current
+      // MCP/git/runtime behavior while replacing only the filesystem wrapper.
+      allowAllUnixSockets: true
+    },
+    filesystem: {
+      // SRT's shared default temp path is not part of AgentConnect's per-agent
+      // storage. The provider redirects TMPDIR into the private HOME; hide the
+      // shared fallback so agents cannot exchange data through it.
+      denyRead: canonical([...policy.denyRead, '/tmp/claude', '/private/tmp/claude']),
+      allowRead: canonical(policy.allowRead),
+      allowWrite: canonical(policy.writable),
+      denyWrite: canonical(['/tmp/claude', '/private/tmp/claude']),
+      // Agents must be able to update repo-local git config; SRT still protects
+      // hooks and the other mandatory code-execution paths.
+      allowGitConfig: true
+    },
+    ...(policy.gitSafeDirectories?.length ? { git: { safeDirectories: canonical(policy.gitSafeDirectories) } } : {})
+  }
+
+  const settingsPath = join(settingsDir, 'settings.json')
+  const temporary = join(settingsDir, `.${randomUUID()}.tmp`)
+  try {
+    writeFileSync(temporary, `${JSON.stringify(config, null, 2)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    chmodSync(temporary, 0o600)
+    renameSync(temporary, settingsPath)
+    chmodSync(settingsPath, 0o600)
+  } catch (error) {
+    try {
+      unlinkSync(temporary)
+    } catch {
+      // The temp may not exist or may already have been renamed.
+    }
+    throw error
+  }
+  return settingsPath
+}
+
+/** Wrap an ordinary ACP command in AgentConnect's per-host SRT provider. */
 export function sandboxWrap(
   cmd: string,
   args: string[],
-  opts: { mechanism: SandboxMechanism; writable: string[]; maskedReadRoots?: string[] }
+  opts: { mechanism: SandboxMechanism; writable: string[]; settingsPath?: string; maskedReadRoots?: string[] }
 ): { cmd: string; args: string[] } {
-  if (opts.mechanism !== 'bwrap' && (opts.maskedReadRoots?.length ?? 0) > 0) {
-    throw new SandboxError('sandbox mechanism cannot mask read roots')
+  if (!opts.settingsPath || !isAbsolute(opts.settingsPath)) {
+    throw new SandboxError('sandbox settings path is required')
   }
-  const writable = canonical(opts.writable)
-  if (opts.mechanism === 'bwrap') {
-    const maskedReadRoots = canonical(opts.maskedReadRoots ?? [])
-    const bwrap: string[] = [
-      // A PID namespace is REQUIRED for the read-only root to hold: without it the
-      // fresh /proc still lists the daemon (same UID), and a confined agent could
-      // follow /proc/<daemon-pid>/root/... into the daemon's original writable mount
-      // namespace and write arbitrary host paths (#642). --unshare-pid hides host
-      // processes; --die-with-parent tears the sandbox down if the daemon dies.
-      '--unshare-pid',
-      '--die-with-parent',
-      '--ro-bind',
-      '/',
-      '/', // whole fs readable...
-      '--dev',
-      '/dev',
-      '--proc',
-      '/proc', // procfs for THIS pid namespace (mounted after --unshare-pid)
-      '--tmpfs',
-      tmpdir(), // ...fresh writable tmp...
-      ...writable.flatMap((w) => ['--bind', w, w]), // ...and these dirs writable (later binds win)
-      ...maskedReadRoots.flatMap((root) => ['--tmpfs', root]), // mask daemon-owned private socket sources
-      '--'
-    ]
-    return { cmd: 'bwrap', args: [...bwrap, cmd, ...args] }
+  const provider = sandboxProviderLauncher()
+  return {
+    cmd: provider.cmd,
+    args: [...provider.args, '__sandbox-runtime', opts.settingsPath, String(process.pid), '--', cmd, ...args]
   }
-  // sandbox-exec (macOS Seatbelt): allow all, deny writes, re-allow the writable set.
-  // Inline profile via -p avoids a temp file. subpath must be a realpath (canonical()).
-  const seatbeltWritable = canonical([...writable, tmpdir()])
-  const profile =
-    '(version 1)(allow default)(deny file-write*)' +
-    seatbeltWritable.map((w) => `(allow file-write* (subpath "${w}"))`).join('')
-  return { cmd: 'sandbox-exec', args: ['-p', profile, cmd, ...args] }
+}
+
+/** Legacy bwrap base retained only for delegated cells that require source→target
+ * bind remapping, which SRT cannot currently express. Ordinary ACP hosts never use it. */
+function delegatedBwrapBaseWrap(
+  cmd: string,
+  args: string[],
+  writable: string[],
+  maskedReadRoots: string[]
+): { cmd: string; args: string[] } {
+  const bwrap: string[] = [
+    '--unshare-pid',
+    '--die-with-parent',
+    '--ro-bind',
+    '/',
+    '/',
+    '--dev',
+    '/dev',
+    '--proc',
+    '/proc',
+    '--tmpfs',
+    tmpdir(),
+    ...canonical(writable).flatMap((path) => ['--bind', path, path]),
+    ...canonical(maskedReadRoots).flatMap((path) => ['--tmpfs', path]),
+    '--'
+  ]
+  return { cmd: 'bwrap', args: [...bwrap, cmd, ...args] }
 }
 
 /**
@@ -290,11 +412,7 @@ export function delegatedCellSandboxWrap(
     )
   })
 
-  const wrapped = sandboxWrap(cmd, args, {
-    mechanism: 'bwrap',
-    writable: safeBaseWritable,
-    maskedReadRoots: validatedMaskedRoots
-  })
+  const wrapped = delegatedBwrapBaseWrap(cmd, args, safeBaseWritable, validatedMaskedRoots)
   const separator = wrapped.args.indexOf('--')
   const privateBinds = [
     '--dir',

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -216,7 +216,7 @@ export const AgentSchema = z.object({
   // off — the daemon seeds each integration's channel baseline silently, so only
   // channels joined AFTER the baseline (never a restart/re-list) trigger an intro.
   introduceOnJoin: z.boolean().default(false),
-  // Request an OS sandbox for this agent (issue #642). Daemon policy may force it
+  // Request an OS sandbox for this agent (issue #312). Daemon policy may force it
   // on; an unavailable optional sandbox is ineffective. New agents default off.
   restrictFileAccess: z.boolean().default(false),
   // Which memory backend this agent uses (see agents/memory-provider.ts). Absent ⇒

--- a/packages/daemon/src/agents/config-file-env.ts
+++ b/packages/daemon/src/agents/config-file-env.ts
@@ -13,11 +13,10 @@
  * ecosystem convention — kubectl, helm, helmfile, client-go/SDK programs the
  * agent writes — not just the binaries we remembered to wrap.
  *
- * Placement: files live under the TRUSTED agent dir, never $TMPDIR. The OS
- * sandbox (acp/sandbox.ts) mounts a fresh tmpfs over tmp (bwrap), so a /tmp
- * file would be invisible to a confined agent; the agent dir is readable under
- * both mechanisms and NOT writable (the writable set is cwd/home/memory only),
- * so a confined runtime cannot tamper with its own materialized config.
+ * Placement: files live under the TRUSTED agent dir, never $TMPDIR. The Linux
+ * SRT policy explicitly re-allows this directory for reads beneath the otherwise
+ * hidden agent root, but never grants writes, so a confined runtime cannot
+ * tamper with its own materialized config.
  *
  * Precedence: an explicitly configured pointer var wins. When the merged env
  * already sets e.g. `KUBECONFIG`, the `KUBECONFIG_DATA` secret is NOT

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -433,7 +433,7 @@ function applySpecFields(
   if (spec.allowedTargetAgentIds !== undefined) raw.allowedTargetAgentIds = spec.allowedTargetAgentIds
   // Self-introduce-on-join (#536): absent ⇒ leave the on-disk value alone (like pause/fastMode).
   if (spec.introduceOnJoin !== undefined) raw.introduceOnJoin = spec.introduceOnJoin
-  // Sandbox toggle (#642): the CP always ships it (definite column); absent ⇒ leave alone.
+  // Sandbox toggle (#312): the CP always ships it (definite column); absent ⇒ leave alone.
   if (spec.restrictFileAccess !== undefined) raw.restrictFileAccess = spec.restrictFileAccess
   if (spec.memory !== undefined) raw.memory = spec.memory
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -128,8 +128,8 @@ export const ConfigSchema = z.object({
       // to the signed-in cloud account. Explicit local and daemon-injected MCP
       // servers remain available. Set false only to opt this daemon out.
       isolateAccountApps: z.boolean().default(true),
-      // Daemon-wide sandbox policy (issue #642). When true, startup fails unless
-      // bwrap / sandbox-exec is available and every agent runs sandboxed; the
+      // Daemon-wide sandbox policy (issue #312). When true, startup fails unless
+      // Linux SRT/bwrap is available and every agent runs sandboxed; the
       // console locks the per-agent option on. false leaves it agent-selectable.
       requireSandbox: z.boolean().default(false),
       // Operator-owned remote-origin policy for daemon-managed workspace clone/pull.

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -87,6 +87,9 @@ export function createWorkspaceGit(
       const root = rootFor(agentId)
       if (!isRepo(root)) return { agentId, isRepo: false, clean: true }
 
+      // Status consults branch/upstream config. Reject executable checkout
+      // settings first; SRT keeps the audited config read-only while confined.
+      await assertSafeWorkspaceGitConfig(root)
       const git = gitFor(root).env(workspaceGitLocalEnv())
       const s = await git.status()
       const files: WorkspaceGitFile[] = s.files

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1462,9 +1462,9 @@ export class Daemon {
   /** All installed winners, including curated candidates still awaiting ACP admission. */
   private runtimeCatalog: ResolvedRuntimeCatalog = { entries: {}, runtimes: {} }
   private readonly curatedRuntimeAdmission: CuratedRuntimeAdmission
-  // OS sandbox launcher available on this host (bwrap / sandbox-exec), detected once
-  // at boot. undefined ⇒ optional per-agent requests are ineffective; a daemon with
-  // security.requireSandbox refuses to start.
+  // Live Linux SRT/bwrap support, detected once at boot. undefined means optional
+  // per-agent requests are ineffective; security.requireSandbox refuses startup
+  // (including on unsupported macOS/Windows hosts).
   private sandboxMechanism: SandboxMechanism | undefined
   private runtimeNames: Record<string, string> = {} // registry id -> display name (for CP reporting)
   private runtimeVersions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
@@ -1651,7 +1651,7 @@ export class Daemon {
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
       installed?: typeof installedRuntimes
-      /** Test seam: null simulates a host without bwrap/sandbox-exec. */
+      /** Test seam: null simulates a host without Linux SRT/bwrap. */
       sandboxMechanism?: SandboxMechanism | null
       /** Test seam for delegated-isolation capability gating. */
       platform?: NodeJS.Platform
@@ -1786,7 +1786,9 @@ export class Daemon {
     this.cfg = cfg
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     if (cfg.security.requireSandbox && !this.sandboxMechanism) {
-      throw new Error('daemon startup refused: security.requireSandbox is true but this host has no bwrap/sandbox-exec')
+      throw new Error(
+        'daemon startup refused: security.requireSandbox is true but this host has no supported Linux SRT/bwrap mechanism'
+      )
     }
     if (this.sandboxMechanism === 'bwrap') {
       for (const privateRoot of [delegatedMcpBrokerRoot(root), delegatedMcpRuntimeHomeRoot(root)]) {
@@ -3518,7 +3520,7 @@ export class Daemon {
       )
       if (agent.restrictFileAccess && !runInSandbox) {
         this.log.warn(
-          `acp: agent "${agentId}" requested Run in sandbox but this host has no sandbox mechanism — running without it (#642)`
+          `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
         )
       }
       const memoryAgent =
@@ -3563,7 +3565,7 @@ export class Daemon {
       if (shimDirs.size > 0) {
         env.PATH = `${[...shimDirs].join(':')}:${env.PATH ?? process.env.PATH ?? ''}`
       }
-      // OS sandbox decision (issue #642). security.requireSandbox forces every agent
+      // OS sandbox decision (issue #312). security.requireSandbox forces every agent
       // on; otherwise the per-agent preference is effective only when this host has a
       // mechanism. The writable set is derived from the TRUSTED agent dir
       // (agent.dir — the daemon's filesystem-scan result), NOT from the mutable

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -2,6 +2,14 @@
 import { startDaemonOpenTelemetry } from './observability.js'
 import { DAEMON_VERSION } from './version.js'
 
+// Internal per-ACP-host SRT provider. Fast-path it before telemetry/Commander:
+// the process is only a stdio-preserving sandbox parent and must not initialize
+// a second daemon's observability or CLI lifecycle.
+if (process.argv[2] === '__sandbox-runtime') {
+  const { runSandboxRuntimeProvider } = await import('./acp/sandbox-runtime-provider.js')
+  process.exit(await runSandboxRuntimeProvider(process.argv.slice(3)))
+}
+
 const telemetry = startDaemonOpenTelemetry({ serviceVersion: DAEMON_VERSION })
 const [{ Command }, { runChat }, { runForeground }, { acquireSingletonLock }, { resolveRoot }] = await Promise.all([
   import('commander'),
@@ -39,7 +47,7 @@ program
   .option('--log-level <level>', 'trace|debug|info|warn|error')
   .option('--agents-dir <dir>', 'override agents directory')
   .option('--max-agents <n>', 'max agents this daemon advertises / enforces')
-  .option('--require-sandbox', 'require an OS sandbox for every agent or refuse daemon startup')
+  .option('--require-sandbox', 'require the Linux SRT sandbox for every agent or refuse daemon startup')
   .option('--dry-run', 'load + validate config and print the reconcile plan, then exit')
   .option('--agent <name>', 'select a single agent by id (run/chat)')
 

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -57,6 +57,8 @@ const UNSAFE_OPTS = {
     allowUnsafeCredentialHelper: true, // the daemon-built credential.https://github.com.helper pairs
     allowUnsafeConfigEnvCount: true, // the daemon-built GIT_CONFIG_COUNT/KEY_n/VALUE_n channel
     allowUnsafeConfigPaths: true, // the daemon-selected empty global/system config view
+    allowUnsafeFsMonitor: true, // the daemon-built false override for checkout fsmonitor commands
+    allowUnsafeHooksPath: true, // the daemon-built /dev/null hooks path for host-side Git
     allowUnsafeSshCommand: true // the daemon-built ssh command that ignores user routing config
   }
 } as const
@@ -140,7 +142,7 @@ const EMPTY_GIT_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null'
 const WORKSPACE_SSH_COMMAND =
   'ssh -F none -o ProxyCommand=none -o ProxyJump=none -o PermitLocalCommand=no -o ClearAllForwardings=yes'
 const UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG =
-  /^(?:url\..*\.insteadof|include(?:if\..*)?\.path|http(?:\..*)?\.(?:proxy|curloptresolve)|remote\..*\.proxy|core\.sshcommand|fetch\.bundleuri)$/i
+  /^(?:url\..*\.insteadof|include(?:if\..*)?\.path|http(?:\..*)?\.(?:proxy|curloptresolve)|remote\..*\.(?:proxy|uploadpack|receivepack|vcs)|core\.(?:sshcommand|hookspath|fsmonitor|worktree|alternaterefscommand|askpass|pager)|pager\..*|filter\..*\.(?:clean|smudge|process)|diff\.(?:external|.*\.(?:command|textconv))|merge\..*\.driver|submodule\..*\.update|fetch\.bundleuri)$/i
 const WORKSPACE_GIT_CONTROLLED_ENV = new Set([
   'GIT_ALLOW_PROTOCOL',
   'GIT_CONFIG_NOSYSTEM',
@@ -167,6 +169,12 @@ function workspaceGitProcessEnv(): Record<string, string> {
 
 function workspaceGitConfigPairs(repository?: string): ReadonlyArray<readonly [string, string]> {
   const pairs: Array<readonly [string, string]> = [
+    // Disable both default/custom hooks and fsmonitor commands for every
+    // daemon-owned operation. Clear checkout-owned credential helpers before
+    // an optional daemon helper is appended below.
+    ['core.hooksPath', EMPTY_GIT_CONFIG],
+    ['core.fsmonitor', 'false'],
+    ['credential.helper', ''],
     ['http.followRedirects', 'false'],
     // Disable checkout- or server-selected secondary download locations.
     ['fetch.bundleURI', ''],
@@ -238,7 +246,11 @@ export function workspaceGitPullTarget(repository: string): {
 
 /** Environment for workspace Git operations that must never contact a remote. */
 export function workspaceGitLocalEnv(): Record<string, string> {
-  return { ...workspaceGitProcessEnv(), GIT_ALLOW_PROTOCOL: '' }
+  return {
+    ...workspaceGitProcessEnv(),
+    GIT_ALLOW_PROTOCOL: '',
+    ...gitConfigEnv(workspaceGitConfigPairs())
+  }
 }
 
 /**
@@ -250,9 +262,9 @@ export function workspaceGitLocalEnv(): Record<string, string> {
 export async function assertSafeWorkspaceGitConfig(cwd: string): Promise<void> {
   const names = await gitFor(cwd)
     .env(workspaceGitLocalEnv())
-    .raw(['config', '--no-includes', '--name-only', '-z', '--list'])
+    .raw(['config', '--local', '--no-includes', '--name-only', '-z', '--list'])
   if (names.split('\0').some((name) => UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG.test(name))) {
-    throw new Error('workspace Git configuration contains a disallowed network override')
+    throw new Error('workspace Git configuration contains a disallowed network override or executable setting')
   }
 }
 

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -562,39 +562,6 @@ describe('AcpHost delegated sandbox launch', () => {
     return { bin, argsFile, maskedRoot, sourceDir, runtimeHomeRoot, runtimeHome, root }
   }
 
-  it('masks both daemon-private roots for an ordinary untrusted ACP host without binding either back', async () => {
-    const fixture = fakeBwrap()
-    const host = new AcpHost(
-      { command: process.execPath, args: [fakeAgent], env: [] },
-      {
-        onUpdate: () => {},
-        env: { PATH: fixture.bin, AC_BWRAP_ARGS: fixture.argsFile },
-        inheritProcessEnv: false,
-        sandbox: {
-          mechanism: 'bwrap',
-          writable: [fixture.runtimeHome],
-          maskedReadRoots: [fixture.maskedRoot, fixture.runtimeHomeRoot]
-        }
-      }
-    )
-    await host.start()
-    await host.stop()
-    const args = readFileSync(fixture.argsFile, 'utf8').split('\n')
-    expect(args).toContain('--unshare-pid')
-    expect(args).toContain('/proc')
-    const maskedRoot = realpathSync(fixture.maskedRoot)
-    expect(args.findIndex((arg, index) => arg === maskedRoot && args[index - 1] === '--tmpfs')).toBeGreaterThan(0)
-    const runtimeHomeRoot = realpathSync(fixture.runtimeHomeRoot)
-    const runtimeHomeMask = args.findIndex((arg, index) => arg === runtimeHomeRoot && args[index - 1] === '--tmpfs')
-    expect(runtimeHomeMask).toBeGreaterThan(0)
-    expect(args).not.toContain(realpathSync(fixture.sourceDir))
-    const runtimeHomeBind = args.findIndex(
-      (arg, index) => arg === realpathSync(fixture.runtimeHome) && args[index - 1] === '--bind'
-    )
-    expect(runtimeHomeBind).toBeGreaterThan(0)
-    expect(runtimeHomeBind).toBeLessThan(runtimeHomeMask)
-  }, 15_000)
-
   it('reveals exactly its validated private cell bind after masking the common broker root', async () => {
     const fixture = fakeBwrap()
     const targetDir = delegatedMcpInCellSocketDirectory()

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -37,7 +37,7 @@ function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', ico
 }
 
 describe('Daemon (no Slack, injected ACP host)', () => {
-  it('masks the private broker root in normal bwrap ACP host construction', async () => {
+  it('masks the private broker root in normal sandboxed ACP host construction', async () => {
     const root = scaffold()
     const repoRoot = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../..'))
     expect(realpathSync(root).startsWith(repoRoot + sep)).toBe(false)
@@ -68,7 +68,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     }
   })
 
-  it('keeps an optional unsandboxed host working on bwrap without advertising a mask', async () => {
+  it('keeps an optional unsandboxed host working on a sandbox-capable host without advertising a mask', async () => {
     const root = scaffold()
     const daemon = new Daemon({
       root,
@@ -95,7 +95,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     )
 
     await expect(new Daemon({ root, sandboxMechanism: null }).start()).rejects.toThrow(
-      /daemon startup refused.*requireSandbox.*no bwrap\/sandbox-exec/
+      /daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/
     )
   })
 

--- a/packages/daemon/test/delegated-mcp-capability.test.ts
+++ b/packages/daemon/test/delegated-mcp-capability.test.ts
@@ -4,7 +4,7 @@ import { Daemon } from '../src/daemon.js'
 
 function features(input: {
   platform: NodeJS.Platform
-  mechanism: 'bwrap' | 'sandbox-exec' | null
+  mechanism: 'bwrap' | null
   requireSandbox: boolean
   completePath: boolean
 }): string[] {
@@ -35,7 +35,6 @@ describe('delegated MCP daemon capability', () => {
   it.each([
     ['optional sandbox policy', 'linux', 'bwrap', false, true],
     ['non-Linux host', 'darwin', 'bwrap', true, true],
-    ['sandbox-exec host', 'linux', 'sandbox-exec', true, true],
     ['missing bwrap', 'linux', null, true, true],
     ['incomplete broker/host path', 'linux', 'bwrap', true, false]
   ] as const)('omits the capability for %s', (_label, platform, mechanism, requireSandbox, completePath) => {

--- a/packages/daemon/test/delegated-mcp-cross-cell.test.ts
+++ b/packages/daemon/test/delegated-mcp-cross-cell.test.ts
@@ -232,7 +232,8 @@ describe('delegated MCP copied socket/token isolation', () => {
       const ordinarySettings = writeSandboxSettings(ordinaryAgentDir, {
         writable: [sharedControlRoot, ordinaryHome],
         denyRead: [brokerRoot, runtimeHomeRoot],
-        allowRead: []
+        allowRead: [],
+        gitSafeDirectories: [sharedControlRoot]
       })
 
       const entitledA = delegatedCellSandboxWrap(
@@ -254,7 +255,8 @@ describe('delegated MCP copied socket/token isolation', () => {
         mechanism: 'bwrap',
         writable: [sharedControlRoot, ordinaryHome],
         maskedReadRoots: [brokerRoot, runtimeHomeRoot],
-        settingsPath: ordinarySettings
+        settingsPath: ordinarySettings,
+        cwd: sharedControlRoot
       })
       const victimB = delegatedCellSandboxWrap(
         process.execPath,

--- a/packages/daemon/test/delegated-mcp-cross-cell.test.ts
+++ b/packages/daemon/test/delegated-mcp-cross-cell.test.ts
@@ -10,7 +10,8 @@ import {
   delegatedMcpInCellSocketDirectory,
   delegatedCellSandboxWrap,
   detectSandbox,
-  sandboxWrap
+  sandboxWrap,
+  writeSandboxSettings
 } from '../src/acp/sandbox.js'
 import { McpControlServer } from '../src/mcp/control-server.js'
 import { SessionMcpBroker } from '../src/mcp/session-mcp-broker.js'
@@ -114,12 +115,14 @@ function descriptorEnv(descriptor: NonNullable<Awaited<ReturnType<SessionMcpBrok
 async function executeProbe(
   wrapped: { cmd: string; args: string[] },
   token: string,
-  endpoints: Array<{ path: string; attach: boolean }>
+  endpoints: Array<{ path: string; attach: boolean }>,
+  env?: NodeJS.ProcessEnv
 ): Promise<Array<{ pathVisible: boolean; connected: boolean; authorized: boolean; error?: string }>> {
   const { stdout } = await run(wrapped.cmd, [...wrapped.args, token, JSON.stringify(endpoints)], {
     timeout: 10_000,
     killSignal: 'SIGKILL',
-    maxBuffer: 64 * 1024
+    maxBuffer: 64 * 1024,
+    ...(env ? { env } : {})
   })
   return JSON.parse(stdout) as Array<{
     pathVisible: boolean
@@ -223,6 +226,14 @@ describe('delegated MCP copied socket/token isolation', () => {
         { path: inCellSocketPath, attach: true },
         { path: sharedControlPath, attach: false }
       ]
+      const ordinaryAgentDir = await privateRoot('.ac-cross-cell-ordinary-')
+      const ordinaryHome = join(ordinaryAgentDir, 'home')
+      await mkdir(ordinaryHome)
+      const ordinarySettings = writeSandboxSettings(ordinaryAgentDir, {
+        writable: [sharedControlRoot, ordinaryHome],
+        denyRead: [brokerRoot, runtimeHomeRoot],
+        allowRead: []
+      })
 
       const entitledA = delegatedCellSandboxWrap(
         process.execPath,
@@ -241,8 +252,9 @@ describe('delegated MCP copied socket/token isolation', () => {
       )
       const ordinaryC = sandboxWrap(process.execPath, ['-e', PROBE_SCRIPT], {
         mechanism: 'bwrap',
-        writable: [sharedControlRoot],
-        maskedReadRoots: [brokerRoot, runtimeHomeRoot]
+        writable: [sharedControlRoot, ordinaryHome],
+        maskedReadRoots: [brokerRoot, runtimeHomeRoot],
+        settingsPath: ordinarySettings
       })
       const victimB = delegatedCellSandboxWrap(
         process.execPath,
@@ -261,7 +273,12 @@ describe('delegated MCP copied socket/token isolation', () => {
       )
 
       const assertCopiedTokenDenied = async (attacker: typeof entitledA, entitled: boolean) => {
-        const attempts = await executeProbe(attacker, tokenB, copiedVictimEndpoints)
+        const attempts = await executeProbe(
+          attacker,
+          tokenB,
+          copiedVictimEndpoints,
+          entitled ? undefined : { ...process.env, HOME: ordinaryHome }
+        )
         expect(attempts).toHaveLength(3)
         // The copied host source must disappear. This assertion fails if the common
         // broker root is accidentally shared into any sibling mount namespace.

--- a/packages/daemon/test/delegated-mcp-isolation.test.ts
+++ b/packages/daemon/test/delegated-mcp-isolation.test.ts
@@ -1,4 +1,13 @@
-import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
@@ -10,7 +19,8 @@ import {
   detectSandbox,
   sandboxWrap,
   SandboxError,
-  supportsDelegatedMcpIsolation
+  supportsDelegatedMcpIsolation,
+  writeSandboxSettings
 } from '../src/acp/sandbox.js'
 
 const privateHomeRoots: string[] = []
@@ -36,9 +46,9 @@ function privateHomeMount() {
 describe('supportsDelegatedMcpIsolation', () => {
   it.each([
     {
-      name: 'macOS sandbox-exec',
+      name: 'non-Linux host',
       platform: 'darwin' as const,
-      mechanism: 'sandbox-exec' as const,
+      mechanism: 'bwrap' as const,
       requireSandbox: true,
       bwrapProbePassed: true
     },
@@ -80,24 +90,21 @@ describe('supportsDelegatedMcpIsolation', () => {
 })
 
 describe('delegated bwrap mount isolation', () => {
-  it('masks the common source root for an ordinary host without binding anything back', () => {
+  it('denies the common source root in an ordinary host SRT policy', () => {
     const maskedRoot = mkdtempSync(join(tmpdir(), 'ac-admin-sockets-'))
     const canonicalMaskedRoot = realpathSync(maskedRoot)
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-ordinary-agent-'))
 
-    const { cmd, args } = sandboxWrap('codex', ['--acp'], {
-      mechanism: 'bwrap',
+    const settingsPath = writeSandboxSettings(agentDir, {
       writable: [],
-      maskedReadRoots: [maskedRoot]
+      denyRead: [maskedRoot],
+      allowRead: []
     })
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'))
 
-    expect(cmd).toBe('bwrap')
-    expect(args).toContain('--unshare-pid')
-    expect(args.slice(args.indexOf('--proc'), args.indexOf('--proc') + 2)).toEqual(['--proc', '/proc'])
-    expect(args.slice(args.indexOf(canonicalMaskedRoot) - 1, args.indexOf(canonicalMaskedRoot) + 1)).toEqual([
-      '--tmpfs',
-      canonicalMaskedRoot
-    ])
-    expect(args).not.toContain('--bind')
+    expect(settings.filesystem.denyRead).toContain(canonicalMaskedRoot)
+    expect(settings.filesystem.allowRead).not.toContain(canonicalMaskedRoot)
+    expect(settings.filesystem.allowWrite).not.toContain(canonicalMaskedRoot)
   })
 
   it('binds back exactly the entitled broker cell and runtime HOME after masking both private roots', () => {
@@ -224,7 +231,8 @@ describe('delegated bwrap mount isolation', () => {
         sandbox.sandboxWrap('codex', ['--acp'], {
           mechanism: 'bwrap',
           writable: [],
-          maskedReadRoots: []
+          maskedReadRoots: [],
+          settingsPath: join(maskedRoot, 'settings.json')
         })
       ).not.toThrow()
       expect(() =>
@@ -401,17 +409,26 @@ describe('bwrap delegated mount behavior', () => {
       writeFileSync(join(sourceB, 'marker'), 'bravo')
       const canonicalMaskedRoot = realpathSync(maskedRoot)
       const canonicalTargetA = CANONICAL_PRIVATE_TARGET_DIRECTORY
+      const ordinaryAgentDir = mkdtempSync(join(tmpdir(), 'ac-ordinary-agent-'))
+      const ordinaryHome = join(ordinaryAgentDir, 'home')
+      mkdirSync(ordinaryHome)
+      const ordinarySettings = writeSandboxSettings(ordinaryAgentDir, {
+        writable: [ordinaryHome],
+        denyRead: [maskedRoot],
+        allowRead: []
+      })
 
       const ordinary = sandboxWrap(
         'sh',
         ['-c', 'test ! -e "$1/cell-a/marker" && test ! -e "$1/cell-b/marker"', 'sh', canonicalMaskedRoot],
         {
           mechanism: 'bwrap',
-          writable: [],
-          maskedReadRoots: [maskedRoot]
+          writable: [ordinaryHome],
+          maskedReadRoots: [maskedRoot],
+          settingsPath: ordinarySettings
         }
       )
-      execFileSync(ordinary.cmd, ordinary.args)
+      execFileSync(ordinary.cmd, ordinary.args, { env: { ...process.env, HOME: ordinaryHome } })
 
       const entitled = delegatedCellSandboxWrap(
         'sh',

--- a/packages/daemon/test/delegated-mcp-isolation.test.ts
+++ b/packages/daemon/test/delegated-mcp-isolation.test.ts
@@ -232,7 +232,8 @@ describe('delegated bwrap mount isolation', () => {
           mechanism: 'bwrap',
           writable: [],
           maskedReadRoots: [],
-          settingsPath: join(maskedRoot, 'settings.json')
+          settingsPath: join(maskedRoot, 'settings.json'),
+          cwd: maskedRoot
         })
       ).not.toThrow()
       expect(() =>
@@ -415,7 +416,8 @@ describe('bwrap delegated mount behavior', () => {
       const ordinarySettings = writeSandboxSettings(ordinaryAgentDir, {
         writable: [ordinaryHome],
         denyRead: [maskedRoot],
-        allowRead: []
+        allowRead: [],
+        gitSafeDirectories: [ordinaryHome]
       })
 
       const ordinary = sandboxWrap(
@@ -425,7 +427,8 @@ describe('bwrap delegated mount behavior', () => {
           mechanism: 'bwrap',
           writable: [ordinaryHome],
           maskedReadRoots: [maskedRoot],
-          settingsPath: ordinarySettings
+          settingsPath: ordinarySettings,
+          cwd: ordinaryHome
         }
       )
       execFileSync(ordinary.cmd, ordinary.args, { env: { ...process.env, HOME: ordinaryHome } })

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -104,6 +104,12 @@ describe('gitEnvBase', () => {
     expect(workspaceGitEnvBase().GIT_CONFIG_GLOBAL).toBe(process.platform === 'win32' ? 'NUL' : '/dev/null')
     expect(Object.keys(workspaceGitEnvBase()).some((key) => /^(?:all|ftp|http|https|no)_proxy$/i.test(key))).toBe(false)
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['http.followRedirects', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual([
+      'core.hooksPath',
+      process.platform === 'win32' ? 'NUL' : '/dev/null'
+    ])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.fsmonitor', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['credential.helper', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.bundleURI', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['transfer.bundleURI', 'false'])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.uriProtocols', ''])
@@ -138,7 +144,7 @@ describe('gitEnvBase', () => {
     const root = mkdtempSync(join(tmpdir(), 'git-context-test-'))
     const workspace = join(root, 'workspace')
     const override = join(root, 'override')
-    const cleanEnv = workspaceGitEnvBase()
+    const cleanEnv = workspaceGitLocalEnv()
     execFileSync('git', ['init', workspace], { env: cleanEnv, stdio: 'ignore' })
     execFileSync('git', ['init', override], { env: cleanEnv, stdio: 'ignore' })
     execFileSync('git', ['-C', workspace, 'remote', 'add', 'origin', 'https://other-host.example/acme/repo'], {
@@ -157,7 +163,7 @@ describe('gitEnvBase', () => {
 
     try {
       await expect(
-        gitFor(workspace).env(workspaceGitEnvBase()).raw(['remote', 'get-url', 'origin'])
+        gitFor(workspace).env(workspaceGitLocalEnv()).raw(['remote', 'get-url', 'origin'])
       ).resolves.toContain('https://other-host.example/acme/repo')
     } finally {
       rmSync(root, { recursive: true, force: true })
@@ -168,10 +174,10 @@ describe('gitEnvBase', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'git-redirect-policy-test-'))
     const repository = 'https://github.com/acme/repo.git'
     try {
-      const cleanEnv = workspaceGitEnvBase()
-      execFileSync('git', ['init', workspace], { env: cleanEnv, stdio: 'ignore' })
+      const localEnv = workspaceGitLocalEnv()
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
       execFileSync('git', ['-C', workspace, 'config', `http.${repository}.followRedirects`, 'true'], {
-        env: cleanEnv
+        env: localEnv
       })
       expect(
         execFileSync('git', ['-C', workspace, 'config', '--get-urlmatch', 'http.followRedirects', repository], {
@@ -246,12 +252,98 @@ describe('gitEnvBase', () => {
     }
   })
 
+  it('rejects checkout-owned executable Git settings before host-side status or pull', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-executable-config-test-'))
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', 'core.hooksPath', 'custom-hooks'], { env: localEnv })
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it.each(['default', 'custom'] as const)('does not execute %s post-merge hooks in daemon-owned Git', (mode) => {
+    const root = mkdtempSync(join(tmpdir(), `git-hook-policy-${mode}-`))
+    const workspace = join(root, 'workspace')
+    const marker = join(root, 'executed')
+    const setupEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', '-b', 'main', workspace], { env: setupEnv, stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', 'user.name', 'Test'], { env: setupEnv })
+      execFileSync('git', ['-C', workspace, 'config', 'user.email', 'test@example.invalid'], { env: setupEnv })
+      writeFileSync(join(workspace, 'initial'), 'initial\n')
+      execFileSync('git', ['-C', workspace, 'add', 'initial'], { env: setupEnv })
+      execFileSync('git', ['-C', workspace, 'commit', '-m', 'initial'], { env: setupEnv, stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'checkout', '-b', 'advance'], { env: setupEnv, stdio: 'ignore' })
+      writeFileSync(join(workspace, 'advance'), 'advance\n')
+      execFileSync('git', ['-C', workspace, 'add', 'advance'], { env: setupEnv })
+      execFileSync('git', ['-C', workspace, 'commit', '-m', 'advance'], { env: setupEnv, stdio: 'ignore' })
+      const advance = execFileSync('git', ['-C', workspace, 'rev-parse', 'HEAD'], {
+        env: setupEnv,
+        encoding: 'utf8'
+      }).trim()
+      execFileSync('git', ['-C', workspace, 'checkout', 'main'], { env: setupEnv, stdio: 'ignore' })
+
+      const hookRoot = mode === 'default' ? join(workspace, '.git', 'hooks') : join(workspace, 'custom-hooks')
+      mkdirSync(hookRoot, { recursive: true })
+      if (mode === 'custom') {
+        execFileSync('git', ['-C', workspace, 'config', 'core.hooksPath', hookRoot], { env: setupEnv })
+      }
+      const hook = join(hookRoot, 'post-merge')
+      writeFileSync(hook, `#!/bin/sh\nprintf executed > '${marker}'\n`)
+      chmodSync(hook, 0o755)
+
+      execFileSync('git', ['-C', workspace, 'merge', '--ff-only', advance], {
+        env: workspaceGitEnvBase(),
+        stdio: 'ignore'
+      })
+      expect(existsSync(marker)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not execute a checkout-owned credential helper in daemon network Git', () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-credential-policy-'))
+    const workspace = join(root, 'workspace')
+    const marker = join(root, 'executed')
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      execFileSync(
+        'git',
+        [
+          '-C',
+          workspace,
+          'config',
+          'credential.https://example.invalid.helper',
+          `!printf executed > '${marker}'; exit 1`
+        ],
+        { env: localEnv }
+      )
+      try {
+        execFileSync('git', ['-C', workspace, 'credential', 'fill'], {
+          env: { ...workspaceGitEnvBase('https://example.invalid/acme/repo.git'), GIT_TERMINAL_PROMPT: '0' },
+          input: 'protocol=https\nhost=example.invalid\npath=acme/repo.git\n\n',
+          stdio: ['pipe', 'ignore', 'ignore']
+        })
+      } catch {
+        // No trusted helper was installed in this fixture; failure is expected.
+      }
+      expect(existsSync(marker)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('updates the origin tracking ref when an explicit URL pull advances HEAD', async () => {
     const root = mkdtempSync(join(tmpdir(), 'git-pull-refspec-test-'))
     const remote = join(root, 'remote.git')
     const seed = join(root, 'seed')
     const workspace = join(root, 'workspace')
-    const env = { ...workspaceGitEnvBase(), GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+    const env = { ...workspaceGitLocalEnv(), GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
     const run = (args: string[]) => execFileSync('git', args, { env, stdio: 'ignore' })
 
     try {

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -50,17 +50,13 @@ describe('prepareRuntimeLaunch', () => {
         maskedReadRoots: maskedRoots
       })
       expect(launch.sandbox?.maskedReadRoots).toEqual(maskedRoots)
-
-      expect(() =>
-        prepareRuntimeLaunch({
-          runtimeId: 'claude-acp',
-          scopeDir,
-          cwd,
-          runInSandbox: true,
-          sandboxMechanism: 'sandbox-exec',
-          maskedReadRoots: maskedRoots
-        })
-      ).toThrow(/mask.*bwrap/i)
+      expect(launch.sandbox?.settingsPath).toBe(
+        join(realpathSync(scopeDir), '.agentconnect', 'sandbox', 'settings.json')
+      )
+      const settings = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+      expect(settings.filesystem.denyRead).toEqual(
+        expect.arrayContaining(maskedRoots.map((path) => realpathSync(path)))
+      )
     } finally {
       rmSync(testRoot, { recursive: true, force: true })
     }
@@ -88,7 +84,7 @@ describe('prepareRuntimeLaunch', () => {
       scopeDir,
       cwd,
       runInSandbox: true,
-      sandboxMechanism: 'sandbox-exec',
+      sandboxMechanism: 'bwrap',
       explicitEnv: { AGENT_VALUE: 'yes' },
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
@@ -97,14 +93,20 @@ describe('prepareRuntimeLaunch', () => {
     expect(launch.runtimeHome).toBe(join(scopeDir, 'home'))
     expect(launch.env.HOME).toBe(join(scopeDir, 'home'))
     expect(launch.env.AGENT_VALUE).toBe('yes')
-    expect(launch.sandbox?.mechanism).toBe('sandbox-exec')
+    expect(launch.sandbox?.mechanism).toBe('bwrap')
+    expect(existsSync(launch.sandbox!.settingsPath)).toBe(true)
+    const settings = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    const canonicalHostHome = realpathSync(hostHome)
+    expect(settings.filesystem.denyRead).toEqual(
+      expect.arrayContaining([join(canonicalHostHome, '.claude'), join(canonicalHostHome, '.claude.json')])
+    )
   })
 
   it('fails before creating a private HOME when sandboxing is required but unavailable', () => {
     const { scopeDir, cwd } = fixture()
 
     expect(() => prepareRuntimeLaunch({ runtimeId: 'claude-acp', scopeDir, cwd, runInSandbox: true })).toThrow(
-      /no bwrap\/sandbox-exec/
+      /no supported Linux SRT\/bwrap/
     )
     expect(existsSync(join(scopeDir, 'home'))).toBe(false)
   })

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -53,6 +53,7 @@ describe('prepareRuntimeLaunch', () => {
       expect(launch.sandbox?.settingsPath).toBe(
         join(realpathSync(scopeDir), '.agentconnect', 'sandbox', 'settings.json')
       )
+      expect(launch.sandbox?.cwd).toBe(realpathSync(cwd))
       const settings = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
       expect(settings.filesystem.denyRead).toEqual(
         expect.arrayContaining(maskedRoots.map((path) => realpathSync(path)))

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -18,10 +18,19 @@ describe('sandboxWrap', () => {
     const { cmd, args } = sandboxWrap('claude', ['acp'], {
       mechanism: 'bwrap',
       writable: [root],
-      settingsPath
+      settingsPath,
+      cwd: root
     })
     expect(cmd).toBe(process.execPath)
-    expect(args.slice(-6)).toEqual(['__sandbox-runtime', settingsPath, String(process.pid), '--', 'claude', 'acp'])
+    expect(args.slice(-7)).toEqual([
+      '__sandbox-runtime',
+      settingsPath,
+      String(process.pid),
+      root,
+      '--',
+      'claude',
+      'acp'
+    ])
   })
 
   it('requires an absolute trusted settings path', () => {
@@ -29,6 +38,9 @@ describe('sandboxWrap', () => {
     expect(() => sandboxWrap('x', [], { mechanism: 'bwrap', writable: [], settingsPath: 'settings.json' })).toThrow(
       SandboxError
     )
+    expect(() =>
+      sandboxWrap('x', [], { mechanism: 'bwrap', writable: [], settingsPath: join(tmpdir(), 'settings.json') })
+    ).toThrow(SandboxError)
   })
 
   it('writes the Linux compatibility policy atomically outside writable roots', () => {
@@ -51,7 +63,7 @@ describe('sandboxWrap', () => {
     expect(settings.filesystem).toMatchObject({
       denyRead: expect.arrayContaining([realpathSync(agentDir)]),
       allowWrite: [realpathSync(workspace), realpathSync(home), realpathSync(memory)],
-      allowGitConfig: true
+      allowGitConfig: false
     })
     expect(settings.filesystem.denyWrite.some((path: string) => basename(path) === 'claude')).toBe(true)
     expect(settings.git.safeDirectories).toEqual([realpathSync(workspace)])
@@ -159,13 +171,15 @@ describe('bwrap PID isolation', () => {
     const settingsPath = writeSandboxSettings(agentDir, {
       writable: [workspace, home],
       denyRead: [],
-      allowRead: []
+      allowRead: [],
+      gitSafeDirectories: [workspace]
     })
     const outerPid = process.pid // the "daemon" PID; must be invisible in the child's /proc
     const { cmd, args } = sandboxWrap('sh', ['-c', `[ -e /proc/${outerPid} ] && echo LEAK || echo OK`], {
       mechanism: 'bwrap',
       writable: [workspace, home],
-      settingsPath
+      settingsPath,
+      cwd: workspace
     })
     const out = execFileSync(cmd, args, { encoding: 'utf8', env: { ...process.env, HOME: home } }).trim()
     expect(out).toBe('OK')

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -1,79 +1,62 @@
 import { describe, it, expect } from 'vitest'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from 'node:fs'
-import { sandboxWrap, sandboxBoundary, SandboxError, detectSandbox } from '../src/acp/sandbox.js'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, symlinkSync } from 'node:fs'
+import { sandboxWrap, sandboxBoundary, SandboxError, detectSandbox, writeSandboxSettings } from '../src/acp/sandbox.js'
 
-// The security-bearing invariant: whatever the mechanism, the whole fs is readable,
-// writes are confined to the agent dir + tmp, and the real command still runs last.
+// Ordinary ACP hosts launch through one SRT provider process with an immutable,
+// daemon-written policy rather than assembling bwrap arguments themselves.
 describe('sandboxWrap', () => {
-  const agentDir = tmpdir() // an existing dir so canonical() resolves it
-
-  it('bwrap: ro-binds /, tmpfs tmp, binds the writable dir, runs cmd last', () => {
-    const { cmd, args } = sandboxWrap('claude', ['acp'], { mechanism: 'bwrap', writable: [agentDir] })
-    expect(cmd).toBe('bwrap')
-    // PID namespace — without it /proc exposes the daemon and /proc/<pid>/root is an escape.
-    expect(args).toContain('--unshare-pid')
-    // root read-only
-    const ro = args.indexOf('--ro-bind')
-    expect([args[ro + 1], args[ro + 2]]).toEqual(['/', '/'])
-    // agent dir writable via --bind
-    const bind = args.indexOf('--bind')
-    expect(bind).toBeGreaterThan(-1)
-    // separator then the untouched command tail
-    expect(args.slice(-3)).toEqual(['--', 'claude', 'acp'])
+  it.skipIf(process.platform === 'linux')('does not advertise SRT on unsupported hosts', () => {
+    expect(detectSandbox()).toBeUndefined()
   })
 
-  it('sandbox-exec: denies writes then re-allows the writable subpath, runs cmd last', () => {
-    const { cmd, args } = sandboxWrap('codex', ['--acp'], {
-      mechanism: 'sandbox-exec',
-      writable: [agentDir],
-      maskedReadRoots: []
-    })
-    expect(cmd).toBe('sandbox-exec')
-    expect(args[0]).toBe('-p')
-    const profile = args[1]!
-    expect(profile).toContain('(allow default)')
-    expect(profile).toContain('(deny file-write*)')
-    expect(profile).toContain('allow file-write* (subpath')
-    expect(args.slice(-2)).toEqual(['codex', '--acp'])
-  })
-
-  it('sandbox-exec: rejects non-empty masked roots instead of silently ignoring them', () => {
-    expect(() =>
-      sandboxWrap('codex', ['--acp'], {
-        mechanism: 'sandbox-exec',
-        writable: [agentDir],
-        maskedReadRoots: [agentDir]
-      })
-    ).toThrow(SandboxError)
-  })
-
-  it('always makes tmp writable even when the caller omits it', () => {
-    const { args } = sandboxWrap('x', [], { mechanism: 'bwrap', writable: [] })
-    // --tmpfs entry present for the tmp dir
-    expect(args).toContain('--tmpfs')
-    expect(args).not.toContain('--bind')
-  })
-
-  it('bwrap: masks trusted read roots without binding their host contents back', () => {
-    const maskedRoot = mkdtempSync(join(tmpdir(), 'ac-admin-sockets-'))
-    const canonicalMaskedRoot = realpathSync(maskedRoot)
-    const { args } = sandboxWrap('x', [], {
+  it('passes the trusted settings path and untouched command argv to the provider', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-srt-wrap-'))
+    const settingsPath = join(root, 'settings.json')
+    const { cmd, args } = sandboxWrap('claude', ['acp'], {
       mechanism: 'bwrap',
-      writable: [],
-      maskedReadRoots: [maskedRoot]
+      writable: [root],
+      settingsPath
     })
+    expect(cmd).toBe(process.execPath)
+    expect(args.slice(-6)).toEqual(['__sandbox-runtime', settingsPath, String(process.pid), '--', 'claude', 'acp'])
+  })
 
-    const proc = args.indexOf('--proc')
-    expect(args[proc + 1]).toBe('/proc')
-    expect(args).toContain('--unshare-pid')
+  it('requires an absolute trusted settings path', () => {
+    expect(() => sandboxWrap('x', [], { mechanism: 'bwrap', writable: [] })).toThrow(SandboxError)
+    expect(() => sandboxWrap('x', [], { mechanism: 'bwrap', writable: [], settingsPath: 'settings.json' })).toThrow(
+      SandboxError
+    )
+  })
 
-    const maskedRootIndex = args.indexOf(canonicalMaskedRoot)
-    expect(maskedRootIndex).toBeGreaterThan(0)
-    expect(args[maskedRootIndex - 1]).toBe('--tmpfs')
-    expect(args).not.toContain('--bind')
+  it('writes the Linux compatibility policy atomically outside writable roots', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-srt-settings-'))
+    const agentDir = join(root, 'agent')
+    const workspace = join(agentDir, 'workspace')
+    const home = join(agentDir, 'home')
+    const memory = join(agentDir, 'memory')
+    mkdirSync(workspace, { recursive: true })
+    mkdirSync(home)
+    mkdirSync(memory)
+    const settingsPath = writeSandboxSettings(agentDir, {
+      writable: [workspace, home, memory],
+      denyRead: [agentDir],
+      allowRead: [workspace, home, memory],
+      gitSafeDirectories: [workspace]
+    })
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'))
+    expect(settings.network).toEqual({ allowedDomains: [], deniedDomains: [], allowAllUnixSockets: true })
+    expect(settings.filesystem).toMatchObject({
+      denyRead: expect.arrayContaining([realpathSync(agentDir)]),
+      allowWrite: [realpathSync(workspace), realpathSync(home), realpathSync(memory)],
+      allowGitConfig: true
+    })
+    expect(settings.filesystem.denyWrite.some((path: string) => basename(path) === 'claude')).toBe(true)
+    expect(settings.git.safeDirectories).toEqual([realpathSync(workspace)])
+    expect(settingsPath.startsWith(`${workspace}/`)).toBe(false)
+    expect(statSync(settingsPath).mode & 0o777).toBe(0o600)
   })
 })
 
@@ -84,7 +67,7 @@ describe('sandboxBoundary', () => {
   const agentDir = join(tmpdir(), 'ac-agent-x')
   const sock = join(tmpdir(), 'run', 'mcp.sock')
 
-  it('confines writes to the cwd + runtime HOME + memory + socket dir — NOT the agent-dir root', () => {
+  it('confines writes to cwd + runtime HOME + memory, not the agent root or socket dir', () => {
     const canonicalAgentDir = join(realpathSync(tmpdir()), 'ac-agent-x')
     const { writable } = sandboxBoundary({
       agentDir,
@@ -95,7 +78,7 @@ describe('sandboxBoundary', () => {
     expect(writable).toContain(join(canonicalAgentDir, 'workspace'))
     expect(writable).toContain(join(canonicalAgentDir, 'home'))
     expect(writable).toContain(join(canonicalAgentDir, 'memory'))
-    expect(writable).toContain(join(realpathSync(tmpdir()), 'run')) // socket dir (platform-tool bridge)
+    expect(writable).not.toContain(join(realpathSync(tmpdir()), 'run'))
     // The agent-dir root itself is never writable ⇒ agent.json and local state stay read-only.
     expect(writable).not.toContain(canonicalAgentDir)
   })
@@ -168,12 +151,23 @@ describe('bwrap PID isolation', () => {
 
   it.skipIf(!hasBwrap)("the parent daemon's PID is not visible inside the sandbox", () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-sbx-'))
+    const agentDir = join(dir, 'agent')
+    const workspace = join(agentDir, 'workspace')
+    const home = join(agentDir, 'home')
+    mkdirSync(workspace, { recursive: true })
+    mkdirSync(home)
+    const settingsPath = writeSandboxSettings(agentDir, {
+      writable: [workspace, home],
+      denyRead: [],
+      allowRead: []
+    })
     const outerPid = process.pid // the "daemon" PID; must be invisible in the child's /proc
     const { cmd, args } = sandboxWrap('sh', ['-c', `[ -e /proc/${outerPid} ] && echo LEAK || echo OK`], {
       mechanism: 'bwrap',
-      writable: [dir]
+      writable: [workspace, home],
+      settingsPath
     })
-    const out = execFileSync(cmd, args, { encoding: 'utf8' }).trim()
+    const out = execFileSync(cmd, args, { encoding: 'utf8', env: { ...process.env, HOME: home } }).trim()
     expect(out).toBe('OK')
   })
 })

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -296,7 +296,7 @@ describe('createWorkspaceGit.pull', () => {
     expect(await git.pull('a')).toMatchObject({
       isRepo: true,
       ok: false,
-      detail: 'workspace Git configuration contains a disallowed network override'
+      detail: 'workspace Git configuration contains a disallowed network override or executable setting'
     })
     expect(pullImpl).not.toHaveBeenCalled()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@agentconnect.md/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@anthropic-ai/sandbox-runtime':
+        specifier: 0.0.67
+        version: 0.0.67
       '@larksuiteoapi/node-sdk':
         specifier: ^1.71.1
         version: 1.71.1
@@ -666,6 +669,11 @@ packages:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
+
+  '@anthropic-ai/sandbox-runtime@0.0.67':
+    resolution: {integrity: sha512-4doSyr6KNdc/4zARMXYEawhFu3z6bPQjgKRq3lKp6dbgEYVMv39oaLJ28QsDc7TmLvrLqzHW+VzD2LAXxvnw8A==}
+    engines: {node: '>=20.11.0'}
+    hasBin: true
 
   '@anthropic-ai/sdk@0.110.0':
     resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
@@ -2423,6 +2431,9 @@ packages:
   '@pnpm/npm-conf@3.0.3':
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
+
+  '@pondwader/socks5-server@1.0.10':
+    resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
 
   '@posthog/browser-common@0.2.1':
     resolution: {integrity: sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==}
@@ -4300,6 +4311,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -8495,6 +8510,9 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -8585,6 +8603,13 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.201
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.201
     optional: true
+
+  '@anthropic-ai/sandbox-runtime@0.0.67':
+    dependencies:
+      '@pondwader/socks5-server': 1.0.10
+      commander: 12.1.0
+      node-forge: 1.4.0
+      zod: 3.25.76
 
   '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
     dependencies:
@@ -9715,6 +9740,8 @@ snapshots:
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-webcontainers-wasm32@0.35.3':
@@ -10685,6 +10712,8 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@pondwader/socks5-server@1.0.10': {}
 
   '@posthog/browser-common@0.2.1':
     dependencies:
@@ -12546,6 +12575,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@12.1.0: {}
 
   commander@14.0.3: {}
 
@@ -15085,8 +15116,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-forge@1.4.0:
-    optional: true
+  node-forge@1.4.0: {}
 
   node-int64@0.4.0:
     optional: true
@@ -17355,6 +17385,8 @@ snapshots:
     dependencies:
       zod: 4.4.3
     optional: true
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## Summary

- replace the ordinary ACP hand-written sandbox wrapper with exact-pinned `@anthropic-ai/sandbox-runtime@0.0.67` on Linux
- launch one SRT provider per ACP host with atomic per-agent filesystem policy, private HOME/temp storage, and owner-process cleanup
- hide daemon-owned agent metadata and the current runtime's host credential source while limiting writes to workspace, private HOME, and managed memory
- keep macOS/Windows disabled and retain the existing narrow delegated-webchat bwrap mount path

## Compatibility

- proxy-aware outbound HTTP(S) remains allowed through the SRT callback
- Unix sockets remain compatibility-open so existing MCP paths continue to work
- `security.requireSandbox` fails closed when the live Linux SRT probe fails; optional per-agent sandboxing remains fail-open
- host access to agent-started local servers, non-proxy-aware clients, whole-host read allowlisting, credential refresh, and socket policy remain tracked in #312

## Validation

- daemon focused tests: 108 passed, 2 skipped
- daemon sandbox smoke: 3 passed
- daemon typecheck and repository format check
- pre-push ESLint
- self-contained daemon build and npm pack
- final x86_64 Linux tarball smoke: ACP stdio, private HOME/temp, read/write boundaries, Unix sockets, HTTPS egress, and owner cleanup
- arm64 Linux bundle smoke during development

Tracks #312

Created by Codex . GPT-5.6
