### PR TITLE
fix(web): prevent collapsed rail logo overlap

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -469,8 +469,8 @@
   }
   /* Collapsed: the toggle overlays the centered logo, invisible but still in the tab
      order (opacity, not display:none) so a keyboard-only user can Tab to it and
-     re-expand. It reveals on brand hover, or on keyboard focus via the global
-     `.railtoggle:focus-visible` rule above. The logo hides on hover, or when the
+     re-expand. It reveals while the rail is hovered, or on keyboard focus via the
+     global rules above. The logo hides for that same rail-wide hover, or when the
      toggle itself is focused — keyed off `:has(.railtoggle:focus-visible)` (not
      `:focus-within`) so Tabbing to the logo link never hides the focused link. */
   .rail.collapsed .railtoggle {
@@ -480,10 +480,7 @@
     height: auto;
     margin: 0;
   }
-  .rail.collapsed .railbrand:hover .railtoggle {
-    opacity: 1;
-  }
-  .rail.collapsed .railbrand:hover .railbrand-logo,
+  .rail.collapsed:hover .railbrand-logo,
   .rail.collapsed .railbrand:has(.railtoggle:focus-visible) .railbrand-logo {
     opacity: 0;
   }


### PR DESCRIPTION
## Summary
- hide the collapsed rail logo whenever the rail-wide hover reveals the expand control
- prevent the logo and expand icon from overlapping while hovering lower navigation items
- remove the redundant brand-only toggle reveal rule

## Validation
- pnpm --filter @agentconnect.md/web build
- pnpm exec prettier --check packages/web/src/app/globals.css
- pre-push eslint

Created by Codex . GPT-5