### PR TITLE
fix(daemon): restart host when sandbox mode changes

### DIFF
--- a/packages/daemon/src/reconciler/reconciler.ts
+++ b/packages/daemon/src/reconciler/reconciler.ts
@@ -16,11 +16,12 @@ function signature(a: Agent): string {
  *  the spawn binary (`runtime`) and the knobs baked into the host at construction:
  *  child env / system-prompt seed (agentChildEnv + cpRuntimeEnv) and the session
  *  config prefs (model / reasoningEffort / fastMode, applied per session via ACP
- *  set_config_option). A change here means the cached host must be evicted so
- *  the next session respawns it fresh. */
+ *  set_config_option), and the OS sandbox wrapper. A change here means the cached
+ *  host must be evicted so the next session respawns it fresh. */
 function hostSpawnSig(a: Agent): string {
   return JSON.stringify({
     runtime: a.runtime,
+    restrictFileAccess: a.restrictFileAccess,
     model: a.runtimeOverrides?.model,
     description: a.description,
     reasoningEffort: a.reasoningEffort,

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -8,6 +8,7 @@ const a = (id: string): Agent =>
     name: id,
     status: 'active',
     runtime: 'claude',
+    restrictFileAccess: false,
     workspace: { mode: 'from-scratch', path: '/tmp', gitBranch: 'main', pullOnNewSession: true, skills: [] },
     integrations: [],
     output: { mode: 'medium' },
@@ -44,6 +45,22 @@ describe('diffAgents', () => {
     expect(toChange).toHaveLength(1)
     expect(toChange[0]).toMatchObject({ hostRespawn: true, workspace: false, integrations: false })
     expect(toChange[0].agent.id).toBe('x')
+  })
+
+  it('classifies enabling or disabling the OS sandbox as a host-spawn change', () => {
+    const unsandboxed = a('x')
+    const sandboxed = { ...unsandboxed, restrictFileAccess: true } as Agent
+
+    expect(diffAgents([sandboxed], actual(unsandboxed)).toChange[0]).toMatchObject({
+      hostRespawn: true,
+      workspace: false,
+      integrations: false
+    })
+    expect(diffAgents([unsandboxed], actual(sandboxed)).toChange[0]).toMatchObject({
+      hostRespawn: true,
+      workspace: false,
+      integrations: false
+    })
   })
 
   it('classifies model / description / reasoningEffort / executionMode / fastMode / env as host-spawn changes', () => {


### PR DESCRIPTION
## Summary

- restart a warm ACP host whenever the per-agent **Run in sandbox** preference changes
- cover both sandbox enable and disable transitions with focused reconciler regression coverage

## Root cause

`restrictFileAccess` determines the OS sandbox wrapper when the ACP child is spawned, but it was omitted from `hostSpawnSig`. Reconciliation therefore treated the saved toggle as a soft-only update and reused an already-running child with its previous sandbox state.

## Impact

Saving the sandbox toggle now evicts the stale host so the next turn starts the runtime with the requested filesystem isolation policy.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/reconciler.test.ts`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec prettier --check packages/daemon/src/reconciler/reconciler.ts packages/daemon/test/reconciler.test.ts`
- `pnpm exec eslint packages/daemon/src/reconciler/reconciler.ts packages/daemon/test/reconciler.test.ts`
- pre-push `eslint .`

Created by Codex . GPT-5
