### PR TITLE
fix(daemon): avoid false long-context cost estimates

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -1057,8 +1057,8 @@ export class AcpHost {
   }
 
   /** Drive one turn to completion. Returns the stop reason plus the agent's token
-   *  `usage` when the runtime reports it (ACP's experimental per-turn usage, which
-   *  carries session-cumulative counts) — `undefined` when it doesn't. */
+   *  `usage` when the runtime reports it. Usage semantics are adapter-defined;
+   *  AgentConnect's managed Codex adapter returns one ACP-prompt delta. */
   async prompt(sessionId: string, blocks: ContentBlock[]): Promise<{ stopReason: StopReason; usage?: Usage }> {
     const res = await this.conn!.agent.request(methods.agent.session.prompt, { sessionId, prompt: blocks })
     return { stopReason: res.stopReason, usage: res.usage ?? undefined }

--- a/packages/daemon/src/runtimes/managed.ts
+++ b/packages/daemon/src/runtimes/managed.ts
@@ -15,6 +15,8 @@ export const MANAGED_RUNTIME_CATALOG: Readonly<Record<string, ManagedRuntimeEntr
     version: '',
     runtime: {
       command: 'npx',
+      // This channel returns PromptResponse.usage as the total-token delta for
+      // one ACP prompt, rather than upstream codex-acp's latest model response.
       args: ['-y', '@agentconnect.md/codex-acp@agentconnect'],
       env: []
     }

--- a/packages/daemon/src/usage/openai-public-pricing.ts
+++ b/packages/daemon/src/usage/openai-public-pricing.ts
@@ -6,10 +6,10 @@
  * `$update-model-pricing` skill and keep the focused tests in sync.
  *
  * Source: https://developers.openai.com/api/docs/pricing
- * Verified: 2026-07-29
+ * Verified: 2026-08-02
  */
 
-export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-07-29'
+export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-08-02'
 export const OPENAI_PUBLIC_PRICING_SOURCE = 'https://developers.openai.com/api/docs/pricing'
 
 const TOKENS_PER_MILLION = 1_000_000
@@ -39,12 +39,12 @@ const MODEL_PRICING: Readonly<Record<string, ModelPricing>> = {
     longContext: { input: 10, cachedInput: 1, cacheWrite: 12.5, output: 45 }
   },
   'gpt-5.6-terra': {
-    standard: { input: 2.5, cachedInput: 0.25, cacheWrite: 3.125, output: 15 },
-    longContext: { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 22.5 }
+    standard: { input: 2, cachedInput: 0.2, cacheWrite: 2.5, output: 12 },
+    longContext: { input: 4, cachedInput: 0.4, cacheWrite: 5, output: 18 }
   },
   'gpt-5.6-luna': {
-    standard: { input: 1, cachedInput: 0.1, cacheWrite: 1.25, output: 6 },
-    longContext: { input: 2, cachedInput: 0.2, cacheWrite: 2.5, output: 9 }
+    standard: { input: 0.2, cachedInput: 0.02, cacheWrite: 0.25, output: 1.2 },
+    longContext: { input: 0.4, cachedInput: 0.04, cacheWrite: 0.5, output: 1.8 }
   },
   'gpt-5.5': {
     standard: { input: 5, cachedInput: 0.5, output: 30 },
@@ -98,6 +98,13 @@ export interface OpenAiTurnUsage {
   outputTokens?: number
   cachedReadTokens?: number | null
   cachedWriteTokens?: number | null
+  /**
+   * Total cached + uncached input size for the single provider request
+   * represented by these buckets.
+   * Omit for ACP turn aggregates that span multiple requests; their sum cannot
+   * determine whether any individual request crossed a pricing-tier boundary.
+   */
+  tierInputTokens?: number | null
 }
 
 export type PublicCostEstimate =
@@ -122,8 +129,12 @@ function validCount(value: number | null | undefined): value is number {
 /**
  * Estimate one Codex turn at public OpenAI Standard API token rates.
  *
- * codex-acp maps provider usage into disjoint ACP buckets: `inputTokens` is
- * non-cached input and `cachedReadTokens` is the cached subset it removed.
+ * AgentConnect's managed `@agentconnect.md/codex-acp@agentconnect` runtime maps
+ * provider usage into disjoint ACP buckets: `inputTokens` is non-cached input
+ * and `cachedReadTokens` is the cached subset it removed. Unlike upstream
+ * codex-acp, its PromptResponse is the total-token delta across every provider
+ * request in the ACP prompt. That aggregate cannot select a per-request pricing
+ * tier, so use standard rates unless request-level tier input is explicit.
  * `thoughtTokens` is intentionally absent: reasoning is already a subset of output
  * and charging it again would double-count. The current adapter does not expose
  * GPT-5.6 cache writes, so those tokens remain in input at the regular input rate;
@@ -142,12 +153,12 @@ export function estimateOpenAiTurnCost(model: string | undefined, usage: OpenAiT
   if (!validCount(usage.inputTokens) || !validCount(usage.outputTokens)) return { ok: false, reason: 'usage_invalid' }
   const cachedRead = usage.cachedReadTokens ?? 0
   const cachedWrite = usage.cachedWriteTokens ?? 0
-  if (!validCount(cachedRead) || !validCount(cachedWrite)) {
+  const tierInput = usage.tierInputTokens
+  if (!validCount(cachedRead) || !validCount(cachedWrite) || (tierInput != null && !validCount(tierInput))) {
     return { ok: false, reason: 'usage_invalid' }
   }
 
-  const requestInput = usage.inputTokens + cachedRead + cachedWrite
-  const isLongContext = requestInput > LONG_CONTEXT_THRESHOLD && pricing.longContext !== undefined
+  const isLongContext = tierInput != null && tierInput > LONG_CONTEXT_THRESHOLD && pricing.longContext !== undefined
   const rates = isLongContext ? pricing.longContext! : pricing.standard
 
   const amount =

--- a/packages/daemon/test/openai-public-pricing.test.ts
+++ b/packages/daemon/test/openai-public-pricing.test.ts
@@ -18,11 +18,12 @@ describe('estimateOpenAiTurnCost', () => {
     expect(estimate.ok && estimate.amount).toBeCloseTo(0.315)
   })
 
-  it('uses total request input, including cache reads, for the long-context threshold', () => {
+  it('uses explicit request input for the long-context threshold', () => {
     const estimate = estimateOpenAiTurnCost('gpt-5.4', {
       inputTokens: 250_000,
       cachedReadTokens: 30_000,
-      outputTokens: 10_000
+      outputTokens: 10_000,
+      tierInputTokens: 280_000
     })
     expect(estimate).toMatchObject({ ok: true, longContext: true })
     if (estimate.ok) expect(estimate.amount).toBeCloseTo(1.49)
@@ -32,10 +33,21 @@ describe('estimateOpenAiTurnCost', () => {
     const estimate = estimateOpenAiTurnCost('gpt-5.4', {
       inputTokens: 250_000,
       cachedReadTokens: 22_000,
-      outputTokens: 0
+      outputTokens: 0,
+      tierInputTokens: 272_000
     })
     expect(estimate).toMatchObject({ ok: true, longContext: false })
     if (estimate.ok) expect(estimate.amount).toBeCloseTo(0.6305)
+  })
+
+  it('does not infer long context from a multi-request ACP turn aggregate', () => {
+    const estimate = estimateOpenAiTurnCost('gpt-5.6-sol', {
+      inputTokens: 227_000,
+      cachedReadTokens: 6_480_000,
+      outputTokens: 19_000
+    })
+    expect(estimate).toMatchObject({ ok: true, longContext: false })
+    if (estimate.ok) expect(estimate.amount).toBeCloseTo(4.945)
   })
 
   it('uses GPT-5.6 public cache-write pricing when the adapter supplies that bucket', () => {
@@ -46,7 +58,7 @@ describe('estimateOpenAiTurnCost', () => {
       outputTokens: 5_000
     })
     if (!estimate.ok) throw new Error(estimate.reason)
-    expect(estimate.amount).toBeCloseTo(0.36125)
+    expect(estimate.amount).toBeCloseTo(0.289)
   })
 
   it('still estimates GPT-5.6 when codex-acp omits the cache-write bucket', () => {
@@ -56,7 +68,7 @@ describe('estimateOpenAiTurnCost', () => {
       outputTokens: 5_000
     })
     if (!estimate.ok) throw new Error(estimate.reason)
-    expect(estimate.amount).toBeCloseTo(0.33)
+    expect(estimate.amount).toBeCloseTo(0.264)
   })
 
   it('supports only explicit aliases and never prefix-guesses a future model', () => {
@@ -102,6 +114,10 @@ describe('estimateOpenAiTurnCost', () => {
       reason: 'usage_incomplete'
     })
     expect(estimateOpenAiTurnCost('gpt-5.4-mini', { inputTokens: -1, outputTokens: 1 })).toEqual({
+      ok: false,
+      reason: 'usage_invalid'
+    })
+    expect(estimateOpenAiTurnCost('gpt-5.6-sol', { inputTokens: 1, outputTokens: 1, tierInputTokens: -1 })).toEqual({
       ok: false,
       reason: 'usage_invalid'
     })


### PR DESCRIPTION
## Summary
- stop treating ACP prompt-wide aggregate input as one provider request for long-context tiering
- retain explicit single-request tier selection and add a PR #405-shaped regression
- refresh current GPT-5.6 Terra and Luna Standard rates and the verification date

## Impact
Future Codex fallback estimates use Standard rates when ACP lacks request-level tier data. The observed 227K non-cached input, 6.48M cached input, and 19K output now estimates to about $4.95 instead of $9.61. Historical stored costs are unchanged.

Pricing source: https://developers.openai.com/api/docs/pricing
Model source: https://developers.openai.com/api/docs/models/gpt-5.6-sol

## Validation
- pricing test: 20 passed
- pricing/local-store/ACP host: 109 passed with a clean exit
- required four-file daemon run: 144 assertions passed; Vitest teardown hit the known macOS EMFILE watcher issue
- daemon typecheck
- format check
- pre-push lint

Created by Codex . gpt-5.6-sol