### PR TITLE
fix(github): scope installation sync to organization

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -190,7 +190,7 @@ stale until a network fetch succeeds.
   daemon uses its local `webAppUrl` or the `http://localhost:3000` default.
   **Do not add configuration.**
   Redirect to `<console>/?github=<note>`, where note is
-  `installed`/`sync-needed`/`pending-approval`, with no orgSlug path segment. If
+  `installed`/`retry-install`/`pending-approval`, with no orgSlug path segment. If
   no console URL is configured, it falls back to a plaintext informational
   page (`routes/github.ts`). Never accept a redirect destination from request
   parameters or state; that would permit open redirects.
@@ -380,14 +380,14 @@ and RBAC. The organization subtree uniformly applies `humanAuth` +
 `owner|collaborator|viewer` in `rbac.ts`, with `denyViewerWrite` on write
 operations. The GitHub routes are therefore registered as two plugins:
 
-| Route                                                                  | Authentication/RBAC                                                                                       | Behavior                                                                                                                                                                                            |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /api/v1/orgs/:orgId/github/app`                                   | Organization-subtree hooks + `denyViewerWrite` (issuing installation state initiates a connection change) | App metadata (slug and enabled status) + installation deep link `…/installations/new?state=…`; state is a domain-separated HMAC signature over **orgId = path organization** + exp + one-time nonce |
-| `POST /api/v1/orgs/:orgId/github/installations/sync`                   | Organization-subtree hooks + `denyViewerWrite`                                                            | Use an App JWT to fully reconcile `GET /app/installations` and claim installations into the **path organization**; mark missing installations with `revokedAt`, **never delete their rows**         |
-| `GET /api/v1/orgs/:orgId/github/installations`                         | Organization-subtree hooks (viewers can read; organization-level resource, **not visibility-filtered**)   | List live installations for this organization, providing the picker's first level                                                                                                                   |
-| `GET …/github/installations/:id/repositories?page`                     | Same                                                                                                      | Mint a token -> `GET /installation/repositories`; paginated with `per_page <= 100`. **This endpoint has no server-side search**; filter in the CP/frontend                                          |
-| `GET …/repositories/:owner/:repo/branches`                             | Same                                                                                                      | Branch picker. **Requires a `contents:read` token** because metadata-only returns 403, exactly reusing the token-cache key `(iid, repo, 'read')`                                                    |
-| `GET /api/v1/github/setup/callback?installation_id&setup_action&state` | **Unauthenticated** because GitHub redirects the browser                                                  | See "Setup Callback Semantics" below                                                                                                                                                                |
+| Route                                                                  | Authentication/RBAC                                                                                       | Behavior                                                                                                                                                                                                                                  |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/orgs/:orgId/github/app`                                   | Organization-subtree hooks + `denyViewerWrite` (issuing installation state initiates a connection change) | App metadata (slug and enabled status) + installation deep link `…/installations/new?state=…`; state is a domain-separated HMAC signature over **orgId = path organization** + exp + one-time nonce                                       |
+| `POST /api/v1/orgs/:orgId/github/installations/sync`                   | Organization-subtree hooks + `denyViewerWrite`                                                            | Use an App JWT to refresh every durable claim already belonging to the **path organization**; mark missing installations with `revokedAt`, **never delete their rows**, and never discover or claim from the deployment-global App roster |
+| `GET /api/v1/orgs/:orgId/github/installations`                         | Organization-subtree hooks (viewers can read; organization-level resource, **not visibility-filtered**)   | List live installations for this organization, providing the picker's first level                                                                                                                                                         |
+| `GET …/github/installations/:id/repositories?page`                     | Same                                                                                                      | Mint a token -> `GET /installation/repositories`; paginated with `per_page <= 100`. **This endpoint has no server-side search**; filter in the CP/frontend                                                                                |
+| `GET …/repositories/:owner/:repo/branches`                             | Same                                                                                                      | Branch picker. **Requires a `contents:read` token** because metadata-only returns 403, exactly reusing the token-cache key `(iid, repo, 'read')`                                                                                          |
+| `GET /api/v1/github/setup/callback?installation_id&setup_action&state` | **Unauthenticated** because GitHub redirects the browser                                                  | See "Setup Callback Semantics" below                                                                                                                                                                                                      |
 
 - **Callback mount point:** it cannot enter the organization subtree because
   it has neither a bearer token nor `:orgId`. Export it as the **second plugin**
@@ -417,17 +417,18 @@ operations. The GitHub routes are therefore registered as two plugins:
 **Setup callback semantics:**
 
 - Forwarding `state` from `installations/new?state=…` to the Setup URL is
