### PR TITLE
feat(github): link profile after app install

### DIFF
--- a/packages/control-plane/src/http/routes/github.ts
+++ b/packages/control-plane/src/http/routes/github.ts
@@ -469,10 +469,17 @@ export function githubCallbackRoutes(deps: HttpDeps) {
         // 302 target is PINNED to the configured console origin — never a
         // request-supplied URL (open-redirect). Unset ⇒ plain-text fallback.
         const consoleUrl = resolveWebAppUrl(deps.config)
-        const back = (note: string) =>
-          consoleUrl
-            ? reply.redirect(`${consoleUrl}/?github=${encodeURIComponent(note)}`)
-            : reply.type('text/plain').send(`GitHub App: ${note}. You can close this tab and open the console.`)
+        const back = (note: string) => {
+          if (!consoleUrl) {
+            return reply.type('text/plain').send(`GitHub App: ${note}. You can close this tab and open the console.`)
+          }
+          // A verified install is also a clear request to use GitHub. Continue
+          // through Profile so an unlinked user can authorize their OWN
+          // identity via Logto's state-bound flow; never infer it from the
+          // installation account (which may be an organization).
+          const path = note === 'installed' ? '/profile' : '/'
+          return reply.redirect(`${consoleUrl}${path}?github=${encodeURIComponent(note)}`)
+        }
 
         // Admin-approval flow: a non-admin requested the install — no usable
         // installation yet. After approval the user must restart the org-bound

--- a/packages/web/src/components/console/SocialSignInCard.test.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.test.tsx
@@ -47,7 +47,13 @@ function RevalidateAccount() {
   )
 }
 
-async function renderCard() {
+async function renderCard({
+  autoLinkTarget,
+  onAutoLinkHandled = vi.fn()
+}: {
+  autoLinkTarget?: 'github'
+  onAutoLinkHandled?: () => void
+} = {}) {
   const cache = new Map()
   container = document.createElement('div')
   document.body.append(container)
@@ -62,7 +68,7 @@ async function renderCard() {
           shouldRetryOnError: true
         }}
       >
-        <SocialSignInCard onNotice={vi.fn()} />
+        <SocialSignInCard onNotice={vi.fn()} autoLinkTarget={autoLinkTarget} onAutoLinkHandled={onAutoLinkHandled} />
         <RevalidateAccount />
       </SWRConfig>
     )
