### PR TITLE
feat(web): rebuild the console shell as a pure left/right split

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -364,13 +364,22 @@
   }
   .railbrand {
     position: relative;
-    height: 56px;
+    height: 52px;
     display: flex;
     align-items: center;
     gap: 10px;
-    /* Right padding is smaller than left to seat the hover-reveal collapse toggle. */
-    padding: 0 12px 0 18px;
+    /* Left padding seats the 24px logo on the SAME centre line as the nav icons and
+       the footer avatar (x = 32), so nothing shifts sideways when the rail collapses
+       onto its 64px centre. The design's own mock leaves the logo 2px light — this
+       is the deliberate correction. Right padding is smaller to seat the two icon
+       buttons (collapse + search). */
+    padding: 0 10px 0 20px;
     border-bottom: 1px solid var(--border-inverse);
+    /* Keep the first nav row off the divider — its hover/active pill is a filled
+       rectangle, and flush against the rule it reads as a seam. Lives on the brand
+       row (not the first item) so expanded and collapsed shift by the same amount
+       and their glyph rows stay on identical y positions. */
+    margin-bottom: 6px;
   }
   /* Brand logo+wordmark link (left) and the collapse toggle (right) are siblings in
      `.railbrand` — a button can't nest inside the logo's <a>. Display lives on the
@@ -382,19 +391,24 @@
     min-width: 0;
     text-decoration: none;
   }
+  /* The brand row's two icon buttons. They read as one pair pushed to the rail's
+     right edge: search is permanent (it is the only way into the search dialog now
+     that the top bar is gone), collapse fades in on rail hover to its left. Both are
+     22px boxes around 16px glyphs, and the negative margin cancels `.railbrand`'s
+     10px flex gap so the glyphs sit ~8px apart without the boxes overlapping. */
   .railtoggle {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 30px;
-    height: 30px;
+    width: 22px;
+    height: 22px;
     margin-left: auto;
     flex: none;
     padding: 0;
     border: 0;
-    border-radius: 6px;
+    border-radius: 5px;
     background: none;
-    color: var(--text-inverse-dim);
+    color: rgba(255, 255, 255, 0.55);
     cursor: pointer;
     opacity: 0;
   }
@@ -402,70 +416,104 @@
   .railtoggle:focus-visible {
     opacity: 1;
   }
-  .railtoggle:hover {
+  .railsrbtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin-right: 2px;
+    flex: none;
+    padding: 0;
+    border: 0;
+    border-radius: 5px;
+    background: none;
+    color: rgba(255, 255, 255, 0.55);
+    cursor: pointer;
+  }
+  .railtoggle + .railsrbtn {
+    margin-left: -9px;
+  }
+  .railtoggle:hover,
+  .railsrbtn:hover {
     background: rgba(255, 255, 255, 0.08);
     color: #fff;
   }
-  .navlbl {
-    font: 600 11px var(--font-mono);
-    color: var(--text-inverse-dim);
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    padding: 16px 16px 8px;
-  }
+  /* Inset pill nav (design v2, ChatGPT-style): no full-bleed tile, no 3px brand
+     edge — a rounded pill with symmetric 10px gutters. The active glyph keeps the
+     brand accent while the label goes white. */
   .navitem {
     display: flex;
     align-items: center;
     gap: 11px;
+    margin: 1px 10px;
     padding: 9px 14px 9px 13px;
-    border-left: 3px solid transparent;
+    border: 0;
+    border-radius: 8px;
     color: var(--text-inverse-dim);
     font: 500 14px var(--font-sans);
     cursor: pointer;
     background: none;
-    border-top: 0;
-    border-right: 0;
-    border-bottom: 0;
-    width: 100%;
+    width: calc(100% - 20px);
     text-align: left;
   }
   /* Rail items sit on the plum surface, where the design system's hover is a
-     low-alpha white overlay — one step below the .on state's 0.07. */
+     low-alpha white overlay — one step below the .on state's 0.09. */
   .navitem:hover {
     color: #fff;
-    background: rgba(255, 255, 255, 0.04);
+    background: rgba(255, 255, 255, 0.05);
   }
   .navitem.on {
     color: #fff;
-    background: rgba(255, 255, 255, 0.07);
-    border-left-color: var(--brand);
+    background: rgba(255, 255, 255, 0.09);
   }
