### PR TITLE
feat(webchat): membership is a standing mention — all participants respond

### DIFF
--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -228,28 +228,30 @@ There is no server-side text parsing: mentions are structural facts from the
 composer, matching the "explicit platform @mention is a trusted routing fact"
 rule in [product-conventions.md](../product-conventions.md).
 
-### 4.2 The webchat ladder is computed client-side, validated server-side
+### 4.2 Membership is a standing mention
 
-IM needs server-side arbitration (`packages/relay/src/bot-arbitration.ts:116`)
-because many humans type free text into a shared channel across many ingress
-pods. A webchat conversation has exactly one composer, owned by the one human
-owner, with structured mentions. The routing ladder therefore runs **in the
-composer** and its result travels explicitly as `targets`:
+The Slack mental model, applied literally: pulling agents into a conversation
+is equivalent to having @-mentioned them all in its first message. From then
+on, **every user message activates the whole roster** unless it explicitly
+@-mentions someone — a mention narrows the turn to the named participants:
 
 1. **Mentions** — `targets = mentions` when non-empty.
-2. **Conversation affinity** — no mention: target the last agent that posted
-   in the conversation (the client renders the transcript, so it knows).
-   This mirrors relay thread affinity without needing the 3-leg
-   `rc/thread-assign` dance — there is no cross-pod ambiguity to resolve.
-3. **Primary agent** — a fresh conversation with no agent post yet.
+2. **Everyone** — no mention: every participant is activated. Each agent runs
+   the standing response-choice contract
+   ([product-conventions.md](../product-conventions.md) §No-response control
+   marker) and silently declines with `AC_NO_RESPONSE` when the message is
+   plainly for someone else; the daemon holds the live stream while the body
+   could still be the bare sentinel, so a decline never flashes into the
+   browser and commits no canonical post. Turn-final context refresh
+   (section 5.4) keeps the concurrent answers coherent — a slower participant
+   sees the faster ones' replies before committing.
 
-The relay does not arbitrate; it **validates and fans out**:
-
-- `targets ⊄ roster` → the turn is refused with a new ack reason
-  `not_participant` (per offending target).
-- `targets` absent or empty → the relay substitutes the primary agent, which
-  makes an old browser build indistinguishable from a one-participant
-  conversation.
+The relay applies the same default itself (`targets` absent or empty ⇒ the
+whole roster), so a resumed conversation with no client-side roster — or an
+older browser build — still reaches everyone; the browser admits stream lanes
+lazily from the per-agent acks. `targets ⊄ roster` is refused with the
+`not_participant` ack reason per offending target. A one-participant roster
+makes every rule above collapse to today's single-agent behavior.
 
 Trusting the client for _targeting_ is sound because it is a UX choice, not an
 authorization boundary: the roster is CP-validated, every target is
@@ -747,9 +749,12 @@ user-facing product ("talk to several agents in one Playground conversation").
 
 ## 12. Alternatives considered
 
-- **Broadcast every turn to every participant** (all agents answer, decline
-  via `AC_NO_RESPONSE`) — rejected: N-fold token cost and noise for no
-  addressing value; IM already solved this with mention-first ladders.
+- **Mention-first ladder with a single default target** (mention → last
+  responder → primary) — the original v1 shape, replaced by the standing-
+  mention model of section 4.2: a roster the owner explicitly assembled IS the
+  addressing, so activating all of it is not indiscriminate broadcast, and the
+  no-response contract plus turn-final refresh absorb the noise the original
+  rejection feared. Cost stays bounded by the roster cap the owner chose.
 - **Server-side arbitration at the relay** (mirror `bot-arbitration.ts` with
   durable affinity) — deferred: with one composer, structured mentions, and a
   single owner, client-computed targeting is strictly simpler and equally
@@ -797,10 +802,15 @@ Questions resolved during design review:
    mirroring the IM answer workflow; the browser stream stays live and a
    superseded generation is replaced in place. Single-participant
    conversations keep today's behavior (section 5.4).
