### PR TITLE
fix(daemon): shorten GitHub PR session titles

### DIFF
--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -66,9 +66,9 @@ function githubSessionTitle(msg: RdMsgHook): string | undefined {
     msg.github?.subjectKind ??
     (context.event?.startsWith('pull_request') ? 'pull_request' : context.event === 'issues' ? 'issue' : undefined)
   const label = subjectKind === 'pull_request' ? 'PR' : subjectKind === 'issue' ? 'Issue' : 'GitHub'
-  const repo = msg.github?.repoFullName ?? context.repo
   const number = subjectKind === 'pull_request' ? (msg.github?.pullNumber ?? context.number) : context.number
-  const target = `${repo ?? ''}${number !== undefined ? `#${number}` : ''}`
+  const repo = subjectKind === 'pull_request' ? '' : (msg.github?.repoFullName ?? context.repo ?? '')
+  const target = `${repo}${number !== undefined ? `#${number}` : ''}`
   const prefix = target ? `${label} ${target}` : label
   const detail = context.title?.replace(/\s+/g, ' ').trim()
   return clampSessionTitle(detail ? `${prefix}: ${detail}` : prefix)

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -194,7 +194,7 @@ describe('Daemon rd/msg hook fires', () => {
     expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
     await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1))
     expect((daemon as any).store.getSessionByAcpId('acp-hook-1')).toMatchObject({
-      title: 'PR agentconnect-md/agentconnect#144: perf(github): speed up review delivery',
+      title: 'PR #144: perf(github): speed up review delivery',
       transportScope: 'github:123'
     })
     expect(cp.sessionEvents.at(-1)?.externalOrigin).toEqual({
@@ -1720,7 +1720,7 @@ describe('buildHookMessage', () => {
         ),
         'trace-pr'
       )
-      expect(pullRequest.initialSessionTitle).toBe('PR acme/infra#144: db down')
+      expect(pullRequest.initialSessionTitle).toBe('PR #144: db down')
 
       const long = buildHookMessage(ghFire({ title: 'x'.repeat(100) }), 'trace-long').initialSessionTitle!
       expect([...long]).toHaveLength(80)


### PR DESCRIPTION
## Summary

- Shorten default GitHub pull-request session titles from `PR owner/repo#144: …` to `PR #144: …`.
- Keep the repository identity in the Integration metadata and leave Issue session titles unchanged.

## Why

The repository is already shown in the Integration column, so repeating it in the session title crowds out the PR subject.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-hook.test.ts -t "builds concise structured titles for GitHub subjects"`
- `pnpm exec eslint packages/daemon/src/messages/hook-message.ts packages/daemon/test/daemon-hook.test.ts`
- `pnpm exec prettier --check packages/daemon/src/messages/hook-message.ts packages/daemon/test/daemon-hook.test.ts`
- Pre-push `eslint .`

Created by Codex . GPT-5
