### PR TITLE
fix(web): multi-agent live view — work-lane supersession marker + per-participant attribution

### DIFF
--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -430,9 +430,11 @@ multi-agent webchat adopts the same workflow with three adaptations:
   replacement's generation ordinal) — not a terminal frame: the turn still
   ends with exactly one `done`, so replay windows, busy state, and older
   browsers (which ignore unknown event kinds) stay coherent. The console
-  collapses the lane with a "the conversation moved on — updating this
-  answer" marker and the replacement generation streams under the same
-  `turnId`. Only the accepted generation becomes the canonical post, fans
+  folds the discarded blocks into the collapsible work lane together with a
+  "the conversation moved on — updating this answer" marker at the point the
+  update happened — live-only chrome, since a refresh rebuilds from the
+  persisted transcript, which records only the accepted generation — and the
+  replacement streams under the same `turnId`. Only the accepted generation becomes the canonical post, fans
   out as context, and is recorded as delivered; discarded generations follow
   that design's transcript and usage rules — audit-visible, usage counted,
   never delivered.

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -204,6 +204,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // where the relay applied the all-participants default) create its stream
   // lane lazily instead of dropping the reply.
   const pendingTurnIds = useRef<Map<string, string>>(new Map())
+  // Participant display names per session id, mirrored in a ref: the socket's
+  // message handlers are closures captured when the socket opened — often the
+  // same tick openPlayground staged the session — so state-based lookups there
+  // would read a stale snapshot and stamp every step without a name.
+  const rosterNames = useRef<Map<string, Map<string, string>>>(new Map())
   // One ordering cursor per stream LANE — a multi-agent turn runs one lane per
   // targeted participant (webchat-multi-agents.md §5.3); keys from lib/webchat-lanes.ts.
   const streamCursors = useRef<Map<string, OrderedWebchatCursor<WebchatOutput, WebchatDone>>>(new Map())