-8. **Primary is invisible** — no "default" marker anywhere; during assembly
+8. **Membership is a standing mention (revised targeting)** — an unmentioned
+   user message activates the whole roster (as if every participant had been
+   @'d when it joined), with explicit mentions narrowing the turn; the
+   last-responder/primary default ladder is retired, and `AC_NO_RESPONSE` +
+   turn-final refresh keep all-respond coherent (section 4.2).
+9. **Primary is invisible** — no "default" marker anywhere; during assembly
    every chip is removable and the primary is re-derived as the first agent
    of the final list (section 9.1).
-9. **No runtime controls in multi-agent conversations** — the Model / Effort /
-   Permission pills and per-agent overrides disappear when the roster has two
-   or more agents; each participant runs its configured runtime defaults, and
-   the `set_*` ops stay single-agent-only (sections 9.1, 9.3).
+10. **No runtime controls in multi-agent conversations** — the Model / Effort /
+    Permission pills and per-agent overrides disappear when the roster has two
+    or more agents; each participant runs its configured runtime defaults, and
+    the `set_*` ops stay single-agent-only (sections 9.1, 9.3).

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -214,6 +214,7 @@ import {
   effectiveMemoryDreamingPolicy,
   gitRepoLabel
 } from '@agentconnect.md/protocol'
+import { isNoResponseBody, isNoResponsePrefix } from './session/no-response.js'
 import { createSessionReader } from './cp/session-reader.js'
 import { createWorkspaceReader, WorkspaceConflictError } from './cp/workspace-reader.js'
 import { createMemoryReader } from './cp/memory-reader.js'
@@ -1274,7 +1275,7 @@ interface Pending {
    * accumulates the agent's message chunks so the finished reply is recorded to the
    * transcript once (webchat has no Slack post boundary where text is otherwise saved).
    */
-  webchat?: WebchatTurnContext & { index: number; replyText: string }
+  webchat?: WebchatTurnContext & { index: number; replyText: string; heldText: string; messageEmitted: boolean }
 }
 
 /** Visible Slack thread messages that establish a new chronological boundary. Any live
@@ -8034,6 +8035,22 @@ export class Daemon {
     return fallback
   }
 
+  /** Release stream text held back by the no-response sentinel check once the
+   *  turn is known to be a real reply (it diverged only at the very end, e.g. a
+   *  body shorter than the sentinel). */
+  private flushHeldWebchatText(wc: NonNullable<Pending['webchat']>): void {
+    if (!wc.heldText) return
+    const held = wc.heldText
+    wc.heldText = ''
+    wc.messageEmitted = true
+    wc.sink.output({
+      conversationId: wc.conversationId,
+      turnId: wc.turnId,
+      index: wc.index++,
+      event: { kind: 'message', text: held }
+    })
+  }
+
   /**
    * Record a conversation post another participant produced (relay `context` op —
    * webchat-multi-agents.md §5.2). Transcript-only, NEVER an activation: the row
@@ -10468,7 +10485,9 @@ export class Daemon {
     // Add the streaming fields onto the SAME webchat object held by QueueEntry. Sharing
     // `doneSent` closes a Pending-vs-gate race where cancel could otherwise terminally
     // signal each copy once.
-    const pendingWebchat = webchat ? Object.assign(webchat, { index: 0, replyText: '' }) : undefined
+    const pendingWebchat = webchat
+      ? Object.assign(webchat, { index: 0, replyText: '', heldText: '', messageEmitted: false })
+      : undefined
     if (!entry.selectedHost) {
       const ordinaryHost = this.hosts.get(agentId)
       if (ordinaryHost) entry.selectedHost = this.selectedOrdinaryTurnHost(agentId, ordinaryHost)
@@ -10831,8 +10850,11 @@ export class Daemon {
         if (p.webchatRefresh && p.webchat) {
           // The canonical post — and post-turn memory / turn.completed.output —
           // must carry only the accepted generation. Webchat chunks accumulate
-          // into BOTH buffers (the stream is never staged), so clear both.
+          // into BOTH buffers (the stream is never staged), so clear both — and
+          // reset the sentinel hold so the replacement gets its own check.
           p.webchat.replyText = ''
+          p.webchat.heldText = ''
+          p.webchat.messageEmitted = false
           p.replyText = ''
         }
         this.emitEvaluation({
@@ -10871,6 +10893,7 @@ export class Daemon {
             // fanned out. Close the browser turn explicitly — a bare return
             // would leave the stream open and the composer stuck busy.
             p.webchat.replyText = ''
+            p.webchat.heldText = ''
             if (!p.webchat.doneSent) {
               p.webchat.doneSent = true
               p.webchat.sink.output({
@@ -10962,7 +10985,17 @@ export class Daemon {
         // Record the agent's reply as a transcript text row (sender = agentId), so a
         // webchat session reads back with its reply like any Slack session does — the
         // Slack path records this at its `post` boundary, which webchat never hits.
-        if (p.webchat.replyText.trim()) {
+        const trimmedWebchatReply = p.webchat.replyText.trim()
+        if (trimmedWebchatReply && isNoResponseBody(trimmedWebchatReply)) {
+          // Silent decline (the conversation-wide activation was not for this
+          // agent): drop the held stream text — nothing was ever streamed — and
+          // commit no canonical post or transcript reply row.
+          p.webchat.heldText = ''
+          p.replyText = ''
+        } else if (trimmedWebchatReply) {
+          // A real reply that never diverged from the sentinel prefix mid-stream
+          // (shorter than the sentinel) is still held — release it before commit.
+          this.flushHeldWebchatText(p.webchat)
           // Shares the strictly-monotonic clock with the inbound user message so a fast
           // turn can't stamp both with the same ms and lose the reply to the unique index.
           // The ts the row actually lands on (post-collision-bump) doubles as the reply
@@ -11100,7 +11133,9 @@ export class Daemon {
           thread: msg.thread,
           statusThread
         })
-        if (p.webchat.replyText.trim()) {
+        const trimmedPartialReply = p.webchat.replyText.trim()
+        if (trimmedPartialReply && !isNoResponseBody(trimmedPartialReply)) {
+          this.flushHeldWebchatText(p.webchat)
           const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
             sender: agentId,
             text: p.webchat.replyText
@@ -13778,7 +13813,22 @@ export class Daemon {
         const text = update.content?.type === 'text' ? (update.content.text ?? '') : ''
         if (text) {
           wc.replyText += text // recorded once at turn end (no Slack post boundary)
-          for (const t of chunkText(text)) emit({ kind: 'message', text: t })
+          // Response-choice hold (product-conventions §No-response control marker):
+          // while the whole accumulated body could still be the bare sentinel,
+          // keep it off the live stream — an agent silently declining a
+          // conversation-wide activation must not flash AC_NO_RESPONSE into the
+          // browser. Everything is released the instant the body diverges.
+          if (wc.messageEmitted) {
+            for (const t of chunkText(text)) emit({ kind: 'message', text: t })
+          } else {
+            wc.heldText += text
+            if (!isNoResponsePrefix(wc.heldText.trim())) {
+              const held = wc.heldText
+              wc.heldText = ''
+              wc.messageEmitted = true
+              for (const t of chunkText(held)) emit({ kind: 'message', text: t })
+            }
+          }
         }
         return
       }

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1195,6 +1195,57 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     ...over
   })
 
+  it('suppresses a silent decline: the streamed sentinel never reaches the browser, no post, no reply row', async () => {
+    const { factory } = streamingHost([text('AC_NO_'), text('RESPONSE')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const events: RdChatEvent[] = []
+    const posts: unknown[] = []
+    const ack = (daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'anyone?', user: 'owner', turnId, post: { postId: turnId, at: 1_000 } }),
+      (event: RdChatEvent) => events.push(event),
+      (post: unknown) => posts.push(post)
+    )
+    expect(ack).toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    const messages = events.flatMap((e) =>
+      e.kind === 'output' && e.output.event?.kind === 'message' ? [e.output.event.text] : []
+    )
+    expect(messages).toEqual([]) // the sentinel was held and dropped
+    expect(posts).toEqual([]) // no canonical post fan-out
+    const replies = (daemon as any).store
+      .transcriptSince(`${CONV}`, `webchat:${CONV}`, null)
+      .filter((row: { sender: string }) => row.sender === AGENT_ID)
+    expect(replies).toEqual([]) // no transcript reply row
+    await daemon.stop()
+  })
+
+  it('releases held text the instant the body diverges from the sentinel prefix', async () => {
+    const { factory } = streamingHost([text('AC_NO'), text(' — actually, here is the answer')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    const events: RdChatEvent[] = []
+    const ack = (daemon as any).handleRelayMsg(
+      rd({ op: 'turn', text: 'anyone?', user: 'owner', turnId, post: { postId: turnId, at: 1_000 } }),
+      (event: RdChatEvent) => events.push(event)
+    )
+    expect(ack).toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(events.some((e) => e.kind === 'done')).toBe(true), WAIT)
+
+    const messages = events.flatMap((e) =>
+      e.kind === 'output' && e.output.event?.kind === 'message' ? [e.output.event.text] : []
+    )
+    expect(messages.join('')).toBe('AC_NO — actually, here is the answer')
+    await daemon.stop()
+  })
+
   it('a turn op preserves the browser turnId and streams rd/chat output→done', async () => {
     const { factory } = streamingHost([text('hi from agent')])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -266,13 +266,15 @@ export class RelayBrowserConnection implements ChatSink {
 
   /** Fan one user turn out to its targeted participants + context to the rest. */
   private async sendTurn(op: Extract<RelayWebchatOp, { op: 'turn' }>, requestedTargets?: string[]): Promise<void> {
-    // The composer-computed ladder travels explicitly as `targets`; an older
-    // browser sends none and falls back to mentions, then to the primary.
+    // Conversation membership is a STANDING mention (webchat-multi-agents.md
+    // §4.2): an unmentioned message activates the WHOLE roster — each agent may
+    // still decline via the no-response contract — while explicit @mentions (or
+    // an explicit `targets` list) narrow the turn to the named participants.
     const targets = requestedTargets?.length
       ? requestedTargets
       : op.mentions?.length
         ? op.mentions
-        : [this.deps.agentId]
+        : [...this.byAgentId.keys()]
     const turnId = op.turnId ?? randomUUID()
     this.lastPostAt = Math.max(Date.now(), this.lastPostAt + 1)
     const post = { postId: randomUUID(), at: this.lastPostAt }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -198,6 +198,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // Creation-time roster per session id (primary first) — drives the
   // conversation-scoped token mint for a multi-agent create.
   const rosterAgentIds = useRef<Map<string, string[]>>(new Map())
+  // The in-flight send's requested turnId — lets an accepted ack from a
+  // participant the client did NOT explicitly lane (a resumed conversation
+  // where the relay applied the all-participants default) create its stream
+  // lane lazily instead of dropping the reply.
+  const pendingTurnIds = useRef<Map<string, string>>(new Map())
   // One ordering cursor per stream LANE — a multi-agent turn runs one lane per
   // targeted participant (webchat-multi-agents.md §5.3), keyed `${id} ${agentId}`.
   const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
@@ -482,14 +487,6 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           ...(name ? { who: name } : {}),
           text: `⚠️ ${result.done.error}`
         })
