### PR TITLE
fix(web): keep session rail navigation in place

### DIFF
--- a/packages/web/src/app/(app)/[slug]/sessions/[id]/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/sessions/[id]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next'
-import SessionDetailView from '@/components/console/views/SessionDetailView'
 
 export const metadata: Metadata = { title: 'Session · AgentConnect' }
 
 export default function Page() {
-  return <SessionDetailView />
+  // /sessions/layout owns the persistent client view. The leaf still exists so
+  // this dynamic URL remains routable and can keep its own metadata.
+  return null
 }

--- a/packages/web/src/app/(app)/[slug]/sessions/layout.tsx
+++ b/packages/web/src/app/(app)/[slug]/sessions/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react'
+import { SessionsRouteFrame } from '@/components/console/SessionsRouteFrame'
+
+// Keep the detail client mounted while only the dynamic session id changes.
+// App Router preserves layouts across sibling-page navigation, so the session
+// rail and the already-loaded detail shell no longer disappear and remount for
+// every click in the rail.
+export default function Layout({ children }: { children: ReactNode }) {
+  return <SessionsRouteFrame>{children}</SessionsRouteFrame>
+}

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 // The session detail page's left rail: the open session's direct family (parent,
 // siblings, and children), globally pinned shortcuts, then the other sessions of
 // the CURRENT agent. Family rows stay in their tree even when pinned and are
@@ -48,6 +46,7 @@ interface RailRow {
   platform: string
   title: string
   tooltip: string
+  session?: Session
 }
 
 const EMPTY_RELATIONS: SessionRelationDto[] = []
