### PR TITLE
feat(daemon): persist the canonical webchat postId on transcript rows (C2 prerequisite)

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2505,6 +2505,9 @@ export const SessionMessageDto = z.object({
   senderAvatarUrl: z.string().url().optional(), // public provider-hosted profile image
   trustedAgentBot: z.boolean().optional(), // daemon-verified AgentConnect Slack bot provenance
   ts: z.string(),
+  // Canonical webchat post identity (merged-conversation-view.md §6) — identical
+  // on every participant's copy; absent on non-webchat and pre-upgrade rows.
+  postId: z.string().optional(),
   kind: z.string(),
   text: z.string(),
   attachments: z.array(SessionImageAttachment).max(1).optional(),

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -299,6 +299,7 @@ export function createSessionReader(
           ...(senderAvatarUrl ? { senderAvatarUrl } : {}),
           ...(r.trustedAgentBot ? { trustedAgentBot: true } : {}),
           ts: r.ts,
+          ...(r.postId ? { postId: r.postId } : {}),
           kind: r.kind,
           text: substituteUserMentions(withoutAttachmentMention(r.text, attachments), names),
           ...(attachments.length ? { attachments } : {})

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5441,6 +5441,11 @@ export class Daemon {
         {
           sender: user,
           recipient: result.agentId,
+          // The canonical identity must ride the ADMISSION write too — without
+          // it the probe falls back to (sender, text) and a distinct same-ms
+          // same-text post from another tab would reuse this row instead of
+          // bumping (§6).
+          postId: post.postId,
           text: observedMention ? `${text}\n${observedMention}`.trim() : text
         }
       )

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5392,7 +5392,7 @@ export class Daemon {
       // participant copy of this turn records the SAME transcript ts, which is
       // what lets co-hosted participants share one text row and cross-daemon
       // transcripts merge by (at, postId) (webchat-multi-agents.md §5.1).
-      ...(post ? { transcriptTs: String(post.at) } : {}),
+      ...(post ? { transcriptTs: String(post.at), transcriptPostId: post.postId } : {}),
       ...(inlineImages?.length
         ? {
             attachments: inlineImages.map((image, index) => {
@@ -8193,6 +8193,8 @@ export class Daemon {
       sender: string
       recipient?: string
       text: string
+      /** Canonical webchat post id — persisted on the row (§6). */
+      postId?: string
       trustedAgentBot?: boolean
       attachments?: SessionImageAttachment[]
     }
@@ -8250,6 +8252,7 @@ export class Daemon {
     this.appendWebchatTextRow(transcriptChannelKey(chatId, undefined), `webchat:${chatId}`, String(contextPost.at), {
       sender,
       recipient: agentId,
+      postId: contextPost.postId,
       text: contextPost.text,
       ...(contextPost.author.kind === 'agent' ? { trustedAgentBot: true } : {}),
       ...(contextPost.attachments?.length
@@ -11176,7 +11179,9 @@ export class Daemon {
           // The ts the row actually lands on (post-collision-bump) doubles as the reply
           // post's canonical `at` (minted ONCE here, the origin) carried to every other
           // participant's copy via rd/webchat-post.
+          const replyPostId = randomUUID()
           const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
+            postId: replyPostId,
             sender: agentId,
             text: p.webchat.replyText
           })
@@ -11187,7 +11192,7 @@ export class Daemon {
             conversationId: p.webchat.conversationId,
             agentId,
             post: {
-              postId: randomUUID(),
+              postId: replyPostId,
               conversationId: p.webchat.conversationId,
               author: { kind: 'agent', agentId },
               text: p.webchat.replyText,
@@ -11311,7 +11316,9 @@ export class Daemon {
         const trimmedPartialReply = p.webchat.replyText.trim()
         if (trimmedPartialReply && !isNoResponseBody(trimmedPartialReply)) {
           this.flushHeldWebchatText(p.webchat)
+          const partialPostId = randomUUID()
           const replyTs = this.appendWebchatTextRow(p.transcriptChannel, statusThread, monotonicTs(), {
+            postId: partialPostId,
             sender: agentId,
             text: p.webchat.replyText
           })
@@ -11321,7 +11328,7 @@ export class Daemon {
             conversationId: p.webchat.conversationId,
             agentId,
             post: {
-              postId: randomUUID(),
+              postId: partialPostId,
               conversationId: p.webchat.conversationId,
               author: { kind: 'agent', agentId },
               text: p.webchat.replyText,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8202,7 +8202,17 @@ export class Daemon {
     let slot = BigInt(ts)
     for (let attempt = 0; attempt < 32; attempt++) {
       const existing = this.store.transcriptTextAt(channel, thread, String(slot))
-      if (!existing || (existing.sender === entry.sender && existing.text === entry.text)) {
+      // Canonical identity decides slot reuse (§6): two DISTINCT posts can share
+      // sender, text, AND millisecond (`at` minting is connection-local, so two
+      // tabs can collide) — only a matching postId proves the occupant IS this
+      // post. Rows without an id on either side keep the historical
+      // (sender, text) heuristic as the legacy fallback.
+      const samePost =
+        existing !== undefined &&
+        (entry.postId && existing.postId
+          ? existing.postId === entry.postId
+          : existing.sender === entry.sender && existing.text === entry.text)
+      if (!existing || samePost) {
         this.store.appendTranscript({ channel, thread, ts: String(slot), kind: 'text', ...entry })
         return String(slot)
       }

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -33,6 +33,10 @@ export interface NormalizedMessage extends Omit<
    * only the timestamp before the separator.
    */
   transcriptTs?: string
+  /** The canonical webchat post id minted beside `transcriptTs` (same origin,
+   *  merged-conversation-view.md §6) — persisted on the transcript row so
+   *  cross-daemon copies share an explicit identity. */
+  transcriptPostId?: string
   source: 'user' | 'cron' | 'agent' | 'hook'
   platform: 'slack' | 'telegram' | 'webchat' | 'discord' | 'feishu' | 'hook'
   /**

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -440,7 +440,15 @@ export class SessionManager {
       let slot = BigInt(ts)
       for (let attempt = 0; attempt < 32; attempt++) {
         const existing = this.deps.store.transcriptTextAt(transcriptChannel, thread, String(slot))
-        if (!existing || (existing.sender === msg.sender.id && existing.text === transcriptText)) break
+        // Mirror the daemon-side probe (§6): matching canonical postId is what
+        // proves the occupant is this same post; (sender, text) only decides
+        // for legacy rows without an id on either side.
+        const samePost =
+          existing !== undefined &&
+          (msg.transcriptPostId && existing.postId
+            ? existing.postId === msg.transcriptPostId
+            : existing.sender === msg.sender.id && existing.text === transcriptText)
+        if (!existing || samePost) break
         slot += 1n
       }
       ts = String(slot)

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -450,6 +450,9 @@ export class SessionManager {
       thread,
       ts,
       sender: msg.sender.id,
+      // The canonical webchat post identity travels with the canonical ts —
+      // identical on every participant copy even when `ts` was bumped (§6).
+      ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {}),
       // This message was delivered TO this agent (handle() runs for `agentId`), so tag the
       // recipient — the console session view scopes to what THIS agent received + produced.
       recipient: agentId,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -194,6 +194,10 @@ export interface TranscriptEntry {
   // prompt replay still compares the original platform `ts`.
   ts: string
   sender: string
+  /** Canonical webchat post id (merged-conversation-view.md §6): minted once at
+   *  origin, identical on every participant's copy regardless of a
+   *  collision-bumped `ts`. Text rows only; absent everywhere else. */
+  postId?: string
   /** True only when the daemon verified that this Slack history row came from an
    *  AgentConnect-managed bot identity. Legacy rows and all other platforms omit it. */
   trustedAgentBot?: boolean
@@ -580,7 +584,8 @@ export class LocalStore {
         channel TEXT NOT NULL, thread TEXT NOT NULL, ts TEXT,
         sender TEXT NOT NULL, kind TEXT NOT NULL, text TEXT NOT NULL,
         tool_call_id TEXT, body TEXT, recipient TEXT, eventTimeUs INTEGER,
-        attachmentsJson TEXT, quoteJson TEXT, trustedAgentBot INTEGER, revision INTEGER NOT NULL DEFAULT 0
+        attachmentsJson TEXT, quoteJson TEXT, trustedAgentBot INTEGER, revision INTEGER NOT NULL DEFAULT 0,
+        postId TEXT
       );
       CREATE INDEX IF NOT EXISTS transcript_thread_seq ON transcript (channel, thread, seq);
       -- Dedup conversational rows by platform ts (double-fired inbound / redelivery);
@@ -1050,6 +1055,8 @@ export class LocalStore {
     const cols = this.db.prepare('PRAGMA table_info(transcript)').all() as { name: string }[]
     if (!cols.some((c) => c.name === 'attachmentsJson'))
       this.db.exec('ALTER TABLE transcript ADD COLUMN attachmentsJson TEXT')
+    // Canonical webchat post identity (merged-conversation-view.md §6).
+    if (!cols.some((c) => c.name === 'postId')) this.db.exec('ALTER TABLE transcript ADD COLUMN postId TEXT')
   }
 
   /** Add daemon-private quoted-reply context to existing transcript tables. The JSON
@@ -2469,13 +2476,14 @@ export class LocalStore {
     const inserted = this.db
       .prepare(
         `INSERT OR IGNORE INTO transcript
-           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, quoteJson, trustedAgentBot, revision)
+           (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, attachmentsJson, quoteJson, trustedAgentBot, revision, postId)
          VALUES
-           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @quoteJson, @trustedAgentBot, @revision)`
+           (@channel, @thread, @ts, @sender, @kind, @text, @recipient, @eventTimeUs, @attachmentsJson, @quoteJson, @trustedAgentBot, @revision, @postId)`
       )
       .run({
         ...entry,
         recipient: e.recipient ?? null,
+        postId: e.postId ?? null,
         eventTimeUs: transcriptEventTimeUs(e.ts),
         attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
         quoteJson: durableQuoteJson,
@@ -2496,6 +2504,17 @@ export class LocalStore {
             )
             .run(e.channel, e.thread, e.ts)
         : undefined
+    // The same canonical post can be recorded first by a pre-upgrade write (no
+    // postId column value) and re-observed by a copy that carries it. Upgrade in
+    // place; an identity can be added but never changed or cleared.
+    if (Number(inserted.changes) === 0 && e.postId) {
+      this.db
+        .prepare(
+          `UPDATE transcript SET postId = ?
+           WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND postId IS NULL`
+        )
+        .run(e.postId, e.channel, e.thread, e.ts)
+    }
     // A later duplicate can be the first copy that carries provider reply metadata
     // (or a corrected selected passage). Upgrade it without ever clearing a quote when
     // a provider snapshot subsequently re-appends the same text row without metadata.

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2463,10 +2463,16 @@ export class LocalStore {
    *  `INSERT OR IGNORE` under the `transcript_text_ts` unique index would silently
    *  drop a DIFFERENT post landing on an occupied millisecond, so writers check
    *  the slot first and bump when it holds foreign content. */
-  transcriptTextAt(channel: string, thread: string, ts: string): { sender: string; text: string } | undefined {
+  transcriptTextAt(
+    channel: string,
+    thread: string,
+    ts: string
+  ): { sender: string; text: string; postId: string | null } | undefined {
     return this.db
-      .prepare(`SELECT sender, text FROM transcript WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'`)
-      .get(channel, thread, ts) as { sender: string; text: string } | undefined
+      .prepare(
+        `SELECT sender, text, postId FROM transcript WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'`
+      )
+      .get(channel, thread, ts) as { sender: string; text: string; postId: string | null } | undefined
   }
 
   appendTranscript(e: TranscriptEntry): void {
@@ -2552,7 +2558,16 @@ export class LocalStore {
         .prepare("UPDATE transcript SET revision = ? WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text'")
         .run(deliveryRevision, e.channel, e.thread, e.ts)
       this.transcriptRevision = deliveryRevision
-      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient], deliveryRevision)
+      // An in-place upgrade mutates the SHARED row: every agent whose scoped
+      // view already contains it must be invalidated, not just this append's
+      // sender/recipient — a co-hosted participant delivered earlier would
+      // otherwise keep serving the stale copy until an unrelated mutation.
+      const sharedRecipients = (
+        this.db
+          .prepare('SELECT agentId FROM transcript_recipient WHERE channel = ? AND thread = ? AND ts = ?')
+          .all(e.channel, e.thread, e.ts) as { agentId: string }[]
+      ).map((r) => r.agentId)
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender, e.recipient, ...sharedRecipients], deliveryRevision)
     }
   }
 

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2507,14 +2507,15 @@ export class LocalStore {
     // The same canonical post can be recorded first by a pre-upgrade write (no
     // postId column value) and re-observed by a copy that carries it. Upgrade in
     // place; an identity can be added but never changed or cleared.
-    if (Number(inserted.changes) === 0 && e.postId) {
-      this.db
-        .prepare(
-          `UPDATE transcript SET postId = ?
-           WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND postId IS NULL`
-        )
-        .run(e.postId, e.channel, e.thread, e.ts)
-    }
+    const postIdUpgraded =
+      Number(inserted.changes) === 0 && e.postId
+        ? this.db
+            .prepare(
+              `UPDATE transcript SET postId = ?
+               WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND postId IS NULL`
+            )
+            .run(e.postId, e.channel, e.thread, e.ts)
+        : undefined
     // A later duplicate can be the first copy that carries provider reply metadata
     // (or a corrected selected passage). Upgrade it without ever clearing a quote when
     // a provider snapshot subsequently re-appends the same text row without metadata.
@@ -2543,6 +2544,7 @@ export class LocalStore {
     } else if (
       Number(provenanceUpgraded?.changes ?? 0) === 1 ||
       Number(quoteUpgraded?.changes ?? 0) === 1 ||
+      Number(postIdUpgraded?.changes ?? 0) === 1 ||
       Number(delivered?.changes ?? 0) === 1
     ) {
       const deliveryRevision = this.transcriptRevision + 1

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -429,4 +429,56 @@ describe('webchat turn-final context refresh', () => {
     ])
     await daemon.stop()
   })
+  it('turn ADMISSION writes carry the canonical id — distinct same-text turns bump, not merge', async () => {
+    // The pre-queue observed-inbound write must be identity-aware too: two
+    // tabs can mint distinct turn posts on one millisecond with the same user
+    // and text. Without the id on the admission append, the second turn would
+    // reuse the first row — no new revision, nothing for the in-flight
+    // generation to coalesce, and a lost post if its queued activation never
+    // runs.
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-wc-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async () => {
+        await firstBlocked
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const turnPost = (n: number) => ({ postId: `0000000${n}-2222-4000-8000-00000000000${n}`, at: 9_000 })
+    const t1 = '11111111-aaaa-4aaa-8aaa-111111111111'
+    const t2 = '22222222-bbbb-4bbb-8bbb-222222222222'
+    expect(
+      (daemon as any).handleRelayMsg(
+        rd({ op: 'turn', text: 'same words', user: 'owner', turnId: t1, post: turnPost(1) }),
+        () => {}
+      )
+    ).toMatchObject({ accepted: true })
+    expect(
+      (daemon as any).handleRelayMsg(
+        rd({ op: 'turn', text: 'same words', user: 'owner', turnId: t2, post: turnPost(2) }, { msgId: 'm-2' }),
+        () => {}
+      )
+    ).toMatchObject({ accepted: true })
+
+    const rows = (daemon as any).store.transcriptSince(
+      transcriptChannelKey(CONV, undefined),
+      `webchat:${CONV}`,
+      null
+    ) as { ts: string; postId?: string | null; text: string }[]
+    expect(rows.filter((r) => r.text === 'same words').map((r) => [r.ts, r.postId])).toEqual([
+      ['9000', turnPost(1).postId],
+      ['9001', turnPost(2).postId]
+    ])
+    releaseFirst()
+    await daemon.stop()
+  })
 })

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -387,4 +387,46 @@ describe('webchat turn-final context refresh', () => {
     expect(replies).toEqual([])
     await daemon.stop()
   })
+  it('distinct canonical posts sharing millisecond, sender, and text occupy separate slots', async () => {
+    // The C2 dedupe prerequisite: `at` minting is connection-local, so two
+    // tabs can mint distinct posts on the same millisecond — and a same-user
+    // repeat ("ok" twice) also matches the legacy (sender, text) heuristic.
+    // Only a matching canonical postId may reuse an occupied slot; a distinct
+    // id must bump, or the second post is silently lost.
+    const daemon = new Daemon({
+      root: scaffold(),
+      hostFactory: () => ({ start: vi.fn(async () => {}) }) as any
+    })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const dup = (n: number) => ({
+      postId: `0000000${n}-1111-4000-8000-00000000000${n}`,
+      conversationId: CONV,
+      author: { kind: 'agent' as const, agentId: PEER_ID },
+      text: 'ok',
+      at: 7_000
+    })
+    expect(
+      (daemon as any).handleRelayMsg(rd({ op: 'context', post: dup(1) }, { msgId: 'c-1' }), () => {})
+    ).toMatchObject({ accepted: true })
+    expect(
+      (daemon as any).handleRelayMsg(rd({ op: 'context', post: dup(2) }, { msgId: 'c-2' }), () => {})
+    ).toMatchObject({ accepted: true })
+    // An identical re-fan of post 1 dedups in place (no third row).
+    expect(
+      (daemon as any).handleRelayMsg(rd({ op: 'context', post: dup(1) }, { msgId: 'c-3' }), () => {})
+    ).toMatchObject({ accepted: true })
+
+    const rows = (daemon as any).store.transcriptSince(
+      transcriptChannelKey(CONV, undefined),
+      `webchat:${CONV}`,
+      null
+    ) as { ts: string; postId?: string | null }[]
+    expect(rows.map((r) => [r.ts, r.postId])).toEqual([
+      ['7000', dup(1).postId],
+      ['7001', dup(2).postId]
+    ])
+    await daemon.stop()
+  })
 })

--- a/packages/daemon/test/webchat-turn-refresh.test.ts
+++ b/packages/daemon/test/webchat-turn-refresh.test.ts
@@ -142,6 +142,19 @@ describe('webchat turn-final context refresh', () => {
       .filter((row: { sender: string }) => row.sender === AGENT_ID)
       .map((row: { text: string }) => row.text)
     expect(replies).toEqual(['fresh replacement'])
+
+    // Canonical post identity (merged-conversation-view.md §6): every webchat
+    // text row persists the origin-minted postId — the trigger carries the
+    // relay-minted one, the peer's context copy the peer's, and the reply row
+    // the SAME id its rd/webchat-post fan-out announced.
+    const rows = (daemon as any).store.transcriptSince(
+      transcriptChannelKey(CONV, undefined),
+      `webchat:${CONV}`,
+      null
+    ) as { sender: string; text: string; postId?: string | null }[]
+    expect(rows.find((r) => r.text === 'original request')?.postId).toBe(TURN)
+    expect(rows.find((r) => r.text === 'peer answer 1')?.postId).toBe(peerPost(1, 0).postId)
+    expect(rows.find((r) => r.text === 'fresh replacement')?.postId).toBe(posts[0]!.post.postId)
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -105,6 +105,10 @@ export const SessionMessage = z.object({
   // compatibility and absent on legacy rows or every non-Slack transport.
   trustedAgentBot: z.boolean().optional(),
   ts: z.string(), // platform timestamp (daemon-local string form)
+  // Canonical webchat post identity (merged-conversation-view.md §6): minted once
+  // at origin and identical on every participant's copy, independent of a
+  // collision-bumped `ts`. Absent on non-webchat rows and pre-upgrade rows.
+  postId: z.string().uuid().optional(),
   kind: z.string(), // "text" / tool / … (daemon transcript kind)
   text: z.string(),
   attachments: z.array(SessionImageAttachment).max(1).optional(),

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -523,6 +523,9 @@ export interface SessionMessageDto {
   senderAvatarUrl?: string // public provider-hosted profile image
   trustedAgentBot?: boolean // daemon-verified AgentConnect Slack bot provenance
   ts: string
+  /** Canonical webchat post identity (merged-conversation-view.md §6) — identical
+   *  on every participant's copy; absent on non-webchat and pre-upgrade rows. */
+  postId?: string
   kind: string
   text: string
   attachments?: SessionImage[]


### PR DESCRIPTION
C2 prerequisite from [merged-conversation-view.md](../blob/main/docs/designs/merged-conversation-view.md) §6 (#420): the merged view dedupes webchat text rows across participant transcripts by the **origin-minted canonical `postId`** — timestamp shape cannot establish provenance in webchat's integer-millisecond domain, and a collision-bumped copy changes `ts` but never its identity.

- **Daemon store**: `transcript` gains a nullable `postId` column (additive SQLite migration). `appendTranscript` writes it, and upgrades a NULL-`postId` row in place when a later copy carries the identity (add-only; never changed or cleared — mirroring the trustedAgentBot provenance upgrade).
- **Write sites**: the inbound turn row stores the relay-minted id (`NormalizedMessage.transcriptPostId`, stamped beside `transcriptTs`); the reply commit mints its `postId` once and shares it between the transcript row and the `rd/webchat-post` fan-out (success AND partial-reply paths — previously each fan-out minted independently, leaving the row identity-less); context copies store the origin post's id.
- **Read chain**: protocol `SessionMessage`, the daemon session reader, the CP messages DTO, and the web DTO expose the optional `postId` end to end.
- **Tests**: the turn-refresh suite asserts the trigger row, the peer's context copy, and the committed reply row each persist their canonical identity, and that the reply row's id equals its fan-out post's.

Daemon suite: 2698 passing (the 3 failing skills files are the known pre-existing local-macOS environment issue, identical on origin/main — CI is authoritative). Typecheck clean across daemon/CP/web; protocol rebuilt.

Next up on this track: `conversation-merge.ts` (C2b) consumes this field for webchat dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)