### PR TITLE
docs: move remote MCP idempotency into control plane

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -661,10 +661,10 @@ catalog only to a private, user-owned webchat session. It never attaches this
 catalog to an arbitrary agent, an IM session, automation, or an agent-to-agent
 session.
 
-The daemon admits the descriptor only when the selected runtime proves it can keep
-private HTTPS MCP headers scoped to one ACP session and out of model context,
-transcripts, and diagnostics. The host operating system and daemon sandbox policy
-are irrelevant to this feature.
+The daemon admits the descriptor only when the selected runtime supports the
+standard ACP HTTPS MCP descriptor. AgentConnect defines no private ACP capability
+or runtime-generated retry header. The host operating system and daemon sandbox
+policy are irrelevant to this feature.
 
 On success, daemon registration advertises `webchat_remote_mcp_v1`. The relay
 delivers only a non-secret entitlement. The daemon obtains a short-lived opaque
@@ -675,8 +675,8 @@ proxy MCP requests, mint per-request assertions, or run an administrative broker
 
 The runtime calls the standard CP `POST /api/v1/mcp` endpoint directly. The CP
 derives the actor from the stored grant and durable webchat owner, re-runs live
-authorization, and provides conversation-scoped request idempotency across
-authority generations. Tool catalog execution is therefore a control operation; browser messages and ACP
+authorization, and owns confirmation plus exactly-once execution for every
+operation with side effects. Tool catalog execution is therefore a control operation; browser messages and ACP
 `session/update` streams remain on the relay↔daemon/daemon-local data path and
 never cross the CP.
 
@@ -1003,7 +1003,7 @@ control channel.
     "platforms": ["slack", "telegram", "discord", "feishu"], // Implemented platform drivers
     "runtimes": ["claude", "codex"], // Object.keys(resolveRuntimes); validate executables at startup
     "acp": true,
