### PR TITLE
fix(messages): never split a streamed reply mid-sentence

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -33,6 +33,20 @@ an operator explicitly paused remains `paused`. Once the operation succeeds, fai
 expires, the console returns to the daemon's current connection status; a daemon that
 did not return then reads `offline`.
 
+## Where a streamed reply may be split
+
+A long reply may be delivered as more than one chat message, but a split must always fall
+on a boundary the reader can see. The streaming transport's own rhythm is not such a
+boundary: model output arrives in token-sized pieces, so a pause in the stream routinely
+lands mid-sentence or mid-word, and cutting there splits one answer across two messages at
+a meaningless point.
+
+So a split driven by elapsed time may only happen at a paragraph break outside a fenced
+code block; text after the last such break stays buffered until more arrives, until the
+agent finishes the text block (a tool call, a plan, a thinking step), or until the turn
+ends. Splits the reader already expects — a completed text block before the agent starts
+working, or a body longer than the platform's per-message limit — are unaffected.
+
 ## Slack message attribution footer
 
 The attribution footer for an agent response must be attached to the final Slack

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10127,18 +10127,20 @@ export class Daemon {
         // Some runtimes narrate their terminal error into the message stream just
         // before rejecting the prompt — codex-acp mirrors quota exhaustion / auth
         // expiry as an agent_message_chunk — and that text is still sitting in the
-        // converger buffer (the idle flush never fired). Flush it as the reply so it
-        // isn't dropped with the turn, and skip the ⚠️ notice when the flushed text
-        // already carries the same message (posting both would say it twice). The
-        // notice rides the apply chain as a `post` so it lands after the flushed
-        // body and is recorded into the transcript either way.
+        // converger buffer (the idle flush never fired, or held a partial paragraph
+        // back). `flushTerminal` takes the WHOLE buffer — this turn has no later flush
+        // and never reaches onFinal — so the runtime's text isn't dropped with it, and
+        // the ⚠️ notice is skipped when the flushed text already carries the same
+        // message (posting both would say it twice). The notice rides the apply chain
+        // as a `post` so it lands after the flushed body and is recorded into the
+        // transcript either way.
         const reason = turnFailureReason(err)
         if (p.conv instanceof FeishuConverger) {
           const attribution = showFooter ? currentAttributionInfo() : undefined
           for (const action of p.conv.onFailure(reason, attribution)) this.enqueueApply(p, action)
         } else {
           let covered = false
-          for (const action of p.conv.flushBuffered()) {
+          for (const action of p.conv.flushTerminal()) {
             covered ||= action.kind === 'post' && action.text.includes(reason)
             this.enqueueApply(p, action)
           }

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -1,5 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
+import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 
 /**
@@ -338,7 +339,7 @@ export class DiscordConverger {
       if (!trimmed || isNoResponsePrefix(trimmed)) return []
       return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
     }
-    return [...this.drainReasoning(), ...this.flush()]
+    return [...this.drainReasoning(), ...this.flushStreaming()]
   }
 
   /** minimal: a Discord message caps at 2000 chars; head-clamp the live view when longer
@@ -385,6 +386,23 @@ export class DiscordConverger {
     if (isNoResponsePrefix(trimmed)) return []
     const text = this.buf
     this.buf = ''
+    return this.emitBody(text)
+  }
+
+  /** The idle timer's body flush. Unlike a semantic boundary (tool call / plan / thinking,
+   *  where the model really did finish a text block) this fires on a mere pause in the ACP
+   *  stream, so it posts only up to the last paragraph break and re-buffers the rest —
+   *  otherwise one reply is split across two messages mid-sentence (§stream-boundary). */
+  private flushStreaming(): DiscordAction[] {
+    const trimmed = this.buf.trim()
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    const { ready, tail } = splitAtParagraphBoundary(this.buf)
+    if (!ready) return []
+    this.buf = tail
+    return this.emitBody(ready)
+  }
+
+  private emitBody(text: string): DiscordAction[] {
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -332,14 +332,27 @@ export class DiscordConverger {
   /** Idle-timer flush: one in-place reasoning update (high) placed ABOVE the body, then the body.
    *  minimal: just refresh the single in-place `live-reply` with the current segment. */
   flushBuffered(): DiscordAction[] {
-    if (this.mode === 'minimal') {
-      const trimmed = this.buf.trim()
-      // Hold the live reply while the body could still be the bare response-control marker, so a
-      // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
-      if (!trimmed || isNoResponsePrefix(trimmed)) return []
-      return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
-    }
+    if (this.mode === 'minimal') return this.liveRefresh()
     return [...this.drainReasoning(), ...this.flushStreaming()]
+  }
+
+  /** Drain everything for a turn that is ending abnormally: the runtime narrated its terminal
+   *  error into the message stream and then rejected the prompt, so `onFinal` never runs and
+   *  there is no later flush to hold a partial paragraph for. Unlike the idle flush this takes
+   *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
+   *  dropped and replaced by the generic failure notice. */
+  flushTerminal(): DiscordAction[] {
+    if (this.mode === 'minimal') return this.liveRefresh()
+    return [...this.drainReasoning(), ...this.flush()]
+  }
+
+  /** minimal: refresh the single in-place `live-reply` with the current segment. */
+  private liveRefresh(): DiscordAction[] {
+    const trimmed = this.buf.trim()
+    // Hold the live reply while the body could still be the bare response-control marker, so a
+    // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
   }
 
   /** minimal: a Discord message caps at 2000 chars; head-clamp the live view when longer

--- a/packages/daemon/src/messages/stream-boundary.ts
+++ b/packages/daemon/src/messages/stream-boundary.ts
@@ -1,0 +1,54 @@
+/**
+ * Where a *streamed* reply may be cut into separate chat messages (§9.1 text-buffer).
+ *
+ * The daemon's idle-flush timer fires on a pause in the ACP stream, which says nothing
+ * about whether the reply's text is complete: ACP text deltas are token-sized, so the
+ * buffer routinely ends mid-sentence — and even mid-word ("…rebuilding the depend" /
+ * "ency graph"). Posting it verbatim splits one answer across two chat messages at that
+ * arbitrary point.
+ *
+ * A time-triggered flush therefore cuts only at a paragraph break — a blank line outside a
+ * fenced code block, the one place CommonMark guarantees the preceding block has ended.
+ * Anything after the last such break stays buffered for the next flush, for a semantic
+ * boundary (tool call / plan / thinking, where the model really did finish a text block),
+ * or for turn end. A buffer with no break yet is held whole.
+ *
+ * Semantic boundaries and turn end still drain the whole buffer — they are not this
+ * function's business.
+ */
+
+/** Opening/closing CommonMark fence: up to 3 spaces of indent, then 3+ backticks or tildes. */
+const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
+
+/**
+ * Split a streaming body into the part that is safe to send now and the tail that must stay
+ * buffered. `ready` ends just past the last top-level blank line; `tail` is the rest.
+ * `ready` is empty (and `tail` is the whole input) when no paragraph break has arrived yet.
+ * `ready + tail` always reconstructs the input exactly, so no content is lost or duplicated.
+ */
+export function splitAtParagraphBoundary(text: string): { ready: string; tail: string } {
+  let cut = 0
+  let fence: string | undefined
+  let pos = 0
+  while (pos < text.length) {
+    const nl = text.indexOf('\n', pos)
+    // The trailing line has no newline yet — it is still streaming, so it can never be a
+    // boundary and nothing after the last complete line matters.
+    if (nl < 0) break
+    const line = text.slice(pos, nl)
+    pos = nl + 1
+    const [, run = '', rest = ''] = FENCE.exec(line) ?? []
+    if (fence) {
+      // A fence closes on the same character, at least as long, alone on its line.
+      if (run && run[0] === fence[0] && run.length >= fence.length && !rest.trim()) fence = undefined
+      continue
+    }
+    if (run) {
+      fence = run
+      continue
+    }
+    if (!line.trim()) cut = pos
+  }
+  const ready = text.slice(0, cut)
+  return ready.trim() ? { ready, tail: text.slice(cut) } : { ready: '', tail: text }
+}

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -15,6 +15,7 @@ export {
   encodePermValue
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
+import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { splitIntoSections } from './formatter.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -855,7 +856,7 @@ export class OutputConverger {
       if (!trimmed || isNoResponsePrefix(trimmed)) return []
       return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
     }
-    return [...this.drainReasoning(), ...this.flush()]
+    return [...this.drainReasoning(), ...this.flushStreaming()]
   }
 
   /** minimal: the single live message can hold one Block Kit `markdown` block (≤12000
@@ -907,6 +908,23 @@ export class OutputConverger {
     if (isNoResponsePrefix(trimmed)) return []
     const text = this.buf
     this.buf = ''
+    return this.emitBody(text)
+  }
+
+  /** The idle timer's body flush. Unlike a semantic boundary (tool call / plan / thinking,
+   *  where the model really did finish a text block) this fires on a mere pause in the ACP
+   *  stream, so it posts only up to the last paragraph break and re-buffers the rest —
+   *  otherwise one reply is split across two messages mid-sentence (§stream-boundary). */
+  private flushStreaming(): SlackAction[] {
+    const trimmed = this.buf.trim()
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    const { ready, tail } = splitAtParagraphBoundary(this.buf)
+    if (!ready) return []
+    this.buf = tail
+    return this.emitBody(ready)
+  }
+
+  private emitBody(text: string): SlackAction[] {
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` is handled
     // before the connection check on every platform, so it lands even though replyConn is unset.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -846,17 +846,30 @@ export class OutputConverger {
    *  block is first-posted ABOVE the reply: thinking precedes the answer (§9.1), so the
    *  Thinking block must sit above it, not below.
    *
-   *  minimal: no per-window `post`s — just refresh the single in-place `live-reply` with the
-   *  current segment (display only; the transcript record happens at segment boundaries). */
+   *  minimal: no per-window `post`s — just the `live-reply` refresh. */
   flushBuffered(): SlackAction[] {
-    if (this.mode === 'minimal') {
-      const trimmed = this.buf.trim()
-      // Hold the live reply while the body could still be the bare response-control marker, so a
-      // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
-      if (!trimmed || isNoResponsePrefix(trimmed)) return []
-      return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
-    }
+    if (this.mode === 'minimal') return this.liveRefresh()
     return [...this.drainReasoning(), ...this.flushStreaming()]
+  }
+
+  /** Drain everything for a turn that is ending abnormally: the runtime narrated its terminal
+   *  error into the message stream and then rejected the prompt, so `onFinal` never runs and
+   *  there is no later flush to hold a partial paragraph for. Unlike the idle flush this takes
+   *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
+   *  dropped and replaced by the generic failure notice. */
+  flushTerminal(): SlackAction[] {
+    if (this.mode === 'minimal') return this.liveRefresh()
+    return [...this.drainReasoning(), ...this.flush()]
+  }
+
+  /** minimal: refresh the single in-place `live-reply` with the current segment (display only;
+   *  the transcript record happens at segment boundaries). */
+  private liveRefresh(): SlackAction[] {
+    const trimmed = this.buf.trim()
+    // Hold the live reply while the body could still be the bare response-control marker, so a
+    // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
   }
 
   /** minimal: the single live message can hold one Block Kit `markdown` block (≤12000

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -1,5 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { splitIntoSections } from '../slack/formatter.js'
+import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 
 /**
@@ -233,7 +234,7 @@ export class TelegramConverger {
       if (!trimmed || isNoResponsePrefix(trimmed)) return []
       return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
     }
-    return [...this.drainReasoning(), ...this.flush()]
+    return [...this.drainReasoning(), ...this.flushStreaming()]
   }
 
   /** minimal: a Telegram message caps at 4096 chars; head-clamp the live view when longer
@@ -282,6 +283,23 @@ export class TelegramConverger {
     if (isNoResponsePrefix(trimmed)) return []
     const text = this.buf
     this.buf = ''
+    return this.emitBody(text, final)
+  }
+
+  /** The idle timer's body flush. Unlike a semantic boundary (tool call / plan / thinking,
+   *  where the model really did finish a text block) this fires on a mere pause in the ACP
+   *  stream, so it posts only up to the last paragraph break and re-buffers the rest —
+   *  otherwise one reply is split across two messages mid-sentence (§stream-boundary). */
+  private flushStreaming(): TelegramAction[] {
+    const trimmed = this.buf.trim()
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    const { ready, tail } = splitAtParagraphBoundary(this.buf)
+    if (!ready) return []
+    this.buf = tail
+    return this.emitBody(ready, false)
+  }
+
+  private emitBody(text: string, final: boolean): TelegramAction[] {
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` runs before
     // the connection check, so it lands even though replyConn is unset for this mode.
     const recordOnly = this.mode === 'none'

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -227,14 +227,27 @@ export class TelegramConverger {
   /** Idle-timer flush: one in-place reasoning update (high) placed ABOVE the body, then the body.
    *  minimal: just refresh the single in-place `live-reply` with the current segment. */
   flushBuffered(): TelegramAction[] {
-    if (this.mode === 'minimal') {
-      const trimmed = this.buf.trim()
-      // Hold the live reply while the body could still be the bare response-control marker, so a
-      // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
-      if (!trimmed || isNoResponsePrefix(trimmed)) return []
-      return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
-    }
+    if (this.mode === 'minimal') return this.liveRefresh()
     return [...this.drainReasoning(), ...this.flushStreaming()]
+  }
+
+  /** Drain everything for a turn that is ending abnormally: the runtime narrated its terminal
+   *  error into the message stream and then rejected the prompt, so `onFinal` never runs and
+   *  there is no later flush to hold a partial paragraph for. Unlike the idle flush this takes
+   *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
+   *  dropped and replaced by the generic failure notice. */
+  flushTerminal(): TelegramAction[] {
+    if (this.mode === 'minimal') return this.liveRefresh()
+    return [...this.drainReasoning(), ...this.flush()]
+  }
+
+  /** minimal: refresh the single in-place `live-reply` with the current segment. */
+  private liveRefresh(): TelegramAction[] {
+    const trimmed = this.buf.trim()
+    // Hold the live reply while the body could still be the bare response-control marker, so a
+    // suppressed turn never flashes a partial reply in-place (onFinal drops it entirely).
+    if (!trimmed || isNoResponsePrefix(trimmed)) return []
+    return [{ kind: 'live-reply', text: this.liveDisplay(this.buf) }]
   }
 
   /** minimal: a Telegram message caps at 4096 chars; head-clamp the live view when longer

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -972,6 +972,66 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   }, 15_000)
 
+  // Same path, but the narrated error is a single line with no trailing paragraph break —
+  // the idle flush would hold that back, so the terminal drain must not be the idle one.
+  it('flushes a runtime-streamed terminal error that has no paragraph break', async () => {
+    const root = scaffold()
+    let onUpdate!: (sid: string, update: unknown) => void
+    const fakeHost = {
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-quota-3'),
+      hasSession: (id: string) => id === 'acp-quota-3',
+      prompt: vi.fn(async (sid: string) => {
+        onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: USAGE_LIMIT_MSG } })
+        throw usageLimitError()
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    }
+    const daemon = new Daemon({
+      root,
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return fakeHost as any
+      }
+    })
+    await daemon.start()
+    const posts: string[] = []
+    vi.spyOn(daemon as any, 'replyConnFor').mockReturnValue({
+      setStatus: vi.fn(async () => {}),
+      setTitle: vi.fn(async () => {}),
+      postMessage: vi.fn(async (_c: string, text: string) => {
+        posts.push(text)
+        return undefined
+      }),
+      postContext: vi.fn(async () => {})
+    })
+
+    await expect(
+      (daemon as any).dispatch('bot-a', {
+        msgId: 'slack:C1:402.1',
+        traceId: 'quota-no-break',
+        source: 'cron',
+        platform: 'slack',
+        channel: 'C1',
+        thread: '402.1',
+        sender: { id: 'U1', isBot: false },
+        text: 'summarize the day',
+        mentionedBots: [],
+        isDm: false
+      })
+    ).rejects.toThrow('Internal error')
+
+    // Delivered verbatim exactly once, with no ⚠️ notice standing in for the lost body.
+    expect(posts).toEqual([USAGE_LIMIT_MSG])
+    const { rows } = (daemon as any).store.transcriptPage('C1', '402.1', null, 10)
+    const agentRows = rows.filter((r: any) => r.sender === 'bot-a' && r.kind === 'text')
+    expect(agentRows).toHaveLength(1)
+    expect(agentRows[0]!.text).toBe(USAGE_LIMIT_MSG)
+    await daemon.stop()
+  }, 15_000)
+
   it('surfaces the detailed data.message (not "Internal error") when nothing was streamed', async () => {
     const root = scaffold()
     const fakeHost = {

--- a/packages/daemon/test/discord-render.test.ts
+++ b/packages/daemon/test/discord-render.test.ts
@@ -19,6 +19,21 @@ describe('DiscordConverger modes', () => {
     const c = new DiscordConverger('medium')
     expect(kinds(c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash' })))).toEqual(['typing', 'progress'])
   })
+
+  it('idle-flushes only through the last paragraph break so a reply is never cut mid-sentence', () => {
+    const c = new DiscordConverger('medium')
+    c.onUpdate(chunk('First paragraph.\n\nStill streaming mid-wo'))
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'First paragraph.\n\n' }])
+    c.onUpdate(chunk('rd.'))
+    expect(c.onFinal()).toContainEqual({ kind: 'post', text: 'Still streaming mid-word.' })
+  })
+
+  it('idle-flushes nothing while the buffer holds no paragraph break yet', () => {
+    const c = new DiscordConverger('medium')
+    c.onUpdate(chunk('one long line so f'))
+    expect(c.flushBuffered()).toEqual([])
+    expect(c.hasBuffered()).toBe(true)
+  })
 })
 
 describe('DiscordConverger AC_NO_RESPONSE suppression', () => {

--- a/packages/daemon/test/discord-render.test.ts
+++ b/packages/daemon/test/discord-render.test.ts
@@ -34,6 +34,18 @@ describe('DiscordConverger modes', () => {
     expect(c.flushBuffered()).toEqual([])
     expect(c.hasBuffered()).toBe(true)
   })
+
+  it('flushTerminal drains a boundary-less body and a held tail — the turn never reaches onFinal', () => {
+    const noBreak = new DiscordConverger('medium')
+    noBreak.onUpdate(chunk("You've hit your usage limit."))
+    expect(noBreak.flushTerminal()).toEqual([{ kind: 'post', text: "You've hit your usage limit." }])
+    expect(noBreak.hasBuffered()).toBe(false)
+
+    const withTail = new DiscordConverger('medium')
+    withTail.onUpdate(chunk('Quota exceeded.\n\nRetry after the reset at'))
+    expect(withTail.flushTerminal()).toEqual([{ kind: 'post', text: 'Quota exceeded.\n\nRetry after the reset at' }])
+    expect(withTail.hasBuffered()).toBe(false)
+  })
 })
 
 describe('DiscordConverger AC_NO_RESPONSE suppression', () => {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -394,7 +394,10 @@ describe('OutputConverger', () => {
   it('high mode: an idle flush emits reasoning before the body so Thinking posts above the reply', () => {
     const hi = new OutputConverger('high')
     hi.onUpdate({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'weighing options' } } as any)
-    hi.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Here is the answer.' } } as any)
+    hi.onUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'Here is the answer.\n\n' }
+    } as any)
     const actions = hi.flushBuffered()
     const rIdx = actions.findIndex((a) => a.kind === 'reasoning')
     const pIdx = actions.findIndex((a) => a.kind === 'post')
@@ -574,26 +577,60 @@ describe('OutputConverger', () => {
   it('hasBuffered tracks the body buffer; flushBuffered drains it for the idle timer', () => {
     const c = new OutputConverger('medium')
     expect(c.hasBuffered()).toBe(false)
-    c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'streaming…' } } as any)
+    c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'streaming…\n\n' } } as any)
     expect(c.hasBuffered()).toBe(true)
-    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'streaming…' }])
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'streaming…\n\n' }])
     expect(c.hasBuffered()).toBe(false)
     expect(c.flushBuffered()).toEqual([]) // nothing left
+  })
+
+  it('idle-flushes only through the last paragraph break so a reply is never cut mid-sentence', () => {
+    const c = new OutputConverger('medium')
+    const chunk = (text: string) =>
+      c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } } as any)
+    // ACP text deltas are token-sized, so a pause in the stream can leave the buffer mid-word.
+    chunk('The pinned tag is nine commits stale.\n\nSo I am rebuilding the depend')
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'The pinned tag is nine commits stale.\n\n' }])
+    // The held tail keeps streaming and settles as one message at turn end.
+    chunk('ency graph before building.')
+    expect(c.onFinal(undefined)).toContainEqual({
+      kind: 'post',
+      text: 'So I am rebuilding the dependency graph before building.'
+    })
+  })
+
+  it('idle-flushes nothing while the buffer holds no paragraph break yet', () => {
+    const c = new OutputConverger('medium')
+    c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'one long line so f' } } as any)
+    expect(c.flushBuffered()).toEqual([])
+    expect(c.hasBuffered()).toBe(true) // still buffered, not dropped
+  })
+
+  it('a tool boundary still drains the whole buffer — the model finished that text block', () => {
+    const c = new OutputConverger('low')
+    c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Let me check.' } } as any)
+    const actions = c.onUpdate({
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      title: 'Read',
+      status: 'pending'
+    } as any)
+    expect(actions[0]).toEqual({ kind: 'post', text: 'Let me check.' })
   })
 
   it('posts the agent markdown verbatim when flushing body text (no mrkdwn conversion)', () => {
     const c = new OutputConverger('medium')
     c.onUpdate({
       sessionUpdate: 'agent_message_chunk',
-      content: { type: 'text', text: 'see **bold** and [docs](https://x.io)' }
+      content: { type: 'text', text: 'see **bold** and [docs](https://x.io)\n\n' }
     } as any)
     const [post] = c.flushBuffered()
-    expect(post).toEqual({ kind: 'post', text: 'see **bold** and [docs](https://x.io)' })
+    expect(post).toEqual({ kind: 'post', text: 'see **bold** and [docs](https://x.io)\n\n' })
   })
 
   it('splits an over-long body into multiple ≤block-limit post sections', () => {
     const c = new OutputConverger('medium')
-    const big = `${'a'.repeat(9000)}\n${'b'.repeat(9000)}`
+    const big = `${'a'.repeat(9000)}\n${'b'.repeat(9000)}\n\n`
     c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: big } } as any)
     const posts = c.flushBuffered()
     expect(posts.length).toBe(2)

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -606,6 +606,27 @@ describe('OutputConverger', () => {
     expect(c.hasBuffered()).toBe(true) // still buffered, not dropped
   })
 
+  it('flushTerminal drains a body with no paragraph break — the turn never reaches onFinal', () => {
+    const c = new OutputConverger('medium')
+    // A runtime that narrates its terminal error then rejects the prompt: one line, no break.
+    c.onUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: "You've hit your usage limit." }
+    } as any)
+    expect(c.flushTerminal()).toEqual([{ kind: 'post', text: "You've hit your usage limit." }])
+    expect(c.hasBuffered()).toBe(false)
+  })
+
+  it('flushTerminal drains the held tail too, not just the completed paragraph', () => {
+    const c = new OutputConverger('medium')
+    c.onUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'Quota exceeded.\n\nRetry after the reset at' }
+    } as any)
+    expect(c.flushTerminal()).toEqual([{ kind: 'post', text: 'Quota exceeded.\n\nRetry after the reset at' }])
+    expect(c.hasBuffered()).toBe(false)
+  })
+
   it('a tool boundary still drains the whole buffer — the model finished that text block', () => {
     const c = new OutputConverger('low')
     c.onUpdate({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Let me check.' } } as any)

--- a/packages/daemon/test/stream-boundary.test.ts
+++ b/packages/daemon/test/stream-boundary.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { splitAtParagraphBoundary } from '../src/messages/stream-boundary.js'
+
+describe('splitAtParagraphBoundary', () => {
+  it('cuts just past the last top-level blank line', () => {
+    expect(splitAtParagraphBoundary('one\n\ntwo\n\nthree in progre')).toEqual({
+      ready: 'one\n\ntwo\n\n',
+      tail: 'three in progre'
+    })
+  })
+
+  it('holds the whole buffer while no paragraph break has arrived', () => {
+    expect(splitAtParagraphBoundary('a single streaming senten')).toEqual({
+      ready: '',
+      tail: 'a single streaming senten'
+    })
+  })
+
+  it('does not cut on a single newline — a list or table must stay in one message', () => {
+    expect(splitAtParagraphBoundary('- one\n- two\n- thr')).toEqual({ ready: '', tail: '- one\n- two\n- thr' })
+  })
+
+  it('ignores blank lines inside a fenced code block', () => {
+    const text = 'intro\n\n```ts\nconst a = 1\n\nconst b = 2\n'
+    expect(splitAtParagraphBoundary(text)).toEqual({ ready: 'intro\n\n', tail: '```ts\nconst a = 1\n\nconst b = 2\n' })
+  })
+
+  it('resumes cutting after the fence closes', () => {
+    const text = '```\ncode\n\nmore\n```\n\nafter the fence'
+    expect(splitAtParagraphBoundary(text)).toEqual({ ready: '```\ncode\n\nmore\n```\n\n', tail: 'after the fence' })
+  })
+
+  it('treats a tilde fence the same and does not close it on a backtick run', () => {
+    const text = '~~~\ncode\n\n```\n\nstill inside\n'
+    expect(splitAtParagraphBoundary(text).ready).toBe('')
+  })
+
+  it('never cuts on the trailing line — it is still streaming', () => {
+    expect(splitAtParagraphBoundary('para\n\n')).toEqual({ ready: 'para\n\n', tail: '' })
+    expect(splitAtParagraphBoundary('para\n')).toEqual({ ready: '', tail: 'para\n' })
+  })
+
+  it('yields nothing when everything before the break is whitespace', () => {
+    expect(splitAtParagraphBoundary('\n\nreal text')).toEqual({ ready: '', tail: '\n\nreal text' })
+  })
+
+  it('is lossless — ready + tail reconstructs the input', () => {
+    for (const text of ['a\n\nb\n\nc', '```\nx\n\ny\n```\n\nz', 'no break at all', '\n\n\n', '']) {
+      const { ready, tail } = splitAtParagraphBoundary(text)
+      expect(ready + tail).toBe(text)
+    }
+  })
+})

--- a/packages/daemon/test/telegram-render.test.ts
+++ b/packages/daemon/test/telegram-render.test.ts
@@ -48,6 +48,18 @@ describe('TelegramConverger body buffering', () => {
     ).toBe(true)
   })
 
+  it('flushTerminal drains a boundary-less body and a held tail — the turn never reaches onFinal', () => {
+    const noBreak = new TelegramConverger('medium')
+    noBreak.onUpdate(chunk("You've hit your usage limit."))
+    expect(noBreak.flushTerminal()).toEqual([{ kind: 'post', text: "You've hit your usage limit." }])
+    expect(noBreak.hasBuffered()).toBe(false)
+
+    const withTail = new TelegramConverger('medium')
+    withTail.onUpdate(chunk('Quota exceeded.\n\nRetry after the reset at'))
+    expect(withTail.flushTerminal()).toEqual([{ kind: 'post', text: 'Quota exceeded.\n\nRetry after the reset at' }])
+    expect(withTail.hasBuffered()).toBe(false)
+  })
+
   it('splits an over-long body across posts at the 4096 cap', () => {
     const c = new TelegramConverger('low')
     const line = 'x'.repeat(3000)

--- a/packages/daemon/test/telegram-render.test.ts
+++ b/packages/daemon/test/telegram-render.test.ts
@@ -32,16 +32,26 @@ describe('TelegramConverger body buffering', () => {
   it('buffers message chunks and flushes them as plain-text post actions', () => {
     const c = new TelegramConverger('low')
     expect(c.onUpdate(chunk('hello '))).toEqual([])
-    expect(c.onUpdate(chunk('world'))).toEqual([])
+    expect(c.onUpdate(chunk('world\n\n'))).toEqual([])
     expect(c.hasBuffered()).toBe(true)
     const out = c.flushBuffered()
-    expect(out).toEqual([{ kind: 'post', text: 'hello world' }])
+    expect(out).toEqual([{ kind: 'post', text: 'hello world\n\n' }])
+  })
+
+  it('idle-flushes only through the last paragraph break, holding the streaming tail', () => {
+    const c = new TelegramConverger('low')
+    c.onUpdate(chunk('First paragraph.\n\nSecond one is still mid-wo'))
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'First paragraph.\n\n' }])
+    c.onUpdate(chunk('rd.'))
+    expect(
+      c.onFinal('https://example/session').some((a) => a.kind === 'post' && a.text === 'Second one is still mid-word.')
+    ).toBe(true)
   })
 
   it('splits an over-long body across posts at the 4096 cap', () => {
     const c = new TelegramConverger('low')
     const line = 'x'.repeat(3000)
-    c.onUpdate(chunk(`${line}\n${line}`))
+    c.onUpdate(chunk(`${line}\n${line}\n\n`))
     const out = c.flushBuffered()
     expect(out).toHaveLength(2)
     for (const a of out) {
@@ -92,7 +102,7 @@ describe('TelegramConverger modes', () => {
     const c = new TelegramConverger('high')
     c.onUpdate(thought('let me '))
     c.onUpdate(thought('consider'))
-    c.onUpdate(chunk('the answer'))
+    c.onUpdate(chunk('the answer\n\n'))
     const out = c.flushBuffered()
     expect(kinds(out)).toEqual(['reasoning', 'post'])
     const reasoning = out[0] as { text: string; parseMode: string }
@@ -229,8 +239,8 @@ describe('TelegramConverger continue hint', () => {
 
   it('annotates an idle-flushed reply the same way, and only once', () => {
     const c = new TelegramConverger('medium', { continueHint: true })
-    c.onUpdate(chunk('streamed answer'))
-    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'streamed answer' }])
+    c.onUpdate(chunk('streamed answer\n\n'))
+    expect(c.flushBuffered()).toEqual([{ kind: 'post', text: 'streamed answer\n\n' }])
     const out = c.onFinal('https://app/s/1')
     expect(kinds(out)).toEqual(['continue-hint', 'notice'])
   })


### PR DESCRIPTION
## The bug

A single agent answer sometimes arrives in the chat as two messages, cut at a meaningless
point — including mid-word:

> …so I'm also applying the `rebase-reth` workflow to create an exact op-re *(edited)*
>
> th-specific dependency branch before building. *(edited)*

## Why

`OutputConverger.flushBuffered()` — the ~2s idle-flush timer (`IDLE_FLUSH_MS`, `armIdle`
in `daemon.ts`) — drained the whole body buffer and emitted it as a `post`, which on Slack
is a new `chat.postMessage`. That timer fires on a **pause in the ACP stream**, which says
nothing about whether the reply's text is complete: text deltas are token-sized, so the
buffer routinely ends mid-sentence. The old `flush()` posted it verbatim with no boundary
trimming (only the 12000-char block cap ever split on a newline).

Both messages read *(edited)* because the attribution footer is then moved to the last one,
per the footer convention in `docs/product-conventions.md`.

Reproduced against the converger directly, and the new tests cover it.

## The fix

New `packages/daemon/src/messages/stream-boundary.ts`:
`splitAtParagraphBoundary(text) → { ready, tail }` cuts at the **last top-level blank line**,
tracking fenced code blocks (both ``` and ~~~) so a blank line inside a fence is not a
boundary. No boundary yet ⇒ the whole buffer is held. The split is lossless
(`ready + tail === text`), so nothing is dropped or duplicated in the transcript records.

The idle path in each converger now goes through `flushStreaming()`, which posts `ready` and
re-buffers `tail`.

**Semantic boundaries are deliberately unchanged.** A tool call, plan, or thinking step still
drains the whole buffer: the model genuinely finished a text block there, so the cut is safe —
and holding text at those points would push the body *below* the tool/progress chrome and
reorder the conversation. Only the purely time-triggered flush was unsafe.

Feishu is unaffected: its channel output is one streamed CardKit card and only its `recordOnly`
transcript writes are chunked, so it never showed a visible break.

## Scope of behavior change

Affects output modes `low` / `medium` / `high`. `minimal` already used a single in-place live
message. A long answer with no paragraph break at all now arrives once, at turn end, instead of
being cut mid-sentence on the way — the status bar / progress chrome still signals liveness.

## Reviewer notes

Eight existing tests asserted the old contract (an idle flush posting a boundary-less partial
buffer); they were updated, and new coverage was added for the hold behavior on all three
platforms plus 9 unit tests for the helper.

`docs/product-conventions.md` gains a "Where a streamed reply may be split" section stating the
invariant.

## Verification

- `pnpm --filter @agentconnect.md/daemon test` — 2573 passed, 4 skipped
- `typecheck`, `eslint`, `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)