### PR TITLE
fix(webchat): make agentconnect-admin actually reachable

### DIFF
--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -296,7 +296,7 @@ The daemon adds a remote MCP server only to the entitled ACP session:
 ```json
 {
   "name": "agentconnect-admin",
-  "url": "https://control.example.com/api/v1/mcp",
+  "url": "https://control.example.com/v1/mcp",
   "headers": {
     "Authorization": "Bearer acmcp_REDACTED"
   }
@@ -306,6 +306,11 @@ The daemon adds a remote MCP server only to the entitled ACP session:
 Requirements:
 
 - The descriptor is structured ACP/runtime configuration, not prompt text.
+- `url` is the CP's **canonical public MCP resource URL** — the same one the endpoint
+  advertises as RFC 9728 `resource` (a dedicated MCP origin where one is deployed,
+  else `<public base>/v1/mcp`). The adapter dials it directly, with no discovery step
+  and no fallback, so an internal-only mount path is a silent total failure of the
+  administration surface.
 - The runtime must handle transport headers as standard MCP configuration rather
   than model input or tool arguments. AgentConnect does not add a private ACP
   extension to attest this behavior.
@@ -347,6 +352,14 @@ After constant-time token verification, the CP:
 10. only after authenticated browser approval atomically claims that operation,
     re-authorizes it, and calls the existing REST/service surface in process through
     `InternalInvocationAuth`.
+
+Steps 4-10 govern `tools/list` and `tools/call`. The mandatory MCP transport
+handshake — `initialize`, `notifications/initialized`, and `ping` — is admitted after
+steps 1-3 and answered inside the MCP handler: it carries no tool, no organization
+binding, and no nested REST call. Admitting it is load-bearing, not a relaxation: a
+client cannot issue any tool request before initializing, so denying the handshake
+denies the whole server, and the session loses `agentconnect-admin` entirely. Every
+other JSON-RPC method stays denied.
 
 Nested REST calls receive an already resolved internal principal. The raw grant is
 not replayed as REST Bearer authentication and cannot authenticate an external REST

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -150,6 +150,7 @@ import { createReadiness, type Readiness } from './http/readiness.js'
 import { McpRateLimiter } from './http/mcp/rate-limit.js'
 import { RemoteGrantAuthenticator } from './http/mcp/remote-grant-authenticator.js'
 import { InternalInvocationAuth } from './http/mcp/internal-invocation-auth.js'
+import { webchatMcpDescriptorUrl } from './http/oauth/base.js'
 import { defaultWebchatMcpMetrics } from './observability/webchat-mcp.js'
 import { pingDb } from './persistence/prisma.js'
 import { runWithSharedTx, withSharedTxRouting } from './persistence/ambient-tx.js'
@@ -423,7 +424,9 @@ export function buildContainer(
     daemons: connReg,
     authorities: repos.webchatMcpDelegation,
     grants: repos.webchatMcpAccessGrant,
-    mcpUrl: new URL('/api/v1/mcp', config.PUBLIC_CP_URL ?? 'http://localhost:8080').toString()
+    // The daemon installs this verbatim into the adapter's `agentconnect-admin`
+    // descriptor: the canonical PUBLIC resource URL, never the internal `/api/v1` mount.
+    mcpUrl: webchatMcpDescriptorUrl(config)
   })
   const remoteGrantAuth = new RemoteGrantAuthenticator({
     clock,

--- a/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
+++ b/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
@@ -23,13 +23,23 @@ export interface InvocationContext {
 }
 
 export interface ParsedInvocationMetadata {
-  method: 'tools/list' | 'tools/call'
+  /** The raw JSON-RPC method — classification is this module's job, not the caller's. */
+  method: string
   requestId?: string
   toolName?: string
 }
 
+/** Transport-level methods a grant may issue without an invocation identity. The MCP
+ *  handshake is MANDATORY (a client sends `initialize` before anything else and may
+ *  keep the connection warm with `ping`), so denying these denies the whole server:
+ *  the adapter never completes `initialize` and the session shows no admin tools at
+ *  all. They are answered inside the MCP handler, reach no tool, no nested REST call,
+ *  and no org-scoped data — but they still require a live, unrevoked grant, so an
+ *  expired credential learns nothing beyond the same 401. */
+const HANDSHAKE_METHODS = new Set(['initialize', 'notifications/initialized', 'ping'])
+
 export type RemoteGrantClaimResult =
-  { kind: 'execute'; context: InvocationContext } | { kind: 'denied'; reason: string }
+  { kind: 'execute'; context: InvocationContext } | { kind: 'handshake' } | { kind: 'denied'; reason: string }
 
 export interface RemoteGrantAuthenticatorDeps extends LiveWebchatMcpAuthorityDeps {
   clock: Pick<Clock, 'now'>
@@ -77,10 +87,12 @@ export class RemoteGrantAuthenticator {
     } catch {
       return { kind: 'denied', reason: 'metadata' }
     }
+    if (HANDSHAKE_METHODS.has(metadata.method)) return { kind: 'handshake' }
+    const method = metadata.method
     if (
-      (metadata.method !== 'tools/list' && metadata.method !== 'tools/call') ||
-      (metadata.method === 'tools/list' && metadata.toolName !== undefined) ||
-      (metadata.method === 'tools/call' && (!metadata.toolName || !this.deps.isCuratedTool(metadata.toolName)))
+      (method !== 'tools/list' && method !== 'tools/call') ||
+      (method === 'tools/list' && metadata.toolName !== undefined) ||
+      (method === 'tools/call' && (!metadata.toolName || !this.deps.isCuratedTool(metadata.toolName)))
     ) {
       return { kind: 'denied', reason: 'tool' }
     }
@@ -100,7 +112,7 @@ export class RemoteGrantAuthenticator {
         startedAt: now,
         ...(metadata.requestId ? { requestId: metadata.requestId } : {}),
         requestHash: createHash('sha256').update(input.requestBytes).digest('hex'),
-        method: metadata.method,
+        method,
         ...(metadata.toolName ? { toolName: metadata.toolName } : {})
       }
     }

--- a/packages/control-plane/src/http/mcp/routes.ts
+++ b/packages/control-plane/src/http/mcp/routes.ts
@@ -210,6 +210,9 @@ export function mcpRoutes(deps: HttpDeps) {
       const authorization = authorizationValues[0]
       const remoteGrant = isRemoteGrant(authorization) ? bearerToken(authorization) : null
       let invocationContext: InvocationContext | undefined
+      // A grant-authenticated transport handshake: authorized, but bound to no org and
+      // reaching no tool (see HANDSHAKE_METHODS).
+      let handshakeOnly = false
 
       if (remoteGrant) {
         const claim = await deps.remoteGrantAuth.authenticate({
@@ -218,14 +221,15 @@ export function mcpRoutes(deps: HttpDeps) {
           parseMetadata: () => invocationMetadata(rawBody)
         })
         if (claim.kind === 'denied') return sendRemoteGrantDenied(reply)
-        invocationContext = claim.context
+        if (claim.kind === 'handshake') handshakeOnly = true
+        else invocationContext = claim.context
       }
 
       // Credential = a personal API key or an OAuth access token. `humanAuth` resolved it
       // (req.apiKeyOrgId set) or admitted the caller some other way (devAuth / OIDC ⇒ no
       // key org) — only the key path may proceed: the key's org binding pins this MCP
       // connection to ONE org.
-      if (!invocationContext && !req.apiKeyOrgId) {
+      if (!invocationContext && !handshakeOnly && !req.apiKeyOrgId) {
         return reply
           .header('www-authenticate', mcpAuthenticateChallenge(publicBaseUrl(req, deps.config), deps.config))
           .code(401)
@@ -245,6 +249,62 @@ export function mcpRoutes(deps: HttpDeps) {
           error: { code: -32600, message: 'JSON-RPC batch requests are not supported' },
           id: null
         })
+      }
+
+      // v2 web-standard handler: build a Fetch Request from the raw body + headers,
+      // let the SDK dispatch it, and write the Fetch Response back to Fastify. No
+      // hijack / Express — just this local adapter, so app.inject still works.
+      const headers = new Headers()
+      for (const [k, v] of Object.entries(req.headers)) {
+        // A grant is a daemon-held credential the MCP layer already consumed; it never
+        // travels further, on the handshake path either.
+        if (remoteGrant && k === 'authorization') continue
+        if (typeof v === 'string') headers.set(k, v)
+        else if (Array.isArray(v)) headers.set(k, v.join(', '))
+      }
+      const host = typeof req.headers.host === 'string' ? req.headers.host : 'localhost'
+      const request = new Request(`http://${host}${req.url}`, {
+        method: 'POST',
+        headers,
+        body: rawBody.byteLength > 0 ? rawBody : undefined
+      })
+
+      const runHandler = async (server: Server): Promise<McpWireResponse> => {
+        try {
+          const res = await createMcpHandler(() => server).fetch(request, {})
+          return {
+            statusCode: res.status,
+            headers: res.headers,
+            bytes: res.body ? Buffer.from(await res.arrayBuffer()) : Buffer.alloc(0)
+          }
+        } catch (err) {
+          req.log.error({ err }, 'mcp: transport error')
+          return {
+            statusCode: 500,
+            headers: new Headers({ 'content-type': 'application/json; charset=utf-8' }),
+            bytes: Buffer.from(
+              JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'internal server error' }, id: null })
+            )
+          }
+        }
+      }
+
+      const sendWireResponse = (wire: McpWireResponse) => {
+        reply.code(wire.statusCode)
+        wire.headers.forEach((value, key) => {
+          if (key !== 'content-length') void reply.header(key, value)
+        })
+        return reply.send(wire.bytes)
+      }
+
+      // The handshake is answered by the SDK itself, off a server carrying no tool
+      // handlers and no org context — it advertises the same identity and tool
+      // capability, so the client proceeds to `tools/list`, which then runs the full
+      // invocation path below.
+      if (handshakeOnly) {
+        return sendWireResponse(
+          await runHandler(new Server(serverInfo(deps.config.PUBLIC_WEB_URL), { capabilities: { tools: {} } }))
+        )
       }
 
       const orgId = invocationContext?.orgId ?? req.apiKeyOrgId!
