### PR TITLE
feat(auth): support Lark and Feishu profile linking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,9 +141,9 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # Static bearer token (CI/service). Leave unset when the CP runs the devAuth stub.
 # NEXT_PUBLIC_CP_TOKEN=
 # Social login via Logto (opt-in). Login and Profile share one static
-# GitHub/Google/Slack provider list. Set ENDPOINT + APP_ID to enable it; unset ⇒
-# no-auth (the login buttons just enter the app). Add matching `github`, `google`,
-# and `slack` social connectors inside Logto.
+# social-provider list. Set ENDPOINT + APP_ID to enable it; unset ⇒
+# no-auth (the login buttons just enter the app). Add a matching Logto social
+# connector for every target selected below.
 # Register `https://<console-origin>/auth/callback` on the Logto SPA app.
 # To show and link social accounts in AgentConnect's Profile UI, enable Logto's
 # Account API and give Social identities `Edit` access. Linking uses the current
@@ -163,12 +163,12 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # OIDC_AUDIENCE to the app id then). Must equal the CP's OIDC_AUDIENCE.
 # NEXT_PUBLIC_LOGTO_API_RESOURCE=https://api.example.com
 # Which social sign-in methods the console offers, as comma-separated Logto
-# connector targets. Available: github, google, slack. Unset or `*` => all of
-# them; the example below narrows it to one. Set this to match the connectors
-# your tenant actually has, so nobody is offered a button that lands on Logto's
-# error page. Read by the console only — the CP does not gate on it, so there is
-# one place this decision lives; what it permits in the end is whether your
-# tenant has that connector configured.
+# connector targets. Available: github, google, slack, lark, feishu. Unset keeps
+# github, google, and slack; `*` opts into the whole catalog. Set this to match
+# the connectors your tenant actually has, so nobody is offered a button that
+# lands on Logto's error page. Read by the console only — the CP does not gate
+# on it, so there is one place this decision lives; what it permits in the end
+# is whether your tenant has that connector configured.
 # SOCIAL_PROVIDERS=github
 
 # Rail-footer Help menu links. Unset ⇒ the agentconnect.md defaults; override to

--- a/compose.env.example
+++ b/compose.env.example
@@ -48,10 +48,10 @@
 # LOGTO_APP_ID=
 # LOGTO_API_RESOURCE=https://api.example.com
 # Which social sign-in methods the console offers, as comma-separated Logto
-# connector targets. Available: github, google, slack. Unset or `*` => all of
-# them; the example below narrows it to one. Set this to match the connectors
-# your tenant actually has, so nobody is offered a button that lands on Logto's
-# error page.
+# connector targets. Available: github, google, slack, lark, feishu. Unset keeps
+# github, google, and slack; `*` opts into the whole catalog. Set this to match
+# the connectors your tenant actually has, so nobody is offered a button that
+# lands on Logto's error page.
 # SOCIAL_PROVIDERS=github
 # OIDC_ISSUER=https://tenant.example.com/oidc
 # OIDC_AUDIENCE=https://api.example.com

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -583,13 +583,19 @@ login from Logto and asks GitHub for that user's current effective repository
 permission. AgentConnect stores neither the GitHub login nor a copied provider
 ACL; only bounded allow/deny/error verdicts are cached in process.
 
