### PR TITLE
fix(web): one word, and one way out, per conversation row

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -129,7 +129,8 @@ their transcripts, and an agent may still post there when something else — a s
 task, another agent's hand-off — directs it to.
 
 Off is therefore the Console's answer to "stop responding here" while the bot stays put.
-Actually removing it is a separate action — see "Leaving and forgetting a conversation".
+Actually removing it is a separate action — see "Leaving a conversation and removing its
+row".
 
 A restricted agent expresses the same choice through its conversation gate, which is
 independently fail-closed: a conversation it has never been enabled in stays unroutable
@@ -142,28 +143,43 @@ had no way to know it was private. A channel switched Off says nothing at all: a
 operator already decided, and pointing the room at an admin would be both wrong and
 noise. Off is silence; the gate is a closed door with a sign on it.
 
-## Leaving and forgetting a conversation
+## Leaving a conversation and removing its row
 
 Three different things can end a conversation, and the Console must not blur them:
 
 - **Off** — the bot stays and goes quiet. Reversible in one click.
-- **Leave** — the bot is removed at the platform. It requires the bot to still be
-  there, and undoing it means re-inviting.
-- **Forget** — the row stops being listed. Nothing outside AgentConnect changes.
+- **Leave** — the bot is removed at the platform, and the row goes with it. Undoing it
+  means re-inviting.
+- **Remove from this list** — the row stops being listed. Nothing outside AgentConnect
+  changes.
 
-Forget exists because departure is not always observable. Only Slack reports its own
-membership authoritatively; a Telegram, Discord, or Lark report can only ever add, so
-a conversation the bot has already left would otherwise be listed forever with no way
-to clear it. Forget is that way. It follows that a forgotten row REAPPEARS on the next
-authoritative listing if the bot is in fact still a member — which is the correct
-answer to "why did it come back", not a bug: it never left, and Forget never claimed
-to make it.
+A row offers exactly ONE of the last two: the strongest the platform allows. Where the
+bot can be made to leave, Leave is the only choice on offer, because it already does
+everything removing the row does; presenting both would ask an operator to choose
+between two outcomes that differ only in reach, at the moment they least want a
+taxonomy. Where the bot cannot be made to leave, removing the row is the only choice,
+and its own wording carries the rest of the answer — that the bot is still in there and
+has to be shown out in the chat app.
+
+That collapse puts a requirement on Leave. On a leave-capable platform a row has no
+second escape hatch, so Leave must also succeed when the bot is ALREADY out — the stale
+row left behind by someone removing the bot in the chat app is the very case these
+controls exist for, and a refusal there would strand an operator with a row they can
+see and cannot clear. A platform saying "not a member" therefore completes the Leave;
+any other refusal is still reported.
+
+Removing the row exists because departure is not always observable. Only Slack reports
+its own membership authoritatively; a Telegram, Discord, or Lark report can only ever
+add, so a conversation the bot has already left would otherwise be listed forever with
+no way to clear it. It follows that a removed row REAPPEARS on the next authoritative
+listing if the bot is in fact still a member — which is the correct answer to "why did
+it come back", not a bug: it never left, and removing a row never claimed to make it.
 
 Ending a listing must OUTLAST the reporting that produced it. On a platform that cannot
 enumerate, the conversation list is derived from session history, and leaving a
-conversation does not erase the sessions held in it — so both Leave and Forget are
-remembered durably at the edge, or the next refresh would rebuild the row from that
-history and quietly undo the operator. The suppression lifts when the conversation
+conversation does not erase the sessions held in it — so both actions are remembered
+durably at the edge, or the next refresh would rebuild the row from that history and
+quietly undo the operator. The suppression lifts when the conversation
 sends a message again: a platform only delivers those for a conversation the bot is
 actually in, so traffic is proof it was re-invited, and that is how re-inviting undoes
 a Leave without anyone having to find a button for it.
@@ -173,8 +189,9 @@ cosmetic. Telegram can withdraw from one conversation. A Discord bot has no
 per-channel membership at all — it joins a server and sees that server's channels
 through permissions — so the smallest thing it can leave is the whole server, taking
 every channel of it along. That action therefore belongs to the server, is confirmed
-as such, and is never offered on a channel row as though it were smaller than it is.
-Where a platform cannot leave at all, the Console offers only Off and Forget.
+as such, and is never offered on a channel row as though it were smaller than it is —
+which makes a Discord channel row one that cannot leave, so it offers removing the row
+and points at the server for the rest.
 
 Slack is deliberately in that last group even though its API could leave a channel.
 Doing so requires a scope that also grants creating, archiving, renaming and kicking,

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -161,6 +161,10 @@ taxonomy. Where the bot cannot be made to leave, removing the row is the only ch
 and its own wording carries the rest of the answer — that the bot is still in there and
 has to be shown out in the chat app.
 