-      } else if (agentId) {
-        // Rung 2 of the composer targeting ladder: the last participant to
-        // complete a reply is the default target of an unmentioned follow-up.
-        setPgSessions((cur) => {
-          const s = cur[id]
-          if (!s || s.lastResponderAgentId === agentId) return cur
-          return { ...cur, [id]: { ...s, lastResponderAgentId: agentId } }
-        })
       }
       // The turn stays busy until every targeted participant's lane finished.
       if (lanesOf(id).length === 0) setBusy(id, false)
@@ -673,7 +670,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               } else if (m.type === 'done') {
                 if (m.done) receiveDone(id, m.done)
               } else if (m.type === 'ack' && m.ack?.accepted !== false) {
-                const key = cursorKeyFor(id, m.ack?.agentId)
+                let key = cursorKeyFor(id, m.ack?.agentId)
+                // The relay may target participants the client did not lane (a
+                // resumed conversation without a local roster): admit the lane
+                // on its ack so the reply stream binds instead of dropping.
+                if (!key && m.ack?.agentId && m.ack.turnId === pendingTurnIds.current.get(id)) {
+                  key = laneKey(id, m.ack.agentId)
+                  streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(m.ack.turnId))
+                }
                 const cursor = key ? streamCursors.current.get(key) : undefined
                 if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
               } else if (m.type === 'resumed' && m.ack?.accepted !== false) {
@@ -860,9 +864,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       setPgImage(id)
       setBusy(id, true)
       const requestedTurnId = crypto.randomUUID()
-      // The composer targeting ladder (webchat-multi-agents.md §4.2), computed
-      // client-side: @mentions in the text → the last responder → the primary.
-      // The relay validates targets against the verified roster.
+      // Targeting (webchat-multi-agents.md §4.2): conversation membership is a
+      // STANDING mention — an unmentioned message goes to the WHOLE roster
+      // (each agent may silently decline); explicit @mentions narrow the turn
+      // to the named participants. The relay validates against its verified
+      // roster, and also applies the same all-participants default itself, so a
+      // resumed conversation with no client-side roster still reaches everyone.
       const session = pgSessions[id]
       const roster = session?.participants ?? []
       const mentions =
@@ -873,13 +880,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               )
               .map((p) => p.agentId)
           : []
