### PR TITLE
fix(web): align the Home dashboard columns on a shared row height

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,7 +178,7 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # HELP_MCP_URL=https://docs.agentconnect.md/docs/mcp-connector
 # HELP_DOCS_URL=https://docs.agentconnect.md
 # HELP_RELEASES_URL=https://github.com/agentconnect-md/agentconnect/releases
-# HELP_SUPPORT_URL=mailto:support@agentconnect.md
+# HELP_SUPPORT_URL=mailto:contact@agentconnect.md
 
 # Sender the waitlist page tells approved users their activation link comes from.
 # Must match the verified sender the admin mailer actually sends as, or the page

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1035,7 +1035,7 @@
   /* The runtime brand mark falls through to a bare <img> (no data attribute) —
      a colored logo, not a monochrome glyph, so the dark inverse plate shows
      through its transparent areas. Keep the plate transparent (as with glyphs)
-     so the mark reads on the card surface, e.g. Usage "By type" rows. */
+     so the mark reads on the card surface, e.g. Usage "By runtime" rows. */
   .av:has(> img:not([data-agent-icon-image])) {
     background: transparent;
   }

--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -5,30 +5,27 @@
 // name, platform mark + channel, relative time. The small Card/CardLink/EmptyRow
 // primitives live here too — HomeView's other cards reuse them.
 
-import { useEffect, useRef, useState, type ReactNode, type Ref } from 'react'
+import { type ReactNode } from 'react'
 import Link from 'next/link'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
 import { sessionChannelDisplay, type Session } from '@/lib/data'
