### PR TITLE
fix(web): link bot agents to configuration

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -9,6 +9,7 @@
 // and the Roles explainer.
 
 import { Fragment, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import { Avatar, Button, Icon, Toggle } from '@/components/ui'
@@ -843,6 +844,7 @@ function BotsCard({
   targetBotId: string | null
   onDelete: (b: BotDto) => void
 }) {
+  const { orgPath } = useOrgs()
   const {
     bots,
     integrations,
@@ -1129,15 +1131,18 @@ function BotsCard({
                   b.agentIds.map((id, idx) => {
                     const ag = getAgent(id)
                     return (
-                      <span
+                      <Link
                         key={id}
+                        href={orgPath(`/agents/${encodeURIComponent(id)}?tab=config`)}
+                        aria-label={`Open ${ag ? agentLabel(ag) : id} configuration`}
                         title={ag ? agentLabel(ag) : id}
-                        className={`av h-[22px] w-[22px] rounded-[6px] ${
+                        className={`av h-[22px] w-[22px] rounded-[6px] no-underline focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) ${
                           idx > 0 ? '-ml-[6px] shadow-[-1px_0_0_0_var(--surface-card)]' : ''
                         }`}
+                        onClick={(e) => e.stopPropagation()}
                       >
                         <AgentIconView icon={ag?.icon} runtime={ag?.runtime || ag?.model || ''} size={22} />
-                      </span>
+                      </Link>
                     )
                   })
                 ) : (


### PR DESCRIPTION
## Summary

- Link each Agent avatar in Settings > Bots to that Agent's Configuration tab.
- Stop the avatar click from also expanding or collapsing the Bot row.
- Preserve the existing Agent-name tooltip and add a keyboard focus indicator.

## Why

The Agent avatars were static elements inside a clickable Bot row, so clicking an Agent could only toggle the Bot's conversation roster. Operators had no direct path from the Bot assignment to that Agent's configuration.

## Validation

- `pnpm exec prettier --check packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- Pre-push full-repository `eslint .`
- Local mock verification confirmed the generated `?tab=config` link and Configuration destination.

Created by Codex . GPT-5
