### PR TITLE
feat(web): agent filter above the session rail's list

### DIFF
--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -14,22 +14,39 @@
 // a divider, pin lit in the brand color, ahead of the dated groups. Pins live in
 // localStorage — see lib/session-pins.ts for why they are not CP state.
 //
-// The caller's rows are the agent-filtered FIRST PAGE, so two kinds of row would
+// Above the list sits the agent filter: a chip per selected agent (removable), plus
+// a "+" that opens the agent picker. It is seeded by the caller with the open
+// session's agent — "the other runs of THIS agent" is the rail's default question —
+// and clearing it widens the list to every session the viewer can see. Only one
+// agent at a time for now: the CP list endpoint filters by a single `agentId`. The
+// prop is already a list so the eventual multi-agent filter (conversations several
+// agents took part in) is a wire change, not a redesign here.
+//
+// The caller's rows are the filtered FIRST PAGE, so two kinds of row would
 // otherwise be missing from a long-running agent's rail: the open session itself
 // (a deep link to session 51+), and pinned runs that newer runs pushed off page
 // one or that belong to another agent. Both are the rail's whole point, so
 // `current` is merged in and off-page pins are fetched individually (bounded by
-// SESSION_PIN_HYDRATE_MAX).
+// SESSION_PIN_HYDRATE_MAX). `current` stays merged in under a foreign agent filter
+// too — the open session is where the reader is, and dropping its row would leave
+// the rail with nothing marked `aria-current`.
 
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import useSWR from 'swr'
-import { canonicalSessionId, mergeCanonicalSessions, sessionChannelDisplay, type Session } from '@/lib/data'
+import {
+  agentLabel,
+  canonicalSessionId,
+  mergeCanonicalSessions,
+  sessionChannelDisplay,
+  type Agent,
+  type Session
+} from '@/lib/data'
 import { fetchSessionDetail, sessionFromDetailDto, type SessionDetailDto, type SessionRelationDto } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
