### PR TITLE
fix(daemon): dreams run with/without a sandbox + bind adoption to reviewed bytes (#36)

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -721,3 +721,23 @@ needs it, and log only the agent, repository, credential plane, and outcome.
 This is defense in depth against casual extraction, not a claim that software can
 hide a bearer token from a host administrator who can inspect or modify the daemon
 and its child processes.
+
+## Sandbox availability and feature support
+
+Every feature is supported in environments both **with and without** an OS sandbox,
+and a trusted agent may deliberately run unsandboxed. A sandbox is a best-effort
+isolation layer, never a precondition: no feature may fail closed just because the
+host has no sandbox mechanism (for example macOS, or a Linux host without
+bubblewrap) or because the agent is configured to run outside one. Doing so would
+silently make the feature unavailable in a supported environment, which is a
+regression, not a safety win.
+
+When a feature processes attacker-influenced input — the clearest case is memory
+dreaming, whose consolidation reads the agent's own past sessions — it confines that
+work exactly when the agent itself runs sandboxed, as best-effort isolation of that
+input from provider and host credentials. When the agent runs unsandboxed (trusted,
+or no mechanism available) the feature still runs; the residual credential exposure
+in that mode is an accepted, documented trade-off, closed later by per-runtime
+credential brokering, not by refusing to run. Independent, sandbox-agnostic
+mitigations (for example excluding an agent's tool credentials from a dream's
+environment entirely) still apply in both modes.

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -49,6 +49,7 @@ import {
   type TrustedOrganizationSkillTarget
 } from './memory-dreamer.js'
 import { publishAcceptedDreamSkill } from '../skills/dream-skills.js'
+import { inspectLocalSkillSource } from '../skills/skill-source-snapshot.js'
 
 /**
  * `DreamRunner` — the daemon's dream-job engine (design:
@@ -1148,7 +1149,7 @@ export class DreamRunner {
   /** Accept a mined skill by publishing an immutable bounded local-source
    * revision under the daemon-owned agent root. Workspace materialization is
    * deferred to the unified installer and the warm host is fenced first. */
-  async skillAccept(agentId: string, dreamId: string, name: string): Promise<DreamInfo> {
+  async skillAccept(agentId: string, dreamId: string, name: string, reviewToken?: string): Promise<DreamInfo> {
     this.assertStagedContentAllowed()
     const dir = this.dirFor(agentId)
     return this.withLock(agentId, async () => {
@@ -1157,6 +1158,16 @@ export class DreamRunner {
       if (skill.state === 'dismissed') throw new DreamStateError('this skill candidate was already dismissed')
 
       const staged = join(this.dreamDir(agentId, dreamId), 'skills', name)
+      // Same-bytes review fence (task #36 Phase B): bind acceptance to the exact
+      // staged skill bytes the caller reviewed. inspectLocalSkillSource uses the
+      // same canonical no-follow walker + digest as the publish snapshot, so any
+      // change to the staged skill since review yields a different digest and
+      // forces a re-review instead of accepting un-reviewed bytes.
+      if (reviewToken !== undefined && (await inspectLocalSkillSource(staged)).sha256 !== reviewToken) {
+        throw new DreamStateError(
+          'the staged skill changed since it was reviewed; re-review the current skill before accepting'
+        )
+      }
       const publish = async (): Promise<void> => {
         await publishAcceptedDreamSkill({ agentDir: dir, sourceDir: staged, name })
       }

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -49,7 +49,6 @@ import {
   type TrustedOrganizationSkillTarget
 } from './memory-dreamer.js'
 import { publishAcceptedDreamSkill } from '../skills/dream-skills.js'
-import { inspectLocalSkillSource } from '../skills/skill-source-snapshot.js'
 
 /**
  * `DreamRunner` — the daemon's dream-job engine (design:
@@ -1159,17 +1158,13 @@ export class DreamRunner {
 
       const staged = join(this.dreamDir(agentId, dreamId), 'skills', name)
       // Same-bytes review fence (task #36 Phase B): bind acceptance to the exact
-      // staged skill bytes the caller reviewed. inspectLocalSkillSource uses the
-      // same canonical no-follow walker + digest as the publish snapshot, so any
-      // change to the staged skill since review yields a different digest and
-      // forces a re-review instead of accepting un-reviewed bytes.
-      if (reviewToken !== undefined && (await inspectLocalSkillSource(staged)).sha256 !== reviewToken) {
-        throw new DreamStateError(
-          'the staged skill changed since it was reviewed; re-review the current skill before accepting'
-        )
-      }
+      // staged skill bytes the caller reviewed. The check runs INSIDE
+      // publishAcceptedDreamSkill against its own capture snapshot (not a separate
+      // preflight inspection), so a concurrent writer cannot swap the staged bytes
+      // between inspection and capture — the digest verified is the digest that is
+      // actually pinned and published.
       const publish = async (): Promise<void> => {
-        await publishAcceptedDreamSkill({ agentDir: dir, sourceDir: staged, name })
+        await publishAcceptedDreamSkill({ agentDir: dir, sourceDir: staged, name, expectedDigest: reviewToken })
       }
       if (this.deps.withSkillAcceptance) await this.deps.withSkillAcceptance(agentId, publish)
       else await publish()

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -811,7 +811,7 @@ export class DreamRunner {
    * `.history` record is distill-sourced, those additions are replayed onto the
    * replacement and adoption proceeds; anything else still refuses.
    */
-  async adopt(agentId: string, dreamId: string, force: boolean): Promise<DreamInfo> {
+  async adopt(agentId: string, dreamId: string, force: boolean, reviewToken?: string): Promise<DreamInfo> {
     this.assertStagedContentAllowed()
     const dir = this.dirFor(agentId)
     return this.withLock(agentId, async () => {
@@ -820,10 +820,26 @@ export class DreamRunner {
       if (this.active.has(agentId)) throw new DreamStateError('a dream is in flight for this agent; wait or cancel it')
 
       const out = join(this.dreamDir(agentId, dreamId), 'output')
-      const staged = (await fsp.readdir(out, { withFileTypes: true }))
+      const stagedNames = (await fsp.readdir(out, { withFileTypes: true }))
         .filter((entry) => entry.isFile() && stagedPathOk(entry.name))
         .map((entry) => entry.name)
-      if (!staged.includes(MEMORY_INDEX)) throw new DreamStateError('this dream has no staged index to adopt')
+      if (!stagedNames.includes(MEMORY_INDEX)) throw new DreamStateError('this dream has no staged index to adopt')
+      // Read the staged bytes once; they define both the replacement and the
+      // same-bytes review fence below.
+      const stagedFiles = await Promise.all(
+        stagedNames.map(async (name) => ({ name, content: await fsp.readFile(join(out, name), 'utf8') }))
+      )
+      // Same-bytes review fence (task #36 Phase B): when the caller adopts a
+      // proposal it reviewed, bind adoption to those exact staged bytes. Any
+      // change to the staging since review (a re-run, a distill rebase, manual
+      // edit) yields a different digest, so adoption is refused and the user must
+      // re-review the current proposal rather than silently adopt un-reviewed
+      // content. Auto-adopt passes no token (it opted out of content review).
+      if (reviewToken !== undefined && storeDigest(stagedFiles) !== reviewToken) {
+        throw new DreamStateError(
+          'the staged proposal changed since it was reviewed; re-review the current proposal before adopting'
+        )
+      }
 
       const live = memoryDir(dir)
       const at = this.nowIso()
@@ -834,9 +850,8 @@ export class DreamRunner {
       const replacement = join(dir, `.memory.adopting-${dreamId}`)
       await fsp.rm(replacement, { recursive: true, force: true })
       await fsp.mkdir(replacement, { recursive: true })
-      for (const name of staged) {
-        const content = await fsp.readFile(join(out, name), 'utf8')
-        await fsp.writeFile(join(replacement, name), content, 'utf8')
+      for (const file of stagedFiles) {
+        await fsp.writeFile(join(replacement, file.name), file.content, 'utf8')
       }
 
       // 2) Fence + swap under the shared memory-dir lock, so no writeMemoryFile
@@ -943,7 +958,7 @@ export class DreamRunner {
           this.emitLifecycle({ type: 'memory.dream.adopted', dream: adopted })
           const superseded = await this.supersedeCompletedDreams(agentId, dreamId, adoptedAt)
           this.deps.log.info(
-            `dream ${dreamId} adopted for agent ${agentId} (${staged.length} files, ${superseded} competing proposal(s) superseded)`
+            `dream ${dreamId} adopted for agent ${agentId} (${stagedFiles.length} files, ${superseded} competing proposal(s) superseded)`
           )
           return adopted
         })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4601,9 +4601,9 @@ export class Daemon {
     const agent = this.agents.get(agentId)
     if (!agent) throw new Error(`unknown agent ${agentId}`)
     // Credential isolation (task #36 A2): the dream runs on its OWN dedicated,
-    // sandbox-forced host — NOT the agent's warm host — so the attacker-controlled
-    // transcript can never reach provider credentials, and the confined child is
-    // torn down the moment the extraction settles.
+    // one-off host — NOT the agent's warm host — sandboxed whenever the agent
+    // runs sandboxed so the attacker-controlled transcript is confined from
+    // provider credentials, and torn down the moment the extraction settles.
     const host = await this.buildDreamHost(agent, context.inputDir)
     const ref: { sessionId?: string } = {}
     try {
@@ -4624,30 +4624,24 @@ export class Daemon {
   }
 
   /**
-   * Build + start a DEDICATED, sandbox-forced, one-off host for a single dream
-   * (task #36 A2). Fail closed if this host has no sandbox mechanism: without
-   * confinement the mined (attacker-controlled) transcript could drive the
-   * runtime's native tools against the host and its credentials. A sandboxed
-   * runtime is denied the HOST's credentials (HOME + runtime-state dirs are
-   * denyRead), and on Claude the inner sandbox also denies the agent's own
-   * provider credential to the model's bash, so the dream model reads its
-   * materialized inputs (cwd) yet cannot read those secrets.
+   * Build + start a DEDICATED, one-off host for a single dream (task #36 A2).
    *
-   * All agent harnesses are supported by default (owner decision): on runtimes
-   * without an inner provider-credential confinement (e.g. Codex) the agent's
-   * OWN provider auth can still be reached by the model's own tools, since it
-   * must stay readable by the runtime parent to authenticate. That residual gap
-   * is a tracked P2 to be closed by a per-runtime credential broker; it does NOT
-   * gate which harnesses may dream.
+   * Dreams are supported in every environment — with OR without a sandbox — and
+   * NEVER fail closed on a missing sandbox mechanism (owner principle: any
+   * feature must run with or without a sandbox; trusted agents may run
+   * unsandboxed). The dedicated host follows the agent's own effective sandbox
+   * decision (`agentRunsInSandbox`): when the agent runs sandboxed the dream is
+   * confined too — best-effort isolation of the attacker-controlled transcript,
+   * since a sandboxed runtime is denied the HOST's credentials (HOME +
+   * runtime-state dirs are denyRead) and, on Claude, the inner sandbox also
+   * denies the agent's own provider credential to the model's bash. When the
+   * agent runs unsandboxed (trusted, or no mechanism available) the dream runs
+   * unsandboxed too; the residual credential exposure there is a tracked P2 (as
+   * with the Codex provider-credential gap), not a gate on dreaming.
    */
   private async buildDreamHost(agent: LoadedAgent, cwd: string): Promise<AcpHost> {
-    if (!this.sandboxMechanism) {
-      throw new DreamStateError(
-        'memory dream requires a supported OS sandbox to isolate provider credentials from the mined transcript; none is available on this host'
-      )
-    }
     const { host } = this.buildAcpHost(agent, this.cfg, {
-      runInSandbox: true,
+      runInSandbox: this.agentRunsInSandbox(agent),
       cwd,
       // A dream needs only its materialized inputs, never the agent's tool
       // credentials — keep github-app/gh/`*_DATA` secrets out of the

--- a/packages/daemon/src/skills/dream-skills.ts
+++ b/packages/daemon/src/skills/dream-skills.ts
@@ -170,6 +170,12 @@ export async function publishAcceptedDreamSkill(input: {
   agentDir: string
   sourceDir: string
   name: string
+  /** Same-bytes review fence (task #36 Phase B): when set, the digest of the
+   *  captured publication snapshot must equal this reviewed digest, else publish
+   *  refuses. Checked against the SNAPSHOT (not a separate preflight inspection)
+   *  so a concurrent writer cannot swap staged bytes between review and capture —
+   *  the digest verified is the digest actually pinned and activated. */
+  expectedDigest?: string
 }): Promise<{ sourceDir: string; digest: string }> {
   if (!SKILL_DIR_RE.test(input.name)) throw new Error('invalid accepted Dream skill name')
   const { root, bundles } = await ensureAcceptedRoots(input.agentDir)
@@ -182,6 +188,10 @@ export async function publishAcceptedDreamSkill(input: {
   await pruneUnreferencedBundles(root, records)
   const temporary = join(bundles, `.new-${randomUUID()}`)
   const snapshot = await snapshotLocalSkillSource(input.sourceDir, temporary)
+  if (input.expectedDigest !== undefined && snapshot.sha256 !== input.expectedDigest) {
+    await fsp.rm(temporary, { recursive: true, force: true }).catch(() => undefined)
+    throw new Error('the staged skill changed since it was reviewed; re-review the current skill before accepting')
+  }
   const hex = snapshot.sha256.replace('sha256:', '')
   const directory = `${BUNDLES_DIRNAME}/${input.name}-${hex}`
   const target = join(root, ...directory.split('/'))

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -200,10 +200,6 @@ describe('Daemon evaluation surface', () => {
       evaluation: { observer: collector, runId: 'eval-run-dream' }
     })
     await daemon.start()
-    // Dreaming now runs on a dedicated sandboxed host to isolate provider
-    // credentials from the mined transcript (task #36 A2); simulate a host that
-    // has an OS sandbox mechanism so the extraction is admitted.
-    ;(daemon as any).sandboxMechanism = 'bwrap'
     const usageReports: any[] = []
     ;(daemon as any).cpClient = {
       emitEventSession: vi.fn(),
@@ -334,8 +330,6 @@ describe('Daemon evaluation surface', () => {
       evaluation: { observer: collector, runId: 'eval-run-dream-default-model' }
     })
     await daemon.start()
-    // A dedicated sandboxed dream host isolates credentials (task #36 A2).
-    ;(daemon as any).sandboxMechanism = 'bwrap'
 
     const started = await (daemon as any).dreamRunner().start(AGENT_ID, { trigger: 'manual' })
     let dream
@@ -397,8 +391,6 @@ describe('Daemon evaluation surface', () => {
       evaluation: { observer: collector, runId: 'eval-run-dream-ignored-cancel' }
     })
     await daemon.start()
-    // A dedicated sandboxed dream host isolates credentials (task #36 A2).
-    ;(daemon as any).sandboxMechanism = 'bwrap'
 
     try {
       vi.useFakeTimers()

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -1510,19 +1510,27 @@ describe('DreamRunner skill mining (D-3)', () => {
     expect(withSkillAcceptance).toHaveBeenCalledOnce()
   })
 
-  it('binds skill acceptance to the reviewed staged bytes (same-bytes review fence)', async () => {
+  it('binds skill acceptance to the PUBLISHED bytes: wrong token or a post-review mutation is refused', async () => {
     const { dir, runner, dreamId } = await mining(grounded)
     const staged = join(dir, 'memory-dreams', dreamId, 'skills', 'deploy-staging')
+    const skillMd = join(staged, 'SKILL.md')
     const token = (await inspectLocalSkillSource(staged)).sha256
 
-    // A stale/incorrect token is refused before the skill is published.
+    // A stale/incorrect token is refused.
     await expect(runner.skillAccept('a1', dreamId, 'deploy-staging', `sha256:${'0'.repeat(64)}`)).rejects.toThrow(
       /re-review/i
     )
 
-    // The exact reviewed digest accepts (proving the failed attempt left the
-    // candidate reviewable).
-    const after = await runner.skillAccept('a1', dreamId, 'deploy-staging', token)
+    // A mutation AFTER the token was minted is caught at the publication snapshot
+    // (the fence is verified against publish's own capture, not a preflight
+    // inspection), so a concurrent swap of staged bytes can never publish
+    // un-reviewed content.
+    await writeFile(skillMd, `${await readFile(skillMd, 'utf8')}\n<!-- tampered -->\n`, 'utf8')
+    await expect(runner.skillAccept('a1', dreamId, 'deploy-staging', token)).rejects.toThrow(/re-review/i)
+
+    // Re-reviewing the current bytes (fresh token) accepts.
+    const current = (await inspectLocalSkillSource(staged)).sha256
+    const after = await runner.skillAccept('a1', dreamId, 'deploy-staging', current)
     expect(after.skills?.[0]).toMatchObject({ state: 'accepted' })
   })
 

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -27,6 +27,7 @@ import {
   type MemoryHistoryRecord
 } from '../src/agents/memory.js'
 import { acceptedDreamSkillSources } from '../src/skills/dream-skills.js'
+import { storeDigest } from '../src/agents/memory-dreamer.js'
 
 const silent = { info() {}, warn() {} }
 
@@ -457,6 +458,30 @@ describe('DreamRunner adoption', () => {
     const history = await readFile(join(memoryDir(dir), MEMORY_HISTORY_FILENAME), 'utf8')
     expect(history).toContain('"source":"dream"')
     expect(history).toContain('"source":"tool"') // pre-adoption rows preserved
+  })
+
+  it('binds adoption to the reviewed staged bytes (same-bytes review fence)', async () => {
+    const { dir, store, runner } = await setup({})
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    // The review token is the digest of the exact staged output the user reviewed.
+    const out = join(dir, 'memory-dreams', started.dreamId, 'output')
+    const names = await readdir(out)
+    const stagedFiles = await Promise.all(
+      names.map(async (name) => ({ name, content: await readFile(join(out, name), 'utf8') }))
+    )
+    const token = storeDigest(stagedFiles)
+
+    // A stale/incorrect token is refused before any mutation — the reviewed bytes
+    // must match what is about to be adopted.
+    await expect(runner.adopt('a1', started.dreamId, false, `sha256:${'0'.repeat(64)}`)).rejects.toThrow(/re-review/i)
+    expect(store.dreams.get(started.dreamId)?.status).toBe('completed')
+
+    // The exact reviewed digest adopts cleanly.
+    const adopted = await runner.adopt('a1', started.dreamId, false, token)
+    expect(adopted.status).toBe('adopted')
+    expect(await readMemoryFile(dir, 'prefs.md')).toBe('- Uses tabs, not spaces (2026-07-24).\n')
   })
 
   it('records the exact add, update, and delete set with live before snapshots', async () => {

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../src/agents/memory.js'
 import { acceptedDreamSkillSources } from '../src/skills/dream-skills.js'
 import { storeDigest } from '../src/agents/memory-dreamer.js'
+import { inspectLocalSkillSource } from '../src/skills/skill-source-snapshot.js'
 
 const silent = { info() {}, warn() {} }
 
@@ -1507,6 +1508,22 @@ describe('DreamRunner skill mining (D-3)', () => {
     await expect(runner.skillAccept('a1', dreamId, 'deploy-staging')).resolves.toMatchObject({})
     expect(events.filter((event) => event.type === 'memory.dream.skill_accepted')).toHaveLength(1)
     expect(withSkillAcceptance).toHaveBeenCalledOnce()
+  })
+
+  it('binds skill acceptance to the reviewed staged bytes (same-bytes review fence)', async () => {
+    const { dir, runner, dreamId } = await mining(grounded)
+    const staged = join(dir, 'memory-dreams', dreamId, 'skills', 'deploy-staging')
+    const token = (await inspectLocalSkillSource(staged)).sha256
+
+    // A stale/incorrect token is refused before the skill is published.
+    await expect(runner.skillAccept('a1', dreamId, 'deploy-staging', `sha256:${'0'.repeat(64)}`)).rejects.toThrow(
+      /re-review/i
+    )
+
+    // The exact reviewed digest accepts (proving the failed attempt left the
+    // candidate reviewable).
+    const after = await runner.skillAccept('a1', dreamId, 'deploy-staging', token)
+    expect(after.skills?.[0]).toMatchObject({ state: 'accepted' })
   })
 
   it('an accepted skill survives discarding the dream it came from', async () => {

--- a/packages/daemon/test/dream-scheduler.test.ts
+++ b/packages/daemon/test/dream-scheduler.test.ts
@@ -219,39 +219,13 @@ describe('scheduled dream lifecycle gates (daemon)', () => {
     }
   }, 15_000)
 
-  // task #36 A2 — credential isolation: the dream runs on a DEDICATED,
-  // sandbox-forced host and is torn down after, so the attacker-controlled
-  // transcript is never mined next to provider credentials.
-  it('fails closed when the host has no OS sandbox to isolate dream credentials', async () => {
-    const root = scaffold()
-    const hostFactory = vi.fn(() => ({}) as any)
-    const daemon = new Daemon({ root, hostFactory, dreamOperationPolicy: 'test-only' })
-    await daemon.start()
-    try {
-      const inner = daemon as any
-      // test-only policy admits the extraction past the operation gate; without a
-      // sandbox mechanism the dedicated dream host must refuse rather than run the
-      // dream model unconfined next to credentials.
-      inner.sandboxMechanism = undefined
-      await expect(
-        inner.runDreamExtraction('bot-a', 'system', 'prompt', new AbortController().signal, {
-          dreamId: 'drm-nosandbox',
-          trigger: 'manual',
-          sessionIds: [],
-          inputDir: join(root, 'in')
-        })
-      ).rejects.toThrow(/sandbox/i)
-      // Fail-closed happens before any host is built.
-      expect(hostFactory).not.toHaveBeenCalled()
-    } finally {
-      await daemon.stop()
-    }
-  }, 15_000)
-
-  it('runs the dream on a dedicated sandboxed host (cwd = input dir) then tears it down', async () => {
-    const root = scaffold()
-    let stopped = 0
-    const dreamHost = {
+  // task #36 A2 — the dream runs on a DEDICATED one-off host, torn down after.
+  // Sandboxed when the AGENT runs sandboxed (best-effort isolation of the
+  // attacker-controlled transcript), but supported WITH OR WITHOUT a sandbox and
+  // never fail-closed on a missing mechanism (owner principle: trusted agents
+  // may run unsandboxed).
+  const stubDreamHost = (onStop: () => void) =>
+    ({
       start: async () => {},
       hasSession: () => true,
       usesMetaSystemPrompt: () => false,
@@ -262,16 +236,49 @@ describe('scheduled dream lifecycle gates (daemon)', () => {
       prompt: async () => ({ stopReason: 'end_turn' }),
       discardSession: () => {},
       cancel: async () => {},
-      stop: async () => {
-        stopped++
-      }
-    }
-    const hostFactory = vi.fn(() => dreamHost as any)
+      stop: async () => onStop()
+    }) as any
+
+  it('runs the dream without a sandbox mechanism, on an unsandboxed dedicated host', async () => {
+    const root = scaffold()
+    let stopped = 0
+    const hostFactory = vi.fn(() => stubDreamHost(() => stopped++))
     const daemon = new Daemon({ root, hostFactory, dreamOperationPolicy: 'test-only' })
     await daemon.start()
     try {
       const inner = daemon as any
-      inner.sandboxMechanism = 'bwrap' // simulate a host with an OS sandbox
+      inner.sandboxMechanism = undefined // no OS sandbox available on this host
+      const buildSpy = vi.spyOn(inner, 'buildAcpHost')
+      const res = await inner.runDreamExtraction('bot-a', 'system', 'prompt', new AbortController().signal, {
+        dreamId: 'drm-nosandbox',
+        trigger: 'manual',
+        sessionIds: [],
+        inputDir: join(root, 'in')
+      })
+      // Never fail-closed: the dream still runs, on an unsandboxed dedicated host.
+      expect(buildSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'bot-a' }),
+        expect.anything(),
+        expect.objectContaining({ runInSandbox: false, cwd: join(root, 'in') })
+      )
+      expect(stopped).toBe(1)
+      expect(inner.hosts.has('bot-a')).toBe(false)
+      expect(res.sessionId).toBe('dream-sess')
+    } finally {
+      await daemon.stop()
+    }
+  }, 15_000)
+
+  it('sandboxes the dedicated dream host when the agent runs sandboxed, then tears it down', async () => {
+    const root = scaffold()
+    let stopped = 0
+    const hostFactory = vi.fn(() => stubDreamHost(() => stopped++))
+    const daemon = new Daemon({ root, hostFactory, dreamOperationPolicy: 'test-only' })
+    await daemon.start()
+    try {
+      const inner = daemon as any
+      inner.sandboxMechanism = 'bwrap'
+      inner.agents.get('bot-a').runInSandbox = true // the agent opts into the sandbox
       const buildSpy = vi.spyOn(inner, 'buildAcpHost')
       const res = await inner.runDreamExtraction('bot-a', 'system', 'prompt', new AbortController().signal, {
         dreamId: 'drm-sandboxed',
@@ -279,8 +286,8 @@ describe('scheduled dream lifecycle gates (daemon)', () => {
         sessionIds: [],
         inputDir: join(root, 'in')
       })
-      // The dedicated dream host is built with sandbox FORCED on + cwd = the
-      // materialized input dir — never the agent's warm (possibly unsandboxed) host.
+      // Sandboxed (agent runs sandboxed + a mechanism exists) + cwd = the
+      // materialized input dir — never the agent's warm host.
       expect(buildSpy).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'bot-a' }),
         expect.anything(),


### PR DESCRIPTION
Two daemon-side changes for task #36, on top of the merged A2 dedicated dream host.

## 1. Dreams run with OR without a sandbox — never fail closed (correction to A2)
Owner principle: any feature must be supported in environments **with or without** a sandbox, and trusted agents may run unsandboxed; requiring a sandbox breaks "supported everywhere". A2's `buildDreamHost` wrongly failed closed when no OS sandbox mechanism was present (macOS, hosts without bubblewrap), making Dream unavailable there.

`buildDreamHost` now follows the agent's own effective sandbox decision (`agentRunsInSandbox`): the dedicated dream host is sandboxed when the agent runs sandboxed (best-effort isolation of the attacker-controlled transcript from provider credentials) and runs unsandboxed for a trusted agent or a host with no mechanism. The residual no-sandbox credential exposure is a tracked **P2**, not a gate on dreaming (same posture as the Codex provider-credential gap).

## 2. Phase B foundation: bind adoption/acceptance to the reviewed bytes
First step toward closing `DREAM_UNBOUND_STAGED_CONTENT_REASON` (the "reviewed bytes are not cryptographically bound to adoption" hold). Both `adopt` (memory store) and `skillAccept` (skill) now take an optional `reviewToken` — the digest of the staged content the caller reviewed — and refuse the operation if the current staged bytes no longer match it, forcing a re-review instead of adopting un-reviewed content. `adopt` reuses the canonical `storeDigest`; `skillAccept` uses `inspectLocalSkillSource` (the same canonical walker + digest as the publish snapshot). Backward-compatible: no token preserves current behaviour, and auto-adopt (which opted out of review) passes none.

**Incremental:** the review read that *returns* these tokens, the protocol/CP/web wiring that carries them from the console, and the cancel/replay fencing land in a follow-up PR. The gate (`dreamOperationsAllowed()`) is unchanged — dreaming stays disabled until Phase C.

## Tests
- dream-scheduler: "runs without a sandbox mechanism" (still runs, unsandboxed) + "sandboxes when the agent runs sandboxed"; daemon-evaluation dream tests no longer stub a sandbox mechanism.
- dream-runner: "binds adoption to the reviewed staged bytes" + "binds skill acceptance to the reviewed staged bytes".
- Full daemon suite green locally (2722 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)