### PR TITLE
feat(integrations): let any agent switch a channel off

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -941,9 +941,15 @@ agents.
 - `gated` is **derived** from `agent.visibility === 'restricted'` at spec
   assembly; there is no separate stored toggle (see §14.7).
 - Web `IntegrationChannelList`: tri-state segmented control per channel row
-  (Off / Mention / All messages), a Direct-messages section with binary rows,
-  pending badges, and a banner on restricted agents' integration cards
-  explaining the gate.
+  (Off / Mention / All messages) — offered for every agent, not only a gated
+  one — a Direct-messages section with binary rows, pending badges, and a
+  banner on restricted agents' integration cards explaining the gate.
+- On an UNGATED integration, Off cannot be expressed by withholding a rule: its
+  defaults are unscoped (@-mention anywhere + DMs) and additive. The CP
+  therefore ships an explicit `mutedChannels` fence — on the integration spec
+  for a daemon-arbitrated bot, and on `rc/bot-assign` / `rc/routes` for a
+  relay-arbitrated one — which both arbiters apply ahead of every rung. A gated
+  integration leaves it empty; its Off remains the absence of a scoped rule.
 
 ### 14.4 Visibility transitions
 
@@ -953,9 +959,13 @@ agents.
   conversations start Off — rows appear as counterparts next write, each
   receiving the one-time notice.
 - **restricted → org:** gating turns off; unscoped defaults return. Rows and
-  their trigger values persist inert (an `off` row on a non-gated integration
-  is ignored) so flipping back restores the previous decisions — the same
-  preservation principle as Decision 4.
+  their trigger values persist so flipping back restores the previous
+  decisions — the same preservation principle as Decision 4. Only the DIRECT
+  rows go inert, because the Console hides them for an org-visible agent and
+  honouring one would be behaviour with no visible control. A CHANNEL row keeps
+  its trigger, Off included: Off is a control every agent has (see
+  "Per-channel trigger" in product-conventions.md), and the row stays on screen
+  for an editor to change.
 
 ### 14.5 Rollout / migration
 

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -944,12 +944,29 @@ agents.
   (Off / Mention / All messages) — offered for every agent, not only a gated
   one — a Direct-messages section with binary rows, pending badges, and a
   banner on restricted agents' integration cards explaining the gate.
-- On an UNGATED integration, Off cannot be expressed by withholding a rule: its
-  defaults are unscoped (@-mention anywhere + DMs) and additive. The CP
-  therefore ships an explicit `mutedChannels` fence — on the integration spec
-  for a daemon-arbitrated bot, and on `rc/bot-assign` / `rc/routes` for a
-  relay-arbitrated one — which both arbiters apply ahead of every rung. A gated
-  integration leaves it empty; its Off remains the absence of a scoped rule.
+- Off cannot always be expressed by withholding a rule, because some rungs are
+  unscoped and additive — `@-mention` anywhere and DMs on a daemon-arbitrated
+  integration; the agent-slug keyword and the group's `defaultAgentId` on a
+  relay-arbitrated bot. The CP therefore ships an explicit `mutedChannels` fence,
+  applied ahead of every rung, which the two arbiters populate differently
+  because their unscoped rungs differ:
+  - **Daemon** (`IntegrationSpec.mutedChannels`, per integration): the Off
+    channels of an UNGATED integration. A gated one leaves it empty — it ships
+    no unscoped defaults at all, so its Off already is the absence of a scoped
+    rule, and stating the same fact twice would let the two drift apart.
+  - **Relay** (`rc/bot-assign` / `rc/routes`, per bot): EVERY Off channel,
+    gated owner or not. A gated owner's missing route is not enough here: an
+    ungated sibling's unscoped rungs are still in the same table, so on a
+    mixed-visibility bot a bare `@bot` would otherwise reach the public default
+    in a channel the console shows as Off.
+- Because the relay fence covers both, it also has to say which Off channels
+  still deserve the §14.3 notice. `gatedOffChannels` carries that subset — the
+  muted channels whose owner is gated, i.e. Off because nobody has enabled them
+  rather than because an operator silenced them. The relay posts the notice only
+  for those; an operator's Off is silent (see "Per-channel trigger" in
+  product-conventions.md). The two states share a trigger value and the relay
+  cannot infer channel ownership from a table that holds no route for them, so
+  this is explicit wire state rather than something derived.
 
 ### 14.4 Visibility transitions
 

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -101,6 +101,27 @@ transcript display. The first real reply in that thread receives the root as pre
 context before the new message. Session initialization itself produces no agent output,
 tool calls, memory recall or capture, turn evaluation, or token usage.
 
+## Per-channel trigger
+
+Every channel a bot is in carries a trigger, and every agent gets all three settings —
+Off, every message, or @-mention (the default). Off is not a gating feature: an
+org-visible agent is entitled to the same control as a restricted one.
+
+Off means the agent does not respond in that channel at all. Not to an @-mention, not to
+a follow-up in a thread it had already joined, not to a control command, and not through
+a shared bot's slug or default-dispatch fallback. It leaves everything else intact: the
+bot stays in the channel, the channel keeps its row and its owner, past sessions keep
+their transcripts, and an agent may still post there when something else — a scheduled
+task, another agent's hand-off — directs it to.
+
+Off is therefore the Console's answer to "stop responding here", and the only one it
+has. Removing the bot from a channel or group is a platform action, done in Slack,
+Telegram, Discord, or Lark; the Console reflects that membership but never changes it.
+
+A restricted agent expresses the same choice through its conversation gate, which is
+independently fail-closed: a conversation it has never been enabled in stays unroutable
+whether or not anyone set it to Off.
+
 ## Shared-bot channel ownership
 
 Every active channel served by a shared bot has exactly one default agent. A newly

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -122,6 +122,13 @@ A restricted agent expresses the same choice through its conversation gate, whic
 independently fail-closed: a conversation it has never been enabled in stays unroutable
 whether or not anyone set it to Off.
 
+Those two states read alike on the row and mean different things, so they answer an
+@-mention differently. A conversation a restricted agent was never enabled in replies
+once, telling the person to ask an admin — the bot must not look broken to someone who
+had no way to know it was private. A channel switched Off says nothing at all: an
+operator already decided, and pointing the room at an admin would be both wrong and
+noise. Off is silence; the gate is a closed door with a sign on it.
+
 ## Shared-bot channel ownership
 
 Every active channel served by a shared bot has exactly one default agent. A newly

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -466,6 +466,29 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.mutedChannels).toEqual(['C9'])
     })
 
+    // The §14.3 notice is what tells someone a gated conversation was never enabled.
+    // Muting the channel would suppress it and leave the bot looking dead, so an Off
+    // channel of a GATED owner is the gate, not an operator's mute.
+    it("never mutes a GATED owner's Off channel — that Off is the gate, and keeps its notice", async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
+      expect(assign.mutedChannels).toEqual([])
+    })
+
+    it('mutes an ungated owner while the gated sibling keeps its gate, on one mixed bot', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [
+        channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' }), // gated → gate
+        channel({ integrationId: INT_B, channelId: 'C8', agentId: BOB, trigger: 'off' }) // ungated → mute
+      ]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.mutedChannels).toEqual(['C8'])
+    })
+
     it('leaves an active channel unmuted', async () => {
       channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'any' })]
       await makeOrch().syncBot(BOT)

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -117,6 +117,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   let threadOwnerLookup: { botId: BotId; channel: string; thread: string } | null
   // §14: agents whose AgentRepo.get returns visibility 'restricted' (⇒ gated).
   let gatedAgents: Set<string>
+  // Agents reported with no daemonId — not placed, so they compile no routes.
+  let unplacedAgents: Set<string>
   // Drives ThreadAffinityStore.get (null = affinity miss → SessionMeta fallback).
   let threadBinding: { agentId: AgentId; daemonId: string } | null
   // revokeBot recordings: the Bot revocation stamp + integration/remove pushes.
@@ -130,8 +132,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
 
   function makeOrch(): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
-      [ALICE]: agent(ALICE, 'alice', D1),
-      [BOB]: agent(BOB, 'bob', D2)
+      [ALICE]: agent(ALICE, 'alice', unplacedAgents.has(ALICE) ? null : D1),
+      [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
     }
     let getCalls = 0
     const bots: Pick<BotRepo, 'get' | 'listHttpActive' | 'revokeIfCurrent'> = {
@@ -294,6 +296,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     threadOwner = null
     threadOwnerLookup = null
     gatedAgents = new Set()
+    unplacedAgents = new Set()
     threadBinding = null
     blockNextChannelList = null
     bumpRevisionAfterFirstGet = false
@@ -445,12 +448,31 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
     })
 
-    it("a NON-gated owner's preserved 'off' row is inert: ownership stays as a mention route (§14.4)", async () => {
+    it("a NON-gated owner's 'off' channel compiles no route and is muted for the whole bot", async () => {
       channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
+      // Dropping the route is not enough on an ungated bot: the keyword slug and
+      // `defaultAgentId` rungs are unscoped, so Off must also be stated as a fence.
+      expect(assign.mutedChannels).toEqual(['C9'])
+    })
+
+    it("mutes an Off channel whose owner isn't placed — the operator's choice outlives the placement", async () => {
+      channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
+      unplacedAgents = new Set([ALICE])
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.mutedChannels).toEqual(['C9'])
+    })
+
+    it('leaves an active channel unmuted', async () => {
+      channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'any' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
+      expect(assign.mutedChannels).toEqual([])
       expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([
-        expect.objectContaining({ agentId: ALICE, match: { kind: 'mention' } })
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
       ])
     })
 

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -466,27 +466,29 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.mutedChannels).toEqual(['C9'])
     })
 