-  undocumented GitHub behavior and cannot be required. When state is present
-  and verifies successfully, verify
-  App ownership, upsert the installation, and claim it into the organization
-  in state. **Missing state is not an error:** redirect with 302 to the
-  console's "GitHub connection" page and ask the user to click Sync, which
-  claims it through an authenticated path. This is a recoverable degradation,
-  not a hard dependency on undocumented behavior.
+  undocumented GitHub behavior. When state is present and verifies successfully,
+  verify App ownership, upsert the installation, and claim it into the
+  organization in state. When state is missing, redirect with 302 to the console
+  and ask the user to restart the org-bound install. The App installation roster
+  is deployment-global, so an authenticated organization path alone is not proof
+  that an unclaimed installation belongs to that organization; Sync must never
+  guess or create the claim.
 - `setup_action === 'request'` means a nonadministrator initiated the request
   and an organization administrator must approve it. There is **no usable
   `installation_id`** at this point. Redirect with 302 directly to the console
-  and display "Pending administrator approval"; Sync claims it later.
+  and display "Pending administrator approval"; after approval, restart the
+  org-bound install so a signed callback can create the claim.
 - No branch trusts callback parameters themselves. The only path into the
   database is an App-JWT lookup that confirms ownership.
 
@@ -872,8 +873,10 @@ an explicit grant, so the daemon cannot name an arbitrary repository.
      operator configuration required."
    - When enabled, show an "Install on GitHub" deep link with state, the
      installation list with accountLogin, repositorySelection, and
-     suspended/revoked states, and a "Sync" button as the common fallback for
-     missing state, administrator approval, or a missed callback.
+     suspended/revoked states, and a "Sync" button that refreshes only the
+     organization's durable claims. Missing state or administrator approval
+     requires restarting the signed install flow; Sync never claims from the
+     deployment-global App roster.
 2. **AddAgentModal workspace step:** in GitHub mode, offer two alternatives:
    - **"Select from GitHub App":** installation selector -> searchable
      repository selector with pagination and client-side filtering, because
@@ -924,12 +927,13 @@ the instance)**
 
 The console's "Install on GitHub" deep link with one-time state -> the user
 selects an organization and repository scope on GitHub -> 302 to the CP setup
-callback -> verify state, or degrade with a Sync prompt if it is absent, and
-verify ownership with an App JWT -> upsert the installation and claim it into
-the organization -> 302 to `<console>/?github=installed`, visible in the
-console. The callback has no orgSlug path segment. A nonadministrator
-installation uses `setup_action=request` -> pending-approval prompt -> Sync
-claims it after approval.
+callback -> verify state and ownership with an App JWT -> upsert the installation
+and claim it into the organization -> 302 to `<console>/?github=installed`,
+visible in the console. The callback has no orgSlug path segment. A missing or
+invalid state returns a retry-install prompt instead of guessing ownership from
+the deployment-global App roster. A nonadministrator installation uses
+`setup_action=request` -> pending-approval prompt -> after approval, restart the
+signed install flow.
 
 **B. Select a repository while creating an agent**
 
@@ -1064,7 +1068,7 @@ the cache and stops requesting.
    `PATCH /agents/:id` must not silently rewrite the workspace. A dedicated
    `PUT /agents/:id/workspace` cold action owns that operation, while
    `lastModifiedBy/At` continues to record the security-relevant actor. The
-   installation sync/claim row could similarly add `createdByUserId` for
+   setup-callback installation claim row could similarly add `createdByUserId` for
    aligned auditing.
    PATCH is gated by `canEdit`. A viewer can never edit; any collaborator can edit an
    organization-visible agent, and any **shared** collaborator can edit a

