### PR TITLE
fix(web): fold the skills install actions into one Add menu

### DIFF
--- a/packages/web/src/components/console/SkillSourcesCard.test.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.test.tsx
@@ -175,6 +175,7 @@ describe('organization Skills library', () => {
         </SWRConfig>
       )
     })
+    await act(async () => buttonWithText('Add').click())
     await act(async () => buttonWithText('Install from skills.sh').click())
 
     await typeInto(host.querySelector<HTMLInputElement>('input.inp')!, 'pdf')

--- a/packages/web/src/components/console/SkillSourcesCard.test.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.test.tsx
@@ -176,7 +176,7 @@ describe('organization Skills library', () => {
       )
     })
     await act(async () => buttonWithText('Add').click())
-    await act(async () => buttonWithText('Install from skills.sh').click())
+    await act(async () => buttonWithText('Search skills.sh').click())
 
     await typeInto(host.querySelector<HTMLInputElement>('input.inp')!, 'pdf')
     await settleUntil(() => host.textContent?.includes('169.9K installs') === true, 40)

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -6,8 +6,9 @@
 // sources install via `npx skills`; managed bundles use the daemon's pinned
 // digest cache. Per-agent enablement for both lives on the agent detail view.
 //
-// A Git source is registered two ways: "Import from GitHub" takes a repository
-// you already know, and "Install from skills.sh" searches the public registry by
+// A Git source is registered two ways, both behind the header's "Add" menu (same
+// shape as the MCP servers card): "Import from GitHub" takes a repository you
+// already know, and "Install from skills.sh" searches the public registry by
 // skill name (InstallRegistrySkillModal). Both end at the same POST — the second
 // just fills the source string and skill filter from the hit you picked.
 //
@@ -32,7 +33,7 @@ import { ManagedSkillTile } from '@/components/console/ManagedSkillTile'
 import { InstallRegistrySkillModal } from '@/components/console/InstallRegistrySkillModal'
 import { VisibilityField, VisibilityValue, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
-import { LoadingState } from '@/components/marks'
+import { GithubMark, LoadingState } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
 
 /** Split a comma/whitespace-separated skill filter into a clean string[]. */
@@ -47,6 +48,7 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
   const { skillSources, skillSourcesLoading } = useConsoleData()
   const { activeOrg } = useOrgs()
   const { mutate: mutateSWR } = useSWRConfig()
+  const [menuOpen, setMenuOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [browsing, setBrowsing] = useState(false)
   const [editing, setEditing] = useState<SkillSourceDto | null>(null)
@@ -88,16 +90,58 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
             <Toggle checked={includeArchived} onChange={setIncludeArchived} />
           </label>
           {canWrite && (
-            <>
-              <Button variant="secondary" size="xs" onClick={() => setBrowsing(true)}>
-                <Icon name="search" size={14} />
-                Install from skills.sh
-              </Button>
-              <Button variant="secondary" size="xs" onClick={() => setCreating(true)}>
+            <span className="relative">
+              <Button variant="secondary" size="xs" onClick={() => setMenuOpen((v) => !v)}>
                 <Icon name="plus" size={14} />
-                Import from GitHub
+                Add
+                <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
               </Button>
-            </>
+              {menuOpen && (
+                <>
+                  <span className="fixed inset-0 z-30" onClick={() => setMenuOpen(false)} />
+                  <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[280px] rounded-lg border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
+                    <button
+                      onClick={() => {
+                        setMenuOpen(false)
+                        setBrowsing(true)
+                      }}
+                      className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
+                    >
+                      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+                        <Icon name="search" size={16} color="var(--brand)" />
+                      </span>
+                      <span className="flex min-w-0 flex-col">
+                        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                          Install from skills.sh
+                        </span>
+                        <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                          Search the public registry by skill name
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      onClick={() => {
+                        setMenuOpen(false)
+                        setCreating(true)
+                      }}
+                      className="flex w-full cursor-pointer items-start gap-[9px] rounded-[6px] border-0 bg-transparent p-[10px] text-left hover:bg-(--surface-hover)"
+                    >
+                      <span className="flex h-8 w-8 flex-none items-center justify-center rounded-[7px] bg-(--brand-soft)">
+                        <GithubMark color="var(--brand)" />
+                      </span>
+                      <span className="flex min-w-0 flex-col">
+                        <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+                          Import from GitHub
+                        </span>
+                        <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+                          Register a repository you already know
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                </>
+              )}
+            </span>
           )}
         </span>
       </div>

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -8,8 +8,8 @@
 //
 // A Git source is registered two ways, both behind the header's "Add" menu (same
 // shape as the MCP servers card): "Import from GitHub" takes a repository you
-// already know, and "Install from skills.sh" searches the public registry by
-// skill name (InstallRegistrySkillModal). Both end at the same POST — the second
+// already know, and "Search skills.sh" searches the public registry by skill
+// name (InstallRegistrySkillModal). Both end at the same POST — the second
 // just fills the source string and skill filter from the hit you picked.
 //
 // A source records only WHERE skills come from (source string + optional ref /
@@ -112,10 +112,10 @@ export function SkillSourcesCard({ canWrite, canManage }: { canWrite: boolean; c
                       </span>
                       <span className="flex min-w-0 flex-col">
                         <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-                          Install from skills.sh
+                          Search skills.sh
                         </span>
                         <span className="mt-[2px] font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-                          Search the public registry by skill name
+                          Find a skill in the public registry by name
                         </span>
                       </span>
                     </button>


### PR DESCRIPTION
## Summary

The Skills library header carried two peer buttons — "Install from skills.sh" and "Import from GitHub" — which crowded the row next to the "Include archived" toggle. They are now a single **Add ▾** dropdown, the same shape the Connectors & MCP servers card already uses on the same page: one trigger, a right-aligned popover, and one icon-tile + title + description row per install path.

- **Search skills.sh** — find a skill in the public registry by name
- **Import from GitHub** — register a repository you already know

Both entries open the existing modals unchanged; no API or data-flow changes. The registry entry is labelled for the browse step it starts — installing still happens inside the modal, whose title is untouched.

## Testing

- `pnpm --filter @agentconnect.md/web test` — 574 passed
- `pnpm --filter @agentconnect.md/web typecheck`, eslint, prettier — clean

`SkillSourcesCard.test.tsx` now opens the menu before clicking the registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)