### PR TITLE
fix(web): show session details on hover

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
@@ -705,8 +705,7 @@ export default function SessionDetailView() {
   } = usePlayground()
   const { user: viewer, me } = useProfile()
   const [copied, setCopied] = useState(false)
-  // Desktop header "Details" popover (run facts: status, duration, tokens, …).
-  const [detailOpen, setDetailOpen] = useState(false)
+  const detailTooltipId = useId()
   const [msgs, setMsgs] = useState<SessionMessageDto[] | null>(null)
   const [msgLoading, setMsgLoading] = useState(false)
   const [msgPaging, setMsgPaging] = useState(false)
@@ -1054,7 +1053,6 @@ export default function SessionDetailView() {
   useEffect(() => {
     imagePrepareGenerationRef.current += 1
     setCopied(false)
-    setDetailOpen(false)
     setWorkOverride(new Map())
     setImagePreparing(false)
     setImageError(null)
@@ -1593,61 +1591,60 @@ export default function SessionDetailView() {
           {visibilityControl}
           {/* `flex` on the wrapper: an inline-flex button in a block div sits on a text
             baseline, and the descender gap under it pushed the button off the row's
-            centre line. */}
-          <div
-            className="relative ml-[-3px] flex flex-none items-center"
-            onKeyDown={(event) => {
-              if (event.key !== 'Escape' || !detailOpen) return
-              event.stopPropagation()
-              setDetailOpen(false)
-            }}
-          >
+            centre line. The transparent top padding bridges the trigger/panel gap so
+            the hover target remains continuous. */}
+          <div className="group relative ml-[-3px] flex flex-none items-center">
             <button
-              className="inline-flex h-[22px] cursor-pointer items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
-              onClick={() => setDetailOpen((o) => !o)}
-              aria-haspopup="dialog"
-              aria-expanded={detailOpen}
-              title="Run details"
+              type="button"
+              className="inline-flex h-[22px] items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
+              aria-describedby={detailTooltipId}
+              onKeyDown={(event) => {
+                if (event.key !== 'Escape') return
+                event.preventDefault()
+                event.stopPropagation()
+                event.currentTarget.blur()
+              }}
             >
               <Icon name="info" size={14} />
               Details
             </button>
-            {detailOpen && (
-              <>
-                <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setDetailOpen(false)} />
-                <div role="dialog" aria-label="Run details" className="fmenu z-50 min-w-[216px] px-0 py-[5px]">
-                  {headerFacts.map((f) => (
-                    <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
-                      <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
-                      <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                        {f.label}
-                      </span>
-                      <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                        {f.value}
-                      </span>
+            <div
+              id={detailTooltipId}
+              role="tooltip"
+              className="pointer-events-none invisible absolute top-full left-0 z-50 w-max pt-[5px] opacity-0 transition-[opacity,visibility] group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100"
+            >
+              <div className="max-h-[340px] min-w-[216px] overflow-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) px-0 py-[5px] shadow-(--shadow-lg)">
+                {headerFacts.map((f) => (
+                  <div key={f.label} className="flex items-center gap-[9px] px-3 py-[5px]">
+                    <Icon name={f.icon} size={13} color="var(--text-tertiary)" className="flex-none" />
+                    <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                      {f.label}
+                    </span>
+                    <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
+                      {f.value}
+                    </span>
+                  </div>
+                ))}
+                {usageEntries.length > 0 && (
+                  <>
+                    <div className="my-1 border-t border-(--border-subtle)" />
+                    <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
+                      Token usage
                     </div>
-                  ))}
-                  {usageEntries.length > 0 && (
-                    <>
-                      <div className="my-1 border-t border-(--border-subtle)" />
-                      <div className="px-3 pt-1 pb-[2px] font-mono text-[10px] font-semibold uppercase tracking-[.06em] text-(--text-tertiary)">
-                        Token usage
+                    {usageEntries.map((e) => (
+                      <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
+                        <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
+                          {e.label}
+                        </span>
+                        <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
+                          {e.value}
+                        </span>
                       </div>
-                      {usageEntries.map((e) => (
-                        <div key={e.label} className="flex items-center gap-[9px] py-1 pr-3 pl-[34px]">
-                          <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
-                            {e.label}
-                          </span>
-                          <span className="mono whitespace-nowrap text-[12px] font-semibold text-(--text-primary)">
-                            {e.value}
-                          </span>
-                        </div>
-                      ))}
-                    </>
-                  )}
-                </div>
-              </>
-            )}
+                    ))}
+                  </>
+                )}
+              </div>
+            </div>
           </div>
           <button
             className="ml-auto flex h-[19px] w-[19px] flex-none cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0 text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary)"

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -706,7 +706,13 @@ export default function SessionDetailView() {
   const { user: viewer, me } = useProfile()
   const [copied, setCopied] = useState(false)
   const detailTooltipId = useId()
-  const [detailOpen, setDetailOpen] = useState(false)
+  const [detailInteraction, setDetailInteraction] = useState({ hovered: false, focused: false, dismissed: false })
+  const detailOpen = (detailInteraction.hovered || detailInteraction.focused) && !detailInteraction.dismissed
+  const updateDetailPresence = (key: 'hovered' | 'focused', value: boolean) =>
+    setDetailInteraction((current) => {
+      const next = { ...current, [key]: value }
+      return { ...next, dismissed: next.hovered || next.focused ? current.dismissed : false }
+    })
   const [msgs, setMsgs] = useState<SessionMessageDto[] | null>(null)
   const [msgLoading, setMsgLoading] = useState(false)
   const [msgPaging, setMsgPaging] = useState(false)
@@ -747,7 +753,7 @@ export default function SessionDetailView() {
       if (event.key !== 'Escape') return
       event.preventDefault()
       event.stopPropagation()
-      setDetailOpen(false)
+      setDetailInteraction((current) => ({ ...current, dismissed: true }))
     }
     document.addEventListener('keydown', dismissDetails, true)
     return () => document.removeEventListener('keydown', dismissDetails, true)
@@ -1068,7 +1074,7 @@ export default function SessionDetailView() {
   useEffect(() => {
     imagePrepareGenerationRef.current += 1
     setCopied(false)
-    setDetailOpen(false)
+    setDetailInteraction({ hovered: false, focused: false, dismissed: false })
     setWorkOverride(new Map())
     setImagePreparing(false)
     setImageError(null)
@@ -1611,10 +1617,10 @@ export default function SessionDetailView() {
             the hover target remains continuous. */}
           <div
             className="relative ml-[-3px] flex flex-none items-center"
-            onMouseEnter={() => setDetailOpen(true)}
-            onMouseLeave={() => setDetailOpen(false)}
-            onFocus={() => setDetailOpen(true)}
-            onBlur={() => setDetailOpen(false)}
+            onMouseEnter={() => updateDetailPresence('hovered', true)}
+            onMouseLeave={() => updateDetailPresence('hovered', false)}
+            onFocus={() => updateDetailPresence('focused', true)}
+            onBlur={() => updateDetailPresence('focused', false)}
           >
             <button
               type="button"

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -706,6 +706,7 @@ export default function SessionDetailView() {
   const { user: viewer, me } = useProfile()
   const [copied, setCopied] = useState(false)
   const detailTooltipId = useId()
+  const [detailOpen, setDetailOpen] = useState(false)
   const [msgs, setMsgs] = useState<SessionMessageDto[] | null>(null)
   const [msgLoading, setMsgLoading] = useState(false)
   const [msgPaging, setMsgPaging] = useState(false)
@@ -737,6 +738,20 @@ export default function SessionDetailView() {
   const tailReadyRef = useRef(false)
   const tailInFlightRef = useRef<Promise<void> | null>(null)
   const tailDirtyRef = useRef(false)
+
+  // Hover does not move focus to the trigger, so Escape has to be observed while
+  // the tooltip is open rather than only on the button.
+  useEffect(() => {
+    if (!detailOpen) return
+    const dismissDetails = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
+      setDetailOpen(false)
+    }
+    document.addEventListener('keydown', dismissDetails, true)
+    return () => document.removeEventListener('keydown', dismissDetails, true)
+  }, [detailOpen])
 
   const localSession =
     getPgSession(id) ??
@@ -1053,6 +1068,7 @@ export default function SessionDetailView() {
   useEffect(() => {
     imagePrepareGenerationRef.current += 1
     setCopied(false)
+    setDetailOpen(false)
     setWorkOverride(new Map())
     setImagePreparing(false)
     setImageError(null)
@@ -1593,17 +1609,17 @@ export default function SessionDetailView() {
             baseline, and the descender gap under it pushed the button off the row's
             centre line. The transparent top padding bridges the trigger/panel gap so
             the hover target remains continuous. */}
-          <div className="group relative ml-[-3px] flex flex-none items-center">
+          <div
+            className="relative ml-[-3px] flex flex-none items-center"
+            onMouseEnter={() => setDetailOpen(true)}
+            onMouseLeave={() => setDetailOpen(false)}
+            onFocus={() => setDetailOpen(true)}
+            onBlur={() => setDetailOpen(false)}
+          >
             <button
               type="button"
               className="inline-flex h-[22px] items-center gap-1 rounded-md border-0 bg-transparent px-[6px] font-sans text-[12px] font-medium leading-normal text-(--text-secondary) hover:bg-(--surface-hover) hover:text-(--text-primary) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand)"
               aria-describedby={detailTooltipId}
-              onKeyDown={(event) => {
-                if (event.key !== 'Escape') return
-                event.preventDefault()
-                event.stopPropagation()
-                event.currentTarget.blur()
-              }}
             >
               <Icon name="info" size={14} />
               Details
@@ -1611,7 +1627,9 @@ export default function SessionDetailView() {
             <div
               id={detailTooltipId}
               role="tooltip"
-              className="pointer-events-none invisible absolute top-full left-0 z-50 w-max pt-[5px] opacity-0 transition-[opacity,visibility] group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100"
+              className={`absolute top-full left-0 z-50 w-max pt-[5px] transition-[opacity,visibility] ${
+                detailOpen ? 'pointer-events-auto visible opacity-100' : 'pointer-events-none invisible opacity-0'
+              }`}
             >
               <div className="max-h-[340px] min-w-[216px] overflow-auto rounded-[9px] border border-(--border-default) bg-(--surface-card) px-0 py-[5px] shadow-(--shadow-lg)">
                 {headerFacts.map((f) => (


### PR DESCRIPTION
## Summary

- show session run details when the user hovers the Details trigger
- keep the same panel available to keyboard users through focus
- remove the click-toggle state and full-page dismissal overlay

## Root cause

The read-only run facts panel was implemented as a click-open dialog, so the user had to click an informational affordance before seeing it.

## Impact

Session metadata is now immediately discoverable on hover without changing the panel content or mobile layout.

## Validation

- `pnpm exec eslint packages/web/src/components/console/views/SessionDetailView.tsx`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- verified the rich tooltip layout on the local mock session detail page

Created by Codex . GPT-5.6