-**Other platforms (future, separate design).** Telegram/Discord/Feishu have no
-OIDC sign-in to piggyback on, so they need a `UserIdentity` table (`userId`,
-`platform`, `workspace`, `platformUserId`, verified-at, unique on the
-`(platform, workspace, platformUserId)` tuple — matching the three-part
-identity format of §2) populated by an explicit link flow (e.g. the bot DMs a
-code, the user pastes it in the console). Once it exists, the same identity-set
-computation reads it; the Slack read-through can fold into that table then.
+**Other platform session access (future, separate design).** A user may link a
+Lark or Feishu social identity through a configured Logto connector. Feishu uses
+Logto's built-in connector; Lark uses its generic OAuth connector pointed at the
+Lark passport endpoints. That alone cannot authorize messaging sessions: the
+message-side `open_id` is scoped to one app, and the social connector may be a
+different app. Telegram, Discord, Lark, and Feishu therefore still need an
+explicit verified binding before their identities can enter the session identity
+set. One option is a `UserIdentity`
+table (`userId`, `platform`, `workspace`, `platformUserId`, verified-at, unique
+on the `(platform, workspace, platformUserId)` tuple — matching the three-part
+identity format of §2) populated by a bot-mediated code flow. Once it exists,
+the same identity-set computation reads it; the Slack read-through can fold
+into that table then.
 
 ## 8. Share-by-link (future, separate design)
 

