### PR TITLE
fix(web): move session status into the crumb and de-blink Getting started

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -42,8 +42,7 @@ function Ring({ ring, size, track }: { ring: string; size: number; track: number
 }
 
 export default function GettingStarted() {
-  const { agents, daemons, integrations, allSessions, orgHasSessions, members, agentsLoading, daemonsLoading } =
-    useConsoleData()
+  const { agents, daemons, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
   const { openPlayground } = usePlayground()
   const { runAction, firstAgent } = useGsActions()
   const pathname = usePathname()
@@ -63,7 +62,10 @@ export default function GettingStarted() {
   // /onboarding wizard is a separate route (AgentsView redirects an empty org there);
   // the pill only steps aside for that route, not for the empty-org state itself.
   const onOnboardingRoute = pathname?.includes('/onboarding')
-  const loading = agentsLoading || daemonsLoading
+  // Gate on the aggregate `loading`, not just agents+daemons: the checklist reads
+  // integrations, sessions and members too, so a partial first paint showed the pill
+  // with a too-low count that then jumped (and could even flash for an org that is
+  // already allDone). One transition, once everything has landed.
   if (loading || gs.allDone || onOnboardingRoute) return null
 
   const shortLabel = `${gs.done}/${gs.total}`

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -479,8 +479,12 @@ function ShellChrome({ children }: { children: ReactNode }) {
     if (section === 'crons') return crons.find((c) => c.id === id)?.name
     return undefined
   })()
-  // The slot beats the list lookup — see lib/crumb.ts for why the list alone isn't enough.
-  const { title: pushTitle, show: titleResolved } = detailCrumb(crumb, listTitle ?? undefined, crumbSlot?.title)
+  // The slot beats the list lookup, but only on the route it describes — see lib/crumb.ts.
+  const {
+    title: pushTitle,
+    show: titleResolved,
+    badge: crumbBadge
+  } = detailCrumb(crumb, seg[1], listTitle ?? undefined, crumbSlot)
 
   // Back from a push screen: pop in-app history when there is any, else (deep-link /
   // hard refresh — no history) route to the parent list so "back" never leaves the app.
@@ -662,19 +666,19 @@ function ShellChrome({ children }: { children: ReactNode }) {
                     </Link>
                     <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
                     <b className="min-w-0 truncate">{pushTitle}</b>
-                    {crumbSlot && (
+                    {crumbBadge && (
                       <span
                         className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
                         style={{
-                          background: status(crumbSlot.status).bg,
-                          color: status(crumbSlot.status).text
+                          background: status(crumbBadge.status).bg,
+                          color: status(crumbBadge.status).text
                         }}
                       >
                         <span
                           className="h-[6px] w-[6px] flex-none rounded-full"
-                          style={{ background: status(crumbSlot.status).dot }}
+                          style={{ background: status(crumbBadge.status).dot }}
                         />
-                        {crumbSlot.statusLabel}
+                        {crumbBadge.statusLabel}
                       </span>
                     )}
                   </>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -152,6 +152,18 @@ const MobileFilterContext = createContext<{
 }>({ filter: null, register: () => {} })
 export const useMobileFilterSlot = () => useContext(MobileFilterContext)
 
+// The same slot idea for the desktop crumb's status badge. The shell can't derive it
+// itself: `allSessions` holds only the cursor pages the list has loaded, while the
+// detail view hydrates a deep-linked or relationship-linked session through
+// `fetchSessionDetail`. So the view — which owns the authoritative merged session —
+// registers its status here while mounted, and the crumb just paints it.
+export interface CrumbStatusSlot {
+  status: string
+  label: string
+}
+const CrumbStatusContext = createContext<{ register: (s: CrumbStatusSlot | null) => void }>({ register: () => {} })
+export const useCrumbStatusSlot = () => useContext(CrumbStatusContext)
+
 export default function ConsoleShell({ children }: { children: ReactNode }) {
   return (
     <OrgProvider>
@@ -268,6 +280,8 @@ function ShellChrome({ children }: { children: ReactNode }) {
   }, [isMobile])
   // Filter slot the current view (Sessions) registers so the app bar can trigger it.
   const [mobileFilter, setMobileFilter] = useState<MobileFilterSlot | null>(null)
+  // Status slot the session detail view registers so the crumb can badge it.
+  const [crumbStatus, setCrumbStatus] = useState<CrumbStatusSlot | null>(null)
   // Active/crumb matching runs on the console path WITHOUT the org segment
   // (`/acme/agents` → `/agents`); hrefs go the other way via orgPath().
   const barePath = subPath(pathname, typeof params.slug === 'string' ? decodeURIComponent(params.slug) : '-')
@@ -484,9 +498,6 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // org-scoped URL, matching the desktop "Copy link" button, and flash the icon
   // to a check for ~1.6s.
   const isSessionDetail = seg[0] === 'sessions' && seg.length === 2
-  // Session status rides the crumb as a pill next to the title (same badge as the
-  // Sessions list), so the detail header row doesn't have to carry it.
-  const crumbSession = isSessionDetail ? allSessions.find((s) => s.id === seg[1]) : undefined
   const copyLink = () => {
     try {
       void navigator.clipboard?.writeText?.(window.location.origin + orgPath(barePath))?.catch?.(() => {})
@@ -499,294 +510,308 @@ function ShellChrome({ children }: { children: ReactNode }) {
 
   return (
     <MobileFilterContext.Provider value={{ filter: mobileFilter, register: setMobileFilter }}>
-      <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
-        {/* ===== RAIL =====
+      <CrumbStatusContext.Provider value={{ register: setCrumbStatus }}>
+        <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
+          {/* ===== RAIL =====
           No tooltips in here. The `title`s below exist as the collapsed rail's
           fallback labels, not as hints — surfacing them would just repeat the
           label already sitting next to the icon. */}
-        <aside data-no-tooltip className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
-          <div className="railbrand">
-            <Link href={orgPath('/home')} className="railbrand-logo cursor-pointer select-none" aria-label="Go to Home">
-              <LogoMark />
-              <span className="brandword font-sans text-[17px] font-semibold leading-normal tracking-[-.02em] text-white">
-                Agent<span className="text-(--magenta-300)">Connect</span>
-              </span>
-            </Link>
-            <button
-              type="button"
-              onClick={toggleRail}
-              className="railtoggle"
-              title={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            >
-              <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={17} />
-            </button>
-          </div>
-          {/* Org picker + "Organization" section label — only in auth mode; the
-            no-auth default org needs neither (there's a single implicit org). A
-            small spacer keeps the nav off the brand divider when both are gone. */}
-          {authOn ? (
-            <>
-              <OrgSwitcher collapsed={railCollapsed} canCreateOrg={canCreateOrg} />
-              <div className="navlbl">Organization</div>
-            </>
-          ) : (
-            <div className="h-3" />
-          )}
-          {NAV_ITEMS.map((item) => {
-            const on = isActive(barePath, item.href)
-            return (
+          <aside data-no-tooltip className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
+            <div className="railbrand">
               <Link
-                key={item.href}
-                href={orgPath(item.href)}
-                title={item.label}
-                className={on ? 'navitem on' : 'navitem'}
+                href={orgPath('/home')}
+                className="railbrand-logo cursor-pointer select-none"
+                aria-label="Go to Home"
               >
-                <Icon name={item.icon} size={18} color={on ? '#fff' : undefined} />
-                <span>{item.label}</span>
+                <LogoMark />
+                <span className="brandword font-sans text-[17px] font-semibold leading-normal tracking-[-.02em] text-white">
+                  Agent<span className="text-(--magenta-300)">Connect</span>
+                </span>
               </Link>
-            )
-          })}
-          {/* Rail footer: Settings (auth mode only, theme toggle lives by the search)
-            + a Help & resources menu that opens UPWARD. The help menu shows in every
-            mode — the docs/MCP links are useful with or without sign-in. */}
-          <div
-            className={`mt-auto border-t border-(--border-inverse) ${railCollapsed ? 'flex flex-col items-stretch gap-1 px-2 py-[10px]' : 'flex items-center gap-[6px] px-4 py-[14px]'}`}
-          >
-            {authOn && (
-              <Link
-                href={orgPath('/settings')}
-                title="Settings"
-                className={`${isActive(barePath, '/settings') ? 'navitem on' : 'navitem'} my-0 rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full justify-center px-0' : 'flex-1 px-3'}`}
-              >
-                <Icon name="settings" size={18} color={isActive(barePath, '/settings') ? 'var(--brand)' : undefined} />
-                <span>Settings</span>
-              </Link>
-            )}
-            <div className={`relative ${railCollapsed ? 'w-full' : 'flex-none'}`}>
               <button
                 type="button"
-                onClick={() => setHelpMenu((v) => !v)}
-                className={`navitem justify-center rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full px-0' : 'w-auto flex-none px-[11px]'}`}
-                title="Help & resources"
-                aria-label="Help & resources"
+                onClick={toggleRail}
+                className="railtoggle"
+                title={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               >
-                <Icon name="circle-question-mark" size={18} color={helpMenu ? 'var(--brand)' : undefined} />
+                <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={17} />
               </button>
-              {helpMenu && (
-                <>
-                  <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
-                  <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
-                    <button
-                      className="dmi"
-                      onClick={() => {
-                        setHelpMenu(false)
-                        setConnectAiOpen(true)
-                      }}
-                    >
-                      <SiModelcontextprotocol className="text-(--text-tertiary)" aria-hidden />
-                      Connect your AI
-                    </button>
-                    <a
-                      className="dmi no-underline"
-                      href={help.docs}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => setHelpMenu(false)}
-                    >
-                      <Icon name="book-open" size={15} color="var(--text-tertiary)" />
-                      Documentation
-                    </a>
-                    <div className="dmsep" />
-                    <button
-                      className="dmi"
-                      onClick={() => {
-                        setHelpMenu(false)
-                        setShortcutsOpen(true)
-                      }}
-                    >
-                      <Icon name="command" size={15} color="var(--text-tertiary)" />
-                      Keyboard shortcuts
-                    </button>
-                    <a
-                      className="dmi no-underline"
-                      href={help.releases}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => setHelpMenu(false)}
-                    >
-                      <Icon name="gift" size={15} color="var(--text-tertiary)" />
-                      What&rsquo;s new
-                    </a>
-                    <a className="dmi no-underline" href={help.support} onClick={() => setHelpMenu(false)}>
-                      <Icon name="life-buoy" size={15} color="var(--text-tertiary)" />
-                      Help &amp; support
-                    </a>
-                  </div>
-                </>
-              )}
             </div>
-          </div>
-        </aside>
+            {/* Org picker + "Organization" section label — only in auth mode; the
+            no-auth default org needs neither (there's a single implicit org). A
+            small spacer keeps the nav off the brand divider when both are gone. */}
+            {authOn ? (
+              <>
+                <OrgSwitcher collapsed={railCollapsed} canCreateOrg={canCreateOrg} />
+                <div className="navlbl">Organization</div>
+              </>
+            ) : (
+              <div className="h-3" />
+            )}
+            {NAV_ITEMS.map((item) => {
+              const on = isActive(barePath, item.href)
+              return (
+                <Link
+                  key={item.href}
+                  href={orgPath(item.href)}
+                  title={item.label}
+                  className={on ? 'navitem on' : 'navitem'}
+                >
+                  <Icon name={item.icon} size={18} color={on ? '#fff' : undefined} />
+                  <span>{item.label}</span>
+                </Link>
+              )
+            })}
+            {/* Rail footer: Settings (auth mode only, theme toggle lives by the search)
+            + a Help & resources menu that opens UPWARD. The help menu shows in every
+            mode — the docs/MCP links are useful with or without sign-in. */}
+            <div
+              className={`mt-auto border-t border-(--border-inverse) ${railCollapsed ? 'flex flex-col items-stretch gap-1 px-2 py-[10px]' : 'flex items-center gap-[6px] px-4 py-[14px]'}`}
+            >
+              {authOn && (
+                <Link
+                  href={orgPath('/settings')}
+                  title="Settings"
+                  className={`${isActive(barePath, '/settings') ? 'navitem on' : 'navitem'} my-0 rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full justify-center px-0' : 'flex-1 px-3'}`}
+                >
+                  <Icon
+                    name="settings"
+                    size={18}
+                    color={isActive(barePath, '/settings') ? 'var(--brand)' : undefined}
+                  />
+                  <span>Settings</span>
+                </Link>
+              )}
+              <div className={`relative ${railCollapsed ? 'w-full' : 'flex-none'}`}>
+                <button
+                  type="button"
+                  onClick={() => setHelpMenu((v) => !v)}
+                  className={`navitem justify-center rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full px-0' : 'w-auto flex-none px-[11px]'}`}
+                  title="Help & resources"
+                  aria-label="Help & resources"
+                >
+                  <Icon name="circle-question-mark" size={18} color={helpMenu ? 'var(--brand)' : undefined} />
+                </button>
+                {helpMenu && (
+                  <>
+                    <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
+                    <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
+                      <button
+                        className="dmi"
+                        onClick={() => {
+                          setHelpMenu(false)
+                          setConnectAiOpen(true)
+                        }}
+                      >
+                        <SiModelcontextprotocol className="text-(--text-tertiary)" aria-hidden />
+                        Connect your AI
+                      </button>
+                      <a
+                        className="dmi no-underline"
+                        href={help.docs}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => setHelpMenu(false)}
+                      >
+                        <Icon name="book-open" size={15} color="var(--text-tertiary)" />
+                        Documentation
+                      </a>
+                      <div className="dmsep" />
+                      <button
+                        className="dmi"
+                        onClick={() => {
+                          setHelpMenu(false)
+                          setShortcutsOpen(true)
+                        }}
+                      >
+                        <Icon name="command" size={15} color="var(--text-tertiary)" />
+                        Keyboard shortcuts
+                      </button>
+                      <a
+                        className="dmi no-underline"
+                        href={help.releases}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => setHelpMenu(false)}
+                      >
+                        <Icon name="gift" size={15} color="var(--text-tertiary)" />
+                        What&rsquo;s new
+                      </a>
+                      <a className="dmi no-underline" href={help.support} onClick={() => setHelpMenu(false)}>
+                        <Icon name="life-buoy" size={15} color="var(--text-tertiary)" />
+                        Help &amp; support
+                      </a>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </aside>
 
-        {/* ===== MAIN ===== */}
-        <div className="main">
-          <header className="top">
-            <div className="crumb min-w-0">
-              {showDetailCrumb ? (
-                <>
-                  <Link
-                    href={parentListHref}
-                    className="flex-none text-(--text-tertiary) no-underline hover:text-(--text-secondary)"
-                  >
-                    {crumb}
-                  </Link>
-                  <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
-                  <b className="min-w-0 truncate">{pushTitle}</b>
-                  {crumbSession && (
-                    <span
-                      className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
-                      style={{
-                        background: status(crumbSession.status).bg,
-                        color: status(crumbSession.status).text
-                      }}
+          {/* ===== MAIN ===== */}
+          <div className="main">
+            <header className="top">
+              <div className="crumb min-w-0">
+                {showDetailCrumb ? (
+                  <>
+                    <Link
+                      href={parentListHref}
+                      className="flex-none text-(--text-tertiary) no-underline hover:text-(--text-secondary)"
                     >
+                      {crumb}
+                    </Link>
+                    <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
+                    <b className="min-w-0 truncate">{pushTitle}</b>
+                    {crumbStatus && (
                       <span
-                        className="h-[6px] w-[6px] flex-none rounded-full"
-                        style={{ background: status(crumbSession.status).dot }}
-                      />
-                      {crumbSession.statusLabel || status(crumbSession.status).label}
-                    </span>
+                        className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
+                        style={{
+                          background: status(crumbStatus.status).bg,
+                          color: status(crumbStatus.status).text
+                        }}
+                      >
+                        <span
+                          className="h-[6px] w-[6px] flex-none rounded-full"
+                          style={{ background: status(crumbStatus.status).dot }}
+                        />
+                        {crumbStatus.label}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  crumb
+                )}
+              </div>
+              <div className="topspacer flex-1" />
+              <GlobalSearch />
+              <ThemeToggle theme={theme} onToggle={toggleTheme} />
+              {authOn && <UserMenu display={display} orgPath={orgPath} onSignOut={signOut} />}
+            </header>
+
+            {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
+            <header className="mtop">
+              {isListRoute ? (
+                <>
+                  <Link href={orgPath('/home')} className="mtop-logo select-none" aria-label="Go to Home">
+                    <LogoMark />
+                  </Link>
+                  <span className="mtop-title">{crumb}</span>
+                  {addKind && (
+                    <button className="mappbtn" aria-label="Add" onClick={() => openModal(addKind)}>
+                      <Icon name="circle-plus" size={22} />
+                    </button>
+                  )}
+                  {/* Sessions registers a filter slot; surface it as an app-bar button
+                  with a dot when any filter is active (design's Sessions tab). */}
+                  {barePath === '/sessions' && mobileFilter && (
+                    <button className="mappbtn relative" aria-label="Filter sessions" onClick={mobileFilter.open}>
+                      <Icon name="sliders-horizontal" size={20} />
+                      {mobileFilter.active && (
+                        <span className="absolute top-[9px] right-[10px] h-[7px] w-[7px] rounded-full border-[1.5px] border-(--surface-card) bg-(--brand)" />
+                      )}
+                    </button>
+                  )}
+                  <button className="mappbtn" aria-label="Search" onClick={() => setMobileSearch(true)}>
+                    <Icon name="search" size={20} />
+                  </button>
+                  <button
+                    className="mappbtn"
+                    aria-label="Toggle theme"
+                    title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                    onClick={toggleTheme}
+                  >
+                    <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={20} />
+                  </button>
+                  {authOn && (
+                    <Link
+                      href={orgPath('/profile')}
+                      aria-label="Profile"
+                      title="Profile"
+                      className="ml-[2px] flex-none leading-[0]"
+                    >
+                      <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
+                    </Link>
                   )}
                 </>
               ) : (
-                crumb
+                <>
+                  <button className="mappbtn" aria-label="Back" onClick={goBack}>
+                    <Icon name="arrow-left" size={20} />
+                  </button>
+                  <span className="mtop-title">{pushTitle}</span>
+                  {isSessionDetail && (
+                    <button
+                      className="mappbtn"
+                      aria-label={linkCopied ? 'Link copied' : 'Copy link'}
+                      onClick={copyLink}
+                    >
+                      <Icon
+                        name={linkCopied ? 'check' : 'link'}
+                        size={20}
+                        color={linkCopied ? 'var(--brand)' : undefined}
+                      />
+                    </button>
+                  )}
+                </>
               )}
+            </header>
+
+            <div className="content">
+              <SearchOpenContext.Provider value={openSearch}>{children}</SearchOpenContext.Provider>
             </div>
-            <div className="topspacer flex-1" />
-            <GlobalSearch />
-            <ThemeToggle theme={theme} onToggle={toggleTheme} />
-            {authOn && <UserMenu display={display} orgPath={orgPath} onSignOut={signOut} />}
-          </header>
 
-          {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
-          <header className="mtop">
-            {isListRoute ? (
-              <>
-                <Link href={orgPath('/home')} className="mtop-logo select-none" aria-label="Go to Home">
-                  <LogoMark />
-                </Link>
-                <span className="mtop-title">{crumb}</span>
-                {addKind && (
-                  <button className="mappbtn" aria-label="Add" onClick={() => openModal(addKind)}>
-                    <Icon name="circle-plus" size={22} />
+            {/* ===== MOBILE BOTTOM NAV — 4 tabs + More, hidden on push screens ===== */}
+            {isListRoute && (
+              <nav className="mnav">
+                <div className="mnav-tabs">
+                  {MOBILE_NAV.map((item) => {
+                    const on = isActive(barePath, item.href)
+                    return (
+                      <Link key={item.href} href={orgPath(item.href)} className={on ? 'mnavitem on' : 'mnavitem'}>
+                        <Icon name={item.icon} size={20} color={on ? 'var(--magenta-300)' : undefined} />
+                        <span>{item.label}</span>
+                      </Link>
+                    )
+                  })}
+                  <button type="button" className="mnavitem" onClick={() => setMobileSheet('more')}>
+                    <Icon name="ellipsis" size={20} />
+                    <span>More</span>
                   </button>
-                )}
-                {/* Sessions registers a filter slot; surface it as an app-bar button
-                  with a dot when any filter is active (design's Sessions tab). */}
-                {barePath === '/sessions' && mobileFilter && (
-                  <button className="mappbtn relative" aria-label="Filter sessions" onClick={mobileFilter.open}>
-                    <Icon name="sliders-horizontal" size={20} />
-                    {mobileFilter.active && (
-                      <span className="absolute top-[9px] right-[10px] h-[7px] w-[7px] rounded-full border-[1.5px] border-(--surface-card) bg-(--brand)" />
-                    )}
-                  </button>
-                )}
-                <button className="mappbtn" aria-label="Search" onClick={() => setMobileSearch(true)}>
-                  <Icon name="search" size={20} />
-                </button>
-                <button
-                  className="mappbtn"
-                  aria-label="Toggle theme"
-                  title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                  onClick={toggleTheme}
-                >
-                  <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={20} />
-                </button>
-                {authOn && (
-                  <Link
-                    href={orgPath('/profile')}
-                    aria-label="Profile"
-                    title="Profile"
-                    className="ml-[2px] flex-none leading-[0]"
-                  >
-                    <Avatar src={display.picture} initials={display.initials} size={30} fontSize={11} />
-                  </Link>
-                )}
-              </>
-            ) : (
-              <>
-                <button className="mappbtn" aria-label="Back" onClick={goBack}>
-                  <Icon name="arrow-left" size={20} />
-                </button>
-                <span className="mtop-title">{pushTitle}</span>
-                {isSessionDetail && (
-                  <button className="mappbtn" aria-label={linkCopied ? 'Link copied' : 'Copy link'} onClick={copyLink}>
-                    <Icon
-                      name={linkCopied ? 'check' : 'link'}
-                      size={20}
-                      color={linkCopied ? 'var(--brand)' : undefined}
-                    />
-                  </button>
-                )}
-              </>
+                </div>
+                <div className="mnav-home">
+                  <span className="home-pill" />
+                </div>
+              </nav>
             )}
-          </header>
-
-          <div className="content">
-            <SearchOpenContext.Provider value={openSearch}>{children}</SearchOpenContext.Provider>
           </div>
 
-          {/* ===== MOBILE BOTTOM NAV — 4 tabs + More, hidden on push screens ===== */}
-          {isListRoute && (
-            <nav className="mnav">
-              <div className="mnav-tabs">
-                {MOBILE_NAV.map((item) => {
-                  const on = isActive(barePath, item.href)
-                  return (
-                    <Link key={item.href} href={orgPath(item.href)} className={on ? 'mnavitem on' : 'mnavitem'}>
-                      <Icon name={item.icon} size={20} color={on ? 'var(--magenta-300)' : undefined} />
-                      <span>{item.label}</span>
-                    </Link>
-                  )
-                })}
-                <button type="button" className="mnavitem" onClick={() => setMobileSheet('more')}>
-                  <Icon name="ellipsis" size={20} />
-                  <span>More</span>
-                </button>
-              </div>
-              <div className="mnav-home">
-                <span className="home-pill" />
-              </div>
-            </nav>
+          {/* ===== MOBILE SHEETS + full-screen search (mobile-only; opened from the nav) ===== */}
+          {mobileSheet && (
+            <MobileSheets
+              which={mobileSheet}
+              authOn={authOn}
+              orgPath={orgPath}
+              orgs={orgs}
+              activeOrg={activeOrg}
+              setActiveOrg={setActiveOrg}
+              openModal={openModal}
+              canCreateOrg={canCreateOrg}
+              onOpenOrg={() => setMobileSheet('org')}
+              onClose={closeSheets}
+            />
           )}
-        </div>
-
-        {/* ===== MOBILE SHEETS + full-screen search (mobile-only; opened from the nav) ===== */}
-        {mobileSheet && (
-          <MobileSheets
-            which={mobileSheet}
-            authOn={authOn}
-            orgPath={orgPath}
-            orgs={orgs}
-            activeOrg={activeOrg}
-            setActiveOrg={setActiveOrg}
-            openModal={openModal}
-            canCreateOrg={canCreateOrg}
-            onOpenOrg={() => setMobileSheet('org')}
-            onClose={closeSheets}
-          />
-        )}
-        {mobileSearch && <GlobalSearch mobile autoFocus onClose={() => setMobileSearch(false)} />}
-        {shortcutsOpen && <KeyboardShortcutsModal onClose={() => setShortcutsOpen(false)} />}
-        {connectAiOpen && <ConnectAiModal onClose={() => setConnectAiOpen(false)} moreUrl={help.mcp} />}
-        {/* Getting-started pill + drawer (design 1a/1b): a corner checklist derived from
+          {mobileSearch && <GlobalSearch mobile autoFocus onClose={() => setMobileSearch(false)} />}
+          {shortcutsOpen && <KeyboardShortcutsModal onClose={() => setShortcutsOpen(false)} />}
+          {connectAiOpen && <ConnectAiModal onClose={() => setConnectAiOpen(false)} moreUrl={help.mcp} />}
+          {/* Getting-started pill + drawer (design 1a/1b): a corner checklist derived from
           live state, self-gated (desktop, setup-started, incomplete). */}
-        <GettingStarted />
-        {/* Renders every `title` in the console on the design system's timing
+          <GettingStarted />
+          {/* Renders every `title` in the console on the design system's timing
           instead of the browser's ~1s native tooltip. Portals to <body>. */}
-        <TooltipLayer />
-      </div>
+          <TooltipLayer />
+        </div>
+      </CrumbStatusContext.Provider>
     </MobileFilterContext.Provider>
   )
 }

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -13,7 +13,7 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import { ConsoleDataProvider, useConsoleData } from '@/lib/data-context'
 import { OrgProvider, useOrgs, orgColor, subPath } from '@/lib/org-context'
 import { ApiError, getMyAccess, type OrgDto } from '@/lib/api'
-import { agentLabel } from '@/lib/data'
+import { agentLabel, status } from '@/lib/data'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
 import ConnectAiModal from './ConnectAiModal'
@@ -484,6 +484,9 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // org-scoped URL, matching the desktop "Copy link" button, and flash the icon
   // to a check for ~1.6s.
   const isSessionDetail = seg[0] === 'sessions' && seg.length === 2
+  // Session status rides the crumb as a pill next to the title (same badge as the
+  // Sessions list), so the detail header row doesn't have to carry it.
+  const crumbSession = isSessionDetail ? allSessions.find((s) => s.id === seg[1]) : undefined
   const copyLink = () => {
     try {
       void navigator.clipboard?.writeText?.(window.location.origin + orgPath(barePath))?.catch?.(() => {})
@@ -640,6 +643,21 @@ function ShellChrome({ children }: { children: ReactNode }) {
                   </Link>
                   <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
                   <b className="min-w-0 truncate">{pushTitle}</b>
+                  {crumbSession && (
+                    <span
+                      className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
+                      style={{
+                        background: status(crumbSession.status).bg,
+                        color: status(crumbSession.status).text
+                      }}
+                    >
+                      <span
+                        className="h-[6px] w-[6px] flex-none rounded-full"
+                        style={{ background: status(crumbSession.status).dot }}
+                      />
+                      {crumbSession.statusLabel || status(crumbSession.status).label}
+                    </span>
+                  )}
                 </>
               ) : (
                 crumb

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -14,6 +14,7 @@ import { ConsoleDataProvider, useConsoleData } from '@/lib/data-context'
 import { OrgProvider, useOrgs, orgColor, subPath } from '@/lib/org-context'
 import { ApiError, getMyAccess, type OrgDto } from '@/lib/api'
 import { agentLabel, status } from '@/lib/data'
+import { detailCrumb, type CrumbSlot } from '@/lib/crumb'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
 import ConnectAiModal from './ConnectAiModal'
@@ -152,17 +153,11 @@ const MobileFilterContext = createContext<{
 }>({ filter: null, register: () => {} })
 export const useMobileFilterSlot = () => useContext(MobileFilterContext)
 
-// The same slot idea for the desktop crumb's status badge. The shell can't derive it
-// itself: `allSessions` holds only the cursor pages the list has loaded, while the
-// detail view hydrates a deep-linked or relationship-linked session through
-// `fetchSessionDetail`. So the view — which owns the authoritative merged session —
-// registers its status here while mounted, and the crumb just paints it.
-export interface CrumbStatusSlot {
-  status: string
-  label: string
-}
-const CrumbStatusContext = createContext<{ register: (s: CrumbStatusSlot | null) => void }>({ register: () => {} })
-export const useCrumbStatusSlot = () => useContext(CrumbStatusContext)
+// The same slot idea for the detail crumb: the view that hydrates its own row publishes
+// title + status here while mounted, and the shell's crumb prefers it over the list
+// lookup. See lib/crumb.ts for why the lists can't carry this on their own.
+const CrumbContext = createContext<{ register: (s: CrumbSlot | null) => void }>({ register: () => {} })
+export const useCrumbSlot = () => useContext(CrumbContext)
 
 export default function ConsoleShell({ children }: { children: ReactNode }) {
   return (
@@ -281,7 +276,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // Filter slot the current view (Sessions) registers so the app bar can trigger it.
   const [mobileFilter, setMobileFilter] = useState<MobileFilterSlot | null>(null)
   // Status slot the session detail view registers so the crumb can badge it.
-  const [crumbStatus, setCrumbStatus] = useState<CrumbStatusSlot | null>(null)
+  const [crumbSlot, setCrumbSlot] = useState<CrumbSlot | null>(null)
   // Active/crumb matching runs on the console path WITHOUT the org segment
   // (`/acme/agents` → `/agents`); hrefs go the other way via orgPath().
   const barePath = subPath(pathname, typeof params.slug === 'string' ? decodeURIComponent(params.slug) : '-')
@@ -472,23 +467,27 @@ function ShellChrome({ children }: { children: ReactNode }) {
   // the design), falling back to the section crumb for top-level push pages
   // (Profile / Analytics / Tools & Skills / Settings) or before the entity has loaded.
   const seg = barePath.split('/').filter(Boolean)
-  const pushTitle = (() => {
-    if (seg.length < 2) return crumb
+  const listTitle = (() => {
+    if (seg.length < 2) return undefined
     const [section, id] = seg
-    if (section === 'agents')
-      return agents.find((a) => a.id === id) ? agentLabel(agents.find((a) => a.id === id)!) : crumb
-    if (section === 'daemons') return daemons.find((d) => d.daemonId === id)?.name ?? crumb
-    if (section === 'sessions') return allSessions.find((s) => s.id === id)?.title ?? crumb
-    if (section === 'crons') return crons.find((c) => c.id === id)?.name ?? crumb
-    return crumb
+    if (section === 'agents') {
+      const agent = agents.find((a) => a.id === id)
+      return agent ? agentLabel(agent) : undefined
+    }
+    if (section === 'daemons') return daemons.find((d) => d.daemonId === id)?.name
+    if (section === 'sessions') return allSessions.find((s) => s.id === id)?.title
+    if (section === 'crons') return crons.find((c) => c.id === id)?.name
+    return undefined
   })()
+  // The slot beats the list lookup — see lib/crumb.ts for why the list alone isn't enough.
+  const { title: pushTitle, show: titleResolved } = detailCrumb(crumb, listTitle ?? undefined, crumbSlot?.title)
 
   // Back from a push screen: pop in-app history when there is any, else (deep-link /
   // hard refresh — no history) route to the parent list so "back" never leaves the app.
   const hasParentList = LIST_ROUTES.includes(`/${seg[0] ?? ''}`)
   const parentList = hasParentList ? `/${seg[0]}` : '/home'
   const parentListHref = orgPath(parentList + (seg[0] === 'sessions' ? sessionFilterSearch(locationSearch) : ''))
-  const showDetailCrumb = hasParentList && seg.length >= 2 && crumb !== '' && pushTitle !== crumb
+  const showDetailCrumb = hasParentList && seg.length >= 2 && crumb !== '' && titleResolved
   const goBack = () => {
     if (typeof window !== 'undefined' && window.history.length > 1) router.back()
     else router.push(parentListHref)
@@ -510,7 +509,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
 
   return (
     <MobileFilterContext.Provider value={{ filter: mobileFilter, register: setMobileFilter }}>
-      <CrumbStatusContext.Provider value={{ register: setCrumbStatus }}>
+      <CrumbContext.Provider value={{ register: setCrumbSlot }}>
         <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
           {/* ===== RAIL =====
           No tooltips in here. The `title`s below exist as the collapsed rail's
@@ -663,19 +662,19 @@ function ShellChrome({ children }: { children: ReactNode }) {
                     </Link>
                     <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
                     <b className="min-w-0 truncate">{pushTitle}</b>
-                    {crumbStatus && (
+                    {crumbSlot && (
                       <span
                         className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
                         style={{
-                          background: status(crumbStatus.status).bg,
-                          color: status(crumbStatus.status).text
+                          background: status(crumbSlot.status).bg,
+                          color: status(crumbSlot.status).text
                         }}
                       >
                         <span
                           className="h-[6px] w-[6px] flex-none rounded-full"
-                          style={{ background: status(crumbStatus.status).dot }}
+                          style={{ background: status(crumbSlot.status).dot }}
                         />
-                        {crumbStatus.label}
+                        {crumbSlot.statusLabel}
                       </span>
                     )}
                   </>
@@ -811,7 +810,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
           instead of the browser's ~1s native tooltip. Portals to <body>. */}
           <TooltipLayer />
         </div>
-      </CrumbStatusContext.Provider>
+      </CrumbContext.Provider>
     </MobileFilterContext.Provider>
   )
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -24,7 +24,6 @@ import {
   sessionChannelDisplay,
   sessionPlatform,
   speaker,
-  status,
   type Agent,
   type SessionImage,
   type SessionStep
@@ -934,7 +933,6 @@ export default function SessionDetailView() {
     )
   }
 
-  const ss = status(session.status)
   // Session visibility (session-visibility.md §4.3/§6). Rendered in the desktop
   // header and the mobile meta strip; null when there is nothing to show (an org
   // session the caller cannot re-classify, or a mock/legacy row).
@@ -1257,9 +1255,9 @@ export default function SessionDetailView() {
     (pgModel === session.model ? session.fastModeAvailable : undefined) ??
     fastModeAvailableFor(agentRuntime, selectedModelCapability)
   // Run facts for the desktop header's "Details" popover — the stats that used to
-  // live in the header cards (status, duration, usage) plus the run's identity rows.
+  // live in the header cards (duration, usage) plus the run's identity rows. Status
+  // is not here: it rides the top-bar crumb as a pill next to the session name.
   const headerFacts: { icon: string; label: string; value: string }[] = [
-    { icon: 'activity', label: 'Status', value: session.statusLabel || ss.label },
     { icon: 'clock', label: 'Duration', value: displayDuration },
     { icon: 'coins', label: 'Tokens', value: session.tokens },
     { icon: 'circle-dollar-sign', label: 'Cost', value: session.cost },
@@ -1346,8 +1344,11 @@ export default function SessionDetailView() {
           </span>
         )}
         {visibilityControl}
+        {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
+            baseline, and the descender gap under it pushed the button off the row's
+            centre line. */}
         <div
-          className="relative ml-[-3px] flex-none"
+          className="relative ml-[-3px] flex flex-none items-center"
           onKeyDown={(event) => {
             if (event.key !== 'Escape' || !detailOpen) return
             event.stopPropagation()

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -916,15 +916,17 @@ export default function SessionDetailView() {
   // title the crumb collapses to the bare "Sessions" label — taking the status badge
   // nested inside it down with it — and the Details popover no longer carries a status
   // the desktop could fall back to.
+  // The slot carries the route id it describes: the shell renders the next route before
+  // this effect's cleanup runs, so without it session A's crumb paints on session B.
   const { register: registerCrumb } = useCrumbSlot()
   const crumbTitle = session?.title ?? ''
   const crumbStatusKey = session?.status ?? ''
   const crumbStatusLabel = session?.statusLabel || (crumbStatusKey ? status(crumbStatusKey).label : '')
   useEffect(() => {
     if (!crumbTitle) return
-    registerCrumb({ title: crumbTitle, status: crumbStatusKey, statusLabel: crumbStatusLabel })
+    registerCrumb({ id, title: crumbTitle, status: crumbStatusKey, statusLabel: crumbStatusLabel })
     return () => registerCrumb(null)
-  }, [registerCrumb, crumbTitle, crumbStatusKey, crumbStatusLabel])
+  }, [registerCrumb, id, crumbTitle, crumbStatusKey, crumbStatusLabel])
 
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -61,7 +61,7 @@ import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { WORK_LANES, toggleWorkPanel, workCounts, workPanelOpen, workSummary } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
-import { useCrumbStatusSlot } from '@/components/console/Shell'
+import { useCrumbSlot } from '@/components/console/Shell'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
   sessionEffortAfterModelChange,
@@ -910,18 +910,21 @@ export default function SessionDetailView() {
     return () => window.clearInterval(timer)
   }, [session?.id, session?.platform, sessionBusy])
 
-  // Publish the run status to the shell's crumb badge. It has to come from here, not
-  // from `allSessions`: a deep link (or a parent/child link) to a session outside the
-  // loaded cursor pages only exists as the `fetchSessionDetail`-backed row above, and
-  // the Details popover no longer carries a status the desktop could fall back to.
-  const { register: registerCrumbStatus } = useCrumbStatusSlot()
+  // Publish title + status to the shell's crumb. Both have to come from here, not from
+  // `allSessions`: a deep link (or a parent/child link) to a session outside the loaded
+  // cursor pages only exists as the `fetchSessionDetail`-backed row above. Without the
+  // title the crumb collapses to the bare "Sessions" label — taking the status badge
+  // nested inside it down with it — and the Details popover no longer carries a status
+  // the desktop could fall back to.
+  const { register: registerCrumb } = useCrumbSlot()
+  const crumbTitle = session?.title ?? ''
   const crumbStatusKey = session?.status ?? ''
   const crumbStatusLabel = session?.statusLabel || (crumbStatusKey ? status(crumbStatusKey).label : '')
   useEffect(() => {
-    if (!crumbStatusLabel) return
-    registerCrumbStatus({ status: crumbStatusKey, label: crumbStatusLabel })
-    return () => registerCrumbStatus(null)
-  }, [registerCrumbStatus, crumbStatusKey, crumbStatusLabel])
+    if (!crumbTitle) return
+    registerCrumb({ title: crumbTitle, status: crumbStatusKey, statusLabel: crumbStatusLabel })
+    return () => registerCrumb(null)
+  }, [registerCrumb, crumbTitle, crumbStatusKey, crumbStatusLabel])
 
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -24,6 +24,7 @@ import {
   sessionChannelDisplay,
   sessionPlatform,
   speaker,
+  status,
   type Agent,
   type SessionImage,
   type SessionStep
@@ -60,6 +61,7 @@ import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { WORK_LANES, toggleWorkPanel, workCounts, workPanelOpen, workSummary } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
+import { useCrumbStatusSlot } from '@/components/console/Shell'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
   sessionEffortAfterModelChange,
@@ -907,6 +909,19 @@ export default function SessionDetailView() {
     const timer = window.setInterval(() => setNowMs(Date.now()), 1000)
     return () => window.clearInterval(timer)
   }, [session?.id, session?.platform, sessionBusy])
+
+  // Publish the run status to the shell's crumb badge. It has to come from here, not
+  // from `allSessions`: a deep link (or a parent/child link) to a session outside the
+  // loaded cursor pages only exists as the `fetchSessionDetail`-backed row above, and
+  // the Details popover no longer carries a status the desktop could fall back to.
+  const { register: registerCrumbStatus } = useCrumbStatusSlot()
+  const crumbStatusKey = session?.status ?? ''
+  const crumbStatusLabel = session?.statusLabel || (crumbStatusKey ? status(crumbStatusKey).label : '')
+  useEffect(() => {
+    if (!crumbStatusLabel) return
+    registerCrumbStatus({ status: crumbStatusKey, label: crumbStatusLabel })
+    return () => registerCrumbStatus(null)
+  }, [registerCrumbStatus, crumbStatusKey, crumbStatusLabel])
 
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the

--- a/packages/web/src/lib/crumb.test.ts
+++ b/packages/web/src/lib/crumb.test.ts
@@ -1,33 +1,65 @@
 import { describe, expect, it } from 'vitest'
-import { detailCrumb } from './crumb'
+import { detailCrumb, type CrumbSlot } from './crumb'
+
+const slot = (id: string, title: string): CrumbSlot => ({ id, title, status: 'completed', statusLabel: 'completed' })
 
 describe('detailCrumb', () => {
   it('uses the list title when the entity is in a loaded page', () => {
-    expect(detailCrumb('Sessions', 'Roll out api@1.4.2 to prod')).toEqual({
+    expect(detailCrumb('Sessions', 's1', 'Roll out api@1.4.2 to prod')).toEqual({
       title: 'Roll out api@1.4.2 to prod',
-      show: true
+      show: true,
+      badge: undefined
     })
   })
 
   it('collapses to the section label while nothing has resolved yet', () => {
-    expect(detailCrumb('Sessions')).toEqual({ title: 'Sessions', show: false })
+    expect(detailCrumb('Sessions', 's1')).toEqual({ title: 'Sessions', show: false, badge: undefined })
   })
 
   // The regression this exists for: a deep link (or a parent/child link) to a session
   // outside the loaded cursor pages has no list row, so without the slot the crumb
   // stayed collapsed and the status badge nested inside it never rendered.
   it('renders an out-of-page deep link from the detail-backed slot alone', () => {
-    expect(detailCrumb('Sessions', undefined, 'Rotate the staging token')).toEqual({
+    const s = slot('s9', 'Rotate the staging token')
+    expect(detailCrumb('Sessions', 's9', undefined, s)).toEqual({
       title: 'Rotate the staging token',
-      show: true
+      show: true,
+      badge: s
     })
   })
 
   it('prefers the slot over a stale list row', () => {
-    expect(detailCrumb('Sessions', 'old title', 'renamed').title).toBe('renamed')
+    expect(detailCrumb('Sessions', 's1', 'old title', slot('s1', 'renamed')).title).toBe('renamed')
   })
 
   it('still opens the crumb for a session named exactly like its section', () => {
-    expect(detailCrumb('Sessions', undefined, 'Sessions')).toEqual({ title: 'Sessions', show: true })
+    expect(detailCrumb('Sessions', 's1', undefined, slot('s1', 'Sessions')).show).toBe(true)
+  })
+
+  // The slot is shell state, so on client navigation it still holds the previous route's
+  // session for one commit — before the old view's effect cleanup runs. Honouring it
+  // there would paint session A's title and badge on session B.
+  it('ignores a slot left over from the previous session', () => {
+    expect(detailCrumb('Sessions', 's2', 'B title', slot('s1', 'A title'))).toEqual({
+      title: 'B title',
+      show: true,
+      badge: undefined
+    })
+  })
+
+  it('ignores a stale session slot on a different section entirely', () => {
+    expect(detailCrumb('Agents', 'agent-7', undefined, slot('s1', 'A title'))).toEqual({
+      title: 'Agents',
+      show: false,
+      badge: undefined
+    })
+  })
+
+  it('ignores any slot on a section route with no id', () => {
+    expect(detailCrumb('Sessions', undefined, undefined, slot('s1', 'A title'))).toEqual({
+      title: 'Sessions',
+      show: false,
+      badge: undefined
+    })
   })
 })

--- a/packages/web/src/lib/crumb.test.ts
+++ b/packages/web/src/lib/crumb.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { detailCrumb } from './crumb'
+
+describe('detailCrumb', () => {
+  it('uses the list title when the entity is in a loaded page', () => {
+    expect(detailCrumb('Sessions', 'Roll out api@1.4.2 to prod')).toEqual({
+      title: 'Roll out api@1.4.2 to prod',
+      show: true
+    })
+  })
+
+  it('collapses to the section label while nothing has resolved yet', () => {
+    expect(detailCrumb('Sessions')).toEqual({ title: 'Sessions', show: false })
+  })
+
+  // The regression this exists for: a deep link (or a parent/child link) to a session
+  // outside the loaded cursor pages has no list row, so without the slot the crumb
+  // stayed collapsed and the status badge nested inside it never rendered.
+  it('renders an out-of-page deep link from the detail-backed slot alone', () => {
+    expect(detailCrumb('Sessions', undefined, 'Rotate the staging token')).toEqual({
+      title: 'Rotate the staging token',
+      show: true
+    })
+  })
+
+  it('prefers the slot over a stale list row', () => {
+    expect(detailCrumb('Sessions', 'old title', 'renamed').title).toBe('renamed')
+  })
+
+  it('still opens the crumb for a session named exactly like its section', () => {
+    expect(detailCrumb('Sessions', undefined, 'Sessions')).toEqual({ title: 'Sessions', show: true })
+  })
+})

--- a/packages/web/src/lib/crumb.ts
+++ b/packages/web/src/lib/crumb.ts
@@ -1,0 +1,31 @@
+// Detail-crumb resolution for the console shell's top bar (and the mobile push-screen
+// app bar, which reuses the same title).
+//
+// The shell derives a push title by looking the route id up in the console data lists.
+// Those lists hold only what has actually been fetched — `allSessions` is the loaded
+// cursor pages (50 rows each) — so a deep link, or a parent/child link, to a session
+// outside them finds nothing and falls back to the section label. That fallback also
+// collapses the crumb entirely (`show === false`), which used to take the session's
+// status badge down with it.
+//
+// So a detail view that hydrates its own row (SessionDetailView, via fetchSessionDetail)
+// publishes it through a CrumbSlot. The slot wins over the list lookup and, on its own,
+// forces the detail crumb open.
+
+/** What a detail view publishes to the shell while mounted. */
+export interface CrumbSlot {
+  title: string
+  status: string
+  statusLabel: string
+}
+
+export function detailCrumb(
+  sectionLabel: string,
+  listTitle?: string,
+  slotTitle?: string
+): { title: string; show: boolean } {
+  const title = slotTitle || listTitle || sectionLabel
+  // A slot title is authoritative even when it happens to equal the section label
+  // (a session literally named "Sessions"), so it opens the crumb by itself.
+  return { title, show: Boolean(slotTitle) || title !== sectionLabel }
+}

--- a/packages/web/src/lib/crumb.ts
+++ b/packages/web/src/lib/crumb.ts
@@ -5,15 +5,23 @@
 // Those lists hold only what has actually been fetched — `allSessions` is the loaded
 // cursor pages (50 rows each) — so a deep link, or a parent/child link, to a session
 // outside them finds nothing and falls back to the section label. That fallback also
-// collapses the crumb entirely (`show === false`), which used to take the session's
+// collapses the crumb entirely (`show === false`), which would take the session's
 // status badge down with it.
 //
 // So a detail view that hydrates its own row (SessionDetailView, via fetchSessionDetail)
 // publishes it through a CrumbSlot. The slot wins over the list lookup and, on its own,
 // forces the detail crumb open.
+//
+// The slot lives in shell state, and on client navigation the shell renders the new
+// route BEFORE the old view's effect cleanup clears it — so it carries the route id it
+// describes and is ignored on any other route. Without that check, navigating from
+// session A to session B (or to an agent/daemon detail) paints A's title and badge on
+// B for a commit.
 
 /** What a detail view publishes to the shell while mounted. */
 export interface CrumbSlot {
+  /** Route id this slot describes — the shell ignores it anywhere else. */
+  id: string
   title: string
   status: string
   statusLabel: string
@@ -21,11 +29,13 @@ export interface CrumbSlot {
 
 export function detailCrumb(
   sectionLabel: string,
+  routeId?: string,
   listTitle?: string,
-  slotTitle?: string
-): { title: string; show: boolean } {
-  const title = slotTitle || listTitle || sectionLabel
+  slot?: CrumbSlot | null
+): { title: string; show: boolean; badge?: CrumbSlot } {
+  const badge = slot && routeId && slot.id === routeId ? slot : undefined
+  const title = badge?.title || listTitle || sectionLabel
   // A slot title is authoritative even when it happens to equal the section label
   // (a session literally named "Sessions"), so it opens the crumb by itself.
-  return { title, show: Boolean(slotTitle) || title !== sectionLabel }
+  return { title, show: Boolean(badge) || title !== sectionLabel, badge }
 }


### PR DESCRIPTION
Three small console fixes on the session detail page and the Getting-started pill.

## Session detail — status as a crumb badge

The run status lived inside the header's **Details** popover, detached from the name it describes. It now renders as a dot + pill badge right after the session name in the top-bar crumb, reusing the same `STATUS_MAP` colours (soft background, saturated text, status dot) as the Sessions list. The `Status` row is gone from the popover, which keeps Duration / Tokens / Cost / Tool calls / Daemon / Runtime / Model.

## Session detail — "Details" button alignment

The button is `inline-flex` inside a plain block wrapper, so it sat on a text baseline and the descender gap under it made the wrapper ~27px tall against a 22px button. The row's `items-center` then centred the *wrapper*, pushing the button above the centre line of the agent / channel / participants text beside it. `flex items-center` on the wrapper collapses the gap — measured button centre now matches its siblings exactly.

## Getting started — no partial-data blink

The pill gated on `agentsLoading || daemonsLoading`, but `computeGettingStarted` also reads integrations, sessions, members and `orgHasSessions`. When only agents+daemons had landed, the pill painted with a too-low count that then jumped as the rest arrived — and an org that was already `allDone` flashed the pill before hiding it for good. It now gates on the aggregate `loading` from `data-context`, which covers all six sources plus `waitingForOrg`, so there is exactly one transition.

No re-blink risk from revalidation: SWR's `isLoading` is only true on a first load with no cached data, so background refreshes never flip the gate back.

## Notes for reviewers

- The crumb badge is desktop chrome; the mobile app bar already carries a status dot, so it was left alone.
- Verified in mock mode (screenshotted the crumb badge and the Details popover contents, and measured the button's centre line against its siblings). The dot addition and the Getting-started gate were checked with typecheck + lint only — a dev server was already holding the port at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)