### PR TITLE
fix(webchat): stop initialize/tools-list losing the session-registration race

### DIFF
--- a/docs/designs/webchat-preset-agentconnect-mcp.md
+++ b/docs/designs/webchat-preset-agentconnect-mcp.md
@@ -361,6 +361,18 @@ client cannot issue any tool request before initializing, so denying the handsha
 denies the whole server, and the session loses `agentconnect-admin` entirely. Every
 other JSON-RPC method stays denied.
 
+The private-current-session predicate (§5.2) is re-checked at request time for
+`tools/call` only. The descriptor is installed during `session/new`, and the daemon
+registers the resulting session with the CP only after that call returns — so the
+adapter's `initialize` and immediate `tools/list` always precede the
+current-session pointer and would deterministically lose that race (adapters do
+not retry a failed connect; the session would show no administration tools until
+the next descriptor rotation). Both are safe without the predicate: the handshake
+reaches no tool and `tools/list` serves the static curated catalog with no
+org-scoped data. `tools/call` — the step that actually wields the delegated
+authority — is issued mid-turn, after registration, and is denied whenever the
+conversation's current session is not private.
+
 Nested REST calls receive an already resolved internal principal. The raw grant is
 not replayed as REST Bearer authentication and cannot authenticate an external REST
 request.

--- a/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
+++ b/packages/control-plane/src/http/mcp/remote-grant-authenticator.ts
@@ -77,9 +77,6 @@ export class RemoteGrantAuthenticator {
       daemonId: authority.daemonId
     })
     if (!live.ok) return { kind: 'denied', reason: live.reason }
