### PR TITLE
feat(web): move memory into knowledge

### DIFF
--- a/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
+++ b/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
@@ -148,8 +148,8 @@ export function ExternalMemoryBindingFields({
       {!isLoading && connections.length === 0 && (
         <div className="text-[12px] leading-[1.5] text-(--text-secondary)">
           No external-memory connection is configured. An organization owner can add one in{' '}
-          <a className="lnk" href={orgPath('/tools')}>
-            Tools &amp; Skills → External memory
+          <a className="lnk" href={orgPath('/knowledge?tab=memory')}>
+            Knowledge → Memory
           </a>
           .
         </div>

--- a/packages/web/src/components/console/MemoryConnectionsCard.tsx
+++ b/packages/web/src/components/console/MemoryConnectionsCard.tsx
@@ -136,7 +136,7 @@ export function MemoryConnectionsCard({ canManage }: { canManage: boolean }) {
 
   const loading = installationsLoading || connectionsLoading
   return (
-    <div className="card mt-[18px]">
+    <div className="card">
       <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-1 border-b border-(--border-subtle) px-4 py-[14px] desktop:items-center">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="cardtitle">External memory</span>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -40,8 +40,8 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
   { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
   { href: '/daemons', label: 'Daemons', icon: 'server' },
-  { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
-  { href: '/knowledge', label: 'Knowledge', icon: 'library-big' },
+  { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
+  { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
   { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
 ]
 
@@ -62,8 +62,8 @@ const MOBILE_NAV: NavItem[] = [
 const MORE_ROWS: NavItem[] = [
   { href: '/daemons', label: 'Daemons', icon: 'server' },
   { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
-  { href: '/tools', label: 'Tools & Skills', icon: 'book-open' },
-  { href: '/knowledge', label: 'Knowledge', icon: 'library-big' },
+  { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
+  { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
 

--- a/packages/web/src/components/console/views/KnowledgeView.test.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.test.tsx
@@ -6,9 +6,11 @@ import { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setApiOrgId, type OrganizationKnowledgeDto, type OrganizationSuggestionDto } from '@/lib/api'
 
+const navigation = vi.hoisted(() => ({ search: '' }))
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams()
+  useSearchParams: () => new URLSearchParams(navigation.search)
 }))
 vi.mock('@/lib/org-context', () => ({
   useOrgs: () => ({ activeOrg: { id: 'org-test' }, myRole: 'owner', orgPath: (path: string) => path })
@@ -81,6 +83,7 @@ async function settleUntil(done: () => boolean): Promise<void> {
 }
 
 beforeEach(() => {
+  navigation.search = ''
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   host = document.createElement('div')
   document.body.append(host)
@@ -225,6 +228,31 @@ describe('organization knowledge surface', () => {
       expect.stringContaining('/knowledge?includeArchived=false')
     ])
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/managed-skills'))).toBe(false)
+  })
+
+  it('hosts external memory under the Memory tab without loading the knowledge library', async () => {
+    navigation.search = 'tab=memory'
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL) =>
+        new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      root.render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+          <KnowledgeView />
+        </SWRConfig>
+      )
+    })
+    await settleUntil(() => host.textContent?.includes('No external-memory connections yet') === true)
+
+    expect(host.textContent).toContain('External memory')
+    expect(host.textContent).not.toContain('Knowledge library')
+    const urls = fetchMock.mock.calls.map(([input]) => String(input))
+    expect(urls.some((url) => url.includes('/memory-plugin-installations'))).toBe(true)
+    expect(urls.some((url) => url.includes('/external-memory-connections'))).toBe(true)
+    expect(urls.some((url) => url.includes('/knowledge?'))).toBe(false)
   })
 
   it('loads and selects historical knowledge content, then refreshes an open entry for a new revision', async () => {

--- a/packages/web/src/components/console/views/KnowledgeView.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { LoadingState } from '@/components/marks'
+import { MemoryConnectionsCard } from '@/components/console/MemoryConnectionsCard'
 import { Button, Icon, Toggle } from '@/components/ui'
 
 const MarkdownView = dynamic(() => import('@/components/console/MarkdownView'), { ssr: false })
@@ -521,14 +522,15 @@ export default function KnowledgeView() {
   const { activeOrg, myRole, orgPath } = useOrgs()
   const router = useRouter()
   const search = useSearchParams()
-  const tab = search.get('tab') === 'suggestions' ? 'suggestions' : 'organization'
+  const requestedTab = search.get('tab')
+  const tab = requestedTab === 'suggestions' || requestedTab === 'memory' ? requestedTab : 'organization'
   const [includeArchived, setIncludeArchived] = useState(false)
   const [suggestionState, setSuggestionState] = useState<SuggestionState>('pending')
   const [editor, setEditor] = useState<OrganizationKnowledgeDto | null | undefined>(undefined)
   const [actionError, setActionError] = useState<string | null>(null)
   const canManage = myRole === 'owner'
 
-  const knowledgeKey = activeOrg ? ['organization-knowledge', activeOrg.id, includeArchived] : null
+  const knowledgeKey = activeOrg && tab !== 'memory' ? ['organization-knowledge', activeOrg.id, includeArchived] : null
   const suggestionsKey =
     activeOrg && canManage && tab === 'suggestions' ? ['organization-suggestions', activeOrg.id, suggestionState] : null
   const knowledge = useSWR(knowledgeKey, () => listOrganizationKnowledge(includeArchived))
@@ -540,8 +542,8 @@ export default function KnowledgeView() {
   const reviewed = async () => {
     await Promise.all([suggestions.mutate(), knowledge.mutate()])
   }
-  const changeTab = (next: 'organization' | 'suggestions') => {
-    router.replace(orgPath(`/knowledge${next === 'suggestions' ? '?tab=suggestions' : ''}`))
+  const changeTab = (next: 'organization' | 'suggestions' | 'memory') => {
+    router.replace(orgPath(`/knowledge${next === 'organization' ? '' : `?tab=${next}`}`))
   }
   const archiveKnowledge = async (record: OrganizationKnowledgeDto) => {
     setActionError(null)
@@ -561,7 +563,9 @@ export default function KnowledgeView() {
     <div className="wrap max-desktop:p-4">
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <p className="psub mt-0 min-w-[240px] flex-1">
-          Owner-approved, revisioned knowledge shared across your organization and discovered by agents on demand.
+          {tab === 'memory'
+            ? 'Manage organization-wide memory services and account connections.'
+            : 'Owner-approved, revisioned knowledge shared across your organization and discovered by agents on demand.'}
         </p>
         {tab === 'organization' && canManage && (
           <Button variant="primary" size="sm" onClick={() => setEditor(null)}>
@@ -579,6 +583,9 @@ export default function KnowledgeView() {
           <button className={tab === 'suggestions' ? 'tab on' : 'tab'} onClick={() => changeTab('suggestions')}>
             Suggestions
           </button>
+          <button className={tab === 'memory' ? 'tab on' : 'tab'} onClick={() => changeTab('memory')}>
+            Memory
+          </button>
         </div>
         {tab === 'organization' && (
           <label className="flex items-center gap-2 pb-2 font-sans text-[11.5px] text-(--text-tertiary)">
@@ -594,7 +601,9 @@ export default function KnowledgeView() {
         </div>
       )}
 
-      {tab === 'organization' ? (
+      {tab === 'memory' ? (
+        <MemoryConnectionsCard canManage={canManage} />
+      ) : tab === 'organization' ? (
         <section className="card overflow-hidden">
           <div className="cardhead justify-between">
             <span className="cardtitle">Knowledge library</span>

--- a/packages/web/src/components/console/views/ToolsHubView.tsx
+++ b/packages/web/src/components/console/views/ToolsHubView.tsx
@@ -4,19 +4,14 @@ import useSWR from 'swr'
 import { MOCK_MODE } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { fetchExternalMemoryConnections, listManagedSkills } from '@/lib/api'
+import { listManagedSkills } from '@/lib/api'
 import { consoleKeys } from '@/lib/swr-keys'
 import { McpServersCard } from '@/components/console/McpServersCard'
 import { SkillSourcesCard } from '@/components/console/SkillSourcesCard'
-import { MemoryConnectionsCard } from '@/components/console/MemoryConnectionsCard'
 
 export default function ToolsHubView() {
   const { mcpProviders, skillSources } = useConsoleData()
   const { activeOrg, myRole } = useOrgs()
-  const memoryConnectionKey = consoleKeys.externalMemoryConnections(activeOrg?.id)
-  const { data: memoryConnections = [] } = useSWR(memoryConnectionKey, ([, orgId]) =>
-    fetchExternalMemoryConnections(orgId)
-  )
   const managedSkillsKey = consoleKeys.managedSkills(activeOrg?.id, false)
   const { data: managedSkills = [] } = useSWR(managedSkillsKey, ([, orgId]) => listManagedSkills(false, orgId))
   const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
@@ -37,8 +32,8 @@ export default function ToolsHubView() {
       <div
         className={
           MOCK_MODE
-            ? 'mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-4'
-            : 'mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-3'
+            ? 'mb-[18px] grid grid-cols-2 gap-[14px] desktop:grid-cols-3'
+            : 'mb-[18px] grid grid-cols-2 gap-[14px]'
         }
       >
         <div className="card stat">
@@ -48,10 +43,6 @@ export default function ToolsHubView() {
         <div className="card stat">
           <div className="statlbl">Skills library</div>
           <div className="statval">{skillSources.length + managedSkills.length}</div>
-        </div>
-        <div className="card stat">
-          <div className="statlbl">External memory</div>
-          <div className="statval">{memoryConnections.length}</div>
         </div>
         {/* Tool-call metering has no backend yet — the design's demo stat renders
             only in mock mode with its demo value. */}
@@ -64,7 +55,6 @@ export default function ToolsHubView() {
       </div>
       <McpServersCard canWrite={canWrite} />
       <SkillSourcesCard canWrite={canWrite} canManage={canManageOwnerResources} />
-      <MemoryConnectionsCard canManage={canManageOwnerResources} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- use the Blocks icon for Tools & Skills and the BookOpen icon for Knowledge across desktop and mobile navigation
- move organization-level external memory connections from Tools & Skills into a dedicated Knowledge > Memory tab
- update empty-state navigation to the new location and avoid loading the knowledge library while viewing Memory

## Why

Tools & Skills represents capabilities agents can call or run. Memory is organization context, so managing memory services under Knowledge gives the navigation a clearer mental model.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- targeted ESLint and Prettier checks
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/views/KnowledgeView.test.tsx src/components/console/ExternalMemoryBindingFields.test.tsx`
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- desktop and mobile visual verification in the local mock console

Created by Codex . gpt-5.6-sol
