### PR TITLE
fix(github): require maintainer authorization for triggers

### DIFF
--- a/docs/designs/github-pr-review-checks.md
+++ b/docs/designs/github-pr-review-checks.md
@@ -388,17 +388,16 @@ meaning "no agent turn was attempted," not a runtime failure. The relay remains
 stateless and uses the ordinary fire-and-forget `rc/run-report`. When no HookRun
 exists, GitHub delivery reconciliation redelivers. When only some hooks have durable
 rows, the CP durably claims a one-time retry of the entire delivery only if all
-existing siblings are no-agent-effect `review_request_required`. PR lifecycle uses
-`OWNER/MEMBER/COLLABORATOR` as its local maintainer fast path. For any other or
-missing association, relay asks CP for the PR author's current write/admin permission
-before dispatching. The request is body-free and carries every matching hook's
-config/dispatch fence, so CP validates the complete durable fan-out around one GitHub
-permission lookup. Denial, incomplete metadata, rate limiting, or lookup failure
-fails the complete fan-out closed into the external-author path; one delivery cannot
-mix the two identity conclusions. A fan-out containing anything already executed or
-any other failure fails closed. Activating the button starts a new queued generation
-and clears the action; the button actor must still pass a live write/admin permission
-check.
+existing siblings are no-agent-effect `review_request_required`. For every PR lifecycle
+event, relay asks CP for the PR author's current write/admin permission before
+dispatching; webhook `author_association` is descriptive only and never authorizes the
+trigger. The request is body-free and carries every matching hook's config/dispatch
+fence, so CP validates the complete durable fan-out around one GitHub permission
+lookup. Denial, incomplete metadata, rate limiting, or lookup failure fails the
+complete fan-out closed into the external-author path; one delivery cannot mix the two
+identity conclusions. A fan-out containing anything already executed or any other
+failure fails closed. Activating the button starts a new queued generation and clears
+the action; the button actor must still pass a live write/admin permission check.
 
 ### 6. Informational Rerequest and Future R2b/R2c Boundaries
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -225,12 +225,14 @@ and `COLLABORATOR` can still represent read or triage access and never bypass
 the current repository-permission lookup.
 
 Issue and pull-request lifecycle events require current write/admin authority
-from the subject author. Every comment requires it from the commenter. An
-unmentioned comment also requires current write/admin authority from the
-Issue/PR author; an explicit mention by an authorized maintainer omits that
-second requirement and can summon the Agent onto an externally authored
-thread. Missing identity metadata, denial, timeout, or an unavailable lookup
-fails closed.
+from the subject author. Every comment requires it from `comment.user`, not the
+top-level action `sender`; this distinction prevents a maintainer edit/delete
+action from authorizing someone else's content. An unmentioned comment also
+requires current write/admin authority from the Issue/PR author; an explicit
+mention by an authorized maintainer omits that second requirement and can summon
+the Agent onto an externally authored thread. Missing identity metadata, denial,
+timeout, or an unavailable lookup fails closed. Matching comment rules with the
+same actor requirement share one fenced authorization decision.
 
 A native `pull_request:review_requested` event can explicitly request the App
 bot as reviewer. It bypasses cadence, labels, and mention filters only after a

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -209,7 +209,7 @@ start turns. A diff-line review comment may match a shared
 `issue_comment` subscription or an explicit
 `pull_request_review_comment` subscription.
 
-### Summon and Collaborator Gates
+### Summon and Maintainer Gates
 
 With `mentionOnly` enabled, authored event text must contain either:
 
@@ -219,32 +219,38 @@ With `mentionOnly` enabled, authored event text must contain either:
 The App handle wins when both forms are present. Unrelated mentions do not
 change the candidate set.
 
-Every comment also passes the collaborator gate. Trusted payload associations
-are `OWNER`, `MEMBER`, and `COLLABORATOR`. When the payload does not provide a
-trusted association, the relay asks the CP for a live, body-free permission
-decision. A comment does not reach the daemon unless the author has current
-write-level authority.
+Every numbered-thread event passes a live, body-free permission decision owned
+by the CP. Webhook `author_association` values are descriptive only: `MEMBER`
+and `COLLABORATOR` can still represent read or triage access and never bypass
+the current repository-permission lookup.
+
+Issue and pull-request lifecycle events require current write/admin authority
+from the subject author. Every comment requires it from the commenter. An
+unmentioned comment also requires current write/admin authority from the
+Issue/PR author; an explicit mention by an authorized maintainer omits that
+second requirement and can summon the Agent onto an externally authored
+thread. Missing identity metadata, denial, timeout, or an unavailable lookup
+fails closed.
 
 A native `pull_request:review_requested` event can explicitly request the App
 bot as reviewer. It bypasses cadence, labels, and mention filters only after a
 live maintainer authorization.
 
-### External Pull Requests
+### External Issues and Pull Requests
 
-Pull-request bodies and diffs are attacker-controlled input. A lifecycle event
-from an author outside the repository write boundary does not run an agent
-automatically.
+Issue/PR bodies and pull-request diffs are attacker-controlled input. A
+lifecycle event from an author outside the repository write boundary does not
+run an agent automatically, even when the body mentions the Agent or App. One
+live decision and a batch of durable hook fences authorize the complete
+repository fan-out before any agent dispatch.
 
-`OWNER`, `MEMBER`, and `COLLABORATOR` payload associations are the local fast
-path. For any other or missing association, the relay asks the CP for the PR
-author's current repository permission using the existing metadata-only GitHub
-App authorization path. Current write/admin permission recovers a stale webhook
-association; denial or an unavailable lookup fails closed. One lookup and a
-batch of durable hook fences decide the complete repository fan-out before any
-agent dispatch.
+An authorized maintainer can request execution on an external thread by
+explicitly mentioning the Agent or App in a comment. An ordinary unmentioned
+comment cannot silently activate an external thread; both its commenter and
+the original subject author must pass the same live write/admin check.
 
-For revision-bearing events such as open, synchronize, ready-for-review, and
-draft conversion, the system records a body-free
+For external PR revision-bearing events such as open, synchronize,
+ready-for-review, and draft conversion, the system records a body-free
 `review_request_required` outcome and may project an informational Check with a
 maintainer action. A maintainer can then request execution through:
 
@@ -467,8 +473,8 @@ without the relay, while a webhook always requires a public ingress process.
 - Repository matching uses numeric IDs.
 - Installation membership comes from CP-owned records.
 - Bot senders never trigger GitHub hooks.
-- Comment authors pass collaborator or live-permission checks.
-- External pull requests require a maintainer request.
+- Issue/PR actors pass live write/admin checks; payload associations never authorize.
+- External Issues and pull requests require an explicit maintainer request.
 - Event bodies remain relay-to-daemon only.
 - Logs contain identifiers and outcomes, never payload text or secrets.
 - `HookSecret` is absent from normal hook queries and DTOs.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -358,6 +358,25 @@ AgentConnect informational review Check in that App suite, with the same live ma
 authorization and revision fences as a single-Check rerun. It does not depend on the
 integration's ordinary event cadence.
 
+## GitHub maintainer trigger authorization
+
+GitHub Issue and pull-request integrations treat current repository permission—not the
+webhook's `author_association` label—as trigger authority. An Issue or pull request whose
+author lacks current `write` or `admin` permission does not start an Agent automatically,
+even when its body mentions the Agent or App. A current `write`/`admin` maintainer can
+explicitly `@` the Agent or App in a comment to request the first turn on that external
+thread; the same mention from a read-only user does nothing.
+
+Every comment sender is checked live. An unmentioned comment follows the configured
+cadence only when both the commenter and the Issue/PR author still have `write` or
+`admin` permission. This keeps automatic follow-ups on maintainer-owned threads while
+requiring an explicit maintainer summon for externally authored threads. Native review
+requests and Check reruns use the same current-maintainer boundary.
+
+Trigger authorization is separate from effect authorization. A formal PR review still
+requires the active HookRun, review policy, Agent repository grant, and GitHub App
+permission checks at the moment the review is submitted.
+
 ## GitHub review mention routing
 
 An explicit `@<agent-name>` in GitHub targets only that AgentConnect agent's
