### PR TITLE
feat(web): remember organization selection per user

### DIFF
--- a/packages/control-plane/prisma/migrations/20260801180000_membership_last_selected_at/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260801180000_membership_last_selected_at/migration.sql
@@ -1,0 +1,3 @@
+-- Remember the active organization on the user-org relationship. Keeping the
+-- preference on membership makes it disappear automatically when access ends.
+ALTER TABLE "membership" ADD COLUMN "lastSelectedAt" TIMESTAMPTZ(6);

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -174,15 +174,18 @@ enum AgentCallPolicy {
 }
 
 model Membership {
-  id        String   @id @default(cuid())
-  orgId     String
-  userId    String
-  role      OrgRole  @default(collaborator)
+  id             String    @id @default(cuid())
+  orgId          String
+  userId         String
+  role           OrgRole   @default(collaborator)
   // When this user joined THIS org — not their account signup. The console's
   // "joined" column reads it, and removal picks the ownership-transfer
   // recipient by it (resource-visibility.md §8.2). Pre-existing rows were
   // backfilled from the cuid embedded in `id`, which is that same instant.
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  createdAt      DateTime  @default(now()) @db.Timestamptz(6)
+  // The last time THIS user selected THIS org in the console. Nullable keeps
+  // existing memberships in their original insertion order until a choice is made.
+  lastSelectedAt DateTime? @db.Timestamptz(6)
 
   org  Org  @relation(fields: [orgId], references: [id], onDelete: Cascade)
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/packages/control-plane/src/http/routes/orgs.ts
+++ b/packages/control-plane/src/http/routes/orgs.ts
@@ -9,6 +9,7 @@
  *
  * Org surface (mounted under `/orgs/:orgId` behind the org-scope guard):
  *   GET    / → the org itself, from the caller's perspective
+ *   PUT    /selection → remember it as the caller's active org
  *   PATCH  / → update identity / new-agent visibility default (owner-only)
  *   DELETE / → delete the org (owner-only; refused while it still has
  *              daemons — physical machines are detached explicitly first;
@@ -152,6 +153,23 @@ export function orgScopedRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'organization not found' })
         }
         return toDto(record, deps)