-    if (!(await this.deps.sessions.hasPrivateWebchatSession(authority.conversationId, authority.agentId as AgentId))) {
-      return { kind: 'denied', reason: 'session_not_private' }
-    }
 
     let metadata: ParsedInvocationMetadata
     try {
@@ -95,6 +92,22 @@ export class RemoteGrantAuthenticator {
       (method === 'tools/call' && (!metadata.toolName || !this.deps.isCuratedTool(metadata.toolName)))
     ) {
       return { kind: 'denied', reason: 'tool' }
+    }
+    // The private-current-session predicate gates only `tools/call`. The descriptor
+    // is installed during `session/new`, and the daemon can register the session row
+    // (`webchat_conversation.currentSessionId` → `session_meta`) only after that call
+    // returns — so the adapter's `initialize` and immediate `tools/list` always race
+    // the registration and would lose deterministically, killing the server for the
+    // session's whole lifetime (adapters do not retry a failed connect). Both are
+    // safe without the predicate: the handshake reaches no tool, and `tools/list`
+    // returns the static curated catalog with no org-scoped data. `tools/call` is
+    // the authority-wielding step; it is issued mid-turn, after registration, and
+    // must stop the moment the conversation's current session is not private.
+    if (
+      method === 'tools/call' &&
+      !(await this.deps.sessions.hasPrivateWebchatSession(authority.conversationId, authority.agentId as AgentId))
+    ) {
+      return { kind: 'denied', reason: 'session_not_private' }
     }
     return {
       kind: 'execute',

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -169,7 +169,7 @@ describe('POST /api/v1/mcp — auth', () => {
 })
 
 describe('delegated webchat MCP operations', () => {
-  async function delegatedFixture() {
+  async function delegatedFixture(opts: { registerSession?: boolean } = {}) {
     const daemonId = randomUUID()
     const hostAgentId = randomUUID()
     const conversationId = randomUUID()
@@ -211,28 +211,33 @@ describe('delegated webchat MCP operations', () => {
     await prisma.presetAgent.create({
       data: { orgId: DEFAULT_ORG_ID, preset: 'general', agentId: hostAgentId, status: 'created' }
     })
-    await prisma.sessionMeta.create({
-      data: {
-        id: `webchat-${conversationId}`,
-        agentId: hostAgentId,
-        platform: 'webchat',
-        channel: conversationId,
-        phase: 'end',
-        orgId: DEFAULT_ORG_ID,
-        ownerIdentity: `user:${DEFAULT_OWNER_ID}`,
-        visibility: 'private',
-        visibilitySource: 'default',
-        lastActivityAt: new Date(),
-        startedAt: new Date(),
-        // The daemon stamps `endedAt` after EVERY turn; authorization must key
-        // off the conversation's current-session pointer, not this timestamp.
-        endedAt: new Date()
-      }
-    })
-    await prisma.webchatConversation.update({
-      where: { id: conversationId },
-      data: { currentSessionId: `webchat-${conversationId}`, currentSessionRev: 1 }
-    })
+    // `registerSession: false` models the `session/new` window: the descriptor is
+    // already installed and the adapter is connecting, but the daemon has not yet
+    // reported the session, so no current-session pointer exists.
+    if (opts.registerSession !== false) {
+      await prisma.sessionMeta.create({
+        data: {
+          id: `webchat-${conversationId}`,
+          agentId: hostAgentId,
+          platform: 'webchat',
+          channel: conversationId,
+          phase: 'end',
+          orgId: DEFAULT_ORG_ID,
+          ownerIdentity: `user:${DEFAULT_OWNER_ID}`,
+          visibility: 'private',
+          visibilitySource: 'default',
+          lastActivityAt: new Date(),
+          startedAt: new Date(),
+          // The daemon stamps `endedAt` after EVERY turn; authorization must key
+          // off the conversation's current-session pointer, not this timestamp.
+          endedAt: new Date()
+        }
+      })
+      await prisma.webchatConversation.update({
+        where: { id: conversationId },
+        data: { currentSessionId: `webchat-${conversationId}`, currentSessionRev: 1 }
+      })
+    }
 
     const app = buildHttpApp(prisma, undefined, {
       get: (id) =>
@@ -312,6 +317,49 @@ describe('delegated webchat MCP operations', () => {
     const off = await remoteMethod({ id: 4, method: 'resources/list' })
     expect(off.statusCode).toBe(401)
     expect(off.headers['www-authenticate']).toBeUndefined()
+  })
+
+  it('admits handshake and catalog before the daemon registers the session, but holds tools/call', async () => {
+    // The adapter connects DURING session/new; the daemon can register the session
+    // (currentSessionId → session_meta) only after that call returns. initialize and
+    // the immediate tools/list must not lose that race — adapters do not retry a
+    // failed connect, so a denial here kills `agentconnect-admin` for the whole
+    // session lifetime.
+    const { remoteMethod, remoteRpc } = await delegatedFixture({ registerSession: false })
+
+    const init = await remoteMethod({
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'adapter', version: '0.0.0' } }
+    })
+    expect(init.statusCode).toBe(200)
+    expect((await remoteMethod({ method: 'notifications/initialized' })).statusCode).toBeLessThan(300)
+
+    const listed = await remoteMethod({ id: 2, method: 'tools/list' })
+    expect(listed.statusCode).toBe(200)
+    expect((mcpMessage(listed).result as { tools: Array<{ name: string }> }).tools.length).toBeGreaterThan(0)
+
+    // The authority-wielding step still fails closed until a private current
+    // session exists.
+    const call = await remoteRpc(3, 'listAgents', {})
+    expect(call.statusCode).toBe(401)
+    expect(call.headers['www-authenticate']).toBeUndefined()
+  })
+
+  it('keeps denying tools/call while the current session is not private', async () => {
+    const { conversationId, remoteMethod, remoteRpc } = await delegatedFixture()
+    await prisma.sessionMeta.update({
+      where: { id: `webchat-${conversationId}` },
+      data: { visibility: 'org' }
+    })
+
+    // The static catalog stays listable — it carries no org-scoped data…
+    const listed = await remoteMethod({ id: 1, method: 'tools/list' })
+    expect(listed.statusCode).toBe(200)
+
+    // …but no tool executes against a widened session.
+    const call = await remoteRpc(2, 'listAgents', {})
+    expect(call.statusCode).toBe(401)
   })
 
   it('refuses the handshake once the grant is revoked — no anonymous transport', async () => {


### PR DESCRIPTION
## Problem

After #357, a webchat session on the general preset **still** showed no `agentconnect-admin` tools. Live evidence from the test deploy (session `bd2aa34e`, conversation `05aaebac`):

- grant issued **10:26:27.309**, activated **10:26:27.321** — descriptor installed into `session/new` ✓
- adapter `initialize` POST hit `/api/v1/mcp` at **10:26:28.257** → **401**
- the `session_meta` row (and `webchat_conversation.currentSessionId`) landed at **10:26:28.368** — 111 ms after the denial

The authenticator required `hasPrivateWebchatSession()` for *every* method, but that predicate cannot hold when the adapter connects: the descriptor is installed into `session/new`, `initialize` + the immediate `tools/list` fire while that call is still running, and the daemon registers the session with the CP only after it returns. The race is lost deterministically, adapters do not retry a failed connect, and the server stays dead for the session's whole lifetime (until the ~25-minute grant rotation forces a `session/load`).

## Fix

Gate the private-current-session predicate on **`tools/call` only**:

- `initialize` / `notifications/initialized` / `ping` and `tools/list` are admitted after the unchanged grant + authority + live-fact checks (conversation binding, membership, agent visibility, preset, placement, daemon feature). The handshake reaches no tool; `tools/list` serves the static curated catalog with no org-scoped data.
- `tools/call` — the step that actually wields the delegated authority — is issued mid-turn, after registration, and still fails closed whenever the conversation's current session is missing or not private.

Design doc §7 updated to record the refinement.

## Why #357's tests missed it

The integration fixture always pre-registered the session before the first request. New tests cover the registration window (`registerSession: false`: initialize 200, tools/list 200, tools/call 401) and keep the widened-session (`visibility: org`) denial for `tools/call` while documenting that `tools/list` stays available.

## Testing

- `pnpm --filter @agentconnect.md/control-plane test:unit` — 939 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 877 passed (mcp.route: 31/31 incl. the two new tests)
- typecheck / prettier / eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)