### PR TITLE
feat(sessions): add GitHub session access UI

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -1,9 +1,9 @@
 # Session Visibility
 
 > **Status:** Implemented for direct `private` / `org` visibility, Slack
-> conversation audiences, and GitHub repository audiences. The GitHub Settings
-> and inaccessible-session recovery UI land separately. Share-by-link and
-> additional providers remain future work.
+> conversation audiences, GitHub repository audiences, and their Console
+> settings/recovery surfaces. Share-by-link and additional providers remain
+> future work.
 >
 > **Scope:** protocol + control-plane + daemon + web. Console authorization is
 > enforced on CP/BFF read paths. The daemon reports immutable source metadata,
@@ -519,10 +519,16 @@ learned from it"); silence is not an option.
   owners allowed to use it.
 - Settings exposes owner-only provider access-sync switches, disabled by
   default. Slack follows current conversation membership; GitHub follows
-  current repository visibility and user access. The GitHub switch and
-  inaccessible-session link action are a separate console change from the core
-  daemon/CP implementation. Provider-bound visibility is read-only; unresolved
-  history and transient provider failures are surfaced without widening access.
+  current repository visibility and user access. Provider-bound visibility is
+  read-only; unresolved history and transient provider failures are surfaced
+  without widening access.
+- Session links emitted into Slack and GitHub carry a non-authoritative provider
+  hint. When such a deep link still resolves to the generic 404 page, the Console
+  offers `Link Slack profile` or `Link GitHub profile` only if that provider is
+  configured and the viewer has not linked it already. Unsupported providers,
+  ordinary/handwritten URLs, and linked viewers get no extra action. The hint is
+  intentionally forgeable and never consulted for authorization, so it cannot
+  confirm whether the session exists; the protected session route remains 404.
 - The existing client-side "mine" heuristic
   (`packages/web/src/lib/session-trigger.ts` email/userId matching) stays as a
   display concern (the "you" label) but is no longer doing authorization work.

--- a/packages/control-plane/src/github/run-reporter.test.ts
+++ b/packages/control-plane/src/github/run-reporter.test.ts
@@ -878,7 +878,7 @@ describe('GithubRunReporter', () => {
       status: 'completed',
       conclusion: 'action_required',
       completed_at: new Date(NOW).toISOString(),
-      details_url: 'https://console.example.com/acme/sessions/session%2Fwith%20space',
+      details_url: 'https://console.example.com/acme/sessions/session%2Fwith%20space?source=github',
       output: { title: 'Review findings need attention' }
     })
     expect(body.output.summary).toContain(`Agent: [review-agent](https://console.example.com/acme/agents/${agentId})`)

