### PR TITLE
fix(web): render peer agents on the left in session detail

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2426,6 +2426,14 @@ export const SessionDetailDto = z.object({
    *  server-side; the console never re-derives permissions from identity. */
   canChangeVisibility: z.boolean(),
   accessSyncDegraded: z.boolean(),
+  /** Multi-agent webchat conversation roster, in pick order (webchat-multi-agents.md
+   *  §3.1). Adopted/refreshed sessions have no live relay socket to deliver the
+   *  verified roster, so the composer and header read it from here. Null for
+   *  single-agent conversations and for every other platform; `name` is null when
+   *  the caller cannot view that participant's agent. */
+  participants: z
+    .array(z.object({ agentId: z.string(), name: z.string().nullable(), primary: z.boolean() }))
+    .nullable(),
   startedAt: z.string(), // ISO-8601
   endedAt: z.string().nullable()
 })

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -531,14 +531,20 @@ export function sessionRoutes(deps: HttpDeps) {
         // Relationships may cross agents (and daemons), so apply the same
         // owning-agent visibility rule to every linked session. A hidden parent
         // is indistinguishable from no parent; hidden children are omitted.
-        const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((a) => a.id)
+        const visibleAgents = await deps.repos.agent.list(orgOf(req), ctxOf(req))
+        const visibleAgentIds = visibleAgents.map((a) => a.id)
         const visibleAgentIdSet = new Set<string>(visibleAgentIds)
         const ctx = ctxOf(req)
-        const [parent, children, siblingCandidates, usage] = await Promise.all([
+        const [parent, children, siblingCandidates, usage, webchatRoster] = await Promise.all([
           s.parentSessionId ? deps.repos.session.get(s.parentSessionId) : Promise.resolve(null),
           deps.repos.session.listChildren(SessionId(s.id), visibleAgentIds),
           s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, visibleAgentIds) : Promise.resolve([]),
-          deps.repos.sessionUsage.get(s.agentId, s.id)
+          deps.repos.sessionUsage.get(s.agentId, s.id),
+          // A webchat session's channel IS its conversation id; the roster feeds
+          // the adopted-session composer/header, which has no relay socket.
+          s.platform === 'webchat' && s.channel
+            ? deps.repos.webchatConversation.participants(s.channel)
+            : Promise.resolve([])
         ])
         const siblings = siblingCandidates.filter((candidate) => candidate.id !== s.id)
         const related = [...(parent ? [parent] : []), ...siblings, ...children]
@@ -579,6 +585,14 @@ export function sessionRoutes(deps: HttpDeps) {
           channelName: s.channelName,
           triggeredByName: s.triggeredByName,
           threadUrl: s.threadUrl,
+          participants:
+            webchatRoster.length > 1
+              ? webchatRoster.map((p) => ({
+                  agentId: p.agentId,
+                  name: visibleAgents.find((a) => a.id === p.agentId)?.name ?? null,
+                  primary: p.role === 'primary'
+                }))
+              : null,
           runtime: s.runtime,
           model: s.model,
           effort: s.effort,

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -12,12 +12,13 @@ import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedLaunch } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { PgAgentRepo, PgHookRepo, PgSessionRepo } from '../../src/persistence/index.js'
+import { PgAgentRepo, PgHookRepo, PgSessionRepo, PgWebchatConversationRepo } from '../../src/persistence/index.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
 import { handleEventSession } from '../../src/ws/handlers/index.js'
 import type { DaemonConnection } from '../../src/ws/connection.js'
 import type { DaemonWsDeps } from '../../src/ws/deps.js'
 import type { AnyFrame } from '@agentconnect.md/protocol'
-import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { InMemorySessionEventSink } from '../../src/events/sink.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 
@@ -48,6 +49,9 @@ async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON
     agentMutations: new AgentMutationGate(),
     hook: new PgHookRepo(prisma),
     session: new PgSessionRepo(prisma),
+    // Resolves the private-session owner for webchat reports (session-visibility
+    // §4.2) — without it a webchat session stores ownerless and no caller can view it.
+    webchatConversation: new PgWebchatConversationRepo(prisma),
     events: new InMemorySessionEventSink()
   } as unknown as DaemonWsDeps
   await handleEventSession(frame, { daemonId } as DaemonConnection, deps)
@@ -458,6 +462,58 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
         expect.objectContaining({ value: `hook:${githubId}`, hookKind: 'github' })
       ])
     )
