### PR TITLE
feat(daemon): mention multiple users with sendMessage

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -179,7 +179,7 @@ sendMessage(target: AgentTarget | UserTarget | ChannelTarget | SessionTarget, me
 ```
 
 The arguments are a top-level union of **two addressing modes** — `toAgent` (wake
-a peer agent) and `toUser` (reach a human) — each with **three delivery forms**
+a peer agent) and `toUser` (reach one or more humans) — each with **three delivery forms**
 selected by the coordinates (dm / channel root / in thread) — plus a bare
 `channel`-only post (no recipient) and the separate `sessionId` reply branch.
 
@@ -193,9 +193,9 @@ type AgentTarget = {
   thread?: string  // in-thread form only (requires `channel`)
 }
 
-// Mode 2 — reach one human platform member.
+// Mode 2 — reach human platform members.
 type UserTarget = {
-  toUser: string             // platform member ID (Slack only for now)
+  toUser: string | string[]  // one member id; channel/thread forms also accept a non-empty unique-id array
   platform?: 'slack' | 'telegram' | 'discord' | 'feishu' | ... // dm defaults to Slack; channel/thread forms default to current session
   channel?: string           // absent ⇒ dm (Slack DM); present without thread ⇒ channel root; with thread ⇒ in thread
   thread?: string            // in-thread form only (requires `channel`)
@@ -214,11 +214,11 @@ type ChannelTarget = {
 Exactly one target key is required: `toAgent`, `toUser`, or `channel`. For the two
 recipient modes the form is decided by the coordinates:
 
-| Mode             | dm                                                              | channel root                                                                                  | in thread                                                                                                    |
-| ---------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `toAgent`        | `{"toAgent":"A","message":"…"}` — postless wake, nothing posted | `{"toAgent":"A","channel":"C","message":"…"}` — visible root post + wake, peer anchored to it | `{"toAgent":"A","channel":"C","thread":"T","message":"…"}` — visible thread post + wake, peer in that thread |
-| `toUser`         | `{"toUser":"U","message":"…"}` — Slack DM                       | `{"toUser":"U","channel":"C","message":"…"}` — root post @-mentioning the user                | `{"toUser":"U","channel":"C","thread":"T","message":"…"}` — thread post @-mentioning the user                |
-| `channel` (bare) | —                                                               | `{"channel":"C","message":"…"}` — root post, no recipient                                     | `{"channel":"C","thread":"T","message":"…"}` — thread post, no recipient                                     |
+| Mode             | dm                                                              | channel root                                                                                     | in thread                                                                                                       |
+| ---------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `toAgent`        | `{"toAgent":"A","message":"…"}` — postless wake, nothing posted | `{"toAgent":"A","channel":"C","message":"…"}` — visible root post + wake, peer anchored to it    | `{"toAgent":"A","channel":"C","thread":"T","message":"…"}` — visible thread post + wake, peer in that thread    |
+| `toUser`         | `{"toUser":"U","message":"…"}` — Slack DM to one person         | `{"toUser":["U1","U2"],"channel":"C","message":"…"}` — one root post mentioning all listed users | `{"toUser":["U1","U2"],"channel":"C","thread":"T","message":"…"}` — one thread post mentioning all listed users |
+| `channel` (bare) | —                                                               | `{"channel":"C","message":"…"}` — root post, no recipient                                        | `{"channel":"C","thread":"T","message":"…"}` — thread post, no recipient                                        |
 
 - The target must identify an action: `toAgent`, `toUser`, or `channel`. The
   daemon rejects an empty action and rejects mixing `toAgent` with `toUser` in
@@ -230,7 +230,8 @@ recipient modes the form is decided by the coordinates:
   (deprecated alias `listChannelAgents`), which lists every peer in the caller's
   organization that the directional call policy admits — a peer need not share a
   channel with the caller, and need not have an IM integration at all. `toUser` is
-  a platform member ID.
+  one platform member ID, or a non-empty array of unique member ids when `channel`
+  is present.
 - A `toAgent` wake is authorized by that call policy alone; `channel` is a
   **delivery coordinate**, not an authorization key. It still decides where the
   optional visible post lands and, through the session key, which session the peer
@@ -250,9 +251,11 @@ recipient modes the form is decided by the coordinates:
 - The daemon injects the caller agent ID from session context. It is never a
   tool argument, so a caller cannot impersonate another agent or call itself as
   a different identity.
-- `toUser` is Slack-only for now: a `toUser` DM posts to the member id directly,
-  and the channel-root / in-thread forms prepend an `<@user>` mention to the
-  visible post. Any other platform is rejected before dispatch.
+- `toUser` is Slack-only for now: a `toUser` DM accepts one string and posts to that
+  member id directly. The channel-root / in-thread forms accept one id or a non-empty
+  unique-id array and prepend every corresponding `<@user>` mention to the single
+  visible post. An array without `channel` is rejected rather than interpreted as a
+  group DM. Any other platform is rejected before dispatch.
 - `thread` determines the platform thread only when `channel` is present.
   Passing an existing thread posts there. Omitting it or passing `""` posts a
   new top-level channel message, **not the current session thread**. Normal

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -84,7 +84,7 @@ platform delivery path.
 
 Whether the hand-off is _visible_ is the caller's choice, set by the `sendMessage`
 target it uses. The tool has two addressing modes — `toAgent` (wake a peer) and
-`toUser` (reach a human) — each with three delivery forms: dm / channel root /
+`toUser` (reach one or more humans) — each with three delivery forms: dm / channel root /
 in thread; plus a bare `channel` post with no recipient:
 
 - `toAgent` **dm form** (`{"toAgent":"<agent id>","message":"..."}`, no `channel`) —
@@ -98,9 +98,12 @@ in thread; plus a bare `channel` post with no recipient:
   is carried into the wake (across the relay for a cross-daemon target) so the
   visible message and the direct delivery collapse to a single transcript row
   (never a duplicate hand-off).
-- `toUser` — reach one human (Slack only for now): dm (`{"toUser":"<id>","message":"..."}`
-  without `channel`, a direct message), channel root (`toUser` + `channel`, a visible
-  post that @-mentions the user), or in thread (`toUser` + `channel` + `thread`).
+- `toUser` — reach humans (Slack only for now): dm (`{"toUser":"<id>","message":"..."}`
+  without `channel`, a direct message to exactly one person), channel root (`toUser` +
+  `channel`, one visible post that @-mentions every listed person), or in thread
+  (`toUser` + `channel` + `thread`). The channel forms accept either one id or a
+  non-empty array of unique ids such as `"toUser":["U1","U2"]`; an array never
+  means group DM.
 - `channel` **bare post** (`{"channel":"<channel id>","message":"..."}`, optionally
   `thread`/`platform`) — publishes a visible message without waking an agent or
   addressing a human, as in case 2a / case 3.

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -480,7 +480,8 @@ const MULTI_INTEGRATION_NOTE =
 
 const SEND_MESSAGE_TARGET_HELP =
   'Valid targets: agent {"toAgent":"<agent-id>","message":"..."}; ' +
-  'user {"toUser":"<Slack-user-id>","message":"..."}; ' +
+  'user DM {"toUser":"<Slack-user-id>","message":"..."}; ' +
+  'channel users {"toUser":["<id-1>","<id-2>"],"channel":"<channel-id>","message":"..."}; ' +
   'channel {"channel":"<channel-id>","message":"..."}; ' +
   'session {"sessionId":"<Parent session>","message":"..."}'
 
@@ -727,7 +728,7 @@ export async function executeTool(
   // (post to a platform channel/user) and `messageAgent` (wake a peer agent), plus SessionTarget
   // replies. Universal (any agent — a memory-only agent can still wake a peer / reply), handled
   // before the platform-gateway gate. The tool takes exactly TWO addressing modes — `toAgent`
-  // (wake a peer agent) and `toUser` (reach a human) — each with THREE delivery forms: dm,
+  // (wake a peer agent) and `toUser` (reach humans) — each with THREE delivery forms: dm,
   // channel root, and in thread. `sessionId` stays a separate reply branch.
   // SECURITY: the caller identity + coords come from the trusted session context, never tool input.
   if (name === 'sendMessage') {
@@ -750,32 +751,35 @@ export async function executeTool(
       })
     }
 
-    // MessageTarget — exactly ONE target: `toAgent` wakes a peer agent, `toUser` reaches a
-    // platform user, and `channel` alone posts a bare visible message without addressing
+    // MessageTarget — exactly ONE target mode: `toAgent` wakes a peer agent, `toUser` reaches
+    // platform users, and `channel` alone posts a bare visible message without addressing
     // anyone. For the two recipient modes the delivery form is selected by the coords: no
     // `channel` ⇒ dm, `channel` without `thread` ⇒ channel root, `channel` + `thread` ⇒ in
     // thread. Branch-specific validation below keeps ignored/mixed fields out even when a
     // caller bypasses the advertised JSON Schema (as unit tests and older clients can).
     const { toAgent, needsReply } = parseAgentTarget(args.toAgent)
-    const toUser = optionalString(args, 'toUser')
+    const toUsers = parseUserTargets(args.toUser)
     const channel = optionalString(args, 'channel')
-    if (toAgent === undefined && toUser === undefined && channel === undefined) {
+    if (toAgent === undefined && toUsers === undefined && channel === undefined) {
       throw new Error(
         `sendMessage: \`toAgent\`, \`toUser\`, or \`channel\` must select the target. ${SEND_MESSAGE_TARGET_HELP}`
       )
     }
