### PR TITLE
feat(daemon): enable Claude inner sandbox

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -24,7 +24,13 @@ import {
 } from '@agentconnect.md/protocol'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
-import { augmentClaudeEfforts, isClaudeRuntimeDef, ULTRACODE_EFFORT } from './claude-runtime.js'
+import {
+  augmentClaudeEfforts,
+  claudeInnerSandboxSettings,
+  isClaudeRuntimeDef,
+  type ClaudeInnerSandboxSettings,
+  ULTRACODE_EFFORT
+} from './claude-runtime.js'
 import { sandboxWrap, type SandboxMechanism } from './sandbox.js'
 import type { Logger } from '../log.js'
 import { accountAppIsolation } from './account-apps.js'
@@ -145,6 +151,9 @@ export interface AcpSandboxLaunch {
   settingsPath?: string
   /** Trusted working directory used to anchor SRT's Linux mandatory-deny scan. */
   cwd?: string
+  /** Credential paths available to the trusted ACP runtime itself but denied to
+   * model-authored commands by a runtime-native nested sandbox. */
+  protectedCredentialRoots?: string[]
 }
 
 /** The `session/set_config_option` call that applies a desired value, or the reason none is needed. */
@@ -285,7 +294,7 @@ export { ULTRACODE_EFFORT }
 
 /** The session `_meta` sent to a Claude runtime on session/new and session/load
  *  (`_meta.claudeCode.options` is spread into the SDK `query()` options layer), or
- *  undefined off Claude runtimes. Three things ride on it:
+ *  undefined off Claude runtimes. Four things ride on it:
  *
  *  - `thinking`: recent models default `thinking.display` to "omitted" — thinking
  *    blocks stream signature-only with empty text, so the ACP wrapper never emits
@@ -297,6 +306,9 @@ export { ULTRACODE_EFFORT }
  *    silently drop the orchestration half. Best-effort: on a non-xhigh-capable model
  *    or with workflows unavailable the runtime reports `applied.ultracode=false` and
  *    the session still runs on its default effort — nothing to fail on our side.
+ *  - `options.sandbox` (only when the ACP runtime already has an outer
+ *    AgentConnect sandbox): enables Claude's native Bash sandbox fail-closed and
+ *    denies its sandboxed commands the provider credentials the parent can read.
  *  - `systemPrompt` (top-level, sibling of `claudeCode`): the agent's system-prompt
  *    seed PLUS, on a fresh session, the agent's memory index (standing context, not a
  *    user turn — see SessionManager). We send it as `{ append }` so it layers ON TOP
@@ -321,13 +333,15 @@ export function claudeSessionMeta(
   reasoningEffort: string | undefined,
   isClaudeRuntime: boolean,
   systemPrompt?: string,
-  memoryAppend?: string
+  memoryAppend?: string,
+  protectedCredentialRoots?: readonly string[]
 ):
   | {
       claudeCode: {
         options: {
           thinking: { type: 'adaptive'; display: 'summarized' }
           settings?: { ultracode: true; enableWorkflows: true }
+          sandbox?: ClaudeInnerSandboxSettings
         }
         emitRawSDKMessages: ReadonlyArray<{ type: string; subtype: string }>
       }
@@ -342,6 +356,7 @@ export function claudeSessionMeta(
     claudeCode: {
       options: {
         thinking: { type: 'adaptive', display: 'summarized' },
+        ...(protectedCredentialRoots ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots) } : {}),
         ...(reasoningEffort === ULTRACODE_EFFORT
           ? { settings: { ultracode: true as const, enableWorkflows: true as const } }
           : {})
@@ -772,7 +787,8 @@ export class AcpHost {
       effortOverride ?? this.opts.configPrefs?.reasoningEffort,
       this.isClaudeRuntime(),
       this.opts.configPrefs?.systemPrompt,
-      systemAppend
+      systemAppend,
+      this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined
     )
     const res = await this.conn!.agent.request(methods.agent.session.new, {
       cwd,
@@ -987,7 +1003,9 @@ export class AcpHost {
       const _meta = claudeSessionMeta(
         effortOverride ?? this.opts.configPrefs?.reasoningEffort,
         this.isClaudeRuntime(),
-        systemAppend ?? this.opts.configPrefs?.systemPrompt
+        systemAppend ?? this.opts.configPrefs?.systemPrompt,
+        undefined,
+        this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined
       )
       const res = await this.conn!.agent.request(methods.agent.session.load, {
         sessionId,

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -29,6 +29,7 @@ import {
   claudeInnerSandboxSettings,
   isClaudeRuntimeDef,
   type ClaudeInnerSandboxSettings,
+  type ClaudeProtectedSettings,
   ULTRACODE_EFFORT
 } from './claude-runtime.js'
 import { sandboxWrap, type SandboxMechanism } from './sandbox.js'
@@ -154,6 +155,9 @@ export interface AcpSandboxLaunch {
   /** Credential paths available to the trusted ACP runtime itself but denied to
    * model-authored commands by a runtime-native nested sandbox. */
   protectedCredentialRoots?: string[]
+  /** SDK flag settings that pin protected parent-only profile selection after
+   * Claude merges workspace-controlled settings. */
+  claudeProtectedSettings?: ClaudeProtectedSettings
 }
 
 /** The `session/set_config_option` call that applies a desired value, or the reason none is needed. */
@@ -300,12 +304,11 @@ export { ULTRACODE_EFFORT }
  *    blocks stream signature-only with empty text, so the ACP wrapper never emits
  *    `agent_thought_chunk` and the transcript loses its reasoning rows. Request
  *    "summarized" (the fullest display the API offers) so thoughts reach the stream.
- *  - `settings.ultracode` (effort "ultracode" only): a session-scoped flag setting
- *    the effort select can't reach — the runtime rejects effort="ultracode".
- *    `enableWorkflows` rides along so the "pro" plan default (workflows off) doesn't
- *    silently drop the orchestration half. Best-effort: on a non-xhigh-capable model
- *    or with workflows unavailable the runtime reports `applied.ultracode=false` and
- *    the session still runs on its default effort — nothing to fail on our side.
+ *  - `settings`: for a sandboxed parent, the SDK's highest-precedence flag tier
+ *    reasserts protected Anthropic profile selection after workspace settings merge;
+ *    effort "ultracode" additionally carries the session-scoped flags the effort
+ *    select can't reach. The adapter's CLAUDE_MODEL_CONFIG fallback is preserved in
+ *    the protected settings because supplying `options.settings` replaces it.
  *  - `options.sandbox` (only when the ACP runtime already has an outer
  *    AgentConnect sandbox): enables Claude's native Bash sandbox fail-closed and
  *    denies its sandboxed commands the provider credentials the parent can read.
@@ -329,18 +332,27 @@ export const SDK_LIFECYCLE_FILTERS = [
   { type: 'system', subtype: 'task_notification' }
 ] as const
 
