### PR TITLE
fix(daemon): harden sandbox Unix socket isolation

### DIFF
--- a/packages/control-plane/prisma/migrations/20260802120000_agent_run_in_sandbox_name/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260802120000_agent_run_in_sandbox_name/migration.sql
@@ -1,0 +1,2 @@
+-- The preference controls the complete ACP process sandbox, not only filesystem access.
+ALTER TABLE "agent" RENAME COLUMN "restrictFileAccess" TO "runInSandbox";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -638,7 +638,7 @@ model Agent {
   outboundPolicy        AgentCallPolicy    @default(all) // 'all' = this agent may discover/call any otherwise-callable org peer
   allowedTargetAgentIds String[]           @default([]) // agent.id set used when outboundPolicy='selected'
   introduceOnJoin       Boolean            @default(false) // #536: self-introduce to peers on a genuine channel join
-  restrictFileAccess    Boolean            @default(false) // #642: request an OS sandbox; daemon policy may force it on
+  runInSandbox          Boolean            @default(false) // #642: request an OS sandbox; daemon policy may force it on
   createdAt             DateTime           @default(now()) @db.Timestamptz(6)
   updatedAt             DateTime           @updatedAt @db.Timestamptz(6)
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -468,7 +468,7 @@ export const CreateAgentBody = z.object({
   allowRuntimeChangesInChat: z.boolean().optional(), // explicit opt-in; absent ⇒ false
   pause: z.boolean().optional(), // operational message-processing toggle (#288)
   introduceOnJoin: z.boolean().optional(), // #536: self-introduce to peers on a genuine channel join
-  restrictFileAccess: z.boolean().optional(), // #642: request an OS sandbox (absent ⇒ default false)
+  runInSandbox: z.boolean().optional(), // #642: request an OS sandbox (absent ⇒ default false)
   env: AgentEnvBody.optional(),
   secrets: AgentSecretsCreateBody.optional(), // write-only secret env vars (values never returned)
   // Names of daemon-configured MCP servers to attach at session/new; the daemon
@@ -516,7 +516,7 @@ export const UpdateAgentBody = z
     allowRuntimeChangesInChat: z.boolean().optional(),
     pause: z.boolean().nullable().optional(), // operational toggle (#288); null clears
     introduceOnJoin: z.boolean().optional(), // #536: self-introduce to peers on a genuine channel join
-    restrictFileAccess: z.boolean().optional(), // #642: request an OS sandbox for this agent
+    runInSandbox: z.boolean().optional(), // #642: request an OS sandbox for this agent
     // Same-repository capability widening only. Workspace identity/conversion
     // stays on the dedicated cold action, and downgrades are deliberately not
     // exposed here because enabled review hooks may depend on write access.
@@ -610,7 +610,7 @@ export const AgentDto = z.object({
   outboundPolicy: AgentCallPolicyEnum, // which peer agents this agent may discover/call
   allowedTargetAgentIds: z.array(z.string()), // agent.id set, meaningful when outboundPolicy='selected'
   introduceOnJoin: z.boolean(), // #536: self-introduce to peers on a genuine channel join
-  restrictFileAccess: z.boolean(), // #642: persisted per-agent sandbox preference (default false)
+  runInSandbox: z.boolean(), // #642: persisted per-agent sandbox preference (default false)
   // #642: whether the placed daemon can enforce the preference. false ⇒ the
   // console renders Run in sandbox unavailable and the effective value is false.
   sandboxSupported: z.boolean(),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -248,7 +248,7 @@ function toDto(
     outboundPolicy: a.outboundPolicy,
     allowedTargetAgentIds: a.allowedTargetAgentIds,
     introduceOnJoin: a.introduceOnJoin,
-    restrictFileAccess: a.restrictFileAccess,
+    runInSandbox: a.runInSandbox,
     sandboxSupported: sandboxPolicy.supported,
     sandboxRequired: sandboxPolicy.required,
     hookKinds
@@ -895,16 +895,16 @@ export function agentRoutes(deps: HttpDeps) {
           return conflict('managed skills require a daemon that supports organization knowledge')
         }
         const sandboxPolicy = sandboxPolicyOf(placedDaemon)
-        if (sandboxPolicy.required && req.body.restrictFileAccess === false) {
+        if (sandboxPolicy.required && req.body.runInSandbox === false) {
           return conflict('Run in sandbox is required by this daemon')
         }
-        if (!sandboxPolicy.supported && req.body.restrictFileAccess === true) {
+        if (!sandboxPolicy.supported && req.body.runInSandbox === true) {
           return conflict('Run in sandbox is unavailable on this daemon')
         }
-        const restrictFileAccess = sandboxPolicy.required
+        const runInSandbox = sandboxPolicy.required
           ? true
           : sandboxPolicy.supported
-            ? (req.body.restrictFileAccess ?? false)
+            ? (req.body.runInSandbox ?? false)
             : false
         // github-app workspace: the picked installation must be a LIVE claim of
         // THIS org, and the repo must sit inside that installation's account +
@@ -1052,7 +1052,7 @@ export function agentRoutes(deps: HttpDeps) {
                     : {}),
                   ...(req.body.pause !== undefined ? { pause: req.body.pause } : {}),
                   ...(req.body.introduceOnJoin !== undefined ? { introduceOnJoin: req.body.introduceOnJoin } : {}),
-                  restrictFileAccess,
+                  runInSandbox,
                   ...(req.body.env !== undefined ? { env: req.body.env } : {}),
                   ...(req.body.mcpServers !== undefined ? { mcpServers: req.body.mcpServers } : {}),
                   ...(req.body.skills !== undefined ? { skills: req.body.skills } : {}),
@@ -1403,14 +1403,14 @@ export function agentRoutes(deps: HttpDeps) {
               .send({ error: 'Conflict', statusCode: 409, message: 'agent changed; refresh and retry the edit' })
           }
           const sandboxPolicy = await sandboxPolicyFor(deps, existing)
-          if (sandboxPolicy.required && req.body.restrictFileAccess === false) {
+          if (sandboxPolicy.required && req.body.runInSandbox === false) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,
               message: 'Run in sandbox is required by this daemon'
             })
           }
-          if (!sandboxPolicy.supported && req.body.restrictFileAccess === true) {
+          if (!sandboxPolicy.supported && req.body.runInSandbox === true) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -232,7 +232,7 @@ export function agentRecordToSpec(
     introduceOnJoin: a.introduceOnJoin,
     // #642: sandbox toggle. Definite column, always shipped so the daemon applies it
     // to agent.json (the daemon then decides fail-open/closed based on host support).
-    restrictFileAccess: a.restrictFileAccess,
+    runInSandbox: a.runInSandbox,
     // Preset marker (preset-agents.md §3.1). Always shipped (definite record field)
     // so the daemon can gate preset-only capabilities locally — e.g. advertise
     // `webchat_remote_mcp_v1` as soon as this agent syncs, without a probe round.

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -524,7 +524,7 @@ export interface CreateAgentInput {
   allowRuntimeChangesInChat?: boolean // explicit opt-in; default false
   pause?: boolean // operational message-processing toggle (#288); true ⇒ daemon skips all turns
   introduceOnJoin?: boolean // #536: self-introduce to peers on a genuine channel join (absent ⇒ DB default false)
-  restrictFileAccess?: boolean // #642: request an OS sandbox (absent ⇒ DB default false)
+  runInSandbox?: boolean // #642: request an OS sandbox (absent ⇒ DB default false)
   env?: Record<string, string> // extra env injected into the runtime (AgentSpec.env)
   // NOTE: write-only secret env vars are NOT part of the agent row — they live behind
   // the AgentSecretStore seam (routes write them there after create).
@@ -573,7 +573,7 @@ export interface UpdateAgentInput {
   allowRuntimeChangesInChat?: boolean
   pause?: boolean | null // operational message-processing toggle (#288); null clears
   introduceOnJoin?: boolean // #536: self-introduce to peers on a genuine channel join
-  restrictFileAccess?: boolean // #642: request an OS sandbox for this agent
+  runInSandbox?: boolean // #642: request an OS sandbox for this agent
   /** Widen an existing App-backed GitHub workspace from read to write. */
   gitAccess?: 'write'
   /** GitHub workspace-relative ACP cwd; null restores repository root. */
@@ -648,7 +648,7 @@ export interface AgentRecord {
   outboundPolicy: AgentCallPolicy
   allowedTargetAgentIds: string[] // agent.id set; meaningful only when outboundPolicy='selected'
   introduceOnJoin: boolean // #536: self-introduce to peers on a genuine channel join (default false)
-  restrictFileAccess: boolean // #642: persisted per-agent sandbox preference (default false)
+  runInSandbox: boolean // #642: persisted per-agent sandbox preference (default false)
   lastModifiedAt: Date // last human edit (create/PATCH); defaults to createdAt
   lastModifiedBy: AgentCreator | null // WebUI user who last edited it; null ⇒ never edited by a human
 }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -250,7 +250,7 @@ function toRecord(a: AgentWithUsers): AgentRecord {
     outboundPolicy: a.outboundPolicy as AgentCallPolicy,
     allowedTargetAgentIds: a.allowedTargetAgentIds,
     introduceOnJoin: a.introduceOnJoin,
-    restrictFileAccess: a.restrictFileAccess,
+    runInSandbox: a.runInSandbox,
     lastModifiedAt: a.lastModifiedAt,
     lastModifiedBy: a.lastModifiedBy
       ? { userId: a.lastModifiedBy.id, displayName: a.lastModifiedBy.displayName, email: a.lastModifiedBy.email }
@@ -361,7 +361,7 @@ export class PgAgentRepo implements AgentRepo {
           // #536 self-introduce-on-join (dedicated column; absent ⇒ DB default false).
           ...(input.introduceOnJoin !== undefined ? { introduceOnJoin: input.introduceOnJoin } : {}),
           // #642 sandbox preference (dedicated column; absent ⇒ DB default false).
-          ...(input.restrictFileAccess !== undefined ? { restrictFileAccess: input.restrictFileAccess } : {}),
+          ...(input.runInSandbox !== undefined ? { runInSandbox: input.runInSandbox } : {}),
           // Initial visibility (absent ⇒ DB default 'org'). sharedWith only bites
           // when restricted; a stray set under 'org' is inert (the predicate ignores it).
           ...(input.visibility ? { visibility: input.visibility } : {}),
@@ -510,7 +510,7 @@ export class PgAgentRepo implements AgentRepo {
         ...(patch.runtime !== undefined ? { runtime: patch.runtime } : {}),
         ...(patch.capabilities !== undefined ? { capabilities: patch.capabilities } : {}),
         ...(patch.introduceOnJoin !== undefined ? { introduceOnJoin: patch.introduceOnJoin } : {}),
-        ...(patch.restrictFileAccess !== undefined ? { restrictFileAccess: patch.restrictFileAccess } : {}),
+        ...(patch.runInSandbox !== undefined ? { runInSandbox: patch.runInSandbox } : {}),
         ...(patch.gitAccess !== undefined ? { gitAccess: patch.gitAccess } : {}),
         ...(patch.agentDir !== undefined ? { agentDir: patch.agentDir } : {}),
         ...(patch.managedSkills !== undefined ? { managedSkills: patch.managedSkills ?? [] } : {}),

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -184,7 +184,7 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
         // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
         introduceOnJoin: false,
         // #642: sandbox preference — always shipped (definite column); default false.
-        restrictFileAccess: false,
+        runInSandbox: false,
         // Preset marker — always shipped so the daemon can gate preset-only capabilities.
         builtin: false,
         workspace: { mode: 'scratch', gitCredential: 'github-app' }

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -165,7 +165,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     })
     expect(unsupported.statusCode).toBe(201)
     expect(unsupported.json()).toMatchObject({
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: false,
       sandboxRequired: false
     })
@@ -178,7 +178,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(optional.statusCode).toBe(201)
     const optionalBody = optional.json() as { id: string }
     expect(optional.json()).toMatchObject({
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: true,
       sandboxRequired: false
     })
@@ -186,10 +186,10 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     const enable = await app.app.inject({
       method: 'PATCH',
       url: `${ORG}/agents/${optionalBody.id}`,
-      payload: { restrictFileAccess: true }
+      payload: { runInSandbox: true }
     })
     expect(enable.statusCode).toBe(200)
-    expect(enable.json()).toMatchObject({ restrictFileAccess: true })
+    expect(enable.json()).toMatchObject({ runInSandbox: true })
 
     const required = await app.app.inject({
       method: 'POST',
@@ -199,7 +199,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     expect(required.statusCode).toBe(201)
     const requiredBody = required.json() as { id: string }
     expect(required.json()).toMatchObject({
-      restrictFileAccess: true,
+      runInSandbox: true,
       sandboxSupported: true,
       sandboxRequired: true
     })
@@ -207,7 +207,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     const disable = await app.app.inject({
       method: 'PATCH',
       url: `${ORG}/agents/${requiredBody.id}`,
-      payload: { restrictFileAccess: false }
+      payload: { runInSandbox: false }
     })
     expect(disable.statusCode).toBe(409)
     expect(disable.json()).toMatchObject({ message: 'Run in sandbox is required by this daemon' })

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -224,7 +224,7 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       // #536: self-introduce-on-join — always shipped (definite column) so a toggle replicates.
       introduceOnJoin: false,
       // #642: sandbox preference — always shipped (definite column); default false.
-      restrictFileAccess: false,
+      runInSandbox: false,
       // Preset marker — always shipped so the daemon can gate preset-only capabilities.
       builtin: false,
       workspace: { mode: 'scratch', gitCredential: 'github-app' }

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -155,6 +155,9 @@ export interface AcpSandboxLaunch {
   /** Credential paths available to the trusted ACP runtime itself but denied to
    * model-authored commands by a runtime-native nested sandbox. */
   protectedCredentialRoots?: string[]
+  /** A deliberately exposed model-side Unix channel, currently gitcred.sock for
+   * GitHub App workspaces. Linux SRT cannot allow AF_UNIX by pathname. */
+  allowModelToolUnixSockets?: boolean
   /** SDK flag settings that pin protected parent-only profile selection after
    * Claude merges workspace-controlled settings. */
   claudeProtectedSettings?: ClaudeProtectedSettings
@@ -346,7 +349,8 @@ export function claudeSessionMeta(
   systemPrompt?: string,
   memoryAppend?: string,
   protectedCredentialRoots?: readonly string[],
-  protectedSettings?: ClaudeProtectedSettings
+  protectedSettings?: ClaudeProtectedSettings,
+  allowModelToolUnixSockets = false
 ):
   | {
       claudeCode: {
@@ -373,7 +377,9 @@ export function claudeSessionMeta(
     claudeCode: {
       options: {
         thinking: { type: 'adaptive', display: 'summarized' },
-        ...(protectedCredentialRoots ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots) } : {}),
+        ...(protectedCredentialRoots
+          ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets) }
+          : {}),
         ...(protectedSettings || ultracode ? { settings } : {})
       },
       emitRawSDKMessages: SDK_LIFECYCLE_FILTERS
@@ -804,7 +810,8 @@ export class AcpHost {
       this.opts.configPrefs?.systemPrompt,
       systemAppend,
       this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
-      this.opts.sandbox?.claudeProtectedSettings
+      this.opts.sandbox?.claudeProtectedSettings,
+      this.opts.sandbox?.allowModelToolUnixSockets
     )
     const res = await this.conn!.agent.request(methods.agent.session.new, {
       cwd,
@@ -1022,7 +1029,8 @@ export class AcpHost {
         systemAppend ?? this.opts.configPrefs?.systemPrompt,
         undefined,
         this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
-        this.opts.sandbox?.claudeProtectedSettings
+        this.opts.sandbox?.claudeProtectedSettings,
+        this.opts.sandbox?.allowModelToolUnixSockets
       )
       const res = await this.conn!.agent.request(methods.agent.session.load, {
         sessionId,

--- a/packages/daemon/src/acp/claude-runtime.ts
+++ b/packages/daemon/src/acp/claude-runtime.ts
@@ -110,6 +110,9 @@ export interface ClaudeInnerSandboxSettings {
   failIfUnavailable: true
   autoAllowBashIfSandboxed: true
   allowUnsandboxedCommands: false
+  network: {
+    allowAllUnixSockets: false
+  }
   filesystem: {
     denyRead: string[]
     denyWrite: string[]
@@ -131,6 +134,12 @@ export function claudeInnerSandboxSettings(protectedCredentialRoots: readonly st
     failIfUnavailable: true,
     autoAllowBashIfSandboxed: true,
     allowUnsandboxedCommands: false,
+    // The trusted Claude parent stays in the outer AgentConnect sandbox, where
+    // it may use mcp.sock and create the nested SRT helpers. Model-authored Bash
+    // gets a second seccomp layer and cannot create AF_UNIX sockets at all.
+    network: {
+      allowAllUnixSockets: false
+    },
     filesystem: {
       denyRead: roots,
       denyWrite: roots

--- a/packages/daemon/src/acp/claude-runtime.ts
+++ b/packages/daemon/src/acp/claude-runtime.ts
@@ -111,7 +111,7 @@ export interface ClaudeInnerSandboxSettings {
   autoAllowBashIfSandboxed: true
   allowUnsandboxedCommands: false
   network: {
-    allowAllUnixSockets: false
+    allowAllUnixSockets: boolean
   }
   filesystem: {
     denyRead: string[]
@@ -127,18 +127,21 @@ export interface ClaudeInnerSandboxSettings {
  * `_meta.claudeCode.options.sandbox`. The outer AgentConnect SRT remains the host
  * boundary; this nested sandbox confines model-authored Bash and its descendants,
  * while the parent Claude process retains shared-login access. */
-export function claudeInnerSandboxSettings(protectedCredentialRoots: readonly string[]): ClaudeInnerSandboxSettings {
+export function claudeInnerSandboxSettings(
+  protectedCredentialRoots: readonly string[],
+  allowAllUnixSockets = false
+): ClaudeInnerSandboxSettings {
   const roots = [...new Set(protectedCredentialRoots)]
   return {
     enabled: true,
     failIfUnavailable: true,
     autoAllowBashIfSandboxed: true,
     allowUnsandboxedCommands: false,
-    // The trusted Claude parent stays in the outer AgentConnect sandbox, where
-    // it may use mcp.sock and create the nested SRT helpers. Model-authored Bash
-    // gets a second seccomp layer and cannot create AF_UNIX sockets at all.
+    // Linux SRT cannot filter AF_UNIX by pathname. Block it unless this launch
+    // deliberately exposes the Git credential channel to model-authored Git;
+    // the outer mount/network namespace remains that channel's host boundary.
     network: {
-      allowAllUnixSockets: false
+      allowAllUnixSockets
     },
     filesystem: {
       denyRead: roots,

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -37,6 +37,51 @@ function disabledClaudeProfileRoot(scopeDir: string): string {
   return realpathSync(target)
 }
 
+/** Ambient desktop/session IPC must not reconnect a sandboxed runtime to host
+ * services merely because the daemon inherited a pointer to their socket. */
+const HOST_SOCKET_POINTER_ENV = [
+  'SSH_AUTH_SOCK',
+  'SSH_AGENT_PID',
+  'DBUS_SESSION_BUS_ADDRESS',
+  'DBUS_SYSTEM_BUS_ADDRESS',
+  'DISPLAY',
+  'WAYLAND_DISPLAY',
+  'PULSE_SERVER',
+  'PIPEWIRE_REMOTE',
+  'GPG_AGENT_INFO',
+  'GNOME_KEYRING_CONTROL',
+  'SESSION_MANAGER',
+  'TMUX',
+  'VSCODE_IPC_HOOK_CLI',
+  'NOTIFY_SOCKET',
+  'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE'
+] as const
+
+const LOCAL_CONTAINER_ENDPOINT_ENV = ['DOCKER_HOST', 'CONTAINER_HOST', 'BUILDKIT_HOST', 'PODMAN_HOST'] as const
+
+function isLocalSocketEndpoint(value: string): boolean {
+  const endpoint = value.trim().toLowerCase()
+  return endpoint.startsWith('/') || /^(?:unix|npipe|fd):/.test(endpoint)
+}
+
+function isolateHostSocketEnvironment(env: Record<string, string>, runtimeHome: string): void {
+  const runtimeDir = join(runtimeHome, '.run')
+  if (existsSync(runtimeDir)) {
+    const stat = lstatSync(runtimeDir)
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error(`private XDG runtime path must be a real directory: ${runtimeDir}`)
+    }
+  }
+  mkdirSync(runtimeDir, { recursive: true, mode: 0o700 })
+  chmodSync(runtimeDir, 0o700)
+
+  for (const name of HOST_SOCKET_POINTER_ENV) delete env[name]
+  for (const name of LOCAL_CONTAINER_ENDPOINT_ENV) {
+    if (env[name] && isLocalSocketEndpoint(env[name])) delete env[name]
+  }
+  env.XDG_RUNTIME_DIR = realpathSync(runtimeDir)
+}
+
 export interface PreparedRuntimeLaunch {
   env: Record<string, string>
   /** Sandboxed launches carry a sanitized environment; unsandboxed launches inherit the daemon environment. */
@@ -151,6 +196,10 @@ export function prepareRuntimeLaunch(opts: {
     const sharedTempRoots = ['/tmp', '/var/tmp', stateSourceEnv.TMPDIR, stateSourceEnv.TMP, stateSourceEnv.TEMP]
       .filter((path): path is string => Boolean(path))
       .map((path) => safeRoot(path, 'shared temp root'))
+    // Linux service sockets conventionally live below /run; /var/run resolves
+    // there as well. The outer parent keeps AF_UNIX available for AgentConnect's
+    // exact carve-backs, so mount visibility is the host-socket boundary.
+    const hostSocketRoots = [safeRoot('/run', 'host socket root')]
     protectedRuntimeStateRoots = Object.keys(RUNTIME_STATE_LOCATIONS).flatMap((id) =>
       runtimeStateLocations(id, stateSourceEnv).map((location) => safeRoot(location.source, `${id} host state root`))
     )
@@ -159,7 +208,8 @@ export function prepareRuntimeLaunch(opts: {
       agentRoot,
       ...(opts.agentsRoot ? [safeRoot(opts.agentsRoot, 'agents root')] : []),
       ...hostHomeRoots,
-      ...sharedTempRoots
+      ...sharedTempRoots,
+      ...hostSocketRoots
     ]
     protectedRoots = [...protectedBoundaryRoots, ...protectedRuntimeStateRoots]
     denyReadRoots = compactReadRoots(protectedRoots)
@@ -199,6 +249,8 @@ export function prepareRuntimeLaunch(opts: {
     ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, opts.hostEnv),
     ...credentials?.env
   }
+
+  if (opts.runInSandbox) isolateHostSocketEnvironment(env, runtimeHome)
 
   if (!opts.runInSandbox) {
     return { env, inheritProcessEnv: false, runtimeHome }

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -150,10 +150,10 @@ function canonicalTarget(path: string): string {
  * Writable set: the cwd, one private runtime HOME, and the managed-memory dir.
  * A runtime credential adapter may add one credential-only host file/directory;
  * it is a separate trusted write capability, never a general read root.
- * AF_UNIX remains available to the trusted ACP parent because it needs the daemon
- * MCP/git credential channels and may launch a nested tool sandbox. Host socket
- * trees are hidden by the caller; the exact daemon MCP socket is re-exposed
- * read-only when an ancestor is hidden, without making its directory writable.
+ * AF_UNIX remains available because the ACP parent needs the daemon MCP channel
+ * and model-authored Git may need the credential channel. Host socket trees are
+ * hidden by the caller; exact AgentConnect sockets are re-exposed read-only when
+ * an ancestor is hidden, without making their directories writable.
  */
 export function sandboxBoundary(opts: {
   agentDir: string
@@ -258,9 +258,9 @@ export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy)
     network: {
       allowedDomains: [],
       deniedDomains: [],
-      // Linux cannot filter AF_UNIX by pathname. Keep it available to the trusted
-      // ACP parent; filesystem visibility limits reachable host sockets, while a
-      // runtime-native inner sandbox may apply seccomp to model-authored tools.
+      // Linux cannot filter AF_UNIX by pathname. Keep it available for the ACP
+      // parent and the model-side Git credential helper; filesystem and network
+      // namespace visibility limit which host sockets are reachable.
       allowAllUnixSockets: true
     },
     filesystem: {

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -150,9 +150,10 @@ function canonicalTarget(path: string): string {
  * Writable set: the cwd, one private runtime HOME, and the managed-memory dir.
  * A runtime credential adapter may add one credential-only host file/directory;
  * it is a separate trusted write capability, never a general read root.
- * Unix-socket policy deliberately remains compatibility-open during the SRT
- * migration. The exact daemon MCP socket is re-exposed read-only when an ancestor
- * is hidden; this does not make its directory a writable filesystem surface.
+ * AF_UNIX remains available to the trusted ACP parent because it needs the daemon
+ * MCP/git credential channels and may launch a nested tool sandbox. Host socket
+ * trees are hidden by the caller; the exact daemon MCP socket is re-exposed
+ * read-only when an ancestor is hidden, without making its directory writable.
  */
 export function sandboxBoundary(opts: {
   agentDir: string
@@ -257,8 +258,9 @@ export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy)
     network: {
       allowedDomains: [],
       deniedDomains: [],
-      // Socket restrictions are a separate policy project. Preserve all current
-      // MCP/git/runtime behavior while replacing only the filesystem wrapper.
+      // Linux cannot filter AF_UNIX by pathname. Keep it available to the trusted
+      // ACP parent; filesystem visibility limits reachable host sockets, while a
+      // runtime-native inner sandbox may apply seccomp to model-authored tools.
       allowAllUnixSockets: true
     },
     filesystem: {

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -231,7 +231,7 @@ export const AgentSchema = z.object({
   introduceOnJoin: z.boolean().default(false),
   // Request an OS sandbox for this agent (issue #312). Daemon policy may force it
   // on; an unavailable optional sandbox is ineffective. New agents default off.
-  restrictFileAccess: z.boolean().default(false),
+  runInSandbox: z.boolean().default(false),
   // Org built-in preset marker (preset-agents.md §3.1), replicated from the CP via
   // AgentSpec.builtin. Gates preset-only capabilities locally — e.g. advertising
   // `webchat_remote_mcp_v1` without waiting for a runtime probe round. Never set

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -437,7 +437,7 @@ function applySpecFields(
   // Self-introduce-on-join (#536): absent ⇒ leave the on-disk value alone (like pause/fastMode).
   if (spec.introduceOnJoin !== undefined) raw.introduceOnJoin = spec.introduceOnJoin
   // Sandbox toggle (#312): the CP always ships it (definite column); absent ⇒ leave alone.
-  if (spec.restrictFileAccess !== undefined) raw.restrictFileAccess = spec.restrictFileAccess
+  if (spec.runInSandbox !== undefined) raw.runInSandbox = spec.runInSandbox
   // Preset marker (preset-agents.md §3.1): the CP always ships it (definite record
   // field), so a flip replicates; absent (older CP) ⇒ leave the on-disk value alone.
   if (spec.builtin !== undefined) raw.builtin = spec.builtin

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -73,7 +73,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
 
   const sandboxMechanism = detectSandbox()
-  const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.restrictFileAccess, sandboxMechanism)
+  const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, sandboxMechanism)
   if (entry?.source === 'curated') {
     const admission = new CuratedRuntimeAdmission()
     const probe = opts.probeRuntimes ?? probeAllRuntimes

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1326,7 +1326,7 @@ export class Daemon {
       const agent = this.agents.get(id)
       if (!agent) return undefined
       return memoryKindOf(agent) === 'native' &&
-        effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.restrictFileAccess, this.sandboxMechanism)
+        effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
         ? runtimeHomePath(agent.dir)
         : agent.dir
     },
@@ -2352,7 +2352,7 @@ export class Daemon {
             enabled: agent.mcpServers,
             defs: this.mcpServerDefs,
             caps: this.runtimeMcpCaps.get(agent.runtime),
-            ...(effectiveRunInSandbox(cfg.security.requireSandbox, agent.restrictFileAccess, this.sandboxMechanism)
+            ...(effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
               ? {
                   resolveStdioCommand: (command: string, entries: { name: string; value: string }[]) =>
                     resolveTrustedExecutable(command, {
@@ -3811,12 +3811,8 @@ export class Daemon {
       // runtimeOverrides env (a user-supplied GIT_CONFIG_* would reopen
       // the machine-credential leak the injection exists to close).
       const baseEnv: Record<string, string> = { ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }
-      const runInSandbox = effectiveRunInSandbox(
-        cfg.security.requireSandbox,
-        agent.restrictFileAccess,
-        this.sandboxMechanism
-      )
-      if (agent.restrictFileAccess && !runInSandbox) {
+      const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
+      if (agent.runInSandbox && !runInSandbox) {
         this.log.warn(
           `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
         )

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3909,7 +3909,7 @@ export class Daemon {
         inheritProcessEnv: launch.inheritProcessEnv,
         runtimeId: agent.runtime,
         isolateAccountApps: cfg.security.isolateAccountApps,
-        sandbox: launch.sandbox,
+        sandbox: launch.sandbox ? { ...launch.sandbox, allowModelToolUnixSockets: githubAppCredentials } : undefined,
         configPrefs: {
           model: agent.runtimeOverrides?.model,
           permissionMode: agent.permissionMode,

--- a/packages/daemon/src/evaluation/runner.ts
+++ b/packages/daemon/src/evaluation/runner.ts
@@ -467,7 +467,7 @@ function prepareSubject(options: EvaluationRunnerOptions, agentIds: readonly str
           ...(typeof agent.permissionMode === 'string' ? { permissionMode: agent.permissionMode } : {}),
           ...(typeof agent.reasoningEffort === 'string' ? { reasoningEffort: agent.reasoningEffort } : {}),
           ...(typeof agent.fastMode === 'boolean' ? { fastMode: agent.fastMode } : {}),
-          ...(typeof agent.restrictFileAccess === 'boolean' ? { restrictFileAccess: agent.restrictFileAccess } : {}),
+          ...(typeof agent.runInSandbox === 'boolean' ? { runInSandbox: agent.runInSandbox } : {}),
           ...(typeof agent.output?.mode === 'string' ? { outputMode: agent.output.mode } : {})
         }
       }
@@ -771,7 +771,7 @@ export class RawAcpEvaluationRunner {
       const runtime = cfg.runtimes?.[agent.runtime]
       if (!runtime) throw new Error(`raw ACP subject runtime "${agent.runtime}" must be explicit in config.json`)
       const mechanism = detectSandbox()
-      const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.restrictFileAccess, mechanism)
+      const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, mechanism)
       const baseEnv = agentChildEnv(agent)
       const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
       const memoryOffEnv = memoryProviderFor(

--- a/packages/daemon/src/reconciler/reconciler.ts
+++ b/packages/daemon/src/reconciler/reconciler.ts
@@ -22,7 +22,7 @@ function signature(a: Agent): string {
 function hostSpawnSig(a: Agent): string {
   return JSON.stringify({
     runtime: a.runtime,
-    restrictFileAccess: a.restrictFileAccess,
+    runInSandbox: a.runInSandbox,
     model: a.runtimeOverrides?.model,
     description: a.description,
     reasoningEffort: a.reasoningEffort,

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -305,6 +305,10 @@ describe('claudeSessionMeta', () => {
     expect(claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
       cc({ thinking: THINKING, sandbox, settings: protectedSettings })
     )
+    expect(
+      claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], protectedSettings, true)?.claudeCode
+        .options.sandbox?.network.allowAllUnixSockets
+    ).toBe(true)
     expect(claudeSessionMeta('ultracode', true, undefined, undefined, [credentialRoot], protectedSettings)).toEqual(
       cc({
         thinking: THINKING,

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -262,6 +262,9 @@ describe('claudeSessionMeta', () => {
       failIfUnavailable: true,
       autoAllowBashIfSandboxed: true,
       allowUnsandboxedCommands: false,
+      network: {
+        allowAllUnixSockets: false
+      },
       filesystem: {
         denyRead: [credentialRoot],
         denyWrite: [credentialRoot]

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -172,7 +172,7 @@ describe('AgentSchema defaults', () => {
     expect(parsed.output.showFooter).toBe(true)
     expect(parsed.output.showStatusBar).toBe(true)
     expect(parsed.allowRuntimeChangesInChat).toBe(false)
-    expect(parsed.restrictFileAccess).toBe(false)
+    expect(parsed.runInSandbox).toBe(false)
     expect(parsed.callPolicy).toBe('all')
     expect(parsed.allowedCallerAgentIds).toEqual([])
     expect(parsed.outboundPolicy).toBe('all')

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -8,7 +8,7 @@ const a = (id: string): Agent =>
     name: id,
     status: 'active',
     runtime: 'claude',
-    restrictFileAccess: false,
+    runInSandbox: false,
     workspace: { mode: 'from-scratch', path: '/tmp', gitBranch: 'main', pullOnNewSession: true, skills: [] },
     integrations: [],
     output: { mode: 'medium' },
@@ -49,7 +49,7 @@ describe('diffAgents', () => {
 
   it('classifies enabling or disabling the OS sandbox as a host-spawn change', () => {
     const unsandboxed = a('x')
-    const sandboxed = { ...unsandboxed, restrictFileAccess: true } as Agent
+    const sandboxed = { ...unsandboxed, runInSandbox: true } as Agent
 
     expect(diffAgents([sandboxed], actual(unsandboxed)).toChange[0]).toMatchObject({
       hostRespawn: true,

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -93,15 +93,30 @@ describe('prepareRuntimeLaunch', () => {
       explicitEnv: {
         AGENT_VALUE: 'yes',
         ANTHROPIC_IDENTITY_TOKEN_FILE: identityTokenFile,
-        AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile
+        AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile,
+        SSH_AUTH_SOCK: '/run/user/1000/ssh-agent.sock',
+        DOCKER_HOST: 'unix:///run/docker.sock',
+        BUILDKIT_HOST: 'tcp://builder.example.test:1234'
       },
-      hostEnv: { HOME: hostHome, CLAUDE_CONFIG_DIR: customClaudeConfig, PATH: '/usr/bin' }
+      hostEnv: {
+        HOME: hostHome,
+        CLAUDE_CONFIG_DIR: customClaudeConfig,
+        PATH: '/usr/bin',
+        XDG_RUNTIME_DIR: '/run/user/1000',
+        DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/1000/bus'
+      }
     })
 
     expect(launch.inheritProcessEnv).toBe(false)
     expect(launch.runtimeHome).toBe(join(scopeDir, 'home'))
     expect(launch.env.HOME).toBe(join(scopeDir, 'home'))
     expect(launch.env.AGENT_VALUE).toBe('yes')
+    expect(launch.env.XDG_RUNTIME_DIR).toBe(realpathSync(join(scopeDir, 'home', '.run')))
+    expect(statSync(launch.env.XDG_RUNTIME_DIR).mode & 0o777).toBe(0o700)
+    expect(launch.env.SSH_AUTH_SOCK).toBeUndefined()
+    expect(launch.env.DBUS_SESSION_BUS_ADDRESS).toBeUndefined()
+    expect(launch.env.DOCKER_HOST).toBeUndefined()
+    expect(launch.env.BUILDKIT_HOST).toBe('tcp://builder.example.test:1234')
     expect(launch.sandbox?.mechanism).toBe('bwrap')
     expect(statSync(join(cwd, '.claude')).isDirectory()).toBe(true)
     expect(existsSync(join(cwd, '.claude', 'settings.json'))).toBe(false)
@@ -122,6 +137,7 @@ describe('prepareRuntimeLaunch', () => {
     expect(launch.env.ANTHROPIC_IDENTITY_TOKEN_FILE).toBe(canonicalIdentityToken)
     expect(launch.env.AWS_WEB_IDENTITY_TOKEN_FILE).toBe(canonicalAwsWebIdentityToken)
     expect(coveredBy(settings.filesystem.denyRead, canonicalHostHome)).toBe(true)
+    expect(coveredBy(settings.filesystem.denyRead, '/run')).toBe(true)
     expect(coveredBy(settings.filesystem.denyRead, realpathSync(customClaudeConfig))).toBe(true)
     expect(coveredBy(settings.filesystem.denyRead, realpathSync(dirname(scopeDir)))).toBe(true)
     expect(settings.filesystem.allowRead).toEqual(

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import {
   mkdirSync,
   mkdtempSync,
@@ -234,7 +234,7 @@ describe('Claude credential environment isolation', () => {
 
     try {
       const config = SandboxRuntimeConfigSchema.parse({
-        network: { allowedDomains: [], deniedDomains: [], allowAllUnixSockets: true },
+        network: { allowedDomains: [], deniedDomains: [], ...settings.network },
         filesystem: { ...settings.filesystem, allowWrite: [workspace] },
         credentials: settings.credentials
       })
@@ -279,6 +279,25 @@ describe('Claude credential environment isolation', () => {
           })
         ).toThrow()
       }
+
+      const socketPath = join(workspace, 'model-bash.sock')
+      const socketScript =
+        "require('node:net').createServer().on('error',(error)=>{console.error(error.code);process.exit(2)}).listen(process.argv[1],()=>process.exit(0))"
+      const socketAttempt = await SandboxManager.wrapWithSandboxArgv(
+        `${process.execPath} -e ${JSON.stringify(socketScript)} ${JSON.stringify(socketPath)}`,
+        undefined,
+        undefined,
+        undefined,
+        workspace
+      )
+      const socketResult = spawnSync(socketAttempt.argv[0]!, socketAttempt.argv.slice(1), {
+        cwd: workspace,
+        env: socketAttempt.env,
+        encoding: 'utf8'
+      })
+      expect(socketResult.status).toBe(2)
+      expect(socketResult.stderr).toMatch(/EPERM|operation not permitted/i)
+      expect(existsSync(socketPath)).toBe(false)
     } finally {
       SandboxManager.cleanupAfterCommand()
       await SandboxManager.reset()

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
 import {
   mkdirSync,
   mkdtempSync,
@@ -211,12 +214,33 @@ describe('Claude credential environment isolation', () => {
     const awsWebIdentityToken = 'trusted-parent-aws-token'
     const privateClaudeConfig = join(root, 'private-home', '.claude')
     const privateClaudeSettings = join(privateClaudeConfig, 'settings.json')
+    const credentialSocket = join(root, 'run', 'gitcred.sock')
+    let credentialRequest: Record<string, unknown> | undefined
+    const credentialServer = createServer((socket) => {
+      let input = ''
+      socket.setEncoding('utf8')
+      socket.on('data', (chunk) => {
+        input += chunk
+        const newline = input.indexOf('\n')
+        if (newline === -1) return
+        credentialRequest = JSON.parse(input.slice(0, newline)) as Record<string, unknown>
+        socket.end(
+          `${JSON.stringify({
+            ok: true,
+            username: 'x-access-token',
+            password: 'test-installation-token',
+            repoFullName: 'owner/repo'
+          })}\n`
+        )
+      })
+    })
     const seededCredentialEnvironment = {
       AWS_CONTAINER_AUTHORIZATION_TOKEN: 'trusted-parent-container-token',
       AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile
     }
     mkdirSync(workspace)
     mkdirSync(privateClaudeConfig, { recursive: true })
+    mkdirSync(join(root, 'run'))
     writeFileSync(identityTokenFile, identityToken, { mode: 0o600 })
     writeFileSync(awsWebIdentityTokenFile, awsWebIdentityToken, { mode: 0o600 })
     writeFileSync(
@@ -224,7 +248,7 @@ describe('Claude credential environment isolation', () => {
       JSON.stringify({ env: { ANTHROPIC_API_KEY: 'trusted-parent-settings-token' } }),
       { mode: 0o600 }
     )
-    const settings = claudeInnerSandboxSettings([identityTokenFile, awsWebIdentityTokenFile, privateClaudeConfig])
+    const settings = claudeInnerSandboxSettings([identityTokenFile, awsWebIdentityTokenFile, privateClaudeConfig], true)
     const names = settings.credentials.envVars.map(({ name }) => name)
     const restoredNames = new Set([...names, ...Object.keys(seededCredentialEnvironment)])
     const previous = new Map([...restoredNames].map((name) => [name, process.env[name]]))
@@ -233,6 +257,10 @@ describe('Claude credential environment isolation', () => {
     Object.assign(process.env, seededCredentialEnvironment)
 
     try {
+      await new Promise<void>((resolve, reject) => {
+        credentialServer.once('error', reject)
+        credentialServer.listen(credentialSocket, resolve)
+      })
       const config = SandboxRuntimeConfigSchema.parse({
         network: { allowedDomains: [], deniedDomains: [], ...settings.network },
         filesystem: { ...settings.filesystem, allowWrite: [workspace] },
@@ -280,25 +308,57 @@ describe('Claude credential environment isolation', () => {
         ).toThrow()
       }
 
-      const socketPath = join(workspace, 'model-bash.sock')
-      const socketScript =
-        "require('node:net').createServer().on('error',(error)=>{console.error(error.code);process.exit(2)}).listen(process.argv[1],()=>process.exit(0))"
+      // GitHub App workspaces deliberately keep one model-side Unix channel:
+      // exercise the real helper, not just a generic socket connect.
+      const req = createRequire(import.meta.url)
+      const daemonEntry = fileURLToPath(new URL('../src/index.ts', import.meta.url))
+      const helperCommand = [process.execPath, req.resolve('tsx/cli'), daemonEntry, 'git-credential', 'agent-1', 'get']
+        .map(JSON.stringify)
+        .join(' ')
       const socketAttempt = await SandboxManager.wrapWithSandboxArgv(
-        `${process.execPath} -e ${JSON.stringify(socketScript)} ${JSON.stringify(socketPath)}`,
+        helperCommand,
         undefined,
         undefined,
         undefined,
         workspace
       )
-      const socketResult = spawnSync(socketAttempt.argv[0]!, socketAttempt.argv.slice(1), {
-        cwd: workspace,
-        env: socketAttempt.env,
-        encoding: 'utf8'
+      const socketResult = await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn(socketAttempt.argv[0]!, socketAttempt.argv.slice(1), {
+            cwd: workspace,
+            env: {
+              ...socketAttempt.env,
+              AGENTCONNECT_ROOT: root,
+              AC_GITCRED_AGENT: 'agent-1',
+              AC_GITCRED_CAPABILITY: 'test-capability'
+            },
+            stdio: ['pipe', 'pipe', 'pipe']
+          })
+          let stdout = ''
+          let stderr = ''
+          const timeout = setTimeout(() => child.kill('SIGKILL'), 10_000)
+          child.stdout.setEncoding('utf8').on('data', (chunk) => (stdout += chunk))
+          child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk))
+          child.once('error', reject)
+          child.once('close', (code) => {
+            clearTimeout(timeout)
+            resolve({ code, stdout, stderr })
+          })
+          child.stdin.end('protocol=https\nhost=github.com\npath=owner/repo.git\n\n')
+        }
+      )
+      expect(socketResult.code, socketResult.stderr).toBe(0)
+      expect(socketResult.stdout).toBe('username=x-access-token\npassword=test-installation-token\n')
+      expect(credentialRequest).toMatchObject({
+        op: 'get',
+        agentId: 'agent-1',
+        capability: 'test-capability',
+        repoFullName: 'owner/repo'
       })
-      expect(socketResult.status).toBe(2)
-      expect(socketResult.stderr).toMatch(/EPERM|operation not permitted/i)
-      expect(existsSync(socketPath)).toBe(false)
     } finally {
+      if (credentialServer.listening) {
+        await new Promise<void>((resolve) => credentialServer.close(() => resolve()))
+      }
       SandboxManager.cleanupAfterCommand()
       await SandboxManager.reset()
       for (const [name, value] of previous) {

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -276,7 +276,7 @@ export const AgentSpec = z.object({
   // host has bwrap/sandbox-exec; daemon `security.requireSandbox` forces it on and
   // prevents daemon startup when no mechanism exists. Optional means leave the
   // on-disk agent.json value alone; a brand-new agent defaults to false.
-  restrictFileAccess: z.boolean().optional(),
+  runInSandbox: z.boolean().optional(),
   // True when this agent is an org built-in preset (preset-agents.md §3.1): a
   // `preset_agent` row references it. Replicated so the daemon can gate
   // preset-only capabilities locally (e.g. advertising `webchat_remote_mcp_v1`

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -793,7 +793,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           : memoryProvider !== 'managed'
             ? { memory: { provider: memoryProvider as 'native' | 'none' } }
             : {}),
-        restrictFileAccess: effectiveRunInSandbox,
+        runInSandbox: effectiveRunInSandbox,
         ...(Object.keys(envRecord).length ? { env: envRecord } : {}),
         ...(Object.keys(secretsRecord).length ? { secrets: secretsRecord } : {}),
         permissionMode: selectedPermissionMode,

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -113,8 +113,8 @@ export default function EditAgentModal({
   const initialAllowRuntimeChangesInChat = useRef(agent.allowRuntimeChangesInChat)
   const [introduceOnJoin, setIntroduceOnJoin] = useState(agent.introduceOnJoin)
   const initialIntroduceOnJoin = useRef(agent.introduceOnJoin)
-  const [restrictFileAccess, setRestrictFileAccess] = useState(agent.restrictFileAccess)
-  const initialRestrictFileAccess = useRef(agent.restrictFileAccess)
+  const [runInSandbox, setRunInSandbox] = useState(agent.runInSandbox)
+  const initialRunInSandbox = useRef(agent.runInSandbox)
   // Agent-call visibility (both directions) — prefilled from the list `Agent`
   // (which already carries the policy), edited here, and saved on the modal's
   // Save alongside the spec/sharing diffs rather than immediately per change.
@@ -185,8 +185,8 @@ export default function EditAgentModal({
         initialAllowRuntimeChangesInChat.current = dto.allowRuntimeChangesInChat ?? false
         setIntroduceOnJoin(dto.introduceOnJoin ?? false)
         initialIntroduceOnJoin.current = dto.introduceOnJoin ?? false
-        setRestrictFileAccess(dto.restrictFileAccess ?? false)
-        initialRestrictFileAccess.current = dto.restrictFileAccess ?? false
+        setRunInSandbox(dto.runInSandbox ?? false)
+        initialRunInSandbox.current = dto.runInSandbox ?? false
         setSandboxSupported(dto.sandboxSupported ?? false)
         setSandboxRequired(dto.sandboxRequired ?? false)
         const fresh: SharingValue = { visibility: dto.visibility, sharedWith: dto.sharedWith }
@@ -298,7 +298,7 @@ export default function EditAgentModal({
   const selectedSandboxSupported = daemonChanged
     ? selectedSandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
     : sandboxSupported
-  const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && restrictFileAccess)
+  const effectiveRunInSandbox = selectedSandboxRequired || (selectedSandboxSupported && runInSandbox)
   const moveReady = (d: (typeof daemons)[number] | undefined) =>
     !!d && d.status === 'online' && d.caps.features.includes('agent-move-v1')
   const daemonLabel = daemon?.name ?? (daemonId ? `Current daemon (${daemonId.slice(0, 8)})` : 'No daemon')
@@ -419,7 +419,7 @@ export default function EditAgentModal({
     ...(permissionMode !== initialPermissionMode.current ? { permissionMode } : {}),
     ...(allowRuntimeChangesInChat !== initialAllowRuntimeChangesInChat.current ? { allowRuntimeChangesInChat } : {}),
     ...(introduceOnJoin !== initialIntroduceOnJoin.current ? { introduceOnJoin } : {}),
-    ...(restrictFileAccess !== initialRestrictFileAccess.current ? { restrictFileAccess } : {}),
+    ...(runInSandbox !== initialRunInSandbox.current ? { runInSandbox } : {}),
     ...(envChanged ? { env: envRecord } : {}),
     ...(secretsChanged ? { secrets: secretsPatch } : {})
   }
@@ -844,7 +844,7 @@ export default function EditAgentModal({
                   required={selectedSandboxRequired}
                   disabled={placementRequested}
                   disabledDetail="Save the computer change before adjusting sandboxing."
-                  onChange={setRestrictFileAccess}
+                  onChange={setRunInSandbox}
                 />
                 <OutputModeField
                   className="desktop:col-span-2"

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -245,7 +245,7 @@ export interface AgentDto {
   outboundPolicy: AgentCallPolicy // which peer agents this agent may discover/call
   allowedTargetAgentIds: string[] // agent.id set, meaningful when outboundPolicy='selected'
   introduceOnJoin: boolean // #536: self-introduce to peers on a genuine channel join
-  restrictFileAccess: boolean // #642: persisted per-agent Run in sandbox preference
+  runInSandbox: boolean // #642: persisted per-agent Run in sandbox preference
   sandboxSupported: boolean // #642: whether the placed daemon can provide an OS sandbox
   sandboxRequired: boolean // #642: whether daemon policy forces the effective value on
   hookKinds: ('webhook' | 'github')[] // distinct kinds of enabled inbound triggers (list-view marks)
@@ -753,8 +753,8 @@ export interface UpdateAgentInput {
   pause?: boolean | null
   /** #536: self-introduce to peers on a genuine channel join (default off). */
   introduceOnJoin?: boolean
-  /** #642: confine the agent process to its agent dir via an OS sandbox (default on). */
-  restrictFileAccess?: boolean
+  /** #642: confine the agent process to its agent dir via an OS sandbox (default off). */
+  runInSandbox?: boolean
   /** Widen an existing App-backed GitHub workspace from read to write. */
   gitAccess?: 'write'
   /** Repository-relative ACP working directory; null selects the repository root. */
@@ -924,7 +924,7 @@ export interface CreateAgentInput {
   /** Memory backend; absent ⇒ managed default. */
   memory?: AgentMemoryConfig
   /** Request an OS sandbox for this agent; absent ⇒ false unless daemon policy requires it. */
-  restrictFileAccess?: boolean
+  runInSandbox?: boolean
   /** Initial visibility (absent ⇒ 'org'); sharedWith is intersected with org members. */
   visibility?: ResourceVisibility
   sharedWith?: string[]
@@ -1557,8 +1557,8 @@ export function agentFromDto(d: AgentDto): Agent {
     allowedTargetAgentIds: d.allowedTargetAgentIds ?? [],
     // Unset (older CP) reads as off — the product default.
     introduceOnJoin: d.introduceOnJoin ?? false,
-    // Older CPs omit the policy fields; the safe UI fallback is unavailable/off.
-    restrictFileAccess: d.restrictFileAccess ?? false,
+    // Missing policy fields fail closed; the removed legacy field is not read.
+    runInSandbox: d.runInSandbox ?? false,
     sandboxSupported: d.sandboxSupported ?? false,
     sandboxRequired: d.sandboxRequired ?? false,
     hookKinds: d.hookKinds ?? [],

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -312,7 +312,7 @@ export interface Agent {
   /** #536: when true, the agent introduces itself to peers on a genuine channel join. */
   introduceOnJoin: boolean
   /** #642: persisted per-agent Run in sandbox preference. */
-  restrictFileAccess: boolean
+  runInSandbox: boolean
   /** #642: whether the placed daemon can provide the sandbox (else the toggle is disabled). */
   sandboxSupported: boolean
   /** #642: whether daemon policy forces the effective value on and locks the toggle. */
@@ -887,7 +887,7 @@ export const AGENTS: Agent[] = (
       outboundPolicy: 'all',
       allowedTargetAgentIds: [],
       introduceOnJoin: false,
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: false,
       sandboxRequired: false,
       name: 'agentconnect',
@@ -939,7 +939,7 @@ export const AGENTS: Agent[] = (
       outboundPolicy: 'all',
       allowedTargetAgentIds: [],
       introduceOnJoin: false,
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: true,
       sandboxRequired: false,
       name: 'deploy-bot',
@@ -1033,7 +1033,7 @@ export const AGENTS: Agent[] = (
       outboundPolicy: 'all',
       allowedTargetAgentIds: [],
       introduceOnJoin: true,
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: true,
       sandboxRequired: false,
       name: 'review-bot',
@@ -1110,7 +1110,7 @@ export const AGENTS: Agent[] = (
       outboundPolicy: 'selected',
       allowedTargetAgentIds: ['deploy'],
       introduceOnJoin: false,
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: true,
       sandboxRequired: false,
       name: 'oncall-bot',
@@ -1176,7 +1176,7 @@ export const AGENTS: Agent[] = (
       outboundPolicy: 'selected',
       allowedTargetAgentIds: ['review'],
       introduceOnJoin: false,
-      restrictFileAccess: false,
+      runInSandbox: false,
       sandboxSupported: true,
       sandboxRequired: false,
       name: 'docs-bot',


### PR DESCRIPTION
## Summary

- rename the persisted, REST, ACP, daemon, and web preference from `restrictFileAccess` to `runInSandbox`, including an in-place database column rename
- hide Linux host socket trees from sandboxed runtimes, clear inherited host IPC pointers, and redirect `XDG_RUNTIME_DIR` into the agent's private runtime HOME
- preserve the trusted ACP parent's exact AgentConnect socket carve-backs; Claude model tools block AF_UNIX by default and enable it only when a GitHub App workspace deliberately exposes the scoped `gitcred.sock` channel
- expose only the new field with no legacy alias or mixed-version compatibility path; ordinary unsandboxed-agent HOME behavior remains unchanged

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- focused daemon sandbox/config/launch/host tests: 96 passed, 2 platform-skipped on macOS
- focused control-plane protocol and agent route integration tests: 50 passed
- complete Prisma migration chain applied successfully in integration tests
- live Linux SRT smoke tests on agent-0: `/run` socket hidden, exact socket carve-back connectable, default inner AF_UNIX creation rejected with `EPERM`, and the actual scoped `agentconnect git-credential` helper succeeds when explicitly enabled

Created by Codex . GPT-5.6
