### PR TITLE
fix(daemon): route Slack DMs through app conversations

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -243,19 +243,21 @@ recipient modes the form is decided by the coordinates:
   (`webchat` / `dream`) is replaced by the caller-derived `a2a:<callerAgentId>`, so
   every wake from one caller into one peer shares a single pairwise session. See
   [agent-collaboration-implementation.md](agent-collaboration-implementation.md) §2.5.
-- Omitting `platform` means Slack for a `toUser` DM (the destination is the user
-  id) and the current session platform otherwise. Cross-platform cases 3 and 3b
-  specify it. The daemon owns all bot tokens and selects the connection by
-  platform and, when necessary, integration. The model sees no token. This
-  preserves the existing `sendPlatformMessage` boundary at `mcp/tools.ts:55-98`.
+- Omitting `platform` means Slack for a `toUser` DM (the member id is resolved to
+  the app's direct-message conversation before posting) and the current session
+  platform otherwise. Cross-platform cases 3 and 3b specify it. The daemon owns
+  all bot tokens and selects the connection by platform and, when necessary,
+  integration. The model sees no token. This preserves the existing
+  `sendPlatformMessage` boundary at `mcp/tools.ts:55-98`.
 - The daemon injects the caller agent ID from session context. It is never a
   tool argument, so a caller cannot impersonate another agent or call itself as
   a different identity.
-- `toUser` is Slack-only for now: a `toUser` DM accepts one string and posts to that
-  member id directly. The channel-root / in-thread forms accept one id or a non-empty
-  unique-id array and prepend every corresponding `<@user>` mention to the single
-  visible post. An array without `channel` is rejected rather than interpreted as a
-  group DM. Any other platform is rejected before dispatch.
+- `toUser` is Slack-only for now: a `toUser` DM accepts one member id, opens or reuses
+  the app's real DM conversation, and posts to the returned channel id. The
+  channel-root / in-thread forms accept one id or a non-empty unique-id array and
+  prepend every corresponding `<@user>` mention to the single visible post. An array
+  without `channel` is rejected rather than interpreted as a group DM. Any other
+  platform is rejected before dispatch.
 - `thread` determines the platform thread only when `channel` is present.
   Passing an existing thread posts there. Omitting it or passing `""` posts a
   new top-level channel message, **not the current session thread**. Normal

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -31,6 +31,10 @@ export interface SendIdentity {
 }
 
 export interface MessageGateway {
+  /** Resolve one platform user to the app's real direct-message conversation.
+   *  Slack needs this before posting with a customized agent identity: sending to
+   *  a raw U… id routes the message through Slack's system-notification DM. */
+  openDirectMessage?(user: string): Promise<string>
   /** Post a message; returns the resulting message id (`ts` / message_id) so the
    *  daemon can record it. `identity` carries the agent's stable id and optional
    *  visual identity; other platforms may ignore it. */
@@ -811,10 +815,10 @@ export async function executeTool(
     const wakeRejection = baseWakeReq !== undefined ? (deps.preflightWake?.(baseWakeReq) ?? null) : null
 
     // (A) Post a visible IM to a platform channel or Slack user. The destination is the
-    // `channel` for the channel-root / in-thread forms; the `toUser` DM form (no channel) uses
-    // the Slack member id directly as chat.postMessage's destination, which opens or reuses
-    // that DM. Routing is by `platform` (+ optional `integrationId`) to ANY platform the agent
-    // is connected to; identity is stamped from the trusted session. THREAD DEFAULT: a
+    // `channel` for the channel-root / in-thread forms; the `toUser` DM form (no channel) first
+    // resolves the Slack member id to the app's real D… conversation. Routing is by `platform`
+    // (+ optional `integrationId`) to ANY platform the agent is connected to; identity is
+    // stamped from the trusted session. THREAD DEFAULT: a
     // deliberate `sendMessage` posts to the channel ROOT — "reply here" is the agent's normal
     // turn output, so an explicit send is a top-level post unless it names a `thread`.
     // `thread:"<id>"` targets that thread; absent or "" ⇒ root. We post BEFORE any peer wake
@@ -831,9 +835,9 @@ export async function executeTool(
     // back — the peer then falls back to messageAgent's default thread).
     let postedThread: string | undefined
     // Destination: an explicit `channel` (channel-root / in-thread forms), else the `toUser`
-    // DM form targets the user id itself.
-    const postChannel = channel ?? toUsers?.[0]
-    if (postChannel !== undefined && wakeRejection === null) {
+    // DM form starts from the user id and resolves it below.
+    const requestedChannel = channel ?? toUsers?.[0]
+    if (requestedChannel !== undefined && wakeRejection === null) {
       const directMessage = toUsers !== undefined && channel === undefined
       const wantPlatform = optionalString(args, 'platform') ?? (directMessage ? 'slack' : ctx.platform)
       const wantIntegrationId = optionalString(args, 'integrationId')
@@ -851,6 +855,7 @@ export async function executeTool(
           body = `${mentions.join(' ')} ${message}`
         }
       }
+      const postChannel = directMessage ? await openDirectMessage(gw, requestedChannel) : requestedChannel
       const identity: SendIdentity = {
         ...(ctx.agentName ? { username: ctx.agentName } : {}),
         ...(ctx.iconUrl ? { icon_url: ctx.iconUrl } : {}),
@@ -1237,6 +1242,13 @@ function parseUserTargets(value: unknown): string[] | undefined {
     throw new Error('sendMessage: `toUser` must not contain duplicate user ids')
   }
   return ids
+}
+
+async function openDirectMessage(gateway: MessageGateway, user: string): Promise<string> {
+  if (!gateway.openDirectMessage) {
+    throw new Error('sendMessage: the selected Slack integration cannot open direct messages')
+  }
+  return gateway.openDirectMessage(user)
 }
 
 function assertOnlyKeys(args: Record<string, unknown>, allowed: readonly string[], target: string): void {

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -277,6 +277,7 @@ type AppLike = {
       delete: (a: unknown) => Promise<unknown>
     }
     conversations: {
+      open: (a: unknown) => Promise<{ channel?: { id?: string } }>
       info: (a: unknown) => Promise<{
         channel?: {
           id?: string
@@ -1116,6 +1117,16 @@ export class SlackConnection {
   }
 
   // ── MCP MessageGateway: read helpers backing the injected channel tools ──
+
+  /** Open or reuse the app's actual DM with one Slack member. Passing a U… id
+   * directly to chat.postMessage while customizing the agent identity makes Slack
+   * deliver through its notification-only USLACK conversation instead. */
+  async openDirectMessage(user: string): Promise<string> {
+    const res = await this.app.client.conversations.open({ users: user })
+    const channel = res.channel?.id
+    if (!channel) throw new Error('Slack conversations.open did not return a direct-message channel')
+    return channel
+  }
 
   async getChannelInfo(
     channel: string

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -137,6 +137,28 @@ describe('SlackConnection.downloadFile', () => {
   })
 })
 
+describe('SlackConnection.openDirectMessage', () => {
+  it('resolves a Slack member to the app DM channel', async () => {
+    const open = vi.fn(async () => ({ channel: { id: 'D123' } }))
+    const conn = new SlackConnection(
+      deps() as any,
+      () =>
+        ({
+          message() {},
+          event() {},
+          action() {},
+          shortcut() {},
+          client: { conversations: { open } },
+          start: async () => {},
+          stop: async () => {}
+        }) as any
+    )
+
+    await expect(conn.openDirectMessage('U123')).resolves.toBe('D123')
+    expect(open).toHaveBeenCalledWith({ users: 'U123' })
+  })
+})
+
 describe('SlackConnection.listBotChannels', () => {
   const fakeAppWithConversations = (pages: any[], fail = false) => {
     let call = 0

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -27,6 +27,7 @@ const authorIdentity = { agentAuthorId: 'bot-a' }
 
 function fakeGateway(over: Partial<MessageGateway> = {}): MessageGateway {
   return {
+    openDirectMessage: vi.fn(async (user) => `D-${user}`),
     postMessage: vi.fn(async () => 'ts-123'),
     getChannelInfo: vi.fn(async (id) => ({ id, name: 'general' })),
     listMembers: vi.fn(async () => [{ id: 'U1', name: 'alice', isBot: false }]),
@@ -501,9 +502,10 @@ describe('executeTool: sendMessage (channel post)', () => {
     const res = (await executeTool(ctx, 'sendMessage', { toUser: 'U9', message: 'ping' }, d)) as {
       post: Record<string, unknown>
     }
-    expect(gw.postMessage).toHaveBeenCalledWith('U9', 'ping', undefined, authorIdentity)
-    expect(recorded).toEqual([{ channel: 'U9', thread: 'ts-123', text: 'ping', ts: 'ts-123' }])
-    expect(res.post).toMatchObject({ platform: 'slack', channel: 'U9', thread: null, ts: 'ts-123' })
+    expect(gw.openDirectMessage).toHaveBeenCalledWith('U9')
+    expect(gw.postMessage).toHaveBeenCalledWith('D-U9', 'ping', undefined, authorIdentity)
+    expect(recorded).toEqual([{ channel: 'D-U9', thread: 'ts-123', text: 'ping', ts: 'ts-123' }])
+    expect(res.post).toMatchObject({ platform: 'slack', channel: 'D-U9', thread: null, ts: 'ts-123' })
   })
 
   it('rejects toUser off Slack before posting', async () => {


### PR DESCRIPTION
## Summary

- resolve Slack `toUser` recipients to the app's real `D…` direct-message conversation before posting
- persist and return the resolved DM channel so replies and session history stay on the app conversation
- cover both the Slack API boundary and the `sendMessage` routing path
- align the session design documentation with the resolved `D…` channel behavior

## Root cause

Agent-initiated DMs passed a raw Slack member `U…` id to `chat.postMessage` while applying the agent's custom username and icon. Slack routes that combination through the notification-only `USLACK` conversation instead of the app's DM. Opening the conversation first and posting to the returned `D…` id keeps the message under the AgentConnect app.

## User impact

Proactive agent DMs now appear in the agent's normal Slack conversation and remain replyable, instead of landing in the Slack system notification thread.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/mcp-ops.test.ts test/connection.test.ts` — 128 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- targeted ESLint and Prettier checks
- full daemon suite executed 2,593 passing assertions (7 skipped); the runner exited during teardown with the existing `EMFILE: too many open files, watch` harness failure

Created by Codex . gpt-5.6-sol
