### PR TITLE
fix(web): show current user avatar in playground

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -547,7 +547,6 @@ function ParticipantAvatar({
           bg={sp.avBg}
           fg={sp.avText}
           fontSize={9.5}
-          style={{ borderRadius: 'inherit' }}
         />
       )}
     </span>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -51,7 +51,7 @@ import { usePlayground } from '@/components/console/PlaygroundProvider'
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
-import { Icon } from '@/components/ui'
+import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { formatTranscriptTime, parseTranscriptTime } from '@/lib/transcript-time'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
@@ -507,6 +507,7 @@ type Turn =
       sp: ReturnType<typeof speaker>
       agent: Agent | null
       avatarUrl?: string | null
+      avatarInitials?: string
       sourceLabel: string
       time: string
       text: string
@@ -519,11 +520,13 @@ type Turn =
 function ParticipantAvatar({
   agent,
   avatarUrl,
+  avatarInitials,
   sp,
   isCron
 }: {
   agent: Agent | null
   avatarUrl?: string | null
+  avatarInitials?: string
   sp: ReturnType<typeof speaker>
   isCron: boolean
 }) {
@@ -534,17 +537,18 @@ function ParticipantAvatar({
     >
       {agent ? (
         <AgentIconView icon={agent.icon} runtime={agent.runtime} size={26} />
-      ) : avatarUrl ? (
-        <img src={avatarUrl} alt="" className="object-cover" style={{ width: '100%', height: '100%' }} />
       ) : isCron ? (
         <Icon name="calendar-clock" size={14} color="var(--text-secondary)" />
       ) : (
-        <span
-          className="flex h-full w-full items-center justify-center rounded-[inherit]"
-          style={{ background: sp.avBg, color: sp.avText }}
-        >
-          {sp.initials || '?'}
-        </span>
+        <Avatar
+          src={avatarUrl}
+          initials={avatarInitials || sp.initials || '?'}
+          size={26}
+          bg={sp.avBg}
+          fg={sp.avText}
+          fontSize={9.5}
+          style={{ borderRadius: 'inherit' }}
+        />
       )}
     </span>
   )
@@ -696,7 +700,7 @@ export default function SessionDetailView() {
     pgSetFast,
     pgCancel
   } = usePlayground()
-  const { me } = useProfile()
+  const { user: viewer, me } = useProfile()
   const [copied, setCopied] = useState(false)
   // Desktop header "Details" popover (run facts: status, duration, tokens, …).
   const [detailOpen, setDetailOpen] = useState(false)
@@ -1162,7 +1166,8 @@ export default function SessionDetailView() {
         const senderAgent = participantAgent(m.sender, m.text, m.trustedAgentBot)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined
-        const participant = isSelf(m.sender)
+        const self = isSelf(m.sender)
+        const participant = self
           ? speaker('@you')
           : speaker(
               senderAgentName ?? m.sender,
@@ -1173,7 +1178,8 @@ export default function SessionDetailView() {
           kind: 'user',
           sp: participant,
           agent: senderAgent ?? null,
-          avatarUrl: isSelf(m.sender) ? me?.picture : memberPictureByIdentity.get(m.sender),
+          avatarUrl: self ? viewer.picture : memberPictureByIdentity.get(m.sender),
+          avatarInitials: self ? viewer.initials : undefined,
           sourceLabel: platName(sessionIntegration),
           time: formatTranscriptTime(m.ts),
           text: m.text,
@@ -1191,13 +1197,17 @@ export default function SessionDetailView() {
         const cron = asCron(who)
         const senderAgent = participantAgent(who, stp.text)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
-        const participant = speaker(senderAgentName ?? who, cron?.name ?? (cron ? 'Schedule' : senderAgentName))
+        const self = isSelf(who)
+        const participant = self
+          ? speaker('@you')
+          : speaker(senderAgentName ?? who, cron?.name ?? (cron ? 'Schedule' : senderAgentName))
         speakers.set(senderAgent?.id ?? who, participant.name)
         turns.push({
           kind: 'user',
           sp: participant,
           agent: senderAgent ?? null,
-          avatarUrl: isSelf(who) ? me?.picture : memberPictureByIdentity.get(who),
+          avatarUrl: self ? viewer.picture : memberPictureByIdentity.get(who),
+          avatarInitials: self ? viewer.initials : undefined,
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? (firstMsg ? session.time : ''),
           text: stp.text,
@@ -1227,13 +1237,15 @@ export default function SessionDetailView() {
         const who = stp.who ?? session.user
         const senderAgent = participantAgent(who, stp.text)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
-        const participant = speaker(senderAgentName ?? who, senderAgentName)
+        const self = isSelf(who)
+        const participant = self ? speaker('@you') : speaker(senderAgentName ?? who, senderAgentName)
         speakers.set(senderAgent?.id ?? who, participant.name)
         turns.push({
           kind: 'user',
           sp: participant,
           agent: senderAgent ?? null,
-          avatarUrl: isSelf(who) ? me?.picture : memberPictureByIdentity.get(who),
+          avatarUrl: self ? viewer.picture : memberPictureByIdentity.get(who),
+          avatarInitials: self ? viewer.initials : undefined,
           sourceLabel: platName(sessionIntegration),
           time: stp.time ?? '',
           text: stp.text,
@@ -1720,6 +1732,7 @@ export default function SessionDetailView() {
                     <ParticipantAvatar
                       agent={turn.agent}
                       avatarUrl={turn.avatarUrl}
+                      avatarInitials={turn.avatarInitials}
                       sp={turn.sp}
                       isCron={turn.isCron}
                     />

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -532,7 +532,9 @@ function ParticipantAvatar({
 }) {
   return (
     <span
-      className="av flex h-[26px] w-[26px] flex-none items-center justify-center overflow-hidden rounded-md font-sans text-[9.5px] font-semibold leading-normal"
+      className={`av flex h-[26px] w-[26px] flex-none items-center justify-center overflow-hidden rounded-md font-sans text-[9.5px] font-semibold leading-normal ${
+        !agent && !isCron ? 'bg-transparent' : ''
+      }`}
       title={sp.name}
     >
       {agent ? (

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1830,15 +1830,17 @@ export function speaker(handle: string, name?: string): Speaker {
   return { name: display, handle, initials, avBg, avText }
 }
 
-/** Is `sender` (a raw trigger/sender id) the signed-in viewer? A webchat session's
- *  triggeredBy is the CP principal — the user's email in an OIDC deployment, the devAuth
- *  owner id locally — the same identity `/me` returns, so their own runs read as "You".
- *  Slack/Telegram/Discord senders are platform ids and never match. `me` is the CP
- *  profile record (typed structurally to avoid an api ↔ data import cycle). */
+/** Is `sender` the signed-in viewer? Live Playground steps use the canonical local
+ *  `@you` marker before a durable webchat sender id exists. Persisted webchat rows use
+ *  the CP principal — the user's email in an OIDC deployment, the devAuth owner id
+ *  locally — which is the same identity `/me` returns. Slack/Telegram/Discord senders
+ *  are platform ids and never match. `me` is typed structurally to avoid an api ↔ data
+ *  import cycle. */
 export function isSelfSender(
   sender: string | null | undefined,
   me: { userId: string; email: string | null } | null | undefined
 ): boolean {
+  if (sender === '@you') return true
   return !!sender && !!me && (sender === me.userId || (!!me.email && sender === me.email))
 }
 

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -6,7 +6,7 @@ import {
   type SessionDetailDto,
   type SessionDto
 } from './api'
-import { platName, sessionPlatform } from './data'
+import { isSelfSender, platName, sessionPlatform } from './data'
 import {
   githubRepoIdFromSessionTriggerFilter,
   sessionAttributionAgentAuthors,
@@ -212,6 +212,12 @@ describe('sessionSenderLabel', () => {
     expect(sessionSenderLabel('agent-id', 'agent-id', agents, members, me)).toBe('Release agent')
     expect(sessionSenderLabel('member-id', 'member-id', agents, members, me)).toBe('Ada')
     expect(sessionSenderLabel('me', 'me', agents, members, me)).toBe('You')
+  })
+})
+
+describe('isSelfSender', () => {
+  it('recognizes the live Playground viewer marker before /me is available', () => {
+    expect(isSelfSender('@you', null)).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- recognize the live Playground `@you` marker as the current viewer
- render the viewer's merged profile photo in user message turns
- fall back to the viewer's real profile initials, including when an avatar image fails

## Root cause

Live Playground messages use the synthetic `@you` sender before a durable webchat identity exists. The shared self-identity helper only matched `/me` user IDs and email addresses, so the message renderer never selected the current user's avatar. It also read the raw `/me` picture rather than the merged display profile used elsewhere in the console.

## Impact

Current-user messages in Playground now use the same profile identity as the rest of the console instead of always showing a `Y` placeholder.

## Validation

- `pnpm --filter @agentconnect.md/web test` (78 files, 573 tests on the rebased head)
- Web TypeScript check
- focused ESLint
- Prettier check

Created by Codex . gpt-5.6-sol
