### PR TITLE
feat(webchat): turn-final context refresh for multi-agent conversations

### DIFF
--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -115,10 +115,13 @@ answer publication boundary.
 - V1 does not reconcile message edits, deletes, reactions, or transient platform
   chrome. The context revision is advanced by newly observed conversational messages.
 - Headless hooks, cron turns without an IM destination, GitHub final comments, and
-  webchat are outside the initial rollout. Webchat can adopt the same staging contract
-  later, but a single-agent webchat conversation has no independent shared IM thread
-  to refresh today. Multi-agent webchat conversations do, and specify that adoption in
-  [webchat-multi-agents.md](webchat-multi-agents.md) section 5.4.
+  webchat are outside the initial rollout. A single-agent webchat conversation has no
+  independent shared IM thread to refresh. Multi-agent webchat conversations do, and
+  implement the adoption specified in
+  [webchat-multi-agents.md](webchat-multi-agents.md) section 5.4 — the same
+  coordinator, budgets, and regeneration loop, with the commit fence on the canonical
+  conversation post instead of staged platform delivery (the browser stream stays
+  live).
 - The design does not merge ACP sessions between agents. Each agent still has its own
   ACP session and catches up through normalized thread text.
 

--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -388,10 +388,11 @@ concurrent agent streams need only an attribution field:
 - `cancel` gains optional `agentId`; absent means every live turn in the
   conversation (today's resolution is already conversation-scoped,
   `daemon.ts:5240-5267`, but must stop matching only the first hit).
-- `WebchatOutput`/`WebchatDone` gain a `generation` counter and `WebchatDone`
-  a `superseded` stop reason, used by the turn-final context refresh
-  (section 5.4): a superseded generation's stream ends, and the replacement
-  streams under the same `turnId` with `generation + 1`.
+- `WebchatEvent` gains a `superseded` kind (carrying the replacement's
+  generation ordinal), used by the turn-final context refresh (section 5.4):
+  the discarded candidate's lane collapses in place and the replacement
+  streams under the same `turnId`. Supersession is an event rather than a
+  terminal frame — the turn still ends with exactly one `done`.
 
 ### 5.4 Turn-final context refresh before commit
 
@@ -423,17 +424,26 @@ multi-agent webchat adopts the same workflow with three adaptations:
   the audience is a shared channel; the webchat live stream is a watch
   surface private to the one human who is also the only source of human
   churn. Tokens keep streaming as today. When the final refresh invalidates a
-  candidate, the browser receives `done { stopReason: 'superseded' }` plus a
-  chrome notice ("the conversation moved on — updating the answer"), and the
-  replacement generation streams under the same `turnId`. Only the accepted
-  generation becomes the canonical post, fans out as context, and is recorded
-  as delivered; discarded generations follow that design's transcript and
-  usage rules — audit-visible, usage counted, never delivered.
+  candidate, the browser receives a `superseded` stream EVENT (carrying the
+  replacement's generation ordinal) — not a terminal frame: the turn still
+  ends with exactly one `done`, so replay windows, busy state, and older
+  browsers (which ignore unknown event kinds) stay coherent. The console
+  collapses the lane with a "the conversation moved on — updating this
+  answer" marker and the replacement generation streams under the same
+  `turnId`. Only the accepted generation becomes the canonical post, fans
+  out as context, and is recorded as delivered; discarded generations follow
+  that design's transcript and usage rules — audit-visible, usage counted,
+  never delivered.
+- **One co-hosting subtlety.** A co-hosted participant dispatching the SAME
+  user turn bumps the shared trigger row's transcript revision (its
+  recipient-delivery write), which would re-surface this agent's own trigger
+  as a "new" message at the final fence. The trigger's canonical `at` is
+  carried on the message, so the invalidation filter excludes that exact ts.
 
 Retry budgets are the IM defaults (three replacement generations, a
-two-minute regeneration cap, the 50-event replay cap). Exhaustion follows the
-context-churn terminalization rules, with the daemon-authored notice rendered
-as chrome in the conversation.
+two-minute regeneration cap, the 50-event replay cap). Exhaustion closes the
+browser turn explicitly — a daemon-authored warning message event followed by
+`done { stopReason: 'context_churn' }` — and commits no canonical post.
 
 Two scope rules:
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5255,6 +5255,19 @@ export class Daemon {
       this.agents.get(result.agentId)?.allowRuntimeChangesInChat === true ? requestedRuntime : undefined
     const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink, initialRuntime, remoteMcp)
     if (postSink) stream.postSink = postSink
