### PR TITLE
feat(sandbox): protect Codex credentials from model tools

### DIFF
--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -1,0 +1,82 @@
+import { isAbsolute, normalize } from 'node:path'
+
+export const CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV = 'CODEX_ACP_PERMISSION_PROFILE_CONFIG'
+
+const PROFILE_IDS = {
+  'read-only': 'agentconnect-protected-read-only',
+  agent: 'agentconnect-protected-workspace',
+  'agent-full-access': 'agentconnect-protected-full-access'
+} as const
+
+export interface CodexPermissionProfileConfig {
+  configOverrides: string[]
+  modeProfiles: Record<keyof typeof PROFILE_IDS, string>
+}
+
+/** Prevent session config from redefining the daemon-owned profiles selected by
+ * the adapter. Invalid/non-object input remains the adapter's responsibility. */
+export function codexConfigWithoutPermissionOverrides(raw: string | undefined): string | undefined {
+  if (!raw?.trim()) return raw
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return raw
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return raw
+
+  const config = parsed as Record<string, unknown>
+  let changed = false
+  for (const key of Object.keys(config)) {
+    if (
+      key === 'permissions' ||
+      key.startsWith('permissions.') ||
+      key === 'default_permissions' ||
+      key.startsWith('default_permissions.')
+    ) {
+      delete config[key]
+      changed = true
+    }
+  }
+  return changed ? JSON.stringify(config) : raw
+}
+
+/** Build the complete inner-tool policy from daemon-owned canonical paths. */
+export function codexPermissionProfileConfig(
+  protectedRoots: readonly string[]
+): CodexPermissionProfileConfig | undefined {
+  const roots = [...new Set(protectedRoots.map((root) => normalize(root)))]
+  if (roots.length === 0) return undefined
+  if (roots.some((root) => !isAbsolute(root))) {
+    throw new Error('Codex protected permission roots must be absolute paths')
+  }
+
+  const deny = tomlInlineTable(roots.map((root): [string, string] => [root, 'deny']))
+  const fullAccess = tomlInlineTable([
+    [':root', 'write'],
+    ['/.git', 'write'],
+    ['/.agents', 'write'],
+    ['/.codex', 'write'],
+    ...roots.map((root): [string, string] => [root, 'deny'])
+  ])
+
+  return {
+    configOverrides: [
+      `default_permissions="${PROFILE_IDS.agent}"`,
+      `permissions.${PROFILE_IDS['read-only']}.extends=":read-only"`,
+      `permissions.${PROFILE_IDS['read-only']}.filesystem=${deny}`,
+      `permissions.${PROFILE_IDS.agent}.extends=":workspace"`,
+      `permissions.${PROFILE_IDS.agent}.filesystem=${deny}`,
+      `permissions.${PROFILE_IDS['agent-full-access']}.filesystem=${fullAccess}`,
+      `permissions.${PROFILE_IDS['agent-full-access']}.network.enabled=true`,
+      `permissions.${PROFILE_IDS['agent-full-access']}.network.allow_local_binding=true`,
+      `permissions.${PROFILE_IDS['agent-full-access']}.network.dangerously_allow_all_unix_sockets=true`
+    ],
+    modeProfiles: { ...PROFILE_IDS }
+  }
+}
+
+function tomlInlineTable(entries: Array<[string, string]>): string {
+  return `{ ${[...new Map(entries)].map(([key, value]) => `${JSON.stringify(key)} = ${JSON.stringify(value)}`).join(', ')} }`
+}

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -4,7 +4,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep 
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from './sandbox.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
-import { prepareSharedRuntimeCredentials } from '../runtimes/runtime-credentials.js'
+import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
 import { prepareRuntimeHome, runtimeHomeEnvironment, runtimeHomePath } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import {
@@ -14,6 +14,11 @@ import {
   isClaudeRuntimeDef,
   type ClaudeProtectedSettings
 } from './claude-runtime.js'
+import {
+  CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV,
+  codexConfigWithoutPermissionOverrides,
+  codexPermissionProfileConfig
+} from './codex-permission-profiles.js'
 
 function disabledClaudeProfileRoot(scopeDir: string): string {
   const root = realpathSync(resolve(scopeDir))
@@ -58,7 +63,6 @@ const HOST_SOCKET_POINTER_ENV = [
 ] as const
 
 const LOCAL_CONTAINER_ENDPOINT_ENV = ['DOCKER_HOST', 'CONTAINER_HOST', 'BUILDKIT_HOST', 'PODMAN_HOST'] as const
-
 function isLocalSocketEndpoint(value: string): boolean {
   const endpoint = value.trim().toLowerCase()
   return endpoint.startsWith('/') || /^(?:unix|npipe|fd):/.test(endpoint)
@@ -245,6 +249,7 @@ export function prepareRuntimeLaunch(opts: {
     credentials?.seedExclusions
   )
   credentials?.preparePrivateHome(runtimeHome)
+  const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const env = {
     ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, opts.hostEnv),
     ...credentials?.env
@@ -315,6 +320,7 @@ export function prepareRuntimeLaunch(opts: {
         .filter(existsSync)
         .map((path) => realpathSync(path))
     : []
+  const privateCodexStateRoots = credentialProfile === 'codex' ? [realpathSync(join(runtimeHome, '.codex'))] : []
 
   const boundary = sandboxBoundary({
     agentDir: opts.scopeDir,
@@ -345,6 +351,20 @@ export function prepareRuntimeLaunch(opts: {
     allowRead: boundary.allowRead,
     gitSafeDirectories: boundary.gitSafeDirectories
   })
+  const protectedCredentialRoots = compactReadRoots([
+    ...credentialWritableRoots,
+    ...providerCredentialReadRoots,
+    ...privateClaudeStateRoots,
+    ...privateCodexStateRoots
+  ])
+  if (credentialProfile === 'codex') {
+    const profileConfig = codexPermissionProfileConfig(protectedCredentialRoots)
+    if (profileConfig) {
+      const codexConfig = codexConfigWithoutPermissionOverrides(env.CODEX_CONFIG)
+      if (codexConfig !== undefined) env.CODEX_CONFIG = codexConfig
+      env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV] = JSON.stringify(profileConfig)
+    }
+  }
   return {
     env,
     inheritProcessEnv: false,
@@ -356,11 +376,7 @@ export function prepareRuntimeLaunch(opts: {
       cwd: boundary.gitSafeDirectories[0]!,
       denyReadRoots,
       allowReadRoots: boundary.allowRead,
-      protectedCredentialRoots: compactReadRoots([
-        ...credentialWritableRoots,
-        ...providerCredentialReadRoots,
-        ...privateClaudeStateRoots
-      ]),
+      protectedCredentialRoots,
       ...(protectedClaudeSettings ? { claudeProtectedSettings: protectedClaudeSettings } : {})
     }
   }

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { codexPermissionProfileConfig } from '../src/acp/codex-permission-profiles.js'
+
+describe('Codex permission profile launch config', () => {
+  it('keeps daemon-owned denies in every ACP mode', () => {
+    const config = codexPermissionProfileConfig(['/agent/home/.codex', '/host/.codex/auth.json'])!
+
+    expect(config.modeProfiles).toEqual({
+      'read-only': 'agentconnect-protected-read-only',
+      agent: 'agentconnect-protected-workspace',
+      'agent-full-access': 'agentconnect-protected-full-access'
+    })
+    expect(config.configOverrides.filter((value) => value.includes('filesystem='))).toEqual([
+      expect.stringContaining('"/agent/home/.codex" = "deny"'),
+      expect.stringContaining('"/agent/home/.codex" = "deny"'),
+      expect.stringContaining('"/agent/home/.codex" = "deny"')
+    ])
+    expect(config.configOverrides).toContain('permissions.agentconnect-protected-full-access.network.enabled=true')
+  })
+
+  it('rejects non-absolute policy roots', () => {
+    expect(() => codexPermissionProfileConfig(['relative/auth.json'])).toThrow('must be absolute')
+  })
+})

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { prepareRuntimeLaunch } from '../src/acp/runtime-launch.js'
+import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 
 const roots: string[] = []
 
@@ -199,6 +200,16 @@ describe('Linux shared runtime login', () => {
       runInSandbox: true,
       sandboxMechanism: 'bwrap',
       credentialPlatform: 'linux',
+      explicitEnv: {
+        [CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]: '{"modeProfiles":{"agent":"attacker"}}',
+        CODEX_CONFIG: JSON.stringify({
+          model: 'gpt-test',
+          default_permissions: 'attacker',
+          permissions: { 'agentconnect-protected-workspace': { extends: ':workspace' } },
+          'permissions.agentconnect-protected-full-access.filesystem': { ':root': 'write' },
+          features: { fast_mode: true }
+        })
+      },
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
@@ -208,7 +219,22 @@ describe('Linux shared runtime login', () => {
     expect(realpathSync(privateAuth)).toBe(realpathSync(hostAuth))
     expect(readFileSync(hostAuth, 'utf8')).toContain('"new"')
     expect(settings(launch.sandbox!.settingsPath).filesystem.allowWrite).toContain(realpathSync(hostAuth))
-    expect(launch.sandbox?.protectedCredentialRoots).toEqual([realpathSync(hostAuth)])
+    const protectedRoots = [realpathSync(hostAuth), realpathSync(privateCodex)]
+    expect(launch.sandbox?.protectedCredentialRoots).toEqual(protectedRoots)
+    const profileConfig = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as {
+      configOverrides: string[]
+      modeProfiles: Record<string, string>
+    }
+    expect(profileConfig.modeProfiles.agent).toBe('agentconnect-protected-workspace')
+    expect(JSON.parse(launch.env.CODEX_CONFIG!)).toEqual({
+      model: 'gpt-test',
+      features: { fast_mode: true }
+    })
+    const filesystemOverrides = profileConfig.configOverrides.filter((value) => value.includes('filesystem='))
+    expect(filesystemOverrides).toHaveLength(3)
+    for (const root of protectedRoots) {
+      expect(filesystemOverrides.every((value) => value.includes(`${JSON.stringify(root)} = "deny"`))).toBe(true)
+    }
 
     writeFileSync(privateAuth, '{"last_refresh":"2026-03-01T00:00:00Z","token":"refreshed"}')
     expect(lstatSync(privateAuth).isSymbolicLink()).toBe(true)


### PR DESCRIPTION
## Summary

- build daemon-owned Codex permission profiles from canonical protected credential roots, including the private `CODEX_HOME` state root
- preserve read-only, workspace, and full-access mode semantics while applying mandatory file denies to model-authored tools
- inject the opaque launch profile mapping into the managed codex-acp runtime while continuing to resolve the unpinned `@agentconnect.md/codex-acp@agentconnect` channel
- keep the existing outer SRT boundary, additional workspace roots, MCP configuration, session resume, and Auto reviewer behavior unchanged

## Security model

The Codex ACP parent remains trusted so it can authenticate and refresh shared host login state. Codex native named permission profiles provide the inner boundary for model-authored terminal and filesystem operations. Agent configuration and model output never supply protected host paths; the daemon constructs the complete policy from paths it already owns.

No terminal provider or credential broker is introduced. Runtimes without the Codex credential profile keep their existing launch behavior.

## Validation

- fork main is linearly rebased onto upstream codex-acp 1.1.9 with all AgentConnect commits on top
- scoped publish workflow succeeded for `1.1.9-agentconnect.1`, and npm's `agentconnect` dist-tag resolves to it
- fork validation: typecheck, build, and 345 tests passed (28 skipped)
- focused daemon tests: 22 passed (4 integration tests skipped by their existing gate)
- daemon typecheck
- ESLint and Prettier checks for all changed files
- Linux app-server canary exercised new, resumed, and mode-switched sessions across all three ACP modes
- Linux sandbox canary confirmed a denied file remained unreadable without the legacy per-turn sandbox override

Closes #383

Created by Codex . GPT-5.6
