### PR TITLE
fix(sessions): suggest Slack profile linking

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7743,7 +7743,11 @@ export class Daemon {
         return true
       }
       const info = this.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
-      const link = acpSessionId ? this.sessionLink(acpSessionId) : undefined
+      const link = acpSessionId
+        ? msg.platform === 'slack'
+          ? this.slackSessionLink(acpSessionId)
+          : this.sessionLink(acpSessionId)
+        : undefined
       if (msg.platform === 'telegram') {
         // HTML chrome (not recorded) — renders the compact line + a tappable View link.
         void (conn as TelegramConnection | undefined)?.postChrome(msg.channel, renderStatusReply(info, link), {
@@ -9554,7 +9558,7 @@ export class Daemon {
       botUrl: this.agentLink(agentId),
       runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
       model: this.buildStatusInfo(p).model ?? turnModel ?? 'default',
-      sessionUrl: this.sessionLink(sessionId)
+      sessionUrl: msg.platform === 'slack' ? this.slackSessionLink(sessionId) : this.sessionLink(sessionId)
     })
     try {
       if (!p.selectedHost) {
@@ -10934,6 +10938,12 @@ export class Daemon {
     return `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
   }
 
+  /** A Slack-originated session link carries only the source context the 404 UI
+   *  already knows from the click. It never changes session authorization. */
+  private slackSessionLink(acpSessionId: string): string {
+    return `${this.sessionLink(acpSessionId)}?source=slack`
+  }
+
   /** The console deep link to an agent: `<base>/<orgSlug>/agents/<agentId>`. Same
    *  org-segment rule as {@link sessionLink}. */
   private agentLink(agentId: string): string {
@@ -11200,7 +11210,7 @@ export class Daemon {
       ...(iconUrl ? { iconUrl } : {}),
       ...(sessionTitle ? { sessionTitle } : {})
     }
-    const link = rec.acpSessionId ? this.sessionLink(rec.acpSessionId) : undefined
+    const link = rec.acpSessionId ? this.slackSessionLink(rec.acpSessionId) : undefined
     const pending = [...this.pending.values()].find((turn) => turn.sessionKey === sessionKey)
     const cancellable = pending?.statusCancellable ?? this.inflight.has(sessionKey)
     return { info, identity, ...(link ? { link } : {}), cancellable }
@@ -11249,7 +11259,7 @@ export class Daemon {
       // runtimes only advertise the model after the first prompt). It fills in via edits
       // as usage_update / turn-end land.
       p.lastStatusBar = key
-      const link = this.sessionLink(p.acpSessionId)
+      const link = this.slackSessionLink(p.acpSessionId)
       const sessionTarget = this.httpSlackSessionTarget(p)
       const shared =
         sessionTarget && p.integrationId

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1248,7 +1248,7 @@ describe('Slack interactive status bar', () => {
     const section = blocks.find((b) => b.type === 'section')!
     expect(blocks).toHaveLength(1)
     expect(section.text!.text).toContain('opus-4.8')
-    expect(section.text!.text).toContain('View Session')
+    expect(section.text!.text).toContain('<http://localhost:3000/sessions/acp-1?source=slack|View Session>')
     expect(section.accessory.action_id).toBe('ac_more')
     await daemon.stop()
   }, 15_000)
@@ -1691,7 +1691,7 @@ describe('Slack interactive status bar', () => {
     await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true))
     // The connection queries statusInfoForKey to build the modal; it resolves the deep link.
     const data = (daemon as any).statusInfoForKey(SESSION_KEY)
-    expect(data.link).toBe('https://console.example.com/sessions/acp-1')
+    expect(data.link).toBe('https://console.example.com/sessions/acp-1?source=slack')
     expect(data.info.models).toEqual(['opus-4.8', 'sonnet-5'])
     expect(data.identity).toMatchObject({
       name: AGENT_IDENTITY.displayName,

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -131,7 +131,7 @@ function classicFooter(botName = 'bot-a', runtime = 'claude', model = 'default')
     elements: [
       {
         type: 'mrkdwn',
-        text: `sent by <https://app.example.com/agents/bot-a|${botName}> (${runtime} · ${model}) · <https://app.example.com/sessions/acp-1|open in session>`
+        text: `sent by <https://app.example.com/agents/bot-a|${botName}> (${runtime} · ${model}) · <https://app.example.com/sessions/acp-1?source=slack|open in session>`
       }
     ]
   }

--- a/packages/web/src/components/console/NotFound.tsx
+++ b/packages/web/src/components/console/NotFound.tsx
@@ -9,8 +9,9 @@ import { useSearchOpen } from './search-open'
 // (agent / session / schedule / daemon) and for an unknown route: a brand-soft
 // icon well badged with `search-x`, a mono `404 · KIND` eyebrow, a title, a calm
 // one-line explanation with the id/path in a mono chip, then a primary "back to
-// the list" action and a "Search" affordance (⌘K on desktop). Rendered inside the
-// detail views' `.card`, so it inherits the surrounding `wrap`/loading gate.
+// the list" action, an optional recovery action, and a "Search" affordance (⌘K
+// on desktop). Rendered inside the detail views' `.card`, so it inherits the
+// surrounding `wrap`/loading gate.
 //
 // Design: "Not Found Pages.dc.html" (claude.ai/design) — a single pattern applied
 // across resources, calm tone, states a plausible reason.
@@ -23,6 +24,7 @@ export function NotFound({
   post,
   actionLabel,
   actionHref,
+  secondaryAction,
   searchLabel = 'Search',
   showSearch = true
 }: {
@@ -42,6 +44,8 @@ export function NotFound({
   actionLabel: string
   /** Resolved href for the primary action (caller applies `orgPath`). */
   actionHref: string
+  /** Optional recovery action shown beside/below the primary action. */
+  secondaryAction?: { label: string; href: string; icon?: string }
   /** Mobile secondary button label (e.g. "Search agents"); desktop reads "Search". */
   searchLabel?: string
   /** Show the Search affordance. Off for the bare root 404, which renders outside
@@ -75,11 +79,17 @@ export function NotFound({
         {post}
       </div>
 
-      {/* Desktop actions: inline primary + ghost "Search ⌘K" */}
+      {/* Desktop actions: inline primary, optional recovery, and ghost "Search ⌘K" */}
       <div className="mt-5 hidden items-center gap-2 desktop:flex">
         <Button size="sm" onClick={() => router.push(actionHref)}>
           {actionLabel}
         </Button>
+        {secondaryAction ? (
+          <Button variant="secondary" size="sm" onClick={() => router.push(secondaryAction.href)}>
+            {secondaryAction.icon ? <Icon name={secondaryAction.icon} size={14} /> : null}
+            {secondaryAction.label}
+          </Button>
+        ) : null}
         {showSearch && (
           <Button variant="ghost" size="sm" onClick={openSearch}>
             <span className="inline-flex items-center gap-[7px]">
@@ -98,6 +108,17 @@ export function NotFound({
           <Icon name="arrow-left" size={15} />
           {actionLabel}
         </Button>
+        {secondaryAction ? (
+          <Button
+            variant="secondary"
+            size="md"
+            className="h-11 w-full text-[14px]"
+            onClick={() => router.push(secondaryAction.href)}
+          >
+            {secondaryAction.icon ? <Icon name={secondaryAction.icon} size={15} /> : null}
+            {secondaryAction.label}
+          </Button>
+        ) : null}
         {showSearch && (
           <Button variant="secondary" size="md" className="h-11 w-full text-[14px]" onClick={openSearch}>
             <Icon name="search" size={15} />

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -362,7 +362,7 @@ export default function SocialSignInCard({
 
   return (
     <>
-      <section className={shell} aria-label="Sign-in methods">
+      <section id="sign-in-methods" className={shell} aria-label="Sign-in methods">
         <div className={header}>
           <div className={mobile ? '' : 'flex flex-col gap-0.5'}>
             <div className={mobile ? 'font-sans text-[14px] font-semibold leading-normal' : 'cardtitle'}>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
   agentLabel,
@@ -30,6 +30,8 @@ import {
   type SessionStep
 } from '@/lib/data'
 import {
+  ApiError,
+  fetchMySlackIdentity,
   fetchSessionMessages,
   fetchSessionDetail,
   fetchToolBody,
@@ -55,6 +57,8 @@ import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
 import { mergeSessionMessages } from '@/lib/session-transcript'
+import { socialLoginProviders } from '@/lib/social-login-providers'
+import { isAuthConfigured } from '@/lib/auth'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { ContextWindowIndicator } from '@/components/console/ContextWindowIndicator'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
@@ -634,6 +638,7 @@ export default function SessionDetailView() {
   const acpRegistry = useAcpRegistry()
   const { activeOrg, orgPath } = useOrgs()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { id } = useParams<{ id: string }>()
   const {
     agents,
@@ -704,6 +709,7 @@ export default function SessionDetailView() {
       : null
   const {
     data: sessionDetail,
+    error: sessionDetailError,
     isLoading: sessionDetailLoading,
     mutate: mutateSessionDetail
   } = useSWR<SessionDetailDto>(
@@ -711,6 +717,29 @@ export default function SessionDetailView() {
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
     { refreshInterval: 30_000 }
   )
+  // A Slack-rendered View Session link carries source=slack. That caller-provided
+  // context is independent of whether the requested id exists, so the CP can keep
+  // unknown and unauthorized 404 payloads byte-for-byte equivalent.
+  const slackRecoveryCandidate =
+    sessionDetailError instanceof ApiError &&
+    sessionDetailError.status === 404 &&
+    searchParams.get('source') === 'slack' &&
+    isAuthConfigured() &&
+    socialLoginProviders().some((provider) => provider.target === 'slack')
+  const {
+    data: slackIdentity,
+    error: slackIdentityError,
+    isValidating: slackIdentityLoading
+  } = useSWR(slackRecoveryCandidate ? 'logto-slack-identity' : null, fetchMySlackIdentity, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    shouldRetryOnError: false
+  })
+  const showSlackLink =
+    slackRecoveryCandidate &&
+    !slackIdentityLoading &&
+    slackIdentityError === undefined &&
+    slackIdentity?.linked === false
   const detailSession = sessionDetail ? sessionFromDetailDto(sessionDetail) : null
   // The cursor-loaded list row can predate the final Dream usage report. Keep
   // its local/live fields, but let the independently refreshed detail snapshot
@@ -927,7 +956,16 @@ export default function SessionDetailView() {
             post=" in this organization. It may have expired or been deleted."
             actionLabel="Back to sessions"
             actionHref={orgPath('/sessions')}
-            searchLabel="Search sessions"
+            secondaryAction={
+              showSlackLink
+                ? {
+                    label: 'Link Slack profile',
+                    href: orgPath('/profile#sign-in-methods'),
+                    icon: 'link'
+                  }
+                : undefined
+            }
+            showSearch={false}
           />
         )}
       </div>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3034,6 +3034,21 @@ export async function fetchMySocialAccount(): Promise<MySocialAccountDto> {
   return apiGet<MySocialAccountDto>('/me/social-identities')
 }
 
+export type MySlackIdentityDto =
+  | { linked: false }
+  | {
+      linked: true
+      teamId: string
+      userId: string
+      teamName?: string
+      teamDomain?: string
+    }
+
+/** The narrow linked/not-linked read used by Slack session recovery. */
+export function fetchMySlackIdentity(): Promise<MySlackIdentityDto> {
+  return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
+}
+
 // Linking runs browser→provider, so the CP never sees that write and its cached
 // copy would hide the new identity. Say so once, right after a link lands.
 export async function refreshMySocialIdentities(): Promise<void> {


### PR DESCRIPTION
## Summary

- keep every unknown or unauthorized session response on the identical generic Session not found 404
- mark only Slack-rendered View Session deep links with source=slack; the marker is UI context and never participates in authorization
- show Link Slack profile only when the link came from Slack, Slack sign-in is offered, and the current account reports linked: false
- omit the action for already-linked users, ordinary session URLs, GitHub or other sources, identity lookup failures, and deployments without Slack sign-in
- link directly to the Profile page Sign-in methods section

## Safety

No session lookup result is added to the 404 body. Unknown and unauthorized ids remain indistinguishable. The source marker is supplied by the Slack link itself and can only change the profile-linking action; it grants no access.

## Validation

- pnpm --filter @agentconnect.md/web test (72 files, 509 tests)
- pnpm --filter @agentconnect.md/daemon typecheck
- pnpm --filter @agentconnect.md/web typecheck
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint
- focused daemon transcript assertions passed (28/28); the local macOS Vitest process then hit the known EMFILE watcher-exhaustion harness error

Created by Codex . GPT-5.6-sol