### PR TITLE
test(control-plane): stabilize Feishu registration polling

### DIFF
--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -497,13 +497,16 @@ describe('Feishu/Lark one-click app registration', () => {
     const startDto = started.json() as { id: string; transport: string }
     expect(startDto.transport).toBe('http')
 
-    await vi.waitFor(async () => {
-      const polled = await app.app.inject({
-        method: 'GET',
-        url: `${ORG}/integrations/feishu/app/${startDto.id}`
-      })
-      expect(polled.json()).toMatchObject({ status: 'completed' })
-    })
+    await vi.waitFor(
+      async () => {
+        const polled = await app.app.inject({
+          method: 'GET',
+          url: `${ORG}/integrations/feishu/app/${startDto.id}`
+        })
+        expect(polled.json()).toMatchObject({ status: 'completed' })
+      },
+      { timeout: 5_000 }
+    )
 
     const bot = await prisma.bot.findFirstOrThrow({ where: { feishuAppId: 'cli_http_oneclick' } })
     const secret = await prisma.botSecret.findUniqueOrThrow({ where: { botId: bot.id } })


### PR DESCRIPTION
## Summary

- give the Feishu/Lark one-click HTTP integration test an explicit 5-second polling budget
- keep the production registration flow unchanged

## Root cause

The test performs two real handler polls against Postgres because the first authorized Lark response switches provider domains before the second poll completes registration. Vitest's implicit 1-second `waitFor` budget was too tight under CI load: the same test previously passed in 950 ms, while the focused local reproduction took 1100 ms.

## Validation

- `INTEGRATION_TEST_WORKERS=1 pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/feishu-registration.route.test.ts -t 'one-click HTTP configures the relay callback before completing'`
- `pnpm exec prettier --check packages/control-plane/test/integration/feishu-registration.route.test.ts`
- `pnpm exec eslint packages/control-plane/test/integration/feishu-registration.route.test.ts`
- pre-push `eslint .`

Created by Codex . GPT-5.6-sol
