### PR TITLE
fix(control-plane): resolve all external session scopes

### DIFF
--- a/packages/control-plane/src/http/github-session-access.test.ts
+++ b/packages/control-plane/src/http/github-session-access.test.ts
@@ -30,6 +30,14 @@ const scope: ExternalScopeRecord = {
   revokedAt: null
 }
 
+function scopeAt(index: number): ExternalScopeRecord {
+  return {
+    ...scope,
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    resourceKey: String(index)
+  }
+}
+
 function make(privateRepo: boolean, permissionForUser = vi.fn()) {
   const clock = new FakeClock()
   const repoRefById = vi.fn().mockResolvedValue({
@@ -48,6 +56,17 @@ function make(privateRepo: boolean, permissionForUser = vi.fn()) {
 }
 
 describe('GithubSessionAccessService', () => {
+  it('resolves allowed scopes beyond the first 200', async () => {
+    const h = make(false)
+    const scopes = Array.from({ length: 201 }, (_, index) => scopeAt(index + 1))
+
+    const result = await h.service.resolve(scopes, 'user-1')
+
+    expect(result.degraded).toBe(false)
+    expect(result.allowedScopes).toHaveLength(201)
+    expect(result.allowedScopes.at(-1)).toEqual({ id: scopes[200]!.id, aclRevision: scopes[200]!.aclRevision })
+  })
+
   it('allows an org member to read a public repository session without a linked GitHub identity', async () => {
     const h = make(false)
 

--- a/packages/control-plane/src/http/github-session-access.ts
+++ b/packages/control-plane/src/http/github-session-access.ts
@@ -7,7 +7,8 @@ const ALLOW_TTL_MS = 120_000
 const DENY_TTL_MS = 30_000
 const UNKNOWN_TTL_MS = 5_000
 const MAX_CACHE_ENTRIES = 10_000
-const MAX_SCOPES_PER_REQUEST = 200
+const SCOPES_PER_BATCH = 200
+const SCOPE_CONCURRENCY = 6
 
 type Decision = 'allow' | 'deny' | 'unknown'
 type CachedDecision = { decision: Decision; expiresAt: number }
@@ -52,13 +53,19 @@ export class GithubSessionAccessService implements GithubSessionAccessResolver {
 
   async resolve(scopes: readonly ExternalScopeRecord[], userId: string): Promise<GithubSessionAccessResult> {
     if (scopes.length === 0) return { allowedScopes: [], degraded: false }
-    const bounded = scopes.slice(0, MAX_SCOPES_PER_REQUEST)
-    let degraded = scopes.length > bounded.length
-    const decisions = await mapLimited(bounded, 6, async (scope) => {
-      const decision = await this.resolveScope(scope, userId)
-      if (decision === 'unknown') degraded = true
-      return { scope, decision }
-    })
+    let degraded = false
+    const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
+    // 200 is a provider-work batch, never a visibility ceiling. Walk every
+    // batch so UUID ordering cannot silently hide an otherwise-allowed scope.
+    for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
+      decisions.push(
+        ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
+          const decision = await this.resolveScope(scope, userId)
+          if (decision === 'unknown') degraded = true
+          return { scope, decision }
+        }))
+      )
+    }
     return {
       allowedScopes: decisions
         .filter(({ decision }) => decision === 'allow')

--- a/packages/control-plane/src/http/slack-session-access.test.ts
+++ b/packages/control-plane/src/http/slack-session-access.test.ts
@@ -19,6 +19,14 @@ function scope(): ExternalScopeRecord {
   }
 }
 
+function scopeAt(index: number): ExternalScopeRecord {
+  return {
+    ...scope(),
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    resourceKey: `C_CHANNEL_${index}`
+  }
+}
+
 function bot(): BotRecord {
   return {
     id: BOT_ID,
@@ -45,6 +53,25 @@ function json(body: unknown, status = 200): Response {
 }
 
 describe('SlackSessionAccessService', () => {
+  it('resolves allowed scopes beyond the first 200', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('conversations.info')) {
+        return json({ ok: true, channel: { is_private: false, is_im: false, is_mpim: false } })
+      }
+      if (url.includes('users.info')) {
+        return json({ ok: true, user: { team_id: 'T_INSTALL', deleted: false, is_restricted: false } })
+      }
+      throw new Error(`unexpected Slack request: ${url}`)
+    })
+    const scopes = Array.from({ length: 201 }, (_, index) => scopeAt(index + 1))
+
+    const result = await service(fetchImpl).resolve(scopes, new Set(['slack:T_INSTALL:U_MEMBER']))
+
+    expect(result.degraded).toBe(false)
+    expect(result.allowedScopes).toHaveLength(201)
+    expect(result.allowedScopes.at(-1)).toEqual({ id: scopes[200]!.id, aclRevision: scopes[200]!.aclRevision })
+  })
+
   it('allows a full workspace member to read a public channel without joining it', async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       if (url.includes('conversations.info')) {

--- a/packages/control-plane/src/http/slack-session-access.ts
+++ b/packages/control-plane/src/http/slack-session-access.ts
@@ -7,7 +7,8 @@ const ALLOW_TTL_MS = 120_000
 const DENY_TTL_MS = 30_000
 const UNKNOWN_TTL_MS = 5_000
 const MAX_CACHE_ENTRIES = 10_000
-const MAX_SCOPES_PER_REQUEST = 200
+const SCOPES_PER_BATCH = 200
+const SCOPE_CONCURRENCY = 6
 const MAX_MEMBER_PAGES = 50
 const PAGE_SIZE = 200
 const TIMEOUT_MS = 5_000
@@ -94,14 +95,20 @@ export class SlackSessionAccessService implements SlackSessionAccessResolver {
   ): Promise<SlackSessionAccessResult> {
     const principals = slackPrincipals(identitySet)
     if (principals.length === 0 || scopes.length === 0) return { allowedScopes: [], degraded: false }
-    const bounded = scopes.slice(0, MAX_SCOPES_PER_REQUEST)
-    const signal = AbortSignal.timeout(TIMEOUT_MS)
-    let degraded = scopes.length > bounded.length
-    const decisions = await mapLimited(bounded, 6, async (scope) => {
-      const result = await this.resolveScope(scope, principals, signal)
-      if (result === 'unknown') degraded = true
-      return { scope, decision: result }
-    })
+    let degraded = false
+    const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
+    // 200 is a provider-work batch, never a visibility ceiling. Walk every
+    // batch so UUID ordering cannot silently hide an otherwise-allowed scope.
+    for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
+      const signal = AbortSignal.timeout(TIMEOUT_MS)
+      decisions.push(
+        ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
+          const decision = await this.resolveScope(scope, principals, signal)
+          if (decision === 'unknown') degraded = true
+          return { scope, decision }
+        }))
+      )
+    }
     return {
       allowedScopes: decisions
         .filter(({ decision }) => decision === 'allow')


### PR DESCRIPTION
## Summary

- Treat 200 external scopes as a provider-work batch size instead of a total authorization ceiling.
- Walk every Slack and GitHub scope batch while retaining concurrency 6.
- Give each Slack batch a fresh timeout and report degraded access only for genuinely unresolved scopes.
- Cover the 201st scope regression for both providers.

## Root cause

The session query loaded every matching external scope, ordered by scope UUID, but the provider resolvers sliced the list to the first 200. An allowed session in scope 201 or later could therefore never enter the authorized SQL predicate and disappeared from the user session list.

## Validation

- Control-plane unit suite: 110 files, 946 tests passed
- Control-plane typecheck
- Session visibility integration suite: 24 tests passed
- Pre-push repository ESLint

Created by Codex . GPT-5.6