### PR TITLE
fix(web): admit webchat stream lanes from early tagged frames

### DIFF
--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -249,7 +249,10 @@ on, **every user message activates the whole roster** unless it explicitly
 The relay applies the same default itself (`targets` absent or empty ⇒ the
 whole roster), so a resumed conversation with no client-side roster — or an
 older browser build — still reaches everyone; the browser admits stream lanes
-lazily from the per-agent acks. `targets ⊄ roster` is refused with the
+lazily from ANY tagged frame carrying the in-flight turn's id — usually the
+per-agent ack, but a warm session's first output can beat its ack to the
+browser (the daemon emits it synchronously inside turn admission), and
+dropping it would strand that lane's ordering cursor. `targets ⊄ roster` is refused with the
 `not_participant` ack reason per offending target. A one-participant roster
 makes every rule above collapse to today's single-agent behavior.
 

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -223,6 +223,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // where the relay applied the all-participants default) create its stream
   // lane lazily instead of dropping the reply.
   const pendingTurnIds = useRef<Map<string, string>>(new Map())
+  // Lanes that already COMPLETED for the in-flight turn (done applied, cursor
+  // removed), per session id. With done-before-ack ordering the trailing ack
+  // must not re-admit an empty cursor for a finished participant — it would
+  // never receive another terminal frame and wedge the busy state. Reset on
+  // each send (one in-flight turn per session).
+  const finishedTurnLanes = useRef<Map<string, { turnId: string; agents: Set<string> }>>(new Map())
   // Participant display names per session id, mirrored in a ref: the socket's
   // message handlers are closures captured when the socket opened — often the
   // same tick openPlayground staged the session — so state-based lookups there
@@ -465,6 +471,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // ack — while the sole-lane fallback is reserved for legacy frames that omit
   // agentId.
   const lanesOf = (id: string): string[] => lanesOfLanes(streamCursors.current, id)
+  const finishedFor = (id: string, turnId: string | undefined): ReadonlySet<string> | undefined => {
+    const rec = finishedTurnLanes.current.get(id)
+    return rec && rec.turnId === turnId ? rec.agents : undefined
+  }
   const cursorKeyFor = (id: string, agentId?: string): string | undefined =>
     cursorKeyForLanes(streamCursors.current, id, agentId)
   const dropLanes = (id: string): void => {
@@ -499,6 +509,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!result.done) return
       reconnectAttempts.current.delete(id)
       streamCursors.current.delete(cursorKey)
