### PR TITLE
fix(daemon): harden workspace skill installation

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -60,6 +60,7 @@
     "fflate": "^0.8.3",
     "grammy": "^1.45.1",
     "simple-git": "^3.36.0",
+    "skills": "1.5.21",
     "systeminformation": "^5.33.1",
     "undici": "^7.29.0",
     "ws": "^8.21.1",

--- a/packages/daemon/scripts/assert-self-contained.mjs
+++ b/packages/daemon/scripts/assert-self-contained.mjs
@@ -13,15 +13,21 @@ import { readFileSync } from 'node:fs'
 const bundlePath = new URL('../dist/index.js', import.meta.url)
 const bundle = readFileSync(bundlePath, 'utf8')
 
-// Any static `import ... from '@agentconnect.md/x'` / `export ... from '...'`
-// left in the bundle means a workspace package wasn't inlined. These are never
-// published as deps, so they are unresolvable at runtime.
-const leaked = [...bundle.matchAll(/\bfrom\s*["'](@agentconnect\.md\/[^"']+)["']/g)].map((m) => m[1])
+// These packages must be embedded because the published manifest has no runtime
+// dependencies. Cover both static imports and the dynamic import used by the
+// daemon's hidden, exact-pinned skills CLI entry.
+const specs = [
+  ...bundle.matchAll(/\bfrom\s*["']([^"']+)["']/g),
+  ...bundle.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g)
+].map((match) => match[1])
+const leaked = specs.filter(
+  (spec) => spec.startsWith('@agentconnect.md/') || spec === 'skills' || spec.startsWith('skills/')
+)
 
 if (leaked.length > 0) {
   const unique = [...new Set(leaked)].sort()
   console.error(
-    '✗ daemon bundle is not self-contained — these workspace imports were left external:\n' +
+    '✗ daemon bundle is not self-contained — these required imports were left external:\n' +
       unique.map((s) => `    ${s}`).join('\n') +
       '\n  tsdown must inline them. Ensure workspace deps are built before tsdown runs\n' +
       "  (the build's `pnpm --filter '{.}^...' build` step needs `dependencies` intact).\n"
@@ -29,4 +35,4 @@ if (leaked.length > 0) {
   process.exit(1)
 }
 
-console.log('✓ daemon bundle is self-contained (no external @agentconnect.md/* imports)')
+console.log('✓ daemon bundle is self-contained (workspace packages and skills CLI are bundled)')

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -202,8 +202,8 @@ export const AgentSchema = z.object({
   // at ACP session/new|load, after the daemon's own bridge entry. Empty ⇒ none;
   // unknown names are skipped with a warn (see mcp/resolve-servers.ts).
   mcpServers: z.array(z.string()).default([]),
-  // Skill sources to install into the workspace via `npx skills` after clone and
-  // before the ACP host spawns (design: docs/designs/shared-skills.md). CP-owned,
+  // Skill sources to install into the workspace via the daemon-bundled `skills`
+  // CLI after clone and before the ACP host spawns (design: docs/designs/shared-skills.md). CP-owned,
   // shipped inline on AgentSpec.skills — each entry is self-contained so the daemon
   // needs nothing but agent.json to install. Supersedes the deprecated
   // `workspace.skills` string list below (which is now an unused no-op).

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14942,7 +14942,7 @@ export class Daemon {
               await this.flushReconcile()
               return { ok: false, reason: `agent/activate: ${capabilityError}` }
             }
-            let rollbackPreparedWorkspace: (() => void) | undefined
+            let rollbackPreparedWorkspace: (() => Promise<void>) | undefined
             if (activate.prepareWorkspace || activate.reconcileWorkspace) {
               try {
                 rollbackPreparedWorkspace = await prepareWorkspaceForActivation(agent, {
@@ -14965,7 +14965,7 @@ export class Daemon {
               this.moveStagedAgents.add(agentId)
               await this.stopHost(agentId).catch(() => {})
               try {
-                rollbackPreparedWorkspace?.()
+                await rollbackPreparedWorkspace?.()
               } catch (rollbackErr) {
                 this.log.error(
                   `agent/activate: failed to roll workspace back for "${agentId}": ${formatErr(rollbackErr)}`
@@ -14979,7 +14979,7 @@ export class Daemon {
             } catch (err) {
               await this.stopHost(agentId).catch(() => {})
               try {
-                rollbackPreparedWorkspace?.()
+                await rollbackPreparedWorkspace?.()
               } catch (rollbackErr) {
                 this.log.error(
                   `agent/activate: failed to roll workspace back for "${agentId}": ${formatErr(rollbackErr)}`

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { startDaemonOpenTelemetry } from './observability.js'
+import { SKILLS_CLI_VERSION } from './skills/version.js'
 import { DAEMON_VERSION } from './version.js'
 
 // Internal per-ACP-host SRT provider. Fast-path it before telemetry/Commander:
@@ -8,6 +9,24 @@ import { DAEMON_VERSION } from './version.js'
 if (process.argv[2] === '__sandbox-runtime') {
   const { runSandboxRuntimeProvider } = await import('./acp/sandbox-runtime-provider.js')
   process.exit(await runSandboxRuntimeProvider(process.argv.slice(3)))
+}
+
+// Internal, exact-pinned skills installer. The daemon launches this hidden
+// command with its own Node entry instead of `npx`, so an agent-controlled
+// workspace cannot shadow the trusted CLI with `node_modules/.bin/skills`.
+// Remove the internal selector before loading the upstream CLI: it reads
+// `process.argv.slice(2)` and owns process exit after the command completes.
+if (process.argv[2] === '__skills-cli') {
+  if (process.argv[3] === '--version' || process.argv[3] === '-v') {
+    console.log(SKILLS_CLI_VERSION)
+    process.exit(0)
+  }
+  process.argv.splice(2, 1)
+  await import('skills/dist/cli.mjs')
+  // The upstream module starts (but does not export/await) its async main and
+  // calls process.exit when that finishes. Keep this entry from falling through
+  // into the daemon CLI while that owned lifecycle is still running.
+  await new Promise<never>(() => undefined)
 }
 
 const telemetry = startDaemonOpenTelemetry({ serviceVersion: DAEMON_VERSION })

--- a/packages/daemon/src/skills/dream-skill-install.ts
+++ b/packages/daemon/src/skills/dream-skill-install.ts
@@ -14,7 +14,7 @@
  * So every path here goes through `fs/contained-path.ts`: components are walked
  * with `lstat` and a symlink is REFUSED rather than followed, each step is
  * re-checked against the workspace boundary, and files publish through an
- * exclusive temp + rename. Delegating to the `npx skills` installer would NOT
+ * exclusive temp + rename. Delegating to the bundled `skills` installer would NOT
  * have helped — process indirection changes who writes, not the authority or
  * the pathname containment.
  *

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -20,7 +20,7 @@ import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { existsSync, promises as fsp } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, relative } from 'node:path'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import type { AgentSkillEntry } from '@agentconnect.md/protocol'
@@ -51,6 +51,8 @@ const SKILL_ROOTS = ['.claude/skills', '.agents/skills'] as const
 
 interface WorkspaceRecord {
   fingerprint?: string
+  /** Canonical cwd used to confirm that this directory instance still exists. */
+  workspacePath?: string
   /** cwd-relative skill dirs this daemon created (for reconcile removal). */
   installed: string[]
 }
@@ -86,15 +88,24 @@ function fingerprint(runtime: string, agentId: string, entries: AgentSkillEntry[
 /** Bind private ownership state to one concrete workspace directory instance.
  * The canonical path catches cwd switches; dev+ino catches a materialization
  * replaced at the same path. The agent cannot forge this private marker. */
-async function workspaceIdentity(cwd: string): Promise<string> {
+interface WorkspaceIdentity {
+  id: string
+  path: string
+}
+
+function workspaceId(path: string, stat: import('node:fs').Stats): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ path, dev: String(stat.dev), ino: String(stat.ino) }))
+    .digest('hex')
+}
+
+async function workspaceIdentity(cwd: string): Promise<WorkspaceIdentity> {
   const canonical = await fsp.realpath(cwd)
   const stat = await fsp.lstat(canonical)
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new ContainedPathError('skills workspace is not a real directory')
   }
-  return createHash('sha256')
-    .update(JSON.stringify({ path: canonical, dev: String(stat.dev), ino: String(stat.ino) }))
-    .digest('hex')
+  return { id: workspaceId(canonical, stat), path: canonical }
 }
 
 function markerPath(stateDir: string): string {
@@ -150,9 +161,14 @@ async function readMarker(stateDir: string): Promise<Marker> {
   const workspaces: Record<string, WorkspaceRecord> = {}
   for (const [workspaceId, value] of Object.entries(raw.workspaces)) {
     if (!WORKSPACE_ID.test(workspaceId) || !value || typeof value !== 'object' || Array.isArray(value)) continue
-    const record = value as { fingerprint?: unknown; installed?: unknown }
+    const record = value as { fingerprint?: unknown; workspacePath?: unknown; installed?: unknown }
     workspaces[workspaceId] = {
       ...(typeof record.fingerprint === 'string' ? { fingerprint: record.fingerprint } : {}),
+      ...(typeof record.workspacePath === 'string' &&
+      isAbsolute(record.workspacePath) &&
+      !record.workspacePath.includes('\0')
+        ? { workspacePath: record.workspacePath }
+        : {}),
       installed: Array.isArray(record.installed)
         ? record.installed.filter((path): path is string => typeof path === 'string')
         : []
@@ -174,16 +190,29 @@ async function writeMarker(stateDir: string, marker: Marker): Promise<void> {
   )
 }
 
-/** Reserve one bounded private-state slot before invoking the CLI. Empty
- * records carry no deletion authority, so they are the only safe eviction
- * candidates. Refuse a new workspace rather than create untracked copies. */
-function ensureWorkspaceCapacity(marker: Marker, workspaceId: string): Marker {
-  if (marker.workspaces[workspaceId]) return marker
+/** Reserve one bounded private-state slot before invoking the CLI. A record is
+ * reclaimable when it owns nothing or its exact directory instance no longer
+ * exists. Refuse a new workspace rather than evict ownership from a live one. */
+async function ensureWorkspaceCapacity(marker: Marker, workspace: WorkspaceIdentity): Promise<Marker> {
+  if (marker.workspaces[workspace.id]) return marker
   const workspaces = { ...marker.workspaces }
   let size = Object.keys(workspaces).length
   for (const [id, record] of Object.entries(workspaces)) {
     if (size < MAX_WORKSPACE_RECORDS) break
-    if (record.installed.length > 0) continue
+    let reclaimable = record.installed.length === 0
+    if (!reclaimable && record.workspacePath) {
+      if (record.workspacePath === workspace.path) {
+        reclaimable = true
+      } else {
+        try {
+          const stat = await fsp.lstat(record.workspacePath)
+          reclaimable = !stat.isDirectory() || stat.isSymbolicLink() || workspaceId(record.workspacePath, stat) !== id
+        } catch (err) {
+          if (isErrno(err, 'ENOENT') || isErrno(err, 'ENOTDIR')) reclaimable = true
+        }
+      }
+    }
+    if (!reclaimable) continue
     delete workspaces[id]
     size -= 1
   }
@@ -390,15 +419,15 @@ export async function installSkills(
   const env = { GIT_TERMINAL_PROMPT: '0', ...process.env, ...opts.env, DISABLE_TELEMETRY: '1' }
 
   try {
-    const workspaceId = await workspaceIdentity(cwd)
-    const fp = fingerprint(agent.runtime, agentId ?? '', entries, workspaceId)
-    const marker = ensureWorkspaceCapacity(await readMarker(opts.stateDir), workspaceId)
+    const workspace = await workspaceIdentity(cwd)
+    const fp = fingerprint(agent.runtime, agentId ?? '', entries, workspace.id)
+    const marker = await ensureWorkspaceCapacity(await readMarker(opts.stateDir), workspace)
     // Create/validate the private marker parent before mutating the workspace.
     await containedTarget(opts.stateDir, join(opts.stateDir, MARKER_DIR), markerPath(opts.stateDir), {
       create: true,
       label: 'skills marker'
     })
-    const prior = marker.workspaces[workspaceId] ?? { installed: [] }
+    const prior = marker.workspaces[workspace.id] ?? { installed: [] }
     const priorTracked = prior.installed.filter(isTrackedSkillDir)
 
     // Validate existing roots before any reconcile operation. This rejects a
@@ -409,6 +438,12 @@ export async function installSkills(
     const targetsIntact = priorTracked.length === prior.installed.length && intact.every(Boolean)
     const cacheCoversDesired = entries.length === 0 || priorTracked.length > 0
     if (prior.fingerprint === fp && targetsIntact && cacheCoversDesired) {
+      if (prior.workspacePath !== workspace.path) {
+        await writeMarker(
+          opts.stateDir,
+          withWorkspaceRecord(marker, workspace.id, { ...prior, workspacePath: workspace.path })
+        )
+      }
       await removeLegacyMarker(cwd)
       result.skipped = 'unchanged'
       return result
@@ -433,8 +468,9 @@ export async function installSkills(
       }
       await writeMarker(
         opts.stateDir,
-        withWorkspaceRecord(marker, workspaceId, {
+        withWorkspaceRecord(marker, workspace.id, {
           ...(retained.length === 0 ? { fingerprint: fp } : {}),
+          workspacePath: workspace.path,
           installed: retained
         })
       )
@@ -487,8 +523,9 @@ export async function installSkills(
     const effective = retained.length === 0 && result.errors.length === 0 && created.length > 0
     await writeMarker(
       opts.stateDir,
-      withWorkspaceRecord(marker, workspaceId, {
+      withWorkspaceRecord(marker, workspace.id, {
         ...(effective ? { fingerprint: fp } : {}),
+        workspacePath: workspace.path,
         installed: [...new Set([...retained, ...created])]
       })
     )

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -47,6 +47,7 @@ const LOCAL_LOCK_FILE = 'skills-lock.json'
 const MAX_LOCAL_LOCK_BYTES = 1024 * 1024
 const MAX_WORKSPACE_RECORDS = 16
 const WORKSPACE_ID = /^[0-9a-f]{64}$/
+const WORKSPACE_GENERATION = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const SKILL_ROOTS = ['.claude/skills', '.agents/skills'] as const
 
 interface WorkspaceRecord {
@@ -58,6 +59,8 @@ interface WorkspaceRecord {
 }
 
 interface Marker {
+  /** Daemon-issued identity for the currently materialized workspace tree. */
+  generation?: string
   /** Ownership records keyed by daemon-computed workspace directory identity. */
   workspaces: Record<string, WorkspaceRecord>
 }
@@ -85,27 +88,24 @@ function fingerprint(runtime: string, agentId: string, entries: AgentSkillEntry[
     .digest('hex')
 }
 
-/** Bind private ownership state to one concrete workspace directory instance.
- * The canonical path catches cwd switches; dev+ino catches a materialization
- * replaced at the same path. The agent cannot forge this private marker. */
+/** Bind private ownership state to one cwd within a daemon-issued workspace
+ * generation. The agent cannot forge the generation in this private marker. */
 interface WorkspaceIdentity {
   id: string
   path: string
 }
 
-function workspaceId(path: string, stat: import('node:fs').Stats): string {
-  return createHash('sha256')
-    .update(JSON.stringify({ path, dev: String(stat.dev), ino: String(stat.ino) }))
-    .digest('hex')
+function workspaceId(generation: string, path: string): string {
+  return createHash('sha256').update(JSON.stringify({ generation, path })).digest('hex')
 }
 
-async function workspaceIdentity(cwd: string): Promise<WorkspaceIdentity> {
+async function workspaceIdentity(cwd: string, generation: string): Promise<WorkspaceIdentity> {
   const canonical = await fsp.realpath(cwd)
   const stat = await fsp.lstat(canonical)
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     throw new ContainedPathError('skills workspace is not a real directory')
   }
-  return { id: workspaceId(canonical, stat), path: canonical }
+  return { id: workspaceId(generation, canonical), path: canonical }
 }
 
 function markerPath(stateDir: string): string {
@@ -154,9 +154,11 @@ async function readMarker(stateDir: string): Promise<Marker> {
     throw new ContainedPathError('skills marker is not a regular file')
   }
   if (stat.size > MAX_MARKER_BYTES) throw new ContainedPathError('skills marker exceeds its size cap')
-  const raw = JSON.parse(await fsp.readFile(target, 'utf8')) as { workspaces?: unknown }
+  const raw = JSON.parse(await fsp.readFile(target, 'utf8')) as { generation?: unknown; workspaces?: unknown }
+  const generation =
+    typeof raw.generation === 'string' && WORKSPACE_GENERATION.test(raw.generation) ? raw.generation : undefined
   if (!raw.workspaces || typeof raw.workspaces !== 'object' || Array.isArray(raw.workspaces)) {
-    return { workspaces: {} }
+    return { ...(generation ? { generation } : {}), workspaces: {} }
   }
   const workspaces: Record<string, WorkspaceRecord> = {}
   for (const [workspaceId, value] of Object.entries(raw.workspaces)) {
@@ -177,7 +179,7 @@ async function readMarker(stateDir: string): Promise<Marker> {
       throw new ContainedPathError('skills marker has too many workspace records')
     }
   }
-  return { workspaces }
+  return { ...(generation ? { generation } : {}), workspaces }
 }
 
 async function writeMarker(stateDir: string, marker: Marker): Promise<void> {
@@ -188,6 +190,13 @@ async function writeMarker(stateDir: string, marker: Marker): Promise<void> {
     JSON.stringify(marker) + '\n',
     'skills marker'
   )
+}
+
+/** Invalidate every deletion grant before the daemon replaces a workspace
+ * tree. A random generation cannot alias a later directory through inode reuse. */
+export async function rotateSkillsWorkspaceGeneration(stateDir: string): Promise<void> {
+  await readMarker(stateDir)
+  await writeMarker(stateDir, { generation: randomUUID(), workspaces: {} })
 }
 
 /** Reserve one bounded private-state slot before invoking the CLI. A record is
@@ -206,7 +215,7 @@ async function ensureWorkspaceCapacity(marker: Marker, workspace: WorkspaceIdent
       } else {
         try {
           const stat = await fsp.lstat(record.workspacePath)
-          reclaimable = !stat.isDirectory() || stat.isSymbolicLink() || workspaceId(record.workspacePath, stat) !== id
+          reclaimable = !stat.isDirectory() || stat.isSymbolicLink()
         } catch (err) {
           if (isErrno(err, 'ENOENT') || isErrno(err, 'ENOTDIR')) reclaimable = true
         }
@@ -219,11 +228,11 @@ async function ensureWorkspaceCapacity(marker: Marker, workspace: WorkspaceIdent
   if (size >= MAX_WORKSPACE_RECORDS) {
     throw new ContainedPathError('skills ownership state is full')
   }
-  return { workspaces }
+  return { ...marker, workspaces }
 }
 
 function withWorkspaceRecord(marker: Marker, workspaceId: string, record: WorkspaceRecord): Marker {
-  return { workspaces: { ...marker.workspaces, [workspaceId]: record } }
+  return { ...marker, workspaces: { ...marker.workspaces, [workspaceId]: record } }
 }
 
 /** Only a direct child of a known project skill root can be daemon-owned. */
@@ -419,9 +428,16 @@ export async function installSkills(
   const env = { GIT_TERMINAL_PROMPT: '0', ...process.env, ...opts.env, DISABLE_TELEMETRY: '1' }
 
   try {
-    const workspace = await workspaceIdentity(cwd)
+    const loadedMarker = await readMarker(opts.stateDir)
+    const generation = loadedMarker.generation ?? randomUUID()
+    // Pre-generation records used reusable filesystem identities. Forget their
+    // deletion grants rather than risk applying one to a fresh materialization.
+    const generatedMarker = loadedMarker.generation
+      ? loadedMarker
+      : { generation, workspaces: {} as Record<string, WorkspaceRecord> }
+    const workspace = await workspaceIdentity(cwd, generation)
     const fp = fingerprint(agent.runtime, agentId ?? '', entries, workspace.id)
-    const marker = await ensureWorkspaceCapacity(await readMarker(opts.stateDir), workspace)
+    const marker = await ensureWorkspaceCapacity(generatedMarker, workspace)
     // Create/validate the private marker parent before mutating the workspace.
     await containedTarget(opts.stateDir, join(opts.stateDir, MARKER_DIR), markerPath(opts.stateDir), {
       create: true,

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -1,144 +1,320 @@
 /**
- * Install an agent's enabled skills into its workspace via `npx skills`
- * (docs/designs/shared-skills.md §6). Runs after the workspace is ready and
- * before the ACP session starts, so the runtime discovers the skills in its
- * project-scope directory (Claude: `<cwd>/.claude/skills`). The CLI owns the
- * per-runtime target layout — we only name the agent (`-a`).
+ * Install an agent's enabled skills into its workspace with the exact-pinned
+ * `skills` CLI bundled into the daemon (docs/designs/shared-skills.md §6).
+ * Runs after the workspace is ready and before the ACP session starts, so the
+ * runtime discovers skills in its project-scope directory.
  *
- * Non-blocking by contract: any failure (offline, missing CLI, bad source, a
- * runtime with no `npx skills` mapping) degrades to "no skill installed" and the
- * session still starts. Idempotent: a fingerprint marker in the workspace skips
- * the whole `npx` pass when the enabled set + runtime are unchanged, so the
- * common case costs one stat, not a network round-trip.
+ * The workspace is agent-writable across sessions while this installer runs
+ * with daemon authority. Consequently:
  *
- * Reconciling: `npx skills add` only ADDS, so disabling or narrowing a source
- * would leave stale skill copies the runtime keeps auto-discovering. The marker
- * records exactly the skill directories THIS daemon created; a changed run removes
- * those first (never touching manually-authored skills) before re-installing the
- * desired set — including the zero-desired case.
+ * - the CLI is launched through the daemon's own hidden entry, never `npx` or
+ *   project-local package resolution;
+ * - reconciliation state lives below the daemon-owned agent root, not `cwd`;
+ * - every workspace path the daemon removes or the CLI writes is checked with
+ *   no-follow containment first.
+ *
+ * Non-blocking by contract: a refused path, offline source, or unsupported
+ * runtime degrades to no newly installed skill and the session still starts.
  */
 import { execFile } from 'node:child_process'
-import { createHash } from 'node:crypto'
-import {
-  appendFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync
-} from 'node:fs'
-import { dirname, join } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import { existsSync, promises as fsp } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import type { AgentSkillEntry } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
+import { ContainedPathError, containedRemoveDir, containedTarget } from '../fs/contained-path.js'
 import { skillsAgentId } from './runtime-agent-map.js'
+import { SKILLS_CLI_VERSION } from './version.js'
 
-const execFileAsync = promisify(execFile)
+export { SKILLS_CLI_VERSION } from './version.js'
 
-// The `npx skills` package spec (design §6.2 — pinning guards against CLI drift).
-// Ops pin a specific version via AC_SKILLS_CLI (e.g. "skills@1.4.0" or a tarball
-// URL) without a code change; the default tracks latest. Trimmed + validated to a
-// plain package spec so the env value can't smuggle extra npx arguments.
-const DEFAULT_SKILLS_CLI_SPEC = 'skills'
-export function resolveSkillsCliSpec(env: NodeJS.ProcessEnv = process.env): string {
-  const raw = env.AC_SKILLS_CLI?.trim()
-  if (!raw || raw.startsWith('-') || /\s/.test(raw)) return DEFAULT_SKILLS_CLI_SPEC
-  return raw
-}
-// Per-source install budget. A wedged network fetch must not hold the session.
+type SkillsExec = (
+  file: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; timeout: number }
+) => Promise<unknown>
+
+const execFileAsync = promisify(execFile) as SkillsExec
+
 const INSTALL_TIMEOUT_MS = 20_000
 const MARKER_DIR = '.agentconnect'
 const MARKER_FILE = 'skills-install.json'
-// Project-scope skill roots the CLI writes into, relative to the ACP cwd: Claude
-// uses `.claude/skills`, the other supported agents (codex/cursor/opencode/gemini)
-// use `.agents/skills`. Both are watched for reconcile + git-excluded.
-const SKILL_ROOTS = ['.claude/skills', '.agents/skills']
+const MAX_MARKER_BYTES = 64 * 1024
+const LOCAL_LOCK_FILE = 'skills-lock.json'
+const MAX_LOCAL_LOCK_BYTES = 1024 * 1024
+const MAX_WORKSPACE_RECORDS = 16
+const WORKSPACE_ID = /^[0-9a-f]{64}$/
+const SKILL_ROOTS = ['.claude/skills', '.agents/skills'] as const
 
-interface Marker {
+interface WorkspaceRecord {
   fingerprint?: string
   /** cwd-relative skill dirs this daemon created (for reconcile removal). */
   installed: string[]
 }
 
-/** Compose the string handed to `npx skills add` from a skill entry, folding an
- *  optional ref/subDir into the GitHub `tree/<ref>/<subdir>` path form (design §5).
- *  A source that already carries a `tree/` path, or a non-GitHub URL, passes
- *  through untouched. */
+interface Marker {
+  /** Ownership records keyed by daemon-computed workspace directory identity. */
+  workspaces: Record<string, WorkspaceRecord>
+}
+
+function isErrno(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === code
+}
+
+/** Compose the string handed to `skills add` from a skill entry, folding an
+ * optional ref/subDir into the GitHub `tree/<ref>/<subdir>` path form. */
 export function composeSource(entry: AgentSkillEntry): string {
   const { source, ref, subDir } = entry
-  if (/\/tree\//.test(source)) return source // already pinned to a ref/path
+  if (/\/tree\//.test(source)) return source
   if (!ref && !subDir) return source
   const shorthand = /^[^/\s]+\/[^/\s]+$/.test(source)
   const base = shorthand ? `https://github.com/${source}` : source
-  if (!/^https?:\/\/github\.com\//i.test(base)) return source // only github supports the tree path form
+  if (!/^https?:\/\/github\.com\//i.test(base)) return source
   const suffix = subDir ? `/${subDir.replace(/^\/+/, '')}` : ''
   return `${base.replace(/\/+$/, '')}/tree/${ref ?? 'main'}${suffix}`
 }
 
-function fingerprint(runtime: string, agentId: string, entries: AgentSkillEntry[], cliSpec: string): string {
-  return createHash('sha256').update(JSON.stringify({ runtime, agentId, entries, cliSpec })).digest('hex')
+function fingerprint(runtime: string, agentId: string, entries: AgentSkillEntry[], workspaceId: string): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ runtime, agentId, entries, cliVersion: SKILLS_CLI_VERSION, workspaceId }))
+    .digest('hex')
 }
 
-function markerPath(cwd: string): string {
-  return join(cwd, MARKER_DIR, MARKER_FILE)
+/** Bind private ownership state to one concrete workspace directory instance.
+ * The canonical path catches cwd switches; dev+ino catches a materialization
+ * replaced at the same path. The agent cannot forge this private marker. */
+async function workspaceIdentity(cwd: string): Promise<string> {
+  const canonical = await fsp.realpath(cwd)
+  const stat = await fsp.lstat(canonical)
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new ContainedPathError('skills workspace is not a real directory')
+  }
+  return createHash('sha256')
+    .update(JSON.stringify({ path: canonical, dev: String(stat.dev), ino: String(stat.ino) }))
+    .digest('hex')
 }
 
-function readMarker(cwd: string): Marker {
+function markerPath(stateDir: string): string {
+  return join(stateDir, MARKER_DIR, MARKER_FILE)
+}
+
+async function atomicContainedWrite(
+  boundary: string,
+  root: string,
+  destination: string,
+  body: string,
+  label: string,
+  mode = 0o600
+): Promise<void> {
+  const target = await containedTarget(boundary, root, destination, { create: true, label })
+  if (!target) throw new ContainedPathError(`${label} could not be resolved`)
+  const temp = join(dirname(target), `.agentconnect-${randomUUID()}.tmp`)
   try {
-    const raw = JSON.parse(readFileSync(markerPath(cwd), 'utf8')) as { fingerprint?: unknown; installed?: unknown }
-    return {
-      ...(typeof raw.fingerprint === 'string' ? { fingerprint: raw.fingerprint } : {}),
-      installed: Array.isArray(raw.installed) ? raw.installed.filter((p): p is string => typeof p === 'string') : []
+    const handle = await fsp.open(temp, 'wx', mode)
+    try {
+      await handle.writeFile(body, 'utf8')
+    } finally {
+      await handle.close()
     }
-  } catch {
-    return { installed: [] }
+    await fsp.rename(temp, target)
+  } catch (err) {
+    await fsp.rm(temp, { force: true }).catch(() => undefined)
+    throw err
   }
 }
 
-function writeMarker(cwd: string, marker: Marker): void {
+async function readMarker(stateDir: string): Promise<Marker> {
+  const target = await containedTarget(stateDir, join(stateDir, MARKER_DIR), markerPath(stateDir), {
+    create: false,
+    label: 'skills marker'
+  })
+  if (!target) return { workspaces: {} }
+  let stat: import('node:fs').Stats
   try {
-    mkdirSync(join(cwd, MARKER_DIR), { recursive: true })
-    writeFileSync(markerPath(cwd), JSON.stringify(marker) + '\n')
-  } catch {
-    // A missing/stale marker only costs a redundant re-install next session — never fatal.
+    stat = await fsp.lstat(target)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return { workspaces: {} }
+    throw err
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new ContainedPathError('skills marker is not a regular file')
+  }
+  if (stat.size > MAX_MARKER_BYTES) throw new ContainedPathError('skills marker exceeds its size cap')
+  const raw = JSON.parse(await fsp.readFile(target, 'utf8')) as { workspaces?: unknown }
+  if (!raw.workspaces || typeof raw.workspaces !== 'object' || Array.isArray(raw.workspaces)) {
+    return { workspaces: {} }
+  }
+  const workspaces: Record<string, WorkspaceRecord> = {}
+  for (const [workspaceId, value] of Object.entries(raw.workspaces)) {
+    if (!WORKSPACE_ID.test(workspaceId) || !value || typeof value !== 'object' || Array.isArray(value)) continue
+    const record = value as { fingerprint?: unknown; installed?: unknown }
+    workspaces[workspaceId] = {
+      ...(typeof record.fingerprint === 'string' ? { fingerprint: record.fingerprint } : {}),
+      installed: Array.isArray(record.installed)
+        ? record.installed.filter((path): path is string => typeof path === 'string')
+        : []
+    }
+    if (Object.keys(workspaces).length > MAX_WORKSPACE_RECORDS) {
+      throw new ContainedPathError('skills marker has too many workspace records')
+    }
+  }
+  return { workspaces }
+}
+
+async function writeMarker(stateDir: string, marker: Marker): Promise<void> {
+  await atomicContainedWrite(
+    stateDir,
+    join(stateDir, MARKER_DIR),
+    markerPath(stateDir),
+    JSON.stringify(marker) + '\n',
+    'skills marker'
+  )
+}
+
+/** Reserve one bounded private-state slot before invoking the CLI. Empty
+ * records carry no deletion authority, so they are the only safe eviction
+ * candidates. Refuse a new workspace rather than create untracked copies. */
+function ensureWorkspaceCapacity(marker: Marker, workspaceId: string): Marker {
+  if (marker.workspaces[workspaceId]) return marker
+  const workspaces = { ...marker.workspaces }
+  let size = Object.keys(workspaces).length
+  for (const [id, record] of Object.entries(workspaces)) {
+    if (size < MAX_WORKSPACE_RECORDS) break
+    if (record.installed.length > 0) continue
+    delete workspaces[id]
+    size -= 1
+  }
+  if (size >= MAX_WORKSPACE_RECORDS) {
+    throw new ContainedPathError('skills ownership state is full')
+  }
+  return { workspaces }
+}
+
+function withWorkspaceRecord(marker: Marker, workspaceId: string, record: WorkspaceRecord): Marker {
+  return { workspaces: { ...marker.workspaces, [workspaceId]: record } }
+}
+
+/** Only a direct child of a known project skill root can be daemon-owned. */
+function isTrackedSkillDir(rel: string): boolean {
+  const match = /^(\.claude\/skills|\.agents\/skills)\/([^/]+)$/.exec(rel)
+  return match !== null && match[2] !== '.' && match[2] !== '..' && !match[2]!.includes('\0')
+}
+
+function trackedPath(cwd: string, rel: string): { root: string; target: string } {
+  const rootRel = rel.slice(0, rel.lastIndexOf('/'))
+  return {
+    root: join(cwd, ...rootRel.split('/')),
+    target: join(cwd, ...rel.split('/'))
   }
 }
 
-/** The marker lives inside `cwd`, so its recorded paths are untrusted input. Only a
- *  single non-dotted directory segment directly under a known skill root is a valid
- *  daemon-managed target; anything else (a `..` segment, an absolute path, a nested
- *  or dotted segment) is rejected so reconciliation only ever acts within a managed
- *  skill root. */
-function isTrackedSkillDir(rel: string): boolean {
-  const m = /^(\.claude\/skills|\.agents\/skills)\/([^/]+)$/.exec(rel)
-  if (!m) return false
-  const seg = m[2]!
-  return seg !== '.' && seg !== '..' && !seg.includes('\0')
+/** Resolve a skill root by walking every parent with lstat. Passing a synthetic
+ * child makes the root itself part of that walk, so a symlink at `.claude`,
+ * `.agents`, or `skills` is refused rather than followed. */
+async function safeSkillRoot(cwd: string, rootRel: (typeof SKILL_ROOTS)[number], create: boolean) {
+  const root = join(cwd, ...rootRel.split('/'))
+  const probe = await containedTarget(cwd, root, join(root, '.agentconnect-path-check'), {
+    create,
+    label: 'skill root'
+  })
+  return probe ? dirname(probe) : null
 }
 
-/** cwd-relative paths of the skill directories currently present under the CLI's
- *  project-scope roots. Used to diff before/after an install (what WE created) and
- *  to remove exactly our own copies on a later change. */
-function listSkillDirs(cwd: string): string[] {
-  const out: string[] = []
-  for (const root of SKILL_ROOTS) {
-    const abs = join(cwd, root)
+async function skillDirSnapshot(cwd: string): Promise<Map<string, string>> {
+  const out = new Map<string, string>()
+  for (const rootRel of SKILL_ROOTS) {
+    const root = await safeSkillRoot(cwd, rootRel, false)
+    if (!root) continue
     let entries: import('node:fs').Dirent[]
     try {
-      entries = readdirSync(abs, { withFileTypes: true })
-    } catch {
-      continue // root absent
+      entries = await fsp.readdir(root, { withFileTypes: true })
+    } catch (err) {
+      if (isErrno(err, 'ENOENT')) continue
+      throw err
     }
-    for (const e of entries) if (e.isDirectory()) out.push(`${root}/${e.name}`)
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const stat = await fsp.lstat(join(root, entry.name))
+      if (!stat.isDirectory() || stat.isSymbolicLink()) continue
+      // The pinned CLI replaces a target directory before copying. Tracking the
+      // inode/timestamps as well as new names lets the first private-marker pass
+      // adopt copies installed by an older daemon without reading its untrusted
+      // workspace marker.
+      out.set(`${rootRel}/${entry.name}`, `${stat.dev}:${stat.ino}:${stat.ctimeMs}:${stat.mtimeMs}`)
+    }
   }
   return out
 }
 
-/** Walk up from `cwd` to the repository root (the dir holding `.git`), so exclude
- *  patterns land in the real repo even when the ACP cwd is a nested `agentDir`.
- *  Returns undefined for a from-scratch workspace (no `.git` above cwd). */
+async function validateSkillRoots(cwd: string): Promise<void> {
+  for (const rootRel of SKILL_ROOTS) await safeSkillRoot(cwd, rootRel, false)
+}
+
+async function trackedTargetIntact(cwd: string, rel: string): Promise<boolean> {
+  const { root, target } = trackedPath(cwd, rel)
+  const resolved = await containedTarget(cwd, root, target, { create: false, label: 'skill path' })
+  if (!resolved) return false
+  try {
+    const stat = await fsp.lstat(resolved)
+    return stat.isDirectory() && !stat.isSymbolicLink()
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return false
+    throw err
+  }
+}
+
+/** `skills add` writes this project lock alongside the skill roots. Refuse a
+ * symlink, special file, hard link, or unbounded file before handing the path to
+ * the trusted CLI; the agent is not running concurrently with this prep step. */
+async function assertSafeLocalLock(cwd: string): Promise<void> {
+  const target = join(cwd, LOCAL_LOCK_FILE)
+  let stat: import('node:fs').Stats
+  try {
+    stat = await fsp.lstat(target)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return
+    throw err
+  }
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+    throw new ContainedPathError(`${LOCAL_LOCK_FILE} is not a private regular file`)
+  }
+  if (stat.size > MAX_LOCAL_LOCK_BYTES) throw new ContainedPathError(`${LOCAL_LOCK_FILE} exceeds its size cap`)
+}
+
+/** Remove the obsolete workspace marker only by unlinking its final entry. Its
+ * contents never influence ownership; a symlink parent is refused and ignored. */
+async function removeLegacyMarker(cwd: string): Promise<void> {
+  try {
+    const root = join(cwd, MARKER_DIR)
+    const target = await containedTarget(cwd, root, join(root, MARKER_FILE), {
+      create: false,
+      label: 'legacy skills marker'
+    })
+    if (!target) return
+    const stat = await fsp.lstat(target)
+    if (stat.isFile() || stat.isSymbolicLink()) await fsp.unlink(target)
+  } catch {
+    // Private state is already authoritative; legacy cleanup is cosmetic.
+  }
+}
+
+/** Source/dev runs through tsx; the published self-contained daemon re-enters
+ * its dist entry directly. Neither path consults the workspace's node_modules. */
+function skillsCliLauncher(): { cmd: string; args: string[] } {
+  const sourceEntry = fileURLToPath(new URL('../index.ts', import.meta.url))
+  if (existsSync(sourceEntry)) {
+    const req = createRequire(import.meta.url)
+    return { cmd: process.execPath, args: [req.resolve('tsx/cli'), sourceEntry] }
+  }
+  const entry = process.argv[1]
+  if (!entry) throw new Error('cannot locate the AgentConnect skills CLI entry')
+  return { cmd: process.execPath, args: [entry] }
+}
+
+/** Walk up to the repository root so exclude patterns work for a nested ACP cwd. */
 function findRepoRoot(cwd: string): string | undefined {
   let dir = cwd
   for (;;) {
@@ -149,32 +325,37 @@ function findRepoRoot(cwd: string): string | undefined {
   }
 }
 
-/** Keep installed skill dirs (and the marker) out of a git-repo workspace's tracked
- *  tree so the agent's `git status` stays clean. Excludes at the repo root (not the
- *  possibly-nested cwd), covering both `.claude/skills` and `.agents/skills`.
- *  Best-effort; from-scratch workspaces have no `.git` and are skipped. */
-function excludeFromGit(cwd: string): void {
+/** Cosmetic only, but still a daemon-authority write into an agent-writable repo.
+ * Use the same no-follow + atomic publish discipline as correctness state. */
+async function excludeFromGit(cwd: string): Promise<void> {
   const repoRoot = findRepoRoot(cwd)
-  if (repoRoot === undefined) return
+  if (!repoRoot) return
   const gitPath = join(repoRoot, '.git')
-  // A linked worktree has `.git` as a file pointing elsewhere; skip (cosmetic only).
   try {
-    if (!statSync(gitPath).isDirectory()) return
+    const gitStat = await fsp.lstat(gitPath)
+    if (!gitStat.isDirectory() || gitStat.isSymbolicLink()) return // linked worktree or refused link
+    const info = join(gitPath, 'info')
+    const exclude = join(info, 'exclude')
+    const target = await containedTarget(repoRoot, info, exclude, { create: true, label: 'git exclude' })
+    if (!target) return
+    let current = ''
+    try {
+      const stat = await fsp.lstat(target)
+      if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > MAX_LOCAL_LOCK_BYTES) return
+      current = await fsp.readFile(target, 'utf8')
+    } catch (err) {
+      if (!isErrno(err, 'ENOENT')) return
+    }
+    const prefix = relative(repoRoot, cwd)
+    const rooted = prefix ? `${prefix}/` : ''
+    const want = [...SKILL_ROOTS.map((root) => `${rooted}${root}/`), `${rooted}${MARKER_DIR}/`]
+    const lines = new Set(current.split(/\r?\n/))
+    const missing = want.filter((entry) => !lines.has(entry))
+    if (missing.length === 0) return
+    const next = current + (current === '' || current.endsWith('\n') ? '' : '\n') + missing.join('\n') + '\n'
+    await atomicContainedWrite(repoRoot, info, exclude, next, 'git exclude')
   } catch {
-    return
-  }
-  const exclude = join(gitPath, 'info', 'exclude')
-  // Patterns are repo-root-relative — anchor them under the (possibly nested) cwd.
-  const rel = cwd === repoRoot ? '' : `${cwd.slice(repoRoot.length + 1)}/`
-  const want = [...SKILL_ROOTS.map((r) => `${rel}${r}/`), `${rel}${MARKER_DIR}/`]
-  try {
-    mkdirSync(dirname(exclude), { recursive: true })
-    const current = existsSync(exclude) ? readFileSync(exclude, 'utf8') : ''
-    const missing = want.filter((p) => !current.includes(p))
-    if (missing.length)
-      appendFileSync(exclude, (current === '' || current.endsWith('\n') ? '' : '\n') + missing.join('\n') + '\n')
-  } catch {
-    // ignore — a dirty status is cosmetic, not correctness
+    // A dirty status is cosmetic; path refusal must not block the session.
   }
 }
 
@@ -185,109 +366,142 @@ export interface InstallSkillsResult {
   errors: Array<{ source: string; error: string }>
 }
 
-/**
- * Install `agent.skills` into `cwd`, reconciling away skill copies this daemon
- * previously created but that are no longer desired. Never throws. `env` is merged
- * into the child (git credential helper vars for private sources,
- * GIT_TERMINAL_PROMPT=0, etc.); `warn` receives non-fatal diagnostics.
- */
+export interface InstallSkillsOptions {
+  /** Trusted loader-derived agent root; never derive this from workspace config. */
+  stateDir: string
+  env?: NodeJS.ProcessEnv
+  warn?: (msg: string) => void
+  /** Test seam; production always uses Node + the daemon's hidden CLI entry. */
+  execFile?: SkillsExec
+}
+
+/** Install and reconcile agent skills. Never throws. */
 export async function installSkills(
   agent: Pick<Agent, 'id' | 'runtime' | 'skills'>,
   cwd: string,
-  opts: { env?: NodeJS.ProcessEnv; warn?: (msg: string) => void } = {}
+  opts: InstallSkillsOptions
 ): Promise<InstallSkillsResult> {
   const result: InstallSkillsResult = { installed: [], removed: [], skipped: null, errors: [] }
   const entries = agent.skills ?? []
   const agentId = skillsAgentId(agent.runtime)
-  const env = { GIT_TERMINAL_PROMPT: '0', ...process.env, ...opts.env }
-  const cliSpec = resolveSkillsCliSpec(env)
-  // Fingerprint over runtime + mapped agent id + entries + the CLI spec: a runtime
-  // switch changes the target dir, and re-pinning AC_SKILLS_CLI must invalidate the
-  // cache so a changed CLI actually re-installs (it produces the on-disk skills).
-  const fp = fingerprint(agent.runtime, agentId ?? '', entries, cliSpec)
+  // The bundled upstream module cannot discover its own package.json after
+  // bundling; disable its optional telemetry rather than reporting the daemon's
+  // package version as the CLI version.
+  const env = { GIT_TERMINAL_PROMPT: '0', ...process.env, ...opts.env, DISABLE_TELEMETRY: '1' }
 
-  // Only paths that are valid daemon-managed skill dirs may drive removal — the
-  // marker is untrusted input, so its out-of-root entries are filtered out here.
-  const prior = readMarker(cwd)
-  const priorTracked = prior.installed.filter(isTrackedSkillDir)
+  try {
+    const workspaceId = await workspaceIdentity(cwd)
+    const fp = fingerprint(agent.runtime, agentId ?? '', entries, workspaceId)
+    const marker = ensureWorkspaceCapacity(await readMarker(opts.stateDir), workspaceId)
+    // Create/validate the private marker parent before mutating the workspace.
+    await containedTarget(opts.stateDir, join(opts.stateDir, MARKER_DIR), markerPath(opts.stateDir), {
+      create: true,
+      label: 'skills marker'
+    })
+    const prior = marker.workspaces[workspaceId] ?? { installed: [] }
+    const priorTracked = prior.installed.filter(isTrackedSkillDir)
 
-  // The fast path requires more than a fingerprint match: every recorded target must
-  // still exist (a deleted/never-created install must repair, not stay "unchanged"),
-  // and a non-empty desired set must have recorded at least one owned target.
-  const targetsIntact =
-    priorTracked.length === prior.installed.length && priorTracked.every((rel) => existsSync(join(cwd, rel)))
-  const cacheCoversDesired = entries.length === 0 || priorTracked.length > 0
-  if (prior.fingerprint === fp && targetsIntact && cacheCoversDesired) {
-    result.skipped = 'unchanged'
+    // Validate existing roots before any reconcile operation. This rejects a
+    // planted root symlink even when it is unrelated to the first tracked path.
+    if (priorTracked.length > 0 || entries.length > 0) await validateSkillRoots(cwd)
+
+    const intact = await Promise.all(priorTracked.map((rel) => trackedTargetIntact(cwd, rel)))
+    const targetsIntact = priorTracked.length === prior.installed.length && intact.every(Boolean)
+    const cacheCoversDesired = entries.length === 0 || priorTracked.length > 0
+    if (prior.fingerprint === fp && targetsIntact && cacheCoversDesired) {
+      await removeLegacyMarker(cwd)
+      result.skipped = 'unchanged'
+      return result
+    }
+
+    // Failed removals stay owned in the private marker so a later prep retries.
+    const retained: string[] = []
+    for (const rel of priorTracked) {
+      const { root, target } = trackedPath(cwd, rel)
+      try {
+        await containedRemoveDir(cwd, root, target)
+        result.removed.push(rel)
+      } catch (err) {
+        retained.push(rel)
+        opts.warn?.(`skills: could not remove stale skill "${rel}" — ${err instanceof Error ? err.message : ''}`)
+      }
+    }
+
+    if (entries.length === 0 || !agentId) {
+      if (!agentId && entries.length > 0) {
+        opts.warn?.(`skills: no installer mapping for runtime "${agent.runtime}"; skipping install`)
+      }
+      await writeMarker(
+        opts.stateDir,
+        withWorkspaceRecord(marker, workspaceId, {
+          ...(retained.length === 0 ? { fingerprint: fp } : {}),
+          installed: retained
+        })
+      )
+      await removeLegacyMarker(cwd)
+      return result
+    }
+
+    const rootRel = agentId === 'claude-code' ? '.claude/skills' : '.agents/skills'
+    await safeSkillRoot(cwd, rootRel, true)
+    await assertSafeLocalLock(cwd)
+    const before = await skillDirSnapshot(cwd)
+    const launch = skillsCliLauncher()
+    const run = opts.execFile ?? execFileAsync
+
+    for (const entry of entries) {
+      const composed = composeSource(entry)
+      if (composed.startsWith('-')) {
+        result.errors.push({ source: entry.name, error: 'source resolves to an option-like argument' })
+        opts.warn?.(`skills: skipping option-like source for "${entry.name}": ${composed}`)
+        continue
+      }
+      const skillFlags = entry.skills.filter((skill) => !skill.startsWith('-'))
+      if (skillFlags.length !== entry.skills.length) {
+        opts.warn?.(`skills: dropped option-like skill name(s) for "${entry.name}"`)
+      }
+      const args = [
+        ...launch.args,
+        '__skills-cli',
+        'add',
+        composed,
+        '-a',
+        agentId,
+        '-y',
+        '--copy',
+        ...skillFlags.flatMap((skill) => ['-s', skill])
+      ]
+      try {
+        await run(launch.cmd, args, { cwd, env, timeout: INSTALL_TIMEOUT_MS })
+        result.installed.push(entry.name)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        result.errors.push({ source: entry.name, error: message })
+        opts.warn?.(`skills: install failed for "${entry.name}" (${composed}): ${message}`)
+      }
+    }
+
+    const after = await skillDirSnapshot(cwd)
+    const created = [...after].filter(([path, signature]) => before.get(path) !== signature).map(([path]) => path)
+    await excludeFromGit(cwd)
+    const effective = retained.length === 0 && result.errors.length === 0 && created.length > 0
+    await writeMarker(
+      opts.stateDir,
+      withWorkspaceRecord(marker, workspaceId, {
+        ...(effective ? { fingerprint: fp } : {}),
+        installed: [...new Set([...retained, ...created])]
+      })
+    )
+    await removeLegacyMarker(cwd)
+    return result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    result.errors.push({ source: '*', error: message })
+    opts.warn?.(
+      err instanceof ContainedPathError
+        ? `skills: refused workspace installation — ${message}`
+        : `skills: could not prepare workspace installation — ${message}`
+    )
     return result
   }
-
-  // Reconcile: remove exactly the dirs we created last time (disable / narrow /
-  // runtime change / zero-desired all pass through here). Manually-authored skills
-  // are never in `priorTracked`, so they survive.
-  for (const rel of priorTracked) {
-    try {
-      rmSync(join(cwd, rel), { recursive: true, force: true })
-      result.removed.push(rel)
-    } catch {
-      // best-effort
-    }
-  }
-
-  if (entries.length === 0 || !agentId) {
-    if (!agentId && entries.length > 0) {
-      // P1: no native installer for this runtime; prompt-fallback is P2 (§6.5).
-      opts.warn?.(`skills: no npx-skills mapping for runtime "${agent.runtime}"; skipping install`)
-    }
-    // Nothing to install, but the reconcile above happened — record the empty state.
-    writeMarker(cwd, { fingerprint: fp, installed: [] })
-    return result
-  }
-
-  const before = new Set(listSkillDirs(cwd))
-  for (const entry of entries) {
-    const composed = composeSource(entry)
-    // Belt-and-suspenders (the protocol/CP boundary already validates these): a
-    // source or skill value beginning with "-" would be read by `npx skills` as a
-    // flag rather than a value, so skip option-like values here too.
-    if (composed.startsWith('-')) {
-      result.errors.push({ source: entry.name, error: 'source resolves to an option-like argument' })
-      opts.warn?.(`skills: skipping option-like source for "${entry.name}": ${composed}`)
-      continue
-    }
-    const skillFlags = entry.skills.filter((s) => !s.startsWith('-'))
-    if (skillFlags.length !== entry.skills.length) {
-      opts.warn?.(`skills: dropped option-like skill name(s) for "${entry.name}"`)
-    }
-    const args = [
-      '--yes',
-      cliSpec,
-      'add',
-      composed,
-      '-a',
-      agentId,
-      '-y',
-      '--copy',
-      ...skillFlags.flatMap((s) => ['-s', s])
-    ]
-    try {
-      await execFileAsync('npx', args, { cwd, env, timeout: INSTALL_TIMEOUT_MS })
-      result.installed.push(entry.name)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      result.errors.push({ source: entry.name, error: msg })
-      opts.warn?.(`skills: install failed for "${entry.name}" (${composed}): ${msg}`)
-    }
-  }
-
-  // Whatever appeared under the skill roots is ours to track (and later remove).
-  const created = listSkillDirs(cwd).filter((p) => !before.has(p))
-  excludeFromGit(cwd)
-  // Commit the fingerprint (the "unchanged" fast path) ONLY when the pass fully
-  // succeeded AND actually produced an owned target — otherwise a run that errored,
-  // or claimed success while creating nothing, must retry next session rather than
-  // caching a phantom install. Always record `created` so a later change cleans up.
-  const effective = result.errors.length === 0 && created.length > 0
-  writeMarker(cwd, { ...(effective ? { fingerprint: fp } : {}), installed: created })
-  return result
 }

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -54,6 +54,8 @@ interface WorkspaceRecord {
   fingerprint?: string
   /** Canonical cwd used to confirm that this directory instance still exists. */
   workspacePath?: string
+  /** Kernel replacement witness for the actual ACP cwd, including agentDir. */
+  workspaceWitness?: string
   /** cwd-relative skill dirs this daemon created (for reconcile removal). */
   installed: string[]
 }
@@ -93,19 +95,36 @@ function fingerprint(runtime: string, agentId: string, entries: AgentSkillEntry[
 interface WorkspaceIdentity {
   id: string
   path: string
+  witness: string
 }
 
 function workspaceId(generation: string, path: string): string {
   return createHash('sha256').update(JSON.stringify({ generation, path })).digest('hex')
 }
 
+async function directoryWitness(path: string): Promise<string | null> {
+  let stat: import('node:fs').BigIntStats
+  try {
+    stat = await fsp.lstat(path, { bigint: true })
+  } catch (err) {
+    if (isErrno(err, 'ENOENT') || isErrno(err, 'ENOTDIR')) return null
+    throw err
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return null
+  // birthtime is stable across writes but changes when a directory is replaced.
+  // Some filesystems expose no birthtime; ctime is a conservative fail-closed
+  // fallback there (ordinary top-level edits may invalidate ownership early).
+  const born = stat.birthtimeNs > 0n ? ['birth', stat.birthtimeNs] : ['ctime', stat.ctimeNs]
+  return createHash('sha256')
+    .update(JSON.stringify({ dev: String(stat.dev), ino: String(stat.ino), born: born.map(String) }))
+    .digest('hex')
+}
+
 async function workspaceIdentity(cwd: string, generation: string): Promise<WorkspaceIdentity> {
   const canonical = await fsp.realpath(cwd)
-  const stat = await fsp.lstat(canonical)
-  if (!stat.isDirectory() || stat.isSymbolicLink()) {
-    throw new ContainedPathError('skills workspace is not a real directory')
-  }
-  return { id: workspaceId(generation, canonical), path: canonical }
+  const witness = await directoryWitness(canonical)
+  if (!witness) throw new ContainedPathError('skills workspace is not a real directory')
+  return { id: workspaceId(generation, canonical), path: canonical, witness }
 }
 
 function markerPath(stateDir: string): string {
@@ -163,13 +182,21 @@ async function readMarker(stateDir: string): Promise<Marker> {
   const workspaces: Record<string, WorkspaceRecord> = {}
   for (const [workspaceId, value] of Object.entries(raw.workspaces)) {
     if (!WORKSPACE_ID.test(workspaceId) || !value || typeof value !== 'object' || Array.isArray(value)) continue
-    const record = value as { fingerprint?: unknown; workspacePath?: unknown; installed?: unknown }
+    const record = value as {
+      fingerprint?: unknown
+      workspacePath?: unknown
+      workspaceWitness?: unknown
+      installed?: unknown
+    }
     workspaces[workspaceId] = {
       ...(typeof record.fingerprint === 'string' ? { fingerprint: record.fingerprint } : {}),
       ...(typeof record.workspacePath === 'string' &&
       isAbsolute(record.workspacePath) &&
       !record.workspacePath.includes('\0')
         ? { workspacePath: record.workspacePath }
+        : {}),
+      ...(typeof record.workspaceWitness === 'string' && WORKSPACE_ID.test(record.workspaceWitness)
+        ? { workspaceWitness: record.workspaceWitness }
         : {}),
       installed: Array.isArray(record.installed)
         ? record.installed.filter((path): path is string => typeof path === 'string')
@@ -213,12 +240,8 @@ async function ensureWorkspaceCapacity(marker: Marker, workspace: WorkspaceIdent
       if (record.workspacePath === workspace.path) {
         reclaimable = true
       } else {
-        try {
-          const stat = await fsp.lstat(record.workspacePath)
-          reclaimable = !stat.isDirectory() || stat.isSymbolicLink()
-        } catch (err) {
-          if (isErrno(err, 'ENOENT') || isErrno(err, 'ENOTDIR')) reclaimable = true
-        }
+        const witness = await directoryWitness(record.workspacePath)
+        reclaimable = !witness || witness !== record.workspaceWitness
       }
     }
     if (!reclaimable) continue
@@ -444,7 +467,8 @@ export async function installSkills(
       label: 'skills marker'
     })
     const prior = marker.workspaces[workspace.id] ?? { installed: [] }
-    const priorTracked = prior.installed.filter(isTrackedSkillDir)
+    const priorMatchesWorkspace = prior.workspaceWitness === workspace.witness
+    const priorTracked = priorMatchesWorkspace ? prior.installed.filter(isTrackedSkillDir) : []
 
     // Validate existing roots before any reconcile operation. This rejects a
     // planted root symlink even when it is unrelated to the first tracked path.
@@ -453,7 +477,7 @@ export async function installSkills(
     const intact = await Promise.all(priorTracked.map((rel) => trackedTargetIntact(cwd, rel)))
     const targetsIntact = priorTracked.length === prior.installed.length && intact.every(Boolean)
     const cacheCoversDesired = entries.length === 0 || priorTracked.length > 0
-    if (prior.fingerprint === fp && targetsIntact && cacheCoversDesired) {
+    if (priorMatchesWorkspace && prior.fingerprint === fp && targetsIntact && cacheCoversDesired) {
       if (prior.workspacePath !== workspace.path) {
         await writeMarker(
           opts.stateDir,
@@ -487,6 +511,7 @@ export async function installSkills(
         withWorkspaceRecord(marker, workspace.id, {
           ...(retained.length === 0 ? { fingerprint: fp } : {}),
           workspacePath: workspace.path,
+          workspaceWitness: (await workspaceIdentity(cwd, generation)).witness,
           installed: retained
         })
       )
@@ -542,6 +567,7 @@ export async function installSkills(
       withWorkspaceRecord(marker, workspace.id, {
         ...(effective ? { fingerprint: fp } : {}),
         workspacePath: workspace.path,
+        workspaceWitness: (await workspaceIdentity(cwd, generation)).witness,
         installed: [...new Set([...retained, ...created])]
       })
     )

--- a/packages/daemon/src/skills/runtime-agent-map.ts
+++ b/packages/daemon/src/skills/runtime-agent-map.ts
@@ -1,10 +1,10 @@
 /**
- * Map an AgentConnect runtime id to the `npx skills` agent identifier used by
+ * Map an AgentConnect runtime id to the bundled `skills` CLI agent identifier used by
  * vercel-labs/skills (docs/designs/shared-skills.md §6.2). The CLI knows each
  * agent's per-runtime skills directory, so we only need to name the agent.
  *
  * Returns undefined when no native mapping exists — the caller then skips the
- * `npx skills` install for that runtime (the prompt-fallback path is P2, §6.5).
+ * installer for that runtime (the prompt-fallback path is P2, §6.5).
  * Matching is by substring so both bare ids ("claude") and ACP-suffixed ids
  * ("claude-acp") resolve.
  */

--- a/packages/daemon/src/skills/version.ts
+++ b/packages/daemon/src/skills/version.ts
@@ -1,0 +1,2 @@
+/** Must match the exact dependency in packages/daemon/package.json. */
+export const SKILLS_CLI_VERSION = '1.5.21'

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -44,7 +44,7 @@ const skillsLog = makeLogger('info')
 
 /**
  * Post-clone skills step (docs/designs/shared-skills.md §6). Installs the agent's
- * enabled skills into its resolved ACP cwd via `npx skills`, then returns that cwd.
+ * enabled skills into its resolved ACP cwd via the daemon-bundled CLI, then returns that cwd.
  * Best-effort and non-blocking: `installSkills` never throws, and the common
  * no-skills path is a single stat. Kept out of the return expressions so both the
  * scratch and git-repo branches funnel through one install point.
@@ -56,20 +56,26 @@ export interface PrepareWorkspaceOptions {
 }
 
 async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
-  await installSkills(agent, acpCwd, {
-    env: {
-      ...gitEnvBase(),
-      GIT_TERMINAL_PROMPT: '0',
-      ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {})
-    },
-    warn: (msg) => skillsLog.warn(msg)
-  })
+  // `dir` is present on every discovered agent (LoadedAgent). Never fall back to
+  // cwd for installer state: cwd remains agent-writable across sandboxed runs.
+  const agentRoot = (agent as { dir?: string }).dir
+  if (agentRoot) {
+    await installSkills(agent, acpCwd, {
+      stateDir: agentRoot,
+      env: {
+        ...gitEnvBase(),
+        GIT_TERMINAL_PROMPT: '0',
+        ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {})
+      },
+      warn: (msg) => skillsLog.warn(msg)
+    })
+  } else if ((agent.skills?.length ?? 0) > 0) {
+    skillsLog.warn(`skills: agent "${agent.id}" has no trusted state directory; skipping install`)
+  }
   // Skills the user ACCEPTED from a dream are daemon-owned (they live under the
   // agent root, not in `agent.skills`), so they get their own materialization
   // pass — one that treats every path in the agent-writable cwd as hostile.
   // Runs AFTER installSkills so its reconciliation cannot remove these copies.
-  // `dir` is present on every discovered agent (LoadedAgent); a bare spec has none.
-  const agentRoot = (agent as { dir?: string }).dir
   if (agentRoot) {
     const managedSkills = await opts.managedSkills?.(agent)
     await materializeAcceptedDreamSkills({ dir: agentRoot, runtime: agent.runtime }, acpCwd, {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -20,7 +20,7 @@ import {
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
 import { makeLogger } from '../log.js'
-import { installSkills } from '../skills/install-skills.js'
+import { installSkills, rotateSkillsWorkspaceGeneration } from '../skills/install-skills.js'
 import {
   materializeAcceptedDreamSkills,
   type ManagedSkillMaterializationSource
@@ -55,10 +55,19 @@ export interface PrepareWorkspaceOptions {
   managedSkills?: (agent: Agent) => Promise<ManagedSkillMaterializationSource[]>
 }
 
+function trustedAgentRoot(agent: Agent): string | undefined {
+  return (agent as { dir?: string }).dir
+}
+
+async function rotateWorkspaceSkillsGeneration(agent: Agent): Promise<void> {
+  const agentRoot = trustedAgentRoot(agent)
+  if (agentRoot) await rotateSkillsWorkspaceGeneration(agentRoot)
+}
+
 async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
   // `dir` is present on every discovered agent (LoadedAgent). Never fall back to
   // cwd for installer state: cwd remains agent-writable across sandboxed runs.
-  const agentRoot = (agent as { dir?: string }).dir
+  const agentRoot = trustedAgentRoot(agent)
   if (agentRoot) {
     await installSkills(agent, acpCwd, {
       stateDir: agentRoot,
@@ -383,7 +392,7 @@ export async function prepareWorkspaceForActivation(
     allowExistingCheckout = true,
     reconcileMaterialization = false
   }: { allowExistingCheckout?: boolean; reconcileMaterialization?: boolean } = {}
-): Promise<() => void> {
+): Promise<() => Promise<void>> {
   const cwd = agent.workspace.path
   mkdirSync(cwd, { recursive: true })
   const previousMaterialization = reconcileMaterialization ? readMaterialization(agent) : undefined
@@ -395,12 +404,14 @@ export async function prepareWorkspaceForActivation(
 
   if (agent.workspace.mode === 'from-scratch') {
     if (replace) {
+      await rotateWorkspaceSkillsGeneration(agent)
       rmSync(cwd, { recursive: true, force: true })
       mkdirSync(cwd, { recursive: true })
     }
     if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-    return () => {
+    return async () => {
       if (replace) {
+        await rotateWorkspaceSkillsGeneration(agent)
         rmSync(cwd, { recursive: true, force: true })
         mkdirSync(cwd, { recursive: true })
       }
@@ -424,7 +435,9 @@ export async function prepareWorkspaceForActivation(
       if (!replace) {
         resolveAcpCwd(cwd, normalizeRepoSubdir(agent.workspace.agentDir))
         if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
-        return restoreMarker
+        return async () => {
+          restoreMarker()
+        }
       }
     }
     // A different repo/branch is cloned below before the old checkout is
@@ -440,6 +453,7 @@ export async function prepareWorkspaceForActivation(
     await cloneRepoAt(agent, staged)
     resolveAcpCwd(staged, normalizeRepoSubdir(agent.workspace.agentDir))
     if (replace) {
+      await rotateWorkspaceSkillsGeneration(agent)
       rmSync(cwd, { recursive: true, force: true })
       renameSync(staged, cwd)
       try {
@@ -450,7 +464,8 @@ export async function prepareWorkspaceForActivation(
         restoreMarker()
         throw err
       }
-      return () => {
+      return async () => {
+        await rotateWorkspaceSkillsGeneration(agent)
         rmSync(cwd, { recursive: true, force: true })
         mkdirSync(cwd, { recursive: true })
         restoreMarker()
@@ -461,6 +476,7 @@ export async function prepareWorkspaceForActivation(
     if (!isWorkspaceEmpty(agent)) {
       throw new Error('workspace changed while conversion was cloning; retry after making it empty')
     }
+    await rotateWorkspaceSkillsGeneration(agent)
     try {
       // POSIX directory replacement is atomic when the destination is still
       // empty. If an operator writes into cwd after the check above, rename
@@ -481,7 +497,8 @@ export async function prepareWorkspaceForActivation(
 
   if (reconcileMaterialization) recordWorkspaceMaterialization(agent)
 
-  return () => {
+  return async () => {
+    await rotateWorkspaceSkillsGeneration(agent)
     rmSync(cwd, { recursive: true, force: true })
     mkdirSync(cwd, { recursive: true })
     restoreMarker()

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -1,12 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { composeSource, installSkills, resolveSkillsCliSpec } from '../src/skills/install-skills.js'
+import { composeSource, installSkills, SKILLS_CLI_VERSION } from '../src/skills/install-skills.js'
 import { skillsAgentId } from '../src/skills/runtime-agent-map.js'
 
 describe('skillsAgentId', () => {
-  it('maps known runtimes (bare + acp-suffixed) to npx-skills agent ids', () => {
+  it('maps known runtimes (bare + acp-suffixed) to skills CLI agent ids', () => {
     expect(skillsAgentId('claude')).toBe('claude-code')
     expect(skillsAgentId('claude-acp')).toBe('claude-code')
     expect(skillsAgentId('codex-acp')).toBe('codex')
@@ -14,22 +24,17 @@ describe('skillsAgentId', () => {
     expect(skillsAgentId('qwen-code')).toBe('gemini-cli')
     expect(skillsAgentId('cursor')).toBe('cursor')
   })
+
   it('returns undefined for an unmapped runtime', () => {
     expect(skillsAgentId('some-exotic-agent')).toBeUndefined()
   })
 })
 
-describe('resolveSkillsCliSpec (AC_SKILLS_CLI pin)', () => {
-  it('defaults to "skills" when unset', () => {
-    expect(resolveSkillsCliSpec({})).toBe('skills')
-  })
-  it('honors a clean pinned version spec', () => {
-    expect(resolveSkillsCliSpec({ AC_SKILLS_CLI: 'skills@1.4.0' })).toBe('skills@1.4.0')
-  })
-  it('rejects option-like or whitespace-bearing values (no arg smuggling)', () => {
-    expect(resolveSkillsCliSpec({ AC_SKILLS_CLI: '--evil' })).toBe('skills')
-    expect(resolveSkillsCliSpec({ AC_SKILLS_CLI: 'skills --run x' })).toBe('skills')
-    expect(resolveSkillsCliSpec({ AC_SKILLS_CLI: '   ' })).toBe('skills')
+describe('trusted skills CLI', () => {
+  it('keeps the bundled CLI constant aligned with the exact package dependency', () => {
+    const req = createRequire(import.meta.url)
+    const manifest = req('skills/package.json') as { version: string }
+    expect(manifest.version).toBe(SKILLS_CLI_VERSION)
   })
 })
 
@@ -59,8 +64,8 @@ describe('composeSource', () => {
   })
 
   it('leaves an already-tree source alone', () => {
-    const s = 'https://github.com/acme/skills/tree/main/pack'
-    expect(composeSource({ ...base, source: s, ref: 'ignored' })).toBe(s)
+    const source = 'https://github.com/acme/skills/tree/main/pack'
+    expect(composeSource({ ...base, source, ref: 'ignored' })).toBe(source)
   })
 
   it('does not compose non-github sources', () => {
@@ -70,76 +75,291 @@ describe('composeSource', () => {
   })
 })
 
-describe('installSkills reconcile (no npx: empty/unmapped paths)', () => {
+describe('installSkills reconcile and containment', () => {
+  let root: string
   let cwd: string
-  const marker = () => join(cwd, '.agentconnect', 'skills-install.json')
-  const writeMarker = (m: unknown) => {
-    mkdirSync(join(cwd, '.agentconnect'), { recursive: true })
-    writeFileSync(marker(), JSON.stringify(m))
+  let stateDir: string
+  let outside: string
+  const marker = () => join(stateDir, '.agentconnect', 'skills-install.json')
+  const writeMarker = (value: unknown) => {
+    mkdirSync(join(stateDir, '.agentconnect'), { recursive: true })
+    writeFileSync(marker(), JSON.stringify(value))
   }
+  const readMarker = () =>
+    JSON.parse(readFileSync(marker(), 'utf8')) as {
+      workspaces: Record<string, { fingerprint?: string; installed: string[] }>
+    }
+  const markerRecords = () => Object.values(readMarker().workspaces)
 
   beforeEach(() => {
-    cwd = mkdtempSync(join(tmpdir(), 'skills-'))
+    root = mkdtempSync(join(tmpdir(), 'skills-'))
+    cwd = join(root, 'workspace')
+    stateDir = join(root, 'agent')
+    outside = join(root, 'outside')
+    mkdirSync(cwd)
+    mkdirSync(stateDir)
+    mkdirSync(outside)
   })
+
   afterEach(() => {
-    rmSync(cwd, { recursive: true, force: true })
+    rmSync(root, { recursive: true, force: true })
   })
 
-  it('disabling the last skill removes previously-installed dirs and clears the marker', async () => {
-    mkdirSync(join(cwd, '.claude', 'skills', 'review-pr'), { recursive: true })
-    writeMarker({ fingerprint: 'old', installed: ['.claude/skills/review-pr'] })
+  it('stores reconciliation state in the daemon-owned agent directory', async () => {
+    const legacy = join(cwd, '.agentconnect', 'skills-install.json')
+    mkdirSync(join(cwd, '.agentconnect'))
+    writeFileSync(legacy, JSON.stringify({ fingerprint: 'untrusted', installed: ['/etc'] }))
 
-    const res = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd)
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
 
-    expect(existsSync(join(cwd, '.claude', 'skills', 'review-pr'))).toBe(false)
-    expect(res.removed).toEqual(['.claude/skills/review-pr'])
-    expect(JSON.parse(readFileSync(marker(), 'utf8'))).toMatchObject({ installed: [] })
+    expect(existsSync(marker())).toBe(true)
+    expect(existsSync(legacy)).toBe(false)
   })
 
-  it('never removes a manually-authored skill (one not recorded as daemon-installed)', async () => {
+  it.each([
+    { runtime: 'claude', agentId: 'claude-code', rootRel: '.claude/skills' },
+    { runtime: 'codex-acp', agentId: 'codex', rootRel: '.agents/skills' }
+  ])('installs and later reconciles $runtime copies', async ({ runtime, agentId, rootRel }) => {
+    const calls: Array<{ file: string; args: string[] }> = []
+    const exec = async (file: string, args: string[]) => {
+      calls.push({ file, args })
+      mkdirSync(join(cwd, ...rootRel.split('/'), 'review-pr'), { recursive: true })
+    }
+
+    const installed = await installSkills(
+      { id: 'a1', runtime, skills: [{ name: 'source', source: 'acme/skills', skills: ['review-pr'] }] },
+      cwd,
+      { stateDir, execFile: exec }
+    )
+
+    expect(installed.installed).toEqual(['source'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.file).toBe(process.execPath)
+    expect(calls[0]!.args).toEqual(
+      expect.arrayContaining(['__skills-cli', 'add', 'acme/skills', '-a', agentId, '-y', '--copy'])
+    )
+    expect(markerRecords()).toEqual([expect.objectContaining({ installed: [`${rootRel}/review-pr`] })])
+
+    const removed = await installSkills({ id: 'a1', runtime, skills: [] }, cwd, { stateDir })
+    expect(removed.removed).toEqual([`${rootRel}/review-pr`])
+    expect(existsSync(join(cwd, ...rootRel.split('/'), 'review-pr'))).toBe(false)
+  })
+
+  it.skipIf(process.platform === 'win32')('runs the bundled CLI, not a workspace-local skills package', async () => {
+    const sentinel = join(outside, 'workspace-package-ran')
+    const localBin = join(cwd, 'node_modules', '.bin', 'skills')
+    mkdirSync(join(cwd, 'node_modules', '.bin'), { recursive: true })
+    writeFileSync(localBin, `#!/bin/sh\ntouch '${sentinel}'\n`)
+    chmodSync(localBin, 0o755)
+    const source = join(outside, 'source')
+    mkdirSync(source)
+    writeFileSync(
+      join(source, 'SKILL.md'),
+      [
+        '---',
+        'name: safe-copy',
+        'description: Verifies the daemon-bundled skills CLI.',
+        '---',
+        '',
+        '# Safe copy',
+        ''
+      ].join('\n')
+    )
+    mkdirSync(join(cwd, '.claude', 'skills', 'safe-copy'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'skills', 'safe-copy', 'OLD'), 'old daemon copy')
+
+    const result = await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [{ name: 'source', source, skills: [] }] },
+      cwd,
+      { stateDir }
+    )
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toEqual(['source'])
+    expect(existsSync(join(cwd, '.claude', 'skills', 'safe-copy', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(cwd, '.claude', 'skills', 'safe-copy', 'OLD'))).toBe(false)
+    expect(markerRecords()).toEqual([expect.objectContaining({ installed: ['.claude/skills/safe-copy'] })])
+    expect(existsSync(sentinel)).toBe(false)
+  })
+
+  it('keeps manually-authored skills while removing recorded copies', async () => {
     mkdirSync(join(cwd, '.claude', 'skills', 'mine'), { recursive: true })
-    mkdirSync(join(cwd, '.claude', 'skills', 'daemon-installed'), { recursive: true })
-    writeMarker({ fingerprint: 'old', installed: ['.claude/skills/daemon-installed'] })
+    await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [{ name: 'source', source: 'acme/skills', skills: [] }] },
+      cwd,
+      {
+        stateDir,
+        execFile: async () => {
+          mkdirSync(join(cwd, '.claude', 'skills', 'daemon-installed'), { recursive: true })
+        }
+      }
+    )
 
-    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd)
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
 
     expect(existsSync(join(cwd, '.claude', 'skills', 'mine'))).toBe(true)
     expect(existsSync(join(cwd, '.claude', 'skills', 'daemon-installed'))).toBe(false)
   })
 
-  it('changing AC_SKILLS_CLI invalidates the fingerprint (re-install, not skip)', async () => {
-    const readFp = () => JSON.parse(readFileSync(marker(), 'utf8')).fingerprint as string
-    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { env: { AC_SKILLS_CLI: 'skills@1.0.0' } })
-    const first = readFp()
-    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { env: { AC_SKILLS_CLI: 'skills@2.0.0' } })
-    expect(readFp()).not.toBe(first) // the pinned CLI spec is part of the fingerprint
+  it('does not carry daemon ownership into a different workspace', async () => {
+    const desired = {
+      id: 'a1',
+      runtime: 'claude',
+      skills: [{ name: 'source', source: 'acme/skills', skills: ['same-name'] }]
+    }
+    await installSkills(desired, cwd, {
+      stateDir,
+      execFile: async () => {
+        mkdirSync(join(cwd, '.claude', 'skills', 'same-name'), { recursive: true })
+      }
+    })
+
+    const nextCwd = join(root, 'workspace-b')
+    const manual = join(nextCwd, '.claude', 'skills', 'same-name')
+    mkdirSync(manual, { recursive: true })
+    writeFileSync(join(manual, 'MANUAL'), 'keep')
+    let installs = 0
+
+    const reconciled = await installSkills(desired, nextCwd, {
+      stateDir,
+      execFile: async () => {
+        installs += 1
+      }
+    })
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, nextCwd, { stateDir })
+
+    expect(reconciled.skipped).toBeNull()
+    expect(installs).toBe(1)
+    expect(readFileSync(join(manual, 'MANUAL'), 'utf8')).toBe('keep')
   })
 
-  it('an unchanged fingerprint skips entirely (no removal)', async () => {
-    // fingerprint of runtime=claude, agentId=claude-code, skills=[] — recompute-stable.
-    const first = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd)
-    expect(first.skipped).toBeNull() // first run writes the marker
+  it('retains independent ownership when switching away and back', async () => {
+    const installed = join(cwd, '.claude', 'skills', 'owned-in-a')
+    await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [{ name: 'source', source: 'acme/skills', skills: [] }] },
+      cwd,
+      {
+        stateDir,
+        execFile: async () => {
+          mkdirSync(installed, { recursive: true })
+        }
+      }
+    )
+
+    const nextCwd = join(root, 'workspace-b')
+    mkdirSync(nextCwd)
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, nextCwd, { stateDir })
+    const reconciled = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+
+    expect(reconciled.removed).toEqual(['.claude/skills/owned-in-a'])
+    expect(existsSync(installed)).toBe(false)
+  })
+
+  it('uses an intact private fingerprint as the unchanged fast path', async () => {
+    const first = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+    expect(first.skipped).toBeNull()
     mkdirSync(join(cwd, '.claude', 'skills', 'untracked'), { recursive: true })
-    const second = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd)
+
+    const second = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+
     expect(second.skipped).toBe('unchanged')
     expect(existsSync(join(cwd, '.claude', 'skills', 'untracked'))).toBe(true)
   })
 
-  it('an unmapped runtime still reconciles away prior daemon-installed copies', async () => {
-    mkdirSync(join(cwd, '.agents', 'skills', 'x'), { recursive: true })
-    writeMarker({ fingerprint: 'old', installed: ['.agents/skills/x'] })
-    await installSkills({ id: 'a1', runtime: 'exotic-agent', skills: [{ name: 'x', source: 'o/r', skills: [] }] }, cwd)
+  it('an unmapped runtime still reconciles prior daemon-owned copies', async () => {
+    await installSkills(
+      { id: 'a1', runtime: 'codex', skills: [{ name: 'source', source: 'acme/skills', skills: [] }] },
+      cwd,
+      {
+        stateDir,
+        execFile: async () => {
+          mkdirSync(join(cwd, '.agents', 'skills', 'x'), { recursive: true })
+        }
+      }
+    )
+
+    await installSkills(
+      { id: 'a1', runtime: 'exotic-agent', skills: [{ name: 'x', source: 'o/r', skills: [] }] },
+      cwd,
+      { stateDir }
+    )
+
     expect(existsSync(join(cwd, '.agents', 'skills', 'x'))).toBe(false)
   })
 
-  it('only removes marker paths that are direct children of a managed skill root', async () => {
-    // The marker lives in the workspace, so its paths are untrusted input. An entry
-    // that resolves outside a managed skill root must be ignored — the reconcile only
-    // acts on paths matching the strict "<root>/<segment>" grammar.
+  it('ignores marker entries outside direct managed-root children', async () => {
     mkdirSync(join(cwd, 'sub', 'keep'), { recursive: true })
-    writeMarker({ fingerprint: 'old', installed: ['.claude/skills/../../sub/keep', '../outside', '/etc'] })
-    const res = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd)
-    expect(existsSync(join(cwd, 'sub', 'keep'))).toBe(true) // unrelated dir untouched
-    expect(res.removed).toEqual([]) // none matched the managed-root grammar
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+    const saved = readMarker()
+    const workspaceId = Object.keys(saved.workspaces)[0]!
+    saved.workspaces[workspaceId] = {
+      fingerprint: 'old',
+      installed: ['.claude/skills/../../sub/keep', '../outside', '/etc']
+    }
+    writeMarker(saved)
+
+    const result = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+
+    expect(existsSync(join(cwd, 'sub', 'keep'))).toBe(true)
+    expect(result.removed).toEqual([])
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a symlinked private marker without touching its target',
+    async () => {
+      const canary = join(outside, 'marker.json')
+      writeFileSync(canary, 'CANARY')
+      mkdirSync(join(stateDir, '.agentconnect'))
+      symlinkSync(canary, marker(), 'file')
+
+      const result = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+
+      expect(result.errors[0]?.source).toBe('*')
+      expect(readFileSync(canary, 'utf8')).toBe('CANARY')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('refuses a symlinked skill root before invoking the CLI', async () => {
+    const canary = join(outside, 'keep')
+    writeFileSync(canary, 'CANARY')
+    mkdirSync(join(cwd, '.claude'))
+    symlinkSync(outside, join(cwd, '.claude', 'skills'), 'dir')
+    let invoked = false
+
+    const result = await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [{ name: 'source', source: 'acme/skills', skills: [] }] },
+      cwd,
+      {
+        stateDir,
+        execFile: async () => {
+          invoked = true
+        }
+      }
+    )
+
+    expect(invoked).toBe(false)
+    expect(result.errors[0]?.error).toMatch(/symlink|non-directory/)
+    expect(readFileSync(canary, 'utf8')).toBe('CANARY')
+  })
+
+  it.skipIf(process.platform === 'win32')('refuses a symlinked CLI lock before invoking the CLI', async () => {
+    const canary = join(outside, 'lock.json')
+    writeFileSync(canary, 'CANARY')
+    symlinkSync(canary, join(cwd, 'skills-lock.json'), 'file')
+    let invoked = false
+
+    await installSkills(
+      { id: 'a1', runtime: 'claude', skills: [{ name: 'source', source: 'acme/skills', skills: [] }] },
+      cwd,
+      {
+        stateDir,
+        execFile: async () => {
+          invoked = true
+        }
+      }
+    )
+
+    expect(invoked).toBe(false)
+    expect(readFileSync(canary, 'utf8')).toBe('CANARY')
   })
 })

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -325,6 +325,43 @@ describe('installSkills reconcile and containment', () => {
     expect(readFileSync(manual, 'utf8')).toBe('keep')
   })
 
+  it('does not reuse deletion ownership after a nested ACP cwd is replaced', async () => {
+    const nested = join(cwd, 'service')
+    mkdirSync(nested)
+    const desired = {
+      id: 'a1',
+      runtime: 'claude',
+      skills: [{ name: 'source', source: 'acme/skills', skills: [] }]
+    }
+    await installSkills(desired, nested, {
+      stateDir,
+      execFile: async () => {
+        mkdirSync(join(nested, '.claude', 'skills', 'same-name'), { recursive: true })
+      }
+    })
+
+    const replacement = join(cwd, 'replacement')
+    mkdirSync(replacement)
+    rmSync(nested, { recursive: true, force: true })
+    renameSync(replacement, nested)
+    const manual = join(nested, '.claude', 'skills', 'same-name', 'MANUAL')
+    mkdirSync(dirname(manual), { recursive: true })
+    writeFileSync(manual, 'keep')
+    let installs = 0
+
+    const reconciled = await installSkills(desired, nested, {
+      stateDir,
+      execFile: async () => {
+        installs += 1
+      }
+    })
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, nested, { stateDir })
+
+    expect(reconciled.skipped).toBeNull()
+    expect(installs).toBe(1)
+    expect(readFileSync(manual, 'utf8')).toBe('keep')
+  })
+
   it('uses an intact private fingerprint as the unchanged fast path', async () => {
     const first = await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
     expect(first.skipped).toBeNull()

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync
@@ -253,6 +254,33 @@ describe('installSkills reconcile and containment', () => {
 
     expect(reconciled.removed).toEqual(['.claude/skills/owned-in-a'])
     expect(existsSync(installed)).toBe(false)
+  })
+
+  it('reclaims ownership capacity after the workspace directory is replaced', async () => {
+    const desired = {
+      id: 'a1',
+      runtime: 'claude',
+      skills: [{ name: 'source', source: 'acme/skills', skills: [] }]
+    }
+    const replacements = Array.from({ length: 16 }, (_, index) => join(root, `replacement-${index}`))
+    for (const replacement of replacements) mkdirSync(replacement)
+
+    for (let replacement = 0; replacement <= 16; replacement += 1) {
+      if (replacement > 0) {
+        rmSync(cwd, { recursive: true, force: true })
+        renameSync(replacements[replacement - 1]!, cwd)
+      }
+      const result = await installSkills(desired, cwd, {
+        stateDir,
+        execFile: async () => {
+          mkdirSync(join(cwd, '.claude', 'skills', `copy-${replacement}`), { recursive: true })
+        }
+      })
+
+      expect(result.errors).toEqual([])
+    }
+
+    expect(Object.keys(readMarker().workspaces)).toHaveLength(16)
   })
 
   it('uses an intact private fingerprint as the unchanged fast path', async () => {

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -12,8 +12,13 @@ import {
 } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { composeSource, installSkills, SKILLS_CLI_VERSION } from '../src/skills/install-skills.js'
+import { dirname, join } from 'node:path'
+import {
+  composeSource,
+  installSkills,
+  rotateSkillsWorkspaceGeneration,
+  SKILLS_CLI_VERSION
+} from '../src/skills/install-skills.js'
 import { skillsAgentId } from '../src/skills/runtime-agent-map.js'
 
 describe('skillsAgentId', () => {
@@ -267,6 +272,7 @@ describe('installSkills reconcile and containment', () => {
 
     for (let replacement = 0; replacement <= 16; replacement += 1) {
       if (replacement > 0) {
+        await rotateSkillsWorkspaceGeneration(stateDir)
         rmSync(cwd, { recursive: true, force: true })
         renameSync(replacements[replacement - 1]!, cwd)
       }
@@ -280,7 +286,43 @@ describe('installSkills reconcile and containment', () => {
       expect(result.errors).toEqual([])
     }
 
-    expect(Object.keys(readMarker().workspaces)).toHaveLength(16)
+    expect(Object.keys(readMarker().workspaces)).toHaveLength(1)
+  })
+
+  it('does not reuse deletion ownership after the workspace generation rotates', async () => {
+    const desired = {
+      id: 'a1',
+      runtime: 'claude',
+      skills: [{ name: 'source', source: 'acme/skills', skills: [] }]
+    }
+    await installSkills(desired, cwd, {
+      stateDir,
+      execFile: async () => {
+        mkdirSync(join(cwd, '.claude', 'skills', 'same-name'), { recursive: true })
+      }
+    })
+
+    const replacement = join(root, 'replacement')
+    mkdirSync(replacement)
+    await rotateSkillsWorkspaceGeneration(stateDir)
+    rmSync(cwd, { recursive: true, force: true })
+    renameSync(replacement, cwd)
+    const manual = join(cwd, '.claude', 'skills', 'same-name', 'MANUAL')
+    mkdirSync(dirname(manual), { recursive: true })
+    writeFileSync(manual, 'keep')
+    let installs = 0
+
+    const reconciled = await installSkills(desired, cwd, {
+      stateDir,
+      execFile: async () => {
+        installs += 1
+      }
+    })
+    await installSkills({ id: 'a1', runtime: 'claude', skills: [] }, cwd, { stateDir })
+
+    expect(reconciled.skipped).toBeNull()
+    expect(installs).toBe(1)
+    expect(readFileSync(manual, 'utf8')).toBe('keep')
   })
 
   it('uses an intact private fingerprint as the unchanged fast path', async () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -305,10 +305,15 @@ describe('prepareWorkspaceForActivation', () => {
     expect(cloneTarget).not.toBe(path)
     expect(existsSync(join(path, '.git'))).toBe(true)
     expect(existsSync(cloneTarget)).toBe(false)
+    const skillsMarker = join(dirname(path), '.agentconnect', 'skills-install.json')
+    const activatedGeneration = (JSON.parse(readFileSync(skillsMarker, 'utf8')) as { generation: string }).generation
 
-    rollback()
+    await rollback()
     expect(existsSync(path)).toBe(true)
     expect(readdirSync(path)).toEqual([])
+    expect((JSON.parse(readFileSync(skillsMarker, 'utf8')) as { generation: string }).generation).not.toBe(
+      activatedGeneration
+    )
   })
 
   it('refuses a non-empty scratch directory without starting a clone', async () => {
@@ -389,7 +394,7 @@ describe('prepareWorkspaceForActivation', () => {
 
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(existsSync(join(path, 'local.txt'))).toBe(true)
-    rollback()
+    await rollback()
     expect(existsSync(join(path, 'local.txt'))).toBe(true)
   })
 
@@ -422,7 +427,7 @@ describe('prepareWorkspaceForActivation', () => {
     ])
     expect(existsSync(join(path, 'untrusted.txt'))).toBe(false)
     expect(readFileSync(join(path, 'README.md'), 'utf8')).toBe('authorized GitHub content')
-    rollback()
+    await rollback()
   })
 
   it('retries a failed rename convergence without replacing local files on a later agentDir-only edit', async () => {
@@ -461,7 +466,7 @@ describe('prepareWorkspaceForActivation', () => {
     ).toHaveLength(2)
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(readFileSync(join(path, 'local.txt'), 'utf8')).toBe('keep me')
-    rollback()
+    await rollback()
     expect(readFileSync(join(path, 'local.txt'), 'utf8')).toBe('keep me')
   })
 
@@ -487,7 +492,7 @@ describe('prepareWorkspaceForActivation', () => {
 
     expect(existsSync(join(path, 'local.txt'))).toBe(false)
     expect(readFileSync(join(path, 'README.md'), 'utf8')).toBe('replacement')
-    rollback()
+    await rollback()
     expect(readdirSync(path)).toEqual([])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0
+      skills:
+        specifier: 1.5.21
+        version: 1.5.21
       systeminformation:
         specifier: ^5.33.1
         version: 5.33.1
@@ -1720,6 +1723,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4231,6 +4238,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
@@ -6418,6 +6429,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -7622,6 +7637,11 @@ packages:
   simple-git@3.36.0:
     resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
+  skills@1.5.21:
+    resolution: {integrity: sha512-CJ4wx692UkQAW+DLpjJg/ww6dJBojq5E8sQBOqP639GutO72v4EFiV/fq1etW2r9NhM/mwaIq8YoqKFJ9XV7ng==}
+    engines: {node: '>=22.20.0'}
+    hasBin: true
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -7885,6 +7905,10 @@ packages:
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -8459,6 +8483,10 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -9862,6 +9890,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -12495,6 +12527,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  chownr@3.0.0: {}
+
   cjs-module-lexer@2.2.0: {}
 
   classnames@2.5.1: {}
@@ -14944,6 +14978,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@3.0.1: {}
@@ -16467,6 +16505,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  skills@1.5.21:
+    dependencies:
+      tar: 7.5.22
+      yaml: 2.9.0
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -16773,6 +16816,14 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   teex@1.0.1:
     dependencies:
@@ -17300,6 +17351,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
 
   yaml@1.10.3: {}
 


### PR DESCRIPTION
## Summary

- pin `skills@1.5.21` and bundle its CLI into the daemon, removing workspace-local `npx` resolution
- keep bounded, per-workspace reconciliation ownership under the daemon-owned agent root and bind each record to a concrete workspace materialization
- refuse symlinked or escaping skill roots, lock/marker paths, and use contained deletion plus atomic private-state writes
- cover Claude and Codex reconciliation and prove a malicious workspace-local `skills` binary is never executed

## Why

Skill installation runs before the sandboxed ACP process but with daemon authority. The previous installer resolved `npx skills` from an agent-writable cwd and trusted a marker stored in that workspace, so workspace contents could influence privileged installation and reconciliation.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/skills.test.ts test/workspace.test.ts` (58 passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- scoped ESLint and Prettier checks
- `pnpm --filter @agentconnect.md/daemon build` including the self-contained bundle assertion
- full daemon run reached 145 passing files / 2525 passing assertions; the local macOS runner then exited on watcher `EMFILE` teardown noise

Created by Codex . GPT-5