@@ -172,6 +178,29 @@ describe('SocialSignInCard account state', () => {
 
     expect(container?.querySelector('[role="dialog"]')).toBeNull()
     expect(resolveMySocialConnectorId).toHaveBeenCalled()
+  })
+
+  it('continues a verified install through linking only when GitHub is unlinked', async () => {
+    vi.mocked(fetchMySocialAccount).mockResolvedValue({ identities: [], hasSecurityVerificationMethod: false })
+    const onAutoLinkHandled = vi.fn()
+
+    await renderCard({ autoLinkTarget: 'github', onAutoLinkHandled })
+    await waitUntil(() => vi.mocked(resolveMySocialConnectorId).mock.calls.length === 1)
+
+    expect(onAutoLinkHandled).toHaveBeenCalledOnce()
+  })
+
+  it('does not reauthorize GitHub when the installed app user already linked it', async () => {
+    vi.mocked(fetchMySocialAccount).mockResolvedValue({
+      identities: [{ target: 'github', userId: 'github-user', name: 'Phil Z' }],
+      hasSecurityVerificationMethod: false
+    })
+    const onAutoLinkHandled = vi.fn()
+
+    await renderCard({ autoLinkTarget: 'github', onAutoLinkHandled })
+    await waitUntil(() => onAutoLinkHandled.mock.calls.length === 1)
+
+    expect(resolveMySocialConnectorId).not.toHaveBeenCalled()
   })
 
   it('skips the code dialog for a second link while the ownership proof is fresh', async () => {

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useId, useState, type ReactNode } from 'react'
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import useSWR from 'swr'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { SocialLoginMark } from '@/components/marks'
@@ -23,7 +23,7 @@ import {
   type AccountNotice
 } from '@/lib/logto-account'
 import { rememberOwnershipProof, reusableOwnershipProof } from '@/lib/ownership-proof'
-import { socialLoginProviders, type SocialLoginProvider } from '@/lib/social-login-providers'
+import { socialLoginProviders, type SocialLoginProvider, type SocialLoginTarget } from '@/lib/social-login-providers'
 
 const byTarget = (account: MySocialAccountDto, target: string): MySocialIdentityDto | undefined =>
   account.identities.find((identity) => identity.target === target)
@@ -275,11 +275,17 @@ function Notice({ notice }: { notice: AccountNotice }) {
 export default function SocialSignInCard({
   mobile = false,
   notice,
-  onNotice
+  onNotice,
+  autoLinkTarget,
+  onAutoLinkHandled
 }: {
   mobile?: boolean
   notice?: AccountNotice
   onNotice: (notice: AccountNotice) => void
+  /** Continue an explicit upstream action (currently a verified GitHub App
+   *  install) through the same state-bound link flow as the row button. */
+  autoLinkTarget?: SocialLoginTarget
+  onAutoLinkHandled?: () => void
 }) {
   const {
     data: account,
@@ -296,6 +302,7 @@ export default function SocialSignInCard({
   const [pendingUnlink, setPendingUnlink] = useState<SocialLoginProvider>()
   const [pendingVerify, setPendingVerify] = useState<SocialLoginProvider>()
   const [busyProvider, setBusyProvider] = useState<SocialLoginProvider['target']>()
+  const handledAutoLink = useRef<SocialLoginTarget | undefined>(undefined)
   const currentAccount = error ? undefined : account
   const linkedProviderCount = currentAccount
     ? socialLoginProviders().filter((provider) => byTarget(currentAccount, provider.target)).length
@@ -348,6 +355,18 @@ export default function SocialSignInCard({
       setBusyProvider(undefined)
     }
   }
+
+  useEffect(() => {
+    if (!autoLinkTarget || !currentAccount || handledAutoLink.current === autoLinkTarget) return
+    const provider = socialLoginProviders().find((candidate) => candidate.target === autoLinkTarget)
+    handledAutoLink.current = autoLinkTarget
+    onAutoLinkHandled?.()
+    if (!provider) {
+      onNotice({ message: 'GitHub profile linking is not available on this deployment.' })
+      return
+    }
+    if (!byTarget(currentAccount, autoLinkTarget)) beginLink(provider)
+  }, [autoLinkTarget, currentAccount, onAutoLinkHandled, onNotice])
 
   const unlink = async (provider: SocialLoginProvider) => {
     await unlinkMySocialIdentity(provider.target)

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -8,7 +8,7 @@
 // the two must agree). Personal access tokens and "last active" have no backend
 // yet: they render the design's demo values only in mock mode, otherwise empty / '—'.
 
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
@@ -46,6 +46,18 @@ export default function ProfileView() {
   // ProfileView survives its desktop-first hydration switch to the mobile tree,
   // so it holds the card's failure notice instead of either short-lived card.
   const [socialNotice, setSocialNotice] = useState<AccountNotice>()
+  const [autoLinkGithub, setAutoLinkGithub] = useState(false)
+
+  // The GitHub Setup URL only sends a verified installation here. Consume the
+  // marker before starting the provider round trip so cancel/reload cannot loop.
+  useEffect(() => {
+    if (!authOn) return
+    const url = new URL(window.location.href)
+    if (url.searchParams.get('github') !== 'installed') return
+    url.searchParams.delete('github')
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
+    setAutoLinkGithub(true)
+  }, [authOn])
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
   // With no match (mock mode / CP down) the fields fall back to the design's
@@ -123,7 +135,15 @@ export default function ProfileView() {
             </div>
           </div>
 
-          {authOn ? <SocialSignInCard mobile notice={socialNotice} onNotice={setSocialNotice} /> : null}
+          {authOn ? (
+            <SocialSignInCard
+              mobile
+              notice={socialNotice}
+              onNotice={setSocialNotice}
+              autoLinkTarget={autoLinkGithub ? 'github' : undefined}
+              onAutoLinkHandled={() => setAutoLinkGithub(false)}
+            />
+          ) : null}
 
           {/* Personal API keys — the caller's own REST credentials */}
           <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} mobile />
@@ -184,7 +204,14 @@ export default function ProfileView() {
         </div>
       </div>
 
-      {authOn ? <SocialSignInCard notice={socialNotice} onNotice={setSocialNotice} /> : null}
+      {authOn ? (
+        <SocialSignInCard
+          notice={socialNotice}
+          onNotice={setSocialNotice}
+          autoLinkTarget={autoLinkGithub ? 'github' : undefined}
+          onAutoLinkHandled={() => setAutoLinkGithub(false)}
+        />
+      ) : null}
 
       <ApiKeysCard orgs={orgs} defaultOrgId={activeOrg?.id} />
 


### PR DESCRIPTION
## Summary
- send successfully claimed GitHub App installations to Profile
- automatically continue through the existing state-bound GitHub profile link when needed
- skip provider authorization when GitHub is already linked and preserve account ownership verification

## Rationale
GitHub OAuth during installation would disable the verified Setup URL flow and does not carry caller-controlled state or PKCE in the automatic authorization request. This keeps installation claiming and profile identity linking separate, then chains the existing secure flow for the user.

## Validation
- pnpm --filter @agentconnect.md/web exec vitest run src/components/console/SocialSignInCard.test.tsx
- web and control-plane focused ESLint
- web and control-plane TypeScript checks
- web and control-plane production builds
- pre-push full repository lint

Created by Codex . GPT-5