### PR TITLE
feat(web): merge Auto-review into permission modes

### DIFF
--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -9,7 +9,6 @@ import { useOrgs } from '@/lib/org-context'
 import {
   FALLBACK_RUNTIME_IDS,
   approvalsReviewerDefault,
-  approvalsReviewerOptions,
   loginRequiredRuntimeIds,
   agentSlugFinalize,
   agentSlugSanitize,
@@ -25,7 +24,9 @@ import {
   resolveEffortForModel,
   permissionModeChoicesFor,
   permissionModeDefault,
-  supportsApprovalsReviewer,
+  permissionModePresets,
+  permissionPresetSettings,
+  selectedPermissionPreset,
   type AgentCallPolicy,
   type ApprovalsReviewer,
   supportsModes
@@ -391,10 +392,16 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // currentValue), else the first offered mode. No "(unavailable)" here: unlike
   // Edit, nothing in this modal is stored yet.
   const selectedPermissionMode = resolvedPermissionMode(permissionMode, permissionChoices, modelCatalog)
-  const permissionOptions = permissionChoices
-  const showApprovalsReviewer = supportsApprovalsReviewer(effectiveRuntime)
-  const selectedApprovalsReviewer = approvalsReviewer || approvalsReviewerDefault(effectiveRuntime)
-  const approvalsReviewerChoices = approvalsReviewerOptions(effectiveRuntime)
+  const defaultApprovalsReviewer = approvalsReviewerDefault(effectiveRuntime)
+  const selectedApprovalsReviewer = defaultApprovalsReviewer
+    ? approvalsReviewer || defaultApprovalsReviewer
+    : defaultApprovalsReviewer
+  const permissionOptions = permissionModePresets(effectiveRuntime, permissionChoices)
+  const selectedPermissionModePreset = selectedPermissionPreset(
+    effectiveRuntime,
+    selectedPermissionMode,
+    selectedApprovalsReviewer
+  )
 
   // A daemon selection defines the product default: optional means off; required
   // means on and immutable. Capability refreshes converge the same way.
@@ -813,7 +820,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
         ...(Object.keys(envRecord).length ? { env: envRecord } : {}),
         ...(Object.keys(secretsRecord).length ? { secrets: secretsRecord } : {}),
         permissionMode: selectedPermissionMode,
-        ...(showApprovalsReviewer && selectedApprovalsReviewer ? { approvalsReviewer: selectedApprovalsReviewer } : {}),
+        ...(selectedApprovalsReviewer ? { approvalsReviewer: selectedApprovalsReviewer } : {}),
         allowRuntimeChangesInChat,
         workspace,
         // Atomic restricted-create: the CP intersects sharedWith with org members.
@@ -1041,7 +1048,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           <section ref={sectionRef('runtime')} className="mt-5 border-t border-(--border-subtle) pt-5">
             <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Runtime</div>
             <div className="mt-[13px] grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
-              {(showEffort || fastModeAvailable || showPermission || showApprovalsReviewer) && (
+              {(showEffort || fastModeAvailable || showPermission) && (
                 <div className="fld desktop:col-span-2">
                   <div className="grid grid-cols-1 gap-x-7 gap-y-[14px] desktop:grid-cols-[minmax(0,1fr)_auto]">
                     {showEffort && (
@@ -1094,40 +1101,22 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     {showPermission && (
                       <div className="flex min-w-0 flex-col gap-[6px] desktop:col-span-2">
                         <span className="fldlbl">Permission mode</span>
-                        <div className="pillbar self-start">
+                        <div className="pillbar max-w-full overflow-x-auto self-start">
                           {permissionOptions.map((o) => (
                             <button
                               key={o.v}
                               type="button"
                               title={o.description}
                               className={
-                                selectedPermissionMode === o.v
-                                  ? 'pill on px-[10px] py-1 text-[12px]'
-                                  : 'pill px-[10px] py-1 text-[12px]'
+                                selectedPermissionModePreset === o.v
+                                  ? 'pill on whitespace-nowrap px-[10px] py-1 text-[12px]'
+                                  : 'pill whitespace-nowrap px-[10px] py-1 text-[12px]'
                               }
-                              onClick={() => setPermissionMode(o.v)}
-                            >
-                              {o.l}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {showApprovalsReviewer && (
-                      <div className="flex min-w-0 flex-col gap-[6px] desktop:col-span-2">
-                        <span className="fldlbl">Approval reviewer</span>
-                        <div className="pillbar self-start">
-                          {approvalsReviewerChoices.map((o) => (
-                            <button
-                              key={o.v}
-                              type="button"
-                              title={o.description}
-                              className={
-                                selectedApprovalsReviewer === o.v
-                                  ? 'pill on px-[10px] py-1 text-[12px]'
-                                  : 'pill px-[10px] py-1 text-[12px]'
-                              }
-                              onClick={() => setApprovalsReviewer(o.v)}
+                              onClick={() => {
+                                const next = permissionPresetSettings(effectiveRuntime, o.v)
+                                setPermissionMode(next.permissionMode)
+                                setApprovalsReviewer(next.approvalsReviewer)
+                              }}
                             >
                               {o.l}
                             </button>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   approvalsReviewerDefault,
-  approvalsReviewerOptions,
   effortChoicesFor,
   effortField,
   effortLabel,
@@ -18,8 +17,10 @@ import {
   permissionModeChoicesFor,
   permissionModeDefault,
   permissionModeLabel,
+  permissionModePresets,
+  permissionPresetSettings,
   runtimeLabel,
-  supportsApprovalsReviewer,
+  selectedPermissionPreset,
   supportsModes,
   agentLabel,
   type Agent,
@@ -369,15 +370,15 @@ export default function EditAgentModal({
   const fastModeAvailable = fastModeAvailableFor(runtime, capability)
   const permissionChoices = permissionModeChoicesFor(runtime, modelCatalog)
   const showPermission = !!modelCatalog?.permissionModes?.length || runtimeSupportsModes
-  const permissionOptions =
+  const permissionModeOptions =
     modelCatalog?.permissionModes?.length && !permissionChoices.some((o) => o.v === permissionMode)
       ? [
           ...permissionChoices,
           { v: permissionMode, l: `${permissionModeLabel(runtime, permissionMode)} (unavailable)` }
         ]
       : permissionChoices
-  const showApprovalsReviewer = supportsApprovalsReviewer(runtime)
-  const approvalsReviewerChoices = approvalsReviewerOptions(runtime)
+  const permissionOptions = permissionModePresets(runtime, permissionModeOptions)
+  const selectedPermissionModePreset = selectedPermissionPreset(runtime, permissionMode, approvalsReviewer)
   const runtimeUnavailable = daemonChanged && reportedRuntimeIds.length > 0 && !reportedRuntimeIds.includes(runtime)
   const modelUnavailable =
     daemonChanged && !!selectedModel && reportedModels.length > 0 && !reportedModels.includes(selectedModel)
@@ -789,7 +790,7 @@ export default function EditAgentModal({
             <section ref={sectionRef('runtime')} className="mt-5 border-t border-(--border-subtle) pt-5">
               <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Runtime</div>
               <div className="mt-[13px] grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
-                {(showEffort || fastModeAvailable || showPermission || showApprovalsReviewer) && (
+                {(showEffort || fastModeAvailable || showPermission) && (
                   <div className="fld desktop:col-span-2">
                     <div className="grid grid-cols-1 gap-x-7 gap-y-[14px] desktop:grid-cols-[minmax(0,1fr)_auto]">
                       {showEffort && (
@@ -842,40 +843,22 @@ export default function EditAgentModal({
                       {showPermission && (
                         <div className="flex min-w-0 flex-col gap-[6px] desktop:col-span-2">
                           <span className="fldlbl">Permission mode</span>
-                          <div className="pillbar self-start">
+                          <div className="pillbar max-w-full overflow-x-auto self-start">
                             {permissionOptions.map((o) => (
                               <button
                                 key={o.v}
                                 type="button"
                                 title={o.description}
                                 className={
-                                  permissionMode === o.v
-                                    ? 'pill on px-[10px] py-1 text-[12px]'
-                                    : 'pill px-[10px] py-1 text-[12px]'
+                                  selectedPermissionModePreset === o.v
+                                    ? 'pill on whitespace-nowrap px-[10px] py-1 text-[12px]'
+                                    : 'pill whitespace-nowrap px-[10px] py-1 text-[12px]'
                                 }
-                                onClick={() => setPermissionMode(o.v)}
-                              >
-                                {o.l}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                      {showApprovalsReviewer && (
-                        <div className="flex min-w-0 flex-col gap-[6px] desktop:col-span-2">
-                          <span className="fldlbl">Approval reviewer</span>
-                          <div className="pillbar self-start">
-                            {approvalsReviewerChoices.map((o) => (
-                              <button
-                                key={o.v}
-                                type="button"
-                                title={o.description}
-                                className={
-                                  approvalsReviewer === o.v
-                                    ? 'pill on px-[10px] py-1 text-[12px]'
-                                    : 'pill px-[10px] py-1 text-[12px]'
-                                }
-                                onClick={() => setApprovalsReviewer(o.v)}
+                                onClick={() => {
+                                  const next = permissionPresetSettings(runtime, o.v)
+                                  setPermissionMode(next.permissionMode)
+                                  setApprovalsReviewer(next.approvalsReviewer)
+                                }}
                               >
                                 {o.l}
                               </button>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -5,7 +5,6 @@ import useSWR from 'swr'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import {
-  approvalsReviewerLabel,
   agentEffortDisplay,
   agentLabel,
   agentModelDisplay,
@@ -18,7 +17,6 @@ import {
   MOCK_PREFIX,
   runtimeLabel,
   status,
-  supportsApprovalsReviewer,
   supportsModes,
   workspaceStatus
 } from '@/lib/data'
@@ -895,19 +893,9 @@ export default function AgentDetailView() {
                         Permission mode
                       </span>
                       <span className="badge bg-(--surface-active) text-(--text-secondary) max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]">
-                        {agentPermissionDisplay(owningDaemon, da.runtime, da.permissionMode)}
+                        {agentPermissionDisplay(owningDaemon, da.runtime, da.permissionMode, da.approvalsReviewer)}
                       </span>
                     </div>
-                    {supportsApprovalsReviewer(da.runtime) && (
-                      <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
-                        <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary) desktop:text-[13px]">
-                          Approval reviewer
-                        </span>
-                        <span className="badge bg-(--surface-active) text-(--text-secondary) max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]">
-                          {approvalsReviewerLabel(da.approvalsReviewer)}
-                        </span>
-                      </div>
-                    )}
                     <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
                       <span className="font-sans text-[14px] font-normal leading-normal text-(--text-tertiary) desktop:text-[13px]">
                         {effortField(da.runtime).label}

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   approvalsReviewerDefault,
-  approvalsReviewerLabel,
-  approvalsReviewerOptions,
   agentEffortDisplay,
   agentModelDisplay,
   agentPermissionDisplay,
@@ -17,6 +15,8 @@ import {
   modelCapability,
   modelLabel,
   permissionModeChoicesFor,
+  permissionModePresets,
+  permissionPresetSettings,
   preferredModelFor,
   PLAYGROUND_CHANNEL_FILTER,
   resolvedPermissionMode,
@@ -25,6 +25,7 @@ import {
   resolveEffortForModel,
   sessionChannelDisplay,
   sessionChannelFilterValue,
+  selectedPermissionPreset,
   status,
   type DaemonRow,
   type RuntimeModelCatalog,
@@ -276,17 +277,27 @@ describe('permissionModeChoicesFor', () => {
   })
 })
 
-describe('Auto-review options', () => {
-  it('keeps the reviewer separate from Codex permission modes', () => {
-    expect(permissionModeOptions('codex').map((option) => option.v)).toEqual([
-      'read-only',
-      'agent',
-      'agent-full-access'
+describe('Codex permission presets', () => {
+  it('merges Auto-review into the Agent editor without inventing a runtime mode', () => {
+    const modes = permissionModeOptions('codex')
+    expect(modes.map((option) => option.v)).toEqual(['read-only', 'agent', 'agent-full-access'])
+    expect(permissionModePresets('codex', modes).map((option) => option.l)).toEqual([
+      'Read Only',
+      'Ask for approval',
+      'Auto',
+      'Full Access'
     ])
-    expect(approvalsReviewerOptions('codex').map((option) => option.v)).toEqual(['user', 'auto_review'])
+    expect(selectedPermissionPreset('codex', 'agent', 'auto_review')).toBe('agent:auto-review')
+    expect(permissionPresetSettings('codex', 'agent:auto-review')).toEqual({
+      permissionMode: 'agent',
+      approvalsReviewer: 'auto_review'
+    })
+    expect(permissionPresetSettings('codex', 'read-only')).toEqual({
+      permissionMode: 'read-only',
+      approvalsReviewer: 'user'
+    })
     expect(approvalsReviewerDefault('codex')).toBe('user')
     expect(approvalsReviewerDefault('claude')).toBe('')
-    expect(approvalsReviewerLabel('auto_review')).toBe('Auto-review')
   })
 })
 
@@ -605,6 +616,9 @@ describe('agent config display helpers (card ↔ editor parity)', () => {
     })
     it('resolves a blank mode through the catalog default', () => {
       expect(agentPermissionDisplay(codexDaemon, 'codex', '')).toBe('Ask for approval')
+    })
+    it('shows the merged Auto preset when Agent requests use Auto-review', () => {
+      expect(agentPermissionDisplay(codexDaemon, 'codex', 'agent', 'auto_review')).toBe('Auto')
     })
     it('falls back to the static permission table without a catalog', () => {
       expect(agentPermissionDisplay(undefined, 'codex', 'agent-full-access')).toBe('Full Access')

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -451,8 +451,9 @@ export function permissionModeOptions(runtime: string): { v: string; l: string }
     // console can't misrepresent them. Values are codex-acp's runtime-owned ids (probed
     // from session/new): `agent` is Codex's default, labeled "Ask for approval"
     // (on-request + workspace-write); `agent-full-access` is danger-full-access —
-    // out-of-workspace + network. Codex's "Approve for me" behavior is exposed
-    // separately through approvalsReviewer; it is not a fourth permission mode.
+    // out-of-workspace + network. Codex's Auto preset is composed in the Agent
+    // editor from `agent` + approvalsReviewer; it is not a runtime mode and must
+    // stay out of this raw list (session controls can only stage the mode itself).
     return [
       { v: 'read-only', l: 'Read Only' },
       { v: 'agent', l: 'Ask for approval' },
@@ -482,28 +483,56 @@ export function permissionModeLabel(runtime: string, v: string): string {
   return o?.l ?? mode
 }
 
-export function supportsApprovalsReviewer(runtime: string): boolean {
+function supportsApprovalsReviewer(runtime: string): boolean {
   return runtimeLabel(runtime) === 'Codex'
-}
-
-export function approvalsReviewerOptions(runtime: string): Array<{
-  v: ApprovalsReviewer
-  l: string
-  description: string
-}> {
-  if (!supportsApprovalsReviewer(runtime)) return []
-  return [
-    { v: 'user', l: 'User', description: 'Ask an agent editor to approve or deny requests' },
-    { v: 'auto_review', l: 'Auto-review', description: 'Use a reviewer agent for eligible requests' }
-  ]
 }
 
 export function approvalsReviewerDefault(runtime: string): ApprovalsReviewer | '' {
   return supportsApprovalsReviewer(runtime) ? 'user' : ''
 }
 
-export function approvalsReviewerLabel(value: ApprovalsReviewer | null | undefined): string {
-  return value === 'auto_review' ? 'Auto-review' : 'User'
+const CODEX_AUTO_REVIEW_PRESET = 'agent:auto-review'
+
+/** Agent-editor presets compose Codex's independent mode + reviewer selectors
+ * into the single permissions control users see in Codex. Other runtimes keep
+ * their advertised mode list unchanged. */
+export function permissionModePresets(
+  runtime: string,
+  modes: Array<{ v: string; l: string; description?: string }>
+): Array<{ v: string; l: string; description?: string }> {
+  if (!supportsApprovalsReviewer(runtime) || !modes.some((mode) => mode.v === 'agent')) return modes
+  return modes.flatMap((mode) =>
+    mode.v === 'agent'
+      ? [
+          mode,
+          {
+            v: CODEX_AUTO_REVIEW_PRESET,
+            l: 'Auto',
+            description: 'Use Auto-review for eligible requests without widening the sandbox'
+          }
+        ]
+      : [mode]
+  )
+}
+
+export function selectedPermissionPreset(
+  runtime: string,
+  permissionMode: string,
+  approvalsReviewer: ApprovalsReviewer | ''
+): string {
+  return supportsApprovalsReviewer(runtime) && permissionMode === 'agent' && approvalsReviewer === 'auto_review'
+    ? CODEX_AUTO_REVIEW_PRESET
+    : permissionMode
+}
+
+export function permissionPresetSettings(
+  runtime: string,
+  preset: string
+): { permissionMode: string; approvalsReviewer: ApprovalsReviewer | '' } {
+  if (!supportsApprovalsReviewer(runtime)) return { permissionMode: preset, approvalsReviewer: '' }
+  return preset === CODEX_AUTO_REVIEW_PRESET
+    ? { permissionMode: 'agent', approvalsReviewer: 'auto_review' }
+    : { permissionMode: preset, approvalsReviewer: 'user' }
 }
 
 // ── dynamic model catalog (runtime-model-catalog.md §7) ─────────────────────
@@ -767,11 +796,13 @@ export function agentEffortDisplay(
 export function agentPermissionDisplay(
   daemon: Pick<DaemonRow, 'runtimeModels'> | undefined,
   runtime: string,
-  permissionMode: string
+  permissionMode: string,
+  approvalsReviewer?: ApprovalsReviewer
 ): string {
   const catalog = daemon?.runtimeModels.find((r) => r.runtime === runtime)?.modelCatalog ?? undefined
   const choices = permissionModeChoicesFor(runtime, catalog)
   const mode = permissionMode || catalog?.defaultPermissionMode || permissionModeDefault(runtime)
+  if (supportsApprovalsReviewer(runtime) && mode === 'agent' && approvalsReviewer === 'auto_review') return 'Auto'
   return choices.find((o) => o.v === mode)?.l ?? permissionModeLabel(runtime, permissionMode)
 }
 


### PR DESCRIPTION
## Summary

- replace the separate Codex `Permission mode` and `Approval reviewer` controls with one four-preset permissions row: `Read-only`, `Agent`, `Auto`, and `Agent (full access)`
- map the UI-only `Auto` preset to `permissionMode=agent` plus `approvalsReviewer=auto_review`; selecting another Codex preset restores `approvalsReviewer=user`
- show the combined preset on Agent Detail and keep the four-choice control horizontally usable on narrow screens

## Why

Follow-up to #407. codex-acp correctly exposes permission mode and approval reviewer as independent session options, but users should choose the familiar combined Codex permissions preset rather than coordinate two protocol-level controls.

The raw permission-mode catalog and session composer remain unchanged because session controls currently stage only the runtime mode, not the Agent-level reviewer preference.

## Validation

- Web data tests: 55 passed
- Web typecheck
- Web production build
- full repository ESLint via the pre-push hook

Created by Codex . GPT-5.6 Sol
