### PR TITLE
fix(github): keep public repositories visible

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -1121,8 +1121,16 @@ the cache and stops requesting.
    `GET /repos/{owner}/{repo}/collaborators/{username}/permission`, which
    includes team- and organization-derived access. Read operations accept an
    effective permission or a public repository; write operations require
-   write/admin. Missing identity metadata requires the user to refresh their
-   GitHub sign-in and never silently grants access.
+   write/admin. Missing identity metadata does not remove public read access;
+   private repositories and write operations still require the user to link a
+   GitHub profile and never silently gain access.
+
+   Installing the GitHub App is not a human-identity assertion. The setup
+   callback proves an organization-bound installation claim, but it does not
+   identify the person who completed an organization install. AgentConnect
+   therefore never infers a Profile link from an installation account or
+   callback. Profile linking remains an explicit social authorization through
+   the existing sign-in-method flow.
 
    **Remaining limits:**
 
@@ -1160,8 +1168,9 @@ the cache and stops requesting.
      accept any effective permission **or a public repository**. For
      need=write, require write/admin. GitHub folds maintain into write and
      triage into read; a public repository alone does not confer write.
-     Missing GitHub identity, such as Google sign-in, returns
-     `GITHUB_IDENTITY_REQUIRED` and never silently permits access.
+     Missing GitHub identity, such as Google sign-in, still permits public
+     reads. Identity-dependent checks return `GITHUB_IDENTITY_REQUIRED` and
+     never silently permit private access or writes.
    - **Enforcement points:** (1)
      `GET …/repositories/:owner/:repo/access` provides picker preflight and is
      registered only when the gateway is enabled. The web interprets 404 as
@@ -1190,10 +1199,10 @@ the cache and stops requesting.
      `Repository.collaborators(login:)`: installation tokens can return an
      empty collaborator connection for a user whose REST effective permission
      is non-`none`.
-     An account without a GitHub identity receives
-     `GITHUB_IDENTITY_REQUIRED` for the list as well, with a machine-coded 403
-     and an explicit console prompt, consistent with all other checks. Access
-     is never silently granted.
+     An account without a GitHub identity receives the public subset with
+     `privateReposHidden: true`. The console presents that as an informational
+     state and links to Profile -> Sign-in methods; it does not render a failed
+     or empty picker. Private names remain undisclosed.
 
      API-key principals are covered through
      key->userId->oidcSubject, with no browser session required. The
@@ -1202,7 +1211,7 @@ the cache and stops requesting.
    - **Web:** preflight `/access` as soon as a repository is selected. No read
      access shows a red inline error under the field and blocks submission.
      Read without write pins "Allow push" to read-only and submits
-     `gitAccess: 'read'`. `GITHUB_IDENTITY_REQUIRED` prompts "Sign in with
-     GitHub and retry."
+     `gitAccess: 'read'`. `GITHUB_IDENTITY_REQUIRED` points to the existing
+     Profile GitHub-linking action.
    - Identity-provider application IDs and `LOGTO_MGMT_*` values are supplied
      through runtime configuration.

--- a/packages/control-plane/src/github/user-authz.test.ts
+++ b/packages/control-plane/src/github/user-authz.test.ts
@@ -240,6 +240,19 @@ describe('GithubUserAuthzService', () => {
     })
   })
 
