### PR TITLE
fix(sessions): honor Slack public channel access

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -2,7 +2,7 @@
 
 > **Status:** Implemented for direct `private` / `org` visibility, Slack
 > conversation audiences, GitHub repository audiences, and their Console
-> settings/recovery surfaces. Share-by-link and additional providers remain
+> settings/profile-linking surfaces. Share-by-link and additional providers remain
 > future work.
 >
 > **Scope:** protocol + control-plane + daemon + web. Console authorization is
@@ -29,12 +29,14 @@ This design gives every session its own visibility:
 - **`org`** — visible to every org member who can view the owning agent.
   Default for automation-originated sessions and shared IM sessions when the
   corresponding external-audience policy is disabled.
-- **`external`** — visible only when the viewer currently belongs to the
-  immutable external source scope recorded when the session was created.
-  Slack stores `(workspace, conversation)` and resolves current conversation
-  membership. GitHub hook sessions store the rename-proof numeric repository
-  id: public repositories require no linked identity; private repositories
-  require the viewer's currently linked GitHub account to retain read access.
+- **`external`** — visible only when the viewer currently has provider access
+  to the immutable external source scope recorded when the session was created.
+  Slack stores `(workspace, conversation)`: public channels admit linked,
+  active full members of that workspace; private channels, group DMs, guests,
+  and Slack Connect users require current conversation membership. GitHub hook
+  sessions store the rename-proof numeric repository id: public repositories
+  require no linked identity; private repositories require the viewer's
+  currently linked GitHub account to retain read access.
 - **Share-by-link ("public")** — future work; a session with an active share
   link is readable by anyone holding the link. Deliberately **not** a member of
   the visibility enum; see §8.
