### PR TITLE
fix(daemon): skills follow the agent's own sandbox, not a forced fleet requirement (#36)

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -76,17 +76,11 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
 
   const sandboxMechanism = detectSandbox()
-  const enforceSkillSandbox = opts.hostFactory === undefined
-  if (enforceSkillSandbox && !sandboxMechanism) {
-    throw new Error(
-      'AgentConnect skill authority requires every real ACP host to use a supported Linux SRT/bwrap sandbox'
-    )
-  }
-  const runInSandbox = effectiveRunInSandbox(
-    cfg.security.requireSandbox || enforceSkillSandbox,
-    agent.runInSandbox,
-    sandboxMechanism
-  )
+  // Sandbox-optional principle (#36): the single-shot host follows the agent's OWN
+  // sandbox decision (and the explicit operator requireSandbox), never a forced
+  // skill-authority requirement — so chat runs on hosts with or without an OS
+  // sandbox instead of failing closed.
+  const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, sandboxMechanism)
   if (entry?.source === 'curated') {
     const admission = new CuratedRuntimeAdmission()
     const probe = opts.probeRuntimes ?? probeAllRuntimes

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1611,8 +1611,6 @@ export class Daemon {
   // per-agent requests are ineffective; security.requireSandbox refuses startup
   // (including on unsupported macOS/Windows hosts).
   private sandboxMechanism: SandboxMechanism | undefined
-  /** Daemon-wide same-UID boundary. It is established before the first real ACP
-   * child, so no earlier unconfined sibling can pre-forge later skill authority. */
   private runtimeNames: Record<string, string> = {} // registry id -> display name (for CP reporting)
   private runtimeVersions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
   // Models learned by actively probing each runtime (registry id -> model ids).
@@ -1962,10 +1960,6 @@ export class Daemon {
         'daemon startup refused: security.requireSandbox is true but this host has no supported Linux SRT/bwrap mechanism'
       )
     }
-    // Skills are mutable executable authority stored under the daemon's UID.
-    // Establish the fleet-wide boundary on first boot, before probes or hosts;
-    // waiting until a skill exists would let an earlier unconfined ACP sibling
-    // forge the marker, registry, ledger, and installed bytes retroactively.
     // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
     // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the
     // daemon boots, reconciles, and connects on hosts with or without an OS
@@ -17400,13 +17394,12 @@ export class Daemon {
     // With a hostFactory (unit tests use fake in-memory hosts) we don't spawn real
     // subprocesses unless a probe seam is injected.
     if (this.opts.hostFactory && !this.opts.probeRuntimes) return
-    // Runtime probes are ACP children under the same UID. Never let a pre-skill
-    // unsandboxed probe establish the bootstrap-forgery window that real hosts
-    // are forbidden from creating. Injected probes are trusted test seams.
-    if (!this.sandboxMechanism && !this.opts.probeRuntimes) {
-      this.log.warn('probe: skipped because no supported OS sandbox is available')
-      return
-    }
+    // Runtime probes are ACP children under the same UID. Sandbox-optional
+    // principle (#36): probe sandboxed when a mechanism exists (launchFor below
+    // sets runInSandbox from `this.sandboxMechanism`), but still probe UNSANDBOXED
+    // when none is available — otherwise curated runtimes are never admitted and
+    // their agents cannot run on a no-sandbox host. The explicit operator
+    // `security.requireSandbox` already refused boot without a mechanism.
     if (this.probing) {
       if (includeOrdinary) this.ordinaryProbePending = true
       else this.curatedProbePending = true

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -139,7 +139,6 @@ import {
   prefetchWorkspace
 } from './workspace/workspace-manager.js'
 import { ManagedSkillCache } from './skills/managed-skill-cache.js'
-import { persistSkillSandboxRequirement, skillSandboxRequirementPresent } from './skills/skill-sandbox-policy.js'
 import {
   OutputConverger,
   renderStatusBar,
@@ -1614,7 +1613,6 @@ export class Daemon {
   private sandboxMechanism: SandboxMechanism | undefined
   /** Daemon-wide same-UID boundary. It is established before the first real ACP
    * child, so no earlier unconfined sibling can pre-forge later skill authority. */
-  private globalSkillSandboxRequired = false
   private runtimeNames: Record<string, string> = {} // registry id -> display name (for CP reporting)
   private runtimeVersions: Record<string, string> = {} // registry id -> version (for the facts/daemon-runtimes snapshot)
   // Models learned by actively probing each runtime (registry id -> model ids).
@@ -1968,8 +1966,11 @@ export class Daemon {
     // Establish the fleet-wide boundary on first boot, before probes or hosts;
     // waiting until a skill exists would let an earlier unconfined ACP sibling
     // forge the marker, registry, ledger, and installed bytes retroactively.
-    await persistSkillSandboxRequirement(root)
-    this.globalSkillSandboxRequired = true
+    // Sandbox-optional principle (#36): skills are NOT force-sandboxed fleet-wide.
+    // A skill runs sandboxed only when its agent does (agentRunsInSandbox), so the
+    // daemon boots, reconciles, and connects on hosts with or without an OS
+    // sandbox. The residual "an unconfined ACP child could tamper with skill
+    // authority" exposure on an unsandboxed agent is a tracked P2.
     // Mint a stable local daemonId only when we are NOT onboarding via a CP
     // token: with a `controlPlane.key` and no explicit id, the CP assigns the
     // id from the token's `sub` and the daemon adopts it (see startCpClient).
@@ -2723,7 +2724,6 @@ export class Daemon {
       )
     }
     this.fileAgents = nextFileAgents
-    await this.activateGlobalSkillSandbox(false, desired)
     const { toStart, toStop, toChange } = diffAgents(desired, this.agents)
     if (toStart.length || toStop.length || toChange.length)
       this.log.info(
@@ -3965,46 +3965,16 @@ export class Daemon {
    * cache, trusted installer state, and runtime CLI identity together prevents
    * a non-session warmup from spawning with a weaker preparation path. */
   private agentRunsInSandbox(agent: Agent): boolean {
-    const requireSandbox =
-      this.cfg.security.requireSandbox || (this.globalSkillSandboxRequired && this.opts.hostFactory === undefined)
-    return effectiveRunInSandbox(requireSandbox, agent.runInSandbox, this.sandboxMechanism)
-  }
-
-  private async activateGlobalSkillSandbox(
-    force = false,
-    agents: readonly Agent[] = [...this.agents.values()]
-  ): Promise<void> {
-    if (!force && !skillSandboxRequirementPresent(this.root, agents)) return
-    const transitioned = !this.globalSkillSandboxRequired
-    if (transitioned) {
-      // Publish the sticky boundary before stopping current hosts. A crash at any
-      // later point therefore makes the next daemon fail closed before ACP spawn.
-      await persistSkillSandboxRequirement(this.root)
-      this.globalSkillSandboxRequired = true
-    }
-
-    if (transitioned && !this.opts.hostFactory) {
-      for (const agentId of [...this.hosts.keys()]) {
-        const wasDraining = this.drainingAgents.has(agentId)
-        this.drainingAgents.add(agentId)
-        this.interruptAgentTurns(agentId, 'stop')
-        try {
-          await this.stopHost(agentId)
-        } finally {
-          if (!wasDraining && !this.agentDestructivePending(agentId)) this.drainingAgents.delete(agentId)
-        }
-      }
-    }
-    if (!this.sandboxMechanism && !this.opts.hostFactory) {
-      throw new Error(
-        'AgentConnect skill authority requires every real ACP host to use a supported Linux SRT/bwrap sandbox'
-      )
-    }
+    // Sandbox-optional principle (#36): skills follow the agent's OWN sandbox
+    // decision, never a forced fleet-wide requirement. Only the explicit operator
+    // `security.requireSandbox` still forces confinement; a trusted/unsandboxed
+    // agent runs (and installs/uses skills) unsandboxed, and the daemon never
+    // fails closed on a host with no OS sandbox.
+    return effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
   }
 
   private async runAgentWorkspacePreparation(agent: Agent): Promise<string> {
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
-    await this.activateGlobalSkillSandbox(false, [agent])
     return prepareWorkspace(agent, {
       managedSkills: (value) => this.managedSkillCache?.resolve(value) ?? Promise.resolve([]),
       skillsStateDir: join(this.root, 'skill-installs'),
@@ -5032,7 +5002,6 @@ export class Daemon {
           this.log.warn(`cp: organization suggestion sync failed (${err instanceof Error ? err.name : 'unknown'})`)
         ),
       withSkillAcceptance: async (agentId, publish) => {
-        await this.activateGlobalSkillSandbox(true)
         return this.withWorkspaceFileWrite(agentId, publish)
       },
       onEvent: (event) => this.recordDreamLifecycle(event),

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -5,7 +5,6 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable } from 'node:stream'
 import { runChat } from '../src/cli/chat.js'
-import { detectSandbox } from '../src/acp/sandbox.js'
 import type { AcpHost } from '../src/acp/acp-host.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 
@@ -90,11 +89,10 @@ describe('runChat', () => {
   it('single-shot: discovers the lone agent, spawns runtime, streams the echoed reply', async () => {
     const { agentsDir, configPath, root } = scaffold()
     const out = capture()
+    // Sandbox-optional principle (#36): the single-shot host runs (sandboxed where
+    // a mechanism exists, unsandboxed otherwise) instead of failing closed, so the
+    // echo path holds on hosts with or without an OS sandbox.
     const run = runChat({ agentsDir, message: 'hi', configPath, root, out: out.stream })
-    if (!detectSandbox()) {
-      await expect(run).rejects.toThrow(/requires every real ACP host.*sandbox/)
-      return
-    }
     await run
     expect(out.text()).toContain('echo:hi')
   }, 20_000)

--- a/packages/daemon/test/curated-runtime-daemon.test.ts
+++ b/packages/daemon/test/curated-runtime-daemon.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { FakeClock } from './cp/fake-clock.js'
@@ -63,6 +64,33 @@ describe('daemon curated runtime admission', () => {
       await daemon.stop()
     }
   })
+
+  it('probes and admits a curated runtime UNSANDBOXED on a host with no sandbox mechanism (#36)', async () => {
+    // Regression: the probe used to be skipped on a no-sandbox host, so curated
+    // runtimes were never admitted and their agents could not run there. With no
+    // injected probe and no hostFactory this exercises the REAL probe path.
+    const fakeAgent = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'fake-acp-agent.mjs')
+    const runtime = { command: process.execPath, args: [fakeAgent], env: [] }
+    const daemon = new Daemon({
+      root: root(),
+      sandboxMechanism: null,
+      resolveCatalog: async () => ({
+        entries: { 'hermes-agent': { runtime, source: 'curated', name: 'Hermes Agent', version: '' } },
+        runtimes: { 'hermes-agent': runtime }
+      }),
+      installed: (runtimes) => runtimes
+    })
+    try {
+      await daemon.start()
+      // The real probe runs unconfined instead of skipping, so the curated runtime
+      // is admitted (recorded) and becomes launchable.
+      await vi.waitFor(() => expect(Object.keys((daemon as any).runtimes)).toContain('hermes-agent'), {
+        timeout: 10_000
+      })
+    } finally {
+      await daemon.stop()
+    }
+  }, 20_000)
 
   it('reports an auth-required curated runtime with the login warning without admitting it', async () => {
     const probe = vi.fn(async (runtimes: Record<string, unknown>) =>

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -39,7 +39,7 @@ function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', ico
 }
 
 describe('Daemon (no Slack, injected ACP host)', () => {
-  it('forces every real ACP host through the daemon-wide sandbox boundary', async () => {
+  it('sandboxes a host only when the agent opts in — skills are not force-sandboxed (#36)', async () => {
     const root = scaffold()
     const daemon = new Daemon({
       root,
@@ -48,8 +48,18 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     })
     try {
       await daemon.start()
-      const host = (daemon as any).ensureHost('bot-a', (daemon as any).cfg)
-      expect((host as any).opts.sandbox).toMatchObject({ mechanism: 'bwrap' })
+      const agent = (daemon as any).agents.get('bot-a')
+      // Sandbox-optional principle: a default agent is NOT force-sandboxed by the
+      // skill-authority requirement, even with a mechanism available.
+      expect((daemon as any).agentRunsInSandbox(agent)).toBe(false)
+      const defaultHost = (daemon as any).ensureHost('bot-a', (daemon as any).cfg)
+      expect((defaultHost as any).opts.sandbox).toBeUndefined()
+      // Opting the agent into the sandbox confines it via the available mechanism.
+      ;(daemon as any).hosts.delete('bot-a')
+      agent.runInSandbox = true
+      expect((daemon as any).agentRunsInSandbox(agent)).toBe(true)
+      const sandboxed = (daemon as any).ensureHost('bot-a', (daemon as any).cfg)
+      expect((sandboxed as any).opts.sandbox).toMatchObject({ mechanism: 'bwrap' })
     } finally {
       await daemon.stop().catch(() => undefined)
       const repoRoot = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../..'))
@@ -70,15 +80,18 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     )
   })
 
-  it('refuses every real ACP host without a sandbox before any skills exist', async () => {
+  it('does not force the skill sandbox or fail closed when the host has no sandbox mechanism (#36)', async () => {
     const root = scaffold()
     const daemon = new Daemon({ root, sandboxMechanism: null })
     try {
+      // Sandbox-optional principle: skills are NOT force-sandboxed fleet-wide, so
+      // boot/reconcile must not throw on a host with no OS sandbox (the exact
+      // reconcile/CP-handshake path that used to break).
       await daemon.start()
-      await expect((daemon as any).ensureHostAsync('bot-a')).rejects.toThrow(
-        /skill authority requires every real ACP host.*sandbox/
-      )
-      expect(existsSync(join(root, 'skill-installs', 'sandbox-required-v1'))).toBe(true)
+      // The agent follows its OWN sandbox decision — unset ⇒ unsandboxed — rather
+      // than a forced skill-authority requirement. (start() completing already
+      // proves boot/reconcile did not fail closed on this no-sandbox host.)
+      expect((daemon as any).agentRunsInSandbox((daemon as any).agents.get('bot-a'))).toBe(false)
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })


### PR DESCRIPTION
## Production regression (urgent)
On a host with **no supported Linux SRT/bwrap sandbox**, the daemon's fleet-wide skill-authority requirement threw during reconcile (`activateGlobalSkillSandbox`) and in the single-shot chat CLI:

```
ERROR cp: integration reconcile failed: Error: AgentConnect skill authority requires every real ACP host to use a supported Linux SRT/bwrap sandbox
    at Daemon.activateGlobalSkillSandbox → runReconcile → reconcile → CpAgentRegistry.onChange → CpClient.handshake
```

So the daemon could not reconcile or complete the CP handshake — it **failed closed and never ran** on no-sandbox hosts.

## Fix
Per the sandbox-optional product principle (any feature is supported with or without a sandbox; trusted agents may run unsandboxed), skill confinement is no longer **forced fleet-wide**. A host is sandboxed only when the agent itself opts in (`agent.runInSandbox`) or the operator sets `security.requireSandbox`; skills run wherever their agent runs. The daemon boots, reconciles, and connects on hosts with or without an OS sandbox.

- `agentRunsInSandbox` drops the `globalSkillSandboxRequired` term.
- Delete `activateGlobalSkillSandbox`, its unconditional boot establishment, its three callers, and the now-unused `skill-sandbox-policy` imports.
- `cli/chat.ts`: the single-shot host follows the agent's own sandbox decision instead of throwing when no mechanism exists.

The explicit operator gate (`security.requireSandbox: true` refuses boot with no mechanism) is unchanged — that stays an opt-in strictness.

## Security note (owner-accepted P2)
The residual exposure — an unconfined ACP child could tamper with the skill registry/ledger/installed bytes on an **unsandboxed** agent — is a documented, owner-accepted P2, to be revisited with per-runtime credential/authority brokering. `docs/product-conventions.md` documents the sandbox-optional invariant.

## Tests
- daemon-smoke: a default agent is NOT force-sandboxed (and is sandboxed only when it opts in); boot/reconcile do not fail closed with no mechanism.
- chat single-shot runs on hosts with or without a sandbox.
- Full daemon suite green locally (2724 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)