### PR TITLE
fix(web): move managed skills into Skills library

### DIFF
--- a/docs/designs/organization-knowledge.md
+++ b/docs/designs/organization-knowledge.md
@@ -43,10 +43,11 @@ The console gains a separate top-level **Knowledge** destination at
    state. Owners may accept or reject a pending item. Rejected items remain in
    history.
 
-Managed organization skills appear below the knowledge library on the
-Knowledge/Organization tab, while Git-backed sources remain in Tools & Skills.
-Opening one loads the immutable revision history and shows the selected bundle's
-manifest, sizes, digest, and provenance.
+Managed organization skills appear in the existing **Skills library** card on
+Tools & Skills, alongside Git-backed sources. A managed tile is labeled as an
+immutable managed bundle; opening it loads the revision history and shows the
+selected bundle's manifest, sizes, digest, and provenance. Knowledge/Organization
+contains organization knowledge only.
 Pending skill candidates remain reviewable from Knowledge/Suggestions;
 accepted bundles are never enabled automatically. An agent editor must select
 each managed skill explicitly.
@@ -488,7 +489,7 @@ daemon converges without waiting for an unrelated agent edit or restart.
 - **Web:** separate route/nav, both tabs, Markdown safety, loading/empty/error and
   offline states, role-gated controls, accept/reject refresh, responsive layout,
   knowledge and managed-skill revision selectors/provenance, managed skills in
-  library and agent picker.
+  the Tools & Skills library card alongside Git sources, and the agent picker.
 - **Repository:** migration from empty and existing PostgreSQL, protocol/daemon/
   control-plane/web tests, typecheck, lint, formatting, production build, and
   desktop/mobile browser smoke.

--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -407,6 +407,11 @@ each source, following `facts/daemon-runtimes`.
 
 Replace mock data with the real surface, following `McpServersCard`:
 
+- The **Skills library** is one card for both source kinds: Git-backed sources
+  from this design and centrally accepted immutable managed bundles from
+  [organization-knowledge.md](organization-knowledge.md). Managed bundles are
+  labeled separately and expose their lazy revision history in place; they do
+  not pass through `npx skills` or this source registry.
 - **Import from GitHub** opens a modal that (1) selects or enters a repository,
   reusing the installation-to-picker flow from `AddAgentRepoModal` or accepting
   `owner/repo`; (2) optionally selects a branch, tag, or commit ref and a

--- a/packages/web/src/components/console/ManagedSkillTile.test.tsx
+++ b/packages/web/src/components/console/ManagedSkillTile.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setApiOrgId, type ManagedSkillDto } from '@/lib/api'
+import { ManagedSkillTile } from './ManagedSkillTile'
+
+let host: HTMLDivElement
+let root: Root
+
+async function settleUntil(done: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    if (done()) return
+  }
+  throw new Error('managed skill tile did not settle')
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  setApiOrgId('org-test')
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  setApiOrgId(null)
+  vi.unstubAllGlobals()
+})
+
+describe('managed skill library tile', () => {
+  it('lazily browses immutable revisions and refreshes an open tile when the current revision advances', async () => {
+    const skill: ManagedSkillDto = {
+      id: '66666666-6666-4666-8666-666666666666',
+      name: 'release-service',
+      description: 'Release safely',
+      currentRevision: 2,
+      digest: `sha256:${'d'.repeat(64)}`,
+      compressedBytes: 120,
+      expandedBytes: 300,
+      fileCount: 2,
+      manifest: { files: [{ path: 'SKILL.md', bytes: 100, digest: `sha256:${'e'.repeat(64)}` }] },
+      archivedAt: null,
+      createdAt: '2026-07-30T00:00:00.000Z',
+      updatedAt: '2026-07-31T00:00:00.000Z',
+      canManage: true
+    }
+    let currentRevision = 2
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            {
+              managedSkillId: skill.id,
+              revision: currentRevision,
+              digest: skill.digest,
+              compressedBytes: 120,
+              expandedBytes: 300,
+              fileCount: 2,
+              manifest:
+                currentRevision === 2
+                  ? skill.manifest
+                  : { files: [{ path: 'references/latest.md', bytes: 100, digest: `sha256:${'3'.repeat(64)}` }] },
+              source: 'dream',
+              sourceAgentId: 'agent-1',
+              sourceDreamId: 'dream-2',
+              sourceSessionIds: ['session-2'],
+              createdByUserId: null,
+              reviewedByUserId: 'owner-1',
+              createdAt: '2026-07-31T00:00:00.000Z'
+            },
+            {
+              managedSkillId: skill.id,
+              revision: 1,
+              digest: `sha256:${'1'.repeat(64)}`,
+              compressedBytes: 90,
+              expandedBytes: 180,
+              fileCount: 1,
+              manifest: {
+                files: [{ path: 'references/initial.md', bytes: 80, digest: `sha256:${'2'.repeat(64)}` }]
+              },
+              source: 'dream',
+              sourceAgentId: 'agent-1',
+              sourceDreamId: 'dream-1',
+              sourceSessionIds: ['session-1'],
+              createdByUserId: null,
+              reviewedByUserId: 'owner-1',
+              createdAt: '2026-07-30T00:00:00.000Z'
+            }
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const render = async (value: ManagedSkillDto) => {
+      await act(async () => {
+        root.render(
+          <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+            <ManagedSkillTile skill={value} canManage={false} onArchive={() => undefined} />
+          </SWRConfig>
+        )
+      })
+    }
+    await render(skill)
+
+    expect(host.textContent).toContain('managed · rev 2')
+    expect(fetchMock).not.toHaveBeenCalled()
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('[aria-label="Show revision history"]')!.click()
+    })
+    await settleUntil(() => host.querySelector('select') !== null)
+
+    const select = host.querySelector('select')!
+    await act(async () => {
+      select.value = '1'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(host.textContent).toContain('references/initial.md')
+    expect(host.textContent).toContain('reviewed by owner-1')
+
+    currentRevision = 3
+    await render({ ...skill, currentRevision: 3 })
+    await settleUntil(() => host.textContent?.includes('references/latest.md') === true)
+
+    expect(host.textContent).toContain('managed · rev 3')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(host.textContent).not.toContain('Revision history is unavailable.')
+  })
+})

