### PR TITLE
feat(cp,web): grouped conversations list — merged-conversation-view C1

### DIFF
--- a/packages/control-plane/prisma/migrations/20260803000000_session_tenant_scope_conversation_index/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260803000000_session_tenant_scope_conversation_index/migration.sql
@@ -1,0 +1,11 @@
+-- Conversation grouping (merged-conversation-view.md §5.1/§5.2):
+-- persist the durable workspace/tenant scope on session rows and index the
+-- conversation key for the emit-at-max probe + member backfill/resolver.
+ALTER TABLE "session_meta" ADD COLUMN "tenantScope" TEXT;
+
+DROP INDEX "session_meta_platform_channel_idx";
+
+CREATE INDEX "session_meta_conversation_key_idx" ON "session_meta"(
+  "orgId" ASC, "platform" ASC, "tenantScope" ASC, "channel" ASC, "thread" ASC,
+  "lastActivityAt" DESC, "startedAt" DESC, "id" DESC
+);

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -867,6 +867,11 @@ model SessionMeta {
   platform            String? // denormalized sessionKey echo for dashboard filters (free string so webchat can be listed)
   channel             String?
   thread              String?
+  // Durable workspace/tenant scope (EventSession.transportScope — a Slack team
+  // id, Feishu tenant key, or stable per-integration mint), persisted so the
+  // conversation grouping key (merged-conversation-view.md §5.1) can tell
+  // installations apart. NOT the daemon's credential-derived transport scope.
+  tenantScope         String?
   phase               SessionPhase        @default(start)
   link                String? // deep-link (NOT a body)
   summary             String?             @db.Text // short milestone text (NOT the stream)
@@ -932,7 +937,10 @@ model SessionMeta {
   @@index([agentId, triggeredBy, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_agent_trigger_page_idx")
   @@index([orgId, visibility, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_org_visibility_page_idx")
   @@index([parentSessionId])
-  @@index([platform, channel])
+  // Conversation grouping (merged-conversation-view.md §5.2): serves the
+  // emit-at-max exists-newer probe, the member backfill, and the
+  // conversationKey resolver. Replaces the unused bare (platform, channel).
+  @@index([orgId, platform, tenantScope, channel, thread, lastActivityAt(sort: Desc), startedAt(sort: Desc), id(sort: Desc)], map: "session_meta_conversation_key_idx")
   @@index([launchId])
   @@index([daemonId])
   @@index([orgId, externalProvider, externalScopeId])

--- a/packages/control-plane/src/http/conversation-key.test.ts
+++ b/packages/control-plane/src/http/conversation-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { decodeConversationKey, encodeConversationKey } from './conversation-key.js'
+
+describe('conversation key codec', () => {
+  it('round-trips an IM key with and without a tenant scope', () => {
+    const scoped = { platform: 'slack', tenantScope: 'T024BE7LD', channel: 'C123', thread: '1754123456.000200' }
+    const encoded = encodeConversationKey(scoped)!
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/) // base64url, path/query safe
+    expect(decodeConversationKey(encoded)).toEqual(scoped)
+
+    const unscoped = { platform: 'slack', tenantScope: null, channel: 'C123', thread: 'C123' }
+    expect(decodeConversationKey(encodeConversationKey(unscoped)!)).toEqual(unscoped)
+  })
+
+  it('uses the bare conversation id for webchat', () => {
+    const id = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
+    const key = { platform: 'webchat', tenantScope: null, channel: id, thread: id }
+    expect(encodeConversationKey(key)).toBe(id)
+    expect(decodeConversationKey(id)).toEqual(key)
+  })
+
+  it('never encodes singletons and rejects garbage', () => {
+    expect(encodeConversationKey({ platform: 'hook', tenantScope: null, channel: null, thread: null })).toBeNull()
+    expect(encodeConversationKey({ platform: 'slack', tenantScope: null, channel: 'C1', thread: null })).toBeNull()
+    expect(decodeConversationKey('!!!not-a-key!!!')).toBeNull()
+    expect(decodeConversationKey(Buffer.from('only two').toString('base64url'))).toBeNull()
+  })
+})

--- a/packages/control-plane/src/http/conversation-key.ts
+++ b/packages/control-plane/src/http/conversation-key.ts
@@ -1,0 +1,32 @@
+import type { ConversationKey } from '../persistence/ports.js'
+
+/**
+ * Conversation key codec (merged-conversation-view.md §5.1).
+ *
+ * - Webchat: the bare conversation id (a CP-minted UUID; the session row's
+ *   `channel` == `thread` == the conversation id).
+ * - Everything else: base64url of `platform NUL tenantScope NUL channel NUL
+ *   thread` — NUL can appear in none of the parts, and base64url keeps the key
+ *   path/query safe.
+ *
+ * Singleton conversations (NULL channel or thread) are not key-addressable;
+ * `encode` returns null for them and callers use the ordinary session routes.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const SEP = '\u0000'
+
+export function encodeConversationKey(key: ConversationKey): string | null {
+  if (key.channel === null || key.thread === null) return null
+  if (key.platform === 'webchat') return key.channel
+  return Buffer.from([key.platform, key.tenantScope ?? '', key.channel, key.thread].join(SEP), 'utf8').toString(
+    'base64url'
+  )
+}
+
+export function decodeConversationKey(raw: string): ConversationKey | null {
+  if (UUID_RE.test(raw)) return { platform: 'webchat', tenantScope: null, channel: raw, thread: raw }
+  const decoded = Buffer.from(raw, 'base64url').toString('utf8')
+  const parts = decoded.split(SEP)
+  if (parts.length !== 4 || !parts[0] || !parts[2] || !parts[3]) return null
+  return { platform: parts[0]!, tenantScope: parts[1]! || null, channel: parts[2]!, thread: parts[3]! }
+}

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2365,9 +2365,28 @@ export const SessionFacetsDto = z.object({
     })
   )
 })
+/** One grouped-list row (merged-conversation-view.md §5.2): a conversation and
+ *  its current member sessions. */
+export const ConversationDto = z.object({
+  /** §5.1 encoded key — null for singleton conversations (no groupable
+   *  channel/thread), which are not key-addressable. */
+  key: z.string().nullable(),
+  platform: z.string().nullable(),
+  channel: z.string().nullable(),
+  thread: z.string().nullable(),
+  /** Current member sessions, representative (the caller's newest visible
+   *  member) first, one row per agent. Singleton conversations carry exactly
+   *  one session; its row renders like the flat list's. */
+  sessions: SessionListDto
+})
+
 export const SessionListPageDto = z.object({
-  sessions: SessionListDto,
+  /** `view=flat`: the raw session rows (the pre-grouped list shape). */
+  sessions: SessionListDto.optional(),
+  /** Default (grouped) view: one row per conversation, newest-first. */
+  conversations: z.array(ConversationDto).optional(),
   // Counting is skipped on cursor pages; the first page remains authoritative.
+  // Grouped pages count conversations, flat pages count session rows.
   total: z.number().int().nonnegative().nullable(),
   nextCursor: z.string().nullable(),
   // Org-level "any session exists" boolean (first page only) — deliberately a bare

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -17,6 +17,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
 import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf, denyNonOwner } from '../rbac.js'
+import { decodeConversationKey, encodeConversationKey } from '../conversation-key.js'
 import { canChangeSessionVisibility, canView, canViewSession } from '../../authorization/policy.js'
 import { makeSessionAccessResolver } from '../session-access.js'
 import { Tag } from '../plugins/openapi.js'
@@ -51,7 +52,13 @@ const SessionFilterQueryDto = z.object({
 
 const SessionQueryDto = SessionFilterQueryDto.extend({
   cursor: z.string().optional(),
-  limit: z.coerce.number().int().positive().max(200).default(50)
+  limit: z.coerce.number().int().positive().max(200).default(50),
+  // merged-conversation-view.md §5.2: the grouped list is the DEFAULT response
+  // shape; `view=flat` returns the raw session rows (the pre-grouped shape).
+  view: z.enum(['grouped', 'flat']).default('grouped'),
+  // §5.2 key-addressed member resolver: resolves one conversation's current
+  // visible member sessions without paging the grouped list.
+  conversationKey: z.string().min(1).max(512).optional()
 })
 
 type SessionCursor = { activityMs: number; startedMs: number; id: string }
@@ -439,16 +446,25 @@ export function sessionRoutes(deps: HttpDeps) {
           tags: [Tag.Sessions],
           summary: 'List sessions',
           description:
-            'Lists CP-stored session metadata synced by daemon event/session snapshots; transcript bodies remain daemon-local.',
+            'Lists CP-stored session metadata synced by daemon event/session snapshots; transcript bodies remain ' +
+            'daemon-local. Returns one row per CONVERSATION by default (merged-conversation-view.md §5.2) — sessions ' +
+            'sharing a thread group into `conversations`, each carrying its current member sessions. `view=flat` ' +
+            'returns the raw `sessions` rows (the pre-grouped shape); `conversationKey` resolves one conversation’s ' +
+            'members directly.',
           operationId: 'listSessions',
           querystring: SessionQueryDto,
           response: { 200: SessionListPageDto, 400: ErrorDto }
         }
       },
       async (req, reply) => {
+        const grouped = req.query.view !== 'flat'
         const cursor = req.query.cursor ? decodeSessionCursor(req.query.cursor) : undefined
         if (req.query.cursor && !cursor) {
           return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'invalid session cursor' })
+        }
+        const conversationKey = req.query.conversationKey ? decodeConversationKey(req.query.conversationKey) : undefined
+        if (req.query.conversationKey && (!conversationKey || conversationKey.channel === null)) {
+          return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: 'invalid conversation key' })
         }
 
         // The set of agents THIS caller may see under the resource policy. Roles
@@ -465,10 +481,10 @@ export function sessionRoutes(deps: HttpDeps) {
         // FULL org — including sessions the caller can't see — which is safe precisely
         // because it is a bare boolean; the getting-started conversation step derives
         // from it so a collaborator in an active org isn't asked to run a redundant chat.
-        const orgHasSessions = cursor ? undefined : await deps.repos.session.orgHasAny(orgOf(req))
+        const orgHasSessions = cursor || conversationKey ? undefined : await deps.repos.session.orgHasAny(orgOf(req))
         if (selectedAgentIds.length === 0) {
           return {
-            sessions: [],
+            ...(grouped || conversationKey ? { conversations: [] } : { sessions: [] }),
             total: cursor ? null : 0,
             nextCursor: null,
             ...(orgHasSessions !== undefined ? { orgHasSessions } : {})
@@ -491,12 +507,62 @@ export function sessionRoutes(deps: HttpDeps) {
           includeTotal: !cursor
         }
         const { viewer, access } = await viewerForQuery(req, query)
-        const page = await deps.repos.session.listPage({ ...query, viewer })
-        const hookMetadata = await hookMetadataForSessions(deps, page.sessions, orgOf(req))
-        const nextCursor = page.hasMore ? encodeSessionCursor(page.sessions[page.sessions.length - 1]!) : null
 
+        // §5.2 key-addressed resolver: a bounded metadata-only member lookup for
+        // a direct conversation load — the paginated list is not a key lookup.
+        if (conversationKey) {
+          const members = await deps.repos.session.listConversationMembers(
+            { agentIds: selectedAgentIds, viewer },
+            conversationKey
+          )
+          const hookMetadata = await hookMetadataForSessions(deps, members, orgOf(req))
+          return {
+            conversations:
+              members.length > 0
+                ? [
+                    {
+                      key: encodeConversationKey(conversationKey),
+                      platform: conversationKey.platform,
+                      channel: conversationKey.channel,
+                      thread: conversationKey.thread,
+                      sessions: members.map((session) => sessionDto(session, hookMetadata))
+                    }
+                  ]
+                : [],
+            total: members.length > 0 ? 1 : 0,
+            nextCursor: null,
+            accessSyncDegraded: access.degraded
+          }
+        }
+
+        if (!grouped) {
+          const page = await deps.repos.session.listPage({ ...query, viewer })
+          const hookMetadata = await hookMetadataForSessions(deps, page.sessions, orgOf(req))
+          const nextCursor = page.hasMore ? encodeSessionCursor(page.sessions[page.sessions.length - 1]!) : null
+          return {
+            sessions: page.sessions.map((session) => sessionDto(session, hookMetadata)),
+            total: page.total,
+            nextCursor,
+            accessSyncDegraded: access.degraded,
+            ...(orgHasSessions !== undefined ? { orgHasSessions } : {})
+          }
+        }
+
+        const page = await deps.repos.session.listConversationPage({ ...query, viewer })
+        const allRows = page.conversations.flatMap((c) => c.sessions)
+        const hookMetadata = await hookMetadataForSessions(deps, allRows, orgOf(req))
+        // The grouped cursor is the last conversation's REPRESENTATIVE row —
+        // emit-at-max makes resumption stateless (§5.2).
+        const lastRep = page.conversations[page.conversations.length - 1]?.sessions[0]
+        const nextCursor = page.hasMore && lastRep ? encodeSessionCursor(lastRep) : null
         return {
-          sessions: page.sessions.map((session) => sessionDto(session, hookMetadata)),
+          conversations: page.conversations.map((c) => ({
+            key: encodeConversationKey(c.key),
+            platform: c.key.platform,
+            channel: c.key.channel,
+            thread: c.key.thread,
+            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata))
+          })),
           total: page.total,
           nextCursor,
           accessSyncDegraded: access.degraded,

--- a/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
@@ -69,6 +69,7 @@ function slackDmSession() {
 
 function fakeDeps(overrides: { slackIdentityFor?: () => Promise<{ teamId: string; userId: string } | null> }) {
   const listPage = vi.fn(async () => ({ sessions: [], total: 0, hasMore: false }))
+  const listConversationPage = vi.fn(async () => ({ conversations: [], total: 0, hasMore: false }))
   const deps = {
     repos: {
       agent: {
@@ -82,6 +83,7 @@ function fakeDeps(overrides: { slackIdentityFor?: () => Promise<{ teamId: string
         getExternalScopes: vi.fn(async () => []),
         getExternalAccessPolicy: vi.fn(async () => null),
         listPage,
+        listConversationPage,
         listChildren: vi.fn(async () => []),
         listFacets: vi.fn(async () => ({ agents: [], integrations: [], channels: [], triggers: [] }))
       },
@@ -91,7 +93,7 @@ function fakeDeps(overrides: { slackIdentityFor?: () => Promise<{ teamId: string
     clock: { now: () => Date.now() },
     ...(overrides.slackIdentityFor ? { logtoIdentity: { slackIdentityFor: overrides.slackIdentityFor } } : {})
   } as unknown as HttpDeps
-  return { deps, listPage }
+  return { deps, listPage, listConversationPage }
 }
 
 async function appAs(deps: HttpDeps, caller: { userId: string; oidcSubject?: string }): Promise<FastifyInstance> {
@@ -110,13 +112,24 @@ async function appAs(deps: HttpDeps, caller: { userId: string; oidcSubject?: str
 
 describe('session routes × viewer identity', () => {
   it('feeds the linked Slack identity into the list projection viewer', async () => {
-    const { deps, listPage } = fakeDeps({
+    const { deps, listPage, listConversationPage } = fakeDeps({
       slackIdentityFor: async () => ({ teamId: 'T024BE7LD', userId: 'U0123ABCD' })
     })
     const app = await appAs(deps, { userId: 'u-1', oidcSubject: 'logto-sub' })
     try {
+      // Default (grouped) view and the flat escape hatch feed the SAME viewer.
       const res = await app.inject({ method: 'GET', url: '/sessions' })
       expect(res.statusCode).toBe(200)
+      expect(listConversationPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          viewer: expect.objectContaining({
+            role: 'collaborator',
+            identitySet: expect.arrayContaining(['user:u-1', SLACK_OWNER])
+          })
+        })
+      )
+      const flat = await app.inject({ method: 'GET', url: '/sessions?view=flat' })
+      expect(flat.statusCode).toBe(200)
       expect(listPage).toHaveBeenCalledWith(
         expect.objectContaining({
           viewer: expect.objectContaining({

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1057,6 +1057,32 @@ export interface SessionPageRecord {
   hasMore: boolean
 }
 
+/** One conversation grouping key (merged-conversation-view.md §5.1). Legacy
+ *  NULL-platform rows read as 'slack'. A row with a NULL channel or thread
+ *  never groups — it is its own singleton conversation, and its key carries
+ *  the null through. */
+export interface ConversationKey {
+  platform: string
+  tenantScope: string | null
+  channel: string | null
+  thread: string | null
+}
+
+export interface ConversationRecord {
+  key: ConversationKey
+  /** Current member sessions, newest-first under the page's total order and
+   *  collapsed to ONE row per agentId (superseded ACP session rows are
+   *  history, not members). The first entry is the conversation's
+   *  representative — the caller's newest visible member row. */
+  sessions: SessionListRecord[]
+}
+
+export interface ConversationPageRecord {
+  conversations: ConversationRecord[]
+  total: number | null
+  hasMore: boolean
+}
+
 export interface SessionFacetRecord {
   id: SessionId
   agentId: AgentId
@@ -1086,6 +1112,18 @@ export interface SessionRepo {
   /** Filter, keyset-page, and order in Postgres; usage is hydrated only for the
    *  returned page. `total` is computed only when explicitly requested. */
   listPage(q: SessionPageQuery): Promise<SessionPageRecord>
+  /** The grouped list (merged-conversation-view.md §5.2): one row per
+   *  conversation, newest-first, emit-at-max pagination — a scanned row yields
+   *  its conversation only when it is the newest same-key row under the full
+   *  (lastActivityAt, startedAt, id) order AND the caller's own predicate.
+   *  Cursor semantics match `listPage` (the cursor is the previous page's last
+   *  representative row). */
+  listConversationPage(q: SessionPageQuery): Promise<ConversationPageRecord>
+  /** Bounded key-addressed member resolution for a direct conversation load
+   *  (merged-conversation-view.md §5.2): every visible row matching the key,
+   *  collapsed to the current session per agent. Grouped keys only — callers
+   *  resolve singletons through the ordinary session detail route. */
+  listConversationMembers(q: SessionFacetQuery, key: ConversationKey): Promise<SessionListRecord[]>
   /** Org-level "any session exists" — a bare boolean over the org's FULL session set
    *  (no visibility predicate), safe to return to any org member: it reveals nothing
    *  about sessions the caller can't see. Drives the getting-started conversation step. */

--- a/packages/control-plane/src/persistence/repositories/session-access-sql.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.ts
@@ -2,18 +2,22 @@ import { Prisma } from '../../generated/prisma/client.js'
 import type { SessionFilterQuery } from '../ports.js'
 
 /** SQL mirror of authorization/policy.ts#canViewSession. The caller's query
- * must expose SessionMeta as alias `s`. Undefined is reserved for internal
- * unfiltered reads; every human role uses the same predicate. */
-export function sessionViewerSql(viewer: SessionFilterQuery['viewer']): Prisma.Sql | null {
+ * must expose SessionMeta under `alias` (default `s`). Undefined is reserved
+ * for internal unfiltered reads; every human role uses the same predicate. */
+export function sessionViewerSql(
+  viewer: SessionFilterQuery['viewer'],
+  alias: Prisma.Sql = Prisma.raw('s')
+): Prisma.Sql | null {
   if (!viewer) return null
+  const s = alias
   const direct = Prisma.sql`(
-    s."externalProvider" IS NULL
+    ${s}."externalProvider" IS NULL
     AND (
-      s."visibility" = 'org'::"SessionVisibility"
+      ${s}."visibility" = 'org'::"SessionVisibility"
       OR (
-        s."visibility" = 'private'::"SessionVisibility"
-        AND s."ownerIdentity" IS NOT NULL
-        AND s."ownerIdentity" = ANY(${viewer.identitySet}::text[])
+        ${s}."visibility" = 'private'::"SessionVisibility"
+        AND ${s}."ownerIdentity" IS NOT NULL
+        AND ${s}."ownerIdentity" = ANY(${viewer.identitySet}::text[])
       )
     )
   )`
@@ -22,17 +26,17 @@ export function sessionViewerSql(viewer: SessionFilterQuery['viewer']): Prisma.S
   const externalArms: Prisma.Sql[] = []
   for (const policy of snapshot.policies) {
     externalArms.push(Prisma.sql`(
-      s."externalProvider" = ${policy.provider}
-      AND s."visibility" = 'org'::"SessionVisibility"
+      ${s}."externalProvider" = ${policy.provider}
+      AND ${s}."visibility" = 'org'::"SessionVisibility"
       AND EXISTS (
         SELECT 1 FROM "session_external_access_policy" policy
-        WHERE policy."orgId" = s."orgId"
-          AND policy."provider" = s."externalProvider"
+        WHERE policy."orgId" = ${s}."orgId"
+          AND policy."provider" = ${s}."externalProvider"
           AND (
             policy."readFenceRev" IS NULL
             OR (
-              s."classifiedPolicyRev" IS NOT NULL
-              AND s."classifiedPolicyRev" >= policy."readFenceRev"
+              ${s}."classifiedPolicyRev" IS NOT NULL
+              AND ${s}."classifiedPolicyRev" >= policy."readFenceRev"
             )
           )
       )
@@ -40,19 +44,19 @@ export function sessionViewerSql(viewer: SessionFilterQuery['viewer']): Prisma.S
   }
   for (const allowed of snapshot.allowedScopes) {
     externalArms.push(Prisma.sql`(
-      s."visibility" = 'external'::"SessionVisibility"
-      AND s."externalResolution" = 'settled'::"ExternalResolution"
-      AND s."externalScopeId" = ${allowed.id}::uuid
+      ${s}."visibility" = 'external'::"SessionVisibility"
+      AND ${s}."externalResolution" = 'settled'::"ExternalResolution"
+      AND ${s}."externalScopeId" = ${allowed.id}::uuid
       AND EXISTS (
         SELECT 1 FROM "session_external_access_policy" policy
-        WHERE policy."orgId" = s."orgId"
-          AND policy."provider" = s."externalProvider"
+        WHERE policy."orgId" = ${s}."orgId"
+          AND policy."provider" = ${s}."externalProvider"
       )
       AND EXISTS (
         SELECT 1 FROM "external_scope" scope
-        WHERE scope."id" = s."externalScopeId"
-          AND scope."orgId" = s."orgId"
-          AND scope."provider" = s."externalProvider"
+        WHERE scope."id" = ${s}."externalScopeId"
+          AND scope."orgId" = ${s}."orgId"
+          AND scope."provider" = ${s}."externalProvider"
           AND scope."aclRevision" = ${allowed.aclRevision}
           AND scope."revokedAt" IS NULL
       )

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -23,6 +23,8 @@ import type {
   SessionFilterQuery,
   SessionPageQuery,
   SessionPageRecord,
+  ConversationKey,
+  ConversationPageRecord,
   SessionFacetQuery,
   SessionFacetRecord,
   SessionFacetIndex,
@@ -184,71 +186,76 @@ function queryAgentIds(q: SessionQuery): string[] {
   return q.agentIds ?? []
 }
 
-function platformSql(platform: Platform): Prisma.Sql {
+// Default row alias for the predicate builders. The conversation grouping
+// query (listConversationPage) applies the SAME predicate to an inner probe
+// row, so every builder takes the alias as a parameter.
+const S = Prisma.raw('s')
+
+function platformSql(platform: Platform, a: Prisma.Sql = S): Prisma.Sql {
   return platform === 'slack'
-    ? Prisma.sql`(s."platform" = 'slack' OR s."platform" IS NULL)`
-    : Prisma.sql`s."platform" = ${platform}`
+    ? Prisma.sql`(${a}."platform" = 'slack' OR ${a}."platform" IS NULL)`
+    : Prisma.sql`${a}."platform" = ${platform}`
 }
 
-function hookTriggerSql(hookIds: string[]): Prisma.Sql {
+function hookTriggerSql(hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
   if (hookIds.length === 0) return Prisma.sql`FALSE`
   const triggers = hookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
   return Prisma.sql`
     (
-      s."triggeredBy" IN (${Prisma.join(triggers)})
+      ${a}."triggeredBy" IN (${Prisma.join(triggers)})
       OR (
-        s."platform" = 'hook'
+        ${a}."platform" = 'hook'
         AND
         (
-          s."triggeredBy" IS NULL
-          OR s."triggeredBy" = ${HOOK_TRIGGER_PREFIX}
-          OR s."triggeredBy" NOT LIKE ${`${HOOK_TRIGGER_PREFIX}%`}
+          ${a}."triggeredBy" IS NULL
+          OR ${a}."triggeredBy" = ${HOOK_TRIGGER_PREFIX}
+          OR ${a}."triggeredBy" NOT LIKE ${`${HOOK_TRIGGER_PREFIX}%`}
         )
-        AND s."channel" IN (${Prisma.join(hookIds)})
+        AND ${a}."channel" IN (${Prisma.join(hookIds)})
       )
     )
   `
 }
 
-function githubHookSql(githubHookIds: string[]): Prisma.Sql {
-  return Prisma.sql`s."platform" = 'hook' AND ${hookTriggerSql(githubHookIds)}`
+function githubHookSql(githubHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
+  return Prisma.sql`${a}."platform" = 'hook' AND ${hookTriggerSql(githubHookIds, a)}`
 }
 
-function genericHookSql(githubHookIds: string[]): Prisma.Sql {
-  if (githubHookIds.length === 0) return Prisma.sql`s."platform" = 'hook'`
+function genericHookSql(githubHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
+  if (githubHookIds.length === 0) return Prisma.sql`${a}."platform" = 'hook'`
   const triggers = githubHookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
   return Prisma.sql`
-    s."platform" = 'hook'
-    AND (s."triggeredBy" IS NULL OR s."triggeredBy" NOT IN (${Prisma.join(triggers)}))
+    ${a}."platform" = 'hook'
+    AND (${a}."triggeredBy" IS NULL OR ${a}."triggeredBy" NOT IN (${Prisma.join(triggers)}))
     AND (
-      (s."triggeredBy" LIKE ${`${HOOK_TRIGGER_PREFIX}%`} AND s."triggeredBy" <> ${HOOK_TRIGGER_PREFIX})
-      OR s."channel" IS NULL
-      OR s."channel" NOT IN (${Prisma.join(githubHookIds)})
+      (${a}."triggeredBy" LIKE ${`${HOOK_TRIGGER_PREFIX}%`} AND ${a}."triggeredBy" <> ${HOOK_TRIGGER_PREFIX})
+      OR ${a}."channel" IS NULL
+      OR ${a}."channel" NOT IN (${Prisma.join(githubHookIds)})
     )
   `
 }
 
-function integrationSql(q: SessionFilterQuery): Prisma.Sql | null {
+function integrationSql(q: SessionFilterQuery, a: Prisma.Sql = S): Prisma.Sql | null {
   if (!q.integration) return null
   const githubHookIds = q.githubHookIds ?? []
-  if (q.integration === 'github') return githubHookSql(githubHookIds)
-  if (q.integration === 'hook') return genericHookSql(githubHookIds)
-  return platformSql(q.integration)
+  if (q.integration === 'github') return githubHookSql(githubHookIds, a)
+  if (q.integration === 'hook') return genericHookSql(githubHookIds, a)
+  return platformSql(q.integration, a)
 }
 
-function pageWhereSql(q: SessionFilterQuery, includeCursor: boolean): Prisma.Sql {
-  const filters: Prisma.Sql[] = [Prisma.sql`s."agentId" IN (${Prisma.join(queryAgentIds(q))})`]
-  const viewerArm = sessionViewerSql(q.viewer)
+function pageWhereSql(q: SessionFilterQuery, includeCursor: boolean, a: Prisma.Sql = S): Prisma.Sql {
+  const filters: Prisma.Sql[] = [Prisma.sql`${a}."agentId" IN (${Prisma.join(queryAgentIds(q))})`]
+  const viewerArm = sessionViewerSql(q.viewer, a)
   if (viewerArm) filters.push(viewerArm)
-  if (q.platform) filters.push(platformSql(q.platform))
-  const integration = integrationSql(q)
+  if (q.platform) filters.push(platformSql(q.platform, a))
+  const integration = integrationSql(q, a)
   if (integration) filters.push(integration)
-  if (q.channel) filters.push(Prisma.sql`s."channel" = ${q.channel}`)
-  if (q.triggeredBy) filters.push(Prisma.sql`s."triggeredBy" = ${q.triggeredBy}`)
-  if (q.hookTriggerIds) filters.push(hookTriggerSql(q.hookTriggerIds))
+  if (q.channel) filters.push(Prisma.sql`${a}."channel" = ${q.channel}`)
+  if (q.triggeredBy) filters.push(Prisma.sql`${a}."triggeredBy" = ${q.triggeredBy}`)
+  if (q.hookTriggerIds) filters.push(hookTriggerSql(q.hookTriggerIds, a))
   if (includeCursor && q.cursor) {
     filters.push(Prisma.sql`
-      (s."lastActivityAt", s."startedAt", s."id") < (
+      (${a}."lastActivityAt", ${a}."startedAt", ${a}."id") < (
         ${new Date(q.cursor.activityMs)},
         ${new Date(q.cursor.startedMs)},
         ${q.cursor.id}
@@ -267,6 +274,24 @@ function integrationFacetSql(githubHookIds: string[]): Prisma.Sql {
       ELSE s."platform"
     END
   `
+}
+
+/** Conversation-key equality between two aliased session rows
+ *  (merged-conversation-view.md §5.1): legacy NULL platform reads as 'slack'
+ *  (mirroring `platformWhere`), tenant scope matches NULL-safely. Callers only
+ *  apply this to rows whose channel/thread are both present. */
+function conversationKeyJoinSql(a: Prisma.Sql, b: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`
+    COALESCE(${a}."platform", 'slack') = COALESCE(${b}."platform", 'slack')
+    AND ${a}."tenantScope" IS NOT DISTINCT FROM ${b}."tenantScope"
+    AND ${a}."channel" = ${b}."channel"
+    AND ${a}."thread" = ${b}."thread"
+  `
+}
+
+/** In-process mirror of `conversationKeyJoinSql` for bucketing fetched rows. */
+function conversationKeyOf(row: Pick<SessionMeta, 'platform' | 'tenantScope' | 'channel' | 'thread'>): string {
+  return [row.platform ?? 'slack', row.tenantScope ?? '', row.channel ?? '', row.thread ?? ''].join(' ')
 }
 
 const SESSION_ORDER: Prisma.SessionMetaOrderByWithRelationInput[] = [
@@ -690,7 +715,7 @@ export class PgSessionRepo implements SessionRepo {
     const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
       INSERT INTO "session_meta" (
         "id", "parentSessionId", "agentId", "launchId", "platform", "channel",
-        "thread", "phase", "link", "summary", "title", "status",
+        "thread", "tenantScope", "phase", "link", "summary", "title", "status",
         "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
         "threadUrl", "runtime", "model", "effort", "fastMode",
         "permissionMode", "outputMode", "daemonId", "orgId", "visibility",
@@ -700,7 +725,7 @@ export class PgSessionRepo implements SessionRepo {
       ) VALUES (
         ${ev.sessionId}, ${ev.parentSessionId ?? null}, ${ev.agentId},
         ${ev.launchId ?? null}, ${ev.platform ?? null}, ${ev.channel ?? null},
-        ${ev.thread ?? null}, ${ev.phase}::"SessionPhase", ${ev.link ?? null},
+        ${ev.thread ?? null}, ${ev.transportScope ?? null}, ${ev.phase}::"SessionPhase", ${ev.link ?? null},
         ${ev.summary ?? null}, ${ev.title ?? null}, ${ev.status ?? null},
         ${lastActivityAt}, ${ev.triggeredBy ?? null}, ${ev.channelName ?? null},
         ${ev.triggeredByName ?? null}, ${ev.threadUrl ?? null},
@@ -733,6 +758,7 @@ export class PgSessionRepo implements SessionRepo {
         "platform" = COALESCE(EXCLUDED."platform", "session_meta"."platform"),
         "channel" = COALESCE(EXCLUDED."channel", "session_meta"."channel"),
         "thread" = COALESCE(EXCLUDED."thread", "session_meta"."thread"),
+        "tenantScope" = COALESCE(EXCLUDED."tenantScope", "session_meta"."tenantScope"),
         "link" = COALESCE(EXCLUDED."link", "session_meta"."link"),
         "summary" = COALESCE(EXCLUDED."summary", "session_meta"."summary"),
         "title" = COALESCE(EXCLUDED."title", "session_meta"."title"),
@@ -872,6 +898,139 @@ export class PgSessionRepo implements SessionRepo {
       total,
       hasMore
     }
+  }
+
+  async listConversationPage(q: SessionPageQuery): Promise<ConversationPageRecord> {
+    if (queryAgentIds(q).length === 0) {
+      return { conversations: [], total: q.includeTotal ? 0 : null, hasMore: false }
+    }
+    const N = Prisma.raw('n')
+    const pageWhere = pageWhereSql(q, true)
+    // The probe runs the caller's OWN predicate (org/agents/viewer/filters) on
+    // the inner row — a newer row the caller cannot see must not suppress a
+    // conversation they can (merged-conversation-view.md §5.2). Cursor excluded:
+    // the probe asks about the whole authorized row set, not the current page.
+    const probeWhere = pageWhereSql({ ...q, cursor: undefined }, false, N)
+    const countWhere = pageWhereSql(q, false)
+    // Emit-at-max: a row yields its conversation only when no same-key row is
+    // strictly greater under the full page tuple. Rows without a groupable key
+    // (NULL channel or thread — cron/hook/dream and legacy shapes) are
+    // singleton conversations and always emit.
+    const emitAtMax = Prisma.sql`
+      (
+        s."channel" IS NULL OR s."thread" IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM "session_meta" AS n
+          ${probeWhere}
+            AND ${conversationKeyJoinSql(N, S)}
+            AND (n."lastActivityAt", n."startedAt", n."id") > (s."lastActivityAt", s."startedAt", s."id")
+        )
+      )
+    `
+    const [reps, totalRows] = await Promise.all([
+      this.db.$queryRaw<SessionMeta[]>(Prisma.sql`
+        SELECT s.*
+        FROM "session_meta" AS s
+        ${pageWhere} AND ${emitAtMax}
+        ORDER BY s."lastActivityAt" DESC, s."startedAt" DESC, s."id" DESC
+        LIMIT ${q.limit + 1}
+      `),
+      q.includeTotal
+        ? this.db.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+            SELECT
+              (
+                SELECT COUNT(*) FROM (
+                  SELECT DISTINCT COALESCE(s."platform", 'slack'), s."tenantScope", s."channel", s."thread"
+                  FROM "session_meta" AS s
+                  ${countWhere} AND s."channel" IS NOT NULL AND s."thread" IS NOT NULL
+                ) AS grouped
+              )
+              + (
+                SELECT COUNT(*) FROM "session_meta" AS s
+                ${countWhere} AND (s."channel" IS NULL OR s."thread" IS NULL)
+              ) AS count
+          `)
+        : Promise.resolve(null)
+    ])
+    const hasMore = reps.length > q.limit
+    const page = hasMore ? reps.slice(0, q.limit) : reps
+    const groupable = page.filter((r) => r.channel !== null && r.thread !== null)
+    const membersByKey = new Map<string, SessionMeta[]>()
+    if (groupable.length > 0) {
+      const memberWhere = pageWhereSql({ ...q, cursor: undefined }, false)
+      const keyTuples = groupable.map(
+        (r) => Prisma.sql`(${r.platform ?? 'slack'}, ${r.tenantScope ?? ''}, ${r.channel}, ${r.thread})`
+      )
+      const members = await this.db.$queryRaw<SessionMeta[]>(Prisma.sql`
+        SELECT s.*
+        FROM "session_meta" AS s
+        ${memberWhere}
+          AND s."channel" IS NOT NULL AND s."thread" IS NOT NULL
+          AND (COALESCE(s."platform", 'slack'), COALESCE(s."tenantScope", ''), s."channel", s."thread")
+            IN (${Prisma.join(keyTuples)})
+        ORDER BY s."lastActivityAt" DESC, s."startedAt" DESC, s."id" DESC
+      `)
+      for (const row of members) {
+        const key = conversationKeyOf(row)
+        const bucket = membersByKey.get(key)
+        if (bucket) bucket.push(row)
+        else membersByKey.set(key, [row])
+      }
+    }
+    // Collapse each conversation to the current session per agent: rows arrive
+    // newest-first, so the first row seen for an agentId wins and superseded
+    // ACP session rows drop out. The representative is by construction the
+    // group's first row.
+    const collapsed = page.map((rep) => {
+      const rows =
+        rep.channel !== null && rep.thread !== null ? (membersByKey.get(conversationKeyOf(rep)) ?? [rep]) : [rep]
+      const perAgent: SessionMeta[] = []
+      const seen = new Set<string>()
+      for (const row of rows) {
+        if (seen.has(row.agentId)) continue
+        seen.add(row.agentId)
+        perAgent.push(row)
+      }
+      return { rep, rows: perAgent }
+    })
+    const hydrated = await this.hydrate(collapsed.flatMap((c) => c.rows))
+    const byId = new Map(hydrated.map((rec) => [rec.id, rec]))
+    return {
+      conversations: collapsed.map((c) => ({
+        key: {
+          platform: c.rep.platform ?? 'slack',
+          tenantScope: c.rep.tenantScope,
+          channel: c.rep.channel,
+          thread: c.rep.thread
+        },
+        sessions: c.rows.map((row) => byId.get(SessionId(row.id))!).filter(Boolean)
+      })),
+      total: totalRows ? Number(totalRows[0]?.count ?? 0n) : null,
+      hasMore
+    }
+  }
+
+  async listConversationMembers(q: SessionFacetQuery, key: ConversationKey): Promise<SessionListRecord[]> {
+    if (queryAgentIds(q).length === 0 || key.channel === null || key.thread === null) return []
+    const where = pageWhereSql(q, false)
+    const rows = await this.db.$queryRaw<SessionMeta[]>(Prisma.sql`
+      SELECT s.*
+      FROM "session_meta" AS s
+      ${where}
+        AND COALESCE(s."platform", 'slack') = ${key.platform}
+        AND COALESCE(s."tenantScope", '') = ${key.tenantScope ?? ''}
+        AND s."channel" = ${key.channel}
+        AND s."thread" = ${key.thread}
+      ORDER BY s."lastActivityAt" DESC, s."startedAt" DESC, s."id" DESC
+    `)
+    const perAgent: SessionMeta[] = []
+    const seen = new Set<string>()
+    for (const row of rows) {
+      if (seen.has(row.agentId)) continue
+      seen.add(row.agentId)
+      perAgent.push(row)
+    }
+    return this.hydrate(perAgent)
   }
 
   async orgHasAny(orgId: OrgId): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -289,9 +289,11 @@ function conversationKeyJoinSql(a: Prisma.Sql, b: Prisma.Sql): Prisma.Sql {
   `
 }
 
-/** In-process mirror of `conversationKeyJoinSql` for bucketing fetched rows. */
+/** In-process mirror of `conversationKeyJoinSql` for bucketing fetched rows.
+ *  NUL-joined like the §5.1 codec — a printable separator could collide on
+ *  parts that contain it. */
 function conversationKeyOf(row: Pick<SessionMeta, 'platform' | 'tenantScope' | 'channel' | 'thread'>): string {
-  return [row.platform ?? 'slack', row.tenantScope ?? '', row.channel ?? '', row.thread ?? ''].join(' ')
+  return [row.platform ?? 'slack', row.tenantScope ?? '', row.channel ?? '', row.thread ?? ''].join('\u0000')
 }
 
 const SESSION_ORDER: Prisma.SessionMetaOrderByWithRelationInput[] = [

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Grouped sessions list (merged-conversation-view.md §5.2).
+ *
+ * `GET /sessions` returns one row per CONVERSATION by default — sessions
+ * sharing `(platform, tenantScope, channel, thread)` group, collapsed to the
+ * current session per agent — with emit-at-max pagination and the
+ * `conversationKey` member resolver. `view=flat` keeps the pre-grouped shape
+ * (covered by the pre-existing suites, now pinned to that view).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PgAgentRepo, PgHookRepo, PgSessionRepo, PgWebchatConversationRepo } from '../../src/persistence/index.js'
+import { AgentId, OrgId } from '../../src/domain/ids.js'
+import { handleEventSession } from '../../src/ws/handlers/index.js'
+import type { DaemonConnection } from '../../src/ws/connection.js'
+import type { DaemonWsDeps } from '../../src/ws/deps.js'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
+import { InMemorySessionEventSink } from '../../src/events/sink.js'
+import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
+import { encodeConversationKey } from '../../src/http/conversation-key.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+const DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT_A = 'a1a1a1a1-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const AGENT_B = 'b1b1b1b1-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+async function reportSession(payload: Record<string, unknown>, daemonId = DAEMON): Promise<void> {
+  const frame = {
+    v: 1,
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    type: 'event/session',
+    payload
+  } as AnyFrame
+  const deps = {
+    agent: new PgAgentRepo(prisma),
+    agentMutations: new AgentMutationGate(),
+    hook: new PgHookRepo(prisma),
+    session: new PgSessionRepo(prisma),
+    webchatConversation: new PgWebchatConversationRepo(prisma),
+    events: new InMemorySessionEventSink()
+  } as unknown as DaemonWsDeps
+  await handleEventSession(frame, { daemonId } as DaemonConnection, deps)
+}
+
+/** A Slack thread milestone at a given activity instant. */
+function slackReport(sessionId: string, agentId: string, atMs: number, extra: Record<string, unknown> = {}) {
+  const at = new Date(atMs).toISOString()
+  return reportSession({
+    sessionId,
+    agentId,
+    phase: 'start',
+    platform: 'slack',
+    channel: 'C-OPS',
+    thread: 'T-1',
+    transportScope: 'TEAM-1',
+    lastActivityAt: at,
+    ts: at,
+    ...extra
+  })
+}
+
+type ConversationsBody = {
+  conversations: Array<{
+    key: string | null
+    platform: string | null
+    channel: string | null
+    thread: string | null
+    sessions: Array<{ sessionId: string; agentId: string }>
+  }>
+  total: number | null
+  nextCursor: string | null
+}
+
+describe('GET /sessions — grouped conversations', () => {
+  it('groups a thread into one conversation, collapsed to the current session per agent', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    // Agent A: a superseded ACP session, then its replacement. Agent B: one.
+    await slackReport('sess-a-old', AGENT_A, 1_000)
+    await slackReport('sess-a-new', AGENT_A, 3_000)
+    await slackReport('sess-b', AGENT_B, 2_000)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as ConversationsBody
+    expect(body.conversations).toHaveLength(1)
+    expect(body.total).toBe(1)
+    const conv = body.conversations[0]!
+    expect(conv.platform).toBe('slack')
+    expect(conv.channel).toBe('C-OPS')
+    expect(conv.thread).toBe('T-1')
+    expect(conv.key).toBe(
+      encodeConversationKey({ platform: 'slack', tenantScope: 'TEAM-1', channel: 'C-OPS', thread: 'T-1' })
+    )
+    // Representative first (A's newest), one row per agent, superseded row gone.
+    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-a-new', 'sess-b'])
+
+    // The flat escape hatch still lists every row.
+    const flat = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
+    expect((flat.json() as { sessions: unknown[] }).sessions).toHaveLength(3)
+  })
+
+  it('splits identical coordinates by tenant scope; null-scope legacy rows stand apart', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-t1', AGENT_A, 1_000)
+    await slackReport('sess-t2', AGENT_A, 2_000, { transportScope: 'TEAM-2' })
+    await slackReport('sess-legacy', AGENT_A, 3_000, { transportScope: undefined })
+
+    const stored = await prisma.sessionMeta.findUniqueOrThrow({ where: { id: 'sess-t2' } })
+    expect(stored.tenantScope).toBe('TEAM-2')
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const body = res.json() as ConversationsBody
+    expect(body.conversations).toHaveLength(3)
+    expect(body.total).toBe(3)
+    expect(body.conversations.map((c) => c.sessions[0]!.sessionId)).toEqual(['sess-legacy', 'sess-t2', 'sess-t1'])
+  })
+
+  it('emit-at-max never re-emits a conversation across page boundaries', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    // Conversation X straddles the page cursor: members at t=100s and t=1s.
+    // Conversation Y (different thread) sits between them at t=90s.
+    await slackReport('sess-x-idle', AGENT_B, 1_000)
+    await slackReport('sess-x-active', AGENT_A, 100_000)
+    await slackReport('sess-y', AGENT_A, 90_000, { thread: 'T-2' })
+
+    const first = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?limit=1` })
+    const firstBody = first.json() as ConversationsBody
+    expect(firstBody.conversations.map((c) => c.thread)).toEqual(['T-1'])
+    expect(firstBody.total).toBe(2)
+    expect(firstBody.nextCursor).not.toBeNull()
+
+    const second = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?limit=1&cursor=${encodeURIComponent(firstBody.nextCursor!)}`
+    })
+    const secondBody = second.json() as ConversationsBody
+    // X's idle member row falls after the cursor but fails the emit-at-max
+    // probe — X must NOT reappear; the page holds Y alone and the scan ends.
+    expect(secondBody.conversations.map((c) => c.thread)).toEqual(['T-2'])
+    expect(secondBody.nextCursor).toBeNull()
+  })
+
+  it('omits invisible members with no count or placeholder', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    // Restricted agent owned by another user — invisible to the caller. Its
+    // participation must leave NO trace on the grouped row (§7: hidden
+    // sessions' existence is itself hidden).
+    const stranger = await prisma.user.create({
+      data: { id: randomUUID(), email: `stranger-${randomUUID().slice(0, 8)}@example.com`, displayName: 'Stranger' }
+    })
+    await seedAgent(prisma, AGENT_B, {
+      daemonId: DAEMON,
+      visibility: 'restricted',
+      ownerUserId: stranger.id
+    })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-vis', AGENT_A, 1_000)
+    await slackReport('sess-hidden', AGENT_B, 2_000)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const body = res.json() as ConversationsBody
+    expect(body.conversations).toHaveLength(1)
+    const conv = body.conversations[0]!
+    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-vis'])
+    expect(JSON.stringify(body)).not.toContain('sess-hidden')
+    expect(JSON.stringify(body)).not.toContain(AGENT_B)
+  })
+
+  it('resolves one conversation by key, and a webchat conversation by its id', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON })
+    const CONVO = 'c2c2c2c2-cccc-4ccc-8ccc-cccccccccccc'
+    const conversations = new PgWebchatConversationRepo(prisma)
+    await conversations.create(
+      { conversationId: CONVO, orgId: OrgId(DEFAULT_ORG_ID), agentId: AgentId(AGENT_A), userId: DEFAULT_OWNER_ID },
+      [AgentId(AGENT_B)]
+    )
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-k1', AGENT_A, 1_000)
+    await slackReport('sess-k2', AGENT_B, 2_000)
+    for (const [session, agent, at] of [
+      ['sess-wc-a', AGENT_A, 3_000],
+      ['sess-wc-b', AGENT_B, 4_000]
+    ] as const) {
+      await reportSession({
+        sessionId: session,
+        agentId: agent,
+        phase: 'start',
+        platform: 'webchat',
+        channel: CONVO,
+        thread: CONVO,
+        lastActivityAt: new Date(at).toISOString(),
+        ts: new Date(at).toISOString()
+      })
+    }
+
+    const imKey = encodeConversationKey({ platform: 'slack', tenantScope: 'TEAM-1', channel: 'C-OPS', thread: 'T-1' })!
+    const im = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${encodeURIComponent(imKey)}`
+    })
+    expect(im.statusCode).toBe(200)
+    const imBody = im.json() as ConversationsBody
+    expect(imBody.conversations).toHaveLength(1)
+    expect(imBody.conversations[0]!.sessions.map((s) => s.sessionId)).toEqual(['sess-k2', 'sess-k1'])
+
+    const wc = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?conversationKey=${CONVO}` })
+    const wcBody = wc.json() as ConversationsBody
+    expect(wcBody.conversations).toHaveLength(1)
+    expect(wcBody.conversations[0]!.key).toBe(CONVO)
+    expect(wcBody.conversations[0]!.sessions.map((s) => s.sessionId)).toEqual(['sess-wc-b', 'sess-wc-a'])
+
+    const missing = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${encodeURIComponent(
+        encodeConversationKey({ platform: 'slack', tenantScope: null, channel: 'C-NONE', thread: 'T-0' })!
+      )}`
+    })
+    expect((missing.json() as ConversationsBody).conversations).toHaveLength(0)
+
+    const invalid = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?conversationKey=%21%21%21` })
+    expect(invalid.statusCode).toBe(400)
+  })
+})

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -188,7 +188,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     expect(stored.daemonId).toBe(DAEMON)
 
     // The list route carries the same execution-config snapshot.
-    const list = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const list = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
     expect(list.statusCode).toBe(200)
     const listBody = list.json() as {
       sessions: Array<{
@@ -397,7 +397,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       data: { agentId: reassignedAgent, name: 'new-owner/repo' }
     })
 
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
     expect(res.statusCode).toBe(200)
     const body = res.json() as {
       sessions: Array<{
@@ -434,7 +434,7 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
       triggeredByName: 'owner/repo'
     })
 
-    const filtered = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?integration=github` })
+    const filtered = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&integration=github` })
     expect(filtered.statusCode).toBe(200)
     expect(
       (filtered.json() as { sessions: Array<{ sessionId: string }>; total: number }).sessions.map(
@@ -443,7 +443,10 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     ).toEqual(['acp-github-headless'])
     expect((filtered.json() as { total: number }).total).toBe(1)
 
-    const genericWebhook = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?integration=hook` })
+    const genericWebhook = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&integration=hook`
+    })
     expect(genericWebhook.statusCode).toBe(200)
     expect(
       (genericWebhook.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((session) => session.sessionId)

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -65,7 +65,7 @@ describe('session visibility — list & detail', () => {
     })
 
     const mineApp = appAs(mine)
-    const listed = sessionIds((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json())
+    const listed = sessionIds((await mineApp.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })).json())
     expect(listed).toEqual(expect.arrayContaining([orgSession, ownSession]))
     expect(listed).not.toContain(otherSession)
     expect(listed).not.toContain(orphanSession)
@@ -78,7 +78,7 @@ describe('session visibility — list & detail', () => {
     // No governance override on sessions: an org owner filters exactly like any
     // other member — a private transcript is its owner's, role grants nothing.
     const ownerApp = appAs(owner)
-    const asOwner = sessionIds((await ownerApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json())
+    const asOwner = sessionIds((await ownerApp.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })).json())
     expect(asOwner).toContain(orgSession)
     expect(asOwner).not.toContain(ownSession)
     expect(asOwner).not.toContain(otherSession)
@@ -92,7 +92,7 @@ describe('session visibility — list & detail', () => {
 
     // Before any session exists: the boolean is present and false on the first page.
     const viewerApp = appAs(viewer)
-    const emptyPage = (await viewerApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json() as {
+    const emptyPage = (await viewerApp.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })).json() as {
       sessions: unknown[]
       orgHasSessions?: boolean
     }
@@ -107,7 +107,7 @@ describe('session visibility — list & detail', () => {
       visibility: 'private',
       ownerIdentity: `user:${other}`
     })
-    const page = (await viewerApp.app.inject({ method: 'GET', url: `${ORG}/sessions` })).json() as {
+    const page = (await viewerApp.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })).json() as {
       sessions: unknown[]
       orgHasSessions?: boolean
     }
@@ -137,7 +137,7 @@ describe('session visibility — list & detail', () => {
     const collected: string[] = []
     let cursor: string | null = null
     for (let page = 0; page < 5; page++) {
-      const url = `${ORG}/sessions?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+      const url = `${ORG}/sessions?view=flat&limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
       const body = (await app.app.inject({ method: 'GET', url })).json() as {
         sessions: Array<{ sessionId: string }>
         nextCursor: string | null

--- a/packages/control-plane/test/integration/sessions.history.route.test.ts
+++ b/packages/control-plane/test/integration/sessions.history.route.test.ts
@@ -109,7 +109,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
     })
     running = buildHttpApp(prisma)
 
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
     expect(res.statusCode).toBe(200)
     const body = res.json() as {
       sessions: Array<{
@@ -158,7 +158,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
       }
     })
     running = buildHttpApp(prisma) // default liveness: nothing connected
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
     expect(res.statusCode).toBe(200)
     expect((res.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual([
       SESSION
@@ -194,7 +194,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
     })
     running = buildHttpApp(prisma)
 
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
     expect(res.statusCode).toBe(200)
     const body = res.json() as { sessions: Array<{ sessionId: string }> }
     expect(body.sessions.map((s) => s.sessionId)).toEqual([newer, older])
@@ -253,7 +253,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
     })
     running = buildHttpApp(prisma)
 
-    const first = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?limit=2` })
+    const first = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&limit=2` })
     expect(first.statusCode).toBe(200)
     const firstBody = first.json() as { sessions: Array<{ sessionId: string }>; nextCursor: string | null }
     expect(firstBody.sessions.map((s) => s.sessionId)).toEqual([tieZ, tieM])
@@ -261,7 +261,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 
     const second = await running.app.inject({
       method: 'GET',
-      url: `${ORG}/sessions?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor!)}`
+      url: `${ORG}/sessions?view=flat&limit=2&cursor=${encodeURIComponent(firstBody.nextCursor!)}`
     })
     expect(second.statusCode).toBe(200)
     const secondBody = second.json() as {
@@ -309,7 +309,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
     })
     running = buildHttpApp(prisma)
 
-    const first = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?limit=1` })
+    const first = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&limit=1` })
     expect(first.statusCode).toBe(200)
     const firstBody = first.json() as {
       sessions: Array<{ sessionId: string }>
@@ -329,7 +329,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 
     const filtered = await running.app.inject({
       method: 'GET',
-      url: `${ORG}/sessions?limit=1&channel=C-OLDER&triggeredBy=U-OLDER`
+      url: `${ORG}/sessions?view=flat&limit=1&channel=C-OLDER&triggeredBy=U-OLDER`
     })
     expect(filtered.statusCode).toBe(200)
     const filteredBody = filtered.json() as {
@@ -516,7 +516,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
       ])
     )
 
-    const filtered = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?githubRepoId=123` })
+    const filtered = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&githubRepoId=123` })
     expect(filtered.statusCode).toBe(200)
     const filteredBody = filtered.json() as { sessions: Array<{ sessionId: string }>; total: number }
     expect(filteredBody.sessions.map((session) => session.sessionId)).toEqual([secondSession, firstSession])
@@ -550,7 +550,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
     })
     running = buildHttpApp(prisma)
 
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?channel=%23ops` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&channel=%23ops` })
     const body = res.json() as { sessions: Array<{ sessionKey: { channel: string } }> }
     expect(body.sessions).toHaveLength(1)
     expect(body.sessions[0]!.sessionKey.channel).toBe('#ops')
@@ -558,7 +558,7 @@ describe('GET /sessions (metadata list from CP DB)', () => {
 
   it('400s on an invalid pagination cursor', async () => {
     running = buildHttpApp(prisma)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?cursor=not-a-cursor` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&cursor=not-a-cursor` })
     expect(res.statusCode).toBe(400)
   })
 })

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -119,7 +119,7 @@ export default function SessionsView() {
         : {}),
     ...(fGithubRepoId ? { githubRepoId: fGithubRepoId } : fTrigger !== 'all' ? { triggeredBy: fTrigger } : {})
   } satisfies SessionListFilters
-  const sessionList = useSessionList(activeOrg?.id, sessionFilters)
+  const sessionList = useSessionList(activeOrg?.id, sessionFilters, { grouped: true })
   const { data: sessionFacets = baseSessionFacets } = useSessionFacets(activeOrg?.id, sessionFilters, baseSessionFacets)
   const demoSessions = useMemo(
     () => (MOCK_MODE ? allSessions.filter((session) => DEMO_AGENT_IDS.has(session.agentId ?? '')) : []),
@@ -293,6 +293,32 @@ export default function SessionsView() {
     const agent = agentId ? agentById.get(agentId) : undefined
     return (
       <AgentIconView icon={agent?.icon} runtime={agent?.runtime || fallbackRuntime || agent?.model || ''} size={size} />
+    )
+  }
+  // Multi-participant conversation rows (merged-conversation-view.md §5.2):
+  // stacked participant icons replace the single agent face; the label counts
+  // agents instead of naming one.
+  const agentCell = (s: Session, av: string, size: number, label: string) => {
+    const roster = s.participants ?? []
+    if (roster.length <= 1) {
+      return (
+        <>
+          <span className={`av flex-none ${av}`}>{agentAvatar(s.agentId, s.model, size)}</span>
+          <span className={`truncate ${label}`}>{s.agentName}</span>
+        </>
+      )
+    }
+    return (
+      <>
+        <span className="flex flex-none items-center -space-x-[5px]">
+          {roster.slice(0, 4).map((p) => (
+            <span key={p.agentId} className={`av flex-none ${av}`}>
+              {agentAvatar(p.agentId, undefined, size)}
+            </span>
+          ))}
+        </span>
+        <span className={`truncate ${label}`}>{roster.length} agents</span>
+      </>
     )
   }
 
@@ -588,10 +614,12 @@ export default function SessionsView() {
                   the session title down to only a few characters. */}
               <span className="col-span-2 flex min-w-0 items-center gap-3 desktop:hidden">
                 <span className="inline-flex min-w-0 max-w-[45%] items-center gap-[6px]">
-                  <span className="av h-4 w-4 flex-none rounded-xs">{agentAvatar(s.agentId, s.model, 16)}</span>
-                  <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                    {s.agentName}
-                  </span>
+                  {agentCell(
+                    s,
+                    'h-4 w-4 rounded-xs',
+                    16,
+                    'font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)'
+                  )}
                 </span>
                 <span className="ml-auto inline-flex min-w-0 flex-1 items-center justify-end gap-[5px]">
                   <span className="inline-flex h-[14px] w-[14px] flex-none items-center justify-center">
@@ -618,8 +646,7 @@ export default function SessionsView() {
                 </div>
               </div>
               <div className="hidden min-w-0 items-center gap-2 desktop:flex">
-                <span className="av h-6 w-6 rounded-sm">{agentAvatar(s.agentId, s.model, 24)}</span>
-                <span className="mono truncate text-[12px] text-(--text-secondary)">{s.agentName}</span>
+                {agentCell(s, 'h-6 w-6 rounded-sm', 24, 'mono text-[12px] text-(--text-secondary)')}
               </div>
               <div className="hidden min-w-0 items-center gap-2 desktop:flex">
                 <span className="imark h-5 w-5 rounded-[5px]">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -393,8 +393,22 @@ export interface SessionFacetsDto {
   }>
 }
 
-export interface SessionListPageDto {
+/** One grouped-list row (merged-conversation-view.md §5.2). */
+export interface ConversationDto {
+  /** §5.1 encoded key — null for singleton conversations. */
+  key: string | null
+  platform: string | null
+  channel: string | null
+  thread: string | null
+  /** Current member sessions, representative (newest visible) first. */
   sessions: SessionDto[]
+}
+
+export interface SessionListPageDto {
+  /** Present on `view=flat` responses (and older CPs). */
+  sessions?: SessionDto[]
+  /** Present on default (grouped) responses. */
+  conversations?: ConversationDto[]
   total: number | null
   nextCursor: string | null
   /** Org-level "any session exists" boolean (first page only) — a bare boolean so the
@@ -1869,12 +1883,56 @@ export async function fetchSessions(
   orgId?: string,
   filters: SessionListFilters = {}
 ): Promise<SessionListPage> {
-  const q = new URLSearchParams({ limit: String(limit) })
+  // The CP's default response shape is the GROUPED conversation list
+  // (merged-conversation-view.md §5.2); this fetcher serves the flat-row
+  // consumers (rails, agent pages), so it pins the escape hatch explicitly.
+  const q = new URLSearchParams({ limit: String(limit), view: 'flat' })
   if (cursor) q.set('cursor', cursor)
   appendSessionFilters(q, filters)
   const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
   return {
-    sessions: page.sessions.map(sessionFromDto),
+    sessions: (page.sessions ?? []).map(sessionFromDto),
+    total: page.total,
+    nextCursor: page.nextCursor,
+    ...(page.orgHasSessions !== undefined ? { orgHasSessions: page.orgHasSessions } : {}),
+    ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {})
+  }
+}
+
+/** The grouped sessions list (merged-conversation-view.md §5.2): one row per
+ *  conversation. Each conversation is projected onto its REPRESENTATIVE member
+ *  session (the newest visible one) so the list pipeline renders it exactly
+ *  like a session row; multi-participant conversations additionally carry
+ *  `participants` (one per member agent, representative first) and the §5.1
+ *  `conversationKey`. */
+export async function fetchConversations(
+  cursor?: string,
+  limit = 50,
+  orgId?: string,
+  filters: SessionListFilters = {}
+): Promise<SessionListPage> {
+  const q = new URLSearchParams({ limit: String(limit) })
+  if (cursor) q.set('cursor', cursor)
+  appendSessionFilters(q, filters)
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  const sessions = (page.conversations ?? []).map((conversation) => {
+    const members = conversation.sessions.map(sessionFromDto)
+    const rep = members[0]!
+    if (members.length <= 1) return rep
+    return {
+      ...rep,
+      ...(conversation.key !== null ? { conversationKey: conversation.key } : {}),
+      // Names resolve at render time from the org agent list (the DTO carries
+      // ids only); the placeholder keeps the field shape valid.
+      participants: members.map((member, i) => ({
+        agentId: member.agentId ?? '',
+        name: member.agentName ?? member.agentId ?? '',
+        ...(i === 0 ? { primary: true } : {})
+      }))
+    }
+  })
+  return {
+    sessions,
     total: page.total,
     nextCursor: page.nextCursor,
     ...(page.orgHasSessions !== undefined ? { orgHasSessions: page.orgHasSessions } : {}),

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -924,6 +924,9 @@ export interface Session {
   /** Multi-agent webchat roster (webchat-multi-agents.md §3.1), primary first —
    *  present on live conversations with more than one participant. */
   participants?: Array<{ agentId: string; name: string; primary?: boolean }>
+  /** merged-conversation-view.md §5.1 key — present on grouped-list rows that
+   *  represent a multi-participant conversation. */
+  conversationKey?: string
   /** Runtime id + daemonId the session ran with: the session-recorded snapshot,
    *  with the owning agent's current values as the legacy-row fallback (attached
    *  at flatten time, like `model`). Views resolve `daemon` to a display name. */

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -35,8 +35,22 @@ export const consoleKeys = {
     platform: string,
     channel: string,
     triggeredBy: string,
-    githubRepoId: string
-  ) => consoleKey(orgId, 'sessions', cursor, limit, agentId, integration, platform, channel, triggeredBy, githubRepoId),
+    githubRepoId: string,
+    view: string
+  ) =>
+    consoleKey(
+      orgId,
+      'sessions',
+      cursor,
+      limit,
+      agentId,
+      integration,
+      platform,
+      channel,
+      triggeredBy,
+      githubRepoId,
+      view
+    ),
   sessionFacets: (
     orgId: string | null | undefined,
     agentId: string,

--- a/packages/web/src/lib/use-session-list.ts
+++ b/packages/web/src/lib/use-session-list.ts
@@ -2,14 +2,22 @@
 
 import { useCallback, useMemo } from 'react'
 import useSWRInfinite from 'swr/infinite'
-import { fetchSessions, type SessionListFilters, type SessionListPage } from '@/lib/api'
+import { fetchConversations, fetchSessions, type SessionListFilters, type SessionListPage } from '@/lib/api'
 import { consoleKeys } from '@/lib/swr-keys'
 
 const SESSION_PAGE_LIMIT = 50
 const SESSION_FALLBACK_REFRESH_MS = 60_000
 type SessionPageKey = NonNullable<ReturnType<typeof consoleKeys.sessions>>
 
-export function useSessionList(orgId: string | null | undefined, filters: SessionListFilters = {}) {
+export function useSessionList(
+  orgId: string | null | undefined,
+  filters: SessionListFilters = {},
+  // The sessions LIST page reads the grouped conversation view (one row per
+  // conversation, merged-conversation-view.md §5.2); every other consumer
+  // (rails, agent pages) keeps the flat rows.
+  options: { grouped?: boolean } = {}
+) {
+  const grouped = options.grouped === true
   const agentId = filters.agentId ?? ''
   const integration = filters.integration ?? ''
   const platform = filters.platform ?? ''
@@ -30,10 +38,11 @@ export function useSessionList(orgId: string | null | undefined, filters: Sessio
         platform,
         channel,
         triggeredBy,
-        githubRepoId
+        githubRepoId,
+        grouped ? 'grouped' : 'flat'
       )
     },
-    [agentId, channel, githubRepoId, integration, orgId, platform, triggeredBy]
+    [agentId, channel, githubRepoId, grouped, integration, orgId, platform, triggeredBy]
   )
   const {
     data: pages = [],
@@ -57,9 +66,11 @@ export function useSessionList(orgId: string | null | undefined, filters: Sessio
         keyPlatform,
         keyChannel,
         keyTriggeredBy,
-        keyGithubRepoId
+        keyGithubRepoId,
+        keyView
       ] = args as SessionPageKey
-      return fetchSessions(cursor || undefined, Number(limit), keyOrgId, {
+      const fetchPage = keyView === 'grouped' ? fetchConversations : fetchSessions
+      return fetchPage(cursor || undefined, Number(limit), keyOrgId, {
         ...(keyAgentId ? { agentId: keyAgentId } : {}),
         ...(keyIntegration ? { integration: keyIntegration } : {}),
         ...(keyPlatform ? { platform: keyPlatform } : {}),


### PR DESCRIPTION
Implements **C1** of [merged-conversation-view.md](../blob/main/docs/designs/merged-conversation-view.md) (#420): the sessions list becomes one row per conversation.

## Control plane

- **`GET /sessions` returns conversations by default**; `?view=flat` keeps the raw session rows (pre-grouped shape, still used by rails/agent pages and pinned by every non-list consumer). OpenAPI documents both shapes on the operation.
- **`SessionMeta.tenantScope`** persists the durable workspace/tenant scope the daemon already reports on `event/session` (§5.1 — never the credential-derived transport scope). Conversation key = `(platform, tenantScope, channel, thread)`; rows with a NULL channel/thread are ungrouped singletons.
- **Emit-at-max pagination** (§5.2): a scanned row yields its conversation only when no same-key row is strictly greater under the full `(lastActivityAt, startedAt, id)` order AND the caller's own org/visibility predicate — stateless across page boundaries, no aggregate query. The list predicate builders take a row alias so the probe reuses the exact same predicate.
- **Member backfill + current-session collapse**: each page's conversations fetch their members in one batch and collapse to the newest session per agent; superseded ACP rows remain reachable only via `view=flat`. Invisible members are simply absent — no count, no placeholder (§7).
- **`?conversationKey=<key>`** resolves one conversation's current visible members directly (webchat: bare conversation id; IM: base64url `platform`/`tenantScope`/`channel`/`thread`). New `session_meta_conversation_key_idx` replaces the unused `(platform, channel)` index.

## Web

- The sessions list reads the grouped view. Each conversation renders through its representative session row — single-participant rows (the overwhelming majority) are pixel-identical to today. Multi-participant rows show a stacked participant-avatar cell ("N agents") and link to the representative's session page until C2's `/conversations/:key` route lands.
- `fetchConversations` maps grouped rows onto the existing `Session` pipeline (attaching `participants` + `conversationKey`); `fetchSessions` pins `view=flat`.

## Tests

- 5 new integration cases: thread grouping + per-agent collapse (+ `view=flat` parity), tenant-scope split (incl. legacy null-scope), the cross-page emit-at-max no-duplicate scenario from the design review, silent invisible members, and the key resolver (IM + webchat + 400s).
- Key-codec unit suite; pre-existing flat-shape suites pinned to `view=flat`.
- CP: 965 unit + 900 integration green; web: 598 green; typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)