+    // Observed-inbound analogue for webchat (turn-final refresh, §5.4): record the
+    // user message at ADMISSION — not only when its turn eventually runs — so a
+    // generation already in flight for this agent can see it at the final fence
+    // and coalesce the queued activation. The identical later append from
+    // SessionManager.handle dedups in place (same canonical ts, sender, text).
+    if (post && this.cfg.features.turnFinalContextRefresh) {
+      const observedMention = attachmentMention(msg.attachments)
+      this.appendWebchatTextRow(transcriptChannelKey(chatId, undefined), `webchat:${chatId}`, String(post.at), {
+        sender: user,
+        recipient: result.agentId,
+        text: observedMention ? `${text}\n${observedMention}`.trim() : text
+      })
+    }
     void this.dispatch(result.agentId, msg, undefined, stream).catch((err) => {
       if (!(err instanceof LifecycleCleanupBlockedError))
         this.log.error(`webchat dispatch failed for agent "${result.agentId}": ${formatErr(err)}`)
@@ -8309,6 +8322,14 @@ export class Daemon {
         continue
       }
       count += 1
+      if (entry.webchat && !entry.webchat.doneSent) {
+        entry.webchat.doneSent = true
+        entry.webchat.sink.done({
+          conversationId: entry.webchat.conversationId,
+          turnId: entry.webchat.turnId,
+          stopReason: 'coalesced_into_turn'
+        })
+      }
       const { thread, ts } = transcriptCoords(entry.msg)
       const mention = attachmentMention(entry.msg.attachments)
       this.store.appendTranscript({
@@ -10629,17 +10650,21 @@ export class Daemon {
         // runtime ready gates were awaiting. Queue entries remain untouched until
         // every gate above has succeeded.
         const initialRefresh = await this.refreshTurnContext(p, baseRevision, providerCheckpoint, false)
+        // Webchat: a co-hosted participant's recipient-delivery bump can re-surface
+        // this agent's OWN trigger during the pre-prompt gates too — same exclusion
+        // as the final fence (the trigger's canonical ts rides the message).
+        const initialEvents = p.webchatRefresh
+          ? initialRefresh.events.filter((event) => msg.transcriptTs === undefined || event.ts !== msg.transcriptTs)
+          : initialRefresh.events
         const representedEventTs = new Set([
           ...(handled.contextEventTs ?? []),
-          ...initialRefresh.events.map((event) => event.ts)
+          ...initialEvents.map((event) => event.ts)
         ])
         const deltaBlocks: import('@agentclientprotocol/sdk').ContentBlock[] = []
-        if (initialRefresh.events.length > 0) {
+        if (initialEvents.length > 0) {
           deltaBlocks.push({
             type: 'text',
-            text: initialContextDeltaText(initialRefresh.events, (event) =>
-              this.observedQuoteBlock(event, initialRefresh.events)
-            )
+            text: initialContextDeltaText(initialEvents, (event) => this.observedQuoteBlock(event, initialEvents))
           })
         }
         promptBlocks.push(...deltaBlocks)
@@ -10776,19 +10801,11 @@ export class Daemon {
 
         this.discardStagedAttempt(p)
         if (p.webchatRefresh && p.webchat) {
-          // The live stream already showed the discarded candidate (webchat
-          // streams are never staged, §5.4) — tell the browser to collapse the
-          // lane in place; the replacement generation streams under the SAME
-          // turnId. The canonical post must carry only the accepted text.
+          // The canonical post — and post-turn memory / turn.completed.output —
+          // must carry only the accepted generation. Webchat chunks accumulate
+          // into BOTH buffers (the stream is never staged), so clear both.
           p.webchat.replyText = ''
-          if (!p.webchat.doneSent) {
-            p.webchat.sink.output({
-              conversationId: p.webchat.conversationId,
-              turnId: p.webchat.turnId,
-              index: p.webchat.index++,
-              event: { kind: 'superseded', generation: generation + 1 }
-            })
-          }
+          p.replyText = ''
         }
         this.emitEvaluation({
           type: 'turn.context_changed',
@@ -10857,6 +10874,17 @@ export class Daemon {
 
         // Retry-budget decision precedes queue mutation. Only activations whose
         // provider ids are present in this exact replacement prompt are absorbed.
+        // The browser supersession marker fires HERE — after the budget check —
+        // so it is only ever followed by a real replacement generation, never by
+        // the context-churn terminal (§5.4: "the replacement streams next").
+        if (p.webchatRefresh && p.webchat && !p.webchat.doneSent) {
+          p.webchat.sink.output({
+            conversationId: p.webchat.conversationId,
+            turnId: p.webchat.turnId,
+            index: p.webchat.index++,
+            event: { kind: 'superseded', generation: generation + 1 }
+          })
+        }
         defaultTurnOutputMetrics.candidateDiscarded('context_changed')
         this.coalesceQueuedContext(key, sessionId, eventTs)
         baseRevision = this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread)

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5262,11 +5262,22 @@ export class Daemon {
     // SessionManager.handle dedups in place (same canonical ts, sender, text).
     if (post && this.cfg.features.turnFinalContextRefresh) {
       const observedMention = attachmentMention(msg.attachments)
-      this.appendWebchatTextRow(transcriptChannelKey(chatId, undefined), `webchat:${chatId}`, String(post.at), {
-        sender: user,
-        recipient: result.agentId,
-        text: observedMention ? `${text}\n${observedMention}`.trim() : text
-      })
+      const observedTs = this.appendWebchatTextRow(
+        transcriptChannelKey(chatId, undefined),
+        `webchat:${chatId}`,
+        String(post.at),
+        {
+          sender: user,
+          recipient: result.agentId,
+          text: observedMention ? `${text}\n${observedMention}`.trim() : text
+        }
+      )
+      // The slot may have been collision-bumped (a self-authored row can occupy
+      // the canonical millisecond). The message must carry the ts its row
+      // ACTUALLY landed on: queue coalescing matches activations by
+      // transcriptCoords ts, and a mismatch would run the follow-up again as a
+      // separate turn after the regeneration already answered it.
+      msg.transcriptTs = observedTs
     }
     void this.dispatch(result.agentId, msg, undefined, stream).catch((err) => {
       if (!(err instanceof LifecycleCleanupBlockedError))

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1110,6 +1110,13 @@ interface Pending {
   /** Interactive IM platforms use staged answer delivery; webchat/hooks keep their
    * existing transport-specific contracts and remain outside the initial rollout. */
   stageAnswer: boolean
+  /** Turn-final context refresh for webchat conversations (webchat-multi-agents.md
+   * §5.4): the browser stream stays LIVE (no answer staging) — only the canonical
+   * post commit (reply record + rd/webchat-post) is fenced. Invalidation comes
+   * from conversation posts other participants produced (relay `context` ops
+   * recorded into the shared transcript); a single-agent conversation receives
+   * none, so the check is inert there. */
+  webchatRefresh: boolean
   /** Tool-call ids structurally identified as this daemon's own MCP tools. Approval
    *  requests may carry only this opaque id, regardless of which ACP path is used. */
   builtinSystemToolCallIds: Set<string>
@@ -10432,6 +10439,7 @@ export class Daemon {
           msg.platform === 'telegram' ||
           msg.platform === 'discord' ||
           msg.platform === 'feishu'),
+      webchatRefresh: this.cfg.features.turnFinalContextRefresh && !!webchat && msg.platform === 'webchat',
       builtinSystemToolCallIds: new Set(),
       hiddenSessionTitleToolCallIds: new Set(),
       agentId,
@@ -10616,7 +10624,7 @@ export class Daemon {
       let baseRevision =
         handled.contextRevision ?? this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread)
       let providerCheckpoint = handled.providerCheckpoint
-      if (p.stageAnswer) {
+      if (p.stageAnswer || p.webchatRefresh) {
         // Recheck observations that landed while attachments, memory recall, or
         // runtime ready gates were awaiting. Queue entries remain untouched until
         // every gate above has succeeded.
@@ -10730,7 +10738,7 @@ export class Daemon {
           }
         }
 
-        if (!p.stageAnswer) break
+        if (!p.stageAnswer && !p.webchatRefresh) break
 
         const refresh = await this.refreshTurnContext(p, baseRevision, providerCheckpoint, true)
         providerCheckpoint = refresh.providerCheckpoint ?? providerCheckpoint
@@ -10749,13 +10757,17 @@ export class Daemon {
         // Recheck once more after provider I/O reconciliation returned. This is the
         // local commit fence that catches gateway events arriving during that read.
         const lateEvents = this.localInvalidatingEvents(p, refresh.revision)
-        const invalidatingEvents = [...refresh.events, ...lateEvents].sort(
-          (a, b) => a.eventTimeUs - b.eventTimeUs || a.seq - b.seq
-        )
+        const invalidatingEvents = [...refresh.events, ...lateEvents]
+          // Webchat: a co-hosted participant dispatching the SAME user turn bumps
+          // the shared trigger row's revision (recipient-delivery write), which
+          // would re-surface this agent's OWN trigger as a "new" message. The
+          // trigger's canonical ts is carried on the message — exclude it.
+          .filter((event) => !p.webchatRefresh || msg.transcriptTs === undefined || event.ts !== msg.transcriptTs)
+          .sort((a, b) => a.eventTimeUs - b.eventTimeUs || a.seq - b.seq)
         const finalRevision = this.store.threadTranscriptRevision(p.transcriptChannel, p.statusThread)
 
         if (invalidatingEvents.length === 0) {
-          this.acceptStagedAttempt(p)
+          if (p.stageAnswer) this.acceptStagedAttempt(p)
           if (generation > 0) defaultTurnOutputMetrics.regeneration(p.platform, 'accepted')
           defaultTurnOutputMetrics.generations(generation + 1)
           baseRevision = finalRevision
@@ -10763,6 +10775,21 @@ export class Daemon {
         }
 
         this.discardStagedAttempt(p)
+        if (p.webchatRefresh && p.webchat) {
+          // The live stream already showed the discarded candidate (webchat
+          // streams are never staged, §5.4) — tell the browser to collapse the
+          // lane in place; the replacement generation streams under the SAME
+          // turnId. The canonical post must carry only the accepted text.
+          p.webchat.replyText = ''
+          if (!p.webchat.doneSent) {
+            p.webchat.sink.output({
+              conversationId: p.webchat.conversationId,
+              turnId: p.webchat.turnId,
+              index: p.webchat.index++,
+              event: { kind: 'superseded', generation: generation + 1 }
+            })
+          }
+        }
         this.emitEvaluation({
           type: 'turn.context_changed',
           agentId,
@@ -10794,6 +10821,30 @@ export class Daemon {
           defaultTurnOutputMetrics.contextChurnExhausted(p.platform)
           defaultTurnOutputMetrics.generations(generation + 1)
           finishEvaluation('turn.cancelled', { reason: 'context_churn', generations: generation + 1 })
+          if (p.webchat) {
+            // No canonical post: the churned candidate is never committed or
+            // fanned out. Close the browser turn explicitly — a bare return
+            // would leave the stream open and the composer stuck busy.
+            p.webchat.replyText = ''
+            if (!p.webchat.doneSent) {
+              p.webchat.doneSent = true
+              p.webchat.sink.output({
+                conversationId: p.webchat.conversationId,
+                turnId: p.webchat.turnId,
+                index: p.webchat.index++,
+                event: {
+                  kind: 'message',
+                  text: '⚠️ The conversation kept changing while I was answering, so I stopped this reply. Ask again when it settles.'
+                }
+              })
+              p.webchat.sink.done({
+                conversationId: p.webchat.conversationId,
+                turnId: p.webchat.turnId,
+                stopReason: 'context_churn'
+              })
+            }
+            return null
+          }
           this.showActivity(replyConn, msg.channel, statusThread, '')
           if (p.conv instanceof FeishuConverger) this.enqueueApply(p, { kind: 'card-cancel' })
           if (queuedMatches.length === 0 && mode !== 'none') {

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -223,6 +223,90 @@ describe('webchat turn-final context refresh', () => {
     await daemon.stop()
   })
 
+  it('coalesces a busy follow-up even when its canonical millisecond was collision-bumped', async () => {
+    let onUpdate!: (sid: string, u: unknown) => void
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const prompts: string[] = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-wc-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string, blocks: { text?: string }[]) => {
+        prompts.push(blocks.map((b) => b.text ?? '').join('\n'))
+        if (prompts.length === 1) {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'stale candidate' } })
+          await firstBlocked
+        } else {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'combined answer' } })
+        }
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent: unknown, cb: (sid: string, u: unknown) => void) => {
+        onUpdate = cb
+        return host as any
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const first: RdChatEvent[] = []
+    const second: RdChatEvent[] = []
+    const posts: RdWebchatPost[] = []
+    ;(daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'original request', user: 'owner', turnId: TURN, post: { postId: TURN, at: 1_000 } }),
+      (event: RdChatEvent) => first.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
+
+    // A FOREIGN row (e.g. this agent's own earlier reply) already occupies the
+    // follow-up's canonical millisecond, so its admission row lands one slot
+    // later. The bumped ts must ride the queued message — otherwise the queue
+    // match misses and the follow-up runs again as a third prompt.
+    ;(daemon as any).store.appendTranscript({
+      channel: transcriptChannelKey(CONV, undefined),
+      thread: `webchat:${CONV}`,
+      ts: '1500',
+      sender: AGENT_ID,
+      kind: 'text',
+      text: 'earlier self-authored row'
+    })
+    const secondTurn = '66666666-6666-4666-8666-666666666666'
+    ;(daemon as any).handleRelayMsg(
+      rd(
+        {
+          op: 'turn',
+          text: 'also compare memory usage',
+          user: 'owner',
+          turnId: secondTurn,
+          post: { postId: secondTurn, at: 1_500 }
+        },
+        { msgId: 'm-2' }
+      ),
+      (event: RdChatEvent) => second.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+    releaseFirst()
+
+    await vi.waitFor(() => expect(first.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    await vi.waitFor(() => expect(second.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    expect(host.prompt).toHaveBeenCalledTimes(2) // regeneration absorbed it — no third prompt
+    expect(prompts[1]).toContain('[owner] also compare memory usage')
+    const secondDone = second.find((e) => e.kind === 'done')
+    expect(secondDone && secondDone.kind === 'done' ? secondDone.done.stopReason : undefined).toBe(
+      'coalesced_into_turn'
+    )
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.post.text).toBe('combined answer')
+    await daemon.stop()
+  })
+
   it('context-churn exhaustion closes the browser turn with stopReason context_churn and commits no post', async () => {
     let onUpdate!: (sid: string, u: unknown) => void
     let promptCount = 0

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { Daemon } from '../src/daemon.js'
+import { transcriptChannelKey } from '../src/store/local-store.js'
+import type { RdChatEvent, RdMsgWebchat, RdWebchatPost } from '@agentconnect.md/protocol'
+
+// Turn-final context refresh for multi-agent webchat (webchat-multi-agents.md §5.4):
+// the browser stream stays live, so supersession is a stream EVENT and the fenced
+// commit is the canonical post (transcript reply row + rd/webchat-post).
+
+const AGENT_ID = 'bot-a'
+const PEER_ID = 'agent-b'
+const CONV = '88888888-8888-4888-8888-888888888888'
+const TURN = '77777777-7777-4777-8777-777777777777'
+const WAIT = { timeout: 10_000 }
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-wc-refresh-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      features: { turnFinalContextRefresh: true },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', AGENT_ID)
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: AGENT_ID,
+      name: AGENT_ID,
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' }
+    })
+  )
+  return root
+}
+
+function fakeCpClient() {
+  return { emitUsageReport: vi.fn(), emitSessionActivity: vi.fn(), stop: vi.fn(async () => {}) }
+}
+
+const rd = (payload: RdMsgWebchat['payload'], over: Partial<RdMsgWebchat> = {}): RdMsgWebchat => ({
+  source: 'webchat',
+  agentId: AGENT_ID,
+  sessionKey: CONV,
+  msgId: 'm-1',
+  chatId: CONV,
+  payload,
+  ...over
+})
+
+const peerPost = (n: number, at: number) => ({
+  postId: `0000000${n}-0000-4000-8000-00000000000${n}`,
+  conversationId: CONV,
+  author: { kind: 'agent' as const, agentId: PEER_ID },
+  text: `peer answer ${n}`,
+  at
+})
+
+describe('webchat turn-final context refresh', () => {
+  it('a peer context post discards the streamed candidate; only the replacement becomes the canonical post', async () => {
+    let onUpdate!: (sid: string, u: unknown) => void
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const prompts: string[] = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-wc-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string, blocks: { text?: string }[]) => {
+        prompts.push(blocks.map((b) => b.text ?? '').join('\n'))
+        if (prompts.length === 1) {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'stale candidate' } })
+          await firstBlocked
+        } else {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'fresh replacement' } })
+        }
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent: unknown, cb: (sid: string, u: unknown) => void) => {
+        onUpdate = cb
+        return host as any
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const events: RdChatEvent[] = []
+    const posts: RdWebchatPost[] = []
+    const ack = (daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'original request', user: 'owner', turnId: TURN, post: { postId: TURN, at: 1_000 } }),
+      (event: RdChatEvent) => events.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+    expect(ack).toMatchObject({ accepted: true, turnId: TURN })
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
+
+    // A peer participant's reply lands as a transcript-only context post while
+    // this agent is still generating — it must invalidate the candidate.
+    const ctxAck = (daemon as any).handleRelayMsg(
+      rd({ op: 'context', post: peerPost(1, 2_000) }, { msgId: 'ctx-1' }),
+      () => {}
+    )
+    expect(ctxAck).toMatchObject({ accepted: true })
+    releaseFirst()
+
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    // The browser saw the supersession marker (same turnId, live stream), then
+    // the replacement, then exactly one terminal done.
+    const kinds = events.flatMap((e) => (e.kind === 'output' && e.output.event ? [e.output.event.kind] : []))
+    expect(kinds).toContain('superseded')
+    expect(events.filter((e) => e.kind === 'done')).toHaveLength(1)
+
+    // The replacement prompt names the peer's message; the agent's OWN trigger
+    // is not re-presented as a "new" thread message.
+    expect(prompts[1]).toContain('AgentConnect context update')
+    expect(prompts[1]).toContain(`[${PEER_ID}] peer answer 1`)
+    expect(prompts[1]).not.toContain('original request')
+
+    // Canonical commit: one rd/webchat-post and one transcript reply row, both
+    // carrying only the accepted generation.
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.post.text).toBe('fresh replacement')
+    const replies = (daemon as any).store
+      .transcriptSince(transcriptChannelKey(CONV, undefined), `webchat:${CONV}`, null)
+      .filter((row: { sender: string }) => row.sender === AGENT_ID)
+      .map((row: { text: string }) => row.text)
+    expect(replies).toEqual(['fresh replacement'])
+    await daemon.stop()
+  })
+
+  it('context-churn exhaustion closes the browser turn with stopReason context_churn and commits no post', async () => {
+    let onUpdate!: (sid: string, u: unknown) => void
+    let promptCount = 0
+    const daemonHolder: { current?: Daemon } = {}
+    const injectContext = (n: number): void => {
+      ;(daemonHolder.current as any).handleRelayMsg(
+        rd({ op: 'context', post: peerPost(n, 2_000 + n) }, { msgId: `ctx-${n}` }),
+        () => {}
+      )
+    }
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-wc-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string) => {
+        promptCount += 1
+        onUpdate(sid, {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: `candidate ${promptCount}` }
+        })
+        // A fresh peer post lands during EVERY generation, so the final refresh
+        // never accepts and the retry budget (3 regenerations) runs dry.
+        injectContext(promptCount)
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent: unknown, cb: (sid: string, u: unknown) => void) => {
+        onUpdate = cb
+        return host as any
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+    daemonHolder.current = daemon
+
+    const events: RdChatEvent[] = []
+    const posts: RdWebchatPost[] = []
+    ;(daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'original request', user: 'owner', turnId: TURN, post: { postId: TURN, at: 1_000 } }),
+      (event: RdChatEvent) => events.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    expect(host.prompt).toHaveBeenCalledTimes(4) // original + 3 budgeted regenerations
+    const done = events.find((e) => e.kind === 'done')
+    expect(done && done.kind === 'done' ? done.done.stopReason : undefined).toBe('context_churn')
+    // The churned candidate is never committed: no canonical post, no reply row.
+    expect(posts).toHaveLength(0)
+    const replies = (daemon as any).store
+      .transcriptSince(transcriptChannelKey(CONV, undefined), `webchat:${CONV}`, null)
+      .filter((row: { sender: string }) => row.sender === AGENT_ID)
+    expect(replies).toEqual([])
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -145,6 +145,84 @@ describe('webchat turn-final context refresh', () => {
     await daemon.stop()
   })
 
+  it('a busy same-agent follow-up is visible to the running generation and coalesces into it', async () => {
+    let onUpdate!: (sid: string, u: unknown) => void
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const prompts: string[] = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-wc-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sid: string, blocks: { text?: string }[]) => {
+        prompts.push(blocks.map((b) => b.text ?? '').join('\n'))
+        if (prompts.length === 1) {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'stale candidate' } })
+          await firstBlocked
+        } else {
+          onUpdate(sid, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'combined answer' } })
+        }
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: (_agent: unknown, cb: (sid: string, u: unknown) => void) => {
+        onUpdate = cb
+        return host as any
+      }
+    })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const first: RdChatEvent[] = []
+    const second: RdChatEvent[] = []
+    const posts: RdWebchatPost[] = []
+    ;(daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'original request', user: 'owner', turnId: TURN, post: { postId: TURN, at: 1_000 } }),
+      (event: RdChatEvent) => first.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
+
+    // A follow-up targeted at the SAME busy agent (e.g. from another tab): it is
+    // observed at admission, so the running generation can see and absorb it.
+    const secondTurn = '66666666-6666-4666-8666-666666666666'
+    const ack2 = (daemon as any).handleRelayMsg(
+      rd(
+        {
+          op: 'turn',
+          text: 'also compare memory usage',
+          user: 'owner',
+          turnId: secondTurn,
+          post: { postId: secondTurn, at: 1_500 }
+        },
+        { msgId: 'm-2' }
+      ),
+      (event: RdChatEvent) => second.push(event),
+      (post: RdWebchatPost) => posts.push(post)
+    )
+    expect(ack2).toMatchObject({ accepted: true, turnId: secondTurn })
+    releaseFirst()
+
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    await vi.waitFor(() => expect(first.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    // The replacement prompt carries the follow-up; the queued activation is
+    // coalesced — its browser turn closes explicitly instead of hanging.
+    expect(prompts[1]).toContain('[owner] also compare memory usage')
+    await vi.waitFor(() => expect(second.some((e) => e.kind === 'done')).toBe(true), WAIT)
+    const secondDone = second.find((e) => e.kind === 'done')
+    expect(secondDone && secondDone.kind === 'done' ? secondDone.done.stopReason : undefined).toBe(
+      'coalesced_into_turn'
+    )
+    expect(posts).toHaveLength(1)
+    expect(posts[0]!.post.text).toBe('combined answer')
+    await daemon.stop()
+  })
+
   it('context-churn exhaustion closes the browser turn with stopReason context_churn and commits no post', async () => {
     let onUpdate!: (sid: string, u: unknown) => void
     let promptCount = 0
@@ -196,6 +274,14 @@ describe('webchat turn-final context refresh', () => {
     expect(host.prompt).toHaveBeenCalledTimes(4) // original + 3 budgeted regenerations
     const done = events.find((e) => e.kind === 'done')
     expect(done && done.kind === 'done' ? done.done.stopReason : undefined).toBe('context_churn')
+    // A superseded marker promises a replacement generation — it fires once per
+    // budgeted regeneration and NEVER on the exhausted discard (the browser must
+    // not see "updating this answer…" right before the turn dies).
+    const outputEvents = events.flatMap((e) => (e.kind === 'output' && e.output.event ? [e.output.event] : []))
+    expect(outputEvents.filter((e) => e.kind === 'superseded')).toHaveLength(3)
+    const lastSuperseded = outputEvents.map((e) => e.kind).lastIndexOf('superseded')
+    const warning = outputEvents.findIndex((e) => e.kind === 'message' && e.text.startsWith('⚠️'))
+    expect(warning).toBeGreaterThan(lastSuperseded)
     // The churned candidate is never committed: no canonical post, no reply row.
     expect(posts).toHaveLength(0)
     const replies = (daemon as any).store

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -79,7 +79,15 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // daemon persists it (session/list surfaces it on the persisted row); this streams
   // the same value so the LIVE playground session renames itself in place, matching
   // what a Slack session shows once its title lands.
-  z.object({ kind: z.literal('session_info'), title: z.string() })
+  z.object({ kind: z.literal('session_info'), title: z.string() }),
+  // A turn-final context refresh discarded the streamed candidate
+  // (webchat-multi-agents.md §5.4): the conversation changed while the agent was
+  // answering, so the browser collapses this lane's streamed text in place and
+  // the replacement generation streams next under the SAME turnId. `generation`
+  // is the replacement's ordinal (1 = first retry). An event rather than a
+  // terminal frame: the turn still ends with exactly one `done`, so replay,
+  // busy-state, and older browsers (which ignore unknown kinds) stay coherent.
+  z.object({ kind: z.literal('superseded'), generation: z.number().int() })
 ])
 export type WebchatEvent = z.infer<typeof WebchatEvent>
 

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -334,10 +334,18 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         ]
         if (ev.kind === 'superseded') {
           // Turn-final context refresh discarded the streamed candidate
-          // (webchat-multi-agents.md §5.4): break the lane with a marker so the
-          // replacement generation starts a fresh block instead of merging into
-          // the discarded text.
-          return [...steps, lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…' })]
+          // (webchat-multi-agents.md §5.4): COLLAPSE the discarded answer —
+          // this lane's streamed 'done' blocks since the last user message move
+          // into the collapsible work lane ('plan') — then break the lane with
+          // a marker so the replacement starts a fresh answer block.
+          const collapsed = [...steps]
+          for (let i = collapsed.length - 1; i >= 0; i--) {
+            const step = collapsed[i]!
+            if (step.kind === 'msg' && step.agentId === undefined) break
+            if ((step.agentId ?? undefined) !== agentId) continue
+            if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan' }
+          }
+          return [...collapsed, lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…' })]
         }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -322,7 +322,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           for (let i = steps.length - 1; i >= 0; i--) {
             const step = steps[i]!
             if (step.kind === 'msg' && step.agentId === undefined) return -1
-            if ((step.agentId ?? undefined) === agentId) return i
+            if ((step.agentId ?? undefined) !== agentId) continue
+            // The supersession marker is a hard boundary: the replacement
+            // generation starts fresh blocks instead of merging into it (or
+            // into the collapsed discarded work behind it).
+            if (step.boundary) return -1
+            return i
           }
           return -1
         })()
@@ -343,9 +348,16 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             const step = collapsed[i]!
             if (step.kind === 'msg' && step.agentId === undefined) break
             if ((step.agentId ?? undefined) !== agentId) continue
+            if (step.boundary) break
             if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan' }
           }
-          return [...collapsed, lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…' })]
+          // The marker is a VISIBLE conversation step ('done', not the
+          // collapsible work lane) fenced with `boundary` so replacement chunks
+          // never merge into it.
+          return [
+            ...collapsed,
+            lane({ kind: 'done', text: 'The conversation moved on — updating this answer…', boundary: true })
+          ]
         }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -131,6 +131,7 @@ type WebchatEvent =
   | { kind: 'tool_call'; toolCallId: string; title: string; status: string }
   | { kind: 'tool_update'; toolCallId: string; status: string }
   | { kind: 'session_info'; title: string }
+  | { kind: 'superseded'; generation: number }
 
 /** The session status snapshot carried in a relay `rd/chat` WebchatOutput payload
  *  (mirrors protocol WebchatStatus). Partial: context/cost stream live, token
@@ -331,6 +332,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           step,
           ...steps.slice(i + 1)
         ]
+        if (ev.kind === 'superseded') {
+          // Turn-final context refresh discarded the streamed candidate
+          // (webchat-multi-agents.md §5.4): break the lane with a marker so the
+          // replacement generation starts a fresh block instead of merging into
+          // the discarded text.
+          return [...steps, lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…' })]
+        }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {
             return replaceAt(laneIndex, { ...last, text: last.text + ev.text, observedAtMs })

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -766,6 +766,10 @@ export interface SessionStep {
   /** Authoring participant of a live multi-agent webchat step — keys the per-agent
    *  stream lane accumulation and the per-block attribution label. */
   agentId?: string
+  /** Hard lane boundary (the supersession marker): chunk accumulation for this
+   *  step's lane never merges across it, so a replacement generation starts
+   *  fresh blocks while the marker stays a visible part of the conversation. */
+  boundary?: boolean
   /** Display timestamp for live/mock-only steps. Persisted transcripts use their raw ts. */
   time?: string
   text: string


### PR DESCRIPTION
## What

Turn-final context refresh for **multi-agent webchat conversations** (`webchat-multi-agents.md` §5.4) — the follow-up to #402, reusing the IM turn-output machinery from `turn-final-context-refresh.md` rather than building a parallel one.

An agent can spend minutes answering while the conversation keeps moving (a peer participant finishes first, a message from another tab lands). Before committing its reply, the agent's daemon now re-checks the conversation and regenerates in the same ACP session when it changed.

## How

Deliberately thin: the existing coordinator, regeneration loop, budgets, and metrics are reused as-is. The webchat difference is **where the commit fence sits**:

- **No answer staging.** The browser stream is a watch surface private to the owner, so tokens keep streaming live. The fenced commit is the **canonical conversation post** — the transcript reply row + `rd/webchat-post` fan-out — which already sits at turn end.
- **Invalidation source** = conversation posts other participants produced (relay `context` ops recorded into the shared transcript). A single-agent conversation receives none, so the check is inert there — "roster == 1 keeps today's behavior" needs no roster knowledge in the daemon.
- **Supersession is a stream EVENT** (`WebchatEvent` kind `superseded`, carrying the replacement's generation ordinal), not a terminal frame: the turn still ends with exactly one `done`, so replay windows, busy state, and older browsers (which ignore unknown kinds) stay coherent. The console collapses the lane with a "conversation moved on — updating this answer" marker; the replacement streams under the same `turnId`. Only the accepted generation is recorded and fanned out.
- **Churn exhaustion** (3 regenerations / 2-minute budget, the IM defaults) closes the browser turn explicitly: a warning message event + `done { stopReason: 'context_churn' }`, committing no post.
- **Co-hosting subtlety**: a co-hosted participant dispatching the same user turn bumps the shared trigger row's revision (recipient-delivery write), which would re-surface the agent's OWN trigger as "new" at the final fence — excluded by the trigger's canonical ts carried on the message.

Design docs updated in the same change (§5.3/§5.4 now describe the event-based mechanism; `turn-final-context-refresh.md`'s webchat note points at the implemented adoption).

## Tests

New `webchat-turn-refresh.test.ts`: (1) a peer context post mid-generation produces the `superseded` event, a replacement prompt naming the peer message (and NOT re-presenting the agent's own trigger), and exactly one canonical post/transcript row carrying only the accepted text; (2) sustained churn exhausts the budget → `done { stopReason: 'context_churn' }`, no post, no reply row. Daemon webchat/session/turn-output suites, web 573, protocol 240 all green; workspace typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
