### PR TITLE
fix(daemon): preserve cached models after probe failure

### DIFF
--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -382,19 +382,19 @@ Lifecycle rules:
    visible through `observedAt` and the mismatch, until a new discovery replaces
    them. The UI must not fall back to knowing nothing the instant an adapter is
    upgraded.
-5. Division of responsibility with existing **fail-to-empty** behavior
-   (`daemon.ts:10561-10573`), which clears the runtime's advertised models after
-   probe failure to avoid advertising an unusable runtime: that behavior still
-   governs **advertisement** (`models[]`) unchanged. Probe failure means this
-   frame reports `models: []`. **Capability** (`modelCatalog`) comes from
-   independent `runtimeCatalogs` and is **not cleared by fail-to-empty**; the
-   failure frame still carries it. The model picker uses `models[]` and does not
-   advertise an unusable runtime, while CP capability knowledge is not reset to
-   null by one 30-second timeout. When the runtime recovers, the next successful
-   probe restores advertisement; capabilities never disappeared and need no
-   repeat discovery. "Never probed" (cold startup) is distinct from "probe
-   failed": the former serves cached advertisement; the latter clears only
-   advertisement.
+5. **Advertisement refresh failures preserve a cache-hydrated last-good list.**
+   A successful probe replaces `models[]` authoritatively, including a successful
+   empty selector. A known authentication rejection also clears the list and
+   carries `authRequired`, because the runtime cannot serve it until the operator
+   signs in. Any other failure of the first background refresh keeps non-empty
+   cache-hydrated `models[]` with `modelsSource: 'cached'`. Package-launch probes
+   use a fresh private HOME and can time out while warming dependencies even when
+   established agent homes remain healthy; erasing the cache in that state makes
+   the picker appear after restart and then disappear. Cached provenance keeps
+   activation/move validation permissive until a later successful probe replaces
+   it. A cold daemon with no cached list still reports `models: []` on failure.
+   **Capability** (`modelCatalog`) remains independent and is never cleared by a
+   probe failure.
 6. **Garbage collection**: during hydration, ignore runtime IDs absent from the
    current catalog resolved from registry/user/curated sources. Do not advertise
    or report them, but retain the rows because resolution may have failed
@@ -592,12 +592,12 @@ fails**.
 
 Every old/new component combination is lossless:
 
-| Combination                              | Behavior                                                                                                                                                                    |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| New daemon + old CP                      | zod strips/ignores new fields; old behavior remains                                                                                                                         |
-| Old daemon + new CP                      | catalog/modelsSource/seq are always absent; UI uses static fallback exactly as today; capability gates use probed semantics, also matching today                            |
-| First startup of new daemon (cold cache) | First frame has empty models and no catalog; phase 1/2 fill them in subsequent frames                                                                                       |
-| Restart of new daemon (warm cache)       | First frame includes last-good models (`modelsSource: 'cached'`) + catalog, fixing the clearing window for registry/user runtimes; see the §4 rule-1 scope note for curated |
+| Combination                              | Behavior                                                                                                                                                                                                  |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| New daemon + old CP                      | zod strips/ignores new fields; old behavior remains                                                                                                                                                       |
+| Old daemon + new CP                      | catalog/modelsSource/seq are always absent; UI uses static fallback exactly as today; capability gates use probed semantics, also matching today                                                          |
+| First startup of new daemon (cold cache) | First frame has empty models and no catalog; phase 1/2 fill them in subsequent frames                                                                                                                     |
+| Restart of new daemon (warm cache)       | First frame includes last-good models (`modelsSource: 'cached'`) + catalog; a non-auth refresh failure keeps that fallback until a successful probe replaces it; see the §4 rule-1 scope note for curated |
 
 Delivery order, with each step independently releasable:
 
@@ -638,9 +638,11 @@ existing `probeRuntimes` / `hostFactory` seams.
   `modelsSource: 'cached'`; curated runtime is absent before admission.
 - **Capability-gate provenance**: a `cached` list does not reject model
   activation/move; a `probed` list remains strict.
