### PR TITLE
fix(web): keep GitHub recovery actionable without auth

### DIFF
--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -779,13 +779,26 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 <span className="min-w-0 flex-1 font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
                   {githubNotice.message}
                 </span>
-                <Link
-                  href={orgPath('/settings')}
-                  className="lnk flex-none text-[12px]"
-                  onClick={() => setGithubNotice(null)}
-                >
-                  Settings
-                </Link>
+                {authOn ? (
+                  <Link
+                    href={orgPath('/settings')}
+                    className="lnk flex-none text-[12px]"
+                    onClick={() => setGithubNotice(null)}
+                  >
+                    Settings
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    className="lnk flex-none text-[12px]"
+                    onClick={() => {
+                      setGithubNotice(null)
+                      openModal('agent')
+                    }}
+                  >
+                    Add agent
+                  </button>
+                )}
                 <button
                   type="button"
                   className="iconbtn -m-1 h-7 w-7 flex-none"


### PR DESCRIPTION
## Summary

- keep the GitHub setup-callback recovery notice linked to Settings when authentication is configured
- open Add Agent directly in supported no-auth mode, where Settings is intentionally unavailable

## Context

Follow-up to #425 and its exact-head review feedback. The original notice always linked to Settings, but the no-auth console redirects that route to Home. This keeps the recovery action usable in both deployment modes.

## Validation

- web suite: 81 files, 598 tests passed
- web typecheck passed
- focused Shell ESLint and Prettier checks passed
- pre-push full ESLint passed

Created by Codex . GPT-5.6
