### PR TITLE
docs(designs): merged conversation view — platform-neutral, webchat + Slack together

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -1,0 +1,316 @@
+# Merged Conversation View
+
+Status: draft for review
+Owner: console/web + control plane
+Related: [webchat-multi-agents.md](webchat-multi-agents.md) (§8/§9, milestone M3),
+[session-visibility.md](session-visibility.md),
+[daemon-centric-architecture.md](daemon-centric-architecture.md),
+issue #415 (participants in agent standing context — the same
+explicit-roster/emergent-roster duality, surfaced to agents instead of humans)
+
+## 1. Summary
+
+A conversation with several participants is one thing, but the console renders
+it as N per-agent session pages — one per participating agent — because
+sessions are agent-scoped 4-tuples (`platform:channel:thread:agentId`). This
+design adds a **merged conversation view**: one page per conversation that
+interleaves every participant's transcript — including each agent's private
+work lanes (reasoning / tool steps), which today are only visible by switching
+to that agent's own session page.
+
+The view is **platform-neutral from day one** and ships with two adapters
+together: **webchat** (multi-agent Playground conversations) and **Slack**
+(threads where one or more agents participate alongside humans). It is a
+read-composition layer only: no new content storage, no new daemon protocol,
+no new authorization objects. The merge is computed in the browser over the
+existing per-session read endpoints, so every architecture and visibility
+invariant is inherited rather than re-implemented.
+
+What each surface gains:
+
+- **Webchat** — the live Playground already _is_ a merged view (every
+  participant streams into one canvas). On refresh, the user currently lands on
+  one agent's session page and the other participants' work lanes vanish. The
+  merged view closes that live/persisted gap: refresh returns to the same
+  merged canvas.
+- **Slack** — a multi-bot ops thread becomes debuggable in one place: the
+  thread timeline with each bot's reasoning and tool activity expandable
+  inline, instead of tab-hopping across per-agent sessions to answer "why did
+  this bot say that".
+- **Both** — the sessions list stops showing N near-identical rows for one
+  conversation.
+
+## 2. Goals and non-goals
+
+Goals:
+
+1. One list row and one page per conversation, for webchat conversations and
+   Slack threads alike.
+2. The merged page shows the complete conversation in canonical order with
+   per-participant attribution, each agent's work lanes collapsible inline.
+3. Platform-neutral core (grouping key + ordering coordinate + dedupe rule +
+   roster feed), with per-platform adapters — not a webchat feature with a
+   Slack bolt-on.
+4. Zero new content-plane surface: the CP still never persists or proxies
+   anything beyond the existing bounded per-session reads.
+
+Non-goals (v1):
+
+- **No live streaming for the Slack merge.** The merged Slack page refreshes
+  like today's session detail (poll/revalidate). Live console streaming of IM
+  turns is future work that belongs to the CP ACP gateway track.
+- **No conversation-level ACL.** There is no new shareable object; each
+  transcript source is authorized independently by the existing session read
+  policy (§7).
+- **No removal of per-agent session pages.** They remain the drill-down/debug
+  view (and the only view for single-agent sessions, which are the vast
+  majority). The merged view links to them and back.
+- **No Telegram/Discord/Feishu adapters yet.** They are shaped like the Slack
+  adapter (platform-assigned ordering coordinate, emergent roster) and can
+  follow it mechanically once it exists.
+- **No cross-thread channel view.** A conversation is one thread, mirroring
+  the session model.
+
+## 3. The conversation abstraction
+
+A conversation is defined by four things. Everything else — rendering, turn
+grouping, attribution — is shared.
+
+|                             | Webchat                                                                                                                         | Slack                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                      | `(platform, channel, thread)`                                              |
+| **Ordering coordinate**     | canonical `at` minted at origin, collision-bumped per (channel, thread) — [webchat-multi-agents.md §5](webchat-multi-agents.md) | platform-assigned message `ts`, unique and ordered within a thread         |
+| **Duplicate identity**      | transcript row `ts` (== canonical `at`) shared by every participant's copy of a post                                            | transcript row `ts` shared by every participant's copy of a thread message |
+| **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                      | emergent — derived from the merged rows (senders + trusted a2a bots)       |
+| **Composer**                | full send (fans out to the roster, all-respond semantics)                                                                       | read-only; "Open in Slack" deep link (`threadUrl`)                         |
+
+Two observations that make the Slack adapter _cheaper_ than the webchat one:
+
+- Slack's `ts` is exactly the canonical coordinate webchat had to mint for
+  itself. No new bookkeeping.
+- §8.4 mid-thread backfill means every participating agent's transcript
+  already contains the full thread _text_. The merge adds each agent's work
+  lanes — the one thing per-agent pages structurally cannot show together —
+  and dedupes the N text copies.
+
+The grouping key deliberately matches the daemon's own session identity
+(`platform:channel:thread:agentId` minus the agent): the conversation is the
+set of sessions that share a thread. `SessionMeta` already stores
+`platform/channel/thread` denormalized per row, so grouping is a metadata
+query — no schema change.
+
+## 4. Reading the conversation (no new content plane)
+
+The defining constraint from
+[daemon-centric-architecture.md](daemon-centric-architecture.md) holds: the CP
+stores only metadata; transcript bodies are daemon-local and reach the console
+as bounded, authorized, non-persisted reads (`GET /sessions/:id/messages`).
+
+The merged view therefore reads exactly what the per-agent pages read:
+
+1. Resolve the conversation's member sessions (one CP metadata query, §5).
+2. Fetch each member session's transcript through the **existing** per-session
+   messages endpoint — one bounded read per member, each independently
+   authorized, each proxied live from its owning daemon (members may live on
+   different daemons; that is already how cross-daemon a2a threads work).
+3. Merge client-side (§6) in a pure, unit-testable module
+   (`packages/web/src/lib/conversation-merge.ts`, mirroring how
+   `webchat-lanes.ts` isolates lane resolution).
+
+A member read that fails with 403/404 (restricted agent) or a daemon-offline
+error degrades to a **partial merge** with an explicit notice (§7) — never a
+page-level failure, because the remaining sources are still a legitimate view
+of the thread (it is what any one participant legitimately sees today).
+
+Rejected alternative: a CP-side `/conversations/:key/messages` fan-out
+endpoint. It would centralize retries and paging, but it puts the CP in the
+business of joining message content across daemons — a step toward the content
+plane it must not become — and re-implements per-source authorization that the
+per-session endpoint already enforces. Client-side composition keeps the CP's
+role unchanged. (If paging coordination proves painful in practice, a BFF
+aggregation that still streams per-source and persists nothing is the fallback
+— explicitly deferred.)
+
+## 5. Conversation identity, grouping, and the list
+
+### 5.1 Key encoding
+
+- Webchat: `conversationId` (already a UUID; the session row's `channel`).
+- Slack: `platform:channel:thread`, base64url-encoded for the URL. `thread`
+  falls back to the channel-root marker exactly as sessions record it, so a
+  channel-root conversation groups its root-thread sessions.
+
+`SessionMeta` has no integration/workspace column, and neither does the
+daemon's session key — thread identity has always been
+`(platform, channel, thread)` in this system. The conversation key inherits
+that model (and its theoretical cross-workspace channel-id collision, which is
+pre-existing and unobserved) rather than inventing a stricter identity only on
+the read side.
+
+### 5.2 Grouped sessions list
+
+`GET /sessions` gains `group=conversation`. Instead of raw session rows it
+returns one row per conversation, aggregated over the same visibility-filtered
+row set the flat list uses (a session invisible to the caller is absent from
+the aggregate too):
+
+```
+{
+  conversations: [{
+    key,                 // §5.1
+    platform, channel, thread, channelName, threadUrl,
+    title,               // primary participant's title (webchat) / first session's (slack)
+    lastActivityAt,      // max over members
+    activityState,       // any member active ⇒ active
+    participants: [{ agentId, sessionId, name }],  // member sessions, roster order (webchat) / first-seen (slack)
+    hiddenParticipants   // count of member sessions the caller cannot view
+  }],
+  nextCursor
+}
+```
+
+Pagination is by `lastActivityAt` over the aggregate, matching the flat list's
+order. Single-agent conversations (the overwhelming majority) come back as
+1-participant rows — the web renders those exactly like today's session rows,
+so the grouped mode can simply replace the default list rendering rather than
+adding a toggle.
+
+`hiddenParticipants` requires care: the aggregate must count members that
+exist but are invisible **without leaking which agent** — a bare count is the
+same information the partial-merge notice shows (§7).
+
+### 5.3 Routes and cross-links
+
+- `/conversations/:key` — the merged page.
+- Sessions list rows link here when `participants.length > 1`, to the
+  per-agent session page otherwise (no behavior change for the common case).
+- The per-agent session page gains a "View conversation" link when its
+  `(platform, channel, thread)` groups more than one session; the merged page
+  links each participant chip to its per-agent session (drill-down).
+- Webchat Playground adoption: when a live multi-agent playground session is
+  reopened after refresh, land on `/conversations/:conversationId` instead of
+  the primary's session page — this is what closes the live/persisted gap.
+
+## 6. The merge algorithm
+
+Inputs: per-member transcript pages, each row carrying
+`(sender, ts, kind, text, attachments, body, trustedAgentBot)` plus its source
+session (`sessionId`, `agentId`).
+
+1. **Union** all rows from all readable sources.
+2. **Dedupe by `ts`** within the conversation. Rows sharing `ts` are copies of
+   the same message (webchat: canonical `at`, probe-and-bump guarantees
+   distinct posts got distinct `ts`; Slack: platform-assigned `ts`).
+   Precedence among copies:
+   - **Author copy wins**: the row whose source session's `agentId` matches
+     the row's author (`sender === source.agentId`, or the daemon-relabeled
+     own-bot frames). The author copy is the full-fidelity one.
+   - Human/system rows (identical in every copy): first source in stable
+     order — roster order for webchat, `sessionId` sort for Slack — so the
+     merge is deterministic across reloads.
+3. **Work-lane rows pass through un-deduped**: `kind: tool | reasoning` rows
+   exist only in their author's transcript. They interleave by `ts` and render
+   inside that agent's collapsible work lane, exactly as on its own page.
+4. **Sort by `ts` ascending**; ties (distinct messages can share a millisecond
+   only across platforms' guarantees failing) break by `(sender, sessionId)`
+   for determinism.
+5. **Attribution and turn grouping reuse the session detail machinery**: the
+   merged row list feeds the same turn builder the per-agent page uses — the
+   right side is reserved for the viewer, every agent renders as its own
+   left-side block via the `agentId`-keyed grouping (`sameBotSpeaker`), humans
+   render as sender rows. No new rendering rules; the merged view is "the
+   per-agent page fed a union instead of one source".
+
+Notes:
+
+- **Supersession needs nothing**: a regenerated webchat answer is already the
+  only committed reply in its author's transcript; stale generations were
+  live-stream chrome and never persisted.
+- **A mid-conversation joiner's** transcript starts late; earlier rows come
+  from the other sources' copies. The union is complete as long as any one
+  participant observed the region.
+- **Paging**: v1 loads each source's latest page and merges; "load earlier"
+  fetches the earlier page of whichever sources still overlap the requested
+  window (the merge module tracks per-source cursors). This is the one place
+  client-side composition costs real logic — it is contained in the pure
+  module and unit-testable.
+
+## 7. Visibility and partial merges
+
+No new authorization surface. Each source is fetched under the existing
+session read policy; the merge renders what comes back:
+
+- A **restricted participant** (agent the caller cannot view) contributes no
+  source: its work lanes and its authored copies are absent. Its _messages_
+  may still appear — via other participants' recipient copies, exactly as
+  they appear on any per-agent page today. Hiding a session hides an agent's
+  private work, not the thread messages every participant legitimately
+  received.
+- The page shows a quiet notice when sources are missing: "N participants'
+  records aren't visible to you" (count only, no identity), and per-source
+  daemon-offline errors degrade the same way ("K participants' records are on
+  an offline daemon").
+- **Webchat send fence unchanged**: the composer on a merged webchat
+  conversation resumes through the existing conversation-token mint, which
+  already requires _all_ participants viewable. A caller with partial view
+  gets a read-only merged page with the standard error on send.
+- The webchat per-conversation privacy model (owner-private by default) and
+  Slack's org-visible default both pass through untouched — the merged page is
+  as visible as its most visible member session, because that is literally
+  what it fetches.
+
+## 8. Composer and live behavior
+
+|             | Webchat conversation                                                                                                                                                | Slack thread                                                                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Composer    | Full: same conversation resume + all-respond fan-out as today's adopted session page; placeholder "Message everyone…"                                               | None. "Open in Slack" (threadUrl). The console is an observer of IM platforms, not a poster — replying belongs to Slack (a console→Slack composer is a separate product question, out of scope). |
+| Live        | On resume the existing relay socket streams all lanes into the merged canvas — identical to the live Playground (which this page effectively replaces post-refresh) | SWR revalidate / poll, like the session detail today. Streaming deferred to the ACP gateway track.                                                                                               |
+| Typing/busy | per-participant, from existing lane state                                                                                                                           | activity dot from `activityState`, as today                                                                                                                                                      |
+
+## 9. Milestones
+
+Per the product decision, **webchat and Slack ship together in each milestone**
+— the platform-neutral core is the point, and building webchat-only first is
+how divergence starts.
+
+- **C1 — grouped sessions list.** CP `group=conversation` aggregate +
+  grouped list rendering (participant avatar stack, single row per
+  conversation, both platforms). Cheapest milestone, fixes the most visible
+  confusion (N rows per conversation).
+- **C2 — merged page.** `conversation-merge.ts` (union/dedupe/order, unit
+  tests over both adapters' fixtures), `/conversations/:key` route, renderer
+  reuse, partial-merge notices, cross-links from/to per-agent pages. Webchat
+  composer wired through the existing adoption path; Slack read-only with
+  deep link. Playground refresh lands here.
+- **C3 — polish.** Conversation-level usage roll-up (sum of member sessions),
+  "load earlier" cross-source paging, mobile pass, default-collapsed work
+  lanes for non-focused participants.
+
+## 10. Alternatives considered
+
+- **CP-side merge endpoint** — rejected in v1 (§4): moves the CP toward the
+  content plane and duplicates per-source authorization. Revisit only if
+  client paging proves unworkable, and then as a non-persisting BFF
+  aggregation.
+- **Materializing a conversation object** (row per conversation, membership,
+  ACL) — rejected: webchat already has its object (the conversation row), and
+  Slack's membership is emergent; a second registry would drift from both.
+  The conversation stays a _view_ over sessions.
+- **Slack composer in the console** — rejected for this design: posting to
+  Slack from the console is an identity and product question (who is the
+  author?), not a rendering one.
+- **Webchat-first, Slack later** — rejected by product decision: the two
+  adapters are what keep the core honest; Slack is also the higher-value
+  debugging surface (multi-bot ops threads).
+
+## 11. Open questions
+
+1. Should the grouped list become the only list mode (single-participant rows
+   render as today), or ship behind a toggle first? (Design assumes: replace,
+   no toggle — §5.2.)
+2. `group=conversation` aggregate cost on large orgs — needs an index over
+   `(orgId, platform, channel, thread, lastActivityAt)`; verify against the
+   existing list indexes before C1.
+3. Does the per-agent page's composer stay on multi-agent webchat
+   conversations, or point users to the merged page? (Design assumes: stays —
+   it already routes correctly post-#409/#414.)

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -62,9 +62,10 @@ Non-goals (v1):
 - **No conversation-level ACL.** There is no new shareable object; each
   transcript source is authorized independently by the existing session read
   policy (§7).
-- **No removal of per-agent session pages.** They remain the drill-down/debug
-  view (and the only view for single-agent sessions, which are the vast
-  majority). The merged view links to them and back.
+- **Per-agent session pages survive only where they are the conversation.**
+  Single-agent sessions (the vast majority) keep today's page. For
+  multi-participant conversations the per-agent page is no longer surfaced
+  anywhere; existing deep links redirect to the merged page (§5.3).
 - **No Telegram/Discord/Feishu adapters yet.** They are shaped like the Slack
   adapter (platform-assigned ordering coordinate, emergent roster) and can
   follow it mechanically once it exists.
@@ -147,12 +148,18 @@ that model (and its theoretical cross-workspace channel-id collision, which is
 pre-existing and unobserved) rather than inventing a stricter identity only on
 the read side.
 
-### 5.2 Grouped sessions list
+### 5.2 Grouped list is the default
 
-`GET /sessions` gains `group=conversation`. Instead of raw session rows it
-returns one row per conversation, aggregated over the same visibility-filtered
-row set the flat list uses (a session invisible to the caller is absent from
-the aggregate too):
+`GET /sessions` returns **conversations by default**; `?view=flat` returns
+today's raw session rows. The console passes the same parameter through (a
+list-mode switch, defaulting to grouped). This deliberately changes the
+default response shape of a public REST operation — accepted by product
+decision: console and CP ship on the same train, external consumers pin
+`view=flat`, and the OpenAPI doc describes both shapes on the operation.
+
+The default response is one row per conversation, computed over the same
+visibility-filtered row set the flat list uses (a session invisible to the
+caller never contributes):
 
 ```
 {
@@ -169,11 +176,20 @@ the aggregate too):
 }
 ```
 
-Pagination is by `lastActivityAt` over the aggregate, matching the flat list's
-order. Single-agent conversations (the overwhelming majority) come back as
+Pagination stays newest-first by `lastActivityAt`, and the implementation
+needs **no aggregate query and no new page index** (verified against the
+schema): on the same descending scan the flat list already pages with
+(`session_meta_org_visibility_page_idx`), the FIRST row seen for a conversation
+key is that conversation's `max(lastActivityAt)` — so the grouped page is a
+streaming dedupe over the flat scan until N distinct keys fill the page. The
+page's remaining members then backfill with one `(platform, channel, thread)`
+lookup batch; the existing `@@index([platform, channel])` covers it, extended
+with `thread` at C1 so a busy Slack channel doesn't post-filter thousands of
+rows per lookup.
+
+Single-agent conversations (the overwhelming majority) come back as
 1-participant rows — the web renders those exactly like today's session rows,
-so the grouped mode can simply replace the default list rendering rather than
-adding a toggle.
+so grouped simply IS the list, with no toggle in the default UI.
 
 `hiddenParticipants` requires care: the aggregate must count members that
 exist but are invisible **without leaking which agent** — a bare count is the
@@ -181,15 +197,22 @@ same information the partial-merge notice shows (§7).
 
 ### 5.3 Routes and cross-links
 
-- `/conversations/:key` — the merged page.
+- `/conversations/:key` — the merged page, and **the only surfaced page for a
+  multi-participant conversation**.
 - Sessions list rows link here when `participants.length > 1`, to the
-  per-agent session page otherwise (no behavior change for the common case).
-- The per-agent session page gains a "View conversation" link when its
-  `(platform, channel, thread)` groups more than one session; the merged page
-  links each participant chip to its per-agent session (drill-down).
-- Webchat Playground adoption: when a live multi-agent playground session is
-  reopened after refresh, land on `/conversations/:conversationId` instead of
-  the primary's session page — this is what closes the live/persisted gap.
+  per-agent session page otherwise (for a single-agent session that page IS
+  the conversation page — no change for the common case).
+- Existing `/sessions/:id` deep links (GitHub check footers, shared URLs,
+  crumbs) whose session belongs to a multi-participant conversation
+  **redirect** to `/conversations/:key?focus=<agentId>` — the focus preserves
+  "whose perspective was linked" as scroll/highlight rather than as a
+  different page. Per-agent pages for such conversations are reachable only
+  as this redirect; nothing links to them (product decision).
+- Participant chips link to the agent's page (`/agents/:id`); session-level
+  lineage navigation lifts to the conversation level (§9).
+- Webchat Playground adoption: a live multi-agent playground session reopened
+  after refresh lands on `/conversations/:conversationId` instead of the
+  primary's session page — this is what closes the live/persisted gap.
 
 ## 6. The merge algorithm
 
@@ -267,26 +290,80 @@ session read policy; the merge renders what comes back:
 | Live        | On resume the existing relay socket streams all lanes into the merged canvas — identical to the live Playground (which this page effectively replaces post-refresh) | SWR revalidate / poll, like the session detail today. Streaming deferred to the ACP gateway track.                                                                                               |
 | Typing/busy | per-participant, from existing lane state                                                                                                                           | activity dot from `activityState`, as today                                                                                                                                                      |
 
-## 9. Milestones
+## 9. Conversations and session lineage (parent/child)
+
+Sessions carry a second graph besides the conversation: **lineage** —
+`parentSessionId` edges recorded when one session wakes another via
+`sendMessage`, plus the sibling/child links the session detail route derives
+from them. The two graphs are orthogonal by construction:
+
+- a **conversation groups by location** — sessions sharing a thread ("who is
+  in the room");
+- **lineage links by causation** — who woke whom, freely crossing rooms.
+
+The design connects them at three points:
+
+### 9.1 In-thread wakes are intra-conversation edges
+
+A `sendMessage` in channel/thread form posts into a thread, so the woken
+agent's session shares `(platform, channel, thread)` with the waker — same
+conversation. The merged view already shows both parties in full; the lineage
+edge contributes **attribution, not navigation**: the woken agent's first turn
+can carry a "woken by <agent>" affordance (C3 chrome). Membership neither
+grows nor splits because of the edge.
+
+### 9.2 Cross-conversation edges lift to conversation-level navigation
+
+A DM-form (channel-free) wake creates the child session on its own a2a
+coordinate — its own, usually single-member, conversation. That edge crosses
+conversations, and its navigation today lives on the per-agent session detail
+page (parent/sibling/child links) — a page this design stops surfacing for
+multi-participant conversations. The merged page therefore inherits it at
+conversation level: the union of member sessions' lineage links, each mapped
+to the conversation its target session belongs to, rendered as **"Parent
+conversation"** and **"Delegations"** (child conversations, grouped by the
+waking member). No new CP surface — the member detail DTOs already carry the
+links, and mapping a session to its conversation key is a metadata lookup.
+(C2 ships the links; grouping delegations by waking turn is C3.)
+
+One invariant stays absolute: **lineage never changes membership**. A child
+spawned elsewhere is linked, never merged in — merging by causation would
+break the location-pure dedupe (§6) and blur the structural guarantees around
+context delivery (context frames never activate; a delegation is not a
+participant).
+
+### 9.3 Report-backs surface naturally
+
+A child's `sessionId`-form reply to its parent is delivered only into the
+parent session's transcript. In the merged view it appears exactly once (it
+exists in exactly one source), attributed to the child agent inside the
+parent's conversation — the union needs no special casing. Cron / hook /
+headless sessions are ordinary single-member conversations and keep their
+lineage links unchanged.
+
+## 10. Milestones
 
 Per the product decision, **webchat and Slack ship together in each milestone**
 — the platform-neutral core is the point, and building webchat-only first is
 how divergence starts.
 
-- **C1 — grouped sessions list.** CP `group=conversation` aggregate +
-  grouped list rendering (participant avatar stack, single row per
-  conversation, both platforms). Cheapest milestone, fixes the most visible
-  confusion (N rows per conversation).
+- **C1 — grouped sessions list.** CP grouped-by-default list with the
+  `view=flat` escape hatch (desc-scan dedupe + member backfill, §5.2), the
+  `(platform, channel)` index extended with `thread`, grouped rendering
+  (participant avatar stack, single row per conversation, both platforms).
+  Cheapest milestone, fixes the most visible confusion (N rows per
+  conversation).
 - **C2 — merged page.** `conversation-merge.ts` (union/dedupe/order, unit
   tests over both adapters' fixtures), `/conversations/:key` route, renderer
-  reuse, partial-merge notices, cross-links from/to per-agent pages. Webchat
+  reuse, partial-merge notices, session→conversation deep-link redirects
+  (`?focus=<agentId>`), conversation-level lineage links (§9.2). Webchat
   composer wired through the existing adoption path; Slack read-only with
   deep link. Playground refresh lands here.
 - **C3 — polish.** Conversation-level usage roll-up (sum of member sessions),
   "load earlier" cross-source paging, mobile pass, default-collapsed work
   lanes for non-focused participants.
 
-## 10. Alternatives considered
+## 11. Alternatives considered
 
 - **CP-side merge endpoint** — rejected in v1 (§4): moves the CP toward the
   content plane and duplicates per-source authorization. Revisit only if
@@ -303,14 +380,23 @@ how divergence starts.
   adapters are what keep the core honest; Slack is also the higher-value
   debugging surface (multi-bot ops threads).
 
-## 11. Open questions
+## 12. Decision log
 
-1. Should the grouped list become the only list mode (single-participant rows
-   render as today), or ship behind a toggle first? (Design assumes: replace,
-   no toggle — §5.2.)
-2. `group=conversation` aggregate cost on large orgs — needs an index over
-   `(orgId, platform, channel, thread, lastActivityAt)`; verify against the
-   existing list indexes before C1.
-3. Does the per-agent page's composer stay on multi-agent webchat
-   conversations, or point users to the merged page? (Design assumes: stays —
-   it already routes correctly post-#409/#414.)
+1. **Grouped list replaces the flat list as the default.** `GET /sessions`
+   returns conversations; `view=flat` (a UI parameter passed through to the
+   CP) returns raw session rows. Accepted as a deliberate change to the
+   operation's default response shape.
+2. **Index question resolved — no new aggregate index.** Newest-first
+   conversation paging falls out of the existing
+   `session_meta_org_visibility_page_idx` descending scan (first occurrence
+   of a key = the conversation's max activity); member backfill extends
+   `@@index([platform, channel])` with `thread` at C1.
+3. **Per-agent session pages are not surfaced for multi-participant
+   conversations.** Every entry point leads to the merged page; existing
+   session deep links redirect with `?focus=<agentId>`; the conversation
+   composer exists only on the merged page.
+4. **Webchat and Slack adapters ship together** in every milestone — the
+   platform-neutral core is the point.
+5. **Lineage never changes conversation membership** — parent/child edges are
+   linked (attribution in-thread, navigation across conversations), never
+   merged (§9).

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -303,14 +303,26 @@ from them. The two graphs are orthogonal by construction:
 
 The design connects them at three points:
 
-### 9.1 In-thread wakes are intra-conversation edges
+### 9.1 Intra-conversation edges are attribution, not navigation
 
-A `sendMessage` in channel/thread form posts into a thread, so the woken
-agent's session shares `(platform, channel, thread)` with the waker — same
-conversation. The merged view already shows both parties in full; the lineage
-edge contributes **attribution, not navigation**: the woken agent's first turn
-can carry a "woken by <agent>" affordance (C3 chrome). Membership neither
-grows nor splits because of the edge.
+The classifying rule is **whether the edge's two sessions share the
+conversation key** — not the wake form. An in-thread `sendMessage` wakes an
+agent into the same `(platform, channel, thread)`, so both endpoints are
+already in the room; the merged view shows both parties in full, and the
+lineage edge contributes only attribution: the woken agent's first turn can
+carry a "woken by <agent>" affordance (C3 chrome). Membership neither grows
+nor splits because of the edge, and intra-conversation edges are **excluded**
+from the lifted navigation in §9.2 — otherwise a co-participant that is also
+a lineage child (A wakes B and C into the same thread: room-mates AND
+lineage-siblings) would be listed twice.
+
+Co-membership itself is NOT siblinghood: "sibling sessions" keeps its precise
+lineage meaning (other children of the same parent session). Sessions in one
+room are already fully related by conversation membership — encoding that
+relation a second time as synthetic lineage would demand a fabricated common
+parent (a user message is not a session) and retroactive edge maintenance as
+the roster grows. The per-agent detail DTO's parent/sibling/child computation
+is untouched by this design.
 
 ### 9.2 Cross-conversation edges lift to conversation-level navigation
 
@@ -319,10 +331,11 @@ coordinate — its own, usually single-member, conversation. That edge crosses
 conversations, and its navigation today lives on the per-agent session detail
 page (parent/sibling/child links) — a page this design stops surfacing for
 multi-participant conversations. The merged page therefore inherits it at
-conversation level: the union of member sessions' lineage links, each mapped
-to the conversation its target session belongs to, rendered as **"Parent
-conversation"** and **"Delegations"** (child conversations, grouped by the
-waking member). No new CP surface — the member detail DTOs already carry the
+conversation level: the union of member sessions' lineage links whose target
+lies in a DIFFERENT conversation (§9.1 filters the intra-room ones), each
+mapped to the conversation its target session belongs to, rendered as
+**"Parent conversation"** and **"Delegations"** (child conversations, grouped
+by the waking member). No new CP surface — the member detail DTOs already carry the
 links, and mapping a session to its conversation key is a metadata lookup.
 (C2 ships the links; grouping delegations by waking turn is C3.)
 
@@ -400,3 +413,8 @@ how divergence starts.
 5. **Lineage never changes conversation membership** — parent/child edges are
    linked (attribution in-thread, navigation across conversations), never
    merged (§9).
+6. **Co-membership is not siblinghood.** Sessions sharing a room relate
+   through conversation membership only; "sibling" keeps its lineage meaning
+   (same parent session). An edge whose endpoints share the conversation key
+   renders as attribution and is excluded from lifted navigation — the
+   room-mates-AND-siblings overlap is displayed once, not twice (§9.1).

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -77,13 +77,13 @@ Non-goals (v1):
 A conversation is defined by four things. Everything else — rendering, turn
 grouping, attribution — is shared.
 
-|                             | Webchat                                                                                                                                                               | Slack                                                                                            |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                                                            | `(platform, tenantScope, channel, thread)` (§5.1)                                                |
-| **Duplicate identity**      | raw `ts` string (== canonical `at` minted at origin, collision-bumped — [webchat-multi-agents.md §5](webchat-multi-agents.md)), identical in every participant's copy | raw `ts` string (the platform message `ts`), identical in every participant's copy               |
-| **Ordering**                | normalized event time (§6): canonical `at` (epoch ms) → µs                                                                                                            | normalized event time (§6): platform `ts` (decimal seconds) and daemon work-row stamps (ms) → µs |
-| **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                                                            | emergent — derived from the merged rows (senders + trusted a2a bots)                             |
-| **Composer**                | full send (fans out to the roster, all-respond semantics)                                                                                                             | read-only; "Open in Slack" deep link (`threadUrl`)                                               |
+|                             | Webchat                                                                                                                                                                                       | Slack                                                                                            |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                                                                                    | `(platform, tenantScope, channel, thread)` (§5.1)                                                |
+| **Duplicate identity**      | canonical `postId` (minted once at origin — [webchat-multi-agents.md §5](webchat-multi-agents.md)), persisted on the row and exposed to the merge at C2; independent of collision-bumped `ts` | raw `ts` string (the platform message `ts`), identical in every participant's copy               |
+| **Ordering**                | normalized event time (§6): canonical `at` (epoch ms) → µs                                                                                                                                    | normalized event time (§6): platform `ts` (decimal seconds) and daemon work-row stamps (ms) → µs |
+| **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                                                                                    | emergent — derived from the merged rows (senders + trusted a2a bots)                             |
+| **Composer**                | full send (fans out to the roster, all-respond semantics)                                                                                                                                     | read-only; "Open in Slack" deep link (`threadUrl`)                                               |
 
 Two observations that make the Slack adapter _cheaper_ than the webchat one:
 
@@ -279,23 +279,35 @@ Inputs: per-member transcript pages, each row carrying
 session (`sessionId`, `agentId`).
 
 1. **Union** all rows from all readable sources.
-2. **Dedupe is scoped to `kind === 'text'` rows and is provenance-aware**
-   (raw `ts` equality only — never order). A `ts` string identifies the same
-   message across copies only when the coordinate was minted once for all of
-   them: webchat rows always qualify (origin-minted canonical `at`,
-   probe-and-bump guarantees distinct posts got distinct `ts`); Slack rows
-   qualify only when `ts` is the provider-native decimal-seconds form —
-   exactly `^\d+\.\d+$`, anchored with the dot escaped, so an integer
-   `monotonicTs()` millisecond value can never match (the merge tests carry
-   integer-local vs decimal-provider fixtures for this predicate). The
-   matched value is the platform message id, identical in every delivery.
-   Daemon-local text rows — a2a report-backs and other silent deliveries
-   stamped with process-local millisecond `monotonicTs()` — exist in exactly
-   one source transcript and are NEVER deduped across sources: two daemons
-   can mint the same millisecond for distinct rows, and raw equality would
-   discard one (review finding). Work-lane rows never dedupe (step 3), so a
-   coincidental `ts` collision between a text row and a tool/reasoning row
-   is inert.
+2. **Dedupe is scoped to `kind === 'text'` rows and is provenance-explicit**
+   (identity equality only — never order). A row deduplicates across sources
+   only when it carries an identity minted once for every copy:
+   - **Webchat: canonical `postId`.** Timestamp shape cannot establish
+     provenance here — canonical `at` and daemon-local `monotonicTs()` stamps
+     share the integer-millisecond domain, so a local a2a report-back in one
+     source colliding with a distinct canonical post in another would be
+     wrongly merged (review finding). Instead, C2 has the daemon persist the
+     origin-minted `postId` on webchat text rows (nullable column) and expose
+     it on the messages DTO; the merge dedupes webchat rows only on equal
+     `postId`. This is also more correct than raw `ts` in the OTHER
+     direction: a collision-bumped copy carries a different `ts` than its
+     siblings, which raw equality would fail to dedupe — `postId` identifies
+     copies regardless of the bump, and the author copy's coordinates win
+     for placement. Rows without a `postId` (daemon-local report-backs,
+     pre-C2 legacy rows) never dedupe across sources — failing toward a
+     visible duplicate, never toward data loss.
+   - **Slack: provider-native `ts` form.** Rows qualify only when `ts` is
+     exactly `^\d+\.\d+$` (anchored, dot escaped) — the platform message
+     id, identical in every delivery; an integer `monotonicTs()` value can
+     never match. Daemon-local text rows are single-source by construction
+     and never dedupe: two daemons can mint the same millisecond for
+     distinct rows.
+
+   The merge tests carry integer-local vs decimal-provider fixtures for the
+   Slack predicate, plus webchat canonical-vs-local same-millisecond
+   collision and collision-bumped-copy fixtures. Work-lane rows never dedupe
+   (step 3), so a coincidental `ts` collision between a text row and a
+   tool/reasoning row is inert.
    Precedence among copies:
    - **Author copy wins**: the row whose source session's `agentId` matches
      the row's author (`sender === source.agentId`, or the daemon-relabeled
@@ -303,6 +315,7 @@ session (`sessionId`, `agentId`).
    - Human/system rows (identical in every copy): first source in stable
      order — roster order for webchat, `sessionId` sort for Slack — so the
      merge is deterministic across reloads.
+
 3. **Work-lane rows pass through un-deduped**: `kind: tool | reasoning` rows
    exist only in their author's transcript. They interleave by `ts` and render
    inside that agent's collapsible work lane, exactly as on its own page.
@@ -450,9 +463,11 @@ how divergence starts.
 - **C2 — merged page.** `conversation-merge.ts` (union/dedupe/order, unit
   tests over both adapters' fixtures), `/conversations/:key` route, renderer
   reuse, partial-merge notices, session→conversation deep-link redirects
-  (`?focus=<agentId>`), conversation-level lineage links (§9.2). Webchat
-  composer wired through the existing adoption path; Slack read-only with
-  deep link. Playground refresh lands here.
+  (`?focus=<agentId>`), conversation-level lineage links (§9.2). Daemon
+  prerequisite: persist the canonical `postId` on webchat text rows and
+  expose it on the messages DTO (§6 step 2). Webchat composer wired through
+  the existing adoption path; Slack read-only with deep link. Playground
+  refresh lands here.
 - **C3 — polish.** Conversation-level usage roll-up (sum of member sessions),
   "load earlier" cross-source paging, mobile pass, default-collapsed work
   lanes for non-focused participants.
@@ -509,7 +524,15 @@ how divergence starts.
    org/visibility predicate; text-row dedupe is provenance-aware (webchat
    canonical `at` always, Slack only provider-native decimal `ts`,
    daemon-local millisecond rows never).
-8. **Co-membership is not siblinghood.** Sessions sharing a room relate
+8. **Review revisions (v4/v5).** Direct conversation loads resolve members
+   through a bounded key-addressed metadata query
+   (`GET /sessions?conversationKey=…`); the Slack provenance predicate is
+   exact (`^\d+\.\d+$`); webchat duplicate identity moves from raw `at`
+   equality to the origin-minted canonical `postId` persisted on the row —
+   timestamp shape cannot prove provenance in webchat's integer-millisecond
+   domain, and `postId` also survives collision-bumped copies. No-`postId`
+   rows never dedupe (duplicate over data loss).
+9. **Co-membership is not siblinghood.** Sessions sharing a room relate
    through conversation membership only; "sibling" keeps its lineage meaning
    (same parent session). An edge whose endpoints share the conversation key
    renders as attribution and is excluded from lifted navigation — the

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -225,6 +225,17 @@ falls. The scan itself still pages on the existing
 `session_meta_org_visibility_page_idx`, so grouped cost ≈ the flat scan + one
 index probe per scanned row + one member-backfill batch per page.
 
+Direct loads of `/conversations/:key` need the reverse lookup — key in hand,
+members unknown. The activity-paginated grouped list cannot serve that
+(scanning pages for a key is unbounded and misses idle conversations), so C1
+also defines a **key-addressed resolver**: `GET /sessions?conversationKey=…`,
+a bounded metadata-only query on the same C1 index — every row matching
+`(orgId, platform, tenantScope, channel, thread)` under the same
+org/visibility predicate, collapsed to the current session per agent (§6),
+returned in the grouped row shape. Transcript bodies still flow through the
+existing per-session endpoints; the resolver reads the same `SessionMeta`
+rows the list reads, so no content-plane surface is added.
+
 Single-agent conversations (the overwhelming majority) come back as
 1-participant rows — the web renders those exactly like today's session rows,
 so grouped simply IS the list, with no toggle in the default UI.
@@ -273,8 +284,11 @@ session (`sessionId`, `agentId`).
    message across copies only when the coordinate was minted once for all of
    them: webchat rows always qualify (origin-minted canonical `at`,
    probe-and-bump guarantees distinct posts got distinct `ts`); Slack rows
-   qualify only when `ts` is the provider-native decimal-seconds form
-   (`\d+.\d+` — the platform message id, identical in every delivery).
+   qualify only when `ts` is the provider-native decimal-seconds form —
+   exactly `^\d+\.\d+$`, anchored with the dot escaped, so an integer
+   `monotonicTs()` millisecond value can never match (the merge tests carry
+   integer-local vs decimal-provider fixtures for this predicate). The
+   matched value is the platform message id, identical in every delivery.
    Daemon-local text rows — a2a report-backs and other silent deliveries
    stamped with process-local millisecond `monotonicTs()` — exist in exactly
    one source transcript and are NEVER deduped across sources: two daemons
@@ -427,6 +441,7 @@ how divergence starts.
 
 - **C1 — grouped sessions list.** CP grouped-by-default list with the
   `view=flat` escape hatch (emit-at-max scan + member backfill, §5.2), the
+  key-addressed member resolver (`conversationKey=…`, §5.2), the
   `(orgId, platform, tenantScope, channel, thread, lastActivityAt, startedAt, id)`
   index, persistence of the already-reported durable tenant scope as
   `SessionMeta.tenantScope` (§5.1), grouped rendering (participant avatar

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -77,18 +77,24 @@ Non-goals (v1):
 A conversation is defined by four things. Everything else — rendering, turn
 grouping, attribution — is shared.
 
-|                             | Webchat                                                                                                                         | Slack                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                      | `(platform, channel, thread)`                                              |
-| **Ordering coordinate**     | canonical `at` minted at origin, collision-bumped per (channel, thread) — [webchat-multi-agents.md §5](webchat-multi-agents.md) | platform-assigned message `ts`, unique and ordered within a thread         |
-| **Duplicate identity**      | transcript row `ts` (== canonical `at`) shared by every participant's copy of a post                                            | transcript row `ts` shared by every participant's copy of a thread message |
-| **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                      | emergent — derived from the merged rows (senders + trusted a2a bots)       |
-| **Composer**                | full send (fans out to the roster, all-respond semantics)                                                                       | read-only; "Open in Slack" deep link (`threadUrl`)                         |
+|                             | Webchat                                                                                                                                                               | Slack                                                                                            |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                                                            | `(platform, channel, thread)`                                                                    |
+| **Duplicate identity**      | raw `ts` string (== canonical `at` minted at origin, collision-bumped — [webchat-multi-agents.md §5](webchat-multi-agents.md)), identical in every participant's copy | raw `ts` string (the platform message `ts`), identical in every participant's copy               |
+| **Ordering**                | normalized event time (§6): canonical `at` (epoch ms) → µs                                                                                                            | normalized event time (§6): platform `ts` (decimal seconds) and daemon work-row stamps (ms) → µs |
+| **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                                                            | emergent — derived from the merged rows (senders + trusted a2a bots)                             |
+| **Composer**                | full send (fans out to the roster, all-respond semantics)                                                                                                             | read-only; "Open in Slack" deep link (`threadUrl`)                                               |
 
 Two observations that make the Slack adapter _cheaper_ than the webchat one:
 
-- Slack's `ts` is exactly the canonical coordinate webchat had to mint for
-  itself. No new bookkeeping.
+- Slack's platform `ts` is exactly the canonical duplicate-identity coordinate
+  webchat had to mint for itself — and the mixed timestamp **domains** (platform
+  decimal seconds for text rows vs daemon millisecond stamps for work rows) are
+  an already-solved problem: the daemon store normalizes every stored form onto
+  one epoch-microsecond axis for its own chronological reads
+  (`transcriptEventTimeUs` + `(eventTimeUs, seq)` paging in `local-store.ts`);
+  the merge reuses that normalization (§6) and never compares raw `ts` for
+  order.
 - §8.4 mid-thread backfill means every participating agent's transcript
   already contains the full thread _text_. The merge adds each agent's work
   lanes — the one thing per-agent pages structurally cannot show together —
@@ -119,7 +125,8 @@ The merged view therefore reads exactly what the per-agent pages read:
    `webchat-lanes.ts` isolates lane resolution).
 
 A member read that fails with 403/404 (restricted agent) or a daemon-offline
-error degrades to a **partial merge** with an explicit notice (§7) — never a
+error degrades to a **partial merge** (silently for authorization failures,
+with a notice only for offline daemons — §7) — never a
 page-level failure, because the remaining sources are still a legitimate view
 of the thread (it is what any one participant legitimately sees today).
 
@@ -137,16 +144,26 @@ aggregation that still streams per-source and persists nothing is the fallback
 ### 5.1 Key encoding
 
 - Webchat: `conversationId` (already a UUID; the session row's `channel`).
-- Slack: `platform:channel:thread`, base64url-encoded for the URL. `thread`
-  falls back to the channel-root marker exactly as sessions record it, so a
-  channel-root conversation groups its root-thread sessions.
+- Slack: `platform:transportScope:channel:thread` (empty scope segment when
+  null), base64url-encoded for the URL. `thread` falls back to the
+  channel-root marker exactly as sessions record it, so a channel-root
+  conversation groups its root-thread sessions.
 
-`SessionMeta` has no integration/workspace column, and neither does the
-daemon's session key — thread identity has always been
-`(platform, channel, thread)` in this system. The conversation key inherits
-that model (and its theoretical cross-workspace channel-id collision, which is
-pre-existing and unobserved) rather than inventing a stricter identity only on
-the read side.
+Thread identity in this system is `(platform, channel, thread)` **plus the
+daemon's `transportScope`** wherever a shared ingress multiplexes
+installations — the scope is already part of the daemon session key and of
+the daemon's transcript channel key, but it is not reported to the CP today.
+C1 closes that gap: `event/session` gains an optional `transportScope`,
+`SessionMeta` stores it (nullable), and the conversation key is
+`(platform, transportScope ?? '', channel, thread)` — two installations
+sharing a channel id can never merge into one conversation when the daemon
+itself keeps them apart. Pre-upgrade rows carry a null scope and may
+transiently render as a separate conversation from post-upgrade scoped rows
+of the same thread — a display artifact that ages out with activity, accepted
+for C1. Socket-mode connections have no transportScope; a cross-**workspace**
+channel-id collision there is the same pre-existing (and unobserved) exposure
+the daemon's own keys carry, and lifting workspace identity (the platform team
+id) into both layers together is platform-identity work outside this design.
 
 ### 5.2 Grouped list is the default
 
@@ -169,31 +186,34 @@ caller never contributes):
     title,               // primary participant's title (webchat) / first session's (slack)
     lastActivityAt,      // max over members
     activityState,       // any member active ⇒ active
-    participants: [{ agentId, sessionId, name }],  // member sessions, roster order (webchat) / first-seen (slack)
-    hiddenParticipants   // count of member sessions the caller cannot view
+    participants: [{ agentId, sessionId, name }]   // VISIBLE member sessions, roster order (webchat) / first-seen (slack)
   }],
   nextCursor
 }
 ```
 
-Pagination stays newest-first by `lastActivityAt`, and the implementation
-needs **no aggregate query and no new page index** (verified against the
-schema): on the same descending scan the flat list already pages with
-(`session_meta_org_visibility_page_idx`), the FIRST row seen for a conversation
-key is that conversation's `max(lastActivityAt)` — so the grouped page is a
-streaming dedupe over the flat scan until N distinct keys fill the page. The
-page's remaining members then backfill with one `(platform, channel, thread)`
-lookup batch; the existing `@@index([platform, channel])` covers it, extended
-with `thread` at C1 so a busy Slack channel doesn't post-filter thousands of
-rows per lookup.
+Pagination stays newest-first by `lastActivityAt` with **no aggregate
+query**, but naive streaming dedupe is not enough: dedupe state resets at
+every page boundary, so a conversation whose members' activity straddles a
+cursor would reappear on a later page (review finding). The stateless rule is
+**emit-at-max**: a scanned row yields its conversation only if it IS the
+conversation's newest member row, checked with an indexed exists-newer probe
+per candidate on `(platform, transportScope, channel, thread, lastActivityAt)`
+— the C1 replacement of today's `@@index([platform, channel])`, which also
+serves the member backfill. Rows failing the probe are skipped: their
+conversation already surfaced (or will) at its true max position, on whatever
+page that position falls. The scan itself still pages on the existing
+`session_meta_org_visibility_page_idx`, so grouped cost ≈ the flat scan + one
+index probe per scanned row + one member-backfill batch per page.
 
 Single-agent conversations (the overwhelming majority) come back as
 1-participant rows — the web renders those exactly like today's session rows,
 so grouped simply IS the list, with no toggle in the default UI.
 
-`hiddenParticipants` requires care: the aggregate must count members that
-exist but are invisible **without leaking which agent** — a bare count is the
-same information the partial-merge notice shows (§7).
+Invisible members are simply **absent** — no count, no placeholder. The
+established session-visibility bar is that a hidden session's existence is
+itself hidden (a hidden parent is indistinguishable from no parent); the
+grouped list and the merged page both hold to it (§7).
 
 ### 5.3 Routes and cross-links
 
@@ -216,14 +236,24 @@ same information the partial-merge notice shows (§7).
 
 ## 6. The merge algorithm
 
+Member resolution first collapses the location's session rows to **one
+current session per `agentId`** (newest `lastActivityAt`): an agent whose ACP
+session was recreated leaves superseded `SessionMeta` rows at the same
+location, and those must not become duplicate sources or fetch obsolete
+session ids — the daemon transcript is keyed by `(channel, thread)`, so the
+current session's read already covers the whole thread. Superseded rows stay
+reachable only through `view=flat`.
+
 Inputs: per-member transcript pages, each row carrying
 `(sender, ts, kind, text, attachments, body, trustedAgentBot)` plus its source
 session (`sessionId`, `agentId`).
 
 1. **Union** all rows from all readable sources.
-2. **Dedupe by `ts`** within the conversation. Rows sharing `ts` are copies of
-   the same message (webchat: canonical `at`, probe-and-bump guarantees
-   distinct posts got distinct `ts`; Slack: platform-assigned `ts`).
+2. **Dedupe text rows by raw `ts` string equality** within the conversation
+   (equality only — never order). Rows sharing the exact `ts` string are
+   copies of the same message (webchat: canonical `at`, probe-and-bump
+   guarantees distinct posts got distinct `ts`; Slack: the platform-assigned
+   `ts`, identical in every delivery).
    Precedence among copies:
    - **Author copy wins**: the row whose source session's `agentId` matches
      the row's author (`sender === source.agentId`, or the daemon-relabeled
@@ -234,9 +264,14 @@ session (`sessionId`, `agentId`).
 3. **Work-lane rows pass through un-deduped**: `kind: tool | reasoning` rows
    exist only in their author's transcript. They interleave by `ts` and render
    inside that agent's collapsible work lane, exactly as on its own page.
-4. **Sort by `ts` ascending**; ties (distinct messages can share a millisecond
-   only across platforms' guarantees failing) break by `(sender, sessionId)`
-   for determinism.
+4. **Sort on the normalized event-time axis, never on raw `ts`.** Raw `ts`
+   mixes domains (Slack decimal seconds for text rows vs daemon millisecond
+   stamps for work rows) and is an identity, not an order. The daemon store
+   already normalizes every stored form onto epoch microseconds for its own
+   chronological reads (`transcriptEventTimeUs`); the merge module implements
+   the same normalization (the console's timestamp parser already matches it
+   row-wise), sorts ascending, and breaks ties by `(sender, sessionId)` while
+   preserving each source's own relative row order (stable merge).
 5. **Attribution and turn grouping reuse the session detail machinery**: the
    merged row list feeds the same turn builder the per-agent page uses — the
    right side is reserved for the viewer, every agent renders as its own
@@ -269,10 +304,12 @@ session read policy; the merge renders what comes back:
   they appear on any per-agent page today. Hiding a session hides an agent's
   private work, not the thread messages every participant legitimately
   received.
-- The page shows a quiet notice when sources are missing: "N participants'
-  records aren't visible to you" (count only, no identity), and per-source
-  daemon-offline errors degrade the same way ("K participants' records are on
-  an offline daemon").
+- **Authorization-hidden sources are silent.** No count, no placeholder —
+  disclosing that hidden records exist is itself a leak by the
+  session-visibility bar this codebase already holds (a hidden parent is
+  indistinguishable from no parent). Only non-authorization failures surface
+  a notice: a daemon-offline source degrades with "some participants' records
+  are on an offline daemon" — an operational condition, not a protected fact.
 - **Webchat send fence unchanged**: the composer on a merged webchat
   conversation resumes through the existing conversation-token mint, which
   already requires _all_ participants viewable. A caller with partial view
@@ -361,11 +398,12 @@ Per the product decision, **webchat and Slack ship together in each milestone**
 how divergence starts.
 
 - **C1 — grouped sessions list.** CP grouped-by-default list with the
-  `view=flat` escape hatch (desc-scan dedupe + member backfill, §5.2), the
-  `(platform, channel)` index extended with `thread`, grouped rendering
-  (participant avatar stack, single row per conversation, both platforms).
-  Cheapest milestone, fixes the most visible confusion (N rows per
-  conversation).
+  `view=flat` escape hatch (emit-at-max scan + member backfill, §5.2), the
+  `(platform, transportScope, channel, thread, lastActivityAt)` index, the
+  `event/session` `transportScope` report + nullable `SessionMeta` column
+  (§5.1), grouped rendering (participant avatar stack, single row per
+  conversation, both platforms). Fixes the most visible confusion (N rows
+  per conversation).
 - **C2 — merged page.** `conversation-merge.ts` (union/dedupe/order, unit
   tests over both adapters' fixtures), `/conversations/:key` route, renderer
   reuse, partial-merge notices, session→conversation deep-link redirects
@@ -399,11 +437,13 @@ how divergence starts.
    returns conversations; `view=flat` (a UI parameter passed through to the
    CP) returns raw session rows. Accepted as a deliberate change to the
    operation's default response shape.
-2. **Index question resolved — no new aggregate index.** Newest-first
-   conversation paging falls out of the existing
-   `session_meta_org_visibility_page_idx` descending scan (first occurrence
-   of a key = the conversation's max activity); member backfill extends
-   `@@index([platform, channel])` with `thread` at C1.
+2. **Pagination is emit-at-max — still no aggregate query.** A scanned row
+   yields its conversation only when it is the conversation's newest member
+   row (indexed exists-newer probe on the C1
+   `(platform, transportScope, channel, thread, lastActivityAt)` index); the
+   plain streaming-dedupe shortcut was wrong across page boundaries and is
+   rejected (review finding). The scan still pages on
+   `session_meta_org_visibility_page_idx`.
 3. **Per-agent session pages are not surfaced for multi-participant
    conversations.** Every entry point leads to the merged page; existing
    session deep links redirect with `?focus=<agentId>`; the conversation
@@ -413,7 +453,14 @@ how divergence starts.
 5. **Lineage never changes conversation membership** — parent/child edges are
    linked (attribution in-thread, navigation across conversations), never
    merged (§9).
-6. **Co-membership is not siblinghood.** Sessions sharing a room relate
+6. **Review revisions (v2).** Conversation keys carry the daemon's
+   `transportScope` (reported on `event/session`, stored nullable on
+   `SessionMeta`); authorization-hidden members are absent, never counted;
+   ordering uses the daemon's normalized event-time axis (`transcriptEventTimeUs`
+   semantics) with raw `ts` demoted to duplicate identity; member resolution
+   collapses to one current session per agent, retiring superseded ACP rows
+   from the merge.
+7. **Co-membership is not siblinghood.** Sessions sharing a room relate
    through conversation membership only; "sibling" keeps its lineage meaning
    (same parent session). An edge whose endpoints share the conversation key
    renders as attribution and is excluded from lifted navigation — the

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -79,7 +79,7 @@ grouping, attribution — is shared.
 
 |                             | Webchat                                                                                                                                                               | Slack                                                                                            |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                                                            | `(platform, channel, thread)`                                                                    |
+| **Identity (grouping key)** | `conversationId` (the session's `channel`)                                                                                                                            | `(platform, tenantScope, channel, thread)` (§5.1)                                                |
 | **Duplicate identity**      | raw `ts` string (== canonical `at` minted at origin, collision-bumped — [webchat-multi-agents.md §5](webchat-multi-agents.md)), identical in every participant's copy | raw `ts` string (the platform message `ts`), identical in every participant's copy               |
 | **Ordering**                | normalized event time (§6): canonical `at` (epoch ms) → µs                                                                                                            | normalized event time (§6): platform `ts` (decimal seconds) and daemon work-row stamps (ms) → µs |
 | **Roster**                  | explicit, owner-assembled (`webchat_conversation_agent`; served on the session detail DTO)                                                                            | emergent — derived from the merged rows (senders + trusted a2a bots)                             |
@@ -144,26 +144,31 @@ aggregation that still streams per-source and persists nothing is the fallback
 ### 5.1 Key encoding
 
 - Webchat: `conversationId` (already a UUID; the session row's `channel`).
-- Slack: `platform:transportScope:channel:thread` (empty scope segment when
-  null), base64url-encoded for the URL. `thread` falls back to the
+- Slack: `platform:tenantScope:channel:thread` (empty scope segment when
+  unknown), base64url-encoded for the URL. `thread` falls back to the
   channel-root marker exactly as sessions record it, so a channel-root
   conversation groups its root-thread sessions.
 
-Thread identity in this system is `(platform, channel, thread)` **plus the
-daemon's `transportScope`** wherever a shared ingress multiplexes
-installations — the scope is already part of the daemon session key and of
-the daemon's transcript channel key, but it is not reported to the CP today.
-C1 closes that gap: `event/session` gains an optional `transportScope`,
-`SessionMeta` stores it (nullable), and the conversation key is
-`(platform, transportScope ?? '', channel, thread)` — two installations
-sharing a channel id can never merge into one conversation when the daemon
-itself keeps them apart. Pre-upgrade rows carry a null scope and may
-transiently render as a separate conversation from post-upgrade scoped rows
-of the same thread — a display artifact that ages out with activity, accepted
-for C1. Socket-mode connections have no transportScope; a cross-**workspace**
-channel-id collision there is the same pre-existing (and unobserved) exposure
-the daemon's own keys carry, and lifting workspace identity (the platform team
-id) into both layers together is platform-identity work outside this design.
+Raw `(channel, thread)` coordinates are not a shared namespace across
+installations — the daemon already keeps them apart (its session key and
+transcript channel key both carry a scope). The conversation key needs a
+scope too, and the right one already crosses the wire: `event/session`
+carries the protocol's **durable workspace/tenant scope**
+(`EventSession.transportScope` — a Slack team id, Feishu tenant key, or a
+minted stable per-integration scope; the daemon fills it for Socket Mode and
+HTTP ingress alike once the workspace is known). That field is explicitly
+NOT the daemon session key's credential-derived physical transport scope —
+that value is hashed from bot/app tokens and rotates with them, so grouping
+on it would split a workspace's conversations at every token rotation
+(review finding; the two scopes also carry different security semantics —
+the durable one already anchors `ownerIdentity` for session visibility).
+C1 persists the durable value under an unambiguous CP name — a nullable
+`SessionMeta.tenantScope` column (today it is only folded into
+`ownerIdentity`, not queryable) — and the conversation key is
+`(platform, tenantScope ?? '', channel, thread)`. Pre-upgrade rows carry a
+null scope and may transiently render apart from post-upgrade rows of the
+same thread — a display artifact that ages out with activity, accepted for
+C1.
 
 ### 5.2 Grouped list is the default
 
@@ -192,17 +197,31 @@ caller never contributes):
 }
 ```
 
-Pagination stays newest-first by `lastActivityAt` with **no aggregate
-query**, but naive streaming dedupe is not enough: dedupe state resets at
-every page boundary, so a conversation whose members' activity straddles a
-cursor would reappear on a later page (review finding). The stateless rule is
-**emit-at-max**: a scanned row yields its conversation only if it IS the
-conversation's newest member row, checked with an indexed exists-newer probe
-per candidate on `(platform, transportScope, channel, thread, lastActivityAt)`
-— the C1 replacement of today's `@@index([platform, channel])`, which also
-serves the member backfill. Rows failing the probe are skipped: their
-conversation already surfaced (or will) at its true max position, on whatever
-page that position falls. The scan itself still pages on the existing
+Pagination stays newest-first with **no aggregate query**, but naive
+streaming dedupe is not enough: dedupe state resets at every page boundary,
+so a conversation whose members' activity straddles a cursor would reappear
+on a later page (review finding). The stateless rule is **emit-at-max**,
+made exact by two requirements (review finding):
+
+- **Total order, not bare `lastActivityAt`.** The representative is the
+  maximum member row under the flat cursor's full tuple
+  `(lastActivityAt, startedAt, id)` — two members sharing the same
+  millisecond cannot both win, so a conversation is emitted exactly once.
+- **The probe applies the outer scan's own predicate.** The exists-newer
+  check runs under the identical org and session-visibility filter —
+  otherwise a newer invisible or cross-org member row would suppress a
+  conversation the caller can legitimately see. Grouping is
+  visibility-filtered, so the representative is the caller's newest VISIBLE
+  member.
+
+A scanned row yields its conversation only if no same-key member row is
+strictly greater in that tuple under that predicate — one indexed probe per
+candidate on the C1 index
+`(orgId, platform, tenantScope, channel, thread, lastActivityAt, startedAt, id)`
+(replacing today's `@@index([platform, channel])`; it also serves the member
+backfill). Rows failing the probe are skipped: their conversation already
+surfaced (or will) at its true max position, on whatever page that position
+falls. The scan itself still pages on the existing
 `session_meta_org_visibility_page_idx`, so grouped cost ≈ the flat scan + one
 index probe per scanned row + one member-backfill batch per page.
 
@@ -249,11 +268,20 @@ Inputs: per-member transcript pages, each row carrying
 session (`sessionId`, `agentId`).
 
 1. **Union** all rows from all readable sources.
-2. **Dedupe text rows by raw `ts` string equality** within the conversation
-   (equality only — never order). Rows sharing the exact `ts` string are
-   copies of the same message (webchat: canonical `at`, probe-and-bump
-   guarantees distinct posts got distinct `ts`; Slack: the platform-assigned
-   `ts`, identical in every delivery).
+2. **Dedupe is scoped to `kind === 'text'` rows and is provenance-aware**
+   (raw `ts` equality only — never order). A `ts` string identifies the same
+   message across copies only when the coordinate was minted once for all of
+   them: webchat rows always qualify (origin-minted canonical `at`,
+   probe-and-bump guarantees distinct posts got distinct `ts`); Slack rows
+   qualify only when `ts` is the provider-native decimal-seconds form
+   (`\d+.\d+` — the platform message id, identical in every delivery).
+   Daemon-local text rows — a2a report-backs and other silent deliveries
+   stamped with process-local millisecond `monotonicTs()` — exist in exactly
+   one source transcript and are NEVER deduped across sources: two daemons
+   can mint the same millisecond for distinct rows, and raw equality would
+   discard one (review finding). Work-lane rows never dedupe (step 3), so a
+   coincidental `ts` collision between a text row and a tool/reasoning row
+   is inert.
    Precedence among copies:
    - **Author copy wins**: the row whose source session's `agentId` matches
      the row's author (`sender === source.agentId`, or the daemon-relabeled
@@ -399,11 +427,11 @@ how divergence starts.
 
 - **C1 — grouped sessions list.** CP grouped-by-default list with the
   `view=flat` escape hatch (emit-at-max scan + member backfill, §5.2), the
-  `(platform, transportScope, channel, thread, lastActivityAt)` index, the
-  `event/session` `transportScope` report + nullable `SessionMeta` column
-  (§5.1), grouped rendering (participant avatar stack, single row per
-  conversation, both platforms). Fixes the most visible confusion (N rows
-  per conversation).
+  `(orgId, platform, tenantScope, channel, thread, lastActivityAt, startedAt, id)`
+  index, persistence of the already-reported durable tenant scope as
+  `SessionMeta.tenantScope` (§5.1), grouped rendering (participant avatar
+  stack, single row per conversation, both platforms). Fixes the most
+  visible confusion (N rows per conversation).
 - **C2 — merged page.** `conversation-merge.ts` (union/dedupe/order, unit
   tests over both adapters' fixtures), `/conversations/:key` route, renderer
   reuse, partial-merge notices, session→conversation deep-link redirects
@@ -439,11 +467,10 @@ how divergence starts.
    operation's default response shape.
 2. **Pagination is emit-at-max — still no aggregate query.** A scanned row
    yields its conversation only when it is the conversation's newest member
-   row (indexed exists-newer probe on the C1
-   `(platform, transportScope, channel, thread, lastActivityAt)` index); the
-   plain streaming-dedupe shortcut was wrong across page boundaries and is
-   rejected (review finding). The scan still pages on
-   `session_meta_org_visibility_page_idx`.
+   row under the full `(lastActivityAt, startedAt, id)` total order AND the
+   outer scan's own org/visibility predicate (indexed exists-newer probe on
+   the C1 index, §5.2); the plain streaming-dedupe shortcut was wrong across
+   page boundaries and is rejected (review finding).
 3. **Per-agent session pages are not surfaced for multi-participant
    conversations.** Every entry point leads to the merged page; existing
    session deep links redirect with `?focus=<agentId>`; the conversation
@@ -453,14 +480,21 @@ how divergence starts.
 5. **Lineage never changes conversation membership** — parent/child edges are
    linked (attribution in-thread, navigation across conversations), never
    merged (§9).
-6. **Review revisions (v2).** Conversation keys carry the daemon's
-   `transportScope` (reported on `event/session`, stored nullable on
-   `SessionMeta`); authorization-hidden members are absent, never counted;
-   ordering uses the daemon's normalized event-time axis (`transcriptEventTimeUs`
-   semantics) with raw `ts` demoted to duplicate identity; member resolution
-   collapses to one current session per agent, retiring superseded ACP rows
-   from the merge.
-7. **Co-membership is not siblinghood.** Sessions sharing a room relate
+6. **Review revisions (v2).** Authorization-hidden members are absent,
+   never counted; ordering uses the daemon's normalized event-time axis
+   (`transcriptEventTimeUs` semantics) with raw `ts` demoted to duplicate
+   identity; member resolution collapses to one current session per agent,
+   retiring superseded ACP rows from the merge. (v2's scope proposal is
+   superseded by v3's durable tenant scope.)
+7. **Review revisions (v3).** Conversation scope is the protocol's DURABLE
+   workspace/tenant scope (`EventSession.transportScope`, persisted as
+   `SessionMeta.tenantScope`) — never the credential-derived rotating
+   physical scope; emit-at-max selects its representative by the full
+   `(lastActivityAt, startedAt, id)` tuple under the outer scan's own
+   org/visibility predicate; text-row dedupe is provenance-aware (webchat
+   canonical `at` always, Slack only provider-native decimal `ts`,
+   daemon-local millisecond rows never).
+8. **Co-membership is not siblinghood.** Sessions sharing a room relate
    through conversation membership only; "sibling" keeps its lineage meaning
    (same parent session). An edge whose endpoints share the conversation key
    renders as attribution and is excluded from lifted navigation — the

--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -742,9 +742,10 @@ here.
   (section 5.4) also lands here — a2a wakes make peer churn common — and
   depends on the `ThreadContextCoordinator` extraction, rollout step 1 of
   [turn-final-context-refresh.md](turn-final-context-refresh.md).
-- **M3 — polish.** Agent-initiated live streaming, grouped conversation view in
-  the console sessions list, merged console transcript, per-agent runtime
-  controls, mobile pass.
+- **M3 — polish.** Agent-initiated live streaming, per-agent runtime controls,
+  mobile pass. The grouped sessions list and merged console transcript have
+  grown into their own platform-neutral design (webchat + Slack together):
+  [merged-conversation-view.md](merged-conversation-view.md).
 
 Each milestone is independently shippable; M1 without M2 already delivers the
 user-facing product ("talk to several agents in one Playground conversation").


### PR DESCRIPTION
Design-only PR: [docs/designs/merged-conversation-view.md](../blob/claude/merged-conversation-view/docs/designs/merged-conversation-view.md).

Follow-up to the multi-agent webchat series (#402/#405/#409/#412/#414): after the per-agent session view fixes, what remains is structural — one conversation renders as N session pages and N list rows, and each agent's work lanes are visible only on its own page. This design adds a **merged conversation view**, platform-neutral from day one, with the **webchat and Slack adapters shipping together** (product decision).

Core shape:

- A conversation = grouping key + ordering coordinate + dedupe rule + roster feed; everything else (turn building, attribution, work-lane rendering) is the existing session-detail machinery fed a union instead of one source.
- **Webchat adapter**: `conversationId` / canonical `at` / explicit roster / full composer (existing resume + all-respond).
- **Slack adapter**: `(platform, channel, thread)` / platform `ts` (the canonical coordinate for free) / emergent roster / read-only + "Open in Slack". §8.4 backfill means the merge only adds work lanes and dedupes text copies.
- **No new content plane**: merge computed client-side over the existing bounded per-session reads; per-source authorization inherited; partial merges degrade with a count-only notice. No new ACL object; per-agent pages remain as drill-down.
- Milestones: C1 grouped sessions list → C2 merged page (`/conversations/:key`, `conversation-merge.ts` pure module; Playground refresh lands here) → C3 polish (usage roll-up, cross-source paging, mobile).

Also updates webchat-multi-agents.md M3 to point here instead of carrying the grouped-list/merged-transcript items itself.

Open questions are listed in §11 — notably whether the grouped list replaces the flat list outright (design assumes yes), and the aggregate index needed before C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)