### PR TITLE
fix(daemon): repair sandboxed Claude and Qoder access

### DIFF
--- a/packages/daemon/src/runtimes/launch-policy.ts
+++ b/packages/daemon/src/runtimes/launch-policy.ts
@@ -46,7 +46,7 @@ export function runtimeSandboxReadRoots(
     readRoots: trustedRuntimeReadRoots({
       runtime,
       hostEnv: stateSourceEnv,
-      ...(claudeExecutable ? { executableCommands: [claudeExecutable] } : {})
+      ...(claudeCommand ? { executableCommands: [claudeCommand] } : {})
     }),
     runtimeExecutable: resolveTrustedExecutable(runtime.command, trustedRuntimeEnv),
     ...(claudeExecutable ? { claudeExecutable } : {})

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -144,8 +144,9 @@ function state(source: string | undefined, destination: string, seedFiles?: read
  * per-agent runtime HOME. Sources honor host env overrides; destinations always use
  * the runtime's conventional layout under the private HOME.
  */
-/** Config + browser-login credential files a Qoder edition writes under its
- * config dir. `brand` is the credential-file prefix (`qoder-cli`/`qoder-cli-cn`). */
+/** Config + legacy browser-login files a Qoder edition writes under its config
+ * dir. Current `.auth/` login state is shared separately by runtime-credentials;
+ * `brand` is the legacy credential-file prefix (`qoder-cli`/`qoder-cli-cn`). */
 const QODER_SEED = (brand: string): readonly string[] => [
   'settings.json',
   'config.json',

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -267,7 +267,7 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // together decrypt in the private HOME); sessions/workflows stay private.
   'qoder-cli': (env) => {
     const base = env.QODER_CLI_HOME || env.GEMINI_CLI_HOME
-    const name = env.QODER_CONFIG_DIR_NAME || '.qoder'
+    const name = (env.QODER_CONFIG_DIR_NAME || '.qoder').normalize('NFC')
     return [
       ...state(env.QODER_CONFIG_DIR, '.qoder', QODER_SEED('qoder-cli')),
       ...state(base ? join(base, name) : undefined, '.qoder', QODER_SEED('qoder-cli')),
@@ -279,7 +279,7 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // $QODERCN_CONFIG_DIR / $QODERCN_CLI_HOME (or the shared $GEMINI_CLI_HOME).
   'qoder-cli-cn': (env) => {
     const base = env.QODERCN_CLI_HOME || env.GEMINI_CLI_HOME
-    const name = env.QODERCN_CONFIG_DIR_NAME || '.qoder-cn'
+    const name = (env.QODERCN_CONFIG_DIR_NAME || '.qoder-cn').normalize('NFC')
     return [
       ...state(env.QODERCN_CONFIG_DIR, '.qoder-cn', QODER_SEED('qoder-cli-cn')),
       ...state(base ? join(base, name) : undefined, '.qoder-cn', QODER_SEED('qoder-cli-cn')),

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -267,10 +267,11 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // together decrypt in the private HOME); sessions/workflows stay private.
   'qoder-cli': (env) => {
     const base = env.QODER_CLI_HOME || env.GEMINI_CLI_HOME
+    const name = env.QODER_CONFIG_DIR_NAME || '.qoder'
     return [
       ...state(env.QODER_CONFIG_DIR, '.qoder', QODER_SEED('qoder-cli')),
-      ...state(base ? join(base, '.qoder') : undefined, '.qoder', QODER_SEED('qoder-cli')),
-      ...state(join(home(env), '.qoder'), '.qoder', QODER_SEED('qoder-cli'))
+      ...state(base ? join(base, name) : undefined, '.qoder', QODER_SEED('qoder-cli')),
+      ...state(join(home(env), name), '.qoder', QODER_SEED('qoder-cli'))
     ]
   },
 
@@ -278,10 +279,11 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // $QODERCN_CONFIG_DIR / $QODERCN_CLI_HOME (or the shared $GEMINI_CLI_HOME).
   'qoder-cli-cn': (env) => {
     const base = env.QODERCN_CLI_HOME || env.GEMINI_CLI_HOME
+    const name = env.QODERCN_CONFIG_DIR_NAME || '.qoder-cn'
     return [
       ...state(env.QODERCN_CONFIG_DIR, '.qoder-cn', QODER_SEED('qoder-cli-cn')),
-      ...state(base ? join(base, '.qoder-cn') : undefined, '.qoder-cn', QODER_SEED('qoder-cli-cn')),
-      ...state(join(home(env), '.qoder-cn'), '.qoder-cn', QODER_SEED('qoder-cli-cn'))
+      ...state(base ? join(base, name) : undefined, '.qoder-cn', QODER_SEED('qoder-cli-cn')),
+      ...state(join(home(env), name), '.qoder-cn', QODER_SEED('qoder-cli-cn'))
     ]
   },
 

--- a/packages/daemon/src/runtimes/runtime-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-credentials.ts
@@ -450,7 +450,9 @@ function qoderConfigDirectory(profile: 'qoder' | 'qoder-cn', env: NodeJS.Process
   const cn = profile === 'qoder-cn'
   const configured = cn ? env.QODERCN_CONFIG_DIR : env.QODER_CONFIG_DIR
   const base = (cn ? env.QODERCN_CLI_HOME : env.QODER_CLI_HOME) || env.GEMINI_CLI_HOME
-  const name = (cn ? env.QODERCN_CONFIG_DIR_NAME : env.QODER_CONFIG_DIR_NAME) || (cn ? '.qoder-cn' : '.qoder')
+  const name = (
+    (cn ? env.QODERCN_CONFIG_DIR_NAME : env.QODER_CONFIG_DIR_NAME) || (cn ? '.qoder-cn' : '.qoder')
+  ).normalize('NFC')
   return ensureOwnedDirectory(
     absoluteConfiguredPath(
       configured || (base ? join(base, name) : join(hostHome(env), name)),

--- a/packages/daemon/src/runtimes/runtime-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-credentials.ts
@@ -1,13 +1,17 @@
 import { randomUUID, timingSafeEqual } from 'node:crypto'
 import {
   chmodSync,
+  constants,
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   statSync,
   symlinkSync,
   unlinkSync,
@@ -17,7 +21,7 @@ import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import type { RuntimeDef } from '../config/config-schema.js'
 
-export type SharedCredentialProfile = 'claude' | 'codex'
+export type SharedCredentialProfile = 'claude' | 'codex' | 'qoder' | 'qoder-cn'
 
 export interface SharedRuntimeCredentialAccess {
   env: Record<string, string>
@@ -41,6 +45,12 @@ export function sharedCredentialProfile(runtimeId: string, runtime?: RuntimeDef)
   }
   if (runtimeId === 'codex-acp' || signature(runtime, /(?:^|[\\/])codex-acp(?:@[^\\/]*)?$/)) {
     return 'codex'
+  }
+  if (runtimeId === 'qoder-cli-cn' || signature(runtime, /(?:^|[\\/@])qoderclicn(?:@[^\\/]*)?$/)) {
+    return 'qoder-cn'
+  }
+  if (runtimeId === 'qoder-cli' || signature(runtime, /(?:^|[\\/@])qodercli(?:@[^\\/]*)?$/)) {
+    return 'qoder'
   }
   return undefined
 }
@@ -363,6 +373,126 @@ function prepareCodexCredentials(env: NodeJS.ProcessEnv): SharedRuntimeCredentia
   }
 }
 
+function moveCredentialFile(source: string, destination: string): void {
+  try {
+    renameSync(source, destination)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EXDEV') throw error
+    copyFileSync(source, destination, constants.COPYFILE_EXCL)
+    unlinkSync(source)
+  }
+  secureCredentialFile(destination)
+}
+
+function regularFileIfPresent(path: string, label: string): ReturnType<typeof lstatSync> | undefined {
+  const info = lstatIfPresent(path)
+  if (!info) return undefined
+  if (info.isSymbolicLink() || !info.isFile()) throw new Error(`${label} is not a regular file: ${path}`)
+  return info
+}
+
+/** Fold a pre-shared-login private Qoder auth directory into the host directory.
+ * The opaque `user` credential is never chosen silently: a divergent host/private
+ * login fails closed. A private login may become authoritative only when the host
+ * has no login yet; its paired machine id follows it. */
+function migratePrivateQoderAuth(privateAuth: string, sharedAuth: string, label: string): void {
+  const privateUser = join(privateAuth, 'user')
+  const sharedUser = join(sharedAuth, 'user')
+  const privateHasUser = regularFileIfPresent(privateUser, `${label} private user credential`) !== undefined
+  const sharedHasUser = regularFileIfPresent(sharedUser, `${label} host user credential`) !== undefined
+
+  if (privateHasUser && sharedHasUser && !sameFileContents(privateUser, sharedUser)) {
+    throw new Error(
+      `conflicting ${label} credentials at ${privateUser} and ${sharedUser}; run host ${label} /login after resolving the conflict`
+    )
+  }
+
+  const privateLoginWins = privateHasUser && !sharedHasUser
+  if (privateLoginWins) {
+    moveCredentialFile(privateUser, sharedUser)
+    const privateMachine = join(privateAuth, 'machine_id')
+    const sharedMachine = join(sharedAuth, 'machine_id')
+    if (regularFileIfPresent(privateMachine, `${label} private machine id`)) {
+      if (regularFileIfPresent(sharedMachine, `${label} host machine id`)) unlinkSync(sharedMachine)
+      moveCredentialFile(privateMachine, sharedMachine)
+    }
+  }
+
+  for (const entry of readdirSync(privateAuth, { withFileTypes: true })) {
+    if (!entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error(`${label} private auth contains an unsupported entry: ${join(privateAuth, entry.name)}`)
+    }
+    const source = join(privateAuth, entry.name)
+    const destination = join(sharedAuth, entry.name)
+    regularFileIfPresent(source, `${label} private auth file`)
+    const destinationInfo = regularFileIfPresent(destination, `${label} host auth file`)
+    if (!destinationInfo) {
+      moveCredentialFile(source, destination)
+    } else if (
+      sameFileContents(source, destination) ||
+      entry.name === 'machine_id' ||
+      entry.name === 'dynamic-error-codes.json' ||
+      entry.name === 'dynamic-texts.json'
+    ) {
+      // Host login state wins over a logged-out private machine id; the other
+      // two files are provider-owned caches, not credentials.
+      unlinkSync(source)
+    } else {
+      throw new Error(
+        `conflicting ${label} auth state at ${source} and ${destination}; run host ${label} /login after resolving the conflict`
+      )
+    }
+  }
+  rmdirSync(privateAuth)
+}
+
+function qoderConfigDirectory(profile: 'qoder' | 'qoder-cn', env: NodeJS.ProcessEnv): string {
+  const cn = profile === 'qoder-cn'
+  const configured = cn ? env.QODERCN_CONFIG_DIR : env.QODER_CONFIG_DIR
+  const base = (cn ? env.QODERCN_CLI_HOME : env.QODER_CLI_HOME) || env.GEMINI_CLI_HOME
+  const name = cn ? '.qoder-cn' : '.qoder'
+  return ensureOwnedDirectory(
+    absoluteConfiguredPath(
+      configured || (base ? join(base, name) : join(hostHome(env), name)),
+      env,
+      `${profile} config`
+    ),
+    `host ${profile} config directory`
+  )
+}
+
+function prepareQoderCredentials(profile: 'qoder' | 'qoder-cn', env: NodeJS.ProcessEnv): SharedRuntimeCredentialAccess {
+  const configName = profile === 'qoder-cn' ? '.qoder-cn' : '.qoder'
+  const sharedAuth = ensureOwnedDirectory(join(qoderConfigDirectory(profile, env), '.auth'), `host ${profile} auth`)
+  return {
+    env: {},
+    writablePaths: [sharedAuth],
+    seedExclusions: [join(configName, '.auth', 'user'), join(configName, '.auth', 'machine_id')],
+    preparePrivateHome: (runtimeHome) => {
+      const privateConfig = ensureOwnedDirectory(join(runtimeHome, configName), `private ${profile} config directory`)
+      const privateAuth = join(privateConfig, '.auth')
+      const privateInfo = lstatIfPresent(privateAuth)
+      if (privateInfo?.isSymbolicLink()) {
+        let linked: string
+        try {
+          linked = realpathSync(privateAuth)
+        } catch {
+          throw new Error(`private ${profile} auth link is dangling: ${privateAuth}`)
+        }
+        if (linked !== sharedAuth)
+          throw new Error(`private ${profile} auth link points outside host credentials: ${privateAuth}`)
+        return
+      }
+      if (privateInfo) {
+        if (!privateInfo.isDirectory())
+          throw new Error(`private ${profile} auth path is not a directory: ${privateAuth}`)
+        migratePrivateQoderAuth(privateAuth, sharedAuth, profile)
+      }
+      symlinkSync(sharedAuth, privateAuth)
+    }
+  }
+}
+
 export function prepareSharedRuntimeCredentials(opts: {
   runtimeId: string
   runtime?: RuntimeDef
@@ -373,5 +503,7 @@ export function prepareSharedRuntimeCredentials(opts: {
   const profile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   if (!profile) return undefined
   const env = opts.hostEnv ?? process.env
-  return profile === 'claude' ? prepareClaudeCredentials(env) : prepareCodexCredentials(env)
+  if (profile === 'claude') return prepareClaudeCredentials(env)
+  if (profile === 'codex') return prepareCodexCredentials(env)
+  return prepareQoderCredentials(profile, env)
 }

--- a/packages/daemon/src/runtimes/runtime-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-credentials.ts
@@ -450,7 +450,7 @@ function qoderConfigDirectory(profile: 'qoder' | 'qoder-cn', env: NodeJS.Process
   const cn = profile === 'qoder-cn'
   const configured = cn ? env.QODERCN_CONFIG_DIR : env.QODER_CONFIG_DIR
   const base = (cn ? env.QODERCN_CLI_HOME : env.QODER_CLI_HOME) || env.GEMINI_CLI_HOME
-  const name = cn ? '.qoder-cn' : '.qoder'
+  const name = (cn ? env.QODERCN_CONFIG_DIR_NAME : env.QODER_CONFIG_DIR_NAME) || (cn ? '.qoder-cn' : '.qoder')
   return ensureOwnedDirectory(
     absoluteConfiguredPath(
       configured || (base ? join(base, name) : join(hostHome(env), name)),

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -228,6 +228,11 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
     ZEROCLAW_CONFIG_DIR: join(home, '.zeroclaw'),
     ZEROCLAW_DATA_DIR: join(home, '.zeroclaw', 'data')
   }),
+  // Pin global state even when CONFIG_DIR_NAME is customized. That variable may
+  // still select the project-local directory, but auth always resolves through
+  // the reviewed private-HOME link prepared by runtime-credentials.
+  'qoder-cli': (home) => ({ QODER_CONFIG_DIR: join(home, '.qoder') }),
+  'qoder-cli-cn': (home) => ({ QODERCN_CONFIG_DIR: join(home, '.qoder-cn') }),
   omp: (home) => ({ PI_CODING_AGENT_DIR: join(home, '.omp', 'agent') }),
   'pi-acp': (home) => ({ PI_CODING_AGENT_DIR: join(home, '.pi', 'agent') }),
   cline: (home) => ({

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -198,8 +198,8 @@ describe('isRuntimeAvailable / custom probes', () => {
     expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: cleanHome, GEMINI_CLI_HOME: cliHome }))).toBe(true)
 
     const namedHome = mkdtempSync(join(tmpdir(), 'ac-qoder-named-home-'))
-    mkdirSync(join(namedHome, 'custom-qoder'))
-    expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: namedHome, QODER_CONFIG_DIR_NAME: 'custom-qoder' }))).toBe(
+    mkdirSync(join(namedHome, '\u00e9-qoder'))
+    expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: namedHome, QODER_CONFIG_DIR_NAME: 'e\u0301-qoder' }))).toBe(
       true
     )
   })

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -196,6 +196,12 @@ describe('isRuntimeAvailable / custom probes', () => {
     mkdirSync(join(cliHome, '.qoder'))
     expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: cleanHome, QODER_CLI_HOME: cliHome }))).toBe(true)
     expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: cleanHome, GEMINI_CLI_HOME: cliHome }))).toBe(true)