+  it('allows public read without a GitHub identity but keeps write identity-gated', async () => {
+    const { svc, calls } = authz({ login: null, repo: { private: false } })
+    await expect(svc.assertAccess('u1', INS, 'o', 'public', 'read')).resolves.toMatchObject({
+      canRead: true,
+      canWrite: false,
+      identityRequired: true
+    })
+    await expect(svc.assertAccess('u1', INS, 'o', 'public', 'write')).rejects.toMatchObject({
+      code: 'GITHUB_IDENTITY_REQUIRED'
+    })
+    expect(calls.permission).toBe(0)
+  })
+
   it('private + none ⇒ no read; public + none ⇒ read but never write', async () => {
     const closed = authz({ login: 'me', repo: { private: true }, permission: 'none' })
     await expect(closed.svc.assertAccess('u1', INS, 'o', 'r', 'read')).rejects.toMatchObject({
@@ -303,7 +316,8 @@ describe('GithubUserAuthzService', () => {
       { fullName: 'o/secret', private: true }
     ]
     const visible = await svc.filterReposForUser('u1', INS, page)
-    expect(visible.map((r) => r.fullName)).toEqual(['o/pub', 'o/readable'])
+    expect(visible.repos.map((r) => r.fullName)).toEqual(['o/pub', 'o/readable'])
+    expect(visible.privateReposHidden).toBe(false)
     expect(calls.permission).toBe(2) // public repos are never probed
   })
 
@@ -314,10 +328,16 @@ describe('GithubUserAuthzService', () => {
     expect(calls.permission).toBe(1)
   })
 
-  it('list filter denies GITHUB_IDENTITY_REQUIRED like every other check', async () => {
+  it('list filter keeps public rows and marks private rows hidden without a GitHub identity', async () => {
     const { svc } = authz({ login: null })
-    await expect(svc.filterReposForUser('u1', INS, [{ fullName: 'o/pub', private: false }])).rejects.toMatchObject({
-      code: 'GITHUB_IDENTITY_REQUIRED'
+    await expect(
+      svc.filterReposForUser('u1', INS, [
+        { fullName: 'o/pub', private: false },
+        { fullName: 'o/private', private: true }
+      ])
+    ).resolves.toEqual({
+      repos: [{ fullName: 'o/pub', private: false }],
+      privateReposHidden: true
     })
   })
 

--- a/packages/control-plane/src/github/user-authz.ts
+++ b/packages/control-plane/src/github/user-authz.ts
@@ -20,7 +20,8 @@
  *  - need=write ⇒ effective write/admin (GitHub collapses maintain→write) —
  *    public repos do NOT satisfy write;
  *  - no GitHub identity on the account (Google sign-in, deleted at provider)
- *    ⇒ GITHUB_IDENTITY_REQUIRED, never a silent allow;
+ *    ⇒ public read remains available, while private/read-write checks return
+ *    GITHUB_IDENTITY_REQUIRED;
  *  - authorization is asserted at pick/create time; the daemon keeps running
  *    on installation tokens (creator drift is the tracked re-attest follow-up).
  */
@@ -49,6 +50,9 @@ export interface UserRepoAccess {
   repoPrivate: boolean
   canRead: boolean
   canWrite: boolean
+  /** No linked GitHub identity was available. Public read is still valid, but
+   *  every identity-dependent capability must keep failing closed. */
+  identityRequired: boolean
 }
 
 // Narrow structural deps (the composition root passes LogtoIdentityService /
@@ -96,7 +100,7 @@ export class GithubUserAuthzService {
     const login = await this.deps.identity.githubLoginFor(sub, maxCacheAgeMs)
     if (!login) {
       throw new UserAuthzDeniedError(
-        'no GitHub identity on this account — sign in with GitHub to verify repo access',
+        'no GitHub identity on this account — link GitHub to verify repository access',
         'GITHUB_IDENTITY_REQUIRED'
       )
     }
@@ -176,16 +180,28 @@ export class GithubUserAuthzService {
    * The repo is assumed already resolved inside `ins` (callers 404 first).
    */
   async accessFor(userId: string, ins: GithubInstallationRecord, owner: string, repo: string): Promise<UserRepoAccess> {
-    const login = await this.loginOf(userId)
     const meta = await this.metaOf(ins, owner, repo)
     // Out-of-grant repo: callers normally 404 before asking; report no access.
     const repoPrivate = meta?.private ?? true
+    let login: string
+    try {
+      login = await this.loginOf(userId)
+    } catch (error) {
+      // Public repository metadata is itself enough to authorize a read. Do
+      // not turn the absence of an unrelated personal identity into a denial,
+      // but retain the fact so write remains identity-gated below.
+      if (error instanceof UserAuthzDeniedError && error.code === 'GITHUB_IDENTITY_REQUIRED' && meta && !repoPrivate) {
+        return { permission: 'none', repoPrivate, canRead: true, canWrite: false, identityRequired: true }
+      }
+      throw error
+    }
     const permission = meta ? await this.permissionOf(login, ins, owner, repo) : 'none'
     return {
       permission,
       repoPrivate,
       canRead: permission !== 'none' || !repoPrivate,
-      canWrite: permission === 'admin' || permission === 'write'
+      canWrite: permission === 'admin' || permission === 'write',
+      identityRequired: false
     }
   }
 
@@ -193,15 +209,26 @@ export class GithubUserAuthzService {
    * List filter for the picker: keep public repos and private repos the caller
    * can read on GitHub — so no-access repo NAMES never render in the console.
    * Private repos are probed with the same cached permission unit as the gates
-   * using the verified REST endpoint with bounded concurrency. Throws
-   * GITHUB_IDENTITY_REQUIRED like every other check — never a silent allow.
+   * using the verified REST endpoint with bounded concurrency. Without a
+   * linked identity the public subset is returned and the result explicitly
+   * says that private repositories were hidden.
    */
   async filterReposForUser<T extends { fullName: string; private: boolean }>(
     userId: string,
     ins: GithubInstallationRecord,
     repos: T[]
-  ): Promise<T[]> {
-    const login = await this.loginOf(userId)
+  ): Promise<{ repos: T[]; privateReposHidden: boolean }> {
+    if (!repos.some((repo) => repo.private)) return { repos, privateReposHidden: false }
+
+    let login: string
+    try {
+      login = await this.loginOf(userId)
+    } catch (error) {
+      if (error instanceof UserAuthzDeniedError && error.code === 'GITHUB_IDENTITY_REQUIRED') {
+        return { repos: repos.filter((repo) => !repo.private), privateReposHidden: true }
+      }
+      throw error
+    }
     const results = new Array<boolean>(repos.length).fill(false)
     let next = 0
     const worker = async (): Promise<void> => {
@@ -219,7 +246,7 @@ export class GithubUserAuthzService {
       }
     }
     await Promise.all(Array.from({ length: Math.min(FILTER_CONCURRENCY, repos.length) }, worker))
-    return repos.filter((_, index) => results[index])
+    return { repos: repos.filter((_, index) => results[index]), privateReposHidden: false }
   }
 
   /** The enforcement form: resolve access and throw USER_NO_ACCESS below `need`. */
@@ -233,6 +260,12 @@ export class GithubUserAuthzService {
     const access = await this.accessFor(userId, ins, owner, repo)
     const ok = need === 'write' ? access.canWrite : access.canRead
     if (!ok) {
+      if (access.identityRequired) {
+        throw new UserAuthzDeniedError(
+          'no GitHub identity on this account — link GitHub to verify repository write access',
+          'GITHUB_IDENTITY_REQUIRED'
+        )
+      }
       throw new UserAuthzDeniedError(
         need === 'write'
           ? `you do not have write access to ${owner}/${repo} on GitHub (effective: ${access.permission})`

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1694,7 +1694,10 @@ export const GithubRepoDto = z.object({
 export const GithubRepoPageDto = z.object({
   repos: z.array(GithubRepoDto),
   /** Total the installation can reach (GitHub `total_count`) — drives pager UI. */
-  totalCount: z.number()
+  totalCount: z.number(),
+  /** Public rows are still returned; this tells the picker why private rows
+   *  are absent and lets it offer the explicit Profile-linking action. */
+  privateReposHidden: z.boolean()
 })
 
 export const GithubBranchListDto = z.array(z.object({ name: z.string() }))
@@ -1705,7 +1708,10 @@ export const GithubBranchListDto = z.array(z.object({ name: z.string() }))
 export const GithubRepoAccessDto = z.object({
   permission: z.enum(['admin', 'write', 'read', 'none']),
   canRead: z.boolean(),
-  canWrite: z.boolean()
+  canWrite: z.boolean(),
+  /** Public read may succeed without a linked GitHub identity. This remains
+   *  true so write controls can explain what the caller must link. */
+  identityRequired: z.boolean()
 })
 
 export const GithubRepoPageQuery = z.object({

--- a/packages/control-plane/src/http/routes/github.ts
+++ b/packages/control-plane/src/http/routes/github.ts
@@ -258,7 +258,7 @@ export function githubRoutes(deps: HttpDeps) {
           tags: [Tag.GitHub],
           summary: 'List installation repositories',
           description:
-            'Repositories the installation is granted (paged, max 100/page). With the per-user authorization gate configured, the page is filtered to repositories the CALLER can read on GitHub (public, or any effective permission) — no-access repo names never reach the console. GitHub offers NO server-side search on this listing — the console filters client-side.',
+            'Repositories the installation is granted (paged, max 100/page). With the per-user authorization gate configured, public repositories remain visible while private repositories are filtered to those the CALLER can read on GitHub. Without a linked GitHub identity, only the public subset is returned and `privateReposHidden` is true — no private repository names reach the console. GitHub offers NO server-side search on this listing — the console filters client-side.',
           operationId: 'listGithubInstallationRepositories',
           params: IdParam,
           querystring: GithubRepoPageQuery,
@@ -280,9 +280,9 @@ export function githubRoutes(deps: HttpDeps) {
                 ins,
                 repos.map((r) => ({ fullName: r.full_name, private: r.private, repo: r }))
               )
-            : repos.map((r) => ({ repo: r }))
+            : { repos: repos.map((r) => ({ repo: r })), privateReposHidden: false }
           return {
-            repos: visible.map(({ repo }) => ({
+            repos: visible.repos.map(({ repo }) => ({
               repoId: String(repo.id),
               fullName: repo.full_name,
               private: repo.private,
@@ -290,7 +290,8 @@ export function githubRoutes(deps: HttpDeps) {
               description: repo.description,
               updatedAt: repo.pushed_at ?? repo.updated_at ?? null
             })),
-            totalCount
+            totalCount,
+            privateReposHidden: visible.privateReposHidden
           }
         } catch (e) {
           if (e instanceof UserAuthzDeniedError) return userAuthzDenied(reply, e)
@@ -418,7 +419,12 @@ export function githubRoutes(deps: HttpDeps) {
           }
           try {
             const access = await authz.accessFor(req.principal!.userId, ins, req.params.owner, req.params.repo)
-            return { permission: access.permission, canRead: access.canRead, canWrite: access.canWrite }
+            return {
+              permission: access.permission,
+              canRead: access.canRead,
+              canWrite: access.canWrite,
+              identityRequired: access.identityRequired
+            }
           } catch (e) {
             if (e instanceof UserAuthzDeniedError) return userAuthzDenied(reply, e)
             return githubUpstreamFailure(reply, e)

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -243,7 +243,7 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
           need: 'read' | 'write'
         ) => {
           needs.push(need)
-          return { permission: 'write', repoPrivate: true, canRead: true, canWrite: true }
+          return { permission: 'write', repoPrivate: true, canRead: true, canWrite: true, identityRequired: false }
         }
       } as never
     })
@@ -725,7 +725,7 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
         if (need === 'write') {
           throw new UserAuthzDeniedError(`you do not have write access to ${owner}/${repo} on GitHub`, 'USER_NO_ACCESS')
         }
-        return { permission: 'read', repoPrivate: true, canRead: true, canWrite: false }
+        return { permission: 'read', repoPrivate: true, canRead: true, canWrite: false, identityRequired: false }
       }
     }
     const a = app({ githubUserAuthz: githubUserAuthz as never })

--- a/packages/control-plane/test/integration/github-installations.route.test.ts
+++ b/packages/control-plane/test/integration/github-installations.route.test.ts
@@ -42,7 +42,7 @@ function appAs(
     userId?: string
     githubStatus?: number
     githubFetch?: (url: string, init?: RequestInit) => Promise<Response>
-    githubUserAuthz?: Pick<GithubUserAuthzService, 'assertAccess'>
+    githubUserAuthz?: Partial<Pick<GithubUserAuthzService, 'assertAccess' | 'filterReposForUser'>>
   } = {}
 ) {
   const calls: GithubCall[] = []
@@ -89,6 +89,77 @@ async function makeUser(sub: string, role: OrgMemberRole): Promise<string> {
   await users.addMemberByEmail(DEFAULT_ORG_ID, email, role)
   return userId
 }
+
+describe('GET /orgs/:orgId/github/installations/:id/repositories', () => {
+  it('returns public repositories while explicitly marking private repositories hidden', async () => {
+    const row = await seedInstallation()
+    let filterCalls = 0
+    const filterReposForUser: GithubUserAuthzService['filterReposForUser'] = async (_userId, _installation, repos) => {
+      filterCalls += 1
+      return {
+        repos: repos.filter((repo) => !repo.private),
+        privateReposHidden: true
+      }
+    }
+    const h = appAs({
+      githubFetch: async (url) => {
+        if (url.endsWith(`/app/installations/${INSTALLATION}/access_tokens`)) {
+          return Response.json(
+            { token: 'ghs_metadata', expires_at: new Date(Date.now() + 3_600_000).toISOString() },
+            { status: 201 }
+          )
+        }
+        if (url.includes('/installation/repositories?')) {
+          return Response.json({
+            total_count: 2,
+            repositories: [
+              {
+                id: 41,
+                full_name: 'acme/public-repository',
+                private: false,
+                default_branch: 'main',
+                description: 'Public',
+                pushed_at: '2026-08-01T00:00:00.000Z'
+              },
+              {
+                id: 42,
+                full_name: 'acme/private-repository',
+                private: true,
+                default_branch: 'main',
+                description: 'Private',
+                pushed_at: '2026-08-01T00:00:00.000Z'
+              }
+            ]
+          })
+        }
+        throw new Error(`unexpected github call: ${url}`)
+      },
+      githubUserAuthz: { filterReposForUser }
+    })
+
+    const res = await h.app.app.inject({
+      method: 'GET',
+      url: `${ORG}/github/installations/${row.id}/repositories?page=1&perPage=100`
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      repos: [
+        {
+          repoId: '41',
+          fullName: 'acme/public-repository',
+          private: false,
+          defaultBranch: 'main',
+          description: 'Public',
+          updatedAt: '2026-08-01T00:00:00.000Z'
+        }
+      ],
+      totalCount: 2,
+      privateReposHidden: true
+    })
+    expect(filterCalls).toBe(1)
+  })
+})
 
 describe('GET /orgs/:orgId/github/installations/:id/repositories/:owner/:repo', () => {
   it('resolves an authorized private repository outside the initial picker page', async () => {

--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -4,6 +4,7 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  GithubPrivateReposNotice,
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
@@ -30,6 +31,16 @@ afterEach(async () => {
 })
 
 describe('WorkspaceFormFields', () => {
+  it('keeps missing private repositories informational and links to Profile', async () => {
+    await render(<GithubPrivateReposNotice profileHref="/acme/profile#sign-in-methods" />)
+
+    expect(container?.textContent).toContain('Public repositories are shown.')
+    const link = container?.querySelector('a')
+    expect(link?.textContent).toBe('Link your GitHub profile')
+    expect(link?.getAttribute('href')).toBe('/acme/profile#sign-in-methods')
+    expect(container?.querySelector('[class*="status-error"]')).toBeNull()
+  })
+
   it('uses one workspace source picker for create and edit flows', async () => {
     const onChange = vi.fn()
     await render(<WorkspaceModeField value="scratch" onChange={onChange} />)

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -151,6 +151,21 @@ export function GithubConnectedBanner({ onManage }: { onManage: () => void }) {
   )
 }
 
+export function GithubPrivateReposNotice({ profileHref }: { profileHref: string }) {
+  return (
+    <div className="mt-[6px] flex items-start gap-[6px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-secondary)">
+      <Icon name="info" size={13} className="mt-[1px] flex-none" />
+      <span>
+        Public repositories are shown.{' '}
+        <a className="lnk font-medium" href={profileHref}>
+          Link your GitHub profile
+        </a>
+        &#32;to see private repositories.
+      </span>
+    </div>
+  )
+}
+
 export function GithubRepositoryField({
   value,
   icon = 'lock',

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -74,6 +74,7 @@ import type { MemoryProviderChoice } from '@/components/console/memory-settings'
 import {
   GithubConnectedBanner,
   GithubInstallPrompt,
+  GithubPrivateReposNotice,
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
@@ -188,7 +189,7 @@ async function searchPublicGithubRepos(query: string, signal?: AbortSignal): Pro
 export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const { createAgent, daemons, agents } = useConsoleData()
   const { me } = useProfile()
-  const { activeOrg } = useOrgs()
+  const { activeOrg, orgPath } = useOrgs()
   const defaultAgentVisibility = activeOrg?.defaultAgentVisibility ?? 'all'
   const [name, setName] = useState('')
   const [displayName, setDisplayName] = useState('')
@@ -231,10 +232,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   // identity-assertion gate). null = unknown/loading — never blocks the UI;
   // the CP re-checks at create either way.
   const [ghAccess, setGhAccess] = useState<GithubRepoAccess | null>(null)
-  // Set when the REPO LIST itself was denied (per-user gate): the account has
-  // no GitHub identity to assert — show the sign-in note instead of an
-  // inexplicably empty picker.
-  const [ghListDenied, setGhListDenied] = useState(false)
+  // Public repositories remain available without a linked GitHub identity;
+  // this only records that the private subset is intentionally hidden.
+  const [ghPrivateReposHidden, setGhPrivateReposHidden] = useState(false)
   const [ghLoading, setGhLoading] = useState(false)
   // At least one installation's roster failed to load (e.g. a GitHub outage) —
   // the list may be incomplete, which must not read as "no repositories".
@@ -441,7 +441,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     let alive = true
     const ctrl = new AbortController()
     setGhLoading(true)
-    setGhListDenied(false)
+    setGhPrivateReposHidden(false)
     setGhReposFailed(false)
     const applyRoster = (refreshed: Array<GithubRepoDto & { installationId: string }>) => {
       if (!alive) return
@@ -465,9 +465,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
       })
     }
     void fetchGithubRepoRoster(ghInstalls, ctrl.signal, applyRoster)
-      .then(({ repos, denied, failed }) => {
+      .then(({ repos, privateReposHidden, failed }) => {
         if (!alive) return
-        setGhListDenied(denied)
+        setGhPrivateReposHidden(privateReposHidden)
         // A failed roster read (GitHub outage) must not render as an empty
         // list — keep the pages that loaded and surface the gap with a retry.
         setGhReposFailed(failed)
@@ -735,7 +735,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     if (usingPicker && ghDenied) {
       setErr(
         ghDenied.denied === 'GITHUB_IDENTITY_REQUIRED'
-          ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
+          ? 'Link your GitHub profile to verify repository access, then retry.'
           : 'You don’t have access to this repository on GitHub.'
       )
       return
@@ -1200,16 +1200,12 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                           <span className="mt-[6px] inline-flex items-start gap-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--red-500)">
                             <Icon name="triangle-alert" size={13} className="mt-[1px] flex-none" />
                             {ghDenied.denied === 'GITHUB_IDENTITY_REQUIRED'
-                              ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
+                              ? 'Link your GitHub profile to verify repository access, then retry.'
                               : 'You don’t have access to this repository on GitHub, so it can’t be attached to an agent.'}
                           </span>
                         )}
-                        {ghListDenied && (
-                          <span className="mt-[6px] inline-flex items-start gap-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--red-500)">
-                            <Icon name="triangle-alert" size={13} className="mt-[1px] flex-none" />
-                            Your GitHub identity could not be verified — synced repositories are hidden. Sign in with
-                            GitHub, then reopen this dialog.
-                          </span>
+                        {ghPrivateReposHidden && (
+                          <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} />
                         )}
                       </>
                     }
@@ -1301,7 +1297,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                           <Icon name="info" size={13} className="mt-[1px] flex-none" />
                           {manualPublicRepo
                             ? 'Public repository — read-only clone.'
-                            : 'You have read-only access to this repository on GitHub.'}
+                            : ghAccess?.identityRequired
+                              ? 'Link your GitHub profile to verify write access.'
+                              : 'You have read-only access to this repository on GitHub.'}
                         </span>
                       ) : undefined
                     }

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -14,6 +14,8 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, type Agent } from '@/lib/data'
+import { useOrgs } from '@/lib/org-context'
+import { GithubPrivateReposNotice } from '@/components/console/WorkspaceFormFields'
 import {
   ApiError,
   createAgentRepo,
@@ -69,15 +71,16 @@ export default function AddAgentRepoModal({
   onClose: () => void
   onCreated: (row: AgentRepoAuthDto) => void
 }) {
+  const { orgPath } = useOrgs()
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
   // Repos merged across every installation; partial pages render immediately
   // and each row remembers which installation owns its preflight.
   const [repos, setRepos] = useState<Array<GithubRepoDto & { installationId: string }> | null>(null)
   // At least one installation's roster failed to load — the list may be
-  // incomplete, which must not read as "no repositories". `denied` = the
-  // per-user identity gate refused the caller; `failed` = upstream trouble.
-  const [reposError, setReposError] = useState<'failed' | 'denied' | null>(null)
+  // incomplete, which must not read as "no repositories".
+  const [reposError, setReposError] = useState<'failed' | null>(null)
+  const [privateReposHidden, setPrivateReposHidden] = useState(false)
   const [reposNonce, setReposNonce] = useState(0)
   const [pick, setPick] = useState(fixedRepo ?? initialRepo ?? '')
   const [pickOpen, setPickOpen] = useState(false)
@@ -124,14 +127,15 @@ export default function AddAgentRepoModal({
     if (!gh?.enabled || gh.installations.length === 0) return
     let alive = true
     const ctrl = new AbortController()
+    setPrivateReposHidden(false)
     void fetchGithubRepoRoster(gh.installations, ctrl.signal, (partial) => {
       if (alive) setRepos(partial)
-    }).then(({ repos, denied, failed }) => {
+    }).then(({ repos, privateReposHidden, failed }) => {
       if (!alive) return
       // A failed roster read (GitHub outage) must not render as an empty
       // list — keep the pages that loaded and surface the gap with a retry.
-      // An identity denial outranks a generic failure for messaging.
-      setReposError(denied ? 'denied' : failed ? 'failed' : null)
+      setReposError(failed ? 'failed' : null)
+      setPrivateReposHidden(privateReposHidden)
       setRepos(repos)
     })
     return () => {
@@ -153,6 +157,7 @@ export default function AddAgentRepoModal({
       const installations = await syncGithubInstallations()
       setGh({ enabled: true, installations })
       setReposError(null)
+      setPrivateReposHidden(false)
       setRepos(null) // fresh install set ⇒ re-pull the repo list
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -194,8 +199,8 @@ export default function AddAgentRepoModal({
   const needWrite = access === 'write'
   const probeDenies = !!probe?.gated && (needWrite ? !probe.canWrite : !probe.canRead)
   const probeNote = probeDenies
-    ? probe?.denied === 'GITHUB_IDENTITY_REQUIRED'
-      ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
+    ? probe?.identityRequired || probe?.denied === 'GITHUB_IDENTITY_REQUIRED'
+      ? 'Link your GitHub profile to verify repository access, then retry.'
       : needWrite && probe?.canRead
         ? 'You need write access to this repository on GitHub to grant the write tier.'
         : 'You don’t have access to this repository on GitHub.'
@@ -221,7 +226,7 @@ export default function AddAgentRepoModal({
       onCreated(row)
     } catch (e) {
       if (e instanceof ApiError && e.code === 'GITHUB_IDENTITY_REQUIRED') {
-        setErr('Your GitHub identity could not be verified — sign in with GitHub, then retry.')
+        setErr('Link your GitHub profile to verify repository access, then retry.')
       } else if (e instanceof ApiError && e.code === 'USER_NO_ACCESS') {
         setErr(
           needWrite
@@ -337,6 +342,9 @@ export default function AddAgentRepoModal({
                   </span>
                   {!fixedRepo && <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />}
                 </div>
+                {privateReposHidden ? (
+                  <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} />
+                ) : null}
                 {!fixedRepo && pickOpen && (
                   <>
                     <div className="fscrim" onClick={() => setPickOpen(false)} />
@@ -348,12 +356,10 @@ export default function AddAgentRepoModal({
                         placeholder="Search or type owner/repo…"
                         autoFocus
                       />
-                      {reposError && (
+                      {reposError === 'failed' && (
                         <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
                           <span className="min-w-0 flex-1">
-                            {reposError === 'denied'
-                              ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
-                              : 'Couldn’t load repositories from GitHub — the list may be incomplete.'}
+                            Couldn’t load repositories from GitHub — the list may be incomplete.
                           </span>
                           <button
                             type="button"
@@ -361,6 +367,7 @@ export default function AddAgentRepoModal({
                             onClick={() => {
                               invalidateGithubRepoRosterCache()
                               setReposError(null)
+                              setPrivateReposHidden(false)
                               setRepos(null)
                               setReposNonce((n) => n + 1)
                             }}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { GithubMark, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
+import { GithubPrivateReposNotice } from '@/components/console/WorkspaceFormFields'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
@@ -1105,10 +1106,9 @@ export default function AddIntegrationModal({
   const [ghRepos, setGhRepos] = useState<GithubRepoChoice[] | null>(null)
   const [ghReposNonce, setGhReposNonce] = useState(0)
   // At least one installation's roster failed to load — the list may be
-  // incomplete, which must not read as "no repositories". `denied` = the
-  // per-user identity gate refused the caller (actionable: sign in with
-  // GitHub); `failed` = upstream trouble (actionable: retry).
-  const [ghReposError, setGhReposError] = useState<'failed' | 'denied' | null>(null)
+  // incomplete, which must not read as "no repositories".
+  const [ghReposError, setGhReposError] = useState<'failed' | null>(null)
+  const [ghPrivateReposHidden, setGhPrivateReposHidden] = useState(false)
   const [ghRepoPick, setGhRepoPick] = useState<string | null>(
     agent.workspace.mode === 'github' ? agent.workspace.repo : null
   )
@@ -1124,7 +1124,7 @@ export default function AddIntegrationModal({
   const [ghWorkspaceAccessOverride, setGhWorkspaceAccessOverride] = useState<'write' | null>(null)
   // Repos this agent ALREADY watches — offered rows are disabled, free-typed
   // duplicates rejected inline (the CP 409s them as the backstop).
-  const { activeOrg } = useOrgs()
+  const { activeOrg, orgPath } = useOrgs()
   const agentHooksKey = consoleKeys.agentHooks(activeOrg?.id, agent.id)
   const { data: agentHooksData } = useSWR(agentHooksKey, ([, orgId, , agentId]) => fetchAgentHooks(agentId, orgId))
   const watchedRepos = useMemo(
@@ -1477,6 +1477,7 @@ export default function AddIntegrationModal({
     if (platform !== 'github' || !gh?.enabled || gh.installations.length === 0) return
     let alive = true
     const ctrl = new AbortController()
+    setGhPrivateReposHidden(false)
     const applyRoster = (incoming: GithubRepoChoice[]) => {
       if (!alive) return
       setGhRepos((current) => {
@@ -1488,14 +1489,16 @@ export default function AddIntegrationModal({
         return [...merged.values()]
       })
     }
-    void fetchGithubRepoRoster(gh.installations, ctrl.signal, applyRoster).then(({ repos, denied, failed }) => {
-      if (!alive) return
-      // A failed roster read (GitHub outage) must not render as an empty
-      // list — keep the pages that loaded and surface the gap with a retry.
-      // An identity denial outranks a generic failure for messaging.
-      setGhReposError(denied ? 'denied' : failed ? 'failed' : null)
-      applyRoster(repos)
-    })
+    void fetchGithubRepoRoster(gh.installations, ctrl.signal, applyRoster).then(
+      ({ repos, privateReposHidden, failed }) => {
+        if (!alive) return
+        // A failed roster read (GitHub outage) must not render as an empty
+        // list — keep the pages that loaded and surface the gap with a retry.
+        setGhReposError(failed ? 'failed' : null)
+        setGhPrivateReposHidden(privateReposHidden)
+        applyRoster(repos)
+      }
+    )
     return () => {
       alive = false
       ctrl.abort()
@@ -1581,6 +1584,7 @@ export default function AddIntegrationModal({
       const installations = await syncGithubInstallations()
       setGh({ enabled: true, installations })
       setGhReposError(null)
+      setGhPrivateReposHidden(false)
       setGhRepos(null) // fresh install set ⇒ re-pull the repo list
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -2493,6 +2497,9 @@ export default function AddIntegrationModal({
                         </span>
                         <Icon name="chevron-down" size={15} color="var(--text-tertiary)" />
                       </div>
+                      {ghPrivateReposHidden ? (
+                        <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} />
+                      ) : null}
                       {ghRepoOpen && (
                         <>
                           <div className="fscrim" onClick={() => setGhRepoOpen(false)} />
@@ -2510,12 +2517,10 @@ export default function AddIntegrationModal({
                               </div>
                             ) : (
                               <>
-                                {ghReposError && (
+                                {ghReposError === 'failed' && (
                                   <div className="flex items-center gap-2 px-2 py-[7px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
                                     <span className="min-w-0 flex-1">
-                                      {ghReposError === 'denied'
-                                        ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
-                                        : 'Couldn’t load repositories from GitHub — the list may be incomplete.'}
+                                      Couldn’t load repositories from GitHub — the list may be incomplete.
                                     </span>
                                     <button
                                       type="button"
@@ -2523,6 +2528,7 @@ export default function AddIntegrationModal({
                                       onClick={() => {
                                         invalidateGithubRepoRosterCache()
                                         setGhReposError(null)
+                                        setGhPrivateReposHidden(false)
                                         setGhRepos(null) // re-arms the roster effect
                                         setGhReposNonce((value) => value + 1)
                                       }}

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, type Agent } from '@/lib/data'
+import { useOrgs } from '@/lib/org-context'
 import {
   ApiError,
   setAgentWorkspace,
@@ -28,6 +29,7 @@ import { agentDirInputValue, normalizeAgentDir } from '@/lib/repo-subdir'
 import {
   GithubConnectedBanner,
   GithubInstallPrompt,
+  GithubPrivateReposNotice,
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
@@ -52,6 +54,7 @@ export default function EditWorkspaceModal({
   onClose: () => void
   onChanged: () => void
 }) {
+  const { orgPath } = useOrgs()
   const githubWorkspace = agent.workspace.mode === 'github' ? agent.workspace : null
   const currentWrite = githubWorkspace ? !!githubWorkspace.installationId && githubWorkspace.gitAccess !== 'read' : null
   const currentAgentDir = agentDirInputValue(githubWorkspace?.agentDir)
@@ -59,7 +62,8 @@ export default function EditWorkspaceModal({
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
   const [repos, setRepos] = useState<Array<GithubRepoDto & { installationId: string }> | null>(null)
-  const [reposError, setReposError] = useState<'failed' | 'denied' | null>(null)
+  const [reposError, setReposError] = useState<'failed' | null>(null)
+  const [privateReposHidden, setPrivateReposHidden] = useState(false)
   const [reposNonce, setReposNonce] = useState(0)
   const [pick, setPick] = useState(githubWorkspace?.repo ?? authorized[0]?.repoFullName ?? '')
   const [pickOpen, setPickOpen] = useState(false)
@@ -110,13 +114,15 @@ export default function EditWorkspaceModal({
     if (!gh?.enabled || gh.installations.length === 0) return
     let alive = true
     const ctrl = new AbortController()
+    setPrivateReposHidden(false)
     void fetchGithubRepoRoster(gh.installations, ctrl.signal, (partial) => {
       if (alive) setRepos(partial)
-    }).then(({ repos, denied, failed }) => {
+    }).then(({ repos, privateReposHidden, failed }) => {
       if (!alive) return
       // A failed roster read (GitHub outage) must not render as an empty
       // list — keep the pages that loaded and surface the gap with a retry.
-      setReposError(denied ? 'denied' : failed ? 'failed' : null)
+      setReposError(failed ? 'failed' : null)
+      setPrivateReposHidden(privateReposHidden)
       setRepos(repos)
     })
     return () => {
@@ -138,6 +144,7 @@ export default function EditWorkspaceModal({
       const installations = await syncGithubInstallations()
       setGh({ enabled: true, installations })
       setReposError(null)
+      setPrivateReposHidden(false)
       setRepos(null) // fresh install set ⇒ re-pull the repo list
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -195,8 +202,8 @@ export default function EditWorkspaceModal({
 
   const probeDenies = !!probe?.gated && (write ? !probe.canWrite : !probe.canRead)
   const probeNote = probeDenies
-    ? probe?.denied === 'GITHUB_IDENTITY_REQUIRED'
-      ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
+    ? probe?.identityRequired || probe?.denied === 'GITHUB_IDENTITY_REQUIRED'
+      ? 'Link your GitHub profile to verify repository access, then retry.'
       : write && probe?.canRead
         ? 'You need write access to this repository on GitHub to enable push access.'
         : 'You don’t have access to this repository on GitHub.'
@@ -276,7 +283,7 @@ export default function EditWorkspaceModal({
       onChanged()
     } catch (error) {
       if (error instanceof ApiError && error.code === 'GITHUB_IDENTITY_REQUIRED') {
-        setErr('Your GitHub identity could not be verified — sign in with GitHub, then retry.')
+        setErr('Link your GitHub profile to verify repository access, then retry.')
       } else if (error instanceof ApiError && error.code === 'USER_NO_ACCESS') {
         setErr(
           write
@@ -378,18 +385,22 @@ export default function EditWorkspaceModal({
                   onClose={() => setPickOpen(false)}
                   onQueryChange={setQ}
                   error={
-                    reposError === 'denied'
-                      ? 'Your GitHub identity could not be verified — sign in with GitHub, then retry.'
-                      : reposError === 'failed'
-                        ? 'Couldn’t load repositories from GitHub — the list may be incomplete.'
-                        : undefined
+                    reposError === 'failed'
+                      ? 'Couldn’t load repositories from GitHub — the list may be incomplete.'
+                      : undefined
                   }
                   onRetry={() => {
                     invalidateGithubRepoRosterCache()
                     setReposError(null)
+                    setPrivateReposHidden(false)
                     setRepos(null)
                     setReposNonce((value) => value + 1)
                   }}
+                  note={
+                    privateReposHidden ? (
+                      <GithubPrivateReposNotice profileHref={orgPath('/profile#sign-in-methods')} />
+                    ) : undefined
+                  }
                 >
                   {matches.map((repo) => {
                     const grant = grantOf(repo.fullName)

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -334,7 +334,7 @@ describe('GitHub installation repositories', () => {
           : page === '2'
             ? [{ fullName: 'acme/beta-private', private: true }]
             : [{ fullName: 'acme/gamma', private: false }]
-      return new Response(JSON.stringify({ repos, totalCount: 101 }), {
+      return new Response(JSON.stringify({ repos, totalCount: 101, privateReposHidden: page === '2' }), {
         status: 200,
         headers: { 'content-type': 'application/json' }
       })
@@ -343,11 +343,12 @@ describe('GitHub installation repositories', () => {
     setApiOrgId('org-1')
 
     const progress: string[][] = []
-    const repos = await fetchAllGithubRepos('installation-1', undefined, (partial) => {
+    const result = await fetchAllGithubRepos('installation-1', undefined, (partial) => {
       progress.push(partial.map((repo) => repo.fullName))
     })
 
-    expect(repos.map((repo) => repo.fullName)).toEqual(['acme/alpha', 'acme/beta-private', 'acme/gamma'])
+    expect(result.repos.map((repo) => repo.fullName)).toEqual(['acme/alpha', 'acme/beta-private', 'acme/gamma'])
+    expect(result.privateReposHidden).toBe(true)
     expect(progress[0]).toEqual(['acme/alpha'])
     expect(progress.at(-1)).toEqual(['acme/alpha', 'acme/beta-private', 'acme/gamma'])
     expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -357,7 +358,7 @@ describe('GitHub installation repositories', () => {
       '50'
     ])
 
-    await expect(fetchAllGithubRepos('installation-1')).resolves.toEqual(repos)
+    await expect(fetchAllGithubRepos('installation-1')).resolves.toEqual(result)
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
@@ -367,7 +368,8 @@ describe('GitHub installation repositories', () => {
       return new Response(
         JSON.stringify({
           repos: [{ fullName: `${installationId}/repo`, private: true }],
-          totalCount: 1
+          totalCount: 1,
+          privateReposHidden: false
         }),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )
@@ -382,7 +384,7 @@ describe('GitHub installation repositories', () => {
       (repos) => progress.push(repos.map((repo) => repo.installationId))
     )
 
-    expect(result).toMatchObject({ denied: false, failed: false })
+    expect(result).toMatchObject({ privateReposHidden: false, failed: false })
     expect(result.repos.map((repo) => repo.installationId)).toEqual(['installation-1', 'installation-2'])
     expect(progress.at(-1)).toEqual(['installation-1', 'installation-2'])
   })
@@ -397,21 +399,29 @@ describe('GitHub installation repositories', () => {
         })
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ repos: [{ fullName: 'acme/recovered', private: true }], totalCount: 1 }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' }
-        })
+        new Response(
+          JSON.stringify({
+            repos: [{ fullName: 'acme/recovered', private: true }],
+            totalCount: 1,
+            privateReposHidden: false
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          }
+        )
       )
     vi.stubGlobal('fetch', fetchMock)
     setApiOrgId('org-1')
 
-    await expect(fetchAllGithubRepos('installation-1')).resolves.toEqual([
-      { fullName: 'acme/recovered', private: true }
-    ])
+    await expect(fetchAllGithubRepos('installation-1')).resolves.toEqual({
+      repos: [{ fullName: 'acme/recovered', private: true }],
+      privateReposHidden: false
+    })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('does not retry a per-user authorization verdict (403)', async () => {
+  it('treats a legacy identity denial as private repositories hidden without retrying', async () => {
     const fetchMock = vi.fn(
       async () =>
         new Response(JSON.stringify({ message: 'sign in with GitHub', code: 'GITHUB_IDENTITY_REQUIRED' }), {
@@ -422,8 +432,11 @@ describe('GitHub installation repositories', () => {
     vi.stubGlobal('fetch', fetchMock)
     setApiOrgId('org-1')
 
-    const error = await fetchAllGithubRepos('installation-1').catch((reason: unknown) => reason)
-    expect(error).toMatchObject({ name: 'ApiError', status: 403, code: 'GITHUB_IDENTITY_REQUIRED' })
+    await expect(fetchGithubRepoRoster([{ id: 'installation-1' }])).resolves.toEqual({
+      repos: [],
+      privateReposHidden: true,
+      failed: false
+    })
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
@@ -440,7 +453,8 @@ describe('GitHub installation repositories', () => {
       return new Response(
         JSON.stringify({
           repos: [{ fullName: `${url.pathname}-${url.searchParams.get('page')}`, private: true }],
-          totalCount: 51
+          totalCount: 51,
+          privateReposHidden: false
         }),
         { status: 200, headers: { 'content-type': 'application/json' } }
       )

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3166,6 +3166,9 @@ export async function fetchMySessionIdentity(provider: SessionAccessProvider): P
 // copy would hide the new identity. Say so once, right after a link lands.
 export async function refreshMySocialIdentities(): Promise<void> {
   await apiPost('/me/social-identities/refresh', {})
+  // Repository rosters are identity-filtered. A successful GitHub link must
+  // not leave the public-only result cached when the user reopens a picker.
+  invalidateGithubRepoRosterCache()
 }
 
 async function putMyProfilePicture(blob: Blob): Promise<MeDto> {
@@ -3802,7 +3805,18 @@ type GithubRepoRequestWaiter = {
 
 let activeGithubRepoRequests = 0
 const githubRepoRequestWaiters: GithubRepoRequestWaiter[] = []
-const githubRepoRosterCache = new Map<string, { repos: GithubRepoDto[]; expiresAt: number }>()
+type GithubRepoPage = {
+  repos: GithubRepoDto[]
+  totalCount: number
+  privateReposHidden: boolean
+}
+
+type GithubRepoRoster = {
+  repos: GithubRepoDto[]
+  privateReposHidden: boolean
+}
+
+const githubRepoRosterCache = new Map<string, GithubRepoRoster & { expiresAt: number }>()
 
 export function invalidateGithubRepoRosterCache(installationId?: string): void {
   if (installationId) githubRepoRosterCache.delete(installationId)
@@ -3877,15 +3891,20 @@ export async function fetchGithubRepos(
   installationId: string,
   page = 1,
   signal?: AbortSignal
-): Promise<{ repos: GithubRepoDto[]; totalCount: number }> {
-  // Not apiGet: a per-user-gate denial (403) carries a machine `code` in the
-  // body that the picker branches on (GITHUB_IDENTITY_REQUIRED ⇒ "sign in with
-  // GitHub" note instead of a silently empty list).
+): Promise<GithubRepoPage> {
+  // Not apiGet: rolling deployments can still return the former machine-coded
+  // identity denial, which the aggregate below degrades to the same explicit
+  // private-repositories-hidden state.
   const path = `${orgBase()}/github/installations/${encodeURIComponent(installationId)}/repositories?page=${page}&perPage=${GITHUB_REPO_PAGE_SIZE}`
   return withGithubRepoRequestLimit(async () => {
     for (let attempt = 0; ; attempt++) {
       const res = await fetch(`${cpBase()}${path}`, { headers: await authHeaders(), cache: 'no-store', signal })
-      if (res.ok) return (await res.json()) as { repos: GithubRepoDto[]; totalCount: number }
+      if (res.ok) {
+        const body = (await res.json()) as Omit<GithubRepoPage, 'privateReposHidden'> & {
+          privateReposHidden?: boolean
+        }
+        return { ...body, privateReposHidden: body.privateReposHidden ?? false }
+      }
       const body = (await res.json().catch(() => ({}))) as { code?: string; message?: string }
       // Only upstream trouble (5xx, rate-limit) is worth retrying — a 4xx
       // verdict (403 identity gate, 404) would just repeat.
@@ -3898,9 +3917,7 @@ export async function fetchGithubRepos(
   }, signal)
 }
 
-function mergeGithubRepoPages(
-  pages: Array<{ repos: GithubRepoDto[]; totalCount: number } | undefined>
-): GithubRepoDto[] {
+function mergeGithubRepoPages(pages: Array<GithubRepoPage | undefined>): GithubRepoDto[] {
   const unique = new Map<string, GithubRepoDto>()
   for (const repo of pages.flatMap((page) => page?.repos ?? [])) {
     const key = repo.fullName.toLowerCase()
@@ -3916,17 +3933,17 @@ export async function fetchAllGithubRepos(
   installationId: string,
   signal?: AbortSignal,
   onProgress?: (repos: GithubRepoDto[]) => void
-): Promise<GithubRepoDto[]> {
+): Promise<GithubRepoRoster> {
   const cached = githubRepoRosterCache.get(installationId)
   if (cached && cached.expiresAt > Date.now()) {
     onProgress?.(cached.repos)
-    return cached.repos
+    return { repos: cached.repos, privateReposHidden: cached.privateReposHidden }
   }
   if (cached) githubRepoRosterCache.delete(installationId)
 
   const first = await fetchGithubRepos(installationId, 1, signal)
   const pageCount = Math.ceil(first.totalCount / GITHUB_REPO_PAGE_SIZE)
-  const pages: Array<{ repos: GithubRepoDto[]; totalCount: number } | undefined> = Array.from({
+  const pages: Array<GithubRepoPage | undefined> = Array.from({
     length: Math.max(1, pageCount)
   })
   pages[0] = first
@@ -3941,8 +3958,13 @@ export async function fetchAllGithubRepos(
   )
 
   const repos = mergeGithubRepoPages(pages)
-  githubRepoRosterCache.set(installationId, { repos, expiresAt: Date.now() + GITHUB_REPO_ROSTER_CACHE_MS })
-  return repos
+  const privateReposHidden = pages.some((page) => page?.privateReposHidden)
+  githubRepoRosterCache.set(installationId, {
+    repos,
+    privateReposHidden,
+    expiresAt: Date.now() + GITHUB_REPO_ROSTER_CACHE_MS
+  })
+  return { repos, privateReposHidden }
 }
 
 function mergeGithubInstallationRosters(
@@ -3966,8 +3988,9 @@ export async function fetchGithubRepoRoster(
   installations: readonly Pick<GithubInstallationDto, 'id'>[],
   signal?: AbortSignal,
   onProgress?: (repos: GithubInstalledRepoDto[]) => void
-): Promise<{ repos: GithubInstalledRepoDto[]; denied: boolean; failed: boolean }> {
+): Promise<{ repos: GithubInstalledRepoDto[]; privateReposHidden: boolean; failed: boolean }> {
   const rosters = new Map<string, GithubRepoDto[]>()
+  const hiddenByInstallation = new Map<string, boolean>()
   const publish = (installationId: string, repos: GithubRepoDto[]) => {
     rosters.set(installationId, repos)
     onProgress?.(mergeGithubInstallationRosters(installations, rosters))
@@ -3975,8 +3998,11 @@ export async function fetchGithubRepoRoster(
   const errors = await Promise.all(
     installations.map(async (installation) => {
       try {
-        const repos = await fetchAllGithubRepos(installation.id, signal, (partial) => publish(installation.id, partial))
-        publish(installation.id, repos)
+        const result = await fetchAllGithubRepos(installation.id, signal, (partial) =>
+          publish(installation.id, partial)
+        )
+        hiddenByInstallation.set(installation.id, result.privateReposHidden)
+        publish(installation.id, result.repos)
         return null
       } catch (error) {
         return error
@@ -3985,7 +4011,9 @@ export async function fetchGithubRepoRoster(
   )
   return {
     repos: mergeGithubInstallationRosters(installations, rosters),
-    denied: errors.some((error) => error instanceof ApiError && error.code === 'GITHUB_IDENTITY_REQUIRED'),
+    privateReposHidden:
+      [...hiddenByInstallation.values()].some(Boolean) ||
+      errors.some((error) => error instanceof ApiError && error.code === 'GITHUB_IDENTITY_REQUIRED'),
     failed: errors.some(
       (error) => error !== null && !(error instanceof ApiError && error.code === 'GITHUB_IDENTITY_REQUIRED')
     )
@@ -4030,6 +4058,7 @@ export interface GithubRepoAccess {
   gated: boolean
   canRead: boolean
   canWrite: boolean
+  identityRequired: boolean
   denied?: string
   message?: string
 }
@@ -4041,20 +4070,26 @@ export async function fetchGithubRepoAccess(
 ): Promise<GithubRepoAccess> {
   const path = `${orgBase()}/github/installations/${encodeURIComponent(installationId)}/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/access`
   const res = await fetch(`${cpBase()}${path}`, { headers: await authHeaders(), cache: 'no-store' })
-  if (res.status === 404) return { gated: false, canRead: true, canWrite: true }
+  if (res.status === 404) return { gated: false, canRead: true, canWrite: true, identityRequired: false }
   if (res.status === 403) {
     const body = (await res.json().catch(() => ({}))) as { code?: string; message?: string }
     return {
       gated: true,
       canRead: false,
       canWrite: false,
+      identityRequired: body.code === 'GITHUB_IDENTITY_REQUIRED',
       denied: body.code ?? 'USER_NO_ACCESS',
       ...(body.message ? { message: body.message } : {})
     }
   }
   if (!res.ok) throw new ApiError(`GET ${path} → ${res.status} ${res.statusText}`, res.status)
-  const body = (await res.json()) as { canRead: boolean; canWrite: boolean }
-  return { gated: true, canRead: body.canRead, canWrite: body.canWrite }
+  const body = (await res.json()) as { canRead: boolean; canWrite: boolean; identityRequired?: boolean }
+  return {
+    gated: true,
+    canRead: body.canRead,
+    canWrite: body.canWrite,
+    identityRequired: body.identityRequired ?? false
+  }
 }
 
 // ── agent repository authorizations (agent-multi-repo-authorization.md) ──────


### PR DESCRIPTION
## Summary
- keep GitHub App public repositories visible for users without a linked GitHub profile while hiding private repository names
- replace the roster-wide red identity error with a neutral Profile link across repository pickers and refresh cached rosters after linking
- keep private repository and write authorization identity-gated, and document why the installation callback cannot safely auto-link a human identity

## Validation
- pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/github/user-authz.test.ts
- pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/github-installations.route.test.ts
- pnpm --filter @agentconnect.md/web exec vitest run src/lib/api.test.ts src/components/console/WorkspaceFormFields.test.tsx
- pnpm --filter @agentconnect.md/control-plane typecheck
- pnpm --filter @agentconnect.md/web typecheck
- pnpm --filter @agentconnect.md/web build
- targeted ESLint, Prettier, and git diff checks

Created by Codex . GPT-5