@@ -57,7 +56,8 @@ export function SessionRail({
   current,
   total,
   agentId,
-  family
+  family,
+  onSelect
 }: {
   /** The agent-filtered first page of sessions, newest first. */
   sessions: Session[]
@@ -69,11 +69,12 @@ export function SessionRail({
   agentId: string | undefined
   /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
   family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
+  /** Seed the persistent detail view before the route id changes. */
+  onSelect: (session: Session) => void
 }) {
   const { orgPath, activeOrg } = useOrgs()
   // Schedule-triggered rows show the schedule's name, so the rail needs the crons
-  // list — read here rather than taken as a prop (a function prop on a 'use client'
-  // module trips the Next TS plugin's Server-Action serializability check).
+  // list — resolve it here instead of threading another display-only callback.
   const { crons } = useConsoleData()
   const cronName = useCallback((cronId: string) => crons.find((c) => c.id === cronId)?.name, [crons])
 
@@ -174,7 +175,8 @@ export function SessionRail({
       id: canonicalSessionId(s),
       platform: channel.platform,
       title: s.title,
-      tooltip: `${s.title}\n${s.time} · ${channel.label}`
+      tooltip: `${s.title}\n${s.time} · ${channel.label}`,
+      session: s
     }
   }
   const relationRow = (relation: SessionRelationDto): RailRow => {
@@ -191,9 +193,7 @@ export function SessionRail({
     return (
       <div
         key={item.id}
-        className={`group flex w-full items-center gap-2 rounded-sm py-[6px] pr-[9px] ${
-          depth === 2 ? 'pl-[26px]' : 'pl-[9px]'
-        } ${
+        className={`group relative w-full rounded-sm ${
           on
             ? 'bg-(--brand-soft) text-(--text-primary)'
             : 'text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)'
@@ -203,7 +203,18 @@ export function SessionRail({
           href={orgPath(`/sessions/${encodeURIComponent(item.id)}`)}
           title={item.tooltip}
           aria-current={on ? 'page' : undefined}
-          className="flex min-w-0 flex-1 items-center gap-2"
+          onClick={(event) => {
+            // A selected row is already the current view. Letting Next navigate
+            // to the same dynamic URL needlessly refreshes its route payload.
+            if (on) {
+              event.preventDefault()
+              return
+            }
+            if (item.session) onSelect(item.session)
+          }}
+          className={`flex w-full min-w-0 items-center gap-2 rounded-sm py-[6px] pr-[34px] focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
+            depth === 2 ? 'pl-[26px]' : 'pl-[9px]'
+          }`}
         >
           {depth > 0 && (
             <span
@@ -227,8 +238,10 @@ export function SessionRail({
           onClick={() => togglePin(item.id)}
           aria-pressed={pinnedRow}
           title={pinnedRow ? 'Unpin session' : 'Pin session'}
-          className={`-my-[2px] h-[19px] w-[19px] flex-none items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
-            pinnedRow ? 'flex text-(--brand)' : 'hidden text-(--text-tertiary) group-hover:flex group-focus-within:flex'
+          className={`absolute top-1/2 right-[7px] z-10 flex h-[19px] w-[19px] -translate-y-1/2 items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
+            pinnedRow
+              ? 'text-(--brand)'
+              : 'pointer-events-none opacity-0 text-(--text-tertiary) group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100'
           }`}
         >
           <Icon name="pin" size={12} />

--- a/packages/web/src/components/console/SessionsRouteFrame.tsx
+++ b/packages/web/src/components/console/SessionsRouteFrame.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useParams } from 'next/navigation'
+import SessionDetailView from '@/components/console/views/SessionDetailView'
+
+export function SessionsRouteFrame({ children }: { children: ReactNode }) {
+  const { id } = useParams<{ id?: string }>()
+
+  // The frame lives in /sessions/layout rather than [id]/page. That static
+  // layout survives /sessions/a -> /sessions/b, so React updates the existing
+  // detail view instead of rebuilding the whole right-hand page.
+  return id ? <SessionDetailView /> : children
+}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -27,6 +27,7 @@ import {
   speaker,
   status,
   type Agent,
+  type Session,
   type SessionImage,
   type SessionStep
 } from '@/lib/data'
@@ -705,6 +706,7 @@ export default function SessionDetailView() {
   const [msgPaging, setMsgPaging] = useState(false)
   const [msgErr, setMsgErr] = useState<string | null>(null)
   const [tailReady, setTailReady] = useState(false)
+  const [transcriptSessionId, setTranscriptSessionId] = useState<string | null>(null)
   const [nowMs, setNowMs] = useState(() => Date.now())
   // The visibility the user last chose for a bot turn's collapsed "work" panel (keyed
   // by turn index), overriding the default that turn's content implies. Stored as the
@@ -719,6 +721,10 @@ export default function SessionDetailView() {
   const [runtimeSelections, setRuntimeSelections] = useState<
     Record<string, { model?: string; effort?: string; permissionMode?: string; fast?: boolean }>
   >({})
+  // A rail row already carries enough metadata to paint the next session while
+  // its detail/transcript requests catch up. Keeping it here also holds the
+  // agent-filtered rail steady instead of briefly dropping it between ids.
+  const [routeSession, setRouteSession] = useState<Session | null>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
   const liveCursorRef = useRef<string | null>(null)
   const tailSessionRef = useRef<string | null>(null)
@@ -726,7 +732,10 @@ export default function SessionDetailView() {
   const tailInFlightRef = useRef<Promise<void> | null>(null)
   const tailDirtyRef = useRef(false)
 
-  const localSession = getPgSession(id) ?? allSessions.find((s) => s.id === id) ?? null
+  const localSession =
+    getPgSession(id) ??
+    allSessions.find((s) => s.id === id) ??
+    (routeSession && (routeSession.id === id || routeSession.realSessionId === id) ? routeSession : null)
   // Relationship links can point outside the cursor pages loaded by SessionsView.
   // Fetch CP-stored detail metadata for real sessions (or an otherwise-missing
   // deep link) and use it as a fallback row. Mock sessions carry local steps and
@@ -785,7 +794,11 @@ export default function SessionDetailView() {
     !profileIdentityLoading &&
     profileIdentityError === undefined &&
     profileIdentity?.linked === false
-  const detailSession = sessionDetail ? sessionFromDetailDto(sessionDetail) : null
+  // SWR normally clears data when its key changes. Keep the id check explicit
+  // because this view now persists across route ids and must never merge a
+  // retained previous snapshot into the newly selected rail row.
+  const currentSessionDetail = sessionDetail?.id === detailId ? sessionDetail : null
+  const detailSession = currentSessionDetail ? sessionFromDetailDto(currentSessionDetail) : null
   // The cursor-loaded list row can predate the final Dream usage report. Keep
   // its local/live fields, but let the independently refreshed detail snapshot
   // supply the authoritative per-session token and cost totals.
@@ -842,6 +855,14 @@ export default function SessionDetailView() {
   const sid = session?.id
   const aid = session?.agentId
   const wantTranscript = !!session && session.platform !== 'playground' && session.steps.length === 0 && !!aid
+  // This component now survives id changes. Do not paint session A's transcript
+  // for one frame under session B's header before the loading effect clears it.
+  const transcriptMatchesSession = !wantTranscript || transcriptSessionId === sid
+  const visibleMsgs = transcriptMatchesSession ? msgs : null
+  const visibleMsgLoading = transcriptMatchesSession ? msgLoading : wantTranscript
+  const visibleMsgPaging = wantTranscript && transcriptMatchesSession && msgPaging
+  const visibleMsgErr = wantTranscript && transcriptMatchesSession ? msgErr : null
+  const visibleTailReady = wantTranscript && transcriptMatchesSession && tailReady
   const agentNameById = useMemo(() => new Map(agents.map((a) => [a.id, agentLabel(a)])), [agents])
   const memberNameByIdentity = useMemo(() => {
     const names = new Map<string, string>()
@@ -862,8 +883,8 @@ export default function SessionDetailView() {
     return pictures
   }, [members])
   const attributedAgentIdBySender = useMemo(
-    () => sessionAttributionAgentAuthors(session?.platform ?? '', msgs ?? [], agentById),
-    [session?.platform, msgs, agentById]
+    () => sessionAttributionAgentAuthors(session?.platform ?? '', visibleMsgs ?? [], agentById),
+    [session?.platform, visibleMsgs, agentById]
   )
   const participantAgent = (sender: string, text: string, trustedAgentBot?: boolean): Agent | undefined => {
     const id = agentById.has(sender)
@@ -881,6 +902,7 @@ export default function SessionDetailView() {
   useEffect(() => {
     if (!wantTranscript || !sid || !aid) return
     let active = true
+    setTranscriptSessionId(sid)
     tailSessionRef.current = sid
     tailReadyRef.current = false
     liveCursorRef.current = null
@@ -981,15 +1003,15 @@ export default function SessionDetailView() {
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
   useEffect(() => {
-    if (!tailReady || sessionBusy) return
+    if (!visibleTailReady || sessionBusy) return
     void refreshTranscriptTail()
-  }, [tailReady, sessionBusy, sessionActivityVersion, sessionStreamGeneration, refreshTranscriptTail])
+  }, [visibleTailReady, sessionBusy, sessionActivityVersion, sessionStreamGeneration, refreshTranscriptTail])
 
   useEffect(() => {
-    if (!tailReady) return
+    if (!visibleTailReady) return
     const timer = window.setInterval(() => void refreshTranscriptTail(), 15_000)
     return () => window.clearInterval(timer)
-  }, [tailReady, refreshTranscriptTail])
+  }, [visibleTailReady, refreshTranscriptTail])
 
   useEffect(() => {
     if (!session || (session.platform !== 'playground' && session.platform !== 'webchat') || !sessionBusy) return
@@ -1018,6 +1040,19 @@ export default function SessionDetailView() {
     registerCrumb({ id, title: crumbTitle, status: crumbStatusKey, statusLabel: crumbStatusLabel })
     return () => registerCrumb(null)
   }, [registerCrumb, id, crumbTitle, crumbStatusKey, crumbStatusLabel])
+
+  // Page-local popovers and turn expansion choices must not leak from one
+  // session into the next now that the shared route layout preserves this
+  // component instance.
+  useEffect(() => {
+    setCopied(false)
+    setDetailOpen(false)
+    setWorkOverride(new Map())
+    setImagePreparing(false)
+    setImageError(null)
+    setAttachMenuOpen(false)
+    setComposerMenuOpen(null)
+  }, [id])
 
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the
@@ -1057,14 +1092,15 @@ export default function SessionDetailView() {
   // header and the mobile meta strip; null when there is nothing to show (an org
   // session the caller cannot re-classify, or a mock/legacy row).
   const visibilityControl =
-    sessionDetail && detailId ? (
+    currentSessionDetail && detailId ? (
       <SessionVisibilityControl
+        key={detailId}
         sessionId={detailId}
-        visibility={sessionDetail.visibility ?? undefined}
-        state={sessionDetail.visibilityState}
-        canChange={sessionDetail.canChangeVisibility === true}
-        externalProvider={sessionDetail.externalProvider}
-        externalResolution={sessionDetail.externalResolution}
+        visibility={currentSessionDetail.visibility ?? undefined}
+        state={currentSessionDetail.visibilityState}
+        canChange={currentSessionDetail.canChangeVisibility === true}
+        externalProvider={currentSessionDetail.externalProvider}
+        externalResolution={currentSessionDetail.externalResolution}
         // Native runtime memory has no per-session gate, so the copy must not
         // promise a memory boundary this tier cannot deliver.
         nativeMemory={owner?.memoryProvider === 'native'}
@@ -1146,7 +1182,7 @@ export default function SessionDetailView() {
   if (wantTranscript) {
     // Real transcript: agent output carries `sender === agentId`; everything else
     // is a human/cron author. Group consecutive agent messages into one turn.
-    for (const m of msgs ?? []) {
+    for (const m of visibleMsgs ?? []) {
       if (m.sender === session.agentId) {
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot') {
@@ -1284,9 +1320,10 @@ export default function SessionDetailView() {
   const pgEmpty = isPg && session.steps.length === 0 && !pgBusy
   // "No messages" only when nothing is rendered — a resumed webchat turn folds into
   // `turns`, so once you've sent one the empty card gives way to the transcript.
-  const transcriptEmpty = wantTranscript && !msgLoading && !msgErr && (msgs?.length ?? 0) === 0 && turns.length === 0
+  const transcriptEmpty =
+    wantTranscript && !visibleMsgLoading && !visibleMsgErr && (visibleMsgs?.length ?? 0) === 0 && turns.length === 0
   const prompts = pgPrompts(session.agentId ?? '')
-  const loadedTranscriptStats = wantTranscript && msgs !== null ? activityStatsFromTranscript(msgs) : null
+  const loadedTranscriptStats = wantTranscript && visibleMsgs !== null ? activityStatsFromTranscript(visibleMsgs) : null
   const liveActivityStats = isPg ? activityStatsFromSteps(session.steps) : activityStatsFromSteps(liveSteps)
   const durationFirst = minTime(loadedTranscriptStats?.firstMs, liveActivityStats.firstMs)
   const durationLast = maxTime(
@@ -1427,7 +1464,8 @@ export default function SessionDetailView() {
         current={session}
         total={railSessionTotal}
         agentId={session.agentId}
-        family={sessionDetail?.id === session.id ? sessionDetail : undefined}
+        family={currentSessionDetail?.id === session.id ? currentSessionDetail : undefined}
+        onSelect={setRouteSession}
       />
       <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">
         {/* DESKTOP TITLE ROW — the session name + its status badge. These used to live
@@ -1569,7 +1607,7 @@ export default function SessionDetailView() {
           </button>
         </div>
 
-        {sessionDetail?.accessSyncDegraded && (
+        {currentSessionDetail?.accessSyncDegraded && (
           <div className="mb-3 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-2 font-sans text-[12px] font-medium leading-normal text-(--text-secondary) max-desktop:mx-4 max-desktop:mt-3">
             External access could not be verified. Related sessions remain hidden until access checks succeed.
           </div>
@@ -1633,11 +1671,11 @@ export default function SessionDetailView() {
           </div>
         )}
 
-        {sessionDetail?.id === session.id && (
+        {currentSessionDetail?.id === session.id && (
           <MobileSessionFamilyLinks
-            parent={sessionDetail.parentSession}
-            siblings={sessionDetail.siblingSessions ?? []}
-            children={sessionDetail.childSessions}
+            parent={currentSessionDetail.parentSession}
+            siblings={currentSessionDetail.siblingSessions ?? []}
+            children={currentSessionDetail.childSessions}
             agentById={agentById}
             orgPath={orgPath}
           />
@@ -1645,6 +1683,7 @@ export default function SessionDetailView() {
 
         {owner?.canEdit && !owner.name.startsWith(MOCK_PREFIX) && session.agentId && (
           <ApprovalRequestsCard
+            key={session.id}
             agentId={session.agentId}
             sessionId={session.realSessionId ?? session.id}
             hideWhenEmpty
@@ -1652,12 +1691,12 @@ export default function SessionDetailView() {
           />
         )}
 
-        {wantTranscript && msgLoading && (
+        {wantTranscript && visibleMsgLoading && (
           <div className="flex justify-center py-10">
             <Spinner size={30} />
           </div>
         )}
-        {wantTranscript && msgErr && (
+        {wantTranscript && visibleMsgErr && (
           <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
             <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
             <span>
@@ -1675,7 +1714,7 @@ export default function SessionDetailView() {
           </div>
         )}
 
-        {msgPaging && (
+        {visibleMsgPaging && (
           <div className="flex items-center justify-center gap-2 pt-[10px] font-sans text-[11.5px] font-medium leading-normal text-(--text-tertiary) desktop:pt-1 desktop:pb-3">
             <Spinner size={14} />
             Loading earlier activity…
@@ -1692,7 +1731,7 @@ export default function SessionDetailView() {
                 turn.kind === 'user' ? (
                   // 2b: user turns are right-aligned brand-soft bubbles. A sender label
                   // sits above the bubble only when it isn't you (platform user / cron).
-                  <div key={ti} className="flex items-start justify-end gap-[9px]">
+                  <div key={`${session.id}:${ti}`} className="flex items-start justify-end gap-[9px]">
                     <div className="flex min-w-0 max-w-[86%] flex-col items-end gap-[3px]">
                       {(turn.isCron || turn.sp.handle !== '@you') && (
                         <span className="flex items-center gap-[6px] pr-1 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary)">
@@ -1740,7 +1779,7 @@ export default function SessionDetailView() {
                     const autoOpen = textSteps.length === 0
                     const openWork = workPanelOpen(workOverride.get(ti), autoOpen)
                     return (
-                      <div key={ti} className="flex items-start gap-[9px]">
+                      <div key={`${session.id}:${ti}`} className="flex items-start gap-[9px]">
                         <span className="av h-[26px] w-[26px] flex-none rounded-md">
                           <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={26} />
                         </span>
@@ -1842,6 +1881,7 @@ export default function SessionDetailView() {
             <>
               {activeOrg && session.agentId && webchatConversationId && (
                 <WebchatMcpApprovalCard
+                  key={webchatConversationId}
                   orgId={activeOrg.id}
                   agentId={session.agentId}
                   conversationId={webchatConversationId}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -726,6 +726,7 @@ export default function SessionDetailView() {
   // agent-filtered rail steady instead of briefly dropping it between ids.
   const [routeSession, setRouteSession] = useState<Session | null>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
+  const imagePrepareGenerationRef = useRef(0)
   const liveCursorRef = useRef<string | null>(null)
   const tailSessionRef = useRef<string | null>(null)
   const tailReadyRef = useRef(false)
@@ -1045,6 +1046,7 @@ export default function SessionDetailView() {
   // session into the next now that the shared route layout preserves this
   // component instance.
   useEffect(() => {
+    imagePrepareGenerationRef.current += 1
     setCopied(false)
     setDetailOpen(false)
     setWorkOverride(new Map())
@@ -1143,16 +1145,22 @@ export default function SessionDetailView() {
   }
   const onImageFile = async (file: File | undefined): Promise<void> => {
     if (!file || imagePreparing) return
+    const generation = ++imagePrepareGenerationRef.current
     setAttachMenuOpen(false)
     setImagePreparing(true)
     setImageError(null)
     try {
-      setPgImage(session.id, await prepareWebchatImage(file))
+      const image = await prepareWebchatImage(file)
+      if (imagePrepareGenerationRef.current !== generation) return
+      setPgImage(session.id, image)
     } catch (error) {
+      if (imagePrepareGenerationRef.current !== generation) return
       setImageError(error instanceof Error ? error.message : 'Couldn’t prepare that image.')
     } finally {
-      setImagePreparing(false)
-      if (imageInputRef.current) imageInputRef.current.value = ''
+      if (imagePrepareGenerationRef.current === generation) {
+        setImagePreparing(false)
+        if (imageInputRef.current) imageInputRef.current.value = ''
+      }
     }
   }
   const webchatConversationId = isLive ? session.channelId : undefined

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1052,6 +1052,7 @@ export default function SessionDetailView() {
     setWorkOverride(new Map())
     setImagePreparing(false)
     setImageError(null)
+    if (imageInputRef.current) imageInputRef.current.value = ''
     setAttachMenuOpen(false)
     setComposerMenuOpen(null)
   }, [id])


### PR DESCRIPTION
## Summary

- keep the session detail client mounted while navigating between left-rail sessions
- make the full rail row clickable while reserving only the pin control as a separate target
- prevent stale transcript/detail state from flashing across session changes
- preserve the new parent, sibling, and child session tree from main

## Validation

- pnpm exec eslint on changed Web files
- pnpm --filter @agentconnect.md/web typecheck
- pnpm --filter @agentconnect.md/web test (78 files, 572 tests)
- NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build
- browser-verified session switching, back navigation, selected-row behavior, and console errors

Created by Codex . GPT-5