### PR TITLE
fix(daemon): limit Claude private home seeding

### DIFF
--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -158,17 +158,16 @@ const QODER_SEED = (brand: string): readonly string[] => [
 ]
 
 export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
-  // Anthropic Claude Code — $CLAUDE_CONFIG_DIR (or ~/.claude) state +
-  // ~/.claude.json global config.
+  // Anthropic Claude Code — seed only its ~/.claude.json global config.
   // The daemon pins CLAUDE_CONFIG_DIR=<private-home>/.claude (RUNTIME_PRIVATE_ENV),
   // and Claude Code then reads its global config — including the GrowthBook feature
   // cache that gates newer models (e.g. Fable 5) — from $CLAUDE_CONFIG_DIR/.claude.json,
-  // NOT the HOME-root copy. Seed both: the config-dir copy is what a CLAUDE_CONFIG_DIR
-  // launch actually reads (without it the private home advertises a stale, reduced
-  // model list); the HOME-root copy stays for Claude versions that ignore the env.
+  // NOT the HOME-root copy. Host settings are daemon input and credentials are shared
+  // separately through CLAUDE_SECURESTORAGE_CONFIG_DIR; neither belongs in the private
+  // HOME. The HOME-root copy stays for Claude versions that ignore the config-dir env.
   'claude-acp': (env) => [
-    ...state(env.CLAUDE_CONFIG_DIR, '.claude'),
-    ...state(join(home(env), '.claude'), '.claude'),
+    ...state(env.CLAUDE_CONFIG_DIR, '.claude', ['.claude.json']),
+    ...state(join(home(env), '.claude'), '.claude', ['.claude.json']),
     ...state(join(home(env), '.claude.json'), '.claude.json'),
     ...state(join(home(env), '.claude.json'), join('.claude', '.claude.json'))
   ],

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -122,6 +122,7 @@ describe('Linux shared runtime login', () => {
     })
     expect(readFileSync(join(hostClaude, '.credentials.json'), 'utf8')).toContain('default-login')
     expect(readFileSync(join(secureDir, '.credentials.json'), 'utf8')).toContain('isolated-login')
+    expect(existsSync(join(scopeDir, 'home', '.claude', 'settings.json'))).toBe(false)
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(canonicalSecureDir)
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).not.toContain(realpathSync(hostClaude))
     expect(launch.sandbox?.protectedCredentialRoots).toEqual([canonicalSecureDir])

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -17,7 +17,7 @@ function fixture(): { root: string; hostHome: string; scopeDir: string } {
 }
 
 describe('private runtime HOME', () => {
-  it('seeds only small top-level runtime config and keeps generated state private', () => {
+  it('seeds only Claude global config and keeps host settings and credentials out', () => {
     const { hostHome, scopeDir } = fixture()
     writeFileSync(join(hostHome, '.claude', '.credentials.json'), '{"token":"host"}')
     writeFileSync(join(hostHome, '.claude', 'settings.json'), '{"theme":"dark"}')
@@ -26,8 +26,8 @@ describe('private runtime HOME', () => {
     writeFileSync(join(hostHome, '.claude.json'), '{"onboarded":true}')
 
     const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
-    expect(readFileSync(join(home, '.claude', '.credentials.json'), 'utf8')).toContain('host')
-    expect(existsSync(join(home, '.claude', 'settings.json'))).toBe(true)
+    expect(existsSync(join(home, '.claude', '.credentials.json'))).toBe(false)
+    expect(existsSync(join(home, '.claude', 'settings.json'))).toBe(false)
     expect(existsSync(join(home, '.claude.json'))).toBe(true)
     // Global config also lands in CLAUDE_CONFIG_DIR (<home>/.claude), which is
     // where a CLAUDE_CONFIG_DIR-pinned Claude Code actually reads it (the feature

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -65,6 +65,7 @@ describe('prepareRuntimeLaunch', () => {
       join(customClaudeConfig, 'settings.json'),
       JSON.stringify({ env: { ANTHROPIC_API_KEY: 'seeded-settings-secret' } })
     )
+    writeFileSync(join(customClaudeConfig, '.claude.json'), JSON.stringify({ source: 'custom-config-dir' }))
     writeFileSync(join(hostHome, '.claude.json'), JSON.stringify({ mcpToken: 'seeded-global-secret' }))
     writeFileSync(identityTokenFile, 'trusted-parent-identity-token')
     writeFileSync(awsWebIdentityTokenFile, 'trusted-parent-aws-token')
@@ -76,6 +77,7 @@ describe('prepareRuntimeLaunch', () => {
       runInSandbox: true,
       daemonRoot: dirname(scopeDir),
       sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
       explicitEnv: {
         AGENT_VALUE: 'yes',
         ANTHROPIC_IDENTITY_TOKEN_FILE: identityTokenFile,
@@ -98,7 +100,8 @@ describe('prepareRuntimeLaunch', () => {
     const canonicalAwsWebIdentityToken = realpathSync(awsWebIdentityTokenFile)
     const privateClaudeConfig = realpathSync(join(scopeDir, 'home', '.claude'))
     const privateClaudeGlobal = realpathSync(join(scopeDir, 'home', '.claude.json'))
-    expect(readFileSync(join(privateClaudeConfig, 'settings.json'), 'utf8')).toContain('seeded-settings-secret')
+    expect(existsSync(join(privateClaudeConfig, 'settings.json'))).toBe(false)
+    expect(readFileSync(join(privateClaudeConfig, '.claude.json'), 'utf8')).toContain('custom-config-dir')
     expect(readFileSync(privateClaudeGlobal, 'utf8')).toContain('seeded-global-secret')
     expect(launch.env.ANTHROPIC_IDENTITY_TOKEN_FILE).toBe(canonicalIdentityToken)
     expect(launch.env.AWS_WEB_IDENTITY_TOKEN_FILE).toBe(canonicalAwsWebIdentityToken)


### PR DESCRIPTION
## Summary

- seed only Claude global `.claude.json` state into new agent-private runtime HOMEs
- continue resolving `CLAUDE_SECURESTORAGE_CONFIG_DIR` from daemon env or host settings, then inject the canonical host directory into the trusted ACP runtime without copying credentials
- keep host `settings.json`, hooks, MCP configuration, provider environment, and other Claude config out of private HOMEs
- leave existing agent-private state untouched; affected older hosts remain a manual repair

## Root cause

Private HOME initialization treated the host Claude config directory as generic agent state. Runtime launch already handles credentials through a separate reviewed shared-login capability, but the generic shallow seeder could still copy host settings and other top-level configuration into each agent once.

The host settings file is daemon input used to resolve secure storage, not agent state. The only host state Claude needs seeded for startup and complete model discovery is `.claude.json`.

## Impact

New Claude private HOMEs receive `.claude.json` at both the HOME-root compatibility location and the pinned `CLAUDE_CONFIG_DIR` location. No host credential or settings file is seeded. Existing private files are preserved and are not migrated automatically.

## Validation

- 42 focused daemon tests passed across runtime home, shared credentials, and runtime launch
- daemon typecheck
- daemon self-contained production build
- changed-file Prettier check
- pre-push full-repository lint
- Linux host validation with Claude Code 2.1.220: disposable private HOME without `settings.json`, shared secure-storage directory, and `auth status` reported logged in through claude.ai

Tracks #312

Created by Codex . GPT-5.6
