### PR TITLE
feat(daemon): enable turn-final context refresh by default

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -290,10 +290,10 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
 
   // ---------- Staged feature rollout ----------
   "features": {
-    // Default false during rollout. When enabled, interactive IM answer text is
-    // staged until a turn-final thread refresh accepts it; changed context causes
-    // bounded regeneration in the same ACP session.
-    "turnFinalContextRefresh": false
+    // Default true. When enabled, interactive IM answer text is staged until a
+    // turn-final thread refresh accepts it; changed context causes bounded
+    // regeneration in the same ACP session. Set false to opt out (kill switch).
+    "turnFinalContextRefresh": true
   },
 
   // ---------- Local capacity/limits ----------

--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -4,7 +4,8 @@
 > Scope: daemon-owned interactive IM turns (Slack, Discord, Lark / Feishu, and Telegram)
 > Primary implementation area: `packages/daemon`
 > Rollout: core staging, local observation, Slack final snapshots, and observed-only
-> fallback are available behind `features.turnFinalContextRefresh` (default `false`)
+> fallback are available behind `features.turnFinalContextRefresh` (default `true`;
+> set to `false` to opt out and keep pre-refresh delivery behavior)
 
 ## 1. Summary
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -161,9 +161,9 @@ export const ConfigSchema = z.object({
    * never negotiated through the control plane or placed on the message hot path. */
   features: z
     .object({
-      turnFinalContextRefresh: z.boolean().default(false)
+      turnFinalContextRefresh: z.boolean().default(true)
     })
-    .default({ turnFinalContextRefresh: false }),
+    .default({ turnFinalContextRefresh: true }),
   limits: z
     .object({
       maxAgents: z.number().int().default(32),

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -24,7 +24,7 @@ describe('loadConfig', () => {
     expect(cfg.runtimes.claude.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
     expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['https://github.com', 'ssh://github.com'])
-    expect(cfg.features.turnFinalContextRefresh).toBe(false)
+    expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
   })

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -595,6 +595,12 @@ describe('Daemon interrupt safety gates', () => {
     }
     const daemon = new Daemon({ root, hostFactory: () => host as any })
     await daemon.start()
+    // Per-turn config rematerialization touches agents/**; on a slow runner the
+    // debounced file-watch reconcile can then land mid-loop and revert the
+    // in-memory integrations injected below (session source turns 'unavailable').
+    await (daemon as any).watcher.close()
+    ;(daemon as any).watcher = undefined
+    clearTimeout((daemon as any).debounceTimer)
     for (const [agentId, integrationId] of [
       [AGENT_ID, 'int-a'],
       ['bot-b', 'int-b']

--- a/packages/daemon/test/daemon-serial-gate.test.ts
+++ b/packages/daemon/test/daemon-serial-gate.test.ts
@@ -20,6 +20,9 @@ function scaffold(): string {
     JSON.stringify({
       version: 1,
       controlPlane: { enabled: false },
+      // This suite pins the base serial-gate contract (one turn per queued
+      // activation); the coalescing on-path is covered by turn-output-workflow.
+      features: { turnFinalContextRefresh: false },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -12,6 +12,9 @@ function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', ico
     JSON.stringify({
       version: 1,
       controlPlane: { enabled: false },
+      // This suite pins pre-staging flush semantics (verbatim terminal-error
+      // delivery); staged delivery is covered by turn-output-workflow.
+      features: { turnFinalContextRefresh: false },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -20,6 +20,9 @@ function scaffold(mode: 'minimal' | 'low' | 'medium' | 'high', agentExtra: Recor
       // Set so onFinal emits the done-footer (gated on a Web App URL) — lets the
       // footer test assert it's posted to Slack but never recorded in the transcript.
       webAppUrl: 'https://app.example.com',
+      // This suite pins incremental-flush renderer behavior; staged delivery is
+      // covered by turn-output-workflow.
+      features: { turnFinalContextRefresh: false },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -184,6 +184,9 @@ function scaffold(agentIds: string[] = ['bot-a']): string {
     JSON.stringify({
       version: 1,
       controlPlane: { enabled: false },
+      // This suite pins one-persisted-row-per-turn inbox replay; queue coalescing
+      // under the refresh fence is covered by turn-output-workflow.
+      features: { turnFinalContextRefresh: false },
       runtimes: { claude: { command: 'node', args: ['unused'] } }
     })
   )


### PR DESCRIPTION
## Summary

Flips `features.turnFinalContextRefresh` from `false` to `true`, making the turn-final context refresh workflow from #359 the default behavior. The flag is kept as an operator-owned opt-out — setting it to `false` in `config.json` restores pre-staging delivery, so it still works as a per-daemon kill switch.

- `config-schema.ts`: field default and `features` block default flipped to `true`
- design docs updated (`turn-final-context-refresh.md` header, `daemon-detailed-design.md` config example)
- suites that pin the base mechanics now set the flag off explicitly in their scaffold configs, with comments pointing at the on-path coverage:
  - `daemon-serial-gate` — one turn per queued activation (coalescing absorbs these when the flag is on)
  - `daemon-smoke` — verbatim terminal-error flush (staged path delivers via the ⚠️ failure notice instead)
  - `daemon-transcript` — incremental-flush renderer behavior
  - `durable-inbox` — one-persisted-row-per-turn replay
  - the staged on-path semantics remain covered by `turn-output-workflow.test.ts`

## Why

Live-verified on the test CP today: with the flag on, a mid-turn correction discards the stale staged answer, coalesces the queued clarification, and regenerates in the same ACP session — exactly the #359 design intent. Defaulting it on gives every daemon that behavior without a config edit.

## Impact

Daemons upgrading to this release enable staging/regeneration automatically unless their `config.json` sets `features.turnFinalContextRefresh: false`. Note for release notes: discarded generations consume provider tokens (recorded as additive discarded-generation usage), and busy threads can see the bounded-regeneration give-up notice.

## Validation

- `pnpm --filter @agentconnect.md/daemon typecheck`
- Prettier + ESLint on all changed files
- Full daemon suite: 2572 passed | 1 failed — the one failure is the pre-existing environment-specific `git-injection.test.ts` case already called out in #359's validation notes (Git returns an empty remote URL on this box), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)