### PR TITLE
fix(sessions): load provider participant avatars

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2463,6 +2463,7 @@ export const SessionMessageDto = z.object({
   seq: z.number(),
   sender: z.string(),
   senderName: z.string().optional(), // daemon-resolved display name; absent if unknown
+  senderAvatarUrl: z.string().url().optional(), // public provider-hosted profile image
   trustedAgentBot: z.boolean().optional(), // daemon-verified AgentConnect Slack bot provenance
   ts: z.string(),
   kind: z.string(),

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -282,13 +282,21 @@ export function createSessionReader(
       const names = store.getDisplayNames(
         projected.flatMap(({ row, sender }) => [sender, ...mentionedUserIds(row.text)])
       )
+      const avatars = rec.transportScope
+        ? store.getProfileAvatars(
+            rec.transportScope,
+            projected.map(({ sender }) => sender)
+          )
+        : new Map<string, string>()
       const built = projected.map<SessionMessage>(({ row: r, sender }) => {
         const senderName = names.get(sender)
+        const senderAvatarUrl = avatars.get(sender)
         const attachments = transcriptAttachments(r.attachmentsJson)
         const base: SessionMessage = {
           seq: r.seq,
           sender,
           ...(senderName ? { senderName } : {}),
+          ...(senderAvatarUrl ? { senderAvatarUrl } : {}),
           ...(r.trustedAgentBot ? { trustedAgentBot: true } : {}),
           ts: r.ts,
           kind: r.kind,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2170,10 +2170,18 @@ export class Daemon {
     })
     // Off-hot-path Slack id → display-name resolution, cached into the store so
     // session read-back can label channels/senders without a live Slack call.
-    this.nameResolver = new SlackNameResolver((id, name) => {
-      this.store.setDisplayName(id, name, Date.now())
-      this.emitSessionMetadataSnapshotsForDisplayName(id)
-    }, this.log)
+    this.nameResolver = new SlackNameResolver(
+      (id, name) => {
+        this.store.setDisplayName(id, name, Date.now())
+        this.emitSessionMetadataSnapshotsForDisplayName(id)
+      },
+      this.log,
+      Date.now,
+      (conn, id, avatarUrl) => {
+        const scope = this.transportScopeForIntegrationIds(this.srcIntegrationIds(conn))
+        if (scope) this.store.setProfileAvatar(scope, id, avatarUrl, Date.now())
+      }
+    )
     // Same cache-then-emit sink for Discord/Telegram/Feishu channel and user names.
     this.channelNameResolver = new ChannelNameResolver(
       (id, name) => {
@@ -2190,6 +2198,10 @@ export class Daemon {
         saveScope: (id, scope) => {
           this.store.setChannelScope(id, scope, Date.now())
           this.refreshObservedChannels()
+        },
+        saveAvatar: (source, id, avatarUrl) => {
+          const scope = this.transportScopeForIntegrationIds(this.srcIntegrationIds(source))
+          if (scope) this.store.setProfileAvatar(scope, id, avatarUrl, Date.now())
         },
         log: this.log
       }
@@ -4993,6 +5005,8 @@ export class Daemon {
     }
     this.clearRetractionOnTraffic(msg, srcIntegrationIds)
     msg.transportScope ??= this.transportScopeForIntegrationIds(srcIntegrationIds)
+    if (msg.sender.avatarUrl && msg.transportScope)
+      this.store.setProfileAvatar(msg.transportScope, msg.sender.id, msg.sender.avatarUrl, Date.now())
     // A mention in a watched Slack channel can arrive via both `message.*` and
     // `app_mention`; both share channel:ts, so dedup the double-fire from ONE bot
     // connection. Do not dedup across bot connections: several Slack apps receive
@@ -9536,6 +9550,8 @@ export class Daemon {
     if (integrationId !== undefined) {
       msg.transportScope ??= this.transportScopeForIntegrationIds([integrationId])
     }
+    if (msg.sender.avatarUrl && msg.transportScope)
+      this.store.setProfileAvatar(msg.transportScope, msg.sender.id, msg.sender.avatarUrl, Date.now())
     if (
       this.cfg.features.turnFinalContextRefresh &&
       (msg.platform === 'slack' ||

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -318,6 +318,7 @@ export class DiscordConnection {
       content: text,
       authorId: interaction.user.id,
       authorIsBot: interaction.user.bot,
+      authorAvatarUrl: interaction.user.displayAvatarURL(),
       inGuild: interaction.inGuild(),
       isThread: interaction.channel?.isThread() ?? false,
       mentionUserIds: [],
@@ -336,6 +337,7 @@ export class DiscordConnection {
       content: message.content,
       authorId: message.author.id,
       authorIsBot: message.author.bot,
+      authorAvatarUrl: message.author.displayAvatarURL(),
       inGuild: message.inGuild(),
       isThread: message.channel.isThread(),
       mentionUserIds: [...message.mentions.users.keys()],
@@ -697,10 +699,18 @@ export class DiscordConnection {
     }
   }
 
-  async getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }> {
+  async getUserProfile(
+    user: string
+  ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }> {
     try {
       const u = await this.client.users.fetch(user)
-      return { id: user, name: u.username, realName: u.globalName ?? undefined, isBot: u.bot }
+      return {
+        id: user,
+        name: u.username,
+        realName: u.globalName ?? undefined,
+        isBot: u.bot,
+        avatarUrl: u.displayAvatarURL()
+      }
     } catch {
       return { id: user }
     }

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -136,7 +136,9 @@ export interface FeishuApi {
   /** im.chat.list (capped). */
   listChats(cap: number): Promise<{ id: string; name?: string }[]>
   /** contact.user.get. */
-  getUser(userId: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
+  getUser(
+    userId: string
+  ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }>
   /** GET /open-apis/bot/v3/info — the bot's own open_id + display name. */
   getBotInfo(): Promise<{ openId?: string; name?: string }>
 }
@@ -311,9 +313,23 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
       const res = (await client.contact.user.get({
         path: { user_id: userId },
         params: { user_id_type: 'open_id' }
-      })) as { data?: { user?: { name?: string; en_name?: string } } }
+      })) as {
+        data?: {
+          user?: {
+            name?: string
+            en_name?: string
+            avatar?: { avatar_72?: string; avatar_240?: string; avatar_origin?: string }
+          }
+        }
+      }
       const u = res?.data?.user ?? {}
-      return { id: userId, ...(u.name ? { name: u.name } : {}), ...(u.en_name ? { realName: u.en_name } : {}) }
+      const avatarUrl = u.avatar?.avatar_72 ?? u.avatar?.avatar_240 ?? u.avatar?.avatar_origin
+      return {
+        id: userId,
+        ...(u.name ? { name: u.name } : {}),
+        ...(u.en_name ? { realName: u.en_name } : {}),
+        ...(avatarUrl ? { avatarUrl } : {})
+      }
     },
     async getBotInfo() {
       const res = (await client.request({ method: 'GET', url: '/open-apis/bot/v3/info' })) as {
@@ -992,7 +1008,9 @@ export class FeishuConnection {
     }
   }
 
-  async getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }> {
+  async getUserProfile(
+    user: string
+  ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }> {
     try {
       return await this.handle.api.getUser(user)
     } catch (err) {

--- a/packages/daemon/src/messages/channel-name-resolver.ts
+++ b/packages/daemon/src/messages/channel-name-resolver.ts
@@ -21,7 +21,9 @@ export interface ChannelInfoSource {
     /** That space's display name (the Discord server name). */
     spaceName?: string
   }>
-  getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }>
+  getUserProfile(
+    user: string
+  ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }>
 }
 
 /**
@@ -61,6 +63,8 @@ export interface ResolvedChannelScope {
 export interface ChannelNameResolverOpts {
   /** Sink for the conversation's scope, saved next to its display name. */
   saveScope?: (id: string, scope: ResolvedChannelScope) => void
+  /** Public provider-hosted user avatar cache sink. */
+  saveAvatar?: (source: ChannelInfoSource, id: string, avatarUrl: string) => void
   log?: Logger
   now?: () => number
 }
@@ -69,6 +73,7 @@ export class ChannelNameResolver {
   /** channel id → epoch ms until which we won't re-attempt a lookup. */
   private nextAttemptAt = new Map<string, number>()
   private saveScope?: (id: string, scope: ResolvedChannelScope) => void
+  private saveAvatar?: (source: ChannelInfoSource, id: string, avatarUrl: string) => void
   private log?: Logger
   private now: () => number
 
@@ -77,6 +82,7 @@ export class ChannelNameResolver {
     opts: ChannelNameResolverOpts = {}
   ) {
     this.saveScope = opts.saveScope
+    this.saveAvatar = opts.saveAvatar
     this.log = opts.log
     this.now = opts.now ?? Date.now
   }
@@ -161,6 +167,7 @@ export class ChannelNameResolver {
         const p = await src.getUserProfile(triggeredBy)
         const name = p.realName || p.name
         if (name) this.save(channel, `@${name}`)
+        if (p.avatarUrl) this.saveAvatar?.(src, triggeredBy, p.avatarUrl)
       }
     } catch (err) {
       this.nextAttemptAt.set(channel, this.now() + FAIL_TTL_MS)
@@ -177,6 +184,7 @@ export class ChannelNameResolver {
       const p = await src.getUserProfile(user)
       const name = p.realName || p.name
       if (name) this.save(user, name)
+      if (p.avatarUrl) this.saveAvatar?.(src, user, p.avatarUrl)
     } catch (err) {
       this.nextAttemptAt.set(user, this.now() + FAIL_TTL_MS)
       this.log?.debug(`name lookup failed for user ${user}: ${(err as Error).message}`)

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -292,6 +292,7 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
   const initialSessionTitle = githubSessionTitle(msg)
   const sessionTriggerId = `hook:${msg.hookId}`
   const senderId = githubEventActor(msg) ?? sessionTriggerId
+  const senderAvatarUrl = msg.context?.source === 'github' ? msg.context.senderAvatarUrl : undefined
   // `msgId` is the collision-free delivery identity but is not a timestamp. Keep
   // the display/order key in epoch milliseconds and append the complete identity
   // so distinct same-millisecond deliveries cannot share a transcript primary key.
@@ -310,7 +311,7 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
       platform: target.platform,
       channel: target.channel,
       thread: msg.msgId,
-      sender: { id: senderId, isBot: false },
+      sender: { id: senderId, isBot: false, ...(senderAvatarUrl ? { avatarUrl: senderAvatarUrl } : {}) },
       sessionTriggerId,
       text: buildHookText(msg),
       ...(initialSessionTitle ? { initialSessionTitle } : {}),
@@ -331,7 +332,7 @@ export function buildHookMessage(msg: RdMsgHook, traceId: string): NormalizedMes
     // repository id here creates a clean runtime after upgrade instead of
     // letting a mutable hook id claim legacy context from another repository.
     ...(msg.github ? { transportScope: `github:${msg.github.repoId}` } : {}),
-    sender: { id: senderId, isBot: false },
+    sender: { id: senderId, isBot: false, ...(senderAvatarUrl ? { avatarUrl: senderAvatarUrl } : {}) },
     sessionTriggerId,
     text: buildHookText(msg),
     ...(initialSessionTitle ? { initialSessionTitle } : {}),

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -218,7 +218,7 @@ type SlackUserResult = {
   name?: string
   real_name?: string
   is_bot?: boolean
-  profile?: { real_name?: string; display_name?: string }
+  profile?: { real_name?: string; display_name?: string; image_48?: string; image_72?: string }
 }
 
 /** The subset of a Block Kit `block_actions` payload we read: the interacted element
@@ -1210,10 +1210,18 @@ export class SlackConnection {
     this.deps.log?.debug(`slack: left channel ${channel}`)
   }
 
-  async getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }> {
+  async getUserProfile(
+    user: string
+  ): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean; avatarUrl?: string }> {
     const res = await this.app.client.users.info({ user })
     const u = res.user ?? {}
-    return { id: u.id ?? user, name: u.name, realName: u.real_name ?? u.profile?.real_name, isBot: u.is_bot }
+    return {
+      id: u.id ?? user,
+      name: u.name,
+      realName: u.real_name ?? u.profile?.real_name,
+      isBot: u.is_bot,
+      avatarUrl: u.profile?.image_72 ?? u.profile?.image_48
+    }
   }
 
   /**

--- a/packages/daemon/src/slack/name-resolver.ts
+++ b/packages/daemon/src/slack/name-resolver.ts
@@ -27,7 +27,8 @@ export class SlackNameResolver {
   constructor(
     private save: (id: string, name: string) => void,
     private log?: Logger,
-    private now: () => number = Date.now
+    private now: () => number = Date.now,
+    private saveAvatar?: (conn: SlackConnection, id: string, avatarUrl: string) => void
   ) {}
 
   /** Kick off (cached) resolution for a message's channel, human sender, and any
@@ -74,6 +75,7 @@ export class SlackNameResolver {
         const p = await conn.getUserProfile(info.user)
         const name = p.realName || p.name
         if (name) this.save(channel, `@${name}`)
+        if (p.avatarUrl) this.saveAvatar?.(conn, info.user, p.avatarUrl)
       }
     } catch (err) {
       this.nextAttemptAt.set(channel, this.now() + FAIL_TTL_MS)
@@ -87,6 +89,7 @@ export class SlackNameResolver {
       const p = await conn.getUserProfile(user)
       const name = p.realName || p.name
       if (name) this.save(user, name)
+      if (p.avatarUrl) this.saveAvatar?.(conn, user, p.avatarUrl)
     } catch (err) {
       this.nextAttemptAt.set(user, this.now() + FAIL_TTL_MS)
       this.log?.debug(`slack: name lookup failed for user ${user}: ${(err as Error).message}`)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -535,6 +535,12 @@ export class LocalStore {
       CREATE TABLE IF NOT EXISTS display_names (
         id TEXT PRIMARY KEY, name TEXT NOT NULL, updatedAt INTEGER
       );
+      -- Platform id → public provider-hosted profile image. Kept separate from
+      -- display_names because a provider may expose an avatar without a name.
+      CREATE TABLE IF NOT EXISTS profile_avatars (
+        transportScope TEXT NOT NULL, id TEXT NOT NULL, url TEXT NOT NULL, updatedAt INTEGER,
+        PRIMARY KEY (transportScope, id)
+      );
       -- Where a conversation id SITS: its enclosing channel (a Discord thread's parent
       -- channel — a session keys on the thread id, so the reachable channel it belongs
       -- to is otherwise unrecoverable) and its enclosing space (the Discord guild, whose
@@ -2745,6 +2751,38 @@ export class LocalStore {
       .prepare(`SELECT id, name FROM display_names WHERE id IN (${unique.map(() => '?').join(',')})`)
       .all(...unique) as unknown as { id: string; name: string }[]
     for (const r of rows) if (r.name) out.set(r.id, r.name)
+    return out
+  }
+
+  /** Cache a public provider-hosted profile image. Latest-wins as users update avatars. */
+  setProfileAvatar(transportScope: string, id: string, url: string, updatedAt: number): void {
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      return
+    }
+    if ((parsed.protocol !== 'https:' && parsed.protocol !== 'http:') || parsed.username || parsed.password) return
+    this.db
+      .prepare(
+        `INSERT INTO profile_avatars (transportScope, id, url, updatedAt) VALUES (?, ?, ?, ?)
+         ON CONFLICT(transportScope, id) DO UPDATE SET url=excluded.url, updatedAt=excluded.updatedAt`
+      )
+      .run(transportScope, id, url, updatedAt)
+  }
+
+  /** Profile images for platform ids on one physical provider connection. */
+  getProfileAvatars(transportScope: string, ids: string[]): Map<string, string> {
+    const out = new Map<string, string>()
+    const unique = [...new Set(ids)]
+    if (unique.length === 0) return out
+    const rows = this.db
+      .prepare(
+        `SELECT id, url FROM profile_avatars
+         WHERE transportScope = ? AND id IN (${unique.map(() => '?').join(',')})`
+      )
+      .all(transportScope, ...unique) as unknown as { id: string; url: string }[]
+    for (const row of rows) if (row.url) out.set(row.id, row.url)
     return out
   }
 

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -1672,6 +1672,7 @@ describe('buildHookMessage', () => {
           number: 42,
           title: 'db down',
           senderLogin: 'mallory',
+          senderAvatarUrl: 'https://avatars.example.test/mallory.png',
           authorAssociation: 'NONE',
           labels: ['bug', 'p0'],
           htmlUrl: 'https://github.com/acme/infra/issues/42',
@@ -1700,7 +1701,7 @@ describe('buildHookMessage', () => {
 
     it('attributes the message to the GitHub actor while retaining the hook trigger', () => {
       expect(buildHookMessage(ghFire(), 'trace-actor')).toMatchObject({
-        sender: { id: 'mallory' },
+        sender: { id: 'mallory', avatarUrl: 'https://avatars.example.test/mallory.png' },
         sessionTriggerId: `hook:${HOOK_ID}`
       })
     })

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -490,6 +490,21 @@ describe('LocalStore session/transcript read-back (session/list, session/history
     s.close()
   })
 
+  it('profile avatars: latest-wins upsert, batch lookup returns only known ids', () => {
+    const s = store()
+    s.setProfileAvatar('slack:one', 'bad', 'not-a-url', 1)
+    s.setProfileAvatar('slack:one', 'U1', 'https://avatars.example.test/old.png', 1)
+    s.setProfileAvatar('slack:one', 'U1', 'https://avatars.example.test/new.png', 2)
+    s.setProfileAvatar('slack:two', 'U1', 'https://avatars.example.test/other.png', 2)
+    const avatars = s.getProfileAvatars('slack:one', ['U1', 'U-unknown'])
+    expect(avatars.get('U1')).toBe('https://avatars.example.test/new.png')
+    expect(avatars.has('U-unknown')).toBe(false)
+    expect(s.getProfileAvatars('slack:two', ['U1']).get('U1')).toBe('https://avatars.example.test/other.png')
+    expect(s.getProfileAvatars('slack:one', ['bad']).size).toBe(0)
+    expect(s.getProfileAvatars('slack:one', []).size).toBe(0)
+    s.close()
+  })
+
   it('channel scopes: latest-wins, batch lookup returns only known ids', () => {
     const s = store()
     s.setChannelScope('T1', { parentId: 'C1' }, 1)

--- a/packages/daemon/test/name-resolver.test.ts
+++ b/packages/daemon/test/name-resolver.test.ts
@@ -7,7 +7,12 @@ import { ChannelNameResolver, type ChannelInfoSource } from '../src/messages/cha
 function fakeConn(over: Partial<Pick<SlackConnection, 'getChannelInfo' | 'getUserProfile'>> = {}) {
   return {
     getChannelInfo: vi.fn(async (id: string) => ({ id, name: 'deploys' })),
-    getUserProfile: vi.fn(async (id: string) => ({ id, name: 'dana', realName: 'Dana Reyes' })),
+    getUserProfile: vi.fn(async (id: string) => ({
+      id,
+      name: 'dana',
+      realName: 'Dana Reyes',
+      avatarUrl: 'https://avatars.example.test/dana.png'
+    })),
     ...over
   } as unknown as SlackConnection & {
     getChannelInfo: ReturnType<typeof vi.fn>
@@ -22,13 +27,20 @@ const flush = () => new Promise((r) => setImmediate(r))
 describe('SlackNameResolver', () => {
   it('resolves channel + human sender once and saves realName over handle', async () => {
     const saved = new Map<string, string>()
+    const avatars = new Map<string, string>()
     const conn = fakeConn()
-    const r = new SlackNameResolver((id, name) => saved.set(id, name))
+    const r = new SlackNameResolver(
+      (id, name) => saved.set(id, name),
+      undefined,
+      Date.now,
+      (_conn, id, avatarUrl) => avatars.set(id, avatarUrl)
+    )
     r.noteMessage(conn, msg('C1', 'U1'))
     r.noteMessage(conn, msg('C1', 'U1')) // same ids again — must not re-hit the API
     await flush()
     expect(saved.get('C1')).toBe('deploys')
     expect(saved.get('U1')).toBe('Dana Reyes')
+    expect(avatars.get('U1')).toBe('https://avatars.example.test/dana.png')
     expect(conn.getChannelInfo).toHaveBeenCalledTimes(1)
     expect(conn.getUserProfile).toHaveBeenCalledTimes(1)
   })
@@ -92,7 +104,12 @@ describe('SlackNameResolver', () => {
 describe('ChannelNameResolver', () => {
   const source = (info: Awaited<ReturnType<ChannelInfoSource['getChannelInfo']>>): ChannelInfoSource => ({
     getChannelInfo: vi.fn(async () => info),
-    getUserProfile: vi.fn(async (id: string) => ({ id, name: 'dana', realName: 'Dana Reyes' }))
+    getUserProfile: vi.fn(async (id: string) => ({
+      id,
+      name: 'dana',
+      realName: 'Dana Reyes',
+      avatarUrl: 'https://avatars.example.test/dana.png'
+    }))
   })
 
   it('labels a Discord thread with its enclosing channel, not the thread title', async () => {
@@ -130,12 +147,17 @@ describe('ChannelNameResolver', () => {
 
   it('noteMessage caches the human sender and the users they mentioned', async () => {
     const saved = new Map<string, string>()
+    const avatars = new Map<string, string>()
     const src = source({ id: 'C1', name: 'general' })
-    const r = new ChannelNameResolver((id, name) => saved.set(id, name))
+    const r = new ChannelNameResolver((id, name) => saved.set(id, name), {
+      saveAvatar: (_source, id, avatarUrl) => avatars.set(id, avatarUrl)
+    })
     r.noteMessage(src, { channel: 'C1', sender: { id: 'U9', isBot: false }, mentionedUserIds: ['U7'] })
     await flush()
     expect(saved.get('U9')).toBe('Dana Reyes')
     expect(saved.get('U7')).toBe('Dana Reyes')
+    expect(avatars.get('U9')).toBe('https://avatars.example.test/dana.png')
+    expect(avatars.get('U7')).toBe('https://avatars.example.test/dana.png')
   })
 
   it('noteMessage skips a bot sender (agent frames are labelled by agentId upstream)', async () => {

--- a/packages/daemon/test/session-reader.test.ts
+++ b/packages/daemon/test/session-reader.test.ts
@@ -263,12 +263,15 @@ describe('SessionReader', () => {
 
   it('history labels senders with cached names and leaves unknown ids raw', () => {
     const s = store()
+    const transportScope = 'slack:one'
+    const transcriptChannel = transcriptChannelKey('C1', transportScope)
     s.upsertSession({
-      key: sessionKey('slack', 'C1', 'T1', AGENT),
+      key: sessionKey('slack', 'C1', 'T1', AGENT, transportScope),
       agentId: AGENT,
       platform: 'slack',
       channel: 'C1',
       thread: 'T1',
+      transportScope,
       acpSessionId: 'acp-1',
       state: 'idle',
       lastDeliveredTs: null,
@@ -276,7 +279,7 @@ describe('SessionReader', () => {
     })
     // The inbound message is delivered TO this agent (recipient), the reply is FROM it.
     s.appendTranscript({
-      channel: 'C1',
+      channel: transcriptChannel,
       thread: 'T1',
       ts: '1',
       sender: 'U1',
@@ -284,14 +287,22 @@ describe('SessionReader', () => {
       kind: 'text',
       text: 'hi'
     })
-    s.appendTranscript({ channel: 'C1', thread: 'T1', ts: '2', sender: AGENT, kind: 'text', text: 'hello' })
+    s.appendTranscript({
+      channel: transcriptChannel,
+      thread: 'T1',
+      ts: '2',
+      sender: AGENT,
+      kind: 'text',
+      text: 'hello'
+    })
     s.setDisplayName('U1', 'Dana Reyes', 1)
+    s.setProfileAvatar(transportScope, 'U1', 'https://avatars.example.test/dana.png', 1)
 
     const reader = createSessionReader(s)
     const { messages } = reader.history({ agentId: AGENT, sessionId: 'acp-1', limit: 50 })
-    expect(messages.map((m) => [m.sender, m.senderName])).toEqual([
-      ['U1', 'Dana Reyes'],
-      [AGENT, undefined] // agent-id senders have no display_names entry → omitted
+    expect(messages.map((m) => [m.sender, m.senderName, m.senderAvatarUrl])).toEqual([
+      ['U1', 'Dana Reyes', 'https://avatars.example.test/dana.png'],
+      [AGENT, undefined, undefined] // agent-id senders have no cached provider profile → omitted
     ])
     s.close()
   })

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -18,6 +18,7 @@ export interface DiscordMessageLike {
   content: string
   authorId: string
   authorIsBot: boolean
+  authorAvatarUrl?: string
   /** False when the message is a DM with no guild. */
   inGuild: boolean
   /** True when `channelId` is itself a Discord thread channel. */
@@ -76,7 +77,11 @@ export function normalizeDiscordMessage(
     // Discord thread channels are conversations, so the channel itself is the
     // stable session/thread coordinate.
     thread: message.channelId,
-    sender: { id: message.authorId, isBot: message.authorIsBot },
+    sender: {
+      id: message.authorId,
+      isBot: message.authorIsBot,
+      ...(message.authorAvatarUrl ? { avatarUrl: message.authorAvatarUrl } : {})
+    },
     text: humanizeDiscordText(message.content, message.mentionUserNames),
     mentionedBots: message.mentionUserIds,
     ...(attachments.length ? { attachments } : {}),

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -28,7 +28,8 @@ export interface SlackMessageLike {
   user?: string
   bot_id?: string
   app_id?: string
-  bot_profile?: { app_id?: string }
+  bot_profile?: { app_id?: string; icons?: { image_72?: string } }
+  user_profile?: { image_72?: string }
   hidden?: boolean
   message?: unknown
   text?: string
@@ -74,6 +75,7 @@ export function normalizeSlackMessage(
     .map(toSlackAttachment)
     .filter((attachment): attachment is PlatformAttachment => attachment !== null)
   const appId = message.app_id ?? message.bot_profile?.app_id
+  const avatarUrl = message.user_profile?.image_72 ?? message.bot_profile?.icons?.image_72
   const msgId = `slack:${message.channel}:${message.ts}`
 
   return {
@@ -86,7 +88,8 @@ export function normalizeSlackMessage(
     sender: {
       id: message.user ?? message.bot_id ?? 'unknown',
       isBot: Boolean(message.bot_id || appId),
-      ...(appId ? { appId } : {})
+      ...(appId ? { appId } : {}),
+      ...(avatarUrl ? { avatarUrl } : {})
     },
     text,
     mentionedBots,

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -162,6 +162,7 @@ export const HookContext = z.object({
   number: z.number().int().optional(), // issue/PR number
   title: z.string().optional(),
   senderLogin: z.string().optional(),
+  senderAvatarUrl: z.string().url().optional(),
   authorAssociation: z.string().optional(),
   labels: z.array(z.string()).optional(),
   htmlUrl: z.string().optional(),

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -100,6 +100,7 @@ export const SessionMessage = z.object({
   seq: z.number().int(), // daemon-local insertion order within the session
   sender: z.string(), // platform handle/id of the author
   senderName: z.string().optional(), // display name (daemon-resolved; absent if unknown)
+  senderAvatarUrl: z.string().url().optional(), // public provider profile image; absent if unavailable
   // Daemon-verified AgentConnect Slack app/bot provenance. Optional for rolling
   // compatibility and absent on legacy rows or every non-Slack transport.
   trustedAgentBot: z.boolean().optional(),

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -40,7 +40,9 @@ export const NormalizedPlatformMessageSchema = z.object({
   sender: z.object({
     id: z.string(),
     isBot: z.boolean(),
-    appId: z.string().optional()
+    appId: z.string().optional(),
+    /** Public provider-hosted profile image. Auth-gated file URLs must not be exposed here. */
+    avatarUrl: z.string().url().optional()
   }),
   text: z.string(),
   mentionedBots: z.array(z.string()),

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -2185,10 +2185,16 @@ describe('buildGithubContext', () => {
     const c = buildGithubContext('pull_request', {
       action: 'opened',
       repository: { id: REPO_ID, full_name: 'acme/infra' },
-      sender: { login: 'alice', type: 'User' },
+      sender: { login: 'alice', type: 'User', avatar_url: 'https://avatars.example.test/alice.png' },
       pull_request: { number: 7, title: 'fix', body: 'diff', html_url: 'u', author_association: 'OWNER', labels: [] }
     })
-    expect(c).toMatchObject({ source: 'github', number: 7, title: 'fix', bodyExcerpt: 'diff' })
+    expect(c).toMatchObject({
+      source: 'github',
+      number: 7,
+      title: 'fix',
+      senderAvatarUrl: 'https://avatars.example.test/alice.png',
+      bodyExcerpt: 'diff'
+    })
   })
 
   it('a null subject body yields no excerpt and truncated:false', () => {

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -84,7 +84,7 @@ interface GithubPayload {
   action?: string
   installation?: { id?: number }
   repository?: { id?: number; full_name?: string }
-  sender?: { login?: string; type?: string }
+  sender?: { login?: string; type?: string; avatar_url?: string }
   requested_reviewer?: { login?: string; type?: string }
   requested_action?: { identifier?: string }
   issue?: GithubSubject
@@ -344,6 +344,7 @@ export function buildGithubContext(event: string, payload: GithubPayload): HookC
     ...(subject?.number !== undefined ? { number: subject.number } : {}),
     ...(subject?.title ? { title: sanitizeTitle(subject.title) } : {}),
     ...(payload.sender?.login ? { senderLogin: payload.sender.login } : {}),
+    ...(payload.sender?.avatar_url ? { senderAvatarUrl: payload.sender.avatar_url } : {}),
     ...((payload.comment?.author_association ?? subject?.author_association)
       ? { authorAssociation: payload.comment?.author_association ?? subject?.author_association }
       : {}),

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -522,12 +522,14 @@ function ParticipantAvatar({
   agent,
   avatarUrl,
   avatarInitials,
+  platformMark,
   sp,
   isCron
 }: {
   agent: Agent | null
   avatarUrl?: string | null
   avatarInitials?: string
+  platformMark?: string
   sp: ReturnType<typeof speaker>
   isCron: boolean
 }) {
@@ -542,6 +544,13 @@ function ParticipantAvatar({
         <AgentIconView icon={agent.icon} runtime={agent.runtime} size={26} />
       ) : isCron ? (
         <Icon name="calendar-clock" size={14} color="var(--text-secondary)" />
+      ) : platformMark && !avatarUrl && !avatarInitials ? (
+        <span
+          className="flex h-full w-full items-center justify-center rounded-[inherit]"
+          style={{ background: sp.avBg, color: sp.avText }}
+        >
+          <PlatformMark platform={platformMark} />
+        </span>
       ) : (
         <Avatar
           src={avatarUrl}
@@ -1247,7 +1256,7 @@ export default function SessionDetailView() {
           kind: 'user',
           sp: participant,
           agent: senderAgent ?? null,
-          avatarUrl: self ? viewer.picture : memberPictureByIdentity.get(m.sender),
+          avatarUrl: m.senderAvatarUrl ?? (self ? viewer.picture : memberPictureByIdentity.get(m.sender)),
           avatarInitials: self ? viewer.initials : undefined,
           sourceLabel: platName(sessionIntegration),
           time: formatTranscriptTime(m.ts),
@@ -1812,6 +1821,7 @@ export default function SessionDetailView() {
                       agent={turn.agent}
                       avatarUrl={turn.avatarUrl}
                       avatarInitials={turn.avatarInitials}
+                      platformMark={usesIntegrationAvatar ? sessionIntegration : undefined}
                       sp={turn.sp}
                       isCron={turn.isCron}
                     />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -500,6 +500,7 @@ export interface SessionMessageDto {
   seq: number
   sender: string
   senderName?: string // daemon-resolved display name; absent if unknown
+  senderAvatarUrl?: string // public provider-hosted profile image
   trustedAgentBot?: boolean // daemon-verified AgentConnect Slack bot provenance
   ts: string
   kind: string


### PR DESCRIPTION
## Summary

- carry public provider-hosted participant avatar URLs through normalized ingress, daemon session history, the Control Plane DTO, and the Web UI
- resolve human avatars from Slack `users.info`, Discord's CDN URL, Feishu/Lark `contact.user.get`, and GitHub's signed webhook actor metadata
- prefer the platform avatar over linked AgentConnect profile pictures or initials; use the GitHub mark only as the GitHub Hook actor fallback
- isolate cached avatars by physical provider connection so identical platform user IDs cannot bleed across integrations

## Provider coverage

- Slack: cached off the message hot path from `profile.image_72` (including shared HTTP ingress)
- Discord: captured directly from the gateway user and refreshed by user lookup
- Feishu/Lark: cached from `avatar_72`
- GitHub: propagated from the webhook sender metadata
- Telegram: retains initials because Bot API profile photos require an authenticated file URL; no bot-token-bearing URL is exposed to the browser

## Validation

- typecheck: protocol, message, daemon, relay, Control Plane, and Web packages
- ESLint on all changed source and test files; full repository lint also passed in the pre-push hook
- daemon resolver/store/session-reader tests: 76 passed
- protocol relay-daemon tests: 24 passed
- focused GitHub hook normalization tests passed in daemon and relay

Created by Codex . GPT-5