+A direct conversation is the exception on both counts. Nobody is invited to one, so
+there is no membership to end and nothing to point the operator at; removing the row
+there is only ever removing a listing, and it says exactly that.
+
 That collapse puts a requirement on Leave. On a leave-capable platform a row has no
 second escape hatch, so Leave must also succeed when the bot is ALREADY out — the stale
 row left behind by someone removing the bot in the chat app is the very case these

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -315,9 +315,9 @@ function formatErr(err: unknown): string {
  * Does this Telegram failure just mean the bot is ALREADY out of the chat?
  *
  * Telegram offers no "am I in this chat" query, so the only way to learn it is to try
- * to leave and read the refusal. These are the shapes it uses for a chat the bot
- * cannot be in — removed, kicked, or the chat is gone. Anything else is a genuine
- * failure and must still reach the operator.
+ * to leave and read the refusal. These are the `description`s the Bot API returns from
+ * `leaveChat` for a chat the bot cannot be in — removed, kicked, or the chat is gone.
+ * Anything else is a genuine failure and must still reach the operator.
  *
  * Matching on message text is a heuristic, and deliberately a safe one: a mis-read
  * error only retires a row that is still live, which is the already-documented
@@ -325,14 +325,7 @@ function formatErr(err: unknown): string {
  */
 function isAlreadyOutOfChat(err: unknown): boolean {
   const message = ((err as { message?: string })?.message ?? '').toLowerCase()
-  return (
-    message.includes('chat not found') ||
-    message.includes('not a member') ||
-    message.includes('bot was kicked') ||
-    message.includes('bot is not a member') ||
-    message.includes('user_not_participant') ||
-    message.includes('peer_id_invalid')
-  )
+  return message.includes('chat not found') || message.includes('bot was kicked') || message.includes('not a member')
 }
 
 // ACP runtime identities for THIS daemon's own MCP tools. ALL_TOOL_NAMES is the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -311,6 +311,30 @@ function formatErr(err: unknown): string {
   return e?.stack ?? String(err)
 }
 
+/**
+ * Does this Telegram failure just mean the bot is ALREADY out of the chat?
+ *
+ * Telegram offers no "am I in this chat" query, so the only way to learn it is to try
+ * to leave and read the refusal. These are the shapes it uses for a chat the bot
+ * cannot be in — removed, kicked, or the chat is gone. Anything else is a genuine
+ * failure and must still reach the operator.
+ *
+ * Matching on message text is a heuristic, and deliberately a safe one: a mis-read
+ * error only retires a row that is still live, which is the already-documented
+ * behaviour of a removed row — it returns on that conversation's next message.
+ */
+function isAlreadyOutOfChat(err: unknown): boolean {
+  const message = ((err as { message?: string })?.message ?? '').toLowerCase()
+  return (
+    message.includes('chat not found') ||
+    message.includes('not a member') ||
+    message.includes('bot was kicked') ||
+    message.includes('bot is not a member') ||
+    message.includes('user_not_participant') ||
+    message.includes('peer_id_invalid')
+  )
+}
+
 // ACP runtime identities for THIS daemon's own MCP tools. ALL_TOOL_NAMES is the
 // registry of every tool the agentconnect MCP server can inject; both approval
 // transports below derive their trust policy from this same set.
@@ -3336,7 +3360,19 @@ export class Daemon {
         return { ok: true }
       }
       if (conn instanceof TelegramConnection) {
-        await conn.leaveChannel(target.channel)
+        try {
+          await conn.leaveChannel(target.channel)
+        } catch (err) {
+          // Already out — someone removed the bot in Telegram and the row simply
+          // outlived it, which is the whole reason these rows accumulate. Leaving is
+          // the ONLY action offered on a Telegram row, so it has to finish the job in
+          // both states: refusing here would strand the operator with a row they can
+          // see, cannot leave, and have no other control over. Any other failure is
+          // still reported. Worst case of a mis-read error is the documented
+          // behaviour of a removed row — it returns on the conversation's next message.
+          if (!isAlreadyOutOfChat(err)) throw err
+          this.log.debug(`telegram: already out of ${target.channel} — retracting the row`)
+        }
         this.retractChannels(leave.integrationId, [target.channel])
         return { ok: true }
       }

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -1082,6 +1082,50 @@ describe('Daemon.leaveConversation', () => {
     await second.stop()
   })
 
+  // Leaving is the ONLY action a Telegram row offers, so it has to finish the job even
+  // when the bot is already out — that stale row is the whole reason this exists, and
+  // refusing would leave the operator with a row they can see and cannot clear.
+  it('clears the row when Telegram says the bot is already out of the chat', async () => {
+    const { daemon } = makeStubDaemon(root1())
+    await daemon.start()
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    telegramAgent(daemon)
+    ;(daemon as any).channelSnapshots.set('tg-int', { channels: [{ id: '-100123' }], authoritative: false })
+    ;(daemon as any).connForIntegration = () =>
+      Object.assign(Object.create(TelegramConnection.prototype), {
+        leaveChannel: vi.fn().mockRejectedValue(new Error('Bad Request: chat not found'))
+      })
+
+    const verdict = await (daemon as any).leaveConversation({
+      integrationId: 'tg-int',
+      target: { kind: 'conversation', channel: '-100123' }
+    })
+
+    expect(verdict).toEqual({ ok: true })
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({ removed: ['-100123'] }))
+  })
+
+  it('still reports a refusal that does NOT mean the bot is out', async () => {
+    const { daemon } = makeStubDaemon(root1())
+    await daemon.start()
+    const emit = vi.fn()
+    ;(daemon as any).cpClient = { emitIntegrationChannels: emit, stop: vi.fn().mockResolvedValue(undefined) }
+    telegramAgent(daemon)
+    ;(daemon as any).connForIntegration = () =>
+      Object.assign(Object.create(TelegramConnection.prototype), {
+        leaveChannel: vi.fn().mockRejectedValue(new Error('Too Many Requests: retry after 30'))
+      })
+
+    const verdict = await (daemon as any).leaveConversation({
+      integrationId: 'tg-int',
+      target: { kind: 'conversation', channel: '-100123' }
+    })
+
+    expect(verdict).toEqual({ ok: false, error: 'Too Many Requests: retry after 30' })
+    expect(emit).not.toHaveBeenCalled() // the row must not vanish on a transient failure
+  })
+
   it('refuses a conversation-scoped leave on Discord, where a bot can only leave a server', async () => {
     const { daemon } = makeStubDaemon(root1())
     await daemon.start()

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { channelOwners, groupBySpace, placePopover } from './IntegrationChannelList'
+import { channelOwners, groupBySpace, placePopover, rowLabel, rowMenuAction } from './IntegrationChannelList'
 import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
 
 // A shared bot fans its membership snapshot out to one integration per member
@@ -153,5 +153,65 @@ describe('groupBySpace', () => {
   it('takes the label from whichever row of the server carries one', () => {
     const rows = [chan('C1', 'G1'), chan('C2', 'G1', 'Acme HQ')]
     expect(groupBySpace(rows)).toEqual([{ key: 'G1', label: 'Acme HQ', rows }])
+  })
+})
+
+// A row offers exactly ONE way out, and the copy has to carry whatever that one action
+// leaves undone — which differs by platform AND by what kind of place the row is.
+describe('rowMenuAction', () => {
+  const row = (kind: IntegrationChannelRow['kind'], name = 'acme docs'): IntegrationChannelRow => ({
+    channelId: 'C1',
+    name,
+    kind,
+    trigger: 'mention'
+  })
+
+  it('offers leaving, and only leaving, where the platform can leave one conversation', () => {
+    const action = rowMenuAction(row('channel'), 'telegram')
+    expect(action).toMatchObject({ leave: true, label: 'Leave group' })
+    expect(action.hint).toContain('leaves this group in Telegram')
+  })
+
+  it('offers removing the row, and says where to remove the bot, where it cannot', () => {
+    const action = rowMenuAction(row('channel'), 'slack')
+    expect(action).toMatchObject({ leave: false, label: 'Remove from this list' })
+    expect(action.hint).toContain('remove it in Slack')
+    expect(action.confirm).toContain('the row will come back')
+  })
+
+  // A Discord bot joins a SERVER, so naming Discord would send the operator hunting for
+  // a per-channel control that does not exist; the way out is the band above the row.
+  it('points a Discord row at its server, not at Discord', () => {
+    const action = rowMenuAction(row('channel'), 'discord')
+    expect(action.leave).toBe(false)
+    expect(action.hint).toContain('Leave on the server heading above')
+    expect(action.hint).not.toContain('remove it in Discord')
+  })
+
+  // Nobody is ADDED to a direct conversation, so telling the operator to remove the bot
+  // there describes something that cannot be done — on Discord it would also point at a
+  // server heading a DM row does not sit under.
+  it.each(['telegram', 'slack', 'discord'])('describes a %s direct conversation as a listing only', (platform) => {
+    for (const kind of ['im', 'mpim'] as const) {
+      const action = rowMenuAction(row(kind), platform)
+      expect(action.leave).toBe(false)
+      expect(action.hint).toContain('Nobody adds or removes a bot')
+      expect(action.hint).toContain('the row comes back on the next message')
+      expect(action.hint).not.toContain('server heading')
+      expect(action.hint).not.toMatch(/remove it in/)
+    }
+  })
+
+  // The stored DM label already carries the "@" the glyph column renders.
+  it('names a DM in a confirm without doubling its @', () => {
+    expect(rowMenuAction(row('im', '@Alice'), 'slack').confirm).toContain('Remove Alice from this list?')
+  })
+})
+
+describe('rowLabel', () => {
+  it('strips the stored @ from a direct conversation and leaves a channel alone', () => {
+    expect(rowLabel({ kind: 'im', name: '@Alice' })).toBe('Alice')
+    expect(rowLabel({ kind: 'mpim', name: '@Alice, Bob' })).toBe('Alice, Bob')
+    expect(rowLabel({ kind: 'channel', name: 'deploys' })).toBe('deploys')
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -15,10 +15,13 @@ import type { AgentIcon } from '@/lib/agent-icon'
  *  hover copy. */
 function TriggerToggle({
   channel,
+  platform,
   disabled,
   onChange
 }: {
   channel: IntegrationChannelRow
+  /** Names the room the way its platform does — one noun per card. */
+  platform?: string
   /** Demo rows (no live integration id) render the control inert. */
   disabled: boolean
   onChange: (trigger: IntegrationChannelRow['trigger']) => void
@@ -54,7 +57,7 @@ function TriggerToggle({
   // who wants the bot silent here but still in the channel on the platform has nowhere
   // else to say so. A GROUP DM takes the channel's choice, not the DM's: several people
   // share it, so "every message" must stay opt-in.
-  const here = channel.kind === 'mpim' ? 'this group DM' : 'this channel'
+  const here = `this ${rowNoun(channel.kind, platform)}`
   const segs: [IntegrationChannelRow['trigger'], string, string][] =
     channel.kind === 'im'
       ? [
@@ -203,9 +206,24 @@ type MemberAgent = { id: string; label: string; runtime: string; icon?: AgentIco
  */
 const canLeaveConversation = (platform?: string): boolean => platform === 'telegram'
 
-/** What "leave" is called where — the console should use the platform's own word for
- *  the room, not a generic one the operator has to translate. */
-const conversationNoun = (platform?: string): string => (platform === 'telegram' ? 'group' : 'channel')
+/**
+ * What this platform calls the room, and what to call a row of it.
+ *
+ * ONE noun per card. Telegram and Lark have groups; Slack and Discord have channels.
+ * Mixing them — a "#" row, a "channel" footer and a "Leave group" menu item, all
+ * describing the same Telegram row — makes an operator wonder whether they are three
+ * different things. A direct conversation is neither, so it keeps its own word.
+ */
+const roomNoun = (platform?: string): string => (platform === 'telegram' || platform === 'feishu' ? 'group' : 'channel')
+
+/** The noun for ONE row: a DM is never a channel or a group, whatever the platform. */
+const rowNoun = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
+  kind === 'im' ? 'conversation' : kind === 'mpim' ? 'group chat' : roomNoun(platform)
+
+/** The list marker. "#" is the channel convention Slack and Discord share; a Telegram
+ *  or Lark group has no such sigil, so it gets none rather than a borrowed one. */
+const roomGlyph = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
+  kind === 'im' ? '@' : kind === 'mpim' ? '@@' : roomNoun(platform) === 'group' ? '' : '#'
 
 /** Fixed-position placement of the portalled popover, measured off its button. */
 type PopoverBox = { style: { left?: number; right?: number; top?: number; bottom?: number } }
@@ -282,7 +300,7 @@ function RowActions({
     setBusy(true)
     void action().finally(() => setBusy(false))
   }
-  const noun = conversationNoun(platform)
+  const noun = rowNoun(channel.kind, platform)
   const item = (label: string, icon: string, hint: string, onClick: () => void) => (
     <button
       onClick={onClick}
@@ -341,14 +359,14 @@ function RowActions({
                     })
                 )}
               {item(
-                'Forget this conversation',
+                `Forget this ${noun}`,
                 'trash-2',
                 'Removes the row here only. Use it when the bot has already left.',
                 () =>
                   run(async () => {
                     if (
                       !window.confirm(
-                        `Stop listing ${channel.name}? The bot is not touched — if it is still in the conversation, the row comes back.`
+                        `Stop listing ${channel.name}? The bot is not touched — if it is still in the ${noun}, the row comes back.`
                       )
                     ) {
                       return
@@ -627,7 +645,7 @@ export function IntegrationChannelList({
         style={{ padding: `10px ${padX}px` }}
       >
         <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
-          {c.kind === 'im' ? '@' : c.kind === 'mpim' ? '@@' : '#'}
+          {roomGlyph(c.kind, platform)}
         </span>
         {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
             renders the marker, so strip a leading @ to avoid "@@Alice". */}
@@ -656,6 +674,7 @@ export function IntegrationChannelList({
           )}
           <TriggerToggle
             channel={c}
+            platform={platform}
             disabled={!integrationId}
             onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
@@ -688,8 +707,7 @@ export function IntegrationChannelList({
         >
           <Icon name="lock" size={13} className="mt-[2px] flex-none" />
           <span>
-            This agent is private: conversations start off. Enable each channel or direct message below before the agent
-            responds there.
+            {`This agent is private: conversations start off. Enable each ${roomNoun(platform)} or direct message below before the agent responds there.`}
           </span>
         </div>
       )}
@@ -717,17 +735,13 @@ export function IntegrationChannelList({
       >
         <Icon name="info" size={14} className="mt-[3px] flex-none" />
         <span>
-          {shareable
-            ? 'Channels appear here when the bot is invited to them. Trigger is set per channel; default dispatch is the agent who handles unmatched messages.'
-            : gated
-              ? 'Channels appear here when the bot is invited; direct messages appear when someone writes to the bot.'
-              : 'Channels appear here when the bot is invited to them. Trigger is set per channel.'}{' '}
-          {/* Off silences without leaving; the row menu covers the rest. What the menu
-              can offer differs by platform, so promise only what is there — and where
-              leaving is not offered, say where it IS done rather than leaving the
-              operator to wonder. */}
-          Set a channel to off to silence the agent there, or use a row&rsquo;s menu to{' '}
-          {canLeaveConversation(platform) ? 'leave it or stop listing it' : 'stop listing it'}.
+          {/* Says where rows COME FROM, and — only where the row menu cannot do it —
+              where leaving is done instead. It deliberately no longer narrates the
+              menu's own items: those explain themselves on screen, and repeating them
+              here in different words was most of what made this card read oddly. */}
+          {`A ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per ${roomNoun(platform)}.`}
+          {gated && ' Direct messages appear when someone writes to the bot.'}
+          {shareable && ' Default dispatch is the agent who handles unmatched messages.'}
           {platform === 'discord' && ' A Discord bot joins servers, not channels, so it can only leave a whole server.'}
           {platform === 'slack' && ' To remove the bot from a channel, do it in Slack — this list updates by itself.'}
         </span>

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -221,9 +221,33 @@ const rowNoun = (kind: IntegrationChannelRow['kind'], platform?: string): string
   kind === 'im' ? 'conversation' : kind === 'mpim' ? 'group chat' : roomNoun(platform)
 
 /** The list marker. "#" is the channel convention Slack and Discord share; a Telegram
- *  or Lark group has no such sigil, so it gets none rather than a borrowed one. */
-const roomGlyph = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
+ *  or Lark group has no such sigil, so it gets none rather than a borrowed one.
+ *  Exported because the mobile card header summarises the same row and must not
+ *  disagree with it — the two sit one above the other at ≤768px. */
+export const roomGlyph = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
   kind === 'im' ? '@' : kind === 'mpim' ? '@@' : roomNoun(platform) === 'group' ? '' : '#'
+
+/** The place, named as the operator knows it. "on the platform" is our word for it,
+ *  not theirs — a person deciding whether to remove a bot wants to read "in Telegram". */
+const platformName = (platform?: string): string =>
+  platform === 'telegram'
+    ? 'Telegram'
+    : platform === 'slack'
+      ? 'Slack'
+      : platform === 'discord'
+        ? 'Discord'
+        : platform === 'feishu'
+          ? 'Lark'
+          : 'the chat app'
+
+/** Where the bot cannot be shown out from here, this is the sentence that says so.
+ *  Discord is the odd one: a bot belongs to a SERVER, so the way out is the band
+ *  heading above the row, not the chat app — pointing at Discord would send the
+ *  operator looking for a per-channel control that does not exist. */
+const manualExit = (platform: string | undefined, noun: string): string =>
+  platform === 'discord'
+    ? `A Discord bot belongs to a server, not one ${noun} — use Leave on the server heading above to take it out.`
+    : `The bot stays in the ${noun} — remove it in ${platformName(platform)} for that.`
 
 /** Fixed-position placement of the portalled popover, measured off its button. */
 type PopoverBox = { style: { left?: number; right?: number; top?: number; bottom?: number } }
@@ -250,14 +274,22 @@ export function placePopover(
 }
 
 /**
- * The per-row overflow menu: forget the row, and — where the platform allows it —
- * actually leave the conversation.
+ * The per-row overflow menu, which offers exactly ONE action — the strongest one the
+ * platform allows. Where the bot can leave, leaving is the only choice: it does
+ * everything the weaker one does and more, so offering both would ask the operator to
+ * distinguish two outcomes that differ only in how far they reach. Where it cannot
+ * (a Slack channel — see `canLeaveConversation`), removing from the list is the only
+ * choice, and its own copy is what tells the operator the bot is still in there and
+ * has to be shown out by hand.
  *
- * The two are deliberately worded apart, because confusing them is the whole trap
- * this list used to set. Forgetting only stops AgentConnect listing a conversation
- * and is the sole remedy for one the bot already left on a platform that cannot
- * report its own departure; leaving changes the outside world and needs the bot to
- * still be there. Both confirm, since neither is undoable from here.
+ * That collapse is what makes the "already gone" case load-bearing: on a leave-capable
+ * platform a stale row has no second escape hatch, so Leave must also succeed when the
+ * bot has already been removed there (`isAlreadyOutOfChat`, daemon side).
+ *
+ * Each label names its OUTCOME. Neither says "forget", the earlier wording: it
+ * describes our bookkeeping, not the user's outcome, and in a product that gives agents
+ * a MEMORY it reads like erasing what was said. Both confirm, since neither is undoable
+ * from here.
  */
 function RowActions({
   channel,
@@ -341,39 +373,39 @@ function RowActions({
               className="fixed z-[1100] w-[264px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
               style={box.style}
             >
-              {onLeave &&
-                item(
-                  `Leave ${noun}`,
-                  'log-out',
-                  `Removes the bot from this ${noun} on the platform. Add it again to undo.`,
-                  () =>
-                    run(async () => {
-                      if (
-                        !window.confirm(
-                          `Remove the bot from ${channel.name}? It leaves the ${noun} on the platform and stops receiving anything there. Re-invite it to undo.`
-                        )
-                      ) {
-                        return
-                      }
-                      await onLeave()
-                    })
-                )}
-              {item(
-                `Forget this ${noun}`,
-                'trash-2',
-                'Removes the row here only. Use it when the bot has already left.',
-                () =>
-                  run(async () => {
-                    if (
-                      !window.confirm(
-                        `Stop listing ${channel.name}? The bot is not touched — if it is still in the ${noun}, the row comes back.`
-                      )
-                    ) {
-                      return
-                    }
-                    await onForget()
-                  })
-              )}
+              {onLeave
+                ? item(
+                    `Leave ${noun}`,
+                    'log-out',
+                    `The bot leaves this ${noun} in ${platformName(platform)} and the row goes with it. Add it back to undo.`,
+                    () =>
+                      run(async () => {
+                        if (
+                          !window.confirm(
+                            `Have the bot leave ${channel.name}? It leaves the ${noun} in ${platformName(platform)} and stops receiving anything there. Add it back to undo.`
+                          )
+                        ) {
+                          return
+                        }
+                        await onLeave()
+                      })
+                  )
+                : item(
+                    'Remove from this list',
+                    'trash-2',
+                    `Only stops showing it here. ${manualExit(platform, noun)}`,
+                    () =>
+                      run(async () => {
+                        if (
+                          !window.confirm(
+                            `Remove ${channel.name} from this list? ${manualExit(platform, noun)} If it is still in there, the row will come back.`
+                          )
+                        ) {
+                          return
+                        }
+                        await onForget()
+                      })
+                  )}
             </div>
           </>,
           document.body

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -240,14 +240,61 @@ const platformName = (platform?: string): string =>
           ? 'Lark'
           : 'the chat app'
 
-/** Where the bot cannot be shown out from here, this is the sentence that says so.
- *  Discord is the odd one: a bot belongs to a SERVER, so the way out is the band
- *  heading above the row, not the chat app — pointing at Discord would send the
- *  operator looking for a per-channel control that does not exist. */
-const manualExit = (platform: string | undefined, noun: string): string =>
-  platform === 'discord'
-    ? `A Discord bot belongs to a server, not one ${noun} — use Leave on the server heading above to take it out.`
-    : `The bot stays in the ${noun} — remove it in ${platformName(platform)} for that.`
+/** The row's name as displayed. DM labels are stored as "@Alice" (the name resolvers
+ *  write them that way) and the glyph column already renders the marker, so a leading
+ *  "@" is stripped to avoid "@@Alice". Exported alongside `roomGlyph` for the same
+ *  reason: the mobile card header summarises this row directly above it. */
+export const rowLabel = (row: Pick<IntegrationChannelRow, 'kind' | 'name'>): string =>
+  isDirectConversation(row.kind) ? row.name.replace(/^@+/, '') : row.name
+
+/** Whether the bot can be made to leave THIS row from here — the platform must have a
+ *  per-conversation leave, and the row must be somewhere membership applies at all. */
+export const canLeaveRow = (kind: IntegrationChannelRow['kind'], platform?: string): boolean =>
+  canLeaveConversation(platform) && !isDirectConversation(kind)
+
+/**
+ * The ONE action a row's menu offers, fully worded. Exported and pure because the rule
+ * it encodes — one action, the strongest the platform allows, and the copy carries
+ * whatever that leaves undone — is the whole design and belongs in a test rather than
+ * only in a rendered popover.
+ *
+ * Three cases hide behind "cannot leave", and they call for different sentences:
+ * a Discord bot belongs to a SERVER, so the way out is the band heading above the row,
+ * and naming Discord would send the operator hunting for a per-channel control that
+ * does not exist; a direct conversation is not somewhere the bot was ever ADDED, so
+ * there is nothing to be shown out of and the row is only a listing; everything else
+ * has a real membership the operator ends in the chat app.
+ */
+export function rowMenuAction(
+  row: Pick<IntegrationChannelRow, 'kind' | 'name'>,
+  platform?: string
+): { leave: boolean; name: string; label: string; icon: string; hint: string; confirm: string } {
+  const noun = rowNoun(row.kind, platform)
+  const name = rowLabel(row)
+  if (canLeaveRow(row.kind, platform)) {
+    return {
+      leave: true,
+      name,
+      label: `Leave ${noun}`,
+      icon: 'log-out',
+      hint: `The bot leaves this ${noun} in ${platformName(platform)} and the row goes with it. Add it back to undo.`,
+      confirm: `Have the bot leave ${name}? It leaves the ${noun} in ${platformName(platform)} and stops receiving anything there. Add it back to undo.`
+    }
+  }
+  const rest = isDirectConversation(row.kind)
+    ? `Nobody adds or removes a bot in a ${noun} — the row comes back on the next message.`
+    : platform === 'discord'
+      ? `A Discord bot belongs to a server, not one ${noun} — use Leave on the server heading above to take it out. If it is still in there, the row will come back.`
+      : `The bot stays in the ${noun} — remove it in ${platformName(platform)} for that. If it is still in there, the row will come back.`
+  return {
+    leave: false,
+    name,
+    label: 'Remove from this list',
+    icon: 'trash-2',
+    hint: `Only stops showing it here. ${rest}`,
+    confirm: `Remove ${name} from this list? ${rest}`
+  }
+}
 
 /** Fixed-position placement of the portalled popover, measured off its button. */
 type PopoverBox = { style: { left?: number; right?: number; top?: number; bottom?: number } }
@@ -274,13 +321,11 @@ export function placePopover(
 }
 
 /**
- * The per-row overflow menu, which offers exactly ONE action — the strongest one the
- * platform allows. Where the bot can leave, leaving is the only choice: it does
- * everything the weaker one does and more, so offering both would ask the operator to
- * distinguish two outcomes that differ only in how far they reach. Where it cannot
- * (a Slack channel — see `canLeaveConversation`), removing from the list is the only
- * choice, and its own copy is what tells the operator the bot is still in there and
- * has to be shown out by hand.
+ * The per-row overflow menu, which offers exactly ONE action — the strongest the
+ * platform allows, worded by `rowMenuAction`. Where the bot can leave, leaving is the
+ * only choice: it does everything the weaker one does and more, so offering both would
+ * ask the operator to distinguish two outcomes that differ only in how far they reach.
+ * Where it cannot, removing the row is the only choice and its copy carries the rest.
  *
  * That collapse is what makes the "already gone" case load-bearing: on a leave-capable
  * platform a stale row has no second escape hatch, so Leave must also succeed when the
@@ -300,7 +345,7 @@ function RowActions({
   channel: IntegrationChannelRow
   platform?: string
   onForget: () => Promise<void>
-  onLeave?: () => Promise<void>
+  onLeave: () => Promise<void>
 }) {
   const [box, setBox] = useState<PopoverBox | null>(null)
   const [busy, setBusy] = useState(false)
@@ -332,7 +377,7 @@ function RowActions({
     setBusy(true)
     void action().finally(() => setBusy(false))
   }
-  const noun = rowNoun(channel.kind, platform)
+  const action = rowMenuAction(channel, platform)
   const item = (label: string, icon: string, hint: string, onClick: () => void) => (
     <button
       onClick={onClick}
@@ -358,8 +403,8 @@ function RowActions({
       <button
         ref={btnRef}
         onClick={toggle}
-        title={`More actions for ${channel.name}`}
-        aria-label={`More actions for ${channel.name}`}
+        title={`More actions for ${action.name}`}
+        aria-label={`More actions for ${action.name}`}
         aria-expanded={open}
         className={`iconbtn h-7 w-7 ${busy ? 'opacity-60' : ''}`}
       >
@@ -373,39 +418,12 @@ function RowActions({
               className="fixed z-[1100] w-[264px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
               style={box.style}
             >
-              {onLeave
-                ? item(
-                    `Leave ${noun}`,
-                    'log-out',
-                    `The bot leaves this ${noun} in ${platformName(platform)} and the row goes with it. Add it back to undo.`,
-                    () =>
-                      run(async () => {
-                        if (
-                          !window.confirm(
-                            `Have the bot leave ${channel.name}? It leaves the ${noun} in ${platformName(platform)} and stops receiving anything there. Add it back to undo.`
-                          )
-                        ) {
-                          return
-                        }
-                        await onLeave()
-                      })
-                  )
-                : item(
-                    'Remove from this list',
-                    'trash-2',
-                    `Only stops showing it here. ${manualExit(platform, noun)}`,
-                    () =>
-                      run(async () => {
-                        if (
-                          !window.confirm(
-                            `Remove ${channel.name} from this list? ${manualExit(platform, noun)} If it is still in there, the row will come back.`
-                          )
-                        ) {
-                          return
-                        }
-                        await onForget()
-                      })
-                  )}
+              {item(action.label, action.icon, action.hint, () =>
+                run(async () => {
+                  if (!window.confirm(action.confirm)) return
+                  await (action.leave ? onLeave() : onForget())
+                })
+              )}
             </div>
           </>,
           document.body
@@ -679,11 +697,7 @@ export function IntegrationChannelList({
         <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
           {roomGlyph(c.kind, platform)}
         </span>
-        {/* DM labels are stored as "@Alice" (name resolvers); the glyph column already
-            renders the marker, so strip a leading @ to avoid "@@Alice". */}
-        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">
-          {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
-        </span>
+        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">{rowLabel(c)}</span>
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
           {def && (
             <>
@@ -711,18 +725,16 @@ export function IntegrationChannelList({
             onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
           {/* Demo rows have no integration to act on, so they carry no menu at all
-              rather than an inert one. */}
+              rather than an inert one. Both callbacks below are always wired; which ONE
+              the menu offers is `rowMenuAction`'s call, so that rule lives in one place. */}
           {integrationId && (
             <RowActions
               channel={c}
               platform={platform}
               onForget={() => act(() => forgetChannel(integrationId, c.channelId))}
-              {...(canLeaveConversation(platform) && !isDirectConversation(c.kind)
-                ? {
-                    onLeave: () =>
-                      act(() => leaveConversation(integrationId, { kind: 'conversation', channel: c.channelId }))
-                  }
-                : {})}
+              onLeave={() =>
+                act(() => leaveConversation(integrationId, { kind: 'conversation', channel: c.channelId }))
+              }
             />
           )}
         </div>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -44,7 +44,7 @@ import { AgentToolsCard } from '@/components/console/AgentToolsCard'
 import { AgentSkillsCard } from '@/components/console/AgentSkillsCard'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
-import { IntegrationChannelList, roomGlyph } from '@/components/console/IntegrationChannelList'
+import { IntegrationChannelList, roomGlyph, rowLabel } from '@/components/console/IntegrationChannelList'
 import { RecentSessionsCard } from '@/components/console/RecentSessionsCard'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
@@ -1142,7 +1142,7 @@ export default function AgentDetailView() {
                             {g.channels[0] && (
                               <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
                                 {roomGlyph(g.channels[0].kind, g.platform)}
-                                {g.channels[0].name}
+                                {rowLabel(g.channels[0])}
                               </span>
                             )}
                           </span>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -44,7 +44,7 @@ import { AgentToolsCard } from '@/components/console/AgentToolsCard'
 import { AgentSkillsCard } from '@/components/console/AgentSkillsCard'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
-import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
+import { IntegrationChannelList, roomGlyph } from '@/components/console/IntegrationChannelList'
 import { RecentSessionsCard } from '@/components/console/RecentSessionsCard'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
@@ -1141,7 +1141,8 @@ export default function AgentDetailView() {
                             </span>
                             {g.channels[0] && (
                               <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                                #{g.channels[0].name}
+                                {roomGlyph(g.channels[0].kind, g.platform)}
+                                {g.channels[0].name}
                               </span>
                             )}
                           </span>


### PR DESCRIPTION
Follow-up to #330, from looking at a real Telegram card. Two passes: first the words on the card, then how many choices it offers.

## Pass 1 — one noun per card

One Telegram group was called three different things at once, side by side:

| Where | Word |
|---|---|
| Row glyph | `#` — the Slack/Discord channel sigil |
| Footer | "**Channels** appear here… trigger is set per **channel**… set a **channel** to off" |
| Menu item 1 | "Leave **group**" |
| Menu item 2 | "Forget this **conversation**" |
| Trigger tooltips | "in this **channel**" |

An operator reasonably wonders whether those are three different objects. #330 caused this: it added the menu in the platform's own vocabulary without changing the copy around it, so the new item disagreed with everything it sat next to.

**One noun per card, chosen by platform.** Telegram and Lark have groups; Slack and Discord have channels. A direct message keeps its own word, since it is neither. Every surface on the card — glyph, footer, menu, confirms, trigger tooltips — now uses it. The `#` marker goes with it: that sigil is a Slack/Discord convention, and a Telegram group borrowing it was the same mistake in punctuation rather than prose.

**The footer stops narrating the row menu.** Those items explain themselves on screen, and restating them underneath in different words was the other half of the confusion. It now says only where rows come from and — where the menu cannot leave — where leaving is done instead.

## Pass 2 — one way out, not two

The menu still asked the operator to choose between "Leave" and a remove-the-row item. Those differ only in how far they reach, and the difference is our bookkeeping, not their goal. "Forget" was the worse half of it: it names our internal state, and in a product that gives agents a MEMORY it reads like erasing what was said.

**Each row now offers exactly one action — the strongest the platform allows.**

| Row | The one item | Why |
|---|---|---|
| Telegram channel | **Leave group** | It can withdraw from one conversation, and leaving already does everything removing the row does. |
| Slack channel | **Remove from this list** | Leaving would cost a scope that also grants create/archive/rename/kick (see #330); the copy says the bot stays and is removed in Slack. |
| Discord channel | **Remove from this list** | A bot belongs to a *server*, not a channel — the copy points at **Leave** on the server heading above the row. |
| Any DM / group DM | **Remove from this list** | Nobody is invited to a direct conversation, so there is no membership to end — the copy describes removing a listing and nothing more. |

That last row is the whole reason the decision is one exported pure function, `rowMenuAction(row, platform)` → `{ leave, name, label, icon, hint, confirm }`: "cannot leave" hides three different situations that need three different sentences, and getting one of them wrong is invisible until someone opens that exact menu. It is unit-tested rather than only rendered.

```
- ⋯ → "Leave group"  /  "Forget this group"
+ ⋯ → "Leave group"
+       The bot leaves this group in Telegram and the row goes with it. Add it back to undo.
```

### What that costs, and the fix

The two-item menu had a fallback the one-item menu does not: the row left behind when someone removes the bot in the chat app. Leaving would fail there ("chat not found" / "not a member"), and with the other item gone the operator would be stranded with a row they can see and cannot clear — the exact case these controls exist for.

So the daemon now treats a Telegram refusal that *means the bot is already out* as a completed leave, and retracts the row. Any other refusal is still reported verbatim, and the row stays put — a rate limit must not make a row disappear. Two daemon tests pin both directions.

## Verification

`typecheck`, `lint`, daemon 2514, CP unit 935, web 517 — all pass. Two new daemon tests cover the already-out path and the transient-failure path; eight new web tests pin the menu rule, every cannot-leave sentence, and the `@`-stripping shared by the row, the mobile header and the confirm.

Rendered all three platforms and read the menus out of the DOM:

```
telegram #row → ["Leave group — The bot leaves this group in Telegram and the row goes with it…"]
slack    #row → ["Remove from this list — …The bot stays in the channel — remove it in Slack for that."]
discord  #row → ["Remove from this list — …A Discord bot belongs to a server, not one channel —
                  use Leave on the server heading above to take it out."]
any DM / mpim → ["Remove from this list — …Nobody adds or removes a bot in a conversation —
                  the row comes back on the next message."]
```

Exactly one item each, and the Discord server heading still carries its own Leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