+interface ClaudeSessionSettings {
+  env?: ClaudeProtectedSettings['env']
+  modelOverrides?: unknown
+  availableModels?: unknown
+  ultracode?: true
+  enableWorkflows?: true
+}
+
 export function claudeSessionMeta(
   reasoningEffort: string | undefined,
   isClaudeRuntime: boolean,
   systemPrompt?: string,
   memoryAppend?: string,
-  protectedCredentialRoots?: readonly string[]
+  protectedCredentialRoots?: readonly string[],
+  protectedSettings?: ClaudeProtectedSettings
 ):
   | {
       claudeCode: {
         options: {
           thinking: { type: 'adaptive'; display: 'summarized' }
-          settings?: { ultracode: true; enableWorkflows: true }
+          settings?: ClaudeSessionSettings
           sandbox?: ClaudeInnerSandboxSettings
         }
         emitRawSDKMessages: ReadonlyArray<{ type: string; subtype: string }>
@@ -352,14 +364,17 @@ export function claudeSessionMeta(
   // The seed and the memory index ride the SAME append (seed first, blank line, then
   // memory). Either/both/neither — an empty result omits `systemPrompt` entirely.
   const append = [systemPrompt, memoryAppend].filter(Boolean).join('\n\n')
+  const ultracode = reasoningEffort === ULTRACODE_EFFORT
+  const settings: ClaudeSessionSettings = {
+    ...(protectedSettings ?? {}),
+    ...(ultracode ? { ultracode: true, enableWorkflows: true } : {})
+  }
   return {
     claudeCode: {
       options: {
         thinking: { type: 'adaptive', display: 'summarized' },
         ...(protectedCredentialRoots ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots) } : {}),
-        ...(reasoningEffort === ULTRACODE_EFFORT
-          ? { settings: { ultracode: true as const, enableWorkflows: true as const } }
-          : {})
+        ...(protectedSettings || ultracode ? { settings } : {})
       },
       emitRawSDKMessages: SDK_LIFECYCLE_FILTERS
     },
@@ -788,7 +803,8 @@ export class AcpHost {
       this.isClaudeRuntime(),
       this.opts.configPrefs?.systemPrompt,
       systemAppend,
-      this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined
+      this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
+      this.opts.sandbox?.claudeProtectedSettings
     )
     const res = await this.conn!.agent.request(methods.agent.session.new, {
       cwd,
@@ -1005,7 +1021,8 @@ export class AcpHost {
         this.isClaudeRuntime(),
         systemAppend ?? this.opts.configPrefs?.systemPrompt,
         undefined,
-        this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined
+        this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
+        this.opts.sandbox?.claudeProtectedSettings
       )
       const res = await this.conn!.agent.request(methods.agent.session.load, {
         sessionId,

--- a/packages/daemon/src/acp/claude-runtime.ts
+++ b/packages/daemon/src/acp/claude-runtime.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import type { RuntimeDef } from '../config/config-schema.js'
 
 /** Effort sentinel `'ultracode'` (matching Claude Code's own `ultracode` settings
@@ -5,6 +6,106 @@ import type { RuntimeDef } from '../config/config-schema.js'
  *  deliberately NOT a `thought_level` select value: the claude-acp runtime rejects
  *  effort="ultracode" ("Invalid value"). See `claudeSessionMeta` in acp-host.ts. */
 export const ULTRACODE_EFFORT = 'ultracode'
+
+/** Provider credential files that the trusted Claude parent may read but its
+ * native sandbox must hide from model-authored Bash. */
+const CLAUDE_PROVIDER_CREDENTIAL_FILE_ENV = [
+  'ANTHROPIC_IDENTITY_TOKEN_FILE',
+  'AWS_CONFIG_FILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+  'GOOGLE_APPLICATION_CREDENTIALS'
+] as const
+
+/** Anthropic profile selectors are unsupported for sandboxed Claude launches.
+ * Profile JSON may be agent-writable and must never choose host exceptions. */
+export const CLAUDE_PROFILE_ENV = ['ANTHROPIC_CONFIG_DIR', 'ANTHROPIC_PROFILE'] as const
+
+/** Claude provider credentials the parent runtime may consume but the native
+ * sandbox removes from sandboxed Bash commands. Shared-login credentials normally
+ * live in a file; these cover explicit API/gateway configurations as well. */
+const CLAUDE_PROVIDER_CREDENTIAL_ENV = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_IDENTITY_TOKEN',
+  'ANTHROPIC_IDENTITY_TOKEN_FILE',
+  ...CLAUDE_PROFILE_ENV,
+  'ANTHROPIC_CUSTOM_HEADERS',
+  'ANTHROPIC_AWS_API_KEY',
+  'ANTHROPIC_FOUNDRY_API_KEY',
+  'ANTHROPIC_FOUNDRY_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_REFRESH_TOKEN',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_EC2_METADATA_SERVICE_ENDPOINT',
+  'AWS_CONFIG_FILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'CLOUDSDK_AUTH_ACCESS_TOKEN',
+  'GOOGLE_APPLICATION_CREDENTIALS'
+] as const
+
+type ClaudeCredentialPathEnv = (typeof CLAUDE_PROVIDER_CREDENTIAL_FILE_ENV)[number]
+
+/** Discover direct provider credential file pointers from the trusted runtime
+ * environment. Profile JSON is deliberately not inspected: agent-writable input
+ * must never generate an outer-sandbox exception. */
+export function claudeProviderCredentialFiles(
+  env: NodeJS.ProcessEnv,
+  cwd: string
+): Array<{ envName: ClaudeCredentialPathEnv; path: string }> {
+  return CLAUDE_PROVIDER_CREDENTIAL_FILE_ENV.flatMap((name) => {
+    const path = env[name]?.trim()
+    return path ? [{ envName: name, path: resolve(cwd, path) }] : []
+  })
+}
+
+export interface ClaudeInnerSandboxSettings {
+  enabled: true
+  failIfUnavailable: true
+  autoAllowBashIfSandboxed: true
+  allowUnsandboxedCommands: false
+  filesystem: {
+    denyRead: string[]
+    denyWrite: string[]
+  }
+  credentials: {
+    files: Array<{ path: string; mode: 'deny' }>
+    envVars: Array<{ name: (typeof CLAUDE_PROVIDER_CREDENTIAL_ENV)[number]; mode: 'deny' }>
+  }
+}
+
+/** Build the SDK-native policy passed through claude-agent-acp's
+ * `_meta.claudeCode.options.sandbox`. Using the dedicated option preserves the
+ * adapter's CLAUDE_MODEL_CONFIG fallback (which `options.settings` would replace).
+ * The outer AgentConnect SRT remains the host boundary; this nested sandbox
+ * confines model-authored Bash and its descendants, while the parent Claude
+ * process retains shared-login access. */
+export function claudeInnerSandboxSettings(protectedCredentialRoots: readonly string[]): ClaudeInnerSandboxSettings {
+  const roots = [...new Set(protectedCredentialRoots)]
+  return {
+    enabled: true,
+    failIfUnavailable: true,
+    autoAllowBashIfSandboxed: true,
+    allowUnsandboxedCommands: false,
+    filesystem: {
+      denyRead: roots,
+      denyWrite: roots
+    },
+    credentials: {
+      files: roots.map((path) => ({ path, mode: 'deny' as const })),
+      envVars: CLAUDE_PROVIDER_CREDENTIAL_ENV.map((name) => ({ name, mode: 'deny' as const }))
+    }
+  }
+}
 
 /** A Claude Code runtime (its command/args reference `claude`) — these embed the
  *  @anthropic-ai/claude-agent-sdk, which needs a Claude Code executable. The ONE

--- a/packages/daemon/src/acp/claude-runtime.ts
+++ b/packages/daemon/src/acp/claude-runtime.ts
@@ -19,9 +19,45 @@ const CLAUDE_PROVIDER_CREDENTIAL_FILE_ENV = [
 ] as const
 
 /** Anthropic profile selectors from operator/agent input are unsupported for
- * sandboxed Claude launches. The config root is replaced with a daemon-owned
- * empty directory, while the profile name is removed. */
+ * sandboxed Claude launches. The spawn environment drops both before the config
+ * root is replaced with a daemon-owned empty directory; per-session flag settings
+ * then reassert that root and a fixed profile after user/project settings merge. */
 export const CLAUDE_PROFILE_ENV = ['ANTHROPIC_CONFIG_DIR', 'ANTHROPIC_PROFILE'] as const
+export const CLAUDE_DISABLED_PROFILE = 'agentconnect-disabled'
+
+export interface ClaudeProtectedSettings {
+  env: Record<(typeof CLAUDE_PROFILE_ENV)[number], string>
+  modelOverrides?: unknown
+  availableModels?: unknown
+}
+
+/** Build the highest-precedence SDK flag settings that pin Anthropic profile
+ * discovery after Claude has merged user/project/local settings. Supplying any
+ * `options.settings` makes claude-agent-acp skip its CLAUDE_MODEL_CONFIG fallback,
+ * so preserve the two fields that fallback would otherwise contribute. */
+export function claudeProtectedSettings(env: NodeJS.ProcessEnv): ClaudeProtectedSettings {
+  const configDir = env.ANTHROPIC_CONFIG_DIR
+  if (!configDir) throw new Error('sandboxed Claude launch is missing its protected Anthropic config root')
+
+  const modelConfig: Pick<ClaudeProtectedSettings, 'modelOverrides' | 'availableModels'> = {}
+  if (env.CLAUDE_MODEL_CONFIG) {
+    const parsed = JSON.parse(env.CLAUDE_MODEL_CONFIG) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('CLAUDE_MODEL_CONFIG must be a JSON object')
+    }
+    const value = parsed as Record<string, unknown>
+    if (value.modelOverrides !== undefined) modelConfig.modelOverrides = value.modelOverrides
+    if (value.availableModels !== undefined) modelConfig.availableModels = value.availableModels
+  }
+
+  return {
+    ...modelConfig,
+    env: {
+      ANTHROPIC_CONFIG_DIR: configDir,
+      ANTHROPIC_PROFILE: CLAUDE_DISABLED_PROFILE
+    }
+  }
+}
 
 /** Claude provider credentials the parent runtime may consume but the native
  * sandbox removes from sandboxed Bash commands. Shared-login credentials normally
@@ -85,11 +121,9 @@ export interface ClaudeInnerSandboxSettings {
 }
 
 /** Build the SDK-native policy passed through claude-agent-acp's
- * `_meta.claudeCode.options.sandbox`. Using the dedicated option preserves the
- * adapter's CLAUDE_MODEL_CONFIG fallback (which `options.settings` would replace).
- * The outer AgentConnect SRT remains the host boundary; this nested sandbox
- * confines model-authored Bash and its descendants, while the parent Claude
- * process retains shared-login access. */
+ * `_meta.claudeCode.options.sandbox`. The outer AgentConnect SRT remains the host
+ * boundary; this nested sandbox confines model-authored Bash and its descendants,
+ * while the parent Claude process retains shared-login access. */
 export function claudeInnerSandboxSettings(protectedCredentialRoots: readonly string[]): ClaudeInnerSandboxSettings {
   const roots = [...new Set(protectedCredentialRoots)]
   return {

--- a/packages/daemon/src/acp/claude-runtime.ts
+++ b/packages/daemon/src/acp/claude-runtime.ts
@@ -18,8 +18,9 @@ const CLAUDE_PROVIDER_CREDENTIAL_FILE_ENV = [
   'GOOGLE_APPLICATION_CREDENTIALS'
 ] as const
 
-/** Anthropic profile selectors are unsupported for sandboxed Claude launches.
- * Profile JSON may be agent-writable and must never choose host exceptions. */
+/** Anthropic profile selectors from operator/agent input are unsupported for
+ * sandboxed Claude launches. The config root is replaced with a daemon-owned
+ * empty directory, while the profile name is removed. */
 export const CLAUDE_PROFILE_ENV = ['ANTHROPIC_CONFIG_DIR', 'ANTHROPIC_PROFILE'] as const
 
 /** Claude provider credentials the parent runtime may consume but the native

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -1,12 +1,13 @@
 import { existsSync, mkdirSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { basename, delimiter, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from './sandbox.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials.js'
 import { prepareRuntimeHome, runtimeHomeEnvironment, runtimeHomePath } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
+import { CLAUDE_PROFILE_ENV, claudeProviderCredentialFiles, isClaudeRuntimeDef } from './claude-runtime.js'
 
 export interface PreparedRuntimeLaunch {
   env: Record<string, string>
@@ -20,6 +21,9 @@ export interface PreparedRuntimeLaunch {
     cwd: string
     denyReadRoots: string[]
     allowReadRoots: string[]
+    /** Credential paths deliberately exposed to the trusted runtime parent but
+     * denied again inside a runtime-native tool sandbox. */
+    protectedCredentialRoots: string[]
   }
 }
 
@@ -185,19 +189,53 @@ export function prepareRuntimeLaunch(opts: {
   const credentialWritableRoots = compactReadRoots(
     (credentials?.writablePaths ?? []).map((path) => validateException(path, 'shared credential write root'))
   )
+  const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
+  if (claudeRuntime) {
+    // Anthropic profile JSON may live in the agent-writable private HOME and may
+    // reference arbitrary host paths. Fail closed instead of letting that mutable
+    // input influence the outer sandbox. Shared Claude /login uses the separate
+    // daemon-managed secure-storage directory prepared above.
+    for (const name of CLAUDE_PROFILE_ENV) delete env[name]
+  }
+  const providerCredentialFiles = claudeRuntime ? claudeProviderCredentialFiles(env, opts.cwd) : []
+  const providerCredentialReadRoots = compactReadRoots(
+    providerCredentialFiles.map(({ envName, path }) => {
+      const canonical = validateException(path, 'Claude provider credential file')
+      // The exception is canonical; point the trusted parent at that same path so
+      // a credential symlink below a hidden HOME cannot become unreadable.
+      if (envName) env[envName] = canonical
+      return canonical
+    })
+  )
+  // Claude user state is copied into the private HOME for the trusted parent.
+  // It may contain settings.env secrets or MCP credentials, so deny every seeded
+  // Claude state surface to the inner Bash sandbox without changing outer access.
+  const privateClaudeStateRoots = claudeRuntime
+    ? [join(runtimeHome, '.claude'), join(runtimeHome, '.claude.json')]
+        .filter(existsSync)
+        .map((path) => realpathSync(path))
+    : []
 
   const boundary = sandboxBoundary({
     agentDir: opts.scopeDir,
     cwd: opts.cwd,
     runtimeHome,
     mcpSocketPath: opts.mcpSocketPath,
-    trustedReadRoots: trustedRuntimeReadRoots,
+    trustedReadRoots: [...trustedRuntimeReadRoots, ...providerCredentialReadRoots],
     trustedWriteRoots: credentialWritableRoots
   })
   // SRT write roots must exist before spawn.
   // This also initializes workspace/memory for a newly-created agent.
   for (const path of boundary.writable) {
     if (!existsSync(path)) mkdirSync(path, { recursive: true })
+  }
+  if (opts.runtime && isClaudeRuntimeDef(opts.runtime)) {
+    // Both layers use SRT. If `.claude` itself is absent, the outer layer masks
+    // that first missing component read-only while protecting nested Claude
+    // config paths; Claude's inner bwrap can then no longer create its own
+    // settings mountpoint. An empty directory is enough and produces no Git diff.
+    const projectClaudeDir = join(boundary.gitSafeDirectories[0]!, '.claude')
+    if (!existsSync(projectClaudeDir)) mkdirSync(projectClaudeDir, { mode: 0o700 })
   }
   const settingsPath = writeSandboxSettings(opts.scopeDir, {
     writable: boundary.writable,
@@ -217,7 +255,12 @@ export function prepareRuntimeLaunch(opts: {
       settingsPath,
       cwd: boundary.gitSafeDirectories[0]!,
       denyReadRoots,
-      allowReadRoots: boundary.allowRead
+      allowReadRoots: boundary.allowRead,
+      protectedCredentialRoots: compactReadRoots([
+        ...credentialWritableRoots,
+        ...providerCredentialReadRoots,
+        ...privateClaudeStateRoots
+      ])
     }
   }
 }

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -7,7 +7,13 @@ import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials.js'
 import { prepareRuntimeHome, runtimeHomeEnvironment, runtimeHomePath } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
-import { CLAUDE_PROFILE_ENV, claudeProviderCredentialFiles, isClaudeRuntimeDef } from './claude-runtime.js'
+import {
+  CLAUDE_PROFILE_ENV,
+  claudeProtectedSettings,
+  claudeProviderCredentialFiles,
+  isClaudeRuntimeDef,
+  type ClaudeProtectedSettings
+} from './claude-runtime.js'
 
 function disabledClaudeProfileRoot(scopeDir: string): string {
   const root = realpathSync(resolve(scopeDir))
@@ -46,6 +52,9 @@ export interface PreparedRuntimeLaunch {
     /** Credential paths deliberately exposed to the trusted runtime parent but
      * denied again inside a runtime-native tool sandbox. */
     protectedCredentialRoots: string[]
+    /** Highest-precedence Claude settings that keep project/local settings from
+     * redirecting the trusted parent to an attacker-selected credential profile. */
+    claudeProtectedSettings?: ClaudeProtectedSettings
   }
 }
 
@@ -221,6 +230,7 @@ export function prepareRuntimeLaunch(opts: {
     for (const name of CLAUDE_PROFILE_ENV) delete env[name]
     env.ANTHROPIC_CONFIG_DIR = disabledClaudeProfileRoot(opts.scopeDir)
   }
+  const protectedClaudeSettings = claudeRuntime ? claudeProtectedSettings(env) : undefined
   const providerCredentialFiles = claudeRuntime ? claudeProviderCredentialFiles(env, opts.cwd) : []
   const providerCredentialReadRoots = compactReadRoots(
     providerCredentialFiles.map(({ envName, path }) => {
@@ -284,7 +294,8 @@ export function prepareRuntimeLaunch(opts: {
         ...credentialWritableRoots,
         ...providerCredentialReadRoots,
         ...privateClaudeStateRoots
-      ])
+      ]),
+      ...(protectedClaudeSettings ? { claudeProtectedSettings: protectedClaudeSettings } : {})
     }
   }
 }

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, realpathSync } from 'node:fs'
+import { chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from './sandbox.js'
@@ -8,6 +8,28 @@ import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials
 import { prepareRuntimeHome, runtimeHomeEnvironment, runtimeHomePath } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import { CLAUDE_PROFILE_ENV, claudeProviderCredentialFiles, isClaudeRuntimeDef } from './claude-runtime.js'
+
+function disabledClaudeProfileRoot(scopeDir: string): string {
+  const root = realpathSync(resolve(scopeDir))
+  const target = join(root, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')
+  let current = root
+  for (const part of relative(root, target).split(sep).filter(Boolean)) {
+    current = join(current, part)
+    if (existsSync(current)) {
+      const stat = lstatSync(current)
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error(`disabled Claude profile path is not a real directory: ${current}`)
+      }
+      continue
+    }
+    mkdirSync(current, { mode: 0o700 })
+  }
+  if (readdirSync(target).length > 0) {
+    throw new Error(`disabled Claude profile directory is not empty: ${target}`)
+  }
+  chmodSync(target, 0o500)
+  return realpathSync(target)
+}
 
 export interface PreparedRuntimeLaunch {
   env: Record<string, string>
@@ -193,9 +215,11 @@ export function prepareRuntimeLaunch(opts: {
   if (claudeRuntime) {
     // Anthropic profile JSON may live in the agent-writable private HOME and may
     // reference arbitrary host paths. Fail closed instead of letting that mutable
-    // input influence the outer sandbox. Shared Claude /login uses the separate
-    // daemon-managed secure-storage directory prepared above.
+    // input influence the trusted parent or outer sandbox. The fixed empty root is
+    // daemon-owned and only read-exposed by sandboxBoundary; shared Claude /login
+    // uses the separate daemon-managed secure-storage directory prepared above.
     for (const name of CLAUDE_PROFILE_ENV) delete env[name]
+    env.ANTHROPIC_CONFIG_DIR = disabledClaudeProfileRoot(opts.scopeDir)
   }
   const providerCredentialFiles = claudeRuntime ? claudeProviderCredentialFiles(env, opts.cwd) : []
   const providerCredentialReadRoots = compactReadRoots(

--- a/packages/daemon/src/runtimes/launch-policy.ts
+++ b/packages/daemon/src/runtimes/launch-policy.ts
@@ -21,7 +21,7 @@ import {
 } from '../agents/runtime-memory.js'
 import { MemoryProviderUnavailableError, type MemoryProviderKind } from '../agents/memory-provider.js'
 import type { RuntimeDef } from '../config/config-schema.js'
-import { isClaudeRuntimeDef } from '../acp/claude-runtime.js'
+import { CLAUDE_PROFILE_ENV, isClaudeRuntimeDef } from '../acp/claude-runtime.js'
 import { resolveCommandPath } from './probe.js'
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './read-roots.js'
 
@@ -191,7 +191,12 @@ export function composeRuntimeLaunch(opts: {
     ...opts.runtime,
     command: sandboxAccess?.runtimeExecutable ?? opts.runtime.command,
     args: [...opts.runtime.args],
-    env: [...opts.runtime.env]
+    // AcpHost merges runtime.env before launch.env. Filter here as well as in
+    // prepareRuntimeLaunch so omission cannot restore a disabled profile selector.
+    env:
+      opts.runInSandbox && isClaudeRuntimeDef(opts.runtime)
+        ? opts.runtime.env.filter(({ name }) => !CLAUDE_PROFILE_ENV.some((profileName) => profileName === name))
+        : [...opts.runtime.env]
   }
 
   if (!protectedMemory) return { runtime: composed, launch }

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -247,9 +247,79 @@ describe('claudeSessionMeta', () => {
     )
   })
 
+  it('enables the native Claude sandbox only behind an outer AgentConnect sandbox', () => {
+    const credentialRoot = '/host/.claude/agentconnect-auth'
+    const sandbox = {
+      enabled: true,
+      failIfUnavailable: true,
+      autoAllowBashIfSandboxed: true,
+      allowUnsandboxedCommands: false,
+      filesystem: {
+        denyRead: [credentialRoot],
+        denyWrite: [credentialRoot]
+      },
+      credentials: {
+        files: [{ path: credentialRoot, mode: 'deny' }],
+        envVars: [
+          { name: 'ANTHROPIC_API_KEY', mode: 'deny' },
+          { name: 'ANTHROPIC_AUTH_TOKEN', mode: 'deny' },
+          { name: 'ANTHROPIC_IDENTITY_TOKEN', mode: 'deny' },
+          { name: 'ANTHROPIC_IDENTITY_TOKEN_FILE', mode: 'deny' },
+          { name: 'ANTHROPIC_CONFIG_DIR', mode: 'deny' },
+          { name: 'ANTHROPIC_PROFILE', mode: 'deny' },
+          { name: 'ANTHROPIC_CUSTOM_HEADERS', mode: 'deny' },
+          { name: 'ANTHROPIC_AWS_API_KEY', mode: 'deny' },
+          { name: 'ANTHROPIC_FOUNDRY_API_KEY', mode: 'deny' },
+          { name: 'ANTHROPIC_FOUNDRY_AUTH_TOKEN', mode: 'deny' },
+          { name: 'CLAUDE_CODE_OAUTH_TOKEN', mode: 'deny' },
+          { name: 'CLAUDE_CODE_OAUTH_REFRESH_TOKEN', mode: 'deny' },
+          { name: 'AWS_ACCESS_KEY_ID', mode: 'deny' },
+          { name: 'AWS_SECRET_ACCESS_KEY', mode: 'deny' },
+          { name: 'AWS_SESSION_TOKEN', mode: 'deny' },
+          { name: 'AWS_BEARER_TOKEN_BEDROCK', mode: 'deny' },
+          { name: 'AWS_CONTAINER_AUTHORIZATION_TOKEN', mode: 'deny' },
+          { name: 'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE', mode: 'deny' },
+          { name: 'AWS_CONTAINER_CREDENTIALS_FULL_URI', mode: 'deny' },
+          { name: 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI', mode: 'deny' },
+          { name: 'AWS_EC2_METADATA_SERVICE_ENDPOINT', mode: 'deny' },
+          { name: 'AWS_CONFIG_FILE', mode: 'deny' },
+          { name: 'AWS_SHARED_CREDENTIALS_FILE', mode: 'deny' },
+          { name: 'AWS_WEB_IDENTITY_TOKEN_FILE', mode: 'deny' },
+          { name: 'CLOUDSDK_AUTH_ACCESS_TOKEN', mode: 'deny' },
+          { name: 'GOOGLE_APPLICATION_CREDENTIALS', mode: 'deny' }
+        ]
+      }
+    }
+
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot])).toEqual(
+      cc({ thinking: THINKING, sandbox })
+    )
+    expect(claudeSessionMeta('ultracode', true, undefined, undefined, [credentialRoot])).toEqual(
+      cc({
+        thinking: THINKING,
+        sandbox,
+        settings: { ultracode: true, enableWorkflows: true }
+      })
+    )
+    // An empty array still means an outer sandbox is active; undefined means it
+    // is not, and must preserve the existing unsandboxed Claude behavior.
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, [])).toEqual(
+      cc({
+        thinking: THINKING,
+        sandbox: {
+          ...sandbox,
+          filesystem: { ...sandbox.filesystem, denyRead: [], denyWrite: [] },
+          credentials: { ...sandbox.credentials, files: [] }
+        }
+      })
+    )
+    expect(claudeSessionMeta(undefined, true)).toEqual(cc({ thinking: THINKING }))
+  })
+
   it('returns undefined off a Claude runtime (the _meta is claude-acp-specific)', () => {
     expect(claudeSessionMeta(undefined, false)).toBeUndefined()
     expect(claudeSessionMeta('ultracode', false)).toBeUndefined()
+    expect(claudeSessionMeta(undefined, false, undefined, undefined, ['/credential'])).toBeUndefined()
   })
 
   it('appends the system prompt (sibling of claudeCode) when one is set', () => {

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -322,15 +322,6 @@ describe('claudeSessionMeta', () => {
         }
       })
     )
-    const projectEnv = {
-      ANTHROPIC_CONFIG_DIR: '/workspace/.profiles',
-      ANTHROPIC_PROFILE: '../../host-secret',
-      PROJECT_VALUE: 'kept'
-    }
-    expect({ ...projectEnv, ...protectedSettings.env }).toEqual({
-      ...protectedSettings.env,
-      PROJECT_VALUE: 'kept'
-    })
     expect(claudeSessionMeta(undefined, true)).toEqual(cc({ thinking: THINKING }))
   })
 

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -249,6 +249,14 @@ describe('claudeSessionMeta', () => {
 
   it('enables the native Claude sandbox only behind an outer AgentConnect sandbox', () => {
     const credentialRoot = '/host/.claude/agentconnect-auth'
+    const protectedSettings = {
+      modelOverrides: { sonnet: 'bedrock/sonnet' },
+      availableModels: ['sonnet'],
+      env: {
+        ANTHROPIC_CONFIG_DIR: '/agent/.agentconnect/runtime-policy/claude-profile-disabled',
+        ANTHROPIC_PROFILE: 'agentconnect-disabled'
+      }
+    }
     const sandbox = {
       enabled: true,
       failIfUnavailable: true,
@@ -291,21 +299,22 @@ describe('claudeSessionMeta', () => {
       }
     }
 
-    expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot])).toEqual(
-      cc({ thinking: THINKING, sandbox })
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
+      cc({ thinking: THINKING, sandbox, settings: protectedSettings })
     )
-    expect(claudeSessionMeta('ultracode', true, undefined, undefined, [credentialRoot])).toEqual(
+    expect(claudeSessionMeta('ultracode', true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
       cc({
         thinking: THINKING,
         sandbox,
-        settings: { ultracode: true, enableWorkflows: true }
+        settings: { ...protectedSettings, ultracode: true, enableWorkflows: true }
       })
     )
     // An empty array still means an outer sandbox is active; undefined means it
     // is not, and must preserve the existing unsandboxed Claude behavior.
-    expect(claudeSessionMeta(undefined, true, undefined, undefined, [])).toEqual(
+    expect(claudeSessionMeta(undefined, true, undefined, undefined, [], protectedSettings)).toEqual(
       cc({
         thinking: THINKING,
+        settings: protectedSettings,
         sandbox: {
           ...sandbox,
           filesystem: { ...sandbox.filesystem, denyRead: [], denyWrite: [] },
@@ -313,6 +322,15 @@ describe('claudeSessionMeta', () => {
         }
       })
     )
+    const projectEnv = {
+      ANTHROPIC_CONFIG_DIR: '/workspace/.profiles',
+      ANTHROPIC_PROFILE: '../../host-secret',
+      PROJECT_VALUE: 'kept'
+    }
+    expect({ ...projectEnv, ...protectedSettings.env }).toEqual({
+      ...protectedSettings.env,
+      PROJECT_VALUE: 'kept'
+    })
     expect(claudeSessionMeta(undefined, true)).toEqual(cc({ thinking: THINKING }))
   })
 

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -73,6 +73,7 @@ describe('Linux shared runtime login', () => {
     expect(existsSync(join(hostClaude, '.credentials.json'))).toBe(false)
     expect(existsSync(join(privateClaude, '.credentials.json'))).toBe(false)
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(sharedDir)
+    expect(launch.sandbox?.protectedCredentialRoots).toEqual([sharedDir])
 
     writeFileSync(join(sharedDir, '.credentials.json'), '{"accessToken":"refreshed"}')
     const scopeB = join(daemonRoot, 'agents', 'agent-b')
@@ -120,6 +121,7 @@ describe('Linux shared runtime login', () => {
     expect(realpathSync(privateAuth)).toBe(realpathSync(hostAuth))
     expect(readFileSync(hostAuth, 'utf8')).toContain('"new"')
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(realpathSync(hostAuth))
+    expect(launch.sandbox?.protectedCredentialRoots).toEqual([realpathSync(hostAuth)])
 
     writeFileSync(privateAuth, '{"last_refresh":"2026-03-01T00:00:00Z","token":"refreshed"}')
     expect(lstatSync(privateAuth).isSymbolicLink()).toBe(true)

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -141,7 +141,15 @@ describe('prepareRuntimeLaunch', () => {
       runInSandbox: true,
       daemonRoot: dirname(scopeDir),
       sandboxMechanism: 'bwrap',
-      explicitEnv: { ANTHROPIC_CONFIG_DIR: profileRoot, ANTHROPIC_PROFILE: 'corp' },
+      explicitEnv: {
+        ANTHROPIC_CONFIG_DIR: profileRoot,
+        ANTHROPIC_PROFILE: 'corp',
+        CLAUDE_MODEL_CONFIG: JSON.stringify({
+          modelOverrides: { sonnet: 'bedrock/sonnet' },
+          availableModels: ['sonnet'],
+          ignored: 'not an adapter model setting'
+        })
+      },
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
@@ -150,6 +158,14 @@ describe('prepareRuntimeLaunch', () => {
     )
     expect(launch.env.ANTHROPIC_CONFIG_DIR).toBe(disabledProfileRoot)
     expect(launch.env.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(launch.sandbox?.claudeProtectedSettings).toEqual({
+      modelOverrides: { sonnet: 'bedrock/sonnet' },
+      availableModels: ['sonnet'],
+      env: {
+        ANTHROPIC_CONFIG_DIR: disabledProfileRoot,
+        ANTHROPIC_PROFILE: 'agentconnect-disabled'
+      }
+    })
     expect(readdirSync(disabledProfileRoot)).toEqual([])
     expect(coveredBy(launch.sandbox!.allowReadRoots, disabledProfileRoot)).toBe(true)
     expect(launch.sandbox?.writable).not.toContain(disabledProfileRoot)
@@ -183,6 +199,10 @@ describe('prepareRuntimeLaunch', () => {
     expect(discoveredProfileRoot).toBe(
       realpathSync(join(scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled'))
     )
+    expect(launch.sandbox?.claudeProtectedSettings?.env).toEqual({
+      ANTHROPIC_CONFIG_DIR: discoveredProfileRoot,
+      ANTHROPIC_PROFILE: 'agentconnect-disabled'
+    })
     expect(readdirSync(discoveredProfileRoot)).toEqual([])
     expect(discoveredProfileRoot).not.toBe(join(scopeDir, 'home', '.config', 'anthropic'))
     expect(launch.sandbox?.writable).not.toContain('/etc')
@@ -310,6 +330,10 @@ describe('composeRuntimeLaunch', () => {
     )
     expect(childEnv.ANTHROPIC_CONFIG_DIR).toBe(disabledProfileRoot)
     expect(childEnv.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(composed.launch.sandbox?.claudeProtectedSettings?.env).toEqual({
+      ANTHROPIC_CONFIG_DIR: disabledProfileRoot,
+      ANTHROPIC_PROFILE: 'agentconnect-disabled'
+    })
     expect(readdirSync(disabledProfileRoot)).toEqual([])
     expect(childEnv.SAFE_VALUE).toBe('kept')
   })

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -42,6 +42,7 @@ describe('prepareRuntimeLaunch', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const launch = prepareRuntimeLaunch({
       runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
       scopeDir,
       cwd,
       runInSandbox: false,
@@ -56,15 +57,29 @@ describe('prepareRuntimeLaunch', () => {
   it('uses a private HOME only for an effective sandboxed launch', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const customClaudeConfig = join(dirname(hostHome), 'host-claude-config')
+    const identityTokenFile = join(hostHome, 'identity.jwt')
+    const awsWebIdentityTokenFile = join(hostHome, 'aws-web-identity.jwt')
     mkdirSync(customClaudeConfig)
+    writeFileSync(
+      join(customClaudeConfig, 'settings.json'),
+      JSON.stringify({ env: { ANTHROPIC_API_KEY: 'seeded-settings-secret' } })
+    )
+    writeFileSync(join(hostHome, '.claude.json'), JSON.stringify({ mcpToken: 'seeded-global-secret' }))
+    writeFileSync(identityTokenFile, 'trusted-parent-identity-token')
+    writeFileSync(awsWebIdentityTokenFile, 'trusted-parent-aws-token')
     const launch = prepareRuntimeLaunch({
       runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
       scopeDir,
       cwd,
       runInSandbox: true,
       daemonRoot: dirname(scopeDir),
       sandboxMechanism: 'bwrap',
-      explicitEnv: { AGENT_VALUE: 'yes' },
+      explicitEnv: {
+        AGENT_VALUE: 'yes',
+        ANTHROPIC_IDENTITY_TOKEN_FILE: identityTokenFile,
+        AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile
+      },
       hostEnv: { HOME: hostHome, CLAUDE_CONFIG_DIR: customClaudeConfig, PATH: '/usr/bin' }
     })
 
@@ -73,15 +88,92 @@ describe('prepareRuntimeLaunch', () => {
     expect(launch.env.HOME).toBe(join(scopeDir, 'home'))
     expect(launch.env.AGENT_VALUE).toBe('yes')
     expect(launch.sandbox?.mechanism).toBe('bwrap')
+    expect(statSync(join(cwd, '.claude')).isDirectory()).toBe(true)
+    expect(existsSync(join(cwd, '.claude', 'settings.json'))).toBe(false)
     expect(existsSync(launch.sandbox!.settingsPath)).toBe(true)
     const settings = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
     const canonicalHostHome = realpathSync(hostHome)
+    const canonicalIdentityToken = realpathSync(identityTokenFile)
+    const canonicalAwsWebIdentityToken = realpathSync(awsWebIdentityTokenFile)
+    const privateClaudeConfig = realpathSync(join(scopeDir, 'home', '.claude'))
+    const privateClaudeGlobal = realpathSync(join(scopeDir, 'home', '.claude.json'))
+    expect(readFileSync(join(privateClaudeConfig, 'settings.json'), 'utf8')).toContain('seeded-settings-secret')
+    expect(readFileSync(privateClaudeGlobal, 'utf8')).toContain('seeded-global-secret')
+    expect(launch.env.ANTHROPIC_IDENTITY_TOKEN_FILE).toBe(canonicalIdentityToken)
+    expect(launch.env.AWS_WEB_IDENTITY_TOKEN_FILE).toBe(canonicalAwsWebIdentityToken)
     expect(coveredBy(settings.filesystem.denyRead, canonicalHostHome)).toBe(true)
     expect(coveredBy(settings.filesystem.denyRead, realpathSync(customClaudeConfig))).toBe(true)
     expect(coveredBy(settings.filesystem.denyRead, realpathSync(dirname(scopeDir)))).toBe(true)
     expect(settings.filesystem.allowRead).toEqual(
-      expect.arrayContaining([realpathSync(cwd), realpathSync(join(scopeDir, 'home'))])
+      expect.arrayContaining([
+        realpathSync(cwd),
+        realpathSync(join(scopeDir, 'home')),
+        canonicalIdentityToken,
+        canonicalAwsWebIdentityToken
+      ])
     )
+    expect(launch.sandbox?.protectedCredentialRoots).toEqual(
+      expect.arrayContaining([
+        canonicalIdentityToken,
+        canonicalAwsWebIdentityToken,
+        privateClaudeConfig,
+        privateClaudeGlobal
+      ])
+    )
+  })
+
+  it('drops host Anthropic profile auth instead of deriving outer exceptions from its JSON', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const profileRoot = join(hostHome, 'anthropic-profiles')
+    const profileConfigDir = join(profileRoot, 'configs')
+    mkdirSync(profileConfigDir, { recursive: true })
+    writeFileSync(
+      join(profileConfigDir, 'corp.json'),
+      JSON.stringify({ authentication: { type: 'user_oauth', credentials_path: '/etc/agentconnect-oauth.json' } })
+    )
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      explicitEnv: { ANTHROPIC_CONFIG_DIR: profileRoot, ANTHROPIC_PROFILE: 'corp' },
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.env.ANTHROPIC_CONFIG_DIR).toBeUndefined()
+    expect(launch.env.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(launch.sandbox?.allowReadRoots).not.toContain(realpathSync(profileRoot))
+    expect(launch.sandbox?.writable).not.toContain('/etc')
+    expect(launch.sandbox?.protectedCredentialRoots).not.toContain('/etc')
+  })
+
+  it('never trusts an Anthropic profile planted in the private runtime HOME', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const privateProfileDir = join(scopeDir, 'home', '.config', 'anthropic', 'configs')
+    mkdirSync(privateProfileDir, { recursive: true })
+    writeFileSync(
+      join(privateProfileDir, 'default.json'),
+      JSON.stringify({ authentication: { credentials_path: '/etc/agentconnect-oauth.json' } })
+    )
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.sandbox?.writable).not.toContain('/etc')
+    expect(launch.sandbox?.allowReadRoots).not.toContain('/etc/agentconnect-oauth.json')
+    expect(launch.sandbox?.protectedCredentialRoots).not.toContain('/etc')
   })
 
   it('resolves version-manager PATH links before hiding the host HOME', () => {
@@ -172,6 +264,38 @@ describe('prepareRuntimeLaunch', () => {
 const runtime = (command: string, args: string[] = ['acp']): RuntimeDef => ({ command, args, env: [] })
 
 describe('composeRuntimeLaunch', () => {
+  it('removes Anthropic profile selectors from the actual sandboxed child environment', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const composed = composeRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: {
+        command: process.execPath,
+        args: ['claude-agent-acp'],
+        env: [
+          { name: 'ANTHROPIC_CONFIG_DIR', value: '/etc/anthropic' },
+          { name: 'ANTHROPIC_PROFILE', value: 'corp' },
+          { name: 'SAFE_VALUE', value: 'kept' }
+        ]
+      },
+      provider: 'managed',
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      hostEnv: { HOME: hostHome, PATH: dirname(process.execPath) }
+    })
+    const childEnv = {
+      ...Object.fromEntries(composed.runtime.env.map(({ name, value }) => [name, value])),
+      ...composed.launch.env
+    }
+
+    expect(composed.launch.inheritProcessEnv).toBe(false)
+    expect(childEnv.ANTHROPIC_CONFIG_DIR).toBeUndefined()
+    expect(childEnv.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(childEnv.SAFE_VALUE).toBe('kept')
+  })
+
   it('keeps a Claude launcher symlink under the host HOME readable', () => {
     const testRoot = mkdtempSync(join(tmpdir(), 'ac-claude-launch-roots-'))
     const hostHome = join(testRoot, 'home')

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   statSync,
@@ -144,8 +145,14 @@ describe('prepareRuntimeLaunch', () => {
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
-    expect(launch.env.ANTHROPIC_CONFIG_DIR).toBeUndefined()
+    const disabledProfileRoot = realpathSync(
+      join(scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')
+    )
+    expect(launch.env.ANTHROPIC_CONFIG_DIR).toBe(disabledProfileRoot)
     expect(launch.env.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(readdirSync(disabledProfileRoot)).toEqual([])
+    expect(coveredBy(launch.sandbox!.allowReadRoots, disabledProfileRoot)).toBe(true)
+    expect(launch.sandbox?.writable).not.toContain(disabledProfileRoot)
     expect(launch.sandbox?.allowReadRoots).not.toContain(realpathSync(profileRoot))
     expect(launch.sandbox?.writable).not.toContain('/etc')
     expect(launch.sandbox?.protectedCredentialRoots).not.toContain('/etc')
@@ -155,6 +162,7 @@ describe('prepareRuntimeLaunch', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const privateProfileDir = join(scopeDir, 'home', '.config', 'anthropic', 'configs')
     mkdirSync(privateProfileDir, { recursive: true })
+    writeFileSync(join(dirname(privateProfileDir), 'active_config'), 'default')
     writeFileSync(
       join(privateProfileDir, 'default.json'),
       JSON.stringify({ authentication: { credentials_path: '/etc/agentconnect-oauth.json' } })
@@ -171,6 +179,12 @@ describe('prepareRuntimeLaunch', () => {
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
+    const discoveredProfileRoot = launch.env.ANTHROPIC_CONFIG_DIR ?? join(launch.env.XDG_CONFIG_HOME!, 'anthropic')
+    expect(discoveredProfileRoot).toBe(
+      realpathSync(join(scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled'))
+    )
+    expect(readdirSync(discoveredProfileRoot)).toEqual([])
+    expect(discoveredProfileRoot).not.toBe(join(scopeDir, 'home', '.config', 'anthropic'))
     expect(launch.sandbox?.writable).not.toContain('/etc')
     expect(launch.sandbox?.allowReadRoots).not.toContain('/etc/agentconnect-oauth.json')
     expect(launch.sandbox?.protectedCredentialRoots).not.toContain('/etc')
@@ -264,7 +278,7 @@ describe('prepareRuntimeLaunch', () => {
 const runtime = (command: string, args: string[] = ['acp']): RuntimeDef => ({ command, args, env: [] })
 
 describe('composeRuntimeLaunch', () => {
-  it('removes Anthropic profile selectors from the actual sandboxed child environment', () => {
+  it('pins Anthropic profile discovery away from the actual sandboxed child HOME', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const composed = composeRuntimeLaunch({
       runtimeId: 'claude-acp',
@@ -291,8 +305,12 @@ describe('composeRuntimeLaunch', () => {
     }
 
     expect(composed.launch.inheritProcessEnv).toBe(false)
-    expect(childEnv.ANTHROPIC_CONFIG_DIR).toBeUndefined()
+    const disabledProfileRoot = realpathSync(
+      join(scopeDir, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')
+    )
+    expect(childEnv.ANTHROPIC_CONFIG_DIR).toBe(disabledProfileRoot)
     expect(childEnv.ANTHROPIC_PROFILE).toBeUndefined()
+    expect(readdirSync(disabledProfileRoot)).toEqual([])
     expect(childEnv.SAFE_VALUE).toBe('kept')
   })
 

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -2,8 +2,19 @@ import { describe, it, expect } from 'vitest'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, symlinkSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { SandboxManager, SandboxRuntimeConfigSchema } from '@anthropic-ai/sandbox-runtime'
 import { sandboxWrap, sandboxBoundary, SandboxError, detectSandbox, writeSandboxSettings } from '../src/acp/sandbox.js'
+import { claudeInnerSandboxSettings } from '../src/acp/claude-runtime.js'
 
 // Ordinary ACP hosts launch through one SRT provider process with an immutable,
 // daemon-written policy rather than assembling bwrap arguments themselves.
@@ -183,5 +194,99 @@ describe('bwrap PID isolation', () => {
     })
     const out = execFileSync(cmd, args, { encoding: 'utf8', env: { ...process.env, HOME: home } }).trim()
     expect(out).toBe('OK')
+  })
+})
+
+// The trusted Claude parent needs provider credentials to reach the model, but
+// model-authored Bash must not inherit any supported direct/cloud auth secret.
+describe('Claude credential environment isolation', () => {
+  const hasBwrap = detectSandbox() === 'bwrap'
+
+  it.skipIf(!hasBwrap)('hides protected provider credential env and files from sandboxed commands', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-claude-credential-env-'))
+    const workspace = join(root, 'workspace')
+    const identityTokenFile = join(root, 'identity.jwt')
+    const identityToken = 'trusted-parent-identity-token'
+    const awsWebIdentityTokenFile = join(root, 'aws-web-identity.jwt')
+    const awsWebIdentityToken = 'trusted-parent-aws-token'
+    const privateClaudeConfig = join(root, 'private-home', '.claude')
+    const privateClaudeSettings = join(privateClaudeConfig, 'settings.json')
+    const seededCredentialEnvironment = {
+      AWS_CONTAINER_AUTHORIZATION_TOKEN: 'trusted-parent-container-token',
+      AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile
+    }
+    mkdirSync(workspace)
+    mkdirSync(privateClaudeConfig, { recursive: true })
+    writeFileSync(identityTokenFile, identityToken, { mode: 0o600 })
+    writeFileSync(awsWebIdentityTokenFile, awsWebIdentityToken, { mode: 0o600 })
+    writeFileSync(
+      privateClaudeSettings,
+      JSON.stringify({ env: { ANTHROPIC_API_KEY: 'trusted-parent-settings-token' } }),
+      { mode: 0o600 }
+    )
+    const settings = claudeInnerSandboxSettings([identityTokenFile, awsWebIdentityTokenFile, privateClaudeConfig])
+    const names = settings.credentials.envVars.map(({ name }) => name)
+    const restoredNames = new Set([...names, ...Object.keys(seededCredentialEnvironment)])
+    const previous = new Map([...restoredNames].map((name) => [name, process.env[name]]))
+
+    for (const name of names) process.env[name] = `secret-for-${name}`
+    Object.assign(process.env, seededCredentialEnvironment)
+
+    try {
+      const config = SandboxRuntimeConfigSchema.parse({
+        network: { allowedDomains: [], deniedDomains: [], allowAllUnixSockets: true },
+        filesystem: { ...settings.filesystem, allowWrite: [workspace] },
+        credentials: settings.credentials
+      })
+      await SandboxManager.initialize(config, async () => false)
+      expect(readFileSync(identityTokenFile, 'utf8')).toBe(identityToken)
+      expect(readFileSync(awsWebIdentityTokenFile, 'utf8')).toBe(awsWebIdentityToken)
+      expect(readFileSync(privateClaudeSettings, 'utf8')).toContain('trusted-parent-settings-token')
+      const wrapped = await SandboxManager.wrapWithSandboxArgv(
+        '/usr/bin/env',
+        undefined,
+        undefined,
+        undefined,
+        workspace
+      )
+      const output = execFileSync(wrapped.argv[0]!, wrapped.argv.slice(1), {
+        cwd: workspace,
+        env: wrapped.env,
+        encoding: 'utf8'
+      })
+      const visible = new Set(
+        output
+          .split('\n')
+          .map((line) => line.split('=', 1)[0])
+          .filter(Boolean)
+      )
+      for (const name of names) expect(visible).not.toContain(name)
+      for (const value of Object.values(seededCredentialEnvironment)) expect(output).not.toContain(value)
+
+      for (const credentialFile of [identityTokenFile, awsWebIdentityTokenFile, privateClaudeSettings]) {
+        const fileRead = await SandboxManager.wrapWithSandboxArgv(
+          `/usr/bin/cat ${credentialFile}`,
+          undefined,
+          undefined,
+          undefined,
+          workspace
+        )
+        expect(() =>
+          execFileSync(fileRead.argv[0]!, fileRead.argv.slice(1), {
+            cwd: workspace,
+            env: fileRead.env,
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+        ).toThrow()
+      }
+    } finally {
+      SandboxManager.cleanupAfterCommand()
+      await SandboxManager.reset()
+      for (const [name, value] of previous) {
+        if (value === undefined) delete process.env[name]
+        else process.env[name] = value
+      }
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- enable Claude Agent SDK's native sandbox for Bash whenever AgentConnect's outer SRT sandbox is active
- keep the trusted ACP parent able to refresh the daemon-managed shared `/login` credential while denying shared and direct provider credentials to sandboxed commands
- deny seeded private Claude state (`CLAUDE_CONFIG_DIR` and `.claude.json`) to inner Bash so `settings.env` and local MCP secrets are not readable
- fail closed for Anthropic profile auth at both boundaries: pin the spawn environment to a daemon-owned empty root, then reassert that root and a fixed profile through Claude's highest-precedence SDK settings after user/project/local settings merge
- preserve `CLAUDE_MODEL_CONFIG` model overrides when the protected SDK settings replace claude-agent-acp's fallback
- inject the policy for both fresh and resumed sessions through the unified ACP host path
- precreate an empty workspace `.claude/` directory so nested Linux `bwrap` can establish its settings mountpoint

## Why

AgentConnect's outer SRT intentionally exposes the dedicated shared Claude credential directory to the trusted ACP runtime so login refresh can work. Without a second boundary, model-authored Bash inherits that access. Claude's native sandbox supplies the inner subprocess boundary, but nested SRT failed when `.claude/` did not already exist because the outer layer masked the first missing component read-only.

Sandboxed launches do not trust `ANTHROPIC_CONFIG_DIR` or `ANTHROPIC_PROFILE` from operator, agent, or workspace settings. Profile JSON can reference arbitrary credential paths and remote endpoints, so the child starts with profile discovery pointed at an empty daemon policy directory and every session reasserts the same policy in the SDK flag-settings tier after Claude merges user/project/local settings. Standard AgentConnect shared login remains available through the daemon-managed `CLAUDE_SECURESTORAGE_CONFIG_DIR`.

## Security boundary

This confines Claude Bash and its descendants. It does not move Claude's in-process filesystem tools or trusted stdio MCP children into the inner sandbox, and `bypassPermissions` behavior remains unchanged.

With `autoAllowBashIfSandboxed`, Bash calls under a non-bypass permission mode are auto-approved once the inner sandbox is active instead of round-tripping through Claude's normal approval flow; the inner sandbox provides the command-level confinement in that case.

Public webchat continues to use the current remote-grant MCP architecture; this change does not restore or add a delegated-host sandbox branch.

## Validation

- exact-head GitHub Build, Check, Unit Test, and both Integration jobs pass
- 112 focused daemon tests passed locally across seven sandbox/runtime files (2 Linux-only tests skipped on macOS)
- daemon typecheck, changed-file ESLint and Prettier, plus pre-push full-repo ESLint
- regression coverage proves operator-selected profile values cannot survive the real child-environment merge and the final config root is daemon-owned, read-only, and empty
- regression coverage proves `active_config` and `configs/default.json` planted under the private `XDG_CONFIG_HOME` are not discovered
- regression coverage proves protected profile values are sent in Claude's highest-precedence SDK settings for sandboxed sessions while `modelOverrides` and `availableModels` are preserved
- regression coverage proves operator-selected and private-home Anthropic profiles cannot add `/etc` or profile-derived paths to outer `allowRead`/`allowWrite`
- a real inner-SRT regression keeps seeded `settings.env` and `.claude.json` secrets readable by the trusted parent but denies them to sandboxed Bash
- agent-2 credential isolation covers direct Anthropic/OIDC, AWS, Vertex, and Foundry environment/file sources while the trusted parent retains shared-login refresh access
- nested SRT retains workspace writes, web egress, and the existing stdio MCP path

Created by Codex . GPT-5