@@ -151,7 +153,7 @@ enum VisibilitySource {
   share-by-link (§8) covers the near-term "share this session" ask.
 - `ExternalScope` stores only the stable provider resource identity and the
   credential locator needed to ask the provider. It never stores provider ACLs.
-  Slack membership and GitHub repository-access decisions are bounded,
+  Slack channel-access and GitHub repository-access decisions are bounded,
   short-lived in-process cache entries. Linked Slack and GitHub identities
   remain provider-owned and are resolved from Logto rather than copied into the
   AgentConnect database.
@@ -266,8 +268,10 @@ Notes:
   visibility default: for `org` sessions it is provenance and the anchor for
   §4.3 reclassification rights, not an access gate.
 - A provider-bound conversation or repository never uses one initiator as its
-  access owner. With provider sync enabled, the current external audience is
-  authoritative; with sync disabled, new provider sessions remain `org`.
+  access owner. With Slack sync enabled, public-channel access follows active
+  full workspace membership while restricted conversations and restricted
+  users follow current conversation membership. With provider sync disabled,
+  new provider sessions remain `org`.
 - A cron or daemon-owned continuation delivered into an attributable Slack
   conversation is provider-bound at creation just like a human-started thread.
   Automation without a trusted external destination remains `org` with no owner.
@@ -386,9 +390,11 @@ canViewSession(s, ctx, identitySet) =
 
 `currentExternalAudienceAllows` requires a settled scope and matching durable
 policy/scope revisions. Slack additionally requires a linked identity and
-current conversation membership. GitHub permits a currently public repository
-without a linked identity; a private repository requires the linked GitHub user
-to retain read permission. Provider errors, timeouts, unresolved history, and
+current Slack access: active full workspace membership for a public channel,
+or current conversation membership for private channels, group DMs, guests,
+and Slack Connect users. GitHub permits a currently public repository without
+a linked identity; a private repository requires the linked GitHub user to
+retain read permission. Provider errors, timeouts, unresolved history, and
 stale revisions deny access. Organization roles, including owner, never bypass
 this predicate.
 
@@ -518,7 +524,8 @@ learned from it"); silence is not an option.
   for `external`, and the §4.3 visibility control only for direct-session
   owners allowed to use it.
 - Settings exposes owner-only provider access-sync switches, disabled by
-  default. Slack follows current conversation membership; GitHub follows
+  default. Slack follows current channel access (workspace access for public
+  channels; conversation membership for restricted audiences); GitHub follows
   current repository visibility and user access. Provider-bound visibility is
   read-only; unresolved history and transient provider failures are surfaced
   without widening access.
@@ -602,7 +609,8 @@ link ends public access without touching the session row.
   and retrying with an equal revision yields a fresh ACK without
   reapplying state.
 - **Slack external audience:** disabled baseline and owner-only enablement;
-  linked-identity and current-membership allow/deny/error behavior; Slack
+  linked full-workspace access for public channels; current-membership checks
+  for restricted audiences; allow/deny/error behavior; Slack
   Connect home-team validation; unresolved-history hiding; list, detail,
   relationships, transcript/tool-body reauthorization, SSE, and usage parity;
   immutable direct source binding; A2A lineage across local and relay paths;

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -359,6 +359,13 @@ descendants; publishing one never does — widening a child stays that child's o
 A session the caller may not see is reported as missing, not as forbidden: the console must
 not reveal that it exists.
 
+When Slack session access sync is enabled, a public-channel session is visible to a user
+with a linked, active full-member identity in that Slack workspace even when the user has
+not joined the channel. Private channels and group DMs require current conversation
+membership. Guests and Slack Connect users also require current conversation membership,
+including for a channel that is public to full members of the installing workspace. The
+organization-owner role never bypasses these provider checks.
+
 Making a session private hides its transcript immediately, but agent memory is shared
 across the whole agent, so the guarantee about memory is narrower and must be stated
 plainly wherever the change is offered: capture into shared memory stops once the owning

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -327,7 +327,7 @@ export interface HttpDeps {
   /** Server-side Logto identity management for the signed-in user's Profile.
    *  Absent ⇒ LOGTO_MGMT_* or real OIDC auth is not configured. */
   logtoIdentity?: LogtoIdentityService
-  /** Current Slack conversation membership for external Session reads. */
+  /** Current Slack channel access for external Session reads. */
   slackSessionAccess?: SlackSessionAccessResolver
   /** Current GitHub repository visibility for external Session reads. */
   githubSessionAccess?: GithubSessionAccessResolver

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -11,7 +11,7 @@ function scope(): ExternalScopeRecord {
     provider: 'slack',
     realmKey: 'T_INSTALL',
     resourceKind: 'conversation',
-    resourceKey: 'C_PRIVATE',
+    resourceKey: 'C_CHANNEL',
     credentialKind: 'bot',
     credentialId: BOT_ID,
     aclRevision: 2n,
@@ -45,8 +45,73 @@ function json(body: unknown, status = 200): Response {
 }
 
 describe('SlackSessionAccessService', () => {
-  it('allows only a linked identity that is a current conversation member', async () => {
-    const fetchImpl = vi.fn(async () => json({ ok: true, members: ['U_MEMBER'], response_metadata: {} }))
+  it('allows a full workspace member to read a public channel without joining it', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('users.info')) {
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      }
+      throw new Error(`unexpected Slack request: ${url}`)
+    })
+
+    await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_INSTALL:U_NOT_JOINED']))).resolves.toEqual({
+      allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+      degraded: false
+    })
+    expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('conversations.members'))).toBe(false)
+  })
+
+  it('requires a public-channel guest to be a current conversation member', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('users.info')) {
+        return json({ ok: true, user: { team_id: 'T_INSTALL', is_restricted: true } })
+      }
+      return json({ ok: true, members: ['U_GUEST'], response_metadata: {} })
+    })
+    const resolver = service(fetchImpl)
+
+    await expect(resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_GUEST']))).resolves.toEqual({
+      allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+      degraded: false
+    })
+    await expect(resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_OTHER_GUEST']))).resolves.toEqual({
+      allowedScopes: [],
+      degraded: false
+    })
+  })
+
+  it.each(['is_profile_only_user', 'is_invited_user'] as const)(
+    'does not grant public-channel access to a user with %s',
+    async (field) => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes('conversations.info')) {
+          return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+        }
+        if (url.includes('users.info')) {
+          return json({ ok: true, user: { team_id: 'T_INSTALL', [field]: true } })
+        }
+        throw new Error(`unexpected Slack request: ${url}`)
+      })
+
+      await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_INSTALL:U_LIMITED']))).resolves.toEqual({
+        allowedScopes: [],
+        degraded: false
+      })
+      expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('conversations.members'))).toBe(false)
+    }
+  )
+
+  it('allows only a linked identity that is a current private-conversation member', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('conversations.info')
+        ? json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+        : json({ ok: true, members: ['U_MEMBER'], response_metadata: {} })
+    )
     const resolver = service(fetchImpl)
 
     await expect(resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_MEMBER']))).resolves.toEqual({
@@ -57,17 +122,39 @@ describe('SlackSessionAccessService', () => {
       allowedScopes: [],
       degraded: false
     })
+    expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('users.info'))).toBe(false)
   })
 
