### PR TITLE
fix(collab): isolate agents by default

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -403,10 +403,16 @@ snapshot that has not caught up.
 
 The data model stores:
 
-- `callPolicy: 'all' | 'selected'`, defaulting to `all`, allows any peer in the same org.
+- `Org.defaultAgentVisibility: 'all' | 'selected'`, defaulting to `selected`, seeds both
+  directions for newly created agents and never rewrites existing ones.
+- `callPolicy: 'all' | 'selected'`; when `selected`, accepts no peer until allowed.
 - `allowedCallerAgentIds: string[]` is the set of agent IDs allowed when `callPolicy='selected'`.
-- `outboundPolicy: 'all' | 'selected'` and `allowedTargetAgentIds` constrain
-  which peers the caller may select.
+- `outboundPolicy: 'all' | 'selected'`; its
+  `allowedTargetAgentIds` constrain which peers the caller may select.
+
+An agent create may override either direction explicitly. The Agent columns retain
+`selected` database defaults as a fail-closed fallback for writes that bypass the
+repository creation seam.
 
 `AgentSpec` carries local target policy, while the versioned collaboration
 snapshot supplies caller/target organization, placement, and policy data for

--- a/docs/designs/directional-agent-visibility.md
+++ b/docs/designs/directional-agent-visibility.md
@@ -55,10 +55,18 @@ This is an intersection, not an override. Selecting B on A never grants A access
 B's inbound restriction, and selecting A on B never expands A's outbound scope. Self-call
 and hop-limit guards remain independent and unchanged.
 
-Both directions default to `all`, preserving the pre-migration graph. Under `all`, the
-associated id array is stored empty; under `selected`, an empty array means no peers.
+Each organization has a `defaultAgentVisibility` policy that seeds both directions of a
+new agent. It defaults to `selected`, so a new agent neither discovers peers nor accepts
+peer calls until configured; an owner may instead choose `all` for future agents. A create
+request can explicitly override either direction. Changing the organization setting never
+rewrites existing agents. Under `all`, the associated id array is stored empty; under
+`selected`, an empty array means no peers. The Agent table keeps `selected` as its database
+default so writes outside the repository creation seam remain fail-closed.
 
 ## Control plane and console
+
+Organization owners edit the creation default in organization settings. The Add Agent
+form initializes both directional controls from it while retaining per-direction overrides.
 
 The existing `PUT /agents/:id/call-policy` endpoint updates both directions atomically.
 The outbound fields are optional on input so an older client updating only the inbound
@@ -129,22 +137,24 @@ closed. A new direct wake of A still requires B → A authorization.
 
 ## Compatibility and failure behavior
 
-On a fresh agent, the new policy defaults to `all`. When a newer daemon decodes an older
-control-plane payload, both outbound fields remain absent so the daemon preserves the
-complete on-disk outbound half instead of retaining `selected` while clearing its list.
-Once a `selected` outbound policy is received, enforcement is fail-closed: missing targets
-are denied. Local and cross-daemon delivery both fail closed when the collaboration
-snapshot does not contain **both** the caller and the target in one organization.
+On a fresh agent, both policies default to `selected` with empty lists. A missing policy in
+local configuration or a collaboration snapshot also defaults to `selected`, so incomplete
+state cannot create an edge. When a newer daemon decodes an older control-plane agent
+payload, both outbound fields remain absent so the daemon preserves the complete on-disk
+outbound half instead of retaining `selected` while clearing its list. Local and
+cross-daemon delivery both fail closed when the collaboration snapshot does not contain
+**both** the caller and the target in one organization.
 Consequently, a local-only daemon that has never received a control-plane collaboration
 snapshot cannot authorize same-daemon direct agent calls.
 
 Rolling upgrade: the flat org directory arrives only from a control plane that advertises
 `agent-directory-org-scope-v1`. Against an older control plane, relay and daemon derive the
-directory from the channel-keyed rows they do receive, so integration-backed pairs keep
-resolving; an integration-less agent stays invisible until the flat list arrives, which is
-exactly the pre-change behavior. A daemon likewise keeps sending the caller's current
-channel with a discovery request until the feature appears.
+directory from the channel-keyed rows they do receive. A missing directional policy in
+those rows defaults to `selected` with an empty list, so it cannot create an implicit edge;
+an integration-less agent also stays invisible until the flat list arrives. A daemon
+likewise keeps sending the caller's current channel with a discovery request until the
+feature appears.
 
 A data-plane consumer from before this design ignores the new fields and therefore keeps
-the historical unrestricted outbound behavior. A selected outbound restriction is fully
-effective only on daemon and relay versions that understand the directional policy.
+the historical unrestricted outbound behavior. The private default is fully effective only
+on daemon and relay versions that understand the directional policy.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -247,8 +247,13 @@ name it (a self-_wake_ is still refused separately).
 The agent-directory tool must hide peers that fail any part of this check. Message
 delivery must repeat the same authorization instead of trusting discovery: a remembered,
 guessed, or stale agent id must not bypass either policy. Rejection does not wake the
-target and uses the same `not_allowed` result as an inbound-policy denial. Both directions
-default to all peers so existing agents retain their current collaboration behavior.
+target and uses the same `not_allowed` result as an inbound-policy denial. An organization
+defaults new agents to `selected` with an empty list in both directions: they discover no
+peers and accept no peer calls. An owner may explicitly set the organization's creation
+default to `all`, and an individual create may still override either direction. Changing
+the organization default affects only future agents and never rewrites an existing agent's
+persisted policy. A local or otherwise unconfigured agent remains fail-closed at
+`selected + []`.
 
 **Two unrelated settings are both called "visibility".** The `callPolicy` /
 `outboundPolicy` pair above is what the console labels "Agent visibility", and it is the

--- a/packages/control-plane/prisma/migrations/20260801090000_private_agent_collaboration_defaults/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801090000_private_agent_collaboration_defaults/migration.sql
@@ -1,0 +1,5 @@
+-- New agents start with no inbound or outbound peer grants. Existing agents
+-- retain their explicitly persisted policies; this changes column defaults only.
+ALTER TABLE "public"."agent"
+  ALTER COLUMN "callPolicy" SET DEFAULT 'selected',
+  ALTER COLUMN "outboundPolicy" SET DEFAULT 'selected';

