### PR TITLE
fix(web): stop plating brand marks on dark, and keep work panels collapsed

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -251,10 +251,25 @@
   --shadow-xl: 0 12px 28px rgba(0, 0, 0, 0.55), 0 32px 72px rgba(0, 0, 0, 0.72);
 }
 /* Component-level dark tweaks that a token swap alone can't express. */
+/* Mark tiles go plateless on dark: a light plate under every brand logo turns lists
+   and rows into a strip of bright chips, and the logos read fine straight on the
+   surface (full-color ones as-is, `currentColor` ones on the base `.imark` color,
+   which is `--text-primary`). The overlap spacer goes with the plate — without one
+   there are no tile edges left to separate. Unlayered on purpose: the dark `.imark`
+   plate this replaced had to outrank `bg-*` utilities, and so does the reset. */
 :root[data-theme='dark'] .imark {
-  background: #e8ecf1;
-  border-color: #e8ecf1;
-  color: var(--surface-inverse);
+  background: transparent;
+  border-color: transparent;
+}
+:root[data-theme='dark'] .imark.imark-overlap {
+  box-shadow: none;
+}
+/* Same on the avatar tile: an uploaded icon's white plate (see `.av:has(…)` below,
+   plus the matching `bg-white` on the <img> itself) is there so a transparent PNG
+   doesn't sit on the dark fallback plate — on a dark surface it is just a white
+   card. Opaque uploads cover the tile either way, so only alpha ones change. */
+:root[data-theme='dark'] .av:has(> [data-agent-icon-image]) {
+  background: transparent;
 }
 :root[data-theme='dark'] .pill.on {
   background: #2f2440;

--- a/packages/web/src/components/console/IntegrationMarks.tsx
+++ b/packages/web/src/components/console/IntegrationMarks.tsx
@@ -1,5 +1,4 @@
 import { GithubMark, PlatformMark } from '@/components/marks'
-import { Icon } from '@/components/ui'
 
 type HookKind = 'webhook' | 'github'
 
@@ -36,15 +35,17 @@ export function IntegrationMarks({
         {visibleHookKinds.map((kind, index) => (
           <span
             key={kind}
-            className={`imark h-[21px] w-[21px] ${visibleIntegrations.length + index === 0 ? '' : 'imark-overlap -ml-[7px]'} ${kind === 'webhook' ? 'bg-(--surface-inverse)' : ''}`}
+            className={`imark h-[21px] w-[21px] ${visibleIntegrations.length + index === 0 ? '' : 'imark-overlap -ml-[7px]'}`}
             title={kind === 'github' ? 'GitHub events' : 'Inbound webhook'}
           >
             {kind === 'github' ? (
               <span className="flex h-[13px] w-[13px] items-center justify-center">
-                <GithubMark />
+                <GithubMark fillPct={90} />
               </span>
             ) : (
-              <Icon name="webhook" size={11} color="#fff" />
+              // The brand-pink webhook mark, not a white glyph on an inverted plate:
+              // unplated on dark, that glyph had nothing left to sit on.
+              <PlatformMark platform="webhook" />
             )}
           </span>
         ))}

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -53,28 +53,19 @@ describe('workSummary', () => {
 })
 
 describe('work panel visibility', () => {
-  it('defaults to open only while a turn has no answer text', () => {
-    expect(workPanelOpen(undefined, true)).toBe(true)
-    expect(workPanelOpen(undefined, false)).toBe(false)
+  it('defaults to collapsed, including a turn with no answer text yet', () => {
+    expect(workPanelOpen(undefined)).toBe(false)
   })
 
-  it('lets the user collapse a work-only turn, whose default is open', () => {
-    const after = toggleWorkPanel(new Map(), 0, true)
-    expect(workPanelOpen(after.get(0), true)).toBe(false)
+  it('opens on click and collapses again on the next one', () => {
+    const shown = toggleWorkPanel(new Map(), 0)
+    expect(workPanelOpen(shown.get(0))).toBe(true)
+    expect(workPanelOpen(toggleWorkPanel(shown, 0).get(0))).toBe(false)
   })
 
-  it('keeps a hidden panel hidden when the answer text lands and flips the default', () => {
-    // Work-only turn (autoOpen = true) that the user hides mid-stream...
-    const after = toggleWorkPanel(new Map(), 0, true)
-    // ...then its answer arrives, so the default becomes closed. The stored choice must
-    // not read as "flipped from the default" here, or the panel would re-open itself.
-    expect(workPanelOpen(after.get(0), false)).toBe(false)
-  })
-
-  it('re-expands on a second click, and only for the toggled turn', () => {
-    const hidden = toggleWorkPanel(new Map(), 3, true)
-    const shown = toggleWorkPanel(hidden, 3, true)
-    expect(workPanelOpen(shown.get(3), true)).toBe(true)
-    expect(workPanelOpen(shown.get(4), false)).toBe(false)
+  it('toggles only the clicked turn', () => {
+    const shown = toggleWorkPanel(new Map(), 3)
+    expect(workPanelOpen(shown.get(3))).toBe(true)
+    expect(workPanelOpen(shown.get(4))).toBe(false)
   })
 })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -28,25 +28,17 @@ export function workCounts(steps: { lane: string; files: { path: string }[] }[])
   return { thinkCount: steps.length - toolCount - editStepCount, toolCount, editCount: editPaths.size + bareEdits }
 }
 
-/** Is a turn's work panel open? `autoOpen` is the default the turn's own content
- *  implies (a turn with no answer text yet defaults OPEN so a mid-stream agent isn't
- *  hidden); `override` is the visibility the user last chose for it, if any.
- *
- *  The user's choice is stored as the explicit desired state rather than as "flipped
- *  from the default" — otherwise, when a work-only turn's answer text lands and the
- *  default flips, a "flipped" bit would silently re-open a panel the user had hidden. */
-export function workPanelOpen(override: boolean | undefined, autoOpen: boolean): boolean {
-  return override ?? autoOpen
+/** Is a turn's work panel open? Every turn starts collapsed — including a work-only
+ *  one still waiting on its answer text — so the transcript never expands a panel the
+ *  reader didn't ask for. `override` is the visibility the user last chose for it. */
+export function workPanelOpen(override: boolean | undefined): boolean {
+  return override ?? false
 }
 
 /** Record the user's toggle of turn `ti`, as the state opposite to what they see now. */
-export function toggleWorkPanel(
-  prev: ReadonlyMap<number, boolean>,
-  ti: number,
-  autoOpen: boolean
-): Map<number, boolean> {
+export function toggleWorkPanel(prev: ReadonlyMap<number, boolean>, ti: number): Map<number, boolean> {
   const next = new Map(prev)
-  next.set(ti, !workPanelOpen(prev.get(ti), autoOpen))
+  next.set(ti, !workPanelOpen(prev.get(ti)))
   return next
 }
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -840,11 +840,9 @@ export default function SessionDetailView() {
   const [transcriptSessionId, setTranscriptSessionId] = useState<string | null>(null)
   const [nowMs, setNowMs] = useState(() => Date.now())
   // The visibility the user last chose for a bot turn's collapsed "work" panel (keyed
-  // by turn index), overriding the default that turn's content implies. Stored as the
-  // explicit desired state, so a hidden panel stays hidden when streaming flips the
-  // default — see workPanelOpen().
+  // by turn index). Every panel starts collapsed — see workPanelOpen().
   const [workOverride, setWorkOverride] = useState<ReadonlyMap<number, boolean>>(() => new Map())
-  const toggleWork = (ti: number, autoOpen: boolean) => setWorkOverride((prev) => toggleWorkPanel(prev, ti, autoOpen))
+  const toggleWork = (ti: number) => setWorkOverride((prev) => toggleWorkPanel(prev, ti))
   const [imagePreparing, setImagePreparing] = useState(false)
   const [imageError, setImageError] = useState<string | null>(null)
   const [attachMenuOpen, setAttachMenuOpen] = useState(false)
@@ -1825,8 +1823,8 @@ export default function SessionDetailView() {
             </span>
           )}
           <span className="inline-flex min-w-0 flex-[0_1_auto] items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-            <span className="imark h-4 w-4 flex-none rounded-xs">
-              <PlatformMark platform={channelDisplay.platform} fillPct={100} />
+            <span className="imark h-5 w-5 flex-none rounded-xs">
+              <PlatformMark platform={channelDisplay.platform} />
             </span>
             {session.threadUrl ? (
               <a
@@ -2100,11 +2098,7 @@ export default function SessionDetailView() {
                     // EDIT rows, since one EDIT row can touch several files).
                     const { thinkCount, toolCount, editCount } = workCounts(workSteps)
                     const summary = workSummary(thinkCount, toolCount, editCount)
-                    // Auto-open while a turn has produced only work (mid-stream), so the
-                    // live agent isn't hidden; collapse once its answer text lands. Either
-                    // default stays user-overridable, so thinking-only turns can be closed.
-                    const autoOpen = textSteps.length === 0
-                    const openWork = workPanelOpen(workOverride.get(ti), autoOpen)
+                    const openWork = workPanelOpen(workOverride.get(ti))
                     return (
                       <div key={`${session.id}:${ti}`} className="flex items-start gap-[9px]">
                         <span className="av h-[26px] w-[26px] flex-none rounded-md">
@@ -2147,7 +2141,7 @@ export default function SessionDetailView() {
                             <>
                               <button
                                 type="button"
-                                onClick={() => toggleWork(ti, autoOpen)}
+                                onClick={() => toggleWork(ti)}
                                 className="mt-2 inline-flex items-center gap-[6px] border-0 bg-transparent p-0 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
                                 title={openWork ? 'Hide the agent’s work' : 'Show the agent’s work'}
                               >

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -199,11 +199,9 @@ export function OrgIconView({
 // GitHub octocat mark — rendered on the workspace tiles and cards instead of
 // <Icon name="github" /> (which lucide no longer ships).
 export function GithubMark({ color = 'currentColor', fillPct = 60 }: { color?: string; fillPct?: number }) {
-  const s =
-    fillPct === 60
-      ? { width: '60%', height: '60%', display: 'block' }
-      : ({ width: `${fillPct}%`, height: `${fillPct}%`, display: 'block' } as const)
-  return <SiGithub className="block" style={s} color={color} aria-hidden />
+  return (
+    <SiGithub style={{ width: `${fillPct}%`, height: `${fillPct}%`, display: 'block' }} color={color} aria-hidden />
+  )
 }
 
 export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fillPct?: number }) {
@@ -228,8 +226,9 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   if (x.includes('dream')) {
     return (
       <span style={{ width: s.width, height: s.height }} className="flex items-center justify-center" aria-hidden>
-        {/* --brand, not --brand-soft-text: the mark's usual home is an `.imark` tile,
-            whose plate stays light in dark mode — the soft tint vanishes on it. */}
+        {/* --brand, not --brand-soft-text: that token swings with the theme (a pale tint
+            on dark, a deep wine on light), while one magenta reads on both surfaces —
+            and matches the webhook mark above, the other brand-colored glyph here. */}
         <Icon name="moon" className="h-full w-full text-(--brand)" />
       </span>
     )

--- a/packages/web/src/components/marks.tsx
+++ b/packages/web/src/components/marks.tsx
@@ -17,6 +17,13 @@ import type { SocialLoginTarget } from '@/lib/social-login-providers'
 
 const fill = { width: '60%', height: '60%', display: 'block' } as const
 
+// Dark-mode treatment for the brand logos we can only load as an <img> (ACP registry
+// / lobehub SVGs, so no per-path recoloring): most are `currentColor`-black and have
+// to be flipped to read on the dark surface, but a plain `invert` also rotates the
+// hue of the colored ones (Kiro's purple ghost came out green). The extra 180°
+// rotation puts those hues back; on a pure black glyph it is a no-op.
+const DARK_MARK_FILTER = "[html[data-theme='dark']_&]:invert [html[data-theme='dark']_&]:hue-rotate-180"
+
 export function AgentMark({ model, fillPct = 60 }: { model: string; fillPct?: number }) {
   const registry = useAcpRegistry()
   const registryIcon = acpRuntime(registry, model)?.icon
@@ -26,7 +33,7 @@ export function AgentMark({ model, fillPct = 60 }: { model: string; fillPct?: nu
       src={registryIcon}
       alt=""
       style={{ width: `${fillPct}%`, height: `${fillPct}%` }}
-      className="block object-contain [html[data-theme='dark']_&]:invert"
+      className={`block object-contain ${DARK_MARK_FILTER}`}
     />
   )
 }
@@ -102,7 +109,7 @@ export function ModelMark({
       alt=""
       onError={() => setFailedSlug(slug)}
       style={{ width: `${fillPct}%`, height: `${fillPct}%` }}
-      className="block object-contain [html[data-theme='dark']_&]:invert"
+      className={`block object-contain ${DARK_MARK_FILTER}`}
     />
   )
 }
@@ -150,7 +157,7 @@ export function AgentIconView({ icon, runtime, size }: { icon?: AgentIcon | null
         src={icon.url}
         alt=""
         data-agent-icon-image="true"
-        className="rounded-[inherit] bg-white object-cover"
+        className="rounded-[inherit] bg-white object-cover [html[data-theme='dark']_&]:bg-transparent"
         style={{ width: '100%', height: '100%' }}
       />
     )
@@ -191,8 +198,12 @@ export function OrgIconView({
 
 // GitHub octocat mark — rendered on the workspace tiles and cards instead of
 // <Icon name="github" /> (which lucide no longer ships).
-export function GithubMark({ color = 'currentColor' }: { color?: string }) {
-  return <SiGithub className="block h-[60%] w-[60%]" color={color} aria-hidden />
+export function GithubMark({ color = 'currentColor', fillPct = 60 }: { color?: string; fillPct?: number }) {
+  const s =
+    fillPct === 60
+      ? { width: '60%', height: '60%', display: 'block' }
+      : ({ width: `${fillPct}%`, height: `${fillPct}%`, display: 'block' } as const)
+  return <SiGithub className="block" style={s} color={color} aria-hidden />
 }
 
 export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fillPct?: number }) {
@@ -217,7 +228,9 @@ export function PlatformMark({ platform, fillPct = 60 }: { platform: string; fil
   if (x.includes('dream')) {
     return (
       <span style={{ width: s.width, height: s.height }} className="flex items-center justify-center" aria-hidden>
-        <Icon name="moon" className="h-full w-full text-(--brand-soft-text)" />
+        {/* --brand, not --brand-soft-text: the mark's usual home is an `.imark` tile,
+            whose plate stays light in dark mode — the soft tint vanishes on it. */}
+        <Icon name="moon" className="h-full w-full text-(--brand)" />
       </span>
     )
   }


### PR DESCRIPTION
## Why

In dark mode `:root[data-theme='dark'] .imark` forced a light `#e8ecf1` plate under every mark tile, while `<AgentMark>`/`<ModelMark>` inverted their logos *for a dark surface*. The two cancelled out: the ACP registry ships `fill="currentColor"` SVGs that resolve to black in an `<img>`, so inverting them put white logos on a white plate — Claude Code and Cursor were invisible in the RuntimeSelect dropdown, and the agents list read as a strip of bright chips against a dark table row.

## What changed

**Mark tiles are plateless on dark** (`globals.css`) — background/border transparent, and the `.imark-overlap` spacer goes with them (no tile edges left to separate). This is what the dozen `imark … border-0 bg-transparent` call sites always wanted; that unlayered override had been silently beating their utility. Monochrome marks fall back to the base `.imark` color (`--text-primary`), so GitHub / plug / calendar-clock glyphs go light.

**`invert` → `invert hue-rotate-180`** on the two `<img>`-only brand marks. Black glyphs still flip to white (the rotation is a no-op on them), but colored logos keep their hue instead of flipping — Kiro's purple ghost was coming out green.

**Uploaded agent avatars** (`AgentIconView`, `kind: 'image'`) drop their white plate on dark, from both `.av:has(> [data-agent-icon-image])` and the `<img>`'s own `bg-white`. Opaque uploads cover the tile either way, so only alpha ones change.

**IntegrationMarks:** the inbound-webhook mark was a `#fff` glyph on an inverted plate — unplated it had nothing to sit on, so it reuses the brand-pink `<PlatformMark platform="webhook" />`. The dream mark moves from `--brand-soft-text` (a pale pink in dark) to `--brand`.

**Work panels start collapsed** (`session-work.ts`, `SessionDetailView`) — a turn with no answer text yet no longer auto-expands its reasoning/tool/edit panel. That removes the `autoOpen` parameter and the default-flip guard it needed (the guard existed only because the default could change mid-stream).

## Notes for the reviewer

- Trade-off, stated plainly: without the white plate, a **dark-on-transparent** uploaded avatar blends into the dark surface. Detecting alpha would mean flagging it at upload time; not worth it for the rare case.
- One hunk was already in the working tree before this session and is included because it sits in the same file and the same theme: the channel mark in `SessionDetailView` goes `h-4 w-4 fillPct=100` → `h-5 w-5` at default fill.
- Light mode is unchanged throughout.
- Verified by rendering the real components in both themes: runtime + model marks (incl. the colored Kiro/Qoder ones), every `IntegrationMarks` combination (slack/telegram/discord, lark/github/webhook, playground/schedule/dream, unknown platform, hook kinds), and all `AgentIconView` kinds. `pnpm typecheck` / `lint` / `prettier --check` / 600 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)