+  })
+
+  it('serves the multi-agent webchat roster on the detail route; single-agent stays null', async () => {
+    // An adopted/refreshed webchat session has no relay socket to deliver the
+    // verified roster — the composer/header read it from this DTO field instead.
+    const AGENT2 = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    const CONVO = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
+    const SOLO = 'c1c1c1c1-cccc-4ccc-8ccc-cccccccccccc'
+    const SESSION2 = '5691f21b-3911-4d7f-a45d-28ce75d79338'
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON, name: 'answer-bot' })
+    await seedAgent(prisma, AGENT2, { daemonId: DAEMON, name: 'peer-bot' })
+    const conversations = new PgWebchatConversationRepo(prisma)
+    await conversations.create(
+      { conversationId: CONVO, orgId: OrgId(DEFAULT_ORG_ID), agentId: AgentId(AGENT), userId: DEFAULT_OWNER_ID },
+      [AgentId(AGENT2)]
+    )
+    await conversations.create({
+      conversationId: SOLO,
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId: AgentId(AGENT),
+      userId: DEFAULT_OWNER_ID
+    })
+    running = buildHttpApp(prisma)
+
+    await reportSession({
+      sessionId: SESSION,
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'webchat',
+      channel: CONVO,
+      ts: '2026-07-05T00:00:00.000Z'
+    })
+    await reportSession({
+      sessionId: SESSION2,
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'webchat',
+      channel: SOLO,
+      ts: '2026-07-05T00:00:00.000Z'
+    })
+
+    const multi = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION}` })
+    expect(multi.statusCode).toBe(200)
+    expect((multi.json() as { participants: unknown }).participants).toEqual([
+      { agentId: AGENT, name: 'answer-bot', primary: true },
+      { agentId: AGENT2, name: 'peer-bot', primary: false }
+    ])
+
+    const solo = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/${SESSION2}` })
+    expect(solo.statusCode).toBe(200)
+    expect((solo.json() as { participants: unknown }).participants).toBeNull()
   })
 
   it('404s for an unknown session', async () => {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -163,8 +163,28 @@ interface FmtStep {
   code: string
   files: { tag: string; path: string; color: string }[]
   time?: string
+  // A peer participant's message attachment (rendered like the user bubble's).
+  image?: SessionImage
   // Present only on real-transcript tool rows that carry a captured body.
   msg?: SessionMessageDto
+}
+
+// A bare text step (no lane chrome) — how a peer participant's message renders
+// inside its agent block.
+function plainStep(text: string, time?: string, image?: SessionImage): FmtStep {
+  return {
+    lane: '',
+    laneColor: 'var(--text-tertiary)',
+    dot: 'var(--text-disabled)',
+    weight: 400,
+    textColor: 'var(--text-primary)',
+    codeColor: 'var(--text-secondary)',
+    text,
+    code: '',
+    files: [],
+    ...(time ? { time } : {}),
+    ...(image ? { image } : {})
+  }
 }
 
 // A step's non-text extras (code block, file chips, captured tool body) — rendered
@@ -1246,14 +1266,36 @@ export default function SessionDetailView() {
 
   const turns: Turn[] = []
   const speakers = new Map<string, string>()
+  // Another agent speaking in this session — a webchat peer participant or a
+  // trusted a2a bot — renders as its own left-side agent block: the right side
+  // is reserved for humans. Groups consecutive rows like live bot steps.
+  const pushAgentTurn = (agent: Agent, step: FmtStep): void => {
+    const name = agentLabel(agent)
+    speakers.set(agent.id, name)
+    let last = turns[turns.length - 1]
+    if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: agent.id, agentName: name })) {
+      last = { kind: 'bot', agentName: name, agentId: agent.id, model: '', time: '', steps: [] }
+      turns.push(last)
+    }
+    last.steps.push(step)
+    if (!last.time && step.time) last.time = step.time
+  }
   if (wantTranscript) {
     // Real transcript: agent output carries `sender === agentId`; everything else
     // is a human/cron author. Group consecutive agent messages into one turn.
     for (const m of visibleMsgs ?? []) {
       if (m.sender === session.agentId) {
         let last = turns[turns.length - 1]
-        if (!last || last.kind !== 'bot') {
-          last = { kind: 'bot', agentName: session.agentName ?? '', model: session.model ?? '', time: '', steps: [] }
+        const ownerName = session.agentName ?? ''
+        if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: m.sender, agentName: ownerName })) {
+          last = {
+            kind: 'bot',
+            agentName: ownerName,
+            agentId: m.sender,
+            model: session.model ?? '',
+            time: '',
+            steps: []
+          }
           turns.push(last)
         }
         const step = msgStep(m)
@@ -1266,6 +1308,10 @@ export default function SessionDetailView() {
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined
         const self = isSelf(m.sender)
+        if (senderAgent && !self) {
+          pushAgentTurn(senderAgent, { ...msgStep(m), ...(m.attachments?.[0] ? { image: m.attachments[0] } : {}) })
+          continue
+        }
         const participant = self
           ? speaker('@you')
           : speaker(
@@ -1297,6 +1343,11 @@ export default function SessionDetailView() {
         const senderAgent = participantAgent(who, stp.text)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const self = isSelf(who)
+        if (senderAgent && !self) {
+          pushAgentTurn(senderAgent, plainStep(stp.text, stp.time ?? (firstMsg ? session.time : ''), stp.image))
+          firstMsg = false
+          return
+        }
         const participant = self
           ? speaker('@you')
           : speaker(senderAgentName ?? who, cron?.name ?? (cron ? 'Schedule' : senderAgentName))
@@ -1355,6 +1406,10 @@ export default function SessionDetailView() {
         const senderAgent = participantAgent(who, stp.text)
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const self = isSelf(who)
+        if (senderAgent && !self) {
+          pushAgentTurn(senderAgent, plainStep(stp.text, stp.time ?? '', stp.image))
+          continue
+        }
         const participant = self ? speaker('@you') : speaker(senderAgentName ?? who, senderAgentName)
         speakers.set(senderAgent?.id ?? who, participant.name)
         turns.push({
@@ -1910,6 +1965,13 @@ export default function SessionDetailView() {
                           </div>
                           {textSteps.map((st, si) => (
                             <div key={si} className={si > 0 ? 'mt-2' : ''}>
+                              {st.image && (
+                                <img
+                                  src={`data:${st.image.mimeType};base64,${st.image.data}`}
+                                  alt={st.image.name}
+                                  className={`max-h-[360px] max-w-full rounded-md object-contain ${st.text ? 'mb-[10px]' : ''}`}
+                                />
+                              )}
                               {st.text && (
                                 <div className="font-sans text-[13.5px] leading-[1.6] whitespace-pre-wrap text-(--text-primary)">
                                   <MessageText text={st.text} />
@@ -2087,7 +2149,9 @@ export default function SessionDetailView() {
                   )}
                   <textarea
                     className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
-                    placeholder={`Message ${session.agentName}…`}
+                    placeholder={
+                      (session.participants?.length ?? 0) > 1 ? 'Message everyone…' : `Message ${session.agentName}…`
+                    }
                     value={pgInput}
                     onChange={(e) => setPgInput(e.target.value)}
                     onPaste={(event) => {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -859,7 +859,14 @@ export default function SessionDetailView() {
   // The cursor-loaded list row can predate the final Dream usage report. Keep
   // its local/live fields, but let the independently refreshed detail snapshot
   // supply the authoritative per-session token and cost totals.
-  const sessionBase = localSession ? mergeSessionDetailUsage(localSession, detailSession) : detailSession
+  const sessionMerged = localSession ? mergeSessionDetailUsage(localSession, detailSession) : detailSession
+  // The conversation roster only exists on the detail snapshot (list rows and
+  // adopted local state don't carry it); a live playground session's own roster
+  // (which tracks mid-conversation joins) stays authoritative when present.
+  const sessionBase =
+    sessionMerged && !sessionMerged.participants && detailSession?.participants
+      ? { ...sessionMerged, participants: detailSession.participants }
+      : sessionMerged
   const agentById = useMemo(() => new Map(agents.map((agent) => [agent.id, agent])), [agents])
   const owner = sessionBase?.agentId ? agentById.get(sessionBase.agentId) : undefined
   const session =
@@ -1274,6 +1281,8 @@ export default function SessionDetailView() {
     speakers.set(agent.id, name)
     let last = turns[turns.length - 1]
     if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: agent.id, agentName: name })) {
+      // `model` is the icon-runtime fallback for turns whose agent is missing from
+      // `agentById`; a peer turn's agent came FROM that map, so it stays empty.
       last = { kind: 'bot', agentName: name, agentId: agent.id, model: '', time: '', steps: [] }
       turns.push(last)
     }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -477,6 +477,10 @@ export interface SessionDetailDto {
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
   accessSyncDegraded?: boolean
+  /** Multi-agent webchat conversation roster, in pick order. Null for single-agent
+   *  conversations and other platforms; absent on a CP that predates the feature.
+   *  `name` is null when the caller cannot view that participant's agent. */
+  participants?: Array<{ agentId: string; name: string | null; primary: boolean }> | null
 }
 
 // The full ACP tool body (protocol `ToolBody`), transported as a JSON STRING in
@@ -1738,7 +1742,16 @@ export function sessionFromDto(d: SessionDto): Session {
  *  pages. Detail carries its own latest usage snapshot so a direct link can show
  *  this session's token/cost accounting without depending on list pagination. */
 export function sessionFromDetailDto(d: SessionDetailDto): Session {
-  return sessionFromDto({
+  // The adopted-session composer/header needs the conversation roster before any
+  // relay socket exists; short-id fallback mirrors the provider's ready-frame path.
+  const participants = d.participants?.length
+    ? d.participants.map((p) => ({
+        agentId: p.agentId,
+        name: p.name ?? p.agentId.slice(0, 8),
+        ...(p.primary ? { primary: true } : {})
+      }))
+    : undefined
+  const base = sessionFromDto({
     sessionId: d.id,
     sessionKey: {
       platform: d.platform ?? 'slack',
@@ -1763,6 +1776,7 @@ export function sessionFromDetailDto(d: SessionDetailDto): Session {
     outputMode: d.outputMode,
     daemonId: d.daemonId
   })
+  return participants ? { ...base, participants } : base
 }
 
 /** Keep local/live session fields while refreshing usage from the independently


### PR DESCRIPTION
Follow-up to the multi-agent webchat series (#402/#405/#409/#412), fixing the per-agent session view shown in review: a peer agent's answer rendered as a **right-aligned human bubble**, reading as if it were the viewer's own message.

## Rule

The right side is reserved for humans ("you"). Any transcript sender that resolves to an org agent — a webchat peer participant or a trusted a2a bot on IM — now renders as its own **left-side agent block** (own icon, name, timestamp), the same visual language as the owning agent. Sides encode "is this me"; identity within the left column comes from avatar + name, which scales to any roster size.

## Changes

- All three turn-building paths (real transcript, live steps, adopted-webchat live tail) route agent-authored messages through a shared `pushAgentTurn` that groups consecutive rows with the existing `sameBotSpeaker` identity check.
- Owner-turn grouping gains the same identity check, so consecutive owner and peer rows no longer merge into one block.
- `FmtStep` gains an optional `image`, rendered like the user bubble's attachment, so peer messages with attachments survive the move.
- Composer placeholder becomes **"Message everyone…"** when the conversation has multiple participants — post-#409 semantics are all-respond, so "Message review-bot…" implied a private reply that isn't what sending does.

## Deliberately unchanged

Humans other than the viewer keep the current right-side rendering. Slack sender ↔ console identity linking is deferred (per review discussion); flipping non-self humans left before that lands would also move the viewer's own Slack messages to the left.

Tests: web suite 583 passing, `tsc --noEmit`, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)