@@ -303,6 +308,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const participantName = useCallback(
     (id: string, agentId: string | undefined): string | undefined => {
       if (!agentId) return undefined
+      const named = rosterNames.current.get(id)?.get(agentId)
+      if (named) return named
       const s = pgSessions[id]
       return s?.participants?.find((p) => p.agentId === agentId)?.name
     },
@@ -742,11 +749,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // The roster is fixed at creation (webchat-multi-agents.md §3.1): the
       // first pick is the primary; there is no add/remove after the first send.
       const roster = [da, ...(members ?? []).filter((m) => m.id !== da.id)]
-      if (roster.length > 1)
+      if (roster.length > 1) {
         rosterAgentIds.current.set(
           id,
           roster.map((a) => a.id)
         )
+        rosterNames.current.set(id, new Map(roster.map((a) => [a.id, agentLabel(a)])))
+      }
       setPgSessions((cur) => {
         return {
           ...cur,
@@ -818,6 +827,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       }
       const ids = rosterAgentIds.current.get(id) ?? [primaryId]
       if (!ids.includes(added.id)) rosterAgentIds.current.set(id, [...ids, added.id])
+      const names = rosterNames.current.get(id) ?? new Map<string, string>()
+      if (!names.size && session.agentName) names.set(primaryId, session.agentName)
+      names.set(added.id, agentLabel(added))
+      rosterNames.current.set(id, names)
       setPgSessions((cur) => {
         const s = cur[id]
         if (!s || !s.agentId) return cur

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -357,12 +357,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             if (step.boundary) break
             if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan' }
           }
-          // The marker is a VISIBLE conversation step ('done', not the
-          // collapsible work lane) fenced with `boundary` so replacement chunks
-          // never merge into it.
+          // The marker lives INSIDE the collapsible work lane ('plan'), at the
+          // chronological point the update happened — it is live-only chrome (a
+          // refresh rebuilds from the persisted transcript, which never records
+          // it), so it must not masquerade as standing conversation content.
+          // `boundary` still fences it: replacement chunks start fresh blocks.
           return [
             ...collapsed,
-            lane({ kind: 'done', text: 'The conversation moved on — updating this answer…', boundary: true })
+            lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…', boundary: true })
           ]
         }
         if (ev.kind === 'message') {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -516,7 +516,7 @@ type Turn =
       isCron: boolean
       cronId: string | null
     }
-  | { kind: 'bot'; agentName: string; model: string; time: string; steps: FmtStep[] }
+  | { kind: 'bot'; agentName: string; agentId?: string; model: string; time: string; steps: FmtStep[] }
 
 function ParticipantAvatar({
   agent,
@@ -1315,14 +1315,24 @@ export default function SessionDetailView() {
         })
         firstMsg = false
       } else {
-        // Multi-agent conversations attribute live steps per participant
-        // (`who`/`agentId` from the stream lane); break the bot-turn grouping
-        // when the author changes so each block carries the right name.
-        const stepAgentName = stp.who ?? session.agentName ?? ''
-        if (stp.who) speakers.set(stp.agentId ?? stp.who, stp.who)
+        // Multi-agent conversations attribute live steps per participant. The
+        // lane's `agentId` is authoritative (stamped from the stream cursor);
+        // resolve its display name at RENDER time from the org agent list —
+        // stream-time `who` can be missing (the socket closure predates the
+        // session state) and adopted sessions never had a roster.
+        const stepAgent = stp.agentId ? agents.find((a) => a.id === stp.agentId) : undefined
+        const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
+        if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || last.agentName !== stepAgentName) {
-          last = { kind: 'bot', agentName: stepAgentName, model: session.model ?? '', time: '', steps: [] }
+          last = {
+            kind: 'bot',
+            agentName: stepAgentName,
+            ...(stp.agentId ? { agentId: stp.agentId } : {}),
+            model: session.model ?? '',
+            time: '',
+            steps: []
+          }
           turns.push(last)
         }
         const step = fmtStep(stp)
@@ -1357,11 +1367,19 @@ export default function SessionDetailView() {
           cronId: null
         })
       } else {
-        const stepAgentName = stp.who ?? session.agentName ?? ''
-        if (stp.who) speakers.set(stp.agentId ?? stp.who, stp.who)
+        const stepAgent = stp.agentId ? agents.find((a) => a.id === stp.agentId) : undefined
+        const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
+        if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || last.agentName !== stepAgentName) {
-          last = { kind: 'bot', agentName: stepAgentName, model: session.model ?? '', time: '', steps: [] }
+          last = {
+            kind: 'bot',
+            agentName: stepAgentName,
+            ...(stp.agentId ? { agentId: stp.agentId } : {}),
+            model: session.model ?? '',
+            time: '',
+            steps: []
+          }
           turns.push(last)
         }
         const step = fmtStep(stp)
@@ -1865,7 +1883,16 @@ export default function SessionDetailView() {
                     return (
                       <div key={`${session.id}:${ti}`} className="flex items-start gap-[9px]">
                         <span className="av h-[26px] w-[26px] flex-none rounded-md">
-                          <AgentIconView icon={owner?.icon} runtime={agentRuntime || turn.model} size={26} />
+                          <AgentIconView
+                            icon={
+                              (turn.agentId ? agents.find((a) => a.id === turn.agentId) : owner)?.icon ?? owner?.icon
+                            }
+                            runtime={
+                              (turn.agentId ? agents.find((a) => a.id === turn.agentId)?.runtime : undefined) ??
+                              (agentRuntime || turn.model)
+                            }
+                            size={26}
+                          />
                         </span>
                         <div className="min-w-0 flex-1">
                           <div className="mb-[5px] flex items-center gap-[7px]">

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
+import { sameBotSpeaker } from '@/lib/bot-turn-grouping'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
@@ -1320,11 +1321,11 @@ export default function SessionDetailView() {
         // resolve its display name at RENDER time from the org agent list —
         // stream-time `who` can be missing (the socket closure predates the
         // session state) and adopted sessions never had a roster.
-        const stepAgent = stp.agentId ? agents.find((a) => a.id === stp.agentId) : undefined
+        const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
         if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
-        if (!last || last.kind !== 'bot' || last.agentName !== stepAgentName) {
+        if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
             kind: 'bot',
             agentName: stepAgentName,
@@ -1334,6 +1335,9 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
+        } else if (stp.agentId && last.agentId === undefined) {
+          // A tagged step continuing an untagged block names its author retroactively.
+          last.agentId = stp.agentId
         }
         const step = fmtStep(stp)
         last.steps.push(step)
@@ -1367,11 +1371,11 @@ export default function SessionDetailView() {
           cronId: null
         })
       } else {
-        const stepAgent = stp.agentId ? agents.find((a) => a.id === stp.agentId) : undefined
+        const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
         if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
-        if (!last || last.kind !== 'bot' || last.agentName !== stepAgentName) {
+        if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
             kind: 'bot',
             agentName: stepAgentName,
@@ -1381,6 +1385,9 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
+        } else if (stp.agentId && last.agentId === undefined) {
+          // A tagged step continuing an untagged block names its author retroactively.
+          last.agentId = stp.agentId
         }
         const step = fmtStep(stp)
         last.steps.push(step)
@@ -1884,11 +1891,9 @@ export default function SessionDetailView() {
                       <div key={`${session.id}:${ti}`} className="flex items-start gap-[9px]">
                         <span className="av h-[26px] w-[26px] flex-none rounded-md">
                           <AgentIconView
-                            icon={
-                              (turn.agentId ? agents.find((a) => a.id === turn.agentId) : owner)?.icon ?? owner?.icon
-                            }
+                            icon={((turn.agentId ? agentById.get(turn.agentId) : owner) ?? owner)?.icon}
                             runtime={
-                              (turn.agentId ? agents.find((a) => a.id === turn.agentId)?.runtime : undefined) ??
+                              (turn.agentId ? agentById.get(turn.agentId)?.runtime : undefined) ??
                               (agentRuntime || turn.model)
                             }
                             size={26}

--- a/packages/web/src/lib/bot-turn-grouping.test.ts
+++ b/packages/web/src/lib/bot-turn-grouping.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { sameBotSpeaker } from './bot-turn-grouping'
+
+const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+describe('bot turn grouping', () => {
+  it('splits two participants that share a display name', () => {
+    // The regression: two distinct agents labeled identically must not merge
+    // into one block (whose avatar/runtime would belong to the first).
+    expect(sameBotSpeaker({ agentId: A, agentName: 'review' }, { agentId: B, agentName: 'review' })).toBe(false)
+  })
+
+  it('continues the block for the same tagged participant', () => {
+    expect(sameBotSpeaker({ agentId: A, agentName: 'review' }, { agentId: A, agentName: 'review' })).toBe(true)
+  })
+
+  it('groups legacy untagged steps by display name', () => {
+    expect(sameBotSpeaker({ agentName: 'a' }, { agentName: 'a' })).toBe(true)
+    expect(sameBotSpeaker({ agentName: 'a' }, { agentName: 'b' })).toBe(false)
+  })
+
+  it('lets a one-sided tag fall back to the name', () => {
+    // An untagged warning step pushed while a tagged block is open, and the
+    // tagged step that follows an untagged block, both group by name.
+    expect(sameBotSpeaker({ agentId: A, agentName: 'a' }, { agentName: 'a' })).toBe(true)
+    expect(sameBotSpeaker({ agentName: 'a' }, { agentId: A, agentName: 'a' })).toBe(true)
+  })
+})

--- a/packages/web/src/lib/bot-turn-grouping.ts
+++ b/packages/web/src/lib/bot-turn-grouping.ts
@@ -1,0 +1,14 @@
+// Grouping identity for consecutive live bot steps in the session detail view
+// (webchat-multi-agents.md §5.3): agent display names are NOT unique, so when
+// both sides carry the lane-stamped `agentId` it is authoritative. The name
+// comparison remains only for legacy untagged steps (pre-multi-agent daemons,
+// locally pushed warning steps), which have nothing else to group by.
+
+/** Whether a live step continues the previous bot block. */
+export function sameBotSpeaker(
+  prev: { agentId?: string | undefined; agentName: string },
+  next: { agentId?: string | undefined; agentName: string }
+): boolean {
+  if (prev.agentId !== undefined && next.agentId !== undefined) return prev.agentId === next.agentId
+  return prev.agentName === next.agentName
+}


### PR DESCRIPTION
Two live-view fixes for multi-agent webchat conversations (follow-ups to #405/#409).

## 1. Supersession marker moves into the collapsible work lane

When a peer's reply lands mid-turn and turn-final context refresh regenerates an
answer, the live view showed **“The conversation moved on — updating this answer…”**
as standing conversation text. Product call: the marker is live-only chrome (a
refresh rebuilds the view from the persisted transcript, which never contains it),
so it must not read like part of the conversation.

- The superseded answer still collapses (`done` steps → `plan`), and the marker is
  now emitted as a `plan` step too, so both live inside the collapsible Thought
  lane instead of the message flow.
- A `boundary` flag on the marker step keeps the collapse scan from eating steps
  of the *previous* generation when a turn is superseded more than once.

## 2. Live per-participant attribution (was: every reply merged into one block)

On a multi-agent turn, the second participant's streamed answer rendered inside
the first agent's block until the page was refreshed; the persisted transcript
was always attributed correctly.

Root cause: step authorship was resolved at **stream time** via `participantName`,
which reads `pgSessions` through the socket's `onmessage` closure. That closure is
captured when the socket opens — typically the same tick `openPlayground` stages
the session state — so the lookup read a permanently stale snapshot and `who` was
never stamped. Every bot step then fell back to the session owner's name and the
grouping loop merged them into one block. The lane-derived `agentId` on each step
was correct all along.

- `SessionDetailView` now resolves the block's display name, icon, and runtime
  from the step's `agentId` at **render time** (state-independent), keeping `who`
  and the session owner as fallbacks for legacy untagged frames.
- `PlaygroundProvider` mirrors roster display names in a ref so stream-time `who`
  stamping also works despite the closure snapshot (belt and braces for other
  consumers of `who`).

Tests: web unit suite (579 passing, incl. `webchat-lanes`), `tsc --noEmit`, eslint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)