### PR TITLE
fix(sessions): stop reporting ordinary access outcomes as faults

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -159,6 +159,14 @@ enum VisibilitySource {
   AgentConnect database.
 - `SessionExternalAccessPolicy` is per organization and provider. Its revision
   and read fence make enablement fail closed while historical rows converge.
+  `legacyUnresolved` is the low-water mark of the unresolved count since
+  enablement: history whose scope cannot be reconstructed never settles, so
+  counting it as degradation would pin any organization with pre-existing
+  history to a permanent fault state and bury the one signal that matters.
+  `degraded` therefore means the live unresolved count **exceeds** the mark —
+  a candidate that failed to resolve after the policy was turned on. The mark
+  is adopted at enable and ratchets down as legacy rows settle; the backlog
+  itself stays reportable to owners as `hiddenSessions`.
 
 **Migration / backfill:** the original visibility migration populated `orgId`
 and kept legacy rows `org`; it did not guess DM ownership. The Slack-audience
@@ -397,6 +405,17 @@ a linked identity; a private repository requires the linked GitHub user to
 retain read permission. Provider errors, timeouts, unresolved history, and
 stale revisions deny access. Organization roles, including owner, never bypass
 this predicate.
+
+Denial and degradation are separate outcomes. A provider that **answers** —
+Slack `channel_not_found` / `not_in_channel` (the conversation is deleted, or
+the bot is no longer in it) or `user_not_found`, GitHub returning no repository
+for the id — is a verdict: deny, cached for the deny TTL, `degraded` stays
+false. Losing access to a conversation is an ordinary event and must not be
+reported as a broken deployment. Only a check that could not be completed —
+auth, missing scope, rate limiting, an outage, an unrecognized error code, a
+transport failure — is `unknown`: deny plus `degraded`, which is what raises
+"external access checks are unavailable" and is re-asked on the short unknown
+TTL.
 
 All of these already gate on agent visibility; each additionally applies the
 session predicate:

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -159,14 +159,17 @@ enum VisibilitySource {
   AgentConnect database.
 - `SessionExternalAccessPolicy` is per organization and provider. Its revision
   and read fence make enablement fail closed while historical rows converge.
-  `legacyUnresolved` is the low-water mark of the unresolved count since
-  enablement: history whose scope cannot be reconstructed never settles, so
-  counting it as degradation would pin any organization with pre-existing
-  history to a permanent fault state and bury the one signal that matters.
-  `degraded` therefore means the live unresolved count **exceeds** the mark —
-  a candidate that failed to resolve after the policy was turned on. The mark
-  is adopted at enable and ratchets down as legacy rows settle; the backlog
-  itself stays reportable to owners as `hiddenSessions`.
+  History whose scope cannot be reconstructed only settles if new trusted
+  activity rebinds the same session, so treating it as degradation would pin any
+  organization with pre-existing history to a permanent fault state and bury the
+  one signal that matters. Enablement therefore stamps
+  `SessionMeta.legacyUnresolved` on the rows that are already unresolved
+  at that instant, and `degraded` means an unresolved row exists **without** that
+  mark — a candidate that failed to resolve after the policy was turned on. The
+  provenance is per row on purpose: a mere count of the backlog is fungible, so
+  settling one legacy row would offset a live post-enable failure and silently
+  clear the fault. A2A descendants inherit the mark with the audience they
+  inherit; the backlog stays reportable to owners as `hiddenSessions`.
 
 **Migration / backfill:** the original visibility migration populated `orgId`
 and kept legacy rows `org`; it did not guess DM ownership. The Slack-audience

--- a/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
@@ -1,0 +1,35 @@
+-- Unresolved history is expected, not a fault. Enabling a provider policy hides
+-- every candidate whose source scope the migration could not reconstruct, and
+-- that scope can never be recovered (only NEW activity on the same session
+-- rebinds it). Deriving `degraded` from that count therefore pinned every
+-- organization with pre-existing history to a permanent fault state.
+--
+-- `legacyUnresolved` is the low-water mark of the unresolved count since
+-- enablement: `degraded` now means the live count EXCEEDS it, i.e. a candidate
+-- went unresolved after the policy was turned on — the actually actionable case.
+
+ALTER TABLE "session_external_access_policy"
+  ADD COLUMN "legacyUnresolved" INTEGER NOT NULL DEFAULT 0;
+
+-- Adopt the current backlog as the mark for policies already enabled, and clear
+-- the fault state they were pinned to. A live provider failure re-degrades on
+-- the next classification; a stale 'degraded' here would never clear on its own.
+UPDATE "session_external_access_policy" AS p
+SET "legacyUnresolved" = COALESCE(backlog."count", 0),
+    "state" = CASE WHEN p."state" = 'degraded' THEN 'enabled'::"ExternalAccessPolicyState" ELSE p."state" END,
+    "updatedAt" = CURRENT_TIMESTAMP
+FROM (
+  SELECT p2."orgId" AS "orgId",
+         p2."provider" AS "provider",
+         (
+           SELECT COUNT(*)::int
+           FROM "session_meta" s
+           WHERE s."orgId" = p2."orgId"
+             AND s."externalProvider" = p2."provider"
+             AND s."externalResolution" IN ('pending', 'invalid')
+         ) AS "count"
+  FROM "session_external_access_policy" p2
+  WHERE p2."state" <> 'disabled'
+) AS backlog
+WHERE p."orgId" = backlog."orgId"
+  AND p."provider" = backlog."provider";

--- a/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
@@ -1,43 +1,36 @@
 -- Unresolved history is expected, not a fault. Enabling a provider policy hides
 -- every candidate whose source scope the migration could not reconstruct, and
--- that scope can never be recovered (only NEW activity on the same session
--- rebinds it). Deriving `degraded` from that count therefore pinned every
+-- that scope only comes back if new trusted activity rebinds the same session.
+-- Deriving `degraded` from the unresolved COUNT therefore pinned every
 -- organization with pre-existing history to a permanent fault state.
 --
--- `legacyUnresolved` is the low-water mark of the unresolved count since
--- enablement: `degraded` now means the live count EXCEEDS it, i.e. a candidate
--- went unresolved after the policy was turned on — the actually actionable case.
+-- The distinction has to live per row, not as an aggregate: with a count, a
+-- legacy row settling would offset a genuinely new unresolved candidate and
+-- silently clear the fault while it is still live. `legacyUnresolved`
+-- marks the rows that were already unresolved at enablement; `degraded` now
+-- means an unresolved row exists WITHOUT that mark.
 
-ALTER TABLE "session_external_access_policy"
-  ADD COLUMN "legacyUnresolved" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "session_meta"
+  ADD COLUMN "legacyUnresolved" BOOLEAN NOT NULL DEFAULT false;
 
--- Adopt the current backlog as the mark for policies already enabled, and clear
--- the fault state they were pinned to. A live provider failure re-degrades on
--- the next classification; a stale 'degraded' here would never clear on its own.
---
--- The count MUST use the same predicate as `countExternalUnresolved` and the
--- classify path, `visibility = 'external'` included: a pending candidate that is
--- not external (an A2A child held private behind an unresolved parent, a row
--- tagged before its policy was ever enabled) is not hidden BY this policy, and
--- counting it here would set the mark above anything the live count can reach —
--- masking the first genuine degradation until the mark ratchets back down.
-UPDATE "session_external_access_policy" AS p
-SET "legacyUnresolved" = COALESCE(backlog."count", 0),
-    "state" = CASE WHEN p."state" = 'degraded' THEN 'enabled'::"ExternalAccessPolicyState" ELSE p."state" END,
+-- Adopt the current backlog of every enabled policy as legacy. Same predicate as
+-- `countExternalUnresolved` and the classify path, `visibility = 'external'`
+-- included: a pending candidate that is not external (an A2A child held private
+-- behind an unresolved parent, a row tagged before its policy was ever enabled)
+-- is not hidden BY this policy and must not be absolved by it either.
+UPDATE "session_meta" s
+SET "legacyUnresolved" = true
+FROM "session_external_access_policy" p
+WHERE p."orgId" = s."orgId"
+  AND p."provider" = s."externalProvider"
+  AND p."state" <> 'disabled'::"ExternalAccessPolicyState"
+  AND s."visibility" = 'external'::"SessionVisibility"
+  AND s."externalResolution" IN ('pending'::"ExternalResolution", 'invalid'::"ExternalResolution");
+
+-- Every row that made a policy degraded is now marked legacy, so the fault state
+-- no longer holds. A live provider failure re-degrades on the next
+-- classification; a stale 'degraded' here would never clear on its own.
+UPDATE "session_external_access_policy"
+SET "state" = 'enabled'::"ExternalAccessPolicyState",
     "updatedAt" = CURRENT_TIMESTAMP
-FROM (
-  SELECT p2."orgId" AS "orgId",
-         p2."provider" AS "provider",
-         (
-           SELECT COUNT(*)::int
-           FROM "session_meta" s
-           WHERE s."orgId" = p2."orgId"
-             AND s."externalProvider" = p2."provider"
-             AND s."visibility" = 'external'::"SessionVisibility"
-             AND s."externalResolution" IN ('pending', 'invalid')
-         ) AS "count"
-  FROM "session_external_access_policy" p2
-  WHERE p2."state" <> 'disabled'
-) AS backlog
-WHERE p."orgId" = backlog."orgId"
-  AND p."provider" = backlog."provider";
+WHERE "state" = 'degraded'::"ExternalAccessPolicyState";

--- a/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801170000_session_access_legacy_unresolved/migration.sql
@@ -14,6 +14,13 @@ ALTER TABLE "session_external_access_policy"
 -- Adopt the current backlog as the mark for policies already enabled, and clear
 -- the fault state they were pinned to. A live provider failure re-degrades on
 -- the next classification; a stale 'degraded' here would never clear on its own.
+--
+-- The count MUST use the same predicate as `countExternalUnresolved` and the
+-- classify path, `visibility = 'external'` included: a pending candidate that is
+-- not external (an A2A child held private behind an unresolved parent, a row
+-- tagged before its policy was ever enabled) is not hidden BY this policy, and
+-- counting it here would set the mark above anything the live count can reach —
+-- masking the first genuine degradation until the mark ratchets back down.
 UPDATE "session_external_access_policy" AS p
 SET "legacyUnresolved" = COALESCE(backlog."count", 0),
     "state" = CASE WHEN p."state" = 'degraded' THEN 'enabled'::"ExternalAccessPolicyState" ELSE p."state" END,
@@ -26,6 +33,7 @@ FROM (
            FROM "session_meta" s
            WHERE s."orgId" = p2."orgId"
              AND s."externalProvider" = p2."provider"
+             AND s."visibility" = 'external'::"SessionVisibility"
              AND s."externalResolution" IN ('pending', 'invalid')
          ) AS "count"
   FROM "session_external_access_policy" p2

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -897,6 +897,14 @@ model SessionMeta {
   externalScopeId     String?             @db.Uuid
   externalResolution  ExternalResolution?
   classifiedPolicyRev BigInt?             @db.BigInt
+  // Provenance for the unresolved set: true when this row was ALREADY unresolved
+  // when its policy was enabled. Such a scope only comes back if new trusted
+  // activity rebinds the session, so it is expected rather than a fault, and
+  // `state` degrades only while an unresolved row WITHOUT this mark exists (a
+  // mere COUNT cannot tell the two apart: settling one legacy row would silently
+  // absolve a live post-enable failure). Stamped at enable; A2A descendants
+  // inherit it with the audience they inherit.
+  legacyUnresolved    Boolean             @default(false)
   // Cursor tokens pass through JavaScript Date (millisecond precision), so the
   // complete keyset tuple must use the same precision in Postgres.
   lastActivityAt      DateTime            @db.Timestamptz(3)
@@ -955,20 +963,14 @@ model ExternalScope {
 // Organization/provider policy. Missing is never interpreted as disabled: the
 // ingest transaction ensures this row before creating a supported candidate.
 model SessionExternalAccessPolicy {
-  orgId            String
-  provider         String
-  state            ExternalAccessPolicyState @default(disabled)
-  currentRev       BigInt                    @default(0) @db.BigInt
-  readFenceRev     BigInt?                   @db.BigInt
-  // Low-water mark of the unresolved candidate count since enablement. History
-  // the migration could not bind is expected and permanent (its scope cannot be
-  // reconstructed), so it must NOT read as a fault: `state` is only 'degraded'
-  // while the live count exceeds this mark, i.e. a candidate went unresolved
-  // AFTER enabling. Recomputed at enable and clamped down as legacy rows settle.
-  legacyUnresolved Int                       @default(0)
-  migrationCursor  String?
-  createdAt        DateTime                  @default(now()) @db.Timestamptz(6)
-  updatedAt        DateTime                  @updatedAt @db.Timestamptz(6)
+  orgId           String
+  provider        String
+  state           ExternalAccessPolicyState @default(disabled)
+  currentRev      BigInt                    @default(0) @db.BigInt
+  readFenceRev    BigInt?                   @db.BigInt
+  migrationCursor String?
+  createdAt       DateTime                  @default(now()) @db.Timestamptz(6)
+  updatedAt       DateTime                  @updatedAt @db.Timestamptz(6)
 
   org Org @relation(fields: [orgId], references: [id], onDelete: Cascade)
 

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -955,14 +955,20 @@ model ExternalScope {
 // Organization/provider policy. Missing is never interpreted as disabled: the
 // ingest transaction ensures this row before creating a supported candidate.
 model SessionExternalAccessPolicy {
-  orgId           String
-  provider        String
-  state           ExternalAccessPolicyState @default(disabled)
-  currentRev      BigInt                    @default(0) @db.BigInt
-  readFenceRev    BigInt?                   @db.BigInt
-  migrationCursor String?
-  createdAt       DateTime                  @default(now()) @db.Timestamptz(6)
-  updatedAt       DateTime                  @updatedAt @db.Timestamptz(6)
+  orgId            String
+  provider         String
+  state            ExternalAccessPolicyState @default(disabled)
+  currentRev       BigInt                    @default(0) @db.BigInt
+  readFenceRev     BigInt?                   @db.BigInt
+  // Low-water mark of the unresolved candidate count since enablement. History
+  // the migration could not bind is expected and permanent (its scope cannot be
+  // reconstructed), so it must NOT read as a fault: `state` is only 'degraded'
+  // while the live count exceeds this mark, i.e. a candidate went unresolved
+  // AFTER enabling. Recomputed at enable and clamped down as legacy rows settle.
+  legacyUnresolved Int                       @default(0)
+  migrationCursor  String?
+  createdAt        DateTime                  @default(now()) @db.Timestamptz(6)
+  updatedAt        DateTime                  @updatedAt @db.Timestamptz(6)
 
   org Org @relation(fields: [orgId], references: [id], onDelete: Cascade)
 

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -166,4 +166,56 @@ describe('SlackSessionAccessService', () => {
       degraded: true
     })
   })
+
+  // A deleted private channel — and a bot removed from one, which is the same
+  // answer over the wire — is an everyday event. It denies, but it must not be
+  // reported as "access checks unavailable": nothing is broken and no retry
+  // changes the verdict.
+  it.each(['channel_not_found', 'not_in_channel'] as const)(
+    'denies without degrading when the conversation is gone (%s)',
+    async (error) => {
+      const resolver = service(async () => json({ ok: false, error }))
+      await expect(resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_MEMBER']))).resolves.toEqual({
+        allowedScopes: [],
+        degraded: false
+      })
+    }
+  )
+
+  it('denies without degrading when the member list no longer contains the workspace user', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+      }
+      return json({ ok: false, error: 'user_not_found' })
+    })
+    await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_INSTALL:U_GONE']))).resolves.toEqual({
+      allowedScopes: [],
+      degraded: false
+    })
+  })
+
+  // The definitive verdict earns the deny TTL, so a dead conversation is not
+  // re-asked on every page of every list.
+  it('caches the gone verdict instead of re-asking Slack per request', async () => {
+    const fetchImpl = vi.fn(async () => json({ ok: false, error: 'channel_not_found' }))
+    const resolver = service(fetchImpl)
+    await resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_MEMBER']))
+    const afterFirst = fetchImpl.mock.calls.length
+    await resolver.resolve([scope()], new Set(['slack:T_INSTALL:U_MEMBER']))
+    expect(fetchImpl.mock.calls.length).toBe(afterFirst)
+  })
+
+  it('still degrades when the check itself fails', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: true, is_im: false, is_mpim: false } })
+      }
+      return json({ ok: false, error: 'missing_scope' })
+    })
+    await expect(service(fetchImpl).resolve([scope()], new Set(['slack:T_INSTALL:U_MEMBER']))).resolves.toEqual({
+      allowedScopes: [],
+      degraded: true
+    })
+  })
 })

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -13,7 +13,7 @@ const PAGE_SIZE = 200
 const TIMEOUT_MS = 5_000
 
 type Decision = 'allow' | 'deny' | 'unknown'