--- a/packages/web/src/components/console/ManagedSkillTile.tsx
+++ b/packages/web/src/components/console/ManagedSkillTile.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import useSWR from 'swr'
+import { listManagedSkillRevisions, type ManagedSkillDto, type ManagedSkillRevisionDto } from '@/lib/api'
+import { ToolTile } from '@/components/console/ToolTile'
+import { LoadingState } from '@/components/marks'
+import { Icon } from '@/components/ui'
+
+function when(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+function bytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function Provenance({ value }: { value: ManagedSkillRevisionDto }) {
+  return (
+    <div className="flex flex-wrap gap-x-2 gap-y-1 font-mono text-[10px] text-(--text-disabled)">
+      <span>{value.source === 'dream' ? 'Dream proposal' : 'manual publish'}</span>
+      <span aria-hidden>·</span>
+      <time dateTime={value.createdAt}>{when(value.createdAt)}</time>
+      {value.sourceAgentId && (
+        <>
+          <span aria-hidden>·</span>
+          <span title={value.sourceAgentId}>agent {value.sourceAgentId}</span>
+        </>
+      )}
+      {value.sourceDreamId && (
+        <>
+          <span aria-hidden>·</span>
+          <span title={value.sourceDreamId}>dream {value.sourceDreamId}</span>
+        </>
+      )}
+      {value.sourceSessionIds.length > 0 && (
+        <>
+          <span aria-hidden>·</span>
+          <span title={value.sourceSessionIds.join(', ')}>
+            {value.sourceSessionIds.length} source session{value.sourceSessionIds.length === 1 ? '' : 's'}
+          </span>
+        </>
+      )}
+      {value.reviewedByUserId ? (
+        <>
+          <span aria-hidden>·</span>
+          <span>reviewed by {value.reviewedByUserId}</span>
+        </>
+      ) : value.createdByUserId ? (
+        <>
+          <span aria-hidden>·</span>
+          <span>published by {value.createdByUserId}</span>
+        </>
+      ) : null}
+      <span aria-hidden>·</span>
+      <span title={value.digest}>{value.digest.slice(0, 19)}…</span>
+    </div>
+  )
+}
+
+/**
+ * One centrally accepted immutable skill, rendered inside the same Skills
+ * library grid as Git-backed sources. Revision bodies stay lazy: opening the
+ * tile is the first request, and currentRevision is part of the SWR key so an
+ * accepted update refreshes an already-open tile in place.
+ */
+export function ManagedSkillTile({
+  skill,
+  canManage,
+  onArchive
+}: {
+  skill: ManagedSkillDto
+  canManage: boolean
+  onArchive: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [selectedRevision, setSelectedRevision] = useState(skill.currentRevision)
+  useEffect(() => setSelectedRevision(skill.currentRevision), [skill.currentRevision])
+  const history = useSWR(open ? ['managed-skill-revisions', skill.id, skill.currentRevision] : null, () =>
+    listManagedSkillRevisions(skill.id)
+  )
+  const selected = history.data?.find((revision) => revision.revision === selectedRevision)
+  const historyId = `managed-skill-history-${skill.id}`
+
+  return (
+    <ToolTile
+      mark={
+        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+          <Icon name="sparkles" size={15} color="var(--brand)" />
+        </span>
+      }
+      name={skill.name}
+      badge={
+        <span
+          className={`badge flex-none text-[9.5px] ${
+            skill.archivedAt
+              ? 'bg-(--surface-sunken) text-(--text-disabled)'
+              : 'bg-(--status-info-soft) text-(--status-info)'
+          }`}
+        >
+          {skill.archivedAt ? 'managed · archived' : `managed · rev ${skill.currentRevision}`}
+        </span>
+      }
+      subtitle={skill.description}
+      footer={
+        <span className="mono text-[10.5px] text-(--text-disabled)">
+          {skill.fileCount} file{skill.fileCount === 1 ? '' : 's'} · {bytes(skill.expandedBytes)} expanded · immutable
+          bundle
+        </span>
+      }
+      action={
+        <>
+          <button
+            type="button"
+            className="iconbtn h-6 w-6"
+            onClick={() => setOpen((value) => !value)}
+            aria-label={open ? 'Hide revision history' : 'Show revision history'}
+            aria-expanded={open}
+            aria-controls={historyId}
+            title={open ? 'Hide revision history' : 'Show revision history'}
+          >
+            <Icon name={open ? 'chevron-down' : 'chevron-right'} size={13} />
+          </button>
+          {canManage && skill.canManage && (
+            <button
+              type="button"
+              className="iconbtn h-6 w-6"
+              title={skill.archivedAt ? 'Restore' : 'Archive'}
+              onClick={onArchive}
+            >
+              <Icon name={skill.archivedAt ? 'archive-restore' : 'archive'} size={13} />
+            </button>
+          )}
+        </>
+      }
+      dimmed={!!skill.archivedAt}
+    >
+      {open && (
+        <div id={historyId} className="border-t border-(--border-subtle) bg-(--surface-sunken) px-[14px] py-3">
+          {history.isLoading ? (
+            <LoadingState size={18} padding={12} />
+          ) : history.error ? (
+            <div className="font-sans text-[12px] text-(--status-error)">{history.error.message}</div>
+          ) : !selected ? (
+            <div className="font-sans text-[12px] text-(--text-tertiary)">Revision history is unavailable.</div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <label className="flex items-center gap-2 font-sans text-[11px] text-(--text-tertiary)">
+                  Revision
+                  <select
+                    className="inp h-7 min-w-20 py-0 text-[11px]"
+                    aria-label={`Revision for ${skill.name}`}
+                    value={selectedRevision}
+                    onChange={(event) => setSelectedRevision(Number(event.target.value))}
+                  >
+                    {history.data?.map((revision) => (
+                      <option key={revision.revision} value={revision.revision}>
+                        {revision.revision}
+                        {revision.revision === skill.currentRevision ? ' (current)' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span className="font-mono text-[10px] text-(--text-disabled)">
+                  {selected.fileCount} files · {bytes(selected.expandedBytes)} expanded ·{' '}
+                  {bytes(selected.compressedBytes)} archive
+                </span>
+              </div>
+              <Provenance value={selected} />
+              <div>
+                {(selected.manifest.files ?? []).map((file) => (
+                  <div key={file.path} className="flex gap-2 py-[3px] font-mono text-[10.5px] text-(--text-tertiary)">
+                    <Icon name="file" size={12} />
+                    <span className="min-w-0 flex-1 truncate">{file.path}</span>
+                    <span>{bytes(file.bytes)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </ToolTile>
+  )
+}

--- a/packages/web/src/components/console/SkillSourcesCard.test.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedSkillDto, SkillSourceDto } from '@/lib/api'
+
+const mocks = vi.hoisted(() => ({
+  skillSources: [] as SkillSourceDto[]
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    skillSources: mocks.skillSources,
+    skillSourcesLoading: false,
+    members: []
+  })
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org-test' } }) }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+
+import { SkillSourcesCard } from './SkillSourcesCard'
+
+let host: HTMLDivElement
+let root: Root
+
+async function settleUntil(done: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    if (done()) return
+  }
+  throw new Error('skills library did not settle')
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.skillSources = [
+    {
+      id: 'source-1',
+      name: 'platform-skills',
+      source: 'acme/platform-skills',
+      githubRepoId: null,
+      ref: 'main',
+      subDir: null,
+      skills: [],
+      visibility: 'org',
+      sharedWith: [],
+      createdBy: 'owner-1',
+      ownerUserId: 'owner-1',
+      canEdit: true,
+      canManageSharing: true,
+      createdAt: '2026-07-30T00:00:00.000Z'
+    }
+  ]
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('organization Skills library', () => {
+  it('renders Git sources and accepted managed skills as tiles in one card', async () => {
+    const managed: ManagedSkillDto = {
+      id: '66666666-6666-4666-8666-666666666666',
+      name: 'release-service',
+      description: 'Release safely',
+      currentRevision: 2,
+      digest: `sha256:${'d'.repeat(64)}`,
+      compressedBytes: 120,
+      expandedBytes: 300,
+      fileCount: 2,
+      manifest: { files: [{ path: 'SKILL.md', bytes: 100, digest: `sha256:${'e'.repeat(64)}` }] },
+      archivedAt: null,
+      createdAt: '2026-07-30T00:00:00.000Z',
+      updatedAt: '2026-07-31T00:00:00.000Z',
+      canManage: true
+    }
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify([managed]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      root.render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <SkillSourcesCard canWrite={false} canManage={true} />
+        </SWRConfig>
+      )
+    })
+    await settleUntil(() => host.textContent?.includes('release-service') === true)
+
+    expect(host.querySelectorAll('.card')).toHaveLength(1)
+    expect(host.textContent).toContain('Skills library')
+    expect(host.textContent).toContain('Git sources and managed bundles')
+    expect(host.textContent).toContain('platform-skills')
+    expect(host.textContent).toContain('acme/platform-skills')
+    expect(host.textContent).toContain('release-service')
+    expect(host.textContent).toContain('managed · rev 2')
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      expect.stringContaining('/orgs/org-test/managed-skills?includeArchived=false')
+    ])
+  })
+})

--- a/packages/web/src/components/console/SkillSourcesCard.test.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.test.tsx
@@ -2,9 +2,10 @@
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { SWRConfig } from 'swr'
+import useSWR, { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ManagedSkillDto, SkillSourceDto } from '@/lib/api'
+import { listManagedSkills, setApiOrgId, type ManagedSkillDto, type SkillSourceDto } from '@/lib/api'
+import { consoleKeys } from '@/lib/swr-keys'
 
 const mocks = vi.hoisted(() => ({
   skillSources: [] as SkillSourceDto[]
@@ -21,6 +22,12 @@ vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org-te
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
 
 import { SkillSourcesCard } from './SkillSourcesCard'
+
+function ActiveManagedSkillCount() {
+  const key = consoleKeys.managedSkills('org-test', false)
+  const { data = [] } = useSWR(key, ([, orgId]) => listManagedSkills(false, orgId))
+  return <output data-active-managed-count>{data.length}</output>
+}
 
 let host: HTMLDivElement
 let root: Root
@@ -58,11 +65,13 @@ beforeEach(() => {
   host = document.createElement('div')
   document.body.append(host)
   root = createRoot(host)
+  setApiOrgId('org-test')
 })
 
 afterEach(async () => {
   await act(async () => root.unmount())
   host.remove()
+  setApiOrgId(null)
   vi.unstubAllGlobals()
 })
 
@@ -84,7 +93,7 @@ describe('organization Skills library', () => {
       canManage: true
     }
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL) =>
         new Response(JSON.stringify([managed]), {
           status: 200,
           headers: { 'content-type': 'application/json' }
@@ -111,5 +120,65 @@ describe('organization Skills library', () => {
     expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
       expect.stringContaining('/orgs/org-test/managed-skills?includeArchived=false')
     ])
+  })
+
+  it('revalidates the active-only library count when archiving from the include-archived view', async () => {
+    const managed: ManagedSkillDto = {
+      id: '66666666-6666-4666-8666-666666666666',
+      name: 'release-service',
+      description: 'Release safely',
+      currentRevision: 2,
+      digest: `sha256:${'d'.repeat(64)}`,
+      compressedBytes: 120,
+      expandedBytes: 300,
+      fileCount: 2,
+      manifest: { files: [{ path: 'SKILL.md', bytes: 100, digest: `sha256:${'e'.repeat(64)}` }] },
+      archivedAt: null,
+      createdAt: '2026-07-30T00:00:00.000Z',
+      updatedAt: '2026-07-31T00:00:00.000Z',
+      canManage: true
+    }
+    let archived = false
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === 'POST') {
+        archived = true
+        return new Response(JSON.stringify({ ...managed, archivedAt: '2026-08-01T00:00:00.000Z' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      }
+      const includeArchived = url.includes('includeArchived=true')
+      const rows =
+        includeArchived || !archived ? [{ ...managed, archivedAt: archived ? '2026-08-01T00:00:00.000Z' : null }] : []
+      return new Response(JSON.stringify(rows), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      root.render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <ActiveManagedSkillCount />
+          <SkillSourcesCard canWrite={false} canManage={true} />
+        </SWRConfig>
+      )
+    })
+    await settleUntil(() => host.querySelector('[data-active-managed-count]')?.textContent === '1')
+
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('button[role="switch"]')!.click()
+    })
+    await settleUntil(() => fetchMock.mock.calls.some(([input]) => String(input).includes('includeArchived=true')))
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('button[title="Archive"]')!.click()
+    })
+    await settleUntil(() => host.querySelector('[data-active-managed-count]')?.textContent === '0')
+
+    expect(host.textContent).toContain('managed · archived')
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        init?.method === 'POST' ? false : String(input).includes('includeArchived=false')
+      ).length
+    ).toBeGreaterThanOrEqual(2)
   })
 })

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -1,23 +1,33 @@
 'use client'
 
-// Skills library card (Tools & Skills page) — the org-level shared-skills source
-// registry (docs/designs/shared-skills.md). Each source is a repo / git URL the
-// daemon installs into an agent's workspace via `npx skills` after clone and
-// before the ACP session starts. This card lists the sources as tiles and drives
-// create / edit / delete; per-agent enablement lives on the agent detail view.
+// Skills library card (Tools & Skills page) — one surface for the org-level
+// Git source registry (docs/designs/shared-skills.md) and centrally accepted
+// immutable managed bundles (docs/designs/organization-knowledge.md). Git
+// sources install via `npx skills`; managed bundles use the daemon's pinned
+// digest cache. Per-agent enablement for both lives on the agent detail view.
 //
 // A source records only WHERE skills come from (source string + optional ref /
 // subDir / skill filter) — nothing secret. Self-contained (own create/edit/delete
 // dialogs in a scrim, like the MCP servers card).
 
 import { useRef, useState } from 'react'
+import useSWR from 'swr'
 import { useConsoleData } from '@/lib/data-context'
+import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
-import { fmtDate, type SkillSourceDto } from '@/lib/api'
+import {
+  fmtDate,
+  listManagedSkills,
+  setManagedSkillArchived,
+  type ManagedSkillDto,
+  type SkillSourceDto
+} from '@/lib/api'
+import { consoleKeys } from '@/lib/swr-keys'
+import { ManagedSkillTile } from '@/components/console/ManagedSkillTile'
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
 import { LoadingState } from '@/components/marks'
-import { Button, Icon } from '@/components/ui'
+import { Button, Icon, Toggle } from '@/components/ui'
 
 /** Split a comma/whitespace-separated skill filter into a clean string[]. */
 function parseSkills(raw: string): string[] {
@@ -27,35 +37,70 @@ function parseSkills(raw: string): string[] {
     .filter(Boolean)
 }
 
-export function SkillSourcesCard({ canWrite }: { canWrite: boolean }) {
+export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; canManage: boolean }) {
   const { skillSources, skillSourcesLoading } = useConsoleData()
+  const { activeOrg } = useOrgs()
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<SkillSourceDto | null>(null)
   const [deleting, setDeleting] = useState<SkillSourceDto | null>(null)
+  const [includeArchived, setIncludeArchived] = useState(false)
+  const [managedActionError, setManagedActionError] = useState<string | null>(null)
+  const managedSkillsKey = consoleKeys.managedSkills(activeOrg?.id, includeArchived)
+  const managedSkills = useSWR(managedSkillsKey, ([, orgId, , archiveMode]) =>
+    listManagedSkills(archiveMode === 'include-archived', orgId)
+  )
+  const managedRows = managedSkills.data ?? []
+  const loading = skillSourcesLoading || managedSkills.isLoading
+  const empty = skillSources.length === 0 && managedRows.length === 0
+
+  const archiveManagedSkill = async (skill: ManagedSkillDto) => {
+    setManagedActionError(null)
+    try {
+      await setManagedSkillArchived(skill.id, !skill.archivedAt)
+      await managedSkills.mutate()
+    } catch (cause) {
+      setManagedActionError(cause instanceof Error ? cause.message : String(cause))
+    }
+  }
 
   return (
-    <div className="card">
-      <div className="cardhead justify-between">
+    <div className="card overflow-hidden">
+      <div className="cardhead flex-wrap justify-between gap-2">
         <span className="inline-flex items-baseline gap-[10px]">
           <span className="cardtitle">Skills library</span>
-          <span className="mono text-[11px] text-(--text-tertiary)">installed per agent via npx skills</span>
+          <span className="mono text-[11px] text-(--text-tertiary)">Git sources and managed bundles</span>
         </span>
-        {canWrite && (
-          <Button variant="secondary" size="xs" onClick={() => setCreating(true)}>
-            <Icon name="plus" size={14} />
-            Import from GitHub
-          </Button>
-        )}
+        <span className="flex flex-wrap items-center justify-end gap-3">
+          <label className="flex items-center gap-2 font-sans text-[11.5px] text-(--text-tertiary)">
+            Include archived
+            <Toggle checked={includeArchived} onChange={setIncludeArchived} />
+          </label>
+          {canWrite && (
+            <Button variant="secondary" size="xs" onClick={() => setCreating(true)}>
+              <Icon name="plus" size={14} />
+              Import from GitHub
+            </Button>
+          )}
+        </span>
       </div>
 
-      {skillSourcesLoading && skillSources.length === 0 ? (
+      {loading && empty && !managedSkills.error ? (
         <LoadingState size={22} padding={20} />
-      ) : skillSources.length === 0 ? (
+      ) : empty && !managedSkills.error ? (
         <div className="px-4 py-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-          No skill sources yet. Import a repo of skills to make them available to your agents.
+          No skills yet. Import a GitHub source or accept a managed skill suggestion to make skills available to your
+          agents.
         </div>
       ) : (
         <ToolTileGrid>
+          {managedRows.map((skill) => (
+            <ManagedSkillTile
+              key={skill.id}
+              skill={skill}
+              canManage={canManage}
+              onArchive={() => void archiveManagedSkill(skill)}
+            />
+          ))}
           {skillSources.map((s) => (
             <SourceTile
               key={s.id}
@@ -66,6 +111,12 @@ export function SkillSourcesCard({ canWrite }: { canWrite: boolean }) {
             />
           ))}
         </ToolTileGrid>
+      )}
+
+      {(managedSkills.error || managedActionError) && (
+        <div className="border-t border-(--border-subtle) px-4 py-[11px] font-sans text-[12px] text-(--status-error)">
+          {managedActionError ?? managedSkills.error.message}
+        </div>
       )}
 
       {creating && (

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -11,7 +11,7 @@
 // dialogs in a scrim, like the MCP servers card).
 
 import { useRef, useState } from 'react'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
@@ -40,12 +40,14 @@ function parseSkills(raw: string): string[] {
 export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; canManage: boolean }) {
   const { skillSources, skillSourcesLoading } = useConsoleData()
   const { activeOrg } = useOrgs()
+  const { mutate: mutateSWR } = useSWRConfig()
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<SkillSourceDto | null>(null)
   const [deleting, setDeleting] = useState<SkillSourceDto | null>(null)
   const [includeArchived, setIncludeArchived] = useState(false)
   const [managedActionError, setManagedActionError] = useState<string | null>(null)
   const managedSkillsKey = consoleKeys.managedSkills(activeOrg?.id, includeArchived)
+  const activeManagedSkillsKey = consoleKeys.managedSkills(activeOrg?.id, false)
   const managedSkills = useSWR(managedSkillsKey, ([, orgId, , archiveMode]) =>
     listManagedSkills(archiveMode === 'include-archived', orgId)
   )
@@ -57,7 +59,10 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
     setManagedActionError(null)
     try {
       await setManagedSkillArchived(skill.id, !skill.archivedAt)
-      await managedSkills.mutate()
+      await Promise.all([
+        managedSkills.mutate(),
+        ...(includeArchived && activeManagedSkillsKey ? [mutateSWR(activeManagedSkillsKey)] : [])
+      ])
     } catch (cause) {
       setManagedActionError(cause instanceof Error ? cause.message : String(cause))
     }

--- a/packages/web/src/components/console/views/KnowledgeView.test.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.test.tsx
@@ -4,12 +4,15 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  setApiOrgId,
-  type ManagedSkillDto,
-  type OrganizationKnowledgeDto,
-  type OrganizationSuggestionDto
-} from '@/lib/api'
+import { setApiOrgId, type OrganizationKnowledgeDto, type OrganizationSuggestionDto } from '@/lib/api'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams()
+}))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-test' }, myRole: 'owner', orgPath: (path: string) => path })
+}))
 
 vi.mock('next/dynamic', () => ({
   default: () =>
@@ -18,7 +21,7 @@ vi.mock('next/dynamic', () => ({
     }
 }))
 
-import { KnowledgeEntry, ManagedSkillEntry, SuggestionCard } from './KnowledgeView'
+import KnowledgeView, { KnowledgeEntry, SuggestionCard } from './KnowledgeView'
 
 const BASE: OrganizationSuggestionDto = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -199,8 +202,31 @@ describe('organization suggestion review card', () => {
   })
 })
 
-describe('immutable organization artifact history', () => {
-  it('loads and selects historical knowledge content and managed-skill bundle metadata on expansion', async () => {
+describe('organization knowledge surface', () => {
+  it('keeps managed skills out of Knowledge and never requests their library endpoint', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      root.render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <KnowledgeView />
+        </SWRConfig>
+      )
+    })
+    await settleUntil(() => host.textContent?.includes('No organization knowledge has been published yet.') === true)
+
+    expect(host.textContent).toContain('Knowledge library')
+    expect(host.textContent).not.toContain('Managed skills')
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      expect.stringContaining('/knowledge?includeArchived=false')
+    ])
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/managed-skills'))).toBe(false)
+  })
+
+  it('loads and selects historical knowledge content, then refreshes an open entry for a new revision', async () => {
     const knowledge: OrganizationKnowledgeDto = {
       id: '55555555-5555-4555-8555-555555555555',
       title: 'Release policy',
@@ -221,27 +247,11 @@ describe('immutable organization artifact history', () => {
       revisionCreatedAt: '2026-07-31T00:00:00.000Z',
       canManage: true
     }
-    const skill: ManagedSkillDto = {
-      id: '66666666-6666-4666-8666-666666666666',
-      name: 'release-service',
-      description: 'Release safely',
-      currentRevision: 2,
-      digest: `sha256:${'d'.repeat(64)}`,
-      compressedBytes: 120,
-      expandedBytes: 300,
-      fileCount: 2,
-      manifest: { files: [{ path: 'SKILL.md', bytes: 100, digest: `sha256:${'e'.repeat(64)}` }] },
-      archivedAt: null,
-      createdAt: '2026-07-30T00:00:00.000Z',
-      updatedAt: '2026-07-31T00:00:00.000Z',
-      canManage: true
-    }
     let knowledgeCurrentRevision = 2
-    let skillCurrentRevision = 2
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      const body = url.includes('/knowledge/')
-        ? [
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
             {
               knowledgeId: knowledge.id,
               revision: knowledgeCurrentRevision,
@@ -272,87 +282,38 @@ describe('immutable organization artifact history', () => {
               reviewedByUserId: 'owner-1',
               createdAt: '2026-07-30T00:00:00.000Z'
             }
-          ]
-        : [
-            {
-              managedSkillId: skill.id,
-              revision: skillCurrentRevision,
-              digest: skill.digest,
-              compressedBytes: 120,
-              expandedBytes: 300,
-              fileCount: 2,
-              manifest:
-                skillCurrentRevision === 2
-                  ? skill.manifest
-                  : {
-                      files: [{ path: 'references/latest.md', bytes: 100, digest: `sha256:${'3'.repeat(64)}` }]
-                    },
-              source: 'dream',
-              sourceAgentId: 'agent-1',
-              sourceDreamId: 'dream-2',
-              sourceSessionIds: ['session-2'],
-              createdByUserId: null,
-              reviewedByUserId: 'owner-1',
-              createdAt: '2026-07-31T00:00:00.000Z'
-            },
-            {
-              managedSkillId: skill.id,
-              revision: 1,
-              digest: `sha256:${'1'.repeat(64)}`,
-              compressedBytes: 90,
-              expandedBytes: 180,
-              fileCount: 1,
-              manifest: {
-                files: [{ path: 'references/initial.md', bytes: 80, digest: `sha256:${'2'.repeat(64)}` }]
-              },
-              source: 'dream',
-              sourceAgentId: 'agent-1',
-              sourceDreamId: 'dream-1',
-              sourceSessionIds: ['session-1'],
-              createdByUserId: null,
-              reviewedByUserId: 'owner-1',
-              createdAt: '2026-07-30T00:00:00.000Z'
-            }
-          ]
-      return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
-    })
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     await act(async () => {
       root.render(
         <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
           <KnowledgeEntry record={knowledge} canManage={false} onEdit={() => undefined} onArchive={() => undefined} />
-          <ManagedSkillEntry skill={skill} canManage={false} onArchive={() => undefined} />
         </SWRConfig>
       )
     })
     await act(async () => {
-      for (const details of host.querySelectorAll('details')) {
-        details.open = true
-        details.dispatchEvent(new Event('toggle'))
-      }
+      const details = host.querySelector('details')!
+      details.open = true
+      details.dispatchEvent(new Event('toggle'))
     })
-    await settleUntil(() => host.querySelectorAll('select').length === 2)
+    await settleUntil(() => host.querySelectorAll('select').length === 1)
 
-    const [knowledgeSelect, skillSelect] = [...host.querySelectorAll('select')]
+    const knowledgeSelect = host.querySelector('select')!
     await act(async () => {
-      knowledgeSelect!.value = '1'
-      knowledgeSelect!.dispatchEvent(new Event('change', { bubbles: true }))
-      skillSelect!.value = '1'
-      skillSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+      knowledgeSelect.value = '1'
+      knowledgeSelect.dispatchEvent(new Event('change', { bubbles: true }))
     })
     expect(host.textContent).toContain('# Historical policy')
     expect(host.textContent).toContain('reviewed by owner-1')
-    expect(host.textContent).toContain('references/initial.md')
-    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining(`/knowledge/${knowledge.id}/revisions`),
-        expect.stringContaining(`/managed-skills/${skill.id}/revisions`)
-      ])
-    )
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      expect.stringContaining(`/knowledge/${knowledge.id}/revisions`)
+    ])
 
     knowledgeCurrentRevision = 3
-    skillCurrentRevision = 3
     await act(async () => {
       root.render(
         <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
@@ -362,15 +323,11 @@ describe('immutable organization artifact history', () => {
             onEdit={() => undefined}
             onArchive={() => undefined}
           />
-          <ManagedSkillEntry skill={{ ...skill, currentRevision: 3 }} canManage={false} onArchive={() => undefined} />
         </SWRConfig>
       )
     })
-    await settleUntil(
-      () =>
-        host.textContent?.includes('# Newly published') === true && host.textContent.includes('references/latest.md')
-    )
-    expect(fetchMock.mock.calls.filter(([input]) => String(input).includes('/revisions'))).toHaveLength(4)
+    await settleUntil(() => host.textContent?.includes('# Newly published') === true)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).includes('/revisions'))).toHaveLength(2)
     expect(host.textContent).not.toContain('Revision history is unavailable.')
   })
 })

