### PR TITLE
fix(collab): keep agent visibility open by default

### DIFF
--- a/docs/designs/agent-collaboration-implementation.md
+++ b/docs/designs/agent-collaboration-implementation.md
@@ -403,16 +403,15 @@ snapshot that has not caught up.
 
 The data model stores:
 
-- `Org.defaultAgentVisibility: 'all' | 'selected'`, defaulting to `selected`, seeds both
+- `Org.defaultAgentVisibility: 'all' | 'selected'`, defaulting to `all`, seeds both
   directions for newly created agents and never rewrites existing ones.
-- `callPolicy: 'all' | 'selected'`; when `selected`, accepts no peer until allowed.
+- `callPolicy: 'all' | 'selected'`, defaulting to `all`; when `selected`, accepts no peer until allowed.
 - `allowedCallerAgentIds: string[]` is the set of agent IDs allowed when `callPolicy='selected'`.
 - `outboundPolicy: 'all' | 'selected'`; its
   `allowedTargetAgentIds` constrain which peers the caller may select.
 
-An agent create may override either direction explicitly. The Agent columns retain
-`selected` database defaults as a fail-closed fallback for writes that bypass the
-repository creation seam.
+An agent create may override either direction explicitly. The Agent columns retain `all`
+database defaults for writes that bypass the repository creation seam.
 
 `AgentSpec` carries local target policy, while the versioned collaboration
 snapshot supplies caller/target organization, placement, and policy data for

--- a/docs/designs/directional-agent-visibility.md
+++ b/docs/designs/directional-agent-visibility.md
@@ -56,12 +56,12 @@ B's inbound restriction, and selecting A on B never expands A's outbound scope. 
 and hop-limit guards remain independent and unchanged.
 
 Each organization has a `defaultAgentVisibility` policy that seeds both directions of a
-new agent. It defaults to `selected`, so a new agent neither discovers peers nor accepts
-peer calls until configured; an owner may instead choose `all` for future agents. A create
-request can explicitly override either direction. Changing the organization setting never
-rewrites existing agents. Under `all`, the associated id array is stored empty; under
-`selected`, an empty array means no peers. The Agent table keeps `selected` as its database
-default so writes outside the repository creation seam remain fail-closed.
+new agent. It defaults to `all`, preserving the existing collaboration experience; an
+owner may instead choose `selected` to isolate future agents until peers are configured.
+A create request can explicitly override either direction. Changing the organization
+setting never rewrites existing agents. Under `all`, the associated id array is stored
+empty; under `selected`, an empty array means no peers. The Agent table also defaults both
+directions to `all` for writes outside the repository creation seam.
 
 ## Control plane and console
 
@@ -137,24 +137,22 @@ closed. A new direct wake of A still requires B → A authorization.
 
 ## Compatibility and failure behavior
 
-On a fresh agent, both policies default to `selected` with empty lists. A missing policy in
-local configuration or a collaboration snapshot also defaults to `selected`, so incomplete
-state cannot create an edge. When a newer daemon decodes an older control-plane agent
-payload, both outbound fields remain absent so the daemon preserves the complete on-disk
-outbound half instead of retaining `selected` while clearing its list. Local and
-cross-daemon delivery both fail closed when the collaboration snapshot does not contain
-**both** the caller and the target in one organization.
+On a fresh agent, both policies default to `all`. When a newer daemon decodes an older
+control-plane payload, both outbound fields remain absent so the daemon preserves the
+complete on-disk outbound half instead of retaining `selected` while clearing its list.
+Once a `selected` outbound policy is received, enforcement is fail-closed: missing targets
+are denied. Local and cross-daemon delivery both fail closed when the collaboration
+snapshot does not contain **both** the caller and the target in one organization.
 Consequently, a local-only daemon that has never received a control-plane collaboration
 snapshot cannot authorize same-daemon direct agent calls.
 
 Rolling upgrade: the flat org directory arrives only from a control plane that advertises
 `agent-directory-org-scope-v1`. Against an older control plane, relay and daemon derive the