--- a/packages/control-plane/prisma/migrations/20260801120000_org_default_agent_visibility/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801120000_org_default_agent_visibility/migration.sql
@@ -1,0 +1,4 @@
+-- Organization-level default for both directional policies on newly created agents.
+-- Existing agent rows are intentionally untouched.
+ALTER TABLE "org"
+  ADD COLUMN "defaultAgentVisibility" "AgentCallPolicy" NOT NULL DEFAULT 'selected';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -31,17 +31,20 @@ datasource db {
 // ───────────────────────────────────────────────────────────────────────────
 
 model Org {
-  id        String   @id @default(cuid())
+  id                     String          @id @default(cuid())
   // Optional display name; when absent the console falls back to `slug`.
-  name      String?
-  slug      String   @unique
+  name                   String?
+  slug                   String          @unique
   // Console avatar descriptor (protocol AgentIcon): {kind:'runtime'} | {kind:'glyph',glyph,color}
   // | {kind:'image'}. Null ⇒ generated default (glyph plate keyed off the org id). An `image`
   // icon's bytes live in the object store (docs/designs/icon-uploads.md), served by GET
   // /v1/orgs/:id/icon. Org icons are console-only — never fed to Slack.
-  icon      Json?    @db.JsonB
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime @updatedAt @db.Timestamptz(6)
+  icon                   Json?           @db.JsonB
+  // Applied to both call directions when a new agent does not explicitly choose
+  // a policy. Existing agents keep their persisted directional policies.
+  defaultAgentVisibility AgentCallPolicy @default(selected)
+  createdAt              DateTime        @default(now()) @db.Timestamptz(6)
+  updatedAt              DateTime        @updatedAt @db.Timestamptz(6)
 
   members                   Membership[]
   daemons                   Daemon[]
@@ -626,10 +629,10 @@ model Agent {
   visibility            ResourceVisibility @default(org) // 'org' = all members; 'restricted' = ownership arm + sharedWith
   sharedWith            String[]           @default([]) // app_user.id set granted view when visibility='restricted'
   // ── inbound agent-call policy (UI: Agent visibility) ──
-  callPolicy            AgentCallPolicy    @default(all) // 'all' = any org peer agent may call this as a sub-agent
+  callPolicy            AgentCallPolicy    @default(selected) // selected + [] = no org peer may call by default
   allowedCallerAgentIds String[]           @default([]) // agent.id set used when callPolicy='selected'
   // ── outbound agent-call policy (UI: Agent visibility) ──
-  outboundPolicy        AgentCallPolicy    @default(all) // 'all' = this agent may discover/call any otherwise-callable org peer
+  outboundPolicy        AgentCallPolicy    @default(selected) // selected + [] = no peer discovery/calls by default
   allowedTargetAgentIds String[]           @default([]) // agent.id set used when outboundPolicy='selected'
   introduceOnJoin       Boolean            @default(false) // #536: self-introduce to peers on a genuine channel join
   restrictFileAccess    Boolean            @default(false) // #642: request an OS sandbox; daemon policy may force it on

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -485,12 +485,12 @@ export const CreateAgentBody = z.object({
   // in one call instead of create-then-share.
   visibility: ResourceVisibilityEnum.optional(),
   sharedWith: z.array(z.string()).optional(),
-  // Initial agent-call policy (absent ⇒ 'all'); `allowedCallerAgentIds` is
+  // Initial agent-call policy (absent ⇒ the organization's default); `allowedCallerAgentIds` is
   // intersected with visible same-org peers in the route (same rule as the
   // dedicated call-policy PUT). Lets a create restrict callers in one request.
   callPolicy: AgentCallPolicyEnum.optional(),
   allowedCallerAgentIds: z.array(z.string().uuid()).optional(),
-  // Outbound half of the same policy (absent ⇒ 'all'), intersected the same way.
+  // Outbound half of the same policy (absent ⇒ the organization's default), intersected the same way.
   outboundPolicy: AgentCallPolicyEnum.optional(),
   allowedTargetAgentIds: z.array(z.string().uuid()).optional()
 })
@@ -1857,6 +1857,8 @@ export const OrgDto = z.object({
   slug: z.string(),
   /** Console avatar descriptor; null ⇒ generated default (rendered by the org icon endpoint). */
   icon: AgentIconDto.nullable(),
+  /** Applied to both directional policies when a new agent does not explicitly choose one. */
+  defaultAgentVisibility: AgentCallPolicyEnum,
   /** Resolved URL for an uploaded `image` org icon (object-store public URL); null for
    *  glyph/default (the console renders those locally) or when no store is configured. */
   iconUrl: z.string().nullable(),
@@ -1879,7 +1881,7 @@ export const CreateOrgBody = z.object({
   slug: OrgSlug
 })
 
-/** `PATCH /orgs/:id` — rename / re-slug (owner-only). At least one field.
+/** `PATCH /orgs/:id` — update organization settings (owner-only). At least one field.
  *  A blank `name` clears the display name (back to the slug fallback). */
 export const UpdateOrgBody = z
   .object({
@@ -1887,11 +1889,17 @@ export const UpdateOrgBody = z
     slug: OrgSlug.optional(),
     // Glyph/runtime icon via JSON (the picker's non-upload path); an uploaded `image`
     // icon goes through PUT /orgs/:id/icon, so it is not accepted here. null ⇒ default.
-    icon: AgentIconBody.nullable().optional()
+    icon: AgentIconBody.nullable().optional(),
+    // Seeds both inbound and outbound policies for future agents only.
+    defaultAgentVisibility: AgentCallPolicyEnum.optional()
   })
-  .refine((b) => b.name !== undefined || b.slug !== undefined || b.icon !== undefined, {
-    message: 'nothing to update'
-  })
+  .refine(
+    (b) =>
+      b.name !== undefined || b.slug !== undefined || b.icon !== undefined || b.defaultAgentVisibility !== undefined,
+    {
+      message: 'nothing to update'
+    }
+  )
 
 // ── crons ────────────────────────────────────────────────────────────────
 export const Platform = z.enum(['slack', 'telegram', 'discord', 'feishu'])

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1005,12 +1005,15 @@ export function agentRoutes(deps: HttpDeps) {
           // with visible same-org peers (same rule as PUT /call-policy). The new
           // agent isn't a peer yet, so `agentId` self-exclusion is a harmless no-op.
           const agentId = AgentId(randomUUID())
+          const defaultAgentVisibility = (await deps.repos.org.defaultAgentVisibility(orgOf(req))) ?? 'selected'
+          const callPolicy = req.body.callPolicy ?? defaultAgentVisibility
+          const outboundPolicy = req.body.outboundPolicy ?? defaultAgentVisibility
           const initialAllowedCallers =
-            req.body.callPolicy === 'selected'
+            callPolicy === 'selected'
               ? await resolvePolicyAgentIds(req, agentId, req.body.allowedCallerAgentIds ?? [], [])
               : undefined
           const initialAllowedTargets =
-            req.body.outboundPolicy === 'selected'
+            outboundPolicy === 'selected'
               ? await resolvePolicyAgentIds(req, agentId, req.body.allowedTargetAgentIds ?? [], [])
               : undefined
           // One transaction for the agent row + its initial secret rows (sealing
@@ -1060,10 +1063,10 @@ export function agentRoutes(deps: HttpDeps) {
                     ...(req.principal ? { createdByUserId: req.principal.userId } : {}),
                     ...(req.body.visibility ? { visibility: req.body.visibility } : {}),
                     ...(initialSharedWith ? { sharedWith: initialSharedWith } : {}),
-                    ...(req.body.callPolicy ? { callPolicy: req.body.callPolicy } : {}),
-                    ...(initialAllowedCallers ? { allowedCallerAgentIds: initialAllowedCallers } : {}),
-                    ...(req.body.outboundPolicy ? { outboundPolicy: req.body.outboundPolicy } : {}),
-                    ...(initialAllowedTargets ? { allowedTargetAgentIds: initialAllowedTargets } : {}),
+                    callPolicy,
+                    allowedCallerAgentIds: initialAllowedCallers ?? [],
+                    outboundPolicy,
+                    allowedTargetAgentIds: initialAllowedTargets ?? [],
                     capabilities: req.body.capabilities
                   },
                   // Initial write-only secrets — same transaction, so the first

--- a/packages/control-plane/src/http/routes/orgs.ts
+++ b/packages/control-plane/src/http/routes/orgs.ts
@@ -9,7 +9,7 @@
  *
  * Org surface (mounted under `/orgs/:orgId` behind the org-scope guard):
  *   GET    / → the org itself, from the caller's perspective
- *   PATCH  / → rename / re-slug (owner-only)
+ *   PATCH  / → update identity / new-agent visibility default (owner-only)
  *   DELETE / → delete the org (owner-only; refused while it still has
  *              daemons — physical machines are detached explicitly first;
  *              everything else cascades)
@@ -38,6 +38,7 @@ function toDto(o: OrgRecord, deps: HttpDeps): OrgDtoT {
     name: o.name,
     slug: o.slug,
     icon: o.icon,
+    defaultAgentVisibility: o.defaultAgentVisibility,
     // Only `image` org icons resolve to a URL (object-store public URL); glyph/default
     // render locally in the console. Cache-busted by the org's updatedAt.
     iconUrl: o.icon?.kind === 'image' ? resolveOrgIconUrl(o.id, o.icon, bases, o.updatedAt.getTime()) : null,
@@ -140,7 +141,7 @@ export function orgScopedRoutes(deps: HttpDeps) {
         schema: {
           tags: [Tag.Organizations],
           summary: 'Get the organization',
-          description: 'The organization from the caller’s perspective (id, name, slug, their role, member count).',
+          description: 'The organization from the caller’s perspective, including its new-agent visibility default.',
           operationId: 'getOrganization',
           response: { 200: OrgDto, 404: ErrorDto }
         }
@@ -160,7 +161,8 @@ export function orgScopedRoutes(deps: HttpDeps) {
         schema: {
           tags: [Tag.Organizations],
           summary: 'Update the organization',
-          description: 'Rename or re-slug the organization (owner only). A slug collision returns 409.',
+          description:
+            'Update organization identity or the default visibility policy for newly created agents (owner only). A slug collision returns 409.',
           operationId: 'updateOrganization',
           body: UpdateOrgBody,
           response: { 200: OrgDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -543,11 +543,11 @@ export interface CreateAgentInput {
   visibility?: ResourceVisibility
   /** Initial share set (app_user.id); only meaningful with visibility='restricted'. */
   sharedWith?: string[]
-  /** Initial agent-call policy (absent ⇒ DB default 'all', any org peer may call it). */
+  /** Initial agent-call policy (absent ⇒ the organization's default). */
   callPolicy?: AgentCallPolicy
   /** Initial caller allow-list (agent.id set); only meaningful with callPolicy='selected'. */
   allowedCallerAgentIds?: string[]
-  /** Initial outbound policy (absent ⇒ DB default 'all', it may call any org peer). */
+  /** Initial outbound policy (absent ⇒ the organization's default). */
   outboundPolicy?: AgentCallPolicy
   /** Initial target allow-list (agent.id set); only meaningful with outboundPolicy='selected'. */
   allowedTargetAgentIds?: string[]
@@ -3203,6 +3203,8 @@ export interface OrgRecord {
   slug: string
   /** Console avatar descriptor (protocol AgentIcon); null ⇒ generated default. */
   icon: AgentIcon | null
+  /** Default applied to both directional policies of newly created agents. */
+  defaultAgentVisibility: AgentCallPolicy
   /** The asking user's role in it. */
   role: OrgMemberRole
   memberCount: number
@@ -3328,10 +3330,15 @@ export interface OrgRepo {
   listForUser(userId: string): Promise<OrgRecord[]>
   /** Create an org with `ownerUserId` as its first owner (one transaction). */
   create(input: { name: string | null; slug: string; ownerUserId: string }): Promise<OrgRecord>
-  /** Rename / re-slug / re-icon an org. Throws P2025 when absent, P2002 on a slug collision. */
+  /** Update org settings. Throws P2025 when absent, P2002 on a slug collision. */
   update(
     orgId: string,
-    patch: { name?: string | null; slug?: string; icon?: AgentIcon | null }
+    patch: {
+      name?: string | null
+      slug?: string
+      icon?: AgentIcon | null
+      defaultAgentVisibility?: AgentCallPolicy
+    }
   ): Promise<{ id: string; name: string | null; slug: string }>
   /** Set the org's console icon descriptor (the upload/delete path). Bumps `updatedAt`
    *  so the icon endpoint's `?v=` cache-buster changes. Throws P2025 when absent. */
@@ -3341,6 +3348,9 @@ export interface OrgRepo {
   iconById(orgId: string): Promise<{ icon: AgentIcon | null; updatedAt: Date } | null>
   /** The user's role in the org; null when not a member. */
   roleOf(orgId: string, userId: string): Promise<OrgMemberRole | null>
+
+  /** Default directional policy for newly created agents; null when the org is absent. */
+  defaultAgentVisibility(orgId: string): Promise<AgentCallPolicy | null>
 
   /** The org's slug (its URL segment in the console), or null when the org is absent.
    *  Used to build org-scoped session deep links (`<webAppUrl>/<slug>/sessions/<id>`). */

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -216,6 +216,16 @@ export class PgAgentRepo implements AgentRepo {
       // Close organization deletion's no-agent-row enumeration window without
       // taking a parent-row lock in the reverse order of Hook CRUD.
       await lockHookReviewOrgProducerScope(tx, input.orgId)
+      const orgDefault =
+        input.callPolicy === undefined || input.outboundPolicy === undefined
+          ? await tx.org.findUnique({
+              where: { id: input.orgId },
+              select: { defaultAgentVisibility: true }
+            })
+          : null
+      const defaultAgentVisibility = (orgDefault?.defaultAgentVisibility as AgentCallPolicy | undefined) ?? 'selected'
+      const callPolicy = input.callPolicy ?? defaultAgentVisibility
+      const outboundPolicy = input.outboundPolicy ?? defaultAgentVisibility
       const memberships = await lockResourceWriteMemberships(tx, {
         orgId: input.orgId,
         visibility: input.visibility ?? 'org',
@@ -289,13 +299,13 @@ export class PgAgentRepo implements AgentRepo {
           // when restricted; a stray set under 'org' is inert (the predicate ignores it).
           ...(input.visibility ? { visibility: input.visibility } : {}),
           ...(memberships.sharedWith ? { sharedWith: memberships.sharedWith } : {}),
-          // Initial call policy (absent ⇒ DB default 'all'). allowedCallerAgentIds
-          // only bites when 'selected'; the route intersects it with visible peers.
-          ...(input.callPolicy ? { callPolicy: input.callPolicy } : {}),
-          ...(input.allowedCallerAgentIds ? { allowedCallerAgentIds: input.allowedCallerAgentIds } : {}),
-          // Same for the outbound half (which peers this agent may call).
-          ...(input.outboundPolicy ? { outboundPolicy: input.outboundPolicy } : {}),
-          ...(input.allowedTargetAgentIds ? { allowedTargetAgentIds: input.allowedTargetAgentIds } : {})
+          // Both directions inherit the organization's creation default unless
+          // explicitly chosen. The database's own selected default remains the
+          // fail-closed fallback for writes outside this repository seam.
+          callPolicy,
+          allowedCallerAgentIds: callPolicy === 'selected' ? (input.allowedCallerAgentIds ?? []) : [],
+          outboundPolicy,
+          allowedTargetAgentIds: outboundPolicy === 'selected' ? (input.allowedTargetAgentIds ?? []) : []
         },
         include: withUsers
       })

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -2,11 +2,11 @@
  * PgOrgRepo — the org read/write surface behind the console picker + Settings
  * (design §3.2). Personal orgs are created by `PgUserRepo.provisionOidcUser` at
  * signup; this repo covers everything after: listing the caller's orgs, creating
- * additional ones, and owner-gated rename/re-slug.
+ * additional ones, and owner-gated settings updates.
  */
 import type { PrismaLike } from '../prisma.js'
 import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
-import type { OrgRepo, OrgRecord, OrgMemberRole } from '../ports.js'
+import type { AgentCallPolicy, OrgRepo, OrgRecord, OrgMemberRole } from '../ports.js'
 import type { AgentIcon } from '@agentconnect.md/protocol'
 import { OrgId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
@@ -37,6 +37,7 @@ export class PgOrgRepo implements OrgRepo {
       name: m.org.name,
       slug: m.org.slug,
       icon: parseAgentIcon(m.org.icon),
+      defaultAgentVisibility: m.org.defaultAgentVisibility as AgentCallPolicy,
       role: m.role as OrgMemberRole,
       memberCount: m.org._count.members,
       daemonCount: m.org._count.daemons,
@@ -67,6 +68,7 @@ export class PgOrgRepo implements OrgRepo {
       name: org.name,
       slug: org.slug,
       icon: parseAgentIcon(org.icon),
+      defaultAgentVisibility: org.defaultAgentVisibility as AgentCallPolicy,
       role: 'owner',
       memberCount: 1,
       daemonCount: 0,
@@ -77,7 +79,12 @@ export class PgOrgRepo implements OrgRepo {
 
   async update(
     orgId: string,
-    patch: { name?: string | null; slug?: string; icon?: AgentIcon | null }
+    patch: {
+      name?: string | null
+      slug?: string
+      icon?: AgentIcon | null
+      defaultAgentVisibility?: AgentCallPolicy
+    }
   ): Promise<{ id: string; name: string | null; slug: string }> {
     const org = await this.db.org.update({
       where: { id: orgId },
@@ -86,7 +93,8 @@ export class PgOrgRepo implements OrgRepo {
         ...(patch.slug !== undefined ? { slug: patch.slug } : {}),
         ...(patch.icon !== undefined
           ? { icon: patch.icon === null ? Prisma.JsonNull : (patch.icon as Prisma.InputJsonValue) }
-          : {})
+          : {}),
+        ...(patch.defaultAgentVisibility !== undefined ? { defaultAgentVisibility: patch.defaultAgentVisibility } : {})
       }
     })
     return { id: org.id, name: org.name, slug: org.slug }
@@ -108,6 +116,11 @@ export class PgOrgRepo implements OrgRepo {
   async roleOf(orgId: string, userId: string): Promise<OrgMemberRole | null> {
     const m = await this.db.membership.findUnique({ where: { orgId_userId: { orgId, userId } } })
     return m ? (m.role as OrgMemberRole) : null
+  }
+
+  async defaultAgentVisibility(orgId: string): Promise<AgentCallPolicy | null> {
+    const org = await this.db.org.findUnique({ where: { id: orgId }, select: { defaultAgentVisibility: true } })
+    return (org?.defaultAgentVisibility as AgentCallPolicy | undefined) ?? null
   }
 
   async slugById(orgId: string): Promise<string | null> {

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -176,9 +176,9 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
         // Managed organization skills are a distinct explicit enable-list.
         managedSkills: [],
         // Agent→agent call policy (§2.5) — always shipped so a policy/allow-list change replicates.
-        callPolicy: 'all',
+        callPolicy: 'selected',
         allowedCallerAgentIds: [],
-        outboundPolicy: 'all',
+        outboundPolicy: 'selected',
         allowedTargetAgentIds: [],
         // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
         introduceOnJoin: false,

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -95,6 +95,8 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
       lastModifiedAt: string
       callPolicy: string
       allowedCallerAgentIds: string[]
+      outboundPolicy: string
+      allowedTargetAgentIds: string[]
     }
     expect(created.id).toMatch(/[0-9a-f-]{36}/)
     expect(created.name).toBe('router-bot')
@@ -105,8 +107,10 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(Number.isNaN(Date.parse(created.createdAt))).toBe(false)
     expect(created.lastModifiedBy).toBe(created.createdBy)
     expect(created.lastModifiedAt).toBe(created.createdAt)
-    expect(created.callPolicy).toBe('all')
+    expect(created.callPolicy).toBe('selected')
     expect(created.allowedCallerAgentIds).toEqual([])
+    expect(created.outboundPolicy).toBe('selected')
+    expect(created.allowedTargetAgentIds).toEqual([])
 
     // Persisted in the real DB — the FK points at the seeded owner user.
     const row = await prisma.agent.findUnique({ where: { id: created.id } })
@@ -128,14 +132,18 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
       lastModifiedAt: string
       callPolicy: string
       allowedCallerAgentIds: string[]
+      outboundPolicy: string
+      allowedTargetAgentIds: string[]
     }
     expect(fetched.id).toBe(created.id)
     expect(fetched.name).toBe('router-bot')
     expect(fetched.capabilities).toEqual(['fs.read', 'fs.write'])
     expect(fetched.lastModifiedBy).toBe(created.lastModifiedBy)
     expect(fetched.lastModifiedAt).toBe(created.lastModifiedAt)
-    expect(fetched.callPolicy).toBe('all')
+    expect(fetched.callPolicy).toBe('selected')
     expect(fetched.allowedCallerAgentIds).toEqual([])
+    expect(fetched.outboundPolicy).toBe('selected')
+    expect(fetched.allowedTargetAgentIds).toEqual([])
   })
 
   it('defaults and locks Run in sandbox from the placed daemon policy', async () => {
@@ -339,7 +347,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     })
     expect(outboundOnly.statusCode).toBe(201)
     expect(outboundOnly.json()).toMatchObject({
-      callPolicy: 'all',
+      callPolicy: 'selected',
       allowedCallerAgentIds: [],
       outboundPolicy: 'selected',
       allowedTargetAgentIds: [callerId]
@@ -358,9 +366,9 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     })
     expect(dflt.statusCode).toBe(201)
     expect(dflt.json()).toMatchObject({
-      callPolicy: 'all',
+      callPolicy: 'selected',
       allowedCallerAgentIds: [],
-      outboundPolicy: 'all',
+      outboundPolicy: 'selected',
       allowedTargetAgentIds: []
     })
   })

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -61,7 +61,8 @@ class SpyControl {
   async collaborationRoutes(): Promise<void> {}
 }
 
-/** Create an agent (via REST, with displayName/description) + install its slack integration. */
+/** Create an explicitly open agent + install its Slack integration. Directory-policy
+ * tests opt in to edges; the create-default contract is covered in agents.route.test. */
 async function installAgent(
   app: HttpApp,
   daemonId: string,
@@ -70,7 +71,7 @@ async function installAgent(
   const created = await app.app.inject({
     method: 'POST',
     url: `${ORG}/agents`,
-    payload: { ...agent, runtime: 'claude', daemonId }
+    payload: { ...agent, runtime: 'claude', daemonId, callPolicy: 'all', outboundPolicy: 'all' }
   })
   expect(created.statusCode).toBe(201)
   const agentId = (created.json() as { id: string }).id
@@ -83,8 +84,8 @@ async function installAgent(
   return { agentId, integrationId: (res.json() as { id: string }).id }
 }
 
-/** Create an agent with NO integration — it exists only in the org peer directory and
- *  can appear in no channel-keyed structure at all (webchat / hook / memory-only agents). */
+/** Create an explicitly open agent with NO integration — it exists only in the org peer
+ * directory and can appear in no channel-keyed structure at all. */
 async function createAgent(
   app: HttpApp,
   daemonId: string,
@@ -93,7 +94,7 @@ async function createAgent(
   const created = await app.app.inject({
     method: 'POST',
     url: `${ORG}/agents`,
-    payload: { ...agent, runtime: 'claude', daemonId }
+    payload: { ...agent, runtime: 'claude', daemonId, callPolicy: 'all', outboundPolicy: 'all' }
   })
   expect(created.statusCode).toBe(201)
   return (created.json() as { id: string }).id
@@ -231,7 +232,7 @@ describe('channel/agents (agent collaboration directory)', () => {
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
 
     const caller = await installAgent(running, DAEMON, { name: 'caller' })
-    const openPeer = await installAgent(running, DAEMON, { name: 'open-peer' }) // callPolicy=all (default)
+    const openPeer = await installAgent(running, DAEMON, { name: 'open-peer' }) // helper explicitly opts into all
     const privatePeer = await installAgent(running, DAEMON, { name: 'private-peer' })
     for (const p of [caller, openPeer, privatePeer]) {
       await reportChannels(DAEMON, p.integrationId, [{ id: 'C1', name: 'deploys' }])

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -18,6 +18,7 @@ interface OrgBody {
   id: string
   name: string | null
   slug: string
+  defaultAgentVisibility: 'all' | 'selected'
   role: string
   memberCount: number
   createdAt: string
@@ -34,6 +35,7 @@ describe('GET /orgs', () => {
       expect(body[0]!.id).toBe(DEFAULT_ORG_ID)
       expect(body[0]!.role).toBe('owner')
       expect(body[0]!.memberCount).toBe(1)
+      expect(body[0]!.defaultAgentVisibility).toBe('selected')
     } finally {
       await close()
     }
@@ -53,6 +55,7 @@ describe('POST /orgs', () => {
       const org = res.json() as OrgBody
       expect(org.role).toBe('owner')
       expect(org.memberCount).toBe(1)
+      expect(org.defaultAgentVisibility).toBe('selected')
 
       const list = (await (await app.inject({ method: 'GET', url: '/api/v1/orgs' })).json()) as OrgBody[]
       expect(list.map((o) => o.slug)).toContain('acme')
@@ -130,6 +133,48 @@ describe('PATCH /orgs/:id', () => {
       expect((res.json() as OrgBody).name).toBeNull()
       const row = await prisma.org.findUnique({ where: { id: DEFAULT_ORG_ID } })
       expect(row?.name).toBeNull()
+    } finally {
+      await close()
+    }
+  })
+
+  it('uses the org visibility default for future agents without rewriting existing agents', async () => {
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const before = await app.inject({
+        method: 'POST',
+        url: `${ORG}/agents`,
+        payload: { name: 'before-policy-change', runtime: 'claude' }
+      })
+      expect(before.statusCode).toBe(201)
+      expect(before.json()).toMatchObject({ callPolicy: 'selected', outboundPolicy: 'selected' })
+
+      const updated = await app.inject({
+        method: 'PATCH',
+        url: ORG,
+        payload: { defaultAgentVisibility: 'all' }
+      })
+      expect(updated.statusCode).toBe(200)
+      expect((updated.json() as OrgBody).defaultAgentVisibility).toBe('all')
+
+      const after = await app.inject({
+        method: 'POST',
+        url: `${ORG}/agents`,
+        payload: { name: 'after-policy-change', runtime: 'claude' }
+      })
+      expect(after.statusCode).toBe(201)
+      expect(after.json()).toMatchObject({
+        callPolicy: 'all',
+        allowedCallerAgentIds: [],
+        outboundPolicy: 'all',
+        allowedTargetAgentIds: []
+      })
+
+      const unchanged = await app.inject({
+        method: 'GET',
+        url: `${ORG}/agents/${(before.json() as { id: string }).id}`
+      })
+      expect(unchanged.json()).toMatchObject({ callPolicy: 'selected', outboundPolicy: 'selected' })
     } finally {
       await close()
     }

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -216,9 +216,9 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       skills: [], // resolved skill entries; always shipped (disabling the last skill must replicate)
       managedSkills: [], // managed organization skill bindings; likewise always shipped
       // Agent→agent call policy (§2.5), always shipped so a policy/allow-list change replicates.
-      callPolicy: 'all',
+      callPolicy: 'selected',
       allowedCallerAgentIds: [],
-      outboundPolicy: 'all',
+      outboundPolicy: 'selected',
       allowedTargetAgentIds: [],
       // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
       introduceOnJoin: false,
@@ -445,9 +445,9 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
             agentId: AGENT,
             daemonId: DAEMON,
             integrationId: INTEG,
-            callPolicy: 'all',
+            callPolicy: 'selected',
             allowedCallerAgentIds: [],
-            outboundPolicy: 'all',
+            outboundPolicy: 'selected',
             allowedTargetAgentIds: [],
             // Carried so a peer daemon can label this agent by name in a visible agent-call post.
             name: 'agent-1'

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -214,14 +214,13 @@ export const AgentSchema = z.object({
   managedSkills: z.array(ManagedSkillEntry).default([]),
   // Agent→agent call authorization (design §2.5), replicated from the CP so the
   // daemon enforces it LOCALLY when another agent uses `messageAgent` to wake this
-  // one. `all` (the default) ⇒ any org peer may call; `selected` ⇒ only agents in
-  // `allowedCallerAgentIds`. Absent callPolicy ⇒ treated as `all` (backward-compat;
-  // see §6.5 for the fail-closed alternative — noted as a P1 gap).
-  callPolicy: z.enum(['all', 'selected']).default('all'),
+  // one. `all` ⇒ any org peer may call; `selected` ⇒ only agents in
+  // `allowedCallerAgentIds`. Missing policy fails closed to an empty selection.
+  callPolicy: z.enum(['all', 'selected']).default('selected'),
   allowedCallerAgentIds: z.array(z.string()).default([]),
-  // Caller-side half of collaboration authorization. Defaults preserve the
-  // historical unrestricted behavior for existing agent.json files.
-  outboundPolicy: z.enum(['all', 'selected']).default('all'),
+  // Caller-side half of collaboration authorization. Missing policy likewise
+  // discovers and calls no peer until targets are explicitly selected.
+  outboundPolicy: z.enum(['all', 'selected']).default('selected'),
   allowedTargetAgentIds: z.array(z.string()).default([]),
   // Opt-in (issue #536): when true, on a GENUINE new channel join the agent
   // proactively introduces itself to the other agents already there (via

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -172,6 +172,10 @@ describe('AgentSchema defaults', () => {
     expect(parsed.output.showFooter).toBe(true)
     expect(parsed.allowRuntimeChangesInChat).toBe(false)
     expect(parsed.restrictFileAccess).toBe(false)
+    expect(parsed.callPolicy).toBe('selected')
+    expect(parsed.allowedCallerAgentIds).toEqual([])
+    expect(parsed.outboundPolicy).toBe('selected')
+    expect(parsed.allowedTargetAgentIds).toEqual([])
   })
 
   it('defaults permissionMode to default when omitted', () => {

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -18,7 +18,7 @@ const REMOTE_PEERS = ['bot-a', 'bot-b', 'bot-c', 'main', 'worker', 'third', 'pee
  * wake, coords, and trusted workflow metadata without running a real ACP turn.
  */
 
-/** Scaffold a daemon root with local agents carrying either direction of call policy. */
+/** Scaffold explicitly connected peers; AgentSchema's isolated defaults are tested separately. */
 function scaffold(
   agents: {
     id: string
@@ -50,10 +50,10 @@ function scaffold(
         workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
         integrations: [],
         output: { mode: 'low' },
-        ...(a.callPolicy ? { callPolicy: a.callPolicy } : {}),
-        ...(a.allowedCallerAgentIds ? { allowedCallerAgentIds: a.allowedCallerAgentIds } : {}),
-        ...(a.outboundPolicy ? { outboundPolicy: a.outboundPolicy } : {}),
-        ...(a.allowedTargetAgentIds ? { allowedTargetAgentIds: a.allowedTargetAgentIds } : {})
+        callPolicy: a.callPolicy ?? 'all',
+        allowedCallerAgentIds: a.allowedCallerAgentIds ?? [],
+        outboundPolicy: a.outboundPolicy ?? 'all',
+        allowedTargetAgentIds: a.allowedTargetAgentIds ?? []
       })
     )
   }

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -13,6 +13,7 @@ import type { StartOrchestrationReq, OrchestrationOwnerReq } from '../src/mcp/op
  * one-shot cron deadline — without running a real ACP turn.
  */
 
+/** These scenarios model an explicitly connected worker pool; isolated defaults live in agents.test.ts. */
 function scaffold(agentIds: string[]): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-orch-'))
   writeFileSync(
@@ -35,7 +36,11 @@ function scaffold(agentIds: string[]): string {
         runtime: 'claude',
         workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
         integrations: [],
-        output: { mode: 'low' }
+        output: { mode: 'low' },
+        callPolicy: 'all',
+        allowedCallerAgentIds: [],
+        outboundPolicy: 'all',
+        allowedTargetAgentIds: []
       })
     )
   }

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1186,7 +1186,7 @@ describe('collaboration/routes snapshot', () => {
     expect(r.frame.payload.agents[0]!.orgId).toBe(ORG_ID)
     expect(r.frame.payload.agents[0]!.allowedTargetAgentIds).toEqual([AGENT_ID])
     // Placement defaults still apply through the .extend()
-    expect(r.frame.payload.agents[0]!.callPolicy).toBe('all')
+    expect(r.frame.payload.agents[0]!.callPolicy).toBe('selected')
     expect(r.frame.payload.agents[0]!.allowedCallerAgentIds).toEqual([])
   })
 

--- a/packages/protocol/src/frames/collab.ts
+++ b/packages/protocol/src/frames/collab.ts
@@ -39,11 +39,12 @@ export const CollabAgentPlacement = z.object({
    *  recognize AgentConnect-authored platform messages and keep agent-to-agent
    *  activation on the trusted `messageAgent` path. */
   botAppId: z.string().optional(),
-  callPolicy: z.enum(['all', 'selected']).default('all'),
+  // Missing policy from an older or incomplete snapshot must not create a peer edge.
+  callPolicy: z.enum(['all', 'selected']).default('selected'),
   allowedCallerAgentIds: z.array(z.string()).default([]),
   /** Caller-side authorization. Effective A→B access requires A's outbound
    * policy to admit B and B's inbound call policy to admit A. */
-  outboundPolicy: z.enum(['all', 'selected']).default('all'),
+  outboundPolicy: z.enum(['all', 'selected']).default('selected'),
   allowedTargetAgentIds: z.array(z.string()).default([]),
   // Directory name of the agent — carried so any daemon holding the snapshot can label a
   // REMOTE peer (caller or target) by name in a visible agent-call post, without a CP

--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -245,11 +245,6 @@ export function AgentCallVisibility({
         >
           {peers.length === 0 ? <>No other agents are available yet.</> : allAgentsSummary}
         </div>
-        {variant !== 'section' && (
-          <span className="col-start-2 w-fit rounded-full bg-(--surface-active) px-[9px] py-[2px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-tertiary) desktop:col-auto desktop:flex-none">
-            default
-          </span>
-        )}
       </div>
     ) : !editable ? (
       // Read-only `selected`: the chosen peers as plain chips — no search field,

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
+import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
   agentSlugFinalize,
@@ -181,6 +182,8 @@ async function searchPublicGithubRepos(query: string, signal?: AbortSignal): Pro
 export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const { createAgent, daemons, agents } = useConsoleData()
   const { me } = useProfile()
+  const { activeOrg } = useOrgs()
+  const defaultAgentVisibility = activeOrg?.defaultAgentVisibility ?? 'selected'
   const [name, setName] = useState('')
   const [displayName, setDisplayName] = useState('')
   // New agents default to a random glyph+color (product default — not runtime-branded).
@@ -247,13 +250,10 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [ghExactRepoState, setGhExactRepoState] = useState<RepoCheckState>('idle')
   const [ghManualPublicRepo, setGhManualPublicRepo] = useState<GithubRepoDto | null>(null)
   const [sharing, setSharing] = useState<SharingValue>({ visibility: 'org', sharedWith: [] })
-  // Agent-call visibility: which peer agents may call this one as a sub-agent.
-  // Default 'all' (the CP's default); selected callers are picked from peers.
-  const [callPolicy, setCallPolicy] = useState<AgentCallPolicy>('all')
+  // The org default seeds both directions; this form can still override either one.
+  const [callPolicy, setCallPolicy] = useState<AgentCallPolicy>(defaultAgentVisibility)
   const [allowedCallers, setAllowedCallers] = useState<string[]>([])
-  // Outbound half — which peers this agent may call. Same default ('all') and the
-  // same server-side intersection as inbound.
-  const [outboundPolicy, setOutboundPolicy] = useState<AgentCallPolicy>('all')
+  const [outboundPolicy, setOutboundPolicy] = useState<AgentCallPolicy>(defaultAgentVisibility)
   const [allowedTargets, setAllowedTargets] = useState<string[]>([])
   // Optional env vars + write-only secrets to seed at create (createAgent accepts
   // both). Shared "Secrets and variables" editor with the Edit-agent modal.
@@ -801,14 +801,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         ...(sharing.visibility === 'restricted'
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {}),
-        // Selected-callers-create: send only when restricting (default 'all' is
-        // implicit). The CP intersects the allow-list with visible org peers.
-        ...(callPolicy === 'selected'
-          ? { callPolicy: 'selected' as const, allowedCallerAgentIds: allowedCallers }
-          : {}),
-        ...(outboundPolicy === 'selected'
-          ? { outboundPolicy: 'selected' as const, allowedTargetAgentIds: allowedTargets }
-          : {})
+        // Send both modes explicitly: omission now means isolated, while `all` is
+        // an intentional opt-in. The CP intersects selected lists with visible peers.
+        callPolicy,
+        allowedCallerAgentIds: callPolicy === 'selected' ? allowedCallers : [],
+        outboundPolicy,
+        allowedTargetAgentIds: outboundPolicy === 'selected' ? allowedTargets : []
       })
       onClose()
     } catch (e) {

--- a/packages/web/src/components/console/modals/EditOrgModal.tsx
+++ b/packages/web/src/components/console/modals/EditOrgModal.tsx
@@ -2,21 +2,26 @@
 
 // Edit-organization dialog (design: `isEditWorkspaceModal`). REAL: PATCH
 // /orgs/:id (owner-only server-side; the Settings page only offers the button
-// to owners). Edits the ACTIVE org's URL name (slug) + display name, and hosts
-// the delete-organization danger zone (two-click confirm; the CP refuses while
-// the org still has daemons, and everything else cascades).
+// to owners). Edits the ACTIVE org's URL name (slug), display name, and default
+// policy for future agents, and hosts the delete-organization danger zone
+// (two-click confirm; the CP refuses while the org still has daemons, and
+// everything else cascades).
 
 import { useState } from 'react'
 import { Button, Icon } from '@/components/ui'
 import { ApiError } from '@/lib/api'
 import { useOrgs, orgColor, orgUrlPrefix } from '@/lib/org-context'
+import type { AgentCallPolicy } from '@/lib/data'
 
 const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/
 
 export default function EditOrgModal({ onClose }: { onClose: () => void }) {
-  const { activeOrg, renameOrg, deleteOrg } = useOrgs()
+  const { activeOrg, updateOrg, deleteOrg } = useOrgs()
   const [slug, setSlug] = useState(activeOrg?.slug ?? '')
   const [name, setName] = useState(activeOrg?.name ?? '')
+  const [defaultAgentVisibility, setDefaultAgentVisibility] = useState<AgentCallPolicy>(
+    activeOrg?.defaultAgentVisibility ?? 'selected'
+  )
   const [busy, setBusy] = useState(false)
   const [deleteArmed, setDeleteArmed] = useState(false)
   const [err, setErr] = useState<string | null>(null)
@@ -27,11 +32,16 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
 
   const submit = async () => {
     if (!valid || busy) return
-    if (slug === activeOrg.slug && (nextName || null) === (activeOrg.name ?? null)) return onClose()
+    if (
+      slug === activeOrg.slug &&
+      (nextName || null) === (activeOrg.name ?? null) &&
+      defaultAgentVisibility === (activeOrg.defaultAgentVisibility ?? 'selected')
+    )
+      return onClose()
     setBusy(true)
     setErr(null)
     try {
-      await renameOrg(activeOrg.id, { name: nextName, slug })
+      await updateOrg(activeOrg.id, { name: nextName, slug, defaultAgentVisibility })
       onClose()
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) setErr('That URL name is already taken.')
@@ -102,9 +112,44 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
             Anything you like — shown across the console. Leave blank to use the URL name.
           </span>
         </div>
+        <div className="fld mt-[14px]">
+          <span className="fldlbl">Default agent visibility</span>
+          <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Default agent visibility">
+            {(
+              [
+                { key: 'selected', label: 'Isolated', sub: 'No peer access until agents are selected.' },
+                { key: 'all', label: 'All agents', sub: 'Open in both directions to the organization.' }
+              ] as const
+            ).map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                role="radio"
+                disabled={busy}
+                aria-checked={defaultAgentVisibility === option.key}
+                onClick={() => setDefaultAgentVisibility(option.key)}
+                className={`flex flex-col items-start gap-[1px] rounded-md border px-[11px] py-[8px] text-left ${
+                  defaultAgentVisibility === option.key
+                    ? 'border-(--brand) bg-(--surface-active)'
+                    : 'border-(--border-default) bg-(--surface-app)'
+                } ${busy ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+              >
+                <span className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+                  {option.label}
+                </span>
+                <span className="font-sans text-[11px] font-normal leading-[1.4] text-(--text-tertiary)">
+                  {option.sub}
+                </span>
+              </button>
+            ))}
+          </div>
+          <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+            Applies only to newly created agents. Each agent can still override both directions.
+          </span>
+        </div>
         <div className="mt-[14px] flex items-start gap-2 rounded-md bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
           <Icon name="info" size={14} className="mt-[1px] flex-none" />
-          <span>Only owners can edit these. Changing the name updates the organization URL for everyone.</span>
+          <span>Only owners can edit these settings. Changing the name updates the organization URL for everyone.</span>
         </div>
         <div className="mt-[18px] flex items-center gap-[11px] rounded-[9px] border border-[rgba(220,75,75,.28)] bg-(--status-error-soft) px-[13px] py-3">
           <Icon name="trash-2" size={16} color="var(--status-error)" className="flex-none" />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -879,11 +879,11 @@ export interface CreateAgentInput {
   /** Initial visibility (absent ⇒ 'org'); sharedWith is intersected with org members. */
   visibility?: ResourceVisibility
   sharedWith?: string[]
-  /** Initial agent-call policy (absent ⇒ 'all'); allowedCallerAgentIds is
+  /** Initial agent-call policy (absent ⇒ the organization's default); allowedCallerAgentIds is
    *  intersected with visible same-org peers and only bites when 'selected'. */
   callPolicy?: AgentCallPolicy
   allowedCallerAgentIds?: string[]
-  /** Outbound half (absent ⇒ 'all'); intersected with visible peers server-side. */
+  /** Outbound half (absent ⇒ the organization's default); intersected with visible peers server-side. */
   outboundPolicy?: AgentCallPolicy
   allowedTargetAgentIds?: string[]
 }
@@ -962,6 +962,8 @@ export interface OrgDto {
   icon: AgentIcon | null
   /** Resolved URL for an uploaded `image` org icon; null otherwise. */
   iconUrl: string | null
+  /** Default applied to both directional policies of newly created agents. */
+  defaultAgentVisibility?: AgentCallPolicy
   /** Whether the object store is configured — the console shows Upload only when true. */
   iconUploadEnabled: boolean
   /** The signed-in user's role in this org. */
@@ -1498,9 +1500,9 @@ export function agentFromDto(d: AgentDto): Agent {
     ownerUserId: d.ownerUserId,
     canEdit: d.canEdit,
     canManageSharing: d.canManageSharing,
-    callPolicy: d.callPolicy,
-    allowedCallerAgentIds: d.allowedCallerAgentIds,
-    outboundPolicy: d.outboundPolicy ?? 'all',
+    callPolicy: d.callPolicy ?? 'selected',
+    allowedCallerAgentIds: d.allowedCallerAgentIds ?? [],
+    outboundPolicy: d.outboundPolicy ?? 'selected',
     allowedTargetAgentIds: d.allowedTargetAgentIds ?? [],
     // Unset (older CP) reads as off — the product default.
     introduceOnJoin: d.introduceOnJoin ?? false,
@@ -3105,10 +3107,15 @@ export async function createOrg(input: { name?: string; slug: string }): Promise
   return org
 }
 
-// Rename / re-slug an org (PATCH /orgs/:id, owner of that org only).
+// Update org settings (PATCH /orgs/:id, owner of that org only).
 export async function updateOrg(
   orgId: string,
-  patch: { name?: string; slug?: string; icon?: AgentIcon | null }
+  patch: {
+    name?: string
+    slug?: string
+    icon?: AgentIcon | null
+    defaultAgentVisibility?: AgentCallPolicy
+  }
 ): Promise<OrgDto> {
   return apiPatch<OrgDto>(`/orgs/${encodeURIComponent(orgId)}`, patch)
 }

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -24,6 +24,7 @@ import {
   type MemberRole,
   type OrgDto
 } from '@/lib/api'
+import type { AgentCallPolicy } from '@/lib/data'
 
 // Last-used org slug, kept in a COOKIE (not localStorage) so the proxy
 // can send `/` straight to `/{slug}/agents` with one server redirect — no
@@ -84,12 +85,15 @@ interface OrgContextValue {
   orgPath: (path: string) => string
   /** Switch the active org — navigates to the same page under the new slug. */
   setActiveOrg: (orgId: string) => void
-  /** Re-pull `GET /orgs` (after create / rename / membership changes). */
+  /** Re-pull `GET /orgs` (after create / settings / membership changes). */
   refreshOrgs: () => Promise<void>
   /** Create an org (caller becomes owner) and switch into it. Display name optional. */
   createOrg: (input: { name?: string; slug: string }) => Promise<OrgDto>
-  /** Rename / re-slug an org (owner-only server-side), then re-sync the URL. */
-  renameOrg: (orgId: string, patch: { name?: string; slug?: string }) => Promise<void>
+  /** Update org settings (owner-only server-side), then re-sync the URL if needed. */
+  updateOrg: (
+    orgId: string,
+    patch: { name?: string; slug?: string; defaultAgentVisibility?: AgentCallPolicy }
+  ) => Promise<void>
   /** Delete an org (owner-only; 409 while it has daemons). The console then
    *  moves to a remaining org — or the self-healed personal one. */
   deleteOrg: (orgId: string) => Promise<void>
@@ -181,8 +185,8 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     [pathname, slug, refreshOrgs, router]
   )
 
-  const renameOrg = useCallback(
-    async (orgId: string, patch: { name?: string; slug?: string }) => {
+  const updateOrg = useCallback(
+    async (orgId: string, patch: { name?: string; slug?: string; defaultAgentVisibility?: AgentCallPolicy }) => {
       const updated = await apiUpdateOrg(orgId, patch)
       // Record the new slug BEFORE the list refreshes — the URL reconciliation
       // effect fires on the refreshed list (old slug now unknown) and must
@@ -233,11 +237,11 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       setActiveOrg,
       refreshOrgs,
       createOrg,
-      renameOrg,
+      updateOrg,
       deleteOrg,
       leaveOrg
     }),
-    [orgs, activeOrg, loading, error, orgPath, setActiveOrg, refreshOrgs, createOrg, renameOrg, deleteOrg, leaveOrg]
+    [orgs, activeOrg, loading, error, orgPath, setActiveOrg, refreshOrgs, createOrg, updateOrg, deleteOrg, leaveOrg]
   )
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>


### PR DESCRIPTION
## Summary

- default new agents to `selected + []` for both inbound and outbound agent-call visibility
- let organization owners choose the default for future agents: `Isolated` or `All agents`
- seed both directions from the organization default while retaining per-agent, per-direction overrides
- keep fail-closed defaults consistent through Prisma, REST creation, daemon config, collaboration snapshots, and the console
- preserve every existing agent's persisted policy; changing the organization setting never rewrites existing agents

## Why

The previous defaults implicitly connected every new agent to every otherwise-callable peer. Missing or older policy data also decoded as unrestricted, so an unconfigured agent could discover or wake another agent without an explicit grant.

Organizations now start with an isolated creation default and can deliberately opt future agents into organization-wide collaboration. This affects agent-to-agent collaboration visibility only. Human access to agent resources keeps its existing organization/restricted policy.

## Validation

- Control Plane unit tests: 1,074 passed
- Control Plane integration tests: 925 passed; 2 expected skips
- Web tests: 509 passed
- Control Plane and Web typechecks
- full-repository ESLint and Prettier checks
- Prisma client generation and the complete 57-migration chain against fresh PostgreSQL

Created by Codex . GPT-5
