### PR TITLE
fix(daemon): preserve host Claude credential storage

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -322,8 +322,10 @@ performs a live probe rather than treating installed binaries as sufficient.
 An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
 metadata and the host source from which that runtime state was seeded, and
 re-allows reads only for the workspace, private HOME, managed memory,
-`run/config-files`, and `.agentconnect/runtime-policy`. Writes are limited to the
-workspace, private HOME, managed memory, and SRT temporary storage. Outbound
+`run/config-files`, `.agentconnect/runtime-policy`, trusted runtime installation
+roots, and the runtime's selected host credential path. Writes are limited to
+the workspace, private HOME, managed memory, SRT temporary storage, and that
+credential path. Outbound
 domains are approved by a provider callback and Unix sockets remain
 compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
 egress, but SRT's isolated Linux network namespace means host access to an
@@ -331,6 +333,25 @@ agent-started local server and clients that ignore the proxy environment are not
 yet compatibility guarantees; issue #312 tracks those boundaries. SRT's
 temporary directory is redirected below the private HOME and its shared
 `/tmp/claude` fallback is hidden.
+
+The Claude ACP parent is trusted to manage the host Claude login. By default,
+AgentConnect resolves the host config directory from `CLAUDE_CONFIG_DIR`, falling
+back to `$HOME/.claude`, and passes that directory to the private-HOME runtime as
+`CLAUDE_SECURESTORAGE_CONFIG_DIR`. This preserves the host CLI's default
+`.credentials.json` in place and permits Claude's temporary-file-plus-rename
+refresh behavior. AgentConnect does not rewrite host Claude settings or relocate
+the host credential between secure-storage directories. Claude's nested sandbox
+denies this parent-only path to model-authored Bash and its descendants.
+
+Operators who do not want the trusted ACP parent to see the rest of the host
+Claude config directory can create a dedicated absolute directory and set
+`CLAUDE_SECURESTORAGE_CONFIG_DIR` in the host Claude `settings.json` environment,
+then run host `claude /login`. AgentConnect follows that setting and re-opens only
+the selected directory. A daemon process environment value takes precedence over
+the settings value; to keep host `/login` on the same path, set the value in the
+environment used by both processes or prefer Claude settings. If neither is set,
+the Claude config directory is the intentional trusted default. Installations
+whose settings already select an `agentconnect-auth` directory continue using it.
 
 Read access outside the explicitly denied agent/runtime-state roots remains
 unchanged in this rollout. This is not yet a whole-host read allowlist: unrelated

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -136,6 +136,8 @@ export function prepareRuntimeLaunch(opts: {
   // host credentials. A bad daemon root or escaping workspace must fail without
   // partially migrating login state.
   let protectedRoots: string[] = []
+  let protectedBoundaryRoots: string[] = []
+  let protectedRuntimeStateRoots: string[] = []
   let denyReadRoots: string[] = []
   if (opts.runInSandbox) {
     sandboxBoundary({ agentDir: opts.scopeDir, cwd: opts.cwd, runtimeHome: runtimeHomePath(opts.scopeDir) })
@@ -149,17 +151,17 @@ export function prepareRuntimeLaunch(opts: {
     const sharedTempRoots = ['/tmp', '/var/tmp', stateSourceEnv.TMPDIR, stateSourceEnv.TMP, stateSourceEnv.TEMP]
       .filter((path): path is string => Boolean(path))
       .map((path) => safeRoot(path, 'shared temp root'))
-    const allRuntimeStateRoots = Object.keys(RUNTIME_STATE_LOCATIONS).flatMap((id) =>
+    protectedRuntimeStateRoots = Object.keys(RUNTIME_STATE_LOCATIONS).flatMap((id) =>
       runtimeStateLocations(id, stateSourceEnv).map((location) => safeRoot(location.source, `${id} host state root`))
     )
-    protectedRoots = [
+    protectedBoundaryRoots = [
       daemonRoot,
       agentRoot,
       ...(opts.agentsRoot ? [safeRoot(opts.agentsRoot, 'agents root')] : []),
       ...hostHomeRoots,
-      ...sharedTempRoots,
-      ...allRuntimeStateRoots
+      ...sharedTempRoots
     ]
+    protectedRoots = [...protectedBoundaryRoots, ...protectedRuntimeStateRoots]
     denyReadRoots = compactReadRoots(protectedRoots)
   }
 
@@ -218,7 +220,19 @@ export function prepareRuntimeLaunch(opts: {
       .join(delimiter)
   }
   const credentialWritableRoots = compactReadRoots(
-    (credentials?.writablePaths ?? []).map((path) => validateException(path, 'shared credential write root'))
+    (credentials?.writablePaths ?? []).map((path) => {
+      const trusted = safeRoot(path, 'shared credential write root')
+      // A credential capability may equal one hidden runtime-state root (the
+      // default Claude layout), but it must not contain another protected root
+      // or reopen HOME, daemon state, an agent root, or shared temp wholesale.
+      const broadened =
+        protectedBoundaryRoots.find((denied) => inside(trusted, denied)) ??
+        protectedRuntimeStateRoots.find((denied) => trusted !== denied && inside(trusted, denied))
+      if (broadened) {
+        throw new Error(`shared credential write root "${trusted}" would reopen protected path "${broadened}"`)
+      }
+      return trusted
+    })
   )
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   if (claudeRuntime) {

--- a/packages/daemon/src/runtimes/runtime-credentials.ts
+++ b/packages/daemon/src/runtimes/runtime-credentials.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { timingSafeEqual } from 'node:crypto'
 import {
   chmodSync,
   constants,
@@ -14,8 +14,7 @@ import {
   rmdirSync,
   statSync,
   symlinkSync,
-  unlinkSync,
-  writeFileSync
+  unlinkSync
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
@@ -25,7 +24,7 @@ export type SharedCredentialProfile = 'claude' | 'codex' | 'qoder' | 'qoder-cn'
 
 export interface SharedRuntimeCredentialAccess {
   env: Record<string, string>
-  /** Existing, credential-only host paths that the sandbox may update. */
+  /** Host paths that the trusted ACP runtime may update for login refresh. */
   writablePaths: string[]
   /** Private-HOME destinations that must no longer receive copy-once auth. */
   seedExclusions: string[]
@@ -112,25 +111,6 @@ function jsonObject(path: string): Record<string, unknown> {
   return parsed as Record<string, unknown>
 }
 
-function atomicJsonWrite(path: string, value: Record<string, unknown>): void {
-  const destination = existsSync(path) ? existingFileTarget(path) : path
-  mkdirSync(dirname(destination), { recursive: true, mode: 0o700 })
-  const mode = existsSync(destination) ? statSync(destination).mode & 0o777 : 0o600
-  const temporary = join(dirname(destination), `.${randomUUID()}.tmp`)
-  try {
-    writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { flag: 'wx', mode: mode || 0o600 })
-    renameSync(temporary, destination)
-    secureCredentialFile(destination)
-  } catch (error) {
-    try {
-      unlinkSync(temporary)
-    } catch {
-      // The temporary file may not exist or may already have been renamed.
-    }
-    throw error
-  }
-}
-
 function sameFileContents(a: string, b: string): boolean {
   const left = readFileSync(a)
   const right = readFileSync(b)
@@ -162,79 +142,36 @@ function prepareClaudeCredentials(env: NodeJS.ProcessEnv): SharedRuntimeCredenti
     absoluteConfiguredPath(configured, env, 'host CLAUDE_CONFIG_DIR'),
     'host Claude config directory'
   )
-  const settingsPath = join(configDir, 'settings.json')
-  const settings = existsSync(settingsPath) ? jsonObject(settingsPath) : {}
-  const rawSettingsEnv = settings.env
-  if (
-    rawSettingsEnv !== undefined &&
-    (!rawSettingsEnv || typeof rawSettingsEnv !== 'object' || Array.isArray(rawSettingsEnv))
-  ) {
-    throw new Error(`Claude settings.env must contain a JSON object: ${settingsPath}`)
+  let configuredSecureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR
+  if (!configuredSecureDir) {
+    const settingsPath = join(configDir, 'settings.json')
+    const settings = existsSync(settingsPath) ? jsonObject(settingsPath) : {}
+    const rawSettingsEnv = settings.env
+    if (
+      rawSettingsEnv !== undefined &&
+      (!rawSettingsEnv || typeof rawSettingsEnv !== 'object' || Array.isArray(rawSettingsEnv))
+    ) {
+      throw new Error(`Claude settings.env must contain a JSON object: ${settingsPath}`)
+    }
+    const settingsEnv = (rawSettingsEnv ?? {}) as Record<string, unknown>
+    const setting = settingsEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR
+    if (setting !== undefined && typeof setting !== 'string') {
+      throw new Error(`Claude settings env.CLAUDE_SECURESTORAGE_CONFIG_DIR must be a string: ${settingsPath}`)
+    }
+    configuredSecureDir = setting
   }
-  const settingsEnv = (rawSettingsEnv ?? {}) as Record<string, unknown>
-  const configuredSecureDir = settingsEnv.CLAUDE_SECURESTORAGE_CONFIG_DIR
-  if (configuredSecureDir !== undefined && typeof configuredSecureDir !== 'string') {
-    throw new Error(`Claude settings env.CLAUDE_SECURESTORAGE_CONFIG_DIR must be a string: ${settingsPath}`)
-  }
-  const sharedDir = ensureOwnedDirectory(
-    absoluteConfiguredPath(
-      configuredSecureDir || join(configDir, 'agentconnect-auth'),
-      env,
-      'Claude secure credential directory'
-    ),
+  const credentialDir = ensureOwnedDirectory(
+    absoluteConfiguredPath(configuredSecureDir || configDir, env, 'Claude secure credential directory'),
     'Claude secure credential directory'
   )
-  if (sharedDir === configDir || configDir.startsWith(sharedDir + sep)) {
-    throw new Error(
-      'Claude shared credential storage must be a dedicated directory, not the config directory or its parent'
-    )
-  }
-
-  const source = join(configDir, '.credentials.json')
-  const destination = join(sharedDir, '.credentials.json')
-  let moved = false
-  let removeLegacyAfterSettings = false
-  if (existsSync(source)) {
-    const sourceInfo = lstatSync(source)
-    const sourceTarget = existingFileTarget(source)
-    if (sourceInfo.isSymbolicLink() && (!existsSync(destination) || existingFileTarget(destination) !== sourceTarget)) {
-      throw new Error(`Claude credential symlink must already target the selected shared credential: ${source}`)
-    }
-    if (existsSync(destination)) {
-      const destinationTarget = existingFileTarget(destination)
-      if (sourceTarget === destinationTarget || sameFileContents(sourceTarget, destinationTarget)) {
-        removeLegacyAfterSettings = source !== destination
-      } else if (!configuredSecureDir) {
-        throw new Error(
-          `conflicting Claude credentials at ${source} and ${destination}; run host claude /login after resolving the conflict`
-        )
-      }
-      // If the host already selected this secure-storage directory, its file is
-      // authoritative and a leftover default-path file is deliberately ignored.
-    } else {
-      renameSync(sourceTarget, destination)
-      secureCredentialFile(destination)
-      moved = true
-    }
-  }
-
-  try {
-    if (configuredSecureDir !== sharedDir) {
-      atomicJsonWrite(settingsPath, {
-        ...settings,
-        env: { ...settingsEnv, CLAUDE_SECURESTORAGE_CONFIG_DIR: sharedDir }
-      })
-    }
-  } catch (error) {
-    if (moved && existsSync(destination) && !existsSync(source)) renameSync(destination, source)
-    throw error
-  }
-  if (removeLegacyAfterSettings && existsSync(source)) unlinkSync(source)
+  const destination = join(credentialDir, '.credentials.json')
   if (existsSync(destination)) secureCredentialFile(existingFileTarget(destination))
 
   return {
-    env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: sharedDir },
-    writablePaths: [sharedDir],
+    // The ACP runtime has a private HOME, so pass the resolved host directory
+    // explicitly even when Claude's default secure-storage location is used.
+    env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: credentialDir },
+    writablePaths: [credentialDir],
     seedExclusions: [join('.claude', '.credentials.json')],
     preparePrivateHome: (runtimeHome) => {
       const privateCredential = join(runtimeHome, '.claude', '.credentials.json')

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -36,7 +36,7 @@ function settings(path: string): { filesystem: { allowWrite: string[] } } {
 }
 
 describe('Linux shared runtime login', () => {
-  it('keeps Claude state private while host and agents share one refreshable credential directory', () => {
+  it('trusts the host Claude config directory by default without rewriting its settings', () => {
     const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
     const hostClaude = join(hostHome, '.claude')
     const privateClaude = join(scopeDir, 'home', '.claude')
@@ -61,16 +61,12 @@ describe('Linux shared runtime login', () => {
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
-    const sharedDir = realpathSync(join(hostClaude, 'agentconnect-auth'))
+    const sharedDir = realpathSync(hostClaude)
     expect(launch.env.HOME).toBe(join(scopeDir, 'home'))
     expect(launch.env.CLAUDE_CONFIG_DIR).toBe(join(scopeDir, 'home', '.claude'))
     expect(launch.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(sharedDir)
-    expect(JSON.parse(readFileSync(join(hostClaude, 'settings.json'), 'utf8'))).toMatchObject({
-      theme: 'dark',
-      env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: sharedDir }
-    })
+    expect(JSON.parse(readFileSync(join(hostClaude, 'settings.json'), 'utf8'))).toEqual({ theme: 'dark' })
     expect(readFileSync(join(sharedDir, '.credentials.json'), 'utf8')).toContain('agent-new')
-    expect(existsSync(join(hostClaude, '.credentials.json'))).toBe(false)
     expect(existsSync(join(privateClaude, '.credentials.json'))).toBe(false)
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(sharedDir)
     expect(launch.sandbox?.protectedCredentialRoots).toEqual([sharedDir])
@@ -92,6 +88,96 @@ describe('Linux shared runtime login', () => {
     })
     expect(second.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(sharedDir)
     expect(readFileSync(join(sharedDir, '.credentials.json'), 'utf8')).toContain('refreshed')
+  })
+
+  it('follows a Claude settings secure-storage directory without moving the default credential', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const hostClaude = join(hostHome, '.claude')
+    const secureDir = join(hostClaude, 'agentconnect-auth')
+    mkdirSync(secureDir, { recursive: true })
+    writeFileSync(
+      join(hostClaude, 'settings.json'),
+      JSON.stringify({ theme: 'dark', env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: secureDir } })
+    )
+    writeFileSync(join(hostClaude, '.credentials.json'), '{"accessToken":"default-login"}')
+    writeFileSync(join(secureDir, '.credentials.json'), '{"accessToken":"isolated-login"}')
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      scopeDir,
+      cwd,
+      daemonRoot,
+      agentsRoot: join(daemonRoot, 'agents'),
+      runInSandbox: true,
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const canonicalSecureDir = realpathSync(secureDir)
+    expect(launch.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(canonicalSecureDir)
+    expect(JSON.parse(readFileSync(join(hostClaude, 'settings.json'), 'utf8'))).toEqual({
+      theme: 'dark',
+      env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: secureDir }
+    })
+    expect(readFileSync(join(hostClaude, '.credentials.json'), 'utf8')).toContain('default-login')
+    expect(readFileSync(join(secureDir, '.credentials.json'), 'utf8')).toContain('isolated-login')
+    expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(canonicalSecureDir)
+    expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).not.toContain(realpathSync(hostClaude))
+    expect(launch.sandbox?.protectedCredentialRoots).toEqual([canonicalSecureDir])
+  })
+
+  it('prefers the daemon environment secure-storage directory over Claude settings', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+    const hostClaude = join(hostHome, '.claude')
+    const settingsDir = join(hostClaude, 'settings-auth')
+    const environmentDir = join(hostClaude, 'environment-auth')
+    mkdirSync(settingsDir, { recursive: true })
+    mkdirSync(environmentDir)
+    writeFileSync(
+      join(hostClaude, 'settings.json'),
+      JSON.stringify({ env: { CLAUDE_SECURESTORAGE_CONFIG_DIR: settingsDir } })
+    )
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      scopeDir,
+      cwd,
+      daemonRoot,
+      agentsRoot: join(daemonRoot, 'agents'),
+      runInSandbox: true,
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      hostEnv: {
+        HOME: hostHome,
+        PATH: '/usr/bin',
+        CLAUDE_SECURESTORAGE_CONFIG_DIR: environmentDir
+      }
+    })
+
+    expect(launch.env.CLAUDE_SECURESTORAGE_CONFIG_DIR).toBe(realpathSync(environmentDir))
+  })
+
+  it('refuses a secure-storage override that would reopen the entire host HOME', () => {
+    const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
+
+    expect(() =>
+      prepareRuntimeLaunch({
+        runtimeId: 'claude-acp',
+        scopeDir,
+        cwd,
+        daemonRoot,
+        agentsRoot: join(daemonRoot, 'agents'),
+        runInSandbox: true,
+        sandboxMechanism: 'bwrap',
+        credentialPlatform: 'linux',
+        hostEnv: {
+          HOME: hostHome,
+          PATH: '/usr/bin',
+          CLAUDE_SECURESTORAGE_CONFIG_DIR: hostHome
+        }
+      })
+    ).toThrow(/would reopen protected path/)
   })
 
   it('links private Codex homes to the newest shared auth file and preserves the link across refresh', () => {


### PR DESCRIPTION
## Summary

- keep Claude's default host `.credentials.json` in place and trust the host Claude config directory only for the ACP parent
- honor `CLAUDE_SECURESTORAGE_CONFIG_DIR` from the daemon environment first, then the host Claude `settings.json`, without rewriting settings or relocating host credentials
- allow the selected credential capability to equal its hidden runtime-state root while continuing to reject HOME, daemon, agent, and shared-temp roots
- document the default trust boundary, the optional dedicated-directory hardening, and compatibility with existing `agentconnect-auth` settings

## Why

The previous shared-login setup always created `~/.claude/agentconnect-auth`, moved the host credential, and rewrote Claude settings. That extra isolation is useful for operators who want it, but it should be opt-in because the Claude ACP parent is already trusted to manage login refresh.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/runtime-credentials.test.ts test/runtime-launch.test.ts test/acp-config.test.ts test/sandbox.test.ts test/runtime-prober.test.ts` (91 passed, 2 skipped)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon build`
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint

Created by Codex . GPT-5.6
