### PR TITLE
fix(web): show tooltips only for collapsed navigation

### DIFF
--- a/packages/web/STYLE.md
+++ b/packages/web/STYLE.md
@@ -123,8 +123,10 @@ desktop:grid-cols-4`. The hack rules stay in globals.css (harmless — they
     The layer only restyles hints that were already doing tooltip work — it is
     not a reason to add `title` to something that had none. Where a `title`
     exists for another purpose and would only repeat text the user can already
-    read, mark the subtree `data-no-tooltip`: the nav rail does this, since its
-    `title`s are the collapsed rail's fallback labels, not hints.
+    read, omit it in that state. The nav rail, for example, sets `title` only
+    while collapsed, so icon-only controls use the themed tooltip and expanded
+    labels stay silent. Mark a whole subtree `data-no-tooltip` only when its
+    titles must remain available to the browser without entering this layer.
 
 15. **JSX whitespace after an inline element (SWC gotcha).** Turbopack/SWC
     drops the space in `</span> long text…` when that text run wraps to the

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -198,7 +198,7 @@ function OrgSwitcher({ collapsed, canCreateOrg }: { collapsed: boolean; canCreat
     <div className={`relative pt-[10px] pb-[2px] ${collapsed ? 'px-2' : 'px-3'}`}>
       <button
         onClick={() => setOpen((v) => !v)}
-        title={activeOrg.name ?? activeOrg.slug}
+        title={collapsed ? (activeOrg.name ?? activeOrg.slug) : undefined}
         className={`flex w-full cursor-pointer items-center rounded-[7px] border border-(--border-inverse) bg-[rgba(255,255,255,.05)] py-[6px] text-left ${collapsed ? 'justify-center px-0' : 'gap-[9px] px-[9px]'}`}
       >
         {square(activeOrg)}
@@ -516,10 +516,9 @@ function ShellChrome({ children }: { children: ReactNode }) {
       <CrumbContext.Provider value={{ register: setCrumbSlot }}>
         <div className={`app${isListRoute ? '' : ' pushed'}${mounted ? ' mounted' : ''}`}>
           {/* ===== RAIL =====
-          No tooltips in here. The `title`s below exist as the collapsed rail's
-          fallback labels, not as hints — surfacing them would just repeat the
-          label already sitting next to the icon. */}
-          <aside data-no-tooltip className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
+          Only collapsed, icon-only controls get titles; the global layer turns
+          those titles into the console's themed tooltips. */}
+          <aside className={`rail${railCollapsed ? ' collapsed' : ''}${railAnim ? ' rail-anim' : ''}`}>
             <div className="railbrand">
               <Link
                 href={orgPath('/home')}
@@ -535,7 +534,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 type="button"
                 onClick={toggleRail}
                 className="railtoggle"
-                title={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                title={railCollapsed ? 'Expand sidebar' : undefined}
                 aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               >
                 <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={17} />
@@ -558,7 +557,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 <Link
                   key={item.href}
                   href={orgPath(item.href)}
-                  title={item.label}
+                  title={railCollapsed ? item.label : undefined}
                   className={on ? 'navitem on' : 'navitem'}
                 >
                   <Icon name={item.icon} size={18} color={on ? '#fff' : undefined} />
@@ -575,7 +574,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
               {authOn && (
                 <Link
                   href={orgPath('/settings')}
-                  title="Settings"
+                  title={railCollapsed ? 'Settings' : undefined}
                   className={`${isActive(barePath, '/settings') ? 'navitem on' : 'navitem'} my-0 rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full justify-center px-0' : 'flex-1 px-3'}`}
                 >
                   <Icon
@@ -591,7 +590,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
                   type="button"
                   onClick={() => setHelpMenu((v) => !v)}
                   className={`navitem justify-center rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full px-0' : 'w-auto flex-none px-[11px]'}`}
-                  title="Help & resources"
+                  title={railCollapsed ? 'Help & resources' : undefined}
                   aria-label="Help & resources"
                 >
                   <Icon name="circle-question-mark" size={18} color={helpMenu ? 'var(--brand)' : undefined} />

--- a/packages/web/src/components/console/Tooltip.test.tsx
+++ b/packages/web/src/components/console/Tooltip.test.tsx
@@ -168,6 +168,22 @@ describe('TooltipLayer', () => {
     expect(tooltip()?.textContent).toBe('Ships and rolls back deploys from chat.')
   })
 
+  it('releases a focused title before keyboard activation updates it', async () => {
+    const btn = iconButton('Expand sidebar')
+    // The collapsed rail's click changes its title prop to undefined. By the
+    // time this runs, the tooltip layer has already lifted the DOM attribute.
+    btn.addEventListener('click', () => btn.removeAttribute('title'))
+
+    await focus(btn)
+    expect(tooltip()?.textContent).toBe('Expand sidebar')
+
+    await act(async () => btn.click())
+    await act(async () => btn.dispatchEvent(new FocusEvent('focusout', { bubbles: true })))
+
+    expect(tooltip()).toBeNull()
+    expect(btn.hasAttribute('title')).toBe(false)
+  })
+
   it('stays out of a subtree marked data-no-tooltip', async () => {
     const rail = document.createElement('aside')
     rail.setAttribute('data-no-tooltip', '')

--- a/packages/web/src/components/console/Tooltip.tsx
+++ b/packages/web/src/components/console/Tooltip.tsx
@@ -164,6 +164,9 @@ export function TooltipLayer() {
     document.addEventListener('pointerover', onPointerOver, true)
     document.addEventListener('pointerout', onPointerOut, true)
     document.addEventListener('pointerdown', hide, true)
+    // Keyboard activation has no pointerdown. Release a parked title before the
+    // target's click handler can remove or replace its state-driven title.
+    document.addEventListener('click', hide, true)
     document.addEventListener('focusin', onFocusIn, true)
     document.addEventListener('focusout', hide, true)
     document.addEventListener('keydown', onKeyDown, true)
@@ -176,6 +179,7 @@ export function TooltipLayer() {
       document.removeEventListener('pointerover', onPointerOver, true)
       document.removeEventListener('pointerout', onPointerOut, true)
       document.removeEventListener('pointerdown', hide, true)
+      document.removeEventListener('click', hide, true)
       document.removeEventListener('focusin', onFocusIn, true)
       document.removeEventListener('focusout', hide, true)
       document.removeEventListener('keydown', onKeyDown, true)


### PR DESCRIPTION
## Summary
- show the shared themed tooltip for collapsed navigation icons
- omit navigation titles while the sidebar is expanded to avoid both themed and native hover tooltips
- release parked tooltip titles before keyboard activation updates state, preventing stale expanded-state hints
- document the state-dependent navigation tooltip convention

## Validation
- pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json
- pnpm exec eslint packages/web/src/components/console/Shell.tsx packages/web/src/components/console/Tooltip.tsx packages/web/src/components/console/Tooltip.test.tsx
- pnpm exec prettier --check packages/web/src/components/console/Shell.tsx packages/web/src/components/console/Tooltip.tsx packages/web/src/components/console/Tooltip.test.tsx packages/web/STYLE.md
- pnpm --filter @agentconnect.md/web exec vitest run src/components/console/Tooltip.test.tsx

Created by Codex . GPT-5