--- a/docs/designs/github-pr-review-checks.md
+++ b/docs/designs/github-pr-review-checks.md
@@ -431,7 +431,7 @@ R2a requires App registration/installation `checks:write` and `pull_requests:rea
 
 `GithubInstallation.permissions Json` exists; unknown `{}` fails closed. Setup callback, Sync, and installation doorbell pull (including `new_permissions_accepted`) replace local facts with installation-effective permissions returned by GitHub. Selected repository/projection remains and dynamically refreshes provenance; console displays exact `checksPermission`. With `checks:write`, GitHub App automatically receives `check_run` and `check_suite` rerequests plus `check_run.requested_action`; relay handles only rerequested and `request_review`, returning 202 no-op for other actions.
 
-Installation-claim conflict update preserves original `orgId`; cross-organization claim rejects explicitly so another organization's sync cannot move reporter authority.
+Installation-claim conflict update preserves original `orgId`; Sync refreshes only durable claims already belonging to its organization and cannot discover or move reporter authority.
 
 After callback/Sync/doorbell writes permission/revoke/suspend, all pass through one convergence hook: `InstallationTokenService.invalidateInstallation(iid)` → immediately wake installation's `blocked(permission)`/nonterminal projections → recompile organization hooks. Per-installation invalidation exists; never merely update DB and wait for normal retry.
 

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -243,6 +243,78 @@ describe('install state', () => {
   })
 })
 
+describe('GithubService.sync', () => {
+  it('refreshes only durable org claims and never scans the App-wide installation roster', async () => {
+    const claimed = {
+      id: 'row-42',
+      orgId: 'org-a',
+      installationId: 42n,
+      accountLogin: 'acme',
+      accountType: 'Organization',
+      repositorySelection: 'all',
+      suspendedAt: null,
+      revokedAt: null,
+      permissions: {},
+      createdAt: new Date(0)
+    } as GithubInstallationRecord
+    const revoked = {
+      ...claimed,
+      id: 'row-43',
+      installationId: 43n,
+      accountLogin: 'gone',
+      revokedAt: new Date(1)
+    }
+    const refreshed = { ...claimed, permissions: { checks: 'write' } }
+    const upsertFromGithub = vi.fn(async () => refreshed)
+    const markRevokedByInstallationId = vi.fn(async () => {})
+    const listForOrg = vi.fn(async () => [refreshed])
+    const onInstallationFactsChanged = vi.fn()
+    const urls: string[] = []
+    const svc = new GithubService({
+      cfg: cfg(),
+      clock: new FakeClock(1_700_000_000_000),
+      installations: {
+        listClaimsForOrg: vi.fn(async () => [claimed, revoked]),
+        listForOrg,
+        upsertFromGithub,
+        markRevokedByInstallationId
+      } as never,
+      installState: { put: async () => {}, consume: async () => true },
+      onInstallationFactsChanged,
+      pepper: 'p'.repeat(32),
+      fetchImpl: async (url) => {
+        urls.push(url)
+        if (url.endsWith('/app/installations/42')) {
+          return Response.json({
+            id: 42,
+            account: { login: 'acme', type: 'Organization' },
+            repository_selection: 'all',
+            suspended_at: null,
+            permissions: { checks: 'write' }
+          })
+        }
+        if (url.endsWith('/app/installations/43')) return Response.json({ message: 'Not Found' }, { status: 404 })
+        throw new Error(`unexpected GitHub request: ${url}`)
+      }
+    })
+
+    await expect(svc.sync(claimed.orgId)).resolves.toEqual([refreshed])
+
+    expect(urls).toEqual(['https://api.github.com/app/installations/42', 'https://api.github.com/app/installations/43'])
+    expect(upsertFromGithub).toHaveBeenCalledOnce()
+    expect(upsertFromGithub).toHaveBeenCalledWith(
+      'org-a',
+      expect.objectContaining({ installationId: 42n, permissions: { checks: 'write' } })
+    )
+    expect(markRevokedByInstallationId).toHaveBeenCalledWith(43n)
+    expect(onInstallationFactsChanged.mock.calls).toEqual([
+      [42n, 'org-a'],
+      [43n, 'org-a']
+    ])
+    expect(listForOrg).toHaveBeenCalledWith('org-a')
+  })
+})
+
 describe('GithubService.outdatedInstallations', () => {
   it("reads GitHub's outdated installation filter and briefly caches the result", async () => {
     const clock = new FakeClock(1_700_000_000_000)

--- a/packages/control-plane/src/github/install-state.ts
+++ b/packages/control-plane/src/github/install-state.ts
@@ -10,8 +10,9 @@
  * the signature so a stale row can never be resurrected.
  *
  * GitHub's state passthrough to the Setup URL is undocumented behavior that has
- * regressed before (community #61291) — callers must treat a MISSING state as
- * degraded-but-recoverable (redirect to console → Sync), never an error.
+ * regressed before (community #61291). A missing state cannot safely bind an
+ * App-wide installation to a tenant; callers redirect to the console and ask
+ * the user to restart the signed install flow.
  */
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 import type { Clock } from '../domain/clock.js'

--- a/packages/control-plane/src/github/installation-doorbell.service.test.ts
+++ b/packages/control-plane/src/github/installation-doorbell.service.test.ts
@@ -71,7 +71,7 @@ function make(opts: {
 }
 
 describe('GithubInstallationDoorbell', () => {
-  it('unknown installation: ignored — no pull, no recompile (claiming stays with callback/Sync)', async () => {
+  it('unknown installation: ignored — no pull, no recompile (claiming stays with the signed callback)', async () => {
     const h = make({ known: false })
     h.doorbell.poke({ installationId: INS.toString(), action: 'created' })
     await h.doorbell.settle()

--- a/packages/control-plane/src/github/installation-doorbell.service.ts
+++ b/packages/control-plane/src/github/installation-doorbell.service.ts
@@ -7,7 +7,7 @@
  * and writes what GITHUB says (200 ⇒ upsert under the EXISTING claim's org;
  * 404/410 ⇒ markRevoked), then recompiles that org's github hooks so the relay
  * pool's `installationIds` gates converge. An installation with no org claim
- * yet is ignored — claiming stays with the setup callback / manual Sync.
+ * yet is ignored — claiming stays with the signed setup callback.
  *
  * Throttling: per-installation single-flight + a short cooldown, so an event
  * storm (bulk repo grants fan out one event per change) coalesces into one
@@ -130,8 +130,8 @@ export class GithubInstallationDoorbell {
     try {
       const row = await this.deps.installations.getByInstallationId(installationId)
       if (!row) {
-        // No org claim — the poke can't be attributed; claiming is the setup
-        // callback's / Sync's job (never write from an unclaimed event).
+        // No org claim — the poke can't be attributed; only a signed setup
+        // callback may create one (never write from an unclaimed event).
         this.deps.log.debug({ installationId: key, action }, 'doorbell: unknown installation — ignored')
         return
       }

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -3,9 +3,9 @@
  * (docs/designs/github-app-git-credentials.md §CP Side).
  *
  * Owns install-state minting/consumption, setup-callback verification (App-JWT
- * ownership check — never trust a callback's installation_id), sync
- * reconciliation (mark-revoked, never delete), the repo/branch picker proxies,
- * create-time repo validation, and the gitcred mint resolution
+ * ownership check — never trust a callback's installation_id), org-scoped
+ * installation refresh (mark-revoked, never delete), the repo/branch picker
+ * proxies, create-time repo validation, and the gitcred mint resolution
  * (agent → repo owner → LIVE installation → scoped token).
  */
 import { gitRepoLabel, type GitCommitIdentity, type GitCredCapability } from '@agentconnect.md/protocol'
@@ -201,8 +201,8 @@ export class GithubService {
    * Setup-callback claim: verify the signed state (one-shot nonce), then verify
    * the installation actually belongs to OUR App via an App-JWT read — GitHub's
    * own guidance is to never trust the callback's `installation_id`.
-   * Returns null when the state is invalid/replayed (caller degrades to the
-   * console Sync path — state passthrough is undocumented GitHub behavior).
+   * Returns null when the state is invalid/replayed. The caller must ask the
+   * user to restart the org-bound install; Sync never guesses claim ownership.
    */
   async claimFromCallback(state: string, installationId: number): Promise<GithubInstallationRecord | null> {
     const parsed = verifyInstallState(this.stateKey, state, this.deps.clock)
@@ -217,37 +217,17 @@ export class GithubService {
     return row
   }
 
-  /**
-   * Sync fallback (`POST …/installations/sync`): reconcile the org's claims
-   * against GitHub's full installation list. New installations are claimed by
-   * the CALLING org; rows GitHub no longer reports are MARKED revoked (never
-   * deleted — agents hold provenance pointers). `upsertFromGithub` never moves
-   * an existing claim between orgs.
+  /** Refresh every durable claim belonging to the calling org.
+   *
+   * GitHub's App installation roster is deployment-global, not tenant-scoped.
+   * Sync therefore pulls only ids already bound to this org; it never discovers
+   * or claims an unknown installation. Missing ids are marked revoked, never
+   * deleted, because agents retain provenance pointers.
    */
   async sync(orgId: OrgId): Promise<GithubInstallationRecord[]> {
     this.outdatedInstallationsCache = undefined
-    const before = await this.deps.installations.listForOrg(orgId)
-    const all: GhInstallation[] = []
-    for (let page = 1; page <= 10; page++) {
-      const batch = await this.appRequest<GhInstallation[]>(`/app/installations?per_page=100&page=${page}`)
-      all.push(...batch)
-      if (batch.length < 100) break
-    }
-    for (const ins of all) {
-      const row = await this.deps.installations.upsertFromGithub(orgId, toFacts(ins))
-      this.tokens.invalidateInstallation(BigInt(ins.id))
-      this.invalidateRepositoryRoster(row.installationId)
-      await this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
-    }
-    await this.deps.installations.markRevokedExcept(
-      orgId,
-      all.map((i) => BigInt(i.id))
-    )
-    for (const row of before) {
-      this.tokens.invalidateInstallation(row.installationId)
-      this.invalidateRepositoryRoster(row.installationId)
-    }
-    for (const row of before) await this.deps.onInstallationFactsChanged?.(row.installationId, row.orgId)
+    const claims = await this.deps.installations.listClaimsForOrg(orgId)
+    for (const claim of claims) await this.refreshClaimedInstallation(claim)
     return this.deps.installations.listForOrg(orgId)
   }
 
@@ -536,16 +516,23 @@ export class GithubService {
   async refreshInstallationFacts(installationId: bigint): Promise<GithubInstallationRecord | null> {
     const claimed = await this.deps.installations.getByInstallationId(installationId)
     if (!claimed) return null
+    return this.refreshClaimedInstallation(claimed)
+  }
+
+  private async refreshClaimedInstallation(
+    claimed: GithubInstallationRecord
+  ): Promise<GithubInstallationRecord | null> {
+    const { installationId, orgId } = claimed
     const facts = await this.pullInstallation(installationId)
     let refreshed: GithubInstallationRecord | null = null
     if (facts) {
-      refreshed = await this.deps.installations.upsertFromGithub(claimed.orgId, facts)
+      refreshed = await this.deps.installations.upsertFromGithub(orgId, facts)
     } else {
       await this.deps.installations.markRevokedByInstallationId(installationId)
     }
     this.tokens.invalidateInstallation(installationId)
     this.invalidateRepositoryRoster(installationId)
-    await this.deps.onInstallationFactsChanged?.(installationId, claimed.orgId)
+    await this.deps.onInstallationFactsChanged?.(installationId, orgId)
     return refreshed
   }
 

--- a/packages/control-plane/src/http/routes/github.ts
+++ b/packages/control-plane/src/http/routes/github.ts
@@ -24,6 +24,7 @@ import { OrgId } from '../../domain/ids.js'
 import { GithubApiError } from '../../github/api.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
+import { GithubInstallationClaimConflict } from '../../persistence/errors.js'
 import { orgOf, denyViewerWrite, denyNonOwner } from '../rbac.js'
 import {
   ErrorDto,
@@ -175,7 +176,7 @@ export function githubRoutes(deps: HttpDeps) {
           tags: [Tag.GitHub],
           summary: 'Sync GitHub installations',
           description:
-            'Reconcile claims against GitHub (App-JWT read): claim new installations for this org, mark vanished ones revoked, and refresh the current/outdated permission verdict. The fallback for a lost setup callback, a pending admin approval, or a missing state.',
+            "Refresh this organization's existing installation claims from GitHub, mark vanished ones revoked, and update the current/outdated permission verdict. Unknown installations are never claimed by Sync.",
           operationId: 'syncGithubInstallations',
           response: { 200: GithubInstallationListDto, 403: ErrorDto, 429: ErrorDto, 502: ErrorDto }
         }
@@ -468,13 +469,14 @@ export function githubCallbackRoutes(deps: HttpDeps) {
             : reply.type('text/plain').send(`GitHub App: ${note}. You can close this tab and open the console.`)
 
         // Admin-approval flow: a non-admin requested the install — no usable
-        // installation yet; the eventual approval is picked up by Sync.
+        // installation yet. After approval the user must restart the org-bound
+        // install so a signed callback, rather than an App-wide scan, claims it.
         if (req.query.setup_action === 'request') return back('pending-approval')
 
         // State passthrough is UNDOCUMENTED GitHub behavior that has regressed
-        // before (#61291) — a missing/invalid state degrades to the Sync path,
-        // it is never an error.
-        if (!req.query.state || req.query.installation_id === undefined) return back('sync-needed')
+        // before (#61291). Without it there is no tenant-binding proof, so never
+        // guess from the App-wide installation roster; ask the user to restart.
+        if (!req.query.state || req.query.installation_id === undefined) return back('retry-install')
         try {
           const claimed = await gh.claimFromCallback(req.query.state, req.query.installation_id)
           if (claimed) {
@@ -485,13 +487,22 @@ export function githubCallbackRoutes(deps: HttpDeps) {
               .rebroadcastGithubForOrg(claimed.orgId)
               .catch((err) => req.log.warn({ err }, 'github setup callback: hook rebroadcast failed'))
           }
-          return back(claimed ? 'installed' : 'sync-needed')
+          return back(claimed ? 'installed' : 'retry-install')
         } catch (e) {
           if (e instanceof GithubApiError) {
             // Ownership verify failed (someone else's installation id, GitHub
-            // hiccup) — nothing was claimed; the console Sync path recovers.
+            // hiccup) — nothing was claimed; restart the signed install flow.
             req.log.warn({ status: e.status }, 'github setup callback verify failed')
-            return back('sync-needed')
+            return back('retry-install')
+          }
+          if (e instanceof GithubInstallationClaimConflict) {
+            // Preserve the immutable tenant claim without exposing which other
+            // organization owns it through this unauthenticated callback.
+            req.log.warn(
+              { installationId: e.installationId.toString(), code: e.code },
+              'github setup callback: installation already claimed'
+            )
+            return back('retry-install')
           }
           throw e
         }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2440,11 +2440,15 @@ export interface GithubInstallationRecord extends GithubInstallationFacts {
 }
 
 export interface GithubInstallationRepo {
-  /** Claim/update by GitHub installation id (idempotent for setup-callback + sync). */
+  /** Claim/update by GitHub installation id. The setup callback is the only
+   * path allowed to create a claim; refresh paths pass the durable claim's org. */
   upsertFromGithub(orgId: OrgId, facts: GithubInstallationFacts): Promise<GithubInstallationRecord>
   get(id: string): Promise<GithubInstallationRecord | null>
   /** Live (non-revoked) installations claimed by the org — the picker's first level. */
   listForOrg(orgId: OrgId): Promise<GithubInstallationRecord[]>
+  /** Every durable claim for an org, including revoked rows. Sync refreshes
+   * exactly this set, so it never assigns an unclaimed or foreign installation. */
+  listClaimsForOrg(orgId: OrgId): Promise<GithubInstallationRecord[]>
   /** Mint-time resolution: the live installation covering `accountLogin` in this org. */
   liveByOrgAndAccount(orgId: OrgId, accountLogin: string): Promise<GithubInstallationRecord | null>
   /** Doorbell lookup by GITHUB-side id (revoked rows included — the claim row is
@@ -2452,8 +2456,6 @@ export interface GithubInstallationRepo {
   getByInstallationId(installationId: bigint): Promise<GithubInstallationRecord | null>
   /** Doorbell revoke: GitHub answered 404/410 for this installation (never delete). */
   markRevokedByInstallationId(installationId: bigint): Promise<void>
-  /** Sync reconciliation: mark the org's rows NOT in `liveInstallationIds` revoked (never delete). */
-  markRevokedExcept(orgId: OrgId, liveInstallationIds: bigint[]): Promise<void>
 }
 
 /** One-shot install-state nonces (`github_install_state`): put on mint, consume-once on callback. */

--- a/packages/control-plane/src/persistence/repositories/github.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/github.repo.ts
@@ -79,6 +79,14 @@ export class PgGithubInstallationRepo implements GithubInstallationRepo {
     return rows.map(toRecord)
   }
 
+  async listClaimsForOrg(orgId: OrgId): Promise<GithubInstallationRecord[]> {
+    const rows = await this.prisma.githubInstallation.findMany({
+      where: { orgId },
+      orderBy: { accountLogin: 'asc' }
+    })
+    return rows.map(toRecord)
+  }
+
   async liveByOrgAndAccount(orgId: OrgId, accountLogin: string): Promise<GithubInstallationRecord | null> {
     const row = await this.prisma.githubInstallation.findFirst({
       // GitHub logins are case-insensitive; stored as reported, matched loosely.
@@ -97,13 +105,6 @@ export class PgGithubInstallationRepo implements GithubInstallationRepo {
   async markRevokedByInstallationId(installationId: bigint): Promise<void> {
     await this.prisma.githubInstallation.updateMany({
       where: { installationId, revokedAt: null },
-      data: { revokedAt: new Date() }
-    })
-  }
-
-  async markRevokedExcept(orgId: OrgId, liveInstallationIds: bigint[]): Promise<void> {
-    await this.prisma.githubInstallation.updateMany({
-      where: { orgId, revokedAt: null, installationId: { notIn: liveInstallationIds } },
       data: { revokedAt: new Date() }
     })
   }

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1668,6 +1668,14 @@ describe('R1/R2a persistence foundation', () => {
     const durable = await repo.get(first.id)
     expect(durable).toMatchObject({ orgId: DEFAULT_ORG_ID, accountLogin: 'acme' })
     expect(durable?.permissions).toEqual({ pull_requests: 'write', checks: 'write' })
+
+    await repo.markRevokedByInstallationId(installationId)
+    expect((await repo.listForOrg(OrgId(DEFAULT_ORG_ID))).some((row) => row.installationId === installationId)).toBe(
+      false
+    )
+    expect(await repo.listClaimsForOrg(OrgId(DEFAULT_ORG_ID))).toEqual([
+      expect.objectContaining({ installationId, orgId: DEFAULT_ORG_ID, revokedAt: expect.any(Date) })
+    ])
   })
 
   it('fences start/review/completion and drives the durable projection outbox', async () => {

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -376,8 +376,8 @@ export type RcRunReport = z.infer<typeof RcRunReport>
 // event as a minimal poke; the CP re-pulls `GET /app/installations/{id}` as the
 // source of truth (`action` is observational — the CP never writes from it).
 // Emitted ONLY after X-Hub-Signature-256 verification. A dropped doorbell is
-// safe: the pull-based sync paths (setup callback / manual Sync / mint-failure
-// markRevoked) converge eventually.
+// safe for a durable claim: the setup callback / scoped manual Sync /
+// mint-failure refresh paths converge eventually.
 export const RcGithubInstallation = z.object({
   installationId: z.string().min(1), // GitHub numeric id (BigInt as string)
   action: z.string().min(1) // created|deleted|suspend|…|added|removed

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -14,7 +14,7 @@ import { createContext, useCallback, useContext, useEffect, useState, type React
 import { SiModelcontextprotocol } from 'react-icons/si'
 import { SWRConfig, type SWRConfiguration } from 'swr'
 import Link from 'next/link'
-import { useParams, usePathname, useRouter } from 'next/navigation'
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { ConsoleDataProvider, useConsoleData } from '@/lib/data-context'
 import { OrgProvider, useOrgs, orgColor, subPath } from '@/lib/org-context'
 import { ApiError, getMyAccess, type OrgDto } from '@/lib/api'
@@ -84,6 +84,33 @@ const CONSOLE_SWR_CONFIG = {
   shouldRetryOnError: (error: unknown) =>
     !(error instanceof ApiError) || error.status === 408 || error.status === 429 || error.status >= 500
 } satisfies SWRConfiguration
+
+interface GithubCallbackNotice {
+  message: string
+  tone: 'success' | 'warning'
+}
+
+function githubCallbackNotice(code: string): GithubCallbackNotice | null {
+  if (code === 'installed') {
+    return { message: 'GitHub installation connected.', tone: 'success' }
+  }
+  if (code === 'pending-approval') {
+    return {
+      message:
+        'GitHub is waiting for an organization administrator to approve this installation. After approval, choose Install on GitHub again to finish connecting it.',
+      tone: 'warning'
+    }
+  }
+  if (code === 'retry-install') {
+    return {
+      message:
+        'AgentConnect could not verify which organization this GitHub installation belongs to. Choose Install on GitHub again to restart the connection.',
+      tone: 'warning'
+    }
+  }
+  return null
+}
+
 // The per-list-tab "+" action → which modal it opens.
 const ADD_KIND: Record<string, 'agent' | 'cron' | 'daemon'> = {
   '/agents': 'agent',
@@ -309,6 +336,7 @@ function RailAccount({
 
 function ShellChrome({ children }: { children: ReactNode }) {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const params = useParams<{ slug?: string }>()
   const { orgPath, orgs, activeOrg, setActiveOrg } = useOrgs()
   const { openModal } = useModal()
@@ -337,6 +365,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
   const [helpMenu, setHelpMenu] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
   const [connectAiOpen, setConnectAiOpen] = useState(false)
+  const [githubNotice, setGithubNotice] = useState<GithubCallbackNotice | null>(null)
   const help = resolveHelpLinks()
   // Push-screen share action: the session detail app bar surfaces a top-right link
   // icon (design) that copies the deep link; a brief check-swap confirms the copy.
@@ -452,6 +481,19 @@ function ShellChrome({ children }: { children: ReactNode }) {
     setMobileSearch(false)
     if (typeof window !== 'undefined') setLocationSearch(window.location.search)
   }, [barePath])
+
+  // The GitHub setup callback returns through the bare console entry. Wait for
+  // OrgProvider to canonicalize that entry before removing the one-shot result
+  // parameter, otherwise two competing router.replace calls can lose the org URL.
+  const githubCallback = searchParams.get('github')
+  useEffect(() => {
+    if (!activeOrg || !githubCallback) return
+    const notice = githubCallbackNotice(githubCallback)
+    if (notice) setGithubNotice(notice)
+    const next = new URLSearchParams(searchParams.toString())
+    next.delete('github')
+    router.replace(`${pathname}${next.size ? `?${next}` : ''}`, { scroll: false })
+  }, [activeOrg, githubCallback, pathname, router, searchParams])
 
   // No-auth mode has no identity and a single implicit org, so Profile / Settings
   // don't exist — bounce any direct navigation to those routes back to the home landing.
@@ -723,6 +765,37 @@ function ShellChrome({ children }: { children: ReactNode }) {
           no parent back-link, no title strip. The rail states where you are, and each
           detail view owns its own heading. Mobile still needs one — `.mtop` below. */}
           <div className="main">
+            {githubNotice && (
+              <div
+                role={githubNotice.tone === 'warning' ? 'alert' : 'status'}
+                className="fixed top-[72px] right-4 left-4 z-50 flex items-start gap-3 rounded-md border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-md) desktop:top-4 desktop:left-auto desktop:w-[460px]"
+              >
+                <Icon
+                  name={githubNotice.tone === 'success' ? 'circle-check' : 'triangle-alert'}
+                  size={16}
+                  color={githubNotice.tone === 'success' ? 'var(--status-online)' : 'var(--amber-500)'}
+                  className="mt-[1px] flex-none"
+                />
+                <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+                  {githubNotice.message}
+                </span>
+                <Link
+                  href={orgPath('/settings')}
+                  className="lnk flex-none text-[12px]"
+                  onClick={() => setGithubNotice(null)}
+                >
+                  Settings
+                </Link>
+                <button
+                  type="button"
+                  className="iconbtn -m-1 h-7 w-7 flex-none"
+                  aria-label="Dismiss GitHub installation notice"
+                  onClick={() => setGithubNotice(null)}
+                >
+                  <Icon name="x" size={14} />
+                </button>
+              </div>
+            )}
             {/* ===== MOBILE APP BAR (hidden ≥ tablet) — list-tab vs push variant ===== */}
             <header className="mtop">
               {isListRoute ? (

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -856,9 +856,9 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
   // "Manage access" lands on the App's ACCOUNT CHOOSER (installations/new): every
   // account is listed — already-installed ones open their repo-selection config,
-  // and a fresh org can be installed from the same page (an AgentConnect org can
-  // attach several GitHub orgs; Sync claims them all). Same one-shot link as the
-  // install button.
+  // and a fresh org can be installed from the same page. The signed setup callback
+  // binds each new installation to this AgentConnect org. Same one-shot link as
+  // the install button.
   const manageGithubAccess = installGithubApp
 
   const modeHint =

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -1468,8 +1468,8 @@ function GithubCard({ canWrite, isOwner }: { canWrite: boolean; isOwner: boolean
     }
   }
 
-  // Reconcile with GitHub — the fallback for a lost setup callback, a pending
-  // admin approval, or an install finished in the other tab just now.
+  // Refresh the org's claimed installations after GitHub changes or an install
+  // finished in the other tab just now.
   const sync = async () => {
     if (busy) return
     setBusy(true)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3769,8 +3769,8 @@ export async function fetchGithubInstallUrl(): Promise<string | null> {
   }
 }
 
-/** Reconcile claims against GitHub — the fallback for a lost setup callback /
- *  pending admin approval. Returns the refreshed list. */
+/** Refresh the organization's existing claims from GitHub. Unknown App-wide
+ * installations are never assigned by this endpoint. */
 export async function syncGithubInstallations(): Promise<GithubInstallationDto[]> {
   const installations = await apiPost<GithubInstallationDto[]>(`${orgBase()}/github/installations/sync`, {})
   invalidateGithubRepoRosterCache()


### PR DESCRIPTION
## Summary

- refresh only durable GitHub installation claims already owned by the calling AgentConnect organization
- preserve revoked claims for safe recovery while preventing Sync from discovering or claiming deployment-global installations
- make missing, invalid, pending-approval, and conflicting setup callbacks recover with actionable console notices
- update the GitHub installation design and protocol comments to match the tenant-bound claim flow

## Root cause

`POST /v1/orgs/:orgId/github/installations/sync` read the GitHub App's deployment-global `GET /app/installations` roster, then attempted to upsert every installation under the path organization. The repository correctly rejected an installation already claimed by another organization with `GITHUB_INSTALLATION_CLAIM_CONFLICT`, but the route surfaced that domain error as HTTP 500.

## Behavior after this change

Sync fetches each durable installation ID already bound to the calling organization. Live installations are refreshed, missing installations are marked revoked, and unknown or foreign installations are never claimed. New claims are created only through the signed, one-time setup callback.

## Validation

- control-plane unit suite: 110 files, 963 tests passed
- web suite: 81 files, 598 tests passed
- focused Postgres integration ownership test passed
- control-plane and web typechecks passed
- changed-file ESLint and full repository Prettier check passed
- pre-push full ESLint passed

Created by Codex . GPT-5.6
