### PR TITLE
fix(control-plane): refresh rc daemon releases sooner

### DIFF
--- a/packages/control-plane/src/registry/daemonRelease.test.ts
+++ b/packages/control-plane/src/registry/daemonRelease.test.ts
@@ -83,4 +83,29 @@ describe('DaemonReleaseResolver', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
     await vi.waitFor(() => expect(r.get().latestVersion).toBe('1.4.1'))
   })
+
+  it('uses a shorter default TTL for rc than stable channels', async () => {
+    const clock = new FakeClock(1000)
+    let rcVersion = '1.5.0-rc.1'
+    const rcFetch = vi.fn(async () => ok({ rc: rcVersion }))
+    const stableFetch = vi.fn(async () => ok({ latest: '1.4.0' }))
+    const rc = new DaemonReleaseResolver('rc', clock, rcFetch)
+    const stable = new DaemonReleaseResolver('latest', clock, stableFetch)
+
+    rc.get()
+    stable.get()
+    await vi.waitFor(() => {
+      expect(rc.get().latestVersion).toBe('1.5.0-rc.1')
+      expect(stable.get().latestVersion).toBe('1.4.0')
+    })
+
+    rcVersion = '1.5.0-rc.2'
+    clock.advance(2 * 60_000 + 1)
+    rc.get()
+    stable.get()
+
+    expect(rcFetch).toHaveBeenCalledTimes(2)
+    expect(stableFetch).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(rc.get().latestVersion).toBe('1.5.0-rc.2'))
+  })
 })

--- a/packages/control-plane/src/registry/daemonRelease.ts
+++ b/packages/control-plane/src/registry/daemonRelease.ts
@@ -21,7 +21,8 @@ const NPM_PKG = '@agentconnect.md/daemon'
 // The lightweight dist-tags document (a `{ tag: version }` map) rather than the
 // full packument — a few bytes, cache-friendly, and all we need.
 const DIST_TAGS_URL = `https://registry.npmjs.org/-/package/${encodeURIComponent(NPM_PKG)}/dist-tags`
-const DEFAULT_TTL_MS = 30 * 60_000 // 30 min — daemon releases are infrequent
+const STABLE_TTL_MS = 30 * 60_000 // 30 min — stable daemon releases are infrequent
+const RC_TTL_MS = 2 * 60_000 // RC publishes are frequent; surface them promptly in the console
 const FETCH_TIMEOUT_MS = 4_000
 
 // Same shape as the github `FetchLike` seam: the real `fetch` is assignable to it,
@@ -51,7 +52,7 @@ export class DaemonReleaseResolver {
     private readonly channel: string,
     private readonly clock: Clock,
     private readonly fetchImpl: Fetcher = fetch,
-    private readonly ttlMs: number = DEFAULT_TTL_MS
+    private readonly ttlMs: number = channel === 'rc' ? RC_TTL_MS : STABLE_TTL_MS
   ) {}
 
   /** The current best-known release for the channel. Triggers a background


### PR DESCRIPTION
## Summary

- reduce the daemon release resolver cache TTL from 30 minutes to 2 minutes for the `rc` channel
- keep the 30-minute cache for stable channels
- cover the channel-specific default TTL behavior with a focused resolver test

## Why

The test Control Plane can cache the `rc` dist-tag immediately before a publish, leaving the console without an upgrade hint for nearly 30 minutes. RC builds publish frequently, so that stable-release cache window is too long. With the shorter TTL and the existing 15-second console poll, new RC upgrades should normally surface within about 2 minutes and 15 seconds.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/registry/daemonRelease.test.ts`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- targeted ESLint and Prettier checks
- pre-push full-repository ESLint hook

Created by Codex . gpt-5.6-sol