-import { useIsMobile } from '@/lib/use-is-mobile'
 
 export function Card({
   title,
   action,
   className,
-  children,
-  ref
+  children
 }: {
   title: string
   action?: ReactNode
   className?: string
   children: ReactNode
-  ref?: Ref<HTMLDivElement>
 }) {
   return (
-    <div ref={ref} className={`card overflow-hidden ${className ?? ''}`}>
+    <div className={`card overflow-hidden ${className ?? ''}`}>
       <div className="cardhead justify-between">
         <span className="cardtitle">{title}</span>
         {action}
@@ -50,9 +47,11 @@ export function CardLink({ href, children }: { href: string; children: ReactNode
   )
 }
 
-export function EmptyRow({ children }: { children: ReactNode }) {
+export function EmptyRow({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className="px-4 py-5 text-center font-sans text-[12.5px] leading-normal text-(--text-tertiary)">
+    <div
+      className={`flex items-center justify-center px-4 py-5 text-center font-sans text-[12.5px] leading-normal text-(--text-tertiary) ${className ?? ''}`}
+    >
       {children}
     </div>
   )
@@ -62,9 +61,9 @@ export function EmptyRow({ children }: { children: ReactNode }) {
 // causes no layout shift. Title width cycles deterministically (no Math.random)
 // so server and client render identically.
 const SKEL_TITLE_WIDTHS = ['w-2/5', 'w-1/3', 'w-1/2', 'w-3/5']
-function SessionRowSkeleton({ i }: { i: number }) {
+function SessionRowSkeleton({ i, rowClassName }: { i: number; rowClassName?: string }) {
   return (
-    <div className="row grid-cols-[1fr_auto] gap-3">
+    <div className={`row grid-cols-[1fr_auto] gap-3 ${rowClassName ?? ''}`}>
       <span className="min-w-0">
         <span
           className={`block h-[13px] ${SKEL_TITLE_WIDTHS[i % SKEL_TITLE_WIDTHS.length]} animate-pulse rounded-full bg-(--surface-active)`}
@@ -88,7 +87,7 @@ export function RecentSessionsCard({
   limit = 6,
   className,
   showAgent = true,
-  fillHeight = false
+  rowClassName
 }: {
   title?: string
   sessions: Session[]
@@ -99,53 +98,33 @@ export function RecentSessionsCard({
   className?: string
   /** Agent detail already scopes to one agent — hide the redundant icon+name there. */
   showAgent?: boolean
-  /** Card height is set externally (Home: match the right column) — fit only WHOLE rows,
-   * so the card never ends on a row sliced in half. */
-  fillHeight?: boolean
+  /** Per-row utilities. Home pins every dashboard row to one shared height so its two
+   * columns end on the same line (see HomeView's row-budget note); other surfaces let
+   * the rows size to their content. */
+  rowClassName?: string
 }) {
   const { orgPath } = useOrgs()
   const { getAgent, crons } = useConsoleData()
-  const cardRef = useRef<HTMLDivElement>(null)
-  const bodyRef = useRef<HTMLDivElement>(null)
-  const [fit, setFit] = useState<number | null>(null)
-  // Mobile stacks the card in normal flow, so its height is its own content —
-  // measuring there would feed back into itself. Fit rows on desktop only.
-  const isMobile = useIsMobile()
-  const canFill = fillHeight && !isMobile
-  useEffect(() => {
-    if (!canFill) return
-    const el = cardRef.current
-    const body = bodyRef.current
-    if (!el || !body) return
-    const measure = () => {
-      const row = body.querySelector<HTMLElement>('a.row')
-      if (!row || row.offsetHeight === 0) return
-      setFit(Math.max(1, Math.floor(body.clientHeight / row.offsetHeight)))
-    }
-    measure()
-    const ro = new ResizeObserver(measure)
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [canFill, sessions.length])
-  const recent = sessions.slice(0, canFill && fit !== null ? fit : limit)
+  const recent = sessions.slice(0, limit)
   return (
-    <Card
-      ref={cardRef}
-      title={title}
-      action={<CardLink href={allHref}>All sessions</CardLink>}
-      className={`${fillHeight ? 'desktop:flex desktop:flex-col' : ''} ${className ?? ''}`}
-    >
-      <div ref={bodyRef} className={fillHeight ? 'desktop:min-h-0 desktop:flex-1 desktop:overflow-y-auto' : undefined}>
+    <Card title={title} action={<CardLink href={allHref}>All sessions</CardLink>} className={className}>
+      <>
         {loading && recent.length === 0 ? (
-          Array.from({ length: 4 }, (_, i) => <SessionRowSkeleton key={i} i={i} />)
+          Array.from({ length: Math.min(4, limit) }, (_, i) => (
+            <SessionRowSkeleton key={i} i={i} rowClassName={rowClassName} />
+          ))
         ) : recent.length === 0 ? (
-          <EmptyRow>{emptyText}</EmptyRow>
+          <EmptyRow className={rowClassName}>{emptyText}</EmptyRow>
         ) : (
           recent.map((s) => {
             const owner = s.agentId ? getAgent(s.agentId) : undefined
             const ch = sessionChannelDisplay(s, (id) => crons.find((c) => c.id === id)?.name)
             return (
-              <Link key={s.id} href={orgPath(`/sessions/${s.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
+              <Link
+                key={s.id}
+                href={orgPath(`/sessions/${s.id}`)}
+                className={`row click grid-cols-[1fr_auto] gap-3 ${rowClassName ?? ''}`}
+              >
                 <span className="min-w-0">
                   <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
                     {s.title}
@@ -178,7 +157,7 @@ export function RecentSessionsCard({
             )
           })
         )}
-      </div>
+      </>
     </Card>
   )
 }

--- a/packages/web/src/components/console/RuntimeSelect.test.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.test.tsx
@@ -4,11 +4,11 @@ import { act, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RuntimeSelect } from './RuntimeSelect'
-import { unavailableRuntimeIds } from '@/lib/data'
+import { loginRequiredRuntimeIds } from '@/lib/data'
 
-// The registry is an SWR fetch of /api/acp-registry — stub it empty so the test
-// never opens a request the environment has to abort on teardown. With no entry,
-// labels fall back to the raw runtime id.
+// The registry is an SWR fetch of /api/acp-registry — stub it empty so the test never
+// opens a request the environment has to abort on teardown. Labels then come from
+// `runtimeLabel`'s static table alone.
 vi.mock('@/lib/acp-registry', () => ({
   useAcpRegistry: () => ({}),
   acpRuntime: () => undefined
@@ -19,26 +19,22 @@ let container: HTMLDivElement | undefined
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
-function Harness({ initial = 'claude', unavailable }: { initial?: string; unavailable?: readonly string[] }) {
+function Harness({ initial = 'claude', needsLogin }: { initial?: string; needsLogin?: readonly string[] }) {
   const [value, setValue] = useState(initial)
   return (
-    <RuntimeSelect
-      value={value}
-      options={['claude', 'codex', 'cursor']}
-      unavailable={unavailable}
-      onChange={setValue}
-    />
+    <RuntimeSelect value={value} options={['claude', 'codex', 'cursor']} needsLogin={needsLogin} onChange={setValue} />
   )
 }
+
+const trigger = () => container!.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
+const options = () => [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')]
 
 async function mount(node: React.ReactElement) {
   container = document.createElement('div')
   document.body.append(container)
   root = createRoot(container)
   await act(async () => root?.render(node))
-  const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
-  await act(async () => trigger.click())
-  return { trigger, options: () => [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')] }
+  await act(async () => trigger().click())
 }
 
 afterEach(async () => {
@@ -48,39 +44,45 @@ afterEach(async () => {
   container = undefined
 })
 
-// Rows keep the `options` order, and the registry is empty under test (no /api fetch),
-// so labels fall back to raw ids — index by position rather than by display name.
+// Rows keep the `options` order, so index by position rather than by display name.
 const CLAUDE = 0
 const CODEX = 1
-const CURSOR = 2
 
 describe('RuntimeSelect', () => {
-  it('offers a runtime the daemon cannot launch but refuses to select it', async () => {
-    const { options } = await mount(<Harness unavailable={['codex']} />)
+  it('marks a logged-out runtime without taking the choice away', async () => {
+    await mount(<Harness needsLogin={['codex']} />)
 
     const codex = options()[CODEX]!
-    expect(codex.getAttribute('aria-disabled')).toBe('true')
-    // A `disabled` button emits no pointer events, so the reason has to ride an
-    // enabled element for the tooltip layer to ever show it.
-    expect(codex.hasAttribute('disabled')).toBe(false)
+    expect(codex.textContent).toContain('Login required')
     expect(codex.getAttribute('title')).toContain('Not signed in on this daemon')
+    // Marked, never blocked: placement on a logged-out runtime is a supported state
+    // (docs/designs/preset-agents.md §3.2), so nothing here may refuse the pick.
+    expect(codex.hasAttribute('disabled')).toBe(false)
+    expect(codex.getAttribute('aria-disabled')).toBeNull()
 
     await act(async () => codex.click())
 
-    // Still open on the original value — the click was a no-op.
-    expect(options()[CLAUDE]!.getAttribute('aria-selected')).toBe('true')
-    expect(options()[CODEX]!.getAttribute('aria-selected')).toBe('false')
+    expect(trigger().textContent).toContain('Codex')
+    expect(options()).toHaveLength(0)
   })
 
-  it('never disables the current value, so a form can always keep its own runtime', async () => {
-    const { options } = await mount(<Harness initial="codex" unavailable={['codex', 'cursor']} />)
+  it('leaves a signed-in runtime unmarked', async () => {
+    await mount(<Harness needsLogin={['codex']} />)
 
-    expect(options()[CODEX]!.hasAttribute('aria-disabled')).toBe(false)
-    expect(options()[CURSOR]!.getAttribute('aria-disabled')).toBe('true')
+    expect(options()[CLAUDE]!.textContent).not.toContain('Login required')
+    expect(options()[CLAUDE]!.getAttribute('title')).toBeNull()
   })
 
-  it('steps arrow-key travel over unavailable rows', async () => {
-    const { trigger, options } = await mount(<Harness unavailable={['codex']} />)
+  it('carries the warning on the closed trigger, where the menu text does not fit', async () => {
+    await mount(<Harness initial="codex" needsLogin={['codex']} />)
+    await act(async () => trigger().click()) // close
+
+    expect(options()).toHaveLength(0)
+    expect(trigger().querySelector('[title]')?.getAttribute('title')).toContain('Not signed in on this daemon')
+  })
+
+  it('keeps arrow-key travel on every row', async () => {
+    await mount(<Harness needsLogin={['codex']} />)
 
     const list = container!.querySelector<HTMLDivElement>('[role="listbox"]')!
     await act(async () => {
@@ -90,14 +92,13 @@ describe('RuntimeSelect', () => {
       list.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     })
 
-    // claude → (skips codex) → cursor, and the pick closed the list.
-    expect(trigger.textContent).toContain('cursor')
-    expect(options()).toHaveLength(0)
+    // claude → codex: the marked row is the very next stop, not skipped.
+    expect(trigger().textContent).toContain('Codex')
   })
 })
 
-describe('unavailableRuntimeIds', () => {
-  it('names the runtimes the daemon reports but cannot launch', () => {
+describe('loginRequiredRuntimeIds', () => {
+  it('names the runtimes the daemon reports as needing a login', () => {
     const daemon = {
       runtimeModels: [
         { runtime: 'claude', version: '1.0.0', models: ['sonnet'] },
@@ -106,9 +107,9 @@ describe('unavailableRuntimeIds', () => {
       ]
     }
 
-    // Only the logged-out one — an empty model list is a runtime that advertises
-    // nothing (cursor), not one that cannot run.
-    expect(unavailableRuntimeIds(daemon)).toEqual(['codex'])
-    expect(unavailableRuntimeIds(undefined)).toEqual([])
+    // Only the flagged one — an empty model list is a runtime that advertises nothing
+    // (cursor), not one that needs a login.
+    expect(loginRequiredRuntimeIds(daemon)).toEqual(['codex'])
+    expect(loginRequiredRuntimeIds(undefined)).toEqual([])
   })
 })

--- a/packages/web/src/components/console/RuntimeSelect.test.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RuntimeSelect } from './RuntimeSelect'
+import { unavailableRuntimeIds } from '@/lib/data'
+
+// The registry is an SWR fetch of /api/acp-registry — stub it empty so the test
+// never opens a request the environment has to abort on teardown. With no entry,
+// labels fall back to the raw runtime id.
+vi.mock('@/lib/acp-registry', () => ({
+  useAcpRegistry: () => ({}),
+  acpRuntime: () => undefined
+}))
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+function Harness({ initial = 'claude', unavailable }: { initial?: string; unavailable?: readonly string[] }) {
+  const [value, setValue] = useState(initial)
+  return (
+    <RuntimeSelect
+      value={value}
+      options={['claude', 'codex', 'cursor']}
+      unavailable={unavailable}
+      onChange={setValue}
+    />
+  )
+}
+
+async function mount(node: React.ReactElement) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => root?.render(node))
+  const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
+  await act(async () => trigger.click())
+  return { trigger, options: () => [...container!.querySelectorAll<HTMLButtonElement>('[role="option"]')] }
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+// Rows keep the `options` order, and the registry is empty under test (no /api fetch),
+// so labels fall back to raw ids — index by position rather than by display name.
+const CLAUDE = 0
+const CODEX = 1
+const CURSOR = 2
+
+describe('RuntimeSelect', () => {
+  it('offers a runtime the daemon cannot launch but refuses to select it', async () => {
+    const { options } = await mount(<Harness unavailable={['codex']} />)
+
+    const codex = options()[CODEX]!
+    expect(codex.getAttribute('aria-disabled')).toBe('true')
+    // A `disabled` button emits no pointer events, so the reason has to ride an
+    // enabled element for the tooltip layer to ever show it.
+    expect(codex.hasAttribute('disabled')).toBe(false)
+    expect(codex.getAttribute('title')).toContain('Not signed in on this daemon')
+
+    await act(async () => codex.click())
+
+    // Still open on the original value — the click was a no-op.
+    expect(options()[CLAUDE]!.getAttribute('aria-selected')).toBe('true')
+    expect(options()[CODEX]!.getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('never disables the current value, so a form can always keep its own runtime', async () => {
+    const { options } = await mount(<Harness initial="codex" unavailable={['codex', 'cursor']} />)
+
+    expect(options()[CODEX]!.hasAttribute('aria-disabled')).toBe(false)
+    expect(options()[CURSOR]!.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('steps arrow-key travel over unavailable rows', async () => {
+    const { trigger, options } = await mount(<Harness unavailable={['codex']} />)
+
+    const list = container!.querySelector<HTMLDivElement>('[role="listbox"]')!
+    await act(async () => {
+      list.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+    await act(async () => {
+      list.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    // claude → (skips codex) → cursor, and the pick closed the list.
+    expect(trigger.textContent).toContain('cursor')
+    expect(options()).toHaveLength(0)
+  })
+})
+
+describe('unavailableRuntimeIds', () => {
+  it('names the runtimes the daemon reports but cannot launch', () => {
+    const daemon = {
+      runtimeModels: [
+        { runtime: 'claude', version: '1.0.0', models: ['sonnet'] },
+        { runtime: 'codex', version: '1.1.4', models: [], authRequired: true },
+        { runtime: 'cursor', version: '', models: [] }
+      ]
+    }
+
+    // Only the logged-out one — an empty model list is a runtime that advertises
+    // nothing (cursor), not one that cannot run.
+    expect(unavailableRuntimeIds(daemon)).toEqual(['codex'])
+    expect(unavailableRuntimeIds(undefined)).toEqual([])
+  })
+})

--- a/packages/web/src/components/console/RuntimeSelect.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.tsx
@@ -4,21 +4,33 @@ import { Icon } from '@/components/ui'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { runtimeLabel } from '@/lib/data'
 
+/** Why an option is offered but not choosable. Today the daemon reports exactly one
+ *  such case: a curated runtime whose last probe came back "authentication required"
+ *  — installed on the host, but logged out, so the daemon keeps it unlaunchable. */
+const UNAVAILABLE_HINT = 'Not signed in on this daemon — sign in to the runtime on the daemon host'
+
 export function RuntimeSelect({
   value,
   options,
+  unavailable,
+  unavailableHint = UNAVAILABLE_HINT,
   onChange,
   ariaLabel = 'Runtime'
 }: {
   value: string
   options: readonly string[]
+  /** Ids the daemon reports but cannot currently run — shown dimmed and unpickable.
+   *  The CURRENT value is never disabled, so a form always has a way back to itself. */
+  unavailable?: readonly string[]
+  unavailableHint?: string
   onChange: (value: string) => void
   ariaLabel?: string
 }) {
   const registry = useAcpRegistry()
   const rows = options.map((id) => ({
     id,
-    label: runtimeLabel(id, acpRuntime(registry, id)?.name)
+    label: runtimeLabel(id, acpRuntime(registry, id)?.name),
+    disabled: id !== value && !!unavailable?.includes(id)
   }))
   const selectedIndex = Math.max(
     0,
@@ -47,33 +59,41 @@ export function RuntimeSelect({
     closeAndFocus()
   }
 
+  // Keyboard travel lands only on choosable rows: step from `from` in `delta` steps
+  // until one is enabled, wrapping. Returns `from` when every row is disabled, which
+  // can't happen while a value is set (its own row is always enabled).
+  const nextEnabled = (from: number, delta: number) => {
+    for (let i = 1; i <= rows.length; i++) {
+      const index = (from + delta * i + rows.length * i) % rows.length
+      if (!rows[index]?.disabled) return index
+    }
+    return from
+  }
+  const firstEnabled = (from: number) => (rows[from]?.disabled ? nextEnabled(from, 1) : from)
+
   const openFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault()
-      setActiveIndex(event.key === 'ArrowDown' ? selectedIndex : rows.length - 1)
+      setActiveIndex(event.key === 'ArrowDown' ? firstEnabled(selectedIndex) : nextEnabled(0, -1))
       setOpen(true)
     }
-  }
-
-  const moveActive = (delta: number) => {
-    setActiveIndex((current) => (current + delta + rows.length) % rows.length)
   }
 
   const onListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault()
-      moveActive(event.key === 'ArrowDown' ? 1 : -1)
+      setActiveIndex((current) => nextEnabled(current, event.key === 'ArrowDown' ? 1 : -1))
       return
     }
     if (event.key === 'Home' || event.key === 'End') {
       event.preventDefault()
-      setActiveIndex(event.key === 'Home' ? 0 : rows.length - 1)
+      setActiveIndex(event.key === 'Home' ? firstEnabled(0) : nextEnabled(0, -1))
       return
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       const active = rows[activeIndex]
-      if (active) pick(active.id)
+      if (active && !active.disabled) pick(active.id)
       return
     }
     if (event.key === 'Escape') {
@@ -100,7 +120,7 @@ export function RuntimeSelect({
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         onClick={() => {
-          setActiveIndex(selectedIndex)
+          setActiveIndex(firstEnabled(selectedIndex))
           setOpen((current) => !current)
         }}
         onKeyDown={openFromKeyboard}
@@ -153,15 +173,22 @@ export function RuntimeSelect({
                   role="option"
                   tabIndex={-1}
                   aria-selected={isSelected}
+                  // aria-disabled, not the `disabled` attribute: a disabled button
+                  // emits no pointer events, so the tooltip layer would never get to
+                  // show WHY the row can't be picked.
+                  aria-disabled={row.disabled || undefined}
+                  title={row.disabled ? unavailableHint : undefined}
                   className={`fopt min-h-10 gap-3 rounded-md px-2 py-[6px] text-[13px] ${
-                    isSelected
-                      ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
-                      : isActive
-                        ? 'bg-(--surface-hover)'
-                        : ''
+                    row.disabled
+                      ? 'cursor-not-allowed opacity-45 hover:bg-transparent'
+                      : isSelected
+                        ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                        : isActive
+                          ? 'bg-(--surface-hover)'
+                          : ''
                   }`}
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onClick={() => pick(row.id)}
+                  onMouseEnter={() => !row.disabled && setActiveIndex(index)}
+                  onClick={() => !row.disabled && pick(row.id)}
                 >
                   <span className="imark h-7 w-7 flex-none rounded-md">
                     <AgentMark model={row.id} />

--- a/packages/web/src/components/console/RuntimeSelect.tsx
+++ b/packages/web/src/components/console/RuntimeSelect.tsx
@@ -4,25 +4,22 @@ import { Icon } from '@/components/ui'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { runtimeLabel } from '@/lib/data'
 
-/** Why an option is offered but not choosable. Today the daemon reports exactly one
- *  such case: a curated runtime whose last probe came back "authentication required"
- *  — installed on the host, but logged out, so the daemon keeps it unlaunchable. */
-const UNAVAILABLE_HINT = 'Not signed in on this daemon — sign in to the runtime on the daemon host'
+const LOGIN_HINT = 'Not signed in on this daemon — you can still pick it, then sign in on the daemon host'
 
 export function RuntimeSelect({
   value,
   options,
-  unavailable,
-  unavailableHint = UNAVAILABLE_HINT,
+  needsLogin,
   onChange,
   ariaLabel = 'Runtime'
 }: {
   value: string
   options: readonly string[]
-  /** Ids the daemon reports but cannot currently run — shown dimmed and unpickable.
-   *  The CURRENT value is never disabled, so a form always has a way back to itself. */
-  unavailable?: readonly string[]
-  unavailableHint?: string
+  /** Ids the daemon reports as needing a login on its host. MARKED, never disabled:
+   *  the flag doesn't mean "can't launch" (see `loginRequiredRuntimeIds`), and placing
+   *  an agent on a logged-out runtime is a supported state — creation and placement
+   *  deliberately don't gate on readiness (docs/designs/preset-agents.md §3.2). */
+  needsLogin?: readonly string[]
   onChange: (value: string) => void
   ariaLabel?: string
 }) {
@@ -30,7 +27,7 @@ export function RuntimeSelect({
   const rows = options.map((id) => ({
     id,
     label: runtimeLabel(id, acpRuntime(registry, id)?.name),
-    disabled: id !== value && !!unavailable?.includes(id)
+    needsLogin: !!needsLogin?.includes(id)
   }))
   const selectedIndex = Math.max(
     0,
@@ -59,41 +56,33 @@ export function RuntimeSelect({
     closeAndFocus()
   }
 
-  // Keyboard travel lands only on choosable rows: step from `from` in `delta` steps
-  // until one is enabled, wrapping. Returns `from` when every row is disabled, which
-  // can't happen while a value is set (its own row is always enabled).
-  const nextEnabled = (from: number, delta: number) => {
-    for (let i = 1; i <= rows.length; i++) {
-      const index = (from + delta * i + rows.length * i) % rows.length
-      if (!rows[index]?.disabled) return index
-    }
-    return from
-  }
-  const firstEnabled = (from: number) => (rows[from]?.disabled ? nextEnabled(from, 1) : from)
-
   const openFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault()
-      setActiveIndex(event.key === 'ArrowDown' ? firstEnabled(selectedIndex) : nextEnabled(0, -1))
+      setActiveIndex(event.key === 'ArrowDown' ? selectedIndex : rows.length - 1)
       setOpen(true)
     }
+  }
+
+  const moveActive = (delta: number) => {
+    setActiveIndex((current) => (current + delta + rows.length) % rows.length)
   }
 
   const onListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault()
-      setActiveIndex((current) => nextEnabled(current, event.key === 'ArrowDown' ? 1 : -1))
+      moveActive(event.key === 'ArrowDown' ? 1 : -1)
       return
     }
     if (event.key === 'Home' || event.key === 'End') {
       event.preventDefault()
-      setActiveIndex(event.key === 'Home' ? firstEnabled(0) : nextEnabled(0, -1))
+      setActiveIndex(event.key === 'Home' ? 0 : rows.length - 1)
       return
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       const active = rows[activeIndex]
-      if (active && !active.disabled) pick(active.id)
+      if (active) pick(active.id)
       return
     }
     if (event.key === 'Escape') {
@@ -120,7 +109,7 @@ export function RuntimeSelect({
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         onClick={() => {
-          setActiveIndex(firstEnabled(selectedIndex))
+          setActiveIndex(selectedIndex)
           setOpen((current) => !current)
         }}
         onKeyDown={openFromKeyboard}
@@ -132,6 +121,13 @@ export function RuntimeSelect({
                 <AgentMark model={selected?.id ?? value} />
               </span>
               <span className="truncate">{selected?.label ?? value}</span>
+              {/* The field is a 1/3 column, too narrow for the menu's text tag — carry
+                  the same warning as a mark so the state survives the menu closing. */}
+              {selected?.needsLogin && (
+                <span className="flex-none" title={LOGIN_HINT}>
+                  <Icon name="triangle-alert" size={13} color="var(--status-paused)" />
+                </span>
+              )}
             </>
           ) : (
             // Deferred exec config (an unplaced preset agent): nothing chosen yet —
@@ -173,27 +169,27 @@ export function RuntimeSelect({
                   role="option"
                   tabIndex={-1}
                   aria-selected={isSelected}
-                  // aria-disabled, not the `disabled` attribute: a disabled button
-                  // emits no pointer events, so the tooltip layer would never get to
-                  // show WHY the row can't be picked.
-                  aria-disabled={row.disabled || undefined}
-                  title={row.disabled ? unavailableHint : undefined}
+                  title={row.needsLogin ? LOGIN_HINT : undefined}
                   className={`fopt min-h-10 gap-3 rounded-md px-2 py-[6px] text-[13px] ${
-                    row.disabled
-                      ? 'cursor-not-allowed opacity-45 hover:bg-transparent'
-                      : isSelected
-                        ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
-                        : isActive
-                          ? 'bg-(--surface-hover)'
-                          : ''
+                    isSelected
+                      ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                      : isActive
+                        ? 'bg-(--surface-hover)'
+                        : ''
                   }`}
-                  onMouseEnter={() => !row.disabled && setActiveIndex(index)}
-                  onClick={() => !row.disabled && pick(row.id)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => pick(row.id)}
                 >
                   <span className="imark h-7 w-7 flex-none rounded-md">
                     <AgentMark model={row.id} />
                   </span>
                   <span className="flex-1 whitespace-nowrap">{row.label}</span>
+                  {row.needsLogin && (
+                    <span className="flex flex-none items-center gap-[4px] font-sans text-[11px] font-medium leading-normal text-(--status-paused)">
+                      <Icon name="triangle-alert" size={11} className="flex-none" />
+                      Login required
+                    </span>
+                  )}
                   {isSelected && <Icon name="check" size={16} color="var(--brand)" className="flex-none" />}
                 </button>
               )

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -583,7 +583,9 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 type="button"
                 onClick={toggleRail}
                 className="railtoggle"
-                title={railCollapsed ? 'Expand sidebar' : undefined}
+                // No `title`: the icon already reads as the collapse/expand affordance,
+                // and a tooltip on the collapsed rail's own toggle is noise. Screen
+                // readers still get the state from aria-label.
                 aria-label={railCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
               >
                 <Icon name={railCollapsed ? 'panel-left-open' : 'panel-left-close'} size={16} />

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -118,7 +118,7 @@ const HELP_LINK_DEFAULTS = {
   mcp: 'https://docs.agentconnect.md/docs/mcp-connector',
   docs: 'https://docs.agentconnect.md',
   releases: 'https://github.com/agentconnect-md/agentconnect/releases',
-  support: 'mailto:support@agentconnect.md'
+  support: 'mailto:contact@agentconnect.md'
 }
 
 // Resolve at render (not module load) so it reads the runtime config: window.__AC_ENV

--- a/packages/web/src/components/console/Tooltip.test.tsx
+++ b/packages/web/src/components/console/Tooltip.test.tsx
@@ -169,13 +169,14 @@ describe('TooltipLayer', () => {
   })
 
   it('releases a focused title before keyboard activation updates it', async () => {
-    const btn = iconButton('Expand sidebar')
-    // The collapsed rail's click changes its title prop to undefined. By the
-    // time this runs, the tooltip layer has already lifted the DOM attribute.
+    const btn = iconButton('Show secret')
+    // A control whose activation drops its own title (the reveal toggles do this
+    // when their label flips). By the time this runs, the tooltip layer has
+    // already lifted the DOM attribute.
     btn.addEventListener('click', () => btn.removeAttribute('title'))
 
     await focus(btn)
-    expect(tooltip()?.textContent).toBe('Expand sidebar')
+    expect(tooltip()?.textContent).toBe('Show secret')
 
     await act(async () => btn.click())
     await act(async () => btn.dispatchEvent(new FocusEvent('focusout', { bubbles: true })))

--- a/packages/web/src/components/console/dashboard-rows.test.ts
+++ b/packages/web/src/components/console/dashboard-rows.test.ts
@@ -52,12 +52,36 @@ describe('dashboardRowBudget', () => {
     expect(rowsAt(3)).toEqual([1, 1, 3])
   })
 
-  it('refuses to shrink the right column to match a thin session list', () => {
-    // A quiet org on a full-height window still gets all four agents and three
-    // schedules — trimming them would chase an alignment the left card can't reach.
+  it('trims to meet a short session list on a roomy window', () => {
+    // The viewport has room for 8 rows, but the card can only draw what exists, so
+    // the right column comes down to meet it rather than towering over it.
+    const rowsAt = (sessions: number) => {
+      const b = dashboardRowBudget({ availableHeight: heightFor(8), ...FULL, sessions })
+      return [b.agentRows, b.cronRows, b.sessionRows]
+    }
+
+    expect(rowsAt(8)).toEqual([4, 3, 8])
+    expect(rowsAt(7)).toEqual([4, 2, 7])
+    expect(rowsAt(5)).toEqual([2, 2, 5])
+    expect(rowsAt(3)).toEqual([1, 1, 3])
+  })
+
+  it('squares up for every session count a trim can reach, on a roomy window', () => {
+    for (let sessions = MIN_RIGHT_COLUMN_ROWS; sessions <= 8; sessions++) {
+      const b = dashboardRowBudget({ availableHeight: heightFor(20), ...FULL, sessions })
+
+      expect(b.aligned).toBe(true)
+      expect(b.sessionRows).toBeLessThanOrEqual(sessions)
+      expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
+    }
+  })
+
+  it('refuses to shrink the right column below the floor for a session list it cannot meet', () => {
+    // Two sessions can never reach the right column's two-card floor, so trimming
+    // would cost this org two of its four agents and still not line up.
     const b = dashboardRowBudget({ availableHeight: heightFor(10), sessions: 2, agents: 6, crons: 5 })
 
-    expect(b).toMatchObject({ agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS })
+    expect(b).toMatchObject({ agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS, aligned: false })
   })
 
   describe('sparse orgs — fewer sessions than the right column can go', () => {

--- a/packages/web/src/components/console/dashboard-rows.test.ts
+++ b/packages/web/src/components/console/dashboard-rows.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CARD_CHROME_H,
+  CARD_GAP_H,
+  DASH_ROW_H,
+  dashboardRowBudget,
+  MAX_AGENT_ROWS,
+  MAX_CRON_ROWS,
+  MIN_RIGHT_COLUMN_ROWS
+} from './dashboard-rows'
+
+/** What the browser will lay out, in px, for a given budget. */
+const leftHeight = (rows: number) => CARD_CHROME_H + rows * DASH_ROW_H
+const rightHeight = (agentRows: number, cronRows: number) =>
+  CARD_CHROME_H + agentRows * DASH_ROW_H + CARD_GAP_H + (CARD_CHROME_H + cronRows * DASH_ROW_H)
+
+/** Leftover viewport height that holds exactly `rows` whole left-card rows. */
+const heightFor = (rows: number) => CARD_CHROME_H + rows * DASH_ROW_H
+
+const FULL = { sessions: 20, agents: MAX_AGENT_ROWS, crons: MAX_CRON_ROWS }
+
+describe('dashboardRowBudget', () => {
+  it('lands both columns on the same line whenever the data can reach it', () => {
+    // Every viewport from "right column at its floor" up to the content ceiling.
+    for (let rows = MIN_RIGHT_COLUMN_ROWS; rows <= 12; rows++) {
+      const b = dashboardRowBudget({ availableHeight: heightFor(rows), ...FULL })
+
+      expect(b.aligned).toBe(true)
+      expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
+      // …and never taller than the viewport it was measured against.
+      expect(leftHeight(b.sessionRows)).toBeLessThanOrEqual(heightFor(rows))
+    }
+  })
+
+  it('spends a roomy viewport on the full content, not on stretch', () => {
+    const b = dashboardRowBudget({ availableHeight: heightFor(30), ...FULL })
+
+    expect(b).toMatchObject({ sessionRows: 8, agentRows: 4, cronRows: 3, aligned: true })
+  })
+
+  it('thins both right-hand cards as the window tightens, schedules first', () => {
+    const rowsAt = (rows: number) => {
+      const b = dashboardRowBudget({ availableHeight: heightFor(rows), ...FULL })
+      return [b.agentRows, b.cronRows, b.sessionRows]
+    }
+
+    expect(rowsAt(8)).toEqual([4, 3, 8])
+    expect(rowsAt(7)).toEqual([4, 2, 7]) // a schedule goes first
+    expect(rowsAt(6)).toEqual([3, 2, 6]) // then an agent, rather than a second schedule
+    expect(rowsAt(5)).toEqual([2, 2, 5])
+    expect(rowsAt(4)).toEqual([2, 1, 4]) // only now does either list reach one row
+    expect(rowsAt(3)).toEqual([1, 1, 3])
+  })
+
+  it('refuses to shrink the right column to match a thin session list', () => {
+    // A quiet org on a full-height window still gets all four agents and three
+    // schedules — trimming them would chase an alignment the left card can't reach.
+    const b = dashboardRowBudget({ availableHeight: heightFor(10), sessions: 2, agents: 6, crons: 5 })
+
+    expect(b).toMatchObject({ agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS })
+  })
+
+  describe('sparse orgs — fewer sessions than the right column can go', () => {
+    // The right column floors at one agent row + one schedule row, which is
+    // MIN_RIGHT_COLUMN_ROWS left rows. Nothing shorter can square up, so the budget
+    // reports it instead of pretending.
+    it.each([0, 1, 2])('reports %i sessions as unaligned', (sessions) => {
+      const b = dashboardRowBudget({ availableHeight: heightFor(8), sessions, agents: 4, crons: 3 })
+
+      expect(b.aligned).toBe(false)
+      // The card renders what it has; Home keeps it at that natural height.
+      expect(leftHeight(Math.max(1, sessions))).toBeLessThan(rightHeight(b.agentRows, b.cronRows))
+    })
+
+    it('squares up again at the first session count that can', () => {
+      const b = dashboardRowBudget({
+        availableHeight: heightFor(MIN_RIGHT_COLUMN_ROWS),
+        sessions: MIN_RIGHT_COLUMN_ROWS,
+        agents: 4,
+        crons: 3
+      })
+
+      expect(b).toMatchObject({ sessionRows: MIN_RIGHT_COLUMN_ROWS, aligned: true })
+      expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
+    })
+
+    it('counts an empty agent or schedule list as its placeholder row', () => {
+      const b = dashboardRowBudget({ availableHeight: heightFor(8), sessions: 20, agents: 0, crons: 0 })
+
+      expect(b).toMatchObject({ sessionRows: 3, agentRows: 1, cronRows: 1, aligned: true })
+      expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
+    })
+  })
+
+  it('starts at the content ceiling before the viewport has been measured', () => {
+    // First paint / no scroll container: no cap, so the cards open at their maximum
+    // and only shrink once a real height arrives.
+    const b = dashboardRowBudget({ availableHeight: null, ...FULL })
+
+    expect(b).toMatchObject({ sessionRows: 8, agentRows: 4, cronRows: 3 })
+  })
+
+  it('never goes below the right column floor, however short the window', () => {
+    const b = dashboardRowBudget({ availableHeight: 1, ...FULL })
+
+    expect(b).toMatchObject({ sessionRows: MIN_RIGHT_COLUMN_ROWS, agentRows: 1, cronRows: 1 })
+  })
+})

--- a/packages/web/src/components/console/dashboard-rows.ts
+++ b/packages/web/src/components/console/dashboard-rows.ts
@@ -42,23 +42,22 @@ export interface DashboardRows {
 /**
  * Pick each card's row count.
  *
- * Two facts drive it. The viewport caps how many rows fit at all, and the identity
- * above fixes the left card at one row more than the right column's total. So: trim
- * the right column — schedules first, in two passes down to a 2-row floor before
- * either list is taken to one — until the matching left card fits, then let
- * `sessionRows` follow from what survived.
+ * Two things bound the left card: the viewport caps how many rows fit at all, and it
+ * can only draw the sessions that exist. The identity above then fixes it at one row
+ * more than the right column's total. So: trim the right column — schedules first, in
+ * two passes down to a 2-row floor before either list is taken to one — until the
+ * matching left card fits both bounds, and let `sessionRows` follow from what survived.
  *
- * Deliberately NOT part of the trim: how many sessions the org actually has. Trimming
- * against a thin session list would shrink the other two cards to chase an alignment
- * they can't reach anyway — a quiet org would see one agent instead of four on a
- * full-height window. The right column's floor is MIN_RIGHT_COLUMN_ROWS row
- * equivalents, so an org with fewer sessions than that simply cannot square up; that
- * is reported as `aligned: false` rather than papered over.
+ * The session bound applies ONLY while a trim can still land the alignment. The right
+ * column floors at MIN_RIGHT_COLUMN_ROWS row equivalents (one agent row + one schedule
+ * row, the second card's chrome included), so an org below that cannot square up no
+ * matter how far the trim runs — and trimming anyway would cost it two of its four
+ * agents for nothing. Those orgs keep the full right column and are reported as
+ * `aligned: false` instead.
  *
  * @param availableHeight leftover viewport height for the grid; null ⇒ no cap.
  * @param sessions/agents/crons how many rows each card HAS to draw. An empty card
- *   still draws its placeholder row, so agents and crons cost a row either way — but
- *   sessions are the one list whose shortfall the layout cannot absorb.
+ *   still draws its placeholder row, so every list costs at least one row.
  */
 export function dashboardRowBudget({
   availableHeight,
@@ -77,10 +76,13 @@ export function dashboardRowBudget({
     availableHeight === null
       ? Number.POSITIVE_INFINITY
       : Math.max(MIN_RIGHT_COLUMN_ROWS, Math.floor((availableHeight - CARD_CHROME_H) / DASH_ROW_H))
+  // Rows the Recent card can actually draw, and whether aiming at that is worth it.
+  const reach = Math.max(1, sessions)
+  const budget = Math.min(capacity, reach >= MIN_RIGHT_COLUMN_ROWS ? reach : Number.POSITIVE_INFINITY)
   for (const floor of [2, 1]) {
-    while (a + c + 1 > capacity && c > floor) c--
-    while (a + c + 1 > capacity && a > floor) a--
+    while (a + c + 1 > budget && c > floor) c--
+    while (a + c + 1 > budget && a > floor) a--
   }
   const sessionRows = a + c + 1
-  return { sessionRows, agentRows: a, cronRows: c, aligned: Math.max(1, sessions) >= sessionRows }
+  return { sessionRows, agentRows: a, cronRows: c, aligned: reach >= sessionRows }
 }

--- a/packages/web/src/components/console/dashboard-rows.ts
+++ b/packages/web/src/components/console/dashboard-rows.ts
@@ -1,0 +1,86 @@
+// Home's dashboard row budget.
+//
+// The dashboard is one left card (Recent) beside a stack of two (Agents you use,
+// Scheduled runs), and all three have to end on the same line with no half-drawn row
+// and no dead strip inside a card. That falls out of one identity: every row is pinned
+// to DASH_ROW_H and every card costs the same fixed chrome — its own two borders plus
+// the head (2 + 45) — so the right column's SECOND card, gutter included, costs
+// 2 + 45 + 16 = 63px, i.e. EXACTLY one row. The columns match when the left card shows
+// one row MORE than the right column shows in total:
+//
+//     47 + (n+1)·63  ==  (47 + a·63) + 16 + (47 + c·63)   for a + c == n
+//
+// Hence 63 as the row height, not a rounder number — it is what the second card's
+// chrome measures. Changing the grid's `gap-4`, the card border, or `.cardhead` padding
+// changes it.
+
+/** Every dashboard row, in all three cards. */
+export const DASH_ROW_H = 63
+/** What a card costs before its first row: its own two borders plus the head. */
+export const CARD_CHROME_H = 47
+/** The gutter between the right column's two cards (the grid's `gap-4`). */
+export const CARD_GAP_H = 16
+export const MAX_AGENT_ROWS = 4
+export const MAX_CRON_ROWS = 3
+/** Mobile stacks the cards, so there is nothing to align — a plain content cap. */
+export const MOBILE_SESSION_ROWS = 6
+/** Row equivalents of the right column at its floor (one agent + one schedule). No
+ *  left card shorter than this can meet it, which is the whole sparse-state case. */
+export const MIN_RIGHT_COLUMN_ROWS = 3
+
+export interface DashboardRows {
+  /** Rows the Recent card asks for. It renders `min(this, sessions available)`. */
+  sessionRows: number
+  agentRows: number
+  cronRows: number
+  /** False when the org has fewer sessions than `sessionRows`, so the left card can't
+   *  reach the right column. Home then lets it keep its natural height (`self-start`)
+   *  rather than stretching a mostly-empty card down to a line it didn't earn. */
+  aligned: boolean
+}
+
+/**
+ * Pick each card's row count.
+ *
+ * Two facts drive it. The viewport caps how many rows fit at all, and the identity
+ * above fixes the left card at one row more than the right column's total. So: trim
+ * the right column — schedules first, in two passes down to a 2-row floor before
+ * either list is taken to one — until the matching left card fits, then let
+ * `sessionRows` follow from what survived.
+ *
+ * Deliberately NOT part of the trim: how many sessions the org actually has. Trimming
+ * against a thin session list would shrink the other two cards to chase an alignment
+ * they can't reach anyway — a quiet org would see one agent instead of four on a
+ * full-height window. The right column's floor is MIN_RIGHT_COLUMN_ROWS row
+ * equivalents, so an org with fewer sessions than that simply cannot square up; that
+ * is reported as `aligned: false` rather than papered over.
+ *
+ * @param availableHeight leftover viewport height for the grid; null ⇒ no cap.
+ * @param sessions/agents/crons how many rows each card HAS to draw. An empty card
+ *   still draws its placeholder row, so agents and crons cost a row either way — but
+ *   sessions are the one list whose shortfall the layout cannot absorb.
+ */
+export function dashboardRowBudget({
+  availableHeight,
+  sessions,
+  agents,
+  crons
+}: {
+  availableHeight: number | null
+  sessions: number
+  agents: number
+  crons: number
+}): DashboardRows {
+  let a = Math.min(MAX_AGENT_ROWS, Math.max(1, agents))
+  let c = Math.min(MAX_CRON_ROWS, Math.max(1, crons))
+  const capacity =
+    availableHeight === null
+      ? Number.POSITIVE_INFINITY
+      : Math.max(MIN_RIGHT_COLUMN_ROWS, Math.floor((availableHeight - CARD_CHROME_H) / DASH_ROW_H))
+  for (const floor of [2, 1]) {
+    while (a + c + 1 > capacity && c > floor) c--
+    while (a + c + 1 > capacity && a > floor) a--
+  }
+  const sessionRows = a + c + 1
+  return { sessionRows, agentRows: a, cronRows: c, aligned: Math.max(1, sessions) >= sessionRows }
+}

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -8,7 +8,7 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
-  unavailableRuntimeIds,
+  loginRequiredRuntimeIds,
   agentSlugFinalize,
   agentSlugSanitize,
   effortChoicesFor,
@@ -189,7 +189,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [displayName, setDisplayName] = useState('')
   // New agents default to a random glyph+color (product default — not runtime-branded).
   const [icon, setIcon] = useState<AgentIcon>(() => randomGlyphIcon())
-  const [runtime, setRuntime] = useState(FALLBACK_RUNTIME_IDS[0]!)
+  const [runtime, setRuntime] = useState('') // '' = untouched; the daemon supplies the default
   const [model, setModel] = useState('')
   const [effort, setEffort] = useState('')
   const [fastMode, setFastMode] = useState(false)
@@ -338,15 +338,15 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // that round-trip back to the launch key — so a created agent actually resolves.
   // No daemon (or none reported) ⇒ the static fallback list.
   const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
-  // Reported but unlaunchable (installed, logged out) — offered disabled, and never
-  // the fallback: an agent pinned to one could not take a session.
-  const unavailableRuntimes = unavailableRuntimeIds(daemon)
-  const firstUsableRuntime = runtimeIds.find((id) => !unavailableRuntimes.includes(id)) ?? runtimeIds[0] ?? ''
-  // Keep the selection valid as the option set changes with the daemon. The picker
-  // can't hand back an unavailable id, so one only ever arrives here as the initial
-  // seed — fall back rather than carry it.
-  const effectiveRuntime =
-    runtimeIds.includes(runtime) && !unavailableRuntimes.includes(runtime) ? runtime : firstUsableRuntime
+  // Runtimes the daemon reports as logged out. Marked in the picker, never blocked —
+  // creating on one is a supported state (docs/designs/preset-agents.md §3.2).
+  const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
+  // …but the DEFAULT prefers a signed-in one, mirroring how auto-placement picks a
+  // preset's runtime. Falls through to the first reported id when all are logged out.
+  const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
+  // `runtime` is '' until the user picks one, so the default above applies to a fresh
+  // form while an explicit choice — logged out or not — always survives.
+  const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
   // Models come from the chosen daemon's reported capabilities for this runtime.
   // There is no separate "Default" entry: with real models known, the picker
   // preselects the runtime's resolved default (else the first model) and the
@@ -974,7 +974,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   <RuntimeSelect
                     value={effectiveRuntime}
                     options={runtimeIds}
-                    unavailable={unavailableRuntimes}
+                    needsLogin={runtimesNeedingLogin}
                     onChange={(nextRuntime) => {
                       setRuntime(nextRuntime)
                       setEffort('')

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -8,6 +8,7 @@ import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
+  unavailableRuntimeIds,
   agentSlugFinalize,
   agentSlugSanitize,
   effortChoicesFor,
@@ -337,8 +338,15 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // that round-trip back to the launch key — so a created agent actually resolves.
   // No daemon (or none reported) ⇒ the static fallback list.
   const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
-  // Keep the selection valid as the option set changes with the daemon.
-  const effectiveRuntime = runtimeIds.includes(runtime) ? runtime : (runtimeIds[0] ?? '')
+  // Reported but unlaunchable (installed, logged out) — offered disabled, and never
+  // the fallback: an agent pinned to one could not take a session.
+  const unavailableRuntimes = unavailableRuntimeIds(daemon)
+  const firstUsableRuntime = runtimeIds.find((id) => !unavailableRuntimes.includes(id)) ?? runtimeIds[0] ?? ''
+  // Keep the selection valid as the option set changes with the daemon. The picker
+  // can't hand back an unavailable id, so one only ever arrives here as the initial
+  // seed — fall back rather than carry it.
+  const effectiveRuntime =
+    runtimeIds.includes(runtime) && !unavailableRuntimes.includes(runtime) ? runtime : firstUsableRuntime
   // Models come from the chosen daemon's reported capabilities for this runtime.
   // There is no separate "Default" entry: with real models known, the picker
   // preselects the runtime's resolved default (else the first model) and the
@@ -966,6 +974,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   <RuntimeSelect
                     value={effectiveRuntime}
                     options={runtimeIds}
+                    unavailable={unavailableRuntimes}
                     onChange={(nextRuntime) => {
                       setRuntime(nextRuntime)
                       setEffort('')

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -6,7 +6,7 @@ import {
   effortField,
   effortLabel,
   FALLBACK_RUNTIME_IDS,
-  unavailableRuntimeIds,
+  loginRequiredRuntimeIds,
   fastModeAvailableFor,
   modelCapability,
   modelLabel,
@@ -316,11 +316,10 @@ export default function EditAgentModal({
   const reportedRuntimeIds = daemon?.runtimeModels.map((r) => r.runtime) ?? []
   const runtimeIds = reportedRuntimeIds.length ? reportedRuntimeIds : FALLBACK_RUNTIME_IDS
   const runtimeOptions = runtime && !runtimeIds.includes(runtime) ? [runtime, ...runtimeIds] : runtimeIds
-  // Reported but unlaunchable (installed on the host, logged out) — offered disabled
-  // so a move can't repin the agent onto a runtime that could never take a session.
-  // The agent's OWN runtime is exempt (RuntimeSelect never disables the current value):
-  // an unusable stored runtime is a state to show and fix, not one to hide.
-  const unavailableRuntimes = unavailableRuntimeIds(daemon)
+  // Runtimes the daemon reports as logged out — marked in the picker, never blocked.
+  // An agent may legitimately sit on one (docs/designs/preset-agents.md §3.2), so this
+  // surfaces the state on the choice rather than taking the choice away.
+  const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
   const runtimeMeta = acpRuntime(acpRegistry, runtime)
   // Models are only what the daemon reports for this runtime — advertised ids
   // verbatim, never a synthesized "Default" entry: an agent without an explicit
@@ -724,7 +723,7 @@ export default function EditAgentModal({
                   <RuntimeSelect
                     value={runtime}
                     options={runtimeOptions}
-                    unavailable={unavailableRuntimes}
+                    needsLogin={runtimesNeedingLogin}
                     onChange={onRuntimeChange}
                   />
                 </div>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -6,6 +6,7 @@ import {
   effortField,
   effortLabel,
   FALLBACK_RUNTIME_IDS,
+  unavailableRuntimeIds,
   fastModeAvailableFor,
   modelCapability,
   modelLabel,
@@ -315,6 +316,11 @@ export default function EditAgentModal({
   const reportedRuntimeIds = daemon?.runtimeModels.map((r) => r.runtime) ?? []
   const runtimeIds = reportedRuntimeIds.length ? reportedRuntimeIds : FALLBACK_RUNTIME_IDS
   const runtimeOptions = runtime && !runtimeIds.includes(runtime) ? [runtime, ...runtimeIds] : runtimeIds
+  // Reported but unlaunchable (installed on the host, logged out) — offered disabled
+  // so a move can't repin the agent onto a runtime that could never take a session.
+  // The agent's OWN runtime is exempt (RuntimeSelect never disables the current value):
+  // an unusable stored runtime is a state to show and fix, not one to hide.
+  const unavailableRuntimes = unavailableRuntimeIds(daemon)
   const runtimeMeta = acpRuntime(acpRegistry, runtime)
   // Models are only what the daemon reports for this runtime — advertised ids
   // verbatim, never a synthesized "Default" entry: an agent without an explicit
@@ -715,7 +721,12 @@ export default function EditAgentModal({
                 </div>
                 <div className="fld">
                   <span className="fldlbl">Runtime</span>
-                  <RuntimeSelect value={runtime} options={runtimeOptions} onChange={onRuntimeChange} />
+                  <RuntimeSelect
+                    value={runtime}
+                    options={runtimeOptions}
+                    unavailable={unavailableRuntimes}
+                    onChange={onRuntimeChange}
+                  />
                 </div>
                 <div className="fld">
                   <span className="fldlbl">Model</span>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -255,26 +255,29 @@ export default function HomeView() {
     // content caps.
     if (isMobile) return { sessionRows: MOBILE_SESSION_ROWS, agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS }
     // An empty card still draws its placeholder row, so it costs a row either way.
-    const haveSessions = Math.max(1, allSessions.length)
-    const haveAgents = Math.min(MAX_AGENT_ROWS, Math.max(1, rankedAgents.length))
-    const haveCrons = Math.min(MAX_CRON_ROWS, Math.max(1, crons.length))
+    let a = Math.min(MAX_AGENT_ROWS, Math.max(1, rankedAgents.length))
+    let c = Math.min(MAX_CRON_ROWS, Math.max(1, crons.length))
     // Whole rows the leftover viewport can hold — unmeasured (mobile / first paint)
     // means no cap, so the cards start at their content-driven maximum.
     const capacity = availableHeight
       ? Math.max(3, Math.floor((availableHeight - CARD_CHROME_H) / DASH_ROW_H))
       : Number.POSITIVE_INFINITY
-    const budget = Math.min(capacity, haveSessions)
-    let a = haveAgents
-    let c = haveCrons
-    // Trim the right column until the left card can cover it. Schedules give way
-    // first, but in two passes down to a 2-row floor before either list is taken
-    // to a single row — so a cramped window thins both cards instead of gutting one.
+    // Trim the right column until the matching left card fits the viewport. Schedules
+    // give way first, but in two passes down to a 2-row floor before either list is
+    // taken to a single row — so a cramped window thins both cards instead of gutting
+    // one. Only the VIEWPORT trims here: a thin session list must not shrink the other
+    // two cards, because the left card can't grow to match them anyway (below).
     for (const floor of [2, 1]) {
-      while (a + c + 1 > budget && c > floor) c--
-      while (a + c + 1 > budget && a > floor) a--
+      while (a + c + 1 > capacity && c > floor) c--
+      while (a + c + 1 > capacity && a > floor) a--
     }
-    return { sessionRows: Math.min(budget, a + c + 1), agentRows: a, cronRows: c }
-  }, [isMobile, availableHeight, allSessions.length, rankedAgents.length, crons.length])
+    // The left card always asks for one row more than the right column shows — that IS
+    // the identity. An org with fewer sessions than that is the one case it can't hold
+    // up: the right column's floor is two cards (two heads + a row each = three left
+    // rows), which no shorter card can reach. There the card renders what it has and
+    // stretches to the row height, so the bottoms still meet.
+    return { sessionRows: a + c + 1, agentRows: a, cronRows: c }
+  }, [isMobile, availableHeight, rankedAgents.length, crons.length])
 
   const topAgents = rankedAgents.slice(0, agentRows)
   const scheduled = crons.slice(0, cronRows)

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -17,6 +17,12 @@ import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
 import { Card, CardLink, EmptyRow, RecentSessionsCard } from '@/components/console/RecentSessionsCard'
+import {
+  dashboardRowBudget,
+  MAX_AGENT_ROWS,
+  MAX_CRON_ROWS,
+  MOBILE_SESSION_ROWS
+} from '@/components/console/dashboard-rows'
 import { Icon } from '@/components/ui'
 import { AgentIconView, ModelMark, LoadingState, LogoMark } from '@/components/marks'
 import { useProfile } from '@/lib/profile'
@@ -44,24 +50,6 @@ import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
 const CHIP =
   'inline-flex h-7 items-center gap-[6px] rounded-md px-[9px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
 
-// ── Dashboard row budget ────────────────────────────────────────────────────
-// The dashboard is one left card (Recent) beside a stack of two (Agents you use,
-// Scheduled runs), and all three have to end on the same line with no half-drawn
-// row and no dead strip inside a card. That falls out of one identity: every row
-// is pinned to DASH_ROW_H and every card costs the same fixed chrome — its own two
-// borders plus the head (2 + 45) — so the right column's SECOND card, gutter
-// included, costs 2 + 45 + 16 = 63px, i.e. EXACTLY one row. The columns therefore
-// match when the left card shows one row MORE than the right column shows in total:
-//
-//     47 + (n+1)·63  ==  (47 + a·63) + 16 + (47 + c·63)   for a + c == n
-//
-// (Hence 63 as the row height, not a rounder number — it is what the second card's
-// chrome measures. Changing `gap-4` on the grid, the card border, or `.cardhead`
-// padding changes it.) All the sizing below does is spend that budget: take as many
-// whole rows as the leftover viewport height allows, then trim the right column —
-// schedules first, then the agent list — until the left card can cover it.
-const DASH_ROW_H = 63
-const CARD_CHROME_H = 47
 // The literal Tailwind spelling of DASH_ROW_H (`.row` is a components-layer class, so
 // these utilities win). `content-center` centres the row's single grid track inside the
 // taller box instead of stretching it, which is what keeps a cell's `self-start` (the
@@ -69,9 +57,6 @@ const CARD_CHROME_H = 47
 // Desktop only: the mobile layer stacks the cards, so there is nothing to align there
 // and rows keep their natural height.
 const DASH_ROW = 'desktop:h-[63px] desktop:content-center desktop:py-0'
-const MAX_AGENT_ROWS = 4
-const MAX_CRON_ROWS = 3
-const MOBILE_SESSION_ROWS = 6
 
 // Leftover height under the composer, measured against the SCROLL CONTAINER — never
 // against the dashboard's own box, so a taller grid can't feed back into the row
@@ -246,38 +231,29 @@ export default function HomeView() {
     [agents, sessionsByAgent]
   )
 
-  // How many rows each dashboard card draws — see the row-budget note above.
+  // How many rows each dashboard card draws — see `dashboard-rows.ts` for the identity
+  // that makes the two columns end on the same line.
   const isMobile = useIsMobile()
   const gridRef = useRef<HTMLDivElement>(null)
   const availableHeight = useAvailableHeight(gridRef, !isMobile, blocked)
-  const { sessionRows, agentRows, cronRows } = useMemo(() => {
-    // Mobile stacks the three cards, so there is nothing to align — keep the plain
-    // content caps.
-    if (isMobile) return { sessionRows: MOBILE_SESSION_ROWS, agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS }
-    // An empty card still draws its placeholder row, so it costs a row either way.
-    let a = Math.min(MAX_AGENT_ROWS, Math.max(1, rankedAgents.length))
-    let c = Math.min(MAX_CRON_ROWS, Math.max(1, crons.length))
-    // Whole rows the leftover viewport can hold — unmeasured (mobile / first paint)
-    // means no cap, so the cards start at their content-driven maximum.
-    const capacity = availableHeight
-      ? Math.max(3, Math.floor((availableHeight - CARD_CHROME_H) / DASH_ROW_H))
-      : Number.POSITIVE_INFINITY
-    // Trim the right column until the matching left card fits the viewport. Schedules
-    // give way first, but in two passes down to a 2-row floor before either list is
-    // taken to a single row — so a cramped window thins both cards instead of gutting
-    // one. Only the VIEWPORT trims here: a thin session list must not shrink the other
-    // two cards, because the left card can't grow to match them anyway (below).
-    for (const floor of [2, 1]) {
-      while (a + c + 1 > capacity && c > floor) c--
-      while (a + c + 1 > capacity && a > floor) a--
-    }
-    // The left card always asks for one row more than the right column shows — that IS
-    // the identity. An org with fewer sessions than that is the one case it can't hold
-    // up: the right column's floor is two cards (two heads + a row each = three left
-    // rows), which no shorter card can reach. There the card renders what it has and
-    // stretches to the row height, so the bottoms still meet.
-    return { sessionRows: a + c + 1, agentRows: a, cronRows: c }
-  }, [isMobile, availableHeight, rankedAgents.length, crons.length])
+  const { sessionRows, agentRows, cronRows, aligned } = useMemo(
+    () =>
+      isMobile
+        ? // Mobile stacks the three cards: nothing to align, plain content caps.
+          {
+            sessionRows: MOBILE_SESSION_ROWS,
+            agentRows: MAX_AGENT_ROWS,
+            cronRows: MAX_CRON_ROWS,
+            aligned: false
+          }
+        : dashboardRowBudget({
+            availableHeight,
+            sessions: allSessions.length,
+            agents: rankedAgents.length,
+            crons: crons.length
+          }),
+    [isMobile, availableHeight, allSessions.length, rankedAgents.length, crons.length]
+  )
 
   const topAgents = rankedAgents.slice(0, agentRows)
   const scheduled = crons.slice(0, cronRows)
@@ -486,6 +462,12 @@ export default function HomeView() {
           they come out the same height — see the row-budget note at the top of the file.
           `gap-4` is the 16px the budget accounts for; changing it changes DASH_ROW_H. */}
       <div ref={gridRef} className="grid grid-cols-1 gap-4 desktop:grid-cols-[1.5fr_1fr]">
+        {/* `self-start` is the sparse-state treatment. With enough sessions the card
+            already measures exactly the row height, so it changes nothing; with fewer
+            (a new or quiet org) it stops the grid stretching a two-row card down to
+            the right column's floor, which would trade a shared bottom edge for a tall
+            blank strip. A short card beside a taller column reads as "not much here
+            yet" — the stretched one just reads as broken. */}
         <RecentSessionsCard
           sessions={allSessions}
           loading={loading}
@@ -493,6 +475,7 @@ export default function HomeView() {
           emptyText="No sessions yet — ask an agent above to start one."
           limit={sessionRows}
           rowClassName={DASH_ROW}
+          className={aligned ? undefined : 'desktop:self-start'}
         />
 
         <div className="flex flex-col gap-4">

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -7,11 +7,12 @@
 // do I ask": Recent sessions, Agents you use (ranked by 24h session count),
 // and Scheduled runs.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useOrgs } from '@/lib/org-context'
 import { useOnboardingRedirect } from '@/lib/use-onboarding-redirect'
+import { useIsMobile } from '@/lib/use-is-mobile'
 import { useConsoleData } from '@/lib/data-context'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { ComposerMenu } from '@/components/console/ComposerMenu'
@@ -42,6 +43,61 @@ import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
 // scanner sees them (STYLE.md §8).
 const CHIP =
   'inline-flex h-7 items-center gap-[6px] rounded-md px-[9px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
+
+// ── Dashboard row budget ────────────────────────────────────────────────────
+// The dashboard is one left card (Recent) beside a stack of two (Agents you use,
+// Scheduled runs), and all three have to end on the same line with no half-drawn
+// row and no dead strip inside a card. That falls out of one identity: every row
+// is pinned to DASH_ROW_H and every card costs the same fixed chrome — its own two
+// borders plus the head (2 + 45) — so the right column's SECOND card, gutter
+// included, costs 2 + 45 + 16 = 63px, i.e. EXACTLY one row. The columns therefore
+// match when the left card shows one row MORE than the right column shows in total:
+//
+//     47 + (n+1)·63  ==  (47 + a·63) + 16 + (47 + c·63)   for a + c == n
+//
+// (Hence 63 as the row height, not a rounder number — it is what the second card's
+// chrome measures. Changing `gap-4` on the grid, the card border, or `.cardhead`
+// padding changes it.) All the sizing below does is spend that budget: take as many
+// whole rows as the leftover viewport height allows, then trim the right column —
+// schedules first, then the agent list — until the left card can cover it.
+const DASH_ROW_H = 63
+const CARD_CHROME_H = 47
+// The literal Tailwind spelling of DASH_ROW_H (`.row` is a components-layer class, so
+// these utilities win). `content-center` centres the row's single grid track inside the
+// taller box instead of stretching it, which is what keeps a cell's `self-start` (the
+// timestamp / next-run column) riding the title line rather than the row's top edge.
+// Desktop only: the mobile layer stacks the cards, so there is nothing to align there
+// and rows keep their natural height.
+const DASH_ROW = 'desktop:h-[63px] desktop:content-center desktop:py-0'
+const MAX_AGENT_ROWS = 4
+const MAX_CRON_ROWS = 3
+const MOBILE_SESSION_ROWS = 6
+
+// Leftover height under the composer, measured against the SCROLL CONTAINER — never
+// against the dashboard's own box, so a taller grid can't feed back into the row
+// count and oscillate. Returns null when it can't/shouldn't cap (mobile, no scroller).
+function useAvailableHeight(ref: RefObject<HTMLElement | null>, enabled: boolean, reflow: unknown): number | null {
+  const [height, setHeight] = useState<number | null>(null)
+  useEffect(() => {
+    if (!enabled) {
+      setHeight(null)
+      return
+    }
+    const el = ref.current
+    const scroller = el?.closest<HTMLElement>('.content')
+    if (!el || !scroller) return
+    const measure = () => {
+      const top = el.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop
+      const padBottom = parseFloat(getComputedStyle(scroller).paddingBottom) || 0
+      setHeight(Math.max(0, scroller.clientHeight - top - padBottom))
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(scroller)
+    return () => ro.disconnect()
+  }, [ref, enabled, reflow])
+  return height
+}
 
 // Relative "…ago" for a cron's last run. fmtNextRun covers the future side;
 // this is the (missing) past side. Coarse buckets are all a dashboard needs.
@@ -186,11 +242,42 @@ export default function HomeView() {
     [usage24h]
   )
   const rankedAgents = useMemo(
-    () => [...agents].sort((a, b) => (sessionsByAgent.get(b.id) ?? 0) - (sessionsByAgent.get(a.id) ?? 0)).slice(0, 4),
+    () => [...agents].sort((a, b) => (sessionsByAgent.get(b.id) ?? 0) - (sessionsByAgent.get(a.id) ?? 0)),
     [agents, sessionsByAgent]
   )
 
-  const scheduled = crons.slice(0, 3)
+  // How many rows each dashboard card draws — see the row-budget note above.
+  const isMobile = useIsMobile()
+  const gridRef = useRef<HTMLDivElement>(null)
+  const availableHeight = useAvailableHeight(gridRef, !isMobile, blocked)
+  const { sessionRows, agentRows, cronRows } = useMemo(() => {
+    // Mobile stacks the three cards, so there is nothing to align — keep the plain
+    // content caps.
+    if (isMobile) return { sessionRows: MOBILE_SESSION_ROWS, agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS }
+    // An empty card still draws its placeholder row, so it costs a row either way.
+    const haveSessions = Math.max(1, allSessions.length)
+    const haveAgents = Math.min(MAX_AGENT_ROWS, Math.max(1, rankedAgents.length))
+    const haveCrons = Math.min(MAX_CRON_ROWS, Math.max(1, crons.length))
+    // Whole rows the leftover viewport can hold — unmeasured (mobile / first paint)
+    // means no cap, so the cards start at their content-driven maximum.
+    const capacity = availableHeight
+      ? Math.max(3, Math.floor((availableHeight - CARD_CHROME_H) / DASH_ROW_H))
+      : Number.POSITIVE_INFINITY
+    const budget = Math.min(capacity, haveSessions)
+    let a = haveAgents
+    let c = haveCrons
+    // Trim the right column until the left card can cover it. Schedules give way
+    // first, but in two passes down to a 2-row floor before either list is taken
+    // to a single row — so a cramped window thins both cards instead of gutting one.
+    for (const floor of [2, 1]) {
+      while (a + c + 1 > budget && c > floor) c--
+      while (a + c + 1 > budget && a > floor) a--
+    }
+    return { sessionRows: Math.min(budget, a + c + 1), agentRows: a, cronRows: c }
+  }, [isMobile, availableHeight, allSessions.length, rankedAgents.length, crons.length])
+
+  const topAgents = rankedAgents.slice(0, agentRows)
+  const scheduled = crons.slice(0, cronRows)
 
   if (loading && agents.length === 0 && allSessions.length === 0) return <LoadingState fill />
 
@@ -225,15 +312,13 @@ export default function HomeView() {
   if (holdForOnboarding) return <LoadingState fill />
 
   return (
-    // Desktop: `h-full` pins the page to the viewport so a roomy window shows no page
-    // scrollbar, and `min-h-fit` is the floor — the wrap never shrinks below what the
-    // cards actually need, so .content scrolls instead of squashing a card into a
-    // half-drawn row. The floor is the content's own height, which is row-aligned by
-    // construction (no magic px to keep in sync with row metrics).
+    // Every block here is content-sized: the dashboard picks a row count that fits the
+    // leftover viewport (useAvailableHeight), so the page fills a roomy window without
+    // stretching a card past its rows, and scrolls rather than squashing when it can't.
     // Mobile keeps normal flow + the bottom-nav padding.
-    <div className="wrap max-w-[1000px] max-desktop:px-4 max-desktop:pt-4 max-desktop:pb-24 desktop:flex desktop:h-full desktop:min-h-fit desktop:flex-col">
+    <div className="wrap max-w-[1000px] max-desktop:px-4 max-desktop:pt-4 max-desktop:pb-24">
       {/* Centered greeting above the composer (design: 32px mark, 27px title). */}
-      <div className="mt-[22px] mb-[22px] flex flex-none items-center justify-center gap-[13px]">
+      <div className="mt-[22px] mb-[22px] flex items-center justify-center gap-[13px]">
         <LogoMark size={32} />
         {/* Server and client can sit in different timezones, and the display name
             only resolves after mount — both settle on the client. */}
@@ -246,7 +331,7 @@ export default function HomeView() {
       {/* Composer — hands off to a live session on send. The footer selectors mirror
           the design: agent + model as pills (leading mark), effort + permission as
           chips. Each picks the run's runtime; the choice is applied on send. */}
-      <div className="card mb-3 flex-none overflow-visible">
+      <div className="card mb-3 overflow-visible">
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
@@ -361,7 +446,7 @@ export default function HomeView() {
           offline ⇒ its daemon isn't serving; auth ⇒ online but the daemon's runtime
           reported "sign-in required" (no active AI subscription/login). */}
       {!loading && blocked && (
-        <div className="mb-3 flex flex-none items-center gap-3 rounded-lg border border-(--status-paused-soft) bg-(--status-paused-soft) px-4 py-[10px]">
+        <div className="mb-3 flex items-center gap-3 rounded-lg border border-(--status-paused-soft) bg-(--status-paused-soft) px-4 py-[10px]">
           <Icon name="triangle-alert" size={16} color="var(--status-paused)" />
           <span className="min-w-0 flex-1 font-sans text-[13px] leading-normal text-(--text-secondary)">
             {blocked === 'offline' ? (
@@ -394,37 +479,32 @@ export default function HomeView() {
         </div>
       )}
 
-      {/* Dashboard grid. */}
-      {/* Desktop: the row is sized by the right column (the left card is absolute, so
-          it contributes no height), which keeps both bottoms aligned. */}
-      <div className="grid grid-cols-1 gap-4 desktop:grid-cols-[1.5fr_1fr]">
-        {/* On desktop the grid row height is the leftover viewport space: the card is
-            absolutely positioned (so it never stretches the row itself) and
-            fillHeight fits as many whole session rows as that height allows. */}
-        <div className="desktop:relative">
-          <RecentSessionsCard
-            sessions={allSessions}
-            loading={loading}
-            allHref={orgPath('/sessions')}
-            emptyText="No sessions yet — ask an agent above to start one."
-            fillHeight
-            className="desktop:absolute desktop:inset-0"
-          />
-        </div>
+      {/* Dashboard grid. Both columns are content-sized and the row counts are chosen so
+          they come out the same height — see the row-budget note at the top of the file.
+          `gap-4` is the 16px the budget accounts for; changing it changes DASH_ROW_H. */}
+      <div ref={gridRef} className="grid grid-cols-1 gap-4 desktop:grid-cols-[1.5fr_1fr]">
+        <RecentSessionsCard
+          sessions={allSessions}
+          loading={loading}
+          allHref={orgPath('/sessions')}
+          emptyText="No sessions yet — ask an agent above to start one."
+          limit={sessionRows}
+          rowClassName={DASH_ROW}
+        />
 
         <div className="flex flex-col gap-4">
           <Card title="Agents you use" action={<CardLink href={orgPath('/agents')}>All agents</CardLink>}>
-            {rankedAgents.length === 0 ? (
-              <EmptyRow>No agents yet.</EmptyRow>
+            {topAgents.length === 0 ? (
+              <EmptyRow className={DASH_ROW}>No agents yet.</EmptyRow>
             ) : (
-              rankedAgents.map((a) => {
+              topAgents.map((a) => {
                 const ready = agentReady(a)
                 return (
                   <Link
                     key={a.id}
                     href={orgPath(`/agents/${a.id}`)}
                     title={agentLabel(a)}
-                    className={`row click grid-cols-[auto_1fr_auto] gap-3 ${ready ? '' : 'opacity-60'}`}
+                    className={`row click grid-cols-[auto_1fr_auto] gap-3 ${DASH_ROW} ${ready ? '' : 'opacity-60'}`}
                   >
                     <span className="av h-7 w-7 rounded-md">
                       <AgentIconView icon={a.icon} runtime={a.runtime} size={28} />
@@ -453,12 +533,16 @@ export default function HomeView() {
 
           <Card title="Scheduled runs" action={<CardLink href={orgPath('/crons')}>All schedules</CardLink>}>
             {scheduled.length === 0 ? (
-              <EmptyRow>No schedules yet.</EmptyRow>
+              <EmptyRow className={DASH_ROW}>No schedules yet.</EmptyRow>
             ) : (
               scheduled.map((c) => {
                 const owner = c.agentId ? getAgent(c.agentId) : undefined
                 return (
-                  <Link key={c.id} href={orgPath(`/crons/${c.id}`)} className="row click grid-cols-[1fr_auto] gap-3">
+                  <Link
+                    key={c.id}
+                    href={orgPath(`/crons/${c.id}`)}
+                    className={`row click grid-cols-[1fr_auto] gap-3 ${DASH_ROW}`}
+                  >
                     <span className="min-w-0">
                       <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
                         {c.name || cronHuman(c.schedule) || c.schedule}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -18,7 +18,7 @@ import {
   agentLabel,
   modelLabel,
   preferredModelFor,
-  unavailableRuntimeIds
+  loginRequiredRuntimeIds
 } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 import type { DaemonConnectDto } from '@/lib/api'
@@ -375,13 +375,12 @@ function ConfigureAgent({
   onSkip: () => void
 }) {
   const runtimeIds = daemon.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
-  // Reported but unlaunchable (installed on the new daemon, logged out) — offered
-  // disabled, and never the default: a first agent pinned to one could not answer.
-  const unavailableRuntimes = unavailableRuntimeIds(daemon)
-  const firstUsableRuntime = runtimeIds.find((id) => !unavailableRuntimes.includes(id)) ?? runtimeIds[0] ?? ''
-  const [runtime, setRuntime] = useState('')
-  const effectiveRuntime =
-    runtimeIds.includes(runtime) && !unavailableRuntimes.includes(runtime) ? runtime : firstUsableRuntime
+  // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in
+  // one so a first agent starts answerable where the daemon allows it.
+  const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
+  const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
+  const [runtime, setRuntime] = useState('') // '' = untouched
+  const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
   const models = daemon.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState('')
   // Keep the selection valid as the runtime (and so the model set) changes.
@@ -421,7 +420,7 @@ function ConfigureAgent({
             <RuntimeSelect
               value={effectiveRuntime}
               options={runtimeIds}
-              unavailable={unavailableRuntimes}
+              needsLogin={runtimesNeedingLogin}
               onChange={(next) => {
                 setRuntime(next)
                 setModel('')

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -12,7 +12,14 @@ import { daemonCommands } from '@/lib/daemon-commands'
 import { computeGettingStarted } from '@/lib/getting-started'
 import { AddToSlackRow, GsRows, MeetYourAgents, useGsActions } from '@/components/console/GettingStartedChecklist'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
-import { FALLBACK_RUNTIME_IDS, agentIsPlaced, agentLabel, modelLabel, preferredModelFor } from '@/lib/data'
+import {
+  FALLBACK_RUNTIME_IDS,
+  agentIsPlaced,
+  agentLabel,
+  modelLabel,
+  preferredModelFor,
+  unavailableRuntimeIds
+} from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
 import type { DaemonConnectDto } from '@/lib/api'
 
@@ -368,8 +375,13 @@ function ConfigureAgent({
   onSkip: () => void
 }) {
   const runtimeIds = daemon.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
-  const [runtime, setRuntime] = useState(runtimeIds[0] ?? '')
-  const effectiveRuntime = runtimeIds.includes(runtime) ? runtime : (runtimeIds[0] ?? '')
+  // Reported but unlaunchable (installed on the new daemon, logged out) — offered
+  // disabled, and never the default: a first agent pinned to one could not answer.
+  const unavailableRuntimes = unavailableRuntimeIds(daemon)
+  const firstUsableRuntime = runtimeIds.find((id) => !unavailableRuntimes.includes(id)) ?? runtimeIds[0] ?? ''
+  const [runtime, setRuntime] = useState('')
+  const effectiveRuntime =
+    runtimeIds.includes(runtime) && !unavailableRuntimes.includes(runtime) ? runtime : firstUsableRuntime
   const models = daemon.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState('')
   // Keep the selection valid as the runtime (and so the model set) changes.
@@ -409,6 +421,7 @@ function ConfigureAgent({
             <RuntimeSelect
               value={effectiveRuntime}
               options={runtimeIds}
+              unavailable={unavailableRuntimes}
               onChange={(next) => {
                 setRuntime(next)
                 setModel('')

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -30,13 +30,13 @@ const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 const USAGE_REFRESH_MS = 30_000
 
 // How the by-agent table is rolled up. `agent` is the raw per-agent breakdown
-// (rows tap through to the agent); `type` sums agents sharing a runtime (bot
-// type) — grouped rows are inert. Both roll up the same per-agent aggregate
-// client-side, so adding a dimension is just another case here.
-type GroupBy = 'agent' | 'type'
+// (rows tap through to the agent); `runtime` sums agents sharing a runtime —
+// grouped rows are inert. Both roll up the same per-agent aggregate client-side,
+// so adding a dimension is just another case here.
+type GroupBy = 'agent' | 'runtime'
 const GROUPS: { key: GroupBy; label: string }[] = [
   { key: 'agent', label: 'By agent' },
-  { key: 'type', label: 'By type' }
+  { key: 'runtime', label: 'By runtime' }
 ]
 
 // Buckets are aligned to the viewer's local day/hour (the CP flooring uses the
@@ -105,7 +105,7 @@ export default function UsageView() {
     }
   })
 
-  // Roll up to the selected grouping. `agent` is the raw list; `type` sums agents
+  // Roll up to the selected grouping. `agent` is the raw list; `runtime` sums agents
   // sharing a runtime and drops the per-agent icon/nav (`navId` absent) so grouped
   // rows are inert and show the runtime glyph.
   type Entry = {
@@ -119,12 +119,12 @@ export default function UsageView() {
     costAmount: number
   }
   let entries: Entry[]
-  if (groupBy === 'type') {
-    const byType = new Map<string, Entry>()
+  if (groupBy === 'runtime') {
+    const byRuntime = new Map<string, Entry>()
     for (const e of enriched) {
       const rt = e.runtime || 'unknown'
-      const g = byType.get(rt) ?? {
-        key: `type:${rt}`,
+      const g = byRuntime.get(rt) ?? {
+        key: `runtime:${rt}`,
         name: runtimeLabel(rt),
         runtime: rt,
         totalTokens: 0,
@@ -134,9 +134,9 @@ export default function UsageView() {
       g.totalTokens += e.totalTokens
       g.sessions += e.sessions
       g.costAmount += e.costAmount
-      byType.set(rt, g)
+      byRuntime.set(rt, g)
     }
-    entries = [...byType.values()].sort((a, b) => b.totalTokens - a.totalTokens)
+    entries = [...byRuntime.values()].sort((a, b) => b.totalTokens - a.totalTokens)
   } else {
     entries = enriched.map((e) => ({ ...e, key: e.agentId, navId: e.agentId }))
   }
@@ -340,7 +340,7 @@ export default function UsageView() {
 
         {/* Desktop table header */}
         <div className={`row h hidden desktop:grid ${GRID}`}>
-          <span>{groupBy === 'type' ? 'Type' : 'Agent'}</span>
+          <span>{groupBy === 'runtime' ? 'Runtime' : 'Agent'}</span>
           <span className="text-right">Sessions</span>
           <span className="text-right">Tokens</span>
           <span className="text-right">Spend</span>

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -496,6 +496,104 @@ const MOCK_BOTS: BotDto[] = [
   }
 ]
 
+// Demo schedule roster (MOCK_MODE only) — enough rows that Home's "Scheduled runs"
+// card and the Schedules view render populated with no CP running. Mixed enabled /
+// paused and a never-run row so both the next-run and the "ran …" labels are exercised.
+const MOCK_CRONS: CronDto[] = [
+  {
+    id: 'cron_deps',
+    orgId: 'mock',
+    agentId: 'review',
+    name: 'daily-deps-check',
+    schedule: '0 9 * * *',
+    timezone: 'UTC',
+    targetPlatform: 'slack',
+    targetChannel: '#pull-requests',
+    targetIntegrationId: null,
+    trigger: 'check the dependency report and flag anything new',
+    enabled: true,
+    lastRunAt: '2026-04-11T09:00:00Z',
+    createdBy: 'u_dana',
+    createdAt: '2026-03-01T00:00:00Z',
+    lastModifiedBy: 'u_dana',
+    lastModifiedAt: '2026-03-01T00:00:00Z',
+    visibility: 'org',
+    sharedWith: [],
+    ownerUserId: 'u_dana',
+    canEdit: true,
+    canManageSharing: true
+  },
+  {
+    id: 'cron_bugsweep',
+    orgId: 'mock',
+    agentId: 'deploy',
+    name: 'nightly bug sweep',
+    schedule: '30 2 * * *',
+    timezone: 'UTC',
+    targetPlatform: 'slack',
+    targetChannel: '#deploys',
+    targetIntegrationId: null,
+    trigger: 'sweep yesterday’s error budget and summarize',
+    enabled: true,
+    lastRunAt: '2026-04-11T02:30:00Z',
+    createdBy: 'u_sam',
+    createdAt: '2026-03-04T00:00:00Z',
+    lastModifiedBy: 'u_sam',
+    lastModifiedAt: '2026-03-04T00:00:00Z',
+    visibility: 'org',
+    sharedWith: [],
+    ownerUserId: 'u_sam',
+    canEdit: true,
+    canManageSharing: true
+  },
+  {
+    id: 'cron_wakeup',
+    orgId: 'mock',
+    agentId: 'docs',
+    name: 'daily wake up dm',
+    schedule: '0 8 * * 1-5',
+    timezone: 'UTC',
+    targetPlatform: 'telegram',
+    targetChannel: '@acme_docs',
+    targetIntegrationId: null,
+    trigger: 'post the docs backlog for the day',
+    enabled: true,
+    lastRunAt: null,
+    createdBy: 'u_lee',
+    createdAt: '2026-04-02T00:00:00Z',
+    lastModifiedBy: 'u_lee',
+    lastModifiedAt: '2026-04-02T00:00:00Z',
+    visibility: 'org',
+    sharedWith: [],
+    ownerUserId: 'u_lee',
+    canEdit: true,
+    canManageSharing: true
+  },
+  {
+    id: 'cron_weekly_digest',
+    orgId: 'mock',
+    agentId: 'review',
+    name: 'weekly digest',
+    schedule: '0 16 * * 5',
+    timezone: 'UTC',
+    targetPlatform: 'slack',
+    targetChannel: '#pull-requests',
+    targetIntegrationId: null,
+    trigger: 'summarize the week’s merged pull requests',
+    enabled: false,
+    lastRunAt: '2026-04-04T16:00:00Z',
+    createdBy: 'u_dana',
+    createdAt: '2026-02-14T00:00:00Z',
+    lastModifiedBy: 'u_dana',
+    lastModifiedAt: '2026-02-14T00:00:00Z',
+    visibility: 'org',
+    sharedWith: [],
+    ownerUserId: 'u_dana',
+    canEdit: true,
+    canManageSharing: true
+  }
+]
+
 // Demo MCP-provider registry (MOCK_MODE only) — covers both kinds so the Tools &
 // Skills tiles show the connector icon path and the plain plug, and both access
 // scopes (org-wide vs restricted, which renders the avatar stack). `service` slugs
@@ -655,7 +753,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     refreshInterval: DAEMON_REFRESH_MS
   })
   const {
-    data: crons = [],
+    data: realCrons = [],
     error: cronsError,
     isLoading: cronsIsLoading,
     mutate: mutateCrons
@@ -864,6 +962,10 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   }, [realSessions, agents])
 
   const getSessions = useCallback((id: string) => allSessions.filter((s) => s.agentId === id), [allSessions])
+
+  // crons: live rows, plus the demo roster in mock mode — so Home's "Scheduled runs"
+  // card and the Schedules view are populated with no CP running.
+  const crons = useMemo(() => (MOCK_MODE ? [...realCrons, ...MOCK_CRONS] : realCrons), [realCrons])
 
   // bots: live rows, plus the demo roster in mock mode — so the Settings platform
   // cards + the Add-integration reuse picker are populated with no CP running.

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -543,12 +543,18 @@ export function preferredModelFor(daemon: Pick<DaemonRow, 'runtimeModels'> | und
   return dflt && models.includes(dflt) ? dflt : models[0]!
 }
 
-/** Runtime ids the daemon REPORTS but cannot launch. The daemon's facts snapshot
- *  carries the admitted (launchable) set plus any curated candidate whose fresh probe
- *  came back "authentication required" — installed on the host but logged out, and
- *  admission keeps those unlaunchable until a probe succeeds. So an agent pinned to
- *  one could never take a session; the runtime pickers offer them disabled. */
-export function unavailableRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'> | undefined): string[] {
+/** Runtime ids the daemon reports as needing a login on its host — its probe (or a
+ *  live turn) was rejected with the ACP auth-required error.
+ *
+ *  This is NOT a launchability signal, and must not be used to gate a choice. The flag
+ *  covers two states the facts snapshot cannot tell apart: a curated candidate whose
+ *  probe never succeeded (unadmitted), and an admitted, perfectly launchable runtime
+ *  whose last live turn happened to be rejected for login. Placement is deliberately
+ *  independent of readiness either way — `docs/designs/preset-agents.md` §3.2 makes an
+ *  agent on a logged-out runtime an ordinary supported state, and creation/placement
+ *  never gate on it. So the pickers MARK these and prefer a signed-in default; they do
+ *  not disable them. */
+export function loginRequiredRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'> | undefined): string[] {
   return (daemon?.runtimeModels ?? []).filter((r) => r.authRequired).map((r) => r.runtime)
 }
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1409,6 +1409,44 @@ const RAW_SESSIONS_BY_AGENT: Record<string, Session[]> = {
         { kind: 'tool', text: 'bash · run checkout.spec.ts x20', code: '20/20 passed (no flakes)' },
         { kind: 'done', text: 'Ran it 20 times on main — all green. The retry shim did the trick.' }
       ]
+    },
+    {
+      id: 'r3',
+      title: 'Summarize the review queue',
+      time: '1:12 PM',
+      status: 'online',
+      platform: 'slack',
+      channel: '#pull-requests',
+      user: '@dana',
+      duration: '27s',
+      tokens: '740',
+      cost: '$0.09',
+      toolCount: '1',
+      statusLabel: 'completed',
+      steps: [
+        { kind: 'msg', text: '@review-bot what is still waiting on review?' },
+        { kind: 'tool', text: 'gh · pr list --search "review:required"', code: '4 open pull requests' },
+        { kind: 'done', text: 'Four PRs are waiting — #1284, #1291, #1293 and #1298. Two are older than a day.' }
+      ]
+    },
+    {
+      id: 'r4',
+      title: 'Backport the auth fix to 1.3',
+      time: 'Yesterday',
+      status: 'online',
+      platform: 'telegram',
+      channel: '@acme_reviews',
+      user: '@sam',
+      duration: '1m 12s',
+      tokens: '1.9K',
+      cost: '$0.22',
+      toolCount: '4',
+      statusLabel: 'completed',
+      steps: [
+        { kind: 'msg', text: '@review-bot backport the auth fix to release/1.3' },
+        { kind: 'tool', text: 'git · cherry-pick 9f2c1ab', code: '1 file changed, +18 −4' },
+        { kind: 'done', text: 'Backported to release/1.3 and opened PR #1301 with the cherry-picked commit.' }
+      ]
     }
   ],
   docs: [

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -543,6 +543,15 @@ export function preferredModelFor(daemon: Pick<DaemonRow, 'runtimeModels'> | und
   return dflt && models.includes(dflt) ? dflt : models[0]!
 }
 
+/** Runtime ids the daemon REPORTS but cannot launch. The daemon's facts snapshot
+ *  carries the admitted (launchable) set plus any curated candidate whose fresh probe
+ *  came back "authentication required" — installed on the host but logged out, and
+ *  admission keeps those unlaunchable until a probe succeeds. So an agent pinned to
+ *  one could never take a session; the runtime pickers offer them disabled. */
+export function unavailableRuntimeIds(daemon: Pick<DaemonRow, 'runtimeModels'> | undefined): string[] {
+  return (daemon?.runtimeModels ?? []).filter((r) => r.authRequired).map((r) => r.runtime)
+}
+
 /** One rendered effort choice; `description` (when the runtime provides one)
  *  goes on the control's title attribute. */
 export interface EffortChoice {


### PR DESCRIPTION
## What

Home's dashboard is one left card (Recent) beside a stack of two (Agents you use, Scheduled runs). The three now end on exactly the same line, with no half-drawn row and no dead strip inside any card, and every row in all three cards is the same height.

## Why

Two problems, both visible on a normal desktop window:

- **Ragged bottoms.** The grid row was sized by the right column (the left card was absolutely positioned so it contributed no height), and `RecentSessionsCard`'s `fillHeight` then fitted only *whole* rows into that height — so up to a row's worth of slack was left as a blank strip under the last session row.
- **Three different row heights.** Session rows measured 62px, agent rows 59px, cron rows 62px, so nothing lined up across the columns even by accident.

## How

Pin every dashboard row to one height and let a single identity do the alignment. Each card costs the same fixed chrome — its two borders plus the head (`2 + 45`) — so the right column's **second** card, gutter included, costs `2 + 45 + 16 = 63px`: exactly one row. The columns therefore match when the left card shows one row **more** than the right column shows in total:

```
47 + (n+1)·63  ==  (47 + a·63) + 16 + (47 + c·63)     for a + c == n
```

That is why the row height is 63 rather than a rounder number — it is what the second card's chrome measures. `HomeView` carries this as a comment; changing the grid's `gap-4`, the card border, or `.cardhead` padding changes the constant.

Everything else is just spending that budget:

1. Measure the leftover viewport height **against the scroll container**, never against the grid's own box — otherwise a taller grid feeds back into the row count and oscillates.
2. Take as many whole rows as that height allows.
3. Trim the right column until the left card can cover it. Schedules give way first, but in two passes down to a 2-row floor before either list drops to a single row, so a cramped window thins both cards instead of gutting one.

## Notes for reviewers

- **`RecentSessionsCard.fillHeight` is retired.** The card no longer measures itself; it takes a row count (`limit`) plus optional per-row utilities (`rowClassName`). `AgentDetailView` is the only other consumer and never used `fillHeight`, so it is unaffected. `Card`'s now-unused `ref` prop went with it.
- **Mobile is untouched by the alignment work.** The `≤768px` layer stacks the three cards, so there is nothing to align: rows keep their natural heights and Recent keeps its 6-row cap. The 63px pin is `desktop:`-only.
- **Empty states count as a row.** `EmptyRow` takes the same row class, so a card with no data occupies exactly one row's height and the budget still balances.
- **Mock data.** The demo roster had zero schedules, so the Scheduled card only ever rendered its empty state in mock mode. Added a four-row schedule roster (mixed enabled/paused, one never-run) and two more demo sessions — four rather than two so both the 3-row cap and the trim-to-2 path are actually exercised.

## Verification

Measured in the browser against the mock stack; both columns share one top and one bottom at every size:

| viewport | sessions / agents / schedules | columns |
| --- | --- | --- |
| 1440×900 | 8 / 4 / 3 | 310 → 861 both |
| 1280×800 | 6 / 3 / 2 | 310 → 735 both |
| 1440×760 | 5 / 2 / 2 | 310 → 672 both |
| 1600×1200 | 8 / 4 / 3 | caps at the data ceiling instead of stretching |
| 375×812 | 6 / 4 / 3 | stacked, natural row heights (unchanged) |

`tsc --noEmit`, `eslint`, `prettier --check` and the 555 web tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)