### PR TITLE
fix(daemon): restart host when skills change

### DIFF
--- a/packages/daemon/src/reconciler/reconciler.ts
+++ b/packages/daemon/src/reconciler/reconciler.ts
@@ -12,12 +12,13 @@ function signature(a: Agent): string {
   return JSON.stringify(rest)
 }
 
-/** Sub-signature over the dimensions that determine the ACP host subprocess —
- *  the spawn binary (`runtime`) and the knobs baked into the host at construction:
- *  child env / system-prompt seed (agentChildEnv + cpRuntimeEnv) and the session
- *  config prefs (model / reasoningEffort / fastMode, applied per session via ACP
- *  set_config_option), and the OS sandbox wrapper. A change here means the cached
- *  host must be evicted so the next session respawns it fresh. */
+/** Sub-signature over the dimensions that determine the ACP host subprocess or
+ *  must be materialized before it starts — the spawn binary (`runtime`), workspace
+ *  skills, and the knobs baked into the host at construction: child env /
+ *  system-prompt seed (agentChildEnv + cpRuntimeEnv), session config prefs (model /
+ *  reasoningEffort / fastMode, applied per session via ACP set_config_option), and
+ *  the OS sandbox wrapper. A change here means the cached host must be evicted so
+ *  the next session respawns it fresh. */
 function hostSpawnSig(a: Agent): string {
   return JSON.stringify({
     runtime: a.runtime,
@@ -41,6 +42,10 @@ function hostSpawnSig(a: Agent): string {
     // materialized as config files (config-file-env.ts) — a value edit that
     // doesn't evict the host would leave the child running on the stale value.
     secrets: a.runtimeOverrides?.secrets,
+    // Workspace skills are reconciled before host startup. Evict a live host
+    // before changing them so the runtime never observes the remove/reinstall
+    // transaction halfway through and always discovers the final set.
+    skills: a.skills,
     managedSkills: a.managedSkills
   })
 }

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -89,6 +89,23 @@ describe('diffAgents', () => {
     }
   })
 
+  it('respawns the host when the enabled workspace skills change', () => {
+    const before = {
+      ...a('x'),
+      skills: [{ name: 'kit', source: 'acme/skills', skills: ['review-pr', 'safe-deploy'] }]
+    } as Agent
+    const after = {
+      ...before,
+      skills: [{ name: 'kit', source: 'acme/skills', skills: ['safe-deploy'] }]
+    } as Agent
+
+    expect(diffAgents([after], actual(before)).toChange[0]).toMatchObject({
+      hostRespawn: true,
+      workspace: false,
+      integrations: false
+    })
+  })
+
   it('classifies a workspace edit as a workspace change (only)', () => {
     const after = {
       ...a('x'),


### PR DESCRIPTION
## Summary

- Treat shared workspace skill changes as ACP host-spawn changes.
- Reconcile the final skill set before starting the replacement host, so a running runtime cannot observe the temporary empty directory between removal and reinstall.
- Cover narrowing two enabled skills to one with a regression test.

## Root cause

Shared skill edits updated the in-memory agent config without evicting the live ACP host. The next session reconciled skills beside that running process by removing every previously managed copy before reinstalling the remaining selection. The runtime could observe that intermediate empty state and only recover on a later session.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/reconciler.test.ts` (15 passed)
- `pnpm exec eslint packages/daemon/src/reconciler/reconciler.ts packages/daemon/test/reconciler.test.ts`
- `pnpm exec prettier --check packages/daemon/src/reconciler/reconciler.ts packages/daemon/test/reconciler.test.ts`
- Pre-push `eslint .`
- Full daemon suite: 2,573 passed / 7 skipped; Vitest exited nonzero only because macOS watcher teardown hit `EMFILE` after the assertions completed.

Created by Codex . GPT-5