-type ConversationAudience = 'public' | 'members' | 'unknown'
+type ConversationAudience = 'public' | 'members' | 'gone' | 'unknown'
 type WorkspaceAccess = 'allow' | 'membership' | 'deny' | 'unknown'
 type SlackPrincipal = { key: string; teamId: string; userId: string }
 
@@ -27,6 +27,26 @@ export interface SlackSessionAccessResult {
 
 export interface SlackSessionAccessResolver {
   resolve(scopes: readonly ExternalScopeRecord[], identitySet: ReadonlySet<string>): Promise<SlackSessionAccessResult>
+}
+
+// `ok: false` covers two very different answers, and conflating them is what
+// made an ordinary event — a private channel deleted, or the bot removed from
+// it — report as a degraded access check. These codes are Slack ANSWERING: this
+// credential cannot see that conversation / that user is not in the workspace.
+// Nothing about a later retry changes them, so they are a plain deny (cached for
+// DENY_TTL rather than re-asked every UNKNOWN_TTL). Everything else — auth,
+// scope, rate limiting, outages, unrecognized codes, transport failures — is the
+// CHECK failing, stays 'unknown', and is what `degraded` is for.
+const DEFINITIVE_DENIALS = new Set([
+  'channel_not_found',
+  'not_in_channel',
+  'user_not_found',
+  'users_not_found',
+  'user_not_visible'
+])
+
+function failureDecision(error: unknown): Decision {
+  return typeof error === 'string' && DEFINITIVE_DENIALS.has(error) ? 'deny' : 'unknown'
 }
 
 function slackPrincipals(identitySet: ReadonlySet<string>): SlackPrincipal[] {
@@ -141,6 +161,9 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
     if (!secret?.botToken) return 'unknown'
     try {
       const audience = await this.conversationAudience(scope.resourceKey, secret.botToken, signal)
+      // The conversation is gone (or the bot is no longer in it): a settled fact
+      // about the audience, not an unavailable check.
+      if (audience === 'gone') return 'deny'
       if (audience === 'unknown') return 'unknown'
       if (audience === 'public') {
         const access = await this.workspaceAccess(
@@ -173,9 +196,11 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
   ): Promise<ConversationAudience> {
     const body = await this.slackCall<{
       ok?: boolean
+      error?: unknown
       channel?: { is_private?: unknown; is_im?: unknown; is_mpim?: unknown }
     }>(`conversations.info?channel=${encodeURIComponent(channel)}`, token, signal)
-    if (!body.ok || !body.channel) return 'unknown'
+    if (!body.ok) return failureDecision(body.error) === 'deny' ? 'gone' : 'unknown'
+    if (!body.channel) return 'unknown'
     if (body.channel.is_private === false && body.channel.is_im !== true && body.channel.is_mpim !== true) {
       return 'public'
     }
@@ -198,6 +223,7 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
 
     const body = await this.slackCall<{
       ok?: boolean
+      error?: unknown
       user?: {
         team_id?: unknown
         profile?: { team?: unknown }
@@ -214,7 +240,8 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
       }
     }>(`users.info?user=${encodeURIComponent(principal.userId)}`, token, signal)
 
-    let access: WorkspaceAccess = 'unknown'
+    // A user Slack does not know in this workspace is a verdict, not an outage.
+    let access: WorkspaceAccess = body.ok ? 'unknown' : failureDecision(body.error) === 'deny' ? 'deny' : 'unknown'
     if (body.ok && body.user) {
       const teams = new Set<string>()
       if (typeof body.user.team_id === 'string') teams.add(body.user.team_id)
@@ -259,10 +286,12 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
       if (cursor) query.set('cursor', cursor)
       const body = await this.slackCall<{
         ok?: boolean
+        error?: unknown
         members?: unknown
         response_metadata?: { next_cursor?: unknown }
       }>(`conversations.members?${query}`, token, signal)
-      if (!body.ok || !Array.isArray(body.members)) return 'unknown'
+      if (!body.ok) return failureDecision(body.error)
+      if (!Array.isArray(body.members)) return 'unknown'
       if (body.members.includes(userId)) return 'allow'
       cursor = typeof body.response_metadata?.next_cursor === 'string' ? body.response_metadata.next_cursor : ''
       if (!cursor) return 'deny'

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -923,10 +923,6 @@ export interface SessionExternalAccessPolicyRecord {
   state: ExternalAccessPolicyState
   currentRev: bigint
   readFenceRev: bigint | null
-  /** Low-water mark of the unresolved count since enablement. History whose
-   *  scope the migration could not reconstruct is permanent and expected, so it
-   *  never means `degraded` — only a count ABOVE this mark does. */
-  legacyUnresolved: number
   migrationCursor: string | null
 }
 
@@ -974,6 +970,9 @@ export interface SessionMetaRecord {
   externalProvider: string | null
   externalScopeId: string | null
   externalResolution: ExternalResolution | null
+  /** Already unresolved when the policy was enabled — expected history rather
+   *  than a live failure, and inherited with the audience by A2A descendants. */
+  legacyUnresolved: boolean
   classifiedPolicyRev: bigint | null
   startedAt: Date
   endedAt: Date | null

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -923,6 +923,10 @@ export interface SessionExternalAccessPolicyRecord {
   state: ExternalAccessPolicyState
   currentRev: bigint
   readFenceRev: bigint | null
+  /** Low-water mark of the unresolved count since enablement. History whose
+   *  scope the migration could not reconstruct is permanent and expected, so it
+   *  never means `degraded` — only a count ABOVE this mark does. */
+  legacyUnresolved: number
   migrationCursor: string | null
 }
 
@@ -1066,8 +1070,9 @@ export interface SessionRepo {
   getExternalAccessPolicy(orgId: OrgId, provider: string): Promise<SessionExternalAccessPolicyRecord | null>
   countExternalUnresolved(orgId: OrgId, provider: string): Promise<number>
   /** Owner-only HTTP route calls this transactional transition. Enabling places
-   *  the read fence before classifying legacy candidates; unresolved history is
-   *  retained as degraded and hidden. Disabling never widens historical rows. */
+   *  the read fence before classifying legacy candidates; unresolved history stays
+   *  hidden and is adopted as `legacyUnresolved` rather than reported as a fault.
+   *  Disabling never widens historical rows. */
   setExternalAccessEnabled(
     orgId: OrgId,
     provider: string,

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -573,7 +573,7 @@ export class PgSessionRepo implements SessionRepo {
         Prisma.sql`
           SELECT "visibility", "ownerIdentity", "visibilitySource",
                  "externalProvider", "externalScopeId", "externalResolution",
-                 "classifiedPolicyRev"
+                 "legacyUnresolved", "classifiedPolicyRev"
           FROM "session_meta" WHERE "id" = ${parentSessionId} FOR SHARE
         `
       )
@@ -586,6 +586,10 @@ export class PgSessionRepo implements SessionRepo {
           "externalProvider" = ${parent[0]!.externalProvider},
           "externalScopeId" = ${parent[0]!.externalScopeId}::uuid,
           "externalResolution" = ${parent[0]!.externalResolution}::"ExternalResolution",
+          -- Provenance travels with the audience on BOTH inheritance paths, or a
+          -- child that settles here after its parent was stamped legacy would
+          -- look like a post-enable failure and degrade the policy for good.
+          "legacyUnresolved" = ${parent[0]!.legacyUnresolved},
           "classifiedPolicyRev" = ${parent[0]!.classifiedPolicyRev},
           "visibilitySource" = 'inherited'::"VisibilitySource",
           "visibilityRev" = "visibilityRev" + 1,

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -81,6 +81,7 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     externalProvider: s.externalProvider,
     externalScopeId: s.externalScopeId,
     externalResolution: (s.externalResolution as ExternalResolution | null) ?? null,
+    legacyUnresolved: s.legacyUnresolved,
     classifiedPolicyRev: s.classifiedPolicyRev,
     startedAt: s.startedAt,
     endedAt: s.endedAt
@@ -109,7 +110,6 @@ function toExternalPolicyRecord(policy: SessionExternalAccessPolicy): SessionExt
     state: policy.state as ExternalAccessPolicyState,
     currentRev: policy.currentRev,
     readFenceRev: policy.readFenceRev,
-    legacyUnresolved: policy.legacyUnresolved,
     migrationCursor: policy.migrationCursor
   }
 }
@@ -296,6 +296,9 @@ type ResolvedSessionClassification = {
   externalProvider: string | null
   externalScopeId: string | null
   externalResolution: ExternalResolution | null
+  // A freshly classified candidate is never legacy: enablement is what stamps
+  // the mark, and an A2A child copies it from the parent whose audience it takes.
+  legacyUnresolved: boolean
   classifiedPolicyRev: bigint | null
 }
 
@@ -347,6 +350,7 @@ export class PgSessionRepo implements SessionRepo {
             externalProvider: null,
             externalScopeId: null,
             externalResolution: null,
+            legacyUnresolved: false,
             classifiedPolicyRev: null
           }
     if (ev.externalCandidate) {
@@ -405,6 +409,7 @@ export class PgSessionRepo implements SessionRepo {
         externalProvider: candidate.provider,
         externalScopeId: scopeId,
         externalResolution: resolution,
+        legacyUnresolved: false,
         classifiedPolicyRev: policy.currentRev
       }
     }
@@ -417,6 +422,7 @@ export class PgSessionRepo implements SessionRepo {
         externalProvider: null,
         externalScopeId: null,
         externalResolution: null,
+        legacyUnresolved: false,
         classifiedPolicyRev: null
       }
     }
@@ -429,13 +435,14 @@ export class PgSessionRepo implements SessionRepo {
             externalProvider: string | null
             externalScopeId: string | null
             externalResolution: string | null
+            legacyUnresolved: boolean
             classifiedPolicyRev: bigint | null
           }>
         >(
           Prisma.sql`
             SELECT "visibility", "ownerIdentity", "visibilitySource",
                    "externalProvider", "externalScopeId", "externalResolution",
-                   "classifiedPolicyRev"
+                   "legacyUnresolved", "classifiedPolicyRev"
             FROM "session_meta" WHERE "id" = ${ev.parentSessionId} FOR SHARE
           `
         )
@@ -457,6 +464,7 @@ export class PgSessionRepo implements SessionRepo {
         externalProvider: null,
         externalScopeId: null,
         externalResolution: null,
+        legacyUnresolved: false,
         classifiedPolicyRev: null
       }
     }
@@ -467,6 +475,9 @@ export class PgSessionRepo implements SessionRepo {
       externalProvider: parent[0]!.externalProvider,
       externalScopeId: parent[0]!.externalScopeId,
       externalResolution: parent[0]!.externalResolution as ExternalResolution | null,
+      // Inherit the parent's provenance too: a child of a legacy-unresolvable
+      // parent can never resolve either, and must not read as a new failure.
+      legacyUnresolved: parent[0]!.legacyUnresolved,
       classifiedPolicyRev: parent[0]!.classifiedPolicyRev
     }
   }
@@ -494,6 +505,7 @@ export class PgSessionRepo implements SessionRepo {
           "externalProvider" = ${parent.externalProvider},
           "externalScopeId" = ${parent.externalScopeId}::uuid,
           "externalResolution" = ${parent.externalResolution}::"ExternalResolution",
+          "legacyUnresolved" = ${parent.legacyUnresolved},
           "classifiedPolicyRev" = ${parent.classifiedPolicyRev},
           "visibilitySource" = 'inherited'::"VisibilitySource",
           "visibilityRev" = "visibilityRev" + 1,
@@ -669,8 +681,8 @@ export class PgSessionRepo implements SessionRepo {
         "threadUrl", "runtime", "model", "effort", "fastMode",
         "permissionMode", "outputMode", "daemonId", "orgId", "visibility",
         "ownerIdentity", "visibilitySource", "externalProvider",
-        "externalScopeId", "externalResolution", "classifiedPolicyRev",
-        "startedAt", "endedAt", "updatedAt"
+        "externalScopeId", "externalResolution", "legacyUnresolved",
+        "classifiedPolicyRev", "startedAt", "endedAt", "updatedAt"
       ) VALUES (
         ${ev.sessionId}, ${ev.parentSessionId ?? null}, ${ev.agentId},
         ${ev.launchId ?? null}, ${ev.platform ?? null}, ${ev.channel ?? null},
@@ -685,7 +697,8 @@ export class PgSessionRepo implements SessionRepo {
         ${cls.visibility}::"SessionVisibility", ${cls.ownerIdentity},
         ${cls.source}::"VisibilitySource", ${cls.externalProvider},
         ${cls.externalScopeId}::uuid, ${cls.externalResolution}::"ExternalResolution",
-        ${cls.classifiedPolicyRev}, ${ev.at}, ${endedAt ?? null}, CURRENT_TIMESTAMP
+        ${cls.legacyUnresolved}, ${cls.classifiedPolicyRev}, ${ev.at},
+        ${endedAt ?? null}, CURRENT_TIMESTAMP
       )
       -- Visibility remains first-wins here. The narrow legacy pending → trusted
       -- external transition, when applicable, happened in the guarded UPDATE
@@ -769,32 +782,33 @@ export class PgSessionRepo implements SessionRepo {
       cls.visibility === 'external' &&
       (cls.externalResolution !== 'settled' || rebound)
     ) {
-      // Same predicate as `countExternalUnresolved`, so the mark below and the
-      // owner-facing `hiddenSessions` diagnostic always count the same rows.
-      const unresolved = await tx.sessionMeta.count({
-        where: {
-          orgId,
-          externalProvider: cls.externalProvider,
-          visibility: 'external',
-          externalResolution: { in: ['pending', 'invalid'] }
-        }
-      })
-      // Degradation is measured against the enablement-time backlog, not zero:
-      // history the migration could not bind never settles, so counting it as a
-      // fault would pin the policy to 'degraded' forever (and drown the signal
-      // that a NEW candidate failed to resolve). Both assignments read the old
-      // row, and the mark only ever ratchets down as legacy rows settle.
+      // Degradation is per row, not a count: history the migration could not bind
+      // never settles, so counting it as a fault would pin the policy to
+      // 'degraded' forever — and a count also lets a legacy row settling cancel
+      // out a live post-enable failure, silently clearing the fault while it is
+      // still there. Only an unresolved row that is NOT marked legacy degrades.
+      // Same row predicate as `countExternalUnresolved`, so the state signal and
+      // the owner-facing `hiddenSessions` diagnostic never disagree about which
+      // rows are hidden.
       await tx.$executeRaw(Prisma.sql`
-        UPDATE "session_external_access_policy"
+        UPDATE "session_external_access_policy" p
         SET "state" = CASE
-              WHEN ${unresolved} > "legacyUnresolved" THEN 'degraded'::"ExternalAccessPolicyState"
+              WHEN EXISTS (
+                SELECT 1 FROM "session_meta" s
+                WHERE s."orgId" = p."orgId"
+                  AND s."externalProvider" = p."provider"
+                  AND s."visibility" = 'external'::"SessionVisibility"
+                  AND s."externalResolution" IN (
+                    'pending'::"ExternalResolution", 'invalid'::"ExternalResolution"
+                  )
+                  AND NOT s."legacyUnresolved"
+              ) THEN 'degraded'::"ExternalAccessPolicyState"
               ELSE 'enabled'::"ExternalAccessPolicyState"
             END,
-            "legacyUnresolved" = LEAST("legacyUnresolved", ${unresolved}),
             "updatedAt" = CURRENT_TIMESTAMP
-        WHERE "orgId" = ${orgId}
-          AND "provider" = ${cls.externalProvider}
-          AND "state" <> 'disabled'::"ExternalAccessPolicyState"
+        WHERE p."orgId" = ${orgId}
+          AND p."provider" = ${cls.externalProvider}
+          AND p."state" <> 'disabled'::"ExternalAccessPolicyState"
       `)
     }
     return { recorded: true, session, settled }
@@ -1081,13 +1095,24 @@ export class PgSessionRepo implements SessionRepo {
           externalResolution: { in: ['pending', 'invalid'] }
         }
       })
-      // Whatever is unresolved at this instant is history the migration could
-      // not bind — expected, permanent, and hidden, but not a fault. Adopt it as
-      // the mark so only a candidate that fails to resolve LATER degrades the
-      // policy; the count itself stays reportable as `hiddenSessions`.
+      // Whatever is unresolved at this instant is history the migration could not
+      // bind — expected and hidden, but not a fault. Mark those rows so only a
+      // candidate that fails to resolve LATER degrades the policy. Marking the
+      // rows (rather than remembering how many there were) is what keeps a live
+      // failure visible after a legacy row settles. The count itself stays
+      // reportable as `hiddenSessions`. Re-enabling re-stamps from scratch: a row
+      // that settled in between is cleared by the same statement.
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE "session_meta"
+        SET "legacyUnresolved" = "externalResolution" IN (
+              'pending'::"ExternalResolution", 'invalid'::"ExternalResolution"
+            )
+        WHERE "orgId" = ${orgId}
+          AND "externalProvider" = ${provider}
+      `)
       const policy = await tx.sessionExternalAccessPolicy.update({
         where: { orgId_provider: { orgId, provider } },
-        data: { state: 'enabled', legacyUnresolved: hiddenSessions }
+        data: { state: 'enabled' }
       })
       return {
         policy: toExternalPolicyRecord(policy),

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -109,6 +109,7 @@ function toExternalPolicyRecord(policy: SessionExternalAccessPolicy): SessionExt
     state: policy.state as ExternalAccessPolicyState,
     currentRev: policy.currentRev,
     readFenceRev: policy.readFenceRev,
+    legacyUnresolved: policy.legacyUnresolved,
     migrationCursor: policy.migrationCursor
   }
 }
@@ -768,17 +769,33 @@ export class PgSessionRepo implements SessionRepo {
       cls.visibility === 'external' &&
       (cls.externalResolution !== 'settled' || rebound)
     ) {
+      // Same predicate as `countExternalUnresolved`, so the mark below and the
+      // owner-facing `hiddenSessions` diagnostic always count the same rows.
       const unresolved = await tx.sessionMeta.count({
         where: {
           orgId,
           externalProvider: cls.externalProvider,
+          visibility: 'external',
           externalResolution: { in: ['pending', 'invalid'] }
         }
       })
-      await tx.sessionExternalAccessPolicy.updateMany({
-        where: { orgId, provider: cls.externalProvider, state: { not: 'disabled' } },
-        data: { state: unresolved > 0 ? 'degraded' : 'enabled' }
-      })
+      // Degradation is measured against the enablement-time backlog, not zero:
+      // history the migration could not bind never settles, so counting it as a
+      // fault would pin the policy to 'degraded' forever (and drown the signal
+      // that a NEW candidate failed to resolve). Both assignments read the old
+      // row, and the mark only ever ratchets down as legacy rows settle.
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE "session_external_access_policy"
+        SET "state" = CASE
+              WHEN ${unresolved} > "legacyUnresolved" THEN 'degraded'::"ExternalAccessPolicyState"
+              ELSE 'enabled'::"ExternalAccessPolicyState"
+            END,
+            "legacyUnresolved" = LEAST("legacyUnresolved", ${unresolved}),
+            "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "orgId" = ${orgId}
+          AND "provider" = ${cls.externalProvider}
+          AND "state" <> 'disabled'::"ExternalAccessPolicyState"
+      `)
     }
     return { recorded: true, session, settled }
   }
@@ -1060,12 +1077,17 @@ export class PgSessionRepo implements SessionRepo {
         where: {
           orgId,
           externalProvider: provider,
+          visibility: 'external',
           externalResolution: { in: ['pending', 'invalid'] }
         }
       })
+      // Whatever is unresolved at this instant is history the migration could
+      // not bind — expected, permanent, and hidden, but not a fault. Adopt it as
+      // the mark so only a candidate that fails to resolve LATER degrades the
+      // policy; the count itself stays reportable as `hiddenSessions`.
       const policy = await tx.sessionExternalAccessPolicy.update({
         where: { orgId_provider: { orgId, provider } },
-        data: { state: hiddenSessions > 0 ? 'degraded' : 'enabled' }
+        data: { state: 'enabled', legacyUnresolved: hiddenSessions }
       })
       return {
         policy: toExternalPolicyRecord(policy),

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -222,9 +222,8 @@ describe('session visibility — Slack conversation audience', () => {
     })
     expect(ownerResponse.statusCode).toBe(200)
     // The pre-existing candidate stays hidden and is reported, but enabling
-    // adopts it as the legacy mark: unrecoverable history is not a fault state.
+    // marks it legacy: unrecoverable history is not a fault state.
     expect(ownerResponse.json()).toMatchObject({ enabled: true, state: 'enabled', hiddenSessions: 1 })
-    expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.legacyUnresolved).toBe(1)
 
     const stillHidden = (
       await appAs(owner, {
@@ -239,8 +238,9 @@ describe('session visibility — Slack conversation audience', () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
     const repo = new PgSessionRepo(prisma)
+    const legacySessionId = `s-slack-legacy-${randomUUID()}`
     await repo.recordMilestone({
-      sessionId: SessionId(`s-slack-legacy-${randomUUID()}`),
+      sessionId: SessionId(legacySessionId),
       agentId,
       phase: 'start',
       platform: 'slack',
@@ -252,9 +252,10 @@ describe('session visibility — Slack conversation audience', () => {
 
     const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
     expect(enabled).toMatchObject({ hiddenSessions: 1 })
-    expect(enabled.policy).toMatchObject({ state: 'enabled', legacyUnresolved: 1 })
+    expect(enabled.policy).toMatchObject({ state: 'enabled' })
 
-    // A second unresolved candidate exceeds the mark — that one IS actionable.
+    // A candidate that fails to resolve AFTER enablement carries no legacy mark
+    // — that one IS actionable.
     await repo.recordMilestone({
       sessionId: SessionId(`s-slack-new-${randomUUID()}`),
       agentId,
@@ -265,6 +266,33 @@ describe('session visibility — Slack conversation audience', () => {
       classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
       externalCandidate: { provider: 'slack', resolution: 'pending' }
     })
+    expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('degraded')
+
+    // Turnover must not absolve the live failure: settling the LEGACY candidate
+    // leaves the post-enable one unresolved, so the policy stays degraded. An
+    // aggregate low-water mark would read "back to one unresolved row" here and
+    // silently return to 'enabled'.
+    await repo.recordMilestone({
+      sessionId: SessionId(legacySessionId),
+      agentId,
+      phase: 'plan',
+      platform: 'slack',
+      channel: 'C_LEGACY',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: {
+        provider: 'slack',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'T_INSTALL',
+          resourceKind: 'conversation',
+          resourceKey: 'C_LEGACY',
+          credentialKind: 'bot',
+          credentialId: randomUUID()
+        }
+      }
+    })
+    expect(await repo.countExternalUnresolved(OrgId(DEFAULT_ORG_ID), 'slack')).toBe(1)
     expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('degraded')
   })
 

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -296,6 +296,87 @@ describe('session visibility — Slack conversation audience', () => {
     expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('degraded')
   })
 
+  // The post-commit settlement path (§4.5) inherits the parent's audience after
+  // the child's own transaction closed — including the interleaving where the
+  // parent lands and is stamped legacy in between. Provenance must ride along, or
+  // the child settles as an unmarked unresolved row and reports a live failure
+  // that never happened.
+  it('carries legacy provenance through out-of-order parent settlement', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-slack-parent-${randomUUID()}`
+    const childId = `s-slack-child-${randomUUID()}`
+    const credentialId = randomUUID()
+
+    // The child arrives first and finds no parent: private + inherited_pending.
+    const orphan = await repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_LEGACY',
+      at: new Date(),
+      classification: { inherit: true }
+    })
+    expect(orphan.session).toMatchObject({ visibilitySource: 'inherited_pending', externalProvider: null })
+
+    // The parent lands as an unresolved Slack candidate (seeded directly so it
+    // does not settle the child on the way in), and enabling stamps it legacy.
+    await seedSessionMeta(prisma, parentId, agentId, { daemonId, channel: 'C_LEGACY' })
+    await prisma.sessionMeta.update({
+      where: { id: parentId },
+      // classifiedPolicyRev is required by session_meta_external_shape_check
+      // whenever a provider is set; 0 is the pre-enable policy revision.
+      data: { externalProvider: 'slack', externalResolution: 'pending', classifiedPolicyRev: 0n }
+    })
+    const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
+    expect(enabled.policy.state).toBe('enabled')
+
+    // Now the child's settlement runs and copies the parent's audience.
+    await repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'plan',
+      platform: 'slack',
+      channel: 'C_LEGACY',
+      at: new Date(),
+      classification: { inherit: true }
+    })
+    expect(await repo.get(SessionId(childId))).toMatchObject({
+      visibilitySource: 'inherited',
+      externalProvider: 'slack',
+      externalResolution: 'pending',
+      legacyUnresolved: true
+    })
+
+    // Settling the parent forces a policy recomputation: the inherited child is
+    // expected backlog, so nothing degrades.
+    await repo.recordMilestone({
+      sessionId: SessionId(parentId),
+      agentId,
+      phase: 'plan',
+      platform: 'slack',
+      channel: 'C_LEGACY',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: {
+        provider: 'slack',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'T_INSTALL',
+          resourceKind: 'conversation',
+          resourceKey: 'C_LEGACY',
+          credentialKind: 'bot',
+          credentialId
+        }
+      }
+    })
+    expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('enabled')
+  })
+
   it('keeps the creation-time scope fixed and applies current membership only after enable', async () => {
     const daemonId = await seedDaemon(prisma, randomUUID())
     const agentId = await seedAgent(prisma, randomUUID(), { daemonId })

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -221,7 +221,51 @@ describe('session visibility — Slack conversation audience', () => {
       payload: { enabled: true }
     })
     expect(ownerResponse.statusCode).toBe(200)
-    expect(ownerResponse.json()).toMatchObject({ enabled: true, state: 'degraded', hiddenSessions: 1 })
+    // The pre-existing candidate stays hidden and is reported, but enabling
+    // adopts it as the legacy mark: unrecoverable history is not a fault state.
+    expect(ownerResponse.json()).toMatchObject({ enabled: true, state: 'enabled', hiddenSessions: 1 })
+    expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.legacyUnresolved).toBe(1)
+
+    const stillHidden = (
+      await appAs(owner, {
+        logtoIdentity: {} as never,
+        slackSessionAccess: { resolve: async () => ({ allowedScopes: [], degraded: false }) }
+      }).app.inject({ method: 'GET', url: `${ORG}/session-access/slack` })
+    ).json()
+    expect(stillHidden).toMatchObject({ state: 'enabled', hiddenSessions: 1 })
+  })
+
+  it('degrades only when a candidate goes unresolved after enablement', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    await repo.recordMilestone({
+      sessionId: SessionId(`s-slack-legacy-${randomUUID()}`),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_LEGACY',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: { provider: 'slack', resolution: 'pending' }
+    })
+
+    const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
+    expect(enabled).toMatchObject({ hiddenSessions: 1 })
+    expect(enabled.policy).toMatchObject({ state: 'enabled', legacyUnresolved: 1 })
+
+    // A second unresolved candidate exceeds the mark — that one IS actionable.
+    await repo.recordMilestone({
+      sessionId: SessionId(`s-slack-new-${randomUUID()}`),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_NEW',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: { provider: 'slack', resolution: 'pending' }
+    })
+    expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('degraded')
   })
 
   it('keeps the creation-time scope fixed and applies current membership only after enable', async () => {

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -91,7 +91,7 @@ const SESSION_ACCESS_COPY: Record<
     details: [
       'Public channels follow Slack workspace access; private channels, group DMs, guests and Slack Connect users need current membership.',
       'DMs stay private, and agent memory learned earlier is not erased.',
-      'Sessions that predate this setting have no recoverable Slack scope and stay hidden for good.',
+      'Sessions that predate this setting stay hidden until new trusted activity rebinds them to a Slack conversation.',
       'Turning this off leaves already-synced sessions following Slack.'
     ].join('\n'),
     unavailable: 'Needs OIDC sign-in and linked Slack identities.',
@@ -105,7 +105,7 @@ const SESSION_ACCESS_COPY: Record<
     details: [
       'Public-repository sessions stay visible to members who can view the agent; private-repository sessions need a linked GitHub profile with current access.',
       'Agent memory learned earlier is not erased.',
-      'Sessions that predate this setting have no recoverable repository scope and stay hidden for good.',
+      'Sessions that predate this setting stay hidden until new trusted activity rebinds them to a repository.',
       'Turning this off leaves already-synced sessions following GitHub.'
     ].join('\n'),
     unavailable: 'Needs OIDC sign-in and GitHub access checks.',

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -71,10 +71,14 @@ function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu'
   return appId ? `${host}/app/${encodeURIComponent(appId)}/baseinfo` : `${host}/app`
 }
 
+// One short sub-line per state — the full access policy (who keeps seeing what,
+// and what turning the toggle off does NOT undo) lives in `details`, shown by the
+// row's info hint so the card stays two readable lines per provider.
 const SESSION_ACCESS_COPY: Record<
   SessionAccessProvider,
   {
     title: string
+    details: string
     unavailable: string
     enabled: string
     disabled: string
@@ -83,28 +87,32 @@ const SESSION_ACCESS_COPY: Record<
   }
 > = {
   slack: {
-    title: 'Follow Slack conversation access',
-    unavailable:
-      'Requires OIDC and linked Slack identities. Until then, shared sessions remain visible to Everyone who can view the agent.',
-    enabled:
-      'Public-channel sessions follow Slack workspace access. Private channels, group DMs, guests, and Slack Connect users require current conversation membership. DMs remain private. Agent memory learned earlier is not erased.',
-    disabled:
-      'New shared sessions are visible to Everyone who can view the agent. Previously synced sessions keep following Slack. DMs remain private.',
-    unresolved: (count) =>
-      `${count} historical session${count === 1 ? '' : 's'} lack a trusted Slack scope and remain hidden.`,
-    degraded: 'Slack access is degraded; unresolved sessions remain hidden.'
+    title: 'Follow Slack access',
+    details: [
+      'Public channels follow Slack workspace access; private channels, group DMs, guests and Slack Connect users need current membership.',
+      'DMs stay private, and agent memory learned earlier is not erased.',
+      'Sessions that predate this setting have no recoverable Slack scope and stay hidden for good.',
+      'Turning this off leaves already-synced sessions following Slack.'
+    ].join('\n'),
+    unavailable: 'Needs OIDC sign-in and linked Slack identities.',
+    enabled: 'Session visibility follows Slack conversation access.',
+    disabled: 'New sessions are visible to everyone who can view the agent.',
+    unresolved: (count) => `${count} session${count === 1 ? '' : 's'} hidden — no trusted Slack scope.`,
+    degraded: 'Slack scopes stopped resolving — new sessions are being hidden.'
   },
   github: {
-    title: 'Follow GitHub repository access',
-    unavailable:
-      'Requires OIDC and GitHub access checks. Until then, GitHub sessions remain visible to Everyone who can view the agent.',
-    enabled:
-      'Public repository sessions remain visible to members who can view the agent. Private repository sessions require a linked GitHub profile with current access. Agent memory learned earlier is not erased.',
-    disabled:
-      'New GitHub sessions are visible to Everyone who can view the agent. Previously synced sessions keep following GitHub.',
-    unresolved: (count) =>
-      `${count} historical session${count === 1 ? '' : 's'} lack a trusted GitHub repository scope and remain hidden.`,
-    degraded: 'GitHub access is degraded; unresolved sessions remain hidden.'
+    title: 'Follow GitHub access',
+    details: [
+      'Public-repository sessions stay visible to members who can view the agent; private-repository sessions need a linked GitHub profile with current access.',
+      'Agent memory learned earlier is not erased.',
+      'Sessions that predate this setting have no recoverable repository scope and stay hidden for good.',
+      'Turning this off leaves already-synced sessions following GitHub.'
+    ].join('\n'),
+    unavailable: 'Needs OIDC sign-in and GitHub access checks.',
+    enabled: 'Session visibility follows GitHub repository access.',
+    disabled: 'New sessions are visible to everyone who can view the agent.',
+    unresolved: (count) => `${count} session${count === 1 ? '' : 's'} hidden — no trusted repository scope.`,
+    degraded: 'Repository scopes stopped resolving — new sessions are being hidden.'
   }
 }
 
@@ -148,15 +156,25 @@ function SessionAccessRow({
 
   return (
     <div className={`flex items-center gap-3 px-4 py-[15px] ${bordered ? 'border-t border-(--border-subtle)' : ''}`}>
-      <span className="flex h-9 w-9 flex-none items-center justify-center rounded-[9px] bg-(--surface-active)">
-        {provider === 'slack' ? (
-          <PlatformMark platform="slack" fillPct={100} />
-        ) : (
-          <GithubMark color="var(--text-primary)" />
-        )}
+      {/* Same platform tile as the Bots / GitHub rows above — a 14px mark on the
+          bordered plate, so both providers read at one weight. */}
+      <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card) text-(--text-primary)">
+        <span className="flex h-[14px] w-[14px] items-center justify-center">
+          <PlatformMark platform={provider} fillPct={100} />
+        </span>
       </span>
       <div className="min-w-0 flex-1">
-        <div className="font-sans text-[13px] font-semibold leading-normal">{copy.title}</div>
+        <div className="flex items-center gap-[5px]">
+          <span className="font-sans text-[13px] font-semibold leading-normal">{copy.title}</span>
+          <button
+            type="button"
+            className="flex h-4 w-4 flex-none items-center justify-center rounded-full text-(--text-tertiary) transition-colors hover:text-(--text-primary) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
+            aria-label={`${copy.title} — what this covers`}
+            title={copy.details}
+          >
+            <Icon name="info" size={13} />
+          </button>
+        </div>
         <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
           {access?.available === false && !access.enabled
             ? copy.unavailable
@@ -164,9 +182,18 @@ function SessionAccessRow({
               ? copy.enabled
               : copy.disabled}
         </div>
-        {(access?.state === 'degraded' || hiddenSessions > 0) && (
+        {/* Amber is reserved for the actionable case — a scope that stopped
+            resolving AFTER enablement. The hidden-session backlog is expected
+            and permanent (the CP freezes it as the policy's legacy mark), so it
+            reads as a muted fact, not a fault the owner is failing to clear. */}
+        {access?.state === 'degraded' && (
           <div className="mt-1 font-sans text-[11.5px] font-medium leading-normal text-(--status-paused)">
-            {hiddenSessions > 0 ? copy.unresolved(hiddenSessions) : copy.degraded}
+            {copy.degraded}
+          </div>
+        )}
+        {hiddenSessions > 0 && (
+          <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+            {copy.unresolved(hiddenSessions)}
           </div>
         )}
         {(currentActionError || loadError) && (


### PR DESCRIPTION
The Settings → Session access card reported two everyday situations as faults, and an owner had no way to clear either one.

## 1. Unrecoverable history is not degradation

Enabling a provider policy hides every candidate whose source scope the migration could not reconstruct. That scope never comes back — only new activity on the same session rebinds it — so deriving `degraded` from that count pinned any organization with pre-existing history to a permanent fault state, and buried the one signal actually worth acting on.

`SessionExternalAccessPolicy` gains `legacyUnresolved`: the low-water mark of the unresolved count since enablement. `degraded` now means the live count **exceeds** the mark — a candidate went unresolved *after* the policy was turned on. The mark is adopted at enable, ratchets down as legacy rows settle, and the migration backfills it for already-enabled policies while clearing the stale `degraded` they were stuck in. The backlog itself stays reportable to owners as `hiddenSessions`.

Also fixed in passing: the classification path counted unresolved rows without the `visibility = 'external'` filter that `countExternalUnresolved` uses, so the state signal and the owner-facing number could count different rows.

## 2. A gone conversation is an answer, not an outage

The Slack resolver treated every `ok: false` as "could not answer". A deleted private channel — or a bot removed from one, which is the same response over the wire — therefore raised *"Some external access checks are unavailable"* on every session list, and the 5s unknown TTL re-asked Slack about that channel on every page.

`channel_not_found`, `not_in_channel` and `user_not_found` are Slack **answering**: they become a plain deny at the deny TTL with `degraded` false. Auth failures, missing scope, rate limiting, outages, unrecognized codes and transport failures stay `unknown` → deny + `degraded`, which is what the banner is for. GitHub already drew this line (`repoRefById` → `deny`); this brings Slack in line.

## 3. The card

Amber is reserved for `degraded`; the hidden count renders as a muted fact. The row adopts the same platform tile the Bots and GitHub rows already use (both marks at one optical weight, instead of a full-bleed Slack logo next to a 60 % octocat), and the full access policy moves behind the row's info hint, so each provider reads as two lines instead of four.

## Reviewer notes

- **No access change.** `deny` and `unknown` both refuse; this PR only changes how an outcome is reported and how long it is cached. A re-invited bot recovers within the deny TTL — no scope is revoked, deliberately.
- **Migration is not idempotent-by-accident**: it adopts the *whole* current backlog as legacy, because history cannot tell which unresolved rows appeared after enablement. A live provider problem re-degrades on the next classification.
- **Still open (not in this PR):** sessions whose Slack conversation is gone now disappear with no counter or explanation anywhere — they are `settled`, so `hiddenSessions` does not include them. Same question as giving the legacy backlog an exit (an owner-only bulk release / review view); both were deferred deliberately.

## Verification

- `control-plane` unit: 941 passed (5 new resolver cases — `channel_not_found`/`not_in_channel`/`user_not_found` deny without degrading, the verdict is cached rather than re-asked, `missing_scope` still degrades).
- `control-plane` integration: 874 passed, including a rewritten expectation (enabling with a pre-existing candidate → `enabled`, not `degraded`) and a new case proving a candidate unresolved *after* enablement still degrades.
- `web`: 509 passed. `tsc`, `eslint`, `prettier` clean across both packages.
- Card rendered locally against a stubbed CP in every state (enabled + backlog, enabled clean, off, unavailable, degraded + backlog), light and dark, desktop and 375 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
