### PR TITLE
fix(web): separate memory from knowledge tabs

### DIFF
--- a/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
+++ b/packages/web/src/components/console/ExternalMemoryBindingFields.tsx
@@ -148,8 +148,8 @@ export function ExternalMemoryBindingFields({
       {!isLoading && connections.length === 0 && (
         <div className="text-[12px] leading-[1.5] text-(--text-secondary)">
           No external-memory connection is configured. An organization owner can add one in{' '}
-          <a className="lnk" href={orgPath('/knowledge?tab=memory')}>
-            Knowledge → Memory
+          <a className="lnk" href={orgPath('/knowledge#external-memory')}>
+            Knowledge → External memory
           </a>
           .
         </div>

--- a/packages/web/src/components/console/MemoryConnectionsCard.tsx
+++ b/packages/web/src/components/console/MemoryConnectionsCard.tsx
@@ -136,7 +136,7 @@ export function MemoryConnectionsCard({ canManage }: { canManage: boolean }) {
 
   const loading = installationsLoading || connectionsLoading
   return (
-    <div className="card">
+    <div id="external-memory" className="card mt-[18px]">
       <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-1 border-b border-(--border-subtle) px-4 py-[14px] desktop:items-center">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="cardtitle">External memory</span>

--- a/packages/web/src/components/console/views/KnowledgeView.test.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.test.tsx
@@ -6,11 +6,9 @@ import { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setApiOrgId, type OrganizationKnowledgeDto, type OrganizationSuggestionDto } from '@/lib/api'
 
-const navigation = vi.hoisted(() => ({ search: '' }))
-
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(navigation.search)
+  useSearchParams: () => new URLSearchParams()
 }))
 vi.mock('@/lib/org-context', () => ({
   useOrgs: () => ({ activeOrg: { id: 'org-test' }, myRole: 'owner', orgPath: (path: string) => path })
@@ -83,7 +81,6 @@ async function settleUntil(done: () => boolean): Promise<void> {
 }
 
 beforeEach(() => {
-  navigation.search = ''
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   host = document.createElement('div')
   document.body.append(host)
@@ -206,7 +203,7 @@ describe('organization suggestion review card', () => {
 })
 
 describe('organization knowledge surface', () => {
-  it('keeps managed skills out of Knowledge and never requests their library endpoint', async () => {
+  it('renders knowledge above external memory without loading managed skills', async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL) =>
         new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
@@ -222,37 +219,16 @@ describe('organization knowledge surface', () => {
     })
     await settleUntil(() => host.textContent?.includes('No organization knowledge has been published yet.') === true)
 
-    expect(host.textContent).toContain('Knowledge library')
-    expect(host.textContent).not.toContain('Managed skills')
-    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
-      expect.stringContaining('/knowledge?includeArchived=false')
-    ])
-    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/managed-skills'))).toBe(false)
-  })
-
-  it('hosts external memory under the Memory tab without loading the knowledge library', async () => {
-    navigation.search = 'tab=memory'
-    const fetchMock = vi.fn(
-      async (_input: RequestInfo | URL) =>
-        new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
-    )
-    vi.stubGlobal('fetch', fetchMock)
-
-    await act(async () => {
-      root.render(
-        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-          <KnowledgeView />
-        </SWRConfig>
-      )
-    })
-    await settleUntil(() => host.textContent?.includes('No external-memory connections yet') === true)
-
-    expect(host.textContent).toContain('External memory')
-    expect(host.textContent).not.toContain('Knowledge library')
+    const content = host.textContent ?? ''
+    expect(content).toContain('Knowledge library')
+    expect(content).toContain('External memory')
+    expect(content.indexOf('Knowledge library')).toBeLessThan(content.indexOf('External memory'))
+    expect(content).not.toContain('Managed skills')
     const urls = fetchMock.mock.calls.map(([input]) => String(input))
+    expect(urls.some((url) => url.includes('/knowledge?includeArchived=false'))).toBe(true)
     expect(urls.some((url) => url.includes('/memory-plugin-installations'))).toBe(true)
     expect(urls.some((url) => url.includes('/external-memory-connections'))).toBe(true)
-    expect(urls.some((url) => url.includes('/knowledge?'))).toBe(false)
+    expect(urls.some((url) => url.includes('/managed-skills'))).toBe(false)
   })
 
   it('loads and selects historical knowledge content, then refreshes an open entry for a new revision', async () => {

--- a/packages/web/src/components/console/views/KnowledgeView.tsx
+++ b/packages/web/src/components/console/views/KnowledgeView.tsx
@@ -522,15 +522,14 @@ export default function KnowledgeView() {
   const { activeOrg, myRole, orgPath } = useOrgs()
   const router = useRouter()
   const search = useSearchParams()
-  const requestedTab = search.get('tab')
-  const tab = requestedTab === 'suggestions' || requestedTab === 'memory' ? requestedTab : 'organization'
+  const tab = search.get('tab') === 'suggestions' ? 'suggestions' : 'organization'
   const [includeArchived, setIncludeArchived] = useState(false)
   const [suggestionState, setSuggestionState] = useState<SuggestionState>('pending')
   const [editor, setEditor] = useState<OrganizationKnowledgeDto | null | undefined>(undefined)
   const [actionError, setActionError] = useState<string | null>(null)
   const canManage = myRole === 'owner'
 
-  const knowledgeKey = activeOrg && tab !== 'memory' ? ['organization-knowledge', activeOrg.id, includeArchived] : null
+  const knowledgeKey = activeOrg ? ['organization-knowledge', activeOrg.id, includeArchived] : null
   const suggestionsKey =
     activeOrg && canManage && tab === 'suggestions' ? ['organization-suggestions', activeOrg.id, suggestionState] : null
   const knowledge = useSWR(knowledgeKey, () => listOrganizationKnowledge(includeArchived))
@@ -542,8 +541,8 @@ export default function KnowledgeView() {
   const reviewed = async () => {
     await Promise.all([suggestions.mutate(), knowledge.mutate()])
   }
-  const changeTab = (next: 'organization' | 'suggestions' | 'memory') => {
-    router.replace(orgPath(`/knowledge${next === 'organization' ? '' : `?tab=${next}`}`))
+  const changeTab = (next: 'organization' | 'suggestions') => {
+    router.replace(orgPath(`/knowledge${next === 'suggestions' ? '?tab=suggestions' : ''}`))
   }
   const archiveKnowledge = async (record: OrganizationKnowledgeDto) => {
     setActionError(null)
@@ -563,9 +562,7 @@ export default function KnowledgeView() {
     <div className="wrap max-desktop:p-4">
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <p className="psub mt-0 min-w-[240px] flex-1">
-          {tab === 'memory'
-            ? 'Manage organization-wide memory services and account connections.'
-            : 'Owner-approved, revisioned knowledge shared across your organization and discovered by agents on demand.'}
+          Owner-approved, revisioned knowledge shared across your organization and discovered by agents on demand.
         </p>
         {tab === 'organization' && canManage && (
           <Button variant="primary" size="sm" onClick={() => setEditor(null)}>
@@ -583,9 +580,6 @@ export default function KnowledgeView() {
           <button className={tab === 'suggestions' ? 'tab on' : 'tab'} onClick={() => changeTab('suggestions')}>
             Suggestions
           </button>
-          <button className={tab === 'memory' ? 'tab on' : 'tab'} onClick={() => changeTab('memory')}>
-            Memory
-          </button>
         </div>
         {tab === 'organization' && (
           <label className="flex items-center gap-2 pb-2 font-sans text-[11.5px] text-(--text-tertiary)">
@@ -601,9 +595,7 @@ export default function KnowledgeView() {
         </div>
       )}
 
-      {tab === 'memory' ? (
-        <MemoryConnectionsCard canManage={canManage} />
-      ) : tab === 'organization' ? (
+      {tab === 'organization' ? (
         <section className="card overflow-hidden">
           <div className="cardhead justify-between">
             <span className="cardtitle">Knowledge library</span>
@@ -673,6 +665,8 @@ export default function KnowledgeView() {
           )}
         </div>
       )}
+
+      <MemoryConnectionsCard canManage={canManage} />
 
       {editor !== undefined && (
         <KnowledgeEditor record={editor} onClose={() => setEditor(undefined)} onSaved={refreshOrganization} />


### PR DESCRIPTION
## Summary

- remove Memory from the Organization / Suggestions tab group
- render External memory as an independent section below the Knowledge content
- update the empty-state link to scroll directly to the External memory section

## Why

Organization and Suggestions are two views of Knowledge. Memory is a separate organization-level configuration area, so it should remain visible below Knowledge instead of behaving like a sibling tab.

## Validation

- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/views/KnowledgeView.test.tsx src/components/console/ExternalMemoryBindingFields.test.tsx`
- targeted ESLint and Prettier checks
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- desktop and mobile visual verification in the local mock console

Created by Codex . gpt-5.6-sol
