### PR TITLE
fix(web): promote default agent visibility setting

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -355,6 +355,8 @@ default affects only future agents and never rewrites an existing agent's persis
 A local or otherwise unconfigured agent also defaults to `all` for compatibility.
 The organization-wide creation default is a first-class Settings card at the same
 hierarchy as Session access, not a field inside the Edit organization dialog.
+The Settings page starts directly with its Organization card rather than a generic
+page subtitle, keeping organization-wide controls at the primary content level.
 
 **Two unrelated settings are both called "visibility".** The `callPolicy` /
 `outboundPolicy` pair above is what the console labels "Agent visibility", and it is the

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -353,6 +353,8 @@ directions, so future agents discover no peers and accept no peer calls until co
 An individual create may still override either direction. Changing the organization
 default affects only future agents and never rewrites an existing agent's persisted policy.
 A local or otherwise unconfigured agent also defaults to `all` for compatibility.
+The organization-wide creation default is a first-class Settings card at the same
+hierarchy as Session access, not a field inside the Edit organization dialog.
 
 **Two unrelated settings are both called "visibility".** The `callPolicy` /
 `outboundPolicy` pair above is what the console labels "Agent visibility", and it is the

--- a/packages/web/src/components/console/modals/EditOrgModal.tsx
+++ b/packages/web/src/components/console/modals/EditOrgModal.tsx
@@ -2,8 +2,8 @@
 
 // Edit-organization dialog (design: `isEditWorkspaceModal`). REAL: PATCH
 // /orgs/:id (owner-only server-side; the Settings page only offers the button
-// to owners). Edits the ACTIVE org's URL name (slug), display name, and default
-// policy for future agents, and hosts the delete-organization danger zone
+// to owners). Edits the ACTIVE org's URL name (slug) and display name, and hosts
+// the delete-organization danger zone
 // (two-click confirm; the CP refuses while the org still has daemons, and
 // everything else cascades).
 
@@ -11,7 +11,6 @@ import { useState } from 'react'
 import { Button, Icon } from '@/components/ui'
 import { ApiError } from '@/lib/api'
 import { useOrgs, orgColor, orgUrlPrefix } from '@/lib/org-context'
-import type { AgentCallPolicy } from '@/lib/data'
 
 const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/
 
@@ -19,9 +18,6 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
   const { activeOrg, updateOrg, deleteOrg } = useOrgs()
   const [slug, setSlug] = useState(activeOrg?.slug ?? '')
   const [name, setName] = useState(activeOrg?.name ?? '')
-  const [defaultAgentVisibility, setDefaultAgentVisibility] = useState<AgentCallPolicy>(
-    activeOrg?.defaultAgentVisibility ?? 'all'
-  )
   const [busy, setBusy] = useState(false)
   const [deleteArmed, setDeleteArmed] = useState(false)
   const [err, setErr] = useState<string | null>(null)