--- a/packages/control-plane/src/github/run-reporter.ts
+++ b/packages/control-plane/src/github/run-reporter.ts
@@ -635,7 +635,9 @@ export class GithubRunReporter {
       if (!orgSlug) return fallback
       const base = `${this.deps.webAppUrl.replace(/\/+$/, '')}/${encodeURIComponent(orgSlug)}`
       const agentUrl = hasLiveAgent ? `${base}/agents/${encodeURIComponent(projection.agentId)}` : undefined
-      const detailsUrl = run?.sessionId ? `${base}/sessions/${encodeURIComponent(run.sessionId)}` : undefined
+      const detailsUrl = run?.sessionId
+        ? `${base}/sessions/${encodeURIComponent(run.sessionId)}?source=github`
+        : undefined
       return {
         ...(detailsUrl ? { detailsUrl } : {}),
         ...(agentUrl ? { agentUrl } : {}),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7748,9 +7748,7 @@ export class Daemon {
       }
       const info = this.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
       const link = acpSessionId
-        ? msg.platform === 'slack'
-          ? this.slackSessionLink(acpSessionId)
-          : this.sessionLink(acpSessionId)
+        ? this.sessionLink(acpSessionId, msg.platform === 'slack' ? 'slack' : undefined)
         : undefined
       if (msg.platform === 'telegram') {
         // HTML chrome (not recorded) — renders the compact line + a tappable View link.
@@ -9563,7 +9561,7 @@ export class Daemon {
       botUrl: this.agentLink(agentId),
       runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
       model: this.buildStatusInfo(p).model ?? turnModel ?? 'default',
-      sessionUrl: msg.platform === 'slack' ? this.slackSessionLink(sessionId) : this.sessionLink(sessionId)
+      sessionUrl: this.sessionLink(sessionId, msg.platform === 'slack' ? 'slack' : undefined)
     })
     try {
       if (!p.selectedHost) {
@@ -10950,16 +10948,12 @@ export class Daemon {
   /** The Web App console URL for a session: `<base>/<orgSlug>/sessions/<id>`, where base is
    *  the explicit local `webAppUrl`, else the CP-provided origin, else the local default
    *  (`DEFAULT_WEB_APP_URL`). The console is org-scoped, so the org slug is inserted when
-   *  known; without it the link falls back to `<base>/sessions/<id>`. */
-  private sessionLink(acpSessionId: string): string {
+   *  known; without it the link falls back to `<base>/sessions/<id>`. Slack/GitHub links
+   *  carry a presentation-only source hint for the generic 404 recovery action. */
+  private sessionLink(acpSessionId: string, source?: 'slack' | 'github'): string {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
-    return `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
-  }
-
-  /** A Slack-originated session link carries only the source context the 404 UI
-   *  already knows from the click. It never changes session authorization. */
-  private slackSessionLink(acpSessionId: string): string {
-    return `${this.sessionLink(acpSessionId)}?source=slack`
+    const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
+    return source ? `${link}?source=${source}` : link
   }
 
   /** The console deep link to an agent: `<base>/<orgSlug>/agents/<agentId>`. Same
@@ -11231,7 +11225,7 @@ export class Daemon {
       ...(iconUrl ? { iconUrl } : {}),
       ...(sessionTitle ? { sessionTitle } : {})
     }
-    const link = rec.acpSessionId ? this.slackSessionLink(rec.acpSessionId) : undefined
+    const link = rec.acpSessionId ? this.sessionLink(rec.acpSessionId, 'slack') : undefined
     const pending = [...this.pending.values()].find((turn) => turn.sessionKey === sessionKey)
     const cancellable = pending?.statusCancellable ?? this.inflight.has(sessionKey)
     return { info, identity, ...(link ? { link } : {}), cancellable }
@@ -11287,7 +11281,7 @@ export class Daemon {
       // runtimes only advertise the model after the first prompt). It fills in via edits
       // as usage_update / turn-end land.
       p.lastStatusBar = key
-      const link = this.slackSessionLink(p.acpSessionId)
+      const link = this.sessionLink(p.acpSessionId, 'slack')
       const sessionTarget = this.httpSlackSessionTarget(p)
       const shared =
         sessionTarget && p.integrationId
@@ -15016,7 +15010,7 @@ export class Daemon {
       agentUrl: this.agentLink(agentId),
       runtime: runtime ? (this.runtimeNames[runtime] ?? runtime) : 'unknown',
       model: this.hosts.get(agentId)?.modelOptions?.(sessionId)?.current ?? agent?.runtimeOverrides?.model ?? 'default',
-      sessionUrl: this.sessionLink(sessionId),
+      sessionUrl: this.sessionLink(sessionId, 'github'),
       // Same CP-resolved public avatar Slack uses for icon_url; GitHub renders it
       // inline ahead of the footer sentence.
       ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1753,6 +1753,8 @@ describe('Slack interactive status bar', () => {
     const daemon = new Daemon({ root: scaffold() })
     ;(daemon as any).cfg = {}
     expect((daemon as any).sessionLink('acp-1')).toBe('http://localhost:3000/sessions/acp-1')
+    expect((daemon as any).sessionLink('acp-1', 'slack')).toBe('http://localhost:3000/sessions/acp-1?source=slack')
+    expect((daemon as any).sessionLink('acp-1', 'github')).toBe('http://localhost:3000/sessions/acp-1?source=github')
     expect((daemon as any).agentLink('bot-a')).toBe('http://localhost:3000/agents/bot-a')
   })
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -123,7 +123,8 @@ describe('Daemon rd/msg hook fires', () => {
     expect((daemon as any).githubCommentAttribution(AGENT_ID, 'acp-hook-1')).toMatchObject({
       agentName: 'Review Bot',
       runtime: 'Claude Code',
-      model: 'claude-sonnet-4-5'
+      model: 'claude-sonnet-4-5',
+      sessionUrl: 'http://localhost:3000/sessions/acp-hook-1?source=github'
     })
 
     await daemon.stop()

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -80,18 +80,21 @@ export function SessionVisibilityControl({
   }
 
   if (effective === 'external') {
-    const provider = externalProvider === 'slack' ? 'Slack' : 'External'
+    const github = externalProvider === 'github'
+    const provider = externalProvider === 'slack' ? 'Slack' : github ? 'GitHub' : 'External'
     const title =
       externalResolution === 'settled'
-        ? `Visible to current members of the source ${provider} conversation`
-        : `${provider} membership could not be resolved; access is fail-closed`
+        ? github
+          ? "Visible according to the source GitHub repository's current visibility and access"
+          : `Visible to current members of the source ${provider} conversation`
+        : `${provider} access could not be verified; this session remains hidden`
     return (
       <span
         title={title}
         className="inline-flex items-center gap-[5px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)"
       >
         <Icon name="users" size={13} color="var(--text-tertiary)" />
-        {provider} members
+        {github ? 'GitHub access' : `${provider} members`}
         {state === 'pending' && <Spinner size={10} />}
       </span>
     )

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/lib/data'
 import {
   ApiError,
-  fetchMySlackIdentity,
+  fetchMySessionIdentity,
   fetchSessionMessages,
   fetchSessionDetail,
   fetchToolBody,
@@ -717,29 +717,36 @@ export default function SessionDetailView() {
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
     { refreshInterval: 30_000 }
   )
-  // A Slack-rendered View Session link carries source=slack. That caller-provided
-  // context is independent of whether the requested id exists, so the CP can keep
-  // unknown and unauthorized 404 payloads byte-for-byte equivalent.
-  const slackRecoveryCandidate =
+  // Provider-rendered session links carry only caller-known source context. It
+  // never changes authorization, so unknown and unauthorized 404s stay equivalent.
+  const source = searchParams.get('source')
+  const recoveryProvider =
+    (source === 'slack' || source === 'github') && socialLoginProviders().some((provider) => provider.target === source)
+      ? source
+      : undefined
+  const recoveryCandidate =
     sessionDetailError instanceof ApiError &&
     sessionDetailError.status === 404 &&
-    searchParams.get('source') === 'slack' &&
     isAuthConfigured() &&
-    socialLoginProviders().some((provider) => provider.target === 'slack')
+    recoveryProvider !== undefined
   const {
-    data: slackIdentity,
-    error: slackIdentityError,
-    isValidating: slackIdentityLoading
-  } = useSWR(slackRecoveryCandidate ? 'logto-slack-identity' : null, fetchMySlackIdentity, {
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-    shouldRetryOnError: false
-  })
-  const showSlackLink =
-    slackRecoveryCandidate &&
-    !slackIdentityLoading &&
-    slackIdentityError === undefined &&
-    slackIdentity?.linked === false
+    data: recoveryIdentity,
+    error: recoveryIdentityError,
+    isValidating: recoveryIdentityLoading
+  } = useSWR(
+    recoveryCandidate ? (['logto-session-identity', recoveryProvider] as const) : null,
+    ([, provider]) => fetchMySessionIdentity(provider),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false
+    }
+  )
+  const showRecoveryLink =
+    recoveryCandidate &&
+    !recoveryIdentityLoading &&
+    recoveryIdentityError === undefined &&
+    recoveryIdentity?.linked === false
   const detailSession = sessionDetail ? sessionFromDetailDto(sessionDetail) : null
   // The cursor-loaded list row can predate the final Dream usage report. Keep
   // its local/live fields, but let the independently refreshed detail snapshot
@@ -957,9 +964,9 @@ export default function SessionDetailView() {
             actionLabel="Back to sessions"
             actionHref={orgPath('/sessions')}
             secondaryAction={
-              showSlackLink
+              showRecoveryLink && recoveryProvider
                 ? {
-                    label: 'Link Slack profile',
+                    label: `Link ${recoveryProvider === 'slack' ? 'Slack' : 'GitHub'} profile`,
                     href: orgPath('/profile#sign-in-methods'),
                     icon: 'link'
                   }
@@ -1451,7 +1458,7 @@ export default function SessionDetailView() {
 
       {sessionDetail?.accessSyncDegraded && (
         <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3">
-          Slack membership could not be verified. Related sessions remain hidden until access checks recover.
+          External access could not be verified. Related sessions remain hidden until access checks recover.
         </div>
       )}
 

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -519,7 +519,7 @@ export default function SessionsView() {
       )}
       {sessionList.accessSyncDegraded && (
         <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4">
-          Some Slack membership checks are unavailable. Affected sessions are hidden until access can be verified.
+          Some external access checks are unavailable. Affected sessions are hidden until access can be verified.
         </div>
       )}
       {initialLoading && (

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -29,7 +29,7 @@ import {
   fetchGithubInstallations,
   fetchMembers,
   fetchOrgInviteLink,
-  fetchSlackSessionAccess,
+  fetchSessionExternalAccess,
   memberDisplayName,
   refreshSlackBot,
   getSlackPlatformInstall,
@@ -37,7 +37,7 @@ import {
   ROLE_LABELS,
   syncGithubInstallations,
   startSlackPlatformInstall,
-  putSlackSessionAccess,
+  putSessionExternalAccess,
   updateOrg,
   uploadOrgIcon,
   type BotDto,
@@ -46,6 +46,7 @@ import {
   type MemberDto,
   type MemberRole,
   type OrgInviteLinkDto,
+  type SessionAccessProvider,
   type SlackBotRefreshDto
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
@@ -68,6 +69,122 @@ function botSubline(b: BotDto): string {
 function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu' | 'lark'): string {
   const host = region === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn'
   return appId ? `${host}/app/${encodeURIComponent(appId)}/baseinfo` : `${host}/app`
+}
+
+const SESSION_ACCESS_COPY: Record<
+  SessionAccessProvider,
+  {
+    title: string
+    unavailable: string
+    enabled: string
+    disabled: string
+    unresolved: (count: number) => string
+    degraded: string
+  }
+> = {
+  slack: {
+    title: 'Follow Slack conversation access',
+    unavailable:
+      'Requires OIDC and linked Slack identities. Until then, shared sessions remain visible to Everyone who can view the agent.',
+    enabled:
+      'Each shared session is visible only to current members of its Slack conversation. DMs remain private. Agent memory learned earlier is not erased.',
+    disabled:
+      'New shared sessions are visible to Everyone who can view the agent. Previously synced sessions keep following Slack. DMs remain private.',
+    unresolved: (count) =>
+      `${count} historical session${count === 1 ? '' : 's'} lack a trusted Slack scope and remain hidden.`,
+    degraded: 'Slack access is degraded; unresolved sessions remain hidden.'
+  },
+  github: {
+    title: 'Follow GitHub repository access',
+    unavailable:
+      'Requires OIDC and GitHub access checks. Until then, GitHub sessions remain visible to Everyone who can view the agent.',
+    enabled:
+      'Public repository sessions remain visible to members who can view the agent. Private repository sessions require a linked GitHub profile with current access. Agent memory learned earlier is not erased.',
+    disabled:
+      'New GitHub sessions are visible to Everyone who can view the agent. Previously synced sessions keep following GitHub.',
+    unresolved: (count) =>
+      `${count} historical session${count === 1 ? '' : 's'} lack a trusted GitHub repository scope and remain hidden.`,
+    degraded: 'GitHub access is degraded; unresolved sessions remain hidden.'
+  }
+}
+
+function SessionAccessRow({
+  provider,
+  orgId,
+  isOwner,
+  bordered = false
+}: {
+  provider: SessionAccessProvider
+  orgId?: string
+  isOwner: boolean
+  bordered?: boolean
+}) {
+  const copy = SESSION_ACCESS_COPY[provider]
+  const key = consoleKeys.sessionAccess(orgId, provider)
+  const {
+    data: access,
+    error: loadError,
+    mutate
+  } = useSWR(key, ([, scopedOrgId, , scopedProvider]) => fetchSessionExternalAccess(scopedProvider, scopedOrgId))
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState<{ scope: string; message: string } | null>(null)
+  const hiddenSessions = access?.hiddenSessions ?? 0
+  const scope = `${orgId ?? ''}:${provider}`
+  const currentActionError = actionError?.scope === scope ? actionError.message : null
+
+  const setEnabled = async (enabled: boolean) => {
+    if (!orgId || !isOwner || busy) return
+    setBusy(true)
+    setActionError(null)
+    try {
+      const next = await putSessionExternalAccess(provider, enabled, orgId)
+      await mutate(next, { revalidate: false })
+    } catch (error) {
+      setActionError({ scope, message: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className={`flex items-center gap-3 px-4 py-[15px] ${bordered ? 'border-t border-(--border-subtle)' : ''}`}>
+      <span className="flex h-9 w-9 flex-none items-center justify-center rounded-[9px] bg-(--surface-active)">
+        {provider === 'slack' ? (
+          <PlatformMark platform="slack" fillPct={100} />
+        ) : (
+          <GithubMark color="var(--text-primary)" />
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-sans text-[13px] font-semibold leading-normal">{copy.title}</div>
+        <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+          {access?.available === false && !access.enabled
+            ? copy.unavailable
+            : access?.enabled
+              ? copy.enabled
+              : copy.disabled}
+        </div>
+        {(access?.state === 'degraded' || hiddenSessions > 0) && (
+          <div className="mt-1 font-sans text-[11.5px] font-medium leading-normal text-(--status-paused)">
+            {hiddenSessions > 0 ? copy.unresolved(hiddenSessions) : copy.degraded}
+          </div>
+        )}
+        {(currentActionError || loadError) && (
+          <div role="alert" className="mt-1 font-sans text-[11.5px] font-normal leading-normal text-(--status-error)">
+            {currentActionError ?? `Could not load ${provider === 'slack' ? 'Slack' : 'GitHub'} session access.`}
+          </div>
+        )}
+      </div>
+      <span title={isOwner ? undefined : 'Only organization owners can change this setting'}>
+        <Toggle
+          checked={access?.enabled === true}
+          disabled={!isOwner || !access || busy || (access.available === false && access.enabled === false)}
+          ariaLabel={copy.title}
+          onChange={(next) => void setEnabled(next)}
+        />
+      </span>
+    </div>
+  )
 }
 
 // One rendered member row, precomputed from the wire DTO.
@@ -490,29 +607,6 @@ export default function SettingsView() {
   const [editing, setEditing] = useState<MemberTarget | null>(null)
   const [inviting, setInviting] = useState(false)
   const [deletingBot, setDeletingBot] = useState<BotDto | null>(null)
-  const slackAccessKey = consoleKeys.slackSessionAccess(activeOrg?.id)
-  const {
-    data: slackAccess,
-    error: slackAccessLoadError,
-    mutate: mutateSlackAccess
-  } = useSWR(slackAccessKey, ([, orgId]) => fetchSlackSessionAccess(orgId))
-  const [slackAccessBusy, setSlackAccessBusy] = useState(false)
-  const [slackAccessError, setSlackAccessError] = useState<string | null>(null)
-  const hiddenSlackSessions = slackAccess?.hiddenSessions ?? 0
-
-  const setSlackAccess = async (enabled: boolean) => {
-    if (!activeOrg || !isOwner || slackAccessBusy) return
-    setSlackAccessBusy(true)
-    setSlackAccessError(null)
-    try {
-      const next = await putSlackSessionAccess(enabled, activeOrg.id)
-      await mutateSlackAccess(next, { revalidate: false })
-    } catch (e) {
-      setSlackAccessError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setSlackAccessBusy(false)
-    }
-  }
 
   // `?invite=1` auto-opens the invite-members dialog (the getting-started "Invite
   // teammates" CTA lands here with it). One-shot: the param is stripped immediately
@@ -608,49 +702,8 @@ export default function SettingsView() {
         <div className="cardhead">
           <span className="cardtitle">Session access</span>
         </div>
-        <div className="flex items-center gap-3 px-4 py-[15px]">
-          <span className="flex h-9 w-9 flex-none items-center justify-center rounded-[9px] bg-(--surface-active)">
-            <PlatformMark platform="slack" fillPct={100} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="font-sans text-[13px] font-semibold leading-normal">Follow Slack conversation access</div>
-            <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-              {slackAccess?.available === false && !slackAccess.enabled
-                ? 'Requires OIDC and Logto linked identities. Until then, shared sessions remain visible to Everyone who can view the agent.'
-                : slackAccess?.enabled
-                  ? 'Each shared session is visible only to current members of its Slack conversation. DMs remain private. Agent memory learned earlier is not erased.'
-                  : 'New shared sessions are visible to Everyone who can view the agent. Previously synced sessions keep following Slack. DMs remain private.'}
-            </div>
-            {(slackAccess?.state === 'degraded' || hiddenSlackSessions > 0) && (
-              <div className="mt-1 font-sans text-[11.5px] font-medium leading-normal text-(--status-paused)">
-                {hiddenSlackSessions > 0
-                  ? `${hiddenSlackSessions} historical session${hiddenSlackSessions === 1 ? '' : 's'} lack a trusted Slack scope and remain hidden.`
-                  : 'Slack access is degraded; unresolved sessions remain hidden.'}
-              </div>
-            )}
-            {(slackAccessError || slackAccessLoadError) && (
-              <div
-                role="alert"
-                className="mt-1 font-sans text-[11.5px] font-normal leading-normal text-(--status-error)"
-              >
-                {slackAccessError ?? 'Could not load Slack session access.'}
-              </div>
-            )}
-          </div>
-          <span title={isOwner ? undefined : 'Only organization owners can change this setting'}>
-            <Toggle
-              checked={slackAccess?.enabled === true}
-              disabled={
-                !isOwner ||
-                !slackAccess ||
-                slackAccessBusy ||
-                (slackAccess.available === false && slackAccess.enabled === false)
-              }
-              ariaLabel="Follow Slack conversation access"
-              onChange={(next) => void setSlackAccess(next)}
-            />
-          </span>
-        </div>
+        <SessionAccessRow provider="slack" orgId={activeOrg?.id} isOwner={isOwner} />
+        <SessionAccessRow provider="github" orgId={activeOrg?.id} isOwner={isOwner} bordered />
       </div>
 
       <div className="card mt-[18px]">

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -199,7 +199,7 @@ export default function UsageView() {
 
       {data?.accessSyncDegraded && (
         <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4">
-          Some Slack membership checks are unavailable. Usage is temporarily under-counted rather than exposing
+          Some external access checks are unavailable. Usage is temporarily under-counted rather than exposing
           inaccessible sessions.
         </div>
       )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1872,8 +1872,10 @@ export async function putSessionVisibility(
   })
 }
 
-export interface SlackSessionAccessDto {
-  provider: 'slack'
+export type SessionAccessProvider = 'slack' | 'github'
+
+export interface SessionExternalAccessDto {
+  provider: SessionAccessProvider
   available: boolean
   enabled: boolean
   state: 'disabled' | 'enabling' | 'enabled' | 'degraded'
@@ -1883,12 +1885,19 @@ export interface SlackSessionAccessDto {
   hiddenSessions?: number
 }
 
-export function fetchSlackSessionAccess(orgId?: string): Promise<SlackSessionAccessDto> {
-  return apiGet<SlackSessionAccessDto>(`${orgBase(orgId)}/session-access/slack`)
+export function fetchSessionExternalAccess(
+  provider: SessionAccessProvider,
+  orgId?: string
+): Promise<SessionExternalAccessDto> {
+  return apiGet<SessionExternalAccessDto>(`${orgBase(orgId)}/session-access/${provider}`)
 }
 
-export function putSlackSessionAccess(enabled: boolean, orgId?: string): Promise<SlackSessionAccessDto> {
-  return apiPut<SlackSessionAccessDto>(`${orgBase(orgId)}/session-access/slack`, { enabled })
+export function putSessionExternalAccess(
+  provider: SessionAccessProvider,
+  enabled: boolean,
+  orgId?: string
+): Promise<SessionExternalAccessDto> {
+  return apiPut<SessionExternalAccessDto>(`${orgBase(orgId)}/session-access/${provider}`, { enabled })
 }
 
 // One page of a session's transcript, proxied live from the owning daemon. The
@@ -3048,9 +3057,11 @@ export type MySlackIdentityDto =
       teamDomain?: string
     }
 
-/** The narrow linked/not-linked read used by Slack session recovery. */
-export function fetchMySlackIdentity(): Promise<MySlackIdentityDto> {
-  return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
+/** Narrow linked/not-linked status for a supported session source. */
+export async function fetchMySessionIdentity(provider: SessionAccessProvider): Promise<{ linked: boolean }> {
+  if (provider === 'slack') return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
+  const account = await fetchMySocialAccount()
+  return { linked: account.identities.some((identity) => identity.target === provider) }
 }
 
 // Linking runs browser→provider, so the CP never sees that write and its cached

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -22,7 +22,8 @@ export const consoleKeys = {
   externalMemoryConnections: (orgId: string | null | undefined) => consoleKey(orgId, 'external-memory-connections'),
   members: (orgId: string | null | undefined) => consoleKey(orgId, 'members'),
   inviteLink: (orgId: string | null | undefined) => consoleKey(orgId, 'invite-link'),
-  slackSessionAccess: (orgId: string | null | undefined) => consoleKey(orgId, 'slack-session-access'),
+  sessionAccess: <const Provider extends 'slack' | 'github'>(orgId: string | null | undefined, provider: Provider) =>
+    consoleKey(orgId, 'session-access', provider),
   usage: <const Range extends string>(orgId: string | null | undefined, range: Range) =>
     consoleKey(orgId, 'usage', range),
   sessions: (


### PR DESCRIPTION
## Summary

- add the owner-only GitHub repository access switch beside Slack in Settings
- tag GitHub-generated session links with a presentation-only source hint and offer **Link GitHub profile** on the generic 404 only for configured, unlinked viewers
- keep session authorization unchanged while making external-access badges and degraded-state copy provider-neutral

## Why

GitHub repository visibility enforcement landed in #339, but the Console still lacked its management and recovery surfaces. This completes that follow-up while preserving the same non-oracular 404 for missing and unauthorized sessions.

## Validation

- Web, daemon, and control-plane typechecks
- Web production build
- repository ESLint via the pre-push hook
- control-plane GitHub run reporter: 42 tests passed
- focused daemon Slack/GitHub link tests passed
- Social sign-in card: 5 tests passed
- desktop and mobile visual QA for Session 404 and Settings

Created by Codex . GPT-5
