### PR TITLE
fix(web): make a turn's work panel collapsible with no answer text

### DIFF
--- a/packages/web/src/components/console/MessageText.tsx
+++ b/packages/web/src/components/console/MessageText.tsx
@@ -12,6 +12,7 @@
  * tab. Styling lives under `.mdtxt` (compact, inline — distinct from `.md-body`).
  */
 
+import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -22,7 +23,11 @@ import { slackToMarkdown } from './slack-mrkdwn'
 // large strings, so above this cap we skip parsing and render cheap pre-wrapped text.
 const MAX_PARSE = 100_000
 
-export function MessageText({ text }: { text: string }) {
+// memo: the transcript re-renders on every unrelated state change in
+// SessionDetailView (composer keystrokes, the 1s duration tick, expanding one turn's
+// work), and without this EVERY row re-runs slackToMarkdown + the remark pipeline.
+// The only prop is a string, so shallow compare is exact.
+export const MessageText = memo(function MessageText({ text }: { text: string }) {
   if (text.length > MAX_PARSE) {
     return (
       <div className="mdtxt">
@@ -46,4 +51,4 @@ export function MessageText({ text }: { text: string }) {
       </ReactMarkdown>
     </div>
   )
-}
+})

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { workCounts, workSummary } from './session-work'
+import { toggleWorkPanel, workCounts, workPanelOpen, workSummary } from './session-work'
 
 const step = (lane: string, files: string[] = []) => ({ lane, files: files.map((path) => ({ path })) })
 
@@ -49,5 +49,32 @@ describe('workSummary', () => {
 
   it('is empty when there is no work', () => {
     expect(workSummary(0, 0, 0)).toBe('')
+  })
+})
+
+describe('work panel visibility', () => {
+  it('defaults to open only while a turn has no answer text', () => {
+    expect(workPanelOpen(undefined, true)).toBe(true)
+    expect(workPanelOpen(undefined, false)).toBe(false)
+  })
+
+  it('lets the user collapse a work-only turn, whose default is open', () => {
+    const after = toggleWorkPanel(new Map(), 0, true)
+    expect(workPanelOpen(after.get(0), true)).toBe(false)
+  })
+
+  it('keeps a hidden panel hidden when the answer text lands and flips the default', () => {
+    // Work-only turn (autoOpen = true) that the user hides mid-stream...
+    const after = toggleWorkPanel(new Map(), 0, true)
+    // ...then its answer arrives, so the default becomes closed. The stored choice must
+    // not read as "flipped from the default" here, or the panel would re-open itself.
+    expect(workPanelOpen(after.get(0), false)).toBe(false)
+  })
+
+  it('re-expands on a second click, and only for the toggled turn', () => {
+    const hidden = toggleWorkPanel(new Map(), 3, true)
+    const shown = toggleWorkPanel(hidden, 3, true)
+    expect(workPanelOpen(shown.get(3), true)).toBe(true)
+    expect(workPanelOpen(shown.get(4), false)).toBe(false)
   })
 })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -28,6 +28,28 @@ export function workCounts(steps: { lane: string; files: { path: string }[] }[])
   return { thinkCount: steps.length - toolCount - editStepCount, toolCount, editCount: editPaths.size + bareEdits }
 }
 
+/** Is a turn's work panel open? `autoOpen` is the default the turn's own content
+ *  implies (a turn with no answer text yet defaults OPEN so a mid-stream agent isn't
+ *  hidden); `override` is the visibility the user last chose for it, if any.
+ *
+ *  The user's choice is stored as the explicit desired state rather than as "flipped
+ *  from the default" — otherwise, when a work-only turn's answer text lands and the
+ *  default flips, a "flipped" bit would silently re-open a panel the user had hidden. */
+export function workPanelOpen(override: boolean | undefined, autoOpen: boolean): boolean {
+  return override ?? autoOpen
+}
+
+/** Record the user's toggle of turn `ti`, as the state opposite to what they see now. */
+export function toggleWorkPanel(
+  prev: ReadonlyMap<number, boolean>,
+  ti: number,
+  autoOpen: boolean
+): Map<number, boolean> {
+  const next = new Map(prev)
+  next.set(ti, !workPanelOpen(prev.get(ti), autoOpen))
+  return next
+}
+
 const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`
 
 /** One-line label for the collapsed work: reasoning steps, tool commands, and file

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -58,7 +58,7 @@ import { mergeSessionMessages } from '@/lib/session-transcript'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
-import { WORK_LANES, workCounts, workSummary } from '@/components/console/session-work'
+import { WORK_LANES, toggleWorkPanel, workCounts, workPanelOpen, workSummary } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import {
@@ -671,17 +671,12 @@ export default function SessionDetailView() {
   const [msgErr, setMsgErr] = useState<string | null>(null)
   const [tailReady, setTailReady] = useState(false)
   const [nowMs, setNowMs] = useState(() => Date.now())
-  // Bot turns whose "work" panel the user toggled AWAY from its default state
-  // (keyed by turn index) — so a work-only turn, which defaults to open, can
-  // still be collapsed by clicking its toggle.
-  const [expandedWork, setExpandedWork] = useState<Set<number>>(() => new Set())
-  const toggleWork = (ti: number) =>
-    setExpandedWork((prev) => {
-      const next = new Set(prev)
-      if (next.has(ti)) next.delete(ti)
-      else next.add(ti)
-      return next
-    })
+  // The visibility the user last chose for a bot turn's collapsed "work" panel (keyed
+  // by turn index), overriding the default that turn's content implies. Stored as the
+  // explicit desired state, so a hidden panel stays hidden when streaming flips the
+  // default — see workPanelOpen().
+  const [workOverride, setWorkOverride] = useState<ReadonlyMap<number, boolean>>(() => new Map())
+  const toggleWork = (ti: number, autoOpen: boolean) => setWorkOverride((prev) => toggleWorkPanel(prev, ti, autoOpen))
   const [imagePreparing, setImagePreparing] = useState(false)
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
@@ -1570,7 +1565,7 @@ export default function SessionDetailView() {
                   // live agent isn't hidden; collapse once its answer text lands. Either
                   // default stays user-overridable, so thinking-only turns can be closed.
                   const autoOpen = textSteps.length === 0
-                  const openWork = expandedWork.has(ti) ? !autoOpen : autoOpen
+                  const openWork = workPanelOpen(workOverride.get(ti), autoOpen)
                   return (
                     <div key={ti} className="flex items-start gap-[9px]">
                       <span className="av h-[26px] w-[26px] flex-none rounded-md">
@@ -1599,7 +1594,7 @@ export default function SessionDetailView() {
                           <>
                             <button
                               type="button"
-                              onClick={() => toggleWork(ti)}
+                              onClick={() => toggleWork(ti, autoOpen)}
                               className="mt-2 inline-flex items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
                               title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
                             >

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -671,7 +671,9 @@ export default function SessionDetailView() {
   const [msgErr, setMsgErr] = useState<string | null>(null)
   const [tailReady, setTailReady] = useState(false)
   const [nowMs, setNowMs] = useState(() => Date.now())
-  // Which bot turns have their collapsed "work" expanded (keyed by turn index).
+  // Bot turns whose "work" panel the user toggled AWAY from its default state
+  // (keyed by turn index) — so a work-only turn, which defaults to open, can
+  // still be collapsed by clicking its toggle.
   const [expandedWork, setExpandedWork] = useState<Set<number>>(() => new Set())
   const toggleWork = (ti: number) =>
     setExpandedWork((prev) => {
@@ -1565,8 +1567,10 @@ export default function SessionDetailView() {
                   const { thinkCount, toolCount, editCount } = workCounts(workSteps)
                   const summary = workSummary(thinkCount, toolCount, editCount)
                   // Auto-open while a turn has produced only work (mid-stream), so the
-                  // live agent isn't hidden; collapse once its answer text lands.
-                  const openWork = expandedWork.has(ti) || textSteps.length === 0
+                  // live agent isn't hidden; collapse once its answer text lands. Either
+                  // default stays user-overridable, so thinking-only turns can be closed.
+                  const autoOpen = textSteps.length === 0
+                  const openWork = expandedWork.has(ti) ? !autoOpen : autoOpen
                   return (
                     <div key={ti} className="flex items-start gap-[9px]">
                       <span className="av h-[26px] w-[26px] flex-none rounded-md">


### PR DESCRIPTION
## What

Two fixes to the session detail transcript.

**1. Thinking-only turns could not be collapsed.**
A bot turn auto-opens its collapsed "work" panel while it has produced only work steps (reasoning / tool / edit) and no answer text, so a mid-stream agent isn't hidden behind a toggle. But the open predicate was:

```ts
const openWork = expandedWork.has(ti) || textSteps.length === 0
```

The auto-open default won unconditionally — clicking the chevron added the turn to `expandedWork` and changed nothing. Any turn that finished with only a `THINK` row (no `MSG`/`DONE` text) was stuck expanded forever.

`expandedWork` now records turns the user toggled **away from** their default state, so both defaults stay overridable:

```ts
const autoOpen = textSteps.length === 0
const openWork = expandedWork.has(ti) ? !autoOpen : autoOpen
```

**2. Expanding/collapsing felt sluggish.**
`turns` is built in `SessionDetailView`'s render body (no `useMemo`), so any state change re-renders the whole transcript — and `MessageText` was a bare function component, re-running `slackToMarkdown()` plus the `remark-gfm`/`remark-breaks` pipeline for **every** row each time. remark is superlinear on long strings (hence the existing `MAX_PARSE = 100_000` guard) and reasoning rows are often multi-KB, so a single toggle re-parsed the entire transcript.

`MessageText` is now wrapped in `memo`. Its only prop is a string, so shallow compare is exact.

## Why it matters

Beyond the toggle, the same re-parse fired on every **composer keystroke** (`setPgInput`) and on the 1s `nowMs` tick while a playground run is busy — so the memo also removes typing lag in long sessions.

## Reviewer notes

- No behavior change for turns that do have answer text: they still default collapsed and toggle as before.
- Not done, deliberately: `turns` still isn't memoized and `StepExtras` isn't wrapped. Both are plain array/DOM construction, one to two orders of magnitude cheaper than markdown parsing. Worth revisiting only if sessions with hundreds of messages still stutter.
- Verified with `pnpm --filter @agentconnect.md/web typecheck` and eslint. Not exercised in a browser — reproducing needs a real session with a thinking-only turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)