@@ -367,7 +386,7 @@ are present, broadcast wins; mentioning an unrelated GitHub user does not change
 the configured review cadence.
 
 Mention routing does not bypass the integration's event family, label filter,
-installation attribution, collaborator authorization, or bot-sender veto. A
+installation attribution, live maintainer authorization, or bot-sender veto. A
 targeted agent mention narrows an otherwise broader `updated` fan-out, while an
 event with no AgentConnect mention continues to follow its configured cadence.
 In a pull request conversation, an authorized explicit AgentConnect mention

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -367,11 +367,13 @@ even when its body mentions the Agent or App. A current `write`/`admin` maintain
 explicitly `@` the Agent or App in a comment to request the first turn on that external
 thread; the same mention from a read-only user does nothing.
 
-Every comment sender is checked live. An unmentioned comment follows the configured
-cadence only when both the commenter and the Issue/PR author still have `write` or
-`admin` permission. This keeps automatic follow-ups on maintainer-owned threads while
-requiring an explicit maintainer summon for externally authored threads. Native review
-requests and Check reruns use the same current-maintainer boundary.
+Every comment author is checked live from the comment object; for edit/delete actions,
+the top-level webhook sender is not treated as the content author. An unmentioned
+comment follows the configured cadence only when both the commenter and the Issue/PR
+author still have `write` or `admin` permission. This keeps automatic follow-ups on
+maintainer-owned threads while requiring an explicit maintainer summon for externally
+authored threads. Native review requests and Check reruns use the same
+current-maintainer boundary.
 
 Trigger authorization is separate from effect authorization. A formal PR review still
 requires the active HookRun, review policy, Agent repository grant, and GitHub App

--- a/packages/control-plane/src/github/comment-authz.service.test.ts
+++ b/packages/control-plane/src/github/comment-authz.service.test.ts
@@ -84,6 +84,7 @@ function make(
     hook?: HookRecord
     hooks?: HookRecord[]
     permission?: Permission
+    permissions?: Partial<Record<string, Permission>>
     timeoutMs?: number
   } = {}
 ) {
@@ -94,7 +95,10 @@ function make(
     fullName: request.repoFullName,
     private: true
   }))