-directory from the channel-keyed rows they do receive. A missing directional policy in
-those rows defaults to `selected` with an empty list, so it cannot create an implicit edge;
-an integration-less agent also stays invisible until the flat list arrives. A daemon
-likewise keeps sending the caller's current channel with a discovery request until the
-feature appears.
+directory from the channel-keyed rows they do receive, so integration-backed pairs keep
+resolving; an integration-less agent stays invisible until the flat list arrives, which is
+exactly the pre-change behavior. A daemon likewise keeps sending the caller's current
+channel with a discovery request until the feature appears.
 
 A data-plane consumer from before this design ignores the new fields and therefore keeps
-the historical unrestricted outbound behavior. The private default is fully effective only
-on daemon and relay versions that understand the directional policy.
+the historical unrestricted outbound behavior. A selected outbound restriction is fully
+effective only on daemon and relay versions that understand the directional policy.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -247,13 +247,13 @@ name it (a self-_wake_ is still refused separately).
 The agent-directory tool must hide peers that fail any part of this check. Message
 delivery must repeat the same authorization instead of trusting discovery: a remembered,
 guessed, or stale agent id must not bypass either policy. Rejection does not wake the
-target and uses the same `not_allowed` result as an inbound-policy denial. An organization
-defaults new agents to `selected` with an empty list in both directions: they discover no
-peers and accept no peer calls. An owner may explicitly set the organization's creation
-default to `all`, and an individual create may still override either direction. Changing
-the organization default affects only future agents and never rewrites an existing agent's
-persisted policy. A local or otherwise unconfigured agent remains fail-closed at
-`selected + []`.
+target and uses the same `not_allowed` result as an inbound-policy denial. Both directions
+default to all peers, preserving the existing collaboration experience. An organization
+owner may instead set the creation default to `selected` with an empty list in both
+directions, so future agents discover no peers and accept no peer calls until configured.
+An individual create may still override either direction. Changing the organization
+default affects only future agents and never rewrites an existing agent's persisted policy.
+A local or otherwise unconfigured agent also defaults to `all` for compatibility.
 
 **Two unrelated settings are both called "visibility".** The `callPolicy` /
 `outboundPolicy` pair above is what the console labels "Agent visibility", and it is the