--- a/packages/web/src/components/console/views/KnowledgeView.test.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.test.tsx
@@ -205,7 +205,8 @@ describe('organization suggestion review card', () => {
 describe('organization knowledge surface', () => {
   it('keeps managed skills out of Knowledge and never requests their library endpoint', async () => {
     const fetchMock = vi.fn(
-      async () => new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+      async (_input: RequestInfo | URL) =>
+        new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
     )
     vi.stubGlobal('fetch', fetchMock)
 
@@ -249,7 +250,7 @@ describe('organization knowledge surface', () => {
     }
     let knowledgeCurrentRevision = 2
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL) =>
         new Response(
           JSON.stringify([
             {

--- a/packages/web/src/components/console/views/KnowledgeView.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.tsx
@@ -8,17 +8,12 @@ import {
   ApiError,
   createOrganizationKnowledge,
   fetchOrganizationSuggestionContent,
-  listManagedSkillRevisions,
-  listManagedSkills,
   listOrganizationKnowledge,
   listOrganizationKnowledgeRevisions,
   listOrganizationSuggestions,
   reviewOrganizationSuggestion,
-  setManagedSkillArchived,
   setOrganizationKnowledgeArchived,
   updateOrganizationKnowledge,
-  type ManagedSkillDto,
-  type ManagedSkillRevisionDto,
   type OrganizationKnowledgeDto,
   type OrganizationKnowledgeRevisionDto,
   type OrganizationSuggestionContentDto,
@@ -268,7 +263,7 @@ export function SuggestionCard({
 }
 
 type RevisionProvenance = Pick<
-  OrganizationKnowledgeRevisionDto | ManagedSkillRevisionDto,
+  OrganizationKnowledgeRevisionDto,
   | 'source'
   | 'sourceAgentId'
   | 'sourceDreamId'
@@ -421,106 +416,6 @@ export function KnowledgeEntry({
   )
 }
 
-export function ManagedSkillEntry({
-  skill,
-  canManage,
-  onArchive
-}: {
-  skill: ManagedSkillDto
-  canManage: boolean
-  onArchive: () => void
-}) {
-  const [open, setOpen] = useState(false)
-  const [selectedRevision, setSelectedRevision] = useState(skill.currentRevision)
-  useEffect(() => setSelectedRevision(skill.currentRevision), [skill.currentRevision])
-  const history = useSWR(open ? ['managed-skill-revisions', skill.id, skill.currentRevision] : null, () =>
-    listManagedSkillRevisions(skill.id)
-  )
-  const selected = history.data?.find((revision) => revision.revision === selectedRevision)
-
-  return (
-    <details
-      className={`border-(--border-subtle) desktop:border-b desktop:odd:border-r ${skill.archivedAt ? 'opacity-60' : ''}`}
-      onToggle={(event) => setOpen(event.currentTarget.open)}
-    >
-      <summary className="flex cursor-pointer list-none items-start gap-3 px-4 py-3 marker:hidden">
-        <span className="flex h-8 w-8 flex-none items-center justify-center rounded-md bg-(--brand-soft)">
-          <Icon name="sparkles" size={15} color="var(--brand)" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-mono text-[12px] font-semibold text-(--text-primary)">{skill.name}</span>
-            <span className="badge bg-(--surface-sunken) text-[9.5px] text-(--text-tertiary)">
-              rev {skill.currentRevision}
-            </span>
-            {skill.archivedAt && <span className="badge text-[9.5px]">archived</span>}
-          </div>
-          <p className="mt-1 font-sans text-[11.5px] leading-[1.45] text-(--text-secondary)">{skill.description}</p>
-          <div className="mono mt-2 text-[10px] text-(--text-disabled)">
-            {skill.fileCount} files · {bytes(skill.expandedBytes)} expanded · {bytes(skill.compressedBytes)} archive
-          </div>
-        </div>
-        {canManage && (
-          <button
-            className="iconbtn"
-            title={skill.archivedAt ? 'Restore' : 'Archive'}
-            onClick={(event) => {
-              event.preventDefault()
-              onArchive()
-            }}
-          >
-            <Icon name={skill.archivedAt ? 'archive-restore' : 'archive'} size={13} />
-          </button>
-        )}
-      </summary>
-      <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-4 py-3">
-        {history.isLoading ? (
-          <LoadingState size={18} padding={12} />
-        ) : history.error ? (
-          <div className="font-sans text-[12px] text-(--status-error)">{history.error.message}</div>
-        ) : !selected ? (
-          <div className="font-sans text-[12px] text-(--text-tertiary)">Revision history is unavailable.</div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-wrap items-center gap-3">
-              <label className="flex items-center gap-2 font-sans text-[11px] text-(--text-tertiary)">
-                Revision
-                <select
-                  className="inp h-7 min-w-20 py-0 text-[11px]"
-                  aria-label={`Revision for ${skill.name}`}
-                  value={selectedRevision}
-                  onChange={(event) => setSelectedRevision(Number(event.target.value))}
-                >
-                  {history.data?.map((revision) => (
-                    <option key={revision.revision} value={revision.revision}>
-                      {revision.revision}
-                      {revision.revision === skill.currentRevision ? ' (current)' : ''}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <span className="font-mono text-[10px] text-(--text-disabled)">
-                {selected.fileCount} files · {bytes(selected.expandedBytes)} expanded ·{' '}
-                {bytes(selected.compressedBytes)} archive
-              </span>
-            </div>
-            <Provenance value={selected} />
-            <div>
-              {(selected.manifest.files ?? []).map((file) => (
-                <div key={file.path} className="flex gap-2 py-[3px] font-mono text-[10.5px] text-(--text-tertiary)">
-                  <Icon name="file" size={12} />
-                  <span className="min-w-0 flex-1 truncate">{file.path}</span>
-                  <span>{bytes(file.bytes)}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </details>
-  )
-}
-
 function KnowledgeEditor({
   record,
   onClose,
@@ -634,17 +529,16 @@ export default function KnowledgeView() {
   const canManage = myRole === 'owner'
 
   const knowledgeKey = activeOrg ? ['organization-knowledge', activeOrg.id, includeArchived] : null
-  const skillsKey = activeOrg ? ['managed-skills', activeOrg.id, includeArchived] : null
-  const suggestionsKey = activeOrg && canManage ? ['organization-suggestions', activeOrg.id, suggestionState] : null
+  const suggestionsKey =
+    activeOrg && canManage && tab === 'suggestions' ? ['organization-suggestions', activeOrg.id, suggestionState] : null
   const knowledge = useSWR(knowledgeKey, () => listOrganizationKnowledge(includeArchived))
-  const managedSkills = useSWR(skillsKey, () => listManagedSkills(includeArchived))
   const suggestions = useSWR(suggestionsKey, () => listOrganizationSuggestions({ state: suggestionState }))
 
   const refreshOrganization = async () => {
-    await Promise.all([knowledge.mutate(), managedSkills.mutate()])
+    await knowledge.mutate()
   }
   const reviewed = async () => {
-    await Promise.all([suggestions.mutate(), knowledge.mutate(), managedSkills.mutate()])
+    await Promise.all([suggestions.mutate(), knowledge.mutate()])
   }
   const changeTab = (next: 'organization' | 'suggestions') => {
     router.replace(orgPath(`/knowledge${next === 'suggestions' ? '?tab=suggestions' : ''}`))
@@ -658,16 +552,6 @@ export default function KnowledgeView() {
       setActionError(cause instanceof Error ? cause.message : String(cause))
     }
   }
-  const archiveSkill = async (skill: ManagedSkillDto) => {
-    setActionError(null)
-    try {
-      await setManagedSkillArchived(skill.id, !skill.archivedAt)
-      await managedSkills.mutate()
-    } catch (cause) {
-      setActionError(cause instanceof Error ? cause.message : String(cause))
-    }
-  }
-
   const suggestionCounts = useMemo(() => {
     const rows = suggestions.data ?? []
     return { total: rows.length, available: rows.filter((row) => row.contentAvailable).length }
@@ -711,61 +595,31 @@ export default function KnowledgeView() {
       )}
 
       {tab === 'organization' ? (
-        <div className="flex flex-col gap-4">
-          <section className="card overflow-hidden">
-            <div className="cardhead justify-between">
-              <span className="cardtitle">Knowledge library</span>
-              <span className="mono text-[11px] text-(--text-tertiary)">{knowledge.data?.length ?? 0} entries</span>
+        <section className="card overflow-hidden">
+          <div className="cardhead justify-between">
+            <span className="cardtitle">Knowledge library</span>
+            <span className="mono text-[11px] text-(--text-tertiary)">{knowledge.data?.length ?? 0} entries</span>
+          </div>
+          {knowledge.isLoading ? (
+            <LoadingState size={22} padding={24} />
+          ) : knowledge.error ? (
+            <Empty icon="triangle-alert">{knowledge.error.message}</Empty>
+          ) : !knowledge.data?.length ? (
+            <Empty icon="book-open">No organization knowledge has been published yet.</Empty>
+          ) : (
+            <div className="divide-y divide-(--border-subtle)">
+              {knowledge.data.map((record) => (
+                <KnowledgeEntry
+                  key={record.id}
+                  record={record}
+                  canManage={canManage}
+                  onEdit={() => setEditor(record)}
+                  onArchive={() => void archiveKnowledge(record)}
+                />
+              ))}
             </div>
-            {knowledge.isLoading ? (
-              <LoadingState size={22} padding={24} />
-            ) : knowledge.error ? (
-              <Empty icon="triangle-alert">{knowledge.error.message}</Empty>
-            ) : !knowledge.data?.length ? (
-              <Empty icon="book-open">No organization knowledge has been published yet.</Empty>
-            ) : (
-              <div className="divide-y divide-(--border-subtle)">
-                {knowledge.data.map((record) => (
-                  <KnowledgeEntry
-                    key={record.id}
-                    record={record}
-                    canManage={canManage}
-                    onEdit={() => setEditor(record)}
-                    onArchive={() => void archiveKnowledge(record)}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
-
-          <section className="card overflow-hidden">
-            <div className="cardhead justify-between">
-              <span>
-                <span className="cardtitle">Managed skills</span>
-                <span className="mono ml-2 text-[10.5px] text-(--text-tertiary)">approved .skill bundles</span>
-              </span>
-              <span className="mono text-[11px] text-(--text-tertiary)">{managedSkills.data?.length ?? 0} skills</span>
-            </div>
-            {managedSkills.isLoading ? (
-              <LoadingState size={22} padding={24} />
-            ) : managedSkills.error ? (
-              <Empty icon="triangle-alert">{managedSkills.error.message}</Empty>
-            ) : !managedSkills.data?.length ? (
-              <Empty icon="sparkles">Accepted skill suggestions will appear here.</Empty>
-            ) : (
-              <div className="grid grid-cols-1 divide-y divide-(--border-subtle) desktop:grid-cols-2 desktop:divide-y-0">
-                {managedSkills.data.map((skill) => (
-                  <ManagedSkillEntry
-                    key={skill.id}
-                    skill={skill}
-                    canManage={canManage}
-                    onArchive={() => void archiveSkill(skill)}
-                  />
-                ))}
-              </div>
-            )}
-          </section>
-        </div>
+          )}
+        </section>
       ) : !canManage ? (
         <section className="card">
           <Empty icon="shield">Only organization owners can review Dream suggestions.</Empty>

--- a/packages/web/src/components/console/views/ToolsHubView.tsx
+++ b/packages/web/src/components/console/views/ToolsHubView.tsx
@@ -4,7 +4,7 @@ import useSWR from 'swr'
 import { MOCK_MODE } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { fetchExternalMemoryConnections } from '@/lib/api'
+import { fetchExternalMemoryConnections, listManagedSkills } from '@/lib/api'
 import { consoleKeys } from '@/lib/swr-keys'
 import { McpServersCard } from '@/components/console/McpServersCard'
 import { SkillSourcesCard } from '@/components/console/SkillSourcesCard'
@@ -17,8 +17,10 @@ export default function ToolsHubView() {
   const { data: memoryConnections = [] } = useSWR(memoryConnectionKey, ([, orgId]) =>
     fetchExternalMemoryConnections(orgId)
   )
+  const managedSkillsKey = consoleKeys.managedSkills(activeOrg?.id, false)
+  const { data: managedSkills = [] } = useSWR(managedSkillsKey, ([, orgId]) => listManagedSkills(false, orgId))
   const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
-  const canManageMemory = myRole === 'owner' // installation + connection trust actions are owner-only
+  const canManageOwnerResources = myRole === 'owner' // managed artifacts + connection trust actions are owner-only
   // One responsive tree serves both form factors (the phone gets the same content,
   // reflowed): the MCP tiles and Skills library stack to a single column, while
   // `.psub` is hidden on mobile so the Shell app bar's title stands alone.
@@ -44,8 +46,8 @@ export default function ToolsHubView() {
           <div className="statval">{mcpProviders.length}</div>
         </div>
         <div className="card stat">
-          <div className="statlbl">Skill sources</div>
-          <div className="statval">{skillSources.length}</div>
+          <div className="statlbl">Skills library</div>
+          <div className="statval">{skillSources.length + managedSkills.length}</div>
         </div>
         <div className="card stat">
           <div className="statlbl">External memory</div>
@@ -61,8 +63,8 @@ export default function ToolsHubView() {
         )}
       </div>
       <McpServersCard canWrite={canWrite} />
-      <SkillSourcesCard canWrite={canWrite} />
-      <MemoryConnectionsCard canManage={canManageMemory} />
+      <SkillSourcesCard canWrite={canWrite} canManage={canManageOwnerResources} />
+      <MemoryConnectionsCard canManage={canManageOwnerResources} />
     </div>
   )
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4079,8 +4079,10 @@ export function setOrganizationKnowledgeArchived(id: string, archived: boolean):
   return apiPost<OrganizationKnowledgeDto>(`${orgBase()}/knowledge/${encodeURIComponent(id)}/archive`, { archived })
 }
 
-export function listManagedSkills(includeArchived = false): Promise<ManagedSkillDto[]> {
-  return apiGet<ManagedSkillDto[]>(`${orgBase()}/managed-skills?includeArchived=${includeArchived ? 'true' : 'false'}`)
+export function listManagedSkills(includeArchived = false, orgId?: string): Promise<ManagedSkillDto[]> {
+  return apiGet<ManagedSkillDto[]>(
+    `${orgBase(orgId)}/managed-skills?includeArchived=${includeArchived ? 'true' : 'false'}`
+  )
 }
 
 export function listManagedSkillRevisions(id: string): Promise<ManagedSkillRevisionDto[]> {

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -15,6 +15,8 @@ export const consoleKeys = {
   bots: (orgId: string | null | undefined) => consoleKey(orgId, 'bots'),
   mcpProviders: (orgId: string | null | undefined) => consoleKey(orgId, 'mcp-providers'),
   skillSources: (orgId: string | null | undefined) => consoleKey(orgId, 'skill-sources'),
+  managedSkills: (orgId: string | null | undefined, includeArchived: boolean) =>
+    consoleKey(orgId, 'managed-skills', includeArchived ? 'include-archived' : 'active'),
   connectorsConfig: (orgId: string | null | undefined) => consoleKey(orgId, 'connectors-config'),
   memoryPluginInstallations: (orgId: string | null | undefined) => consoleKey(orgId, 'memory-plugin-installations'),
   externalMemoryConnections: (orgId: string | null | undefined) => consoleKey(orgId, 'external-memory-connections'),


### PR DESCRIPTION
## Summary
- remove accepted managed skills from the Knowledge / Organization surface
- render managed bundles and Git-backed skill sources as tiles inside one Tools & Skills / Skills library card
- preserve lazy immutable revision history, archive/restore, and the current-revision refresh fence
- align the design docs and Skills library summary count with the corrected information architecture

## Verification
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/views/KnowledgeView.test.tsx src/components/console/ManagedSkillTile.test.tsx src/components/console/SkillSourcesCard.test.tsx src/lib/api.test.ts` (33/33)
- `pnpm --filter @agentconnect.md/web test` (508/508)
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- changed-file ESLint and Prettier checks
- `pnpm --filter @agentconnect.md/web build`
- repository pre-push `eslint .`
