### PR TITLE
fix(web): merge agent visibility headings

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -260,13 +260,10 @@ function AgentVisibilityCard({
   return (
     <div className="card mt-[18px]">
       <div className="cardhead">
-        <span className="cardtitle">Agent visibility</span>
+        <span className="cardtitle">Default agent visibility</span>
       </div>
       <div className="px-4 py-[15px]">
-        <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-          Default for new agents
-        </div>
-        <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
+        <div className="font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
           Choose whether newly created agents can collaborate with every agent or start isolated. Existing agents keep
           their own settings.
         </div>


### PR DESCRIPTION
## Summary

- replace the redundant `Agent visibility` / `Default for new agents` heading pair with one `Default agent visibility` card title
- place the explanatory copy directly below the unified title

## Why

Both headings described the same organization-wide creation default. Combining them removes an unnecessary visual hierarchy while preserving the setting behavior and explanatory copy.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/SettingsView.tsx`
- pre-commit formatting and pre-push repository lint hooks

Created by Codex . GPT-5