-  .navitem.on i {
-    color: #fff;
+  /* The active row's glyph keeps the brand accent while its label goes white — that
+     colour step, not just the pill, is what marks the row. Selector is `svg` because
+     the Icon primitive renders a lucide <svg> (the design's markup uses <i>), and the
+     call site must NOT pass an inline `color`, which would outrank this. */
+  .navitem.on svg {
+    color: var(--magenta-300);
   }
-  .navitem i {
-    width: 18px;
-    height: 18px;
+  .navitem svg {
     flex: none;
   }
   /* ----- Collapsed rail (64px, icons only) ----- */
   .rail.collapsed {
     width: 64px;
   }
-  .rail.collapsed .brandword,
-  .rail.collapsed .navlbl {
+  .rail.collapsed .brandword {
     display: none;
   }
   .rail.collapsed .railbrand {
     justify-content: center;
     padding: 0;
+    /* Collapsed, the rail is one uninterrupted column of glyphs — the rules that
+       fenced the brand row off from the nav (and the footer off from it) only make
+       sense next to labels, so both dividers go. */
+    border-bottom: 0;
   }
   .rail.collapsed .navitem {
     justify-content: center;
+    margin: 1px 8px;
     padding: 9px 0;
+    width: calc(100% - 16px);
   }
   .rail.collapsed .navitem span {
     display: none;
+  }
+  /* Collapsed, the brand-row search button gives way to a nav-row one directly above
+     Home, so search stays reachable at the same 32px centre line as every other glyph.
+     It takes the ordinary nav spacing on both sides — an extra top margin here would
+     make the brand→first-row gap wider collapsed than expanded, and the two states
+     have to line up. */
+  .railsrnav {
+    display: none;
+  }
+  .rail.collapsed .railsrbtn {
+    display: none;
+  }
+  .rail.collapsed .railsrnav {
+    display: flex;
   }
   /* Collapsed: the toggle overlays the centered logo, invisible but still in the tab
      order (opacity, not display:none) so a keyboard-only user can Tab to it and
@@ -484,32 +532,63 @@
   .rail.collapsed .railbrand:has(.railtoggle:focus-visible) .railbrand-logo {
     opacity: 0;
   }
+  /* ----- Rail footer: the account block (design v2) -----
+     With the top bar gone this is the console's only identity surface, so it carries
+     the avatar, the signed-in name and the ACTIVE ORG, and its menu absorbs what the
+     old top-bar avatar menu and rail Settings link used to own: org switching,
+     Profile, Settings, the theme toggle and sign-out. */
+  .railfoot {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 10px;
+    border-top: 1px solid var(--border-inverse);
+  }
+  .pfbtn {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    width: 100%;
+    padding: 5px 7px 5px 9px;
+    border: 0;
+    border-radius: 7px;
+    background: none;
+    color: #fff;
+    cursor: pointer;
+    text-align: left;
+  }
+  .pfbtn:hover {
+    background: rgba(255, 255, 255, 0.07);
+  }
+  .pfav {
+    flex: none;
+    line-height: 0;
+  }
+  .rail.collapsed .railfoot {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 10px 8px;
+    border-top: 0;
+  }
+  .rail.collapsed .pfbtn {
+    justify-content: center;
+    padding: 5px 0;
+  }
+  .rail.collapsed .pfname {
+    display: none;
+  }
+  /* The help popover needs room the 64px rail hasn't got, and its contents are all
+     reachable from the docs anyway — collapsed, it steps aside for the account block. */
+  .rail.collapsed .railhelp {
+    display: none;
+  }
   .main {
     flex: 1;
     display: flex;
     flex-direction: column;
     min-width: 0;
-  }
-  .top {
-    height: 56px;
-    flex: none;
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--border-subtle);
-    background: var(--surface-card);
-  }
-  .crumb {
-    font: 500 13px var(--font-sans);
-    color: var(--text-tertiary);
-    display: flex;
-    align-items: center;
-    gap: 7px;
-  }
-  .crumb b {
-    font-weight: 600;
-    color: var(--text-primary);
   }
   .search {
     flex: 1;
@@ -523,12 +602,65 @@
     border: 1px solid var(--border-subtle);
     border-radius: 8px;
   }
-  /* ===== unified search (top-bar search box + results panel) ===== */
+  /* ===== unified search (search box + results panel) ===== */
   .searchwrap {
     position: relative;
     width: 340px;
     flex: none;
     z-index: 60;
+  }
+  /* ----- Rail variant: a centred command dialog instead of an inline box -----
+     The search now lives in the rail, where a 340px box does not fit, so the box
+     itself is hidden and the rail's magnifier opens it. Open, the box and its
+     results panel detach into one 600px stack floating at 16vh — the same markup
+     and the same keyboard model, re-seated. Kept as CSS on the shared component
+     (rather than a second component) so the two presentations cannot drift. */
+  .railsr {
+    position: static;
+    width: auto;
+    margin: 0;
+  }
+  .railsr .search {
+    display: none;
+  }
+  .railsr .search.focus {
+    display: flex;
+    position: fixed;
+    left: 50%;
+    top: 16vh;
+    transform: translateX(-50%);
+    width: 600px;
+    max-width: calc(100vw - 48px);
+    height: 52px;
+    gap: 11px;
+    padding: 0 16px;
+    z-index: 960;
+    background: var(--surface-card);
+    border: 1px solid var(--border-default);
+    border-bottom: 1px solid var(--border-subtle);
+    border-radius: 12px 12px 0 0;
+    box-shadow: var(--shadow-xl);
+  }
+  .railsr .search.focus .srinput {
+    font-size: 15px;
+  }
+  .railsr .srscrim {
+    background: rgba(17, 22, 29, 0.5);
+    backdrop-filter: blur(2px);
+    z-index: 955;
+  }
+  .railsr .srpanel {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    top: calc(16vh + 52px);
+    transform: translateX(-50%);
+    width: 600px;
+    max-width: calc(100vw - 48px);
+    border-top: 0;
+    border-radius: 0 0 12px 12px;
+    box-shadow: var(--shadow-xl);
+    z-index: 960;
   }
   .search.focus {
     background: var(--surface-card);
@@ -702,7 +834,9 @@
   .content {
     flex: 1;
     overflow: auto;
-    padding: 26px 30px;
+    /* Extra top padding: with the top bar deleted the content is the first thing
+       under the window chrome, and 26px let every page's first line ride the edge. */
+    padding: 34px 30px 26px;
   }
   /* Whole-view loading placeholder (see LoadingState `fill`): a fixed, viewport-
    centred overlay. Fixed (not a flow box) so the spinner sits at the SAME screen
@@ -2454,11 +2588,8 @@
       display: none;
     }
 
-    /* ----- app bar: the desktop top bar is swapped for the mobile app bar (.mtop),
-     which comes in two variants (list-tab vs push) rendered by the shell ----- */
-    .top {
-      display: none;
-    }
+    /* ----- app bar: desktop has no top bar at all (v2 is a pure left/right split),
+     so mobile brings its own (.mtop), in two variants (list-tab vs push) ----- */
     .mtop {
       display: flex;
       align-items: center;

--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -53,8 +53,9 @@ const CAP = 3
 export function GlobalSearch({
   autoFocus = false,
   mobile = false,
+  rail = false,
   onClose
-}: { autoFocus?: boolean; mobile?: boolean; onClose?: () => void } = {}) {
+}: { autoFocus?: boolean; mobile?: boolean; rail?: boolean; onClose?: () => void } = {}) {
   const router = useRouter()
   const { orgPath } = useOrgs()
   const { agents, daemons, crons, allSessions } = useConsoleData()
@@ -429,7 +430,9 @@ export function GlobalSearch({
   }
 
   return (
-    <div className="searchwrap">
+    // `railsr` re-seats this same markup as a centred command dialog — the box is
+    // hidden until opened, then floats with its panel (globals.css `.railsr`).
+    <div className={rail ? 'searchwrap railsr' : 'searchwrap'}>
       <div className={open ? 'search focus' : 'search'}>
         <Icon name="search" size={16} color="var(--text-tertiary)" />
         <input

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+// The session detail page's left rail: every session of the CURRENT agent, so a
+// run you are comparing against is one click away instead of a round trip through
+// /sessions. It only appears when the agent has ≥2 sessions (a single-session
+// agent's rail would just repeat the page you are on) and only on desktop —
+// ≤768px navigates sessions through the Shell app bar's back affordance.
+//
+// A row is the owning integration's platform mark (Slack / Telegram / … ) plus the
+// title, and nothing else: at 224px a per-row timestamp crowds out the one thing
+// you are scanning for. Recency moves up to "Today" / "Yesterday" / … group
+// headings, and the exact time — with the channel — moves into the hover tooltip.
+// Hovering (or focusing) a row reveals its pin toggle; pinned sessions group above
+// a divider, pin lit in the brand color, ahead of the dated groups. Pins live in
+// localStorage — see lib/session-pins.ts for why they are not CP state.
+//
+// The caller's rows are the agent-filtered FIRST PAGE, so two kinds of row would
+// otherwise be missing from a long-running agent's rail: the open session itself
+// (a deep link to session 51+), and pinned runs that newer runs pushed off page
+// one. Both are the rail's whole point, so `current` is merged in and this agent's
+// off-page pins are fetched individually (bounded by SESSION_PIN_HYDRATE_MAX).
+
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import useSWR from 'swr'
+import { sessionChannelDisplay, type Session } from '@/lib/data'
+import { fetchSessionDetail, sessionFromDetailDto } from '@/lib/api'
+import { useOrgs } from '@/lib/org-context'
+import { useConsoleData } from '@/lib/data-context'
+import { Icon } from '@/components/ui'
+import { PlatformMark } from '@/components/marks'
+import { groupSessionsByAge } from '@/lib/session-age'
+import {
+  partitionPinned,
+  pinnedIdsForAgent,
+  readSessionPins,
+  SESSION_PIN_HYDRATE_MAX,
+  toggleSessionPin,
+  writeSessionPins,
+  type SessionPin
+} from '@/lib/session-pins'
+
+export function SessionRail({
+  sessions,
+  current,
+  total,
+  agentId
+}: {
+  /** The agent-filtered first page of sessions, newest first. */
+  sessions: Session[]
+  /** The open session — merged in when it is not on the loaded page. */
+  current: Session
+  /** The agent's full session count (CP `total`); 0 when unknown (mock). */
+  total: number
+  /** Owning agent — scopes the pins and the footer link. */
+  agentId: string | undefined
+}) {
+  const { orgPath, activeOrg } = useOrgs()
+  // Schedule-triggered rows show the schedule's name, so the rail needs the crons
+  // list — read here rather than taken as a prop (a function prop on a 'use client'
+  // module trips the Next TS plugin's Server-Action serializability check).
+  const { crons } = useConsoleData()
+  const cronName = useCallback((cronId: string) => crons.find((c) => c.id === cronId)?.name, [crons])
+
+  // Hydration: the server has no localStorage, so the first client paint must match
+  // the SSR markup (every row unpinned) and the stored pins land in an effect.
+  const [pins, setPins] = useState<SessionPin[]>([])
+  useEffect(() => {
+    setPins(readSessionPins())
+  }, [])
+
+  const togglePin = useCallback(
+    (sessionId: string) => {
+      setPins((prev) => {
+        const next = toggleSessionPin(prev, sessionId, agentId ?? '')
+        writeSessionPins(next)
+        return next
+      })
+    },
+    [agentId]
+  )
+
+  // Pinned rows for THIS agent that the loaded page does not carry. Fetched by id
+  // because the list endpoint cannot filter by id; a rail holds a handful of pins,
+  // and the cap only bounds a pathological list. A row that fails to load is simply
+  // not rendered — a 404 here means "missing or not authorized", which is not proof
+  // of deletion, so the pin is left alone (see lib/session-pins.ts).
+  const loadedIds = useMemo(() => new Set([...sessions.map((s) => s.id), current.id]), [sessions, current.id])
+  const missingPinIds = useMemo(
+    () =>
+      pinnedIdsForAgent(pins, agentId ?? '')
+        .filter((id) => !loadedIds.has(id))
+        .slice(0, SESSION_PIN_HYDRATE_MAX),
+    [pins, agentId, loadedIds]
+  )
+  const { data: hydratedPins } = useSWR(
+    missingPinIds.length > 0 ? ['session-rail-pins', activeOrg?.id ?? '', missingPinIds.join(',')] : null,
+    async () => {
+      const rows = await Promise.all(
+        missingPinIds.map((id) =>
+          fetchSessionDetail(id, activeOrg?.id)
+            .then(sessionFromDetailDto)
+            .catch(() => null)
+        )
+      )
+      return rows.filter((row): row is Session => row !== null)
+    },
+    { revalidateOnFocus: false }
+  )
+
+  // One de-duplicated list ordered newest-first. The CP already orders its page by
+  // `lastActivityAt`, so this only decides where the merged rows land.
+  const rows = useMemo(() => {
+    const byId = new Map<string, Session>()
+    for (const s of [...sessions, current, ...(hydratedPins ?? [])]) if (!byId.has(s.id)) byId.set(s.id, s)
+    return [...byId.values()].sort((a, b) => (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? ''))
+  }, [sessions, current, hydratedPins])
+
+  const { pinned, rest } = useMemo(() => partitionPinned(rows, pins), [rows, pins])
+  // Dated groups cover the UNPINNED rows only — a pin is an explicit "keep this at
+  // the top", which outranks how old the run is. `now` is read per render; the rail
+  // only renders once its agent-filtered page has landed on the client, so there is
+  // no server pass whose clock could disagree.
+  const groups = useMemo(() => groupSessionsByAge(rest, new Date()), [rest])
+
+  // The agent's real session count, not the loaded-page length — a 60-session agent
+  // must not read "50". This also gates the rail, so it does not blink into view
+  // once page one lands.
+  const count = Math.max(total, rows.length)
+
+  // A rail that would only show the session already on screen is noise.
+  if (count < 2) return null
+
+  const row = (s: Session, isPinned: boolean) => {
+    const channel = sessionChannelDisplay(s, cronName)
+    const on = s.id === current.id
+    return (
+      <div
+        key={s.id}
+        className={`group flex w-full items-center gap-2 rounded-sm px-[9px] py-[6px] ${
+          on
+            ? 'bg-(--brand-soft) text-(--text-primary)'
+            : 'text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
+        }`}
+      >
+        <Link
+          href={orgPath(`/sessions/${encodeURIComponent(s.id)}`)}
+          // The two facts the row itself drops — when it ran and where — plus the
+          // untruncated title. `\n` is a real break: the tooltip layer renders
+          // whitespace-pre-line.
+          title={`${s.title}\n${s.time} · ${channel.label}`}
+          className="flex min-w-0 flex-1 items-center gap-2"
+        >
+          <span className="imark h-[18px] w-[18px] flex-none rounded-xs">
+            <PlatformMark platform={channel.platform} fillPct={100} />
+          </span>
+          <span
+            className={`min-w-0 flex-1 truncate font-sans text-[12.5px] leading-normal ${
+              on ? 'font-semibold' : 'font-medium'
+            }`}
+          >
+            {s.title}
+          </span>
+        </Link>
+        <button
+          type="button"
+          onClick={() => togglePin(s.id)}
+          aria-pressed={isPinned}
+          title={isPinned ? 'Unpin session' : 'Pin session'}
+          className={`-my-[2px] h-[19px] w-[19px] flex-none items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
+            isPinned ? 'flex text-(--brand)' : 'hidden text-(--text-tertiary) group-hover:flex group-focus-within:flex'
+          }`}
+        >
+          <Icon name="pin" size={12} />
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="hidden w-[224px] flex-none desktop:block">
+      <div className="sticky top-[-9px] flex max-h-[calc(100vh-110px)] flex-col pb-1">
+        <div className="flex items-center gap-2 pr-[9px] pb-[7px] pl-[9px]">
+          <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] font-semibold leading-normal tracking-[0.08em] text-(--text-tertiary) uppercase">
+            Sessions
+          </span>
+          <span className="mono flex-none text-[11px] text-(--text-tertiary)">{count}</span>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
+          {pinned.map((s) => row(s, true))}
+          {pinned.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+          {groups.map((g, i) => (
+            <Fragment key={g.bucket}>
+              {/* No top margin on the very first heading — it would double the gap
+                  the rail header already leaves (or the pinned divider's). */}
+              <div
+                className={`flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase ${
+                  i === 0 ? '' : 'pt-[11px]'
+                }`}
+              >
+                {g.label}
+              </div>
+              {g.rows.map((s) => row(s, false))}
+            </Fragment>
+          ))}
+        </div>
+        <Link
+          className="lnk mt-[10px] mr-[9px] ml-[9px] font-sans text-[12px] font-medium leading-normal"
+          href={orgPath(agentId ? `/sessions?agent=${encodeURIComponent(agentId)}` : '/sessions')}
+        >
+          All sessions
+          <Icon name="arrow-right" size={12} />
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -1,9 +1,14 @@
 'use client'
 
-// The console shell: the persistent rail + top bar that wrap every route, plus
-// the auth gate and the data/playground/modal providers. Replaces the old
-// in-component `page` switch — navigation is now real routing (<Link> +
-// usePathname), so each view lives at its own URL.
+// The console shell: the persistent rail that wraps every route, plus the auth gate
+// and the data/playground/modal providers. Replaces the old in-component `page`
+// switch — navigation is now real routing (<Link> + usePathname), so each view lives
+// at its own URL.
+//
+// Desktop is a pure left/right split (design v2): the rail carries the brand, the
+// search trigger, navigation and the account block, and the main column is content
+// only — no top bar, no breadcrumb, no back-link. Mobile keeps its own app bar
+// (`.mtop`), which is where the section/entity title still shows.
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
 import { SiModelcontextprotocol } from 'react-icons/si'
@@ -13,7 +18,7 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import { ConsoleDataProvider, useConsoleData } from '@/lib/data-context'
 import { OrgProvider, useOrgs, orgColor, subPath } from '@/lib/org-context'
 import { ApiError, getMyAccess, type OrgDto } from '@/lib/api'
-import { agentLabel, status } from '@/lib/data'
+import { agentLabel } from '@/lib/data'
 import { detailCrumb, type CrumbSlot } from '@/lib/crumb'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
@@ -86,7 +91,8 @@ const ADD_KIND: Record<string, 'agent' | 'cron' | 'daemon'> = {
   '/daemons': 'daemon'
 }
 
-// Section label for the header breadcrumb, matched by path prefix.
+// Section label for the mobile app bar, matched by path prefix. (Desktop has no
+// title strip — the rail's active row says where you are.)
 const SECTIONS: { prefix: string; label: string }[] = [
   { prefix: '/home', label: 'Home' },
   { prefix: '/agents', label: 'Agents' },
@@ -175,48 +181,71 @@ export default function ConsoleShell({ children }: { children: ReactNode }) {
   )
 }
 
-// Rail org switcher (design: `ws.*`) — auth mode only. In no-auth mode there is
-// exactly one local default org, so the picker is hidden entirely.
-function OrgSwitcher({ collapsed, canCreateOrg }: { collapsed: boolean; canCreateOrg: boolean }) {
-  const { orgs, activeOrg, setActiveOrg } = useOrgs()
-  const { openModal } = useModal()
+// Rail-footer account block (design v2's `pf.*`) — auth mode only.
+//
+// With the top bar deleted this is the console's single identity surface, so its
+// menu collects everything that used to be spread across the chrome: the org
+// switcher that sat at the TOP of the rail, the top-bar avatar menu's Profile /
+// Settings / Sign out, the rail's Settings link, and the top-bar theme toggle.
+// The button face carries the two facts you need at a glance — who you are and
+// which org you are acting in.
+function RailAccount({
+  display,
+  collapsed,
+  orgs,
+  activeOrg,
+  setActiveOrg,
+  orgPath,
+  openModal,
+  canCreateOrg,
+  theme,
+  onToggleTheme,
+  onSignOut
+}: {
+  display: { picture?: string | null; initials: string; name: string; email?: string }
+  collapsed: boolean
+  orgs: OrgDto[]
+  activeOrg: OrgDto | null
+  setActiveOrg: (id: string) => void
+  orgPath: (path: string) => string
+  openModal: (kind: 'createOrg') => void
+  canCreateOrg: boolean
+  theme: Theme
+  onToggleTheme: () => void
+  onSignOut: () => void
+}) {
   const [open, setOpen] = useState(false)
-  if (!activeOrg) return null
-
-  const square = (org: OrgDto) => (
-    <OrgIconView
-      icon={org.icon}
-      iconUrl={org.iconUrl}
-      label={org.name ?? org.slug}
-      fallbackColor={orgColor(org.id)}
-      size={22}
-      className="rounded-[5px] text-[11px]"
-    />
-  )
+  const orgName = activeOrg ? (activeOrg.name ?? activeOrg.slug) : ''
 
   return (
-    <div className={`relative pt-[10px] pb-[2px] ${collapsed ? 'px-2' : 'px-3'}`}>
+    <div className="relative min-w-0 flex-1">
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
-        title={collapsed ? (activeOrg.name ?? activeOrg.slug) : undefined}
-        className={`flex w-full cursor-pointer items-center rounded-[7px] border border-(--border-inverse) bg-[rgba(255,255,255,.05)] py-[6px] text-left ${collapsed ? 'justify-center px-0' : 'gap-[9px] px-[9px]'}`}
+        className="pfbtn"
+        title={collapsed ? display.name : 'Account'}
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
-        {square(activeOrg)}
-        {!collapsed && (
-          <>
-            <span className="min-w-0 flex-1 truncate font-sans text-[13px] font-semibold leading-normal text-white">
-              {activeOrg.name ?? activeOrg.slug}
-            </span>
-            <Icon name="chevrons-up-down" size={14} color="var(--text-inverse-dim)" className="flex-none" />
-          </>
-        )}
+        <span className="pfav">
+          <Avatar src={display.picture} initials={display.initials} size={26} fontSize={10} />
+        </span>
+        <span className="pfname min-w-0 flex-1 overflow-hidden">
+          <span className="block truncate font-sans text-[12.5px] font-semibold leading-normal text-white">
+            {display.name}
+          </span>
+          {orgName && (
+            <span className="mono block truncate text-[10.5px] font-medium text-(--text-inverse-dim)">{orgName}</span>
+          )}
+        </span>
       </button>
       {open && (
         <>
-          <div onClick={() => setOpen(false)} className="fixed inset-0 z-45" />
-          <div
-            className={`absolute top-[calc(100%_-_1px)] z-50 rounded-md border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg) ${collapsed ? 'left-2 w-[230px]' : 'right-3 left-3'}`}
-          >
+          <div className="fixed inset-0 z-45" onClick={() => setOpen(false)} />
+          <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[238px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
+            {display.email && (
+              <div className="mono truncate px-3 pt-2 pb-[6px] text-[11px] text-(--text-tertiary)">{display.email}</div>
+            )}
             {orgs.map((o) => (
               <button
                 key={o.id}
@@ -226,28 +255,51 @@ function OrgSwitcher({ collapsed, canCreateOrg }: { collapsed: boolean; canCreat
                   setOpen(false)
                 }}
               >
-                <span className="inline-flex items-center gap-[9px]">
-                  {square(o)}
-                  {o.name ?? o.slug}
+                <span className="inline-flex min-w-0 items-center gap-[9px]">
+                  <OrgIconView
+                    icon={o.icon}
+                    iconUrl={o.iconUrl}
+                    label={o.name ?? o.slug}
+                    fallbackColor={orgColor(o.id)}
+                    size={22}
+                    className="rounded-[5px] text-[11px]"
+                  />
+                  <span className="truncate">{o.name ?? o.slug}</span>
                 </span>
-                {o.id === activeOrg.id && <Icon name="check" size={15} color="var(--brand)" />}
+                {o.id === activeOrg?.id && <Icon name="check" size={15} color="var(--brand)" className="flex-none" />}
               </button>
             ))}
             {canCreateOrg && (
-              <>
-                <div className="mx-[2px] my-1 h-[1px] bg-(--border-subtle)" />
-                <button
-                  className="dmi"
-                  onClick={() => {
-                    setOpen(false)
-                    openModal('createOrg')
-                  }}
-                >
-                  <Icon name="plus" size={15} />
-                  Create organization
-                </button>
-              </>
+              <button
+                className="dmi"
+                onClick={() => {
+                  setOpen(false)
+                  openModal('createOrg')
+                }}
+              >
+                <Icon name="plus" size={15} color="var(--text-tertiary)" />
+                Create organization
+              </button>
             )}
+            <div className="dmsep" />
+            <Link href={orgPath('/profile')} className="dmi no-underline" onClick={() => setOpen(false)}>
+              <Icon name="circle-user-round" size={15} color="var(--text-tertiary)" />
+              Profile
+            </Link>
+            <Link href={orgPath('/settings')} className="dmi no-underline" onClick={() => setOpen(false)}>
+              <Icon name="settings" size={15} color="var(--text-tertiary)" />
+              Settings
+            </Link>
+            <div className="dmsep" />
+            <button className="dmi" onClick={onToggleTheme}>
+              <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={15} color="var(--text-tertiary)" />
+              {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+            </button>
+            <div className="dmsep" />
+            <button className="dmi" onClick={onSignOut}>
+              <Icon name="log-out" size={15} color="var(--text-tertiary)" />
+              Sign out
+            </button>
           </div>
         </>
       )}
@@ -480,18 +532,15 @@ function ShellChrome({ children }: { children: ReactNode }) {
     return undefined
   })()
   // The slot beats the list lookup, but only on the route it describes — see lib/crumb.ts.
-  const {
-    title: pushTitle,
-    show: titleResolved,
-    badge: crumbBadge
-  } = detailCrumb(crumb, seg[1], listTitle ?? undefined, crumbSlot)
+  // Only the title is consumed now: the desktop crumb (which also carried the status
+  // badge) is gone, and the mobile app bar shows the title alone.
+  const { title: pushTitle } = detailCrumb(crumb, seg[1], listTitle ?? undefined, crumbSlot)
 
   // Back from a push screen: pop in-app history when there is any, else (deep-link /
   // hard refresh — no history) route to the parent list so "back" never leaves the app.
   const hasParentList = LIST_ROUTES.includes(`/${seg[0] ?? ''}`)
   const parentList = hasParentList ? `/${seg[0]}` : '/home'
   const parentListHref = orgPath(parentList + (seg[0] === 'sessions' ? sessionFilterSearch(locationSearch) : ''))
-  const showDetailCrumb = hasParentList && seg.length >= 2 && crumb !== '' && titleResolved
   const goBack = () => {
     if (typeof window !== 'undefined' && window.history.length > 1) router.back()
     else router.push(parentListHref)
@@ -525,8 +574,8 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 className="railbrand-logo cursor-pointer select-none"
                 aria-label="Go to Home"
               >
-                <LogoMark />
-                <span className="brandword font-sans text-[17px] font-semibold leading-normal tracking-[-.02em] text-white">
+                <LogoMark size={24} />
+                <span className="brandword font-sans text-[16px] font-semibold leading-normal tracking-[-.02em] text-white">
                   Agent<span className="text-(--magenta-300)">Connect</span>
                 </span>
               </Link>
@@ -537,20 +586,24 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 title={railCollapsed ? 'Expand sidebar' : undefined}
                 aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               >
-                <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={17} />
+                <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={16} />
+              </button>
+              {/* Search sits at the rail's outer edge, permanently visible — with no
+              top bar it is the console's only search affordance, so unlike the
+              collapse toggle beside it, it never hides. Collapsed, CSS swaps it for
+              the `.railsrnav` row below. */}
+              <button type="button" onClick={openSearch} className="railsrbtn" title="Search" aria-label="Search">
+                <Icon name="search" size={16} />
               </button>
             </div>
-            {/* Org picker + "Organization" section label — only in auth mode; the
-            no-auth default org needs neither (there's a single implicit org). A
-            small spacer keeps the nav off the brand divider when both are gone. */}
-            {authOn ? (
-              <>
-                <OrgSwitcher collapsed={railCollapsed} canCreateOrg={canCreateOrg} />
-                <div className="navlbl">Organization</div>
-              </>
-            ) : (
-              <div className="h-3" />
-            )}
+            {/* The search dialog itself. It renders in the rail so the trigger and the
+            dialog share one component; `rail` re-seats the open state as a centred
+            command palette (globals.css `.railsr`). */}
+            <GlobalSearch rail />
+            <button type="button" onClick={openSearch} className="navitem railsrnav" title="Search" aria-label="Search">
+              <Icon name="search" size={18} />
+              <span>Search</span>
+            </button>
             {NAV_ITEMS.map((item) => {
               const on = isActive(barePath, item.href)
               return (
@@ -560,37 +613,49 @@ function ShellChrome({ children }: { children: ReactNode }) {
                   title={railCollapsed ? item.label : undefined}
                   className={on ? 'navitem on' : 'navitem'}
                 >
-                  <Icon name={item.icon} size={18} color={on ? '#fff' : undefined} />
+                  {/* No inline color — `.navitem.on svg` tints the active glyph brand. */}
+                  <Icon name={item.icon} size={18} />
                   <span>{item.label}</span>
                 </Link>
               )
             })}
-            {/* Rail footer: Settings (auth mode only, theme toggle lives by the search)
-            + a Help & resources menu that opens UPWARD. The help menu shows in every
-            mode — the docs/MCP links are useful with or without sign-in. */}
-            <div
-              className={`mt-auto border-t border-(--border-inverse) ${railCollapsed ? 'flex flex-col items-stretch gap-1 px-2 py-[10px]' : 'flex items-center gap-[6px] px-4 py-[14px]'}`}
-            >
-              {authOn && (
-                <Link
-                  href={orgPath('/settings')}
-                  title={railCollapsed ? 'Settings' : undefined}
-                  className={`${isActive(barePath, '/settings') ? 'navitem on' : 'navitem'} my-0 rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full justify-center px-0' : 'flex-1 px-3'}`}
+            {/* Rail footer. In auth mode this is the account block: avatar + name +
+            active org, whose menu carries everything the deleted top bar used to —
+            org switching, Profile, Settings, the theme toggle, sign-out. No-auth has
+            no identity and one implicit org, so it keeps just the theme toggle. The
+            Help menu shows in both modes — the docs links are useful either way. */}
+            <div className="railfoot">
+              {authOn ? (
+                <RailAccount
+                  display={display}
+                  collapsed={railCollapsed}
+                  orgs={orgs}
+                  activeOrg={activeOrg}
+                  setActiveOrg={setActiveOrg}
+                  orgPath={orgPath}
+                  openModal={openModal}
+                  canCreateOrg={canCreateOrg}
+                  theme={theme}
+                  onToggleTheme={toggleTheme}
+                  onSignOut={signOut}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  className="navitem m-0 w-auto flex-none justify-center rounded-[6px] px-2 py-[9px]"
+                  title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                  aria-label="Toggle theme"
                 >
-                  <Icon
-                    name="settings"
-                    size={18}
-                    color={isActive(barePath, '/settings') ? 'var(--brand)' : undefined}
-                  />
-                  <span>Settings</span>
-                </Link>
+                  <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={18} />
+                </button>
               )}
-              <div className={`relative ${railCollapsed ? 'w-full' : 'flex-none'}`}>
+              <div className="railhelp relative flex-none">
                 <button
                   type="button"
                   onClick={() => setHelpMenu((v) => !v)}
-                  className={`navitem justify-center rounded-[6px] border-l-0 py-[9px] ${railCollapsed ? 'w-full px-0' : 'w-auto flex-none px-[11px]'}`}
-                  title={railCollapsed ? 'Help & resources' : undefined}
+                  className="navitem m-0 w-auto flex-none justify-center rounded-[6px] px-2 py-[9px]"
+                  title="Help & resources"
                   aria-label="Help & resources"
                 >
                   <Icon name="circle-question-mark" size={18} color={helpMenu ? 'var(--brand)' : undefined} />
@@ -651,46 +716,11 @@ function ShellChrome({ children }: { children: ReactNode }) {
             </div>
           </aside>
 
-          {/* ===== MAIN ===== */}
+          {/* ===== MAIN =====
+          Desktop has NO top bar (design v2 is a pure left/right split): no breadcrumb,
+          no parent back-link, no title strip. The rail states where you are, and each
+          detail view owns its own heading. Mobile still needs one — `.mtop` below. */}
           <div className="main">
-            <header className="top">
-              <div className="crumb min-w-0">
-                {showDetailCrumb ? (
-                  <>
-                    <Link
-                      href={parentListHref}
-                      className="flex-none text-(--text-tertiary) no-underline hover:text-(--text-secondary)"
-                    >
-                      {crumb}
-                    </Link>
-                    <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
-                    <b className="min-w-0 truncate">{pushTitle}</b>
-                    {crumbBadge && (
-                      <span
-                        className="inline-flex flex-none items-center gap-[5px] whitespace-nowrap rounded-full px-2 py-[1px] font-sans text-[12px] font-semibold leading-normal"
-                        style={{
-                          background: status(crumbBadge.status).bg,
-                          color: status(crumbBadge.status).text
-                        }}
-                      >
-                        <span
-                          className="h-[6px] w-[6px] flex-none rounded-full"
-                          style={{ background: status(crumbBadge.status).dot }}
-                        />
-                        {crumbBadge.statusLabel}
-                      </span>
-                    )}
-                  </>
-                ) : (
-                  crumb
-                )}
-              </div>
-              <div className="topspacer flex-1" />
-              <GlobalSearch />
-              <ThemeToggle theme={theme} onToggle={toggleTheme} />
-              {authOn && <UserMenu display={display} orgPath={orgPath} onSignOut={signOut} />}
-            </header>
-
             {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
             <header className="mtop">
               {isListRoute ? (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -15,6 +15,7 @@ import {
   lane,
   modelCapability,
   modelLabel,
+  MOCK_MODE,
   MOCK_PREFIX,
   permissionModeLabel,
   pgPrompts,
@@ -66,6 +67,8 @@ import { WORK_LANES, toggleWorkPanel, workCounts, workPanelOpen, workSummary } f
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import { useCrumbSlot } from '@/components/console/Shell'
+import { SessionRail } from '@/components/console/SessionRail'
+import { useSessionList } from '@/lib/use-session-list'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
   sessionEffortAfterModelChange,
@@ -644,6 +647,7 @@ export default function SessionDetailView() {
   const {
     agents,
     allSessions,
+    getSessions,
     sessionsLoading,
     crons,
     daemons,
@@ -776,6 +780,21 @@ export default function SessionDetailView() {
       : sessionBase
   const agentRuntime = session?.runtime || owner?.runtime || ''
   const runtimeMeta = acpRuntime(acpRegistry, agentRuntime)
+
+  // Sibling sessions for the left rail. Like the agent page's Recent-sessions card
+  // this reads an AGENT-FILTERED page, not the org-wide `allSessions` window — a
+  // busy org's newest 50 may not include this agent at all, which would hide the
+  // rail on an agent that has plenty of runs. The org key stays null until the
+  // agent is known so no unfiltered page is fetched on the way there.
+  const railAgentId = session?.agentId ?? ''
+  const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
+    MOCK_MODE || !railAgentId ? null : activeOrg?.id,
+    { agentId: railAgentId }
+  )
+  const railSessions = useMemo(
+    () => (MOCK_MODE ? (railAgentId ? getSessions(railAgentId) : []) : railSessionRows),
+    [getSessions, railAgentId, railSessionRows]
+  )
   const sessionBusy = session ? isPgBusy(session.id) : false
   const sessionBusyRef = useRef(sessionBusy)
   sessionBusyRef.current = sessionBusy
@@ -967,6 +986,9 @@ export default function SessionDetailView() {
   const crumbTitle = session?.title ?? ''
   const crumbStatusKey = session?.status ?? ''
   const crumbStatusLabel = session?.statusLabel || (crumbStatusKey ? status(crumbStatusKey).label : '')
+  // The desktop title row renders the same pair the crumb used to badge.
+  const headerStatus = status(crumbStatusKey)
+  const headerStatusLabel = crumbStatusLabel
   useEffect(() => {
     if (!crumbTitle) return
     registerCrumb({ id, title: crumbTitle, status: crumbStatusKey, statusLabel: crumbStatusLabel })
@@ -1364,691 +1386,734 @@ export default function SessionDetailView() {
   // cards → transcript. Breakpoint differences are CSS-gated (desktop: /
   // max-desktop:), never JS-forked.
   return (
-    <div className="wrap flex min-h-full max-w-[880px] flex-col max-desktop:pb-6">
-      {/* DESKTOP HEADER — slim single row (design): agent · channel · participants ·
-          visibility · Details popover · copy-link. The title lives in the top-bar
-          crumb, and the old stat/usage cards moved into the Details popover. The
+    // `.wrap` (1180px) is the outer track so the sibling-session rail can sit beside
+    // the 880px body. With no rail the body is still an 880px block centred in that
+    // track — geometrically identical to when it was the wrap itself.
+    <div className="wrap flex min-h-full items-stretch gap-[26px]">
+      <SessionRail sessions={railSessions} current={session} total={railSessionTotal} agentId={session.agentId} />
+      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">
+        {/* DESKTOP TITLE ROW — the session name + its status badge. These used to live
+          in the top-bar crumb; with the crumb gone the page has to name itself. The
           mobile title/status live in Shell's app bar, so this region is desktop-only. */}
-      <div className="mt-[-9px] mb-[10px] hidden items-center gap-2 border-b border-(--border-subtle) pb-[7px] desktop:flex">
-        {agentHref ? (
-          <Link className="lnk min-w-0 flex-[0_1_auto] text-[12.5px] text-(--text-secondary)" href={orgPath(agentHref)}>
-            <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
-              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
-            </span>
-            <span className="truncate">{session.agentName}</span>
-          </Link>
-        ) : (
-          <span className="lnk min-w-0 flex-[0_1_auto] cursor-default text-[12.5px] text-(--text-secondary)">
-            <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
-              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
-            </span>
-            <span className="truncate">{session.agentName}</span>
-          </span>
-        )}
-        <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-          <span className="imark h-4 w-4 flex-none rounded-xs">
-            <PlatformMark platform={channelDisplay.platform} fillPct={100} />
-          </span>
-          {session.threadUrl ? (
-            <a
-              className="lnk truncate font-mono text-[12px] font-medium leading-normal text-(--text-link)"
-              href={session.threadUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`Open the ${platName(sessionIntegration)} thread`}
-            >
-              {channelDisplay.label}
-            </a>
-          ) : (
-            <span className="mono truncate text-[12px]">{channelDisplay.label}</span>
-          )}
-        </span>
-        {headerCron ? (
-          <Link
-            className="lnk min-w-0 flex-[0_1_auto] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)"
-            href={orgPath(`/crons/${headerCron.id}`)}
+        <div className="mt-[-4px] mb-2 hidden min-w-0 items-center gap-[10px] desktop:flex">
+          <h1
+            title={session.title}
+            className="m-0 min-w-0 truncate font-sans text-[17px] font-semibold leading-normal tracking-[-.01em] text-(--text-primary)"
           >
-            <Icon name="calendar-clock" size={13} className="flex-none" />
-            <span className="truncate">{headerCron.name || 'Schedule'}</span>
-          </Link>
-        ) : (
-          <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
-            <Icon name="users" size={13} className="flex-none" />
-            <span className="truncate">{participantsLabel}</span>
+            {session.title}
+          </h1>
+          {headerStatusLabel && (
+            <span className="badge flex-none" style={{ background: headerStatus.bg, color: headerStatus.text }}>
+              <span className="dot h-[6px] w-[6px]" style={{ background: headerStatus.dot }} />
+              {headerStatusLabel}
+            </span>
+          )}
+        </div>
+        {/* DESKTOP META ROW — agent · channel · participants · visibility · Details
+          popover · copy-link. The old stat/usage cards moved into the Details popover. */}
+        <div className="mt-0 mb-[10px] hidden items-center gap-2 border-b border-(--border-subtle) pb-[7px] desktop:flex">
+          {agentHref ? (
+            <Link
+              className="lnk min-w-0 flex-[0_1_auto] text-[12.5px] text-(--text-secondary)"
+              href={orgPath(agentHref)}
+            >
+              <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
+                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
+              </span>
+              <span className="truncate">{session.agentName}</span>
+            </Link>
+          ) : (
+            <span className="lnk min-w-0 flex-[0_1_auto] cursor-default text-[12.5px] text-(--text-secondary)">
+              <span className="av h-[18px] w-[18px] flex-none rounded-[5px]">
+                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={18} />
+              </span>
+              <span className="truncate">{session.agentName}</span>
+            </span>
+          )}
+          <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+            <span className="imark h-4 w-4 flex-none rounded-xs">
+              <PlatformMark platform={channelDisplay.platform} fillPct={100} />
+            </span>
+            {session.threadUrl ? (
+              <a
+                className="lnk truncate font-mono text-[12px] font-medium leading-normal text-(--text-link)"
+                href={session.threadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`Open the ${platName(sessionIntegration)} thread`}
+              >
+                {channelDisplay.label}
+              </a>
+            ) : (
+              <span className="mono truncate text-[12px]">{channelDisplay.label}</span>
+            )}
           </span>
-        )}
-        {visibilityControl}
-        {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
+          {headerCron ? (
+            <Link
+              className="lnk min-w-0 flex-[0_1_auto] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)"
+              href={orgPath(`/crons/${headerCron.id}`)}
+            >
+              <Icon name="calendar-clock" size={13} className="flex-none" />
+              <span className="truncate">{headerCron.name || 'Schedule'}</span>
+            </Link>
+          ) : (
+            <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+              <Icon name="users" size={13} className="flex-none" />
+              <span className="truncate">{participantsLabel}</span>
+            </span>
+          )}
+          {visibilityControl}
+          {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
             baseline, and the descender gap under it pushed the button off the row's
             centre line. */}
-        <div
-          className="relative ml-[-3px] flex flex-none items-center"
-          onKeyDown={(event) => {
-            if (event.key !== 'Escape' || !detailOpen) return
-            event.stopPropagation()
-            setDetailOpen(false)
-          }}
-        >
-          <button
-            className="inline-flex h-[22px] cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
-            onClick={() => setDetailOpen((o) => !o)}
-            aria-haspopup="dialog"
-            aria-expanded={detailOpen}
-            title="Run details"
-          >
-            <Icon name="info" size={14} />
-            Details
-          </button>
-          {detailOpen && (
-            <>
-              <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setDetailOpen(false)} />
-              <div role="dialog" aria-label="Run details" className="fmenu z-50 min-w-[216px] px-0 py-[5px]">
-                {headerFacts.map((f) => (
-                  <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
-                    <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
-                    <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                      {f.label}
-                    </span>
-                    <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                      {f.value}
-                    </span>
-                  </div>
-                ))}
-                {usageEntries.length > 0 && (
-                  <>
-                    <div className="my-1 border-t border-(--border-subtle)" />
-                    <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
-                      Token usage
-                    </div>
-                    {usageEntries.map((e) => (
-                      <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
-                        <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                          {e.label}
-                        </span>
-                        <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                          {e.value}
-                        </span>
-                      </div>
-                    ))}
-                  </>
-                )}
-              </div>
-            </>
-          )}
-        </div>
-        <button
-          className="ml-auto flex h-[19px] w-[19px] flex-none cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
-          onClick={onCopyLink}
-          title={copied ? 'Copied' : 'Copy a link to this session'}
-          aria-label="Copy a link to this session"
-        >
-          <Icon name={copied ? 'check' : 'link'} size={12} />
-        </button>
-      </div>
-
-      {sessionDetail?.accessSyncDegraded && (
-        <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3">
-          External access could not be verified. Related sessions remain hidden until access checks succeed.
-        </div>
-      )}
-
-      {/* MOBILE META STRIP — single-row 4-up, abbreviated labels tuned for 390px. */}
-      <div className="grid grid-cols-[repeat(4,1fr)] border-b border-(--border-subtle) bg-(--surface-card) desktop:hidden">
-        {metaCells.map((c, i) => (
           <div
-            key={c.label}
-            className={`min-w-0 overflow-hidden px-3 py-[10px] ${i < 3 ? 'border-r border-(--border-subtle)' : ''}`}
+            className="relative ml-[-3px] flex flex-none items-center"
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape' || !detailOpen) return
+              event.stopPropagation()
+              setDetailOpen(false)
+            }}
           >
-            <div className="font-sans text-[10px] font-medium uppercase leading-normal tracking-[.06em] text-(--text-tertiary)">
-              {c.label}
+            <button
+              className="inline-flex h-[22px] cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+              onClick={() => setDetailOpen((o) => !o)}
+              aria-haspopup="dialog"
+              aria-expanded={detailOpen}
+              title="Run details"
+            >
+              <Icon name="info" size={14} />
+              Details
+            </button>
+            {detailOpen && (
+              <>
+                <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setDetailOpen(false)} />
+                <div role="dialog" aria-label="Run details" className="fmenu z-50 min-w-[216px] px-0 py-[5px]">
+                  {headerFacts.map((f) => (
+                    <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
+                      <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
+                      <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                        {f.label}
+                      </span>
+                      <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
+                        {f.value}
+                      </span>
+                    </div>
+                  ))}
+                  {usageEntries.length > 0 && (
+                    <>
+                      <div className="my-1 border-t border-(--border-subtle)" />
+                      <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
+                        Token usage
+                      </div>
+                      {usageEntries.map((e) => (
+                        <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
+                          <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                            {e.label}
+                          </span>
+                          <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
+                            {e.value}
+                          </span>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+          <button
+            className="ml-auto flex h-[19px] w-[19px] flex-none cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+            onClick={onCopyLink}
+            title={copied ? 'Copied' : 'Copy a link to this session'}
+            aria-label="Copy a link to this session"
+          >
+            <Icon name={copied ? 'check' : 'link'} size={12} />
+          </button>
+        </div>
+
+        {sessionDetail?.accessSyncDegraded && (
+          <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3">
+            External access could not be verified. Related sessions remain hidden until access checks succeed.
+          </div>
+        )}
+
+        {/* MOBILE META STRIP — single-row 4-up, abbreviated labels tuned for 390px. */}
+        <div className="grid grid-cols-[repeat(4,1fr)] border-b border-(--border-subtle) bg-(--surface-card) desktop:hidden">
+          {metaCells.map((c, i) => (
+            <div
+              key={c.label}
+              className={`min-w-0 overflow-hidden px-3 py-[10px] ${i < 3 ? 'border-r border-(--border-subtle)' : ''}`}
+            >
+              <div className="font-sans text-[10px] font-medium uppercase leading-normal tracking-[.06em] text-(--text-tertiary)">
+                {c.label}
+              </div>
+              <div className="mt-[2px] truncate font-mono text-[13px] font-semibold leading-normal">{c.value}</div>
             </div>
-            <div className="mt-[2px] truncate font-mono text-[13px] font-semibold leading-normal">{c.value}</div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
 
-      {/* MOBILE VISIBILITY ROW — the desktop header is `hidden desktop:flex`, so
+        {/* MOBILE VISIBILITY ROW — the desktop header is `hidden desktop:flex`, so
           the badge/toggle needs its own place in the mobile meta strip. */}
-      {visibilityControl && (
-        <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
-          {visibilityControl}
-        </div>
-      )}
-
-      {/* MOBILE AGENT CONFIG ROW — taps through to the owning agent. */}
-      {agentHref ? (
-        <Link
-          href={orgPath(agentHref)}
-          className="box-border flex w-full items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] no-underline desktop:hidden"
-        >
-          <span className="av h-8 w-8 flex-none rounded-md">
-            <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
-            <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-              {session.agentName}
-            </span>
-            <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
-              {cfgLine}
-            </span>
-          </span>
-          <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
-        </Link>
-      ) : (
-        <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
-          <span className="av h-8 w-8 flex-none rounded-md">
-            <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
-            <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-              {session.agentName}
-            </span>
-            <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
-              {cfgLine}
-            </span>
-          </span>
-        </div>
-      )}
-
-      {sessionDetail?.id === session.id && (
-        <SessionFamilyLinks
-          parent={sessionDetail.parentSession}
-          children={sessionDetail.childSessions}
-          agentById={agentById}
-          orgPath={orgPath}
-        />
-      )}
-
-      {owner?.canEdit && !owner.name.startsWith(MOCK_PREFIX) && session.agentId && (
-        <ApprovalRequestsCard
-          agentId={session.agentId}
-          sessionId={session.realSessionId ?? session.id}
-          hideWhenEmpty
-          className="mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4"
-        />
-      )}
-
-      {wantTranscript && msgLoading && (
-        <div className="flex justify-center py-10">
-          <Spinner size={30} />
-        </div>
-      )}
-      {wantTranscript && msgErr && (
-        <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
-          <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
-          <span>
-            Couldn&apos;t load the transcript — the owning daemon may be offline. Session history is pulled live from
-            the daemon, so it&apos;s unavailable while that machine is disconnected.
-          </span>
-        </div>
-      )}
-      {transcriptEmpty && (
-        <div className="card m-4 flex flex-col items-center gap-[6px] px-6 py-[34px] text-center desktop:m-0">
-          <Icon name="message-square-dashed" size={20} color="var(--text-tertiary)" />
-          <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-            No messages in this session yet.
+        {visibilityControl && (
+          <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
+            {visibilityControl}
           </div>
-        </div>
-      )}
+        )}
 
-      {msgPaging && (
-        <div className="flex items-center justify-center gap-2 pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
-          <Spinner size={14} />
-          Loading earlier activity…
-        </div>
-      )}
-      {/* TRANSCRIPT — one shared tree. Mobile adds the 16px gutter column around
+        {/* MOBILE AGENT CONFIG ROW — taps through to the owning agent. */}
+        {agentHref ? (
+          <Link
+            href={orgPath(agentHref)}
+            className="box-border flex w-full items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] no-underline desktop:hidden"
+          >
+            <span className="av h-8 w-8 flex-none rounded-md">
+              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
+              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                {session.agentName}
+              </span>
+              <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                {cfgLine}
+              </span>
+            </span>
+            <Icon name="chevron-right" size={16} color="var(--text-tertiary)" className="flex-none" />
+          </Link>
+        ) : (
+          <div className="flex items-center gap-[10px] border-b border-(--border-subtle) bg-(--surface-card) px-4 py-[10px] desktop:hidden">
+            <span className="av h-8 w-8 flex-none rounded-md">
+              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={32} />
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
+              <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                {session.agentName}
+              </span>
+              <span className="truncate font-mono text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                {cfgLine}
+              </span>
+            </span>
+          </div>
+        )}
+
+        {sessionDetail?.id === session.id && (
+          <SessionFamilyLinks
+            parent={sessionDetail.parentSession}
+            children={sessionDetail.childSessions}
+            agentById={agentById}
+            orgPath={orgPath}
+          />
+        )}
+
+        {owner?.canEdit && !owner.name.startsWith(MOCK_PREFIX) && session.agentId && (
+          <ApprovalRequestsCard
+            agentId={session.agentId}
+            sessionId={session.realSessionId ?? session.id}
+            hideWhenEmpty
+            className="mx-4 mt-4 max-desktop:rounded-lg desktop:mx-0 desktop:mt-0 desktop:mb-4"
+          />
+        )}
+
+        {wantTranscript && msgLoading && (
+          <div className="flex justify-center py-10">
+            <Spinner size={30} />
+          </div>
+        )}
+        {wantTranscript && msgErr && (
+          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+            <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
+            <span>
+              Couldn&apos;t load the transcript — the owning daemon may be offline. Session history is pulled live from
+              the daemon, so it&apos;s unavailable while that machine is disconnected.
+            </span>
+          </div>
+        )}
+        {transcriptEmpty && (
+          <div className="card m-4 flex flex-col items-center gap-[6px] px-6 py-[34px] text-center desktop:m-0">
+            <Icon name="message-square-dashed" size={20} color="var(--text-tertiary)" />
+            <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+              No messages in this session yet.
+            </div>
+          </div>
+        )}
+
+        {msgPaging && (
+          <div className="flex items-center justify-center gap-2 pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
+            <Spinner size={14} />
+            Loading earlier activity…
+          </div>
+        )}
+        {/* TRANSCRIPT — one shared tree. Mobile adds the 16px gutter column around
           turns + live tail. The column grows to fill the page (flex-1 inside the
           min-h-full wrap) so the flex-1 spacer below can pin the composer to the
           bottom even when the transcript is short. */}
-      <div className="flex flex-1 flex-col gap-4 p-4 desktop:gap-0 desktop:p-0">
-        {turns.length > 0 && (
-          <div className="flex flex-col gap-4 desktop:gap-[15px]">
-            {turns.map((turn, ti) =>
-              turn.kind === 'user' ? (
-                // 2b: user turns are right-aligned brand-soft bubbles. A sender label
-                // sits above the bubble only when it isn't you (platform user / cron).
-                <div key={ti} className="flex items-start justify-end gap-[9px]">
-                  <div className="flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
-                    {(turn.isCron || turn.sp.handle !== '@you') && (
-                      <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
-                        {turn.isCron && turn.cronId ? (
-                          <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
-                            {turn.sp.name}
-                          </Link>
-                        ) : (
-                          <span>{turn.sp.name}</span>
-                        )}
-                        {turn.time && <span className="mono">{turn.time}</span>}
-                      </span>
-                    )}
-                    <div className="max-w-full rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
-                      {turn.image && (
-                        <img
-                          src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
-                          alt={turn.image.name}
-                          className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
-                        />
-                      )}
-                      {turn.text && <MessageText text={turn.text} />}
-                    </div>
-                  </div>
-                  <ParticipantAvatar agent={turn.agent} avatarUrl={turn.avatarUrl} sp={turn.sp} isCron={turn.isCron} />
-                </div>
-              ) : (
-                (() => {
-                  // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
-                  // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
-                  const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
-                  const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
-                  // Reasoning steps / tool commands / edited FILES (distinct paths across
-                  // EDIT rows, since one EDIT row can touch several files).
-                  const { thinkCount, toolCount, editCount } = workCounts(workSteps)
-                  const summary = workSummary(thinkCount, toolCount, editCount)
-                  // Auto-open while a turn has produced only work (mid-stream), so the
-                  // live agent isn't hidden; collapse once its answer text lands. Either
-                  // default stays user-overridable, so thinking-only turns can be closed.
-                  const autoOpen = textSteps.length === 0
-                  const openWork = workPanelOpen(workOverride.get(ti), autoOpen)
-                  return (
-                    <div key={ti} className="flex items-start gap-[9px]">
-                      <span className="av h-[26px] w-[26px] flex-none rounded-md">
-                        <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={26} />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-[5px] flex items-center gap-[7px]">
-                          <span className="font-sans text-[13px] font-semibold leading-normal">{turn.agentName}</span>
-                          {turn.time && (
-                            <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
-                              {turn.time}
-                            </span>
+        <div className="flex flex-1 flex-col gap-4 p-4 desktop:gap-0 desktop:p-0">
+          {turns.length > 0 && (
+            <div className="flex flex-col gap-4 desktop:gap-[15px]">
+              {turns.map((turn, ti) =>
+                turn.kind === 'user' ? (
+                  // 2b: user turns are right-aligned brand-soft bubbles. A sender label
+                  // sits above the bubble only when it isn't you (platform user / cron).
+                  <div key={ti} className="flex items-start justify-end gap-[9px]">
+                    <div className="flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
+                      {(turn.isCron || turn.sp.handle !== '@you') && (
+                        <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
+                          {turn.isCron && turn.cronId ? (
+                            <Link className="lnk text-inherit" href={orgPath(`/crons/${turn.cronId}`)}>
+                              {turn.sp.name}
+                            </Link>
+                          ) : (
+                            <span>{turn.sp.name}</span>
                           )}
-                        </div>
-                        {textSteps.map((st, si) => (
-                          <div key={si} className={si > 0 ? 'mt-2' : ''}>
-                            {st.text && (
-                              <div className="font-sans text-[13.5px] leading-[1.6] whitespace-pre-wrap text-(--text-primary)">
-                                <MessageText text={st.text} />
-                              </div>
-                            )}
-                            <StepExtras step={st} sessionId={sid} />
-                          </div>
-                        ))}
-                        {workSteps.length > 0 && (
-                          <>
-                            <button
-                              type="button"
-                              onClick={() => toggleWork(ti, autoOpen)}
-                              className="mt-2 inline-flex items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
-                              title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
-                            >
-                              <Icon
-                                name={openWork ? 'chevron-down' : 'chevron-right'}
-                                size={13}
-                                color="var(--text-tertiary)"
-                              />
-                              {summary || 'Details'}
-                            </button>
-                            {openWork && (
-                              <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
-                                {workSteps.map((st, si) => (
-                                  <div
-                                    key={si}
-                                    className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
-                                      si > 0 ? 'border-t border-(--border-subtle)' : ''
-                                    }`}
-                                  >
-                                    <div className="flex w-[52px] flex-none items-center gap-[6px] pt-[1px]">
-                                      <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
-                                      <span
-                                        className="mono text-[10px] font-semibold tracking-[.02em]"
-                                        style={{ color: st.laneColor }}
-                                      >
-                                        {st.lane}
-                                      </span>
-                                    </div>
-                                    <div className="min-w-0 flex-1">
-                                      {st.text && (
-                                        <div
-                                          className="font-sans text-[13px] leading-[1.5]"
-                                          style={{ fontWeight: st.weight, color: st.textColor }}
-                                        >
-                                          <MessageText text={st.text} />
-                                        </div>
-                                      )}
-                                      <StepExtras step={st} sessionId={sid} />
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                          </>
+                          {turn.time && <span className="mono">{turn.time}</span>}
+                        </span>
+                      )}
+                      <div className="max-w-full rounded-[12px_12px_4px_12px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[9px] font-sans text-[13.5px] font-normal leading-[1.55] text-(--text-primary)">
+                        {turn.image && (
+                          <img
+                            src={`data:${turn.image.mimeType};base64,${turn.image.data}`}
+                            alt={turn.image.name}
+                            className={`max-h-[360px] max-w-full rounded-md object-contain ${turn.text ? 'mb-[10px]' : ''}`}
+                          />
                         )}
+                        {turn.text && <MessageText text={turn.text} />}
                       </div>
                     </div>
-                  )
-                })()
-              )
-            )}
-          </div>
-        )}
+                    <ParticipantAvatar
+                      agent={turn.agent}
+                      avatarUrl={turn.avatarUrl}
+                      sp={turn.sp}
+                      isCron={turn.isCron}
+                    />
+                  </div>
+                ) : (
+                  (() => {
+                    // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
+                    // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
+                    const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
+                    const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
+                    // Reasoning steps / tool commands / edited FILES (distinct paths across
+                    // EDIT rows, since one EDIT row can touch several files).
+                    const { thinkCount, toolCount, editCount } = workCounts(workSteps)
+                    const summary = workSummary(thinkCount, toolCount, editCount)
+                    // Auto-open while a turn has produced only work (mid-stream), so the
+                    // live agent isn't hidden; collapse once its answer text lands. Either
+                    // default stays user-overridable, so thinking-only turns can be closed.
+                    const autoOpen = textSteps.length === 0
+                    const openWork = workPanelOpen(workOverride.get(ti), autoOpen)
+                    return (
+                      <div key={ti} className="flex items-start gap-[9px]">
+                        <span className="av h-[26px] w-[26px] flex-none rounded-md">
+                          <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={26} />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-[5px] flex items-center gap-[7px]">
+                            <span className="font-sans text-[13px] font-semibold leading-normal">{turn.agentName}</span>
+                            {turn.time && (
+                              <span className="mono ml-auto shrink-0 whitespace-nowrap text-[11px] text-(--text-tertiary)">
+                                {turn.time}
+                              </span>
+                            )}
+                          </div>
+                          {textSteps.map((st, si) => (
+                            <div key={si} className={si > 0 ? 'mt-2' : ''}>
+                              {st.text && (
+                                <div className="font-sans text-[13.5px] leading-[1.6] whitespace-pre-wrap text-(--text-primary)">
+                                  <MessageText text={st.text} />
+                                </div>
+                              )}
+                              <StepExtras step={st} sessionId={sid} />
+                            </div>
+                          ))}
+                          {workSteps.length > 0 && (
+                            <>
+                              <button
+                                type="button"
+                                onClick={() => toggleWork(ti, autoOpen)}
+                                className="mt-2 inline-flex items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+                                title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
+                              >
+                                <Icon
+                                  name={openWork ? 'chevron-down' : 'chevron-right'}
+                                  size={13}
+                                  color="var(--text-tertiary)"
+                                />
+                                {summary || 'Details'}
+                              </button>
+                              {openWork && (
+                                <div className="mt-2 overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+                                  {workSteps.map((st, si) => (
+                                    <div
+                                      key={si}
+                                      className={`flex items-start gap-[11px] px-[14px] py-[10px] ${
+                                        si > 0 ? 'border-t border-(--border-subtle)' : ''
+                                      }`}
+                                    >
+                                      <div className="flex w-[52px] flex-none items-center gap-[6px] pt-[1px]">
+                                        <span className="dot h-[7px] w-[7px]" style={{ background: st.dot }} />
+                                        <span
+                                          className="mono text-[10px] font-semibold tracking-[.02em]"
+                                          style={{ color: st.laneColor }}
+                                        >
+                                          {st.lane}
+                                        </span>
+                                      </div>
+                                      <div className="min-w-0 flex-1">
+                                        {st.text && (
+                                          <div
+                                            className="font-sans text-[13px] leading-[1.5]"
+                                            style={{ fontWeight: st.weight, color: st.textColor }}
+                                          >
+                                            <MessageText text={st.text} />
+                                          </div>
+                                        )}
+                                        <StepExtras step={st} sessionId={sid} />
+                                      </div>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    )
+                  })()
+                )
+              )}
+            </div>
+          )}
 
-        {/* LIVE INDICATOR — mobile-only trailing bot avatar + blue-dot note while a
+          {/* LIVE INDICATOR — mobile-only trailing bot avatar + blue-dot note while a
             platform run is live. (A live playground/webchat surface uses the
             typing-dots affordance below instead.) */}
-        {session.status === 'online' && !isLive && (
-          <div className="flex items-center gap-[10px] desktop:hidden">
-            <span className="av h-[30px] w-[30px] flex-none rounded-md">
-              <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
-            </span>
-            <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
-              <span className="h-[6px] w-[6px] rounded-full bg-(--blue-500)" />
-              {session.statusLabel || 'Live'}
-            </span>
-          </div>
-        )}
+          {session.status === 'online' && !isLive && (
+            <div className="flex items-center gap-[10px] desktop:hidden">
+              <span className="av h-[30px] w-[30px] flex-none rounded-md">
+                <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
+              </span>
+              <span className="inline-flex items-center gap-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
+                <span className="h-[6px] w-[6px] rounded-full bg-(--blue-500)" />
+                {session.statusLabel || 'Live'}
+              </span>
+            </div>
+          )}
 
-        {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
-        {isLive && (
-          <>
-            {activeOrg && session.agentId && /^[0-9a-f-]{36}$/i.test(session.channel) && (
-              <WebchatMcpApprovalCard orgId={activeOrg.id} agentId={session.agentId} conversationId={session.channel} />
-            )}
-            {pgBusy && (
-              <div className="flex items-center gap-[10px] desktop:mt-[14px] desktop:gap-[11px]">
-                <span className="av h-[30px] w-[30px] flex-none rounded-md">
-                  <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
-                </span>
-                <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
-                  <span className="tdot" />
-                  <span className="tdot [animation-delay:.18s]" />
-                  <span className="tdot [animation-delay:.36s]" />
+          {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
+          {isLive && (
+            <>
+              {activeOrg && session.agentId && /^[0-9a-f-]{36}$/i.test(session.channel) && (
+                <WebchatMcpApprovalCard
+                  orgId={activeOrg.id}
+                  agentId={session.agentId}
+                  conversationId={session.channel}
+                />
+              )}
+              {pgBusy && (
+                <div className="flex items-center gap-[10px] desktop:mt-[14px] desktop:gap-[11px]">
+                  <span className="av h-[30px] w-[30px] flex-none rounded-md">
+                    <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
+                  </span>
+                  <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
+                    <span className="tdot" />
+                    <span className="tdot [animation-delay:.18s]" />
+                    <span className="tdot [animation-delay:.36s]" />
+                  </div>
                 </div>
-              </div>
-            )}
-            {pgEmpty && (
-              <div className="desktop:mt-[6px]">
-                <div className="mb-2 font-mono text-[10.5px] font-semibold uppercase tracking-[.08em] text-(--text-tertiary)">
-                  Start with
+              )}
+              {pgEmpty && (
+                <div className="desktop:mt-[6px]">
+                  <div className="mb-2 font-mono text-[10.5px] font-semibold uppercase tracking-[.08em] text-(--text-tertiary)">
+                    Start with
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {prompts.map((p) => (
+                      <button key={p} className="chip whitespace-nowrap" onClick={() => onPgSend(p)}>
+                        {p}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  {prompts.map((p) => (
-                    <button key={p} className="chip whitespace-nowrap" onClick={() => onPgSend(p)}>
-                      {p}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-            {imageError && (
-              <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
-            )}
-            {/* Flexible spacer (design): pushes the composer to the bottom of the page
+              )}
+              {imageError && (
+                <div className="font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">{imageError}</div>
+              )}
+              {/* Flexible spacer (design): pushes the composer to the bottom of the page
                 when the transcript is short; collapses once content overflows. -mt-4
                 cancels the mobile gutter's gap so a collapsed spacer adds no height. */}
-            <div aria-hidden="true" className="-mt-4 flex-1 desktop:mt-0 desktop:min-h-[18px]" />
-            {/* Sticky-to-bottom composer: pinned to the bottom of the scroll area so it's
+              <div aria-hidden="true" className="-mt-4 flex-1 desktop:mt-0 desktop:min-h-[18px]" />
+              {/* Sticky-to-bottom composer: pinned to the bottom of the scroll area so it's
                 always reachable while scrolling the transcript. Its opaque page-colour
                 background covers earlier turns scrolling behind it; the negative `bottom`
                 + matching bottom padding pull it flush past `.content`'s bottom padding
                 (else turns would show through that strip). A top gradient softens the
                 seam where the transcript slides underneath. */}
-            <div className="sticky z-10 bg-(--surface-app) bottom-[calc(-24px-env(safe-area-inset-bottom,0px))] pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-2 desktop:bottom-[-26px] desktop:pb-[26px] desktop:pt-3">
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
-              />
-              {/* Composer card (design "achero"): textarea on top, a toolbar row below
+              <div className="sticky z-10 bg-(--surface-app) bottom-[calc(-24px-env(safe-area-inset-bottom,0px))] pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-2 desktop:bottom-[-26px] desktop:pb-[26px] desktop:pt-3">
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
+                />
+                {/* Composer card (design "achero"): textarea on top, a toolbar row below
                   the divider — attach · model pill (fast toggle in its menu) · effort ·
                   permission · context ring · send. Tokens/cost live in the header's
                   Details popover, not here. */}
-              <div
-                className="relative min-w-0 rounded-[11px] border border-(--border-default) bg-(--surface-card) shadow-(--shadow-xs) transition-[border-color,box-shadow] focus-within:border-(--brand) focus-within:[box-shadow:0_0_0_3px_var(--brand-ring)]"
-                onKeyDown={(event) => {
-                  if (event.key !== 'Escape') return
-                  setAttachMenuOpen(false)
-                  setComposerMenuOpen(null)
-                }}
-              >
-                <input
-                  ref={imageInputRef}
-                  type="file"
-                  accept="image/*"
-                  hidden
-                  onChange={(event) => void onImageFile(event.target.files?.[0])}
-                />
-                {pgImage && (
-                  <div className="relative mx-[15px] mt-3 w-fit">
-                    <img
-                      src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
-                      alt={pgImage.name}
-                      title={pgImage.name}
-                      className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
-                    />
-                    <button
-                      type="button"
-                      className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
-                      title="Remove image"
-                      aria-label="Remove image"
-                      onClick={() => setPgImage(session.id)}
-                    >
-                      <Icon name="x" size={14} />
-                    </button>
-                  </div>
-                )}
-                <textarea
-                  className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
-                  placeholder={`Message ${session.agentName}…`}
-                  value={pgInput}
-                  onChange={(e) => setPgInput(e.target.value)}
-                  onPaste={(event) => {
-                    const image = clipboardImageFile(event.clipboardData)
-                    if (!image) return
-                    event.preventDefault()
-                    void onImageFile(image)
+                <div
+                  className="relative min-w-0 rounded-[11px] border border-(--border-default) bg-(--surface-card) shadow-(--shadow-xs) transition-[border-color,box-shadow] focus-within:border-(--brand) focus-within:[box-shadow:0_0_0_3px_var(--brand-ring)]"
+                  onKeyDown={(event) => {
+                    if (event.key !== 'Escape') return
+                    setAttachMenuOpen(false)
+                    setComposerMenuOpen(null)
                   }}
-                  onKeyDown={(e) => {
-                    // Enter sends — but NOT while an IME is composing (that Enter
-                    // just confirms the candidate), and Shift+Enter is a newline.
-                    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                      e.preventDefault()
-                      onPgSend()
-                    }
-                  }}
-                />
-                <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
-                  <div className="relative flex-none">
-                    <button
-                      type="button"
-                      className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
-                      aria-label="Attach a file"
-                      aria-haspopup="menu"
-                      aria-expanded={attachMenuOpen}
-                      title="Attach a file"
-                      disabled={imagePreparing}
-                      onClick={() => {
-                        setComposerMenuOpen(null)
-                        setAttachMenuOpen((open) => !open)
-                      }}
-                    >
-                      {imagePreparing ? <Spinner size={14} /> : <Icon name="paperclip" size={15} />}
-                    </button>
-                    {attachMenuOpen && (
-                      <>
-                        <div
-                          aria-hidden="true"
-                          className="fixed inset-0 z-40"
-                          onClick={() => setAttachMenuOpen(false)}
-                        ></div>
-                        <div
-                          role="menu"
-                          className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-                        >
-                          <button
-                            type="button"
-                            role="menuitem"
-                            className="fopt"
-                            onClick={() => {
-                              setAttachMenuOpen(false)
-                              imageInputRef.current?.click()
-                            }}
+                >
+                  <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    hidden
+                    onChange={(event) => void onImageFile(event.target.files?.[0])}
+                  />
+                  {pgImage && (
+                    <div className="relative mx-[15px] mt-3 w-fit">
+                      <img
+                        src={`data:${pgImage.mimeType};base64,${pgImage.data}`}
+                        alt={pgImage.name}
+                        title={pgImage.name}
+                        className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+                      />
+                      <button
+                        type="button"
+                        className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+                        title="Remove image"
+                        aria-label="Remove image"
+                        onClick={() => setPgImage(session.id)}
+                      >
+                        <Icon name="x" size={14} />
+                      </button>
+                    </div>
+                  )}
+                  <textarea
+                    className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+                    placeholder={`Message ${session.agentName}…`}
+                    value={pgInput}
+                    onChange={(e) => setPgInput(e.target.value)}
+                    onPaste={(event) => {
+                      const image = clipboardImageFile(event.clipboardData)
+                      if (!image) return
+                      event.preventDefault()
+                      void onImageFile(image)
+                    }}
+                    onKeyDown={(e) => {
+                      // Enter sends — but NOT while an IME is composing (that Enter
+                      // just confirms the candidate), and Shift+Enter is a newline.
+                      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                        e.preventDefault()
+                        onPgSend()
+                      }
+                    }}
+                  />
+                  <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
+                    <div className="relative flex-none">
+                      <button
+                        type="button"
+                        className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+                        aria-label="Attach a file"
+                        aria-haspopup="menu"
+                        aria-expanded={attachMenuOpen}
+                        title="Attach a file"
+                        disabled={imagePreparing}
+                        onClick={() => {
+                          setComposerMenuOpen(null)
+                          setAttachMenuOpen((open) => !open)
+                        }}
+                      >
+                        {imagePreparing ? <Spinner size={14} /> : <Icon name="paperclip" size={15} />}
+                      </button>
+                      {attachMenuOpen && (
+                        <>
+                          <div
+                            aria-hidden="true"
+                            className="fixed inset-0 z-40"
+                            onClick={() => setAttachMenuOpen(false)}
+                          ></div>
+                          <div
+                            role="menu"
+                            className="absolute bottom-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
                           >
-                            <Icon name="image" size={16} color="var(--text-secondary)" />
-                            Add photos
-                          </button>
-                        </div>
-                      </>
-                    )}
-                  </div>
-                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
-                    {runtimeChangesEnabled && pgModelOptions.length > 0 ? (
-                      <ComposerMenu
-                        title="Model"
-                        value={pgModel}
-                        options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
-                        open={composerMenuOpen === 'model'}
-                        align="left"
-                        triggerClassName={COMPOSER_PILL}
-                        tooltips={false}
-                        leading={
-                          <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
-                            <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
-                          </span>
-                        }
-                        trailing={pgFastModeAvailable && pgFastMode ? <FastBadge /> : undefined}
-                        footer={
-                          pgFastModeAvailable ? (
-                            <div className="flex items-center gap-[10px] px-[7px] pt-2 pb-[3px]">
-                              <button
-                                type="button"
-                                role="switch"
-                                aria-checked={pgFastMode}
-                                aria-label="Fast mode"
-                                title="Fast mode trades depth for latency"
-                                className={`relative h-[15px] w-[26px] flex-none cursor-pointer rounded-full border-0 p-0 transition-colors ${
-                                  pgFastMode ? 'bg-(--brand)' : 'bg-(--border-strong)'
-                                }`}
-                                onClick={() => {
-                                  const fast = !pgFastMode
-                                  setRuntimeSelection({ fast })
-                                  pgSetFast(session.id, session.agentId ?? '', fast, webchatConversationId)
-                                }}
-                              >
-                                <span
-                                  className={`absolute top-[1px] h-[13px] w-[13px] rounded-full bg-white transition-[left] ${
-                                    pgFastMode ? 'left-3' : 'left-[1px]'
-                                  }`}
-                                />
-                              </button>
-                              <span className="flex-1 font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
-                                Fast mode
-                              </span>
-                              <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                                lower latency
-                              </span>
-                            </div>
-                          ) : undefined
-                        }
-                        onOpenChange={(open) => {
-                          setAttachMenuOpen(false)
-                          setComposerMenuOpen(open ? 'model' : null)
-                        }}
-                        onChange={(model) => {
-                          const currentEffort = runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
-                          const effort = sessionEffortAfterModelChange(agentRuntime, owningDaemon, model, currentEffort)
-                          setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
-                          pgSetModel(session.id, session.agentId ?? '', model, webchatConversationId)
-                          if (effort !== currentEffort) {
-                            pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                            <button
+                              type="button"
+                              role="menuitem"
+                              className="fopt"
+                              onClick={() => {
+                                setAttachMenuOpen(false)
+                                imageInputRef.current?.click()
+                              }}
+                            >
+                              <Icon name="image" size={16} color="var(--text-secondary)" />
+                              Add photos
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                      {runtimeChangesEnabled && pgModelOptions.length > 0 ? (
+                        <ComposerMenu
+                          title="Model"
+                          value={pgModel}
+                          options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
+                          open={composerMenuOpen === 'model'}
+                          align="left"
+                          triggerClassName={COMPOSER_PILL}
+                          tooltips={false}
+                          leading={
+                            <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
+                              <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                            </span>
                           }
-                        }}
-                      />
-                    ) : (
-                      pgModel && (
-                        <span className={COMPOSER_PILL_STATIC} title="Model">
-                          <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
-                            <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                          trailing={pgFastModeAvailable && pgFastMode ? <FastBadge /> : undefined}
+                          footer={
+                            pgFastModeAvailable ? (
+                              <div className="flex items-center gap-[10px] px-[7px] pt-2 pb-[3px]">
+                                <button
+                                  type="button"
+                                  role="switch"
+                                  aria-checked={pgFastMode}
+                                  aria-label="Fast mode"
+                                  title="Fast mode trades depth for latency"
+                                  className={`relative h-[15px] w-[26px] flex-none cursor-pointer rounded-full border-0 p-0 transition-colors ${
+                                    pgFastMode ? 'bg-(--brand)' : 'bg-(--border-strong)'
+                                  }`}
+                                  onClick={() => {
+                                    const fast = !pgFastMode
+                                    setRuntimeSelection({ fast })
+                                    pgSetFast(session.id, session.agentId ?? '', fast, webchatConversationId)
+                                  }}
+                                >
+                                  <span
+                                    className={`absolute top-[1px] h-[13px] w-[13px] rounded-full bg-white transition-[left] ${
+                                      pgFastMode ? 'left-3' : 'left-[1px]'
+                                    }`}
+                                  />
+                                </button>
+                                <span className="flex-1 font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
+                                  Fast mode
+                                </span>
+                                <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                                  lower latency
+                                </span>
+                              </div>
+                            ) : undefined
+                          }
+                          onOpenChange={(open) => {
+                            setAttachMenuOpen(false)
+                            setComposerMenuOpen(open ? 'model' : null)
+                          }}
+                          onChange={(model) => {
+                            const currentEffort = runtimeSelection?.effort ?? session.effort ?? owner?.reasoning ?? ''
+                            const effort = sessionEffortAfterModelChange(
+                              agentRuntime,
+                              owningDaemon,
+                              model,
+                              currentEffort
+                            )
+                            setRuntimeSelection(effort === currentEffort ? { model } : { model, effort })
+                            pgSetModel(session.id, session.agentId ?? '', model, webchatConversationId)
+                            if (effort !== currentEffort) {
+                              pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                            }
+                          }}
+                        />
+                      ) : (
+                        pgModel && (
+                          <span className={COMPOSER_PILL_STATIC} title="Model">
+                            <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
+                              <ModelMark model={pgModel} fallbackRuntime={agentRuntime} />
+                            </span>
+                            {modelLabel(pgModel)}
+                            {pgFastModeAvailable && pgFastMode && <FastBadge />}
                           </span>
-                          {modelLabel(pgModel)}
-                          {pgFastModeAvailable && pgFastMode && <FastBadge />}
-                        </span>
-                      )
-                    )}
-                    {runtimeChangesEnabled && pgEffortOptions.length > 0 ? (
-                      <ComposerMenu
-                        title="Effort"
-                        value={pgEffort}
-                        options={pgEffortOptions.map((effort) => ({
-                          value: effort.value,
-                          label: effort.label,
-                          description: effort.description
-                        }))}
-                        open={composerMenuOpen === 'effort'}
-                        align="left"
-                        triggerClassName={COMPOSER_CHIP}
-                        tooltips={false}
-                        onOpenChange={(open) => {
-                          setAttachMenuOpen(false)
-                          setComposerMenuOpen(open ? 'effort' : null)
-                        }}
-                        onChange={(effort) => {
-                          setRuntimeSelection({ effort })
-                          pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
-                        }}
-                      />
-                    ) : (
-                      pgEffort && (
-                        <span className={COMPOSER_CHIP_STATIC} title="Effort">
-                          {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ??
-                            effortLabel(agentRuntime, pgEffort)}
-                        </span>
-                      )
-                    )}
-                    {runtimeChangesEnabled && pgPermissionModes.length > 0 ? (
-                      <ComposerMenu
-                        title="Permission"
-                        value={pgPermissionMode}
-                        options={pgPermissionModes.map((mode) => ({
-                          value: mode.v,
-                          label: mode.l,
-                          description: mode.description
-                        }))}
-                        open={composerMenuOpen === 'permission'}
-                        align="left"
-                        triggerClassName={COMPOSER_CHIP}
-                        onOpenChange={(open) => {
-                          setAttachMenuOpen(false)
-                          setComposerMenuOpen(open ? 'permission' : null)
-                        }}
-                        onChange={(permissionMode) => {
-                          setRuntimeSelection({ permissionMode })
-                          pgSetPermissionMode(session.id, session.agentId ?? '', permissionMode, webchatConversationId)
-                        }}
-                      />
-                    ) : (
-                      pgPermissionMode && (
-                        <span className={COMPOSER_CHIP_STATIC} title="Permission">
-                          {agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionMode)}
-                        </span>
-                      )
-                    )}
+                        )
+                      )}
+                      {runtimeChangesEnabled && pgEffortOptions.length > 0 ? (
+                        <ComposerMenu
+                          title="Effort"
+                          value={pgEffort}
+                          options={pgEffortOptions.map((effort) => ({
+                            value: effort.value,
+                            label: effort.label,
+                            description: effort.description
+                          }))}
+                          open={composerMenuOpen === 'effort'}
+                          align="left"
+                          triggerClassName={COMPOSER_CHIP}
+                          tooltips={false}
+                          onOpenChange={(open) => {
+                            setAttachMenuOpen(false)
+                            setComposerMenuOpen(open ? 'effort' : null)
+                          }}
+                          onChange={(effort) => {
+                            setRuntimeSelection({ effort })
+                            pgSetEffort(session.id, session.agentId ?? '', effort, webchatConversationId)
+                          }}
+                        />
+                      ) : (
+                        pgEffort && (
+                          <span className={COMPOSER_CHIP_STATIC} title="Effort">
+                            {pgEffortChoices.find((choice) => choice.value === pgEffort)?.label ??
+                              effortLabel(agentRuntime, pgEffort)}
+                          </span>
+                        )
+                      )}
+                      {runtimeChangesEnabled && pgPermissionModes.length > 0 ? (
+                        <ComposerMenu
+                          title="Permission"
+                          value={pgPermissionMode}
+                          options={pgPermissionModes.map((mode) => ({
+                            value: mode.v,
+                            label: mode.l,
+                            description: mode.description
+                          }))}
+                          open={composerMenuOpen === 'permission'}
+                          align="left"
+                          triggerClassName={COMPOSER_CHIP}
+                          onOpenChange={(open) => {
+                            setAttachMenuOpen(false)
+                            setComposerMenuOpen(open ? 'permission' : null)
+                          }}
+                          onChange={(permissionMode) => {
+                            setRuntimeSelection({ permissionMode })
+                            pgSetPermissionMode(
+                              session.id,
+                              session.agentId ?? '',
+                              permissionMode,
+                              webchatConversationId
+                            )
+                          }}
+                        />
+                      ) : (
+                        pgPermissionMode && (
+                          <span className={COMPOSER_CHIP_STATIC} title="Permission">
+                            {agentPermissionDisplay(owningDaemon, agentRuntime, pgPermissionMode)}
+                          </span>
+                        )
+                      )}
+                    </div>
+                    <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
+                    <button
+                      className="sendbtn ml-1 h-[26px] w-[26px] flex-none rounded-[7px]"
+                      aria-label={pgBusy ? 'Stop response' : 'Send message'}
+                      onClick={() =>
+                        pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
+                      }
+                      disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
+                    >
+                      <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
+                    </button>
                   </div>
-                  <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
-                  <button
-                    className="sendbtn ml-1 h-[26px] w-[26px] flex-none rounded-[7px]"
-                    aria-label={pgBusy ? 'Stop response' : 'Send message'}
-                    onClick={() =>
-                      pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
-                    }
-                    disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
-                  >
-                    <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
-                  </button>
                 </div>
               </div>
-            </div>
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -461,11 +461,8 @@ export default function SessionsView() {
   // bottom sheet rendered at the end of the tree.
   return (
     <div className="wrap max-desktop:pb-24">
-      <div className="mb-4 hidden min-h-[34px] items-center gap-4 desktop:flex">
-        <div className="flex-1">
-          <p className="psub mt-0">Every agent run across your workspace. Open one to replay the full conversation.</p>
-        </div>
-      </div>
+      {/* No description row (design v2): the filter bar states what this page is
+          better than a sentence does, and the list starts at the top of the page. */}
       {/* Desktop filter bar — four custom dropdowns, each showing the selected face. */}
       <div className="mb-4 hidden flex-wrap items-center gap-[10px] desktop:flex">
         <span className="eyebrow mr-[2px]">Filter</span>

--- a/packages/web/src/lib/crumb.ts
+++ b/packages/web/src/lib/crumb.ts
@@ -1,5 +1,7 @@
-// Detail-crumb resolution for the console shell's top bar (and the mobile push-screen
-// app bar, which reuses the same title).
+// Detail-title resolution for the mobile push-screen app bar. (Desktop v2 has no top
+// bar at all, so the badge this returns is currently unused there — the session page
+// renders its own title + status row. The badge stays because the resolution rule is
+// the same one a title strip would need, and dropping it would lose the id guard.)
 //
 // The shell derives a push title by looking the route id up in the console data lists.
 // Those lists hold only what has actually been fetched — `allSessions` is the loaded

--- a/packages/web/src/lib/session-age.test.ts
+++ b/packages/web/src/lib/session-age.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { groupSessionsByAge, sessionAgeBucket } from './session-age'
+
+// A fixed "now" so the calendar-day boundaries are assertable. Mid-afternoon, so
+// "two hours ago" and "today" are not the same thing by accident.
+const NOW = new Date('2026-08-02T15:00:00')
+const at = (iso: string) => ({ lastActivityAt: iso })
+
+describe('sessionAgeBucket', () => {
+  it('buckets by calendar day, not elapsed hours', () => {
+    // 16 hours old, but a different calendar day — people read this as yesterday.
+    expect(sessionAgeBucket('2026-08-01T23:00:00', NOW)).toBe('yesterday')
+    // 15 hours old and the same day.
+    expect(sessionAgeBucket('2026-08-02T00:00:00', NOW)).toBe('today')
+  })
+
+  it('places each boundary on the near side', () => {
+    expect(sessionAgeBucket('2026-08-02T15:00:00', NOW)).toBe('today')
+    expect(sessionAgeBucket('2026-08-01T00:01:00', NOW)).toBe('yesterday')
+    expect(sessionAgeBucket('2026-07-31T12:00:00', NOW)).toBe('week') // 2 days
+    expect(sessionAgeBucket('2026-07-26T12:00:00', NOW)).toBe('week') // 7 days
+    expect(sessionAgeBucket('2026-07-25T12:00:00', NOW)).toBe('month') // 8 days
+    expect(sessionAgeBucket('2026-07-03T12:00:00', NOW)).toBe('month') // 30 days
+    expect(sessionAgeBucket('2026-07-02T12:00:00', NOW)).toBe('older') // 31 days
+  })
+
+  it('reads a future timestamp as today rather than hiding it', () => {
+    // Daemon/browser clock skew must not file a fresh run under "Older".
+    expect(sessionAgeBucket('2026-08-03T09:00:00', NOW)).toBe('today')
+  })
+
+  it('sorts an unusable timestamp to older instead of throwing', () => {
+    expect(sessionAgeBucket(null, NOW)).toBe('older')
+    expect(sessionAgeBucket(undefined, NOW)).toBe('older')
+    expect(sessionAgeBucket('not a date', NOW)).toBe('older')
+  })
+})
+
+describe('groupSessionsByAge', () => {
+  it('emits groups oldest-last and drops empty buckets', () => {
+    const groups = groupSessionsByAge(
+      [at('2026-08-02T09:00:00'), at('2026-07-20T09:00:00'), at('2026-08-01T09:00:00')],
+      NOW
+    )
+    expect(groups.map((g) => g.bucket)).toEqual(['today', 'yesterday', 'month'])
+    expect(groups.map((g) => g.label)).toEqual(['Today', 'Yesterday', 'Previous 30 days'])
+  })
+
+  it('preserves the caller order inside a group', () => {
+    const first = at('2026-08-02T14:00:00')
+    const second = at('2026-08-02T08:00:00')
+    const groups = groupSessionsByAge([first, second], NOW)
+    expect(groups[0]?.rows).toEqual([first, second])
+  })
+
+  it('returns nothing for an empty list', () => {
+    expect(groupSessionsByAge([], NOW)).toEqual([])
+  })
+})

--- a/packages/web/src/lib/session-age.ts
+++ b/packages/web/src/lib/session-age.ts
@@ -1,0 +1,74 @@
+// Age buckets for the session rail's grouped list.
+//
+// The rail dropped its per-row timestamp — at 224px a title and a time fight over
+// the same line, and the title is what you are scanning for. Recency still has to
+// be legible, so it moves up a level: rows group under "Today" / "Yesterday" / …
+// headings, and the exact time lives in the row's hover tooltip.
+//
+// Bucketing is by CALENDAR DAY, not elapsed hours: a run from 11pm last night is
+// "Yesterday" at 1am even though it is two hours old, because that is how people
+// read their own history. `now` is injected so the boundaries are testable.
+
+export type SessionAgeBucket = 'today' | 'yesterday' | 'week' | 'month' | 'older'
+
+export const SESSION_AGE_LABELS: Record<SessionAgeBucket, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  week: 'Previous 7 days',
+  month: 'Previous 30 days',
+  older: 'Older'
+}
+
+/** Bucket order, oldest last — the rail renders groups in this sequence. */
+const BUCKET_ORDER: SessionAgeBucket[] = ['today', 'yesterday', 'week', 'month', 'older']
+
+const startOfDay = (d: Date): number => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+
+/**
+ * Which bucket a timestamp falls in, relative to `now`.
+ *
+ * A missing or unparseable timestamp sorts to `older` rather than throwing — the
+ * rail must still render a row whose activity time the daemon never reported. A
+ * FUTURE timestamp (clock skew between the daemon and this browser) reads as
+ * `today`, which is the least surprising place to find it.
+ */
+export function sessionAgeBucket(iso: string | null | undefined, now: Date): SessionAgeBucket {
+  if (!iso) return 'older'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return 'older'
+  const days = Math.round((startOfDay(now) - startOfDay(d)) / 86_400_000)
+  if (days <= 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days <= 7) return 'week'
+  if (days <= 30) return 'month'
+  return 'older'
+}
+
+export interface SessionAgeGroup<T> {
+  bucket: SessionAgeBucket
+  label: string
+  rows: T[]
+}
+
+/**
+ * Split rows into age groups, dropping empty ones. Within a group the caller's
+ * order is preserved (the CP already returns its page newest-first), so this only
+ * decides where the headings land.
+ */
+export function groupSessionsByAge<T extends { lastActivityAt?: string | null }>(
+  rows: T[],
+  now: Date
+): SessionAgeGroup<T>[] {
+  const byBucket = new Map<SessionAgeBucket, T[]>()
+  for (const row of rows) {
+    const bucket = sessionAgeBucket(row.lastActivityAt, now)
+    const bin = byBucket.get(bucket)
+    if (bin) bin.push(row)
+    else byBucket.set(bucket, [row])
+  }
+  return BUCKET_ORDER.filter((b) => byBucket.has(b)).map((bucket) => ({
+    bucket,
+    label: SESSION_AGE_LABELS[bucket],
+    rows: byBucket.get(bucket) as T[]
+  }))
+}

--- a/packages/web/src/lib/session-pins.test.ts
+++ b/packages/web/src/lib/session-pins.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  partitionPinned,
+  pinnedIdsForAgent,
+  readSessionPins,
+  SESSION_PINS_KEY,
+  SESSION_PINS_MAX,
+  toggleSessionPin,
+  writeSessionPins,
+  type SessionPin
+} from '@/lib/session-pins'
+
+// The suite runs in the `node` environment, so `window` is genuinely absent until
+// stubbed — which also exercises the SSR branch of the storage helpers.
+function stubStorage(initial?: string) {
+  const store = new Map<string, string>()
+  if (initial !== undefined) store.set(SESSION_PINS_KEY, initial)
+  const localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v)
+  }
+  vi.stubGlobal('window', { localStorage })
+  return store
+}
+
+const pin = (id: string, agentId = 'a1'): SessionPin => ({ id, agentId })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('readSessionPins', () => {
+  it('returns [] without a window (SSR)', () => {
+    expect(readSessionPins()).toEqual([])
+  })
+
+  it('reads stored pins in order', () => {
+    stubStorage(JSON.stringify([pin('b'), pin('a', 'a2')]))
+    expect(readSessionPins()).toEqual([pin('b'), pin('a', 'a2')])
+  })
+
+  it('returns [] for an unset key, malformed JSON, or a non-array', () => {
+    stubStorage()
+    expect(readSessionPins()).toEqual([])
+    stubStorage('{oops')
+    expect(readSessionPins()).toEqual([])
+    stubStorage(JSON.stringify({ a: true }))
+    expect(readSessionPins()).toEqual([])
+  })
+
+  it('migrates the legacy flat string[] shape to unattributed pins', () => {
+    stubStorage(JSON.stringify(['s1', 's2']))
+    expect(readSessionPins()).toEqual([
+      { id: 's1', agentId: '' },
+      { id: 's2', agentId: '' }
+    ])
+  })
+
+  it('drops unusable entries, defaults a missing agentId, and de-duplicates by id', () => {
+    stubStorage(JSON.stringify([pin('a'), 3, null, '', { id: 'b' }, { agentId: 'a1' }, pin('a', 'a9')]))
+    expect(readSessionPins()).toEqual([pin('a'), { id: 'b', agentId: '' }])
+  })
+
+  it('survives storage that throws (private mode)', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem() {
+          throw new Error('blocked')
+        },
+        setItem() {
+          throw new Error('blocked')
+        }
+      }
+    })
+    expect(readSessionPins()).toEqual([])
+    expect(() => writeSessionPins([pin('a')])).not.toThrow()
+  })
+})
+
+describe('writeSessionPins', () => {
+  it('persists de-duplicated pins capped at SESSION_PINS_MAX', () => {
+    const store = stubStorage()
+    const pins = Array.from({ length: SESSION_PINS_MAX + 5 }, (_, i) => pin(`s${i}`))
+    writeSessionPins([...pins, pin('s0')])
+    const written = JSON.parse(store.get(SESSION_PINS_KEY) ?? '[]') as SessionPin[]
+    expect(written).toHaveLength(SESSION_PINS_MAX)
+    // Forgetting is by RECENCY: the oldest pins fall off the END.
+    expect(written[0]).toEqual(pin('s0'))
+    expect(written.map((p) => p.id)).not.toContain(`s${SESSION_PINS_MAX}`)
+  })
+
+  it('is a no-op without a window', () => {
+    expect(() => writeSessionPins([pin('a')])).not.toThrow()
+  })
+})
+
+describe('toggleSessionPin', () => {
+  it('pins to the front with its owning agent, and unpins in place', () => {
+    expect(toggleSessionPin([pin('a')], 'b', 'a1')).toEqual([pin('b'), pin('a')])
+    expect(toggleSessionPin([pin('b'), pin('a')], 'b', 'a1')).toEqual([pin('a')])
+    expect(toggleSessionPin([], 'a', 'a7')).toEqual([pin('a', 'a7')])
+  })
+
+  it('unpins by id regardless of the agent passed', () => {
+    expect(toggleSessionPin([pin('a', 'a2')], 'a', 'a1')).toEqual([])
+  })
+
+  it('does not mutate the input', () => {
+    const pins = [pin('a')]
+    toggleSessionPin(pins, 'b', 'a1')
+    expect(pins).toEqual([pin('a')])
+  })
+})
+
+describe('pinnedIdsForAgent', () => {
+  // The regression this locks: the stored list is GLOBAL across agents, so a rail
+  // must never treat another agent's pins as its own — an earlier version pruned
+  // against one agent's loaded page and deleted every other agent's pin.
+  it('claims only the given agent, newest pin first', () => {
+    const pins = [pin('x', 'a2'), pin('y', 'a1'), pin('z', 'a1')]
+    expect(pinnedIdsForAgent(pins, 'a1')).toEqual(['y', 'z'])
+    expect(pinnedIdsForAgent(pins, 'a2')).toEqual(['x'])
+    expect(pinnedIdsForAgent(pins, 'a3')).toEqual([])
+  })
+
+  it('never claims unattributed (legacy) pins — they would be fetched on every rail', () => {
+    expect(pinnedIdsForAgent([{ id: 'old', agentId: '' }], 'a1')).toEqual([])
+  })
+
+  it('claims nothing for an unknown agent', () => {
+    expect(pinnedIdsForAgent([pin('a')], '')).toEqual([])
+  })
+})
+
+describe('partitionPinned', () => {
+  const rows = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+  it('lifts pinned rows in PIN order and keeps the rest in input order', () => {
+    expect(partitionPinned(rows, [pin('c'), pin('a')])).toEqual({
+      pinned: [{ id: 'c' }, { id: 'a' }],
+      rest: [{ id: 'b' }]
+    })
+  })
+
+  it('ignores pinned ids that are not in the list', () => {
+    expect(partitionPinned(rows, [pin('zz'), pin('b')])).toEqual({
+      pinned: [{ id: 'b' }],
+      rest: [{ id: 'a' }, { id: 'c' }]
+    })
+  })
+
+  it('groups an unattributed pin that IS on the page', () => {
+    expect(partitionPinned(rows, [{ id: 'b', agentId: '' }])).toEqual({
+      pinned: [{ id: 'b' }],
+      rest: [{ id: 'a' }, { id: 'c' }]
+    })
+  })
+
+  it('is a pass-through with no pins', () => {
+    expect(partitionPinned(rows, [])).toEqual({ pinned: [], rest: rows })
+  })
+})

--- a/packages/web/src/lib/session-pins.ts
+++ b/packages/web/src/lib/session-pins.ts
@@ -1,0 +1,120 @@
+// Pinned sessions — the session rail floats them above the rest so a run you keep
+// coming back to stays one click away.
+//
+// A pin is a per-DEVICE console preference, stored in localStorage next to
+// `ac-theme` and `ac.rail-collapsed` — deliberately NOT control-plane state:
+//   - the CP holds orchestration metadata, not per-user UI preference rows, and a
+//     pin buys nothing on the message path;
+//   - with `OIDC_ISSUER` unset the CP's devAuth stub admits everyone as ONE
+//     identity, so a server-side pin would be shared by every user of that
+//     deployment — visibly wrong, and the no-auth default;
+//   - the rail is desktop-only (mobile navigates sessions through the app bar),
+//     so there is no cross-device pin to sync in the first place.
+// If cross-device pins are ever wanted, this module is the whole seam: swap the
+// reads/writes for a CP-backed hook and the rail is unchanged.
+//
+// The list is GLOBAL across agents, so each entry records its owning agent. That
+// is what lets the rail tell "this pin belongs to another agent" apart from "this
+// pin is gone", and what lets it fetch the handful of pinned rows that are not on
+// the loaded page (see SESSION_PIN_HYDRATE_MAX).
+//
+// Forgetting is by RECENCY ONLY: `writeSessionPins` keeps the newest
+// SESSION_PINS_MAX entries and drops the tail. Nothing here ever infers that a
+// session was deleted — a pin absent from a loaded page is unknown, not stale, and
+// the console has no cheap proof of deletion (the detail endpoint answers 404 for
+// unauthorized as well as missing). Growth is bounded by the cap instead.
+
+/** One pinned session and the agent whose rail it belongs to. */
+export interface SessionPin {
+  id: string
+  /** Owning agent id; '' for entries written before the agent was recorded. */
+  agentId: string
+}
+
+/** localStorage key holding the pinned sessions, newest pin first. */
+export const SESSION_PINS_KEY = 'ac.pinned-sessions'
+
+/** Hard cap on stored pins. Older pins fall off the end rather than accumulating
+ *  forever in a browser that never revisits the sessions they belong to. */
+export const SESSION_PINS_MAX = 200
+
+/** How many of one agent's pinned rows the rail will fetch individually when they
+ *  are not on the loaded page. A rail holds a handful of pins in practice; the cap
+ *  only stops a pathological list from fanning out into hundreds of requests.
+ *  Pins beyond it still persist — they render once they are on the loaded page. */
+export const SESSION_PIN_HYDRATE_MAX = 12
+
+/** The stored pins, newest first. `[]` on SSR, malformed JSON, or blocked storage.
+ *  Accepts the legacy flat `string[]` shape, attributing those to no agent. */
+export function readSessionPins(): SessionPin[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(SESSION_PINS_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    // Tolerate anything a past version (or another tab) wrote: keep what parses as
+    // a pin, drop the rest, and de-duplicate so a corrupted list renders once.
+    return dedupe(parsed.map(asPin).filter((pin): pin is SessionPin => pin !== null))
+  } catch {
+    return []
+  }
+}
+
+/** Persist `pins` (newest first, capped). Silently no-ops when storage is blocked. */
+export function writeSessionPins(pins: SessionPin[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(SESSION_PINS_KEY, JSON.stringify(dedupe(pins).slice(0, SESSION_PINS_MAX)))
+  } catch {
+    /* private mode / storage disabled — the pin still applies for this page view */
+  }
+}
+
+/** `pins` with `sessionId` pinned (newest first) or unpinned. Pure — persist via
+ *  `writeSessionPins`, so the caller can update React state from the same value. */
+export function toggleSessionPin(pins: SessionPin[], sessionId: string, agentId: string): SessionPin[] {
+  return pins.some((p) => p.id === sessionId)
+    ? pins.filter((p) => p.id !== sessionId)
+    : [{ id: sessionId, agentId }, ...pins]
+}
+
+/** Ids pinned on `agentId`'s rail, newest pin first. Only exact matches — an entry
+ *  with no recorded agent is not claimed here (it would otherwise be fetched on
+ *  every agent's rail); `partitionPinned` still lifts it once it is on the page. */
+export function pinnedIdsForAgent(pins: SessionPin[], agentId: string): string[] {
+  return agentId ? pins.filter((p) => p.agentId === agentId).map((p) => p.id) : []
+}
+
+/** Split `sessions` into the pinned ones (in pin order, newest pin first) and the
+ *  rest (input order preserved). Matches on id alone, so a pin whose agent was
+ *  never recorded still groups correctly on the rail it appears in. */
+export function partitionPinned<T extends { id: string }>(
+  sessions: T[],
+  pins: SessionPin[]
+): { pinned: T[]; rest: T[] } {
+  const byId = new Map(sessions.map((s) => [s.id, s]))
+  const pinned: T[] = []
+  const seen = new Set<string>()
+  for (const { id } of pins) {
+    const hit = byId.get(id)
+    if (hit && !seen.has(id)) {
+      pinned.push(hit)
+      seen.add(id)
+    }
+  }
+  return { pinned, rest: sessions.filter((s) => !seen.has(s.id)) }
+}
+
+function asPin(entry: unknown): SessionPin | null {
+  if (typeof entry === 'string') return entry ? { id: entry, agentId: '' } : null
+  if (!entry || typeof entry !== 'object') return null
+  const { id, agentId } = entry as { id?: unknown; agentId?: unknown }
+  if (typeof id !== 'string' || !id) return null
+  return { id, agentId: typeof agentId === 'string' ? agentId : '' }
+}
+
+function dedupe(pins: SessionPin[]): SessionPin[] {
+  const seen = new Set<string>()
+  return pins.filter((p) => (seen.has(p.id) ? false : (seen.add(p.id), true)))
+}


### PR DESCRIPTION
Syncs the console to the **AgentConnect Console v2** design, which drops the top bar entirely. The rail carries the brand, search, navigation and the account block; the main column is content only.

## What changed

**No top bar.** Breadcrumbs are gone, along with the parent back-link and the status badge nested in it. `detailCrumb` stays — the mobile app bar still titles push screens from it, and it keeps the route-id guard that stops session A's title painting on session B for a commit. Mobile chrome (`.mtop`, bottom nav) is untouched.

**Search moves into the rail.** It sits at the rail's outer edge, permanently visible — with no top bar it's the only way in — with the hover-reveal collapse toggle to its left. Opening it floats the existing box and results panel into one centred 600px command dialog. Same component, same keyboard model (⌘K / ↑↓ / ↵ / esc), re-seated by CSS (`.railsr`) rather than forked into a second component, so the two presentations can't drift.

**Collapsed rail.** The brand-row search button gives way to a nav row directly above Home, and both rules — below the brand, above the footer — disappear: at 64px the rail is one uninterrupted column of glyphs. Collapse behaviour and persistence are otherwise unchanged.

**Rail footer is now the account block** — avatar, name, active org. Its menu absorbs the org switcher that used to sit at the *top* of the rail, the top-bar avatar menu (Profile / Settings / Sign out), and the top-bar theme toggle. No-auth mode has no identity and one implicit org, so it keeps a bare theme toggle beside Help instead — that mode would otherwise lose theme switching along with the top bar.

**Session detail** gains a left rail listing the current agent's sessions, and — since the crumb no longer names the page — its own title + status row. It renders only when the agent has ≥2 sessions and only on desktop.

**Sessions list** drops its description line; the filter bar says what the page is.

## Session rail details

Rows are a platform mark plus the title and nothing else — at 224px a per-row timestamp crowds out the thing you're scanning for. Recency moves up to `Today` / `Yesterday` / `Previous 7 days` / … headings, and the exact time plus the channel move into the hover tooltip.

Bucketing is by **calendar day, not elapsed hours** (`lib/session-age.ts`): a run from 11pm last night reads as "Yesterday" at 1am even though it's two hours old. `now` is injected so the boundaries are testable; a future timestamp (daemon/browser clock skew) reads as `today` rather than being buried in `Older`.

Pins live in `localStorage`, not the CP. In no-auth mode — the default OSS shape — devAuth resolves everyone to one identity, so a CP-side pin would be shared across the whole deployment; the rail is desktop-only besides, so cross-device sync buys little. `lib/session-pins.ts` is the entire seam if that changes.

The rail's data source is the **agent-filtered** session page, not org-wide `allSessions`: a busy org's newest 50 may not contain this agent at all, which would hide the rail precisely on an agent with plenty of runs. Off-page pinned rows are hydrated by id (bounded), and a row that 404s is left pinned — "missing or not authorized" isn't proof of deletion.

## Two deliberate departures from the mock

- **Collapsed collapse-toggle** keeps the existing opacity/inset treatment rather than the design's `display:none`-until-hover. The latter is unreachable by keyboard, so a keyboard-only user could never re-expand the rail.
- **`.railbrand` gets 20px of left padding** so the logo shares the 32px centre line with the nav glyphs and the footer avatar. The mock leaves the logo 2px light, which shows up as a sideways jump on every collapse.

Nav rows also pick up the design's inset-pill treatment (no full-bleed tile, no 3px brand edge), keeping the existing 14px/18px type and icon sizes.

One thing worth a reviewer's eye: `.navitem.on svg` is what tints the active glyph. The `Icon` primitive renders a lucide `<svg>`, not the design's `<i>`, and an inline `color` prop at the call site outranks the rule — which is why the call site passes none.

## Verification

`typecheck` · `eslint` · `prettier` · **555 web tests** (76 files) all green — 16 new for `session-pins`, 7 for `session-age`.

Exercised in a browser against a live CP with seeded data: light + dark, expanded + collapsed (glyph centre lines measured identical at x=32 in both states), the search dialog, the account menu, session-rail grouping, pin persistence across reload, and the hover tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