-  const userRepoPermissionForCommentAuthz = vi.fn(async () => opts.permission ?? 'write')
+  const userRepoPermissionForCommentAuthz = vi.fn(
+    async (_installation: GithubInstallationRecord, _owner: string, _repo: string, username: string) =>
+      opts.permissions?.[username] ?? opts.permission ?? 'write'
+  )
   const service = new GithubCommentAuthzService({
     hooks: { getMany } as unknown as Pick<HookRepo, 'getMany'>,
     installations: { getByInstallationId } as unknown as Pick<GithubInstallationRepo, 'getByInstallationId'>,
@@ -122,6 +126,13 @@ describe('GithubCommentAuthzService', () => {
 
   it('denies read-only repository permission', async () => {
     await expect(make({ permission: 'read' }).service.allowed(request)).resolves.toBe(false)
+  })
+
+  it('requires write permission from both an unmentioned commenter and the thread author', async () => {
+    const h = make({ permissions: { octocat: 'write', 'issue-author': 'read' } })
+
+    await expect(h.service.allowed({ ...request, subjectAuthorLogin: 'issue-author' })).resolves.toBe(false)
+    expect(h.userRepoPermissionForCommentAuthz).toHaveBeenCalledTimes(2)
   })
 
   it('denies a stale config revision before consulting GitHub', async () => {

--- a/packages/control-plane/src/github/comment-authz.service.ts
+++ b/packages/control-plane/src/github/comment-authz.service.ts
@@ -14,7 +14,7 @@ export interface GithubCommentAuthzDeps {
 const DEFAULT_TIMEOUT_MS = 4_000
 
 /**
- * Resolve a GitHub actor's current repository permission without trusting
+ * Resolve every relevant GitHub actor's current repository permission without trusting
  * webhook `author_association`. Every local metadata mismatch denies before a
  * GitHub request. Operational failures and the bounded overall timeout
  * propagate so the wire handler can distinguish them from a definitive denial.
@@ -82,13 +82,11 @@ export class GithubCommentAuthzService {
     const resolved = await this.deps.github.repoRefForCommentAuthz(installation, owner, repo)
     if (!resolved || resolved.repoId !== hook.repoId) return false
 
-    const permission = await this.deps.github.userRepoPermissionForCommentAuthz(
-      installation,
-      owner,
-      repo,
-      req.senderLogin
+    const actorLogins = [...new Set([req.senderLogin, req.subjectAuthorLogin].filter((login) => login !== undefined))]
+    const permissions = await Promise.all(
+      actorLogins.map((login) => this.deps.github.userRepoPermissionForCommentAuthz(installation, owner, repo, login))
     )
-    if (permission !== 'admin' && permission !== 'write') return false
+    if (permissions.some((permission) => permission !== 'admin' && permission !== 'write')) return false
 
     // The GitHub calls above can take seconds. Re-read immediately before the
     // allow verdict so a concurrent disable, retarget, or reassignment cannot

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -129,7 +129,7 @@ export class HookService {
         ...(hook.commentFamilies.length > 0 ? { commentFamilies: hook.commentFamilies } : {}),
         labelFilter: hook.labelFilter,
         // P3: the App slug broadcasts to every matching rule; the immutable
-        // agent slug targets this rule. Comments also pass the collaborator gate.
+        // agent slug targets this rule. Thread actors also pass live maintainer auth.
         mentionOnly: hook.mentionOnly,
         ...(this.appSlug ? { appSlug: this.appSlug } : {}),
         agentName: agent.name,

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1872,7 +1872,7 @@ export const CreateGithubHookBody = HookBodyBase.extend({
   commentFamilies: GithubCommentFamilies.default([]),
   labelFilter: z.array(z.string().trim().min(1).max(100)).max(20).default([]),
   // P3 summon mode: every event's authored text must @-mention the assigned
-  // agent or the App (comments also pass the relay's collaborator gate).
+  // agent or the App (thread actors also pass the relay's live maintainer gate).
   mentionOnly: z.boolean().default(false),
   reviewPolicy: HookReviewPolicyEnum.default('off'),
   reportingMode: HookReportingModeEnum.default('off'),

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -160,6 +160,7 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
       repoId: '67890',
       repoFullName: 'acme/infra',
       senderLogin: 'octocat',
+      subjectAuthorLogin: 'issue-author',
       configRevision: '7',
       dispatchRevision: '9',
       siblingFences: [

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -111,11 +111,10 @@ export const RcVerifyResult = z.object({
 })
 export type RcVerifyResult = z.infer<typeof RcVerifyResult>
 
-// R→C REQ → rc/github-comment-authz/ok. A GitHub comment or PR webhook may
-// carry a stale `author_association`, so the relay asks the CP (which owns the
-// App installation) for a current repository-permission verdict. This frame
-// is deliberately metadata-only: authored content must never cross the
-// relay↔CP control plane.
+// R→C REQ → rc/github-comment-authz/ok. The relay asks the CP (which owns the
+// App installation) for a current repository-permission verdict instead of
+// treating webhook `author_association` as authority. This frame is deliberately
+// metadata-only: authored content must never cross the relay↔CP control plane.
 export const RcGithubHookFence = z
   .object({
     hookId: z.string().uuid(),
@@ -132,11 +131,15 @@ export const RcGithubCommentAuthz = z
     repoId: z.string().regex(/^[1-9]\d*$/),
     repoFullName: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
     senderLogin: z.string().min(1),
-    // Fence the fallback to the exact compiled rule that accepted the
+    // An unmentioned thread comment may continue automatically only when both
+    // its commenter and the issue/PR author still have write authority. An
+    // explicit maintainer summon omits this second actor.
+    subjectAuthorLogin: z.string().min(1).optional(),
+    // Fence authorization to the exact compiled rule that accepted the
     // delivery. A stale relay copy cannot authorize after retarget/reassign.
     configRevision: HookBigIntString,
     dispatchRevision: HookBigIntString,
-    // PR-author authorization is repository-wide, but every matching sibling
+    // Thread-actor authorization is repository-wide, but every matching sibling
     // must still be fenced against current CP state before one allow verdict
     // can authorize the complete fan-out.
     siblingFences: z.array(RcGithubHookFence).min(1).optional()
@@ -256,8 +259,8 @@ export const RcHookAssign = z
         // the console-selected thread families so the relay can isolate replies.
         commentFamilies: z.array(z.enum(['issues', 'pull_request'])).optional(),
         // P3 summon mode: every event's authored text must @-mention either
-        // this agent or the App. Comments ALWAYS pass the collaborator gate in
-        // addition to this flag.
+        // this agent or the App. Thread events always pass the live maintainer
+        // gate in addition to this flag.
         mentionOnly: z.boolean(),
         // The App slug is the broadcast handle: `@<appSlug>` keeps every
         // matching rule in the repo fan-out. Compiled from the CP's

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -130,6 +130,8 @@ export const RcGithubCommentAuthz = z
     installationId: z.string().regex(/^[1-9]\d*$/),
     repoId: z.string().regex(/^[1-9]\d*$/),
     repoFullName: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+    // Legacy field name: comment deliveries carry `comment.user.login`, not
+    // the top-level webhook action sender. Maintainer controls carry the actor.
     senderLogin: z.string().min(1),
     // An unmentioned thread comment may continue automatically only when both
     // its commenter and the issue/PR author still have write authority. An

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -69,6 +69,7 @@ function rule(
 
 /** A minimal `issues` payload; override to shape other events. */
 function issuesPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const sender = (overrides.sender as Record<string, unknown> | undefined) ?? { login: 'alice', type: 'User' }
   const issue = {
     number: 42,
     title: 'db down',
@@ -79,13 +80,16 @@ function issuesPayload(overrides: Record<string, unknown> = {}): Record<string, 
     labels: [{ name: 'bug' }],
     ...((overrides.issue as Record<string, unknown> | undefined) ?? {})
   }
+  const commentOverride = overrides.comment as Record<string, unknown> | undefined
+  const comment = commentOverride ? { user: { login: sender.login }, ...commentOverride } : undefined
   return {
     action: 'opened',
     installation: { id: INSTALLATION },
     repository: { id: REPO_ID, full_name: 'acme/infra' },
-    sender: { login: 'alice', type: 'User' },
+    sender,
     ...overrides,
-    issue
+    issue,
+    ...(comment ? { comment } : {})
   }
 }
 
@@ -1390,6 +1394,28 @@ describe('github ingress', () => {
       expect(h.sent).toHaveLength(0)
     })
 
+    it('authorizes deleted comment content as its author rather than the action sender', async () => {
+      h.table.upsert(rule({}, { events: ['issue_comment:*'], appSlug: 'example-app' }))
+      h.authzResult = (request) => request.senderLogin === 'maintainer'
+
+      await post(
+        'issue_comment',
+        issuesPayload({
+          action: 'deleted',
+          sender: { login: 'maintainer', type: 'User' },
+          comment: {
+            user: { login: 'external-commenter' },
+            body: '@example-app run these instructions',
+            author_association: 'NONE'
+          }
+        })
+      )
+      await flush()
+
+      expect(h.authzRequests).toEqual([expect.objectContaining({ senderLogin: 'external-commenter' })])
+      expect(h.sent).toHaveLength(0)
+    })
+
     it('live-checks comments regardless of OWNER/MEMBER/COLLABORATOR association', async () => {
       h.table.upsert(rule({}, { events: ['issue_comment:created'] }))
       for (const [i, assoc] of ['OWNER', 'MEMBER', 'COLLABORATOR'].entries()) {
@@ -1412,7 +1438,11 @@ describe('github ingress', () => {
           event === 'issue_comment'
             ? issuesPayload({
                 action: 'created',
-                comment: { body: 'please retry', author_association: 'CONTRIBUTOR' }
+                comment: {
+                  user: { login: 'alice' },
+                  body: 'please retry',
+                  author_association: 'CONTRIBUTOR'
+                }
               })
             : {
                 action: 'created',
@@ -1420,7 +1450,11 @@ describe('github ingress', () => {
                 repository: { id: REPO_ID, full_name: 'acme/infra' },
                 sender: { login: 'alice', type: 'User' },
                 pull_request: { number: 7, user: { login: 'alice' } },
-                comment: { body: 'please retry', author_association: 'CONTRIBUTOR' }
+                comment: {
+                  user: { login: 'alice' },
+                  body: 'please retry',
+                  author_association: 'CONTRIBUTOR'
+                }
               }
 
         h.authzResult = true
@@ -1482,26 +1516,26 @@ describe('github ingress', () => {
       expect(h.reports).toHaveLength(0)
     })
 
-    it('shares the authz budget across hooks watching the same repository', async () => {
+    it('batches matching hooks into one repository-scoped authorization', async () => {
       await h.app.close()
-      h = makeHarness(3)
+      h = makeHarness(1)
       h.table.upsert(rule({}, { events: ['issue_comment:created'] }))
       h.table.upsert(rule({ hookId: HOOK_B }, { events: ['issue_comment:created'] }))
-      h.authzResult = false
       const payload = issuesPayload({
         action: 'created',
         comment: { body: 'please retry', author_association: 'CONTRIBUTOR' }
       })
 
-      await post('issue_comment', payload, { headers: { 'x-github-delivery': 'fanout-1' } })
-      await post('issue_comment', payload, { headers: { 'x-github-delivery': 'fanout-2' } })
+      await post('issue_comment', payload, { headers: { 'x-github-delivery': 'fanout' } })
       await flush()
 
-      // Capacity is three per installation+repo, not three per hook: the two
-      // deliveries would otherwise have issued four upstream authorizations.
-      expect(h.authzRequests).toHaveLength(3)
-      expect(new Set(h.authzRequests.map((request) => request.hookId))).toEqual(new Set([HOOK, HOOK_B]))
-      expect(h.sent).toHaveLength(0)
+      expect(h.authzRequests).toEqual([
+        expect.objectContaining({
+          hookId: HOOK,
+          siblingFences: [{ hookId: HOOK_B, configRevision: '3', dispatchRevision: '5' }]
+        })
+      ])
+      expect(h.sent).toHaveLength(2)
     })
 
     it('created mode accepts later explicit summons but not ordinary or out-of-scope updates', async () => {
@@ -1670,6 +1704,7 @@ describe('github ingress', () => {
             comment: {
               id: 3565283658,
               in_reply_to_id: null,
+              user: { login: 'alice' },
               body: 'should this retry be exponential?',
               html_url: 'https://github.com/acme/infra/pull/7#discussion_r1',
               author_association: assoc
@@ -1714,6 +1749,7 @@ describe('github ingress', () => {
         comment: {
           id: 3565656411,
           in_reply_to_id: 3565283658,
+          user: { login: 'alice' },
           body: 'translate this?',
           author_association: 'COLLABORATOR'
         }
@@ -1736,7 +1772,11 @@ describe('github ingress', () => {
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
-        comment: { body: 'should this retry be exponential?', author_association: 'MEMBER' }
+        comment: {
+          user: { login: 'alice' },
+          body: 'should this retry be exponential?',
+          author_association: 'MEMBER'
+        }
       }
 
       h.table.upsert(rule({}, { events: ['issues:*', 'issue_comment:created'], commentFamilies: ['issues'] }))
@@ -1763,7 +1803,11 @@ describe('github ingress', () => {
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
-        comment: { body: '@example-review-app is this right?', author_association: 'MEMBER' }
+        comment: {
+          user: { login: 'alice' },
+          body: '@example-review-app is this right?',
+          author_association: 'MEMBER'
+        }
       }
 
       h.table.upsert(
@@ -1815,7 +1859,7 @@ describe('github ingress', () => {
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, user: { login: 'alice' } },
-        comment: { body: 'explicitly subscribed', author_association: 'MEMBER' }
+        comment: { user: { login: 'alice' }, body: 'explicitly subscribed', author_association: 'MEMBER' }
       })
       await flush()
 
@@ -1833,7 +1877,7 @@ describe('github ingress', () => {
             repository: { id: REPO_ID, full_name: 'acme/infra' },
             sender: { login: 'alice', type: 'User' },
             pull_request: { number: 7, user: { login: 'alice' } },
-            comment: { body, author_association: 'MEMBER' }
+            comment: { user: { login: 'alice' }, body, author_association: 'MEMBER' }
           },
           { headers: { 'x-github-delivery': key } }
         )

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -18,7 +18,6 @@ import { HookTable } from './hook-table.js'
 import { HookRateLimiter } from './rate-limit.js'
 import {
   registerGithubIngress,
-  githubRuleMatches,
   githubRuleVerdict,
   buildGithubContext,
   buildTrustedGithubMetadata,
@@ -70,20 +69,23 @@ function rule(
 
 /** A minimal `issues` payload; override to shape other events. */
 function issuesPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const issue = {
+    number: 42,
+    title: 'db down',
+    body: 'the primary is unreachable',
+    html_url: 'https://github.com/acme/infra/issues/42',
+    user: { login: 'alice' },
+    author_association: 'MEMBER',
+    labels: [{ name: 'bug' }],
+    ...((overrides.issue as Record<string, unknown> | undefined) ?? {})
+  }
   return {
     action: 'opened',
     installation: { id: INSTALLATION },
     repository: { id: REPO_ID, full_name: 'acme/infra' },
     sender: { login: 'alice', type: 'User' },
-    issue: {
-      number: 42,
-      title: 'db down',
-      body: 'the primary is unreachable',
-      html_url: 'https://github.com/acme/infra/issues/42',
-      author_association: 'MEMBER',
-      labels: [{ name: 'bug' }]
-    },
-    ...overrides
+    ...overrides,
+    issue
   }
 }
 
@@ -156,13 +158,13 @@ interface Harness {
   authzRequests: RcGithubCommentAuthz[]
   rerequestRequests: RcGithubRerequest[]
   rerequestResult: RcGithubRerequestResult | (() => Promise<RcGithubRerequestResult>)
-  authzResult: boolean | (() => Promise<boolean>)
+  authzResult: boolean | ((request: RcGithubCommentAuthz) => boolean | Promise<boolean>)
   ack: RdAck | (() => Promise<RdAck>)
   offline: boolean
   onlineDaemons: Set<string>
 }
 
-function makeHarness(): Harness {
+function makeHarness(authzCapacity = 20): Harness {
   const clock = new FakeClock()
   const h: Partial<Harness> &
     Pick<
@@ -175,7 +177,7 @@ function makeHarness(): Harness {
     doorbells: [],
     authzRequests: [],
     rerequestRequests: [],
-    authzResult: false,
+    authzResult: true,
     rerequestResult: { allowed: false },
     ack: { msgId: 'x', accepted: true },
     offline: false,
@@ -201,13 +203,13 @@ function makeHarness(): Harness {
     doorbell: (p) => h.doorbells.push(p),
     authorizeComment: async (request) => {
       h.authzRequests.push(request)
-      return typeof h.authzResult === 'function' ? h.authzResult() : h.authzResult!
+      return typeof h.authzResult === 'function' ? h.authzResult(request) : h.authzResult!
     },
     authorizeRerequest: async (request) => {
       h.rerequestRequests.push(request)
       return typeof h.rerequestResult === 'function' ? h.rerequestResult() : h.rerequestResult!
     },
-    authzLimiter: new HookRateLimiter(clock, { capacity: 3, refillPerSec: 0 }),
+    authzLimiter: new HookRateLimiter(clock, { capacity: authzCapacity, refillPerSec: 0 }),
     limiter: new HookRateLimiter(clock, { capacity: 3, refillPerSec: 0 }),
     clock,
     log,
@@ -478,6 +480,8 @@ describe('github ingress', () => {
     })
 
     it('exhausts the authorization budget before doing another CP projection lookup', async () => {
+      await h.app.close()
+      h = makeHarness(3)
       h.table.upsert(rule())
 
       for (let i = 0; i < 4; i++) {
@@ -764,6 +768,7 @@ describe('github ingress', () => {
       'keeps an external PR %s out of the daemon and publishes the manual-request Check intent',
       async (action) => {
         h.table.upsert(rule({}, { events: ['pull_request:*'], appSlug: 'example-review-app' }))
+        h.authzResult = false
 
         await post('pull_request', pullPayload({ action }))
         await flush()
@@ -793,7 +798,7 @@ describe('github ingress', () => {
     )
 
     it.each(['OWNER', 'MEMBER', 'COLLABORATOR'] as const)(
-      'automatically reviews a PR authored by a trusted %s association',
+      'live-checks a PR author even when the payload association is %s',
       async (authorAssociation) => {
         h.table.upsert(rule({}, { events: ['pull_request:*'] }))
         const pullRequest = pullPayload().pull_request as Record<string, unknown>
@@ -809,13 +814,13 @@ describe('github ingress', () => {
         )
         await flush()
 
-        expect(h.authzRequests).toHaveLength(0)
+        expect(h.authzRequests).toEqual([expect.objectContaining({ senderLogin: 'alice' })])
         expect(h.sent).toHaveLength(1)
         expect(h.reports).toEqual([expect.objectContaining({ status: 'accepted' })])
       }
     )
 
-    it('fans out a trusted PR association without a separate permission lookup', async () => {
+    it('live-checks a PR author once before dispatching the complete fan-out', async () => {
       h.table.upsert(rule({}, { events: ['pull_request:*'] }))
       h.table.upsert(
         rule(
@@ -842,7 +847,12 @@ describe('github ingress', () => {
       )
       await flush()
 
-      expect(h.authzRequests).toHaveLength(0)
+      expect(h.authzRequests).toEqual([
+        expect.objectContaining({
+          senderLogin: 'alice',
+          siblingFences: [{ hookId: HOOK_B, configRevision: '3', dispatchRevision: '5' }]
+        })
+      ])
       expect(h.sent).toHaveLength(2)
       expect(h.reports).toHaveLength(2)
       expect(h.reports.every((report) => report.status === 'accepted')).toBe(true)
@@ -901,6 +911,7 @@ describe('github ingress', () => {
       const external = pullPayload()
       const externalSubject = external.pull_request as Record<string, unknown>
       externalSubject.body = '@example-review-app please review'
+      h.authzResult = false
 
       await post('pull_request', external, { headers: { 'x-github-delivery': 'external-body-mention' } })
       await flush()
@@ -909,6 +920,7 @@ describe('github ingress', () => {
         status: 'failed',
         reason: HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED
       })
+      h.authzResult = true
 
       await post(
         'issue_comment',
@@ -1087,7 +1099,7 @@ describe('github ingress', () => {
       expect(h.reports[0]?.github).toEqual(msg.github)
     })
 
-    it('forces review/reporting off when a rolling rule lacks the complete dispatch fence', async () => {
+    it('fails closed when a rolling rule lacks the complete dispatch fence', async () => {
       h.table.upsert(
         rule({
           configRevision: undefined,
@@ -1099,12 +1111,9 @@ describe('github ingress', () => {
       )
       await post('issues', issuesPayload())
       await flush()
-      const msg = h.sent[0]!
-      expect(msg).toMatchObject({ reviewPolicy: 'off', reportingMode: 'off', gateMode: 'informational' })
-      expect(msg.configRevision).toBeUndefined()
-      expect(msg.dispatchRevision).toBeUndefined()
-      expect(msg.dispatchDaemonId).toBeUndefined()
-      expect(h.reports[0]).toMatchObject({ reviewPolicy: 'off', reportingMode: 'off' })
+      expect(h.authzRequests).toHaveLength(0)
+      expect(h.sent).toHaveLength(0)
+      expect(h.reports).toHaveLength(0)
     })
 
     it('event:* wildcard matches every action of the family', async () => {
@@ -1320,28 +1329,68 @@ describe('github ingress', () => {
       expect(h.sent.map((m) => m.sessionKey)).toEqual(['acme/infra#42', 'acme/infra#43'])
     })
 
-    it('issue_comment requires collaborator standing — opening events stay open to anyone (P3)', async () => {
-      h.table.upsert(rule({}, { events: ['issues:*', 'issue_comment:created'] }))
-      // A drive-by (NONE/CONTRIBUTOR) comment must not steer the session…
-      for (const [i, assoc] of ['NONE', 'CONTRIBUTOR', undefined].entries()) {
-        await post(
-          'issue_comment',
-          issuesPayload({
-            action: 'created',
-            comment: { body: 'do something', author_association: assoc }
-          }),
-          { headers: { 'x-github-delivery': `assoc-${i}` } }
-        )
-      }
+    it('keeps an external Issue out of the daemon until a live maintainer explicitly summons the agent', async () => {
+      h.table.upsert(
+        rule({}, { events: ['issues:*', 'issue_comment:created'], commentFamilies: ['issues'], appSlug: 'example-app' })
+      )
+      h.authzResult = (request) => request.senderLogin === 'maintainer'
+
+      await post(
+        'issues',
+        issuesPayload({
+          sender: { login: 'external-author', type: 'User' },
+          issue: {
+            number: 43,
+            user: { login: 'external-author' },
+            body: '@example-app please investigate',
+            author_association: 'MEMBER'
+          }
+        }),
+        { headers: { 'x-github-delivery': 'external-issue' } }
+      )
       await flush()
       expect(h.sent).toHaveLength(0)
-      // …while the SAME author opening an issue still fires (the gate is comment-only).
-      await post('issues', issuesPayload({ issue: { number: 43, author_association: 'NONE' } }))
+      expect(h.authzRequests).toEqual([expect.objectContaining({ senderLogin: 'external-author' })])
+
+      await post(
+        'issue_comment',
+        issuesPayload({
+          action: 'created',
+          sender: { login: 'maintainer', type: 'User' },
+          issue: { number: 43, user: { login: 'external-author' } },
+          comment: { body: '@example-app please investigate', author_association: 'MEMBER' }
+        }),
+        { headers: { 'x-github-delivery': 'maintainer-summon' } }
+      )
       await flush()
+
       expect(h.sent).toHaveLength(1)
+      expect(h.authzRequests[1]).toEqual(expect.objectContaining({ senderLogin: 'maintainer' }))
+      expect(h.authzRequests[1]?.subjectAuthorLogin).toBeUndefined()
     })
 
-    it('trusted comment standings (OWNER/MEMBER/COLLABORATOR) pass the gate', async () => {
+    it('requires both live commenter and thread-author authority for an unmentioned follow-up', async () => {
+      h.table.upsert(rule({}, { events: ['issue_comment:created'], appSlug: 'example-app' }))
+      h.authzResult = (request) => request.subjectAuthorLogin === undefined
+
+      await post(
+        'issue_comment',
+        issuesPayload({
+          action: 'created',
+          sender: { login: 'maintainer', type: 'User' },
+          issue: { number: 43, user: { login: 'external-author' } },
+          comment: { body: 'ordinary follow-up', author_association: 'MEMBER' }
+        })
+      )
+      await flush()
+
+      expect(h.authzRequests).toEqual([
+        expect.objectContaining({ senderLogin: 'maintainer', subjectAuthorLogin: 'external-author' })
+      ])
+      expect(h.sent).toHaveLength(0)
+    })
+
+    it('live-checks comments regardless of OWNER/MEMBER/COLLABORATOR association', async () => {
       h.table.upsert(rule({}, { events: ['issue_comment:created'] }))
       for (const [i, assoc] of ['OWNER', 'MEMBER', 'COLLABORATOR'].entries()) {
         await post(
@@ -1352,11 +1401,11 @@ describe('github ingress', () => {
       }
       await flush()
       expect(h.sent).toHaveLength(3)
-      expect(h.authzRequests).toHaveLength(0)
+      expect(h.authzRequests).toHaveLength(3)
     })
 
     it.each(['issue_comment', 'pull_request_review_comment'] as const)(
-      '%s uses the same live fallback for an untrusted payload association',
+      '%s uses live authorization for an untrusted payload association',
       async (event) => {
         h.table.upsert(rule({}, { events: ['issue_comment:created'] }))
         const body =
@@ -1370,7 +1419,7 @@ describe('github ingress', () => {
                 installation: { id: INSTALLATION },
                 repository: { id: REPO_ID, full_name: 'acme/infra' },
                 sender: { login: 'alice', type: 'User' },
-                pull_request: { number: 7 },
+                pull_request: { number: 7, user: { login: 'alice' } },
                 comment: { body: 'please retry', author_association: 'CONTRIBUTOR' }
               }
 
@@ -1434,6 +1483,8 @@ describe('github ingress', () => {
     })
 
     it('shares the authz budget across hooks watching the same repository', async () => {
+      await h.app.close()
+      h = makeHarness(3)
       h.table.upsert(rule({}, { events: ['issue_comment:created'] }))
       h.table.upsert(rule({ hookId: HOOK_B }, { events: ['issue_comment:created'] }))
       h.authzResult = false
@@ -1471,6 +1522,7 @@ describe('github ingress', () => {
           { headers: { 'x-github-delivery': key } }
         )
 
+      h.authzResult = false
       await comment('ordinary follow-up', 'MEMBER', 'created-summon-0')
       await comment('@example-review-app please look', 'NONE', 'created-summon-1')
       await post('issues', issuesPayload({ action: 'labeled', issue: { number: 42, body: 'ordinary update' } }), {
@@ -1479,6 +1531,7 @@ describe('github ingress', () => {
       await flush()
       expect(h.sent).toHaveLength(0)
 
+      h.authzResult = true
       await comment('@example-review-app please look', 'COLLABORATOR', 'created-summon-3')
       await post(
         'issues',
@@ -1613,7 +1666,7 @@ describe('github ingress', () => {
             installation: { id: INSTALLATION },
             repository: { id: REPO_ID, full_name: 'acme/infra' },
             sender: { login: 'alice', type: 'User' },
-            pull_request: { number: 7, title: 'tighten backoff' },
+            pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
             comment: {
               id: 3565283658,
               in_reply_to_id: null,
@@ -1625,10 +1678,12 @@ describe('github ingress', () => {
           { headers: { 'x-github-delivery': key } }
         )
 
-      await reviewComment('NONE', 'rc-0') // collaborator gate applies to review comments too
+      h.authzResult = false
+      await reviewComment('NONE', 'rc-0')
       await flush()
       expect(h.sent).toHaveLength(0)
 
+      h.authzResult = true
       await reviewComment('COLLABORATOR', 'rc-1')
       await flush()
       expect(h.sent).toHaveLength(1)
@@ -1655,7 +1710,7 @@ describe('github ingress', () => {
         installation: { id: INSTALLATION },
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
-        pull_request: { number: 7, title: 'tighten backoff' },
+        pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: {
           id: 3565656411,
           in_reply_to_id: 3565283658,
@@ -1680,7 +1735,7 @@ describe('github ingress', () => {
         installation: { id: INSTALLATION },
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
-        pull_request: { number: 7, title: 'tighten backoff' },
+        pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: { body: 'should this retry be exponential?', author_association: 'MEMBER' }
       }
 
@@ -1707,7 +1762,7 @@ describe('github ingress', () => {
         installation: { id: INSTALLATION },
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
-        pull_request: { number: 7, title: 'tighten backoff' },
+        pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: { body: '@example-review-app is this right?', author_association: 'MEMBER' }
       }
 
@@ -1759,7 +1814,7 @@ describe('github ingress', () => {
         installation: { id: INSTALLATION },
         repository: { id: REPO_ID, full_name: 'acme/infra' },
         sender: { login: 'alice', type: 'User' },
-        pull_request: { number: 7 },
+        pull_request: { number: 7, user: { login: 'alice' } },
         comment: { body: 'explicitly subscribed', author_association: 'MEMBER' }
       })
       await flush()
@@ -1777,7 +1832,7 @@ describe('github ingress', () => {
             installation: { id: INSTALLATION },
             repository: { id: REPO_ID, full_name: 'acme/infra' },
             sender: { login: 'alice', type: 'User' },
-            pull_request: { number: 7 },
+            pull_request: { number: 7, user: { login: 'alice' } },
             comment: { body, author_association: 'MEMBER' }
           },
           { headers: { 'x-github-delivery': key } }
@@ -2003,17 +2058,17 @@ describe('buildTrustedGithubMetadata review comment ids', () => {
   )
 })
 
-describe('githubRuleMatches (pure predicate)', () => {
+describe('githubRuleVerdict (pure predicate)', () => {
   const ctx = {
     event: 'issues',
     eventAction: 'issues:opened',
     installationId: String(INSTALLATION),
     labels: ['bug'],
     senderType: 'User' as string | undefined,
-    authorAssociation: undefined as string | undefined,
     mentionText: undefined as string | undefined,
     commentSubjectFamily: undefined as 'issues' | 'pull_request' | undefined
   }
+  const matches = (candidate: RcHookAssign, context = ctx) => githubRuleVerdict(candidate, context) !== 'no-match'
 
   it('treats summons as additive in created mode and exclusive in mention-only mode', () => {
     const update = { ...ctx, eventAction: 'issues:labeled', mentionText: 'ordinary update' }
@@ -2022,24 +2077,24 @@ describe('githubRuleMatches (pure predicate)', () => {
     const updated = rule({}, { events: ['issues:*'], appSlug: 'example-review-app' })
     const mentionOnly = rule({}, { events: ['issues:*'], mentionOnly: true, appSlug: 'example-review-app' })
 
-    expect(githubRuleMatches(created, update)).toBe(false)
-    expect(githubRuleMatches(created, summoned)).toBe(true)
-    expect(githubRuleMatches(updated, update)).toBe(true)
-    expect(githubRuleMatches(updated, summoned)).toBe(true)
-    expect(githubRuleMatches(mentionOnly, update)).toBe(false)
-    expect(githubRuleMatches(mentionOnly, summoned)).toBe(true)
+    expect(matches(created, update)).toBe(false)
+    expect(matches(created, summoned)).toBe(true)
+    expect(matches(updated, update)).toBe(true)
+    expect(matches(updated, summoned)).toBe(true)
+    expect(matches(mentionOnly, update)).toBe(false)
+    expect(matches(mentionOnly, summoned)).toBe(true)
   })
 
   it('mention mode gates EVERY event on its text — no mention (or no text) fails closed', () => {
     const r = rule({}, { mentionOnly: true, appSlug: 'example-review-app' })
-    expect(githubRuleMatches(r, ctx)).toBe(false) // no text at all
-    expect(githubRuleMatches(r, { ...ctx, mentionText: 'just an issue body' })).toBe(false)
-    expect(githubRuleMatches(r, { ...ctx, mentionText: 'summon @example-review-app please' })).toBe(true)
+    expect(matches(r, ctx)).toBe(false) // no text at all
+    expect(matches(r, { ...ctx, mentionText: 'just an issue body' })).toBe(false)
+    expect(matches(r, { ...ctx, mentionText: 'summon @example-review-app please' })).toBe(true)
     // Bounded on BOTH sides — emails/URLs are not mentions, and neither is a
     // longer login that merely starts with our slug.
-    expect(githubRuleMatches(r, { ...ctx, mentionText: 'mail team@example-review-app.test' })).toBe(false)
-    expect(githubRuleMatches(r, { ...ctx, mentionText: 'see /apps/@example-review-app/config' })).toBe(true) // '/' is a boundary
-    expect(githubRuleMatches(r, { ...ctx, mentionText: 'cc @example-review-apper' })).toBe(false)
+    expect(matches(r, { ...ctx, mentionText: 'mail team@example-review-app.test' })).toBe(false)
+    expect(matches(r, { ...ctx, mentionText: 'see /apps/@example-review-app/config' })).toBe(true) // '/' is a boundary
+    expect(matches(r, { ...ctx, mentionText: 'cc @example-review-apper' })).toBe(false)
   })
 
   it.each([
@@ -2050,21 +2105,14 @@ describe('githubRuleMatches (pure predicate)', () => {
     ['pull_request', 'pull_request:edited'],
     ['pull_request', 'pull_request:reopened']
   ])('hard-vetoes silent %s action even for an explicit legacy subscription', (event, eventAction) => {
-    expect(githubRuleMatches(rule({}, { events: [eventAction] }), { ...ctx, event, eventAction })).toBe(false)
+    expect(matches(rule({}, { events: [eventAction] }), { ...ctx, event, eventAction })).toBe(false)
   })
 
   it('keeps PR synchronize while vetoing every edited action', () => {
     const r = rule({}, { events: ['pull_request:*'] })
     const pr = { ...ctx, event: 'pull_request' }
     expect(githubRuleVerdict(r, { ...pr, eventAction: 'pull_request:synchronize' })).toBe('needs-authz')
-    expect(
-      githubRuleMatches(r, {
-        ...pr,
-        eventAction: 'pull_request:synchronize',
-        pullAuthorAssociation: 'MEMBER'
-      })
-    ).toBe(true)
-    expect(githubRuleMatches(r, { ...pr, eventAction: 'pull_request:edited' })).toBe(false)
+    expect(matches(r, { ...pr, eventAction: 'pull_request:edited' })).toBe(false)
   })
 
   it('applies comment subject scope only when commentFamilies is non-empty', () => {
@@ -2072,22 +2120,19 @@ describe('githubRuleMatches (pure predicate)', () => {
       ...ctx,
       event: 'issue_comment',
       eventAction: 'issue_comment:created',
-      authorAssociation: 'MEMBER',
       mentionText: 'reply',
       commentSubjectFamily: 'pull_request' as const
     }
     const mixed = { events: ['issues:*', 'issue_comment:created'] }
 
-    expect(githubRuleMatches(rule({}, mixed), commentCtx)).toBe(true)
-    expect(githubRuleMatches(rule({}, { ...mixed, commentFamilies: [] }), commentCtx)).toBe(true)
-    expect(githubRuleMatches(rule({}, { ...mixed, commentFamilies: ['issues'] }), commentCtx)).toBe(false)
-    expect(githubRuleMatches(rule({}, { ...mixed, commentFamilies: ['pull_request'] }), commentCtx)).toBe(true)
+    expect(matches(rule({}, mixed), commentCtx)).toBe(true)
+    expect(matches(rule({}, { ...mixed, commentFamilies: [] }), commentCtx)).toBe(true)
+    expect(matches(rule({}, { ...mixed, commentFamilies: ['issues'] }), commentCtx)).toBe(false)
+    expect(matches(rule({}, { ...mixed, commentFamilies: ['pull_request'] }), commentCtx)).toBe(true)
   })
 
   it('a webhook-kind rule never matches', () => {
-    expect(githubRuleMatches({ ...rule(), kind: 'webhook', github: undefined, webhook: { urlToken: 't' } }, ctx)).toBe(
-      false
-    )
+    expect(matches({ ...rule(), kind: 'webhook', github: undefined, webhook: { urlToken: 't' } }, ctx)).toBe(false)
   })
 })
 

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -62,9 +62,8 @@ export interface GithubIngressDeps {
   report: (report: RcRunReport) => void
   /** Emit one `rc/github-installation` doorbell EVT to the CP (fire-and-forget). */
   doorbell: (poke: RcGithubInstallation) => void
-  /** Resolve a comment or PR author whose payload association is
-   *  missing/untrusted. This is metadata-only; the implementation delegates
-   *  to the CP's GitHub App. */
+  /** Resolve the current write authority of every issue/PR actor. This is
+   *  metadata-only; the implementation delegates to the CP's GitHub App. */
   authorizeComment: (request: RcGithubCommentAuthz) => Promise<boolean>
   /** Resolve an App-owned Check Run rerequest through the CP's durable
    * projection. The response contains metadata only, never PR content. */
@@ -142,12 +141,10 @@ export interface GithubMatchCtx {
   installationId: string | undefined // String(payload.installation.id); absent ⇒ never matches
   labels: string[] // the subject's CURRENT labels (not payload.label)
   senderType: string | undefined // 'User' | 'Bot' | …
-  // P3 gating inputs: the COMMENTER's association (comment events only) and
-  // the event's authored text — comment body, else issue/PR body, else the
-  // head commit message. Matched against App/agent handles, never logged.
-  authorAssociation: string | undefined // payload.comment.author_association
-  pullAuthorAssociation?: string
-  pullAuthorLogin?: string
+  // P3 gating inputs: the thread author's login and the event's authored text —
+  // comment body, else issue/PR body, else the head commit message. Handles are
+  // matched locally, but actor permission is always resolved live by the CP.
+  subjectAuthorLogin?: string
   mentionText: string | undefined
   /** GitHub's native reviewer request target. Only this App's `[bot]` login
    * turns `pull_request:review_requested` into a manual review request. */
@@ -155,14 +152,6 @@ export interface GithubMatchCtx {
   /** The derived family of the comment's subject/thread. `issue_comment` uses
    *  the issue object's `pull_request` marker; review comments are always PR. */
   commentSubjectFamily: 'issues' | 'pull_request' | undefined
-}
-
-/** GitHub's trusted repository relationships. These are the local fast path;
- * missing/untrusted associations require a live repository permission check. */
-const TRUSTED_GITHUB_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
-
-function isTrustedGithubAssociation(association: string | undefined): boolean {
-  return association !== undefined && TRUSTED_GITHUB_ASSOCIATIONS.has(association)
 }
 
 const EXTERNAL_PR_REVISION_EVENTS = new Set([
@@ -173,7 +162,7 @@ const EXTERNAL_PR_REVISION_EVENTS = new Set([
 ])
 
 /** A no-match failed a static rule gate; trusted is immediately dispatchable;
- *  needs-authz passed every static gate but needs a live permission fallback. */
+ *  needs-authz passed every static gate but needs live maintainer authorization. */
 export type GithubRuleVerdict = 'no-match' | 'trusted' | 'needs-authz'
 
 /** `@<handle>` as a whole token, case-insensitive (GitHub logins are), bounded
@@ -202,6 +191,17 @@ function githubRuleSupportsPullRequests(rule: RcHookAssign): boolean {
   )
 }
 
+function isGithubThreadComment(ctx: GithubMatchCtx): boolean {
+  return ctx.event === 'issue_comment' || ctx.event === 'pull_request_review_comment'
+}
+
+function githubRuleIsSummoned(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
+  return (
+    mentionsGithubHandle(ctx.mentionText, rule.github?.appSlug) ||
+    mentionsGithubHandle(ctx.mentionText, rule.github?.agentName)
+  )
+}
+
 /** Explicit agent handles narrow a repo fan-out; the App handle deliberately
  *  wins as the broadcast form. A non-AgentConnect @mention changes nothing. */
 export function githubMentionCandidates(rules: RcHookAssign[], body: string | undefined): RcHookAssign[] {
@@ -215,7 +215,7 @@ export function githubMentionCandidates(rules: RcHookAssign[], body: string | un
 /**
  * One rule's verdict for one delivery (pure; exported for unit tests).
  * Order: lifecycle-noise veto → bot veto → attribution gate → cadence/additive
- * summon match → comment scope/collaborator gates → mention-only gate → labels.
+ * summon match → comment scope → mention-only gate → labels → live-authz gate.
  */
 export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): GithubRuleVerdict {
   if (rule.kind !== 'github' || !rule.github) return 'no-match'
@@ -259,9 +259,7 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
   // Diff-line review comments may ride the shared issue_comment subscription;
   // an explicit review-comment API subscription remains authoritative.
   const sharedCommentAliasMatched = ctx.event === 'pull_request_review_comment' && matchesPattern('issue_comment')
-  const summoned =
-    mentionsGithubHandle(ctx.mentionText, rule.github.appSlug) ||
-    mentionsGithubHandle(ctx.mentionText, rule.github.agentName)
+  const summoned = githubRuleIsSummoned(rule, ctx)
   // "created" is an additive cadence: opening events fire normally, while a
   // later explicit summon in the same selected issue/PR family may fire too.
   // Keep the fallback to the same event universe as mention-only mode: thread
@@ -303,21 +301,10 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
   if (rule.github.labelFilter.length > 0 && !ctx.labels.some((l) => rule.github!.labelFilter.includes(l)))
     return 'no-match'
 
-  // Comments STEER an ongoing session. A trusted payload association is the
-  // relay-local fast path; a missing/untrusted association is not a static
-  // mismatch because GitHub can serialize a stale association for one comment
-  // event family. The caller may recover it through the metadata-only CP RPC.
-  if (ctx.event === 'issue_comment' || ctx.event === 'pull_request_review_comment') {
-    return isTrustedGithubAssociation(ctx.authorAssociation) ? 'trusted' : 'needs-authz'
-  }
-  if (ctx.event === 'pull_request' && !isTrustedGithubAssociation(ctx.pullAuthorAssociation)) return 'needs-authz'
-  return 'trusted'
-}
-
-/** Compatibility predicate for callers that cannot perform the live fallback.
- *  It returns true only for an immediately trusted verdict. */
-export function githubRuleMatches(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
-  return githubRuleVerdict(rule, ctx) === 'trusted'
+  // GitHub's relationship labels are descriptive, not an authorization proof:
+  // MEMBER and COLLABORATOR may still have only read/triage access. Every
+  // numbered-thread event therefore resolves current write/admin authority.
+  return ctx.event === 'push' ? 'trusted' : 'needs-authz'
 }
 
 /** Truncate on a UTF-8 BYTE budget, cutting at a code-point boundary — the
@@ -682,12 +669,7 @@ async function dispatchGithubRerequest(
 }
 
 function pullRequestNeedsMaintainer(ctx: GithubMatchCtx, prAuthorCanWrite: boolean): boolean {
-  return (
-    ctx.event === 'pull_request' &&
-    ctx.eventAction !== 'pull_request:review_requested' &&
-    !isTrustedGithubAssociation(ctx.pullAuthorAssociation) &&
-    !prAuthorCanWrite
-  )
+  return ctx.event === 'pull_request' && ctx.eventAction !== 'pull_request:review_requested' && !prAuthorCanWrite
 }
 
 function reportReviewRequestRequired(deps: GithubIngressDeps, rule: RcHookAssign, msg: RdMsgHook): void {
@@ -778,9 +760,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         installationId: payload.installation?.id !== undefined ? String(payload.installation.id) : undefined,
         labels: (subject?.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
         senderType: payload.sender?.type,
-        authorAssociation: payload.comment?.author_association,
-        pullAuthorAssociation: payload.pull_request?.author_association,
-        pullAuthorLogin: payload.pull_request?.user?.login,
+        subjectAuthorLogin: subject?.user?.login,
         requestedReviewerLogin: payload.requested_reviewer?.login,
         commentSubjectFamily:
           event === 'pull_request_review_comment'
@@ -880,7 +860,11 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
 
       const authorizeAndDispatch = async (
         fanout: RcHookAssign[],
-        senderLogin: string | undefined,
+        actors: {
+          senderLogin: string | undefined
+          subjectAuthorLogin?: string
+          requireSubjectAuthor?: boolean
+        },
         onDenied: 'skip' | 'request-review'
       ): Promise<void> => {
         const installationId = ctx.installationId
@@ -894,7 +878,8 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           !installationId ||
           payloadRepoId === undefined ||
           !repoFullName ||
-          !senderLogin ||
+          !actors.senderLogin ||
+          (actors.requireSubjectAuthor === true && !actors.subjectAuthorLogin) ||
           fanout.some(
             (rule) => !rule.github || rule.configRevision === undefined || rule.dispatchRevision === undefined
           )
@@ -904,8 +889,8 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           return
         }
 
-        // Permission lookups have their own budget. For a PR-author fallback,
-        // the repository-wide fact is resolved once before any rule dispatch.
+        // Permission lookups have their own budget. The repository-wide actor
+        // facts are resolved once before any rule dispatch.
         if (!deps.authzLimiter.allow(`${installationId}:${payloadRepoId}`)) {
           deps.log.info(`github ingress: authz rate-limited ${representative.hookId}:${deliveryKey}`)
           if (onDenied === 'request-review') for (const rule of fanout) dispatchRule(rule)
@@ -917,7 +902,10 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
           installationId,
           repoId: String(payloadRepoId),
           repoFullName,
-          senderLogin,
+          senderLogin: actors.senderLogin,
+          ...(actors.subjectAuthorLogin && actors.subjectAuthorLogin !== actors.senderLogin
+            ? { subjectAuthorLogin: actors.subjectAuthorLogin }
+            : {}),
           configRevision: representative.configRevision!,
           dispatchRevision: representative.dispatchRevision!,
           ...(fanout.length > 1
@@ -940,7 +928,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         }
         if (!allowed && onDenied === 'skip') return
 
-        // Authorization waited on two remote calls. Re-read the table so a
+        // Authorization waited on at least two remote calls. Re-read the table so a
         // remove/reconfigure/reassignment during that window cannot dispatch
         // the captured stale rule. Exact revisions fence configuration; the
         // assignment tuple is checked explicitly and the CURRENT object is the
@@ -961,13 +949,16 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       const matched = candidates
         .map((rule) => ({ rule, verdict: githubRuleVerdict(rule, ctx) }))
         .filter((candidate) => candidate.verdict !== 'no-match')
-      if (pullRequestNeedsMaintainer(ctx, false)) {
+      if (
+        ctx.event === 'issues' ||
+        (ctx.event === 'pull_request' && ctx.eventAction !== 'pull_request:review_requested')
+      ) {
         void authorizeAndDispatch(
           matched.map((candidate) => candidate.rule),
-          ctx.pullAuthorLogin,
-          'request-review'
+          { senderLogin: ctx.subjectAuthorLogin },
+          ctx.event === 'pull_request' ? 'request-review' : 'skip'
         ).catch((err) => {
-          deps.log.warn(`github ingress: PR-author authz task failed ${deliveryKey}: ${String(err)}`)
+          deps.log.warn(`github ingress: thread-author authz task failed ${deliveryKey}: ${String(err)}`)
         })
         return reply.code(202).send({ deliveryKey })
       }
@@ -980,7 +971,17 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         // Never hold GitHub's HTTP request open on the CP/GitHub permission
         // lookup. Every rule resolves independently and every rejection is
         // contained so it cannot become an unhandled process rejection.
-        void authorizeAndDispatch([rule], payload.sender?.login, 'skip').catch((err) => {
+        const summoned = githubRuleIsSummoned(rule, ctx)
+        void authorizeAndDispatch(
+          [rule],
+          {
+            senderLogin: payload.sender?.login,
+            ...(!summoned && isGithubThreadComment(ctx)
+              ? { subjectAuthorLogin: ctx.subjectAuthorLogin, requireSubjectAuthor: true }
+              : {})
+          },
+          'skip'
+        ).catch((err) => {
           deps.log.warn(`github ingress: authz task failed ${rule.hookId}:${deliveryKey}: ${String(err)}`)
         })
       }

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -94,6 +94,7 @@ interface GithubPayload {
     in_reply_to_id?: number | null
     body?: string
     html_url?: string
+    user?: { login?: string }
     author_association?: string
   }
   // push ("commits") deliveries — no subject, no action.
@@ -141,10 +142,11 @@ export interface GithubMatchCtx {
   installationId: string | undefined // String(payload.installation.id); absent ⇒ never matches
   labels: string[] // the subject's CURRENT labels (not payload.label)
   senderType: string | undefined // 'User' | 'Bot' | …
-  // P3 gating inputs: the thread author's login and the event's authored text —
+  // P3 gating inputs: content/thread authors and the event's authored text —
   // comment body, else issue/PR body, else the head commit message. Handles are
   // matched locally, but actor permission is always resolved live by the CP.
   subjectAuthorLogin?: string
+  commentAuthorLogin?: string
   mentionText: string | undefined
   /** GitHub's native reviewer request target. Only this App's `[bot]` login
    * turns `pull_request:review_requested` into a manual review request. */
@@ -761,6 +763,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         labels: (subject?.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
         senderType: payload.sender?.type,
         subjectAuthorLogin: subject?.user?.login,
+        commentAuthorLogin: payload.comment?.user?.login,
         requestedReviewerLogin: payload.requested_reviewer?.login,
         commentSubjectFamily:
           event === 'pull_request_review_comment'
@@ -963,27 +966,44 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         return reply.code(202).send({ deliveryKey })
       }
 
-      for (const { rule, verdict } of matched) {
-        if (verdict === 'trusted') {
-          dispatchRule(rule)
-          continue
-        }
+      for (const { rule, verdict } of matched) if (verdict === 'trusted') dispatchRule(rule)
+
+      const needsAuthz = matched.filter((candidate) => candidate.verdict === 'needs-authz').map(({ rule }) => rule)
+      const queueAuthorizedFanout = (
+        fanout: RcHookAssign[],
+        actorLogin: string | undefined,
+        requireSubjectAuthor = false
+      ): void => {
+        if (fanout.length === 0) return
         // Never hold GitHub's HTTP request open on the CP/GitHub permission
-        // lookup. Every rule resolves independently and every rejection is
-        // contained so it cannot become an unhandled process rejection.
-        const summoned = githubRuleIsSummoned(rule, ctx)
+        // lookup. One repository-scoped decision fences the complete matching
+        // fan-out, and every rejection is contained locally.
         void authorizeAndDispatch(
-          [rule],
+          fanout,
           {
-            senderLogin: payload.sender?.login,
-            ...(!summoned && isGithubThreadComment(ctx)
-              ? { subjectAuthorLogin: ctx.subjectAuthorLogin, requireSubjectAuthor: true }
-              : {})
+            senderLogin: actorLogin,
+            ...(requireSubjectAuthor ? { subjectAuthorLogin: ctx.subjectAuthorLogin, requireSubjectAuthor: true } : {})
           },
           'skip'
         ).catch((err) => {
-          deps.log.warn(`github ingress: authz task failed ${rule.hookId}:${deliveryKey}: ${String(err)}`)
+          deps.log.warn(`github ingress: authz task failed ${fanout[0]!.hookId}:${deliveryKey}: ${String(err)}`)
         })
+      }
+
+      if (isGithubThreadComment(ctx)) {
+        queueAuthorizedFanout(
+          needsAuthz.filter((rule) => githubRuleIsSummoned(rule, ctx)),
+          ctx.commentAuthorLogin
+        )
+        queueAuthorizedFanout(
+          needsAuthz.filter((rule) => !githubRuleIsSummoned(rule, ctx)),
+          ctx.commentAuthorLogin,
+          true
+        )
+      } else {
+        // Native reviewer requests authorize the action actor. Issue/PR
+        // lifecycle events already returned through the subject-author batch.
+        queueAuthorizedFanout(needsAuthz, payload.sender?.login)
       }
       return reply.code(202).send({ deliveryKey })
     })

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -226,9 +226,9 @@ async function main(): Promise<void> {
   // webhook secret is configured; unset ⇒ the whole endpoint answers 404
   // (webhook-triggers doc, decision 13).
   if (config.GITHUB_APP_WEBHOOK_SECRET) {
-    // Live comment permission fallbacks cost two GitHub calls. Keep their
+    // Live Issue/PR actor checks cost at least two GitHub calls. Keep their
     // repository-wide upstream budget separate from per-hook run capacity.
-    const githubAuthzLimiter = new HookRateLimiter(systemClock, { capacity: 5, refillPerSec: 0.1 })
+    const githubAuthzLimiter = new HookRateLimiter(systemClock, { capacity: 10, refillPerSec: 0.25 })
     registerGithubIngress(server, {
       table: hookTable,
       daemons: () => held.rdServer,

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -17,7 +17,7 @@ import type { GithubCommentFamily } from './api'
  *              an event fires ONLY when its text (issue/PR body, comment body,
  *              commit message) @-mentions the assigned agent or the App. The
  *              agent handle targets one rule; the App handle broadcasts.
- *              Comments additionally pass the relay's collaborator gate.
+ *              Thread actors additionally pass the relay's live maintainer gate.
  *
  * The REST DTO accepts finer `family:action` values — these helpers just never
  * emit them.


### PR DESCRIPTION
## Summary

- require live `write`/`admin` authorization for every GitHub Issue/PR lifecycle author and commenter
- keep externally authored Issues and PRs from starting an Agent until an authorized maintainer explicitly mentions the Agent or App
- require both commenter and thread-author authority for unmentioned follow-ups, while preserving separate formal-review effect authorization

## Root cause

The relay treated webhook `author_association` values such as `MEMBER` and `COLLABORATOR` as proof of write access, although those relationships can resolve to read/triage permission. Issue openings also bypassed the author gate entirely.

## Validation

- `pnpm --filter @agentconnect.md/protocol exec vitest run src/frames/relay-cp.test.ts`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run src/github/comment-authz.service.test.ts`
- `pnpm --filter @agentconnect.md/relay exec vitest run src/hooks/github-ingress.test.ts`
- `pnpm --filter @agentconnect.md/relay... build`
- focused ESLint and Prettier checks

Created by Codex . GPT-5