@@ -487,51 +547,7 @@ export function mcpRoutes(deps: HttpDeps) {
         return { content: [{ type: 'text' as const, text: result.body || `OK (HTTP ${result.statusCode})` }] }
       })
 
-      // v2 web-standard handler: build a Fetch Request from the raw body + headers,
-      // let the SDK dispatch it, and write the Fetch Response back to Fastify. No
-      // hijack / Express — just this local adapter, so app.inject still works.
-      const handler = createMcpHandler(() => server)
-      const headers = new Headers()
-      for (const [k, v] of Object.entries(req.headers)) {
-        if (invocationContext && k === 'authorization') continue
-        if (typeof v === 'string') headers.set(k, v)
-        else if (Array.isArray(v)) headers.set(k, v.join(', '))
-      }
-      const host = typeof req.headers.host === 'string' ? req.headers.host : 'localhost'
-      const request = new Request(`http://${host}${req.url}`, {
-        method: 'POST',
-        headers,
-        body: rawBody.byteLength > 0 ? rawBody : undefined
-      })
-
-      const dispatch = async (): Promise<McpWireResponse> => {
-        try {
-          const res = await handler.fetch(request, {})
-          return {
-            statusCode: res.status,
-            headers: res.headers,
-            bytes: res.body ? Buffer.from(await res.arrayBuffer()) : Buffer.alloc(0)
-          }
-        } catch (err) {
-          req.log.error({ err }, 'mcp: transport error')
-          return {
-            statusCode: 500,
-            headers: new Headers({ 'content-type': 'application/json; charset=utf-8' }),
-            bytes: Buffer.from(
-              JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'internal server error' }, id: null })
-            )
-          }
-        }
-      }
-
-      const sendWireResponse = (wire: McpWireResponse) => {
-        reply.code(wire.statusCode)
-        wire.headers.forEach((value, key) => {
-          if (key !== 'content-length') void reply.header(key, value)
-        })
-        return reply.send(wire.bytes)
-      }
-
+      const dispatch = () => runHandler(server)
       if (!invocationContext) return sendWireResponse(await dispatch())
       const invocationExecution = deps.internalInvocationAuth.start(invocationContext, dispatch)
       try {

--- a/packages/control-plane/src/http/oauth/base.test.ts
+++ b/packages/control-plane/src/http/oauth/base.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The MCP endpoint's public identity: the resource URL the CP advertises (RFC 9728)
+ * and the descriptor URL it hands daemons must be the SAME string, under both deploy
+ * shapes. They diverged once — the descriptor pointed at the internal `/api/v1/mcp`
+ * mount, which a two-origin deploy does not expose — and the only symptom was a
+ * webchat session silently missing its entire `agentconnect-admin` server.
+ */
+import { describe, it, expect } from 'vitest'
+import { protectedResourceMetadata, webchatMcpDescriptorUrl } from './base.js'
+
+describe('webchatMcpDescriptorUrl', () => {
+  it('is the dedicated MCP origin when one is configured', () => {
+    const config = { PUBLIC_CP_URL: 'https://api.example.test', PUBLIC_MCP_URL: 'https://mcp.example.test' }
+    expect(webchatMcpDescriptorUrl(config)).toBe('https://mcp.example.test')
+    expect(webchatMcpDescriptorUrl(config)).toBe(protectedResourceMetadata(config.PUBLIC_CP_URL, config).resource)
+  })
+
+  it('falls back to the PUBLIC /v1/mcp alias — never the internal /api/v1 mount', () => {
+    const config = { PUBLIC_CP_URL: 'https://api.example.test/' }
+    expect(webchatMcpDescriptorUrl(config)).toBe('https://api.example.test/v1/mcp')
+    expect(webchatMcpDescriptorUrl(config)).not.toContain('/api/v1')
+    expect(webchatMcpDescriptorUrl(config)).toBe(protectedResourceMetadata('https://api.example.test', config).resource)
+  })
+
+  it('addresses the local direct-hit CP when no public origin is configured', () => {
+    expect(webchatMcpDescriptorUrl({})).toBe('http://localhost:8080/v1/mcp')
+  })
+})

--- a/packages/control-plane/src/http/oauth/base.ts
+++ b/packages/control-plane/src/http/oauth/base.ts
@@ -53,6 +53,16 @@ export function mcpResourceUrl(base: string, config: McpUrlConfig): string {
   return dedicated ? dedicated : `${base}${MCP_PUBLIC_PATH}`
 }
 
+/** The MCP endpoint URL handed to a daemon for a session-scoped `agentconnect-admin`
+ *  descriptor. The adapter dials it straight from the edge with no discovery step, so
+ *  it must be the same canonical public resource `mcpResourceUrl` advertises — the
+ *  internal `/api/v1/mcp` mount is not necessarily exposed (a two-origin deploy 404s
+ *  it), and a descriptor pointing there costs the session its whole administration
+ *  server with no user-visible error. */
+export function webchatMcpDescriptorUrl(config: Pick<HttpServerConfig, 'PUBLIC_CP_URL' | 'PUBLIC_MCP_URL'>): string {
+  return mcpResourceUrl((config.PUBLIC_CP_URL ?? 'http://localhost:8080').replace(/\/+$/, ''), config)
+}
+
 /** The origin the embedded AS lives on. The AS exists solely for MCP browser login
  *  (§7), so it rides the dedicated MCP origin when one is configured — the CP's own
  *  public origin (the api host) then serves NO OAuth at all. Falls back to the CP

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -246,7 +246,7 @@ describe('delegated webchat MCP operations', () => {
           : undefined
     })
     opened.push(app)
-    const remoteRpc = (id: number, name: string, args: Record<string, unknown>) =>
+    const remoteMethod = (payload: Record<string, unknown>) =>
       app.app.inject({
         method: 'POST',
         url: MCP_URL,
@@ -255,10 +255,12 @@ describe('delegated webchat MCP operations', () => {
           accept: 'application/json, text/event-stream',
           'content-type': 'application/json'
         },
-        payload: { jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } }
+        payload: { jsonrpc: '2.0', ...payload }
       })
+    const remoteRpc = (id: number, name: string, args: Record<string, unknown>) =>
+      remoteMethod({ id, method: 'tools/call', params: { name, arguments: args } })
     const decisionPath = `/api/v1/orgs/${DEFAULT_ORG_ID}/agents/${hostAgentId}/webchat/${conversationId}/mcp-operations`
-    return { app, daemonId, hostAgentId, conversationId, remoteRpc, decisionPath }
+    return { app, daemonId, hostAgentId, conversationId, remoteRpc, remoteMethod, decisionPath, credential }
   }
 
   /** Submit a delegated write and return its pending operationId. */
@@ -277,6 +279,54 @@ describe('delegated webchat MCP operations', () => {
     expect(pending.status).toBe('awaiting_confirmation')
     return pending.operationId
   }
+
+  it('completes the mandatory MCP handshake before any tool is reachable', async () => {
+    const { remoteMethod } = await delegatedFixture()
+
+    // An MCP client CANNOT reach tools/* without initializing first. Denying the
+    // handshake denies the whole server: the adapter drops `agentconnect-admin` and
+    // the session shows no administration tools at all.
+    const init = await remoteMethod({
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'adapter', version: '0.0.0' } }
+    })
+    expect(init.statusCode).toBe(200)
+    const initialized = mcpMessage(init).result as {
+      serverInfo?: { name?: string }
+      capabilities?: { tools?: unknown }
+    }
+    expect(initialized.serverInfo?.name).toBe('agentconnect')
+    expect(initialized.capabilities?.tools).toBeDefined()
+
+    // The notification and keepalive complete the transport contract…
+    expect((await remoteMethod({ method: 'notifications/initialized' })).statusCode).toBeLessThan(300)
+    expect((await remoteMethod({ id: 2, method: 'ping' })).statusCode).toBe(200)
+
+    // …and the handshake grants nothing beyond it: the catalog still comes from the
+    // authorized invocation path, and an off-catalog method is still refused.
+    const listed = await remoteMethod({ id: 3, method: 'tools/list' })
+    expect(listed.statusCode).toBe(200)
+    expect((mcpMessage(listed).result as { tools: Array<{ name: string }> }).tools.length).toBeGreaterThan(0)
+
+    const off = await remoteMethod({ id: 4, method: 'resources/list' })
+    expect(off.statusCode).toBe(401)
+    expect(off.headers['www-authenticate']).toBeUndefined()
+  })
+
+  it('refuses the handshake once the grant is revoked — no anonymous transport', async () => {
+    const { remoteMethod, credential } = await delegatedFixture()
+    await prisma.webchatMcpAccessGrant.updateMany({
+      where: { tokenHash: credential.tokenHash },
+      data: { revokedAt: new Date(), status: 'revoked' }
+    })
+    const init = await remoteMethod({
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'adapter', version: '0.0.0' } }
+    })
+    expect(init.statusCode).toBe(401)
+  })
 
   it('executes reads directly but holds writes until the conversation owner approves', async () => {
     const fixture = await delegatedFixture()


### PR DESCRIPTION
A webchat session on the general preset had its `agentconnect-admin` descriptor installed and still showed no administration tools. Traced on the test deployment: the descriptor was present in the running adapter's `--mcp-config`, but the URL it pointed at 404s, and the URL that *does* answer rejects the MCP handshake. Two independent CP-side defects.

## 1. The descriptor URL was the internal mount path

`container.ts` hand-built `PUBLIC_CP_URL` + `/api/v1/mcp`. That is an internal mount an edge need not expose — a deploy with a dedicated MCP origin (`PUBLIC_MCP_URL`) routes neither it nor anything else under `/api/v1`. Measured against the test CP:

| URL | Result |
| --- | --- |
| `<api>/api/v1/mcp` (what was handed to the daemon) | **404** |
| `<api>/v1/mcp` | reaches the route |
| `<mcp-origin>/` (the canonical resource) | reaches the route |

Now derived by `webchatMcpDescriptorUrl()` next to `mcpResourceUrl()`, so the descriptor URL and the RFC 9728 `resource` the endpoint advertises are the same string by construction.

## 2. `initialize` was denied 401

`RemoteGrantAuthenticator` admitted only `tools/list` and `tools/call`; every other JSON-RPC method got `remote MCP grant denied`. The MCP handshake is mandatory, so denying it denies the whole server — a client can never reach the tools it *is* allowed to call.

`initialize`, `notifications/initialized`, and `ping` are now admitted **after** the full check chain (grant active → authority active → live authorization → private webchat session) and answered off a bare `Server`: same `serverInfo` and tool capability, no tool handlers, no org binding, no nested REST, grant header still stripped. Every other method stays denied, and a revoked grant still fails the handshake.

Verified against the live test CP with a real session grant: `tools/list` returns the full catalog, `initialize` was the 401.

## Why tests were green

The §13 adapter behavior harness dials a local mock HTTP server, and the CP-side grant tests only ever sent `tools/*` — nothing exercised a real handshake against the real route, and nothing pinned the handed-out URL to the served one.

- `src/http/oauth/base.test.ts` (new): the descriptor URL must equal the advertised PRM `resource`, for both deploy shapes, and must never contain `/api/v1`.
- `test/integration/mcp.route.test.ts` (+2): full handshake → `tools/list` → an off-catalog method still 401; and a revoked grant cannot handshake.

## Deploy note

Existing sessions do not self-heal — the daemon caches the descriptor per conversation, so a new URL arrives only on grant renewal or a fresh session.

Design doc §6/§7 updated with the URL requirement and the handshake admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