--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -14,6 +14,7 @@ export const AGENTCONNECT_FEISHU_SCOPES = [
   'contact:user.base:readonly',
   'im:chat:read',
   'im:chat.members:bot_access',
+  'im:chat.members:read',
   'im:message',
   'im:message.group_at_msg:readonly',
   'im:message.p2p_msg:readonly',

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -134,9 +134,9 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
     const r = app.withTypeProvider<ZodTypeProvider>()
     // Shape only. WHICH methods a deployment offers is the console's call
     // (SOCIAL_PROVIDERS, web lib/social-login-providers) and duplicating that
-    // decision here is what made the two sides disagree: the console falls back
-    // to its full catalog on an unrecognizable setting, and any second
-    // implementation of that rule drifts from it. The real gate is the tenant —
+    // decision here is what made the two sides disagree: the console owns its
+    // safe fallback for an unrecognizable setting, and any second implementation
+    // of that rule drifts from it. The real gate is the tenant —
     // socialConnectorIdFor 404s unless the admin configured that connector — so
     // this route can never reject a method the console legitimately offers.
     const SocialTarget = z

--- a/packages/control-plane/test/integration/feishu-registration.route.test.ts
+++ b/packages/control-plane/test/integration/feishu-registration.route.test.ts
@@ -173,7 +173,7 @@ describe('Feishu/Lark one-click app registration', () => {
     })
     expect(addons).toMatchObject({
       scopes: {
-        tenant: expect.arrayContaining(['application:application:patch'])
+        tenant: expect.arrayContaining(['application:application:patch', 'im:chat.members:read'])
       }
     })
     await first.close()

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -91,6 +91,7 @@ function button(label: string): HTMLButtonElement | undefined {
 
 beforeEach(() => {
   sessionStorage.clear()
+  window.__AC_ENV = {}
   vi.mocked(fetchMySocialAccount).mockReset()
   mocks.requestEmailVerification.mockReset()
   vi.mocked(resolveMySocialConnectorId).mockReset()
@@ -105,6 +106,20 @@ afterEach(async () => {
 })
 
 describe('SocialSignInCard account state', () => {
+  it('offers configured Lark and Feishu identities through the shared link flow', async () => {
+    window.__AC_ENV = { SOCIAL_PROVIDERS: 'lark,feishu' }
+    vi.mocked(fetchMySocialAccount).mockResolvedValue({ identities: [], hasSecurityVerificationMethod: false })
+
+    await renderCard()
+    await waitUntil(() => container?.textContent?.includes('Not linked') === true)
+
+    expect(container?.textContent).toContain('Lark')
+    expect(container?.textContent).toContain('Feishu')
+    expect(
+      Array.from(container?.querySelectorAll('button') ?? []).filter((item) => item.textContent === 'Link')
+    ).toHaveLength(2)
+  })
+
   it('keeps a failed request idle and marks an explicit Retry as busy', async () => {
     vi.mocked(fetchMySocialAccount)
       .mockRejectedValueOnce(new LogtoAccountError('Unavailable', 500))

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -16,6 +16,8 @@ import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import type { SocialLoginTarget } from '@/lib/social-login-providers'
 
 const fill = { width: '60%', height: '60%', display: 'block' } as const
+const larkBrandClasses =
+  '[&_path:nth-child(1)]:stroke-[#3370FF] [&_path:nth-child(2)]:fill-[#00D6B9] [&_path:nth-child(3)]:stroke-[#133C9A]'
 
 // Dark-mode treatment for the brand logos we can only load as an <img> (ACP registry
 // / lobehub SVGs, so no per-path recoloring): most are `currentColor`-black and have
@@ -252,14 +254,7 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
     return <SiDiscord style={s} color="#5865F2" aria-hidden />
   }
   if (x.includes('feishu') || x.includes('lark')) {
-    return (
-      <IconifyIcon
-        icon={newLarkIcon}
-        style={s}
-        className="[&_path:nth-child(1)]:stroke-[#3370FF] [&_path:nth-child(2)]:fill-[#00D6B9] [&_path:nth-child(3)]:stroke-[#133C9A]"
-        aria-hidden
-      />
-    )
+    return <IconifyIcon icon={newLarkIcon} style={s} className={larkBrandClasses} aria-hidden />
   }
   if (x.includes('slack')) {
     return <IconifyIcon icon={slackIcon} style={s} aria-hidden />
@@ -282,6 +277,15 @@ export function SocialLoginMark({ target, size }: { target: SocialLoginTarget; s
   if (target === 'github') return <SiGithub size={size} aria-hidden />
   if (target === 'slack')
     return <IconifyIcon icon={slackIcon} {...(size ? { width: size, height: size } : {})} aria-hidden />
+  if (target === 'lark' || target === 'feishu')
+    return (
+      <IconifyIcon
+        icon={newLarkIcon}
+        className={larkBrandClasses}
+        {...(size ? { width: size, height: size } : {})}
+        aria-hidden
+      />
+    )
   return <FcGoogle size={size} aria-hidden />
 }
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 // Logto auth for the console (opt-in). When the Logto endpoint + app id are set,
-// "Continue with GitHub/Google/Slack" runs a real Authorization-Code + PKCE sign-in
+// "Continue with …" runs a real Authorization-Code + PKCE social sign-in
 // against Logto and the console sends the resulting bearer token to the Control
 // Plane. When UNSET, auth is disabled and the app stays in the CP's zero-config
 // no-auth mode (the buttons just enter the app) — the default for OSS self-hosters.
@@ -9,9 +9,9 @@
 // at any tenant via plain container env — no rebuild. The NEXT_PUBLIC_* statics
 // remain a build-time fallback for local dev (.env.local) and SSR.
 //
-// The supported provider targets (GitHub/Google/Slack) are a shared static UI list;
-// their credentials and connectors remain configured inside Logto. The buttons
-// use Logto's `direct_sign_in` to jump straight to a connector.
+// Supported provider targets are a shared static UI list; their credentials and
+// connectors remain configured inside Logto. The buttons use Logto's
+// `direct_sign_in` to jump straight to a connector.
 //
 // Token audience: the CP is an OIDC resource server, so it needs a JWT access
 // token scoped to an API *resource*. Set the Logto API resource indicator and

--- a/packages/web/src/lib/social-login-providers.test.ts
+++ b/packages/web/src/lib/social-login-providers.test.ts
@@ -4,18 +4,18 @@ import { SOCIAL_LOGIN_CATALOG, parseEnabledTargets, selectEnabledProviders } fro
 const targets = (raw: string | undefined) => selectEnabledProviders(raw).map((p) => p.target)
 
 describe('social login provider selection', () => {
-  it('offers the whole catalog when nothing is configured', () => {
-    // The OSS default: a deployment that says nothing gets today's behavior.
-    expect(parseEnabledTargets(undefined)).toBeNull()
-    expect(targets(undefined)).toEqual(SOCIAL_LOGIN_CATALOG.map((p) => p.target))
+  it('keeps the original providers by default and requires an explicit wildcard for the whole catalog', () => {
+    expect(parseEnabledTargets(undefined)).toEqual(new Set(['github', 'google', 'slack']))
+    expect(targets(undefined)).toEqual(['github', 'google', 'slack'])
     expect(targets('*')).toEqual(SOCIAL_LOGIN_CATALOG.map((p) => p.target))
-    expect(targets('   ')).toEqual(SOCIAL_LOGIN_CATALOG.map((p) => p.target))
+    expect(targets('   ')).toEqual(['github', 'google', 'slack'])
   })
 
   it('narrows to the configured targets, in catalog order', () => {
     // Order comes from the catalog, not from however the variable was written.
     expect(targets('slack,github')).toEqual(['github', 'slack'])
     expect(targets(' google , slack ')).toEqual(['google', 'slack'])
+    expect(targets('feishu,lark')).toEqual(['lark', 'feishu'])
     expect(targets('github')).toEqual(['github'])
   })
 
@@ -23,17 +23,17 @@ describe('social login provider selection', () => {
     expect(targets('github,facebook')).toEqual(['github'])
   })
 
-  it('falls back to the catalog when the setting names nothing usable', () => {
+  it('falls back to the original providers when the setting names nothing usable', () => {
     // Leaving the sign-in page with zero ways in is worse than ignoring a typo.
-    expect(targets('facebook')).toEqual(SOCIAL_LOGIN_CATALOG.map((p) => p.target))
-    expect(targets(',,')).toEqual(SOCIAL_LOGIN_CATALOG.map((p) => p.target))
+    expect(targets('facebook')).toEqual(['github', 'google', 'slack'])
+    expect(targets(',,')).toEqual(['github', 'google', 'slack'])
   })
 
   // The invariant this variable exists for: whatever the console offers must be
   // linkable. The CP deliberately does NOT re-derive this set -- it accepts any
   // connector slug and lets the tenant's connector list be the gate -- so no
   // second implementation of these rules can drift from these vectors.
-  it.each(['github,google,slack', 'slack', 'facebook', '', '*', 'github,facebook', undefined])(
+  it.each(['github,google,slack', 'lark,feishu', 'slack', 'facebook', '', '*', 'github,facebook', undefined])(
     'only ever offers targets the catalog can render (%s)',
     (raw) => {
       const offered = selectEnabledProviders(raw).map((p) => p.target)

--- a/packages/web/src/lib/social-login-providers.ts
+++ b/packages/web/src/lib/social-login-providers.ts
@@ -15,31 +15,38 @@
 // in `window.__AC_ENV` (see lib/public-env), so it costs no request and cannot
 // flash the wrong buttons on first paint. Querying the tenant would cost both.
 //
-// Unset or `*` ⇒ the whole catalog, matching the CP's own list conventions (see
-// control-plane connectors/filter.ts#parseWhitelist). A target whose connector
-// the tenant has not configured lands the user on Logto's error page, so a
-// deployment offering fewer should say so here.
+// Unset keeps the original GitHub / Google / Slack set. New providers are
+// opt-in because adding one to this catalog must not make an upgraded deployment
+// offer a button for a connector its Logto tenant does not have. `*` explicitly
+// opts into the whole catalog. A target whose connector the tenant has not
+// configured lands the user on Logto's error page, so deployments should name
+// exactly the connectors they offer.
 
 /** Every target this console can render. Order is display order. */
 export const SOCIAL_LOGIN_CATALOG = [
   { target: 'github', name: 'GitHub' },
   { target: 'google', name: 'Google' },
-  { target: 'slack', name: 'Slack' }
+  { target: 'slack', name: 'Slack' },
+  { target: 'lark', name: 'Lark' },
+  { target: 'feishu', name: 'Feishu' }
 ] as const
 
 export type SocialLoginProvider = (typeof SOCIAL_LOGIN_CATALOG)[number]
 /** Any target the catalog knows — independent of what a deployment enables. */
 export type SocialLoginTarget = SocialLoginProvider['target']
 
-/** Parse the configured target list. Unset / blank / `*` ⇒ null (no restriction). */
+const DEFAULT_SOCIAL_LOGIN_TARGETS = new Set<SocialLoginTarget>(['github', 'google', 'slack'])
+
+/** Parse the configured target list. Unset / blank ⇒ legacy defaults; `*` ⇒ all. */
 export function parseEnabledTargets(raw: string | undefined): Set<string> | null {
   const trimmed = raw?.trim()
-  if (!trimmed || trimmed === '*') return null
+  if (!trimmed) return new Set(DEFAULT_SOCIAL_LOGIN_TARGETS)
+  if (trimmed === '*') return null
   const entries = trimmed
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean)
-  return entries.length > 0 ? new Set(entries) : null
+  return entries.length > 0 ? new Set(entries) : new Set(DEFAULT_SOCIAL_LOGIN_TARGETS)
 }
 
 /** Catalog entries this deployment offers, in catalog order. */
@@ -48,8 +55,11 @@ export function selectEnabledProviders(raw: string | undefined): readonly Social
   if (!enabled) return SOCIAL_LOGIN_CATALOG
   const selected = SOCIAL_LOGIN_CATALOG.filter((provider) => enabled.has(provider.target))
   // A value naming only unknown targets would otherwise leave the sign-in page
-  // with no way in at all; the full catalog is the safer reading of a typo.
-  return selected.length > 0 ? selected : SOCIAL_LOGIN_CATALOG
+  // with no way in at all; retain the pre-Lark/Feishu defaults without assuming
+  // that the tenant has either newly supported connector.
+  return selected.length > 0
+    ? selected
+    : SOCIAL_LOGIN_CATALOG.filter((provider) => DEFAULT_SOCIAL_LOGIN_TARGETS.has(provider.target))
 }
 
 /** The providers to render. Reads the runtime config the server inlined. */


### PR DESCRIPTION
## Summary

- add opt-in `lark` and `feishu` targets to the shared social sign-in catalog used by Login and Profile
- reuse the existing Account API Link/Unlink flow and the existing colored Lark brand mark
- preserve the pre-existing GitHub, Google, and Slack default unless a deployment explicitly selects the new targets or `*`
- document Feishu through Logto's built-in connector and Lark through Logto's generic OAuth 2.0 connector with the international passport endpoints
- clarify that linking Lark or Feishu is a sign-in method only and does not authorize messaging sessions
- add `im:chat.members:read` to the one-click Feishu/Lark messaging app template so apps created now are permission-ready for planned provider-backed session visibility sync; this PR prepares the app permission but does not implement the sync

## Safety

The Control Plane still resolves connector targets generically and remains the only side that can discover connector ids. The built-in Feishu connector cannot be reused with Lark credentials because it calls Feishu endpoints; Lark uses a separate generic OAuth connector whose identity provider name is `lark`. This change does not add either identity to session authorization, because messaging `open_id` values are app-scoped and may come from a different app.

Separately, `im:chat.members:read` is a tenant-facing permission expansion for apps created from the AgentConnect Feishu/Lark template. It is needed so the messaging integration can later read chat membership and synchronize session visibility in the same way provider membership underpins Slack visibility. Current code does not call the member-list API and does not change session authorization behavior. Existing apps are not modified automatically; they will still need this permission added and authorized before permission sync is enabled.

## Validation

- focused Web tests: 2 files, 18 tests passed
- focused Control Plane Feishu registration integration test: 1 file, 9 tests passed
- Web typecheck
- Web production build with `SOCIAL_PROVIDERS=*`
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint
- desktop and 390 x 844 visual QA; all five providers fit without overflow
- inspected the current Logto Feishu and generic OAuth connector implementations and verified the corresponding Lark passport routes respond with the same OAuth error shape

No real Lark or Feishu application credentials were used, so the credential-bound provider round trip remains a deployment smoke test.

Created by Codex . GPT-5.6-sol