-- **Fail-to-empty split**: probe failure reports `models: []` while the
-  **catalog remains in the frame** and cache rows remain. The next successful
-  probe restores advertisement immediately without rerunning phase 2.
+- **Last-good refresh fallback**: a non-auth failure of the first probe keeps
+  cache-hydrated `models[]` with `modelsSource: 'cached'`, while a cold-cache or
+  auth-required failure reports `models: []`; the catalog remains in every
+  failure frame. The next successful probe replaces advertisement immediately
+  without rerunning phase 2.
 - **Discovery gate**: after phase 1 writes metadata the gate remains open
   (`complete=0`); after full success, another same-fingerprint sweep does not
   trigger it; changed `probedVersion`, model-set difference, and driver age past

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -16246,13 +16246,21 @@ export class Daemon {
         }
       }
       this.refreshAdmittedRuntimes()
-      // Overwrite unconditionally: a runtime that went from reachable → unreachable
-      // must drop its previously-cached models rather than keep advertising stale ones.
       for (const r of results) {
-        this.runtimeModels.set(r.runtime, r.ok ? r.models : [])
-        // Either way this is now live knowledge — the cached-provenance leniency
-        // (activation/move model gates) ends with the first real probe.
-        this.runtimeModelsSource.set(r.runtime, 'probed')
+        // Successful probes (including empty selectors) and auth failures are
+        // authoritative. Preserve a non-empty cache-hydrated list across other
+        // startup probe failures: disposable probe homes can fail while established
+        // agent homes remain usable. Cached provenance keeps model gates permissive
+        // until a later successful probe supplies live knowledge.
+        const keepCachedAdvertisement =
+          !r.ok &&
+          !r.authRequired &&
+          this.runtimeModelsSource.get(r.runtime) === 'cached' &&
+          (this.runtimeModels.get(r.runtime)?.length ?? 0) > 0
+        if (!keepCachedAdvertisement) {
+          this.runtimeModels.set(r.runtime, r.ok ? r.models : [])
+          this.runtimeModelsSource.set(r.runtime, 'probed')
+        }
         if (r.ok && r.acpProtocolVersion !== undefined) this.runtimeAcpVersions.set(r.runtime, r.acpProtocolVersion)
         else this.runtimeAcpVersions.delete(r.runtime)
         if (r.ok && r.probedVersion) this.runtimeProbedVersions.set(r.runtime, r.probedVersion)

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -15,8 +15,8 @@ import { FakeClock } from './cp/fake-clock.js'
 
 /** Daemon-level integration tests for the runtime-model-catalog wiring
  *  (design runtime-model-catalog.md §4/§6/§9): startup hydrate, the sweep
- *  fold's phase-1 seeding + provenance flip, the fail-to-empty split
- *  (advertisement vs capability), and the cached-provenance activation gate. */
+ *  fold's phase-1 seeding + provenance flip, last-good advertisement fallback,
+ *  and the cached-provenance activation gate. */
 
 const FAKE_RT: RuntimeDef = { command: 'fake-agent', args: ['--acp'], env: [] }
 
@@ -203,8 +203,8 @@ describe('daemon activation gate provenance rule', () => {
   })
 })
 