-    "features": ["session-visibility-v1", "webchat_remote_mcp_v1"] // Advertised only when the runtime supports private, session-scoped remote MCP headers.
+    "features": ["session-visibility-v1", "webchat_remote_mcp_v1"] // Advertised when an installed runtime supports the standard HTTPS MCP descriptor.
   },
   "maxAgents": 32,
   "localState": {
@@ -1032,18 +1032,19 @@ WebSocket drop -> CP-Client enters DEGRADED and reconnects with backoff. Daemon 
 This feature is operator opt-in and the CP gate defaults off. Before setting
 `WEBCHAT_PRESET_MCP_ENABLED=true`, deploy compatible CP, relay, daemon, and runtime
 builds; verify private webchat session enforcement, credential redaction, exact
-grant revocation, revision-fenced descriptor activation, and conversation-scoped
-cross-generation idempotency; then confirm live
+grant revocation, revision-fenced descriptor activation, and CP-owned operation
+idempotency; then confirm live
 registration advertises both `session-visibility-v1` and
 `webchat_remote_mcp_v1`.
 
-No OS sandbox package or Linux kernel setting is a feature prerequisite. Instead,
-the runtime probe must prove that remote MCP Authorization headers are private,
-session-scoped configuration and never model input or diagnostics.
+No OS sandbox package, Linux kernel setting, private ACP field, or runtime-generated
+idempotency header is a feature prerequisite. Runtime integration coverage verifies
+standard descriptor installation and replacement; CP-owned operations provide the
+write execution fence.
 
-Start with a canary and observe grant, descriptor, request, invocation, and
+Start with a canary and observe grant, descriptor, request, operation, and
 confirmation metrics. Labels are closed outcomes/reasons only; they exclude user,
-organization, agent, conversation, grant, invocation, token, Authorization header,
+organization, agent, conversation, grant, operation, token, Authorization header,
 request body, tool arguments, response body, and transcript values.
 
 Rollback sets `WEBCHAT_PRESET_MCP_ENABLED=false`, stops issuance, and invokes the

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -675,10 +675,11 @@ proxy MCP requests, mint per-request assertions, or run an administrative broker
 
 The runtime calls the standard CP `POST /api/v1/mcp` endpoint directly. The CP
 derives the actor from the stored grant and durable webchat owner, re-runs live
-authorization, and owns confirmation plus exactly-once execution for every
-operation with side effects. Standard JSON-RPC request ids index durable transport
-receipts only; CP-owned operation and execution-attempt fences provide the durable
-execution identity. Tool catalog execution is therefore a control operation; browser messages and ACP
+authorization, and owns confirmation plus fail-closed at-most-once execution for
+every operation with side effects, surfacing uncertain outcomes as explicit
+ambiguous terminal states. Standard JSON-RPC request ids index grant-scoped
+transport receipts only; CP-owned operation and execution-attempt fences provide
+the durable execution identity. Tool catalog execution is therefore a control operation; browser messages and ACP
 `session/update` streams remain on the relay↔daemon/daemon-local data path and
 never cross the CP.
 

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -676,7 +676,9 @@ proxy MCP requests, mint per-request assertions, or run an administrative broker
 The runtime calls the standard CP `POST /api/v1/mcp` endpoint directly. The CP
 derives the actor from the stored grant and durable webchat owner, re-runs live
 authorization, and owns confirmation plus exactly-once execution for every
-operation with side effects. Tool catalog execution is therefore a control operation; browser messages and ACP
+operation with side effects. Standard JSON-RPC request ids index durable transport
+receipts only; CP-owned operation and execution-attempt fences provide the durable
+execution identity. Tool catalog execution is therefore a control operation; browser messages and ACP
 `session/update` streams remain on the relay↔daemon/daemon-local data path and
 never cross the CP.
 

--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -40,9 +40,10 @@ where the administrative APIs and their authorization already live.
   AgentConnect MCP endpoint.
 - Keep credentials out of model input, tool arguments, transcripts, telemetry, and
   ordinary logs.
-- Make retries idempotent so an ambiguous write does not execute twice.
-- Work on every platform on which the daemon and selected ACP runtime can configure
-  an HTTPS MCP server with private transport headers.
+- Make writes exactly-once at the CP operation boundary, independently of runtime
+  retry behavior.
+- Work on every platform on which the daemon and selected ACP runtime support the
+  standard ACP HTTPS MCP descriptor and headers.
 - Preserve ordinary webchat and daemon-local tools if the Control Plane or delegated
   MCP is unavailable.
 
@@ -98,10 +99,10 @@ runtime.
 7. Delegated calls cannot mutate their own host preset agent. `updateAgent` and
    `deleteAgent` fail before REST dispatch when their target is the grant's
    `agentId`.
-8. One `(conversationId, invocationId)` is bound to one canonical request hash for
-   the full conversation lifetime. Credential renewal and authority-generation
-   rotation do not change this key. A transport retry may retrieve the same result
-   but cannot execute different bytes or repeat a completed write.
+8. A delegated MCP request never directly executes a write. The CP first creates or
+   reuses an open operation bound to the conversation, authority generation, acting
+   user, canonical intent hash, and confirmation policy. Only browser approval may
+   atomically claim that operation for one execution.
 9. The feature never falls back to a daemon API key, organization principal, user
    API key, system-prompt secret, or unscoped MCP credential.
 10. Disabling or failing delegated MCP removes only `agentconnect-admin`; ordinary
@@ -132,11 +133,23 @@ sequenceDiagram
     Browser->>Relay: Webchat message
     Relay->>Daemon: Message
     Daemon->>Runtime: ACP prompt
-    Runtime->>CP: HTTPS MCP request + Bearer grant + invocation id
+    Runtime->>CP: Standard HTTPS MCP request + Bearer grant
     CP->>CP: Resolve durable owner and re-authorize
-    CP->>REST: In-process call as resolved user
-    REST-->>CP: Result
-    CP-->>Runtime: MCP result
+    alt Read-only tool
+        CP->>REST: In-process read as resolved user
+        REST-->>CP: Result
+        CP-->>Runtime: MCP result
+    else Tool with side effects
+        CP->>CP: Create/reuse open operation
+        CP-->>Runtime: Pending operationId
+        Browser->>CP: Approve exact operation
+        CP->>CP: Re-authorize + atomically claim
+        CP->>REST: Execute once as resolved user
+        REST-->>CP: Result
+        CP-->>Browser: Terminal operation result
+        Runtime->>CP: Optional operation lookup
+        CP-->>Runtime: Same terminal result
+    end
     Runtime-->>Daemon: ACP response
     Daemon-->>Relay: Reply
     Relay-->>Browser: Reply
@@ -191,7 +204,7 @@ The CP may issue a grant only when all of the following hold:
 - the target session is private and reports the required session-visibility
   capability;
 - the user may currently view and use the agent; and
-- the selected runtime advertises support for private HTTPS MCP transport headers.
+- the selected runtime advertises standard HTTPS MCP support.
 
 The raw credential is returned exactly once, in the issuance reply that begins its
 delivery to the runtime. Because the CP retains only its hash, it never attempts to
@@ -253,9 +266,9 @@ authority generation. A runtime that cannot replace a descriptor receives a boun
 authorization-expired tool error after expiry; reconnecting or rebuilding the ACP
 session obtains a fresh grant.
 
-Before implementation ships, runtime probes must establish whether each curated
-runtime can update the descriptor safely. A longer lifetime is not an acceptable
-substitute for a missing rotation mechanism without a separate design review.
+Before implementation ships, integration tests must establish whether each curated
+runtime can install and replace the standard descriptor safely. No AgentConnect-
+specific ACP capability or runtime-generated request header is required.
 
 The grant is revoked on:
 
@@ -286,8 +299,9 @@ The daemon adds a remote MCP server only to the entitled ACP session:
 Requirements:
 
 - The descriptor is structured ACP/runtime configuration, not prompt text.
-- The runtime must keep transport headers out of model input and tool arguments.
-- The runtime MCP client must implement the invocation-id contract in section 8.
+- The runtime must handle transport headers as standard MCP configuration rather
+  than model input or tool arguments. AgentConnect does not add a private ACP
+  extension to attest this behavior.
 - The daemon must redact `headers` from diagnostics, errors, traces, and session
   dumps.
 - `session/new` and `session/load` attach the descriptor only to the exact eligible
@@ -316,13 +330,16 @@ After constant-time token verification, the CP:
    feature gate;
 3. resolves the acting principal exclusively from stored records;
 4. validates the MCP tool against the delegated catalog;
-5. applies current membership, RBAC, and resource-visibility rules;
-6. hard-denies host-agent mutation;
-7. looks up or creates the conversation-level idempotency row;
-8. either claims an operation that needs no confirmation or records
-   `awaiting_confirmation`; and
-9. only after the appropriate state transition, calls the existing REST/service
-   surface in process through `InternalInvocationAuth`.
+5. takes the read-only/side-effect classification from server-owned catalog
+   metadata, never from tool arguments;
+6. applies current membership, RBAC, and resource-visibility rules;
+7. hard-denies host-agent mutation;
+8. executes an authorized read immediately, or creates/reuses an open CP-owned
+   operation for every tool with side effects;
+9. returns the operation without executing it; and
+10. only after authenticated browser approval atomically claims that operation,
+    re-authorizes it, and calls the existing REST/service surface in process through
+    `InternalInvocationAuth`.
 
 Nested REST calls receive an already resolved internal principal. The raw grant is
 not replayed as REST Bearer authentication and cannot authenticate an external REST
@@ -330,57 +347,54 @@ request.
 
 Hidden resources preserve the normal no-existence-oracle behavior.
 
-## 8. Invocation idempotency
+## 8. CP-owned operation idempotency
 
-The runtime MCP client, not the model or daemon, creates a UUIDv4 `invocationId`
-when it begins one logical `tools/call`. It sends that value in the
-`Idempotency-Key` HTTP header. The header is transport metadata and is not exposed
-as a tool argument.
+AgentConnect does not require `Idempotency-Key`, a private ACP capability, or any
+other runtime-specific retry contract. Read-only tools are ordinary idempotent MCP
+requests. A tool with side effects never executes in its initiating MCP request.
 
-The client must retain the invocation id, canonical request bytes, and terminal
-state until it receives a terminal MCP response or the retry window expires.
-Automatic HTTP retries, credential replacement, reconnect, and `session/load` reuse
-the same id and exact request. The MCP JSON-RPC request id is unrelated and must not
-be used as the idempotency key.
+The CP canonicalizes the tool name and arguments into an `intentHash`, then creates
+or reuses the one open operation with the same `(conversationId, intentHash)`.
+Consequently, an HTTP retry that arrives before the pending response is observed
+gets the same operation instead of creating a second approval. A unique partial
+index enforces this rule for nonterminal operations; it does not permanently merge
+two later, deliberate user intents that happen to have identical arguments.
 
-If credential replacement requires a runtime process restart, the runtime adapter
-must persist only the non-secret outstanding invocation records in its session
-state and restore them before retrying. A runtime that cannot satisfy and probe this
-contract is ineligible for `webchat_remote_mcp_v1`. This guarantee covers transport
-retry of an already-created invocation; it cannot deduplicate a model independently
-deciding later to create a new logical tool call.
+The pending MCP result includes a random, non-secret `operationId`. Tool schemas may
+accept that id only as a status/replay selector: supplying it can observe the bound
+operation but cannot approve or execute it. The browser receives the operation over
+its authenticated control surface and is the only approval principal.
 
-The CP canonicalizes the exact tool name and arguments and stores:
+The CP stores:
 
 ```ts
-interface WebchatMcpInvocation {
+interface WebchatMcpOperation {
   conversationId: string
-  invocationId: string
+  operationId: string
   createdAuthorityGeneration: number
   sourceGrantId: string
-  requestHash: string
-  status: 'claimed' | 'awaiting_confirmation' | 'executing' | 'completed' | 'failed' | 'ambiguous' | 'stale'
+  intentHash: string
+  status: 'awaiting_confirmation' | 'executing' | 'completed' | 'failed' | 'ambiguous' | 'stale'
   boundedResponse: Uint8Array | null
   createdAt: Date
-  expiresAt: Date
+  confirmationExpiresAt: Date
+  completedAt: Date | null
 }
 ```
 
-The unique key is `(conversationId, invocationId)`, not an access-grant id or
-authority generation:
+The execution rules are:
 
-- the first request creates the row; a no-confirmation operation claims execution,
-  while a confirmation-gated operation stops at `awaiting_confirmation`;
-- every request first looks up this key across all authority generations;
-- the same hash observes in-progress state or receives the cached final response;
-- a different hash is rejected;
-- a completed, failed, or ambiguous invocation from an older authority generation
-  returns its recorded outcome and can never dispatch again;
-- a nonterminal invocation from an older authority generation atomically becomes
+- the initiating request always stops at `awaiting_confirmation`;
+- a duplicate open intent returns the same `operationId`;
+- an explicit lookup by `operationId` returns pending, executing, or the bounded
+  terminal result and rejects any mismatched conversation or intent;
+- a completed, failed, or ambiguous operation can never dispatch again;
+- a nonterminal operation from an older authority generation atomically becomes
   `stale` and can never dispatch, including an old pending confirmation;
-- an ambiguous write is never executed automatically a second time; and
-- records and cached responses have bounded size and are retained through the full
-  conversation retry and confirmation window, plus a 24-hour safety margin.
+- a crash after the execution claim becomes `ambiguous` and is never automatically
+  dispatched a second time; and
+- operation identity and terminal status are retained for the conversation
+  lifetime; bounded response bytes may be evicted separately.
 
 This ledger replaces the former mint/claim assertion exchange. The runtime already
 calls the final authentication and execution endpoint directly, so a second
@@ -392,28 +406,33 @@ The delegated catalog reuses the existing curated AgentConnect MCP catalog. Exis
 exclusions for credential, membership, organization, access-control, bot, and hook
 writes remain.
 
+Every catalog entry has a server-owned effect classification. Reads may execute in
+the initiating request. Any entry classified as having side effects must enter the
+operation path; adding a write-like tool without that classification fails catalog
+validation and cannot ship as an immediately executable delegated tool.
+
 Authorization is evaluated per request. A grant never snapshots a role into lasting
 authority.
 
-High-impact writes use one execution path. They require a user confirmation bound
-to:
+Every tool with side effects uses one execution path. It requires a user
+confirmation bound to:
 
 ```text
-conversationId + createdAuthorityGeneration + invocationId + requestHash + userId + sourceGrantId + expiresAt
+conversationId + createdAuthorityGeneration + operationId + intentHash + userId + sourceGrantId + confirmationExpiresAt
 ```
 
-The initial MCP request performs live authorization, creates the unique invocation
-row as `awaiting_confirmation`, and returns a pending result. It never dispatches
-the operation. MCP retries only observe that row; they cannot approve, claim, or
-execute it.
+The initial MCP request performs live authorization, creates or reuses the open
+operation as `awaiting_confirmation`, and returns its `operationId`. It never
+dispatches the operation. MCP retries and operation lookups can only observe that
+row; they cannot approve, claim, or execute it.
 
 The model cannot satisfy confirmation by returning `yes`. The authenticated browser
 presents the exact operation to the conversation owner. Approval is the sole
 execution claimant:
 
-1. It locks the invocation row and the conversation authority fence in a serializable
+1. It locks the operation row and the conversation authority fence in a serializable
    transaction.
-2. It verifies the row is still `awaiting_confirmation`, the request hash and bound
+2. It verifies the row is still `awaiting_confirmation`, the intent hash and bound
    fields are unchanged, the source grant is active and unexpired, and its authority
    generation is still current.
 3. It re-runs current owner binding, membership, role, resource visibility, preset
@@ -424,10 +443,10 @@ execution claimant:
    records a terminal response; a crash or uncertain outcome after `executing`
    becomes `ambiguous`, never retryable execution.
 
-Concurrent approvals and MCP retries only observe `executing` or its terminal
+Concurrent approvals and MCP lookups only observe `executing` or its terminal
 result. Denial, confirmation expiry, failed live authorization, revoked grant, or
 generation mismatch transitions the row to a terminal non-executing state. Approval
-never revives a stale invocation.
+never revives a stale operation.
 
 The first implementation may keep the existing catalog's stricter exclusions while
 browser confirmation is completed. It must not silently weaken confirmation to make
@@ -472,18 +491,18 @@ organization, and global feature revocation without requiring daemon isolation.
 
 ## 11. Failure behavior
 
-| Failure                                                  | Behavior                                                                          |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Non-preset or non-webchat session                        | No `agentconnect-admin` descriptor.                                               |
-| Runtime lacks private, session-scoped remote MCP headers | Runtime is ineligible; ordinary chat continues.                                   |
-| Grant missing, forged, expired, revoked, or stale        | MCP returns authorization expired/invalid; no fallback identity.                  |
-| CP unavailable                                           | Admin tool returns a retryable error; ordinary chat and local tools continue.     |
-| User removed or visibility changed                       | Next request fails under live authorization.                                      |
-| Agent moved or authority generation changed              | Old grants fail; reconnect or session update installs the new descriptor.         |
-| Duplicate invocation                                     | Same request returns status/cached result; different request is rejected.         |
-| Ambiguous write                                          | Report ambiguous; do not retry execution automatically.                           |
-| Feature disabled                                         | Stop issuance, revoke active grants, and omit/remove descriptors.                 |
-| Credential appears in a log or transcript                | Treat as a security incident and revoke the access grant or authority generation. |
+| Failure                                           | Behavior                                                                          |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Non-preset or non-webchat session                 | No `agentconnect-admin` descriptor.                                               |
+| Runtime lacks standard HTTPS MCP descriptors      | Runtime is ineligible; ordinary chat continues.                                   |
+| Grant missing, forged, expired, revoked, or stale | MCP returns authorization expired/invalid; no fallback identity.                  |
+| CP unavailable                                    | Admin tool returns a retryable error; ordinary chat and local tools continue.     |
+| User removed or visibility changed                | Next request fails under live authorization.                                      |
+| Agent moved or authority generation changed       | Old grants fail; reconnect or session update installs the new descriptor.         |
+| Duplicate open write intent                       | Returns the same pending operation; execution still requires browser approval.    |
+| Ambiguous write                                   | Report ambiguous; do not retry execution automatically.                           |
+| Feature disabled                                  | Stop issuance, revoke active grants, and omit/remove descriptors.                 |
+| Credential appears in a log or transcript         | Treat as a security incident and revoke the access grant or authority generation. |
 
 Errors shown to the user describe the action needed, for example:
 
@@ -522,16 +541,14 @@ selected runtime. It does not attest to an OS sandbox or hostile-process isolati
 
 The CP feature gate remains default-off. Enablement requires:
 
-1. deployed CP support for grants, authentication, revocation, idempotency, and
+1. deployed CP support for grants, authentication, revocation, CP-owned operations, and
    redaction;
 2. relay support for non-secret entitlement delivery and protocol support for
    confidential CP↔daemon grant delivery;
 3. daemon support for exact-session, revision-fenced descriptor activation and
    removal;
-4. a passing runtime probe proving remote HTTPS MCP headers are session-scoped and
-   absent from model context and diagnostics, and that `Idempotency-Key` is created
-   and preserved across every supported automatic retry and descriptor-renewal
-   path;
+4. runtime integration coverage for standard HTTPS MCP descriptor installation and
+   replacement, without any AgentConnect-specific ACP field or retry header;
 5. private session visibility enforcement; and
 6. a tested revoke path.
 
@@ -549,13 +566,13 @@ Use closed, low-cardinality labels:
 
 | Metric                                              | Labels              |
 | --------------------------------------------------- | ------------------- |
-| `agentconnect.webchat_mcp.grant.transitions`        | `event=issued       | rotated   | revoked                      | expired                                   | failed`, bounded `reason`    |
-| `agentconnect.webchat_mcp.request.duration`         | `stage=authenticate | authorize | execute`, `outcome=succeeded | failed                                    | ambiguous`                   |
-| `agentconnect.webchat_mcp.invocation.transitions`   | `event=claimed      | replayed  | completed                    | failed                                    | ambiguous`, bounded `reason` |
-| `agentconnect.webchat_mcp.confirmation.transitions` | `event=requested    | approved  | denied                       | expired                                   | failed`                      |
+| `agentconnect.webchat_mcp.grant.transitions`        | `event=issued       | rotated   | revoked                      | expired                                   | failed`, bounded `reason` |
+| `agentconnect.webchat_mcp.request.duration`         | `stage=authenticate | authorize | execute`, `outcome=succeeded | failed                                    | ambiguous`                |
+| `agentconnect.webchat_mcp.operation.transitions`    | `event=requested    | claimed   | replayed                     | completed                                 | failed`, bounded `reason` |
+| `agentconnect.webchat_mcp.confirmation.transitions` | `event=requested    | approved  | denied                       | expired                                   | failed`                   |
 | `agentconnect.webchat_mcp.descriptor.transitions`   | `event=attached     | rotated   | removed                      | failed`, `runtime` from a bounded catalog |
 
-Metrics and logs exclude user, organization, agent, conversation, grant, invocation,
+Metrics and logs exclude user, organization, agent, conversation, grant, operation,
 token, Authorization header, request body, tool arguments, response body, and
 transcript values unless an existing privacy-reviewed audit record explicitly
 requires a non-secret identifier.
@@ -579,8 +596,8 @@ The implementation adds:
 - confidential two-phase CP↔daemon grant delivery;
 - exact-session, revision-fenced remote MCP descriptor lifecycle;
 - delegated Bearer authentication at `/api/v1/mcp`;
-- conversation-scoped invocation idempotency across authority generations;
-- runtime capability probes for private headers and session scoping; and
+- conversation-scoped CP operation idempotency across authority generations;
+- standard HTTPS MCP transport capability checks; and
 - credential redaction tests across CP, relay, daemon, and runtime adapters.
 
 Protocol and implementation work must follow this document in separate changes. The

--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -40,8 +40,9 @@ where the administrative APIs and their authorization already live.
   AgentConnect MCP endpoint.
 - Keep credentials out of model input, tool arguments, transcripts, telemetry, and
   ordinary logs.
-- Make writes exactly-once at the CP operation boundary, independently of runtime
-  retry behavior.
+- Dispatch each approved write at most once at the CP operation boundary,
+  independently of runtime retry behavior, and surface an uncertain outcome as an
+  explicit ambiguous terminal state instead of retrying.
 - Work on every platform on which the daemon and selected ACP runtime support the
   standard ACP HTTPS MCP descriptor and headers.
 - Preserve ordinary webchat and daemon-local tools if the Control Plane or delegated
@@ -103,10 +104,10 @@ runtime.
    reuses an open operation bound to the conversation, authority generation, acting
    user, canonical intent hash, and confirmation policy. Only browser approval may
    atomically claim that operation for one execution.
-9. Every side-effecting MCP request has a conversation-scoped transport receipt
-   bound to its standard JSON-RPC request id and exact request hash. The receipt
-   permanently resolves to one operation, including after that operation becomes
-   terminal.
+9. Every side-effecting MCP request has a transport receipt scoped to its access
+   grant and standard JSON-RPC request id and bound to the exact request hash.
+   While retained, the receipt resolves to one operation, including after that
+   operation becomes terminal.
 10. The feature never falls back to a daemon API key, organization principal, user
     API key, system-prompt secret, or unscoped MCP credential.
 11. Disabling or failing delegated MCP removes only `agentconnect-admin`; ordinary
@@ -148,7 +149,7 @@ sequenceDiagram
         CP-->>Runtime: Pending operationId
         Browser->>CP: Approve exact operation
         CP->>CP: Re-authorize + atomically claim
-        CP->>REST: Execute once as resolved user
+        CP->>REST: Dispatch at most once as resolved user
         REST-->>CP: Result
         CP-->>Browser: Terminal operation result
         Runtime->>CP: Optional operation lookup
@@ -217,6 +218,9 @@ reconstruct or re-deliver an existing credential.
 Whenever a daemon restart, ACP session rebuild, or scheduled credential renewal
 requires raw material, the daemon requests a fresh access grant under the current
 logical authority generation. Access-grant renewal does not rotate that generation.
+The daemon never reinstalls previously delivered raw material into a rebuilt ACP
+session: every descriptor installation or reinstallation uses a freshly issued
+grant, so one grant identifies at most one installation into one runtime process.
 
 Each durable webchat `conversationId` maps to one ACP session and therefore exactly
 one `agentconnect-admin` descriptor. That descriptor has one daemon-generated,
@@ -357,30 +361,49 @@ AgentConnect does not require `Idempotency-Key`, a private ACP capability, or an
 other runtime-specific retry contract. Read-only tools are ordinary idempotent MCP
 requests. A tool with side effects never executes in its initiating MCP request.
 
+A standard JSON-RPC id is unique only among one client's outstanding requests. It
+is not a durable logical-operation identity: runtimes reset id counters across
+restarts, reconnects, and `session/load`, and may legally reuse an id once its
+earlier request completes. The CP therefore never keys a receipt on a bare
+conversation-lifetime JSON-RPC id. Every transport receipt is scoped to the access
+grant that authenticated the request. Because section 5.2 requires every descriptor
+installation into a rebuilt ACP session to use a freshly issued grant, a restarted
+runtime that restarts its id sequence lands in a new receipt scope and cannot
+collide with receipts from a previous process.
+
 The CP canonicalizes the standard MCP JSON-RPC request id, tool name, and validated
-arguments. It first creates a durable transport receipt keyed by
-`(conversationId, jsonRpcRequestId)`, bound to the exact request hash and one
-operation. Standard HTTP retry resends the same JSON-RPC body, so a retry finds that
-receipt and observes the same operation even if the original pending response was
-lost and the operation has since become terminal. A different request hash under
-the same receipt key is rejected. String and numeric JSON-RPC ids have distinct
+arguments. In one transaction, the first delivery creates a durable transport
+receipt keyed by `(grantId, jsonRpcRequestId)`, bound to the exact request hash,
+and selects or creates its operation. String and numeric JSON-RPC ids have distinct
 canonical encodings; null, fractional/unsafe numeric, oversized string, and absent
-ids are rejected for side-effecting delegated calls.
+ids are rejected for side-effecting delegated calls. Receipt resolution is:
 
-The JSON-RPC id is only a transport-replay coordinate; it never authorizes or claims
-execution. A later deliberate tool call receives a new JSON-RPC id and may create a
-new operation even when its arguments are identical. Receipts remain as bounded
-tombstones for the durable conversation lifetime. If a runtime restarts and reuses
-an old JSON-RPC id, the CP safely replays the identical request or rejects a
-different one instead of risking a duplicate write. This fail-closed collision is
-preferable to requiring a private runtime extension.
+- the same key with the same request hash replays the bound operation in every
+  operation state. Standard HTTP retry resends the same JSON-RPC body, so a retry
+  observes the same operation even if the original pending response was lost and
+  the operation has since become terminal;
+- the same key with a different request hash while the bound operation is
+  nonterminal fails closed, so a mutated in-flight duplicate can never reach a
+  second confirmation; and
+- the same key with a different request hash after the bound operation is terminal
+  is legitimate JSON-RPC id reuse within one grant: the receipt is superseded and a
+  new operation is created. A later retry of the superseded request no longer
+  matches any receipt and is rejected; its terminal operation stays observable by
+  `operationId`.
 
-The first delivery creates the receipt and selects or creates its operation in one
-transaction. Separately, a unique
+The JSON-RPC id is only a transport-replay coordinate; it never authorizes or
+claims execution. A later deliberate tool call receives a new JSON-RPC id and may
+create a new operation even when its arguments are identical. Receipts are retained
+while their grant can authenticate plus a bounded window that covers in-flight
+retries; they are not conversation-lifetime tombstones. Correctness never depends
+on receipt retention: no operation executes without browser approval, and a unique
 partial index on `(conversationId, intentHash)` for `awaiting_confirmation` rows
-coalesces two concurrent model requests for the same still-open intent into one
-browser confirmation. Once that operation is terminal, a genuinely new JSON-RPC
-request may create a new operation.
+coalesces concurrent duplicate open intents — including a higher-level retry that
+minted a fresh id or arrived under a renewed grant — into one browser confirmation.
+A retry that straddles grant rotation either resends the old credential and fails
+authentication without side effects, or arrives as a new request under the new
+grant and at worst asks the owner to confirm again. Once an operation is terminal,
+a genuinely new JSON-RPC request may create a new operation.
 
 The pending MCP result includes a random, non-secret `operationId`. Tool schemas may
 accept that id only as a status/replay selector: supplying it can observe the bound
@@ -409,11 +432,13 @@ interface WebchatMcpOperation {
 }
 
 interface WebchatMcpTransportReceipt {
+  grantId: string
   conversationId: string
   jsonRpcRequestId: string
   requestHash: string
   operationId: string
   createdAt: Date
+  supersededAt: Date | null
 }
 ```
 
@@ -444,10 +469,21 @@ The execution rules are:
 - a worker may record success or failure only with the same CAS tuple. Whichever
   terminal transition commits first wins, so a late completion cannot overwrite
   `ambiguous`, and the reaper cannot overwrite an already recorded result;
-- process loss or an uncertain external outcome therefore becomes `ambiguous` and
-  is never automatically dispatched a second time; and
+- because the `executing` claim commits before dispatch, the contract is
+  fail-closed at-most-once dispatch per operation: process loss between the claim
+  and dispatch produces zero external effects, and process loss after the business
+  mutation but before the terminal record produces exactly one. Both surface as
+  `ambiguous`, are reported to the owner for manual verification, and are never
+  automatically dispatched a second time; and
 - operation identity and terminal status are retained for the conversation
   lifetime; bounded response bytes may be evicted separately.
+
+When a tool's entire side effect is a mutation inside the CP database, the
+implementation must commit that mutation and the operation's terminal transition in
+one transaction, which removes the ambiguous window for that tool. Tools whose
+effects reach beyond one CP transaction keep the window above: for them this design
+guarantees fail-closed at-most-once dispatch with explicit `ambiguous` outcomes,
+not exactly-once effects, and no document may claim otherwise.
 
 This ledger replaces the former mint/claim assertion exchange. The runtime already
 calls the final authentication and execution endpoint directly, so a second
@@ -493,7 +529,8 @@ execution claimant:
 4. It CAS-transitions the row to `executing`. Revocation and generation rotation
    serialize on the same authority fence, so only one ordering can win.
 5. That same CAS writes the unique execution attempt and recovery deadline. The
-   elected approval worker dispatches the persisted canonical payload exactly once.
+   elected approval worker dispatches the persisted canonical payload at most once,
+   under the at-most-once and ambiguous-outcome contract in section 8.
 6. Success or ordinary failure records a terminal response only when the operation
    is still `executing` under that exact attempt. A reaper applies the same attempt-
    fenced CAS to mark an overdue execution `ambiguous`; it never retries dispatch.
@@ -546,19 +583,20 @@ organization, and global feature revocation without requiring daemon isolation.
 
 ## 11. Failure behavior
 
-| Failure                                           | Behavior                                                                          |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Non-preset or non-webchat session                 | No `agentconnect-admin` descriptor.                                               |
-| Runtime lacks standard HTTPS MCP descriptors      | Runtime is ineligible; ordinary chat continues.                                   |
-| Grant missing, forged, expired, revoked, or stale | MCP returns authorization expired/invalid; no fallback identity.                  |
-| CP unavailable                                    | Admin tool returns a retryable error; ordinary chat and local tools continue.     |
-| User removed or visibility changed                | Next request fails under live authorization.                                      |
-| Agent moved or authority generation changed       | Old grants fail; reconnect or session update installs the new descriptor.         |
-| Duplicate open write intent                       | Returns the same pending operation; execution still requires browser approval.    |
-| Retry after the operation became terminal         | The transport receipt replays that operation; it never creates another write.     |
-| Ambiguous write                                   | Report ambiguous; do not retry execution automatically.                           |
-| Feature disabled                                  | Stop issuance, revoke active grants, and omit/remove descriptors.                 |
-| Credential appears in a log or transcript         | Treat as a security incident and revoke the access grant or authority generation. |
+| Failure                                           | Behavior                                                                                         |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Non-preset or non-webchat session                 | No `agentconnect-admin` descriptor.                                                              |
+| Runtime lacks standard HTTPS MCP descriptors      | Runtime is ineligible; ordinary chat continues.                                                  |
+| Grant missing, forged, expired, revoked, or stale | MCP returns authorization expired/invalid; no fallback identity.                                 |
+| CP unavailable                                    | Admin tool returns a retryable error; ordinary chat and local tools continue.                    |
+| User removed or visibility changed                | Next request fails under live authorization.                                                     |
+| Agent moved or authority generation changed       | Old grants fail; reconnect or session update installs the new descriptor.                        |
+| Duplicate open write intent                       | Returns the same pending operation; execution still requires browser approval.                   |
+| Retry after the operation became terminal         | The transport receipt replays that operation; it never creates another write.                    |
+| JSON-RPC id reused by a restarted runtime         | The rebuilt session's fresh grant scopes new receipts; the write proceeds as a new confirmation. |
+| Ambiguous write                                   | Report ambiguous; do not retry execution automatically.                                          |
+| Feature disabled                                  | Stop issuance, revoke active grants, and omit/remove descriptors.                                |
+| Credential appears in a log or transcript         | Treat as a security incident and revoke the access grant or authority generation.                |
 
 Errors shown to the user describe the action needed, for example:
 
@@ -604,7 +642,9 @@ The CP feature gate remains default-off. Enablement requires:
 3. daemon support for exact-session, revision-fenced descriptor activation and
    removal;
 4. runtime integration coverage for standard HTTPS MCP descriptor installation and
-   replacement, without any AgentConnect-specific ACP field or retry header;
+   replacement — including JSON-RPC id reuse after a runtime restart and a
+   higher-level retry that mints a fresh id — without any AgentConnect-specific
+   ACP field or retry header;
 5. private session visibility enforcement; and
 6. a tested revoke path.
 
@@ -653,7 +693,7 @@ The implementation adds:
 - exact-session, revision-fenced remote MCP descriptor lifecycle;
 - delegated Bearer authentication at `/api/v1/mcp`;
 - conversation-scoped CP operation idempotency across authority generations;
-- durable standard-JSON-RPC transport receipts for side-effecting calls;
+- grant-scoped standard-JSON-RPC transport receipts for side-effecting calls;
 - standard HTTPS MCP transport capability checks; and
 - credential redaction tests across CP, relay, daemon, and runtime adapters.
 

--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -103,9 +103,13 @@ runtime.
    reuses an open operation bound to the conversation, authority generation, acting
    user, canonical intent hash, and confirmation policy. Only browser approval may
    atomically claim that operation for one execution.
-9. The feature never falls back to a daemon API key, organization principal, user
-   API key, system-prompt secret, or unscoped MCP credential.
-10. Disabling or failing delegated MCP removes only `agentconnect-admin`; ordinary
+9. Every side-effecting MCP request has a conversation-scoped transport receipt
+   bound to its standard JSON-RPC request id and exact request hash. The receipt
+   permanently resolves to one operation, including after that operation becomes
+   terminal.
+10. The feature never falls back to a daemon API key, organization principal, user
+    API key, system-prompt secret, or unscoped MCP credential.
+11. Disabling or failing delegated MCP removes only `agentconnect-admin`; ordinary
     webchat and daemon-local MCP tools continue.
 
 ## 4. Architecture
@@ -353,12 +357,30 @@ AgentConnect does not require `Idempotency-Key`, a private ACP capability, or an
 other runtime-specific retry contract. Read-only tools are ordinary idempotent MCP
 requests. A tool with side effects never executes in its initiating MCP request.
 
-The CP canonicalizes the tool name and arguments into an `intentHash`, then creates
-or reuses the one open operation with the same `(conversationId, intentHash)`.
-Consequently, an HTTP retry that arrives before the pending response is observed
-gets the same operation instead of creating a second approval. A unique partial
-index enforces this rule for nonterminal operations; it does not permanently merge
-two later, deliberate user intents that happen to have identical arguments.
+The CP canonicalizes the standard MCP JSON-RPC request id, tool name, and validated
+arguments. It first creates a durable transport receipt keyed by
+`(conversationId, jsonRpcRequestId)`, bound to the exact request hash and one
+operation. Standard HTTP retry resends the same JSON-RPC body, so a retry finds that
+receipt and observes the same operation even if the original pending response was
+lost and the operation has since become terminal. A different request hash under
+the same receipt key is rejected. String and numeric JSON-RPC ids have distinct
+canonical encodings; null, fractional/unsafe numeric, oversized string, and absent
+ids are rejected for side-effecting delegated calls.
+
+The JSON-RPC id is only a transport-replay coordinate; it never authorizes or claims
+execution. A later deliberate tool call receives a new JSON-RPC id and may create a
+new operation even when its arguments are identical. Receipts remain as bounded
+tombstones for the durable conversation lifetime. If a runtime restarts and reuses
+an old JSON-RPC id, the CP safely replays the identical request or rejects a
+different one instead of risking a duplicate write. This fail-closed collision is
+preferable to requiring a private runtime extension.
+
+The first delivery creates the receipt and selects or creates its operation in one
+transaction. Separately, a unique
+partial index on `(conversationId, intentHash)` for `awaiting_confirmation` rows
+coalesces two concurrent model requests for the same still-open intent into one
+browser confirmation. Once that operation is terminal, a genuinely new JSON-RPC
+request may create a new operation.
 
 The pending MCP result includes a random, non-secret `operationId`. Tool schemas may
 accept that id only as a status/replay selector: supplying it can observe the bound
@@ -373,26 +395,57 @@ interface WebchatMcpOperation {
   operationId: string
   createdAuthorityGeneration: number
   sourceGrantId: string
+  toolName: string
+  canonicalArguments: JsonValue
   intentHash: string
   status: 'awaiting_confirmation' | 'executing' | 'completed' | 'failed' | 'ambiguous' | 'stale'
+  executionAttemptId: string | null
+  claimedAt: Date | null
+  recoveryDeadline: Date | null
   boundedResponse: Uint8Array | null
   createdAt: Date
   confirmationExpiresAt: Date
   completedAt: Date | null
 }
+
+interface WebchatMcpTransportReceipt {
+  conversationId: string
+  jsonRpcRequestId: string
+  requestHash: string
+  operationId: string
+  createdAt: Date
+}
 ```
+
+`canonicalArguments` is the bounded, schema-validated representation used both for
+the confirmation display and eventual dispatch. The CP recomputes `intentHash`
+from `toolName + canonicalArguments` before approval and execution; a mismatch is a
+terminal integrity failure. Catalog limits reject an operation whose canonical
+payload is too large. The payload may contain ordinary administrative input but
+never credentials because credential-bearing tools are excluded from this catalog.
 
 The execution rules are:
 
 - the initiating request always stops at `awaiting_confirmation`;
-- a duplicate open intent returns the same `operationId`;
+- a duplicate transport receipt returns the same `operationId` in every operation
+  state;
+- a concurrent duplicate open intent with a different JSON-RPC id shares the same
+  pending operation;
 - an explicit lookup by `operationId` returns pending, executing, or the bounded
   terminal result and rejects any mismatched conversation or intent;
 - a completed, failed, or ambiguous operation can never dispatch again;
 - a nonterminal operation from an older authority generation atomically becomes
   `stale` and can never dispatch, including an old pending confirmation;
-- a crash after the execution claim becomes `ambiguous` and is never automatically
-  dispatched a second time; and
+- an approval CAS writes a fresh `executionAttemptId`, `claimedAt`, and bounded
+  `recoveryDeadline` together with `status='executing'` before dispatch;
+- no worker or recovery path may claim an `executing` operation again;
+- after `recoveryDeadline`, a reaper may CAS only
+  `(operationId, status='executing', executionAttemptId)` to `ambiguous`;
+- a worker may record success or failure only with the same CAS tuple. Whichever
+  terminal transition commits first wins, so a late completion cannot overwrite
+  `ambiguous`, and the reaper cannot overwrite an already recorded result;
+- process loss or an uncertain external outcome therefore becomes `ambiguous` and
+  is never automatically dispatched a second time; and
 - operation identity and terminal status are retained for the conversation
   lifetime; bounded response bytes may be evicted separately.
 
@@ -439,9 +492,11 @@ execution claimant:
    entitlement, placement, catalog scope, host-agent denial, and feature-gate checks.
 4. It CAS-transitions the row to `executing`. Revocation and generation rotation
    serialize on the same authority fence, so only one ordering can win.
-5. The elected approval worker dispatches exactly once. Success or ordinary failure
-   records a terminal response; a crash or uncertain outcome after `executing`
-   becomes `ambiguous`, never retryable execution.
+5. That same CAS writes the unique execution attempt and recovery deadline. The
+   elected approval worker dispatches the persisted canonical payload exactly once.
+6. Success or ordinary failure records a terminal response only when the operation
+   is still `executing` under that exact attempt. A reaper applies the same attempt-
+   fenced CAS to mark an overdue execution `ambiguous`; it never retries dispatch.
 
 Concurrent approvals and MCP lookups only observe `executing` or its terminal
 result. Denial, confirmation expiry, failed live authorization, revoked grant, or
@@ -500,6 +555,7 @@ organization, and global feature revocation without requiring daemon isolation.
 | User removed or visibility changed                | Next request fails under live authorization.                                      |
 | Agent moved or authority generation changed       | Old grants fail; reconnect or session update installs the new descriptor.         |
 | Duplicate open write intent                       | Returns the same pending operation; execution still requires browser approval.    |
+| Retry after the operation became terminal         | The transport receipt replays that operation; it never creates another write.     |
 | Ambiguous write                                   | Report ambiguous; do not retry execution automatically.                           |
 | Feature disabled                                  | Stop issuance, revoke active grants, and omit/remove descriptors.                 |
 | Credential appears in a log or transcript         | Treat as a security incident and revoke the access grant or authority generation. |
@@ -597,6 +653,7 @@ The implementation adds:
 - exact-session, revision-fenced remote MCP descriptor lifecycle;
 - delegated Bearer authentication at `/api/v1/mcp`;
 - conversation-scoped CP operation idempotency across authority generations;
+- durable standard-JSON-RPC transport receipts for side-effecting calls;
 - standard HTTPS MCP transport capability checks; and
 - credential redaction tests across CP, relay, daemon, and runtime adapters.
 


### PR DESCRIPTION
## Summary

- remove the AgentConnect-specific runtime `Idempotency-Key` contract and private ACP capability requirements
- move exactly-once execution for administrative writes into Control Plane-owned operations
- require authenticated browser confirmation before any side-effecting delegated MCP tool can execute
- update daemon capability and rollout guidance to rely only on standard HTTPS MCP descriptors

## Why

The prior design assigned AgentConnect-specific retry semantics to upstream ACP runtime MCP clients. That would require changes to independent Claude and Codex adapters and put an authorization-safety responsibility at the wrong boundary. The Control Plane already owns the acting identity, authorization policy, confirmation UI, and administrative execution surface, so it must also own operation identity and execution fencing.

## Impact

Read-only tools remain ordinary MCP calls. A side-effecting tool creates or reuses a pending operation, returns a non-secret `operationId`, and cannot execute until the authenticated conversation owner approves it. The Control Plane atomically claims the operation and retains its terminal identity, so runtime retries, descriptor renewal, and ACP session reload require no private protocol extension.

## Validation

- Prettier check for both changed design documents
- `git diff --check`
- repository pre-push lint
