### PR TITLE
fix(knowledge): exclude archived records by default

### DIFF
--- a/packages/control-plane/src/http/routes/organization-knowledge.ts
+++ b/packages/control-plane/src/http/routes/organization-knowledge.ts
@@ -41,7 +41,7 @@ import {
   UpdateOrganizationKnowledgeBody
 } from '../dto/index.js'
 
-const IncludeArchivedQuery = z.object({ includeArchived: z.coerce.boolean().default(false) })
+const IncludeArchivedQuery = z.object({ includeArchived: z.stringbool().default(false) })
 
 function knowledgeDto(row: OrganizationKnowledgeRecord, canManage: boolean) {
   return {

--- a/packages/control-plane/test/integration/organization-knowledge.route.test.ts
+++ b/packages/control-plane/test/integration/organization-knowledge.route.test.ts
@@ -187,6 +187,9 @@ describe('organization knowledge REST lifecycle', () => {
       ).statusCode
     ).toBe(200)
     expect((await owner.app.inject({ method: 'GET', url: `${ORG}/knowledge` })).json()).toEqual([])
+    expect((await owner.app.inject({ method: 'GET', url: `${ORG}/knowledge?includeArchived=false` })).json()).toEqual(
+      []
+    )
     expect(await repo.searchKnowledge(DEF_ORG, { query: 'incident commander', limit: 5 })).toEqual([])
     expect(
       (await owner.app.inject({ method: 'GET', url: `${ORG}/knowledge?includeArchived=true` })).json()
@@ -866,6 +869,9 @@ describe('managed organization skills', () => {
       ).statusCode
     ).toBe(400)
     expect((await owner.app.inject({ method: 'GET', url: `${ORG}/managed-skills` })).json()).toEqual([])
+    expect(
+      (await owner.app.inject({ method: 'GET', url: `${ORG}/managed-skills?includeArchived=false` })).json()
+    ).toEqual([])
     expect(
       (await owner.app.inject({ method: 'GET', url: `${ORG}/managed-skills?includeArchived=true` })).json()
     ).toHaveLength(1)


### PR DESCRIPTION
## Summary

- parse `includeArchived` as a semantic boolean instead of JavaScript truthiness
- keep archived organization knowledge and managed skills excluded for omitted or explicit `false`
- add real-Postgres regressions for both list endpoints

## Root cause

Fastify supplies query parameters as strings. `z.coerce.boolean()` converts any non-empty string—including `"false"`—to `true`, so turning the UI switch off still requested archived rows. `z.stringbool()` preserves the intended query semantics.

## Validation

- Control Plane integration: 9/9
- Control Plane typecheck
- changed-file ESLint and Prettier
- pre-push repository lint