-describe('daemon fail-to-empty split (advertisement vs capability)', () => {
-  it('a probe failure empties models[] but keeps the catalog in the frame; a later success restores models without phase 2', async () => {
+describe('daemon last-good advertisement fallback', () => {
+  it('a transient first probe failure keeps cached models + catalog; a later success replaces them without phase 2', async () => {
     const dir = root()
     seedCache(dir, [
       { runtimeId: 'fake', defaultModel: 'm-a', models: [{ id: 'm-a', caps: { efforts: [{ value: 'low' }] } }] }
@@ -225,9 +225,12 @@ describe('daemon fail-to-empty split (advertisement vs capability)', () => {
       await (daemon as any).probeRuntimesAndEmit(true)
       expect(probe).toHaveBeenCalledTimes(1)
       const failed = emitted[0]![0]!
-      // Advertisement empties (don't offer an unreachable runtime)...
-      expect(failed.models).toEqual([])
-      // ...but capability knowledge survives the failure, on the wire and on disk.
+      // A disposable refresh can fail while established runtime homes remain
+      // usable. Keep the last-good advertisement permissive until live evidence
+      // replaces it, instead of making the picker disappear after restart.
+      expect(failed.models).toEqual(['m-a'])
+      expect(failed.modelsSource).toBe('cached')
+      // Capability knowledge also survives the failure, on the wire and on disk.
       expect(failed.modelCatalog).toEqual(cachedCatalog)
       expect(((daemon as any).store as LocalStore).listRuntimeModelCaps('fake').map((r) => r.modelId)).toEqual(['m-a'])
       expect(noteProbe).not.toHaveBeenCalled() // failures never reach phase 2
@@ -250,13 +253,15 @@ describe('daemon fail-to-empty split (advertisement vs capability)', () => {
 
 describe('daemon auth-required probe fold', () => {
   it('flags authRequired in the snapshot on an auth-rejected probe and clears it once a probe succeeds', async () => {
+    const dir = root()
+    seedCache(dir, [{ runtimeId: 'fake', models: [{ id: 'm-cached', caps: {} }] }])
     const clock = new FakeClock()
     clock.advance(10_000)
     let results: RuntimeProbeResult[] = [
       { runtime: 'fake', ok: false, models: [], error: 'Authentication required', authRequired: true }
     ]
     const probe = vi.fn(async () => results)
-    const daemon = daemonWith({ root: root(), catalog: catalogOf({ fake: FAKE_RT }), clock, probe })
+    const daemon = daemonWith({ root: dir, catalog: catalogOf({ fake: FAKE_RT }), clock, probe })
 
     try {
       await daemon.start()
@@ -264,8 +269,13 @@ describe('daemon auth-required probe fold', () => {
       const emitted = captureEmits(daemon)
 
       await (daemon as any).probeRuntimesAndEmit(true)
-      // The runtime stays listed (installed) but carries the login warning.
-      expect(emitted[0]![0]).toMatchObject({ runtime: 'fake', models: [], authRequired: true })
+      // Authentication rejection is authoritative and clears even a warm cache.
+      expect(emitted[0]![0]).toMatchObject({
+        runtime: 'fake',
+        models: [],
+        modelsSource: 'probed',
+        authRequired: true
+      })
 
       // Logged in meanwhile: the next sweep drops the flag off the frame
       // entirely (absent ⇒ ok, matching older-daemon semantics).
@@ -293,6 +303,8 @@ describe('daemon auth-required probe fold', () => {
       const emitted = captureEmits(daemon)
       await (daemon as any).probeRuntimesAndEmit(true)
       expect(emitted[0]![0]!.authRequired).toBeUndefined()
+      // With no last-good cache, there is nothing to preserve.
+      expect(emitted[0]![0]).toMatchObject({ models: [], modelsSource: 'probed' })
     } finally {
       await daemon.stop()
     }


### PR DESCRIPTION
## Summary

- preserve a non-empty cache-hydrated model list when the first background runtime refresh fails for a non-authentication reason
- keep successful probes and authentication rejections authoritative
- update the runtime model catalog contract and focused daemon regressions

## Root cause

On restart, the daemon initially advertised its cached last-good models. The first background probe then unconditionally replaced that advertisement with an empty list when the disposable probe failed, so the Web model picker appeared briefly and disappeared even though capability metadata remained available.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/model-catalog-daemon.test.ts test/model-catalog.test.ts test/runtime-prober.test.ts test/cp/client-handshake.test.ts` (68 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/daemon.ts packages/daemon/test/model-catalog-daemon.test.ts`
- `pnpm exec prettier --check packages/daemon/src/daemon.ts packages/daemon/test/model-catalog-daemon.test.ts docs/designs/runtime-model-catalog.md`
- pre-push `eslint .`

Created by Codex . GPT-5
