### PR TITLE
feat(web): add related session tree to detail rail

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2314,6 +2314,7 @@ export const SessionRelationDto = z.object({
 export const SessionDetailDto = z.object({
   id: z.string(),
   parentSession: SessionRelationDto.nullable(),
+  siblingSessions: z.array(SessionRelationDto),
   childSessions: z.array(SessionRelationDto),
   agentId: z.string(),
   launchId: z.string().nullable(),

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -516,7 +516,7 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'Get session metadata',
           description:
-            'Returns CP-stored session metadata plus visible parent and child session links; transcript bodies remain daemon-local.',
+            'Returns CP-stored session metadata plus visible parent, sibling, and child session links; transcript bodies remain daemon-local.',
           operationId: 'getSession',
           params: IdParam,
           response: { 200: SessionDetailDto, 404: ErrorDto }
@@ -534,23 +534,34 @@ export function sessionRoutes(deps: HttpDeps) {
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((a) => a.id)
         const visibleAgentIdSet = new Set<string>(visibleAgentIds)
         const ctx = ctxOf(req)
-        const [parent, children, usage] = await Promise.all([
+        const [parent, children, siblingCandidates, usage] = await Promise.all([
           s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
           deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds),
+          s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, visibleAgentIds) : Promise.resolve([]),
           deps.repos.sessionUsage.get(s.agentId, s.id)
         ])
-        const related = [...(parent ? [parent] : []), ...children]
+        const siblings = siblingCandidates.filter((candidate) => candidate.id !== s.id)
+        const related = [...(parent ? [parent] : []), ...siblings, ...children]
         const relatedAccess = await sessionAccess.forSessions(req, related)
         const parentVisible =
           parent !== null &&
           visibleAgentIdSet.has(parent.agentId) &&
           canViewSession(parent, ctx, relatedAccess.identitySet, relatedAccess.externalAccess)
+        // A hidden parent is indistinguishable from no parent. Keep its sibling
+        // branch hidden too, otherwise the response would still reveal the
+        // relationship through the parent's other children.
+        const visibleSiblings = parentVisible
+          ? siblings.filter((sibling) =>
+              canViewSession(sibling, ctx, relatedAccess.identitySet, relatedAccess.externalAccess)
+            )
+          : []
         const visibleChildren = children.filter((child) =>
           canViewSession(child, ctx, relatedAccess.identitySet, relatedAccess.externalAccess)
         )
         return {
           id: s.id,
           parentSession: parentVisible ? sessionRelation(parent) : null,
+          siblingSessions: visibleSiblings.map(sessionRelation),
           childSessions: visibleChildren.map(sessionRelation),
           agentId: s.agentId,
           launchId: s.launchId,

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -225,7 +225,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect((res.json() as { endedAt: string | null }).endedAt).not.toBeNull()
   })
 
-  it('returns parent and child session links from daemon-reported lineage', async () => {
+  it('returns parent, sibling, and child session links from daemon-reported lineage', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT, { daemonId: DAEMON })
     running = buildHttpApp(prisma)
@@ -263,6 +263,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       (
         parentRes.json() as {
           parentSession: unknown
+          siblingSessions: unknown[]
           childSessions: Array<{ id: string; platform: string; title: string | null }>
         }
       ).childSessions
@@ -271,6 +272,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       { id: secondChild, agentId: AGENT, platform: 'discord', title: 'Check the API' }
     ])
     expect((parentRes.json() as { parentSession: unknown }).parentSession).toBeNull()
+    expect((parentRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([])
 
     const childRes = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${firstChild}` })
     expect(childRes.statusCode).toBe(200)
@@ -283,6 +285,9 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       platform: 'slack',
       title: 'Coordinate the rollout'
     })
+    expect((childRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([
+      { id: secondChild, agentId: AGENT, platform: 'discord', title: 'Check the API' }
+    ])
     expect((childRes.json() as { childSessions: unknown[] }).childSessions).toEqual([])
   })
 

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -150,7 +150,7 @@ describe('session visibility — list & detail', () => {
     expect(collected).toEqual(visible)
   })
 
-  it('hides a private child and parent from the detail relationship links', async () => {
+  it('hides private relatives from the detail relationship links', async () => {
     const viewer = await makeUser('sv-rel', 'collaborator')
     const other = await makeUser('sv-rel-other', 'collaborator')
     const daemonId = await seedDaemon(prisma, randomUUID())
@@ -171,6 +171,11 @@ describe('session visibility — list & detail', () => {
     }
     expect(body.childSessions.map((c) => c.id)).toEqual([visibleChild])
     expect(body.childSessions.map((c) => c.id)).not.toContain(hiddenChild)
+
+    const visibleChildBody = (
+      await appAs(viewer).app.inject({ method: 'GET', url: `${ORG}/sessions/${visibleChild}` })
+    ).json() as { siblingSessions: Array<{ id: string }> }
+    expect(visibleChildBody.siblingSessions).toEqual([])
   })
 })
 

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -35,6 +35,7 @@ import { PlatformMark } from '@/components/marks'
 import { groupSessionsByAge } from '@/lib/session-age'
 import {
   partitionPinned,
+  pinnedIdsForOrg,
   readSessionPins,
   SESSION_PIN_HYDRATE_MAX,
   toggleSessionPin,
@@ -64,7 +65,7 @@ export function SessionRail({
   current: Session
   /** The agent's full session count (CP `total`); 0 when unknown (mock). */
   total: number
-  /** Owning agent — scopes the pins and the footer link. */
+  /** Owning agent — scopes the footer link. */
   agentId: string | undefined
   /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
   family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
@@ -83,13 +84,16 @@ export function SessionRail({
     setPins(readSessionPins())
   }, [])
 
-  const togglePin = useCallback((sessionId: string) => {
-    setPins((prev) => {
-      const next = toggleSessionPin(prev, sessionId)
-      writeSessionPins(next)
-      return next
-    })
-  }, [])
+  const togglePin = useCallback(
+    (sessionId: string) => {
+      setPins((prev) => {
+        const next = toggleSessionPin(prev, sessionId, activeOrg?.id ?? '')
+        writeSessionPins(next)
+        return next
+      })
+    },
+    [activeOrg?.id]
+  )
 
   const currentId = canonicalSessionId(current)
   const parent = family?.parentSession ?? null
@@ -118,11 +122,10 @@ export function SessionRail({
   )
   const missingPinIds = useMemo(
     () =>
-      pins
-        .map((pin) => pin.id)
+      pinnedIdsForOrg(pins, activeOrg?.id ?? '')
         .filter((id) => !loadedIds.has(id))
         .slice(0, SESSION_PIN_HYDRATE_MAX),
-    [pins, loadedIds]
+    [pins, activeOrg?.id, loadedIds]
   )
   const { data: hydratedPins } = useSWR(
     missingPinIds.length > 0 ? ['session-rail-pins', activeOrg?.id ?? '', missingPinIds.join(',')] : null,

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-// The session detail page's left rail: every session of the CURRENT agent, so a
-// run you are comparing against is one click away instead of a round trip through
-// /sessions. It only appears when the agent has ≥2 sessions (a single-session
-// agent's rail would just repeat the page you are on) and only on desktop —
-// ≤768px navigates sessions through the Shell app bar's back affordance.
+// The session detail page's left rail: the open session's direct family (parent,
+// siblings, and children) followed by the other sessions of the CURRENT agent.
+// Family rows stay in their tree even when pinned and are removed from the ordinary
+// list below, so lineage never appears twice. The rail only appears when there is
+// another session to navigate to and only on desktop — ≤768px uses the relation
+// card in SessionDetailView plus the Shell app bar's back affordance.
 //
 // A row is the owning integration's platform mark (Slack / Telegram / … ) plus the
 // title, and nothing else: at 224px a per-row timestamp crowds out the one thing
@@ -24,7 +25,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import useSWR from 'swr'
 import { canonicalSessionId, mergeCanonicalSessions, sessionChannelDisplay, type Session } from '@/lib/data'
-import { fetchSessionDetail, sessionFromDetailDto } from '@/lib/api'
+import { fetchSessionDetail, sessionFromDetailDto, type SessionDetailDto, type SessionRelationDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
@@ -40,11 +41,22 @@ import {
   type SessionPin
 } from '@/lib/session-pins'
 
+interface RailRow {
+  id: string
+  agentId?: string
+  platform: string
+  title: string
+  tooltip: string
+}
+
+const EMPTY_RELATIONS: SessionRelationDto[] = []
+
 export function SessionRail({
   sessions,
   current,
   total,
-  agentId
+  agentId,
+  family
 }: {
   /** The agent-filtered first page of sessions, newest first. */
   sessions: Session[]
@@ -54,6 +66,8 @@ export function SessionRail({
   total: number
   /** Owning agent — scopes the pins and the footer link. */
   agentId: string | undefined
+  /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
+  family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
 }) {
   const { orgPath, activeOrg } = useOrgs()
   // Schedule-triggered rows show the schedule's name, so the rail needs the crons
@@ -70,9 +84,9 @@ export function SessionRail({
   }, [])
 
   const togglePin = useCallback(
-    (sessionId: string) => {
+    (sessionId: string, rowAgentId?: string) => {
       setPins((prev) => {
-        const next = toggleSessionPin(prev, sessionId, agentId ?? '')
+        const next = toggleSessionPin(prev, sessionId, rowAgentId ?? agentId ?? '')
         writeSessionPins(next)
         return next
       })
@@ -80,13 +94,30 @@ export function SessionRail({
     [agentId]
   )
 
+  const currentId = canonicalSessionId(current)
+  const parent = family?.parentSession ?? null
+  const siblings = family?.siblingSessions ?? EMPTY_RELATIONS
+  const children = family?.childSessions ?? EMPTY_RELATIONS
+  const hasFamily = Boolean(parent || siblings.length > 0 || children.length > 0)
+  const relatedIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (!hasFamily) return ids
+    ids.add(currentId)
+    if (parent) ids.add(parent.id)
+    for (const relation of siblings) ids.add(relation.id)
+    for (const relation of children) ids.add(relation.id)
+    return ids
+  }, [children, currentId, hasFamily, parent, siblings])
+
   // Pinned rows for THIS agent that the loaded page does not carry. Fetched by id
   // because the list endpoint cannot filter by id; a rail holds a handful of pins,
   // and the cap only bounds a pathological list. A row that fails to load is simply
   // not rendered — a 404 here means "missing or not authorized", which is not proof
   // of deletion, so the pin is left alone (see lib/session-pins.ts).
-  const currentId = canonicalSessionId(current)
-  const loadedIds = useMemo(() => new Set([...sessions.map(canonicalSessionId), currentId]), [sessions, currentId])
+  const loadedIds = useMemo(
+    () => new Set([...sessions.map(canonicalSessionId), currentId, ...relatedIds]),
+    [sessions, currentId, relatedIds]
+  )
   const missingPinIds = useMemo(
     () =>
       pinnedIdsForAgent(pins, agentId ?? '')
@@ -120,7 +151,11 @@ export function SessionRail({
     [sessions, current, hydratedPins]
   )
 
-  const { pinned, rest } = useMemo(() => partitionPinned(rows, pins), [rows, pins])
+  const ordinaryRows = useMemo(
+    () => (hasFamily ? rows.filter((session) => !relatedIds.has(session.id)) : rows),
+    [hasFamily, relatedIds, rows]
+  )
+  const { pinned, rest } = useMemo(() => partitionPinned(ordinaryRows, pins), [ordinaryRows, pins])
   // Dated groups cover the UNPINNED rows only — a pin is an explicit "keep this at
   // the top", which outranks how old the run is. `now` is read per render; the rail
   // only renders once its agent-filtered page has landed on the client, so there is
@@ -130,49 +165,75 @@ export function SessionRail({
   // The agent's real session count, not the loaded-page length — a 60-session agent
   // must not read "50". This also gates the rail, so it does not blink into view
   // once page one lands.
-  const count = Math.max(total, rows.length)
+  const count = Math.max(total, rows.length, relatedIds.size)
 
-  // A rail that would only show the session already on screen is noise.
-  if (count < 2) return null
+  // A rail that would only show the session already on screen is noise. Direct
+  // lineage still makes it useful when the current agent itself has one session.
+  if (count < 2 && !hasFamily) return null
 
-  const row = (s: Session, isPinned: boolean) => {
+  const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
-    const on = s.id === currentId
+    return {
+      id: canonicalSessionId(s),
+      agentId: s.agentId ?? agentId,
+      platform: channel.platform,
+      title: s.title,
+      tooltip: `${s.title}\n${s.time} · ${channel.label}`
+    }
+  }
+  const relationRow = (relation: SessionRelationDto): RailRow => {
+    const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
+    return {
+      id: relation.id,
+      agentId: relation.agentId,
+      platform: relation.platform,
+      title,
+      tooltip: title
+    }
+  }
+  const isPinned = (sessionId: string) => pins.some((pin) => pin.id === sessionId)
+  const row = (item: RailRow, pinnedRow: boolean, depth: 0 | 1 | 2 = 0, on = false) => {
     return (
       <div
-        key={s.id}
-        className={`group flex w-full items-center gap-2 rounded-sm px-[9px] py-[6px] ${
+        key={item.id}
+        className={`group flex w-full items-center gap-2 rounded-sm py-[6px] pr-[9px] ${
+          depth === 2 ? 'pl-[26px]' : 'pl-[9px]'
+        } ${
           on
             ? 'bg-(--brand-soft) text-(--text-primary)'
             : 'text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
         }`}
       >
         <Link
-          href={orgPath(`/sessions/${encodeURIComponent(s.id)}`)}
-          // The two facts the row itself drops — when it ran and where — plus the
-          // untruncated title. `\n` is a real break: the tooltip layer renders
-          // whitespace-pre-line.
-          title={`${s.title}\n${s.time} · ${channel.label}`}
+          href={orgPath(`/sessions/${encodeURIComponent(item.id)}`)}
+          title={item.tooltip}
+          aria-current={on ? 'page' : undefined}
           className="flex min-w-0 flex-1 items-center gap-2"
         >
+          {depth > 0 && (
+            <span
+              aria-hidden="true"
+              className="-mt-2 h-[15px] w-[13px] flex-none rounded-bl-[4px] border-b-[1.5px] border-l-[1.5px] border-(--border-strong)"
+            />
+          )}
           <span className="imark h-[18px] w-[18px] flex-none rounded-xs">
-            <PlatformMark platform={channel.platform} fillPct={100} />
+            <PlatformMark platform={item.platform} fillPct={100} />
           </span>
           <span
             className={`min-w-0 flex-1 truncate font-sans text-[12.5px] leading-normal ${
               on ? 'font-semibold' : 'font-medium'
             }`}
           >
-            {s.title}
+            {item.title}
           </span>
         </Link>
         <button
           type="button"
-          onClick={() => togglePin(s.id)}
-          aria-pressed={isPinned}
-          title={isPinned ? 'Unpin session' : 'Pin session'}
+          onClick={() => togglePin(item.id, item.agentId)}
+          aria-pressed={pinnedRow}
+          title={pinnedRow ? 'Unpin session' : 'Pin session'}
           className={`-my-[2px] h-[19px] w-[19px] flex-none items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
-            isPinned ? 'flex text-(--brand)' : 'hidden text-(--text-tertiary) group-hover:flex group-focus-within:flex'
+            pinnedRow ? 'flex text-(--brand)' : 'hidden text-(--text-tertiary) group-hover:flex group-focus-within:flex'
           }`}
         >
           <Icon name="pin" size={12} />
@@ -191,7 +252,20 @@ export function SessionRail({
           <span className="mono flex-none text-[11px] text-(--text-tertiary)">{count}</span>
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
-          {pinned.map((s) => row(s, true))}
+          {hasFamily && (
+            <>
+              <div className="flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
+                Related
+              </div>
+              {parent && row(relationRow(parent), isPinned(parent.id))}
+              {row(sessionRow(current), isPinned(currentId), parent ? 1 : 0, true)}
+              {children.map((child) => row(relationRow(child), isPinned(child.id), parent ? 2 : 1))}
+              {siblings.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+              {siblings.map((sibling) => row(relationRow(sibling), isPinned(sibling.id), 1))}
+              {ordinaryRows.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
+            </>
+          )}
+          {pinned.map((s) => row(sessionRow(s), true, 0, canonicalSessionId(s) === currentId))}
           {pinned.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
           {groups.map((g, i) => (
             <Fragment key={g.bucket}>
@@ -204,7 +278,7 @@ export function SessionRail({
               >
                 {g.label}
               </div>
-              {g.rows.map((s) => row(s, false))}
+              {g.rows.map((s) => row(sessionRow(s), false, 0, canonicalSessionId(s) === currentId))}
             </Fragment>
           ))}
         </div>

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 // The session detail page's left rail: the open session's direct family (parent,
-// siblings, and children) followed by the other sessions of the CURRENT agent.
-// Family rows stay in their tree even when pinned and are removed from the ordinary
-// list below, so lineage never appears twice. The rail only appears when there is
-// another session to navigate to and only on desktop — ≤768px uses the relation
-// card in SessionDetailView plus the Shell app bar's back affordance.
+// siblings, and children), globally pinned shortcuts, then the other sessions of
+// the CURRENT agent. Family rows stay in their tree even when pinned and are
+// removed from the ordinary list below, so lineage never appears twice. The rail
+// only appears when there is another session to navigate to and only on desktop —
+// ≤768px uses the relation card in SessionDetailView plus the Shell app bar's back
+// affordance.
 //
 // A row is the owning integration's platform mark (Slack / Telegram / … ) plus the
 // title, and nothing else: at 224px a per-row timestamp crowds out the one thing
@@ -18,8 +19,9 @@
 // The caller's rows are the agent-filtered FIRST PAGE, so two kinds of row would
 // otherwise be missing from a long-running agent's rail: the open session itself
 // (a deep link to session 51+), and pinned runs that newer runs pushed off page
-// one. Both are the rail's whole point, so `current` is merged in and this agent's
-// off-page pins are fetched individually (bounded by SESSION_PIN_HYDRATE_MAX).
+// one or that belong to another agent. Both are the rail's whole point, so
+// `current` is merged in and off-page pins are fetched individually (bounded by
+// SESSION_PIN_HYDRATE_MAX).
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
@@ -33,7 +35,6 @@ import { PlatformMark } from '@/components/marks'
 import { groupSessionsByAge } from '@/lib/session-age'
 import {
   partitionPinned,
-  pinnedIdsForAgent,
   readSessionPins,
   SESSION_PIN_HYDRATE_MAX,
   toggleSessionPin,
@@ -43,7 +44,6 @@ import {
 
 interface RailRow {
   id: string
-  agentId?: string
   platform: string
   title: string
   tooltip: string
@@ -83,16 +83,13 @@ export function SessionRail({
     setPins(readSessionPins())
   }, [])
 
-  const togglePin = useCallback(
-    (sessionId: string, rowAgentId?: string) => {
-      setPins((prev) => {
-        const next = toggleSessionPin(prev, sessionId, rowAgentId ?? agentId ?? '')
-        writeSessionPins(next)
-        return next
-      })
-    },
-    [agentId]
-  )
+  const togglePin = useCallback((sessionId: string) => {
+    setPins((prev) => {
+      const next = toggleSessionPin(prev, sessionId)
+      writeSessionPins(next)
+      return next
+    })
+  }, [])
 
   const currentId = canonicalSessionId(current)
   const parent = family?.parentSession ?? null
@@ -109,21 +106,23 @@ export function SessionRail({
     return ids
   }, [children, currentId, hasFamily, parent, siblings])
 
-  // Pinned rows for THIS agent that the loaded page does not carry. Fetched by id
-  // because the list endpoint cannot filter by id; a rail holds a handful of pins,
-  // and the cap only bounds a pathological list. A row that fails to load is simply
-  // not rendered — a 404 here means "missing or not authorized", which is not proof
-  // of deletion, so the pin is left alone (see lib/session-pins.ts).
+  // Globally pinned rows that the loaded page or current family does not carry.
+  // Fetched by id because the list endpoint cannot filter by id; a rail holds a
+  // handful of pins, and the cap only bounds a pathological list. A row that fails
+  // to load is simply not rendered — a 404 here means "missing or not authorized",
+  // which is not proof of deletion, so the pin is left alone (see
+  // lib/session-pins.ts).
   const loadedIds = useMemo(
     () => new Set([...sessions.map(canonicalSessionId), currentId, ...relatedIds]),
     [sessions, currentId, relatedIds]
   )
   const missingPinIds = useMemo(
     () =>
-      pinnedIdsForAgent(pins, agentId ?? '')
+      pins
+        .map((pin) => pin.id)
         .filter((id) => !loadedIds.has(id))
         .slice(0, SESSION_PIN_HYDRATE_MAX),
-    [pins, agentId, loadedIds]
+    [pins, loadedIds]
   )
   const { data: hydratedPins } = useSWR(
     missingPinIds.length > 0 ? ['session-rail-pins', activeOrg?.id ?? '', missingPinIds.join(',')] : null,
@@ -162,29 +161,14 @@ export function SessionRail({
   // no server pass whose clock could disagree.
   const groups = useMemo(() => groupSessionsByAge(rest, new Date()), [rest])
 
-  // Start with the owning agent's real count, not the loaded-page length — a
-  // 60-session agent must not read "50". Related sessions from that agent are
-  // already included in `total`; cross-agent relatives are not, so add that
-  // distinct visible set to make the badge match the rail's navigable union.
-  const currentAgentId = agentId ?? current.agentId
-  const crossAgentRelatedCount = useMemo(() => {
-    const ids = new Set<string>()
-    for (const relation of [...(parent ? [parent] : []), ...siblings, ...children]) {
-      if (relation.agentId !== currentAgentId) ids.add(relation.id)
-    }
-    return ids.size
-  }, [children, currentAgentId, parent, siblings])
-  const count = Math.max(total, rows.length) + crossAgentRelatedCount
-
   // A rail that would only show the session already on screen is noise. Direct
   // lineage still makes it useful when the current agent itself has one session.
-  if (count < 2 && !hasFamily) return null
+  if (Math.max(total, rows.length) < 2 && !hasFamily) return null
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
     return {
       id: canonicalSessionId(s),
-      agentId: s.agentId ?? agentId,
       platform: channel.platform,
       title: s.title,
       tooltip: `${s.title}\n${s.time} · ${channel.label}`
@@ -194,7 +178,6 @@ export function SessionRail({
     const title = relation.title?.trim() || `Session ${relation.id.slice(0, 8)}`
     return {
       id: relation.id,
-      agentId: relation.agentId,
       platform: relation.platform,
       title,
       tooltip: title
@@ -238,7 +221,7 @@ export function SessionRail({
         </Link>
         <button
           type="button"
-          onClick={() => togglePin(item.id, item.agentId)}
+          onClick={() => togglePin(item.id)}
           aria-pressed={pinnedRow}
           title={pinnedRow ? 'Unpin session' : 'Pin session'}
           className={`-my-[2px] h-[19px] w-[19px] flex-none items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
@@ -254,12 +237,6 @@ export function SessionRail({
   return (
     <div className="hidden w-[224px] flex-none desktop:block">
       <div className="sticky top-[-9px] flex max-h-[calc(100vh-110px)] flex-col pb-1">
-        <div className="flex items-center gap-2 pr-[9px] pb-[7px] pl-[9px]">
-          <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] font-semibold leading-normal tracking-[0.08em] text-(--text-tertiary) uppercase">
-            Sessions
-          </span>
-          <span className="mono flex-none text-[11px] text-(--text-tertiary)">{count}</span>
-        </div>
         <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
           {hasFamily && (
             <>
@@ -278,8 +255,8 @@ export function SessionRail({
           {pinned.length > 0 && <div className="mx-[9px] my-[6px] h-px flex-none bg-(--border-subtle)" />}
           {groups.map((g, i) => (
             <Fragment key={g.bucket}>
-              {/* No top margin on the very first heading — it would double the gap
-                  the rail header already leaves (or the pinned divider's). */}
+              {/* The first heading starts flush; separators already provide spacing
+                  when Related or pinned rows precede it. */}
               <div
                 className={`flex-none px-[9px] pb-[3px] font-mono text-[10px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase ${
                   i === 0 ? '' : 'pt-[11px]'

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -162,10 +162,19 @@ export function SessionRail({
   // no server pass whose clock could disagree.
   const groups = useMemo(() => groupSessionsByAge(rest, new Date()), [rest])
 
-  // The agent's real session count, not the loaded-page length — a 60-session agent
-  // must not read "50". This also gates the rail, so it does not blink into view
-  // once page one lands.
-  const count = Math.max(total, rows.length, relatedIds.size)
+  // Start with the owning agent's real count, not the loaded-page length — a
+  // 60-session agent must not read "50". Related sessions from that agent are
+  // already included in `total`; cross-agent relatives are not, so add that
+  // distinct visible set to make the badge match the rail's navigable union.
+  const currentAgentId = agentId ?? current.agentId
+  const crossAgentRelatedCount = useMemo(() => {
+    const ids = new Set<string>()
+    for (const relation of [...(parent ? [parent] : []), ...siblings, ...children]) {
+      if (relation.agentId !== currentAgentId) ids.add(relation.id)
+    }
+    return ids.size
+  }, [children, currentAgentId, parent, siblings])
+  const count = Math.max(total, rows.length) + crossAgentRelatedCount
 
   // A rail that would only show the session already on screen is noise. Direct
   // lineage still makes it useful when the current agent itself has one session.

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -590,24 +590,26 @@ function SessionRelationLink({
   )
 }
 
-function SessionFamilyLinks({
+function MobileSessionFamilyLinks({
   parent,
+  siblings,
   children,
   agentById,
   orgPath
 }: {
   parent: SessionRelationDto | null
+  siblings: SessionRelationDto[]
   children: SessionRelationDto[]
   agentById: ReadonlyMap<string, Agent>
   orgPath: (path: string) => string
 }) {
-  if (!parent && children.length === 0) return null
+  if (!parent && siblings.length === 0 && children.length === 0) return null
   return (
-    <div className="card mx-4 mt-4 overflow-hidden desktop:mx-0 desktop:mt-0 desktop:mb-4">
+    <div className="card mx-4 mt-4 overflow-hidden desktop:hidden">
       {parent && (
         <div
-          className={`grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4 desktop:grid-cols-[118px_minmax(0,1fr)] ${
-            children.length > 0 ? 'border-b border-(--border-subtle)' : ''
+          className={`grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4 ${
+            siblings.length > 0 || children.length > 0 ? 'border-b border-(--border-subtle)' : ''
           }`}
         >
           <span className="py-[10px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
@@ -616,8 +618,30 @@ function SessionFamilyLinks({
           <SessionRelationLink relation={parent} agent={agentById.get(parent.agentId)} orgPath={orgPath} />
         </div>
       )}
+      {siblings.length > 0 && (
+        <div
+          className={`grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4 ${
+            children.length > 0 ? 'border-b border-(--border-subtle)' : ''
+          }`}
+        >
+          <span className="py-[10px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
+            {siblings.length === 1 ? 'Sibling session' : `Sibling sessions (${siblings.length})`}
+          </span>
+          <div className="min-w-0">
+            {siblings.map((sibling, index) => (
+              <SessionRelationLink
+                key={sibling.id}
+                relation={sibling}
+                agent={agentById.get(sibling.agentId)}
+                orgPath={orgPath}
+                bordered={index > 0}
+              />
+            ))}
+          </div>
+        </div>
+      )}
       {children.length > 0 && (
-        <div className="grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4 desktop:grid-cols-[118px_minmax(0,1fr)]">
+        <div className="grid grid-cols-[104px_minmax(0,1fr)] gap-3 px-4">
           <span className="py-[10px] font-sans text-[12px] font-medium leading-normal text-(--text-tertiary)">
             {children.length === 1 ? 'Child session' : `Child sessions (${children.length})`}
           </span>
@@ -781,7 +805,7 @@ export default function SessionDetailView() {
   const agentRuntime = session?.runtime || owner?.runtime || ''
   const runtimeMeta = acpRuntime(acpRegistry, agentRuntime)
 
-  // Sibling sessions for the left rail. Like the agent page's Recent-sessions card
+  // Other sessions for the left rail. Like the agent page's Recent-sessions card
   // this reads an AGENT-FILTERED page, not the org-wide `allSessions` window — a
   // busy org's newest 50 may not include this agent at all, which would hide the
   // rail on an agent that has plenty of runs. The org key stays null until the
@@ -1398,7 +1422,13 @@ export default function SessionDetailView() {
     // the 880px body. With no rail the body is still an 880px block centred in that
     // track — geometrically identical to when it was the wrap itself.
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
-      <SessionRail sessions={railSessions} current={session} total={railSessionTotal} agentId={session.agentId} />
+      <SessionRail
+        sessions={railSessions}
+        current={session}
+        total={railSessionTotal}
+        agentId={session.agentId}
+        family={sessionDetail?.id === session.id ? sessionDetail : undefined}
+      />
       <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">
         {/* DESKTOP TITLE ROW — the session name + its status badge. These used to live
           in the top-bar crumb; with the crumb gone the page has to name itself. The
@@ -1604,8 +1634,9 @@ export default function SessionDetailView() {
         )}
 
         {sessionDetail?.id === session.id && (
-          <SessionFamilyLinks
+          <MobileSessionFamilyLinks
             parent={sessionDetail.parentSession}
+            siblings={sessionDetail.siblingSessions ?? []}
             children={sessionDetail.childSessions}
             agentById={agentById}
             orgPath={orgPath}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -394,6 +394,8 @@ export interface SessionRelationDto {
 export interface SessionDetailDto {
   id: string
   parentSession: SessionRelationDto | null
+  /** Absent on a Control Plane that predates sibling navigation. */
+  siblingSessions?: SessionRelationDto[]
   childSessions: SessionRelationDto[]
   agentId: string
   platform: string | null

--- a/packages/web/src/lib/session-pins.test.ts
+++ b/packages/web/src/lib/session-pins.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   partitionPinned,
+  pinnedIdsForOrg,
   readSessionPins,
   SESSION_PINS_KEY,
   SESSION_PINS_MAX,
@@ -22,7 +23,7 @@ function stubStorage(initial?: string) {
   return store
 }
 
-const pin = (id: string): SessionPin => ({ id })
+const pin = (id: string, orgId = 'o1'): SessionPin => ({ id, orgId })
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -34,8 +35,8 @@ describe('readSessionPins', () => {
   })
 
   it('reads stored pins in order', () => {
-    stubStorage(JSON.stringify([pin('b'), pin('a')]))
-    expect(readSessionPins()).toEqual([pin('b'), pin('a')])
+    stubStorage(JSON.stringify([pin('b'), pin('a', 'o2')]))
+    expect(readSessionPins()).toEqual([pin('b'), pin('a', 'o2')])
   })
 
   it('returns [] for an unset key, malformed JSON, or a non-array', () => {
@@ -49,12 +50,12 @@ describe('readSessionPins', () => {
 
   it('migrates the legacy flat string[] shape to session pins', () => {
     stubStorage(JSON.stringify(['s1', 's2']))
-    expect(readSessionPins()).toEqual([{ id: 's1' }, { id: 's2' }])
+    expect(readSessionPins()).toEqual([pin('s1', ''), pin('s2', '')])
   })
 
-  it('drops unusable entries, migrates prior agent-scoped rows, and de-duplicates by id', () => {
+  it('drops unusable entries, migrates prior unscoped rows, and de-duplicates by id', () => {
     stubStorage(JSON.stringify([{ id: 'a', agentId: 'a1' }, 3, null, '', { id: 'b' }, { agentId: 'a1' }, pin('a')]))
-    expect(readSessionPins()).toEqual([pin('a'), pin('b')])
+    expect(readSessionPins()).toEqual([pin('a', ''), pin('b', '')])
   })
 
   it('survives storage that throws (private mode)', () => {
@@ -91,16 +92,29 @@ describe('writeSessionPins', () => {
 })
 
 describe('toggleSessionPin', () => {
-  it('pins to the front and unpins by session id', () => {
-    expect(toggleSessionPin([pin('a')], 'b')).toEqual([pin('b'), pin('a')])
-    expect(toggleSessionPin([pin('b'), pin('a')], 'b')).toEqual([pin('a')])
-    expect(toggleSessionPin([], 'a')).toEqual([pin('a')])
+  it('pins to the front with its organization and unpins by session id', () => {
+    expect(toggleSessionPin([pin('a')], 'b', 'o1')).toEqual([pin('b'), pin('a')])
+    expect(toggleSessionPin([pin('b'), pin('a')], 'b', 'o2')).toEqual([pin('a')])
+    expect(toggleSessionPin([], 'a', 'o2')).toEqual([pin('a', 'o2')])
   })
 
   it('does not mutate the input', () => {
     const pins = [pin('a')]
-    toggleSessionPin(pins, 'b')
+    toggleSessionPin(pins, 'b', 'o1')
     expect(pins).toEqual([pin('a')])
+  })
+})
+
+describe('pinnedIdsForOrg', () => {
+  it('filters by organization before the hydration cap is applied', () => {
+    const pins = [pin('a', 'o1'), pin('b', 'o2'), pin('c', 'o1')]
+    expect(pinnedIdsForOrg(pins, 'o1')).toEqual(['a', 'c'])
+    expect(pinnedIdsForOrg(pins, 'o2')).toEqual(['b'])
+  })
+
+  it('does not speculate about legacy unscoped pins or an unknown organization', () => {
+    expect(pinnedIdsForOrg([pin('old', ''), pin('a')], 'o1')).toEqual(['a'])
+    expect(pinnedIdsForOrg([pin('a')], '')).toEqual([])
   })
 })
 
@@ -122,7 +136,7 @@ describe('partitionPinned', () => {
   })
 
   it('groups a pin that is on the page', () => {
-    expect(partitionPinned(rows, [{ id: 'b' }])).toEqual({
+    expect(partitionPinned(rows, [pin('b', '')])).toEqual({
       pinned: [{ id: 'b' }],
       rest: [{ id: 'a' }, { id: 'c' }]
     })

--- a/packages/web/src/lib/session-pins.test.ts
+++ b/packages/web/src/lib/session-pins.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   partitionPinned,
-  pinnedIdsForAgent,
   readSessionPins,
   SESSION_PINS_KEY,
   SESSION_PINS_MAX,
@@ -23,7 +22,7 @@ function stubStorage(initial?: string) {
   return store
 }
 
-const pin = (id: string, agentId = 'a1'): SessionPin => ({ id, agentId })
+const pin = (id: string): SessionPin => ({ id })
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -35,8 +34,8 @@ describe('readSessionPins', () => {
   })
 
   it('reads stored pins in order', () => {
-    stubStorage(JSON.stringify([pin('b'), pin('a', 'a2')]))
-    expect(readSessionPins()).toEqual([pin('b'), pin('a', 'a2')])
+    stubStorage(JSON.stringify([pin('b'), pin('a')]))
+    expect(readSessionPins()).toEqual([pin('b'), pin('a')])
   })
 
   it('returns [] for an unset key, malformed JSON, or a non-array', () => {
@@ -48,17 +47,14 @@ describe('readSessionPins', () => {
     expect(readSessionPins()).toEqual([])
   })
 
-  it('migrates the legacy flat string[] shape to unattributed pins', () => {
+  it('migrates the legacy flat string[] shape to session pins', () => {
     stubStorage(JSON.stringify(['s1', 's2']))
-    expect(readSessionPins()).toEqual([
-      { id: 's1', agentId: '' },
-      { id: 's2', agentId: '' }
-    ])
+    expect(readSessionPins()).toEqual([{ id: 's1' }, { id: 's2' }])
   })
 
-  it('drops unusable entries, defaults a missing agentId, and de-duplicates by id', () => {
-    stubStorage(JSON.stringify([pin('a'), 3, null, '', { id: 'b' }, { agentId: 'a1' }, pin('a', 'a9')]))
-    expect(readSessionPins()).toEqual([pin('a'), { id: 'b', agentId: '' }])
+  it('drops unusable entries, migrates prior agent-scoped rows, and de-duplicates by id', () => {
+    stubStorage(JSON.stringify([{ id: 'a', agentId: 'a1' }, 3, null, '', { id: 'b' }, { agentId: 'a1' }, pin('a')]))
+    expect(readSessionPins()).toEqual([pin('a'), pin('b')])
   })
 
   it('survives storage that throws (private mode)', () => {
@@ -95,40 +91,16 @@ describe('writeSessionPins', () => {
 })
 
 describe('toggleSessionPin', () => {
-  it('pins to the front with its owning agent, and unpins in place', () => {
-    expect(toggleSessionPin([pin('a')], 'b', 'a1')).toEqual([pin('b'), pin('a')])
-    expect(toggleSessionPin([pin('b'), pin('a')], 'b', 'a1')).toEqual([pin('a')])
-    expect(toggleSessionPin([], 'a', 'a7')).toEqual([pin('a', 'a7')])
-  })
-
-  it('unpins by id regardless of the agent passed', () => {
-    expect(toggleSessionPin([pin('a', 'a2')], 'a', 'a1')).toEqual([])
+  it('pins to the front and unpins by session id', () => {
+    expect(toggleSessionPin([pin('a')], 'b')).toEqual([pin('b'), pin('a')])
+    expect(toggleSessionPin([pin('b'), pin('a')], 'b')).toEqual([pin('a')])
+    expect(toggleSessionPin([], 'a')).toEqual([pin('a')])
   })
 
   it('does not mutate the input', () => {
     const pins = [pin('a')]
-    toggleSessionPin(pins, 'b', 'a1')
+    toggleSessionPin(pins, 'b')
     expect(pins).toEqual([pin('a')])
-  })
-})
-
-describe('pinnedIdsForAgent', () => {
-  // The regression this locks: the stored list is GLOBAL across agents, so a rail
-  // must never treat another agent's pins as its own — an earlier version pruned
-  // against one agent's loaded page and deleted every other agent's pin.
-  it('claims only the given agent, newest pin first', () => {
-    const pins = [pin('x', 'a2'), pin('y', 'a1'), pin('z', 'a1')]
-    expect(pinnedIdsForAgent(pins, 'a1')).toEqual(['y', 'z'])
-    expect(pinnedIdsForAgent(pins, 'a2')).toEqual(['x'])
-    expect(pinnedIdsForAgent(pins, 'a3')).toEqual([])
-  })
-
-  it('never claims unattributed (legacy) pins — they would be fetched on every rail', () => {
-    expect(pinnedIdsForAgent([{ id: 'old', agentId: '' }], 'a1')).toEqual([])
-  })
-
-  it('claims nothing for an unknown agent', () => {
-    expect(pinnedIdsForAgent([pin('a')], '')).toEqual([])
   })
 })
 
@@ -149,8 +121,8 @@ describe('partitionPinned', () => {
     })
   })
 
-  it('groups an unattributed pin that IS on the page', () => {
-    expect(partitionPinned(rows, [{ id: 'b', agentId: '' }])).toEqual({
+  it('groups a pin that is on the page', () => {
+    expect(partitionPinned(rows, [{ id: 'b' }])).toEqual({
       pinned: [{ id: 'b' }],
       rest: [{ id: 'a' }, { id: 'c' }]
     })

--- a/packages/web/src/lib/session-pins.ts
+++ b/packages/web/src/lib/session-pins.ts
@@ -15,8 +15,10 @@
 //
 // The list is GLOBAL across agents. A pin is a session bookmark, not an agent-list
 // preference: opening it restores that session and therefore its current position
-// in the related-session tree. The rail fetches the handful of pinned rows that are
-// not on the loaded page (see SESSION_PIN_HYDRATE_MAX).
+// in the related-session tree. Each entry keeps its organization only so one org's
+// inaccessible ids cannot consume another org's hydration budget; it does not scope
+// the bookmark to an agent. The rail fetches the handful of pinned rows that are not
+// on the loaded page (see SESSION_PIN_HYDRATE_MAX).
 //
 // Forgetting is by RECENCY ONLY: `writeSessionPins` keeps the newest
 // SESSION_PINS_MAX entries and drops the tail. Nothing here ever infers that a
@@ -24,9 +26,11 @@
 // the console has no cheap proof of deletion (the detail endpoint answers 404 for
 // unauthorized as well as missing). Growth is bounded by the cap instead.
 
-/** One pinned session. */
+/** One pinned session and the organization in which it can be opened. */
 export interface SessionPin {
   id: string
+  /** Empty only for entries written before organization scope was recorded. */
+  orgId: string
 }
 
 /** localStorage key holding the pinned sessions, newest pin first. */
@@ -43,7 +47,8 @@ export const SESSION_PINS_MAX = 200
 export const SESSION_PIN_HYDRATE_MAX = 12
 
 /** The stored pins, newest first. `[]` on SSR, malformed JSON, or blocked storage.
- *  Accepts both the legacy flat `string[]` shape and prior `{ id, agentId }` rows. */
+ *  Accepts the legacy flat `string[]` shape and prior `{ id, agentId }` / `{ id }`
+ *  rows as unscoped pins. */
 export function readSessionPins(): SessionPin[] {
   if (typeof window === 'undefined') return []
   try {
@@ -71,13 +76,22 @@ export function writeSessionPins(pins: SessionPin[]): void {
 
 /** `pins` with `sessionId` pinned (newest first) or unpinned. Pure — persist via
  *  `writeSessionPins`, so the caller can update React state from the same value. */
-export function toggleSessionPin(pins: SessionPin[], sessionId: string): SessionPin[] {
-  return pins.some((p) => p.id === sessionId) ? pins.filter((p) => p.id !== sessionId) : [{ id: sessionId }, ...pins]
+export function toggleSessionPin(pins: SessionPin[], sessionId: string, orgId: string): SessionPin[] {
+  return pins.some((p) => p.id === sessionId)
+    ? pins.filter((p) => p.id !== sessionId)
+    : [{ id: sessionId, orgId }, ...pins]
+}
+
+/** Ids that can be hydrated in `orgId`, newest pin first. Legacy unscoped entries
+ *  still lift rows already present in the rail, but are not fetched speculatively:
+ *  their organization cannot be recovered from local storage and 404 is ambiguous. */
+export function pinnedIdsForOrg(pins: SessionPin[], orgId: string): string[] {
+  return orgId ? pins.filter((p) => p.orgId === orgId).map((p) => p.id) : []
 }
 
 /** Split `sessions` into the pinned ones (in pin order, newest pin first) and the
- *  rest (input order preserved). Matches on id alone, so a pin whose agent was
- *  never recorded still groups correctly on the rail it appears in. */
+ *  rest (input order preserved). Matches on id alone, so a legacy pin whose
+ *  organization was never recorded still groups correctly once its row appears. */
 export function partitionPinned<T extends { id: string }>(
   sessions: T[],
   pins: SessionPin[]
@@ -96,11 +110,11 @@ export function partitionPinned<T extends { id: string }>(
 }
 
 function asPin(entry: unknown): SessionPin | null {
-  if (typeof entry === 'string') return entry ? { id: entry } : null
+  if (typeof entry === 'string') return entry ? { id: entry, orgId: '' } : null
   if (!entry || typeof entry !== 'object') return null
-  const { id } = entry as { id?: unknown }
+  const { id, orgId } = entry as { id?: unknown; orgId?: unknown }
   if (typeof id !== 'string' || !id) return null
-  return { id }
+  return { id, orgId: typeof orgId === 'string' ? orgId : '' }
 }
 
 function dedupe(pins: SessionPin[]): SessionPin[] {

--- a/packages/web/src/lib/session-pins.ts
+++ b/packages/web/src/lib/session-pins.ts
@@ -13,10 +13,10 @@
 // If cross-device pins are ever wanted, this module is the whole seam: swap the
 // reads/writes for a CP-backed hook and the rail is unchanged.
 //
-// The list is GLOBAL across agents, so each entry records its owning agent. That
-// is what lets the rail tell "this pin belongs to another agent" apart from "this
-// pin is gone", and what lets it fetch the handful of pinned rows that are not on
-// the loaded page (see SESSION_PIN_HYDRATE_MAX).
+// The list is GLOBAL across agents. A pin is a session bookmark, not an agent-list
+// preference: opening it restores that session and therefore its current position
+// in the related-session tree. The rail fetches the handful of pinned rows that are
+// not on the loaded page (see SESSION_PIN_HYDRATE_MAX).
 //
 // Forgetting is by RECENCY ONLY: `writeSessionPins` keeps the newest
 // SESSION_PINS_MAX entries and drops the tail. Nothing here ever infers that a
@@ -24,11 +24,9 @@
 // the console has no cheap proof of deletion (the detail endpoint answers 404 for
 // unauthorized as well as missing). Growth is bounded by the cap instead.
 
-/** One pinned session and the agent whose rail it belongs to. */
+/** One pinned session. */
 export interface SessionPin {
   id: string
-  /** Owning agent id; '' for entries written before the agent was recorded. */
-  agentId: string
 }
 
 /** localStorage key holding the pinned sessions, newest pin first. */
@@ -38,14 +36,14 @@ export const SESSION_PINS_KEY = 'ac.pinned-sessions'
  *  forever in a browser that never revisits the sessions they belong to. */
 export const SESSION_PINS_MAX = 200
 
-/** How many of one agent's pinned rows the rail will fetch individually when they
- *  are not on the loaded page. A rail holds a handful of pins in practice; the cap
- *  only stops a pathological list from fanning out into hundreds of requests.
- *  Pins beyond it still persist — they render once they are on the loaded page. */
+/** How many pinned rows the rail will fetch individually when they are not on the
+ *  loaded page. A rail holds a handful of pins in practice; the cap only stops a
+ *  pathological list from fanning out into hundreds of requests. Pins beyond it
+ *  still persist — they render once they are on the loaded page. */
 export const SESSION_PIN_HYDRATE_MAX = 12
 
 /** The stored pins, newest first. `[]` on SSR, malformed JSON, or blocked storage.
- *  Accepts the legacy flat `string[]` shape, attributing those to no agent. */
+ *  Accepts both the legacy flat `string[]` shape and prior `{ id, agentId }` rows. */
 export function readSessionPins(): SessionPin[] {
   if (typeof window === 'undefined') return []
   try {
@@ -73,17 +71,8 @@ export function writeSessionPins(pins: SessionPin[]): void {
 
 /** `pins` with `sessionId` pinned (newest first) or unpinned. Pure — persist via
  *  `writeSessionPins`, so the caller can update React state from the same value. */
-export function toggleSessionPin(pins: SessionPin[], sessionId: string, agentId: string): SessionPin[] {
-  return pins.some((p) => p.id === sessionId)
-    ? pins.filter((p) => p.id !== sessionId)
-    : [{ id: sessionId, agentId }, ...pins]
-}
-
-/** Ids pinned on `agentId`'s rail, newest pin first. Only exact matches — an entry
- *  with no recorded agent is not claimed here (it would otherwise be fetched on
- *  every agent's rail); `partitionPinned` still lifts it once it is on the page. */
-export function pinnedIdsForAgent(pins: SessionPin[], agentId: string): string[] {
-  return agentId ? pins.filter((p) => p.agentId === agentId).map((p) => p.id) : []
+export function toggleSessionPin(pins: SessionPin[], sessionId: string): SessionPin[] {
+  return pins.some((p) => p.id === sessionId) ? pins.filter((p) => p.id !== sessionId) : [{ id: sessionId }, ...pins]
 }
 
 /** Split `sessions` into the pinned ones (in pin order, newest pin first) and the
@@ -107,11 +96,11 @@ export function partitionPinned<T extends { id: string }>(
 }
 
 function asPin(entry: unknown): SessionPin | null {
-  if (typeof entry === 'string') return entry ? { id: entry, agentId: '' } : null
+  if (typeof entry === 'string') return entry ? { id: entry } : null
   if (!entry || typeof entry !== 'object') return null
-  const { id, agentId } = entry as { id?: unknown; agentId?: unknown }
+  const { id } = entry as { id?: unknown }
   if (typeof id !== 'string' || !id) return null
-  return { id, agentId: typeof agentId === 'string' ? agentId : '' }
+  return { id }
 }
 
 function dedupe(pins: SessionPin[]): SessionPin[] {

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -115,6 +115,7 @@ describe('sessionTriggerKind', () => {
     const detail: SessionDetailDto = {
       id: 'dream-session-1',
       parentSession: null,
+      siblingSessions: [],
       childSessions: [],
       agentId: 'target-agent',
       platform: 'dream',


### PR DESCRIPTION
## Summary

- add a `Related` tree to the desktop session rail for the current session's parent, siblings, and children
- remove the redundant `Sessions / count` header so the rail begins directly with its contextual group
- keep every session independently pinnable; pins are global shortcuts across agents within an organization, remain in-place inside the active tree, and reopen the pinned session at its current tree position
- scope off-page pin hydration by organization so inaccessible pins from another organization cannot consume the active organization's request budget
- extend session detail metadata with visibility-filtered sibling sessions while retaining parent/sibling/child navigation on mobile

## Why

Session lineage was rendered in the page body while the left rail stayed a flat agent-session list. The detail API also exposed only parent and children, so the current session could not show its siblings as one navigable family. Pins also need to behave as session bookmarks rather than agent-scoped list preferences, especially when a family crosses agents.

## Validation

- `pnpm --filter @agentconnect.md/web build`
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/web test` (572 tests)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/session-metadata.route.test.ts test/integration/session-visibility.route.test.ts` (31 tests)
- full pre-push ESLint plus focused Prettier checks
- local visual QA of the headerless desktop rail and cross-agent pin → unrelated session → restored tree flow

Created by Codex . GPT-5
