### PR TITLE
fix(web): stabilize session participant count

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1383,6 +1383,7 @@ export default function SessionDetailView() {
         // session state) and adopted sessions never had a roster.
         const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
+        if (stp.agentId && stp.agentId !== session.agentId) speakers.set(stp.agentId, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
@@ -1436,6 +1437,7 @@ export default function SessionDetailView() {
       } else {
         const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
+        if (stp.agentId && stp.agentId !== session.agentId) speakers.set(stp.agentId, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
@@ -1466,6 +1468,7 @@ export default function SessionDetailView() {
   const soleAuthor = senderLabel(session.triggeredBy, session.user)
   const soleSpeaker = speakers.size === 1 ? speakers.entries().next().value : undefined
   const participantsLabel = speakers.size > 1 ? speakers.size + ' participants' : (soleSpeaker?.[1] ?? soleAuthor)
+  const participantsTitle = speakers.size > 1 ? [...speakers.values()].join('\n') : undefined
   // The session's `daemon` is the owning agent's daemonId (or '—' when unplaced);
   // resolve it to the daemon's display name — never surface the raw id/host
   // (short-id fallback when it isn't in the fleet), matching the Agents list.
@@ -1705,7 +1708,10 @@ export default function SessionDetailView() {
               <span className="truncate">{headerCron.name || 'Schedule'}</span>
             </Link>
           ) : (
-            <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+            <span
+              className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)"
+              title={participantsTitle}
+            >
               <Icon name="users" size={13} className="flex-none" />
               <span className="truncate">{participantsLabel}</span>
             </span>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1383,7 +1383,6 @@ export default function SessionDetailView() {
         // session state) and adopted sessions never had a roster.
         const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
-        if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
@@ -1437,7 +1436,6 @@ export default function SessionDetailView() {
       } else {
         const stepAgent = stp.agentId ? agentById.get(stp.agentId) : undefined
         const stepAgentName = (stepAgent ? agentLabel(stepAgent) : stp.who) ?? session.agentName ?? ''
-        if (stp.agentId || stp.who) speakers.set(stp.agentId ?? stepAgentName, stepAgentName)
         let last = turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {


### PR DESCRIPTION
## Summary

- keep the session participant count stable while the owning Agent streams
- continue counting additional Agent authors by their stable `agentId`
- show every participant name in the themed hover tooltip when the header collapses them to a count

## Root cause

The live multi-Agent attribution path added every bot step to the same `speakers` map used for the participant label, while the persisted transcript path keeps the owning Agent separate. Tagged and untagged live steps could therefore give that same Agent two map keys, producing transient `You → 2 participants → 3 participants` changes.

## Impact

A single-user Playground session keeps showing `You` while its Agent is working. Legitimate additional Agents and people remain distinct participants; when more than one is present, hovering the count shows their names on separate lines. Stream attribution, icons, grouping, and transcript rendering are unchanged.

## Validation

- `pnpm --filter @agentconnect.md/web build`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm exec eslint packages/web/src/components/console/views/SessionDetailView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/SessionDetailView.tsx`
- `git diff --check`
- local mock session verified `2 participants` exposes `dana` and `sam` to the console tooltip layer
- pre-push repository lint

Created by Codex . GPT-5