-    if (toAgent !== undefined && toUser !== undefined) {
+    if (toAgent !== undefined && toUsers !== undefined) {
       throw new Error(
         `sendMessage: \`toAgent\` and \`toUser\` are mutually exclusive — pick one mode. ${SEND_MESSAGE_TARGET_HELP}`
       )
     }
     if (toAgent !== undefined) assertOnlyKeys(args, ['toAgent', 'channel', 'thread', 'message'], 'agent target')
-    else if (toUser !== undefined) {
+    else if (toUsers !== undefined) {
       assertOnlyKeys(args, ['toUser', 'channel', 'thread', 'platform', 'integrationId', 'message'], 'user target')
     } else {
       assertOnlyKeys(args, ['channel', 'thread', 'platform', 'integrationId', 'message'], 'channel target')
     }
-    if (toUser !== undefined && channel === undefined && optionalString(args, 'thread') !== undefined) {
+    if (toUsers !== undefined && channel === undefined && Array.isArray(args.toUser)) {
+      throw new Error('sendMessage: a `toUser` array requires `channel` — direct messages accept exactly one user id')
+    }
+    if (toUsers !== undefined && channel === undefined && optionalString(args, 'thread') !== undefined) {
       throw new Error('sendMessage: `thread` needs a `channel` — a DM has no thread to post into')
     }
 
@@ -828,23 +832,23 @@ export async function executeTool(
     let postedThread: string | undefined
     // Destination: an explicit `channel` (channel-root / in-thread forms), else the `toUser`
     // DM form targets the user id itself.
-    const postChannel = channel ?? (toUser !== undefined ? toUser : undefined)
+    const postChannel = channel ?? toUsers?.[0]
     if (postChannel !== undefined && wakeRejection === null) {
-      const directMessage = toUser !== undefined && channel === undefined
+      const directMessage = toUsers !== undefined && channel === undefined
       const wantPlatform = optionalString(args, 'platform') ?? (directMessage ? 'slack' : ctx.platform)
       const wantIntegrationId = optionalString(args, 'integrationId')
       const { gw, integrationId: targetId } = resolveGatewayForPlatform(ctx, deps, wantPlatform, wantIntegrationId)
       const thread = optionalString(args, 'thread') || undefined
       let body = message
-      if (toUser !== undefined) {
+      if (toUsers !== undefined) {
         if (wantPlatform !== 'slack') {
           throw new Error(`sendMessage: toUser is only supported on Slack (not ${wantPlatform}) yet`)
         }
-        // dm form: the user id IS the destination and the body is unchanged; the channel-root /
-        // in-thread forms @-mention the user inside the visible post.
+        // dm form: the one user id IS the destination and the body is unchanged; the channel-root /
+        // in-thread forms @-mention every named user inside the one visible post.
         if (channel !== undefined) {
-          const mention = /^<@[^>]+>$/.test(toUser) ? toUser : `<@${toUser}>`
-          body = `${mention} ${message}`
+          const mentions = toUsers.map((user) => (/^<@[^>]+>$/.test(user) ? user : `<@${user}>`))
+          body = `${mentions.join(' ')} ${message}`
         }
       }
       const identity: SendIdentity = {
@@ -1214,6 +1218,25 @@ function parseAgentTarget(value: unknown): { toAgent?: string; needsReply?: bool
     throw new Error('sendMessage: `toAgent.needsReply` must be a boolean')
   }
   return { toAgent: requireString(target, 'agentId'), ...(needsReply === true ? { needsReply: true } : {}) }
+}
+
+/** Normalize `toUser`: one id works for every delivery form; a non-empty array is reserved
+ * for one visible channel-root / in-thread post that @-mentions every listed Slack member. */
+function parseUserTargets(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined
+  const users = typeof value === 'string' ? [value] : value
+  if (!Array.isArray(users)) {
+    throw new Error('sendMessage: `toUser` must be a user id string or a non-empty array of user id strings')
+  }
+  if (users.length === 0 || users.some((user) => typeof user !== 'string' || user.trim().length === 0)) {
+    throw new Error('sendMessage: `toUser` must be a user id string or a non-empty array of user id strings')
+  }
+  const ids = users as string[]
+  const canonicalIds = ids.map((id) => /^<@([^>]+)>$/.exec(id)?.[1] ?? id)
+  if (new Set(canonicalIds).size !== canonicalIds.length) {
+    throw new Error('sendMessage: `toUser` must not contain duplicate user ids')
+  }
+  return ids
 }
 
 function assertOnlyKeys(args: Record<string, unknown>, allowed: readonly string[], target: string): void {

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -178,23 +178,40 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
     )
   }
 
-  // Mode 2 — toUser: reach one human platform member. Forms: dm (no channel — Slack DM),
-  // channel root (channel, no thread — @-mention at root), in thread (channel + thread —
-  // @-mention inside the thread).
+  // Mode 2 — toUser: reach one or more human platform members. DM stays singular (one string,
+  // no channel); channel-root / in-thread sends accept either one id or an array and @-mention
+  // every named user in the one visible post.
   const userTarget = {
-    title: 'toUser — send to a platform user',
+    title: 'toUser — send to platform users',
     description:
-      'Deliver to one human platform member, with three forms: dm (`{"toUser":"<id>","message":"..."}`) ' +
-      'direct-messages that user (Slack only for now); channel root ' +
-      '(`{"toUser":"<id>","channel":"<C>","message":"..."}`) posts at the channel root and @-mentions the user; in ' +
-      'thread (`{"toUser":"<id>","channel":"<C>","thread":"<T>","message":"..."}`) posts into that thread and ' +
-      '@-mentions the user there.',
+      'Reach human platform members (Slack only for now). The dm form takes exactly one id ' +
+      '(`{"toUser":"<id>","message":"..."}`). The channel root and in thread forms accept either one id or a ' +
+      'non-empty id array; `{"toUser":["<id-1>","<id-2>"],"channel":"<C>","message":"..."}` posts one ' +
+      'message that @-mentions every listed user. Add `thread` to post those mentions inside that thread.',
     ...obj(
       {
         toUser: {
-          type: 'string',
-          minLength: 1,
-          description: 'Platform member id to reach, such as Slack `U0123ABC`.'
+          description:
+            'One platform member id, or a non-empty array of unique ids for a channel-root / in-thread post. ' +
+            'An array is not a group DM: it requires `channel` and @-mentions all listed users in one message.',
+          oneOf: [
+            {
+              type: 'string',
+              minLength: 1,
+              description: 'One platform member id, such as Slack `U0123ABC`.'
+            },
+            {
+              type: 'array',
+              minItems: 1,
+              uniqueItems: true,
+              items: {
+                type: 'string',
+                minLength: 1
+              },
+              description:
+                'Platform member ids to @-mention together. Valid only when `channel` is also supplied; never a DM.'
+            }
+          ]
         },
         channel,
         thread,
@@ -253,8 +270,8 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
   return {
     name: 'sendMessage',
     description: collaboration
-      ? 'Send one message to exactly one target: a peer agent (`toAgent`), a human (`toUser`), a channel with no ' +
-        'recipient, or the parent-session reply. The two recipient modes each have three forms: dm / channel root / ' +
+      ? 'Send one message using exactly one target mode: a peer agent (`toAgent`), human users (`toUser`), a channel ' +
+        'with no recipient, or the parent-session reply. The two recipient modes each have three forms: dm / channel root / ' +
         'in thread. Your own turn reply already reaches the conversation you are in, so use this tool only for what ' +
         'that reply cannot do: a different conversation, a human, a peer agent, or a parent-session reply.\n' +
         '- toAgent — wake exactly one peer agent (id from listAgents; never a platform member id):\n' +
@@ -265,12 +282,11 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'posts into that thread and reuses it for the peer.\n' +
         '  Use `{"toAgent":{"agentId":"<agent id>","needsReply":true},"message":"..."}` to have the peer report back ' +
         'when it finishes or fails; pass the returned `childSessionId` to `viewSessionStatus` to check on it.\n' +
-        '- toUser — reach one human (Slack only for now):\n' +
+        '- toUser — reach human users (Slack only for now):\n' +
         '  • dm: `{"toUser":"<Slack user id>","message":"..."}` — direct message; do not set `channel`.\n' +
-        '  • channel root: `{"toUser":"<Slack user id>","channel":"<channel id>","message":"..."}` — posts at the ' +
-        'channel root and @-mentions the user.\n' +
-        '  • in thread: `{"toUser":"<Slack user id>","channel":"<channel id>","thread":"<thread id>","message":"..."}` — ' +
-        'posts into that thread and @-mentions the user there.\n' +
+        '  • channel root: `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}` — ' +
+        'posts once at the channel root and @-mentions every listed user; a single id string also works.\n' +
+        '  • in thread: add `"thread":"<thread id>"` to that channel form to post all mentions inside the thread.\n' +
         '- Channel (bare post, no recipient): `{"channel":"<channel id>","message":"..."}` — posts to the channel ' +
         'without waking anyone or @-mentioning anyone; add `platform`, `thread`, or `integrationId` only when needed.\n' +
         '- Parent session reply: `{"sessionId":"<Parent session>","message":"..."}` — relay an answer back to whoever ' +
@@ -278,12 +294,13 @@ function buildSendMessageTool(platforms: string[], collaboration = true): ToolDe
         'A channel-root post (no `thread`) opens a NEW session of your own on that post; an explicit `thread` ' +
         'continues the existing conversation. Write `message` as CommonMark/GFM. The daemon supplies your identity; ' +
         'you cannot impersonate anyone or wake yourself.'
-      : 'Post one visible message to exactly one channel or human. Your own turn reply already reaches the ' +
+      : 'Post one visible message to exactly one channel or a set of human recipients. Your own turn reply already reaches the ' +
         'conversation you are in, so use this tool only for what that reply cannot do: a different conversation or a ' +
         'human. Use `{"channel":"<channel id>","message":"..."}` for a bare channel post, ' +
-        '`{"toUser":"<Slack user id>","message":"..."}` for a DM, or `{"toUser":"<Slack user id>","channel":"<channel ' +
-        'id>","message":"..."}` for a channel-root post that @-mentions the user; add `"thread":"<thread id>"` to ' +
-        'post into that thread instead. A channel-root post opens a NEW session of your own on that post. Peer-agent ' +
+        '`{"toUser":"<Slack user id>","message":"..."}` for a DM, or `{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel ' +
+        'id>","message":"..."}` for a channel-root post that @-mentions every listed user; a single id also works, ' +
+        'and adding `"thread":"<thread id>"` posts into that thread instead. A channel-root post opens a NEW session ' +
+        'of your own on that post. Peer-agent ' +
         'and parent-session delivery are disabled for this run. Write `message` as CommonMark/GFM. The daemon ' +
         'supplies your identity; you cannot impersonate anyone.',
     inputSchema: unionOf(

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -651,7 +651,7 @@ export class SessionManager {
     ].join('\n')
 
     // Standing guidance for agent↔agent collaboration. `sendMessage` has two modes — `toAgent`
-    // (wake a peer) and `toUser` (reach a human) — each with three forms: dm / channel root /
+    // (wake a peer) and `toUser` (reach humans) — each with three forms: dm / channel root /
     // in thread. `toAgent` without a `channel` (dm form) is the postless, channel-invisible wake.
     const collabAppend =
       this.deps.collaborationEnabled === false
@@ -663,9 +663,11 @@ export class SessionManager {
           `(\`{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}\`, channel-root form) ` +
           `to ALSO post a visible message there and thread that agent's reply under it; add ` +
           `\`"thread":"<thread id>"\` (in-thread form) to post into a specific thread instead. Use these when the ` +
-          `hand-off should be visible to people in the channel. To reach a human, use the \`toUser\` mode: ` +
-          `\`{"toUser":"<Slack user id>","message":"..."}\` DMs them, and adding \`channel\` (and optionally ` +
-          `\`thread\`) posts an @-mention at the channel root (or inside that thread). If you were woken by another ` +
+          `hand-off should be visible to people in the channel. To reach humans, use the \`toUser\` mode: ` +
+          `\`{"toUser":"<Slack user id>","message":"..."}\` DMs that person, and adding \`channel\` (and optionally ` +
+          `\`thread\`) posts an @-mention at the channel root (or inside that thread). In those channel forms, pass ` +
+          `an array such as \`"toUser":["<user id 1>","<user id 2>"]\` to @-mention multiple people in the one ` +
+          `message; arrays are never DMs. If you were woken by another ` +
           `session, reply with \`{"sessionId":"<Parent session>","message":"..."}\`. To leave a visible note others ` +
           `catch up on later without waking anyone, use \`{"channel":"<channel id>","message":"..."}\`.\n` +
           `- Act only on what is asked of YOU. Do not relay a message onward or start your own broadcast to other ` +

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -946,6 +946,58 @@ describe('executeTool: sendMessage (wake / reply)', () => {
     expect(res.post).toMatchObject({ channel: 'C1', thread: null })
   })
 
+  it('toUser array plus channel posts one message mentioning every listed user', async () => {
+    const { deps: d, gw, recorded } = wakeDeps()
+    const res = (await executeTool(
+      ctx,
+      'sendMessage',
+      {
+        toUser: ['U1', '<@U2>'],
+        channel: 'C1',
+        message: 'please review'
+      },
+      d
+    )) as { post?: { channel: string; thread: string | null } }
+    expect(gw.postMessage).toHaveBeenCalledWith('C1', '<@U1> <@U2> please review', undefined, authorIdentity)
+    expect(recorded.at(-1)).toMatchObject({ channel: 'C1', text: '<@U1> <@U2> please review' })
+    expect(res.post).toMatchObject({ channel: 'C1', thread: null })
+  })
+
+  it('toUser array plus channel and thread mentions everyone inside that thread', async () => {
+    const { deps: d, gw } = wakeDeps()
+    await executeTool(
+      ctx,
+      'sendMessage',
+      {
+        toUser: ['U1', 'U2'],
+        channel: 'C1',
+        thread: '222.2',
+        message: 'please review'
+      },
+      d
+    )
+    expect(gw.postMessage).toHaveBeenCalledWith('C1', '<@U1> <@U2> please review', '222.2', authorIdentity)
+  })
+
+  it('rejects a toUser array without channel instead of treating it as a group DM', async () => {
+    const { deps: d, gw } = wakeDeps()
+    await expect(executeTool(ctx, 'sendMessage', { toUser: ['U1', 'U2'], message: 'x' }, d)).rejects.toThrow(
+      /array requires `channel`/
+    )
+    expect(gw.postMessage).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { toUser: [], label: 'empty array' },
+    { toUser: ['U1', ''], label: 'empty member id' },
+    { toUser: ['U1', 42], label: 'non-string member id' },
+    { toUser: ['U1', '<@U1>'], label: 'duplicate member id' }
+  ])('rejects an invalid toUser $label before posting', async ({ toUser }) => {
+    const { deps: d, gw } = wakeDeps()
+    await expect(executeTool(ctx, 'sendMessage', { toUser, channel: 'C1', message: 'x' }, d)).rejects.toThrow(/toUser/)
+    expect(gw.postMessage).not.toHaveBeenCalled()
+  })
+
   it('rejects `thread` on a toUser DM — a DM has no thread to post into', async () => {
     const { deps: d } = wakeDeps()
     await expect(executeTool(ctx, 'sendMessage', { toUser: 'U1', thread: '222.2', message: 'x' }, d)).rejects.toThrow(

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -19,7 +19,7 @@ describe('toolsForIntegrations', () => {
   type ObjectSchema = {
     type?: string
     description?: string
-    properties: Record<string, { enum?: string[]; description?: string }>
+    properties: Record<string, { enum?: string[]; description?: string; oneOf?: Record<string, unknown>[] }>
     required?: string[]
     additionalProperties?: boolean
     oneOf?: ObjectSchema[]
@@ -121,6 +121,10 @@ describe('toolsForIntegrations', () => {
     expect(user.description).toContain('dm')
     expect(user.description).toContain('channel root')
     expect(user.description).toContain('in thread')
+    expect(user.properties.toUser!.oneOf).toMatchObject([
+      { type: 'string', minLength: 1 },
+      { type: 'array', minItems: 1, uniqueItems: true, items: { type: 'string', minLength: 1 } }
+    ])
 
     const channel = sendTargetBranch([slackInt], 'channel')
     expect(channel.required).toEqual(['channel', 'message'])
@@ -133,11 +137,13 @@ describe('toolsForIntegrations', () => {
     expect(session.additionalProperties).toBe(false)
     expect(Object.keys(session.properties)).toEqual(['sessionId', 'correlationId', 'message'])
 
-    expect(tool.description).toMatch(/^Send one message to exactly one target:/)
+    expect(tool.description).toMatch(/^Send one message using exactly one target mode:/)
     expect(tool.description).toContain('{"toAgent":"<agent id>","message":"..."}')
     expect(tool.description).toContain('{"toAgent":"<agent id>","channel":"<channel id>","message":"..."}')
     expect(tool.description).toContain('{"toUser":"<Slack user id>","message":"..."}')
-    expect(tool.description).toContain('{"toUser":"<Slack user id>","channel":"<channel id>","message":"..."}')
+    expect(tool.description).toContain(
+      '{"toUser":["<user id 1>","<user id 2>"],"channel":"<channel id>","message":"..."}'
+    )
     expect(tool.description).toContain('{"channel":"<channel id>","message":"..."}')
     expect(tool.description).toContain('{"sessionId":"<Parent session>","message":"..."}')
   })
@@ -165,10 +171,10 @@ describe('toolsForIntegrations', () => {
     for (const text of [description, sendTargetBranch([slackInt], 'channel').description!])
       expect(text).toMatch(/(at )?channel root/i)
 
-    // …and the toUser mode is not DM-only: its channel-root and in-thread forms post a visible
-    // @-mention, which is a legitimate reason to send into a conversation the agent is in.
-    expect(description).toContain('@-mentions the user')
-    expect(sendTargetBranch([slackInt], 'toUser').description).toContain('@-mentions the user')
+    // …and the toUser mode is not DM-only: its channel-root and in-thread forms post visible
+    // @-mentions, which is a legitimate reason to send into a conversation the agent is in.
+    expect(description).toContain('@-mentions every listed user')
+    expect(sendTargetBranch([slackInt], 'toUser').description).toContain('@-mentions every listed user')
 
     // Collaboration off leaves only the visible platform targets, so the channel-root cost must
     // still be stated there (spawnChannelRootSession runs either way).

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1613,6 +1613,7 @@ describe('SessionManager — collaboration preamble', () => {
     expect(first).toContain('{"toAgent":"<agent id>","message":"..."}')
     expect(first).toContain('{"sessionId":"<Parent session>","message":"..."}')
     expect(first).toContain('{"toUser":"<Slack user id>","message":"..."}')
+    expect(first).toContain('"toUser":["<user id 1>","<user id 2>"]')
     expect(first).not.toContain('`to.toAgent`')
     expect(first).not.toContain('`to.sessionId`')
     expect(first).not.toContain('`messageAgent`')


### PR DESCRIPTION
## What changed

- allow `sendMessage.toUser` to accept a non-empty array of unique Slack member IDs for channel-root and in-thread sends
- prepend every requested mention to one visible Slack message, while preserving the existing single-string form
- keep direct messages singular: a `toUser` array without `channel` is rejected instead of being treated as a group DM
- reject empty arrays, blank or non-string entries, and duplicate IDs before dispatch
- update the tool schema, agent guidance, product conventions, design documentation, and focused coverage

## Why

A channel message often needs to notify several people at once. The previous `toUser` contract allowed only one mention, forcing multiple posts or manual mention text. A recipient array makes this explicit while keeping DM semantics unambiguous.

## Impact

Existing calls such as `{"toUser":"U1","channel":"C1","message":"..."}` remain valid. Channel and thread sends can now use `{"toUser":["U1","U2"],"channel":"C1","message":"..."}` and produce one message prefixed with `<@U1> <@U2>`.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/mcp-tools.test.ts test/mcp-ops.test.ts test/session-manager.test.ts test/mcp-bridge-e2e.test.ts test/mcp-control-server.test.ts` — 197 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- ESLint and Prettier checks on the changed files
- pre-push full-repository ESLint
- full daemon suite: 2,542 passed; one parallel-only GitHub attribution timeout passed when rerun alone; two unchanged `git-injection.test.ts` cases still fail under the current host Git environment