### PR TITLE
feat(sessions): sync GitHub repository visibility

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -1,8 +1,9 @@
 # Session Visibility
 
-> **Status:** Implemented for direct `private` / `org` visibility and the first
-> external-audience adapter (Slack conversations). Share-by-link and additional
-> providers remain future work.
+> **Status:** Implemented for direct `private` / `org` visibility, Slack
+> conversation audiences, and GitHub repository audiences. The GitHub Settings
+> and inaccessible-session recovery UI land separately. Share-by-link and
+> additional providers remain future work.
 >
 > **Scope:** protocol + control-plane + daemon + web. Console authorization is
 > enforced on CP/BFF read paths. The daemon reports immutable source metadata,
@@ -30,9 +31,10 @@ This design gives every session its own visibility:
   corresponding external-audience policy is disabled.
 - **`external`** — visible only when the viewer currently belongs to the
   immutable external source scope recorded when the session was created.
-  Phase one supports Slack channel and group-DM conversations. The stored
-  scope is `(workspace, conversation)`; Slack remains authoritative for its
-  changing member list, which the CP resolves at read time.
+  Slack stores `(workspace, conversation)` and resolves current conversation
+  membership. GitHub hook sessions store the rename-proof numeric repository
+  id: public repositories require no linked identity; private repositories
+  require the viewer's currently linked GitHub account to retain read access.
 - **Share-by-link ("public")** — future work; a session with an active share
   link is readable by anyone holding the link. Deliberately **not** a member of
   the visibility enum; see §8.
