### PR TITLE
fix(sessions): converge playground startup state

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9931,13 +9931,13 @@ export class Daemon {
         this.refreshObservedChannels()
       }
     }
-    this.finishSessionInitialization(agentId, sessionId)
     try {
       onSessionReady?.(sessionId)
     } catch (err) {
       this.log.warn(`dispatch: session-ready notification failed (${formatErr(err)})`)
     }
     if (handled.initializedOnly) {
+      this.finishSessionInitialization(agentId, sessionId)
       this.showActivity(replyConn, msg.channel, statusThread, '')
       releaseReplyConn()
       this.log.info(`dispatch: initialized session ${key} from self-authored channel root without a model turn`)
@@ -10013,6 +10013,10 @@ export class Daemon {
         : {})
     }
     this.pending.set(pendingTurnKey(agentId, sessionId), p)
+    // session/new|load may emit title/usage metadata before the local row exists.
+    // Replay only after Pending owns the live sink so persisted and streamed state
+    // converge in the same turn instead of requiring a browser refresh.
+    this.finishSessionInitialization(agentId, sessionId)
     // §6.7 active-turn context: expose THIS turn's trusted callMeta by logical sessionKey so
     // a nested messageAgent made during the turn can auto-inherit hop/origin + reply-correlation.
     if (callMeta) this.activeTurnCallMeta.set(key, callMeta)

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -56,13 +56,22 @@ function writeAgent(root: string, agentExtra?: Record<string, unknown>): void {
  *  `opts.usage` is returned from prompt() with adapter-owned fold semantics. */
 function streamingHost(
   updates: unknown[],
-  opts: { stopReason?: string; model?: string; models?: string[]; usage?: Record<string, number> } = {}
+  opts: {
+    stopReason?: string
+    model?: string
+    models?: string[]
+    usage?: Record<string, number>
+    initialUpdates?: unknown[]
+  } = {}
 ) {
-  const { stopReason = 'end_turn', model, models, usage } = opts
+  const { stopReason = 'end_turn', model, models, usage, initialUpdates = [] } = opts
   let onUpdate!: (sid: string, u: unknown) => void
   const host = {
     start: vi.fn(async () => {}),
-    newSession: vi.fn(async () => 'acp-wc-1'),
+    newSession: vi.fn(async () => {
+      for (const update of initialUpdates) onUpdate('acp-wc-1', update)
+      return 'acp-wc-1'
+    }),
     modelOptions: vi.fn(() => (model ? { current: model, models: models ?? [model] } : null)),
     hasSession: vi.fn(() => true),
     setSessionModel: vi.fn(async () => true),
@@ -270,6 +279,40 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     // …and the persisted list row (the record) carries the same title (latest wins).
     const list = (daemon as any).store.listSessions(AGENT_ID) as { title: string | null }[]
     expect(list[0]?.title).toBe('Roll back the deploy')
+    await daemon.stop()
+  }, 15_000)
+
+  it('streams a session title emitted during session initialization', async () => {
+    const { factory } = streamingHost([text('done')], {
+      initialUpdates: [sessionInfo('Inspect startup state')]
+    })
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    await (daemon as any).dispatch(
+      AGENT_ID,
+      {
+        msgId: `webchat:${CONV}`,
+        traceId: turnId,
+        source: 'user' as const,
+        platform: 'webchat' as const,
+        channel: CONV,
+        sender: { id: 'alice', isBot: false },
+        text: 'go',
+        mentionedBots: [] as string[],
+        isDm: true,
+        trigger: 'dm' as const
+      },
+      undefined,
+      { conversationId: CONV, turnId, sink: cp.sink }
+    )
+
+    expect(cp.outputs.filter((output) => output.event).map((output) => output.event)).toEqual([
+      { kind: 'session_info', title: 'Inspect startup state' },
+      { kind: 'message', text: 'done' }
+    ])
     await daemon.stop()
   }, 15_000)
 

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -500,7 +500,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                   conversationIds.current.set(id, m.conversationId)
                   setPgSessions((current) => {
                     const session = current[id]
-                    return session ? { ...current, [id]: { ...session, channel: m.conversationId! } } : current
+                    return session ? { ...current, [id]: { ...session, channelId: m.conversationId! } } : current
                   })
                 }
                 if (resumeStream && busyRef.current[id]) {

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -23,7 +23,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import useSWR from 'swr'
-import { sessionChannelDisplay, type Session } from '@/lib/data'
+import { canonicalSessionId, mergeCanonicalSessions, sessionChannelDisplay, type Session } from '@/lib/data'
 import { fetchSessionDetail, sessionFromDetailDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
@@ -85,7 +85,8 @@ export function SessionRail({
   // and the cap only bounds a pathological list. A row that fails to load is simply
   // not rendered — a 404 here means "missing or not authorized", which is not proof
   // of deletion, so the pin is left alone (see lib/session-pins.ts).
-  const loadedIds = useMemo(() => new Set([...sessions.map((s) => s.id), current.id]), [sessions, current.id])
+  const currentId = canonicalSessionId(current)
+  const loadedIds = useMemo(() => new Set([...sessions.map(canonicalSessionId), currentId]), [sessions, currentId])
   const missingPinIds = useMemo(
     () =>
       pinnedIdsForAgent(pins, agentId ?? '')
@@ -109,12 +110,15 @@ export function SessionRail({
   )
 
   // One de-duplicated list ordered newest-first. The CP already orders its page by
-  // `lastActivityAt`, so this only decides where the merged rows land.
-  const rows = useMemo(() => {
-    const byId = new Map<string, Session>()
-    for (const s of [...sessions, current, ...(hydratedPins ?? [])]) if (!byId.has(s.id)) byId.set(s.id, s)
-    return [...byId.values()].sort((a, b) => (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? ''))
-  }, [sessions, current, hydratedPins])
+  // `lastActivityAt`, so this only decides where the merged rows land. The live
+  // current row comes last so it replaces its persisted twin without losing streamed state.
+  const rows = useMemo(
+    () =>
+      mergeCanonicalSessions([...sessions, ...(hydratedPins ?? []), current]).sort((a, b) =>
+        (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? '')
+      ),
+    [sessions, current, hydratedPins]
+  )
 
   const { pinned, rest } = useMemo(() => partitionPinned(rows, pins), [rows, pins])
   // Dated groups cover the UNPINNED rows only — a pin is an explicit "keep this at
@@ -133,7 +137,7 @@ export function SessionRail({
 
   const row = (s: Session, isPinned: boolean) => {
     const channel = sessionChannelDisplay(s, cronName)
-    const on = s.id === current.id
+    const on = s.id === currentId
     return (
       <div
         key={s.id}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1095,7 +1095,7 @@ export default function SessionDetailView() {
       if (imageInputRef.current) imageInputRef.current.value = ''
     }
   }
-  const webchatConversationId = isWebchat ? session.channelId : undefined
+  const webchatConversationId = isLive ? session.channelId : undefined
   const onCopyLink = () => {
     try {
       const canonicalId = session.realSessionId ?? session.id
@@ -1809,11 +1809,11 @@ export default function SessionDetailView() {
           {/* Playground / resumed webchat: typing indicator, starter prompts, composer. */}
           {isLive && (
             <>
-              {activeOrg && session.agentId && /^[0-9a-f-]{36}$/i.test(session.channel) && (
+              {activeOrg && session.agentId && webchatConversationId && (
                 <WebchatMcpApprovalCard
                   orgId={activeOrg.id}
                   agentId={session.agentId}
-                  conversationId={session.channel}
+                  conversationId={webchatConversationId}
                 />
               )}
               {pgBusy && (

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -8,7 +8,9 @@ import {
   MOCK_MODE,
   PLAYGROUND_CHANNEL_FILTER,
   agentLabel,
+  canonicalSessionId,
   enrichSessionWithAgent,
+  mergeCanonicalSessions,
   platName,
   sessionChannelDisplay,
   sessionChannelFilterValue,
@@ -155,12 +157,7 @@ export default function SessionsView() {
   // Live playground sessions, the filtered CP page chain, and demo rows share
   // one timeline. A real ACP id replaces its temporary playground row.
   const sessions = useMemo<Session[]>(() => {
-    const byId = new Map<string, Session>()
-    for (const session of [...localSessions, ...filteredServerSessions]) {
-      const id = session.realSessionId ?? session.id
-      if (!byId.has(id)) byId.set(id, session)
-    }
-    return [...byId.values()]
+    return mergeCanonicalSessions([...filteredServerSessions, ...localSessions])
       .map((s, index) => ({ s, index }))
       .sort((a, b) => {
         const at = activityMs(a.s)
@@ -179,7 +176,7 @@ export default function SessionsView() {
   }, [params])
   const sessionHref = useCallback(
     (session: Session) => {
-      const id = session.realSessionId ?? session.id
+      const id = canonicalSessionId(session)
       const query = new URLSearchParams(filterQuery)
       const provider = sessionPlatform(session)
       if (provider === 'slack' || provider === 'github') query.set('source', provider)
@@ -379,9 +376,7 @@ export default function SessionsView() {
 
   const filtered = sessions
   const loadedServerIds = new Set(sessionList.sessions.map((session) => session.id))
-  const localOnlyCount = localSessions.filter(
-    (session) => !loadedServerIds.has(session.realSessionId ?? session.id)
-  ).length
+  const localOnlyCount = localSessions.filter((session) => !loadedServerIds.has(canonicalSessionId(session))).length
   const totalCount = sessionList.total + localOnlyCount
   const filtActive = !(fAgent === 'all' && fInt === 'all' && fChannel === 'all' && fTrigger === 'all')
   const initialLoading = sessionList.isLoading && sessions.length === 0

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -10,6 +10,7 @@ import {
   effortField,
   fastModeAvailableFor,
   lifecycleStatus,
+  mergeCanonicalSessions,
   modelCapability,
   modelLabel,
   permissionModeChoicesFor,
@@ -85,6 +86,39 @@ describe('sessionChannelDisplay', () => {
       platform: 'slack',
       label: '#deploys'
     })
+  })
+})
+
+describe('mergeCanonicalSessions', () => {
+  const persisted: Session = {
+    id: 'session-real',
+    title: 'Persisted title',
+    time: 'now',
+    status: 'online',
+    platform: 'webchat',
+    channel: 'Playground',
+    channelId: 'conversation-1',
+    user: '@you',
+    duration: 'live',
+    tokens: '0',
+    cost: '—',
+    toolCount: '0',
+    statusLabel: 'Live',
+    steps: []
+  }
+
+  it('collapses a live Playground row into its durable session identity', () => {
+    const live = {
+      ...persisted,
+      id: 'pg_agent-temporary',
+      realSessionId: persisted.id,
+      title: 'Live title',
+      platform: 'playground'
+    }
+
+    expect(mergeCanonicalSessions([persisted, live])).toEqual([
+      expect.objectContaining({ id: 'session-real', realSessionId: 'session-real', title: 'Live title' })
+    ])
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -855,6 +855,22 @@ export interface Session {
   daemon?: string
 }
 
+/** A live Playground row starts with a synthetic id, then learns the durable ACP
+ * session id. Treat both shapes as one session everywhere that merges local and
+ * persisted rows. Later rows win so callers can put the freshest representation last. */
+export function canonicalSessionId(session: Pick<Session, 'id' | 'realSessionId'>): string {
+  return session.realSessionId ?? session.id
+}
+
+export function mergeCanonicalSessions(sessions: readonly Session[]): Session[] {
+  const byId = new Map<string, Session>()
+  for (const session of sessions) {
+    const id = canonicalSessionId(session)
+    byId.set(id, id === session.id ? session : { ...session, id })
+  }
+  return [...byId.values()]
+}
+
 /** Attach owning-agent display metadata to a CP session row. Recorded runtime
  *  values remain authoritative; only legacy rows fall back to current agent config. */
 export function enrichSessionWithAgent(


### PR DESCRIPTION
## Summary

- keep the relay conversation ID in `channelId` so the live Playground header continues to show `Playground`
- canonicalize temporary and durable Playground session identities before merging list and rail rows
- replay session initialization metadata after the live turn sink is installed so an early runtime title reaches the open session immediately

## Root cause

A fresh Playground conversation temporarily exists under a client-only `pg_...` ID. The relay then supplies a conversation ID, and the runtime later supplies the durable ACP session ID and title. Three consumers handled those identities independently: the conversation ID replaced the display channel, the new sibling-session rail deduplicated only by the temporary ID, and metadata emitted during `session/new` was persisted before a live webchat sink existed. The persisted view was correct after refresh, but the in-memory view did not converge during startup.

## User impact

The live session now keeps a stable Playground label, adopts its durable title without a refresh, and appears as one row in the sibling-session rail.

## Validation

- `pnpm --filter @agentconnect.md/web test` (574 tests)
- `CHOKIDAR_USEPOLLING=1 pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-webchat.test.ts` (35 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- focused ESLint and Prettier checks for all changed files

Created by Codex . gpt-5.6-sol