+
+    const namedHome = mkdtempSync(join(tmpdir(), 'ac-qoder-named-home-'))
+    mkdirSync(join(namedHome, 'custom-qoder'))
+    expect(isRuntimeAvailable('qoder-cli', rt, env({ HOME: namedHome, QODER_CONFIG_DIR_NAME: 'custom-qoder' }))).toBe(
+      true
+    )
   })
 
   it('qoder-cli-cn needs ~/.qoder-cn even when qoderclicn is on PATH', () => {
@@ -206,13 +212,18 @@ describe('isRuntimeAvailable / custom probes', () => {
     expect(isRuntimeAvailable('qoder-cli-cn', rt, env())).toBe(true)
   })
 
-  it('qoder-cli-cn honors $QODERCN_CONFIG_DIR override', () => {
+  it('qoder-cli-cn honors its config directory overrides', () => {
     makeExecutable(binDir, 'qoderclicn')
     const rt: RuntimeDef = { command: 'qoderclicn', args: ['--acp'], env: [] }
     const cleanHome = mkdtempSync(join(tmpdir(), 'ac-qodercn-home-'))
     const configDir = mkdtempSync(join(tmpdir(), 'ac-qodercn-cfg-'))
     expect(isRuntimeAvailable('qoder-cli-cn', rt, env({ HOME: cleanHome }))).toBe(false)
     expect(isRuntimeAvailable('qoder-cli-cn', rt, env({ HOME: cleanHome, QODERCN_CONFIG_DIR: configDir }))).toBe(true)
+
+    mkdirSync(join(cleanHome, 'custom-qoder-cn'))
+    expect(
+      isRuntimeAvailable('qoder-cli-cn', rt, env({ HOME: cleanHome, QODERCN_CONFIG_DIR_NAME: 'custom-qoder-cn' }))
+    ).toBe(true)
   })
 
   it('cursor needs the CLI-specific cli-config.json (dir alone is not enough)', () => {

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -155,7 +155,8 @@ describe('Linux shared runtime login', () => {
       runtimeId: 'qoder-cli',
       command: 'qodercli',
       configName: '.qoder',
-      hostConfigName: 'custom-qoder',
+      hostConfigName: '\u00e9-qoder',
+      hostConfigNameValue: 'e\u0301-qoder',
       hostConfigNameEnv: 'QODER_CONFIG_DIR_NAME',
       privateConfigEnv: 'QODER_CONFIG_DIR'
     },
@@ -164,12 +165,13 @@ describe('Linux shared runtime login', () => {
       command: 'qoderclicn',
       configName: '.qoder-cn',
       hostConfigName: 'custom-qoder-cn',
+      hostConfigNameValue: 'custom-qoder-cn',
       hostConfigNameEnv: 'QODERCN_CONFIG_DIR_NAME',
       privateConfigEnv: 'QODERCN_CONFIG_DIR'
     }
   ])(
     'shares refreshable $runtimeId auth while keeping the rest of HOME private',
-    ({ runtimeId, command, configName, hostConfigName, hostConfigNameEnv, privateConfigEnv }) => {
+    ({ runtimeId, command, configName, hostConfigName, hostConfigNameValue, hostConfigNameEnv, privateConfigEnv }) => {
       const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
       const hostConfig = join(hostHome, hostConfigName)
       const sharedAuth = join(hostConfig, '.auth')
@@ -188,7 +190,7 @@ describe('Linux shared runtime login', () => {
         runInSandbox: true,
         sandboxMechanism: 'bwrap',
         credentialPlatform: 'linux',
-        hostEnv: { HOME: hostHome, PATH: '/usr/bin', [hostConfigNameEnv]: hostConfigName }
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin', [hostConfigNameEnv]: hostConfigNameValue }
       })
 
       const privateAuth = join(scopeDir, 'home', configName, '.auth')

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -149,4 +149,92 @@ describe('Linux shared runtime login', () => {
     ).toThrow(/conflicting Codex credentials/)
     expect(lstatSync(join(privateCodex, 'auth.json')).isSymbolicLink()).toBe(false)
   })
+
+  it.each([
+    { runtimeId: 'qoder-cli', command: 'qodercli', configName: '.qoder' },
+    { runtimeId: 'qoder-cli-cn', command: 'qoderclicn', configName: '.qoder-cn' }
+  ])(
+    'shares refreshable $runtimeId auth while keeping the rest of HOME private',
+    ({ runtimeId, command, configName }) => {
+      const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+      const hostConfig = join(hostHome, configName)
+      const sharedAuth = join(hostConfig, '.auth')
+      mkdirSync(sharedAuth, { recursive: true })
+      writeFileSync(join(hostConfig, 'settings.json'), '{"theme":"dark"}')
+      writeFileSync(join(sharedAuth, 'machine_id'), 'host-machine')
+      writeFileSync(join(sharedAuth, 'user'), 'host-login')
+
+      const launch = prepareRuntimeLaunch({
+        runtimeId,
+        runtime: { command, args: ['--acp'], env: [] },
+        scopeDir,
+        cwd,
+        daemonRoot,
+        agentsRoot: join(daemonRoot, 'agents'),
+        runInSandbox: true,
+        sandboxMechanism: 'bwrap',
+        credentialPlatform: 'linux',
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+      })
+
+      const privateAuth = join(scopeDir, 'home', configName, '.auth')
+      expect(lstatSync(privateAuth).isSymbolicLink()).toBe(true)
+      expect(realpathSync(privateAuth)).toBe(realpathSync(sharedAuth))
+      expect(readFileSync(join(scopeDir, 'home', configName, 'settings.json'), 'utf8')).toContain('dark')
+      expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(realpathSync(sharedAuth))
+
+      writeFileSync(join(privateAuth, 'user'), 'refreshed-login')
+      expect(readFileSync(join(sharedAuth, 'user'), 'utf8')).toBe('refreshed-login')
+    }
+  )
+
+  it('migrates an existing private Qoder login when the host has none', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const privateAuth = join(scopeDir, 'home', '.qoder', '.auth')
+    mkdirSync(privateAuth, { recursive: true })
+    writeFileSync(join(privateAuth, 'machine_id'), 'private-machine')
+    writeFileSync(join(privateAuth, 'user'), 'private-login')
+
+    prepareRuntimeLaunch({
+      runtimeId: 'qoder-cli',
+      runtime: { command: 'qodercli', args: ['--acp'], env: [] },
+      scopeDir,
+      cwd,
+      daemonRoot,
+      runInSandbox: true,
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const sharedAuth = join(hostHome, '.qoder', '.auth')
+    expect(lstatSync(privateAuth).isSymbolicLink()).toBe(true)
+    expect(readFileSync(join(sharedAuth, 'user'), 'utf8')).toBe('private-login')
+    expect(readFileSync(join(sharedAuth, 'machine_id'), 'utf8')).toBe('private-machine')
+  })
+
+  it('refuses to replace a divergent host Qoder login with private credentials', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const sharedAuth = join(hostHome, '.qoder', '.auth')
+    const privateAuth = join(scopeDir, 'home', '.qoder', '.auth')
+    mkdirSync(sharedAuth, { recursive: true })
+    mkdirSync(privateAuth, { recursive: true })
+    writeFileSync(join(sharedAuth, 'user'), 'host-login')
+    writeFileSync(join(privateAuth, 'user'), 'private-login')
+
+    expect(() =>
+      prepareRuntimeLaunch({
+        runtimeId: 'qoder-cli',
+        runtime: { command: 'qodercli', args: ['--acp'], env: [] },
+        scopeDir,
+        cwd,
+        daemonRoot,
+        runInSandbox: true,
+        sandboxMechanism: 'bwrap',
+        credentialPlatform: 'linux',
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+      })
+    ).toThrow(/conflicting qoder credentials/)
+    expect(lstatSync(privateAuth).isDirectory()).toBe(true)
+  })
 })

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -151,13 +151,27 @@ describe('Linux shared runtime login', () => {
   })
 
   it.each([
-    { runtimeId: 'qoder-cli', command: 'qodercli', configName: '.qoder' },
-    { runtimeId: 'qoder-cli-cn', command: 'qoderclicn', configName: '.qoder-cn' }
+    {
+      runtimeId: 'qoder-cli',
+      command: 'qodercli',
+      configName: '.qoder',
+      hostConfigName: 'custom-qoder',
+      hostConfigNameEnv: 'QODER_CONFIG_DIR_NAME',
+      privateConfigEnv: 'QODER_CONFIG_DIR'
+    },
+    {
+      runtimeId: 'qoder-cli-cn',
+      command: 'qoderclicn',
+      configName: '.qoder-cn',
+      hostConfigName: 'custom-qoder-cn',
+      hostConfigNameEnv: 'QODERCN_CONFIG_DIR_NAME',
+      privateConfigEnv: 'QODERCN_CONFIG_DIR'
+    }
   ])(
     'shares refreshable $runtimeId auth while keeping the rest of HOME private',
-    ({ runtimeId, command, configName }) => {
+    ({ runtimeId, command, configName, hostConfigName, hostConfigNameEnv, privateConfigEnv }) => {
       const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
-      const hostConfig = join(hostHome, configName)
+      const hostConfig = join(hostHome, hostConfigName)
       const sharedAuth = join(hostConfig, '.auth')
       mkdirSync(sharedAuth, { recursive: true })
       writeFileSync(join(hostConfig, 'settings.json'), '{"theme":"dark"}')
@@ -174,10 +188,11 @@ describe('Linux shared runtime login', () => {
         runInSandbox: true,
         sandboxMechanism: 'bwrap',
         credentialPlatform: 'linux',
-        hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin', [hostConfigNameEnv]: hostConfigName }
       })
 
       const privateAuth = join(scopeDir, 'home', configName, '.auth')
+      expect(launch.env[privateConfigEnv]).toBe(join(scopeDir, 'home', configName))
       expect(lstatSync(privateAuth).isSymbolicLink()).toBe(true)
       expect(realpathSync(privateAuth)).toBe(realpathSync(sharedAuth))
       expect(readFileSync(join(scopeDir, 'home', configName, 'settings.json'), 'utf8')).toContain('dark')

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -88,7 +88,7 @@ describe('private runtime HOME', () => {
       }
     )
     expect(env.HOME).toBe(home)
-    expect(env.QODER_CONFIG_DIR).toBeUndefined()
+    expect(env.QODER_CONFIG_DIR).toBe(join(home, '.qoder'))
     expect(env.QODER_CLI_HOME).toBeUndefined()
     expect(env.GEMINI_CLI_HOME).toBeUndefined()
   })

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -15,7 +16,7 @@ import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'no
 import { fileURLToPath } from 'node:url'
 import { parse as parseYaml } from 'yaml'
 import { prepareRuntimeLaunch } from '../src/acp/runtime-launch.js'
-import { composeRuntimeLaunch } from '../src/runtimes/launch-policy.js'
+import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/runtimes/launch-policy.js'
 import { runtimeMemoryCapabilities } from '../src/agents/runtime-memory.js'
 import { MemoryProviderUnavailableError } from '../src/agents/memory-provider.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
@@ -207,6 +208,31 @@ describe('prepareRuntimeLaunch', () => {
 const runtime = (command: string, args: string[] = ['acp']): RuntimeDef => ({ command, args, env: [] })
 
 describe('composeRuntimeLaunch', () => {
+  it('keeps a Claude launcher symlink under the host HOME readable', () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'ac-claude-launch-roots-'))
+    const hostHome = join(testRoot, 'home')
+    const bin = join(hostHome, '.local', 'bin')
+    const versions = join(hostHome, '.local', 'share', 'claude', 'versions')
+    const executable = join(versions, '2.1.220')
+    mkdirSync(bin, { recursive: true })
+    mkdirSync(versions, { recursive: true })
+    writeFileSync(executable, '#!/bin/sh\n')
+    chmodSync(executable, 0o755)
+    symlinkSync(executable, join(bin, 'claude'))
+
+    try {
+      const sandboxAccess = runtimeSandboxReadRoots(runtime(process.execPath, ['claude-acp']), {
+        HOME: hostHome,
+        PATH: `${bin}${delimiter}${dirname(process.execPath)}`
+      })
+
+      expect(sandboxAccess.claudeExecutable).toBe(realpathSync(executable))
+      expect(coveredBy(sandboxAccess.readRoots, join(bin, 'claude'))).toBe(true)
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true })
+    }
+  })
+
   it('declares the reviewed memory capability matrix including managed-only Maki', () => {
     expect(runtimeMemoryCapabilities(runtime('hermes'), 'hermes-agent')).toEqual({
       managed: true,


### PR DESCRIPTION
## Summary

- preserve the lexical Claude launcher directory when deriving trusted runtime read roots
- share only Qoder/Qoder CN's current `.auth` directory with sandboxed private HOMEs, so host `/login` and in-agent token refresh use the same credential state
- migrate an existing private Qoder login only when the host has none, and fail closed instead of silently choosing divergent credentials
- honor and NFC-normalize host `*_CONFIG_DIR_NAME` layouts while pinning each sandbox child to the reviewed private config root

## Root causes

The Claude sandbox model probe discovered `claude` through a host-HOME symlink, but `runtimeSandboxReadRoots` resolved it before passing it to the shared trusted-executable helper. SRT therefore hid the lexical launcher used by `CLAUDE_CODE_EXECUTABLE`, so `session/new` failed and the daemon reported zero models even though regular sessions could launch the resolved executable.

Qoder 1.1 stores its encrypted login in `.auth/user` and derives the key from `.auth/machine_id`. The existing private-HOME seeder covered only older browser-login files, so a host login was invisible to sandboxed agents and refreshes could not flow back to the host. The new mapping locates the host auth directory using Qoder's config overrides, then exposes that narrow auth directory as the only host-HOME write carve-back. The child receives an exact private config path, so custom directory-name settings cannot bypass the link; settings, caches, projects, sessions, and every other agent HOME remain private.

ACP capability probes continue through the same sandbox launch path as real sessions. This keeps both the security boundary and reported runtime capability aligned with actual agent execution.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/runtime-credentials.test.ts test/runtime-home.test.ts test/runtime-launch.test.ts test/read-roots.test.ts test/probe.test.ts test/runtime-prober.test.ts` (99 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint and Prettier checks for the changed daemon files
- pre-push full-repository lint
- exact Linux SRT daemon-probe reproduction restored Claude ACP 0.64.0 from `0 models` to all 5 advertised models
- verified the Qoder 1.1.10 package's `.auth/user` + `.auth/machine_id` storage contract and both international/CN host layouts on agent-2

Created by Codex . GPT-5