--- a/packages/control-plane/prisma/migrations/20260801150000_restore_open_agent_visibility_defaults/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801150000_restore_open_agent_visibility_defaults/migration.sql
@@ -1,0 +1,14 @@
+-- Keep the historical open collaboration experience as the product default.
+-- Organization owners may still opt future agents into the isolated policy.
+ALTER TABLE "public"."agent"
+  ALTER COLUMN "callPolicy" SET DEFAULT 'all',
+  ALTER COLUMN "outboundPolicy" SET DEFAULT 'all';
+
+-- The organization setting was introduced with the isolated rollout default.
+-- Normalize existing organizations to the intended open default without
+-- rewriting any agent's persisted directional policy.
+UPDATE "public"."org"
+SET "defaultAgentVisibility" = 'all';
+
+ALTER TABLE "public"."org"
+  ALTER COLUMN "defaultAgentVisibility" SET DEFAULT 'all';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -42,7 +42,7 @@ model Org {
   icon                   Json?           @db.JsonB
   // Applied to both call directions when a new agent does not explicitly choose
   // a policy. Existing agents keep their persisted directional policies.
-  defaultAgentVisibility AgentCallPolicy @default(selected)
+  defaultAgentVisibility AgentCallPolicy @default(all)
   createdAt              DateTime        @default(now()) @db.Timestamptz(6)
   updatedAt              DateTime        @updatedAt @db.Timestamptz(6)
 
@@ -629,10 +629,10 @@ model Agent {
   visibility            ResourceVisibility @default(org) // 'org' = all members; 'restricted' = ownership arm + sharedWith
   sharedWith            String[]           @default([]) // app_user.id set granted view when visibility='restricted'
   // ── inbound agent-call policy (UI: Agent visibility) ──
-  callPolicy            AgentCallPolicy    @default(selected) // selected + [] = no org peer may call by default
+  callPolicy            AgentCallPolicy    @default(all) // 'all' = any org peer agent may call this as a sub-agent
   allowedCallerAgentIds String[]           @default([]) // agent.id set used when callPolicy='selected'
   // ── outbound agent-call policy (UI: Agent visibility) ──
-  outboundPolicy        AgentCallPolicy    @default(selected) // selected + [] = no peer discovery/calls by default
+  outboundPolicy        AgentCallPolicy    @default(all) // 'all' = this agent may discover/call any otherwise-callable org peer
   allowedTargetAgentIds String[]           @default([]) // agent.id set used when outboundPolicy='selected'
   introduceOnJoin       Boolean            @default(false) // #536: self-introduce to peers on a genuine channel join
   restrictFileAccess    Boolean            @default(false) // #642: request an OS sandbox; daemon policy may force it on

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1005,7 +1005,7 @@ export function agentRoutes(deps: HttpDeps) {
           // with visible same-org peers (same rule as PUT /call-policy). The new
           // agent isn't a peer yet, so `agentId` self-exclusion is a harmless no-op.
           const agentId = AgentId(randomUUID())
-          const defaultAgentVisibility = (await deps.repos.org.defaultAgentVisibility(orgOf(req))) ?? 'selected'
+          const defaultAgentVisibility = (await deps.repos.org.defaultAgentVisibility(orgOf(req))) ?? 'all'
           const callPolicy = req.body.callPolicy ?? defaultAgentVisibility
           const outboundPolicy = req.body.outboundPolicy ?? defaultAgentVisibility
           const initialAllowedCallers =

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -223,7 +223,7 @@ export class PgAgentRepo implements AgentRepo {
               select: { defaultAgentVisibility: true }
             })
           : null
-      const defaultAgentVisibility = (orgDefault?.defaultAgentVisibility as AgentCallPolicy | undefined) ?? 'selected'
+      const defaultAgentVisibility = (orgDefault?.defaultAgentVisibility as AgentCallPolicy | undefined) ?? 'all'
       const callPolicy = input.callPolicy ?? defaultAgentVisibility
       const outboundPolicy = input.outboundPolicy ?? defaultAgentVisibility
       const memberships = await lockResourceWriteMemberships(tx, {
@@ -300,8 +300,8 @@ export class PgAgentRepo implements AgentRepo {
           ...(input.visibility ? { visibility: input.visibility } : {}),
           ...(memberships.sharedWith ? { sharedWith: memberships.sharedWith } : {}),
           // Both directions inherit the organization's creation default unless
-          // explicitly chosen. The database's own selected default remains the
-          // fail-closed fallback for writes outside this repository seam.
+          // explicitly chosen. The database default matches the open product default
+          // for writes outside this repository seam.
           callPolicy,
           allowedCallerAgentIds: callPolicy === 'selected' ? (input.allowedCallerAgentIds ?? []) : [],
           outboundPolicy,

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -176,9 +176,9 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
         // Managed organization skills are a distinct explicit enable-list.
         managedSkills: [],
         // Agent→agent call policy (§2.5) — always shipped so a policy/allow-list change replicates.
-        callPolicy: 'selected',
+        callPolicy: 'all',
         allowedCallerAgentIds: [],
-        outboundPolicy: 'selected',
+        outboundPolicy: 'all',
         allowedTargetAgentIds: [],
         // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
         introduceOnJoin: false,

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -107,9 +107,9 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(Number.isNaN(Date.parse(created.createdAt))).toBe(false)
     expect(created.lastModifiedBy).toBe(created.createdBy)
     expect(created.lastModifiedAt).toBe(created.createdAt)
-    expect(created.callPolicy).toBe('selected')
+    expect(created.callPolicy).toBe('all')
     expect(created.allowedCallerAgentIds).toEqual([])
-    expect(created.outboundPolicy).toBe('selected')
+    expect(created.outboundPolicy).toBe('all')
     expect(created.allowedTargetAgentIds).toEqual([])
 
     // Persisted in the real DB — the FK points at the seeded owner user.
@@ -140,9 +140,9 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(fetched.capabilities).toEqual(['fs.read', 'fs.write'])
     expect(fetched.lastModifiedBy).toBe(created.lastModifiedBy)
     expect(fetched.lastModifiedAt).toBe(created.lastModifiedAt)
-    expect(fetched.callPolicy).toBe('selected')
+    expect(fetched.callPolicy).toBe('all')
     expect(fetched.allowedCallerAgentIds).toEqual([])
-    expect(fetched.outboundPolicy).toBe('selected')
+    expect(fetched.outboundPolicy).toBe('all')
     expect(fetched.allowedTargetAgentIds).toEqual([])
   })
 
@@ -334,7 +334,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(selectedRow?.allowedTargetAgentIds).toEqual([callerId])
 
     // The halves are independent: restricting only the outbound side leaves the
-    // inbound side at the DB default.
+    // inbound side at the organization default.
     const outboundOnly = await app.app.inject({
       method: 'POST',
       url: `${ORG}/agents`,
@@ -347,7 +347,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     })
     expect(outboundOnly.statusCode).toBe(201)
     expect(outboundOnly.json()).toMatchObject({
-      callPolicy: 'selected',
+      callPolicy: 'all',
       allowedCallerAgentIds: [],
       outboundPolicy: 'selected',
       allowedTargetAgentIds: [callerId]
@@ -358,7 +358,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(outboundOnlyRow?.outboundPolicy).toBe('selected')
     expect(outboundOnlyRow?.allowedTargetAgentIds).toEqual([callerId])
 
-    // Omitting the policy keeps the DB default in both directions.
+    // Omitting the policy uses the organization default in both directions.
     const dflt = await app.app.inject({
       method: 'POST',
       url: `${ORG}/agents`,
@@ -366,9 +366,9 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     })
     expect(dflt.statusCode).toBe(201)
     expect(dflt.json()).toMatchObject({
-      callPolicy: 'selected',
+      callPolicy: 'all',
       allowedCallerAgentIds: [],
-      outboundPolicy: 'selected',
+      outboundPolicy: 'all',
       allowedTargetAgentIds: []
     })
   })

--- a/packages/control-plane/test/integration/channel-agents.route.test.ts
+++ b/packages/control-plane/test/integration/channel-agents.route.test.ts
@@ -61,8 +61,7 @@ class SpyControl {
   async collaborationRoutes(): Promise<void> {}
 }
 
-/** Create an explicitly open agent + install its Slack integration. Directory-policy
- * tests opt in to edges; the create-default contract is covered in agents.route.test. */
+/** Create an agent (via REST, with displayName/description) + install its slack integration. */
 async function installAgent(
   app: HttpApp,
   daemonId: string,
@@ -71,7 +70,7 @@ async function installAgent(
   const created = await app.app.inject({
     method: 'POST',
     url: `${ORG}/agents`,
-    payload: { ...agent, runtime: 'claude', daemonId, callPolicy: 'all', outboundPolicy: 'all' }
+    payload: { ...agent, runtime: 'claude', daemonId }
   })
   expect(created.statusCode).toBe(201)
   const agentId = (created.json() as { id: string }).id
@@ -84,8 +83,8 @@ async function installAgent(
   return { agentId, integrationId: (res.json() as { id: string }).id }
 }
 
-/** Create an explicitly open agent with NO integration — it exists only in the org peer
- * directory and can appear in no channel-keyed structure at all. */
+/** Create an agent with NO integration — it exists only in the org peer directory and
+ *  can appear in no channel-keyed structure at all (webchat / hook / memory-only agents). */
 async function createAgent(
   app: HttpApp,
   daemonId: string,
@@ -94,7 +93,7 @@ async function createAgent(
   const created = await app.app.inject({
     method: 'POST',
     url: `${ORG}/agents`,
-    payload: { ...agent, runtime: 'claude', daemonId, callPolicy: 'all', outboundPolicy: 'all' }
+    payload: { ...agent, runtime: 'claude', daemonId }
   })
   expect(created.statusCode).toBe(201)
   return (created.json() as { id: string }).id
@@ -232,7 +231,7 @@ describe('channel/agents (agent collaboration directory)', () => {
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
 
     const caller = await installAgent(running, DAEMON, { name: 'caller' })
-    const openPeer = await installAgent(running, DAEMON, { name: 'open-peer' }) // helper explicitly opts into all
+    const openPeer = await installAgent(running, DAEMON, { name: 'open-peer' }) // callPolicy=all (default)
     const privatePeer = await installAgent(running, DAEMON, { name: 'private-peer' })
     for (const p of [caller, openPeer, privatePeer]) {
       await reportChannels(DAEMON, p.integrationId, [{ id: 'C1', name: 'deploys' }])

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -35,7 +35,7 @@ describe('GET /orgs', () => {
       expect(body[0]!.id).toBe(DEFAULT_ORG_ID)
       expect(body[0]!.role).toBe('owner')
       expect(body[0]!.memberCount).toBe(1)
-      expect(body[0]!.defaultAgentVisibility).toBe('selected')
+      expect(body[0]!.defaultAgentVisibility).toBe('all')
     } finally {
       await close()
     }
@@ -55,7 +55,7 @@ describe('POST /orgs', () => {
       const org = res.json() as OrgBody
       expect(org.role).toBe('owner')
       expect(org.memberCount).toBe(1)
-      expect(org.defaultAgentVisibility).toBe('selected')
+      expect(org.defaultAgentVisibility).toBe('all')
 
       const list = (await (await app.inject({ method: 'GET', url: '/api/v1/orgs' })).json()) as OrgBody[]
       expect(list.map((o) => o.slug)).toContain('acme')
@@ -147,15 +147,15 @@ describe('PATCH /orgs/:id', () => {
         payload: { name: 'before-policy-change', runtime: 'claude' }
       })
       expect(before.statusCode).toBe(201)
-      expect(before.json()).toMatchObject({ callPolicy: 'selected', outboundPolicy: 'selected' })
+      expect(before.json()).toMatchObject({ callPolicy: 'all', outboundPolicy: 'all' })
 
       const updated = await app.inject({
         method: 'PATCH',
         url: ORG,
-        payload: { defaultAgentVisibility: 'all' }
+        payload: { defaultAgentVisibility: 'selected' }
       })
       expect(updated.statusCode).toBe(200)
-      expect((updated.json() as OrgBody).defaultAgentVisibility).toBe('all')
+      expect((updated.json() as OrgBody).defaultAgentVisibility).toBe('selected')
 
       const after = await app.inject({
         method: 'POST',
@@ -164,9 +164,9 @@ describe('PATCH /orgs/:id', () => {
       })
       expect(after.statusCode).toBe(201)
       expect(after.json()).toMatchObject({
-        callPolicy: 'all',
+        callPolicy: 'selected',
         allowedCallerAgentIds: [],
-        outboundPolicy: 'all',
+        outboundPolicy: 'selected',
         allowedTargetAgentIds: []
       })
 
@@ -174,7 +174,7 @@ describe('PATCH /orgs/:id', () => {
         method: 'GET',
         url: `${ORG}/agents/${(before.json() as { id: string }).id}`
       })
-      expect(unchanged.json()).toMatchObject({ callPolicy: 'selected', outboundPolicy: 'selected' })
+      expect(unchanged.json()).toMatchObject({ callPolicy: 'all', outboundPolicy: 'all' })
     } finally {
       await close()
     }

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -216,9 +216,9 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       skills: [], // resolved skill entries; always shipped (disabling the last skill must replicate)
       managedSkills: [], // managed organization skill bindings; likewise always shipped
       // Agent→agent call policy (§2.5), always shipped so a policy/allow-list change replicates.
-      callPolicy: 'selected',
+      callPolicy: 'all',
       allowedCallerAgentIds: [],
-      outboundPolicy: 'selected',
+      outboundPolicy: 'all',
       allowedTargetAgentIds: [],
       // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
       introduceOnJoin: false,
@@ -445,9 +445,9 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
             agentId: AGENT,
             daemonId: DAEMON,
             integrationId: INTEG,
-            callPolicy: 'selected',
+            callPolicy: 'all',
             allowedCallerAgentIds: [],
-            outboundPolicy: 'selected',
+            outboundPolicy: 'all',
             allowedTargetAgentIds: [],
             // Carried so a peer daemon can label this agent by name in a visible agent-call post.
             name: 'agent-1'

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -214,13 +214,14 @@ export const AgentSchema = z.object({
   managedSkills: z.array(ManagedSkillEntry).default([]),
   // Agent→agent call authorization (design §2.5), replicated from the CP so the
   // daemon enforces it LOCALLY when another agent uses `messageAgent` to wake this
-  // one. `all` ⇒ any org peer may call; `selected` ⇒ only agents in
-  // `allowedCallerAgentIds`. Missing policy fails closed to an empty selection.
-  callPolicy: z.enum(['all', 'selected']).default('selected'),
+  // one. `all` (the default) ⇒ any org peer may call; `selected` ⇒ only agents in
+  // `allowedCallerAgentIds`. Absent callPolicy ⇒ treated as `all` for backward
+  // compatibility with existing agent.json files.
+  callPolicy: z.enum(['all', 'selected']).default('all'),
   allowedCallerAgentIds: z.array(z.string()).default([]),
-  // Caller-side half of collaboration authorization. Missing policy likewise
-  // discovers and calls no peer until targets are explicitly selected.
-  outboundPolicy: z.enum(['all', 'selected']).default('selected'),
+  // Caller-side half of collaboration authorization. Defaults preserve the
+  // historical unrestricted behavior for existing agent.json files.
+  outboundPolicy: z.enum(['all', 'selected']).default('all'),
   allowedTargetAgentIds: z.array(z.string()).default([]),
   // Opt-in (issue #536): when true, on a GENUINE new channel join the agent
   // proactively introduces itself to the other agents already there (via

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -172,9 +172,9 @@ describe('AgentSchema defaults', () => {
     expect(parsed.output.showFooter).toBe(true)
     expect(parsed.allowRuntimeChangesInChat).toBe(false)
     expect(parsed.restrictFileAccess).toBe(false)
-    expect(parsed.callPolicy).toBe('selected')
+    expect(parsed.callPolicy).toBe('all')
     expect(parsed.allowedCallerAgentIds).toEqual([])
-    expect(parsed.outboundPolicy).toBe('selected')
+    expect(parsed.outboundPolicy).toBe('all')
     expect(parsed.allowedTargetAgentIds).toEqual([])
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -18,7 +18,7 @@ const REMOTE_PEERS = ['bot-a', 'bot-b', 'bot-c', 'main', 'worker', 'third', 'pee
  * wake, coords, and trusted workflow metadata without running a real ACP turn.
  */
 
-/** Scaffold explicitly connected peers; AgentSchema's isolated defaults are tested separately. */
+/** Scaffold a daemon root with local agents carrying either direction of call policy. */
 function scaffold(
   agents: {
     id: string
@@ -50,10 +50,10 @@ function scaffold(
         workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
         integrations: [],
         output: { mode: 'low' },
-        callPolicy: a.callPolicy ?? 'all',
-        allowedCallerAgentIds: a.allowedCallerAgentIds ?? [],
-        outboundPolicy: a.outboundPolicy ?? 'all',
-        allowedTargetAgentIds: a.allowedTargetAgentIds ?? []
+        ...(a.callPolicy ? { callPolicy: a.callPolicy } : {}),
+        ...(a.allowedCallerAgentIds ? { allowedCallerAgentIds: a.allowedCallerAgentIds } : {}),
+        ...(a.outboundPolicy ? { outboundPolicy: a.outboundPolicy } : {}),
+        ...(a.allowedTargetAgentIds ? { allowedTargetAgentIds: a.allowedTargetAgentIds } : {})
       })
     )
   }

--- a/packages/daemon/test/orchestration.test.ts
+++ b/packages/daemon/test/orchestration.test.ts
@@ -13,7 +13,6 @@ import type { StartOrchestrationReq, OrchestrationOwnerReq } from '../src/mcp/op
  * one-shot cron deadline — without running a real ACP turn.
  */
 
-/** These scenarios model an explicitly connected worker pool; isolated defaults live in agents.test.ts. */
 function scaffold(agentIds: string[]): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-orch-'))
   writeFileSync(
@@ -36,11 +35,7 @@ function scaffold(agentIds: string[]): string {
         runtime: 'claude',
         workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
         integrations: [],
-        output: { mode: 'low' },
-        callPolicy: 'all',
-        allowedCallerAgentIds: [],
-        outboundPolicy: 'all',
-        allowedTargetAgentIds: []
+        output: { mode: 'low' }
       })
     )
   }

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -1186,7 +1186,7 @@ describe('collaboration/routes snapshot', () => {
     expect(r.frame.payload.agents[0]!.orgId).toBe(ORG_ID)
     expect(r.frame.payload.agents[0]!.allowedTargetAgentIds).toEqual([AGENT_ID])
     // Placement defaults still apply through the .extend()
-    expect(r.frame.payload.agents[0]!.callPolicy).toBe('selected')
+    expect(r.frame.payload.agents[0]!.callPolicy).toBe('all')
     expect(r.frame.payload.agents[0]!.allowedCallerAgentIds).toEqual([])
   })
 

--- a/packages/protocol/src/frames/collab.ts
+++ b/packages/protocol/src/frames/collab.ts
@@ -39,12 +39,11 @@ export const CollabAgentPlacement = z.object({
    *  recognize AgentConnect-authored platform messages and keep agent-to-agent
    *  activation on the trusted `messageAgent` path. */
   botAppId: z.string().optional(),
-  // Missing policy from an older or incomplete snapshot must not create a peer edge.
-  callPolicy: z.enum(['all', 'selected']).default('selected'),
+  callPolicy: z.enum(['all', 'selected']).default('all'),
   allowedCallerAgentIds: z.array(z.string()).default([]),
   /** Caller-side authorization. Effective A→B access requires A's outbound
    * policy to admit B and B's inbound call policy to admit A. */
-  outboundPolicy: z.enum(['all', 'selected']).default('selected'),
+  outboundPolicy: z.enum(['all', 'selected']).default('all'),
   allowedTargetAgentIds: z.array(z.string()).default([]),
   // Directory name of the agent — carried so any daemon holding the snapshot can label a
   // REMOTE peer (caller or target) by name in a visible agent-call post, without a CP

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -183,7 +183,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const { createAgent, daemons, agents } = useConsoleData()
   const { me } = useProfile()
   const { activeOrg } = useOrgs()
-  const defaultAgentVisibility = activeOrg?.defaultAgentVisibility ?? 'selected'
+  const defaultAgentVisibility = activeOrg?.defaultAgentVisibility ?? 'all'
   const [name, setName] = useState('')
   const [displayName, setDisplayName] = useState('')
   // New agents default to a random glyph+color (product default — not runtime-branded).
@@ -801,8 +801,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         ...(sharing.visibility === 'restricted'
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {}),
-        // Send both modes explicitly: omission now means isolated, while `all` is
-        // an intentional opt-in. The CP intersects selected lists with visible peers.
+        // Preserve the choices shown in this form even if the organization default
+        // changes concurrently. The CP intersects selected lists with visible peers.
         callPolicy,
         allowedCallerAgentIds: callPolicy === 'selected' ? allowedCallers : [],
         outboundPolicy,

--- a/packages/web/src/components/console/modals/EditOrgModal.tsx
+++ b/packages/web/src/components/console/modals/EditOrgModal.tsx
@@ -20,7 +20,7 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
   const [slug, setSlug] = useState(activeOrg?.slug ?? '')
   const [name, setName] = useState(activeOrg?.name ?? '')
   const [defaultAgentVisibility, setDefaultAgentVisibility] = useState<AgentCallPolicy>(
-    activeOrg?.defaultAgentVisibility ?? 'selected'
+    activeOrg?.defaultAgentVisibility ?? 'all'
   )
   const [busy, setBusy] = useState(false)
   const [deleteArmed, setDeleteArmed] = useState(false)
@@ -35,7 +35,7 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
     if (
       slug === activeOrg.slug &&
       (nextName || null) === (activeOrg.name ?? null) &&
-      defaultAgentVisibility === (activeOrg.defaultAgentVisibility ?? 'selected')
+      defaultAgentVisibility === (activeOrg.defaultAgentVisibility ?? 'all')
     )
       return onClose()
     setBusy(true)
@@ -117,8 +117,8 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
           <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Default agent visibility">
             {(
               [
-                { key: 'selected', label: 'Isolated', sub: 'No peer access until agents are selected.' },
-                { key: 'all', label: 'All agents', sub: 'Open in both directions to the organization.' }
+                { key: 'all', label: 'All agents', sub: 'Open in both directions to the organization.' },
+                { key: 'selected', label: 'Isolated', sub: 'No peer access until agents are selected.' }
               ] as const
             ).map((option) => (
               <button

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1500,9 +1500,9 @@ export function agentFromDto(d: AgentDto): Agent {
     ownerUserId: d.ownerUserId,
     canEdit: d.canEdit,
     canManageSharing: d.canManageSharing,
-    callPolicy: d.callPolicy ?? 'selected',
+    callPolicy: d.callPolicy ?? 'all',
     allowedCallerAgentIds: d.allowedCallerAgentIds ?? [],
-    outboundPolicy: d.outboundPolicy ?? 'selected',
+    outboundPolicy: d.outboundPolicy ?? 'all',
     allowedTargetAgentIds: d.allowedTargetAgentIds ?? [],
     // Unset (older CP) reads as off — the product default.
     introduceOnJoin: d.introduceOnJoin ?? false,


### PR DESCRIPTION
## Summary

- restore `All agents` as the product, database, daemon, protocol, and compatibility default
- retain the owner-configurable organization policy so teams can opt future agents into `Isolated`
- seed both directional policies from the organization setting while preserving explicit per-agent overrides
- apply organization policy changes only to future agents; existing Agent rows are not rewritten

## Root cause

#327 made `selected + []` the fallback at every layer while adding the organization setting. That changed the default collaboration experience and caused new or unconfigured agents to appear isolated unless an owner opted the organization back into `All agents`.

The forward migration restores existing organizations and column defaults to `all` without changing persisted Agent policies.

## Impact

New and unconfigured agents keep the existing open collaboration experience. Organization owners can still choose `Isolated` for subsequently created agents when their team needs that policy.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- Control Plane unit: 1,074 passed
- Control Plane integration: 72 passed, including all 58 migrations on PostgreSQL
- Web: 510 passed
- Protocol: 235 passed
- Daemon schema defaults: 16 passed

Created by Codex . GPT-5
