### PR TITLE
fix(daemon): seed only Claude model cache

### DIFF
--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -108,6 +108,12 @@ export interface RuntimeStateLocation {
    * seed. Omitted means the generic shallow config-file policy applies.
    */
   seedFiles?: readonly string[]
+  /**
+   * Optional top-level JSON keys to project instead of copying each selected
+   * source file wholesale. Invalid JSON or a source with none of these keys is
+   * not seeded.
+   */
+  seedJsonKeys?: readonly string[]
 }
 
 // --- home / XDG path resolution (honors the standard env overrides) ----------
@@ -134,8 +140,15 @@ function anyExists(...candidates: (string | undefined)[]): boolean {
 
 type RuntimeStateLocator = (env: NodeJS.ProcessEnv) => RuntimeStateLocation[]
 
-function state(source: string | undefined, destination: string, seedFiles?: readonly string[]): RuntimeStateLocation[] {
-  return source ? [{ source, destination, ...(seedFiles ? { seedFiles } : {}) }] : []
+function state(
+  source: string | undefined,
+  destination: string,
+  seedFiles?: readonly string[],
+  seedJsonKeys?: readonly string[]
+): RuntimeStateLocation[] {
+  return source
+    ? [{ source, destination, ...(seedFiles ? { seedFiles } : {}), ...(seedJsonKeys ? { seedJsonKeys } : {}) }]
+    : []
 }
 
 /**
@@ -156,20 +169,21 @@ const QODER_SEED = (brand: string): readonly string[] => [
   'mcp-oauth-tokens.json',
   'a2a-oauth-tokens.json'
 ]
+const CLAUDE_MODEL_CACHE_KEYS = ['additionalModelOptionsCache'] as const
 
 export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
-  // Anthropic Claude Code — seed only its ~/.claude.json global config.
+  // Anthropic Claude Code — seed only the rollout-model cache from ~/.claude.json.
   // The daemon pins CLAUDE_CONFIG_DIR=<private-home>/.claude (RUNTIME_PRIVATE_ENV),
-  // and Claude Code then reads its global config — including the GrowthBook feature
-  // cache that gates newer models (e.g. Fable 5) — from $CLAUDE_CONFIG_DIR/.claude.json,
-  // NOT the HOME-root copy. Host settings are daemon input and credentials are shared
-  // separately through CLAUDE_SECURESTORAGE_CONFIG_DIR; neither belongs in the private
-  // HOME. The HOME-root copy stays for Claude versions that ignore the config-dir env.
+  // and Claude Code reads additionalModelOptionsCache from that directory on its first
+  // session. Projecting that one field preserves rollout models (e.g. Fable 5) without
+  // copying host MCP, project, account, or machine state. Host settings are daemon input
+  // and credentials are shared separately through CLAUDE_SECURESTORAGE_CONFIG_DIR.
+  // The HOME-root copy stays for Claude versions that ignore the config-dir env.
   'claude-acp': (env) => [
-    ...state(env.CLAUDE_CONFIG_DIR, '.claude', ['.claude.json']),
-    ...state(join(home(env), '.claude'), '.claude', ['.claude.json']),
-    ...state(join(home(env), '.claude.json'), '.claude.json'),
-    ...state(join(home(env), '.claude.json'), join('.claude', '.claude.json'))
+    ...state(env.CLAUDE_CONFIG_DIR, '.claude', ['.claude.json'], CLAUDE_MODEL_CACHE_KEYS),
+    ...state(join(home(env), '.claude'), '.claude', ['.claude.json'], CLAUDE_MODEL_CACHE_KEYS),
+    ...state(join(home(env), '.claude.json'), '.claude.json', undefined, CLAUDE_MODEL_CACHE_KEYS),
+    ...state(join(home(env), '.claude.json'), join('.claude', '.claude.json'), undefined, CLAUDE_MODEL_CACHE_KEYS)
   ],
 
   // OpenAI Codex CLI — ~/.codex (honors $CODEX_HOME).

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -1,4 +1,15 @@
-import { chmodSync, constants, copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, renameSync } from 'node:fs'
+import {
+  chmodSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync
+} from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { runtimeStateLocations } from './probe.js'
 import { extractOmpCredentials } from './omp-credentials.js'
@@ -50,7 +61,30 @@ function assertNoDestinationSymlink(home: string, target: string): void {
   }
 }
 
-function copySeedFile(source: string, destination: string, excludedDestinations: ReadonlySet<string>): void {
+function projectedJson(source: string, keys: readonly string[]): string | undefined {
+  const raw = readFileSync(source, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const sourceObject = parsed as Record<string, unknown>
+  const projected: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (Object.hasOwn(sourceObject, key)) projected[key] = sourceObject[key]
+  }
+  if (Object.keys(projected).length === 0) return undefined
+  return `${JSON.stringify(projected)}\n`
+}
+
+function copySeedFile(
+  source: string,
+  destination: string,
+  excludedDestinations: ReadonlySet<string>,
+  seedJsonKeys?: readonly string[]
+): void {
   if (excludedDestinations.has(destination)) return
   if (existsSync(destination)) {
     if (lstatSync(destination).isSymbolicLink()) {
@@ -68,13 +102,19 @@ function copySeedFile(source: string, destination: string, excludedDestinations:
   if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_SEED_FILE_BYTES) return
   ensurePrivateDir(dirname(destination))
   try {
-    copyFileSync(source, destination, constants.COPYFILE_EXCL)
+    if (seedJsonKeys) {
+      const projected = projectedJson(source, seedJsonKeys)
+      if (projected === undefined) return
+      writeFileSync(destination, projected, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+    } else {
+      copyFileSync(source, destination, constants.COPYFILE_EXCL)
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') return
     throw error
   }
   try {
-    chmodSync(destination, stat.mode & 0o700 ? stat.mode & 0o700 : 0o600)
+    chmodSync(destination, seedJsonKeys ? 0o600 : stat.mode & 0o700 ? stat.mode & 0o700 : 0o600)
   } catch {
     // Best effort; the private parent still prevents access by other users.
   }
@@ -95,7 +135,8 @@ function seedLocation(
   source: string,
   destination: string,
   excludedDestinations: ReadonlySet<string>,
-  seedFiles?: readonly string[]
+  seedFiles?: readonly string[],
+  seedJsonKeys?: readonly string[]
 ): void {
   let stat
   try {
@@ -106,7 +147,7 @@ function seedLocation(
   }
   if (stat.isSymbolicLink()) return
   if (stat.isFile()) {
-    copySeedFile(source, destination, excludedDestinations)
+    copySeedFile(source, destination, excludedDestinations, seedJsonKeys)
     return
   }
   if (!stat.isDirectory()) return
@@ -117,13 +158,13 @@ function seedLocation(
       const sourceFile = containedDestination(source, file)
       const destinationFile = containedDestination(destination, file)
       assertNoDestinationSymlink(home, destinationFile)
-      copySeedFile(sourceFile, destinationFile, excludedDestinations)
+      copySeedFile(sourceFile, destinationFile, excludedDestinations, seedJsonKeys)
     }
     return
   }
   for (const entry of readdirSync(source, { withFileTypes: true })) {
     if (!entry.isFile() || !isConfigFile(entry.name)) continue
-    copySeedFile(join(source, entry.name), join(destination, entry.name), excludedDestinations)
+    copySeedFile(join(source, entry.name), join(destination, entry.name), excludedDestinations, seedJsonKeys)
   }
 }
 
@@ -156,7 +197,7 @@ export function prepareRuntimeHome(
   for (const location of locations) {
     const destination = containedDestination(home, location.destination)
     assertNoDestinationSymlink(home, destination)
-    seedLocation(home, location.source, destination, excluded, location.seedFiles)
+    seedLocation(home, location.source, destination, excluded, location.seedFiles, location.seedJsonKeys)
     if (runtimeId === 'omp') {
       extractOmpCredentials(join(location.source, 'agent.db'), join(destination, 'agent.db'))
     }

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -17,24 +17,45 @@ function fixture(): { root: string; hostHome: string; scopeDir: string } {
 }
 
 describe('private runtime HOME', () => {
-  it('seeds only Claude global config and keeps host settings and credentials out', () => {
+  it('seeds only Claude model rollout cache and keeps other host state out', () => {
     const { hostHome, scopeDir } = fixture()
     writeFileSync(join(hostHome, '.claude', '.credentials.json'), '{"token":"host"}')
     writeFileSync(join(hostHome, '.claude', 'settings.json'), '{"theme":"dark"}')
     writeFileSync(join(hostHome, '.claude', 'state.sqlite'), 'do-not-copy')
     writeFileSync(join(hostHome, '.claude', 'sessions', 'old.json'), '{"old":true}')
-    writeFileSync(join(hostHome, '.claude.json'), '{"onboarded":true}')
+    writeFileSync(
+      join(hostHome, '.claude.json'),
+      JSON.stringify({
+        additionalModelOptionsCache: [{ value: 'claude-fable-5[1m]', label: 'Fable', description: 'test' }],
+        mcpServers: { private: { token: 'do-not-copy' } },
+        projects: { '/host/private': { allowedTools: [] } },
+        oauthAccount: { emailAddress: 'do-not-copy@example.test' }
+      })
+    )
 
     const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
     expect(existsSync(join(home, '.claude', '.credentials.json'))).toBe(false)
     expect(existsSync(join(home, '.claude', 'settings.json'))).toBe(false)
-    expect(existsSync(join(home, '.claude.json'))).toBe(true)
+    expect(JSON.parse(readFileSync(join(home, '.claude.json'), 'utf8'))).toEqual({
+      additionalModelOptionsCache: [{ value: 'claude-fable-5[1m]', label: 'Fable', description: 'test' }]
+    })
     // Global config also lands in CLAUDE_CONFIG_DIR (<home>/.claude), which is
     // where a CLAUDE_CONFIG_DIR-pinned Claude Code actually reads it (the feature
     // cache there gates newer models like Fable 5).
-    expect(readFileSync(join(home, '.claude', '.claude.json'), 'utf8')).toContain('onboarded')
+    expect(JSON.parse(readFileSync(join(home, '.claude', '.claude.json'), 'utf8'))).toEqual({
+      additionalModelOptionsCache: [{ value: 'claude-fable-5[1m]', label: 'Fable', description: 'test' }]
+    })
     expect(existsSync(join(home, '.claude', 'state.sqlite'))).toBe(false)
     expect(existsSync(join(home, '.claude', 'sessions'))).toBe(false)
+  })
+
+  it('leaves Claude cold when the host global config has no model rollout cache', () => {
+    const { hostHome, scopeDir } = fixture()
+    writeFileSync(join(hostHome, '.claude.json'), JSON.stringify({ mcpServers: { private: {} } }))
+
+    const home = prepareRuntimeHome('claude-acp', scopeDir, { HOME: hostHome })
+    expect(existsSync(join(home, '.claude.json'))).toBe(false)
+    expect(existsSync(join(home, '.claude', '.claude.json'))).toBe(false)
   })
 
   it('seeds only Pi auth/settings from its nested agent directory', () => {

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -65,8 +65,20 @@ describe('prepareRuntimeLaunch', () => {
       join(customClaudeConfig, 'settings.json'),
       JSON.stringify({ env: { ANTHROPIC_API_KEY: 'seeded-settings-secret' } })
     )
-    writeFileSync(join(customClaudeConfig, '.claude.json'), JSON.stringify({ source: 'custom-config-dir' }))
-    writeFileSync(join(hostHome, '.claude.json'), JSON.stringify({ mcpToken: 'seeded-global-secret' }))
+    writeFileSync(
+      join(customClaudeConfig, '.claude.json'),
+      JSON.stringify({
+        additionalModelOptionsCache: [{ value: 'custom-fable', label: 'Custom Fable', description: 'test' }],
+        source: 'do-not-copy-custom-config-dir'
+      })
+    )
+    writeFileSync(
+      join(hostHome, '.claude.json'),
+      JSON.stringify({
+        additionalModelOptionsCache: [{ value: 'root-fable', label: 'Root Fable', description: 'test' }],
+        mcpToken: 'do-not-copy-global-secret'
+      })
+    )
     writeFileSync(identityTokenFile, 'trusted-parent-identity-token')
     writeFileSync(awsWebIdentityTokenFile, 'trusted-parent-aws-token')
     const launch = prepareRuntimeLaunch({
@@ -101,8 +113,12 @@ describe('prepareRuntimeLaunch', () => {
     const privateClaudeConfig = realpathSync(join(scopeDir, 'home', '.claude'))
     const privateClaudeGlobal = realpathSync(join(scopeDir, 'home', '.claude.json'))
     expect(existsSync(join(privateClaudeConfig, 'settings.json'))).toBe(false)
-    expect(readFileSync(join(privateClaudeConfig, '.claude.json'), 'utf8')).toContain('custom-config-dir')
-    expect(readFileSync(privateClaudeGlobal, 'utf8')).toContain('seeded-global-secret')
+    expect(JSON.parse(readFileSync(join(privateClaudeConfig, '.claude.json'), 'utf8'))).toEqual({
+      additionalModelOptionsCache: [{ value: 'custom-fable', label: 'Custom Fable', description: 'test' }]
+    })
+    expect(JSON.parse(readFileSync(privateClaudeGlobal, 'utf8'))).toEqual({
+      additionalModelOptionsCache: [{ value: 'root-fable', label: 'Root Fable', description: 'test' }]
+    })
     expect(launch.env.ANTHROPIC_IDENTITY_TOKEN_FILE).toBe(canonicalIdentityToken)
     expect(launch.env.AWS_WEB_IDENTITY_TOKEN_FILE).toBe(canonicalAwsWebIdentityToken)
     expect(coveredBy(settings.filesystem.denyRead, canonicalHostHome)).toBe(true)


### PR DESCRIPTION
## Summary

- project only `additionalModelOptionsCache` from the trusted host Claude global config into private runtime HOMEs
- preserve first-session rollout-model discovery without copying host MCP, project, account, machine, or credential state
- keep the generic runtime seeder fail-safe: invalid JSON or a missing projected key produces no seed file and Claude cold-starts normally

## Context

Follow-up to #384. That change stopped seeding the host Claude config directory, but still copied the complete `~/.claude.json` file. Live inspection showed that file also contains host-scoped MCP, project, account, machine, repository, and usage state.

A controlled Linux A/B test with Claude Code 2.1.220 and claude-agent-acp 0.64.0 showed:

- no `.claude.json`: `default`, `opus[1m]`, `sonnet`, `haiku`
- complete host `.claude.json`: the same list plus `claude-fable-5[1m]`
- only `additionalModelOptionsCache`: the same full list including Fable

The daemon is the trusted reader, so it now writes a new minimal JSON object rather than exposing the source file. Credentials continue to use the separately resolved `CLAUDE_SECURESTORAGE_CONFIG_DIR` capability.

## Compatibility

Existing private files remain untouched and are not migrated. New agent and disposable probe HOMEs receive the projected cache at the pinned `CLAUDE_CONFIG_DIR` location and the existing HOME-root compatibility location. If the host cache is absent or invalid, no synthetic file is created.

## Validation

- 43 focused daemon tests across runtime home, shared credentials, and runtime launch
- daemon typecheck
- changed-file ESLint and Prettier
- daemon self-contained production build
- pre-push full-repository lint
- live Linux A/B model-list validation with Claude Code 2.1.220 and claude-agent-acp 0.64.0

Follow-up to #384
Tracks #312

Created by Codex . GPT-5.6