-  it('verifies a Slack Connect member against the linked identity home team', async () => {
-    const fetchImpl = vi.fn(async (url: string) =>
-      url.includes('conversations.members')
-        ? json({ ok: true, members: ['U_CONNECT'], response_metadata: {} })
-        : json({ ok: true, user: { team_id: 'T_HOME' } })
-    )
+  it('requires a Slack Connect user to be a public-channel member', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('conversations.members')) {
+        return json({ ok: true, members: ['U_CONNECT'], response_metadata: {} })
+      }
+      return json({ ok: true, user: { team_id: 'T_HOME', is_external: true } })
+    })
 
     await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_HOME:U_CONNECT']))).resolves.toEqual({
       allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+      degraded: false
+    })
+  })
+
+  it('rejects a private Slack Connect member when the linked home team does not match Slack', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('conversations.members')) {
+        return json({ ok: true, members: ['U_CONNECT'], response_metadata: {} })
+      }
+      return json({ ok: true, user: { team_id: 'T_OTHER' } })
+    })
+
+    await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_HOME:U_CONNECT']))).resolves.toEqual({
+      allowedScopes: [],
       degraded: false
     })
   })

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -13,9 +13,12 @@ const PAGE_SIZE = 200
 const TIMEOUT_MS = 5_000
 
 type Decision = 'allow' | 'deny' | 'unknown'
+type ConversationAudience = 'public' | 'members' | 'unknown'
+type WorkspaceAccess = 'allow' | 'membership' | 'deny' | 'unknown'
 type SlackPrincipal = { key: string; teamId: string; userId: string }
 
 type CachedDecision = { decision: Decision; expiresAt: number }
+type CachedWorkspaceAccess = { access: WorkspaceAccess; expiresAt: number }
 
 export interface SlackSessionAccessResult {
   allowedScopes: Array<{ id: string; aclRevision: bigint }>
@@ -49,10 +52,12 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
   return out
 }
 
