### PR TITLE
fix(daemon): preserve Slack app identity in shared threads

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2291,6 +2291,9 @@ export class Daemon {
       memoryEnabled: this.evaluationProfile.memory === 'configured',
       collaborationEnabled: this.evaluationProfile.collaboration === 'configured',
       quoteForContextEvent: (event, replayed) => this.observedQuoteBlock(event, replayed),
+      // The session integration's own bot identity (auth.test-resolved on both
+      // socket and send-only connections) for the `# Agent` Slack-identity line.
+      slackBotUserIdFor: (integrationId) => this.connByIntegration.get(integrationId)?.botUserId || undefined,
       // No runtime is whitelisted for the model-authored `setSessionTitle` fallback
       // anymore: codex-acp >= 1.1.3 emits native session_info_update titles itself
       // (issue #659), so every runtime now relies on its native ACP title path. The
@@ -5380,6 +5383,17 @@ export class Daemon {
     // Mirror the lookup here so session metadata/history can label the sender.
     const conn = this.connByIntegration.get(msg.integrationId)
     if (conn) this.nameResolver?.noteMessage(conn, normalized)
+    // Restore the trusted activation cause the relay path loses: the wire schema
+    // carries `trigger`, and direct ingress stamps 'mention' from its own router
+    // (onInbound → routeRules), but relay arbitration never populates it. Recompute
+    // from data already in hand — the message's mention list and this integration's
+    // own bot identity. Downstream it gates the explicit-mention prompt reminder
+    // (an opaque <@U…> token is not otherwise recognizable as "you") and the
+    // `!stop` un-mute rule below — without it a muted relay-channel agent could
+    // never be woken again.
+    if (!normalized.trigger && conn?.botUserId && normalized.mentionedBots.includes(conn.botUserId)) {
+      normalized.trigger = 'mention'
+    }
     const feishuConn = this.fsConnByIntegration.get(msg.integrationId)
     if (feishuConn) this.channelNameResolver?.noteMessage(feishuConn, normalized)
     // HTTP-bot ingress is pre-addressed and bypasses onInbound(), so repeat the
@@ -11236,7 +11250,18 @@ export class Daemon {
         }
         if (ts) {
           p.statusBarTs = ts
-          await conn.updateBlocks(p.channel, ts, action.blocks, action.text, true)
+          const updated = await conn.updateBlocks(p.channel, ts, action.blocks, action.text, true)
+          // Duck-typed test connections historically return void; only an explicit
+          // false means Slack rejected the edit — typically cant_update_message on a
+          // bar another Slack app authored (a foreign ts persisted by the
+          // pre-provenance adoption path). Drop the dead ts so the next status emit
+          // re-resolves — provenance-filtered adoption or a fresh own post — instead
+          // of hammering an uneditable message on every usage tick. A transient
+          // failure costs at most one duplicate bar; a foreign ts never heals.
+          if (updated === false) {
+            p.statusBarTs = undefined
+            this.store.clearStatusBarTs(p.sessionKey)
+          }
         } else if (!p.statusBarAttempted) {
           p.statusBarAttempted = true
           // The session status line represents the selected agent, so keep its author
@@ -11257,13 +11282,20 @@ export class Daemon {
 
   /** Best-effort adoption path for sessions that already have an older status bar in
    *  Slack before `statusBarTs` was persisted locally. We scan in Slack's thread order
-   *  and pick the first bot-authored status fallback, so future turns update the topmost
-   *  existing line instead of adding one more duplicate. */
+   *  and pick the first status line THIS connection's own Slack app authored, so future
+   *  turns update the topmost existing line instead of adding one more duplicate.
+   *  Author provenance is mandatory: the bar is edited in place via chat.update, and
+   *  Slack only lets a bot edit its own messages — a sibling agent's bar in a shared
+   *  multi-agent thread (a different app) is neither editable (cant_update_message on
+   *  every usage tick) nor semantically ours (its numbers describe the other agent's
+   *  session). Reply rows keep `sender` = bot_id ?? user, so match either identity. */
   private async findExistingSlackStatusBarTs(conn: SlackConnection, p: Pending): Promise<string | undefined> {
     const getThreadReplies = (conn as { getThreadReplies?: SlackConnection['getThreadReplies'] }).getThreadReplies
     if (!getThreadReplies) return undefined
+    const own = new Set([conn.botId, conn.botUserId].filter(Boolean))
+    if (own.size === 0) return undefined
     const replies = await getThreadReplies.call(conn, p.channel, p.statusThread)
-    return replies.find((m) => m.isBot && isSlackStatusBarText(m.text))?.ts
+    return replies.find((m) => m.isBot && own.has(m.sender) && isSlackStatusBarText(m.text))?.ts
   }
 
   /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11250,7 +11250,7 @@ export class Daemon {
         }
         if (ts) {
           p.statusBarTs = ts
-          const updated = await conn.updateBlocks(p.channel, ts, action.blocks, action.text, true)
+          const updated = await conn.updateBlocks(p.channel, ts, action.blocks, action.text, true, undefined, p.agentId)
           // Duck-typed test connections historically return void; only an explicit
           // false means Slack rejected the edit — typically cant_update_message on a
           // bar another Slack app authored (a foreign ts persisted by the
@@ -11268,7 +11268,8 @@ export class Daemon {
           // identity aligned with the native loading state and the eventual reply.
           const posted = await conn.postBlocks(p.channel, action.blocks, action.text, p.thread, {
             ...(statusBarPostOptions ?? {}),
-            chrome: true
+            chrome: true,
+            chromeOwnerAgentId: p.agentId
           })
           if (posted) {
             p.statusBarTs = posted
@@ -11282,20 +11283,22 @@ export class Daemon {
 
   /** Best-effort adoption path for sessions that already have an older status bar in
    *  Slack before `statusBarTs` was persisted locally. We scan in Slack's thread order
-   *  and pick the first status line THIS connection's own Slack app authored, so future
-   *  turns update the topmost existing line instead of adding one more duplicate.
-   *  Author provenance is mandatory: the bar is edited in place via chat.update, and
-   *  Slack only lets a bot edit its own messages — a sibling agent's bar in a shared
-   *  multi-agent thread (a different app) is neither editable (cant_update_message on
-   *  every usage tick) nor semantically ours (its numbers describe the other agent's
-   *  session). Reply rows keep `sender` = bot_id ?? user, so match either identity. */
+   *  and pick the first status line both this connection's Slack app AND this Agent
+   *  authored, so future turns update the topmost existing line instead of adding one
+   *  more duplicate. Both provenance dimensions are mandatory: another app's bar is not
+   *  editable, while another Agent behind the same shared Slack app is editable but its
+   *  numbers and controls belong to a different session. Reply rows keep `sender` =
+   *  bot_id ?? user, so match either Slack identity plus the AgentConnect chrome owner. */
   private async findExistingSlackStatusBarTs(conn: SlackConnection, p: Pending): Promise<string | undefined> {
     const getThreadReplies = (conn as { getThreadReplies?: SlackConnection['getThreadReplies'] }).getThreadReplies
     if (!getThreadReplies) return undefined
     const own = new Set([conn.botId, conn.botUserId].filter(Boolean))
     if (own.size === 0) return undefined
     const replies = await getThreadReplies.call(conn, p.channel, p.statusThread)
-    return replies.find((m) => m.isBot && own.has(m.sender) && isSlackStatusBarText(m.text))?.ts
+    return replies.find(
+      (m) =>
+        m.isBot && own.has(m.sender) && m.chrome && m.chromeOwnerAgentId === p.agentId && isSlackStatusBarText(m.text)
+    )?.ts
   }
 
   /**

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -262,6 +262,12 @@ export class SessionManager {
       /** Daemon-observed reply-source sidecar for context rows. Standalone/test
        * callers omit it and preserve the historical transcript-only behavior. */
       quoteForContextEvent?: (event: TranscriptEntry, replayed: readonly TranscriptEntry[]) => string | undefined
+      /** The agent's own Slack bot user id on an integration (auth.test-resolved).
+       *  Surfaced as the `Slack identity` line of the `# Agent` block: platform
+       *  mentions are opaque `<@U…>` tokens, and without this binding the model
+       *  cannot tell that a multi-mention message addresses it — the
+       *  response-choice rule then misfires into AC_NO_RESPONSE. */
+      slackBotUserIdFor?: (integrationId: string) => string | undefined
       /** Whether this runtime needs AgentConnect's model-authored title fallback.
        *  Native-title runtimes (for example Claude) leave this false. */
       usesSessionTitleTool?: (agent: Agent) => boolean
@@ -592,11 +598,21 @@ export class SessionManager {
     }).materialize.filter((m) => secretNames.includes(m.sourceVar))
     const fileSecretNames = new Set(fileSecrets.map((m) => m.sourceVar))
     const envSecretNames = secretNames.filter((n) => !fileSecretNames.has(n))
+    // The agent's own Slack mention token. A Slack mention is an opaque user id
+    // (`<@U…>`) that resembles neither the agent's name nor anything else in the
+    // prompt — without this standing line the model cannot recognize its own
+    // mention in a multi-mention message and may wrongly classify the activation
+    // as "not for me" (session/no-response.ts).
+    const slackSelfId =
+      msg.platform === 'slack' && integrationId ? this.deps.slackBotUserIdFor?.(integrationId) : undefined
     const agentMeta = [
       AGENT_META_OPENING[0],
       `${AGENT_META_OPENING[1]} ${agent.name}`,
       `- ID: ${agent.id}`,
       `- Source: ${msg.platform}`,
+      ...(slackSelfId
+        ? [`- Slack identity: bot user <@${slackSelfId}> is YOU — a message mentioning this ID is addressed to you`]
+        : []),
       `- Channel: ${msg.channel}`,
       ...(channelName ? [`- Channel name: ${channelName}`] : []),
       // session-concept §2.3: standing locator lines. `Thread` is this session's thread

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -50,6 +50,10 @@ export interface SlackPostOptions {
    *  Slack metadata so a peer daemon's thread backfill can skip it — chrome is never
    *  conversation and must not be re-ingested as a transcript text row. */
   chrome?: boolean
+  /** Stable AgentConnect owner for agent-scoped chrome such as a session status bar.
+   *  Multiple agents can share one Slack app identity, so bot_id/app_id alone cannot
+   *  safely decide which agent may adopt and edit an existing chrome row. */
+  chromeOwnerAgentId?: string
 }
 
 /** Optional per-status identity overrides supported by assistant.threads.setStatus.
@@ -64,7 +68,16 @@ export interface SlackStatusOptions {
  *  `SlackPostOptions.chrome`). Exported so the backfill can recognize it. */
 export const SLACK_CHROME_EVENT_TYPE = 'agentconnect_chrome'
 
-function slackMessageMetadata(options?: Pick<SlackPostOptions, 'agentAuthorId' | 'chrome'>) {
+function slackMessageMetadata(options?: Pick<SlackPostOptions, 'agentAuthorId' | 'chrome' | 'chromeOwnerAgentId'>) {
+  if (options?.chrome) {
+    const ownerAgentId = options.chromeOwnerAgentId?.trim()
+    return {
+      metadata: {
+        event_type: SLACK_CHROME_EVENT_TYPE,
+        event_payload: ownerAgentId ? { owner_agent_id: ownerAgentId } : {}
+      }
+    }
+  }
   const agentAuthorId = options?.agentAuthorId?.trim()
   if (agentAuthorId) {
     return {
@@ -74,7 +87,7 @@ function slackMessageMetadata(options?: Pick<SlackPostOptions, 'agentAuthorId' |
       }
     }
   }
-  return options?.chrome ? { metadata: { event_type: SLACK_CHROME_EVENT_TYPE, event_payload: {} } } : {}
+  return {}
 }
 
 /** App-level tokens are structured `xapp-1-{APP_ID}-{epoch}-{hex}`. Keep this
@@ -290,7 +303,7 @@ type AppLike = {
           files?: SlackFile[]
           metadata?: {
             event_type?: string
-            event_payload?: { author_agent_id?: unknown }
+            event_payload?: { author_agent_id?: unknown; owner_agent_id?: unknown }
           }
         }[]
         has_more?: boolean
@@ -904,7 +917,8 @@ export class SlackConnection {
     blocks: unknown[],
     text?: string,
     chrome = false,
-    agentAuthorId?: string
+    agentAuthorId?: string,
+    chromeOwnerAgentId?: string
   ): Promise<boolean> {
     try {
       return await this.queue.enqueue(async () => {
@@ -915,7 +929,7 @@ export class SlackConnection {
           blocks,
           unfurl_links: false,
           unfurl_media: false,
-          ...slackMessageMetadata({ chrome, agentAuthorId })
+          ...slackMessageMetadata({ chrome, agentAuthorId, chromeOwnerAgentId })
         })
         return true
       })
@@ -962,6 +976,7 @@ export class SlackConnection {
     {
       sender: string
       agentAuthorId?: string
+      chromeOwnerAgentId?: string
       appId?: string
       ts: string
       text: string
@@ -973,6 +988,7 @@ export class SlackConnection {
     const out: {
       sender: string
       agentAuthorId?: string
+      chromeOwnerAgentId?: string
       appId?: string
       ts: string
       text: string
@@ -1007,11 +1023,17 @@ export class SlackConnection {
             typeof m.metadata.event_payload?.author_agent_id === 'string'
               ? m.metadata.event_payload.author_agent_id.trim()
               : ''
+          const chromeOwnerAgentId =
+            m.metadata?.event_type === SLACK_CHROME_EVENT_TYPE &&
+            typeof m.metadata.event_payload?.owner_agent_id === 'string'
+              ? m.metadata.event_payload.owner_agent_id.trim()
+              : ''
           out.push({
             // Some Slack bot rows expose both `user` and `bot_id`. Keep the stable bot
             // identity as sender so legacy rows from the same app reconcile consistently.
             sender: m.bot_id ?? m.user ?? 'unknown',
             ...(metadataAuthor ? { agentAuthorId: metadataAuthor } : {}),
+            ...(chromeOwnerAgentId ? { chromeOwnerAgentId } : {}),
             ...(appId ? { appId } : {}),
             ts: m.ts,
             text: extractSlackMessageText(m),

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -392,7 +392,7 @@ describe('SlackConnection.getThreadReplies', () => {
           ts: '100.2',
           bot_id: 'BSHARED',
           text: ':bar_chart: opus',
-          metadata: { event_type: 'agentconnect_chrome', event_payload: {} }
+          metadata: { event_type: 'agentconnect_chrome', event_payload: { owner_agent_id: 'agent-a' } }
         },
         { ts: '100.3', user: 'U1', text: 'a human message' }
       ],
@@ -413,7 +413,7 @@ describe('SlackConnection.getThreadReplies', () => {
     )
 
     await expect(conn.getThreadReplies('C1', '100.1')).resolves.toEqual([
-      expect.objectContaining({ ts: '100.2', chrome: true }),
+      expect.objectContaining({ ts: '100.2', chrome: true, chromeOwnerAgentId: 'agent-a' }),
       expect.objectContaining({ ts: '100.3', chrome: false })
     ])
   })
@@ -1037,6 +1037,24 @@ describe('SlackConnection.updateBlocks', () => {
       metadata: {
         event_type: 'agentconnect_thread_event',
         event_payload: { author_agent_id: 'agent-a' }
+      }
+    })
+  })
+
+  it('re-stamps agent-scoped chrome ownership when a status bar is edited', async () => {
+    const calls: any[] = []
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () => withUpdate(async (payload) => void calls.push(payload)) as any
+    )
+    const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: 'status' } }]
+
+    await expect(conn.updateBlocks('C1', '123.45', blocks, 'status', true, undefined, 'agent-a')).resolves.toBe(true)
+
+    expect(calls[0]).toMatchObject({
+      metadata: {
+        event_type: 'agentconnect_chrome',
+        event_payload: { owner_agent_id: 'agent-a' }
       }
     })
   })

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -22,7 +22,8 @@ const AGENT_IDENTITY = {
 const STATUS_BAR_POST_OPTIONS = {
   username: AGENT_IDENTITY.displayName,
   icon_url: AGENT_IDENTITY.iconUrl,
-  chrome: true
+  chrome: true,
+  chromeOwnerAgentId: 'bot-a'
 }
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 const SESSION_KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', TRANSPORT_SCOPE)
@@ -1319,7 +1320,9 @@ describe('Slack interactive status bar', () => {
       'sb1',
       expect.any(Array),
       expect.stringContaining('opus-4.8'),
-      true
+      true,
+      undefined,
+      'bot-a'
     )
     // The in-thread message is one section row: status + View Session + overflow.
     const blocks = conn.postBlocks.mock.calls[0]![1] as { type: string; text?: { text: string }; accessory?: any }[]
@@ -1391,7 +1394,15 @@ describe('Slack interactive status bar', () => {
     p.lastStatusBar = undefined // mimic a usage update that changes the visible header
     ;(daemon as any).emitStatusBar(p)
     await vi.waitFor(() =>
-      expect(conn.updateBlocks).toHaveBeenCalledWith('C1', 'sb1', expect.any(Array), expect.any(String), true)
+      expect(conn.updateBlocks).toHaveBeenCalledWith(
+        'C1',
+        'sb1',
+        expect.any(Array),
+        expect.any(String),
+        true,
+        undefined,
+        'bot-a'
+      )
     )
     expect(p.statusBarTs).toBe('sb1')
     expect((daemon as any).store.getStatusBarTs(p.sessionKey)).toBe('sb1')
@@ -1727,8 +1738,24 @@ describe('Slack interactive status bar', () => {
     ;(conn as any).botId = 'B1'
     ;(conn as any).getThreadReplies = vi.fn(async () => [
       { sender: 'U1', ts: 'T1', text: 'hi', isBot: false, attachments: [] },
-      { sender: 'B1', ts: '111.1', text: ':bar_chart: *old* - ctx 1.0k', isBot: true, attachments: [] },
-      { sender: 'B1', ts: '222.2', text: ':bar_chart: *newer*', isBot: true, attachments: [] }
+      {
+        sender: 'B1',
+        ts: '111.1',
+        text: ':bar_chart: *old* - ctx 1.0k',
+        isBot: true,
+        chrome: true,
+        chromeOwnerAgentId: 'bot-a',
+        attachments: []
+      },
+      {
+        sender: 'B1',
+        ts: '222.2',
+        text: ':bar_chart: *newer*',
+        isBot: true,
+        chrome: true,
+        chromeOwnerAgentId: 'bot-a',
+        attachments: []
+      }
     ])
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
@@ -1738,7 +1765,9 @@ describe('Slack interactive status bar', () => {
         '111.1',
         expect.any(Array),
         expect.stringContaining('opus-4.8'),
-        true
+        true,
+        undefined,
+        'bot-a'
       )
     )
     expect(conn.postBlocks).not.toHaveBeenCalled()
@@ -1760,12 +1789,52 @@ describe('Slack interactive status bar', () => {
     ;(conn as any).botId = 'B-MINE'
     ;(conn as any).getThreadReplies = vi.fn(async () => [
       { sender: 'U1', ts: 'T1', text: 'hi', isBot: false, attachments: [] },
-      { sender: 'B-OTHER', ts: '111.1', text: ':bar_chart: *sibling* - ctx 9k', isBot: true, attachments: [] }
+      {
+        sender: 'B-OTHER',
+        ts: '111.1',
+        text: ':bar_chart: *sibling* - ctx 9k',
+        isBot: true,
+        chrome: true,
+        chromeOwnerAgentId: 'bot-a',
+        attachments: []
+      }
     ])
 
     const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
     await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled())
-    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', '111.1', expect.anything(), expect.anything(), true)
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === '111.1')).toBe(false)
+    expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe('111.1')
+
+    release()
+    await turn
+    await daemon.stop()
+  }, 15_000)
+
+  it('never adopts a sibling Agent status line when both share one Slack app', async () => {
+    const { host, release } = modelHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    const conn = routableWithBlocks(daemon)
+    ;(conn as any).botId = 'B-SHARED'
+    ;(conn as any).getThreadReplies = vi.fn(async () => [
+      {
+        sender: 'B-SHARED',
+        ts: '111.1',
+        text: ':bar_chart: *sibling* - ctx 9k',
+        isBot: true,
+        chrome: true,
+        chromeOwnerAgentId: 'bot-b',
+        attachments: []
+      }
+    ])
+
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled())
+    expect(conn.updateBlocks.mock.calls.some((call) => call[1] === '111.1')).toBe(false)
+    expect(conn.postBlocks.mock.calls[0]?.[4]).toMatchObject({
+      chrome: true,
+      chromeOwnerAgentId: 'bot-a'
+    })
     expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe('111.1')
 
     release()
@@ -1796,7 +1865,15 @@ describe('Slack interactive status bar', () => {
     ;(daemon as any).opts.hostFactory = () => second.host as any
     const turn2 = (daemon as any).dispatch('bot-a', dm('101', 'hi again'), 'int-a')
     await vi.waitFor(() =>
-      expect(conn.updateBlocks).toHaveBeenCalledWith('C1', posted, expect.anything(), expect.anything(), true)
+      expect(conn.updateBlocks).toHaveBeenCalledWith(
+        'C1',
+        posted,
+        expect.anything(),
+        expect.anything(),
+        true,
+        undefined,
+        'bot-a'
+      )
     )
     // The dead ts is dropped and a later emit in the same turn posts a fresh bar.
     await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(2))

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -276,6 +276,84 @@ describe('Daemon in-conversation commands', () => {
     expect(dispatch).toHaveBeenCalledWith('bot-a', payload, 'int-a')
   })
 
+  it('stamps trigger=mention on relay im when the message mentions the integration bot', () => {
+    // Relay arbitration never populates the wire `trigger`; the daemon recomputes it
+    // from the mention list + this integration's own bot identity (see handleRelayIm).
+    const daemon = new Daemon()
+    const dispatch = vi.fn(async () => {})
+    ;(daemon as any).agents.set('bot-a', {})
+    ;(daemon as any).connByIntegration.set('int-a', { botUserId: 'U-SELF' })
+    ;(daemon as any).isSessionMuted = () => false
+    ;(daemon as any).dispatch = dispatch
+    const { trigger: _t, ...bare } = dm('relay-mention', '<@U-SELF> hello')
+    const msg: RdMsgIm = {
+      source: 'im',
+      agentId: 'bot-a',
+      sessionKey: 'slack:C1:dm',
+      msgId: 'relay-mention',
+      botId: '11111111-1111-4111-8111-111111111111',
+      integrationId: 'int-a',
+      chatId: 'C1',
+      payload: { ...bare, mentionedBots: ['U-OTHER', 'U-SELF'] } as any
+    }
+    expect((daemon as any).handleRelayMsg(msg, () => {})).toEqual({ msgId: 'relay-mention', accepted: true })
+    expect(dispatch).toHaveBeenCalledWith('bot-a', expect.objectContaining({ trigger: 'mention' }), 'int-a')
+  })
+
+  it('leaves trigger unset on relay im when the mention list does not name this bot', () => {
+    const daemon = new Daemon()
+    const dispatch = vi.fn(async () => {})
+    ;(daemon as any).agents.set('bot-a', {})
+    ;(daemon as any).connByIntegration.set('int-a', { botUserId: 'U-SELF' })
+    ;(daemon as any).isSessionMuted = () => false
+    ;(daemon as any).dispatch = dispatch
+    const { trigger: _t, ...bare } = dm('relay-no-mention', 'hello')
+    const msg: RdMsgIm = {
+      source: 'im',
+      agentId: 'bot-a',
+      sessionKey: 'slack:C1:dm',
+      msgId: 'relay-no-mention',
+      botId: '11111111-1111-4111-8111-111111111111',
+      integrationId: 'int-a',
+      chatId: 'C1',
+      payload: { ...bare, mentionedBots: ['U-OTHER'] } as any
+    }
+    ;(daemon as any).handleRelayMsg(msg, () => {})
+    expect(dispatch).toHaveBeenCalledWith('bot-a', expect.not.objectContaining({ trigger: expect.anything() }), 'int-a')
+  })
+
+  it('an explicit mention un-mutes a !stop-muted relay session; anything else stays dropped', () => {
+    // Without the recomputed trigger the mute check can never see 'mention' on the
+    // relay path — a !stop-muted agent in a shared channel would be dead forever.
+    const daemon = new Daemon()
+    const dispatch = vi.fn(async () => {})
+    const setSessionMuted = vi.fn()
+    ;(daemon as any).agents.set('bot-a', {})
+    ;(daemon as any).connByIntegration.set('int-a', { botUserId: 'U-SELF' })
+    ;(daemon as any).isSessionMuted = () => true
+    ;(daemon as any).setSessionMuted = setSessionMuted
+    ;(daemon as any).recordUnrouted = vi.fn()
+    ;(daemon as any).dispatch = dispatch
+    const frame = (msgId: string, mentionedBots: string[]): RdMsgIm => {
+      const { trigger: _t, ...bare } = dm(msgId, 'wake up')
+      return {
+        source: 'im',
+        agentId: 'bot-a',
+        sessionKey: 'slack:C1:dm',
+        msgId,
+        botId: '11111111-1111-4111-8111-111111111111',
+        integrationId: 'int-a',
+        chatId: 'C1',
+        payload: { ...bare, mentionedBots } as any
+      }
+    }
+    ;(daemon as any).handleRelayMsg(frame('muted-plain', []), () => {})
+    expect(dispatch).not.toHaveBeenCalled()
+    ;(daemon as any).handleRelayMsg(frame('muted-mention', ['U-SELF']), () => {})
+    expect(setSessionMuted).toHaveBeenCalledWith(expect.any(String), false)
+    expect(dispatch).toHaveBeenCalledWith('bot-a', expect.objectContaining({ trigger: 'mention' }), 'int-a')
+  })
+
   it('dedups shared-bot retries per bot while dispatching the same Slack message for two bots', () => {
     const daemon = new Daemon()
     const dispatch = vi.fn(async () => {})
@@ -1646,6 +1724,7 @@ describe('Slack interactive status bar', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
     await daemon.start()
     const conn = routableWithBlocks(daemon)
+    ;(conn as any).botId = 'B1'
     ;(conn as any).getThreadReplies = vi.fn(async () => [
       { sender: 'U1', ts: 'T1', text: 'hi', isBot: false, attachments: [] },
       { sender: 'B1', ts: '111.1', text: ':bar_chart: *old* - ctx 1.0k', isBot: true, attachments: [] },
@@ -1667,6 +1746,64 @@ describe('Slack interactive status bar', () => {
 
     release()
     await turn
+    await daemon.stop()
+  }, 15_000)
+
+  it('never adopts a status line another Slack app authored — posts its own instead', async () => {
+    // A shared multi-agent thread: each agent runs its own Slack app, and Slack only
+    // lets a bot chat.update its own messages. Adopting the sibling's bar would fail
+    // with cant_update_message on every usage tick (and show the wrong session's data).
+    const { host, release } = modelHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    const conn = routableWithBlocks(daemon)
+    ;(conn as any).botId = 'B-MINE'
+    ;(conn as any).getThreadReplies = vi.fn(async () => [
+      { sender: 'U1', ts: 'T1', text: 'hi', isBot: false, attachments: [] },
+      { sender: 'B-OTHER', ts: '111.1', text: ':bar_chart: *sibling* - ctx 9k', isBot: true, attachments: [] }
+    ])
+
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalled())
+    expect(conn.updateBlocks).not.toHaveBeenCalledWith('C1', '111.1', expect.anything(), expect.anything(), true)
+    expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe('111.1')
+
+    release()
+    await turn
+    await daemon.stop()
+  }, 15_000)
+
+  it('drops a persisted status-bar ts when Slack rejects the update, and reposts', async () => {
+    // Heals rows poisoned by the pre-provenance adoption path: a foreign ts persisted
+    // on the session keeps failing chat.update forever — after an explicit false the
+    // ts must be discarded so a later status emit posts a fresh, editable bar.
+    const { host, release } = modelHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    const conn = routableWithBlocks(daemon)
+
+    // Turn 1: bar posted normally and its ts persisted.
+    const turn1 = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(1))
+    release()
+    await turn1
+    const posted = (daemon as any).store.getStatusBarTs(SESSION_KEY)
+    expect(posted).toBeTruthy()
+
+    // Turn 2: Slack rejects every edit of that ts (cant_update_message).
+    ;(conn.updateBlocks as any).mockResolvedValue(false)
+    const second = modelHost()
+    ;(daemon as any).opts.hostFactory = () => second.host as any
+    const turn2 = (daemon as any).dispatch('bot-a', dm('101', 'hi again'), 'int-a')
+    await vi.waitFor(() =>
+      expect(conn.updateBlocks).toHaveBeenCalledWith('C1', posted, expect.anything(), expect.anything(), true)
+    )
+    // The dead ts is dropped and a later emit in the same turn posts a fresh bar.
+    await vi.waitFor(() => expect(conn.postBlocks).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect((daemon as any).store.getStatusBarTs(SESSION_KEY)).not.toBe(posted))
+
+    second.release()
+    await turn2
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -439,6 +439,37 @@ describe('SessionManager', () => {
     store.close()
   })
 
+  it('surfaces the Slack self identity in the agent meta so the model recognizes its own mention', async () => {
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1') } as any
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => host,
+      agentById: () => agent,
+      memory,
+      slackBotUserIdFor: (integrationId) => (integrationId === 'int-a' ? 'U-SELF' : undefined)
+    })
+    const { blocks } = await sm.handle(
+      'bot-a',
+      msg({ ts: '100.1', text: '<@U-SELF> <@U-OTHER> count off' }),
+      undefined,
+      'int-a'
+    )
+    expect((blocks[0] as any).text).toContain(
+      '- Slack identity: bot user <@U-SELF> is YOU — a message mentioning this ID is addressed to you'
+    )
+    store.close()
+  })
+
+  it('omits the Slack identity line when the bot user id is unresolved', async () => {
+    const store = newStore()
+    const host = { newSession: vi.fn(async () => 'acp-1') } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'hi' }), undefined, 'int-a')
+    expect((blocks[0] as any).text).not.toContain('Slack identity')
+    store.close()
+  })
+
   it('recognizes a codex-acp raw-prompt fallback title as a standing-context echo', async () => {
     const store = newStore()
     // Non-meta runtime: the standing context inlines as block 0, and codex-acp


### PR DESCRIPTION
## Summary

- restore `trigger=mention` for relay-delivered Slack messages by matching mentions against the integration bot identity
- expose the bot's Slack user ID in agent session metadata so models can recognize when a multi-mention message addresses them
- adopt and update only status bars authored by the current Slack app, and recover from persisted uneditable timestamps
- add regression coverage for relay un-muting, Slack self-identity, and multi-agent status-bar ownership

## Why

Relay arbitration does not populate the normalized message trigger, and Slack mention tokens are opaque user IDs. In shared multi-agent threads this could make an explicitly mentioned agent treat the message as unrelated or remain muted after `!stop`.

The prior status-bar adoption path also ignored message provenance, so one Slack app could persist another app's status timestamp and repeatedly receive `cant_update_message` errors.

## Impact

Explicit Slack mentions now reliably activate the intended relay-backed agent, and each agent owns and updates only its own status bar in shared threads.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-commands.test.ts test/session-manager.test.ts` — 136 tests passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `git diff --check`
- pre-push `eslint .`
