### PR TITLE
fix(sessions): preserve profile-link hints

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11065,7 +11065,7 @@ export class Daemon {
    *  the explicit local `webAppUrl`, else the CP-provided origin, else the local default
    *  (`DEFAULT_WEB_APP_URL`). The console is org-scoped, so the org slug is inserted when
    *  known; without it the link falls back to `<base>/sessions/<id>`. Slack/GitHub links
-   *  carry a presentation-only source hint for the generic 404 recovery action. */
+   *  carry a presentation-only source hint for the generic 404 profile-linking action. */
   private sessionLink(acpSessionId: string, source?: 'slack' | 'github'): string {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
     const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -718,12 +718,21 @@ export default function SessionDetailView() {
     ([, orgId, , sessionId]) => fetchSessionDetail(sessionId as string, orgId as string),
     { refreshInterval: 30_000 }
   )
-  // Provider-rendered session links carry only caller-known source context. It
-  // never changes authorization, so unknown and unauthorized 404s stay equivalent.
+  // Provider-rendered links use `source`; links opened from the Sessions list
+  // can also retain its `integration` filter. Both are caller-known hints only:
+  // neither changes authorization, so unknown and unauthorized 404s stay
+  // equivalent.
   const source = searchParams.get('source')
-  const profileLinkProvider =
-    (source === 'slack' || source === 'github') && socialLoginProviders().some((provider) => provider.target === source)
+  const integration = searchParams.get('integration')
+  const hintedProvider =
+    source === 'slack' || source === 'github'
       ? source
+      : integration === 'slack' || integration === 'github'
+        ? integration
+        : undefined
+  const profileLinkProvider =
+    hintedProvider && socialLoginProviders().some((provider) => provider.target === hintedProvider)
+      ? hintedProvider
       : undefined
   const profileLinkCandidate =
     sessionDetailError instanceof ApiError &&

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -178,7 +178,14 @@ export default function SessionsView() {
     return next.toString()
   }, [params])
   const sessionHref = useCallback(
-    (id: string) => orgPath(filterQuery ? `/sessions/${id}?${filterQuery}` : `/sessions/${id}`),
+    (session: Session) => {
+      const id = session.realSessionId ?? session.id
+      const query = new URLSearchParams(filterQuery)
+      const provider = sessionPlatform(session)
+      if (provider === 'slack' || provider === 'github') query.set('source', provider)
+      const suffix = query.size ? `?${query.toString()}` : ''
+      return orgPath(`/sessions/${id}${suffix}`)
+    },
     [filterQuery, orgPath]
   )
 
@@ -559,7 +566,7 @@ export default function SessionsView() {
           return (
             <Link
               key={s.id}
-              href={sessionHref(s.realSessionId ?? s.id)}
+              href={sessionHref(s)}
               className={`row click ${cols} items-center text-left no-underline max-desktop:grid max-desktop:min-h-18 max-desktop:w-full max-desktop:grid-cols-[minmax(0,1fr)_auto] max-desktop:gap-x-3 max-desktop:gap-y-[5px] max-desktop:border-b-0 max-desktop:bg-(--surface-card) ${
                 i > 0 ? 'max-desktop:border-t max-desktop:border-(--border-subtle)' : ''
               }`}


### PR DESCRIPTION
## Summary

- recognize the Sessions list integration=slack|github filter as an authorization-neutral profile-link hint on the generic session 404
- add an explicit source=slack|github hint to new Slack and GitHub session links opened from the Sessions list
- keep unknown and unauthorized 404 responses equivalent; URL hints affect only whether the Console offers a profile-link action
- use profile-linking terminology consistently in the daemon link comment

## Validation

- pnpm --filter @agentconnect.md/web test -- --run (73 files, 517 tests)
- pnpm --filter @agentconnect.md/web typecheck
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint

Created by Codex . GPT-5.6-sol