+      if (agentId && result.done.turnId) {
+        const rec = finishedTurnLanes.current.get(id)
+        if (rec && rec.turnId === result.done.turnId) rec.agents.add(agentId)
+        else finishedTurnLanes.current.set(id, { turnId: result.done.turnId, agents: new Set([agentId]) })
+      }
       if (result.done.error) {
         const name = participantName(id, agentId)
         pushStep(id, {
@@ -522,7 +537,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // Any tagged frame of the in-flight turn admits the lane exactly like the
       // ack — dropping it would leave the ordered cursor holding every later
       // frame while it waits for this one (webchat-multi-agents.md §5.3).
-      if (!key && admitsLane(output.agentId, output.turnId, pendingTurnIds.current.get(id))) {
+      if (
+        !key &&
+        admitsLane(output.agentId, output.turnId, pendingTurnIds.current.get(id), finishedFor(id, output.turnId))
+      ) {
         key = laneKey(id, output.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(output.turnId))
       }
@@ -539,7 +557,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       let key = cursorKeyFor(id, done.agentId)
       // Same early-frame admission as receiveOutput: a participant's terminal
       // frame (e.g. a coalesced turn's immediate done) may also beat its ack.
-      if (!key && admitsLane(done.agentId, done.turnId, pendingTurnIds.current.get(id))) {
+      if (!key && admitsLane(done.agentId, done.turnId, pendingTurnIds.current.get(id), finishedFor(id, done.turnId))) {
         key = laneKey(id, done.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(done.turnId))
       }
@@ -709,9 +727,16 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 // The relay may target participants the client did not lane (a
                 // resumed conversation without a local roster): admit the lane
                 // on its ack so the reply stream binds instead of dropping.
-                if (!key && admitsLane(m.ack?.agentId, m.ack?.turnId, pendingTurnIds.current.get(id))) {
-                  key = laneKey(id, m.ack!.agentId!)
-                  streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(m.ack!.turnId!))
+                const ackAgentId = m.ack?.agentId
+                const ackTurnId = m.ack?.turnId
+                if (
+                  !key &&
+                  ackAgentId &&
+                  ackTurnId &&
+                  admitsLane(ackAgentId, ackTurnId, pendingTurnIds.current.get(id), finishedFor(id, ackTurnId))
+                ) {
+                  key = laneKey(id, ackAgentId)
+                  streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(ackTurnId))
                 }
                 const cursor = key ? streamCursors.current.get(key) : undefined
                 if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
@@ -937,6 +962,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           : []
       const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
       pendingTurnIds.current.set(id, requestedTurnId)
+      finishedTurnLanes.current.delete(id)
       for (const target of targets) {
         streamCursors.current.set(laneKey(id, target), createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
       }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -37,7 +37,13 @@ import {
   type OrderedWebchatCursor,
   type OrderedWebchatResult
 } from '@/lib/webchat-stream'
-import { cursorKeyFor as cursorKeyForLanes, laneAgentId, laneKey, lanesOf as lanesOfLanes } from '@/lib/webchat-lanes'
+import {
+  admitsLane,
+  cursorKeyFor as cursorKeyForLanes,
+  laneAgentId,
+  laneKey,
+  lanesOf as lanesOfLanes
+} from '@/lib/webchat-lanes'
 
 interface PlaygroundData {
   /** Composer buffer for one session id (each live conversation has its own). */
@@ -57,7 +63,13 @@ interface PlaygroundData {
    *  rebuilds the socket so the relay re-verifies and caches the grown roster.
    *  Failures surface as a ⚠️ transcript step. Refused while a turn streams. */
   pgAddAgent: (id: string, agent: Agent) => Promise<void>
-  pgSend: (id: string, agentId: string, text?: string, conversationId?: string) => void
+  pgSend: (
+    id: string,
+    agentId: string,
+    text?: string,
+    conversationId?: string,
+    participants?: Array<{ agentId: string; name: string; primary?: boolean }>
+  ) => void
   /** Switch the session's model (in-session, sticky). */
   pgSetModel: (id: string, agentId: string, model: string, conversationId?: string) => void
   /** Switch the session's reasoning effort (in-session, sticky). */
@@ -504,7 +516,16 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
 
   const receiveOutput = useCallback(
     (id: string, output: WebchatOutput): void => {
-      const key = cursorKeyFor(id, output.agentId)
+      let key = cursorKeyFor(id, output.agentId)
+      // A warm session's first stream frame can beat the participant's ack to
+      // the browser (the daemon emits it synchronously inside turn admission).
+      // Any tagged frame of the in-flight turn admits the lane exactly like the
+      // ack — dropping it would leave the ordered cursor holding every later
+      // frame while it waits for this one (webchat-multi-agents.md §5.3).
+      if (!key && admitsLane(output.agentId, output.turnId, pendingTurnIds.current.get(id))) {
+        key = laneKey(id, output.agentId)
+        streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(output.turnId))
+      }
       const cursor = key ? streamCursors.current.get(key) : undefined
       if (!key || !cursor || !bindWebchatTurn(cursor, output.turnId)) return
       reconnectAttempts.current.delete(id)
@@ -515,7 +536,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
 
   const receiveDone = useCallback(
     (id: string, done: WebchatDone): void => {
-      const key = cursorKeyFor(id, done.agentId)
+      let key = cursorKeyFor(id, done.agentId)
+      // Same early-frame admission as receiveOutput: a participant's terminal
+      // frame (e.g. a coalesced turn's immediate done) may also beat its ack.
+      if (!key && admitsLane(done.agentId, done.turnId, pendingTurnIds.current.get(id))) {
+        key = laneKey(id, done.agentId)
+        streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(done.turnId))
+      }
       const cursor = key ? streamCursors.current.get(key) : undefined
       if (!key || !cursor) return
       applyStreamResult(id, key, acceptWebchatDone(cursor, done))
@@ -682,9 +709,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 // The relay may target participants the client did not lane (a
                 // resumed conversation without a local roster): admit the lane
                 // on its ack so the reply stream binds instead of dropping.
-                if (!key && m.ack?.agentId && m.ack.turnId === pendingTurnIds.current.get(id)) {
-                  key = laneKey(id, m.ack.agentId)
-                  streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(m.ack.turnId))
+                if (!key && admitsLane(m.ack?.agentId, m.ack?.turnId, pendingTurnIds.current.get(id))) {
+                  key = laneKey(id, m.ack!.agentId!)
+                  streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(m.ack!.turnId!))
                 }
                 const cursor = key ? streamCursors.current.get(key) : undefined
                 if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
@@ -869,7 +896,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   )
 
   const pgSend = useCallback(
-    (id: string, agentForId: string, textArg?: string, conversationId?: string) => {
+    (
+      id: string,
+      agentForId: string,
+      textArg?: string,
+      conversationId?: string,
+      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
+    ) => {
       const text = String(textArg ?? pgInputBy[id] ?? '').trim()
       const image = pgImageBy[id]
       if ((!text && !image) || pgBusyBy[id]) return
@@ -885,7 +918,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // roster, and also applies the same all-participants default itself, so a
       // resumed conversation with no client-side roster still reaches everyone.
       const session = pgSessions[id]
-      const roster = session?.participants ?? []
+      // An ADOPTED webchat session has no pgSessions entry — its roster comes
+      // from the fetched session detail (knownParticipants). Without it the
+      // send degrades to the relay's all-participants default: mentions can't
+      // narrow, and no lanes are pre-created (leaving delivery to the
+      // early-frame admission path).
+      const roster = session?.participants ?? knownParticipants ?? []
+      if (!session && knownParticipants && knownParticipants.length > 1 && !rosterNames.current.has(id)) {
+        rosterNames.current.set(id, new Map(knownParticipants.map((p) => [p.agentId, p.name])))
+      }
       const mentions =
         roster.length > 1
           ? roster

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1205,7 +1205,16 @@ export default function SessionDetailView() {
   const onPgSend = (text?: string) => {
     if (imagePreparing) return
     setImageError(null)
-    pgSend(session.id, session.agentId ?? '', text, isWebchat ? session.channelId : undefined)
+    // Pass the fetched roster: an adopted webchat session has no provider-side
+    // state, and without it a multi-agent send can't pre-create stream lanes or
+    // narrow by @mention (the relay would apply its all-participants default).
+    pgSend(
+      session.id,
+      session.agentId ?? '',
+      text,
+      isWebchat ? session.channelId : undefined,
+      isWebchat ? session.participants : undefined
+    )
   }
   const onImageFile = async (file: File | undefined): Promise<void> => {
     if (!file || imagePreparing) return

--- a/packages/web/src/lib/webchat-lanes.test.ts
+++ b/packages/web/src/lib/webchat-lanes.test.ts
@@ -49,6 +49,20 @@ describe('webchat stream lanes', () => {
     expect(admitsLane(B, undefined, turn)).toBe(false)
   })
 
+  it('a completed lane is not re-admitted by its trailing ack', () => {
+    // done-before-ack ordering: a coalesced turn's immediate done(lastIndex:-1)
+    // admits the lane, applies, and retires it — the ack that trails it must
+    // NOT recreate an empty cursor (it would never receive another terminal
+    // frame, wedging the turn's busy state and fencing the next turn).
+    const turn = 'turn-1'
+    const finished = new Set<string>()
+    expect(admitsLane(B, turn, turn, finished)).toBe(true)
+    finished.add(B)
+    expect(admitsLane(B, turn, turn, finished)).toBe(false)
+    // Other participants of the same turn stay admittable.
+    expect(admitsLane(A, turn, turn, finished)).toBe(true)
+  })
+
   it('after lazy admission, both participants resolve independently', () => {
     const lanes = new Map<string, unknown>([[laneKey(ID, A), {}]])
     // Lazy admission on B's ack: the caller creates the exact lane…

--- a/packages/web/src/lib/webchat-lanes.test.ts
+++ b/packages/web/src/lib/webchat-lanes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { cursorKeyFor, laneAgentId, laneKey, lanesOf } from './webchat-lanes'
+import { admitsLane, cursorKeyFor, laneAgentId, laneKey, lanesOf } from './webchat-lanes'
 
 const ID = 'pg_agent-a_x'
 const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -32,6 +32,21 @@ describe('webchat stream lanes', () => {
     // With several lanes an untagged frame is ambiguous — dropped, not guessed.
     lanes.set(laneKey(ID, B), {})
     expect(cursorKeyFor(lanes, ID)).toBeUndefined()
+  })
+
+  it('admits a lane from ANY tagged frame of the in-flight turn — not just the ack', () => {
+    // The resumed-conversation wedge: on a warm session the daemon emits its
+    // first stream frame synchronously inside turn admission, so output#0 can
+    // reach the browser BEFORE the participant's ack. That frame must admit
+    // the lane; dropping it strands the ordered cursor at index 0 forever
+    // (nothing renders, done is held back, busy never clears).
+    const turn = 'turn-1'
+    expect(admitsLane(B, turn, turn)).toBe(true)
+    // Not for a different (stale) turn, an untagged frame, or with no send in flight.
+    expect(admitsLane(B, 'turn-0', turn)).toBe(false)
+    expect(admitsLane(undefined, turn, turn)).toBe(false)
+    expect(admitsLane(B, turn, undefined)).toBe(false)
+    expect(admitsLane(B, undefined, turn)).toBe(false)
   })
 
   it('after lazy admission, both participants resolve independently', () => {

--- a/packages/web/src/lib/webchat-lanes.ts
+++ b/packages/web/src/lib/webchat-lanes.ts
@@ -37,3 +37,22 @@ export function cursorKeyFor(lanes: ReadonlyMap<string, unknown>, id: string, ag
   const all = lanesOf(lanes, id)
   return all.length === 1 ? all[0] : undefined
 }
+
+/**
+ * Whether a tagged frame for an un-laned participant may ADMIT its lane.
+ *
+ * Any frame of the in-flight send's turn is proof the relay accepted that
+ * participant — the ack is merely the usual first such frame, NOT the only
+ * one. On a warm session the daemon emits its first stream frame
+ * synchronously inside turn admission, so `output`/`done` can reach the
+ * browser BEFORE the participant's ack; dropping that first output would
+ * leave the lane's ordered cursor waiting on index 0 forever (no render, no
+ * done, busy never clears).
+ */
+export function admitsLane(
+  agentId: string | undefined,
+  turnId: string | undefined,
+  pendingTurnId: string | undefined
+): boolean {
+  return agentId !== undefined && turnId !== undefined && turnId === pendingTurnId
+}

--- a/packages/web/src/lib/webchat-lanes.ts
+++ b/packages/web/src/lib/webchat-lanes.ts
@@ -52,7 +52,13 @@ export function cursorKeyFor(lanes: ReadonlyMap<string, unknown>, id: string, ag
 export function admitsLane(
   agentId: string | undefined,
   turnId: string | undefined,
-  pendingTurnId: string | undefined
+  pendingTurnId: string | undefined,
+  finishedAgentIds?: ReadonlySet<string>
 ): boolean {
-  return agentId !== undefined && turnId !== undefined && turnId === pendingTurnId
+  if (agentId === undefined || turnId === undefined || turnId !== pendingTurnId) return false
+  // A COMPLETED lane must never be re-admitted: with done-before-ack ordering
+  // the terminal frame both creates and retires the lane, and the trailing ack
+  // would otherwise recreate an empty cursor that can never finish — wedging
+  // the turn's busy state and fencing the participant's next turn.
+  return !finishedAgentIds?.has(agentId)
 }


### PR DESCRIPTION
Fixes the live-view wedge in resumed multi-agent webchat conversations: after a page refresh, sending a message rendered only the primary's reply — every other participant's stream stayed invisible and the busy spinner never cleared until another refresh.

## Root cause (from a live wire capture)

Every frame reached the browser intact. The problem is ordering: on a **warm session** the daemon emits the turn's first stream frame synchronously inside turn admission, so a participant's `output#0` can arrive **before** that participant's ack:

```
+1055 ack     agent=A (primary, lane pre-created)
+1065 output#0 agent=B   ← arrives first…
+1065 ack     agent=B    ← …ack second
+3276 output#1..#6 agent=B (incl. superseded + regeneration)
+5145 done    agent=B lastIndex=6
```

The client admitted unknown lanes **only from acks**, so `output#0` was dropped; the lane created moments later by the ack started its ordering cursor at index 0 and buffered `#1..#6` forever waiting for the dropped frame — nothing rendered, the `done` was held back, and the lane kept the turn busy indefinitely. Fresh conversations were unaffected only because a cold session's first frame always trails the ack, which also masked the bug during initial testing.

## Fix

- `receiveOutput`/`receiveDone` now admit the lane from **any tagged frame whose `turnId` matches the in-flight send** (new shared `admitsLane` predicate in `lib/webchat-lanes.ts`), exactly like the ack path. Any such frame is proof the relay accepted that participant — the ack is merely the usual first one, not the only one.
- **Completed-lane tombstone** (review round 1): with done-before-ack ordering the terminal frame both creates and retires the lane; the trailing ack must not re-admit an empty cursor that can never finish. Participants whose lane completed for the in-flight turn are recorded (reset per send) and excluded from admission at all three sites. Regression: `done(lastIndex:-1)` → ack.
- Adopted webchat sessions pass their fetched roster into `pgSend`, so sends from a resumed view pre-create stream lanes and `@mention` narrowing works. Rebased onto #414, which wires `participants` into the session-detail DTO — before that rebase this passthrough had no data (as review round 1 correctly noted).
- Design doc §5.3 lane-admission sentence updated to match.

Reproduced and captured on the test environment with a two-agent counting-game conversation (fresh turn fine → refresh → resume turn wedged 100%); will re-verify the same flow after deploy.

Tests: `admitsLane` regression cases (early-frame admission, stale-turn rejection, completed-lane tombstone) in `webchat-lanes.test.ts`; web suite 587 passing, typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)