-      const lastResponder = session?.lastResponderAgentId
-      const targets =
-        roster.length > 1
-          ? mentions.length
-            ? mentions
-            : [lastResponder && roster.some((p) => p.agentId === lastResponder) ? lastResponder : agentForId]
-          : [agentForId]
+      const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
+      pendingTurnIds.current.set(id, requestedTurnId)
       for (const target of targets) {
         streamCursors.current.set(laneKey(id, target), createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
       }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -30,6 +30,7 @@ import {
   type OrderedWebchatCursor,
   type OrderedWebchatResult
 } from '@/lib/webchat-stream'
+import { cursorKeyFor as cursorKeyForLanes, laneAgentId, laneKey, lanesOf as lanesOfLanes } from '@/lib/webchat-lanes'
 
 interface PlaygroundData {
   /** Composer buffer for one session id (each live conversation has its own). */
@@ -204,7 +205,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // lane lazily instead of dropping the reply.
   const pendingTurnIds = useRef<Map<string, string>>(new Map())
   // One ordering cursor per stream LANE — a multi-agent turn runs one lane per
-  // targeted participant (webchat-multi-agents.md §5.3), keyed `${id} ${agentId}`.
+  // targeted participant (webchat-multi-agents.md §5.3); keys from lib/webchat-lanes.ts.
   const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
   const reconnectAttempts = useRef<Map<string, number>>(new Map())
   // Standalone set_* operations cannot bind until the first daemon session exists.
@@ -431,22 +432,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }, [])
 
   // ── stream lanes ──────────────────────────────────────────────────────────
