### PR TITLE
feat(agents): add force daemon reassignment

### DIFF
--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -802,6 +802,16 @@ const AgentActivate = z.object({
 
 The CP first receives an acknowledged source detach, releases the source session assignments, then compare-and-sets `Agent.daemonId`. It stages the target with `agent/detach` (an absent agent is valid), followed by one acknowledged authoritative `agent/activate` bundle. Both requests use the same fresh `moveId`; a daemon persists that fence and rejects a late activate from a superseded move. Activation exact-converges CP integrations and CP crons, validates capacity/runtime/model/MCP support, warms the ACP host, and only then opens the dispatch gate.
 
+An explicit emergency reassign is available only while the source is not READY. It
+still attempts `agent/detach`, but an unavailable or negative source response is logged
+and does not block the placement CAS. Session affinities are released before the CAS,
+and every target-side readiness, capacity, compatibility, staging, activation, and
+rollback fence above remains unchanged. The operator must separately confirm that the
+source machine is permanently stopped: while it is disconnected, the CP cannot fence a
+direct platform connection or erase its credential copies. If it reconnects after the
+CAS, the authoritative placement snapshot gives it an ownership-aware `drop.agents`
+detach for the stale local copy.
+
 If target activation fails, the CP must positively detach the target before rolling placement back and reactivating the source; without that ACK it fails closed on the target to avoid split brain. A same-target API retry replays the authoritative bundle as a repair operation. Daemons advertise this lifecycle with the `agent-move-v1` feature; single-agent mode does not advertise it.
 
 The workspace action reuses the same fence on the current daemon. Before detach, the daemon initializes a missing mode/repo/branch materialization marker without overwriting an existing one; the persisted spec may already be the target after a crash while the checkout still belongs to the recorded source. Activation with `reconcileWorkspace` preserves the current checkout when those fields are unchanged, so access and `agentDir` edits do not discard files. When mode, repository, or branch changes, a GitHub target is cloned and its `agentDir` validated in a sibling staging directory before the old workspace is removed; a scratch target is recreated empty. The ACP host starts only after reconciliation so its runtime and sandbox bind the new directory. A known activation NACK restores the DB definition and a valid empty base for the prior workspace, but intentionally cannot restore local files discarded by an acknowledged replacement; this is why the UI requires an irreversible warning. Clone/auth failure occurs before replacement and leaves the old workspace intact. An unknown response is never rolled back blindly, and the durable materialization marker makes a same-target retry preserve work created after a successful but unacknowledged activation. Memory, sessions, integrations, and other agent configuration are preserved. Supporting daemons advertise `workspace-edit-v2` and accept the workspace guard fields shown above.

--- a/docs/designs/daemon-cp-ws-protocol.md
+++ b/docs/designs/daemon-cp-ws-protocol.md
@@ -802,7 +802,7 @@ const AgentActivate = z.object({
 
 The CP first receives an acknowledged source detach, releases the source session assignments, then compare-and-sets `Agent.daemonId`. It stages the target with `agent/detach` (an absent agent is valid), followed by one acknowledged authoritative `agent/activate` bundle. Both requests use the same fresh `moveId`; a daemon persists that fence and rejects a late activate from a superseded move. Activation exact-converges CP integrations and CP crons, validates capacity/runtime/model/MCP support, warms the ACP host, and only then opens the dispatch gate.
 
-An explicit emergency reassign is available only while the source is not READY. It
+An explicit force reassign is available only while the source is not READY. It
 still attempts `agent/detach`, but an unavailable or negative source response is logged
 and does not block the placement CAS. Session affinities are released before the CAS,
 and every target-side readiness, capacity, compatibility, staging, activation, and

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -33,6 +33,27 @@ an operator explicitly paused remains `paused`. Once the operation succeeds, fai
 expires, the console returns to the daemon's current connection status; a daemon that
 did not return then reads `offline`.
 
+## Moving an agent from an unavailable daemon
+
+A normal agent move is the safe default: the current daemon must confirm that it has
+stopped the existing copy before another daemon activates it. When the current daemon
+is offline, the agent Configuration page and placement editor must say that safe move
+is unavailable and name the daemon the operator needs to bring online. The target
+picker must not lead to a request that can only fail without explaining this first.
+
+An emergency reassign is disaster recovery, not another ordinary move mode. Offer it
+only after the operator chooses an online, compatible target while the current daemon
+is offline. It bypasses only confirmation from the source; target readiness, capacity,
+runtime, model, MCP, and managed-skill compatibility remain mandatory. Before enabling
+the destructive action, require the operator to confirm that the source machine is
+permanently stopped and cannot reconnect, and warn that two copies may process messages
+if that assertion is wrong.
+
+Both paths preserve the Agent identity and its centrally managed settings. Neither
+copies daemon-local workspace, memory, transcripts, or attachments. A source that later
+reconnects after an emergency reassign is told to detach the stale local copy during
+placement reconciliation.
+
 ## Where a streamed reply may be split
 
 A long reply may be delivered as more than one chat message, but a split must always fall

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -41,7 +41,7 @@ is offline, the agent Configuration page and placement editor must say that safe
 is unavailable and name the daemon the operator needs to bring online. The target
 picker must not lead to a request that can only fail without explaining this first.
 
-An emergency reassign is disaster recovery, not another ordinary move mode. Offer it
+A force reassign is disaster recovery, not another ordinary move mode. Offer it
 only after the operator chooses an online, compatible target while the current daemon
 is offline. It bypasses only confirmation from the source; target readiness, capacity,
 runtime, model, MCP, and managed-skill compatibility remain mandatory. Before enabling
@@ -51,7 +51,7 @@ if that assertion is wrong.
 
 Both paths preserve the Agent identity and its centrally managed settings. Neither
 copies daemon-local workspace, memory, transcripts, or attachments. A source that later
-reconnects after an emergency reassign is told to detach the stale local copy during
+reconnects after a force reassign is told to detach the stale local copy during
 placement reconciliation.
 
 ## Where a streamed reply may be split

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -535,8 +535,10 @@ export const UpdateAgentBody = z
   .refine((b) => Object.values(b).some((v) => v !== undefined), { message: 'no fields to update' })
 
 /** Explicit cold placement move. Kept separate from spec PATCH because it
- * drains one daemon, reprovisions another, and does not migrate local state. */
-export const SetAgentDaemonBody = z.object({ daemonId: z.string().uuid() }).strict()
+ * drains one daemon, reprovisions another, and does not migrate local state.
+ * `force` is the explicit disaster-recovery path for a source that cannot ACK
+ * its detach; every target-side admission check still applies. */
+export const SetAgentDaemonBody = z.object({ daemonId: z.string().uuid(), force: z.boolean().optional() }).strict()
 
 /** Full desired workspace definition for the acknowledged cold edit path. */
 export const SetAgentWorkspaceBody = z.discriminatedUnion('mode', [

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1805,23 +1805,28 @@ export function agentRoutes(deps: HttpDeps) {
           return conflict('target daemon is at agent capacity')
         }
 
-        if (existing.daemonId) {
-          const source = await deps.registry.get(existing.daemonId)
-          const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
-          const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
-          if (emergency) {
-            if (sourceReady) return conflict('source daemon is ready; use a safe move')
-            if (sourceLive?.reachable === true) {
-              return conflict('source daemon is reconnecting; wait until it is ready')
+        // A same-target retry is an idempotent repair after placement already
+        // committed, not a second handoff. Target admission above still applies,
+        // but there is no separate source to gate before ensureActive below.
+        if (existing.daemonId !== target.daemonId) {
+          if (existing.daemonId) {
+            const source = await deps.registry.get(existing.daemonId)
+            const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
+            const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
+            if (emergency) {
+              if (sourceReady) return conflict('source daemon is ready; use a safe move')
+              if (sourceLive?.reachable === true) {
+                return conflict('source daemon is reconnecting; wait until it is ready')
+              }
+            } else {
+              if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
+              if (!source.capabilities.features.includes(MOVE_FEATURE)) {
+                return conflict('source daemon does not support agent moves')
+              }
             }
-          } else {
-            if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
-            if (!source.capabilities.features.includes(MOVE_FEATURE)) {
-              return conflict('source daemon does not support agent moves')
-            }
+          } else if (emergency) {
+            return conflict('emergency reassign requires an unavailable source daemon')
           }
-        } else if (emergency) {
-          return conflict('emergency reassign requires an unavailable source daemon')
         }
 
         // A move takes NO external-memory mutation scope: its connection work is

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1715,7 +1715,7 @@ export function agentRoutes(deps: HttpDeps) {
 
     // Cold-reprovision an agent on another daemon. The explicit action keeps
     // destructive/local-state semantics out of generic spec PATCH. A safe move
-    // requires both source and target READY; an explicit emergency reassign may
+    // requires both source and target READY; an explicit force reassign may
     // bypass only the unavailable source ACK. The target always receives the
     // complete CP-owned definition and activates last.
     r.put(
@@ -1746,7 +1746,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
 
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
-        const emergency = req.body.force === true
+        const force = req.body.force === true
         // Deferred exec config (preset-agents.md §3.2): placement is where a
         // runtime becomes mandatory — an unplaced preset carries none until the
         // user (or M1 auto-placement) chooses one.
@@ -1813,7 +1813,7 @@ export function agentRoutes(deps: HttpDeps) {
             const source = await deps.registry.get(existing.daemonId)
             const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
             const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
-            if (emergency) {
+            if (force) {
               if (sourceReady) return conflict('source daemon is ready; use a safe move')
               if (sourceLive?.reachable === true) {
                 return conflict('source daemon is reconnecting; wait until it is ready')
@@ -1824,8 +1824,8 @@ export function agentRoutes(deps: HttpDeps) {
                 return conflict('source daemon does not support agent moves')
               }
             }
-          } else if (emergency) {
-            return conflict('emergency reassign requires an unavailable source daemon')
+          } else if (force) {
+            return conflict('force reassign requires an unavailable source daemon')
           }
         }
 
@@ -1886,7 +1886,7 @@ export function agentRoutes(deps: HttpDeps) {
             }
           }
 
-          if (emergency) {
+          if (force) {
             req.log.warn(
               {
                 agentId: existing.id,
@@ -1894,11 +1894,11 @@ export function agentRoutes(deps: HttpDeps) {
                 targetDaemonId: target.daemonId,
                 userId: req.principal?.userId
               },
-              'agent emergency reassign requested while source daemon is unavailable'
+              'agent force reassign requested while source daemon is unavailable'
             )
           }
-          const moved = emergency
-            ? await agentMoves.emergencyReassign(existing, target.daemonId, req.principal?.userId)
+          const moved = force
+            ? await agentMoves.forceReassign(existing, target.daemonId, req.principal?.userId)
             : await agentMoves.move(existing, target.daemonId, req.principal?.userId)
           // The pre-activation probe fact can arrive before the placement CAS and
           // is correctly rejected by the daemon-ownership check. Re-send the

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1714,10 +1714,10 @@ export function agentRoutes(deps: HttpDeps) {
     )
 
     // Cold-reprovision an agent on another daemon. The explicit action keeps
-    // destructive/local-state semantics out of generic spec PATCH: source and
-    // target must both advertise the move protocol and be READY; the source
-    // archives its local root before the CAS placement change, then the target
-    // receives the complete CP-owned definition and activates last.
+    // destructive/local-state semantics out of generic spec PATCH. A safe move
+    // requires both source and target READY; an explicit emergency reassign may
+    // bypass only the unavailable source ACK. The target always receives the
+    // complete CP-owned definition and activates last.
     r.put(
       '/agents/:id/daemon',
       {
@@ -1725,7 +1725,7 @@ export function agentRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Move an agent to another daemon',
           description:
-            'Cold-reprovision an agent on another READY daemon. The active turn is drained; daemon-local workspace, memory, and transcript data are not migrated.',
+            'Cold-reprovision an agent on another READY daemon. The active turn is drained for a safe move; force is an explicit disaster-recovery option when the source is unavailable. Daemon-local workspace, memory, and transcript data are not migrated.',
           operationId: 'moveAgentDaemon',
           params: IdParam,
           body: SetAgentDaemonBody,
@@ -1746,6 +1746,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
 
         const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+        const emergency = req.body.force === true
         // Deferred exec config (preset-agents.md §3.2): placement is where a
         // runtime becomes mandatory — an unplaced preset carries none until the
         // user (or M1 auto-placement) chooses one.
@@ -1806,10 +1807,21 @@ export function agentRoutes(deps: HttpDeps) {
 
         if (existing.daemonId) {
           const source = await deps.registry.get(existing.daemonId)
-          if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
-          if (!source.capabilities.features.includes(MOVE_FEATURE)) {
-            return conflict('source daemon does not support agent moves')
+          const sourceLive = source ? deps.liveness.get(source.daemonId) : undefined
+          const sourceReady = sourceLive?.reachable === true && sourceLive.state === 'READY'
+          if (emergency) {
+            if (sourceReady) return conflict('source daemon is ready; use a safe move')
+            if (sourceLive?.reachable === true) {
+              return conflict('source daemon is reconnecting; wait until it is ready')
+            }
+          } else {
+            if (!source || !moveReady(source.daemonId)) return conflict('source daemon is not ready')
+            if (!source.capabilities.features.includes(MOVE_FEATURE)) {
+              return conflict('source daemon does not support agent moves')
+            }
           }
+        } else if (emergency) {
+          return conflict('emergency reassign requires an unavailable source daemon')
         }
 
         // A move takes NO external-memory mutation scope: its connection work is
@@ -1869,7 +1881,20 @@ export function agentRoutes(deps: HttpDeps) {
             }
           }
 
-          const moved = await agentMoves.move(existing, target.daemonId, req.principal?.userId)
+          if (emergency) {
+            req.log.warn(
+              {
+                agentId: existing.id,
+                sourceDaemonId: existing.daemonId,
+                targetDaemonId: target.daemonId,
+                userId: req.principal?.userId
+              },
+              'agent emergency reassign requested while source daemon is unavailable'
+            )
+          }
+          const moved = emergency
+            ? await agentMoves.emergencyReassign(existing, target.daemonId, req.principal?.userId)
+            : await agentMoves.move(existing, target.daemonId, req.principal?.userId)
           // The pre-activation probe fact can arrive before the placement CAS and
           // is correctly rejected by the daemon-ownership check. Re-send the
           // idempotent definition after commit so the daemon re-emits its current

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -8,7 +8,7 @@
  * detaching the partial target, moving the DB placement back, and reactivating the
  * source archive.
  *
- * An explicit emergency reassign may continue without the source ACK only when
+ * An explicit force reassign may continue without the source ACK only when
  * the HTTP edge has proved the source unavailable and the operator accepted the
  * split-brain risk. It still attempts the detach so a source that reconnects in
  * the race can quiesce normally. This is deliberately a cold reprovision, not
@@ -173,7 +173,7 @@ export class AgentMoveService {
   /** Disaster recovery for a source daemon that cannot confirm detach. Target
    * admission and activation remain fully acknowledged; only the source handoff
    * becomes best-effort. */
-  async emergencyReassign(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
+  async forceReassign(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
     return this.withMoveGate(agent.id, async () =>
       this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor, 'best-effort')
     )
@@ -430,7 +430,7 @@ export class AgentMoveService {
         }
         this.deps.log?.warn(
           { err, agentId: agent.id, sourceDaemonId, targetDaemonId },
-          'agent emergency reassign: source detach unconfirmed; continuing by operator request'
+          'agent force reassign: source detach unconfirmed; continuing by operator request'
         )
       }
       try {

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -1,5 +1,5 @@
 /**
- * Safe cold agent movement between daemons.
+ * Cold agent movement between daemons.
  *
  * The source daemon first ACKs `agent/detach`, which drains the running turn and
  * archives the complete agent root out of the active tree. Only then does the CP
@@ -8,8 +8,11 @@
  * detaching the partial target, moving the DB placement back, and reactivating the
  * source archive.
  *
- * This is deliberately a cold reprovision, not state migration: workspace,
- * transcript, and memory bytes remain daemon-local.
+ * An explicit emergency reassign may continue without the source ACK only when
+ * the HTTP edge has proved the source unavailable and the operator accepted the
+ * split-brain risk. It still attempts the detach so a source that reconnects in
+ * the race can quiesce normally. This is deliberately a cold reprovision, not
+ * state migration: workspace, transcript, and memory bytes remain daemon-local.
  */
 import { randomUUID } from 'node:crypto'
 import {
@@ -106,6 +109,8 @@ interface ActivationSnapshot {
   fingerprint: string
 }
 
+type SourceDetachMode = 'required' | 'best-effort'
+
 const MAX_STABILITY_ATTEMPTS = 3
 
 function requireAck(action: string, ack: Ack): void {
@@ -161,7 +166,16 @@ export class AgentMoveService {
 
   async move(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
     return this.withMoveGate(agent.id, async () =>
-      this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor)
+      this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor, 'required')
+    )
+  }
+
+  /** Disaster recovery for a source daemon that cannot confirm detach. Target
+   * admission and activation remain fully acknowledged; only the source handoff
+   * becomes best-effort. */
+  async emergencyReassign(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
+    return this.withMoveGate(agent.id, async () =>
+      this.moveLocked(await this.reloadAfterGate(agent), targetDaemonId, editor, 'best-effort')
     )
   }
 
@@ -394,7 +408,12 @@ export class AgentMoveService {
     return converted
   }
 
-  private async moveLocked(agent: AgentRecord, targetDaemonId: DaemonId, editor?: string): Promise<AgentRecord> {
+  private async moveLocked(
+    agent: AgentRecord,
+    targetDaemonId: DaemonId,
+    editor: string | undefined,
+    sourceDetachMode: SourceDetachMode
+  ): Promise<AgentRecord> {
     const sourceDaemonId = agent.daemonId
     // Retained only as compensation input if the source is detached but the
     // placement CAS never commits. The target always receives a fresh post-CAS
@@ -405,8 +424,14 @@ export class AgentMoveService {
       try {
         requireAck('source detach', await this.detach(sourceDaemonId, agent.id))
       } catch (err) {
-        if (err instanceof AgentMoveFailed) throw err
-        throw new AgentMoveFailed('source daemon detach failed', err)
+        if (sourceDetachMode === 'required') {
+          if (err instanceof AgentMoveFailed) throw err
+          throw new AgentMoveFailed('source daemon detach failed', err)
+        }
+        this.deps.log?.warn(
+          { err, agentId: agent.id, sourceDaemonId, targetDaemonId },
+          'agent emergency reassign: source detach unconfirmed; continuing by operator request'
+        )
       }
       try {
         const released = await this.deps.assignments.releaseForAgent(agent.id, sourceDaemonId, new Date())

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -32,11 +32,13 @@ afterEach(async () => {
 
 class MoveControlSpy {
   failMemoryUpsertAfterApply = false
+  failSourceDetach = false
   readonly calls: string[] = []
   readonly activations: AgentActivate[] = []
 
   async agentDetach(daemonId: string): Promise<Ack> {
     this.calls.push(`detach:${daemonId}`)
+    if (daemonId === SOURCE && this.failSourceDetach) throw new Error('source is unavailable')
     return { ok: true }
   }
   async agentActivate(daemonId: string, value: AgentActivate): Promise<Ack> {
@@ -301,6 +303,44 @@ describe('PUT /agents/:id/daemon', () => {
     await prisma.daemon.update({ where: { id: TARGET }, data: { load: { agents: 4, cpu: 0, mem: 0 }, maxAgents: 4 } })
     expect((await attempt(live)).json()).toMatchObject({ message: 'target daemon is at agent capacity' })
     expect(control.calls).toEqual([])
+  })
+
+  it('requires an explicit emergency reassign before continuing without a source detach ACK', async () => {
+    await seedMoveDaemons()
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: SOURCE })
+    const control = new MoveControlSpy()
+    let sourceReachable = true
+    const sourceCanDisappear: DaemonLiveness = {
+      get: (id) =>
+        [SOURCE, TARGET].includes(id)
+          ? { state: 'READY', reachable: id === TARGET || sourceReachable, sessionEpoch: 1 }
+          : undefined
+    }
+    running = buildHttpApp(prisma, undefined, sourceCanDisappear, control as unknown as ControlSender)
+    const attempt = (force = false) =>
+      running!.app.inject({
+        method: 'PUT',
+        url: `${ORG}/agents/${agentId}/daemon`,
+        payload: { daemonId: TARGET, ...(force ? { force: true } : {}) }
+      })
+
+    const forcedWhileReady = await attempt(true)
+    expect(forcedWhileReady.statusCode).toBe(409)
+    expect(forcedWhileReady.json()).toMatchObject({ message: 'source daemon is ready; use a safe move' })
+
+    sourceReachable = false
+    const safe = await attempt()
+    expect(safe.statusCode).toBe(409)
+    expect(safe.json()).toMatchObject({ message: 'source daemon is not ready' })
+    expect(control.calls).toEqual([])
+
+    control.failSourceDetach = true
+    const recovered = await attempt(true)
+    expect(recovered.statusCode, recovered.body).toBe(200)
+    expect((recovered.json() as { daemonId: string }).daemonId).toBe(TARGET)
+    expect((await prisma.agent.findUnique({ where: { id: agentId } }))?.daemonId).toBe(TARGET)
+    expect(control.calls).toEqual([`detach:${SOURCE}`, `detach:${TARGET}`, `activate:${TARGET}`])
   })
 
   it('places an unplaced runtime-less preset only after its runtime is set', async () => {

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -341,6 +341,17 @@ describe('PUT /agents/:id/daemon', () => {
     expect((recovered.json() as { daemonId: string }).daemonId).toBe(TARGET)
     expect((await prisma.agent.findUnique({ where: { id: agentId } }))?.daemonId).toBe(TARGET)
     expect(control.calls).toEqual([`detach:${SOURCE}`, `detach:${TARGET}`, `activate:${TARGET}`])
+
+    const retried = await attempt(true)
+    expect(retried.statusCode, retried.body).toBe(200)
+    expect((retried.json() as { daemonId: string }).daemonId).toBe(TARGET)
+    expect(control.calls).toEqual([
+      `detach:${SOURCE}`,
+      `detach:${TARGET}`,
+      `activate:${TARGET}`,
+      `detach:${TARGET}`,
+      `activate:${TARGET}`
+    ])
   })
 
   it('places an unplaced runtime-less preset only after its runtime is set', async () => {

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -305,7 +305,7 @@ describe('PUT /agents/:id/daemon', () => {
     expect(control.calls).toEqual([])
   })
 
-  it('requires an explicit emergency reassign before continuing without a source detach ACK', async () => {
+  it('requires an explicit force reassign before continuing without a source detach ACK', async () => {
     await seedMoveDaemons()
     const agentId = randomUUID()
     await seedAgent(prisma, agentId, { daemonId: SOURCE })

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -136,8 +136,8 @@ export default function EditAgentModal({
   const [sandboxSupported, setSandboxSupported] = useState(agent.sandboxSupported)
   const [sandboxRequired, setSandboxRequired] = useState(agent.sandboxRequired)
   const [repairPlacement, setRepairPlacement] = useState(false)
-  const [emergencyReassign, setEmergencyReassign] = useState(false)
-  const [emergencyConfirmed, setEmergencyConfirmed] = useState(false)
+  const [forceReassign, setForceReassign] = useState(false)
+  const [forceConfirmed, setForceConfirmed] = useState(false)
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const fetched = useRef(false)
@@ -304,8 +304,8 @@ export default function EditAgentModal({
   const daemonLabel = daemon?.name ?? (daemonId ? `Current daemon (${daemonId.slice(0, 8)})` : 'No daemon')
   const sourceUnavailable = !!sourceDaemon && !moveReady(sourceDaemon)
   const sourceOffline = sourceDaemon?.status === 'offline'
-  const emergencyEligible = daemonChanged && !initialPlacement && sourceOffline && moveReady(daemon)
-  const forceMove = emergencyReassign && emergencyEligible
+  const forceEligible = daemonChanged && !initialPlacement && sourceOffline && moveReady(daemon)
+  const forceMove = forceReassign && forceEligible
   const sourceBlocksSafeMove = daemonChanged && sourceUnavailable && !forceMove
 
   // Runtime options come from the SELECTED daemon's reported profiles (same source as
@@ -449,7 +449,7 @@ export default function EditAgentModal({
         )
         return
       }
-      if (forceMove && !emergencyConfirmed) {
+      if (forceMove && !forceConfirmed) {
         setErr(`Confirm that ${sourceDaemon?.name ?? 'the source daemon'} is permanently stopped.`)
         return
       }
@@ -597,8 +597,8 @@ export default function EditAgentModal({
                         className="font-sans text-[11.5px] font-medium leading-normal text-(--accent) hover:underline"
                         onClick={() => {
                           setRepairPlacement((value) => !value)
-                          setEmergencyReassign(false)
-                          setEmergencyConfirmed(false)
+                          setForceReassign(false)
+                          setForceConfirmed(false)
                           setErr(null)
                         }}
                       >
@@ -617,8 +617,8 @@ export default function EditAgentModal({
                       onChange={(e) => {
                         setDaemonId(e.target.value)
                         setRepairPlacement(false)
-                        setEmergencyReassign(false)
-                        setEmergencyConfirmed(false)
+                        setForceReassign(false)
+                        setForceConfirmed(false)
                         setErr(null)
                       }}
                       className="absolute inset-0 cursor-pointer opacity-0"
@@ -671,31 +671,31 @@ export default function EditAgentModal({
                         </div>
                         {sourceOffline && !daemonChanged && (
                           <div className="mt-[5px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-                            Select an online destination to see emergency recovery options.
+                            Select an online destination to see the force reassign option.
                           </div>
                         )}
-                        {emergencyEligible && (
+                        {forceEligible && (
                           <div className="mt-[9px] flex flex-col gap-2">
                             <Button
-                              variant={emergencyReassign ? 'ghost' : 'secondary'}
+                              variant={forceReassign ? 'ghost' : 'secondary'}
                               size="xs"
                               onClick={() => {
-                                setEmergencyReassign((value) => !value)
-                                setEmergencyConfirmed(false)
+                                setForceReassign((value) => !value)
+                                setForceConfirmed(false)
                                 setErr(null)
                               }}
                             >
-                              <Icon name={emergencyReassign ? 'x' : 'triangle-alert'} size={13} />
-                              {emergencyReassign ? 'Cancel emergency reassign' : 'Emergency reassign'}
+                              <Icon name={forceReassign ? 'x' : 'triangle-alert'} size={13} />
+                              {forceReassign ? 'Cancel force reassign' : 'Force reassign'}
                             </Button>
-                            {emergencyReassign && (
+                            {forceReassign && (
                               <label className="flex cursor-pointer items-start gap-2.5 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px]">
                                 <input
                                   type="checkbox"
                                   className="mt-[2px] flex-none accent-(--brand)"
-                                  checked={emergencyConfirmed}
+                                  checked={forceConfirmed}
                                   onChange={(e) => {
-                                    setEmergencyConfirmed(e.target.checked)
+                                    setForceConfirmed(e.target.checked)
                                     setErr(null)
                                   }}
                                 />
@@ -944,7 +944,7 @@ export default function EditAgentModal({
                   </span>
                 ) : daemonChanged && forceMove ? (
                   <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
-                    Emergency reassign activates this agent on{' '}
+                    Force reassign activates this agent on{' '}
                     <span className="font-semibold text-(--text-primary)">{daemon?.name ?? 'the target daemon'}</span>{' '}
                     without confirmation from{' '}
                     <span className="font-semibold text-(--text-primary)">
@@ -993,7 +993,7 @@ export default function EditAgentModal({
         </Button>
         <Button
           variant={forceMove ? 'danger' : 'primary'}
-          disabled={saving || !loaded || sourceBlocksSafeMove || (forceMove && !emergencyConfirmed)}
+          disabled={saving || !loaded || sourceBlocksSafeMove || (forceMove && !forceConfirmed)}
           onClick={() => void save()}
         >
           <Icon name={forceMove ? 'triangle-alert' : 'check'} size={15} />
@@ -1010,7 +1010,7 @@ export default function EditAgentModal({
             : initialPlacement
               ? 'Place agent'
               : forceMove
-                ? 'Reassign agent'
+                ? 'Force reassign'
                 : daemonChanged
                   ? 'Move agent'
                   : repairPlacement

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -136,6 +136,8 @@ export default function EditAgentModal({
   const [sandboxSupported, setSandboxSupported] = useState(agent.sandboxSupported)
   const [sandboxRequired, setSandboxRequired] = useState(agent.sandboxRequired)
   const [repairPlacement, setRepairPlacement] = useState(false)
+  const [emergencyReassign, setEmergencyReassign] = useState(false)
+  const [emergencyConfirmed, setEmergencyConfirmed] = useState(false)
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const fetched = useRef(false)
@@ -300,6 +302,11 @@ export default function EditAgentModal({
   const moveReady = (d: (typeof daemons)[number] | undefined) =>
     !!d && d.status === 'online' && d.caps.features.includes('agent-move-v1')
   const daemonLabel = daemon?.name ?? (daemonId ? `Current daemon (${daemonId.slice(0, 8)})` : 'No daemon')
+  const sourceUnavailable = !!sourceDaemon && !moveReady(sourceDaemon)
+  const sourceOffline = sourceDaemon?.status === 'offline'
+  const emergencyEligible = daemonChanged && !initialPlacement && sourceOffline && moveReady(daemon)
+  const forceMove = emergencyReassign && emergencyEligible
+  const sourceBlocksSafeMove = daemonChanged && sourceUnavailable && !forceMove
 
   // Runtime options come from the SELECTED daemon's reported profiles (same source as
   // the Add-agent picker); fall back to the static runtime list when the daemon reports
@@ -434,8 +441,16 @@ export default function EditAgentModal({
       // A restricted current daemon may be intentionally absent from this
       // viewer's daemon list. Let the server perform the authoritative source
       // readiness check in that case; only reject a source we can actually see.
-      if (initialDaemonId.current && sourceDaemon && !moveReady(sourceDaemon)) {
-        setErr('The current daemon must be online and upgraded before this agent can move.')
+      if (initialDaemonId.current && sourceDaemon && !moveReady(sourceDaemon) && !forceMove) {
+        setErr(
+          sourceDaemon.status === 'offline'
+            ? `To move safely, bring ${sourceDaemon.name} online, then retry.`
+            : `Upgrade ${sourceDaemon.name} before moving this agent.`
+        )
+        return
+      }
+      if (forceMove && !emergencyConfirmed) {
+        setErr(`Confirm that ${sourceDaemon?.name ?? 'the source daemon'} is permanently stopped.`)
         return
       }
       if (!daemon || !moveReady(daemon)) {
@@ -487,7 +502,7 @@ export default function EditAgentModal({
       // CP will accept the daemon (a solo move/repair carries no spec diff at all
       // — the guard above rejected one).
       if (hasSpecChanges && !soloPlacement) await updateAgent(agent.id, patch)
-      if (placementRequested) await moveAgent(agent.id, daemonId)
+      if (placementRequested) await moveAgent(agent.id, daemonId, forceMove ? { force: true } : undefined)
       // Sharing and agent-call visibility ride their own endpoints. Sharing uses
       // canManageSharing; call policy is a normal agent edit and uses canEdit.
       // Only write when they actually changed, and never during a move.
@@ -582,6 +597,8 @@ export default function EditAgentModal({
                         className="font-sans text-[11.5px] font-medium leading-normal text-(--accent) hover:underline"
                         onClick={() => {
                           setRepairPlacement((value) => !value)
+                          setEmergencyReassign(false)
+                          setEmergencyConfirmed(false)
                           setErr(null)
                         }}
                       >
@@ -600,6 +617,8 @@ export default function EditAgentModal({
                       onChange={(e) => {
                         setDaemonId(e.target.value)
                         setRepairPlacement(false)
+                        setEmergencyReassign(false)
+                        setEmergencyConfirmed(false)
                         setErr(null)
                       }}
                       className="absolute inset-0 cursor-pointer opacity-0"
@@ -629,6 +648,70 @@ export default function EditAgentModal({
                       })}
                     </select>
                   </div>
+                  {sourceDaemon && sourceUnavailable && (
+                    <div className="mt-2 flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[10px]">
+                      <Icon name="triangle-alert" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+                      <div className="min-w-0 flex-1">
+                        <div className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+                          Safe move unavailable
+                        </div>
+                        <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
+                          {sourceOffline ? (
+                            <>
+                              To move safely, bring{' '}
+                              <span className="font-semibold text-(--text-primary)">{sourceDaemon.name}</span> online,
+                              then retry. The existing copy must stop before this agent is activated elsewhere.
+                            </>
+                          ) : (
+                            <>
+                              Upgrade <span className="font-semibold text-(--text-primary)">{sourceDaemon.name}</span>{' '}
+                              before moving this agent.
+                            </>
+                          )}
+                        </div>
+                        {sourceOffline && !daemonChanged && (
+                          <div className="mt-[5px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+                            Select an online destination to see emergency recovery options.
+                          </div>
+                        )}
+                        {emergencyEligible && (
+                          <div className="mt-[9px] flex flex-col gap-2">
+                            <Button
+                              variant={emergencyReassign ? 'ghost' : 'secondary'}
+                              size="xs"
+                              onClick={() => {
+                                setEmergencyReassign((value) => !value)
+                                setEmergencyConfirmed(false)
+                                setErr(null)
+                              }}
+                            >
+                              <Icon name={emergencyReassign ? 'x' : 'triangle-alert'} size={13} />
+                              {emergencyReassign ? 'Cancel emergency reassign' : 'Emergency reassign'}
+                            </Button>
+                            {emergencyReassign && (
+                              <label className="flex cursor-pointer items-start gap-2.5 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px]">
+                                <input
+                                  type="checkbox"
+                                  className="mt-[2px] flex-none accent-(--brand)"
+                                  checked={emergencyConfirmed}
+                                  onChange={(e) => {
+                                    setEmergencyConfirmed(e.target.checked)
+                                    setErr(null)
+                                  }}
+                                />
+                                <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-secondary)">
+                                  I confirm that{' '}
+                                  <span className="font-semibold text-(--text-primary)">{sourceDaemon.name}</span> is
+                                  permanently stopped and cannot reconnect. If it is still running, both copies may
+                                  process messages.
+                                </span>
+                              </label>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
                 <div className="fld">
                   <span className="fldlbl">Runtime</span>
@@ -857,8 +940,18 @@ export default function EditAgentModal({
                   <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                     This places the unassigned agent on{' '}
                     <span className="font-semibold text-(--text-primary)">{daemon?.name ?? 'the selected daemon'}</span>{' '}
-                    from its saved control-plane definition. No workspace, memory, or session history is copied from
-                    another daemon.
+                    from its saved settings. No workspace, memory, or session history is copied from another daemon.
+                  </span>
+                ) : daemonChanged && forceMove ? (
+                  <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                    Emergency reassign activates this agent on{' '}
+                    <span className="font-semibold text-(--text-primary)">{daemon?.name ?? 'the target daemon'}</span>{' '}
+                    without confirmation from{' '}
+                    <span className="font-semibold text-(--text-primary)">
+                      {sourceDaemon?.name ?? 'the current daemon'}
+                    </span>
+                    . Local workspace, memory, transcripts, and attachments are not copied. Continue only when the
+                    source machine is permanently stopped.
                   </span>
                 ) : daemonChanged ? (
                   <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
@@ -874,9 +967,8 @@ export default function EditAgentModal({
                   </span>
                 ) : (
                   <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
-                    Repair cold-reprovisions this agent on its current daemon from the saved control-plane definition.
-                    Use it to recover an interrupted move. Current turns are drained; local workspace and memory stay in
-                    place.
+                    Repair cold-reprovisions this agent on its current daemon from its saved settings. Use it to recover
+                    an interrupted move. Current turns are drained; local workspace and memory stay in place.
                   </span>
                 )}
               </div>
@@ -899,23 +991,31 @@ export default function EditAgentModal({
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={() => void save()} className={!saving && loaded ? undefined : 'cursor-default opacity-50'}>
-          <Icon name="check" size={15} />
+        <Button
+          variant={forceMove ? 'danger' : 'primary'}
+          disabled={saving || !loaded || sourceBlocksSafeMove || (forceMove && !emergencyConfirmed)}
+          onClick={() => void save()}
+        >
+          <Icon name={forceMove ? 'triangle-alert' : 'check'} size={15} />
           {saving
             ? initialPlacement
               ? 'Placing…'
-              : daemonChanged
-                ? 'Moving…'
-                : repairPlacement
-                  ? 'Repairing…'
-                  : 'Saving…'
+              : forceMove
+                ? 'Reassigning…'
+                : daemonChanged
+                  ? 'Moving…'
+                  : repairPlacement
+                    ? 'Repairing…'
+                    : 'Saving…'
             : initialPlacement
               ? 'Place agent'
-              : daemonChanged
-                ? 'Move agent'
-                : repairPlacement
-                  ? 'Repair agent'
-                  : 'Save changes'}
+              : forceMove
+                ? 'Reassign agent'
+                : daemonChanged
+                  ? 'Move agent'
+                  : repairPlacement
+                    ? 'Repair agent'
+                    : 'Save changes'}
         </Button>
       </div>
     </>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -788,6 +788,29 @@ export default function AgentDetailView() {
                     <span className="mono text-[12.5px]">{daemonLine}</span>
                   )}
                 </div>
+                {owningDaemon?.status === 'offline' && (
+                  <div className="flex items-start gap-[9px] border-b border-(--amber-500) bg-(--status-paused-soft) px-4 py-3">
+                    <Icon name="triangle-alert" size={14} color="var(--amber-500)" className="mt-[1px] flex-none" />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                        Safe move unavailable
+                      </div>
+                      <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                        Bring <span className="font-semibold text-(--text-primary)">{owningDaemon.name}</span> online
+                        before moving this agent safely.
+                      </div>
+                      {!da.name.startsWith(MOCK_PREFIX) && da.canEdit && (
+                        <button
+                          type="button"
+                          className="mt-[6px] border-0 bg-transparent p-0 font-sans text-[11.5px] font-semibold leading-normal text-(--brand-soft-text) hover:underline"
+                          onClick={() => openModal('editAgent', da, { focusSection: 'basics' })}
+                        >
+                          Open recovery options
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
                 <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
                   <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary) desktop:text-[13px]">
                     Runtime

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2592,14 +2592,23 @@ export async function setAgentWorkspace(agentId: string, input: SetAgentWorkspac
   return agentFromDto(await apiPut<AgentDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace`, input))
 }
 
-// Cold-move an agent to another daemon. The CP coordinates an acknowledged
-// source detach and destination activation; this is deliberately separate from
+// Cold-move an agent to another daemon. A normal move coordinates an
+// acknowledged source detach and destination activation; `force` is the
+// explicit recovery path when the source cannot ACK. This stays separate from
 // the ordinary spec PATCH because placement changes have runtime side effects.
-export async function moveAgent(agentId: string, daemonId: string): Promise<Agent> {
+export async function moveAgent(agentId: string, daemonId: string, options: { force?: boolean } = {}): Promise<Agent> {
   const moved = agentFromDto(
-    await apiPut<AgentDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/daemon`, { daemonId })
+    await apiPut<AgentDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/daemon`, {
+      daemonId,
+      ...(options.force ? { force: true } : {})
+    })
   )
-  track('agent_moved', { org_id: apiOrgId, agent_id: moved.id, to_daemon_id: daemonId })
+  track('agent_moved', {
+    org_id: apiOrgId,
+    agent_id: moved.id,
+    to_daemon_id: daemonId,
+    emergency: options.force === true
+  })
   return moved
 }
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2607,7 +2607,7 @@ export async function moveAgent(agentId: string, daemonId: string, options: { fo
     org_id: apiOrgId,
     agent_id: moved.id,
     to_daemon_id: daemonId,
-    emergency: options.force === true
+    force: options.force === true
   })
   return moved
 }

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -184,8 +184,8 @@ interface ConsoleData {
   deleteAgent: (agentId: string) => Promise<void>
   /** Edit an agent's spec (PATCH), then re-pull. */
   updateAgent: (agentId: string, patch: UpdateAgentInput) => Promise<void>
-  /** Cold-move an agent to another daemon, then refresh placement-derived views. */
-  moveAgent: (agentId: string, daemonId: string) => Promise<void>
+  /** Cold-move or explicitly recover an agent, then refresh placement-derived views. */
+  moveAgent: (agentId: string, daemonId: string, options?: { force?: boolean }) => Promise<void>
   /** Install a Slack integration (POST /integrations), then re-pull. */
   createIntegration: (input: CreateIntegrationInput) => Promise<void>
   /** Finalize the config-token auto-install (§Tier B), then re-pull. Socket passes the
@@ -951,8 +951,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   // A placement move changes the agent row, both daemons' hosted-agent counts,
   // and where live session bodies resolve. Refresh all three projections.
   const moveAgent = useCallback(
-    async (agentId: string, daemonId: string) => {
-      await apiMoveAgent(agentId, daemonId)
+    async (agentId: string, daemonId: string, options?: { force?: boolean }) => {
+      await apiMoveAgent(agentId, daemonId, options)
       settleInBackground(mutateAgents(), mutateDaemons(), revalidateSessionLists())
     },
     [mutateAgents, mutateDaemons, revalidateSessionLists]


### PR DESCRIPTION
## Summary

- Show a visible `Safe move unavailable` warning on an Agent whose owning daemon is offline, including the daemon that must be brought online.
- Add an explicit `Force reassign` recovery flow after an operator selects an online destination, with a required split-brain risk confirmation.
- Allow the move API to bypass only an unavailable source daemon's detach acknowledgement; all destination readiness, capacity, compatibility, staging, and activation checks remain mandatory.
- Document the safe-move and force-reassign recovery invariants.

## Why

The Agent configuration page previously showed only the offline status. Selecting another daemon led to a move request that could not succeed, without explaining that the source daemon had to acknowledge detach first or offering a guarded recovery path.

Force reassign preserves the existing Agent identity and centrally managed settings. It does not copy daemon-local workspace, memory, transcripts, or attachments, and it is only offered when the source is offline.

## Validation

- `prettier --check` on all changed files
- `eslint` on all changed TypeScript files
- Web TypeScript check
- Control Plane TypeScript check
- Agent move service unit tests: 17 passed
- Agent move route integration tests: 9 passed
- Repository pre-push lint

Created by Codex . gpt-5.6-sol