-    // The §14.3 notice is what tells someone a gated conversation was never enabled.
-    // Muting the channel would suppress it and leave the bot looking dead, so an Off
-    // channel of a GATED owner is the gate, not an operator's mute.
-    it("never mutes a GATED owner's Off channel — that Off is the gate, and keeps its notice", async () => {
+    // The fence covers every Off channel: dropping the route is not enough, because
+    // the keyword and defaultAgentId rungs are unscoped and would hand a bare @bot to
+    // a mixed bot's public default in a channel the console shows as Off.
+    it("mutes a GATED owner's Off channel too, and marks it as still owing a notice", async () => {
       gatedAgents = new Set([ALICE])
       channels = [channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' })]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
       expect(assign.routes.filter((r) => r.scope?.channel === 'C9')).toEqual([])
-      expect(assign.mutedChannels).toEqual([])
+      expect(assign.mutedChannels).toEqual(['C9'])
+      expect(assign.gatedOffChannels).toEqual(['C9'])
     })
 
-    it('mutes an ungated owner while the gated sibling keeps its gate, on one mixed bot', async () => {
+    it('separates the two kinds of Off on one mixed bot: both muted, only the gated one speaks', async () => {
       gatedAgents = new Set([ALICE])
       channels = [
-        channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' }), // gated → gate
-        channel({ integrationId: INT_B, channelId: 'C8', agentId: BOB, trigger: 'off' }) // ungated → mute
+        channel({ integrationId: INT_A, channelId: 'C9', agentId: ALICE, trigger: 'off' }), // gate
+        channel({ integrationId: INT_B, channelId: 'C8', agentId: BOB, trigger: 'off' }) // operator mute
       ]
       await makeOrch().syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')!.payload as RcBotAssign
-      expect(assign.mutedChannels).toEqual(['C8'])
+      expect([...assign.mutedChannels].sort()).toEqual(['C8', 'C9'])
+      expect(assign.gatedOffChannels).toEqual(['C9'])
     })
 
     it('leaves an active channel unmuted', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -63,6 +63,12 @@ interface Compiled {
   defaultDaemonId?: string
   /** Members whose ingress is conversation-gated (resource-visibility.md §14). */
   gatedAgentIds: string[]
+  /** Channels the operator switched Off — the relay's subtractive fence over the
+   *  rungs no missing route can suppress (keyword, `defaultAgentId`, continuity). */
+  mutedChannels: string[]
+  /** Every membership row of the bot, read once for the compile and reused by the
+   *  spec push (both need the per-install trigger state). */
+  botChannels: IntegrationChannelRecord[]
   /** DM conversation ids whose §14.3 notice was ACTUALLY DELIVERED — the
    *  pool-wide latch for single-copy DM messages (never row-derived: discovery
    *  without delivery must not latch). */
@@ -169,6 +175,7 @@ export class HttpBotOrchestrator {
         ...(compiled.defaultAgentId ? { defaultAgentId: compiled.defaultAgentId } : {}),
         ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
         gatedAgentIds: compiled.gatedAgentIds,
+        mutedChannels: compiled.mutedChannels,
         noticedDmConversations: compiled.noticedDmConversations,
         ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
       })
@@ -674,6 +681,13 @@ export class HttpBotOrchestrator {
     //    routes to that agent, respecting the channel's trigger (any → auto rule,
     //    mention → mention rule). Emitted FIRST so a scoped rule wins arbitration.
     const chans = await this.channels.listForBot(bot.id)
+    // Channels the operator switched Off. Bot-scoped like ownership itself: the trigger
+    // is replicated across every membership row of the channel, so any row states it —
+    // including one whose owner is not currently placed, where the operator's Off must
+    // still hold. Direct rows never mute (a DM is not a place with an owner to switch off).
+    const mutedChannels = [
+      ...new Set(chans.filter((c) => c.trigger === 'off' && c.kind === 'channel').map((c) => c.channelId))
+    ]
     // A group DM has no owner picker — it is not a place the bot was invited to, so the
     // observation fan-out gives every gated install its own row. Two agents enabling the
     // same one would compile two IDENTICAL scoped mention routes and relay order would
@@ -708,7 +722,10 @@ export class HttpBotOrchestrator {
       // route via defaultAgentId as they always did, and a non-gated group DM via
       // the unscoped mention default.
       if (isDirectConversationKind(c.kind) && (!p.gated || c.trigger === 'off')) continue
-      if (c.trigger === 'off' && p.gated) continue
+      // Off compiles no route for ANY owner. A gated one is then unreachable
+      // (fail-closed, no unscoped rungs exist); an ungated one still has the
+      // keyword/default rungs, which `mutedChannels` below shuts off.
+      if (c.trigger === 'off') continue
       if (c.kind === 'mpim' && groupDmOwner.get(c.channelId) !== c.agentId) continue
       // A DM conversation row activates on any message once enabled (no mention
       // inside a DM); channels follow their trigger.
@@ -789,7 +806,9 @@ export class HttpBotOrchestrator {
       routes,
       ...(first ? { defaultAgentId: first.integration.agentId, defaultDaemonId: first.daemonId } : {}),
       gatedAgentIds: placed.filter((p) => p.gated).map((p) => p.integration.agentId),
+      mutedChannels,
       noticedDmConversations,
+      botChannels: chans,
       placed: placed.map((p) => ({ integration: p.integration, daemonId: p.daemonId, gated: p.gated }))
     }
   }
@@ -802,14 +821,12 @@ export class HttpBotOrchestrator {
     bot: Pick<BotRecord, 'shareable' | 'slackAppId' | 'botUserId'>
   ): Promise<void> {
     // A gated install's spec carries its conversation-scoped rules for the daemon's
-    // last-hop admission backstop (§14.3). One listForBot covers every install; rows
-    // are keyed per install, so filter by integrationId.
-    const anyGated = compiled.placed.some((p) => p.gated)
-    const botChannels =
-      anyGated && compiled.placed[0] ? await this.channels.listForBot(BotId(compiled.placed[0].integration.botId)) : []
+    // last-hop admission backstop (§14.3), and EVERY install carries its Off channels
+    // for the same backstop. The compile already read the bot's rows; they are keyed
+    // per install, so filter by integrationId.
     for (const { integration, daemonId, gated } of compiled.placed) {
       try {
-        const channels = gated ? botChannels.filter((c) => c.integrationId === integration.id) : []
+        const channels = compiled.botChannels.filter((c) => c.integrationId === integration.id)
         await this.control.integrationUpsert(
           daemonId,
           httpIntegrationToSpec(
@@ -864,6 +881,7 @@ export class HttpBotOrchestrator {
       ...(compiled.defaultAgentId ? { defaultAgentId: compiled.defaultAgentId } : {}),
       ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
       gatedAgentIds: compiled.gatedAgentIds,
+      mutedChannels: compiled.mutedChannels,
       noticedDmConversations: compiled.noticedDmConversations,
       ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
     }

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -681,12 +681,32 @@ export class HttpBotOrchestrator {
     //    routes to that agent, respecting the channel's trigger (any → auto rule,
     //    mention → mention rule). Emitted FIRST so a scoped rule wins arbitration.
     const chans = await this.channels.listForBot(bot.id)
+    // The channel's owning agent — the one row of the fan-out that carries it (§10.1).
+    const channelOwner = new Map<string, string>()
+    for (const c of chans) if (c.agentId && !channelOwner.has(c.channelId)) channelOwner.set(c.channelId, c.agentId)
     // Channels the operator switched Off. Bot-scoped like ownership itself: the trigger
     // is replicated across every membership row of the channel, so any row states it —
     // including one whose owner is not currently placed, where the operator's Off must
     // still hold. Direct rows never mute (a DM is not a place with an owner to switch off).
+    //
+    // A channel owned by a GATED agent is NOT a mute, even though its trigger reads the
+    // same. There, Off is §14's fail-closed default for a conversation nobody has enabled
+    // yet, and that state owns the one-time "ask an admin to enable it" notice. Muting it
+    // would swallow that notice and leave the bot looking dead to the person who asked —
+    // the opposite of what the gate promises. Off as an OPERATOR's choice is what mutes,
+    // and only an ungated owner can express it (`mutedChannelIds` draws the same line
+    // per-integration in placement.ts).
     const mutedChannels = [
-      ...new Set(chans.filter((c) => c.trigger === 'off' && c.kind === 'channel').map((c) => c.channelId))
+      ...new Set(
+        chans
+          .filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind))
+          .filter((c) => {
+            const owner = channelOwner.get(c.channelId)
+            const agent = owner ? agentById.get(owner) : undefined
+            return !agent || !isGatedAgent(agent)
+          })
+          .map((c) => c.channelId)
+      )
     ]
     // A group DM has no owner picker — it is not a place the bot was invited to, so the
     // observation fan-out gives every gated install its own row. Two agents enabling the

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -63,9 +63,12 @@ interface Compiled {
   defaultDaemonId?: string
   /** Members whose ingress is conversation-gated (resource-visibility.md §14). */
   gatedAgentIds: string[]
-  /** Channels the operator switched Off — the relay's subtractive fence over the
-   *  rungs no missing route can suppress (keyword, `defaultAgentId`, continuity). */
+  /** Every Off channel — the relay's subtractive fence over the rungs no missing
+   *  route can suppress (keyword, `defaultAgentId`, thread continuity). */
   mutedChannels: string[]
+  /** The muted channels whose owner is GATED: Off because §14 has not enabled them,
+   *  so they keep the one-time notice. Every other muted channel is silent. */
+  gatedOffChannels: string[]
   /** Every membership row of the bot, read once for the compile and reused by the
    *  spec push (both need the per-install trigger state). */
   botChannels: IntegrationChannelRecord[]
@@ -176,6 +179,7 @@ export class HttpBotOrchestrator {
         ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
         gatedAgentIds: compiled.gatedAgentIds,
         mutedChannels: compiled.mutedChannels,
+        gatedOffChannels: compiled.gatedOffChannels,
         noticedDmConversations: compiled.noticedDmConversations,
         ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
       })
@@ -684,30 +688,30 @@ export class HttpBotOrchestrator {
     // The channel's owning agent — the one row of the fan-out that carries it (§10.1).
     const channelOwner = new Map<string, string>()
     for (const c of chans) if (c.agentId && !channelOwner.has(c.channelId)) channelOwner.set(c.channelId, c.agentId)
-    // Channels the operator switched Off. Bot-scoped like ownership itself: the trigger
-    // is replicated across every membership row of the channel, so any row states it —
-    // including one whose owner is not currently placed, where the operator's Off must
-    // still hold. Direct rows never mute (a DM is not a place with an owner to switch off).
+    // Off channels split into two facts the relay needs separately.
     //
-    // A channel owned by a GATED agent is NOT a mute, even though its trigger reads the
-    // same. There, Off is §14's fail-closed default for a conversation nobody has enabled
-    // yet, and that state owns the one-time "ask an admin to enable it" notice. Muting it
-    // would swallow that notice and leave the bot looking dead to the person who asked —
-    // the opposite of what the gate promises. Off as an OPERATOR's choice is what mutes,
-    // and only an ungated owner can express it (`mutedChannelIds` draws the same line
-    // per-integration in placement.ts).
-    const mutedChannels = [
-      ...new Set(
-        chans
-          .filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind))
-          .filter((c) => {
-            const owner = channelOwner.get(c.channelId)
-            const agent = owner ? agentById.get(owner) : undefined
-            return !agent || !isGatedAgent(agent)
-          })
-          .map((c) => c.channelId)
-      )
-    ]
+    // ROUTING (`mutedChannels`): every Off channel, whoever owns it. The trigger is
+    // bot-scoped — replicated across every membership row — so Off means this bot does
+    // not answer here, and a route being absent is not enough to say so: the keyword slug
+    // and `defaultAgentId` rungs are unscoped, and on a mixed bot they would hand a bare
+    // @bot to the public default in a channel the console shows as Off. Any row states
+    // the trigger, including one whose owner is not currently placed. Direct rows never
+    // mute (a DM is not a place with an owner to switch off).
+    //
+    // NOTICE (`gatedOffChannels`): of those, the ones owned by a GATED agent. Their Off
+    // is §14's fail-closed default for a conversation nobody has enabled yet, and it owns
+    // the one-time "ask an admin to enable it" reply — someone who had no way to know the
+    // agent is private must not meet a dead bot. An OPERATOR's Off says nothing: they
+    // already decided, and that advice would be the opposite of what happened. The two
+    // states share a trigger value, so only ownership tells them apart.
+    const offChannels = chans.filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind))
+    const ownerGated = (channelId: string): boolean => {
+      const owner = channelOwner.get(channelId)
+      const agent = owner ? agentById.get(owner) : undefined
+      return !!agent && isGatedAgent(agent)
+    }
+    const mutedChannels = [...new Set(offChannels.map((c) => c.channelId))]
+    const gatedOffChannels = mutedChannels.filter(ownerGated)
     // A group DM has no owner picker — it is not a place the bot was invited to, so the
     // observation fan-out gives every gated install its own row. Two agents enabling the
     // same one would compile two IDENTICAL scoped mention routes and relay order would
@@ -742,9 +746,10 @@ export class HttpBotOrchestrator {
       // route via defaultAgentId as they always did, and a non-gated group DM via
       // the unscoped mention default.
       if (isDirectConversationKind(c.kind) && (!p.gated || c.trigger === 'off')) continue
-      // Off compiles no route for ANY owner. A gated one is then unreachable
-      // (fail-closed, no unscoped rungs exist); an ungated one still has the
-      // keyword/default rungs, which `mutedChannels` below shuts off.
+      // Off compiles no route for ANY owner. That alone does not make the channel
+      // unreachable — `mutedChannels` above is what closes the unscoped rungs, for a
+      // gated owner just as much as an ungated one (a mixed bot's public default
+      // would otherwise answer a bare @bot in a channel the console shows as Off).
       if (c.trigger === 'off') continue
       if (c.kind === 'mpim' && groupDmOwner.get(c.channelId) !== c.agentId) continue
       // A DM conversation row activates on any message once enabled (no mention
@@ -827,6 +832,7 @@ export class HttpBotOrchestrator {
       ...(first ? { defaultAgentId: first.integration.agentId, defaultDaemonId: first.daemonId } : {}),
       gatedAgentIds: placed.filter((p) => p.gated).map((p) => p.integration.agentId),
       mutedChannels,
+      gatedOffChannels,
       noticedDmConversations,
       botChannels: chans,
       placed: placed.map((p) => ({ integration: p.integration, daemonId: p.daemonId, gated: p.gated }))
@@ -902,6 +908,7 @@ export class HttpBotOrchestrator {
       ...(compiled.defaultDaemonId ? { defaultDaemonId: compiled.defaultDaemonId } : {}),
       gatedAgentIds: compiled.gatedAgentIds,
       mutedChannels: compiled.mutedChannels,
+      gatedOffChannels: compiled.gatedOffChannels,
       noticedDmConversations: compiled.noticedDmConversations,
       ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
     }

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -112,12 +112,63 @@ describe('integrationToSpec conversation gating (§14)', () => {
     expect(spec.slack.gated).toBe(true)
   })
 
-  it("non-gated: 'off' rows stay inert (defaults unchanged) and gated is false", () => {
+  it("non-gated: an 'off' channel keeps the defaults but is muted; gated is false", () => {
     const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('D1', 'any', 'im')])
     if (spec.platform !== 'slack') throw new Error('expected slack spec')
     expect(spec.slack.gated).toBe(false)
-    // The im row adds no auto rule either — DMs are covered by the unscoped dm default.
+    // The defaults are unscoped, so Off cannot be expressed by withholding a rule —
+    // the fence is what silences C1. The im row adds no auto rule either; DMs are
+    // covered by the unscoped dm default.
     expect(spec.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(spec.slack.mutedChannels).toEqual(['C1'])
+  })
+})
+
+describe('integrationToSpec mutedChannels', () => {
+  it('mutes every Off channel and nothing else', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [
+      channel('C1', 'off'),
+      channel('C2', 'mention'),
+      channel('C3', 'any'),
+      channel('C4', 'off')
+    ])
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.mutedChannels).toEqual(['C1', 'C4'])
+  })
+
+  // §14.4: the console hides a preserved direct row once its owner is org-visible, so
+  // honouring its Off would silence DMs through a control nobody can see.
+  it('never mutes a direct row on a non-gated integration', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('D1', 'off', 'im'), channel('G1', 'off', 'mpim')])
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.mutedChannels).toEqual([])
+  })
+
+  // A gated integration says Off by having no rule for the conversation; stating it
+  // twice would let the two representations drift apart.
+  it('stays empty for a gated integration, whose Off is the missing rule', () => {
+    const spec = integrationToSpec(INTEGRATION, SECRET, [channel('C1', 'off'), channel('C2', 'mention')], true)
+    if (spec.platform !== 'slack') throw new Error('expected slack spec')
+    expect(spec.slack.mutedChannels).toEqual([])
+    expect(spec.slack.bindRules).toEqual([{ channel: 'C2', match: { kind: 'mention' } }])
+  })
+
+  it('rides every platform variant', () => {
+    const tg = integrationToSpec({ ...INTEGRATION, platform: 'telegram' }, { botToken: '1:a', appToken: null }, [
+      channel('-100', 'off')
+    ])
+    if (tg.platform !== 'telegram') throw new Error('expected telegram spec')
+    expect(tg.telegram.mutedChannels).toEqual(['-100'])
+    const dc = integrationToSpec({ ...INTEGRATION, platform: 'discord' }, { botToken: 'bot', appToken: null }, [
+      channel('999', 'off')
+    ])
+    if (dc.platform !== 'discord') throw new Error('expected discord spec')
+    expect(dc.discord.mutedChannels).toEqual(['999'])
+    const fs = integrationToSpec({ ...INTEGRATION, platform: 'feishu' }, { botToken: 'sec', appToken: 'cli_x' }, [
+      channel('oc_1', 'off')
+    ])
+    if (fs.platform !== 'feishu') throw new Error('expected feishu spec')
+    expect(fs.feishu.mutedChannels).toEqual(['oc_1'])
   })
 })
 

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -197,6 +197,25 @@ function gatedBindRules(channels: IntegrationChannelRecord[]): IntegrationBindRu
 }
 
 /**
+ * The Off channels of an UNGATED integration — its `mutedChannels` fence.
+ *
+ * An ungated integration reaches every conversation through unscoped defaults
+ * (@-mention anywhere + DMs), which no channel-scoped rule can subtract from, so Off
+ * has to be stated rather than merely omitted. A GATED integration needs none of
+ * this: its rules are conversation-scoped already, so Off IS the missing rule, and
+ * naming the channel here would only give the same fact two representations that can
+ * disagree — hence the empty list.
+ *
+ * DIRECT rows never mute. A preserved one is inert on an ungated integration (§14.4 —
+ * the console hides it), and a gated integration expresses its Off DMs the same way it
+ * expresses every other Off conversation.
+ */
+function mutedChannelIds(channels: IntegrationChannelRecord[], gated: boolean): string[] {
+  if (gated) return []
+  return channels.filter((c) => c.trigger === 'off' && !isDirectConversationKind(c.kind)).map((c) => c.channelId)
+}
+
+/**
  * Assemble the wire {@link IntegrationSpec} the daemon opens its socket from —
  * metadata from the `integration` row + tokens from the {@link BotSecretStore}
  * (keyed by the integration's bot) + the per-channel trigger config folded into
@@ -224,12 +243,13 @@ export function integrationToSpec(
     .filter((c) => c.trigger === 'any' && !isDirectConversationKind(c.kind))
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
   const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
+  const mutedChannels = mutedChannelIds(channels, gated)
   if (i.platform === 'telegram') {
     return {
       integrationId: i.id,
       agentId: i.agentId,
       platform: 'telegram',
-      telegram: { botToken: secret.botToken, allowedUserIds: [], bindRules, gated }
+      telegram: { botToken: secret.botToken, allowedUserIds: [], bindRules, mutedChannels, gated }
     }
   }
   if (i.platform === 'discord') {
@@ -238,7 +258,7 @@ export function integrationToSpec(
       agentId: i.agentId,
       platform: 'discord',
       // Discord authenticates the Gateway with the single bot token (no appToken).
-      discord: { botToken: secret.botToken, allowedUserIds: [], bindRules, gated }
+      discord: { botToken: secret.botToken, allowedUserIds: [], bindRules, mutedChannels, gated }
     }
   }
   if (i.platform === 'feishu') {
@@ -256,6 +276,7 @@ export function integrationToSpec(
         region: i.feishuRegion ?? 'feishu',
         allowedUserIds: [],
         bindRules,
+        mutedChannels,
         gated
       }
     }
@@ -276,6 +297,7 @@ export function integrationToSpec(
       appToken: secret.appToken ?? '',
       allowedUserIds: [],
       bindRules,
+      mutedChannels,
       gated
     }
   }
@@ -292,7 +314,9 @@ export function integrationToSpec(
  * ships its conversation-scoped rules + `gated: true` even in relay-managed mode — the
  * relay is still the arbiter, but the daemon uses these for its last-hop
  * admission backstop in `handleRelayIm` (it must not trust a stale relay route
- * snapshot to keep a private agent fail-closed).
+ * snapshot to keep a private agent fail-closed). `mutedChannels` rides along for the
+ * same reason and for every install, gated or not: an Off channel must survive a
+ * relay snapshot that has not caught up yet.
  */
 export function httpIntegrationToSpec(
   i: IntegrationRecord,
@@ -316,6 +340,7 @@ export function httpIntegrationToSpec(
         region: i.feishuRegion ?? 'feishu',
         allowedUserIds: [],
         bindRules: gated ? gatedBindRules(channels) : [],
+        mutedChannels: mutedChannelIds(channels, gated),
         gated
       }
     }
@@ -334,6 +359,7 @@ export function httpIntegrationToSpec(
       ...(providerAppId ? { appId: providerAppId } : {}),
       allowedUserIds: [],
       bindRules: gated ? gatedBindRules(channels) : [],
+      mutedChannels: mutedChannelIds(channels, gated),
       gated
     }
   }

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -33,6 +33,12 @@ export const SlackConfigSchema = z.object({
   botUserId: z.string().optional(), // filled at connect via auth.test if absent; provided by CP for shared
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
+  // Channels the operator switched OFF. bindRules only ADD reach, so an ungated
+  // integration — which reaches every conversation through unscoped defaults — needs
+  // this subtractive fence to say "not here". A muted channel matches no rule of this
+  // integration: no mention, no thread continuity, no control command. A gated
+  // integration leaves it empty; its Off is the ABSENCE of a conversation-scoped rule.
+  mutedChannels: z.array(z.string()).default([]),
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
   // ships only conversation-scoped bindRules; explicitly-addressed unrouted
   // messages get a one-time notice and DM conversations are reported to the CP.
@@ -46,6 +52,7 @@ export const TelegramConfigSchema = z.object({
   botUsername: z.string().optional(), // @username without the '@', for mention detection; filled via getMe
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
   // ships only conversation-scoped bindRules; explicitly-addressed unrouted
   // messages get a one-time notice and DM conversations are reported to the CP.
@@ -59,6 +66,7 @@ export const DiscordConfigSchema = z.object({
   botUserId: z.string().optional(), // numeric bot user id, filled at connect via the ready event if absent
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
   // ships only conversation-scoped bindRules; explicitly-addressed unrouted
   // messages get a one-time notice and DM conversations are reported to the CP.
@@ -76,6 +84,7 @@ export const FeishuConfigSchema = z.object({
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn (default) vs larksuite.com
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
   // ships only conversation-scoped bindRules; explicitly-addressed unrouted
   // messages get a one-time notice and DM conversations are reported to the CP.

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -32,6 +32,7 @@ function toIntegration(spec: IntegrationSpec): Integration {
         botToken: spec.telegram.botToken,
         allowedUserIds: spec.telegram.allowedUserIds,
         bindRules: spec.telegram.bindRules,
+        mutedChannels: spec.telegram.mutedChannels,
         gated: spec.telegram.gated
       }
     }
@@ -46,6 +47,7 @@ function toIntegration(spec: IntegrationSpec): Integration {
         ...(spec.discord.applicationId ? { applicationId: spec.discord.applicationId } : {}),
         allowedUserIds: spec.discord.allowedUserIds,
         bindRules: spec.discord.bindRules,
+        mutedChannels: spec.discord.mutedChannels,
         gated: spec.discord.gated
       }
     }
@@ -63,6 +65,7 @@ function toIntegration(spec: IntegrationSpec): Integration {
         region: spec.feishu.region,
         allowedUserIds: spec.feishu.allowedUserIds,
         bindRules: spec.feishu.bindRules,
+        mutedChannels: spec.feishu.mutedChannels,
         gated: spec.feishu.gated
       }
     }
@@ -83,6 +86,7 @@ function toIntegration(spec: IntegrationSpec): Integration {
       ...(spec.slack.botUserId ? { botUserId: spec.slack.botUserId } : {}),
       allowedUserIds: spec.slack.allowedUserIds,
       bindRules: spec.slack.bindRules,
+      mutedChannels: spec.slack.mutedChannels,
       gated: spec.slack.gated
     }
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -86,6 +86,7 @@ import {
   resolveCpRule,
   resolveAgentIntegration,
   integrationRouting,
+  conversationAdmitted,
   type RoutingRule
 } from './router/routing-rule.js'
 import { CpRoutingLayer } from './router/cp-routing-layer.js'
@@ -5284,7 +5285,7 @@ export class Daemon {
       const routing = integrationRouting(integration)
       const unauthorized =
         (routing.allowedUserIds.length > 0 && (!msg.userId || !routing.allowedUserIds.includes(msg.userId))) ||
-        (routing.gated && !routing.bindRules.some((rule) => rule.channel === payload.channelId))
+        !conversationAdmitted(routing, payload.channelId)
       const transportScope = this.transportScopeForIntegrationIds([integration.id])
       const rec = unauthorized
         ? undefined
@@ -7551,11 +7552,10 @@ export class Daemon {
       ?.integrations.find((candidate) => candidate.id === integrationId && candidate.platform === msg.platform)
     if (!integration) return false
     const routing = integrationRouting(integration)
-    // Conversation gating (§14): control commands resolve their target OUTSIDE
-    // routeRules' scope filter (latest-session fallbacks), so they must repeat the
-    // admission check — an Off conversation of a gated integration takes no commands.
-    if (routing.gated && !routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel))
-      return false
+    // Control commands resolve their target OUTSIDE routeRules' scope filter (latest-
+    // session fallbacks), so they must repeat the admission check — a channel switched
+    // Off, or an Off conversation of a gated integration, takes no commands either.
+    if (!conversationAdmitted(routing, msg.channel, msg.parentChannel)) return false
     const allowed = routing.allowedUserIds
     return allowed.length === 0 || allowed.includes(msg.sender.id)
   }
@@ -8031,7 +8031,7 @@ export class Daemon {
         )
           continue
         const routing = integrationRouting(integration)
-        if (routing.gated && !routing.bindRules.some((rule) => rule.channel === channel)) continue
+        if (!conversationAdmitted(routing, channel)) continue
         const session = this.store.latestSessionForTransport(agentId, channel, transportScope)
         if (session) candidates.push(session)
       }
@@ -8054,7 +8054,7 @@ export class Daemon {
         if (integration.platform !== 'slack' || !srcIntegrationIds.includes(integration.id)) continue
         const routing = integrationRouting(integration)
         if (routing.allowedUserIds.length > 0 && !routing.allowedUserIds.includes(shortcut.userId)) continue
-        if (routing.gated && !routing.bindRules.some((rule) => rule.channel === shortcut.channel)) continue
+        if (!conversationAdmitted(routing, shortcut.channel)) continue
         const session = this.store.latestSessionForTransport(agentId, shortcut.channel, transportScope, shortcut.thread)
         if (session) candidates.push(session)
       }
@@ -8079,7 +8079,7 @@ export class Daemon {
   private resolveCpAgent(
     agentId: string,
     platform?: string
-  ): { integrationId: string; botUserId: string; platform: string } | null {
+  ): { integrationId: string; botUserId: string; platform: string; mutedChannels: string[] } | null {
     return resolveAgentIntegration(this.agents.get(agentId), this.botUserIds, platform)
   }
 
@@ -12806,13 +12806,14 @@ export class Daemon {
     return this.mergedRules().filter((rule) => this.integrationBelongsToSource(rule.integrationId, srcIntegrationIds))
   }
 
-  /** §14 admission for a pre-addressed (relay) message: a gated integration accepts
-   *  a conversation only when its shipped bindRules carry a rule scoped to it. */
+  /** Last-hop admission for a pre-addressed (relay) message. The relay arbitrated it,
+   *  but its routing snapshot can lag a console edit, so the shipped spec decides
+   *  again: an Off channel and (§14) an unenabled conversation of a gated integration
+   *  are both refused here rather than trusted to the relay. */
   private gatedAdmission(integrationId: string, msg: NormalizedMessage): boolean {
     const int = this.integrationConfigById(integrationId)
     if (!int) return true // unknown here — agent/integration existence is checked separately
-    const routing = integrationRouting(int)
-    return !routing.gated || routing.bindRules.some((r) => r.channel === msg.channel || r.channel === msg.parentChannel)
+    return conversationAdmitted(integrationRouting(int), msg.channel, msg.parentChannel)
   }
 
   /**

--- a/packages/daemon/src/router/routing-rule.ts
+++ b/packages/daemon/src/router/routing-rule.ts
@@ -19,6 +19,11 @@ export interface RoutingRule {
   scope: { channel?: string; thread?: string }
   match: RoutingMatch
   allowedUserIds?: string[]
+  // Channels its integration is switched OFF in — the subtractive fence a purely
+  // additive rule set cannot express. Carried per rule (rather than consulted
+  // separately) so `routeRules` stays pure and every rung — mention, thread
+  // continuity, CP override, keyword, auto — is fenced by the one scope filter.
+  mutedChannels?: string[]
   source: 'config' | 'cp'
   epoch?: number // cp layer only
   // Platform this rule belongs to ('slack' | 'telegram'). Undefined = matches any
@@ -33,13 +38,19 @@ export function integrationRouting(int: Integration): {
   staticBotUserId?: string
   bindRules: BindRuleConfig[]
   allowedUserIds: string[]
+  mutedChannels: string[]
   gated: boolean
 } {
+  // `mutedChannels` post-dates the schema, so an integration assembled by hand rather
+  // than parsed (a fixture, a caller mapping a partial spec) can reach here without it.
+  // Absent means "nothing muted" — the behaviour before the field existed — and
+  // normalizing once here keeps every reader free of the same defaulting.
   if (int.platform === 'slack')
     return {
       staticBotUserId: int.slack.botUserId,
       bindRules: int.slack.bindRules,
       allowedUserIds: int.slack.allowedUserIds,
+      mutedChannels: int.slack.mutedChannels ?? [],
       gated: int.slack.gated
     }
   if (int.platform === 'discord')
@@ -47,6 +58,7 @@ export function integrationRouting(int: Integration): {
       staticBotUserId: int.discord.botUserId,
       bindRules: int.discord.bindRules,
       allowedUserIds: int.discord.allowedUserIds,
+      mutedChannels: int.discord.mutedChannels ?? [],
       gated: int.discord.gated
     }
   if (int.platform === 'feishu')
@@ -54,14 +66,39 @@ export function integrationRouting(int: Integration): {
       staticBotUserId: int.feishu.botOpenId,
       bindRules: int.feishu.bindRules,
       allowedUserIds: int.feishu.allowedUserIds,
+      mutedChannels: int.feishu.mutedChannels ?? [],
       gated: int.feishu.gated
     }
   return {
     staticBotUserId: int.telegram.botUserId,
     bindRules: int.telegram.bindRules,
     allowedUserIds: int.telegram.allowedUserIds,
+    mutedChannels: int.telegram.mutedChannels ?? [],
     gated: int.telegram.gated
   }
+}
+
+/**
+ * Is this conversation open to `int` at all? Two independent fences, both applying
+ * to the enclosing channel of a thread (which is the row an operator configures):
+ *
+ *  - Off — the operator muted this channel. Applies to every integration.
+ *  - Gating (resource-visibility.md §14) — a restricted agent's integration admits
+ *    ONLY conversations that carry a scoped rule, so an unknown one is refused too.
+ *
+ * The routing ladder enforces both through the rule set itself; this is for the
+ * paths that resolve a target OUTSIDE it (control commands, message shortcuts, the
+ * relay's pre-addressed hand-off), which would otherwise reach a silenced channel.
+ */
+export function conversationAdmitted(
+  routing: Pick<ReturnType<typeof integrationRouting>, 'bindRules' | 'mutedChannels' | 'gated'>,
+  channel: string,
+  parentChannel?: string
+): boolean {
+  const covers = (candidate: string | undefined): boolean =>
+    candidate !== undefined && (candidate === channel || candidate === parentChannel)
+  if (routing.mutedChannels.some((muted) => covers(muted))) return false
+  return !routing.gated || routing.bindRules.some((rule) => covers(rule.channel))
 }
 
 /** Stored CP-layer rule — integration resolved lazily at merge time. */
@@ -83,7 +120,7 @@ export function resolveAgentIntegration(
   agent: Agent | undefined,
   botUserIds: Record<string, string>,
   platform?: string
-): { integrationId: string; botUserId: string; platform: string } | null {
+): { integrationId: string; botUserId: string; platform: string; mutedChannels: string[] } | null {
   // Prefer an integration on the requested platform — an agent may bridge several (e.g.
   // Slack + Telegram). Delivering a reply/wake into a session on platform X must use X's
   // integration; otherwise the turn's output posts through the wrong platform's client
@@ -92,8 +129,13 @@ export function resolveAgentIntegration(
   const int =
     (platform ? agent?.integrations.find((i) => i.platform === platform) : undefined) ?? agent?.integrations[0]
   if (!int) return null
-  const { staticBotUserId } = integrationRouting(int)
-  return { integrationId: int.id, botUserId: botUserIds[int.id] ?? staticBotUserId ?? '', platform: int.platform }
+  const { staticBotUserId, mutedChannels } = integrationRouting(int)
+  return {
+    integrationId: int.id,
+    botUserId: botUserIds[int.id] ?? staticBotUserId ?? '',
+    platform: int.platform,
+    mutedChannels
+  }
 }
 
 /** Local layer: one resolved RoutingRule per bindRule of EACH integration (any
@@ -101,7 +143,7 @@ export function resolveAgentIntegration(
 export function rulesFromAgent(agent: Agent, botUserIds: Record<string, string>): RoutingRule[] {
   const out: RoutingRule[] = []
   for (const int of agent.integrations) {
-    const { staticBotUserId, bindRules, allowedUserIds } = integrationRouting(int)
+    const { staticBotUserId, bindRules, allowedUserIds, mutedChannels } = integrationRouting(int)
     const botUserId = botUserIds[int.id] ?? staticBotUserId ?? ''
     for (const br of bindRules) {
       out.push({
@@ -111,6 +153,7 @@ export function rulesFromAgent(agent: Agent, botUserIds: Record<string, string>)
         scope: { ...(br.channel ? { channel: br.channel } : {}), ...(br.thread ? { thread: br.thread } : {}) },
         match: br.match,
         allowedUserIds,
+        mutedChannels,
         source: 'config',
         platform: int.platform
       })
@@ -122,7 +165,9 @@ export function rulesFromAgent(agent: Agent, botUserIds: Record<string, string>)
 /** Resolve a stored CP rule to a RoutingRule; null if the agent is unservable. */
 export function resolveCpRule(
   cp: CpRule,
-  resolve: (agentId: string) => { integrationId: string; botUserId: string; platform: string } | null
+  resolve: (
+    agentId: string
+  ) => { integrationId: string; botUserId: string; platform: string; mutedChannels?: string[] } | null
 ): RoutingRule | null {
   const r = resolve(cp.agentId)
   if (!r) return null
@@ -132,6 +177,9 @@ export function resolveCpRule(
     botUserId: r.botUserId,
     scope: cp.scope,
     match: cp.match,
+    // A CP session placement is scoped to a conversation the operator may since have
+    // switched off; it carries its integration's fence for the same reason a local rule does.
+    ...(r.mutedChannels ? { mutedChannels: r.mutedChannels } : {}),
     source: 'cp',
     platform: r.platform,
     ...(cp.epoch !== undefined ? { epoch: cp.epoch } : {})

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -22,6 +22,12 @@ function scopeMatches(r: RoutingRule, msg: NormalizedMessage): boolean {
   // `dm`/`auto` rule can't route a Telegram message (and vice-versa). Undefined
   // platform (legacy/tests) matches any.
   if (r.platform !== undefined && r.platform !== msg.platform) return false
+  // A channel the operator switched OFF silences its integration outright. Applied
+  // here, in the ONE scope filter, so no rung can slip past it: not an unscoped
+  // mention default, not thread continuity (which reads the same candidate set), not
+  // a CP session placement. Threads inherit the enclosing channel's Off through the
+  // same predicate the positive scope uses.
+  if (r.mutedChannels?.some((muted) => channelInScope(muted, msg))) return false
   if (!channelInScope(r.scope.channel, msg)) return false
   if (r.scope.thread !== undefined && r.scope.thread !== msg.thread) return false
   return true

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -120,6 +120,50 @@ describe('routeRules ladder', () => {
     expect(routeRules(msg(), rules, noOwner)).toBeNull()
   })
 
+  describe('muted channels (per-channel Off)', () => {
+    it('silences the unscoped mention default in the muted channel only', () => {
+      const rules = [rule({ botUserId: 'B9', match: { kind: 'mention' }, mutedChannels: ['C1'] })]
+      expect(routeRules(msg({ channel: 'C1', mentionedBots: ['B9'] }), rules, noOwner)).toBeNull()
+      expect(routeRules(msg({ channel: 'C2', mentionedBots: ['B9'] }), rules, noOwner)?.agentId).toBe('a')
+    })
+
+    it('silences a thread inside the muted channel, and thread continuity with it', () => {
+      const rules = [rule({ agentId: 'A', scope: { channel: 'C1' }, match: { kind: 'auto' }, mutedChannels: ['C1'] })]
+      const owner = (c: string, t: string) => (c === 'C1' && t === 'T1' ? 'A' : null)
+      expect(routeRules(msg({ channel: 'C1', thread: 'T1' }), rules, owner)).toBeNull()
+      // Discord keys a thread on its own channel id; the enclosing channel's Off still applies.
+      expect(routeRules(msg({ channel: 'THREAD', parentChannel: 'C1' }), rules, noOwner)).toBeNull()
+    })
+
+    it('silences a CP session placement in the muted channel', () => {
+      const rules = [
+        rule({
+          agentId: 'cpAgent',
+          source: 'cp',
+          scope: { channel: 'C1' },
+          match: { kind: 'auto' },
+          mutedChannels: ['C1']
+        })
+      ]
+      expect(routeRules(msg({ channel: 'C1' }), rules, noOwner)).toBeNull()
+    })
+
+    it('mutes only its OWN integration — a second bot in the channel keeps answering', () => {
+      const rules = [
+        rule({
+          agentId: 'muted',
+          integrationId: 'i1',
+          botUserId: 'B1',
+          match: { kind: 'mention' },
+          mutedChannels: ['C1']
+        }),
+        rule({ agentId: 'live', integrationId: 'i2', botUserId: 'B2', match: { kind: 'mention' } })
+      ]
+      expect(routeRules(msg({ channel: 'C1', mentionedBots: ['B1'] }), rules, noOwner)).toBeNull()
+      expect(routeRules(msg({ channel: 'C1', mentionedBots: ['B2'] }), rules, noOwner)?.agentId).toBe('live')
+    })
+  })
+
   it('explicit agentId (webchat) routes directly, bypassing arbitration', () => {
     // No rules match this webchat message, yet an explicit agentId short-circuits the
     // whole ladder — webchat names its target agent, so there is nothing to arbitrate.
@@ -277,7 +321,8 @@ describe('rulesFromAgent / resolveAgentIntegration (Telegram)', () => {
     expect(resolveAgentIntegration(tgAgent(), { 'i-tg': 'mybot' })).toEqual({
       integrationId: 'i-tg',
       botUserId: 'mybot',
-      platform: 'telegram'
+      platform: 'telegram',
+      mutedChannels: []
     })
     expect(resolveAgentIntegration(undefined, {})).toBeNull()
   })

--- a/packages/daemon/test/routing-rule.test.ts
+++ b/packages/daemon/test/routing-rule.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { rulesFromAgent, resolveCpRule, resolveAgentIntegration, type CpRule } from '../src/router/routing-rule.js'
+import {
+  rulesFromAgent,
+  resolveCpRule,
+  resolveAgentIntegration,
+  conversationAdmitted,
+  type CpRule
+} from '../src/router/routing-rule.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
 function agent(over: Partial<Agent> = {}): Agent {
@@ -78,10 +84,16 @@ describe('resolveAgentIntegration', () => {
     expect(resolveAgentIntegration(a, { int1: 'B1' })).toEqual({
       integrationId: 'int1',
       botUserId: 'B1',
-      platform: 'slack'
+      platform: 'slack',
+      mutedChannels: []
     })
     // falls back to the static botUserId when the map has no entry
-    expect(resolveAgentIntegration(a, {})).toEqual({ integrationId: 'int1', botUserId: 'STATIC', platform: 'slack' })
+    expect(resolveAgentIntegration(a, {})).toEqual({
+      integrationId: 'int1',
+      botUserId: 'STATIC',
+      platform: 'slack',
+      mutedChannels: []
+    })
   })
 
   it('prefers the integration matching the requested platform for a multi-platform agent', () => {
@@ -108,5 +120,42 @@ describe('resolveAgentIntegration', () => {
   it('returns null when the agent has no integrations', () => {
     const a = agent({ integrations: [] })
     expect(resolveAgentIntegration(a, {})).toBeNull()
+  })
+})
+
+describe('conversationAdmitted', () => {
+  const routing = (over: Partial<Parameters<typeof conversationAdmitted>[0]> = {}) => ({
+    bindRules: [],
+    mutedChannels: [],
+    gated: false,
+    ...over
+  })
+
+  it('admits any conversation of an ungated integration with nothing muted', () => {
+    expect(conversationAdmitted(routing(), 'C1')).toBe(true)
+  })
+
+  it('refuses a muted channel, and a thread inside it', () => {
+    const r = routing({ mutedChannels: ['C1'] })
+    expect(conversationAdmitted(r, 'C1')).toBe(false)
+    expect(conversationAdmitted(r, 'THREAD', 'C1')).toBe(false)
+    expect(conversationAdmitted(r, 'C2')).toBe(true)
+  })
+
+  // §14: a gated integration is fail-closed — an unknown conversation has no rule.
+  it('admits a gated conversation only when a scoped rule enables it', () => {
+    const r = routing({ gated: true, bindRules: [{ channel: 'C1', match: { kind: 'mention' } }] })
+    expect(conversationAdmitted(r, 'C1')).toBe(true)
+    expect(conversationAdmitted(r, 'THREAD', 'C1')).toBe(true)
+    expect(conversationAdmitted(r, 'C2')).toBe(false)
+  })
+
+  it('lets the mute override an enabling rule — the two fences are independent', () => {
+    const r = routing({
+      gated: true,
+      mutedChannels: ['C1'],
+      bindRules: [{ channel: 'C1', match: { kind: 'mention' } }]
+    })
+    expect(conversationAdmitted(r, 'C1')).toBe(false)
   })
 })

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -70,6 +70,14 @@ export const IntegrationSlackConfig = z
     botUserId: z.string().optional(), // lazily resolved via auth.test; may be seeded by CP
     allowedUserIds: z.array(z.string()).default([]),
     bindRules: z.array(IntegrationBindRule).default([]), // empty for shared (relay arbitrates)
+    // Channels the operator switched OFF. bindRules can only ADD reach, so an
+    // ungated integration — whose defaults are unscoped (@-mention anywhere + DMs) —
+    // has no way to say "not here" without a subtractive fence. A muted channel
+    // matches no rule of this integration at all: no mention, no thread continuity,
+    // no control command. Channels only (a DM is never muted this way); a GATED
+    // integration leaves this empty, since its Off is already the ABSENCE of a
+    // conversation-scoped rule. Defaults empty (pre-field specs).
+    mutedChannels: z.array(z.string()).default([]),
     // Conversation gating (resource-visibility.md §14): true ⇒ this integration is
     // fail-closed — the CP ships only conversation-scoped bindRules (no unscoped
     // defaults), and the daemon answers explicitly-addressed unrouted messages with
@@ -92,6 +100,7 @@ export const IntegrationTelegramConfig = z.object({
   botToken: z.string(), // BotFather "123456:ABC…"  (plaintext — never log)
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationTelegramConfig = z.infer<typeof IntegrationTelegramConfig>
@@ -107,6 +116,7 @@ export const IntegrationDiscordConfig = z.object({
   applicationId: z.string().optional(), // client/application id — public, for the invite URL
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationDiscordConfig = z.infer<typeof IntegrationDiscordConfig>
@@ -140,6 +150,7 @@ export const IntegrationFeishuConfig = z.object({
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn vs larksuite.com
   allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
 })
 export type IntegrationFeishuConfig = z.infer<typeof IntegrationFeishuConfig>

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -570,13 +570,20 @@ export const RcBotAssign = z.object({
   // only while that agent still has a channel-scoped route in the conversation —
   // otherwise a thread bound before the gate was applied would keep routing forever.
   gatedAgentIds: z.array(z.string().uuid()).default([]),
-  // Channels the operator switched OFF for this bot. The relay's ladder has rungs
-  // no channel-scoped route can suppress — unscoped keyword, the group's
+  // Channels switched OFF for this bot. The relay's ladder has rungs no
+  // channel-scoped route can suppress — unscoped keyword, the group's
   // `defaultAgentId`, thread continuity — so an Off channel needs a subtractive
   // fence rather than the mere absence of a route. A muted channel resolves to no
   // target at all. Bot-scoped, matching how an HTTP bot's channels converge on one
-  // owner. Defaults empty.
+  // owner, and how the trigger is replicated across its membership rows. Defaults empty.
   mutedChannels: z.array(z.string()).default([]),
+  // The muted channels whose owner is a GATED agent. Their Off is §14's fail-closed
+  // default for a conversation nobody has enabled yet, so they keep the one-time
+  // notice; a channel an OPERATOR switched off is silent instead. The two share a
+  // trigger value and are indistinguishable at the relay without this — hence a
+  // second list rather than a flag the relay could derive. Subset of
+  // `mutedChannels`. Defaults empty.
+  gatedOffChannels: z.array(z.string()).default([]),
   // §14.3 one-time gating notice, CHANNEL conversations: the relayId
   // DETERMINISTICALLY responsible for posting it for this bot. A channel mention
   // arrives as two event copies that may land on different pods — only the
@@ -622,6 +629,7 @@ export const RcRoutes = z.object({
   defaultDaemonId: z.string().uuid().optional(),
   gatedAgentIds: z.array(z.string().uuid()).default([]), // §14 — see RcBotAssign.gatedAgentIds
   mutedChannels: z.array(z.string()).default([]), // Off channels — see RcBotAssign.mutedChannels
+  gatedOffChannels: z.array(z.string()).default([]), // notice-keeping subset — see RcBotAssign.gatedOffChannels
   noticeAuthority: z.string().uuid().optional(), // §14.3 — see RcBotAssign.noticeAuthority
   noticedDmConversations: z.array(z.string()).default([]) // §14.3 — see RcBotAssign.noticedDmConversations
 })

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -570,6 +570,13 @@ export const RcBotAssign = z.object({
   // only while that agent still has a channel-scoped route in the conversation —
   // otherwise a thread bound before the gate was applied would keep routing forever.
   gatedAgentIds: z.array(z.string().uuid()).default([]),
+  // Channels the operator switched OFF for this bot. The relay's ladder has rungs
+  // no channel-scoped route can suppress — unscoped keyword, the group's
+  // `defaultAgentId`, thread continuity — so an Off channel needs a subtractive
+  // fence rather than the mere absence of a route. A muted channel resolves to no
+  // target at all. Bot-scoped, matching how an HTTP bot's channels converge on one
+  // owner. Defaults empty.
+  mutedChannels: z.array(z.string()).default([]),
   // §14.3 one-time gating notice, CHANNEL conversations: the relayId
   // DETERMINISTICALLY responsible for posting it for this bot. A channel mention
   // arrives as two event copies that may land on different pods — only the
@@ -614,6 +621,7 @@ export const RcRoutes = z.object({
   defaultAgentId: z.string().uuid().optional(),
   defaultDaemonId: z.string().uuid().optional(),
   gatedAgentIds: z.array(z.string().uuid()).default([]), // §14 — see RcBotAssign.gatedAgentIds
+  mutedChannels: z.array(z.string()).default([]), // Off channels — see RcBotAssign.mutedChannels
   noticeAuthority: z.string().uuid().optional(), // §14.3 — see RcBotAssign.noticeAuthority
   noticedDmConversations: z.array(z.string()).default([]) // §14.3 — see RcBotAssign.noticedDmConversations
 })

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -197,6 +197,23 @@ describe('HTTP-bot arbitration (§10)', () => {
         integrationId: 'iB'
       })
     })
+
+    // The mixed-bot case the fence exists for: ALICE is gated and owns CX with the
+    // channel Off, so it compiles no scoped route — but BOB's unscoped keyword and the
+    // group's defaultAgentId are still in the table. Without the mute a bare @bot would
+    // quietly activate the PUBLIC agent in a channel the console shows as Off.
+    it('a gated owner Off channel does not fall through to the public default', () => {
+      const a = { ...assignment(), gatedAgentIds: [ALICE], mutedChannels: ['CX'], gatedOffChannels: ['CX'] }
+      expect(arbitrate(a, msg({ channel: 'CX', text: '<@UBOT> hi', mentionedBots: [BOTUSER] }), empty())).toBeNull()
+      // …and the slug rung is closed too, so naming the public agent cannot reopen it.
+      expect(arbitrate(a, msg({ channel: 'CX', text: 'bob ship it', mentionedBots: [BOTUSER] }), empty())).toBeNull()
+    })
+
+    it('the notice-keeping subset does not make a channel routable', () => {
+      // gatedOffChannels only steers the notice; arbitration must still refuse.
+      const a = { ...assignment(), mutedChannels: ['C2'], gatedOffChannels: ['C2'] }
+      expect(arbitrate(a, msg({ channel: 'C2', text: 'anything' }), empty())).toBeNull()
+    })
   })
 })
 

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -168,6 +168,36 @@ describe('HTTP-bot arbitration (§10)', () => {
       expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
     })
   })
+
+  describe('muted channels (per-channel Off)', () => {
+    it('resolves nothing in a muted channel, even for an explicit @bot', () => {
+      const a = { ...assignment(), mutedChannels: ['C1'] }
+      const t = arbitrate(a, msg({ channel: 'C1', text: '<@UBOT> deploy', mentionedBots: [BOTUSER] }), empty())
+      expect(t).toBeNull()
+    })
+
+    it('shuts off the rungs a missing route cannot: keyword slug and the group default', () => {
+      const a = { ...assignment(), mutedChannels: ['CX'] }
+      // CX has no scoped route at all, so both of these route today.
+      expect(arbitrate(a, msg({ channel: 'CX', text: 'bob ship it', mentionedBots: [BOTUSER] }), empty())).toBeNull()
+      expect(arbitrate(a, msg({ channel: 'CX', text: '<@UBOT> hi', mentionedBots: [BOTUSER] }), empty())).toBeNull()
+    })
+
+    it('drops thread continuity into a muted channel', () => {
+      const a = { ...assignment(), mutedChannels: ['C2'] }
+      const aff = new Map<string, RouteTarget>([['C2/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      expect(arbitrate(a, msg({ channel: 'C2', thread: 'ts1', text: 'and then?' }), aff)).toBeNull()
+    })
+
+    it('leaves the bot answering everywhere else', () => {
+      const a = { ...assignment(), mutedChannels: ['C1'] }
+      expect(arbitrate(a, msg({ channel: 'C2', text: 'anything' }), empty())).toEqual({
+        agentId: BOB,
+        daemonId: D2,
+        integrationId: 'iB'
+      })
+    })
+  })
 })
 
 describe('BotArbitrationRouter — table + live affinity', () => {

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -45,10 +45,14 @@ export interface BotAssignment {
    *  in the conversation — a binding made before the gate was applied must not keep
    *  routing a private agent in a now-Off conversation. */
   gatedAgentIds?: string[]
-  /** Channels the operator switched OFF. The ladder below has rungs no missing route
-   *  can suppress — thread continuity, the unscoped keyword slug, `defaultAgentId` —
-   *  so Off is a fence rather than an omission: a muted channel resolves to nothing. */
+  /** Channels switched OFF. The ladder below has rungs no missing route can suppress
+   *  — thread continuity, the unscoped keyword slug, `defaultAgentId` — so Off is a
+   *  fence rather than an omission: a muted channel resolves to nothing. */
   mutedChannels?: string[]
+  /** The muted channels whose owner is GATED (§14 never enabled them). They resolve to
+   *  nothing like any mute, but unlike an operator's mute they keep the one-time notice:
+   *  someone who could not know the agent is private must not meet a dead bot. */
+  gatedOffChannels?: string[]
   /** §14.3: the relayId deterministically responsible for this bot's one-time
    *  CHANNEL gating notices (stamped by the CP from the connected roster). */
   noticeAuthority?: string
@@ -203,6 +207,7 @@ export class BotArbitrationRouter {
       | 'defaultDaemonId'
       | 'gatedAgentIds'
       | 'mutedChannels'
+      | 'gatedOffChannels'
       | 'noticeAuthority'
       | 'noticedDmConversations'
     >
@@ -216,6 +221,7 @@ export class BotArbitrationRouter {
     a.defaultDaemonId = patch.defaultDaemonId
     a.gatedAgentIds = patch.gatedAgentIds
     a.mutedChannels = patch.mutedChannels
+    a.gatedOffChannels = patch.gatedOffChannels
     a.noticeAuthority = patch.noticeAuthority
     a.noticedDmConversations = patch.noticedDmConversations
   }
@@ -328,12 +334,16 @@ export class BotArbitrationRouter {
     return candidate
   }
 
-  /** True iff the operator switched `channelId` Off. `arbitrate()` already refuses it,
-   *  but the caller has to tell a mute apart from the other reasons arbitration returns
-   *  null: an unroutable conversation on a gated bot earns a one-time notice, while a
-   *  muted channel is silent by the operator's own decision (§14.3 vs the Off trigger). */
+  /** True iff `channelId` is Off. `arbitrate()` already refuses it; the caller needs
+   *  this to tell a mute apart from the other reasons arbitration returns null. */
   channelMuted(botId: string, channelId: string): boolean {
     return this.bots.get(botId)?.mutedChannels?.includes(channelId) ?? false
+  }
+
+  /** True iff `channelId` is Off because §14 never enabled its gated owner — the one
+   *  muted case that still speaks, once, to say the agent is private. */
+  channelGatedOff(botId: string, channelId: string): boolean {
+    return this.bots.get(botId)?.gatedOffChannels?.includes(channelId) ?? false
   }
 
   /** True iff `channelId` has a channel-scoped `auto` owner — a rule that fires on

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -45,6 +45,10 @@ export interface BotAssignment {
    *  in the conversation — a binding made before the gate was applied must not keep
    *  routing a private agent in a now-Off conversation. */
   gatedAgentIds?: string[]
+  /** Channels the operator switched OFF. The ladder below has rungs no missing route
+   *  can suppress — thread continuity, the unscoped keyword slug, `defaultAgentId` —
+   *  so Off is a fence rather than an omission: a muted channel resolves to nothing. */
+  mutedChannels?: string[]
   /** §14.3: the relayId deterministically responsible for this bot's one-time
    *  CHANNEL gating notices (stamped by the CP from the connected roster). */
   noticeAuthority?: string
@@ -116,6 +120,9 @@ export function arbitrate(
   if (a.botUserId !== undefined && msg.sender.id === a.botUserId) return null
   const explicitlyMentioned = a.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)
   if (msg.sender.isBot && (msg.platform !== 'slack' || !explicitlyMentioned)) return null
+  // A channel switched Off resolves to no target at all — ahead of every rung, so
+  // neither an @-mention nor an existing thread binding can reach into it.
+  if (a.mutedChannels?.includes(msg.channel)) return null
 
   const scoped = a.routes.filter((r) => r.scope?.channel !== undefined && scopeMatches(r, msg))
 
@@ -195,6 +202,7 @@ export class BotArbitrationRouter {
       | 'defaultAgentId'
       | 'defaultDaemonId'
       | 'gatedAgentIds'
+      | 'mutedChannels'
       | 'noticeAuthority'
       | 'noticedDmConversations'
     >
@@ -207,6 +215,7 @@ export class BotArbitrationRouter {
     a.defaultAgentId = patch.defaultAgentId
     a.defaultDaemonId = patch.defaultDaemonId
     a.gatedAgentIds = patch.gatedAgentIds
+    a.mutedChannels = patch.mutedChannels
     a.noticeAuthority = patch.noticeAuthority
     a.noticedDmConversations = patch.noticedDmConversations
   }

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -328,6 +328,14 @@ export class BotArbitrationRouter {
     return candidate
   }
 
+  /** True iff the operator switched `channelId` Off. `arbitrate()` already refuses it,
+   *  but the caller has to tell a mute apart from the other reasons arbitration returns
+   *  null: an unroutable conversation on a gated bot earns a one-time notice, while a
+   *  muted channel is silent by the operator's own decision (§14.3 vs the Off trigger). */
+  channelMuted(botId: string, channelId: string): boolean {
+    return this.bots.get(botId)?.mutedChannels?.includes(channelId) ?? false
+  }
+
   /** True iff `channelId` has a channel-scoped `auto` owner — a rule that fires on
    *  EVERY message. Such a channel needs no durable thread binding: any pod re-resolves
    *  every message (incl. un-mentioned follow-ups) via the channel-ownership rung

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -59,6 +59,7 @@ function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): Bo
     ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {}),
     gatedAgentIds: a.gatedAgentIds,
     mutedChannels: a.mutedChannels,
+    gatedOffChannels: a.gatedOffChannels,
     noticedDmConversations: a.noticedDmConversations,
     ...(a.noticeAuthority ? { noticeAuthority: a.noticeAuthority } : {})
   }
@@ -163,6 +164,7 @@ async function main(): Promise<void> {
         ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {}),
         gatedAgentIds: r.gatedAgentIds,
         mutedChannels: r.mutedChannels,
+        gatedOffChannels: r.gatedOffChannels,
         noticeAuthority: r.noticeAuthority,
         noticedDmConversations: r.noticedDmConversations
       }),

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -58,6 +58,7 @@ function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): Bo
     ...(a.defaultAgentId ? { defaultAgentId: a.defaultAgentId } : {}),
     ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {}),
     gatedAgentIds: a.gatedAgentIds,
+    mutedChannels: a.mutedChannels,
     noticedDmConversations: a.noticedDmConversations,
     ...(a.noticeAuthority ? { noticeAuthority: a.noticeAuthority } : {})
   }
@@ -161,6 +162,7 @@ async function main(): Promise<void> {
         ...(r.defaultAgentId ? { defaultAgentId: r.defaultAgentId } : {}),
         ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {}),
         gatedAgentIds: r.gatedAgentIds,
+        mutedChannels: r.mutedChannels,
         noticeAuthority: r.noticeAuthority,
         noticedDmConversations: r.noticedDmConversations
       }),

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1088,6 +1088,28 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     expect(peer.ingest.postText).not.toHaveBeenCalled()
   })
 
+  // A mixed-visibility bot makes EVERY unrouted mention a notice candidate, whichever
+  // agent owns the channel. An operator who set an org-visible agent's channel to Off
+  // has already decided; "ask an admin to enable it" would be both a broken Off and
+  // misleading advice. The CP never mutes a gated owner's Off channel, so the §14.3
+  // notice above is untouched.
+  it('a MUTED channel stays silent on a mixed bot, even for an explicit @bot', async () => {
+    const auth = pod(true)
+    const a = auth.internals.router.get(BOT_ID)!
+    a.mutedChannels = ['C9'] // ungated member's channel, switched Off in the console
+    await auth.internals.forward(BOT_ID, mention(M1, '1.1'))
+    await auth.internals.forward(BOT_ID, mention(M2, '2.2'))
+    expect(auth.ingest.postText).not.toHaveBeenCalled()
+  })
+
+  it('mutes only the named channel — another gated conversation still gets its notice', async () => {
+    const auth = pod(true)
+    auth.internals.router.get(BOT_ID)!.mutedChannels = ['C7']
+    await auth.internals.forward(BOT_ID, mention(M1, '1.1')) // C9, not muted
+    expect(auth.ingest.postText).toHaveBeenCalledTimes(1)
+    expect(auth.ingest.postText.mock.calls[0]![0]).toBe('C9')
+  })
+
   it('no authority stamped (old CP / empty roster): no pod posts; DM discovery still reports', async () => {
     const reportBotConversation = vi.fn(() => true)
     const manager = new RelayIngressManager(deps({ reportBotConversation, selfRelayId: () => SELF_RELAY }))

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type {
   RdAck,
   RdMsgFeishuAction,
+  RdMsgIm,
   RdMsgSlackAction,
   RcBotChannels,
   RcThreadAssign,
@@ -1088,18 +1089,58 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     expect(peer.ingest.postText).not.toHaveBeenCalled()
   })
 
-  // A mixed-visibility bot makes EVERY unrouted mention a notice candidate, whichever
-  // agent owns the channel. An operator who set an org-visible agent's channel to Off
-  // has already decided; "ask an admin to enable it" would be both a broken Off and
-  // misleading advice. The CP never mutes a gated owner's Off channel, so the §14.3
-  // notice above is untouched.
-  it('a MUTED channel stays silent on a mixed bot, even for an explicit @bot', async () => {
+  // Every Off channel is muted for ROUTING; only the reason differs for the NOTICE.
+  // On a mixed bot a gated member makes every unrouted mention a notice candidate, so
+  // without the split an operator's Off would be answered with "ask an admin to enable
+  // it" — a broken Off and the opposite of what happened.
+  it('an OPERATOR-muted channel stays silent, even for an explicit @bot', async () => {
     const auth = pod(true)
     const a = auth.internals.router.get(BOT_ID)!
-    a.mutedChannels = ['C9'] // ungated member's channel, switched Off in the console
+    a.mutedChannels = ['C9'] // switched Off in the console; NOT in gatedOffChannels
     await auth.internals.forward(BOT_ID, mention(M1, '1.1'))
     await auth.internals.forward(BOT_ID, mention(M2, '2.2'))
     expect(auth.ingest.postText).not.toHaveBeenCalled()
+  })
+
+  // The reviewer's end-to-end case: a gated owner's Off channel on a bot that also has
+  // an ungated default. It must neither activate the public agent nor go silently
+  // indistinguishable from an operator mute — it is unroutable AND says so, once.
+  it('a GATED-Off channel is unroutable but still notices once', async () => {
+    const sendMsg = vi.fn(async (msg: RdMsgIm): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const daemon = { sendMsg } as unknown as RelayDaemonConnection
+    const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, selfRelayId: () => SELF_RELAY }))
+    const internals = manager as unknown as ManagerInternals
+    const ingest = fakeIngest()
+    internals.ingests.set(BOT_ID, ingest)
+    internals.router.upsert({
+      ...gatedAssignment(),
+      agents: [
+        { agentId: AGENT_ID, name: 'agent', daemonId: DAEMON_ID, integrationId: INTEGRATION_ID },
+        { agentId: OTHER_AGENT_ID, name: 'public', daemonId: DAEMON_ID, integrationId: OTHER_INTEGRATION_ID }
+      ],
+      members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID, OTHER_AGENT_ID] }],
+      // The ungated sibling's unscoped rungs — exactly what a missing route cannot suppress.
+      routes: [
+        {
+          agentId: OTHER_AGENT_ID,
+          daemonId: DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID,
+          match: { kind: 'keyword', value: 'public' }
+        }
+      ],
+      defaultAgentId: OTHER_AGENT_ID,
+      defaultDaemonId: DAEMON_ID,
+      mutedChannels: ['C9'],
+      gatedOffChannels: ['C9']
+    })
+
+    await internals.forward(BOT_ID, mention(M1, '1.1'))
+
+    expect(sendMsg).not.toHaveBeenCalled() // the public agent was NOT activated
+    expect(ingest.postText).toHaveBeenCalledTimes(1) // …and the gate explained itself
+    expect(ingest.postText.mock.calls[0]![0]).toBe('C9')
+    await internals.forward(BOT_ID, mention(M2, '2.2')) // still once per conversation
+    expect(ingest.postText).toHaveBeenCalledTimes(1)
   })
 
   it('mutes only the named channel — another gated conversation still gets its notice', async () => {

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -427,6 +427,7 @@ export class RelayIngressManager {
       | 'defaultDaemonId'
       | 'gatedAgentIds'
       | 'mutedChannels'
+      | 'gatedOffChannels'
       | 'noticeAuthority'
       | 'noticedDmConversations'
     >
@@ -644,15 +645,16 @@ export class RelayIngressManager {
       // conversation (the DM row itself was already reported above, un-gated on
       // the routing outcome).
       //
-      // A MUTED channel is the one unroutable case that must stay silent: the notice
-      // exists to tell someone a conversation was never enabled, and an operator who
-      // set this channel to Off already decided. Posting "ask an admin to enable it"
-      // there would both break the Off invariant and give misleading advice. Only
-      // reachable on a mixed-visibility bot, where a gated member makes every
-      // unrouted mention a notice candidate regardless of which agent owns the
-      // channel. The CP never mutes a gated owner's Off channel, so this cannot
-      // swallow a genuine §14.3 notice.
-      if (!msg.sender.isBot && hasGatedMembers && !this.router.channelMuted(botId, msg.channel)) {
+      // Every Off channel arrives here unroutable, and the two kinds answer
+      // differently. A channel an OPERATOR silenced says nothing: they already
+      // decided, and "ask an admin to enable it" would be the opposite of what
+      // happened. A channel that is Off because §14 never enabled its gated owner
+      // still speaks once — the person asking had no way to know the agent is
+      // private. Only ownership separates them (they share a trigger value), so the
+      // CP marks the gated ones and the fence and the notice stay independent.
+      const muted = this.router.channelMuted(botId, msg.channel)
+      const speaks = !muted || this.router.channelGatedOff(botId, msg.channel)
+      if (!msg.sender.isBot && hasGatedMembers && speaks) {
         const mentioned = assignment?.botUserId !== undefined && msg.mentionedBots.includes(assignment.botUserId)
         if (msg.isDm || mentioned) {
           // Feishu callback credentials are receive-only. For its currently

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -643,7 +643,16 @@ export class RelayIngressManager {
       // that backs ≥1 gated agent, must not look silently dead — answer once per
       // conversation (the DM row itself was already reported above, un-gated on
       // the routing outcome).
-      if (!msg.sender.isBot && hasGatedMembers) {
+      //
+      // A MUTED channel is the one unroutable case that must stay silent: the notice
+      // exists to tell someone a conversation was never enabled, and an operator who
+      // set this channel to Off already decided. Posting "ask an admin to enable it"
+      // there would both break the Off invariant and give misleading advice. Only
+      // reachable on a mixed-visibility bot, where a gated member makes every
+      // unrouted mention a notice candidate regardless of which agent owns the
+      // channel. The CP never mutes a gated owner's Off channel, so this cannot
+      // swallow a genuine §14.3 notice.
+      if (!msg.sender.isBot && hasGatedMembers && !this.router.channelMuted(botId, msg.channel)) {
         const mentioned = assignment?.botUserId !== undefined && msg.mentionedBots.includes(assignment.botUserId)
         if (msg.isDm || mentioned) {
           // Feishu callback credentials are receive-only. For its currently

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -426,6 +426,7 @@ export class RelayIngressManager {
       | 'defaultAgentId'
       | 'defaultDaemonId'
       | 'gatedAgentIds'
+      | 'mutedChannels'
       | 'noticeAuthority'
       | 'noticedDmConversations'
     >
@@ -863,6 +864,9 @@ export class RelayIngressManager {
     const sessionKey = sessionKeyOf({ channel: shortcut.channelId, thread: shortcut.threadTs })
     const assignment = this.router.get(botId)
     if (!assignment) return false
+    // A channel switched Off takes no shortcut either — the modal it opens acts on a
+    // session in a conversation the operator has silenced.
+    if (assignment.mutedChannels?.includes(shortcut.channelId)) return false
     const allowedInChannel = (agentId: string): boolean =>
       !assignment.gatedAgentIds?.includes(agentId) ||
       assignment.routes.some((route) => route.agentId === agentId && route.scope?.channel === shortcut.channelId)

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -9,21 +9,18 @@ import { AgentIconView } from '@/components/marks'
 import type { AgentIcon } from '@/lib/agent-icon'
 
 /** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
- *  bar. Channels: "any message" vs "@-mention" (default; mention sits last),
- *  plus an "off" segment on a gated (restricted-agent) integration —
- *  resource-visibility.md §14. DM rows are binary off/on. Every segment
- *  carries hover copy. */
+ *  bar. Channels: "off" / "any message" / "@-mention" (the default, so it sits
+ *  last). DM rows are binary off/on, and only a gated (restricted-agent)
+ *  integration has any — resource-visibility.md §14. Every segment carries
+ *  hover copy. */
 function TriggerToggle({
   channel,
   disabled,
-  gated,
   onChange
 }: {
   channel: IntegrationChannelRow
   /** Demo rows (no live integration id) render the control inert. */
   disabled: boolean
-  /** Restricted-agent integration: conversations are gated, "off" is offered. */
-  gated: boolean
   onChange: (trigger: IntegrationChannelRow['trigger']) => void
 }) {
   const [saving, setSaving] = useState(false)
@@ -53,10 +50,10 @@ function TriggerToggle({
     )
   }
   // A DM conversation activates on any message once enabled — binary off/on. A
-  // channel keeps the any/mention choice (mention last); "off" appears when
-  // gated (and, so the state stays visible, on an inert off row of a
-  // no-longer-gated integration). A GROUP DM takes the channel's three-way choice,
-  // not the DM's: several people share it, so "every message" must stay opt-in.
+  // channel takes the full three-way choice for EVERY agent, gated or not: an operator
+  // who wants the bot silent here but still in the channel on the platform has nowhere
+  // else to say so. A GROUP DM takes the channel's choice, not the DM's: several people
+  // share it, so "every message" must stay opt-in.
   const here = channel.kind === 'mpim' ? 'this group DM' : 'this channel'
   const segs: [IntegrationChannelRow['trigger'], string, string][] =
     channel.kind === 'im'
@@ -64,24 +61,15 @@ function TriggerToggle({
           ['off', 'off', "The agent doesn't respond in this conversation."],
           ['any', 'on', 'The agent responds to messages in this conversation.']
         ]
-      : gated || channel.trigger === 'off'
-        ? [
-            ['off', 'off', `The agent doesn't respond in ${here}.`],
-            ['any', 'any message', `The agent responds to every message in ${here}.`],
-            [
-              'mention',
-              '@-mention',
-              "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
-            ]
+      : [
+          ['off', 'off', `The agent doesn't respond in ${here}, even when @-mentioned.`],
+          ['any', 'any message', `The agent responds to every message in ${here}.`],
+          [
+            'mention',
+            '@-mention',
+            "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
           ]
-        : [
-            ['any', 'any message', `The agent responds to every message in ${here}.`],
-            [
-              'mention',
-              '@-mention',
-              "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
-            ]
-          ]
+        ]
   return (
     <span className="inline-flex items-center gap-[7px] max-desktop:w-full">
       <span title="Trigger — when the agent responds here" className="flex-none leading-none">
@@ -464,7 +452,6 @@ export function IntegrationChannelList({
           <TriggerToggle
             channel={c}
             disabled={!integrationId}
-            gated={gated}
             onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
         </div>
@@ -495,15 +482,21 @@ export function IntegrationChannelList({
       {dmRows.length > 0 && groupHeader('Direct messages', padX)}
       {dmRows.map(row)}
       <div
-        className="flex items-center gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
+        className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)"
         style={{ padding: `10px ${padX}px` }}
       >
-        <Icon name="info" size={14} className="flex-none" />
-        {shareable
-          ? 'Channels appear here when the bot is invited to them. Trigger is set per channel; default dispatch is the agent who handles unmatched messages.'
-          : gated
-            ? 'Channels appear here when the bot is invited; direct messages appear when someone writes to the bot.'
-            : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}
+        <Icon name="info" size={14} className="mt-[3px] flex-none" />
+        <span>
+          {shareable
+            ? 'Channels appear here when the bot is invited to them. Trigger is set per channel; default dispatch is the agent who handles unmatched messages.'
+            : gated
+              ? 'Channels appear here when the bot is invited; direct messages appear when someone writes to the bot.'
+              : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}{' '}
+          {/* Answers the question the list otherwise raises — there is no "leave" here,
+              because leaving is a platform action. Off is the console's equivalent. */}
+          Set a channel to off to silence the agent there; removing the bot from the channel itself is done on the
+          platform.
+        </span>
       </div>
     </>
   )


### PR DESCRIPTION
## Why

The per-channel trigger only offered **off** to a *restricted* agent. That was not a UI omission — it was the honest state of the routing model. A restricted agent's ingress is conversation-scoped only, so Off is simply the absence of a rule. An org-visible agent reaches every conversation through **unscoped** defaults (`@-mention` anywhere + DMs), and bind rules only ever *add* reach, so there was no way to express "not here".

The result: an operator who wanted the bot to stop answering in one channel had to remove the bot from that channel on the platform, or delete the whole integration. The console had no answer to "stop responding here".

## What

Off becomes a control **every** agent has, expressed as a subtractive fence rather than a missing rule:

- `mutedChannels` on the integration spec, for a daemon-arbitrated bot;
- `mutedChannels` on `rc/bot-assign` / `rc/routes`, for a relay-arbitrated one.

Both arbiters apply it **ahead of every rung**, because the rungs a missing route cannot suppress are exactly the ones that matter here — an unscoped mention default, thread continuity into a thread the agent had already joined, a CP session placement, a shared bot's keyword slug, and `defaultAgentId`. A muted channel resolves to nothing at all: no reply, no new session, no control command.

A **gated** integration ships an empty list. Its Off is already the absence of a scoped rule, and stating the same fact twice invites the two representations to drift.

Everything else is deliberately untouched: the bot stays in the channel, the row keeps its owner and trigger, transcripts survive, and the agent can still post there when a scheduled task or another agent's hand-off directs it to.

## Behaviour change worth reviewing

When a restricted agent becomes org-visible, a **channel** row set to Off used to decay to `mention` — §14.4 treated it as inert on the grounds that honouring it would be behaviour with no visible control. That rationale no longer holds now that the console shows the Off segment for org-visible agents, so a channel row keeps its Off across the transition.

**Direct** rows are unchanged: still inert, still never muted. The console hides a preserved DM row once its owner is org-visible, so the original argument still applies to them exactly as written.

## Notes for review

- `conversationAdmitted()` replaces four hand-rolled copies of the gating predicate in the daemon (control commands, both message-shortcut lookups, and the relay's last-hop backstop). Those paths resolve a target *outside* `routeRules`, so they each have to re-check admission; they now share one helper that applies both fences.
- `integrationRouting()` coalesces a missing `mutedChannels` to `[]`. The field post-dates the schema, so an integration assembled by hand rather than zod-parsed can reach it without one; absent means "nothing muted", the behaviour before the field existed.
- `pushSpecs` now reuses the channel rows the compile already read instead of issuing a second `listForBot`, since every install (not just gated ones) needs them.

## Verification

`typecheck`, `lint`, and every suite green on the rebased base: daemon 2515, control-plane 1026 unit + 900 integration (real Postgres), relay 360, web 495, protocol 221. New coverage at each layer — spec emission, relay route compilation, the daemon ladder (mention default, thread continuity, CP placement, cross-integration isolation), and relay arbitration.

Rendered the console in mock mode to confirm the three-segment control on both an org-visible and a restricted agent, desktop and mobile.

## Known gap, not addressed here

Only Slack reports an authoritative membership snapshot. Telegram, Discord, and Feishu rows are upsert-only, so a channel the bot has been removed from lingers in the console. Off now gives an operator a way to silence such a row, but clearing it still means deleting the integration. Investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)