+      }
+    )
+
+    r.put(
+      '/selection',
+      {
+        schema: {
+          tags: [Tag.Organizations],
+          summary: 'Select the organization',
+          description: 'Remember this organization as the signed-in user’s active organization.',
+          operationId: 'selectOrganization',
+          response: { 204: z.null(), 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        await deps.repos.org.selectForUser(req.orgCtx!.orgId, req.principal!.userId, new Date(deps.clock.now()))
+        return reply.code(204).send(null)
       }
     )
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3323,7 +3323,8 @@ export interface UserRepo {
    * email-only row is claimed by setting its `oidcSubject`) AND a personal org is
    * created with the user as its `owner` — so everyone lands in a workspace they
    * own. Later calls are a cheap idempotent fetch (plus the synthetic-email
-   * upgrade). Org selection is per-request (`resolveOrgContext`), not stored here.
+   * upgrade). Authorization remains per-request (`resolveOrgContext`); the last
+   * console choice is only a preference on the user's membership.
    */
   provisionOidcUser(input: ProvisionOidcUserInput): Promise<{ userId: string }>
 
@@ -3420,8 +3421,12 @@ export interface UserRepo {
 }
 
 export interface OrgRepo {
-  /** Every org the user belongs to, with their role — insertion order. */
+  /** Every org the user belongs to, with their role — most recently selected
+   * first, then insertion order for memberships without a selection. */
   listForUser(userId: string): Promise<OrgRecord[]>
+  /** Remember this member's active organization. Throws P2025 when the
+   * membership no longer exists. */
+  selectForUser(orgId: string, userId: string, selectedAt: Date): Promise<void>
   /** Create an org with `ownerUserId` as its first owner (one transaction). */
   create(input: { name: string | null; slug: string; ownerUserId: string }): Promise<OrgRecord>
   /** Update org settings. Throws P2025 when absent, P2002 on a slug collision. */

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -30,7 +30,10 @@ export class PgOrgRepo implements OrgRepo {
     const rows = await this.db.membership.findMany({
       where: { userId },
       include: { org: { include: { _count: { select: { members: true, daemons: true } } } } },
-      orderBy: { id: 'asc' } // cuids are time-sortable ⇒ insertion order (personal org first)
+      orderBy: [
+        { lastSelectedAt: { sort: 'desc', nulls: 'last' } },
+        { id: 'asc' } // cuids are time-sortable ⇒ insertion order when no choice exists
+      ]
     })
     return rows.map((m) => ({
       id: m.org.id,
@@ -44,6 +47,13 @@ export class PgOrgRepo implements OrgRepo {
       createdAt: m.org.createdAt,
       updatedAt: m.org.updatedAt
     }))
+  }
+
+  async selectForUser(orgId: string, userId: string, selectedAt: Date): Promise<void> {
+    await this.db.membership.update({
+      where: { orgId_userId: { orgId, userId } },
+      data: { lastSelectedAt: selectedAt }
+    })
   }
 
   async create(input: { name: string | null; slug: string; ownerUserId: string }): Promise<OrgRecord> {

--- a/packages/control-plane/test/integration/orgs.route.test.ts
+++ b/packages/control-plane/test/integration/orgs.route.test.ts
@@ -40,6 +40,38 @@ describe('GET /orgs', () => {
       await close()
     }
   })
+
+  it('remembers the active org per membership and returns it first', async () => {
+    const other = await prisma.org.create({ data: { name: 'Other', slug: 'other' } })
+    await prisma.membership.create({ data: { orgId: other.id, userId: DEFAULT_OWNER_ID, role: 'collaborator' } })
+    const peer = await prisma.user.create({ data: { email: 'org-choice-peer@example.com' } })
+    await prisma.membership.create({ data: { orgId: other.id, userId: peer.id, role: 'collaborator' } })
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const selected = await app.inject({
+        method: 'PUT',
+        url: `/api/v1/orgs/${other.id}/selection`
+      })
+      expect(selected.statusCode).toBe(204)
+
+      const list = (await (await app.inject({ method: 'GET', url: '/api/v1/orgs' })).json()) as OrgBody[]
+      expect(list.map((org) => org.id)).toEqual([other.id, DEFAULT_ORG_ID])
+      const [mine, theirs] = await Promise.all([
+        prisma.membership.findUniqueOrThrow({
+          where: { orgId_userId: { orgId: other.id, userId: DEFAULT_OWNER_ID } },
+          select: { lastSelectedAt: true }
+        }),
+        prisma.membership.findUniqueOrThrow({
+          where: { orgId_userId: { orgId: other.id, userId: peer.id } },
+          select: { lastSelectedAt: true }
+        })
+      ])
+      expect(mine.lastSelectedAt).toBeInstanceOf(Date)
+      expect(theirs.lastSelectedAt).toBeNull()
+    } finally {
+      await close()
+    }
+  })
 })
 
 describe('POST /orgs', () => {

--- a/packages/web/src/app/home/page.tsx
+++ b/packages/web/src/app/home/page.tsx
@@ -1,11 +1,8 @@
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
-// The literal top-level `/home`. The console is org-scoped (`/{slug}/home`), so
-// resolve the last-used org from the `ac.org` cookie (default: the seeded org
-// `-`) and bounce into its Home. OrgProvider then reconciles an unknown/stale
-// slug to a real org exactly as it does for any other console URL.
-export default async function HomeRedirect() {
-  const slug = (await cookies()).get('ac.org')?.value || '-'
-  redirect(`/${slug}/home`)
+// Proxy normally rewrites this bare entry directly into the org-scoped tree.
+// If the route is reached without that normalization, return to `/` so the
+// signed-in user's server-stored organization preference can resolve it.
+export default function HomeRedirect() {
+  redirect('/')
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1263,13 +1263,14 @@ async function apiPatch<T>(path: string, body: unknown): Promise<T> {
   return (await res.json()) as T
 }
 
-async function apiPut<T>(path: string, body: unknown): Promise<T> {
+async function apiPut<T>(path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${cpBase()}${path}`, {
     method: 'PUT',
-    headers: await authHeaders({ 'content-type': 'application/json' }),
-    body: JSON.stringify(body)
+    headers: await authHeaders(body === undefined ? undefined : { 'content-type': 'application/json' }),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) })
   })
   if (!res.ok) throw await apiErrorFromResponse('PUT', path, res)
+  if (res.status === 204) return undefined as T
   return (await res.json()) as T
 }
 
@@ -3192,6 +3193,13 @@ export async function revokeMyApiKey(id: string): Promise<UserApiKeyDto> {
 // Every org the signed-in user belongs to (GET /orgs) — the picker + Settings.
 export async function fetchOrgs(): Promise<OrgDto[]> {
   return apiGet<OrgDto[]>('/orgs')
+}
+
+// Persist the caller's active org on their membership. The browser cookie is
+// only a stale-link fallback; this preference restores bare entries after
+// sign-out and on other devices.
+export async function selectOrg(orgId: string): Promise<void> {
+  await apiPut<void>(`/orgs/${encodeURIComponent(orgId)}/selection`)
 }
 
 // Create an org (POST /orgs); the caller becomes its first owner. The display

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -153,7 +153,7 @@ function clearLocalSessionMetadata(): void {
   cachedUser = null
   resetAnalytics()
   // The next sign-in may be a different user, so do not carry the previous
-  // user's organization selection into the new session.
+  // session's fallback cookie into it. The CP restores that user's preference.
   document.cookie = 'ac.org=; path=/; max-age=0'
   // A link proof belongs to the session that earned it. Left behind, the next
   // user in this tab would start a link Logto can only reject at the callback.

--- a/packages/web/src/lib/org-context.test.ts
+++ b/packages/web/src/lib/org-context.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveOrgTarget } from './org-context'
+import type { OrgDto } from './api'
+
+const org = (id: string, slug: string) => ({ id, slug }) as OrgDto
+
+describe('resolveOrgTarget', () => {
+  const remembered = org('remembered', 'remembered')
+  const rewrittenDefault = org('default', '-')
+
+  it('restores the server-ordered preference for a bare entry rewrite', () => {
+    expect(resolveOrgTarget([remembered, rewrittenDefault], rewrittenDefault, '-', false)).toBe(remembered)
+  })
+
+  it('keeps an explicit organization URL even when another org was remembered', () => {
+    expect(resolveOrgTarget([remembered, rewrittenDefault], rewrittenDefault, 'remembered', true)).toBe(
+      rewrittenDefault
+    )
+  })
+})

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -7,7 +7,7 @@
 // (never a legal user slug), so no-auth installs read `/-/agents` with zero
 // special-casing — it's just an org like any other. An unknown slug (e.g. the
 // `/-/…` entry point in a hosted deployment where nobody belongs to the
-// default org) falls back to the last-used / first org and fixes the URL.
+// default org) falls back to the remembered / first org and fixes the URL.
 //
 // The resolved org's ID is handed to the API client (`setApiOrgId`) — every
 // org-scoped CP call goes to `/orgs/{orgId}/…`.
@@ -17,6 +17,7 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import {
   fetchOrgs,
   setApiOrgId,
+  selectOrg as apiSelectOrg,
   createOrg as apiCreateOrg,
   updateOrg as apiUpdateOrg,
   deleteOrg as apiDeleteOrg,
@@ -26,9 +27,9 @@ import {
 } from '@/lib/api'
 import type { AgentCallPolicy } from '@/lib/data'
 
-// Last-used org slug, kept in a COOKIE (not localStorage) so the proxy
-// can send `/` straight to `/{slug}/agents` with one server redirect — no
-// visible hop through the default org.
+// Last-used org slug kept only as a browser fallback for a renamed/unknown
+// explicit URL. Bare entries restore the account's server-stored preference;
+// a browser-wide cookie must not choose an organization for a different user.
 const LAST_SLUG_COOKIE = 'ac.org'
 
 function readLastSlug(): string | null {
@@ -68,6 +69,21 @@ export function orgColor(orgId: string): string {
   let h = 0
   for (let i = 0; i < orgId.length; i++) h = (h * 31 + orgId.charCodeAt(i)) >>> 0
   return ORG_COLORS[h % ORG_COLORS.length]!
+}
+
+/** Resolve the organization for the current URL. A real org segment is an
+ * explicit choice; a bare entry is a proxy rewrite and must restore the
+ * account's server-ordered preference instead of treating the rewritten `-`
+ * segment as a choice. */
+export function resolveOrgTarget(
+  orgs: OrgDto[],
+  activeOrg: OrgDto | null,
+  lastSlug: string | null,
+  hasOrgSegment: boolean
+): OrgDto | undefined {
+  if (!hasOrgSegment) return orgs[0]
+  if (activeOrg) return activeOrg
+  return orgs.find((o) => o.slug === lastSlug) ?? orgs[0]
 }
 
 interface OrgContextValue {
@@ -111,12 +127,15 @@ export function OrgProvider({ children }: { children: ReactNode }) {
   const slug = typeof params.slug === 'string' ? decodeURIComponent(params.slug) : '-'
 
   const [orgs, setOrgs] = useState<OrgDto[]>([])
+  const [rememberedOrgId, setRememberedOrgId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const refreshOrgs = useCallback(async () => {
     try {
-      setOrgs(await fetchOrgs())
+      const next = await fetchOrgs()
+      setOrgs(next)
+      setRememberedOrgId(next[0]?.id ?? null)
       setError(null)
     } catch (cause) {
       // CP unreachable — leave whatever we had and surface the failure through
@@ -131,9 +150,13 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     void refreshOrgs()
   }, [refreshOrgs])
 
-  // Resolve the URL slug to an org — nothing more: `-` is simply the seeded
-  // default org's slug, not a special case.
-  const activeOrg = useMemo(() => orgs.find((o) => o.slug === slug) ?? null, [orgs, slug])
+  const hasOrgSegment = pathname.split('/')[1] === slug
+  // A proxy rewrite can supply the internal `-` param while the visible URL is
+  // still bare. It is not an active-org choice until canonicalization finishes.
+  const activeOrg = useMemo(
+    () => (hasOrgSegment ? (orgs.find((o) => o.slug === slug) ?? null) : null),
+    [orgs, slug, hasOrgSegment]
+  )
 
   // Hand the resolved org to the API client DURING render (parent renders
   // before children, so data-context's fetch effects see it; an effect here
@@ -149,16 +172,33 @@ export function OrgProvider({ children }: { children: ReactNode }) {
   // bar still shows the bare entered path.
   useEffect(() => {
     if (loading || orgs.length === 0) return
-    const target = activeOrg ?? orgs.find((o) => o.slug === readLastSlug()) ?? orgs[0]!
-    if (pathname.split('/')[1] !== target.slug) {
+    const target = resolveOrgTarget(orgs, activeOrg, readLastSlug(), hasOrgSegment)
+    if (target && pathname.split('/')[1] !== target.slug) {
       router.replace(`/${target.slug}${subPath(pathname, slug)}${window.location.search}`)
     }
-  }, [loading, orgs, activeOrg, slug, pathname, router])
+  }, [loading, orgs, activeOrg, hasOrgSegment, slug, pathname, router])
 
-  // Remember the resolved org for the next bare-URL entry.
+  // Remember an explicit org URL. During a bare-entry proxy rewrite, `slug`
+  // can be `-` without the user having selected it, so wait for canonicalization.
   useEffect(() => {
-    if (activeOrg) writeLastSlug(activeOrg.slug)
-  }, [activeOrg])
+    if (!activeOrg || !hasOrgSegment) return
+    writeLastSlug(activeOrg.slug)
+    // A different explicit URL is a new choice. Track successful writes
+    // separately from the list so a quick B → A switch cannot mistake stale
+    // ordering for the server's current preference.
+    if (rememberedOrgId !== activeOrg.id) {
+      void apiSelectOrg(activeOrg.id)
+        .then(() => {
+          setRememberedOrgId(activeOrg.id)
+          setOrgs((prev) => {
+            if (prev[0]?.id === activeOrg.id) return prev
+            const selected = prev.find((org) => org.id === activeOrg.id)
+            return selected ? [selected, ...prev.filter((org) => org.id !== selected.id)] : prev
+          })
+        })
+        .catch(() => {})
+    }
+  }, [activeOrg, hasOrgSegment, rememberedOrgId])
 
   const orgPath = useCallback((path: string) => `/${activeOrg?.slug ?? slug}${path}`, [activeOrg, slug])
 
@@ -176,7 +216,7 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     async (input: { name?: string; slug: string }) => {
       const org = await apiCreateOrg(input)
       // Append optimistically BEFORE switching so activeOrg never goes null.
-      setOrgs((prev) => (prev.some((o) => o.id === org.id) ? prev : [...prev, org]))
+      setOrgs((prev) => (prev.some((candidate) => candidate.id === org.id) ? prev : [...prev, org]))
       writeLastSlug(org.slug)
       router.push(`/${org.slug}${subPath(pathname, slug)}`)
       await refreshOrgs()

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -5,26 +5,12 @@ import { NextResponse, type NextRequest } from 'next/server'
 // forbids a user org from taking it), so a no-auth install lives at
 // `/-/agents`; hosted users live on their own slug.
 //
-// Entry points (`/` and hand-typed bare page paths) are normalized WITHOUT an
-// ugly intermediate hop:
-//   - the `ac.org` cookie (written by the org context whenever an org
-//     resolves) names the last-used slug → ONE server redirect straight to
-//     `/{slug}/…`;
-//   - no cookie yet (first visit) → REWRITE to the default org's tree, so the
-//     address bar keeps the entered URL until the client resolves the real
-//     org and replaces it in one step.
-// A stale cookie (renamed/removed org) is fine: the org context's
-// reconciliation replaces an unknown slug with the caller's real org.
+// Entry points (`/` and hand-typed bare page paths) are rewritten to the
+// default org's tree while the address bar keeps the entered URL. OrgProvider
+// then resolves the signed-in user's server-stored preference and replaces the
+// URL in one step. A browser-wide cookie cannot drive this choice: it would
+// leak one account's last org into another account and drift across devices.
 const CONSOLE_ROOTS = ['home', 'agents', 'sessions', 'daemons', 'crons', 'tools', 'usage', 'settings', 'profile']
-
-// A real slug or the reserved `-` — anything else in the cookie is ignored
-// (it goes straight into a redirect path, so validate strictly).
-const SLUG_RE = /^(?:-|[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?)$/
-
-function lastOrgSlug(req: NextRequest): string | null {
-  const raw = req.cookies.get('ac.org')?.value
-  return raw && SLUG_RE.test(raw) ? raw : null
-}
 
 export function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl
@@ -34,11 +20,6 @@ export function proxy(req: NextRequest) {
 
   const consolePath = pathname === '/' ? '/home' : pathname
   const url = req.nextUrl.clone()
-  const slug = lastOrgSlug(req)
-  if (slug) {
-    url.pathname = `/${slug}${consolePath}`
-    return NextResponse.redirect(url)
-  }
   url.pathname = `/-${consolePath}`
   return NextResponse.rewrite(url)
 }


### PR DESCRIPTION
## Summary

- persist each member's most recently selected organization in Control Plane metadata
- restore bare console entries from that per-user preference instead of the browser-global `ac.org` cookie
- keep explicit organization URLs authoritative and update the preference when users switch, create, or open an organization
- add focused migration, route, ordering, isolation, and URL-resolution coverage

## Why

The console previously remembered only one browser-wide cookie and cleared it on sign-out. That lost a user's choice between sessions, could carry the wrong organization between accounts, and could not follow the same person across devices.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/orgs.route.test.ts`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web exec vitest run src/lib/org-context.test.ts`
- `pnpm --filter @agentconnect.md/web typecheck`
- focused ESLint on all changed TypeScript files
- OpenAPI 3.1 generation, including `selectOrganization`

Created by Codex . GPT-5
