### PR TITLE
feat(web,cp): /conversations/:key — the merged conversation page (C2)

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -312,9 +312,11 @@ session (`sessionId`, `agentId`).
    - **Author copy wins**: the row whose source session's `agentId` matches
      the row's author (`sender === source.agentId`, or the daemon-relabeled
      own-bot frames). The author copy is the full-fidelity one.
-   - Human/system rows (identical in every copy): first source in stable
-     order — roster order for webchat, `sessionId` sort for Slack — so the
-     merge is deterministic across reloads.
+   - Human/system rows (identical in every copy): first source in CANONICAL
+     order — a `sessionId` sort on every platform, decoupled from the
+     resolver's activity-ordered response (which is mutable and would flip
+     the surviving copy between refreshes) — so the merge is deterministic
+     across reloads.
 
 3. **Work-lane rows pass through un-deduped**: `kind: tool | reasoning` rows
    exist only in their author's transcript. They interleave by `ts` and render

--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -325,8 +325,11 @@ session (`sessionId`, `agentId`).
    already normalizes every stored form onto epoch microseconds for its own
    chronological reads (`transcriptEventTimeUs`); the merge module implements
    the same normalization (the console's timestamp parser already matches it
-   row-wise), sorts ascending, and breaks ties by `(sender, sessionId)` while
-   preserving each source's own relative row order (stable merge).
+   row-wise) and sorts ascending; ties group by source (deterministic across
+   reloads) and then follow each source's own row order — a hierarchical,
+   transitive tie-break that never reorders a source's internal sequence.
+   (A sender-first tie-break was rejected in review: it reverses same-source
+   rows sharing a timestamp and breaks comparator transitivity.)
 5. **Attribution and turn grouping reuse the session detail machinery**: the
    merged row list feeds the same turn builder the per-agent page uses — the
    right side is reserved for the viewer, every agent renders as its own

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2461,6 +2461,9 @@ export const SessionDetailDto = z.object({
   participants: z
     .array(z.object({ agentId: z.string(), name: z.string().nullable(), primary: z.boolean() }))
     .nullable(),
+  /** Durable workspace/tenant scope (merged-conversation-view.md §5.1) — lets the
+   *  console compute this session's conversation key without a second lookup. */
+  tenantScope: z.string().nullable(),
   startedAt: z.string(), // ISO-8601
   endedAt: z.string().nullable()
 })

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -651,6 +651,7 @@ export function sessionRoutes(deps: HttpDeps) {
           channelName: s.channelName,
           triggeredByName: s.triggeredByName,
           threadUrl: s.threadUrl,
+          tenantScope: s.tenantScope ?? null,
           participants:
             webchatRoster.length > 1
               ? webchatRoster.map((p) => ({

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -979,6 +979,8 @@ export interface SessionMetaRecord {
   platform: Platform | null
   channel: string | null
   thread: string | null
+  /** Durable workspace/tenant scope (merged-conversation-view.md §5.1). */
+  tenantScope: string | null
   phase: SessionPhase
   link: string | null
   summary: string | null

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -56,6 +56,7 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     platform: (s.platform as Platform | null) ?? null,
     channel: s.channel,
     thread: s.thread,
+    tenantScope: s.tenantScope,
     phase: s.phase as SessionPhase,
     link: s.link,
     summary: s.summary,

--- a/packages/web/src/app/(app)/[slug]/conversations/[key]/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/conversations/[key]/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Conversation · AgentConnect' }
+
+export default function Page() {
+  // /conversations/layout owns the persistent client view; the leaf keeps the
+  // dynamic URL routable with its own metadata.
+  return null
+}

--- a/packages/web/src/app/(app)/[slug]/conversations/layout.tsx
+++ b/packages/web/src/app/(app)/[slug]/conversations/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+import { SessionsRouteFrame } from '@/components/console/SessionsRouteFrame'
+
+// Mirror of /sessions/layout: the persistent client frame mounts the merged
+// conversation view (merged-conversation-view.md §5.3) and survives key-to-key
+// navigation without remounting.
+export default function Layout({ children }: { children: ReactNode }) {
+  return <SessionsRouteFrame>{children}</SessionsRouteFrame>
+}

--- a/packages/web/src/components/console/SessionsRouteFrame.tsx
+++ b/packages/web/src/components/console/SessionsRouteFrame.tsx
@@ -5,10 +5,12 @@ import { useParams } from 'next/navigation'
 import SessionDetailView from '@/components/console/views/SessionDetailView'
 
 export function SessionsRouteFrame({ children }: { children: ReactNode }) {
-  const { id } = useParams<{ id?: string }>()
+  const { id, key } = useParams<{ id?: string; key?: string }>()
 
   // The frame lives in /sessions/layout rather than [id]/page. That static
   // layout survives /sessions/a -> /sessions/b, so React updates the existing
-  // detail view instead of rebuilding the whole right-hand page.
-  return id ? <SessionDetailView /> : children
+  // detail view instead of rebuilding the whole right-hand page. The
+  // /conversations/[key] route mounts the SAME view in merged-conversation
+  // mode (merged-conversation-view.md §5.3).
+  return id || key ? <SessionDetailView /> : children
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -169,6 +169,14 @@ function msgStep(m: SessionMessageDto): FmtStep {
   }
 }
 
+/** Whether a member-source read failure may surface in the offline notice.
+ *  Authorization answers (403/404) stay SILENT — a visibility change racing
+ *  the roster must not disclose that a protected source exists (§7); only a
+ *  confirmed non-authorization failure is an operational condition. */
+function countsAsOfflineSource(error: unknown): boolean {
+  return !(error instanceof ApiError && (error.status === 403 || error.status === 404))
+}
+
 /** Render input for conversation mode: mergeConversation over the CURRENT
  *  per-member row map (merged-conversation-view.md §6). */
 function mergeConversationRows(
@@ -1218,8 +1226,8 @@ export default function SessionDetailView() {
                 cursor = page.nextCursor
               }
               rowsBySession.set(src.sessionId, all)
-            } catch {
-              failed += 1
+            } catch (error) {
+              if (countsAsOfflineSource(error)) failed += 1
             }
           })
         )
@@ -1326,8 +1334,8 @@ export default function SessionDetailView() {
               }
               if (!page.liveMore || page.liveCursor === null) break
             }
-          } catch {
-            failed += 1
+          } catch (error) {
+            if (countsAsOfflineSource(error)) failed += 1
           }
         }
         if (tailSessionRef.current !== sid) return

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -838,7 +838,11 @@ export default function SessionDetailView() {
   )
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
-  const conversationSourceKey = conversationMembers?.map((m) => m.sessionId).join(',') ?? ''
+  const conversationSourceKey =
+    conversationMembers
+      ?.map((m) => m.sessionId)
+      .sort()
+      .join(',') ?? ''
   const {
     agents,
     allSessions,
@@ -887,12 +891,18 @@ export default function SessionDetailView() {
     cursors: Map<string, string | null>
   }>({ rows: new Map(), cursors: new Map() })
   const conversationMembersRef = useRef<{ sessionId: string; agentId: string; platform: string }[] | null>(null)
+  // Merge sources in CANONICAL order — sessionId sort, decoupled from the
+  // resolver's representative-first response, whose activity-based order is
+  // mutable: a 30s roster refresh must never swap which recipient copy wins
+  // the first-source rule in mergeConversation().
   conversationMembersRef.current = conversationMembers
-    ? conversationMembers.map((m) => ({
-        sessionId: m.sessionId,
-        agentId: m.agentId ?? '',
-        platform: conversationRoster?.platform ?? 'slack'
-      }))
+    ? [...conversationMembers]
+        .sort((a, b) => (a.sessionId < b.sessionId ? -1 : a.sessionId > b.sessionId ? 1 : 0))
+        .map((m) => ({
+          sessionId: m.sessionId,
+          agentId: m.agentId ?? '',
+          platform: conversationRoster?.platform ?? 'slack'
+        }))
     : null
   const [conversationOffline, setConversationOffline] = useState(0)
   const [msgLoading, setMsgLoading] = useState(false)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1304,24 +1304,34 @@ export default function SessionDetailView() {
       const run = (async () => {
         const state = conversationSourcesRef.current
         const repRows: SessionMessageDto[] = []
+        // Per-source isolation, mirroring the initial fan-out: one member's
+        // daemon going offline mid-conversation must degrade THAT source to
+        // the partial-merge notice, never stall the whole tail round.
+        let failed = 0
         for (const src of sources) {
-          let cursor = state.cursors.get(src.sessionId) ?? null
-          for (let pageNo = 0; pageNo < 20; pageNo++) {
-            const page = await fetchSessionMessages(src.sessionId, {
-              ...(cursor !== null ? { after: cursor } : {}),
-              limit: 200
-            })
-            if (tailSessionRef.current !== sid) return
-            const current = state.rows.get(src.sessionId) ?? []
-            state.rows.set(src.sessionId, mergeSessionMessages(current, page.messages, src.platform))
-            if (src.sessionId === sid) repRows.push(...page.messages)
-            if (page.liveCursor !== null) {
-              cursor = page.liveCursor
-              state.cursors.set(src.sessionId, cursor)
+          try {
+            let cursor = state.cursors.get(src.sessionId) ?? null
+            for (let pageNo = 0; pageNo < 20; pageNo++) {
+              const page = await fetchSessionMessages(src.sessionId, {
+                ...(cursor !== null ? { after: cursor } : {}),
+                limit: 200
+              })
+              if (tailSessionRef.current !== sid) return
+              const current = state.rows.get(src.sessionId) ?? []
+              state.rows.set(src.sessionId, mergeSessionMessages(current, page.messages, src.platform))
+              if (src.sessionId === sid) repRows.push(...page.messages)
+              if (page.liveCursor !== null) {
+                cursor = page.liveCursor
+                state.cursors.set(src.sessionId, cursor)
+              }
+              if (!page.liveMore || page.liveCursor === null) break
             }
-            if (!page.liveMore || page.liveCursor === null) break
+          } catch {
+            failed += 1
           }
         }
+        if (tailSessionRef.current !== sid) return
+        setConversationOffline(failed)
         setMsgs(mergeConversationRows(sources, state.rows))
         if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
           reconcileLiveSteps(sid, repRows, aid)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -11,6 +11,8 @@ import {
 } from 'react'
 import Link from 'next/link'
 import { sameBotSpeaker } from '@/lib/bot-turn-grouping'
+import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
+import { encodeConversationKey } from '@/lib/conversation-key'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
 import {
@@ -42,6 +44,7 @@ import {
 } from '@/lib/data'
 import {
   ApiError,
+  fetchConversationByKey,
   fetchMySessionIdentity,
   fetchSessionMessages,
   fetchSessionDetail,
@@ -164,6 +167,20 @@ function msgStep(m: SessionMessageDto): FmtStep {
     files: [],
     time: formatTranscriptTime(m.ts)
   }
+}
+
+/** Render input for conversation mode: mergeConversation over the CURRENT
+ *  per-member row map (merged-conversation-view.md §6). */
+function mergeConversationRows(
+  sources: { sessionId: string; agentId: string; platform: string }[],
+  rows: Map<string, SessionMessageDto[]>
+): SessionMessageDto[] {
+  const merged = mergeConversation(
+    sources
+      .filter((source) => rows.has(source.sessionId))
+      .map((source) => ({ ...source, rows: rows.get(source.sessionId)! }) satisfies MergeSource)
+  )
+  return merged.map((m) => m.row)
 }
 
 interface FmtStep {
@@ -792,7 +809,26 @@ export default function SessionDetailView() {
   const { activeOrg, orgPath } = useOrgs()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { id } = useParams<{ id: string }>()
+  const { id: routeId, key: conversationKeyParam } = useParams<{ id?: string; key?: string }>()
+  // Merged conversation mode (merged-conversation-view.md §5.3): /conversations/:key
+  // resolves the roster through the bounded key-addressed resolver; the
+  // REPRESENTATIVE (newest visible member) then drives every session-scoped
+  // affordance below — detail metadata, live adoption, the composer target —
+  // exactly like a /sessions/:id load. Peer members only feed the transcript
+  // fan-out and the participants roster.
+  const conversationKey = conversationKeyParam ? decodeURIComponent(conversationKeyParam) : null
+  const {
+    data: conversationRoster,
+    error: conversationError,
+    isLoading: conversationLoading
+  } = useSWR(
+    conversationKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, conversationKey] as const) : null,
+    ([, orgId, key]) => fetchConversationByKey(key, orgId),
+    { refreshInterval: 30_000, revalidateOnFocus: false }
+  )
+  const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
+  const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
+  const conversationSourceKey = conversationMembers?.map((m) => m.sessionId).join(',') ?? ''
   const {
     agents,
     allSessions,
@@ -833,6 +869,22 @@ export default function SessionDetailView() {
       return { ...next, dismissed: next.hovered || next.focused ? current.dismissed : false }
     })
   const [msgs, setMsgs] = useState<SessionMessageDto[] | null>(null)
+  // Conversation mode: per-member fetched rows + live cursors; the rendered
+  // transcript is always mergeConversation() over the CURRENT map, so every
+  // update path (initial load, tail pages) stays consistent by construction.
+  const conversationSourcesRef = useRef<{
+    rows: Map<string, SessionMessageDto[]>
+    cursors: Map<string, string | null>
+  }>({ rows: new Map(), cursors: new Map() })
+  const conversationMembersRef = useRef<{ sessionId: string; agentId: string; platform: string }[] | null>(null)
+  conversationMembersRef.current = conversationMembers
+    ? conversationMembers.map((m) => ({
+        sessionId: m.sessionId,
+        agentId: m.agentId ?? '',
+        platform: conversationRoster?.platform ?? 'slack'
+      }))
+    : null
+  const [conversationOffline, setConversationOffline] = useState(0)
   const [msgLoading, setMsgLoading] = useState(false)
   const [msgPaging, setMsgPaging] = useState(false)
   const [msgErr, setMsgErr] = useState<string | null>(null)
@@ -950,10 +1002,47 @@ export default function SessionDetailView() {
   // The conversation roster only exists on the detail snapshot (list rows and
   // adopted local state don't carry it); a live playground session's own roster
   // (which tracks mid-conversation joins) stays authoritative when present.
+  // Conversation mode synthesizes the roster from the resolver's members when
+  // the detail snapshot carries none (Slack threads have no explicit roster);
+  // names resolve at render time from the org agent list.
+  const conversationParticipants =
+    conversationKey && conversationMembers && conversationMembers.length > 1
+      ? conversationMembers.map((m, i) => ({
+          agentId: m.agentId ?? '',
+          name: m.agentId ?? '',
+          ...(i === 0 ? { primary: true } : {})
+        }))
+      : null
+  const rosterParticipants = detailSession?.participants ?? conversationParticipants ?? undefined
   const sessionBase =
-    sessionMerged && !sessionMerged.participants && detailSession?.participants
-      ? { ...sessionMerged, participants: detailSession.participants }
+    sessionMerged && !sessionMerged.participants && rosterParticipants
+      ? { ...sessionMerged, participants: rosterParticipants }
       : sessionMerged
+  // Session mode: does this session belong to a multi-participant conversation?
+  // One bounded resolver probe per detail view (same SWR cache family as
+  // conversation mode); a hit redirects to the merged page (§5.3), carrying
+  // whose perspective was linked as ?focus.
+  const selfKey = useMemo(() => {
+    if (conversationKey || !currentSessionDetail || currentSessionDetail.platform === 'playground') return null
+    return encodeConversationKey({
+      platform: currentSessionDetail.platform ?? 'slack',
+      tenantScope: currentSessionDetail.tenantScope ?? null,
+      channel: currentSessionDetail.channel,
+      thread: currentSessionDetail.thread
+    })
+  }, [conversationKey, currentSessionDetail])
+  const { data: selfConversation } = useSWR(
+    selfKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, selfKey] as const) : null,
+    ([, orgId, key]) => fetchConversationByKey(key, orgId),
+    { revalidateOnFocus: false }
+  )
+  const selfConversationRedirect =
+    selfKey && selfConversation && selfConversation.sessions.length > 1
+      ? orgPath(`/conversations/${encodeURIComponent(selfKey)}?focus=${currentSessionDetail?.agentId ?? ''}`)
+      : null
+  useEffect(() => {
+    if (selfConversationRedirect) router.replace(selfConversationRedirect)
+  }, [selfConversationRedirect, router])
   const agentById = useMemo(() => new Map(agents.map((agent) => [agent.id, agent])), [agents])
   const owner = sessionBase?.agentId ? agentById.get(sessionBase.agentId) : undefined
   const session =
@@ -1013,10 +1102,25 @@ export default function SessionDetailView() {
   useEffect(() => {
     const realSessionId = session?.platform === 'playground' ? session.realSessionId : undefined
     if (!realSessionId || id === realSessionId) return
-    router.replace(`${orgPath(`/sessions/${encodeURIComponent(realSessionId)}`)}${window.location.search}`, {
+    // A multi-participant conversation's canonical URL is the merged page —
+    // refresh must land where the live Playground already looks merged
+    // (merged-conversation-view.md §5.3). channelId is the conversation id.
+    const conversationId = (session?.participants?.length ?? 0) > 1 ? session?.channelId : undefined
+    const target = conversationId
+      ? orgPath(`/conversations/${encodeURIComponent(conversationId)}`)
+      : orgPath(`/sessions/${encodeURIComponent(realSessionId)}`)
+    router.replace(`${target}${window.location.search}`, {
       scroll: false
     })
-  }, [id, orgPath, router, session?.platform, session?.realSessionId])
+  }, [
+    id,
+    orgPath,
+    router,
+    session?.platform,
+    session?.realSessionId,
+    session?.participants?.length,
+    session?.channelId
+  ])
 
   // A real (CP) session arrives with an empty `steps` — its transcript is a
   // separate on-demand pull from the owning daemon. Playground + mock sessions
@@ -1087,6 +1191,63 @@ export default function SessionDetailView() {
     // nextCursor, prepending each page. Bounded so a pathological session can't
     // keep the proxy busy forever.
     const MAX_PAGES = 40
+    if (conversationKey) {
+      // Merged conversation (merged-conversation-view.md §4/§6): pull every
+      // member's history through the SAME bounded per-session reads, then
+      // render mergeConversation() over the union. A member whose read fails
+      // (daemon offline) degrades to a partial merge with a notice — never a
+      // page-level failure; authorization-hidden members never reached the
+      // roster in the first place.
+      const sources = conversationMembersRef.current ?? []
+      if (sources.length === 0) return
+      const rowsBySession = new Map<string, SessionMessageDto[]>()
+      const cursors = new Map<string, string | null>()
+      let failed = 0
+      ;(async () => {
+        await Promise.all(
+          sources.map(async (src) => {
+            try {
+              let all: SessionMessageDto[] = []
+              let cursor: string | undefined
+              for (let i = 0; i < MAX_PAGES; i++) {
+                const page = await fetchSessionMessages(src.sessionId, { ...(cursor ? { cursor } : {}) })
+                if (!active) return
+                if (i === 0) cursors.set(src.sessionId, page.liveCursor ?? null)
+                all = [...page.messages, ...all]
+                if (!page.nextCursor) break
+                cursor = page.nextCursor
+              }
+              rowsBySession.set(src.sessionId, all)
+            } catch {
+              failed += 1
+            }
+          })
+        )
+        if (!active) return
+        conversationSourcesRef.current = { rows: rowsBySession, cursors }
+        setConversationOffline(failed)
+        setMsgs(mergeConversationRows(sources, rowsBySession))
+        setMsgLoading(false)
+        setMsgPaging(false)
+        liveCursorRef.current = cursors.get(sid) ?? null
+        tailReadyRef.current = true
+        setTailReady(true)
+        const repRows = rowsBySession.get(sid)
+        if (repRows && !sessionBusyRef.current) reconcileLiveSteps(sid, repRows, aid)
+      })().catch((e) => {
+        if (!active) return
+        setMsgErr(e instanceof Error ? e.message : String(e))
+        setMsgLoading(false)
+        setMsgPaging(false)
+      })
+      return () => {
+        active = false
+        if (tailSessionRef.current === sid) {
+          tailSessionRef.current = null
+          tailReadyRef.current = false
+        }
+      }
+    }
     ;(async () => {
       let all: SessionMessageDto[] = []
       let cursor: string | undefined
@@ -1127,7 +1288,9 @@ export default function SessionDetailView() {
         tailReadyRef.current = false
       }
     }
-  }, [wantTranscript, sid, aid, reconcileLiveSteps])
+    // conversationSourceKey keys the fan-out on the member SET — a roster
+    // refresh with identical members must not refetch every transcript.
+  }, [wantTranscript, sid, aid, reconcileLiveSteps, conversationKey, conversationSourceKey])
 
   const refreshTranscriptTail = useCallback((): Promise<void> => {
     if (!wantTranscript || !sid || !tailReadyRef.current || sessionBusyRef.current) return Promise.resolve()
@@ -1136,6 +1299,46 @@ export default function SessionDetailView() {
       return tailInFlightRef.current
     }
     const platform = session?.platform ?? ''
+    if (conversationKey) {
+      const sources = conversationMembersRef.current ?? []
+      const run = (async () => {
+        const state = conversationSourcesRef.current
+        const repRows: SessionMessageDto[] = []
+        for (const src of sources) {
+          let cursor = state.cursors.get(src.sessionId) ?? null
+          for (let pageNo = 0; pageNo < 20; pageNo++) {
+            const page = await fetchSessionMessages(src.sessionId, {
+              ...(cursor !== null ? { after: cursor } : {}),
+              limit: 200
+            })
+            if (tailSessionRef.current !== sid) return
+            const current = state.rows.get(src.sessionId) ?? []
+            state.rows.set(src.sessionId, mergeSessionMessages(current, page.messages, src.platform))
+            if (src.sessionId === sid) repRows.push(...page.messages)
+            if (page.liveCursor !== null) {
+              cursor = page.liveCursor
+              state.cursors.set(src.sessionId, cursor)
+            }
+            if (!page.liveMore || page.liveCursor === null) break
+          }
+        }
+        setMsgs(mergeConversationRows(sources, state.rows))
+        if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
+          reconcileLiveSteps(sid, repRows, aid)
+      })()
+        .catch(() => {
+          // Keep the last good transcript; the next signal retries.
+        })
+        .finally(() => {
+          if (tailInFlightRef.current !== run) return
+          tailInFlightRef.current = null
+          const retry = tailDirtyRef.current && tailSessionRef.current === sid
+          tailDirtyRef.current = false
+          if (retry) void refreshTranscriptTail()
+        })
+      tailInFlightRef.current = run
+      return run
+    }
     const run = (async () => {
       let cursor = liveCursorRef.current
       const persisted: SessionMessageDto[] = []
@@ -1168,7 +1371,7 @@ export default function SessionDetailView() {
       })
     tailInFlightRef.current = run
     return run
-  }, [wantTranscript, sid, aid, session?.platform, reconcileLiveSteps])
+  }, [wantTranscript, sid, aid, session?.platform, reconcileLiveSteps, conversationKey])
 
   const sessionActivityVersion = sid ? (sessionActivityVersionById[sid] ?? 0) : 0
   useEffect(() => {
@@ -1224,6 +1427,40 @@ export default function SessionDetailView() {
     setAttachMenuOpen(false)
     setComposerMenuOpen(null)
   }, [id])
+
+  // A multi-participant conversation is surfaced ONLY at /conversations/:key
+  // (merged-conversation-view.md §5.3): a session deep link into one redirects,
+  // preserving whose perspective was linked as ?focus.
+  if (!conversationKey && selfConversationRedirect) {
+    return (
+      <div className="wrap max-w-[880px] max-desktop:p-4">
+        <LoadingState fill />
+      </div>
+    )
+  }
+  if (conversationKey && (conversationLoading || (!conversationRoster && !conversationError))) {
+    return (
+      <div className="wrap max-w-[880px] max-desktop:p-4">
+        <LoadingState fill />
+      </div>
+    )
+  }
+  if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
+    return (
+      <div className="wrap max-w-[880px] max-desktop:p-4">
+        <NotFound
+          icon="message-square-off"
+          kind="CONVERSATION"
+          title="Conversation not found"
+          pre="No conversation "
+          chip={conversationKey}
+          post=" in this organization — or none of its participants are visible to you."
+          actionLabel="Back to sessions"
+          actionHref={orgPath('/sessions')}
+        />
+      </div>
+    )
+  }
 
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the
@@ -2017,6 +2254,15 @@ export default function SessionDetailView() {
         {wantTranscript && visibleMsgLoading && (
           <div className="flex justify-center py-10">
             <Spinner size={30} />
+          </div>
+        )}
+        {conversationOffline > 0 && (
+          <div className="card m-4 flex items-start gap-[10px] px-[18px] py-4 font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-secondary) desktop:m-0">
+            <Icon name="triangle-alert" size={15} color="var(--amber-500)" />
+            <span>
+              Some participants&apos; records are on an offline daemon — this view may be missing part of the
+              conversation until it reconnects.
+            </span>
           </div>
         )}
         {wantTranscript && visibleMsgErr && (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -170,11 +170,13 @@ function msgStep(m: SessionMessageDto): FmtStep {
 }
 
 /** Whether a member-source read failure may surface in the offline notice.
- *  Authorization answers (403/404) stay SILENT — a visibility change racing
- *  the roster must not disclose that a protected source exists (§7); only a
- *  confirmed non-authorization failure is an operational condition. */
+ *  Only a CONFIRMED daemon-offline response counts (the CP answers 503 when
+ *  the owning daemon has no connection; 502/504 are its gateway shapes).
+ *  Everything else stays silent — above all the authorization answers
+ *  (403/404): a visibility change racing the roster snapshot must never
+ *  disclose that a protected source exists (§7). */
 function countsAsOfflineSource(error: unknown): boolean {
-  return !(error instanceof ApiError && (error.status === 403 || error.status === 404))
+  return error instanceof ApiError && (error.status === 502 || error.status === 503 || error.status === 504)
 }
 
 /** Render input for conversation mode: mergeConversation over the CURRENT

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -176,6 +176,9 @@ export default function SessionsView() {
   }, [params])
   const sessionHref = useCallback(
     (session: Session) => {
+      // A multi-participant conversation row links to the merged page — the
+      // only surfaced view for it (merged-conversation-view.md §5.3).
+      if (session.conversationKey) return orgPath(`/conversations/${encodeURIComponent(session.conversationKey)}`)
       const id = canonicalSessionId(session)
       const query = new URLSearchParams(filterQuery)
       const provider = sessionPlatform(session)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -495,6 +495,9 @@ export interface SessionDetailDto {
    *  conversations and other platforms; absent on a CP that predates the feature.
    *  `name` is null when the caller cannot view that participant's agent. */
   participants?: Array<{ agentId: string; name: string | null; primary: boolean }> | null
+  /** Durable workspace/tenant scope (merged-conversation-view.md §5.1) — part of
+   *  the conversation key. Absent on a CP that predates the feature. */
+  tenantScope?: string | null
 }
 
 // The full ACP tool body (protocol `ToolBody`), transported as a JSON STRING in
@@ -1900,6 +1903,15 @@ export async function fetchSessions(
     ...(page.orgHasSessions !== undefined ? { orgHasSessions: page.orgHasSessions } : {}),
     ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {})
   }
+}
+
+/** Resolve one conversation's current visible member sessions by its §5.1 key
+ *  (the bounded key-addressed resolver). Null when the caller can see none of
+ *  the members (indistinguishable from a conversation that never existed). */
+export async function fetchConversationByKey(key: string, orgId?: string): Promise<ConversationDto | null> {
+  const q = new URLSearchParams({ conversationKey: key })
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  return page.conversations?.[0] ?? null
 }
 
 /** The grouped sessions list (merged-conversation-view.md §5.2): one row per

--- a/packages/web/src/lib/conversation-key.test.ts
+++ b/packages/web/src/lib/conversation-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { encodeConversationKey, isWebchatConversationKey } from './conversation-key'
+
+describe('conversation key (browser port)', () => {
+  it('matches the CP codec byte-for-byte', () => {
+    // Vector mirrored from the CP codec unit test — a drift here means the CP
+    // can no longer decode what the console links to.
+    const encoded = encodeConversationKey({
+      platform: 'slack',
+      tenantScope: 'T024BE7LD',
+      channel: 'C123',
+      thread: '1754123456.000200'
+    })!
+    expect(encoded).toBe(
+      Buffer.from(['slack', 'T024BE7LD', 'C123', '1754123456.000200'].join('\u0000'), 'utf8').toString('base64url')
+    )
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('uses the bare conversation id for webchat and refuses singletons', () => {
+    const id = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
+    expect(encodeConversationKey({ platform: 'webchat', tenantScope: null, channel: id, thread: id })).toBe(id)
+    expect(isWebchatConversationKey(id)).toBe(true)
+    expect(isWebchatConversationKey('not-a-uuid')).toBe(false)
+    expect(encodeConversationKey({ platform: 'slack', tenantScope: null, channel: null, thread: 'T' })).toBeNull()
+    expect(encodeConversationKey({ platform: 'slack', tenantScope: null, channel: 'C', thread: null })).toBeNull()
+  })
+})

--- a/packages/web/src/lib/conversation-key.test.ts
+++ b/packages/web/src/lib/conversation-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { encodeConversationKey, isWebchatConversationKey } from './conversation-key'
+import { encodeConversationKey } from './conversation-key'
 
 describe('conversation key (browser port)', () => {
   it('matches the CP codec byte-for-byte', () => {
@@ -20,8 +20,6 @@ describe('conversation key (browser port)', () => {
   it('uses the bare conversation id for webchat and refuses singletons', () => {
     const id = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
     expect(encodeConversationKey({ platform: 'webchat', tenantScope: null, channel: id, thread: id })).toBe(id)
-    expect(isWebchatConversationKey(id)).toBe(true)
-    expect(isWebchatConversationKey('not-a-uuid')).toBe(false)
     expect(encodeConversationKey({ platform: 'slack', tenantScope: null, channel: null, thread: 'T' })).toBeNull()
     expect(encodeConversationKey({ platform: 'slack', tenantScope: null, channel: 'C', thread: null })).toBeNull()
   })

--- a/packages/web/src/lib/conversation-key.ts
+++ b/packages/web/src/lib/conversation-key.ts
@@ -1,0 +1,28 @@
+// Browser port of the CP conversation-key codec
+// (packages/control-plane/src/http/conversation-key.ts,
+// merged-conversation-view.md §5.1). Keep the two in byte-for-byte agreement —
+// the CP decodes what this encodes.
+
+export interface ConversationKeyParts {
+  platform: string
+  tenantScope: string | null
+  channel: string | null
+  thread: string | null
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const SEP = '\u0000'
+
+export function encodeConversationKey(key: ConversationKeyParts): string | null {
+  if (key.channel === null || key.thread === null) return null
+  if (key.platform === 'webchat') return key.channel
+  const raw = [key.platform, key.tenantScope ?? '', key.channel, key.thread].join(SEP)
+  const bytes = new TextEncoder().encode(raw)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
+}
+
+export function isWebchatConversationKey(key: string): boolean {
+  return UUID_RE.test(key)
+}

--- a/packages/web/src/lib/conversation-key.ts
+++ b/packages/web/src/lib/conversation-key.ts
@@ -10,7 +10,6 @@ export interface ConversationKeyParts {
   thread: string | null
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const SEP = '\u0000'
 
 export function encodeConversationKey(key: ConversationKeyParts): string | null {
@@ -21,8 +20,4 @@ export function encodeConversationKey(key: ConversationKeyParts): string | null 
   let binary = ''
   for (const b of bytes) binary += String.fromCharCode(b)
   return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
-}
-
-export function isWebchatConversationKey(key: string): boolean {
-  return UUID_RE.test(key)
 }

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { duplicateIdentity, mergeConversation, transcriptEventTimeUs, type MergeSource } from './conversation-merge'
+import type { SessionMessageDto } from '@/lib/api'
+
+const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const POST = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
+
+let seq = 0
+function row(over: Partial<SessionMessageDto>): SessionMessageDto {
+  return { seq: ++seq, sender: 'user-1', ts: '1000', kind: 'text', text: 'hi', ...over }
+}
+function src(agentId: string, platform: string, rows: SessionMessageDto[]): MergeSource {
+  return { sessionId: `sess-${agentId.slice(0, 4)}`, agentId, platform, rows }
+}
+
+describe('transcriptEventTimeUs', () => {
+  it('normalizes every stored form onto one microsecond axis', () => {
+    // Slack decimal seconds vs a daemon millisecond stamp one second later.
+    expect(transcriptEventTimeUs('1754123456.000200')).toBe(1_754_123_456_000_200)
+    expect(transcriptEventTimeUs('1754123457123')).toBe(1_754_123_457_123_000)
+    expect(transcriptEventTimeUs('1754123456.000200')).toBeLessThan(transcriptEventTimeUs('1754123457123'))
+    // local- prefix and hook |suffix forms; 10-digit-era integer seconds.
+    expect(transcriptEventTimeUs('local-1754123457123')).toBe(1_754_123_457_123_000)
+    expect(transcriptEventTimeUs('1754123457123|delivery-1')).toBe(1_754_123_457_123_000)
+    expect(transcriptEventTimeUs('1754123456')).toBe(1_754_123_456_000_000)
+    expect(transcriptEventTimeUs('garbage')).toBe(0)
+  })
+})
+
+describe('duplicateIdentity', () => {
+  it('is provenance-explicit — integer monotonicTs values never match the Slack predicate', () => {
+    expect(duplicateIdentity('slack', row({ ts: '1754123456.000200' }))).toBe('ts:1754123456.000200')
+    expect(duplicateIdentity('slack', row({ ts: '1754123457123' }))).toBeNull()
+    expect(duplicateIdentity('webchat', row({ postId: POST }))).toBe(`post:${POST}`)
+    expect(duplicateIdentity('webchat', row({ ts: '1000' }))).toBeNull()
+    // Work-lane rows never dedupe, whatever their coordinates claim.
+    expect(duplicateIdentity('slack', row({ kind: 'tool', ts: '1754123456.000200' }))).toBeNull()
+    expect(duplicateIdentity('webchat', row({ kind: 'reasoning', postId: POST }))).toBeNull()
+  })
+})
+
+describe('mergeConversation', () => {
+  it('dedupes webchat copies by postId with author-copy precedence, surviving a collision bump', () => {
+    // B's copy of A's post got collision-bumped (+1ms): raw-ts equality would
+    // miss it, postId identifies it regardless. The author copy (A's) wins.
+    const merged = mergeConversation([
+      src(B, 'webchat', [row({ sender: A, postId: POST, ts: '1001', text: 'answer', trustedAgentBot: true })]),
+      src(A, 'webchat', [row({ sender: A, postId: POST, ts: '1000', text: 'answer' })])
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.authorCopy).toBe(true)
+    expect(merged[0]!.sourceAgentId).toBe(A)
+    expect(merged[0]!.row.ts).toBe('1000')
+  })
+
+  it('never merges a same-millisecond local report-back with a distinct canonical post', () => {
+    // The §6 data-loss case: A's transcript holds a daemon-local a2a
+    // report-back at ms 5000 (no postId); B's holds a distinct canonical post
+    // whose at collides on the same millisecond. Both must render.
+    const merged = mergeConversation([
+      src(A, 'webchat', [row({ sender: 'peer-agent', ts: '5000', text: 'report-back' })]),
+      src(B, 'webchat', [row({ sender: 'user-1', ts: '5000', postId: POST, text: 'question' })])
+    ])
+    expect(merged.map((m) => m.row.text).sort()).toEqual(['question', 'report-back'])
+  })
+
+  it('dedupes Slack copies only on the provider-native decimal ts', () => {
+    const platformTs = '1754123456.000200'
+    const merged = mergeConversation([
+      src(A, 'slack', [
+        row({ sender: 'U-HUMAN', ts: platformTs, text: 'thread msg' }),
+        row({ sender: A, ts: '1754123457123', text: 'a2a note from A' })
+      ]),
+      src(B, 'slack', [
+        row({ sender: 'U-HUMAN', ts: platformTs, text: 'thread msg' }),
+        // Distinct daemon-local row minting the SAME millisecond on another
+        // daemon — raw equality would discard one; both must survive.
+        row({ sender: B, ts: '1754123457123', text: 'a2a note from B' })
+      ])
+    ])
+    expect(merged.filter((m) => m.row.text === 'thread msg')).toHaveLength(1)
+    expect(merged.map((m) => m.row.text).filter((t) => t.startsWith('a2a'))).toHaveLength(2)
+  })
+
+  it('keeps the human copy from the first source when no author copy exists', () => {
+    const platformTs = '1754123456.000200'
+    const merged = mergeConversation([
+      src(A, 'slack', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello', senderName: 'Dana' })]),
+      src(B, 'slack', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })])
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.sourceAgentId).toBe(A)
+    expect(merged[0]!.row.senderName).toBe('Dana')
+  })
+
+  it('orders on the normalized axis with per-source stability', () => {
+    // Slack text (seconds domain) must interleave with work rows (ms domain)
+    // chronologically, and each source's internal order survives ties.
+    const merged = mergeConversation([
+      src(A, 'slack', [
+        row({ sender: 'U-HUMAN', ts: '1754123456.000200', text: 'first' }),
+        row({ sender: A, kind: 'reasoning', ts: '1754123456500', text: 'thinking' }),
+        row({ sender: A, ts: '1754123457123', text: 'answer' })
+      ])
+    ])
+    expect(merged.map((m) => m.row.text)).toEqual(['first', 'thinking', 'answer'])
+  })
+})

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -94,6 +94,18 @@ describe('mergeConversation', () => {
     expect(merged[0]!.row.senderName).toBe('Dana')
   })
 
+  it('never reorders same-source rows that share a normalized timestamp', () => {
+    // Regression (review finding): a sender-first tie-break flipped
+    // ['first', 'second'] because 'z' > 'a'. Source order must decide.
+    const merged = mergeConversation([
+      src(A, 'slack', [
+        row({ sender: 'z-user', ts: '5000', text: 'first' }),
+        row({ sender: 'a-user', ts: '5000', text: 'second' })
+      ])
+    ])
+    expect(merged.map((m) => m.row.text)).toEqual(['first', 'second'])
+  })
+
   it('orders on the normalized axis with per-source stability', () => {
     // Slack text (seconds domain) must interleave with work rows (ms domain)
     // chronologically, and each source's internal order survives ties.

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -7,9 +7,10 @@ import type { SessionMessageDto } from '@/lib/api'
 
 /** One member session's transcript page, in the order the daemon served it
  *  (each source is internally chronological; the merge preserves that
- *  relative order — a stable merge). Callers pass sources in a stable order
- *  (webchat roster order; sessionId sort otherwise): the FIRST source holding
- *  a duplicate wins when no author copy exists. */
+ *  relative order — a stable merge). Callers MUST pass sources in canonical
+ *  sessionId order — never an activity-derived order, which is mutable: the
+ *  FIRST source holding a duplicate wins when no author copy exists, and a
+ *  reordered source list would flip the surviving copy between refreshes. */
 export interface MergeSource {
   sessionId: string
   agentId: string

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -111,7 +111,9 @@ export function duplicateIdentity(platform: string, row: SessionMessageDto): str
 export function mergeConversation(sources: MergeSource[]): MergedRow[] {
   type Decorated = MergedRow & { us: number; order: number }
   const kept: Decorated[] = []
-  const byIdentity = new Map<string, Decorated>()
+  // Identity → index into `kept`, so the author-copy replacement is O(1)
+  // instead of an indexOf scan per duplicate.
+  const byIdentity = new Map<string, { at: number; entry: Decorated }>()
   let order = 0
   for (const source of sources) {
     for (const row of source.rows) {
@@ -130,15 +132,14 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
       }
       const previous = byIdentity.get(identity)
       if (!previous) {
-        byIdentity.set(identity, candidate)
+        byIdentity.set(identity, { at: kept.length, entry: candidate })
         kept.push(candidate)
-      } else if (!previous.authorCopy && candidate.authorCopy) {
+      } else if (!previous.entry.authorCopy && candidate.authorCopy) {
         // The author copy is the full-fidelity one — replace the recipient
         // copy IN PLACE (keeping its coordinates is wrong: the author's
         // canonical position wins for placement).
-        const at = kept.indexOf(previous)
-        kept[at] = candidate
-        byIdentity.set(identity, candidate)
+        kept[previous.at] = candidate
+        byIdentity.set(identity, { at: previous.at, entry: candidate })
       }
     }
   }

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -1,0 +1,157 @@
+// Merged conversation view — the pure cross-source transcript merge
+// (merged-conversation-view.md §6). Pure functions over per-member message
+// pages so union/dedupe/ordering are unit-testable, mirroring how
+// webchat-lanes.ts isolates lane resolution.
+
+import type { SessionMessageDto } from '@/lib/api'
+
+/** One member session's transcript page, in the order the daemon served it
+ *  (each source is internally chronological; the merge preserves that
+ *  relative order — a stable merge). Callers pass sources in a stable order
+ *  (webchat roster order; sessionId sort otherwise): the FIRST source holding
+ *  a duplicate wins when no author copy exists. */
+export interface MergeSource {
+  sessionId: string
+  agentId: string
+  /** The conversation's platform — selects the duplicate-identity rule. */
+  platform: string
+  rows: SessionMessageDto[]
+}
+
+export interface MergedRow {
+  row: SessionMessageDto
+  sourceSessionId: string
+  sourceAgentId: string
+  /** True when this copy came from its author's own transcript (full
+   *  fidelity); the merge prefers it over recipient copies. */
+  authorCopy: boolean
+}
+
+/**
+ * Normalize the timestamp forms stored in transcript rows onto one
+ * epoch-microsecond axis — the ordering coordinate. Mirrors the daemon
+ * store's own chronological reader (`transcriptEventTimeUs`,
+ * packages/daemon/src/store/local-store.ts): raw `ts` mixes domains
+ * (platform decimal seconds vs daemon millisecond stamps) and must never be
+ * compared for order directly.
+ *
+ * - Slack text rows: decimal epoch seconds with up to microsecond precision.
+ * - daemon-local activity/replies: integer epoch milliseconds (optionally
+ *   `local-` prefixed).
+ * - hook rows: epoch milliseconds with a deterministic `|delivery-id` suffix.
+ * - legacy/synthetic integer seconds and ISO timestamps.
+ *
+ * Unknown/unsafe values fall back to 0 — they sort first and stay stable via
+ * the per-source order.
+ */
+export function transcriptEventTimeUs(ts: string | null | undefined): number {
+  let raw = ts?.trim() ?? ''
+  if (!raw) return 0
+  const local = raw.startsWith('local-')
+  if (local) raw = raw.slice('local-'.length)
+  raw = raw.split('|', 1)[0] ?? ''
+
+  const decimal = /^(\d+)\.(\d+)$/.exec(raw)
+  if (decimal) {
+    const seconds = Number(decimal[1]!)
+    const micros = Number(decimal[2]!.slice(0, 6).padEnd(6, '0'))
+    return safeEventTimeUs(seconds * 1_000_000 + micros)
+  }
+
+  if (/^\d+$/.test(raw)) {
+    const value = Number(raw)
+    // Match the daemon: 10-digit-era values are epoch seconds; modern 13-digit
+    // values (and every explicit `local-` value) are epoch milliseconds.
+    const micros = local || value >= 10_000_000_000 ? value * 1_000 : value * 1_000_000
+    return safeEventTimeUs(micros)
+  }
+
+  const parsed = Date.parse(raw)
+  return Number.isFinite(parsed) && Number.isSafeInteger(parsed * 1_000) ? parsed * 1_000 : 0
+}
+
+function safeEventTimeUs(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0
+}
+
+/** Provider-native Slack message timestamp — the platform message id shared by
+ *  every delivery. Exactly `^\d+\.\d+$` (anchored, dot escaped): an integer
+ *  `monotonicTs()` millisecond value must never match. */
+const SLACK_NATIVE_TS = /^\d+\.\d+$/
+
+/**
+ * The provenance-explicit duplicate identity of a row, or null when the row
+ * must never dedupe across sources (§6 step 2):
+ *
+ * - only `kind === 'text'` rows dedupe — a coincidental `ts` collision with a
+ *   work-lane row is inert by construction;
+ * - webchat: the canonical `postId` — minted once at origin, identical on
+ *   every copy regardless of a collision-bumped `ts`. Rows without one
+ *   (daemon-local a2a report-backs, pre-upgrade rows) never dedupe: failing
+ *   toward a visible duplicate, never toward data loss;
+ * - everything else: the provider-native decimal `ts` only — daemon-local
+ *   millisecond rows are single-source by construction, and two daemons can
+ *   mint the same millisecond for distinct rows.
+ */
+export function duplicateIdentity(platform: string, row: SessionMessageDto): string | null {
+  if (row.kind !== 'text') return null
+  if (platform === 'webchat') return row.postId ? `post:${row.postId}` : null
+  return SLACK_NATIVE_TS.test(row.ts) ? `ts:${row.ts}` : null
+}
+
+/**
+ * Union the sources' rows, dedupe copies by provenance-explicit identity with
+ * author-copy precedence, and order on the normalized event-time axis.
+ *
+ * Ordering is a STABLE merge: rows compare by `eventTimeUs`; ties break by
+ * `(sender, sourceSessionId)` and finally by each source's own row order, so
+ * a source's internal sequence is never reordered and merges are
+ * deterministic across reloads.
+ */
+export function mergeConversation(sources: MergeSource[]): MergedRow[] {
+  type Decorated = MergedRow & { us: number; order: number }
+  const kept: Decorated[] = []
+  const byIdentity = new Map<string, Decorated>()
+  let order = 0
+  for (const source of sources) {
+    for (const row of source.rows) {
+      const candidate: Decorated = {
+        row,
+        sourceSessionId: source.sessionId,
+        sourceAgentId: source.agentId,
+        authorCopy: row.sender === source.agentId,
+        us: transcriptEventTimeUs(row.ts),
+        order: order++
+      }
+      const identity = duplicateIdentity(source.platform, row)
+      if (identity === null) {
+        kept.push(candidate)
+        continue
+      }
+      const previous = byIdentity.get(identity)
+      if (!previous) {
+        byIdentity.set(identity, candidate)
+        kept.push(candidate)
+      } else if (!previous.authorCopy && candidate.authorCopy) {
+        // The author copy is the full-fidelity one — replace the recipient
+        // copy IN PLACE (keeping its coordinates is wrong: the author's
+        // canonical position wins for placement).
+        const at = kept.indexOf(previous)
+        kept[at] = candidate
+        byIdentity.set(identity, candidate)
+      }
+    }
+  }
+  kept.sort((a, b) => {
+    if (a.us !== b.us) return a.us - b.us
+    if (a.row.sender !== b.row.sender) return a.row.sender < b.row.sender ? -1 : 1
+    if (a.sourceSessionId !== b.sourceSessionId) return a.sourceSessionId < b.sourceSessionId ? -1 : 1
+    return a.order - b.order
+  })
+  return kept.map(({ row, sourceSessionId, sourceAgentId, authorCopy }) => ({
+    row,
+    sourceSessionId,
+    sourceAgentId,
+    authorCopy
+  }))
+}

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -104,9 +104,8 @@ export function duplicateIdentity(platform: string, row: SessionMessageDto): str
  * author-copy precedence, and order on the normalized event-time axis.
  *
  * Ordering is a STABLE merge: rows compare by `eventTimeUs`; ties break by
- * `(sender, sourceSessionId)` and finally by each source's own row order, so
- * a source's internal sequence is never reordered and merges are
- * deterministic across reloads.
+ * source (deterministic across reloads) and then by each source's own row
+ * order, so a source's internal sequence is never reordered.
  */
 export function mergeConversation(sources: MergeSource[]): MergedRow[] {
   type Decorated = MergedRow & { us: number; order: number }
@@ -143,9 +142,13 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
       }
     }
   }
+  // Hierarchical, TRANSITIVE tie-break: equal timestamps group by source first
+  // (deterministic across reloads), and within a source the original row order
+  // decides — a source's own sequence is never reordered. (A sender-first
+  // tie-break would both reverse same-source rows and break comparator
+  // transitivity across sources.)
   kept.sort((a, b) => {
     if (a.us !== b.us) return a.us - b.us
-    if (a.row.sender !== b.row.sender) return a.row.sender < b.row.sender ? -1 : 1
     if (a.sourceSessionId !== b.sourceSessionId) return a.sourceSessionId < b.sourceSessionId ? -1 : 1
     return a.order - b.order
   })


### PR DESCRIPTION
Implements **C2** of [merged-conversation-view.md](../blob/main/docs/designs/merged-conversation-view.md) (#420), on top of the C1 grouped list (#428) and the daemon postId prerequisite (#432). Two commits: the pure merge module, then the page.

## conversation-merge.ts (C2b)

Pure, unit-tested module (§6): union per-member message pages; **provenance-explicit dedupe** — webchat by canonical `postId` with author-copy precedence (surviving collision-bumped copies), Slack only by the anchored provider-native decimal `ts`, daemon-local millisecond rows and work-lane rows never; ordering on the normalized epoch-microsecond axis mirroring the daemon's `transcriptEventTimeUs`, stable per source with a deterministic tie-break. Fixtures cover every review-mandated case from the design (same-ms canonical-vs-local, bumped copy, cross-daemon same-ms a2a rows, seconds/ms interleaving).

## The merged page (C2c)

`/conversations/[key]` mounts the **same persistent detail view** in conversation mode. The key resolves the roster through C1's bounded resolver; the **representative** member then drives every session-scoped affordance exactly like `/sessions/:id` — so the webchat composer (all-respond resume, "Message everyone…") and Slack's read-only header with the platform thread link come for free, and peer members' work rows render through the existing per-agent turn machinery (#412/#414) unchanged.

Conversation mode changes only the transcript data layer: fan the existing bounded per-session reads out over every member, keep per-source rows/cursors, and always render `mergeConversation()` over the current union (initial load and live tail converge through one path). A member whose read fails degrades to a **partial merge with a daemon-offline notice**; authorization-hidden members never reach the roster (silent, per §7).

## Redirects & landing (C2d)

- A `/sessions/:id` deep link that belongs to a multi-participant conversation **redirects** to `/conversations/:key?focus=<agentId>` (one bounded resolver probe per detail view, cached in the same SWR family).
- Grouped-list rows link straight to the merged page (replacing C1's interim representative link).
- A live multi-participant Playground swaps its synthetic URL to the **conversation URL**, so refresh lands on the same merged canvas — closing the live/persisted gap.
- Browser port of the key codec with a byte-for-byte vector test against the CP codec; `SessionDetailDto` gains `tenantScope` so the console computes a session's key without a second lookup.

## Deferred (noted in-code)

Conversation-level lineage lift (§9.2 "Parent conversation"/"Delegations" union across members) — the representative's own lineage links keep rendering as today. `?focus` is accepted and carried; scroll/highlight chrome is C3 polish.

Tests: web 609 (merge fixtures + codec vector), CP 967 unit + 901 integration, typecheck ×3, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)