-/** Slack v1 current-conversation membership resolver. The cache retains only a
- * bounded ACL verdict; linked identity remains request-local and provider-owned. */
+/** Slack v1 current-access resolver. Public channels follow workspace access;
+ * restricted conversations follow membership. Caches retain only bounded ACL
+ * verdicts; linked identity remains request-local and provider-owned. */
 export class SlackSessionAccessService implements SlackSessionAccessResolver {
   private readonly cache = new Map<string, CachedDecision>()
+  private readonly workspaceAccessCache = new Map<string, CachedWorkspaceAccess>()
 
   constructor(
     private readonly deps: {
@@ -116,7 +121,7 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
       const cached = this.cache.get(key)
       let decision = cached && cached.expiresAt > this.deps.clock.now() ? cached.decision : undefined
       if (!decision) {
-        decision = await this.checkMembership(scope, principal, bot.id, signal)
+        decision = await this.checkAccess(scope, principal, bot.id, bot.credentialRevision, signal)
         this.putCache(key, decision)
       }
       if (decision === 'allow') return 'allow'
@@ -125,59 +130,145 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
     return sawUnknown ? 'unknown' : 'deny'
   }
 
-  private async checkMembership(
+  private async checkAccess(
     scope: ExternalScopeRecord,
     principal: SlackPrincipal,
     botId: string,
+    credentialRevision: number,
     signal: AbortSignal
   ): Promise<Decision> {
     const secret = await this.deps.botSecrets.get(BotId(botId)).catch(() => null)
     if (!secret?.botToken) return 'unknown'
     try {
-      let cursor = ''
-      let found = false
-      for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
-        const query = new URLSearchParams({ channel: scope.resourceKey, limit: String(PAGE_SIZE) })
-        if (cursor) query.set('cursor', cursor)
-        const body = await this.slackCall<{
-          ok?: boolean
-          error?: string
-          members?: unknown
-          response_metadata?: { next_cursor?: unknown }
-        }>(`conversations.members?${query}`, secret.botToken, signal)
-        if (!body.ok || !Array.isArray(body.members)) return 'unknown'
-        if (body.members.includes(principal.userId)) {
-          found = true
-          break
-        }
-        cursor = typeof body.response_metadata?.next_cursor === 'string' ? body.response_metadata.next_cursor : ''
-        if (!cursor) break
-        if (page === MAX_MEMBER_PAGES - 1) return 'unknown'
+      const audience = await this.conversationAudience(scope.resourceKey, secret.botToken, signal)
+      if (audience === 'unknown') return 'unknown'
+      if (audience === 'public') {
+        const access = await this.workspaceAccess(
+          scope.realmKey,
+          principal,
+          credentialRevision,
+          secret.botToken,
+          signal
+        )
+        if (access !== 'membership') return access
+        return this.checkMembership(scope.resourceKey, principal.userId, secret.botToken, signal)
       }
-      if (!found) return 'deny'
-      if (principal.teamId === scope.realmKey) return 'allow'
+
+      const member = await this.checkMembership(scope.resourceKey, principal.userId, secret.botToken, signal)
+      if (member !== 'allow' || principal.teamId === scope.realmKey) return member
 
       // Slack Connect can return a member from another workspace. Verify the
       // identity's home team instead of treating the installing team as proof.
-      const user = await this.slackCall<{
-        ok?: boolean
-        user?: {
-          team_id?: unknown
-          profile?: { team?: unknown }
-          enterprise_user?: { teams?: unknown }
-        }
-      }>(`users.info?user=${encodeURIComponent(principal.userId)}`, secret.botToken, signal)
-      if (!user.ok || !user.user) return 'unknown'
-      const teams = new Set<string>()
-      if (typeof user.user.team_id === 'string') teams.add(user.user.team_id)
-      if (typeof user.user.profile?.team === 'string') teams.add(user.user.profile.team)
-      if (Array.isArray(user.user.enterprise_user?.teams)) {
-        for (const team of user.user.enterprise_user.teams) if (typeof team === 'string') teams.add(team)
-      }
-      return teams.has(principal.teamId) ? 'allow' : 'deny'
+      const access = await this.workspaceAccess(scope.realmKey, principal, credentialRevision, secret.botToken, signal)
+      return access === 'unknown' || access === 'deny' ? access : 'allow'
     } catch {
       return 'unknown'
     }
+  }
+
+  private async conversationAudience(
+    channel: string,
+    token: string,
+    signal: AbortSignal
+  ): Promise<ConversationAudience> {
+    const body = await this.slackCall<{
+      ok?: boolean
+      channel?: { is_private?: unknown; is_im?: unknown; is_mpim?: unknown }
+    }>(`conversations.info?channel=${encodeURIComponent(channel)}`, token, signal)
+    if (!body.ok || !body.channel) return 'unknown'
+    if (body.channel.is_private === false && body.channel.is_im !== true && body.channel.is_mpim !== true) {
+      return 'public'
+    }
+    if (body.channel.is_private === true || body.channel.is_im === true || body.channel.is_mpim === true) {
+      return 'members'
+    }
+    return 'unknown'
+  }
+
+  private async workspaceAccess(
+    realmKey: string,
+    principal: SlackPrincipal,
+    credentialRevision: number,
+    token: string,
+    signal: AbortSignal
+  ): Promise<WorkspaceAccess> {
+    const key = [realmKey, credentialRevision, principal.key].join(':')
+    const cached = this.workspaceAccessCache.get(key)
+    if (cached && cached.expiresAt > this.deps.clock.now()) return cached.access
+
+    const body = await this.slackCall<{
+      ok?: boolean
+      user?: {
+        team_id?: unknown
+        profile?: { team?: unknown }
+        enterprise_user?: { teams?: unknown }
+        deleted?: unknown
+        suspended?: unknown
+        is_bot?: unknown
+        is_profile_only_user?: unknown
+        is_invited_user?: unknown
+        is_restricted?: unknown
+        is_ultra_restricted?: unknown
+        is_stranger?: unknown
+        is_external?: unknown
+      }
+    }>(`users.info?user=${encodeURIComponent(principal.userId)}`, token, signal)
+
+    let access: WorkspaceAccess = 'unknown'
+    if (body.ok && body.user) {
+      const teams = new Set<string>()
+      if (typeof body.user.team_id === 'string') teams.add(body.user.team_id)
+      if (typeof body.user.profile?.team === 'string') teams.add(body.user.profile.team)
+      if (Array.isArray(body.user.enterprise_user?.teams)) {
+        for (const team of body.user.enterprise_user.teams) if (typeof team === 'string') teams.add(team)
+      }
+      if (
+        !teams.has(principal.teamId) ||
+        body.user.deleted === true ||
+        body.user.suspended === true ||
+        body.user.is_bot === true ||
+        body.user.is_profile_only_user === true ||
+        body.user.is_invited_user === true
+      ) {
+        access = 'deny'
+      } else if (
+        !teams.has(realmKey) ||
+        body.user.is_restricted === true ||
+        body.user.is_ultra_restricted === true ||
+        body.user.is_stranger === true ||
+        body.user.is_external === true
+      ) {
+        access = 'membership'
+      } else {
+        access = 'allow'
+      }
+    }
+    this.putWorkspaceAccess(key, access)
+    return access
+  }
+
+  private async checkMembership(
+    channel: string,
+    userId: string,
+    token: string,
+    signal: AbortSignal
+  ): Promise<Decision> {
+    let cursor = ''
+    for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
+      const query = new URLSearchParams({ channel, limit: String(PAGE_SIZE) })
+      if (cursor) query.set('cursor', cursor)
+      const body = await this.slackCall<{
+        ok?: boolean
+        members?: unknown
+        response_metadata?: { next_cursor?: unknown }
+      }>(`conversations.members?${query}`, token, signal)
+      if (!body.ok || !Array.isArray(body.members)) return 'unknown'
+      if (body.members.includes(userId)) return 'allow'
+      cursor = typeof body.response_metadata?.next_cursor === 'string' ? body.response_metadata.next_cursor : ''
+      if (!cursor) return 'deny'
+      if (page === MAX_MEMBER_PAGES - 1) return 'unknown'
+    }
+    return 'unknown'
   }
 
   private async slackCall<T>(path: string, token: string, signal: AbortSignal): Promise<T> {
@@ -197,5 +288,14 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
     }
     const ttl = decision === 'allow' ? ALLOW_TTL_MS : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
     this.cache.set(key, { decision, expiresAt: this.deps.clock.now() + ttl })
+  }
+
+  private putWorkspaceAccess(key: string, access: WorkspaceAccess): void {
+    if (this.workspaceAccessCache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.workspaceAccessCache.keys().next().value as string | undefined
+      if (oldest) this.workspaceAccessCache.delete(oldest)
+    }
+    const ttl = access === 'allow' ? ALLOW_TTL_MS : access === 'unknown' ? UNKNOWN_TTL_MS : DENY_TTL_MS
+    this.workspaceAccessCache.set(key, { access, expiresAt: this.deps.clock.now() + ttl })
   }
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -720,21 +720,21 @@ export default function SessionDetailView() {
   // Provider-rendered session links carry only caller-known source context. It
   // never changes authorization, so unknown and unauthorized 404s stay equivalent.
   const source = searchParams.get('source')
-  const recoveryProvider =
+  const profileLinkProvider =
     (source === 'slack' || source === 'github') && socialLoginProviders().some((provider) => provider.target === source)
       ? source
       : undefined
-  const recoveryCandidate =
+  const profileLinkCandidate =
     sessionDetailError instanceof ApiError &&
     sessionDetailError.status === 404 &&
     isAuthConfigured() &&
-    recoveryProvider !== undefined
+    profileLinkProvider !== undefined
   const {
-    data: recoveryIdentity,
-    error: recoveryIdentityError,
-    isValidating: recoveryIdentityLoading
+    data: profileIdentity,
+    error: profileIdentityError,
+    isValidating: profileIdentityLoading
   } = useSWR(
-    recoveryCandidate ? (['logto-session-identity', recoveryProvider] as const) : null,
+    profileLinkCandidate ? (['logto-session-identity', profileLinkProvider] as const) : null,
     ([, provider]) => fetchMySessionIdentity(provider),
     {
       revalidateOnFocus: false,
@@ -742,11 +742,11 @@ export default function SessionDetailView() {
       shouldRetryOnError: false
     }
   )
-  const showRecoveryLink =
-    recoveryCandidate &&
-    !recoveryIdentityLoading &&
-    recoveryIdentityError === undefined &&
-    recoveryIdentity?.linked === false
+  const showProfileLink =
+    profileLinkCandidate &&
+    !profileIdentityLoading &&
+    profileIdentityError === undefined &&
+    profileIdentity?.linked === false
   const detailSession = sessionDetail ? sessionFromDetailDto(sessionDetail) : null
   // The cursor-loaded list row can predate the final Dream usage report. Keep
   // its local/live fields, but let the independently refreshed detail snapshot
@@ -964,9 +964,9 @@ export default function SessionDetailView() {
             actionLabel="Back to sessions"
             actionHref={orgPath('/sessions')}
             secondaryAction={
-              showRecoveryLink && recoveryProvider
+              showProfileLink && profileLinkProvider
                 ? {
-                    label: `Link ${recoveryProvider === 'slack' ? 'Slack' : 'GitHub'} profile`,
+                    label: `Link ${profileLinkProvider === 'slack' ? 'Slack' : 'GitHub'} profile`,
                     href: orgPath('/profile#sign-in-methods'),
                     icon: 'link'
                   }
@@ -1458,7 +1458,7 @@ export default function SessionDetailView() {
 
       {sessionDetail?.accessSyncDegraded && (
         <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3">
-          External access could not be verified. Related sessions remain hidden until access checks recover.
+          External access could not be verified. Related sessions remain hidden until access checks succeed.
         </div>
       )}
 

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -87,7 +87,7 @@ const SESSION_ACCESS_COPY: Record<
     unavailable:
       'Requires OIDC and linked Slack identities. Until then, shared sessions remain visible to Everyone who can view the agent.',
     enabled:
-      'Each shared session is visible only to current members of its Slack conversation. DMs remain private. Agent memory learned earlier is not erased.',
+      'Public-channel sessions follow Slack workspace access. Private channels, group DMs, guests, and Slack Connect users require current conversation membership. DMs remain private. Agent memory learned earlier is not erased.',
     disabled:
       'New shared sessions are visible to Everyone who can view the agent. Previously synced sessions keep following Slack. DMs remain private.',
     unresolved: (count) =>

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3076,7 +3076,7 @@ export type MySlackIdentityDto =
       teamDomain?: string
     }
 
-/** Narrow linked/not-linked status for a supported session source. */
+/** Narrow linked/not-linked status used by supported provider profile-linking hints. */
 export async function fetchMySessionIdentity(provider: SessionAccessProvider): Promise<{ linked: boolean }> {
   if (provider === 'slack') return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
   const account = await fetchMySocialAccount()


### PR DESCRIPTION
## Summary

- resolve the current Slack conversation type before authorizing an externally scoped session
- let a linked, active full member of the source Slack workspace view public-channel sessions without joining the channel
- keep private channels, group DMs, guests, profile-only or invited accounts, and Slack Connect users out of the public shortcut
- preserve fail-closed provider errors, bounded in-process verdict caching, and the no-owner-bypass rule
- update Settings and degraded-state copy plus the product/design contracts; no database migration is required

## Slack contract

This follows the provider distinction exposed by [conversations.info](https://docs.slack.dev/reference/methods/conversations.info/) and the account-state flags returned by the [Slack user object](https://docs.slack.dev/reference/objects/user-object/). Linked identities and provider ACLs remain provider-owned; AgentConnect persists neither.

## Validation

- pnpm --filter @agentconnect.md/control-plane test:unit (108 files, 935 tests)
- pnpm --filter @agentconnect.md/web test (72 files, 509 tests)
- pnpm --filter @agentconnect.md/control-plane typecheck
- pnpm --filter @agentconnect.md/web typecheck
- focused Slack access tests after rebase (8/8)
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint

Created by Codex . GPT-5.6-sol