-import { PlatformMark } from '@/components/marks'
+import { AgentIconView, PlatformMark } from '@/components/marks'
 import { groupSessionsByAge } from '@/lib/session-age'
 import {
   partitionPinned,
@@ -55,18 +72,21 @@ export function SessionRail({
   sessions,
   current,
   total,
-  agentId,
+  agentIds,
+  onAgentIdsChange,
   family,
   onSelect
 }: {
-  /** The agent-filtered first page of sessions, newest first. */
+  /** The filtered first page of sessions, newest first. */
   sessions: Session[]
   /** The open session — merged in when it is not on the loaded page. */
   current: Session
-  /** The agent's full session count (CP `total`); 0 when unknown (mock). */
+  /** The filtered session count (CP `total`); 0 when unknown (mock). */
   total: number
-  /** Owning agent — scopes the footer link. */
-  agentId: string | undefined
+  /** Agents the list is filtered to; empty = every session the viewer can see. */
+  agentIds: string[]
+  /** Edit the filter. The caller owns it — the rail is not the only thing it scopes. */
+  onAgentIdsChange: (agentIds: string[]) => void
   /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
   family?: Pick<SessionDetailDto, 'parentSession' | 'siblingSessions' | 'childSessions'>
   /** Seed the persistent detail view before the route id changes. */
@@ -75,7 +95,8 @@ export function SessionRail({
   const { orgPath, activeOrg } = useOrgs()
   // Schedule-triggered rows show the schedule's name, so the rail needs the crons
   // list — resolve it here instead of threading another display-only callback.
-  const { crons } = useConsoleData()
+  // `agents` backs the filter chips and their picker.
+  const { agents, crons } = useConsoleData()
   const cronName = useCallback((cronId: string) => crons.find((c) => c.id === cronId)?.name, [crons])
 
   // Hydration: the server has no localStorage, so the first client paint must match
@@ -167,7 +188,10 @@ export function SessionRail({
 
   // A rail that would only show the session already on screen is noise. Direct
   // lineage still makes it useful when the current agent itself has one session.
-  if (Math.max(total, rows.length) < 2 && !hasFamily) return null
+  // A filter the reader chose is the exception: hiding the rail would take the
+  // filter control away with it, leaving no way back to a wider list.
+  const filterIsDefault = agentIds.length <= 1 && (agentIds[0] ?? '') === (current.agentId ?? '')
+  if (Math.max(total, rows.length) < 2 && !hasFamily && filterIsDefault) return null
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
@@ -253,6 +277,7 @@ export function SessionRail({
   return (
     <div className="hidden w-[224px] flex-none desktop:block">
       <div className="sticky top-[-9px] flex max-h-[calc(100vh-110px)] flex-col pb-1">
+        <RailAgentFilter agents={agents} selected={agentIds} onChange={onAgentIdsChange} />
         <div className="flex min-h-0 flex-1 flex-col gap-px overflow-auto">
           {hasFamily && (
             <>
@@ -284,14 +309,147 @@ export function SessionRail({
             </Fragment>
           ))}
         </div>
+        {/* Carry the rail's filter into the full list so the link is the same
+            question, unabridged. The sessions page takes one agent, which is
+            exactly what the picker can produce today. */}
         <Link
           className="lnk mt-[10px] mr-[9px] ml-[9px] font-sans text-[12px] font-medium leading-normal"
-          href={orgPath(agentId ? `/sessions?agent=${encodeURIComponent(agentId)}` : '/sessions')}
+          href={orgPath(agentIds[0] ? `/sessions?agent=${encodeURIComponent(agentIds[0])}` : '/sessions')}
         >
           All sessions
           <Icon name="arrow-right" size={12} />
         </Link>
       </div>
+    </div>
+  )
+}
+
+// The filter above the list: one chip per selected agent, then the "+" picker.
+// With nothing selected the chip row reads "All agents", so the rail always says
+// what it is showing rather than leaving an unexplained gap above the first group.
+//
+// Single-select while the CP filters by one `agentId`: picking an agent replaces
+// the chip, and picking the selected one clears it (the same toggle the chip's ×
+// performs). The signature stays plural so multi-select is a later change to the
+// menu's click handler and the fetch, not to this component's shape.
+function RailAgentFilter({
+  agents,
+  selected,
+  onChange
+}: {
+  agents: Agent[]
+  selected: string[]
+  onChange: (agentIds: string[]) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  // A restricted agent can own the open session while staying out of this viewer's
+  // roster; show the id rather than dropping the chip and silently misdescribing
+  // the list as unfiltered.
+  const chips = selected.map((id) => {
+    const agent = agents.find((a) => a.id === id)
+    return { id, label: agent ? agentLabel(agent) : id, agent }
+  })
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+      return
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const q = query.trim().toLowerCase()
+  const shown = agents.filter((agent) => agentLabel(agent).toLowerCase().includes(q))
+
+  return (
+    <div className="relative mb-[7px] flex flex-none flex-wrap items-center gap-[5px] px-[9px]">
+      {chips.length === 0 && (
+        <span className="py-[3px] font-sans text-[12.5px] font-medium leading-normal text-(--text-tertiary)">
+          All agents
+        </span>
+      )}
+      {chips.map((chip) => (
+        <span
+          key={chip.id}
+          title={chip.label}
+          className="inline-flex h-[26px] min-w-0 max-w-full items-center gap-[5px] rounded-md border border-(--border-default) bg-(--surface-card) py-0 pr-[3px] pl-[6px]"
+        >
+          <span className="av h-[15px] w-[15px] flex-none rounded-xs">
+            <AgentIconView icon={chip.agent?.icon} runtime={chip.agent?.runtime ?? ''} size={15} />
+          </span>
+          <span className="min-w-0 truncate font-sans text-[12px] font-medium leading-normal text-(--text-primary)">
+            {chip.label}
+          </span>
+          <button
+            type="button"
+            onClick={() => onChange(selected.filter((id) => id !== chip.id))}
+            title="Clear agent filter"
+            aria-label={`Clear agent filter ${chip.label}`}
+            className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-xs border-0 bg-none p-0 text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-primary) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none"
+          >
+            <Icon name="x" size={11} />
+          </button>
+        </span>
+      ))}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Filter by agent"
+        aria-label="Filter by agent"
+        aria-expanded={open}
+        className={`flex h-[22px] w-[22px] flex-none items-center justify-center rounded-sm border p-0 focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
+          open
+            ? 'border-(--brand) bg-(--surface-card) text-(--brand)'
+            : 'border-(--border-default) bg-(--surface-card) text-(--text-tertiary) hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-primary)'
+        }`}
+      >
+        <Icon name="plus" size={12} />
+      </button>
+      {open && (
+        <>
+          <div className="fscrim" onClick={() => setOpen(false)} />
+          {/* .fmenu anchors to the row's left edge; the rail is 224px, so widen the
+              menu past its own 210px minimum only through the row's own width. */}
+          <div className="fmenu" role="listbox">
+            <input
+              className="fsearch"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter agents…"
+              autoFocus
+              aria-label="Filter agents"
+            />
+            {shown.map((agent) => {
+              const on = selected.includes(agent.id)
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  role="option"
+                  aria-selected={on}
+                  className="fopt"
+                  onClick={() => {
+                    onChange(on ? [] : [agent.id])
+                    setOpen(false)
+                  }}
+                >
+                  <span className="av h-5 w-5 flex-none rounded-xs">
+                    <AgentIconView icon={agent.icon} runtime={agent.runtime} size={20} />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{agentLabel(agent)}</span>
+                  {on && <Icon name="check" size={14} color="var(--brand)" className="flex-none" />}
+                </button>
+              )
+            })}
+            {shown.length === 0 && <div className="fnohit">No matches</div>}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -73,6 +73,7 @@ export function SessionRail({
   current,
   total,
   agentIds,
+  filterTouched,
   onAgentIdsChange,
   family,
   onSelect
@@ -85,6 +86,8 @@ export function SessionRail({
   total: number
   /** Agents the list is filtered to; empty = every session the viewer can see. */
   agentIds: string[]
+  /** Whether `agentIds` is the reader's own choice rather than the seeded default. */
+  filterTouched: boolean
   /** Edit the filter. The caller owns it — the rail is not the only thing it scopes. */
   onAgentIdsChange: (agentIds: string[]) => void
   /** Direct lineage from the detail endpoint. Undefined while it is unavailable. */
@@ -189,9 +192,11 @@ export function SessionRail({
   // A rail that would only show the session already on screen is noise. Direct
   // lineage still makes it useful when the current agent itself has one session.
   // A filter the reader chose is the exception: hiding the rail would take the
-  // filter control away with it, leaving no way back to a wider list.
-  const filterIsDefault = agentIds.length <= 1 && (agentIds[0] ?? '') === (current.agentId ?? '')
-  if (Math.max(total, rows.length) < 2 && !hasFamily && filterIsDefault) return null
+  // filter control away with it, leaving no way back to a wider list. That has to
+  // come from `filterTouched` and not from comparing `agentIds` against the open
+  // session — filtering to agent B and then opening B's only session lands on a
+  // filter that LOOKS like the default while still being the reader's own.
+  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) return null
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -70,7 +70,12 @@ import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import { useCrumbSlot } from '@/components/console/Shell'
 import { SessionRail } from '@/components/console/SessionRail'
-import { EMPTY_RAIL_AGENT_FILTER, seedRailAgentFilter, type RailAgentFilter } from '@/lib/session-rail-filter'
+import {
+  EMPTY_RAIL_AGENT_FILTER,
+  railAgentFilterQuery,
+  seedRailAgentFilter,
+  type RailAgentFilter
+} from '@/lib/session-rail-filter'
 import { useSessionList } from '@/lib/use-session-list'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
@@ -886,29 +891,35 @@ export default function SessionDetailView() {
   // Other sessions for the left rail, scoped by the rail's own agent filter — see
   // lib/session-rail-filter.ts for why an untouched filter follows the route and an
   // edited one does not.
+  //
+  // Seeded DURING RENDER rather than in an effect. An effect commits one frame in
+  // which the filter is still empty while `sessionAgentId` is already known — long
+  // enough to paint "All agents" over org-wide rows and fire the unfiltered request
+  // before snapping to the default. `seedRailAgentFilter` is pure and returns an
+  // edited filter unchanged, so the stored state only ever holds the reader's own
+  // choice and the seed is recomputed from the route every time.
   const sessionAgentId = session?.agentId ?? ''
-  const [railFilter, setRailFilter] = useState<RailAgentFilter>(EMPTY_RAIL_AGENT_FILTER)
-  useEffect(() => {
-    setRailFilter((prev) => seedRailAgentFilter(prev, sessionAgentId))
-  }, [sessionAgentId])
-  const setRailAgentIds = useCallback((agentIds: string[]) => setRailFilter({ agentIds, touched: true }), [])
+  const [chosenRailFilter, setChosenRailFilter] = useState<RailAgentFilter>(EMPTY_RAIL_AGENT_FILTER)
+  const railFilter = seedRailAgentFilter(chosenRailFilter, sessionAgentId)
+  const setRailAgentIds = useCallback((agentIds: string[]) => setChosenRailFilter({ agentIds, touched: true }), [])
 
   // With an agent selected this reads an AGENT-FILTERED page, not the org-wide
   // `allSessions` window — a busy org's newest 50 may not include this agent at
   // all, which would hide the rail on an agent that has plenty of runs. Cleared,
-  // the unfiltered page IS the question being asked. The org key stays null while
-  // an untouched filter is still empty, since that only means the session has not
-  // resolved yet and an unfiltered page fetched there would be thrown away.
-  const railAgentId = railFilter.agentIds[0] ?? ''
-  const railFilterReady = railFilter.touched || Boolean(sessionAgentId)
+  // the unfiltered page IS the question being asked. A null query means the filter
+  // has nothing to say yet (no session, and the reader has not touched it), so the
+  // org key stays null and no page is fetched to be thrown away.
+  const railQuery = railAgentFilterQuery(railFilter)
+  const railAgentId = railQuery?.agentId ?? ''
   const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
-    MOCK_MODE || !railFilterReady ? null : activeOrg?.id,
-    railAgentId ? { agentId: railAgentId } : {}
+    MOCK_MODE || !railQuery ? null : activeOrg?.id,
+    railQuery ?? {}
   )
-  const railSessions = useMemo(
-    () => (MOCK_MODE ? (railAgentId ? getSessions(railAgentId) : allSessions) : railSessionRows),
-    [allSessions, getSessions, railAgentId, railSessionRows]
-  )
+  const railSessions = useMemo(() => {
+    if (!MOCK_MODE) return railSessionRows
+    if (!railQuery) return []
+    return railAgentId ? getSessions(railAgentId) : allSessions
+  }, [allSessions, getSessions, railAgentId, railQuery, railSessionRows])
   const sessionBusy = session ? isPgBusy(session.id) : false
   const sessionBusyRef = useRef(sessionBusy)
   sessionBusyRef.current = sessionBusy
@@ -1651,6 +1662,7 @@ export default function SessionDetailView() {
         current={session}
         total={railSessionTotal}
         agentIds={railFilter.agentIds}
+        filterTouched={railFilter.touched}
         onAgentIdsChange={setRailAgentIds}
         family={currentSessionDetail?.id === session.id ? currentSessionDetail : undefined}
         onSelect={setRouteSession}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -70,6 +70,7 @@ import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import { useCrumbSlot } from '@/components/console/Shell'
 import { SessionRail } from '@/components/console/SessionRail'
+import { EMPTY_RAIL_AGENT_FILTER, seedRailAgentFilter, type RailAgentFilter } from '@/lib/session-rail-filter'
 import { useSessionList } from '@/lib/use-session-list'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
 import {
@@ -882,19 +883,31 @@ export default function SessionDetailView() {
   const agentRuntime = session?.runtime || owner?.runtime || ''
   const runtimeMeta = acpRuntime(acpRegistry, agentRuntime)
 
-  // Other sessions for the left rail. Like the agent page's Recent-sessions card
-  // this reads an AGENT-FILTERED page, not the org-wide `allSessions` window — a
-  // busy org's newest 50 may not include this agent at all, which would hide the
-  // rail on an agent that has plenty of runs. The org key stays null until the
-  // agent is known so no unfiltered page is fetched on the way there.
-  const railAgentId = session?.agentId ?? ''
+  // Other sessions for the left rail, scoped by the rail's own agent filter — see
+  // lib/session-rail-filter.ts for why an untouched filter follows the route and an
+  // edited one does not.
+  const sessionAgentId = session?.agentId ?? ''
+  const [railFilter, setRailFilter] = useState<RailAgentFilter>(EMPTY_RAIL_AGENT_FILTER)
+  useEffect(() => {
+    setRailFilter((prev) => seedRailAgentFilter(prev, sessionAgentId))
+  }, [sessionAgentId])
+  const setRailAgentIds = useCallback((agentIds: string[]) => setRailFilter({ agentIds, touched: true }), [])
+
+  // With an agent selected this reads an AGENT-FILTERED page, not the org-wide
+  // `allSessions` window — a busy org's newest 50 may not include this agent at
+  // all, which would hide the rail on an agent that has plenty of runs. Cleared,
+  // the unfiltered page IS the question being asked. The org key stays null while
+  // an untouched filter is still empty, since that only means the session has not
+  // resolved yet and an unfiltered page fetched there would be thrown away.
+  const railAgentId = railFilter.agentIds[0] ?? ''
+  const railFilterReady = railFilter.touched || Boolean(sessionAgentId)
   const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
-    MOCK_MODE || !railAgentId ? null : activeOrg?.id,
-    { agentId: railAgentId }
+    MOCK_MODE || !railFilterReady ? null : activeOrg?.id,
+    railAgentId ? { agentId: railAgentId } : {}
   )
   const railSessions = useMemo(
-    () => (MOCK_MODE ? (railAgentId ? getSessions(railAgentId) : []) : railSessionRows),
-    [getSessions, railAgentId, railSessionRows]
+    () => (MOCK_MODE ? (railAgentId ? getSessions(railAgentId) : allSessions) : railSessionRows),
+    [allSessions, getSessions, railAgentId, railSessionRows]
   )
   const sessionBusy = session ? isPgBusy(session.id) : false
   const sessionBusyRef = useRef(sessionBusy)
@@ -1637,7 +1650,8 @@ export default function SessionDetailView() {
         sessions={railSessions}
         current={session}
         total={railSessionTotal}
-        agentId={session.agentId}
+        agentIds={railFilter.agentIds}
+        onAgentIdsChange={setRailAgentIds}
         family={currentSessionDetail?.id === session.id ? currentSessionDetail : undefined}
         onSelect={setRouteSession}
       />

--- a/packages/web/src/lib/session-rail-filter.test.ts
+++ b/packages/web/src/lib/session-rail-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { EMPTY_RAIL_AGENT_FILTER, seedRailAgentFilter } from './session-rail-filter'
+import { EMPTY_RAIL_AGENT_FILTER, railAgentFilterQuery, seedRailAgentFilter } from './session-rail-filter'
 
 describe('seedRailAgentFilter', () => {
   it('defaults to the open session’s agent', () => {
@@ -30,5 +30,36 @@ describe('seedRailAgentFilter', () => {
   it('returns the same object when the seed does not move', () => {
     const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')
     expect(seedRailAgentFilter(seeded, 'agent-a')).toBe(seeded)
+  })
+
+  it('marks a filter the reader chose even when it matches the open session', () => {
+    // Filtering to agent B and then opening B's own session leaves a filter that
+    // looks identical to the default. The rail keeps its control on screen off
+    // `touched`, so this flag may not be inferred by comparing agent ids.
+    const chosen = { agentIds: ['agent-b'], touched: true }
+    expect(seedRailAgentFilter(chosen, 'agent-b').touched).toBe(true)
+  })
+})
+
+describe('railAgentFilterQuery', () => {
+  it('asks nothing while an untouched filter has no session yet', () => {
+    expect(railAgentFilterQuery(EMPTY_RAIL_AGENT_FILTER)).toBeNull()
+  })
+
+  it('never asks unfiltered for a session whose agent is known', () => {
+    // The regression this pins: deriving readiness from the session id rather than
+    // from the seeded filter made the first render of every deep link fetch — and
+    // paint — the org-wide list before snapping to the session's own agent.
+    expect(railAgentFilterQuery(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a'))).toEqual({
+      agentId: 'agent-a'
+    })
+  })
+
+  it('asks for every session once the reader clears the filter', () => {
+    expect(railAgentFilterQuery({ agentIds: [], touched: true })).toEqual({})
+  })
+
+  it('scopes to the agent the reader chose', () => {
+    expect(railAgentFilterQuery({ agentIds: ['agent-c'], touched: true })).toEqual({ agentId: 'agent-c' })
   })
 })

--- a/packages/web/src/lib/session-rail-filter.test.ts
+++ b/packages/web/src/lib/session-rail-filter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { EMPTY_RAIL_AGENT_FILTER, seedRailAgentFilter } from './session-rail-filter'
+
+describe('seedRailAgentFilter', () => {
+  it('defaults to the open session’s agent', () => {
+    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')).toEqual({ agentIds: ['agent-a'], touched: false })
+  })
+
+  it('stays empty while the session has not resolved', () => {
+    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, '')).toBe(EMPTY_RAIL_AGENT_FILTER)
+  })
+
+  it('follows the route while untouched', () => {
+    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')
+    expect(seedRailAgentFilter(seeded, 'agent-b')).toEqual({ agentIds: ['agent-b'], touched: false })
+  })
+
+  it('keeps a cleared filter cleared when the reader opens another session', () => {
+    // The whole point of the × on the chip: navigating the widened rail must not
+    // silently re-narrow it to the row that was just clicked.
+    const cleared: ReturnType<typeof seedRailAgentFilter> = { agentIds: [], touched: true }
+    expect(seedRailAgentFilter(cleared, 'agent-b')).toBe(cleared)
+  })
+
+  it('keeps a chosen agent across sessions owned by someone else', () => {
+    const chosen = { agentIds: ['agent-c'], touched: true }
+    expect(seedRailAgentFilter(chosen, 'agent-b')).toBe(chosen)
+  })
+
+  it('returns the same object when the seed does not move', () => {
+    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')
+    expect(seedRailAgentFilter(seeded, 'agent-a')).toBe(seeded)
+  })
+})

--- a/packages/web/src/lib/session-rail-filter.ts
+++ b/packages/web/src/lib/session-rail-filter.ts
@@ -1,0 +1,30 @@
+// The session rail's agent filter, and the one rule that governs it: an untouched
+// filter follows whichever session is open; an edited one outranks the route.
+//
+// This exists because the session detail view SURVIVES rail navigation — the route
+// frame lives in the sessions layout, so moving between /sessions/a and /sessions/b
+// never remounts it and there is no mount to re-seed the default on. Re-seeding on
+// every session change instead would undo the reader's edit the moment they clicked
+// a row; never re-seeding would leave a stale agent's name on the chip after a
+// lineage link carried them into another agent's session.
+
+export interface RailAgentFilter {
+  /** Agents the rail's list is filtered to. Empty = every session the viewer can see. */
+  agentIds: string[]
+  /** Whether the reader has edited the filter, which freezes it against re-seeding. */
+  touched: boolean
+}
+
+export const EMPTY_RAIL_AGENT_FILTER: RailAgentFilter = { agentIds: [], touched: false }
+
+/**
+ * The filter after the open session resolved to `sessionAgentId` ('' while unknown).
+ * Returns `prev` unchanged whenever nothing moved, so this is safe to call from a
+ * state updater on every render without churning the subscribers of `agentIds`.
+ */
+export function seedRailAgentFilter(prev: RailAgentFilter, sessionAgentId: string): RailAgentFilter {
+  if (prev.touched) return prev
+  const agentIds = sessionAgentId ? [sessionAgentId] : []
+  const unchanged = prev.agentIds.length === agentIds.length && prev.agentIds[0] === agentIds[0]
+  return unchanged ? prev : { agentIds, touched: false }
+}

--- a/packages/web/src/lib/session-rail-filter.ts
+++ b/packages/web/src/lib/session-rail-filter.ts
@@ -19,12 +19,25 @@ export const EMPTY_RAIL_AGENT_FILTER: RailAgentFilter = { agentIds: [], touched:
 
 /**
  * The filter after the open session resolved to `sessionAgentId` ('' while unknown).
- * Returns `prev` unchanged whenever nothing moved, so this is safe to call from a
- * state updater on every render without churning the subscribers of `agentIds`.
+ * Pure, and returns `chosen` unchanged whenever nothing moved, so the caller can
+ * derive it during render — seeding from an effect instead would commit one frame
+ * carrying the unseeded filter even though the session's agent is already known.
  */
-export function seedRailAgentFilter(prev: RailAgentFilter, sessionAgentId: string): RailAgentFilter {
-  if (prev.touched) return prev
+export function seedRailAgentFilter(chosen: RailAgentFilter, sessionAgentId: string): RailAgentFilter {
+  if (chosen.touched) return chosen
   const agentIds = sessionAgentId ? [sessionAgentId] : []
-  const unchanged = prev.agentIds.length === agentIds.length && prev.agentIds[0] === agentIds[0]
-  return unchanged ? prev : { agentIds, touched: false }
+  const unchanged = chosen.agentIds.length === agentIds.length && chosen.agentIds[0] === agentIds[0]
+  return unchanged ? chosen : { agentIds, touched: false }
+}
+
+/**
+ * The session-list query a seeded filter asks for, or `null` when it asks nothing
+ * yet. Only an UNTOUCHED empty filter means "the session has not resolved" — a
+ * fetch there would be thrown away the moment it seeds. An empty filter the reader
+ * cleared themselves is a real question, and its answer is every session they can
+ * see, so it returns a query with no `agentId`.
+ */
+export function railAgentFilterQuery(filter: RailAgentFilter): { agentId?: string } | null {
+  if (filter.agentIds[0]) return { agentId: filter.agentIds[0] }
+  return filter.touched ? {} : null
 }


### PR DESCRIPTION
## What

The session detail rail always answered exactly one question — "the other runs of **this** agent" — with no way to see that scope, widen it, or point it somewhere else. This puts it on screen as a filter above the list.

- **Chip per selected agent** (avatar + name + clear `×`), seeded from the open session's agent, next to a `+` that opens a searchable agent picker.
- **Cleared**, the row reads `All agents` and the list widens to every session the viewer can see. The `All sessions` footer link drops its `?agent=` param to match, so the link stays the same question, unabridged.
- **Persistence rule**: an untouched filter follows whichever session is open; an edited one outranks the route until reload.

## Why the persistence rule needs its own module

The detail view **survives rail navigation** — the route frame lives in `sessions/layout`, so moving between `/sessions/a` and `/sessions/b` never remounts it and there is no mount to re-seed a default on. Re-seeding on every session change would undo the reader's `×` the moment they clicked a row; never re-seeding would leave a stale agent's name on the chip after a lineage link carried them into another agent's session. That rule is `lib/session-rail-filter.ts` with 6 unit tests.

The "a one-row rail is noise, hide it" guard now makes an exception for a reader-chosen filter — otherwise hiding the rail would take the filter control with it and leave no way back to a wider list.

## Scope note for reviewers

**Single-select**, because `GET /sessions` filters by a single `agentId`. The prop is a list (`agentIds`) end-to-end and the picker's click handler is the only thing holding it to one, so filtering on several agents at once is a wire change rather than a redesign here. Note that the eventual multi-agent feature discussed was *participant*-AND semantics ("conversations several agents took part in"), which is a further step — CP only tracks multi-agent participants for webchat conversations today.

## API surface

None. Web-only; no CP, protocol, or daemon changes.

## Verification

Driven in the mock console (`web-mock`): default chip, clear → widened list, `+` picker selection, filter surviving rail navigation, re-seed on reload, and both light and dark themes. Typecheck, eslint and prettier clean; 81 web test files / 591 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)