@@ -32,16 +28,11 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
 
   const submit = async () => {
     if (!valid || busy) return
-    if (
-      slug === activeOrg.slug &&
-      (nextName || null) === (activeOrg.name ?? null) &&
-      defaultAgentVisibility === (activeOrg.defaultAgentVisibility ?? 'all')
-    )
-      return onClose()
+    if (slug === activeOrg.slug && (nextName || null) === (activeOrg.name ?? null)) return onClose()
     setBusy(true)
     setErr(null)
     try {
-      await updateOrg(activeOrg.id, { name: nextName, slug, defaultAgentVisibility })
+      await updateOrg(activeOrg.id, { name: nextName, slug })
       onClose()
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) setErr('That URL name is already taken.')
@@ -110,41 +101,6 @@ export default function EditOrgModal({ onClose }: { onClose: () => void }) {
           </div>
           <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
             Anything you like — shown across the console. Leave blank to use the URL name.
-          </span>
-        </div>
-        <div className="fld mt-[14px]">
-          <span className="fldlbl">Default agent visibility</span>
-          <div className="grid grid-cols-2 gap-[6px]" role="radiogroup" aria-label="Default agent visibility">
-            {(
-              [
-                { key: 'all', label: 'All agents', sub: 'Open in both directions to the organization.' },
-                { key: 'selected', label: 'Isolated', sub: 'No peer access until agents are selected.' }
-              ] as const
-            ).map((option) => (
-              <button
-                key={option.key}
-                type="button"
-                role="radio"
-                disabled={busy}
-                aria-checked={defaultAgentVisibility === option.key}
-                onClick={() => setDefaultAgentVisibility(option.key)}
-                className={`flex flex-col items-start gap-[1px] rounded-md border px-[11px] py-[8px] text-left ${
-                  defaultAgentVisibility === option.key
-                    ? 'border-(--brand) bg-(--surface-active)'
-                    : 'border-(--border-default) bg-(--surface-app)'
-                } ${busy ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-              >
-                <span className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
-                  {option.label}
-                </span>
-                <span className="font-sans text-[11px] font-normal leading-[1.4] text-(--text-tertiary)">
-                  {option.sub}
-                </span>
-              </button>
-            ))}
-          </div>
-          <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-            Applies only to newly created agents. Each agent can still override both directions.
           </span>
         </div>
         <div className="mt-[14px] flex items-start gap-2 rounded-md bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -50,7 +50,7 @@ import {
   type SessionAccessProvider,
   type SlackBotRefreshDto
 } from '@/lib/api'
-import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
+import { agentLabel, isDirectConversation, type AgentCallPolicy, type IntegrationRow } from '@/lib/data'
 import { slackAppSettingsUrl } from '@/lib/slack-manifest'
 import { slackRefreshNoticeState } from '@/lib/slack-refresh-notice'
 import { discordBotInviteUrl } from '@/lib/discord-invite'
@@ -211,6 +211,101 @@ function SessionAccessRow({
           onChange={(next) => void setEnabled(next)}
         />
       </span>
+    </div>
+  )
+}
+
+const AGENT_VISIBILITY_OPTIONS = [
+  {
+    key: 'all',
+    label: 'All agents',
+    sub: 'Open in both directions to every agent in the organization.'
+  },
+  {
+    key: 'selected',
+    label: 'Isolated',
+    sub: 'No peer access until agents are selected.'
+  }
+] as const satisfies ReadonlyArray<{ key: AgentCallPolicy; label: string; sub: string }>
+
+function AgentVisibilityCard({
+  orgId,
+  policy,
+  isOwner,
+  onChange
+}: {
+  orgId?: string
+  policy: AgentCallPolicy
+  isOwner: boolean
+  onChange: (policy: AgentCallPolicy) => Promise<void>
+}) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const setPolicy = async (next: AgentCallPolicy) => {
+    if (!orgId || !isOwner || busy || next === policy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await onChange(next)
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : String(nextError))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const disabled = !orgId || !isOwner || busy
+
+  return (
+    <div className="card mt-[18px]">
+      <div className="cardhead">
+        <span className="cardtitle">Agent visibility</span>
+      </div>
+      <div className="px-4 py-[15px]">
+        <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+          Default for new agents
+        </div>
+        <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
+          Choose whether newly created agents can collaborate with every agent or start isolated. Existing agents keep
+          their own settings.
+        </div>
+        <div
+          className="mt-3 grid grid-cols-2 gap-[6px]"
+          role="radiogroup"
+          aria-label="Default agent visibility"
+          aria-busy={busy}
+          title={isOwner ? undefined : 'Only organization owners can change this setting'}
+        >
+          {AGENT_VISIBILITY_OPTIONS.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              role="radio"
+              disabled={disabled}
+              aria-checked={policy === option.key}
+              onClick={() => void setPolicy(option.key)}
+              className={`flex flex-col items-start gap-[1px] rounded-md border px-[11px] py-[8px] text-left ${
+                policy === option.key
+                  ? 'border-(--brand) bg-(--surface-active)'
+                  : 'border-(--border-default) bg-(--surface-app)'
+              } ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+            >
+              <span className="font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
+                {option.label}
+              </span>
+              <span className="font-sans text-[11px] font-normal leading-[1.4] text-(--text-tertiary)">
+                {option.sub}
+              </span>
+            </button>
+          ))}
+        </div>
+        {error && (
+          <div role="alert" className="mt-2 font-sans text-[11.5px] font-normal leading-normal text-(--status-error)">
+            {error}
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -619,7 +714,7 @@ function InviteLinksCard({ orgId }: { orgId: string }) {
 export default function SettingsView() {
   const targetBotId = useSearchParams().get('bot')
   const { me } = useProfile()
-  const { activeOrg, myRole, refreshOrgs, leaveOrg, error: orgError } = useOrgs()
+  const { activeOrg, myRole, refreshOrgs, updateOrg: updateOrgSettings, leaveOrg, error: orgError } = useOrgs()
   const { openModal } = useModal()
   const isOwner = myRole === 'owner'
   const canWrite = myRole !== 'viewer' // the CP denies viewer writes; hide the controls too
@@ -725,6 +820,17 @@ export default function SettingsView() {
           </div>
         </div>
       </div>
+
+      <AgentVisibilityCard
+        key={activeOrg?.id ?? 'loading'}
+        orgId={activeOrg?.id}
+        policy={activeOrg?.defaultAgentVisibility ?? 'all'}
+        isOwner={isOwner}
+        onChange={async (policy) => {
+          if (!activeOrg) return
+          await updateOrgSettings(activeOrg.id, { defaultAgentVisibility: policy })
+        }}
+      />
 
       <div className="card mt-[18px]">
         <div className="cardhead">

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -771,9 +771,7 @@ export default function SettingsView() {
 
   return (
     <div className="wrap max-w-[900px] max-desktop:p-4">
-      <p className="psub mt-0">Organization, members and access tokens.</p>
-
-      <div className="card mt-5">
+      <div className="card">
         <div className="cardhead justify-between">
           <span className="cardtitle">Organization</span>
           {isOwner && (


### PR DESCRIPTION
## Summary

- move the organization-wide new-agent visibility default into its own Settings card alongside Session access
- keep Edit organization focused on organization identity and deletion
- remove the redundant Settings page subtitle and its reserved top spacing
- preserve owner-only updates and the existing behavior that only future agents inherit the default
- document the intended Settings hierarchy

## Why

The collaboration default is an organization-wide access policy, but it was buried inside the Edit organization dialog. Presenting it as a first-class Settings card makes its scope consistent with Session access and keeps organization identity editing separate.

The generic Settings subtitle is removed as a requested cleanup because it repeats the sections directly below and leaves unnecessary top spacing before the first Organization card.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx packages/web/src/components/console/modals/EditOrgModal.tsx`
- local desktop visual verification of the Settings card hierarchy
- pre-commit formatting and pre-push repository lint hooks

Created by Codex . GPT-5