@@ -149,9 +151,10 @@ enum VisibilitySource {
   share-by-link (§8) covers the near-term "share this session" ask.
 - `ExternalScope` stores only the stable provider resource identity and the
   credential locator needed to ask the provider. It never stores provider ACLs.
-  Slack membership decisions are bounded, short-lived in-process cache entries;
-  user-to-Slack identity remains provider-owned and is resolved from Logto per
-  request rather than copied into the AgentConnect database.
+  Slack membership and GitHub repository-access decisions are bounded,
+  short-lived in-process cache entries. Linked Slack and GitHub identities
+  remain provider-owned and are resolved from Logto rather than copied into the
+  AgentConnect database.
 - `SessionExternalAccessPolicy` is per organization and provider. Its revision
   and read fence make enablement fail closed while historical rows converge.
 
@@ -159,7 +162,10 @@ enum VisibilitySource {
 and kept legacy rows `org`; it did not guess DM ownership. The Slack-audience
 migration separately tags historical Slack-shaped shared sessions as provider
 candidates. Their source scope cannot be reconstructed safely, so enabling the
-Slack policy hides unresolved history instead of guessing an audience.
+Slack policy hides unresolved history instead of guessing an audience. The
+GitHub migration uses accepted `HookRun` snapshots only when every run tied to
+a session agrees on one numeric repository id; ambiguous history remains a
+hidden unresolved candidate after GitHub sync is enabled.
 
 ## 4. Classifying sessions at ingest
 
@@ -174,7 +180,8 @@ transportScope?: string // trusted workspace/tenant scope for ownerIdentity, §2
 launchCorrelationId?: string // Web API launch provenance, §4.4
 ```
 
-Shared-source sessions additionally report an `externalOrigin` tuple:
+Shared-source sessions additionally report a provider-specific
+`externalOrigin`. Slack reports:
 
 ```ts
 {
@@ -186,10 +193,31 @@ Shared-source sessions additionally report an `externalOrigin` tuple:
 }
 ```
 
+GitHub direct ingress reports:
+
+```ts
+{
+  provider: 'github'
+  realmKey: 'github.com'
+  resourceKind: 'repository'
+  resourceKey: string // numeric, rename-proof repository id
+  hookId: string
+  deliveryKey: string
+  sourceInstallationId: string
+  repoFullName: string // validated snapshot; not the ACL identity
+}
+```
+
 The daemon pins that tuple on first use. A later input from a different source
 is rejected rather than silently reusing the session. A2A descendants carry
-the audience identity (without credentials) and inherit the parent's access
-boundary across daemons.
+only the audience identity (without Slack integration ids or GitHub delivery
+proof) and inherit the parent's access boundary across daemons.
+
+Headless GitHub messages also namespace the daemon-local session key with the
+numeric repository id. The first post-upgrade delivery therefore starts a clean
+runtime instead of claiming an unscoped legacy runtime whose repository cannot
+be proved locally; historical Control-Plane metadata is still backfilled from
+accepted `HookRun` snapshots.
 
 The daemon derives this from `NormalizedMessage.isDm` / `isGroupDm`
 (`packages/daemon/src/messages/normalized.ts`) and reports the normalized fact
@@ -213,6 +241,7 @@ the other origin scalars:
 | Web API session launch (§4.4 correlation)              | `private`           | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
 | IM DM (`conversationKind` = `dm`)                      | `private`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
 | Slack group DM / channel with trusted `externalOrigin` | `org` or `external` | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
+| GitHub hook with an accepted delivery snapshot         | `org` or `external` | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
 | Other IM group DM / channel (or absent kind)           | `org`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
 | Agent-to-agent child (`triggeredBy` is an agent UUID)  | inherits parent     | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
 | Automation without a trusted external destination      | `org`               | `null`                                                                                                                                |
@@ -236,9 +265,9 @@ Notes:
   of visibility** (DM, group DM, and channel alike). It is orthogonal to the
   visibility default: for `org` sessions it is provenance and the anchor for
   §4.3 reclassification rights, not an access gate.
-- A provider-bound group DM or channel never uses one initiator as its access
-  owner. With Slack sync enabled, its current conversation membership is the
-  audience; with sync disabled, new shared Slack sessions remain `org`.
+- A provider-bound conversation or repository never uses one initiator as its
+  access owner. With provider sync enabled, the current external audience is
+  authoritative; with sync disabled, new provider sessions remain `org`.
 - A cron or daemon-owned continuation delivered into an attributable Slack
   conversation is provider-bound at creation just like a human-started thread.
   Automation without a trusted external destination remains `org` with no owner.
@@ -355,11 +384,13 @@ canViewSession(s, ctx, identitySet) =
     : s.visibility === 'org' || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
 ```
 
-`currentExternalAudienceAllows` requires a settled scope, a linked Slack
-identity, current Slack conversation membership, and matching durable policy /
-scope revisions. Provider errors, timeouts, unresolved history, and stale
-revisions deny access. Organization roles, including owner, never bypass this
-predicate.
+`currentExternalAudienceAllows` requires a settled scope and matching durable
+policy/scope revisions. Slack additionally requires a linked identity and
+current conversation membership. GitHub permits a currently public repository
+without a linked identity; a private repository requires the linked GitHub user
+to retain read permission. Provider errors, timeouts, unresolved history, and
+stale revisions deny access. Organization roles, including owner, never bypass
+this predicate.
 
 All of these already gate on agent visibility; each additionally applies the
 session predicate:
@@ -468,7 +499,7 @@ feeding shared memory once every affected daemon has acked (`applied`)",
 not retroactive amnesia.
 
 Shared external sessions are always excluded from managed shared-memory
-capture and recall, even while the Slack access-sync switch is disabled. This
+capture and recall, even while the provider access-sync switch is disabled. This
 prevents a provider-scoped conversation from feeding a broader organization
 memory namespace. The gate covers AgentConnect-managed and external memory
 paths; a runtime's own opaque/native memory cannot be isolated per session by
@@ -486,11 +517,12 @@ learned from it"); silence is not an option.
   The session detail page renders a lock badge for `private`, a provider badge
   for `external`, and the §4.3 visibility control only for direct-session
   owners allowed to use it.
-- Settings exposes an owner-only Slack access-sync switch, disabled by default.
-  When enabled, shared Slack session history follows current Slack conversation
-  membership. The detail page renders provider-bound visibility as read-only;
-  unresolved historical rows and transient provider failures are surfaced
-  without widening access.
+- Settings exposes owner-only provider access-sync switches, disabled by
+  default. Slack follows current conversation membership; GitHub follows
+  current repository visibility and user access. The GitHub switch and
+  inaccessible-session link action are a separate console change from the core
+  daemon/CP implementation. Provider-bound visibility is read-only; unresolved
+  history and transient provider failures are surfaced without widening access.
 - The existing client-side "mine" heuristic
   (`packages/web/src/lib/session-trigger.ts` email/userId matching) stays as a
   display concern (the "you" label) but is no longer doing authorization work.
@@ -507,6 +539,14 @@ user's own session — so `http/viewer-identity.ts` reads it per request
 up for their owners retroactively — no session backfill, per §2. Only a real
 OIDC session qualifies (devAuth and API-key callers have no verified subject),
 and a provider miss or error fails closed to the console identity.
+
+**GitHub (shipped in the provider adapter).** The BFF keeps the session scope as
+a numeric repository id and resolves its current canonical name with the
+installation credential. Public repositories need no user identity. For a
+private repository, `GithubUserAuthzService` resolves the caller's linked GitHub
+login from Logto and asks GitHub for that user's current effective repository
+permission. AgentConnect stores neither the GitHub login nor a copied provider
+ACL; only bounded allow/deny/error verdicts are cached in process.
 
 **Other platforms (future, separate design).** Telegram/Discord/Feishu have no
 OIDC sign-in to piggyback on, so they need a `UserIdentity` table (`userId`,
@@ -561,3 +601,7 @@ link ends public access without touching the session row.
   relationships, transcript/tool-body reauthorization, SSE, and usage parity;
   immutable direct source binding; A2A lineage across local and relay paths;
   managed-memory recall, mutation, automatic recall, capture, and Dream gates.
+- **GitHub external audience:** accepted-delivery and installation-claim
+  validation; numeric repository identity across rename; public, private-linked,
+  no-access, and provider-error decisions; ambiguous-history hiding; A2A scope
+  inheritance; owner-role non-bypass; and parity across every session read path.

--- a/packages/control-plane/prisma/migrations/20260801160000_github_session_external_access/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801160000_github_session_external_access/migration.sql
@@ -1,0 +1,173 @@
+-- GitHub hook sessions become repository-scoped external candidates. The
+-- numeric repository id is the immutable audience key; installation and
+-- owner/repo names are only credential/routing metadata.
+
+-- Identify every historical GitHub root we can prove from a HookRun snapshot,
+-- plus current github HookDefs for mixed legacy rows. Descendants inherit the
+-- same fail-closed candidate boundary.
+INSERT INTO "session_external_access_policy" (
+  "orgId", "provider", "state", "currentRev", "createdAt", "updatedAt"
+)
+WITH RECURSIVE direct_candidates AS (
+  SELECT DISTINCT s."id"
+  FROM "session_meta" s
+  LEFT JOIN "hook_run" run
+    ON run."sessionId" = s."id"
+   AND run."orgId" = s."orgId"
+   AND run."agentId" = s."agentId"
+   AND run."repoId" IS NOT NULL
+  LEFT JOIN "hook_def" hook
+    ON hook."orgId" = s."orgId"
+   AND hook."agentId" = s."agentId"
+   AND hook."kind" = 'github'::"HookKind"
+   AND (
+     s."triggeredBy" = 'hook:' || hook."id"::text
+     OR (s."platform" = 'hook' AND s."channel" = hook."id"::text)
+   )
+  WHERE run."id" IS NOT NULL OR hook."id" IS NOT NULL
+), candidates AS (
+  SELECT "id" FROM direct_candidates
+  UNION
+  SELECT child."id"
+  FROM "session_meta" child
+  JOIN candidates parent ON child."parentSessionId" = parent."id"
+)
+SELECT DISTINCT s."orgId", 'github', 'disabled'::"ExternalAccessPolicyState", 0,
+       CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "session_meta" s
+JOIN candidates c ON c."id" = s."id"
+ON CONFLICT ("orgId", "provider") DO NOTHING;
+
+WITH RECURSIVE direct_candidates AS (
+  SELECT DISTINCT s."id"
+  FROM "session_meta" s
+  LEFT JOIN "hook_run" run
+    ON run."sessionId" = s."id"
+   AND run."orgId" = s."orgId"
+   AND run."agentId" = s."agentId"
+   AND run."repoId" IS NOT NULL
+  LEFT JOIN "hook_def" hook
+    ON hook."orgId" = s."orgId"
+   AND hook."agentId" = s."agentId"
+   AND hook."kind" = 'github'::"HookKind"
+   AND (
+     s."triggeredBy" = 'hook:' || hook."id"::text
+     OR (s."platform" = 'hook' AND s."channel" = hook."id"::text)
+   )
+  WHERE run."id" IS NOT NULL OR hook."id" IS NOT NULL
+), candidates AS (
+  SELECT "id" FROM direct_candidates
+  UNION
+  SELECT child."id"
+  FROM "session_meta" child
+  JOIN candidates parent ON child."parentSessionId" = parent."id"
+)
+UPDATE "session_meta" s
+SET "externalProvider" = 'github',
+    "externalResolution" = CASE
+      WHEN s."visibility" = 'private'::"SessionVisibility"
+        THEN 'invalid'::"ExternalResolution"
+      ELSE 'pending'::"ExternalResolution"
+    END,
+    "visibility" = CASE
+      WHEN s."visibility" = 'private'::"SessionVisibility"
+        THEN 'external'::"SessionVisibility"
+      ELSE s."visibility"
+    END,
+    "classifiedPolicyRev" = 0,
+    "visibilityRev" = s."visibilityRev" + 1,
+    "updatedAt" = CURRENT_TIMESTAMP
+FROM candidates c
+WHERE s."id" = c."id"
+  AND s."externalProvider" IS NULL;
+
+-- A session is safely backfillable only when all accepted HookRuns tied to it
+-- name one numeric repository. Pick its latest known installation credential;
+-- repository rename never changes the ExternalScope identity.
+WITH consistent AS (
+  SELECT s."id" AS "sessionId", s."orgId", s."agentId", MIN(run."repoId") AS "repoId"
+  FROM "session_meta" s
+  JOIN "hook_run" run
+    ON run."sessionId" = s."id"
+   AND run."orgId" = s."orgId"
+   AND run."agentId" = s."agentId"
+  WHERE s."externalProvider" = 'github'
+    AND s."externalResolution" <> 'invalid'::"ExternalResolution"
+  GROUP BY s."id", s."orgId", s."agentId"
+  HAVING COUNT(*) FILTER (WHERE run."repoId" IS NULL) = 0
+     AND COUNT(DISTINCT run."repoId") = 1
+), ranked AS (
+  SELECT consistent.*, installation."id" AS "credentialId",
+         run."startedAt", run."id" AS "runId"
+  FROM consistent
+  JOIN "hook_run" run
+    ON run."sessionId" = consistent."sessionId"
+   AND run."orgId" = consistent."orgId"
+   AND run."agentId" = consistent."agentId"
+   AND run."repoId" = consistent."repoId"
+  JOIN "github_installation" installation
+    ON installation."orgId" = consistent."orgId"
+   AND installation."installationId" = run."sourceInstallationId"
+), scopes AS (
+  SELECT DISTINCT ON ("orgId", "repoId") "orgId", "repoId", "credentialId"
+  FROM ranked
+  ORDER BY "orgId", "repoId", "startedAt" DESC, "runId" DESC
+)
+INSERT INTO "external_scope" (
+  "id", "orgId", "provider", "realmKey", "resourceKind", "resourceKey",
+  "credentialKind", "credentialId", "aclRevision", "createdAt", "updatedAt"
+)
+SELECT gen_random_uuid(), "orgId", 'github', 'github.com', 'repository', "repoId"::text,
+       'github_installation', "credentialId", 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM scopes
+ON CONFLICT ("orgId", "provider", "realmKey", "resourceKind", "resourceKey")
+DO UPDATE SET
+  "credentialKind" = EXCLUDED."credentialKind",
+  "credentialId" = EXCLUDED."credentialId",
+  "aclRevision" = "external_scope"."aclRevision" + CASE
+    WHEN "external_scope"."credentialId" IS DISTINCT FROM EXCLUDED."credentialId" THEN 1
+    ELSE 0
+  END,
+  "revokedAt" = NULL,
+  "updatedAt" = CURRENT_TIMESTAMP;
+
+WITH RECURSIVE consistent AS (
+  SELECT s."id" AS "sessionId", s."orgId", s."agentId", MIN(run."repoId") AS "repoId"
+  FROM "session_meta" s
+  JOIN "hook_run" run
+    ON run."sessionId" = s."id"
+   AND run."orgId" = s."orgId"
+   AND run."agentId" = s."agentId"
+  WHERE s."externalProvider" = 'github'
+    AND s."externalResolution" <> 'invalid'::"ExternalResolution"
+  GROUP BY s."id", s."orgId", s."agentId"
+  HAVING COUNT(*) FILTER (WHERE run."repoId" IS NULL) = 0
+     AND COUNT(DISTINCT run."repoId") = 1
+), roots AS (
+  SELECT consistent."sessionId" AS "id", scope."id" AS "scopeId"
+  FROM consistent
+  JOIN "session_meta" s
+    ON s."id" = consistent."sessionId"
+   AND s."orgId" = consistent."orgId"
+   AND s."agentId" = consistent."agentId"
+  JOIN "external_scope" scope
+    ON scope."orgId" = consistent."orgId"
+   AND scope."provider" = 'github'
+   AND scope."realmKey" = 'github.com'
+   AND scope."resourceKind" = 'repository'
+   AND scope."resourceKey" = consistent."repoId"::text
+), family AS (
+  SELECT "id", "scopeId" FROM roots
+  UNION
+  SELECT child."id", parent."scopeId"
+  FROM "session_meta" child
+  JOIN family parent ON child."parentSessionId" = parent."id"
+)
+UPDATE "session_meta" s
+SET "externalScopeId" = family."scopeId",
+    "externalResolution" = 'settled'::"ExternalResolution",
+    "updatedAt" = CURRENT_TIMESTAMP
+FROM family
+WHERE s."id" = family."id"
+  AND s."externalProvider" = 'github'
+  AND s."visibility" <> 'private'::"SessionVisibility";

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -163,6 +163,7 @@ import { createFeishuAppIconSyncer } from './http/feishu-app-icon.js'
 import { FeishuAppRegistrationService } from './http/feishu-registration.js'
 import { configureFeishuHttpApp } from './http/feishu-app-config.js'
 import { SlackSessionAccessService } from './http/slack-session-access.js'
+import { GithubSessionAccessService } from './http/github-session-access.js'
 
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from './config/defaults.js'
 
@@ -699,6 +700,14 @@ export function buildContainer(
     clock,
     ...(opts.slackFetch ? { fetchImpl: opts.slackFetch } : {})
   })
+  const githubSessionAccess = github
+    ? new GithubSessionAccessService({
+        installations: repos.githubInstallation,
+        github,
+        ...(githubUserAuthz ? { userAuthz: githubUserAuthz } : {}),
+        clock
+      })
+    : undefined
 
   const httpDeps: HttpDeps = {
     clock,
@@ -791,6 +800,7 @@ export function buildContainer(
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(logtoIdentity ? { logtoIdentity } : {}),
     slackSessionAccess,
+    ...(githubSessionAccess ? { githubSessionAccess } : {}),
     ...(iconStore ? { iconStore } : {}),
     ...(connectors ? { connectors } : {}),
     ...(slackPlatformApp ? { slackPlatformApp } : {}),
@@ -950,6 +960,7 @@ export function buildContainer(
     sessionUsage: repos.sessionUsage,
     integration: repos.integration,
     bot: repos.bot,
+    githubInstallation: repos.githubInstallation,
     integrationChannel: repos.integrationChannel,
     agentMutations,
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -331,6 +331,36 @@ describe('GithubService repository picker reads', () => {
     await svc.listRepos(installation, 1, 100)
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
+
+  it('resolves a durable repository id to its current name through the installation grant', async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toContain('/repositories/123')
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer ghs_metadata')
+      return Response.json({
+        id: 123,
+        full_name: 'acme/renamed-repo',
+        private: true,
+        default_branch: 'main',
+        description: null
+      })
+    })
+    const svc = new GithubService({
+      cfg: cfg(),
+      clock: new FakeClock(),
+      installations: {} as never,
+      installState: { put: async () => {}, consume: async () => true },
+      pepper: 'p'.repeat(32),
+      fetchImpl
+    })
+    vi.spyOn(svc.tokens, 'metadataToken').mockResolvedValue('ghs_metadata')
+
+    await expect(svc.repoRefById(installation, 123n)).resolves.toEqual({
+      repoId: 123n,
+      fullName: 'acme/renamed-repo',
+      private: true,
+      defaultBranch: 'main'
+    })
+  })
 })
 
 describe('GithubService.uninstallInstallation', () => {

--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -81,6 +81,7 @@ const TIMEOUT_MS = 10_000
 
 interface CachedLogin {
   login: string | null
+  fetchedAt: number
   expiresAt: number
 }
 
@@ -200,9 +201,12 @@ export class LogtoIdentityService {
    * account has no GitHub identity (e.g. Google sign-in) — callers map null to
    * a GITHUB_IDENTITY_REQUIRED denial, never a silent allow.
    */
-  async githubLoginFor(sub: string): Promise<string | null> {
+  async githubLoginFor(sub: string, maxAgeMs?: number): Promise<string | null> {
     const cached = this.logins.get(sub)
-    if (cached && cached.expiresAt > this.clock.now()) return cached.login
+    const now = this.clock.now()
+    if (cached && cached.expiresAt > now && (maxAgeMs === undefined || now - cached.fetchedAt < maxAgeMs)) {
+      return cached.login
+    }
     let pending = this.loginInFlight.get(sub)
     if (!pending) {
       const tracked: Promise<string | null> = this.lookupLogin(sub).finally(() => {
@@ -391,7 +395,10 @@ export class LogtoIdentityService {
     const current = () => this.epochOf(sub) === epoch
     if (res.status === 404) {
       // Deleted at the provider — no identity, cache the miss briefly.
-      if (current()) this.logins.set(sub, { login: null, expiresAt: this.clock.now() + NEGATIVE_TTL_MS })
+      if (current()) {
+        const fetchedAt = this.clock.now()
+        this.logins.set(sub, { login: null, fetchedAt, expiresAt: fetchedAt + NEGATIVE_TTL_MS })
+      }
       return null
     }
     if (!res.ok) {
@@ -401,9 +408,11 @@ export class LogtoIdentityService {
     const raw = user.identities?.github?.details?.rawData
     const login = firstString(raw?.userInfo?.login, raw?.login)
     if (current()) {
+      const fetchedAt = this.clock.now()
       this.logins.set(sub, {
         login,
-        expiresAt: this.clock.now() + (login ? LOGIN_TTL_MS : NEGATIVE_TTL_MS)
+        fetchedAt,
+        expiresAt: fetchedAt + (login ? LOGIN_TTL_MS : NEGATIVE_TTL_MS)
       })
     }
     return login

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -339,6 +339,34 @@ export class GithubService {
     return pending
   }
 
+  /** Resolve a rename-proof repository id to its current canonical name. The
+   * installation metadata token proves the repository is still in the App's
+   * grant; a genuine miss is a durable deny, while provider failures bubble. */
+  async repoRefById(
+    ins: GithubInstallationRecord,
+    repoId: bigint
+  ): Promise<{ repoId: bigint; fullName: string; private: boolean; defaultBranch: string } | null> {
+    const token = await this.tokens.metadataToken(ins.installationId)
+    try {
+      const repo = await githubRequest<GhRepo>(`/repositories/${repoId}`, {
+        auth: token,
+        fetchImpl: this.deps.fetchImpl,
+        baseUrl: this.deps.baseUrl,
+        bigIdsAsStrings: true
+      })
+      if (BigInt(repo.id) !== repoId) return null
+      return {
+        repoId,
+        fullName: repo.full_name,
+        private: repo.private,
+        defaultBranch: repo.default_branch
+      }
+    } catch (err) {
+      if (err instanceof GithubApiError && (err.status === 404 || err.status === 422)) return null
+      throw err
+    }
+  }
+
   /** Branch names for the picker — needs contents:read (metadata-only 403s). */
   async listBranches(ins: GithubInstallationRecord, owner: string, repo: string): Promise<string[]> {
     const cred = await this.tokens.mint(ins.installationId, `${owner}/${repo}`, 'read')

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -115,6 +115,19 @@ describe('LogtoIdentityService', () => {
     expect(calls.token).toBe(1) // one M2M token covered everything
   })
 
+  it('can bypass the display login cache for a fresh authorization assertion', async () => {
+    const users: Record<string, unknown> = {
+      'sub-1': { identities: { github: { details: { rawData: { userInfo: { login: 'before' } } } } } }
+    }
+    const { fetchImpl, calls } = fakeLogto(users)
+    const svc = new LogtoIdentityService(MGMT, new FakeClock(0), MUTATIONS, fetchImpl)
+
+    expect(await svc.githubLoginFor('sub-1')).toBe('before')
+    users['sub-1'] = { identities: { github: { details: { rawData: { userInfo: { login: 'after' } } } } } }
+    expect(await svc.githubLoginFor('sub-1', 0)).toBe('after')
+    expect(calls.user).toBe(2)
+  })
+
   it('surfaces mgmt-API failures as retryable LogtoApiError (the gate fails closed)', async () => {
     const fetchImpl = async (url: string): Promise<Response> =>
       url.endsWith('/oidc/token')
@@ -266,6 +279,16 @@ describe('GithubUserAuthzService', () => {
     expect(calls.permission).toBe(1)
     clock.advance(5 * 60_000 + 1)
     await svc.assertAccess('u1', INS, 'o', 'r', 'write')
+    expect(calls.permission).toBe(2)
+  })
+
+  it('can bypass the picker cache for a shorter-lived authorization lease', async () => {
+    const { svc, calls } = authz({ login: 'me', permission: 'read' })
+    await svc.permissionForUser('u1', INS, 'o', 'r')
+    await svc.permissionForUser('u1', INS, 'o', 'r')
+    expect(calls.permission).toBe(1)
+
+    await svc.permissionForUser('u1', INS, 'o', 'r', { maxCacheAgeMs: 0 })
     expect(calls.permission).toBe(2)
   })
 

--- a/packages/control-plane/src/github/user-authz.ts
+++ b/packages/control-plane/src/github/user-authz.ts
@@ -54,7 +54,7 @@ export interface UserRepoAccess {
 // Narrow structural deps (the composition root passes LogtoIdentityService /
 // GithubService / PgUserRepo; tests pass plain objects).
 interface UserAuthzDeps {
-  identity: { githubLoginFor(sub: string): Promise<string | null> }
+  identity: { githubLoginFor(sub: string, maxAgeMs?: number): Promise<string | null> }
   github: {
     getRepoMeta(ins: GithubInstallationRecord, owner: string, repo: string): Promise<{ private: boolean } | null>
     userRepoPermission(
@@ -75,7 +75,7 @@ const FILTER_CONCURRENCY = 8
 export class GithubUserAuthzService {
   /** (installation, repo, login) → effective permission; the one cacheable unit
    *  shared by the preflight, the create gate AND the list filter. */
-  private readonly perms = new Map<string, { value: RepoPermission; expiresAt: number }>()
+  private readonly perms = new Map<string, { value: RepoPermission; fetchedAt: number; expiresAt: number }>()
   private readonly permsInFlight = new Map<string, Promise<RepoPermission>>()
   /** (installation, repo) → meta (or null = out of grant), same TTL. */
   private readonly metas = new Map<string, { value: { private: boolean } | null; expiresAt: number }>()
@@ -85,7 +85,7 @@ export class GithubUserAuthzService {
 
   /** The caller's GitHub login, or a GITHUB_IDENTITY_REQUIRED denial — the
    *  shared first leg of every check. */
-  private async loginOf(userId: string): Promise<string> {
+  private async loginOf(userId: string, maxCacheAgeMs?: number): Promise<string> {
     const sub = await this.deps.users.getOidcSubject(userId)
     if (!sub) {
       throw new UserAuthzDeniedError(
@@ -93,7 +93,7 @@ export class GithubUserAuthzService {
         'GITHUB_IDENTITY_REQUIRED'
       )
     }
-    const login = await this.deps.identity.githubLoginFor(sub)
+    const login = await this.deps.identity.githubLoginFor(sub, maxCacheAgeMs)
     if (!login) {
       throw new UserAuthzDeniedError(
         'no GitHub identity on this account — sign in with GitHub to verify repo access',
@@ -112,23 +112,42 @@ export class GithubUserAuthzService {
     login: string,
     ins: GithubInstallationRecord,
     owner: string,
-    repo: string
+    repo: string,
+    maxCacheAgeMs?: number
   ): Promise<RepoPermission> {
     const key = this.permissionKey(login, ins, owner, repo)
     const cached = this.perms.get(key)
-    if (cached && cached.expiresAt > this.deps.clock.now()) return Promise.resolve(cached.value)
+    const now = this.deps.clock.now()
+    if (cached && cached.expiresAt > now && (maxCacheAgeMs === undefined || now - cached.fetchedAt < maxCacheAgeMs)) {
+      return Promise.resolve(cached.value)
+    }
     let pending = this.permsInFlight.get(key)
     if (!pending) {
       pending = this.deps.github
         .userRepoPermission(ins, owner, repo, login)
         .then((value) => {
-          this.perms.set(key, { value, expiresAt: this.deps.clock.now() + ACCESS_TTL_MS })
+          const fetchedAt = this.deps.clock.now()
+          this.perms.set(key, { value, fetchedAt, expiresAt: fetchedAt + ACCESS_TTL_MS })
           return value
         })
         .finally(() => this.permsInFlight.delete(key))
       this.permsInFlight.set(key, pending)
     }
     return pending
+  }
+
+  /** Resolve only the user's effective permission. Callers that already
+   * verified repository metadata can cap or bypass this service's picker cache
+   * instead of extending a shorter authorization lease. */
+  async permissionForUser(
+    userId: string,
+    ins: GithubInstallationRecord,
+    owner: string,
+    repo: string,
+    options: { maxCacheAgeMs?: number } = {}
+  ): Promise<RepoPermission> {
+    const login = await this.loginOf(userId, options.maxCacheAgeMs)
+    return this.permissionOf(login, ins, owner, repo, options.maxCacheAgeMs)
   }
 
   /** Cached + deduped repo meta (privacy flag; null = out of grant). */

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -86,6 +86,7 @@ import type { SessionKey } from '../domain/sessionKey.js'
 import type { IconStore } from '../icons/icon-store.js'
 import type { ConnectorsClient } from '../connectors/client.js'
 import type { SlackSessionAccessResolver } from './slack-session-access.js'
+import type { GithubSessionAccessResolver } from './github-session-access.js'
 
 export interface HttpServerConfig extends HumanAuthConfig {
   /** Drives browser CORS for the Web UI (see `buildHttpServer`). */
@@ -328,6 +329,8 @@ export interface HttpDeps {
   logtoIdentity?: LogtoIdentityService
   /** Current Slack conversation membership for external Session reads. */
   slackSessionAccess?: SlackSessionAccessResolver
+  /** Current GitHub repository visibility for external Session reads. */
+  githubSessionAccess?: GithubSessionAccessResolver
   /** Uploaded-icon object store (docs/designs/icon-uploads.md); absent ⇒ S3_* unset,
    *  the icon upload/delete routes are not mounted and the console hides Upload. */
   iconStore?: IconStore

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2319,10 +2319,11 @@ export const SessionVisibilityDto = z.object({
 })
 
 export const SessionExternalAccessStateEnum = z.enum(['disabled', 'enabling', 'enabled', 'degraded'])
+export const SessionExternalAccessProviderEnum = z.enum(['slack', 'github'])
 export const SessionExternalAccessDto = z.object({
-  provider: z.literal('slack'),
-  /** False when this deployment cannot resolve linked Slack identities and
-   *  live conversation membership. An already-enabled policy still reads
+  provider: SessionExternalAccessProviderEnum,
+  /** False when this deployment cannot resolve linked provider identities and
+   *  current external membership. An already-enabled policy still reads
    *  fail-closed and may be disabled while unavailable. */
   available: z.boolean(),
   enabled: z.boolean(),

--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeClock } from '../../test/fakes/fake-clock.js'
+import type { ExternalScopeRecord, GithubInstallationRecord } from '../persistence/ports.js'
+import { UserAuthzDeniedError } from '../github/user-authz.js'
+import { GithubSessionAccessService } from './github-session-access.js'
+
+const installation: GithubInstallationRecord = {
+  id: '11111111-1111-4111-8111-111111111111',
+  orgId: 'org_1' as GithubInstallationRecord['orgId'],
+  installationId: 456n,
+  accountLogin: 'acme',
+  accountType: 'Organization',
+  repositorySelection: 'all',
+  permissions: { metadata: 'read' },
+  suspendedAt: null,
+  revokedAt: null,
+  createdAt: new Date(0)
+}
+
+const scope: ExternalScopeRecord = {
+  id: '22222222-2222-4222-8222-222222222222',
+  orgId: installation.orgId,
+  provider: 'github',
+  realmKey: 'github.com',
+  resourceKind: 'repository',
+  resourceKey: '123',
+  credentialKind: 'github_installation',
+  credentialId: installation.id,
+  aclRevision: 2n,
+  revokedAt: null
+}
+
+function make(privateRepo: boolean, permissionForUser = vi.fn()) {
+  const clock = new FakeClock()
+  const repoRefById = vi.fn().mockResolvedValue({
+    repoId: 123n,
+    fullName: 'acme/private-repo',
+    private: privateRepo,
+    defaultBranch: 'main'
+  })
+  const service = new GithubSessionAccessService({
+    installations: { get: vi.fn().mockResolvedValue(installation) } as never,
+    github: { repoRefById },
+    userAuthz: { permissionForUser },
+    clock
+  })
+  return { service, repoRefById, permissionForUser, clock }
+}
+
+describe('GithubSessionAccessService', () => {
+  it('allows an org member to read a public repository session without a linked GitHub identity', async () => {
+    const h = make(false)
+
+    await expect(h.service.resolve([scope], 'user-1')).resolves.toEqual({
+      allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }],
+      degraded: false
+    })
+    expect(h.permissionForUser).not.toHaveBeenCalled()
+  })
+
+  it('requires the linked user to retain read access to a private repository', async () => {
+    const allowed = make(true, vi.fn().mockResolvedValue('read'))
+    const denied = make(
+      true,
+      vi.fn().mockRejectedValue(new UserAuthzDeniedError('GitHub identity required', 'GITHUB_IDENTITY_REQUIRED'))
+    )
+
+    expect((await allowed.service.resolve([scope], 'user-1')).allowedScopes).toHaveLength(1)
+    expect(allowed.permissionForUser).toHaveBeenCalledWith('user-1', installation, 'acme', 'private-repo', {
+      maxCacheAgeMs: 0
+    })
+    await expect(denied.service.resolve([scope], 'user-1')).resolves.toEqual({
+      allowedScopes: [],
+      degraded: false
+    })
+  })
+
+  it('refreshes an allowed provider decision at the 120 second hard limit', async () => {
+    const h = make(true, vi.fn().mockResolvedValue('read'))
+
+    await h.service.resolve([scope], 'user-1')
+    h.clock.advance(119_999)
+    await h.service.resolve([scope], 'user-1')
+    expect(h.permissionForUser).toHaveBeenCalledTimes(1)
+
+    h.clock.advance(1)
+    await h.service.resolve([scope], 'user-1')
+    expect(h.permissionForUser).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails closed and reports degradation when GitHub cannot resolve the current repository', async () => {
+    const h = make(true)
+    h.repoRefById.mockRejectedValue(new Error('provider unavailable'))
+
+    await expect(h.service.resolve([scope], 'user-1')).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true
+    })
+  })
+})

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -1,0 +1,122 @@
+import type { Clock } from '../domain/clock.js'
+import type { ExternalScopeRecord, GithubInstallationRepo } from '../persistence/ports.js'
+import type { GithubService } from '../github/service.js'
+import { UserAuthzDeniedError, type GithubUserAuthzService } from '../github/user-authz.js'
+
+const ALLOW_TTL_MS = 120_000
+const DENY_TTL_MS = 30_000
+const UNKNOWN_TTL_MS = 5_000
+const MAX_CACHE_ENTRIES = 10_000
+const MAX_SCOPES_PER_REQUEST = 200
+
+type Decision = 'allow' | 'deny' | 'unknown'
+type CachedDecision = { decision: Decision; expiresAt: number }
+
+export interface GithubSessionAccessResult {
+  allowedScopes: Array<{ id: string; aclRevision: bigint }>
+  degraded: boolean
+}
+
+export interface GithubSessionAccessResolver {
+  resolve(scopes: readonly ExternalScopeRecord[], userId: string): Promise<GithubSessionAccessResult>
+}
+
+async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
+  const out = new Array<R>(values.length)
+  let next = 0
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next++
+        out[index] = await fn(values[index]!)
+      }
+    })
+  )
+  return out
+}
+
+/** Current GitHub repository visibility for one console user. Repository ids
+ * and installation locators are durable; user identity and permission remain
+ * provider-owned and only bounded verdicts are cached in process. */
+export class GithubSessionAccessService implements GithubSessionAccessResolver {
+  private readonly cache = new Map<string, CachedDecision>()
+
+  constructor(
+    private readonly deps: {
+      installations: GithubInstallationRepo
+      github: Pick<GithubService, 'repoRefById'>
+      userAuthz?: Pick<GithubUserAuthzService, 'permissionForUser'>
+      clock: Clock
+    }
+  ) {}
+
+  async resolve(scopes: readonly ExternalScopeRecord[], userId: string): Promise<GithubSessionAccessResult> {
+    if (scopes.length === 0) return { allowedScopes: [], degraded: false }
+    const bounded = scopes.slice(0, MAX_SCOPES_PER_REQUEST)
+    let degraded = scopes.length > bounded.length
+    const decisions = await mapLimited(bounded, 6, async (scope) => {
+      const decision = await this.resolveScope(scope, userId)
+      if (decision === 'unknown') degraded = true
+      return { scope, decision }
+    })
+    return {
+      allowedScopes: decisions
+        .filter(({ decision }) => decision === 'allow')
+        .map(({ scope }) => ({ id: scope.id, aclRevision: scope.aclRevision })),
+      degraded
+    }
+  }
+
+  private async resolveScope(scope: ExternalScopeRecord, userId: string): Promise<Decision> {
+    if (
+      scope.provider !== 'github' ||
+      scope.realmKey !== 'github.com' ||
+      scope.resourceKind !== 'repository' ||
+      scope.revokedAt !== null ||
+      scope.credentialKind !== 'github_installation' ||
+      !scope.credentialId ||
+      !/^[1-9]\d*$/.test(scope.resourceKey)
+    ) {
+      return 'deny'
+    }
+    const installation = await this.deps.installations.get(scope.credentialId).catch(() => null)
+    if (!installation) return 'unknown'
+    if (installation.orgId !== scope.orgId || installation.revokedAt || installation.suspendedAt) return 'deny'
+
+    const key = [scope.id, scope.aclRevision.toString(), installation.installationId.toString(), userId].join(':')
+    const cached = this.cache.get(key)
+    if (cached && cached.expiresAt > this.deps.clock.now()) return cached.decision
+
+    let decision: Decision
+    try {
+      const repo = await this.deps.github.repoRefById(installation, BigInt(scope.resourceKey))
+      if (!repo) decision = 'deny'
+      else if (!repo.private) decision = 'allow'
+      else if (!this.deps.userAuthz) decision = 'deny'
+      else {
+        const [owner, name] = repo.fullName.split('/')
+        if (!owner || !name) decision = 'unknown'
+        else
+          decision =
+            (await this.deps.userAuthz.permissionForUser(userId, installation, owner, name, {
+              maxCacheAgeMs: 0
+            })) !== 'none'
+              ? 'allow'
+              : 'deny'
+      }
+    } catch (err) {
+      decision = err instanceof UserAuthzDeniedError ? 'deny' : 'unknown'
+    }
+    this.putCache(key, decision)
+    return decision
+  }
+
+  private putCache(key: string, decision: Decision): void {
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.cache.keys().next().value as string | undefined
+      if (oldest) this.cache.delete(oldest)
+    }
+    const ttl = decision === 'allow' ? ALLOW_TTL_MS : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
+    this.cache.set(key, { decision, expiresAt: this.deps.clock.now() + ttl })
+  }
+}

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -320,14 +320,18 @@ export function sessionRoutes(deps: HttpDeps) {
       return agent ? { session, agent, access } : null
     }
 
-    const slackAccessDto = async (orgId: OrgId, includeDiagnostics: boolean) => {
+    const externalAccessAvailable = (provider: 'slack' | 'github') =>
+      deps.logtoIdentity !== undefined &&
+      (provider === 'slack' ? deps.slackSessionAccess !== undefined : deps.githubSessionAccess !== undefined)
+
+    const externalAccessDto = async (orgId: OrgId, provider: 'slack' | 'github', includeDiagnostics: boolean) => {
       const [policy, hiddenSessions] = await Promise.all([
-        deps.repos.session.getExternalAccessPolicy(orgId, 'slack'),
-        includeDiagnostics ? deps.repos.session.countExternalUnresolved(orgId, 'slack') : Promise.resolve(undefined)
+        deps.repos.session.getExternalAccessPolicy(orgId, provider),
+        includeDiagnostics ? deps.repos.session.countExternalUnresolved(orgId, provider) : Promise.resolve(undefined)
       ])
       return {
-        provider: 'slack' as const,
-        available: deps.logtoIdentity !== undefined && deps.slackSessionAccess !== undefined,
+        provider,
+        available: externalAccessAvailable(provider),
         enabled: policy?.state !== undefined && policy.state !== 'disabled',
         state: policy?.state ?? ('disabled' as const),
         currentRevision: (policy?.currentRev ?? 0n).toString(),
@@ -336,56 +340,60 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     }
 
-    r.get(
-      '/session-access/slack',
-      {
-        schema: {
-          tags: [Tag.Sessions],
-          summary: 'Get Slack session access sync',
-          description:
-            'Returns whether shared Slack sessions use current Slack conversation membership for console access.',
-          operationId: 'getSlackSessionAccess',
-          response: { 200: SessionExternalAccessDto }
-        }
-      },
-      async (req) => slackAccessDto(orgOf(req), ctxOf(req).role === 'owner')
-    )
+    const registerExternalAccessRoutes = (provider: 'slack' | 'github') => {
+      const label = provider === 'slack' ? 'Slack' : 'GitHub'
+      r.get(
+        `/session-access/${provider}`,
+        {
+          schema: {
+            tags: [Tag.Sessions],
+            summary: `Get ${label} session access sync`,
+            description: `Returns whether ${label} sessions use the provider's current audience for console access.`,
+            operationId: `get${label}SessionAccess`,
+            response: { 200: SessionExternalAccessDto }
+          }
+        },
+        async (req) => externalAccessDto(orgOf(req), provider, ctxOf(req).role === 'owner')
+      )
 
-    r.put(
-      '/session-access/slack',
-      {
-        schema: {
-          tags: [Tag.Sessions],
-          summary: 'Set Slack session access sync',
-          description:
-            'Owner-only setting. When enabled, shared Slack session access follows current conversation membership; unresolved history remains hidden.',
-          operationId: 'setSlackSessionAccess',
-          body: SetSessionExternalAccessBody,
-          response: { 200: SessionExternalAccessDto, 403: ErrorDto, 409: ErrorDto }
+      r.put(
+        `/session-access/${provider}`,
+        {
+          schema: {
+            tags: [Tag.Sessions],
+            summary: `Set ${label} session access sync`,
+            description: `Owner-only setting. When enabled, ${label} sessions follow the provider's current audience; unresolved history remains hidden.`,
+            operationId: `set${label}SessionAccess`,
+            body: SetSessionExternalAccessBody,
+            response: { 200: SessionExternalAccessDto, 403: ErrorDto, 409: ErrorDto }
+          }
+        },
+        async (req, reply) => {
+          if (denyNonOwner(req, reply)) return
+          if (req.body.enabled && !externalAccessAvailable(provider)) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: `${label} session access requires OIDC and linked-identity configuration`
+            })
+          }
+          const result = await deps.repos.session.setExternalAccessEnabled(orgOf(req), provider, req.body.enabled)
+          if (result.affected.length > 0) void deps.visibilityPush?.notifySessions(result.affected)
+          return {
+            provider,
+            available: externalAccessAvailable(provider),
+            enabled: result.policy.state !== 'disabled',
+            state: result.policy.state,
+            currentRevision: result.policy.currentRev.toString(),
+            readFenceRevision: result.policy.readFenceRev?.toString() ?? null,
+            hiddenSessions: result.hiddenSessions
+          }
         }
-      },
-      async (req, reply) => {
-        if (denyNonOwner(req, reply)) return
-        if (req.body.enabled && (!deps.logtoIdentity || !deps.slackSessionAccess)) {
-          return reply.code(409).send({
-            error: 'Conflict',
-            statusCode: 409,
-            message: 'Slack session access requires OIDC and Logto linked-identity configuration'
-          })
-        }
-        const result = await deps.repos.session.setExternalAccessEnabled(orgOf(req), 'slack', req.body.enabled)
-        if (result.affected.length > 0) void deps.visibilityPush?.notifySessions(result.affected)
-        return {
-          provider: 'slack' as const,
-          available: deps.logtoIdentity !== undefined && deps.slackSessionAccess !== undefined,
-          enabled: result.policy.state !== 'disabled',
-          state: result.policy.state,
-          currentRevision: result.policy.currentRev.toString(),
-          readFenceRevision: result.policy.readFenceRev?.toString() ?? null,
-          hiddenSessions: result.hiddenSessions
-        }
-      }
-    )
+      )
+    }
+
+    registerExternalAccessRoutes('slack')
+    registerExternalAccessRoutes('github')
 
     r.get(
       '/sessions/facets',

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -7,7 +7,7 @@ import type {
 } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import { makeViewerIdentitySet } from './viewer-identity.js'
-import { orgOf } from './rbac.js'
+import { ctxOf, orgOf } from './rbac.js'
 
 export interface ResolvedSessionAccess {
   identitySet: Set<string>
@@ -25,44 +25,56 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
     req: FastifyRequest,
     scopes: readonly ExternalScopeRecord[]
   ): Promise<ResolvedSessionAccess> => {
-    const [identitySet, initialSlackPolicy] = await Promise.all([
+    const orgId = orgOf(req)
+    const providers = ['slack', 'github'] as const
+    const [identitySet, initialPolicies] = await Promise.all([
       identitySetFor(req),
-      deps.repos.session.getExternalAccessPolicy(orgOf(req), 'slack')
+      Promise.all(providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider)))
     ])
-    const slackScopes = scopes.filter((scope) => scope.provider === 'slack' && scope.orgId === orgOf(req))
-    const result = deps.slackSessionAccess
-      ? await deps.slackSessionAccess.resolve(slackScopes, identitySet)
-      : { allowedScopes: [], degraded: slackScopes.length > 0 }
+    const slackScopes = scopes.filter((scope) => scope.provider === 'slack' && scope.orgId === orgId)
+    const githubScopes = scopes.filter((scope) => scope.provider === 'github' && scope.orgId === orgId)
+    const [slackResult, githubResult] = await Promise.all([
+      deps.slackSessionAccess
+        ? deps.slackSessionAccess.resolve(slackScopes, identitySet)
+        : Promise.resolve({ allowedScopes: [], degraded: slackScopes.length > 0 }),
+      deps.githubSessionAccess
+        ? deps.githubSessionAccess.resolve(githubScopes, ctxOf(req).userId)
+        : Promise.resolve({ allowedScopes: [], degraded: githubScopes.length > 0 })
+    ])
+    const resolvedScopes = [...slackResult.allowedScopes, ...githubResult.allowedScopes]
     // Provider lookup can take multiple round trips. Re-read the durable fence
     // afterwards so a concurrent enable cannot authorize with an old disabled
     // snapshot. SQL repeats the current-policy check for list reads.
-    const [slackPolicy, currentAllowedScopes] = await Promise.all([
-      deps.repos.session.getExternalAccessPolicy(orgOf(req), 'slack'),
-      deps.repos.session.getExternalScopes(result.allowedScopes.map((scope) => scope.id))
+    const [currentPolicies, currentAllowedScopes] = await Promise.all([
+      Promise.all(providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider))),
+      deps.repos.session.getExternalScopes(resolvedScopes.map((scope) => scope.id))
     ])
     const currentScopeRevisions = new Map(
       currentAllowedScopes
-        .filter((scope) => scope.orgId === orgOf(req) && scope.provider === 'slack' && scope.revokedAt === null)
+        .filter(
+          (scope) =>
+            scope.orgId === orgId &&
+            providers.includes(scope.provider as (typeof providers)[number]) &&
+            scope.revokedAt === null
+        )
         .map((scope) => [scope.id, scope.aclRevision])
     )
-    const allowedScopes = result.allowedScopes.filter(
-      (scope) => currentScopeRevisions.get(scope.id) === scope.aclRevision
-    )
+    const allowedScopes = resolvedScopes.filter((scope) => currentScopeRevisions.get(scope.id) === scope.aclRevision)
     return {
       identitySet,
       externalAccess: {
-        policies:
-          slackPolicy && initialSlackPolicy
-            ? [{ provider: slackPolicy.provider, readFenceRev: slackPolicy.readFenceRev }]
-            : [],
+        policies: currentPolicies.flatMap((policy, index) => {
+          const initial = initialPolicies[index]
+          return policy && initial ? [{ provider: policy.provider, readFenceRev: policy.readFenceRev }] : []
+        }),
         allowedScopes,
         decisionAt: new Date(deps.clock.now())
       },
       // Request diagnostics describe this authorization attempt. Durable
       // migration degradation (for example an unrelated historical pending
       // row) stays on the owner-only settings surface and must not make every
-      // member-facing list/detail claim that Slack itself is unavailable.
-      degraded: result.degraded || allowedScopes.length !== result.allowedScopes.length
+      // member-facing list/detail claim that a provider itself is unavailable.
+      degraded: slackResult.degraded || githubResult.degraded || allowedScopes.length !== resolvedScopes.length
     }
   }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1736,6 +1736,8 @@ export interface HookRecord {
 export interface HookRunRecord {
   id: string
   hookId: HookId
+  /** Organization captured with the accepted delivery. */
+  orgId: OrgId
   deliveryKey: string
   event: string | null
   agentId: AgentId | null

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -117,6 +117,7 @@ function toRunRecord(r: HookRun): HookRunRecord {
   return {
     id: r.id,
     hookId: HookId(r.hookId),
+    orgId: OrgId(r.orgId),
     deliveryKey: r.deliveryKey,
     event: r.event,
     agentId: r.agentId ? AgentId(r.agentId) : null,

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -22,7 +22,8 @@ import type {
   WebchatConversationRepo,
   LaunchRepo,
   OrganizationKnowledgeRepo,
-  BotRepo
+  BotRepo,
+  GithubInstallationRepo
 } from '../persistence/ports.js'
 import type { SessionVisibilityPushService } from '../orchestrator/visibilityPush.js'
 import type { RelayRosterEntry } from '@agentconnect.md/protocol'
@@ -73,6 +74,9 @@ export interface DaemonWsDeps {
   /** Validates a daemon-reported external credential locator before a Session
    *  is bound to its immutable provider scope. */
   bot?: BotRepo
+  /** Resolves a trusted GitHub delivery's installation id to this org's
+   * durable credential locator before binding a repository ExternalScope. */
+  githubInstallation?: GithubInstallationRepo
   /** Persists authoritative membership snapshots and partial conversation reports. */
   integrationChannel: IntegrationChannelRepo
   /** Shares the HTTP agent-move boundary with daemon-originated conversation reports. */

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -10,11 +10,14 @@ const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const SESSION_ID = 'session-407'
 const INTEGRATION_ID = '11111111-1111-4111-8111-111111111111'
 const BOT_ID = '22222222-2222-4222-8222-222222222222'
+const HOOK_ID = '33333333-3333-4333-8333-333333333333'
+const GITHUB_INSTALLATION_ROW_ID = '44444444-4444-4444-8444-444444444444'
 
 function scopedDeps(extra: Record<string, unknown>): DaemonWsDeps {
   return {
     agent: { get: vi.fn().mockResolvedValue({ daemonId: DAEMON_ID }) },
     agentMutations: { tryBeginMutation: vi.fn(() => vi.fn()) },
+    hook: { get: vi.fn().mockResolvedValue(null) },
     ...extra
   } as unknown as DaemonWsDeps
 }
@@ -226,6 +229,122 @@ describe('handleEventSession', () => {
 
     expect(recordMilestone).toHaveBeenCalledWith(
       expect.objectContaining({ externalCandidate: { provider: 'slack', resolution: 'invalid' } })
+    )
+  })
+
+  it('binds a GitHub audience only to the accepted delivery snapshot and installation claim', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      hook: {
+        getRun: vi.fn().mockResolvedValue({
+          orgId: 'org-1',
+          agentId: AGENT_ID,
+          repoId: 123n,
+          repoFullName: 'acme/repo',
+          sourceInstallationId: 456n
+        })
+      },
+      githubInstallation: {
+        getByInstallationId: vi.fn().mockResolvedValue({
+          id: GITHUB_INSTALLATION_ROW_ID,
+          orgId: 'org-1'
+        })
+      },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      externalOrigin: {
+        provider: 'github',
+        realmKey: 'github.com',
+        resourceKind: 'repository',
+        resourceKey: '123',
+        hookId: HOOK_ID,
+        deliveryKey: 'delivery-1',
+        sourceInstallationId: '456',
+        repoFullName: 'acme/repo'
+      }
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalCandidate: {
+          provider: 'github',
+          resolution: 'settled',
+          scope: {
+            realmKey: 'github.com',
+            resourceKind: 'repository',
+            resourceKey: '123',
+            credentialKind: 'github_installation',
+            credentialId: GITHUB_INSTALLATION_ROW_ID
+          }
+        }
+      })
+    )
+  })
+
+  it('rejects a GitHub audience that differs from the accepted delivery snapshot', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
+    const getByInstallationId = vi.fn()
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      hook: {
+        getRun: vi.fn().mockResolvedValue({
+          orgId: 'org-1',
+          agentId: AGENT_ID,
+          repoId: 999n,
+          repoFullName: 'acme/repo',
+          sourceInstallationId: 456n
+        })
+      },
+      githubInstallation: { getByInstallationId },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      externalOrigin: {
+        provider: 'github',
+        realmKey: 'github.com',
+        resourceKind: 'repository',
+        resourceKey: '123',
+        hookId: HOOK_ID,
+        deliveryKey: 'delivery-1',
+        sourceInstallationId: '456',
+        repoFullName: 'acme/repo'
+      }
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({ externalCandidate: { provider: 'github', resolution: 'invalid' } })
+    )
+    expect(getByInstallationId).not.toHaveBeenCalled()
+  })
+
+  it('keeps a GitHub hook session from an older daemon unresolved', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      hook: {
+        get: vi.fn().mockResolvedValue({ kind: 'github', agentId: AGENT_ID })
+      },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      platform: 'hook',
+      channel: HOOK_ID,
+      triggeredBy: `hook:${HOOK_ID}`
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({ externalCandidate: { provider: 'github', resolution: 'pending' } })
     )
   })
 

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -13,7 +13,7 @@
  * daemon, and an existing sessionId remains bound to its first agent.
  */
 import { isFrame, type EventSession } from '@agentconnect.md/protocol'
-import { AgentId, BotId, DaemonId, IntegrationId, LaunchId, SessionId } from '../../domain/ids.js'
+import { AgentId, BotId, DaemonId, HookId, IntegrationId, LaunchId, SessionId } from '../../domain/ids.js'
 import { classifySession } from '../../domain/session-visibility.js'
 import type { DaemonWsDeps } from '../deps.js'
 import type { Handler } from './index.js'
@@ -51,6 +51,15 @@ async function classifyMilestone(p: EventSession, agentId: AgentId, deps: Daemon
 async function externalCandidate(p: EventSession, agentId: AgentId, deps: DaemonWsDeps) {
   const origin = p.externalOrigin
   if (!origin) {
+    const triggerId = p.triggeredBy?.startsWith('hook:')
+      ? p.triggeredBy.slice('hook:'.length)
+      : p.platform === 'hook'
+        ? p.channel
+        : undefined
+    const hook = triggerId ? await deps.hook.get(HookId(triggerId)) : null
+    const legacyGithub = hook?.kind === 'github' && hook.agentId === agentId
+    if (legacyGithub) return { provider: 'github', resolution: 'pending' as const }
+
     // During a homogeneous upgrade every new daemon reports the trusted source
     // tuple. Keep mixed-version ingest fail-closed too: an older root Slack
     // channel/group-DM milestone is a durable unresolved candidate, never an
@@ -66,6 +75,34 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
     return legacySharedSlack ? { provider: 'slack', resolution: 'pending' as const } : undefined
   }
   const pending = { provider: origin.provider, resolution: 'pending' as const }
+  if (origin.provider === 'github') {
+    const run = await deps.hook.getRun(HookId(origin.hookId), origin.deliveryKey)
+    if (!run || !deps.githubInstallation) return pending
+    if (
+      run.agentId !== agentId ||
+      run.repoId?.toString() !== origin.resourceKey ||
+      run.repoFullName !== origin.repoFullName ||
+      run.sourceInstallationId?.toString() !== origin.sourceInstallationId
+    ) {
+      return { provider: 'github', resolution: 'invalid' as const }
+    }
+    const installation = await deps.githubInstallation.getByInstallationId(BigInt(origin.sourceInstallationId))
+    if (!installation) return pending
+    if (installation.orgId !== run.orgId) {
+      return { provider: 'github', resolution: 'invalid' as const }
+    }
+    return {
+      provider: 'github',
+      resolution: 'settled' as const,
+      scope: {
+        realmKey: 'github.com',
+        resourceKind: 'repository',
+        resourceKey: origin.resourceKey,
+        credentialKind: 'github_installation',
+        credentialId: installation.id
+      }
+    }
+  }
   if (!origin.integrationId || !origin.realmKey) return pending
   const integration = await deps.integration.get(IntegrationId(origin.integrationId))
   if (

--- a/packages/control-plane/test/fixtures/github-hook-run.ts
+++ b/packages/control-plane/test/fixtures/github-hook-run.ts
@@ -19,6 +19,7 @@ type HookRunFixtureInput = Partial<HookRunRecord> & Pick<HookRunRecord, Required
 export function githubHookRun(input: HookRunFixtureInput): HookRunRecord {
   return {
     id: 'run-1',
+    orgId: 'org_1' as HookRunRecord['orgId'],
     deliveryKey: 'delivery-1',
     event: 'pull_request:opened',
     configRevision: 1n,

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedLaunch } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { PgAgentRepo, PgSessionRepo } from '../../src/persistence/index.js'
+import { PgAgentRepo, PgHookRepo, PgSessionRepo } from '../../src/persistence/index.js'
 import { handleEventSession } from '../../src/ws/handlers/index.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
@@ -46,6 +46,7 @@ async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON
   const deps = {
     agent: new PgAgentRepo(prisma),
     agentMutations: new AgentMutationGate(),
+    hook: new PgHookRepo(prisma),
     session: new PgSessionRepo(prisma),
     events: new InMemorySessionEventSink()
   } as unknown as DaemonWsDeps

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -369,6 +369,36 @@ describe('session visibility — Slack conversation audience', () => {
   })
 })
 
+describe('session visibility — GitHub repository audience', () => {
+  it('exposes an independent owner-only sync setting', async () => {
+    const owner = await makeUser(`sv-github-owner-${randomUUID()}`, 'owner')
+    const collaborator = await makeUser(`sv-github-collab-${randomUUID()}`, 'collaborator')
+
+    const read = await appAs(collaborator).app.inject({ method: 'GET', url: `${ORG}/session-access/github` })
+    expect(read.statusCode).toBe(200)
+    expect(read.json()).toMatchObject({ provider: 'github', available: false, enabled: false })
+    expect(read.json()).not.toHaveProperty('hiddenSessions')
+
+    const forbidden = await appAs(collaborator).app.inject({
+      method: 'PUT',
+      url: `${ORG}/session-access/github`,
+      payload: { enabled: true }
+    })
+    expect(forbidden.statusCode).toBe(403)
+
+    const enabled = await appAs(owner, {
+      logtoIdentity: {} as never,
+      githubSessionAccess: { resolve: async () => ({ allowedScopes: [], degraded: false }) }
+    }).app.inject({
+      method: 'PUT',
+      url: `${ORG}/session-access/github`,
+      payload: { enabled: true }
+    })
+    expect(enabled.statusCode).toBe(200)
+    expect(enabled.json()).toMatchObject({ provider: 'github', available: true, enabled: true, state: 'enabled' })
+  })
+})
+
 describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {
   it('lets the recorded owner pull an org session private and publish it back', async () => {
     const initiator = await makeUser('sv-put-owner', 'collaborator')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -283,6 +283,7 @@ import type {
   ChildSessionStatusProbe,
   SessionVisibilityPush,
   WebchatRemoteMcpEntitlement,
+  ExternalSessionAudience,
   ExternalSessionOrigin,
   ChannelAgentsOk
 } from '@agentconnect.md/protocol'
@@ -651,7 +652,7 @@ interface CallMeta {
    * daemon-authored metadata and never comes from model text. The credential
    * locator stays at the direct ingress; descendants inherit only the stable
    * provider/realm/resource tuple. */
-  externalOrigin?: Omit<ExternalSessionOrigin, 'integrationId'>
+  externalOrigin?: ExternalSessionAudience
   /** Daemon-internal (issue #536, never a tool input): when this turn calls
    *  `messageAgent`, deliver the woken peer's turn HEADLESS so it records silently
    *  with no channel output. Set only by the self-introduce-on-join fan-out; does
@@ -6863,7 +6864,7 @@ export class Daemon {
     // headless in practice. The relay already opened the HookRun row, so close it
     // honestly as a no-op success rather than orphaning it.
     if (c?.source === 'github' && c.action === 'deleted' && !msg.target) {
-      const key = sessionKey(nmsg.platform, nmsg.channel, nmsg.thread ?? nmsg.msgId, msg.agentId)
+      const key = sessionKey(nmsg.platform, nmsg.channel, nmsg.thread ?? nmsg.msgId, msg.agentId, nmsg.transportScope)
       if (!this.store.getSession(key)?.acpSessionId) {
         this.log.info(`hook: skipping github ${c.event ?? 'event'}:deleted fire ${msg.msgId} — no session for ${key}`)
         // Preserve R2a's admission/outbox guarantee even though this teardown
@@ -9137,14 +9138,14 @@ export class Daemon {
         throw err
       }
     }
-    const sourceBinding = this.bindSessionSource(agentId, key, msg, callMeta)
+    const sourceBinding = this.bindSessionSource(agentId, key, msg, callMeta, hookContext)
     if (sourceBinding !== 'unchanged') {
       finishEvaluation('turn.cancelled', { reason: 'session_source_mismatch' })
       const conn = this.replyConnFor(agentId, integrationId)
       const reason =
         sourceBinding === 'unavailable'
-          ? 'This Slack conversation could not be assigned a stable workspace audience. Reconnect the Slack integration and try again.'
-          : 'This thread already belongs to a session created from another source. Start a new Slack thread and mention the agent there.'
+          ? 'This conversation could not be assigned a stable external audience. Reconnect the integration and try again.'
+          : 'This thread already belongs to a session created from another source. Start a new thread and try again.'
       // Only a human ingress gets a visible repair instruction. A2A delivery is
       // intentionally postless; turning a rejected internal wake into a Slack
       // message would leak workflow state and create unsolicited channel noise.
@@ -9155,7 +9156,7 @@ export class Daemon {
           this.log.warn(`session source: could not post rejection (${formatErr(err)})`)
         }
       }
-      this.log.warn(`session source: rejected Slack audience binding for ${key} (${sourceBinding})`)
+      this.log.warn(`session source: rejected external audience binding for ${key} (${sourceBinding})`)
       return null
     }
     // §3.3 correlation-recording hook: if this turn is an agent→agent delivery carrying a
@@ -9453,7 +9454,7 @@ export class Daemon {
       // from turn one for anything that could be private (session-visibility.md
       // §4.1/§5.1). Persisted on the session row so later re-emits — including
       // after a restart, when `msg` is long gone — still carry the same facts.
-      this.classifyNewSession(agentId, key, sessionId, msg, callMeta, webchat?.evaluation === true)
+      this.classifyNewSession(agentId, key, sessionId, msg, callMeta, hookContext, webchat?.evaluation === true)
       this.emitSessionMetadataSnapshot({
         sessionId,
         agentId,
@@ -11020,11 +11021,14 @@ export class Daemon {
     // persist the same source tuple for the local gate but let the CP inherit
     // the already-validated parent scope instead of presenting the parent's bot
     // integration as if it belonged to the child agent.
-    if (
+    if (classification?.externalOrigin) event.externalOrigin = classification.externalOrigin
+    else if (
       classification?.externalProvider === 'slack' &&
       classification.externalResourceKey &&
       classification.externalIntegrationId
     ) {
+      // Rolling compatibility for a Slack row created before direct-origin
+      // proof was persisted as one object.
       event.externalOrigin = {
         provider: 'slack',
         resourceKind: 'conversation',
@@ -12771,10 +12775,11 @@ export class Daemon {
     acpSessionId: string,
     msg: NormalizedMessage,
     callMeta: CallMeta | undefined,
+    hookContext: HookDispatchContext | undefined,
     isEvaluation = false
   ): void {
     try {
-      this.classifyNewSessionOrThrow(agentId, key, acpSessionId, msg, callMeta, isEvaluation)
+      this.classifyNewSessionOrThrow(agentId, key, acpSessionId, msg, callMeta, hookContext, isEvaluation)
     } catch (err) {
       // Never let classification break a turn — but fail CLOSED: an unclassified
       // session keeps memory capture excluded until the CP confirms otherwise.
@@ -12789,25 +12794,56 @@ export class Daemon {
   private externalOriginForSession(
     agentId: string,
     acpSessionId: string | undefined
-  ): Omit<ExternalSessionOrigin, 'integrationId'> | undefined {
+  ): ExternalSessionAudience | undefined {
     if (!acpSessionId) return undefined
     // ACP session ids are runtime-local and can collide across agents. Bind the
     // lookup to the trusted caller agent so another runtime cannot lend this
     // A2A wake its external audience by accident.
     const rec = this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    if (rec?.externalProvider === 'slack' && rec.externalResourceKind === 'conversation' && rec.externalResourceKey) {
+      return {
+        provider: 'slack',
+        ...(rec.externalRealmKey ? { realmKey: rec.externalRealmKey } : {}),
+        resourceKind: 'conversation',
+        resourceKey: rec.externalResourceKey
+      }
+    }
     if (
-      rec?.externalProvider !== 'slack' ||
-      !rec.externalRealmKey ||
-      rec.externalResourceKind !== 'conversation' ||
-      !rec.externalResourceKey
+      rec?.externalProvider === 'github' &&
+      rec.externalRealmKey === 'github.com' &&
+      rec.externalResourceKind === 'repository' &&
+      rec.externalResourceKey &&
+      /^[1-9]\d*$/.test(rec.externalResourceKey)
     ) {
-      return undefined
+      return {
+        provider: 'github',
+        realmKey: 'github.com',
+        resourceKind: 'repository',
+        resourceKey: rec.externalResourceKey
+      }
+    }
+    return undefined
+  }
+
+  private githubExternalSource(hookContext: HookDispatchContext | undefined) {
+    const github = hookContext?.github
+    if (!github) return undefined
+    const externalOrigin: ExternalSessionOrigin = {
+      provider: 'github',
+      realmKey: 'github.com',
+      resourceKind: 'repository',
+      resourceKey: github.repoId,
+      hookId: hookContext.hookId,
+      deliveryKey: hookContext.deliveryKey,
+      sourceInstallationId: github.sourceInstallationId,
+      repoFullName: github.repoFullName
     }
     return {
-      provider: 'slack',
-      realmKey: rec.externalRealmKey,
-      resourceKind: 'conversation',
-      resourceKey: rec.externalResourceKey
+      externalProvider: 'github' as const,
+      externalRealmKey: externalOrigin.realmKey,
+      externalResourceKind: externalOrigin.resourceKind,
+      externalResourceKey: externalOrigin.resourceKey,
+      externalOrigin
     }
   }
 
@@ -12851,10 +12887,14 @@ export class Daemon {
     agentId: string,
     key: string,
     msg: NormalizedMessage,
-    callMeta: CallMeta | undefined
+    callMeta: CallMeta | undefined,
+    hookContext: HookDispatchContext | undefined
   ): 'unchanged' | 'mismatch' | 'unavailable' {
-    const direct = this.slackExternalSource(agentId, msg, callMeta !== undefined)
-    if (direct && (!direct.externalRealmKey || !direct.externalIntegrationId)) return 'unavailable'
+    const direct =
+      this.githubExternalSource(hookContext) ?? this.slackExternalSource(agentId, msg, callMeta !== undefined)
+    if (direct?.externalProvider === 'slack' && (!direct.externalRealmKey || !direct.externalIntegrationId)) {
+      return 'unavailable'
+    }
     const inherited = callMeta?.externalOrigin
     if (inherited && !inherited.realmKey) return 'unavailable'
     const source =
@@ -12899,6 +12939,7 @@ export class Daemon {
     acpSessionId: string,
     msg: NormalizedMessage,
     callMeta: CallMeta | undefined,
+    hookContext: HookDispatchContext | undefined,
     isEvaluation: boolean
   ): void {
     const isA2aChild = callMeta !== undefined
@@ -12909,8 +12950,9 @@ export class Daemon {
         : this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
     const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
     const tenantScope = integration ? this.tenantScopeForIntegration(integration) : undefined
-    const directSlackSource = this.slackExternalSource(agentId, msg, isA2aChild)
-    const inheritedSlackSource = callMeta?.externalOrigin
+    const directExternalSource =
+      this.githubExternalSource(hookContext) ?? this.slackExternalSource(agentId, msg, isA2aChild)
+    const inheritedExternalSource = callMeta?.externalOrigin
       ? {
           externalProvider: callMeta.externalOrigin.provider,
           externalRealmKey: callMeta.externalOrigin.realmKey,
@@ -12918,15 +12960,15 @@ export class Daemon {
           externalResourceKey: callMeta.externalOrigin.resourceKey
         }
       : undefined
-    const externalSlackSource = directSlackSource ?? inheritedSlackSource
+    const externalSource = directExternalSource ?? inheritedExternalSource
     const launchCorrelationId = this.pendingLaunchCorrelation.get(agentId)
     if (launchCorrelationId) this.pendingLaunchCorrelation.delete(agentId)
     this.store.setSessionClassification(key, {
       conversationKind,
       ...(tenantScope ? { tenantScope } : {}),
       ...(launchCorrelationId ? { launchCorrelationId } : {}),
-      sourceBindingKind: externalSlackSource ? 'external' : 'local',
-      ...(externalSlackSource ?? {})
+      sourceBindingKind: externalSource ? 'external' : 'local',
+      ...(externalSource ?? {})
     })
     const locallyPrivate =
       !isEvaluation &&
@@ -12934,7 +12976,7 @@ export class Daemon {
         msg.isDm ||
         msg.platform === 'webchat' ||
         launchCorrelationId !== undefined ||
-        externalSlackSource !== undefined)
+        externalSource !== undefined)
     this.store.setLocalCaptureGate(acpSessionId, locallyPrivate)
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9144,8 +9144,8 @@ export class Daemon {
       const conn = this.replyConnFor(agentId, integrationId)
       const reason =
         sourceBinding === 'unavailable'
-          ? 'This conversation could not be assigned a stable external audience. Reconnect the integration and try again.'
-          : 'This thread already belongs to a session created from another source. Start a new thread and try again.'
+          ? 'This Slack conversation could not be assigned a stable workspace audience. Reconnect the Slack integration and try again.'
+          : 'This thread already belongs to a session created from another source. Start a new Slack thread and mention the agent there.'
       // Only a human ingress gets a visible repair instruction. A2A delivery is
       // intentionally postless; turning a rejected internal wake into a Slack
       // message would leak workflow state and create unsolicited channel noise.

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -307,6 +307,10 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
     platform: 'hook',
     channel,
     ...(thread ? { thread } : {}),
+    // A pre-audience daemon used an unscoped local key. Pinning the immutable
+    // repository id here creates a clean runtime after upgrade instead of
+    // letting a mutable hook id claim legacy context from another repository.
+    ...(msg.github ? { transportScope: `github:${msg.github.repoId}` } : {}),
     sender: { id: `hook:${msg.hookId}`, isBot: false },
     text: buildHookText(msg),
     ...(initialSessionTitle ? { initialSessionTitle } : {}),

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync, type SQLInputValue } from 'node:sqlite'
 import { chmodSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
-import type { DreamInfo, SessionImageAttachment } from '@agentconnect.md/protocol'
+import type { DreamInfo, ExternalSessionOrigin, SessionImageAttachment } from '@agentconnect.md/protocol'
 import { SESSION_TITLE_TOOL_TITLES } from '../mcp/session-title-tool.js'
 
 /** Per-tool-row rawInput budget in the mining prompt — enough for a command
@@ -95,6 +95,9 @@ export interface SessionRecord {
   externalResourceKind?: string | null
   externalResourceKey?: string | null
   externalIntegrationId?: string | null
+  /** Provider-specific proof retained only so a later event/session retry can
+   * re-present the exact direct origin to the CP. */
+  externalOriginJson?: string | null
   // Null is legacy/unknown. New rows pin either an external shared input or a
   // non-external origin so a later turn cannot silently change audiences.
   sourceBindingKind?: 'local' | 'external' | null
@@ -471,7 +474,7 @@ export class LocalStore {
         outputModeOverride TEXT, statusBarTs TEXT, memoryProvider TEXT,
         originSessionId TEXT, lastTurnOutcome TEXT, needsParentReply INTEGER,
         externalProvider TEXT, externalRealmKey TEXT, externalResourceKind TEXT,
-        externalResourceKey TEXT, externalIntegrationId TEXT,
+        externalResourceKey TEXT, externalIntegrationId TEXT, externalOriginJson TEXT,
         sourceBindingKind TEXT
       );
       -- A !stop can arrive while a cold session is still materializing, before the
@@ -1064,6 +1067,8 @@ export class LocalStore {
       this.db.exec('ALTER TABLE sessions ADD COLUMN externalResourceKey TEXT')
     if (!cols.some((c) => c.name === 'externalIntegrationId'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN externalIntegrationId TEXT')
+    if (!cols.some((c) => c.name === 'externalOriginJson'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN externalOriginJson TEXT')
     if (!cols.some((c) => c.name === 'sourceBindingKind'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN sourceBindingKind TEXT')
   }
@@ -1559,13 +1564,13 @@ export class LocalStore {
         `INSERT INTO sessions
            (key, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, memoryProvider, originSessionId, needsParentReply,
             externalProvider, externalRealmKey, externalResourceKind, externalResourceKey, externalIntegrationId,
-            sourceBindingKind)
+            externalOriginJson, sourceBindingKind)
          VALUES
            (@key, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
             CASE WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = @key) THEN 1 ELSE NULL END,
             @triggeredBy, @memoryProvider, @originSessionId, @needsParentReply,
             @externalProvider, @externalRealmKey, @externalResourceKind, @externalResourceKey, @externalIntegrationId,
-            @sourceBindingKind)
+            @externalOriginJson, @sourceBindingKind)
          ON CONFLICT(key) DO UPDATE SET
            acpSessionId=excluded.acpSessionId, state=excluded.state,
            lastDeliveredTs=excluded.lastDeliveredTs, updatedAt=excluded.updatedAt,
@@ -1584,6 +1589,7 @@ export class LocalStore {
            -- Slack reinstall may replace the integration while the same
            -- workspace/conversation remains the audience.
            externalIntegrationId=COALESCE(excluded.externalIntegrationId, sessions.externalIntegrationId),
+           externalOriginJson=COALESCE(sessions.externalOriginJson, excluded.externalOriginJson),
            sourceBindingKind=COALESCE(sessions.sourceBindingKind, excluded.sourceBindingKind),
            -- Parent link is first-wins: set once when the session is spawned, never cleared by a
            -- later (human-triggered) turn that carries no origin.
@@ -1614,6 +1620,7 @@ export class LocalStore {
         externalResourceKind: rec.externalResourceKind ?? null,
         externalResourceKey: rec.externalResourceKey ?? null,
         externalIntegrationId: rec.externalIntegrationId ?? null,
+        externalOriginJson: rec.externalOriginJson ?? null,
         sourceBindingKind: rec.sourceBindingKind ?? null,
         originSessionId: rec.originSessionId ?? null,
         needsParentReply: rec.needsParentReply === 1 ? 1 : null
@@ -1749,6 +1756,7 @@ export class LocalStore {
       externalResourceKind?: string
       externalResourceKey?: string
       externalIntegrationId?: string
+      externalOrigin?: ExternalSessionOrigin
       sourceBindingKind?: 'local' | 'external'
     }
   ): void {
@@ -1764,6 +1772,7 @@ export class LocalStore {
            externalResourceKey = COALESCE(externalResourceKey, ?),
            -- Unlike the source tuple, the credential locator is replaceable.
            externalIntegrationId = COALESCE(?, externalIntegrationId),
+           externalOriginJson = COALESCE(externalOriginJson, ?),
            sourceBindingKind = COALESCE(sourceBindingKind, ?)
          WHERE key = ?`
       )
@@ -1776,6 +1785,7 @@ export class LocalStore {
         c.externalResourceKind ?? null,
         c.externalResourceKey ?? null,
         c.externalIntegrationId ?? null,
+        c.externalOrigin ? JSON.stringify(c.externalOrigin) : null,
         c.sourceBindingKind ?? null,
         key
       )
@@ -1795,13 +1805,14 @@ export class LocalStore {
         externalResourceKind?: string
         externalResourceKey?: string
         externalIntegrationId?: string
+        externalOrigin?: ExternalSessionOrigin
       }
     | undefined {
     const row = this.db
       .prepare(
         `SELECT conversationKind, tenantScope, launchCorrelationId,
                 externalProvider, externalRealmKey, externalResourceKind,
-                externalResourceKey, externalIntegrationId
+                externalResourceKey, externalIntegrationId, externalOriginJson
          FROM sessions WHERE agentId = ? AND acpSessionId = ?`
       )
       .get(agentId, acpSessionId) as
@@ -1814,6 +1825,7 @@ export class LocalStore {
           externalResourceKind: string | null
           externalResourceKey: string | null
           externalIntegrationId: string | null
+          externalOriginJson: string | null
         }
       | undefined
     if (!row) return undefined
@@ -1825,7 +1837,8 @@ export class LocalStore {
       ...(row.externalRealmKey ? { externalRealmKey: row.externalRealmKey } : {}),
       ...(row.externalResourceKind ? { externalResourceKind: row.externalResourceKind } : {}),
       ...(row.externalResourceKey ? { externalResourceKey: row.externalResourceKey } : {}),
-      ...(row.externalIntegrationId ? { externalIntegrationId: row.externalIntegrationId } : {})
+      ...(row.externalIntegrationId ? { externalIntegrationId: row.externalIntegrationId } : {}),
+      ...(row.externalOriginJson ? { externalOrigin: JSON.parse(row.externalOriginJson) as ExternalSessionOrigin } : {})
     }
   }
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -13,6 +13,7 @@ import { Daemon } from '../src/daemon.js'
 import {
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED,
+  type EventSession,
   type HookReport,
   type RdMsgHook
 } from '@agentconnect.md/protocol'
@@ -82,9 +83,12 @@ function streamingHost() {
 /** Capture and ACK hook/report requests the daemon emits on turn end. */
 function fakeCpClient() {
   const hookReports: HookReport[] = []
+  const sessionEvents: EventSession[] = []
   return {
     hookReports,
+    sessionEvents,
     stop: vi.fn(async () => {}),
+    emitEventSession: (event: EventSession) => sessionEvents.push(event),
     emitHookReport: async (r: HookReport) => {
       hookReports.push(r)
       return 'acknowledged' as const
@@ -166,6 +170,13 @@ describe('Daemon rd/msg hook fires', () => {
     const ack = await (daemon as any).handleRelayMsg(
       fire({
         sessionKey: 'agentconnect-md/agentconnect#144',
+        github: {
+          repoId: '123',
+          repoFullName: 'agentconnect-md/agentconnect',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 144
+        },
         context: {
           source: 'github',
           event: 'pull_request',
@@ -181,9 +192,20 @@ describe('Daemon rd/msg hook fires', () => {
 
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
     await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
-    expect((daemon as any).store.getSessionByAcpId('acp-hook-1')?.title).toBe(
-      'PR agentconnect-md/agentconnect#144: perf(github): speed up review delivery'
-    )
+    expect((daemon as any).store.getSessionByAcpId('acp-hook-1')).toMatchObject({
+      title: 'PR agentconnect-md/agentconnect#144: perf(github): speed up review delivery',
+      transportScope: 'github:123'
+    })
+    expect(cp.sessionEvents.at(-1)?.externalOrigin).toEqual({
+      provider: 'github',
+      realmKey: 'github.com',
+      resourceKind: 'repository',
+      resourceKey: '123',
+      hookId: HOOK_ID,
+      deliveryKey: 'd-1',
+      sourceInstallationId: '456',
+      repoFullName: 'agentconnect-md/agentconnect'
+    })
     await daemon.stop()
   }, 15_000)
 
@@ -1035,6 +1057,12 @@ describe('Daemon rd/msg hook fires', () => {
       sessionKey: 'acme/infra#42',
       msgId: `${HOOK_ID}:${deliveryKey}`,
       deliveryKey,
+      github: {
+        repoId: '123',
+        repoFullName: 'acme/infra',
+        sourceInstallationId: '456',
+        subjectKind: 'issue'
+      },
       context: {
         source: 'github',
         event: 'issues',

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -482,6 +482,39 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(RdAgentMsgFwd.parse(fwd).externalOrigin).toEqual(externalOrigin)
   })
 
+  it('carries only the immutable GitHub repository audience through A2A wire legs', () => {
+    const externalOrigin = {
+      provider: 'github' as const,
+      realmKey: 'github.com' as const,
+      resourceKind: 'repository' as const,
+      resourceKey: '123456789'
+    }
+    const msg = {
+      claimedFromAgentId: AGENT_ID,
+      toAgentId: '44444444-4444-4444-8444-444444444444',
+      text: 'delegate this',
+      // Headless hook callers use the relay's existing Slack-shaped A2A
+      // coordinate; the inherited audience remains GitHub repository-scoped.
+      coords: { platform: 'slack' as const, channel: 'repo-session' },
+      hopCount: 0,
+      deliveryId: 'delivery-1',
+      externalOrigin
+    }
+    expect(RdAgentMsg.parse(msg).externalOrigin).toEqual(externalOrigin)
+    expect(
+      RdAgentMsgFwd.parse({
+        trustedFromAgentId: AGENT_ID,
+        orgId: ORG_ID,
+        toAgentId: msg.toAgentId,
+        text: msg.text,
+        coords: msg.coords,
+        hopCount: 1,
+        deliveryId: msg.deliveryId,
+        externalOrigin
+      }).externalOrigin
+    ).toEqual(externalOrigin)
+  })
+
   it('rd/chat streams webchat output and done events verbatim', () => {
     const output = {
       chatId: CONV_ID,

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ExternalSessionOrigin } from './telemetry.js'
+import { ExternalSessionAudience } from './telemetry.js'
 import {
   NormalizedPlatformMessageSchema,
   PlatformAttachmentSchema,
@@ -372,7 +372,7 @@ export const RdAgentMsg = z.object({
   // Immutable external source inherited from the caller's Session. The relay
   // forwards it opaquely; the target daemon uses it only for its local
   // pre-prompt source-binding gate.
-  externalOrigin: ExternalSessionOrigin.omit({ integrationId: true }).optional(),
+  externalOrigin: ExternalSessionAudience.optional(),
   // session-concept §5.4: the caller asked the woken session to report its outcome back into
   // `originSessionId` (`sendMessage`'s `toAgent.needsReply`). The target daemon turns this into a
   // standing directive on the child; it is never part of the delivered `text`. Meaningless without
@@ -458,7 +458,7 @@ export const RdAgentMsgFwd = z.object({
     .optional(),
   // Forwarded verbatim from RdAgentMsg. It is daemon-authored lineage metadata,
   // never inferred from model text or target coordinates.
-  externalOrigin: ExternalSessionOrigin.omit({ integrationId: true }).optional(),
+  externalOrigin: ExternalSessionAudience.optional(),
   // Forwarded verbatim from RdAgentMsg (session-concept §5.4): the caller's request that the woken
   // session report its outcome back into `originSessionId`. Opaque to the relay — it is the
   // caller's own instruction about its own lineage, not a claim the relay mints or validates.

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -119,6 +119,26 @@ describe('EventSession visibility-classification fields (session-visibility.md Â
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'channel' }).success).toBe(true)
   })
 
+  it('carries the exact accepted GitHub delivery as repository-scope proof', () => {
+    const externalOrigin = {
+      provider: 'github' as const,
+      realmKey: 'github.com' as const,
+      resourceKind: 'repository' as const,
+      resourceKey: '123456789',
+      hookId: '88888888-8888-4888-8888-888888888888',
+      deliveryKey: 'delivery-1',
+      sourceInstallationId: '456',
+      repoFullName: 'acme/repo'
+    }
+    expect(EventSession.parse({ ...legacyMilestone, externalOrigin }).externalOrigin).toEqual(externalOrigin)
+    expect(
+      EventSession.safeParse({
+        ...legacyMilestone,
+        externalOrigin: { ...externalOrigin, resourceKey: 'acme/repo' }
+      }).success
+    ).toBe(false)
+  })
+
   it('rejects an unknown conversationKind, an empty scope, and a non-uuid correlation id', () => {
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'thread' }).success).toBe(false)
     expect(EventSession.safeParse({ ...legacyMilestone, transportScope: '' }).success).toBe(false)

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -22,16 +22,43 @@ export const Heartbeat = z.object({
 })
 export type Heartbeat = z.infer<typeof Heartbeat>
 
-/** Stable source tuple for a supported shared input. Credential locators are
- * optional because A2A lineage carries only the immutable audience identity;
- * direct ingest includes the integration so the CP can validate it. */
-export const ExternalSessionOrigin = z.object({
-  provider: z.literal('slack'),
-  realmKey: z.string().min(1).max(200).optional(),
-  resourceKind: z.literal('conversation'),
-  resourceKey: z.string().min(1).max(200),
-  integrationId: z.string().uuid().optional()
-})
+const ExternalKey = z.string().min(1).max(200)
+const GithubId = z.string().regex(/^[1-9]\d*$/)
+
+/** Immutable audience identity inherited by A2A descendants. Credential proof
+ * stays on the direct root only; children inherit this tuple from their parent. */
+export const ExternalSessionAudience = z.discriminatedUnion('provider', [
+  z.object({
+    provider: z.literal('slack'),
+    realmKey: ExternalKey.optional(),
+    resourceKind: z.literal('conversation'),
+    resourceKey: ExternalKey
+  }),
+  z.object({
+    provider: z.literal('github'),
+    realmKey: z.literal('github.com'),
+    resourceKind: z.literal('repository'),
+    // Rename-proof GitHub repository id, never owner/repo.
+    resourceKey: GithubId
+  })
+])
+export type ExternalSessionAudience = z.infer<typeof ExternalSessionAudience>
+
+/** Direct-ingress audience plus the provider-specific proof the CP validates
+ * before binding a durable ExternalScope. */
+export const ExternalSessionOrigin = z.discriminatedUnion('provider', [
+  ExternalSessionAudience.options[0].extend({
+    integrationId: z.string().uuid().optional()
+  }),
+  ExternalSessionAudience.options[1].extend({
+    hookId: z.string().uuid(),
+    deliveryKey: ExternalKey,
+    sourceInstallationId: GithubId,
+    // Trusted webhook snapshot; display/API-routing hint only. repoId above is
+    // the authorization identity and must still match the accepted HookRun.
+    repoFullName: ExternalKey
+  })
+])
 export type ExternalSessionOrigin = z.infer<typeof ExternalSessionOrigin>
 
 /** Converged session lifecycle milestone — protocol §7.2. NOT the message stream. */


### PR DESCRIPTION
## Summary

- bind GitHub hook sessions to the immutable numeric repository id from the accepted delivery
- enforce current repository visibility on every Control Plane session read path
- add a default-disabled, owner-only GitHub access-sync policy and fail-closed historical convergence
- carry repository scope through A2A descendants while keeping GitHub identities and ACLs out of the database

## Access semantics

- public repository: visible to an organization member who can view the agent; no linked GitHub identity required
- private repository: requires a linked GitHub identity with current read access
- missing identity, lost permission, unresolved provenance, or provider failure: hidden as 404
- organization owners do not bypass repository access
- this PR contains the core protocol, daemon, Control Plane, migration, and design changes; Settings and recovery UI remain a separate PR

## Validation

- protocol focused tests: 34 passed
- Control Plane focused unit tests: 89 passed
- session visibility integration tests: 22 passed
- all 62 Prisma migrations applied successfully from an empty PostgreSQL database
- protocol, daemon, and Control Plane typechecks passed
- pre-push repository lint passed
- 3 focused daemon hook assertions passed; the local Vitest process additionally reported host-level `EMFILE` FSEvent watcher exhaustion after the assertions

Created by Codex . GPT-5