-  // Cursor keys are `${id} ${agentId}`. A frame from an older daemon omits
-  // agentId — it resolves to the session's sole lane.
-  const laneKey = (id: string, agentId?: string): string => `${id} ${agentId ?? ''}`
-  const lanesOf = (id: string): string[] => [...streamCursors.current.keys()].filter((k) => k.startsWith(`${id} `))
-  const laneAgentId = (key: string): string | undefined => {
-    const agentId = key.slice(key.indexOf(' ') + 1)
-    return agentId || undefined
-  }
-  const cursorKeyFor = (id: string, agentId?: string): string | undefined => {
-    const exact = laneKey(id, agentId)
-    if (streamCursors.current.has(exact)) return exact
-    const lanes = lanesOf(id)
-    // Legacy frames without agentId (or a lane created before the ready roster
-    // landed) resolve to the sole lane when there is exactly one.
-    return lanes.length === 1 ? lanes[0] : undefined
-  }
+  // Cursor keys come from lib/webchat-lanes.ts. Agent-tagged frames match their
+  // exact lane only — an unknown tagged participant is admitted lazily from its
+  // ack — while the sole-lane fallback is reserved for legacy frames that omit
+  // agentId.
+  const lanesOf = (id: string): string[] => lanesOfLanes(streamCursors.current, id)
+  const cursorKeyFor = (id: string, agentId?: string): string | undefined =>
+    cursorKeyForLanes(streamCursors.current, id, agentId)
   const dropLanes = (id: string): void => {
     for (const key of lanesOf(id)) streamCursors.current.delete(key)
   }

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -885,9 +885,6 @@ export interface Session {
   /** Multi-agent webchat roster (webchat-multi-agents.md §3.1), primary first —
    *  present on live conversations with more than one participant. */
   participants?: Array<{ agentId: string; name: string; primary?: boolean }>
-  /** The participant that most recently replied — rung 2 of the composer's
-   *  targeting ladder (mention → last responder → primary). */
-  lastResponderAgentId?: string
   /** Runtime id + daemonId the session ran with: the session-recorded snapshot,
    *  with the owning agent's current values as the legacy-row fallback (attached
    *  at flatten time, like `model`). Views resolve `daemon` to a display name. */

--- a/packages/web/src/lib/webchat-lanes.test.ts
+++ b/packages/web/src/lib/webchat-lanes.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { cursorKeyFor, laneAgentId, laneKey, lanesOf } from './webchat-lanes'
+
+const ID = 'pg_agent-a_x'
+const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+describe('webchat stream lanes', () => {
+  it('round-trips lane keys per (session, participant)', () => {
+    const lanes = new Map([[laneKey(ID, A), {}]])
+    expect(laneAgentId(laneKey(ID, A))).toBe(A)
+    expect(laneAgentId(laneKey(ID))).toBeUndefined()
+    expect(lanesOf(lanes, ID)).toEqual([laneKey(ID, A)])
+    expect(lanesOf(lanes, 'other')).toEqual([])
+  })
+
+  it('agent-tagged frames match their exact lane only — never the sole-lane fallback', () => {
+    // The resumed-conversation regression: the client seeded only the primary
+    // lane, and the relay (all-participants default) acked a SECOND agent. That
+    // tagged ack must NOT capture the primary's cursor — it returns undefined so
+    // the caller admits agent B's lane lazily.
+    const lanes = new Map([[laneKey(ID, A), {}]])
+    expect(cursorKeyFor(lanes, ID, A)).toBe(laneKey(ID, A))
+    expect(cursorKeyFor(lanes, ID, B)).toBeUndefined()
+  })
+
+  it('reserves the sole-lane fallback for legacy frames without agentId', () => {
+    const lanes = new Map([[laneKey(ID, A), {}]])
+    // An older daemon omits agentId on every frame — with exactly one live lane
+    // the frame unambiguously belongs to it.
+    expect(cursorKeyFor(lanes, ID)).toBe(laneKey(ID, A))
+    // With several lanes an untagged frame is ambiguous — dropped, not guessed.
+    lanes.set(laneKey(ID, B), {})
+    expect(cursorKeyFor(lanes, ID)).toBeUndefined()
+  })
+
+  it('after lazy admission, both participants resolve independently', () => {
+    const lanes = new Map<string, unknown>([[laneKey(ID, A), {}]])
+    // Lazy admission on B's ack: the caller creates the exact lane…
+    lanes.set(laneKey(ID, B), {})
+    // …and from then on each participant's frames bind their own cursor; one
+    // participant's done removing its lane leaves the other untouched.
+    expect(cursorKeyFor(lanes, ID, A)).toBe(laneKey(ID, A))
+    expect(cursorKeyFor(lanes, ID, B)).toBe(laneKey(ID, B))
+    lanes.delete(laneKey(ID, B))
+    expect(cursorKeyFor(lanes, ID, A)).toBe(laneKey(ID, A))
+    expect(cursorKeyFor(lanes, ID, B)).toBeUndefined()
+  })
+})

--- a/packages/web/src/lib/webchat-lanes.ts
+++ b/packages/web/src/lib/webchat-lanes.ts
@@ -1,0 +1,39 @@
+// Stream-lane keying for multi-agent webchat conversations
+// (webchat-multi-agents.md §5.3): one ordering cursor per (session, participant)
+// lane, keyed `${id} ${agentId}`. Pure helpers over the provider's cursor map so
+// the resolution rules are unit-testable.
+
+/** The cursor-map key for one participant's stream lane. */
+export function laneKey(id: string, agentId?: string): string {
+  return `${id}\u0000${agentId ?? ''}`
+}
+
+/** The participant a lane key addresses (undefined for the anonymous lane). */
+export function laneAgentId(key: string): string | undefined {
+  const agentId = key.slice(key.indexOf('\u0000') + 1)
+  return agentId || undefined
+}
+
+/** Every lane key belonging to one session id. */
+export function lanesOf(lanes: ReadonlyMap<string, unknown>, id: string): string[] {
+  return [...lanes.keys()].filter((k) => k.startsWith(`${id}\u0000`))
+}
+
+/**
+ * Resolve the lane a frame belongs to.
+ *
+ * Agent-tagged frames match their EXACT lane only — a tagged ack/output for a
+ * participant the client has not laned yet must return undefined so the caller
+ * can admit the lane lazily (a resumed conversation where the relay applied the
+ * all-participants default). The sole-lane compatibility fallback is reserved
+ * for legacy frames that omit `agentId`: letting a tagged frame fall back would
+ * share the primary's cursor across participants, misattributing or dropping
+ * replies once one participant's `done` removes it.
+ */
+export function cursorKeyFor(lanes: ReadonlyMap<string, unknown>, id: string, agentId?: string): string | undefined {
+  const exact = laneKey(id, agentId)
+  if (lanes.has(exact)) return exact
+  if (agentId !== undefined) return undefined
+  const all = lanesOf(lanes, id)
+  return all.length === 1 ? all[0] : undefined
+}


### PR DESCRIPTION
## What

Revised multi-agent webchat targeting (stacked on #405): **conversation membership is a standing mention**. Pulling agents into a conversation is equivalent to having @-mentioned them all in its first message — an unmentioned user message activates the **whole roster**; explicit `@mentions` narrow the turn to the named participants. The v1 mention → last-responder → primary ladder is retired (design §4.2 rewritten, decision log entry 8; the original broadcast rejection is superseded in §12 — a roster the owner explicitly assembled IS the addressing).

This directly fixes the "why doesn't test2 respond" confusion: every participant now answers "hello guys", and irrelevant agents excuse themselves silently.

## How

- **Relay** — the no-targets default becomes the whole roster (was: primary). This also covers resumed conversations with no client-side roster and older browser builds. Single-participant rosters collapse to today's behavior exactly.
- **Web** — the composer sends `targets = mentions || all participants`; stream lanes for participants the client did not know about (resumed conversations) are admitted **lazily from their per-agent acks**, closing the adopted-resume targeting gap. The dead last-responder tracking is removed.
- **Daemon** — the no-response contract now covers webchat, which matters once every participant is activated per message: the live stream is **held while the accumulated body could still be the bare `AC_NO_RESPONSE` sentinel** (mirror of the IM convergers' prefix hold, released the instant it diverges), and a silent decline commits **no canonical post, no transcript reply row, and never flashes into the browser** — the lane simply ends. Supersession/churn paths reset the hold state so each generation gets its own check.

Coherence between the concurrent answers comes from #405's turn-final context refresh: a slower participant sees the faster ones' replies before committing.

## Tests

Two new daemon-webchat cases: a streamed bare sentinel produces zero message events / no post / no reply row; a body diverging from the sentinel prefix (`AC_NO — actually…`) is released intact. Relay 378 · web 573 · daemon webchat/refresh/turn-output/session 133 all green; workspace typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
