### PR TITLE
[OLD] feat(auth): sync Feishu and Lark session access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,14 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # SLACK_PLATFORM_CLIENT_SECRET=
 # SLACK_PLATFORM_SIGNING_SECRET=
 
+# ── Platform Feishu/Lark apps for Profile + Session permission sync ─────────
+# Each region is independently optional, but its ID/secret are a pair. The same
+# app must back the matching Logto connector because open_id is app-scoped.
+# FEISHU_PLATFORM_APP_ID=
+# FEISHU_PLATFORM_APP_SECRET=
+# LARK_PLATFORM_APP_ID=
+# LARK_PLATFORM_APP_SECRET=
+
 # ── open-connector integration (optional) ───────────────────────────────────
 # OPEN_CONNECTOR_URL=                 # unset ⇒ Add connectors is hidden
 # OPEN_CONNECTOR_PROVIDER_WHITELIST=* # `*` or unset ⇒ allow every service

--- a/compose.env.example
+++ b/compose.env.example
@@ -79,6 +79,13 @@
 # SLACK_PLATFORM_CLIENT_SECRET=
 # SLACK_PLATFORM_SIGNING_SECRET=
 
+# Optional AgentConnect Feishu/Lark apps used by both the Logto connector and
+# live Session chat-membership checks. Set each regional pair together.
+# FEISHU_PLATFORM_APP_ID=
+# FEISHU_PLATFORM_APP_SECRET=
+# LARK_PLATFORM_APP_ID=
+# LARK_PLATFORM_APP_SECRET=
+
 # Optional GitHub App for private GitHub workspaces and GitHub event
 # integrations. Configure these GitHub App URLs with your public origins:
 #   Setup URL:   https://cp.example.com/v1/github/setup/callback

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -1,7 +1,7 @@
 # Session Visibility
 
-> **Status:** Implemented for direct `private` / `org` visibility, Slack
-> conversation audiences, GitHub repository audiences, and their Console
+> **Status:** Implemented for direct `private` / `org` visibility, Slack and
+> Feishu/Lark conversation audiences, GitHub repository audiences, and their Console
 > settings/profile-linking surfaces. Share-by-link and additional providers remain
 > future work.
 >
@@ -37,6 +37,8 @@ This design gives every session its own visibility:
   sessions store the rename-proof numeric repository id: public repositories
   require no linked identity; private repositories require the viewer's
   currently linked GitHub account to retain read access.
+  Feishu/Lark group sessions created through the deployment's matching
+  platform app require current chat membership; DMs remain owner-only.
 - **Share-by-link ("public")** — future work; a session with an active share
   link is readable by anyone holding the link. Deliberately **not** a member of
   the visibility enum; see §8.
@@ -84,14 +86,15 @@ matches the same three-part tuple.
 
 Matching is set membership: at request time the BFF computes the viewer's
 **identity set** — `{ user:<userId> }` for every caller, plus the caller's
-verified Slack identity (`slack:<teamId>:<userId>`) when they signed in with
-or linked Slack (§7, `http/viewer-identity.ts`) — and a `private` session is
+verified Slack identity (`slack:<teamId>:<userId>`) or a same-app Feishu/Lark
+identity (`feishu:<region>:<appId>:<openId>`) when linked (§7,
+`http/viewer-identity.ts`) — and a `private` session is
 visible when `ownerIdentity ∈ identitySet`.
 
 Consequences:
 
-- Before the identity mapping exists for a platform (today: everything except
-  Slack), a `private` IM DM session is an **owner-orphan**: no console user
+- Before the identity mapping exists for a platform (today: Telegram and
+  Discord), a `private` IM DM session is an **owner-orphan**: no console user
   matches the stored tuple, so no one sees it. This is accepted — it errs
   toward hiding a DM rather than exposing it.
 - When identity linking ships for a platform, those sessions become visible
@@ -153,8 +156,8 @@ enum VisibilitySource {
   share-by-link (§8) covers the near-term "share this session" ask.
 - `ExternalScope` stores only the stable provider resource identity and the
   credential locator needed to ask the provider. It never stores provider ACLs.
-  Slack channel-access and GitHub repository-access decisions are bounded,
-  short-lived in-process cache entries. Linked Slack and GitHub identities
+  Slack/Feishu/Lark conversation-access and GitHub repository-access decisions are bounded,
+  short-lived in-process cache entries. Linked Slack, Feishu/Lark, and GitHub identities
   remain provider-owned and are resolved from Logto rather than copied into the
   AgentConnect database.
 - `SessionExternalAccessPolicy` is per organization and provider. Its revision
@@ -221,6 +224,12 @@ GitHub direct ingress reports:
 }
 ```
 
+Feishu/Lark direct ingress uses provider `feishu`, a `conversation` resource,
+and realm `<region>:<appId>`. The CP accepts the candidate only when that App ID
+matches `FEISHU_PLATFORM_APP_ID` or `LARK_PLATFORM_APP_ID`; user-built apps stay
+on the ordinary organization visibility model because their `open_id` domain
+cannot be compared with the platform Logto connector.
+
 The daemon pins that tuple on first use. A later input from a different source
 is rejected rather than silently reusing the session. A2A descendants carry
 only the audience identity (without Slack integration ids or GitHub delivery
@@ -248,16 +257,16 @@ The CP classifies once, in the `event/session` ingest path
 (`ws/handlers/event-session.ts` → `session.recordMilestone`), first-wins like
 the other origin scalars:
 
-| Origin (how detected)                                  | `visibility`        | `ownerIdentity`                                                                                                                       |
-| ------------------------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Webchat / Playground (`platform === 'webchat'`)        | `private`           | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
-| Web API session launch (§4.4 correlation)              | `private`           | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
-| IM DM (`conversationKind` = `dm`)                      | `private`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Slack group DM / channel with trusted `externalOrigin` | `org` or `external` | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
-| GitHub hook with an accepted delivery snapshot         | `org` or `external` | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
-| Other IM group DM / channel (or absent kind)           | `org`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Agent-to-agent child (`triggeredBy` is an agent UUID)  | inherits parent     | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
-| Automation without a trusted external destination      | `org`               | `null`                                                                                                                                |
+| Origin (how detected)                                                      | `visibility`        | `ownerIdentity`                                                                                                                       |
+| -------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Webchat / Playground (`platform === 'webchat'`)                            | `private`           | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
+| Web API session launch (§4.4 correlation)                                  | `private`           | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
+| IM DM (`conversationKind` = `dm`)                                          | `private`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| Slack or matching-app Feishu/Lark group chat with trusted `externalOrigin` | `org` or `external` | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
+| GitHub hook with an accepted delivery snapshot                             | `org` or `external` | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
+| Other IM group DM / channel (or absent kind)                               | `org`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| Agent-to-agent child (`triggeredBy` is an agent UUID)                      | inherits parent     | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
+| Automation without a trusted external destination                          | `org`               | `null`                                                                                                                                |
 
 Notes:
 
@@ -547,8 +556,9 @@ learned from it"); silence is not an option.
   owners allowed to use it.
 - Settings exposes owner-only provider access-sync switches, disabled by
   default. Slack follows current channel access (workspace access for public
-  channels; conversation membership for restricted audiences); GitHub follows
-  current repository visibility and user access. Provider-bound visibility is
+  channels; conversation membership for restricted audiences); Feishu/Lark
+  follows current chat membership; GitHub follows current repository visibility
+  and user access. Provider-bound visibility is
   read-only; unresolved history and transient provider failures are surfaced
   without widening access.
 - Session links emitted into Slack and GitHub carry a non-authoritative provider
@@ -583,19 +593,19 @@ login from Logto and asks GitHub for that user's current effective repository
 permission. AgentConnect stores neither the GitHub login nor a copied provider
 ACL; only bounded allow/deny/error verdicts are cached in process.
 
-**Other platform session access (future, separate design).** A user may link a
-Lark or Feishu social identity through a configured Logto connector. Feishu uses
-Logto's built-in connector; Lark uses its generic OAuth connector pointed at the
-Lark passport endpoints. That alone cannot authorize messaging sessions: the
-message-side `open_id` is scoped to one app, and the social connector may be a
-different app. Telegram, Discord, Lark, and Feishu therefore still need an
-explicit verified binding before their identities can enter the session identity
-set. One option is a `UserIdentity`
-table (`userId`, `platform`, `workspace`, `platformUserId`, verified-at, unique
-on the `(platform, workspace, platformUserId)` tuple — matching the three-part
-identity format of §2) populated by a bot-mediated code flow. Once it exists,
-the same identity-set computation reads it; the Slack read-through can fold
-into that table then.
+**Feishu/Lark (shipped for the platform apps).** Logto stores the connector's
+raw `open_id`; the BFF reads it without exposing it to the browser and qualifies
+it with the connector region plus deployment App ID. The daemon independently
+reports the messaging App ID in its trusted source realm. The two values enter
+the same identity set only when those App IDs match, which is required because
+`open_id` is app-scoped. Group sessions then page the live chat-members endpoint
+with the corresponding platform app credential. DMs use the same qualified
+identity tuple and remain private. Provider failures fail closed; only bounded
+allow/deny/error verdicts and tenant tokens are cached in process.
+
+**Other platform session access (future, separate design).** Telegram and
+Discord still need an explicit verified identity binding before their platform
+identities can enter the session identity set.
 
 ## 8. Share-by-link (future, separate design)
 
@@ -647,3 +657,7 @@ link ends public access without touching the session row.
   validation; numeric repository identity across rename; public, private-linked,
   no-access, and provider-error decisions; ambiguous-history hiding; A2A scope
   inheritance; owner-role non-bypass; and parity across every session read path.
+- **Feishu/Lark external audience:** same-app Logto identity qualification;
+  platform-app source validation; paginated current-chat membership; regional
+  gateway selection; definitive denial versus degraded provider failure; and
+  custom-app non-participation.

--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -115,6 +115,13 @@ export const AppConfigSchema = z.object({
   SLACK_PLATFORM_CLIENT_ID: z.string().optional(),
   SLACK_PLATFORM_CLIENT_SECRET: z.string().optional(),
   SLACK_PLATFORM_SIGNING_SECRET: z.string().optional(),
+  // Platform-owned Feishu/Lark apps. Each region is independently all-or-none;
+  // the same app id must back its Logto social connector so app-scoped open_id
+  // values can be compared safely during Session membership checks.
+  FEISHU_PLATFORM_APP_ID: z.string().optional(),
+  FEISHU_PLATFORM_APP_SECRET: z.string().optional(),
+  LARK_PLATFORM_APP_ID: z.string().optional(),
+  LARK_PLATFORM_APP_SECRET: z.string().optional(),
   // The MCP endpoint's dedicated public origin (agent-assistant.md §6.1), e.g.
   // https://mcp.example.test. Set ⇒ the canonical MCP resource URL IS this origin (root resource;
   // the URL users paste is just the host) and auth discovery uses the origin-root

--- a/packages/control-plane/src/config/feishu-platform.test.ts
+++ b/packages/control-plane/src/config/feishu-platform.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { resolveFeishuPlatformApps } from './feishu-platform.js'
+
+describe('resolveFeishuPlatformApps', () => {
+  it('supports either region independently', () => {
+    expect(
+      resolveFeishuPlatformApps({
+        FEISHU_PLATFORM_APP_ID: undefined,
+        FEISHU_PLATFORM_APP_SECRET: undefined,
+        LARK_PLATFORM_APP_ID: 'cli_lark',
+        LARK_PLATFORM_APP_SECRET: 'secret'
+      })
+    ).toEqual({ lark: { appId: 'cli_lark', appSecret: 'secret' } })
+  })
+
+  it('fails fast for a partial regional pair', () => {
+    expect(() =>
+      resolveFeishuPlatformApps({
+        FEISHU_PLATFORM_APP_ID: 'cli_feishu',
+        FEISHU_PLATFORM_APP_SECRET: undefined,
+        LARK_PLATFORM_APP_ID: undefined,
+        LARK_PLATFORM_APP_SECRET: undefined
+      })
+    ).toThrow(/FEISHU_PLATFORM_APP_SECRET/)
+  })
+})

--- a/packages/control-plane/src/config/feishu-platform.ts
+++ b/packages/control-plane/src/config/feishu-platform.ts
@@ -1,0 +1,34 @@
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+import type { AppConfig } from './env.js'
+
+export interface FeishuPlatformAppConfig {
+  appId: string
+  appSecret: string
+}
+
+export type FeishuPlatformApps = Partial<Record<FeishuRegion, FeishuPlatformAppConfig>>
+
+type EnvSlice = Pick<
+  AppConfig,
+  'FEISHU_PLATFORM_APP_ID' | 'FEISHU_PLATFORM_APP_SECRET' | 'LARK_PLATFORM_APP_ID' | 'LARK_PLATFORM_APP_SECRET'
+>
+
+/** Resolve each regional app independently. A partial pair is always a deploy
+ * mistake; no pairs is the self-hosted/off default. */
+export function resolveFeishuPlatformApps(config: EnvSlice): FeishuPlatformApps {
+  const apps: FeishuPlatformApps = {}
+  for (const [region, idKey, secretKey] of [
+    ['feishu', 'FEISHU_PLATFORM_APP_ID', 'FEISHU_PLATFORM_APP_SECRET'],
+    ['lark', 'LARK_PLATFORM_APP_ID', 'LARK_PLATFORM_APP_SECRET']
+  ] as const) {
+    const appId = config[idKey]
+    const appSecret = config[secretKey]
+    if (!appId && !appSecret) continue
+    const missing = [!appId && idKey, !appSecret && secretKey].filter(Boolean)
+    if (missing.length > 0) {
+      throw new Error(`feishu platform app config is partial — missing ${missing.join(', ')} (set both or none)`)
+    }
+    apps[region] = { appId: appId!, appSecret: appSecret! }
+  }
+  return apps
+}

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -19,6 +19,7 @@ import { HOOK_DELIVERY_REASON_REVIEW_REQUEST_REQUIRED } from '@agentconnect.md/p
 import { type AppConfig, resolveWebAppUrl } from './config/env.js'
 import { resolveGithubAppConfig } from './github/config.js'
 import { resolveSlackPlatformAppConfig } from './config/slack-platform.js'
+import { resolveFeishuPlatformApps } from './config/feishu-platform.js'
 import type { FetchLike } from './github/api.js'
 import { ConnectorsClient, parseBlocklist, parseWhitelist } from './connectors/index.js'
 import { GithubService } from './github/service.js'
@@ -166,6 +167,7 @@ import { FeishuAppRegistrationService } from './http/feishu-registration.js'
 import { configureFeishuHttpApp } from './http/feishu-app-config.js'
 import { SlackSessionAccessService } from './http/slack-session-access.js'
 import { GithubSessionAccessService } from './http/github-session-access.js'
+import { FeishuSessionAccessService } from './http/feishu-session-access.js'
 
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from './config/defaults.js'
 
@@ -203,6 +205,8 @@ export interface ContainerOpts {
   githubFetch?: FetchLike
   /** Slack Web API fetch override for Session membership checks. */
   slackFetch?: FetchLike
+  /** Feishu/Lark Open Platform fetch override for Session membership checks. */
+  feishuFetch?: FetchLike
   /** npm dist-tags fetch override for the daemon "latest version" resolver — tests
    *  stub it (absent under NODE_ENV=test ⇒ the resolver is inert, no network). */
   daemonReleaseFetch?: FetchLike
@@ -470,6 +474,7 @@ export function buildContainer(
   // Platform-published Slack app (preset-agents.md §5.3) — undefined ⇒ feature
   // absent (routes 404, console hides "Add to Slack"); partial set ⇒ fail-fast.
   const slackPlatformApp = resolveSlackPlatformAppConfig(config)
+  const feishuPlatformApps = resolveFeishuPlatformApps(config)
 
   // Hook compiler/converger (webhook-triggers-and-github-events.md): CRUD routes
   // broadcast through it, and a (re)registering relay gets the full-set replay.
@@ -724,6 +729,12 @@ export function buildContainer(
         clock
       })
     : undefined
+  const feishuSessionAccess = new FeishuSessionAccessService({
+    bots: repos.bot,
+    apps: feishuPlatformApps,
+    clock,
+    ...(opts.feishuFetch ? { fetchImpl: opts.feishuFetch } : {})
+  })
 
   const httpDeps: HttpDeps = {
     clock,
@@ -819,6 +830,8 @@ export function buildContainer(
     ...(logtoIdentity ? { logtoIdentity } : {}),
     slackSessionAccess,
     ...(githubSessionAccess ? { githubSessionAccess } : {}),
+    feishuSessionAccess,
+    feishuPlatformApps,
     ...(iconStore ? { iconStore } : {}),
     ...(connectors ? { connectors } : {}),
     ...(slackPlatformApp ? { slackPlatformApp } : {}),
@@ -979,6 +992,7 @@ export function buildContainer(
     integration: repos.integration,
     bot: repos.bot,
     githubInstallation: repos.githubInstallation,
+    feishuPlatformApps,
     integrationChannel: repos.integrationChannel,
     agentMutations,
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),

--- a/packages/control-plane/src/github/logto-identity.ts
+++ b/packages/control-plane/src/github/logto-identity.ts
@@ -13,7 +13,7 @@
  * `https://tenant.example.com/api`).
  *
  * Caching: the M2M token until 60s before expiry; display/GitHub projections
- * keep a 10 min positive / 60 s negative user cache, while Slack authorization
+ * keep a 10 min positive / 60 s negative user cache, while provider authorization
  * caps reuse of a positive assertion at 2 min. Lookups are single-flight and
  * fail CLOSED at their authorization callers.
  */
@@ -72,11 +72,11 @@ export class LogtoApiError extends Error {
 const TOKEN_SKEW_MS = 60_000
 const LOGIN_TTL_MS = 10 * 60_000
 const NEGATIVE_TTL_MS = 60_000
-// Slack identity participates in live Session authorization. Even if no
+// Provider identity participates in live Session authorization. Even if no
 // in-product unlink invalidation fires (for example an administrator changes
 // the Logto account directly), a positive assertion is never reused beyond
 // this hard lease.
-const SLACK_IDENTITY_TTL_MS = 120_000
+const PROVIDER_IDENTITY_TTL_MS = 120_000
 const TIMEOUT_MS = 10_000
 
 interface CachedLogin {
@@ -134,6 +134,13 @@ export interface SlackIdentity {
   userId: string
   teamName?: string
   teamDomain?: string
+}
+
+export interface FeishuIdentity {
+  region: 'feishu' | 'lark'
+  /** App-scoped human identity. It is comparable only when Logto and the
+   * messaging integration use the same platform app id. */
+  openId: string
 }
 
 // Slack namespaces its non-standard OIDC claims. `sub` carries the same user id
@@ -233,7 +240,13 @@ export class LogtoIdentityService {
    * console's refresh call (`forgetUser`).
    */
   async slackIdentityFor(sub: string): Promise<SlackIdentity | null> {
-    return slackIdentityOf(await this.logtoUser(sub, SLACK_IDENTITY_TTL_MS))
+    return slackIdentityOf(await this.logtoUser(sub, PROVIDER_IDENTITY_TTL_MS))
+  }
+
+  /** Linked Feishu/Lark identities. Their open_id values remain app-scoped;
+   * viewer-identity adds the configured app id before they can authorize. */
+  async feishuIdentitiesFor(sub: string): Promise<FeishuIdentity[]> {
+    return feishuIdentitiesOf(await this.logtoUser(sub, PROVIDER_IDENTITY_TTL_MS))
   }
 
   /**
@@ -566,4 +579,18 @@ function slackIdentityOf(user: LogtoUser | null): SlackIdentity | null {
     ...(teamName ? { teamName } : {}),
     ...(teamDomain ? { teamDomain } : {})
   }
+}
+
+function feishuIdentitiesOf(user: LogtoUser | null): FeishuIdentity[] {
+  const identities: FeishuIdentity[] = []
+  for (const region of ['feishu', 'lark'] as const) {
+    const raw = user?.identities?.[region]?.details?.rawData
+    const data = raw?.data as Record<string, unknown> | undefined
+    const userInfo = raw?.userInfo as Record<string, unknown> | undefined
+    // Built-in Feishu currently stores the normalized user-info body; generic
+    // OAuth2 connectors may preserve the provider's {data:{...}} envelope.
+    const openId = firstString(raw?.open_id, data?.open_id, userInfo?.open_id)
+    if (openId) identities.push({ region, openId })
+  }
+  return identities
 }

--- a/packages/control-plane/src/github/slack-identity.test.ts
+++ b/packages/control-plane/src/github/slack-identity.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the Slack half of LogtoIdentityService (fake fetch — claim
+ * Unit tests for the Slack/Feishu identity projections of LogtoIdentityService (fake fetch — claim
  * extraction, per-provider caching, invalidation on unlink). No Docker, no
  * network. The GitHub half and the connector-id/unlink writes are covered by
  * `user-authz.test.ts`.
@@ -193,6 +193,30 @@ describe('LogtoIdentityService.slackIdentityFor', () => {
     // workspace the user just disconnected.
     users['sub-1'] = { identities: { github: { userId: 'g' } } }
     expect(await svc.slackIdentityFor('sub-1')).toBeNull()
+  })
+})
+
+describe('LogtoIdentityService.feishuIdentitiesFor', () => {
+  it('reads app-scoped open_id values from both built-in Feishu and generic Lark connector rawData', async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': {
+        identities: {
+          feishu: { userId: 'union-f', details: { rawData: { open_id: 'ou_feishu' } } },
+          lark: { userId: 'union-l', details: { rawData: { data: { open_id: 'ou_lark' } } } }
+        }
+      }
+    })
+    await expect(svcOf(fetchImpl).feishuIdentitiesFor('sub-1')).resolves.toEqual([
+      { region: 'feishu', openId: 'ou_feishu' },
+      { region: 'lark', openId: 'ou_lark' }
+    ])
+  })
+
+  it('ignores an identity whose connector rawData has no open_id', async () => {
+    const { fetchImpl } = fakeLogto({
+      'sub-1': { identities: { lark: { userId: 'union-only', details: { rawData: { union_id: 'on_x' } } } } }
+    })
+    await expect(svcOf(fetchImpl).feishuIdentitiesFor('sub-1')).resolves.toEqual([])
   })
 })
 

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -88,6 +88,8 @@ import type { IconStore } from '../icons/icon-store.js'
 import type { ConnectorsClient } from '../connectors/client.js'
 import type { SlackSessionAccessResolver } from './slack-session-access.js'
 import type { GithubSessionAccessResolver } from './github-session-access.js'
+import type { FeishuSessionAccessResolver } from './feishu-session-access.js'
+import type { FeishuPlatformApps } from '../config/feishu-platform.js'
 
 export interface HttpServerConfig extends HumanAuthConfig {
   /** Drives browser CORS for the Web UI (see `buildHttpServer`). */
@@ -343,6 +345,10 @@ export interface HttpDeps {
   slackSessionAccess?: SlackSessionAccessResolver
   /** Current GitHub repository visibility for external Session reads. */
   githubSessionAccess?: GithubSessionAccessResolver
+  /** Current Feishu/Lark chat membership for external Session reads. */
+  feishuSessionAccess?: FeishuSessionAccessResolver
+  /** Platform apps shared by Logto profile linking and membership resolution. */
+  feishuPlatformApps?: FeishuPlatformApps
   /** Uploaded-icon object store (docs/designs/icon-uploads.md); absent ⇒ S3_* unset,
    *  the icon upload/delete routes are not mounted and the console hides Upload. */
   iconStore?: IconStore

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2479,7 +2479,7 @@ export const SessionVisibilityDto = z.object({
 })
 
 export const SessionExternalAccessStateEnum = z.enum(['disabled', 'enabling', 'enabled', 'degraded'])
-export const SessionExternalAccessProviderEnum = z.enum(['slack', 'github'])
+export const SessionExternalAccessProviderEnum = z.enum(['slack', 'github', 'feishu'])
 export const SessionExternalAccessDto = z.object({
   provider: SessionExternalAccessProviderEnum,
   /** False when this deployment cannot resolve linked provider identities and

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BotRecord, ExternalScopeRecord } from '../persistence/ports.js'
+import { FeishuSessionAccessService } from './feishu-session-access.js'
+
+const BOT_ID = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+function scope(): ExternalScopeRecord {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    orgId: 'org-1',
+    provider: 'feishu',
+    realmKey: 'lark:cli_platform',
+    resourceKind: 'conversation',
+    resourceKey: 'oc_chat',
+    credentialKind: 'bot',
+    credentialId: BOT_ID,
+    aclRevision: 2n,
+    revokedAt: null
+  }
+}
+
+function scopeAt(index: number): ExternalScopeRecord {
+  return {
+    ...scope(),
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    resourceKey: `oc_chat_${index}`
+  }
+}
+
+function bot(): BotRecord {
+  return {
+    id: BOT_ID,
+    orgId: 'org-1',
+    platform: 'feishu',
+    feishuRegion: 'lark',
+    feishuAppId: 'cli_platform',
+    revokedAt: null,
+    credentialRevision: 3
+  } as BotRecord
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
+  return new FeishuSessionAccessService({
+    bots: { get: async () => bot() } as never,
+    apps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
+    clock: { now: () => 1_000 } as never,
+    fetchImpl
+  })
+}
+
+describe('FeishuSessionAccessService', () => {
+  it('resolves allowed scopes beyond the first 200', async () => {
+    const fetchImpl = async (url: string) =>
+      url.includes('/auth/v3/')
+        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
+        : json({ code: 0, data: { items: [{ member_id: 'ou_member' }], has_more: false } })
+    const scopes = Array.from({ length: 201 }, (_, index) => scopeAt(index + 1))
+    const result = await service(fetchImpl).resolve(scopes, new Set(['feishu:lark:cli_platform:ou_member']))
+    expect(result.allowedScopes).toHaveLength(201)
+    expect(result.degraded).toBe(false)
+  })
+
+  it('uses the Lark gateway and allows a current chat member', async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes('/auth/v3/')
+        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
+        : json({ code: 0, data: { items: [{ member_id: 'ou_member' }], has_more: false } })
+    )
+
+    await expect(
+      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
+    ).resolves.toEqual({ allowedScopes: [{ id: scope().id, aclRevision: 2n }], degraded: false })
+    expect(fetchImpl.mock.calls.every(([url]) => String(url).startsWith('https://open.larksuite.com/'))).toBe(true)
+  })
+
+  it('walks member pages and denies a user who is absent', async () => {
+    let page = 0
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('/auth/v3/')) return json({ code: 0, tenant_access_token: 'token', expire: 3600 })
+      page++
+      return page === 1
+        ? json({ code: 0, data: { items: [{ member_id: 'ou_other' }], has_more: true, page_token: 'next' } })
+        : json({ code: 0, data: { items: [], has_more: false } })
+    })
+
+    await expect(
+      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_missing']))
+    ).resolves.toEqual({ allowedScopes: [], degraded: false })
+    expect(page).toBe(2)
+  })
+
+  it('treats an inaccessible or dissolved chat as a definitive denial', async () => {
+    const fetchImpl = async (url: string) =>
+      url.includes('/auth/v3/')
+        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
+        : json({ code: 232011, msg: 'operator is not in chat' })
+    await expect(
+      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
+    ).resolves.toEqual({ allowedScopes: [], degraded: false })
+  })
+
+  it('fails closed and reports degradation for missing scope or provider failure', async () => {
+    const fetchImpl = async (url: string) =>
+      url.includes('/auth/v3/')
+        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
+        : json({ code: 99991672, msg: 'missing scope' })
+    await expect(
+      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
+    ).resolves.toEqual({ allowedScopes: [], degraded: true })
+  })
+
+  it('never compares an open_id from a different app domain', async () => {
+    const fetchImpl = vi.fn(async () => json({ code: 0 }))
+    await expect(service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_other:ou_member']))).resolves.toEqual({
+      allowedScopes: [],
+      degraded: false
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -1,0 +1,239 @@
+import type { FeishuRegion } from '@agentconnect.md/protocol'
+import type { Clock } from '../domain/clock.js'
+import { BotId } from '../domain/ids.js'
+import type { FeishuPlatformApps } from '../config/feishu-platform.js'
+import type { FetchLike } from '../github/api.js'
+import type { BotRepo, ExternalScopeRecord } from '../persistence/ports.js'
+
+const REGION_ORIGIN: Record<FeishuRegion, string> = {
+  feishu: 'https://open.feishu.cn',
+  lark: 'https://open.larksuite.com'
+}
+const ALLOW_TTL_MS = 120_000
+const DENY_TTL_MS = 30_000
+const UNKNOWN_TTL_MS = 5_000
+const TOKEN_SKEW_MS = 60_000
+const MAX_CACHE_ENTRIES = 10_000
+const SCOPES_PER_BATCH = 200
+const SCOPE_CONCURRENCY = 6
+const MAX_MEMBER_PAGES = 100
+const TIMEOUT_MS = 5_000
+
+type Decision = 'allow' | 'deny' | 'unknown'
+type Principal = { key: string; region: FeishuRegion; appId: string; openId: string }
+
+const DEFINITIVE_DENIALS = new Set([232006, 232009, 232010, 232011])
+
+export interface FeishuSessionAccessResult {
+  allowedScopes: Array<{ id: string; aclRevision: bigint }>
+  degraded: boolean
+}
+
+export interface FeishuSessionAccessResolver {
+  resolve(scopes: readonly ExternalScopeRecord[], identitySet: ReadonlySet<string>): Promise<FeishuSessionAccessResult>
+}
+
+function principalsOf(identitySet: ReadonlySet<string>): Principal[] {
+  const principals: Principal[] = []
+  for (const key of identitySet) {
+    const match = /^feishu:(feishu|lark):([^:]+):([^:]+)$/.exec(key)
+    if (match) principals.push({ key, region: match[1] as FeishuRegion, appId: match[2]!, openId: match[3]! })
+  }
+  return principals
+}
+
+async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
+  const out = new Array<R>(values.length)
+  let next = 0
+  await Promise.all(
+    Array.from({ length: Math.min(limit, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next++
+        out[index] = await fn(values[index]!)
+      }
+    })
+  )
+  return out
+}
+
+/** Current Feishu/Lark group-chat audience. The Logto identity and chat API
+ * both use the same configured app, making their app-scoped open_id values
+ * comparable. Only bounded verdicts/tokens are retained in process. */
+export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
+  private readonly cache = new Map<string, { decision: Decision; expiresAt: number }>()
+  private readonly tokens = new Map<FeishuRegion, { value: string; expiresAt: number }>()
+  private readonly tokenInFlight = new Map<FeishuRegion, Promise<string>>()
+
+  constructor(
+    private readonly deps: { bots: BotRepo; apps: FeishuPlatformApps; clock: Clock; fetchImpl?: FetchLike }
+  ) {}
+
+  async resolve(
+    scopes: readonly ExternalScopeRecord[],
+    identitySet: ReadonlySet<string>
+  ): Promise<FeishuSessionAccessResult> {
+    const principals = principalsOf(identitySet)
+    if (principals.length === 0 || scopes.length === 0) return { allowedScopes: [], degraded: false }
+    let degraded = false
+    const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
+    for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
+      const signal = AbortSignal.timeout(TIMEOUT_MS)
+      decisions.push(
+        ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
+          const decision = await this.resolveScope(scope, principals, signal)
+          if (decision === 'unknown') degraded = true
+          return { scope, decision }
+        }))
+      )
+    }
+    return {
+      allowedScopes: decisions
+        .filter(({ decision }) => decision === 'allow')
+        .map(({ scope }) => ({ id: scope.id, aclRevision: scope.aclRevision })),
+      degraded
+    }
+  }
+
+  private async resolveScope(
+    scope: ExternalScopeRecord,
+    principals: readonly Principal[],
+    signal: AbortSignal
+  ): Promise<Decision> {
+    if (
+      scope.provider !== 'feishu' ||
+      scope.resourceKind !== 'conversation' ||
+      scope.revokedAt !== null ||
+      scope.credentialKind !== 'bot' ||
+      !scope.credentialId
+    ) {
+      return 'deny'
+    }
+    const bot = await this.deps.bots.get(BotId(scope.credentialId)).catch(() => null)
+    const region = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
+    const appId = bot?.feishuAppId ?? undefined
+    const app = region ? this.deps.apps[region] : undefined
+    if (
+      !bot ||
+      bot.orgId !== scope.orgId ||
+      bot.platform !== 'feishu' ||
+      bot.revokedAt !== null ||
+      !region ||
+      !appId ||
+      !app ||
+      app.appId !== appId ||
+      scope.realmKey !== `${region}:${appId}`
+    ) {
+      return 'deny'
+    }
+
+    let sawUnknown = false
+    for (const principal of principals) {
+      if (principal.region !== region || principal.appId !== appId) continue
+      const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, principal.key].join(':')
+      const cached = this.cache.get(key)
+      let decision = cached && cached.expiresAt > this.deps.clock.now() ? cached.decision : undefined
+      if (!decision) {
+        decision = await this.checkMembership(region, scope.resourceKey, principal.openId, signal)
+        this.putCache(key, decision)
+      }
+      if (decision === 'allow') return 'allow'
+      if (decision === 'unknown') sawUnknown = true
+    }
+    return sawUnknown ? 'unknown' : 'deny'
+  }
+
+  private async checkMembership(
+    region: FeishuRegion,
+    chatId: string,
+    openId: string,
+    signal: AbortSignal
+  ): Promise<Decision> {
+    try {
+      const token = await this.tenantToken(region, signal)
+      let pageToken = ''
+      for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
+        const query = new URLSearchParams({ member_id_type: 'open_id', page_size: '100' })
+        if (pageToken) query.set('page_token', pageToken)
+        const body = await this.call<{
+          code?: unknown
+          data?: { items?: Array<{ member_id?: unknown }>; has_more?: unknown; page_token?: unknown }
+        }>(region, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members?${query}`, token, signal)
+        const code = typeof body.code === 'number' ? body.code : Number(body.code)
+        if (code !== 0) return DEFINITIVE_DENIALS.has(code) ? 'deny' : 'unknown'
+        if (!Array.isArray(body.data?.items)) return 'unknown'
+        if (body.data.items.some((member) => member.member_id === openId)) return 'allow'
+        if (body.data.has_more !== true) return 'deny'
+        pageToken = typeof body.data.page_token === 'string' ? body.data.page_token : ''
+        if (!pageToken || page === MAX_MEMBER_PAGES - 1) return 'unknown'
+      }
+    } catch {
+      return 'unknown'
+    }
+    return 'unknown'
+  }
+
+  private tenantToken(region: FeishuRegion, signal: AbortSignal): Promise<string> {
+    const cached = this.tokens.get(region)
+    if (cached && cached.expiresAt > this.deps.clock.now()) return Promise.resolve(cached.value)
+    let pending = this.tokenInFlight.get(region)
+    if (!pending) {
+      const tracked = this.fetchTenantToken(region, signal).finally(() => {
+        if (this.tokenInFlight.get(region) === tracked) this.tokenInFlight.delete(region)
+      })
+      pending = tracked
+      this.tokenInFlight.set(region, tracked)
+    }
+    return pending
+  }
+
+  private async fetchTenantToken(region: FeishuRegion, signal: AbortSignal): Promise<string> {
+    const app = this.deps.apps[region]!
+    const body = await this.call<{ code?: unknown; tenant_access_token?: unknown; expire?: unknown }>(
+      region,
+      '/open-apis/auth/v3/tenant_access_token/internal',
+      undefined,
+      signal,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ app_id: app.appId, app_secret: app.appSecret })
+      }
+    )
+    if (Number(body.code) !== 0 || typeof body.tenant_access_token !== 'string')
+      throw new Error('token exchange failed')
+    const expire = typeof body.expire === 'number' ? body.expire : 0
+    this.tokens.set(region, {
+      value: body.tenant_access_token,
+      expiresAt: this.deps.clock.now() + Math.max(0, expire * 1000 - TOKEN_SKEW_MS)
+    })
+    return body.tenant_access_token
+  }
+
+  private async call<T>(
+    region: FeishuRegion,
+    path: string,
+    token: string | undefined,
+    signal: AbortSignal,
+    init: RequestInit = {}
+  ): Promise<T> {
+    const headers = new Headers(init.headers)
+    if (token) headers.set('authorization', `Bearer ${token}`)
+    const response = await (this.deps.fetchImpl ?? (fetch as FetchLike))(`${REGION_ORIGIN[region]}${path}`, {
+      ...init,
+      headers,
+      signal
+    })
+    const body = (await response.json()) as T
+    if (!response.ok) throw new Error(`Feishu request failed: ${response.status}`)
+    return body
+  }
+
+  private putCache(key: string, decision: Decision): void {
+    if (this.cache.size >= MAX_CACHE_ENTRIES) {
+      const oldest = this.cache.keys().next().value as string | undefined
+      if (oldest) this.cache.delete(oldest)
+    }
+    const ttl = decision === 'allow' ? ALLOW_TTL_MS : decision === 'deny' ? DENY_TTL_MS : UNKNOWN_TTL_MS
+    this.cache.set(key, { decision, expiresAt: this.deps.clock.now() + ttl })
+  }
+}

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -327,11 +327,16 @@ export function sessionRoutes(deps: HttpDeps) {
       return agent ? { session, agent, access } : null
     }
 
-    const externalAccessAvailable = (provider: 'slack' | 'github') =>
+    type ExternalAccessProvider = 'slack' | 'github' | 'feishu'
+    const externalAccessAvailable = (provider: ExternalAccessProvider) =>
       deps.logtoIdentity !== undefined &&
-      (provider === 'slack' ? deps.slackSessionAccess !== undefined : deps.githubSessionAccess !== undefined)
+      (provider === 'slack'
+        ? deps.slackSessionAccess !== undefined
+        : provider === 'github'
+          ? deps.githubSessionAccess !== undefined
+          : deps.feishuSessionAccess !== undefined && Object.keys(deps.feishuPlatformApps ?? {}).length > 0)
 
-    const externalAccessDto = async (orgId: OrgId, provider: 'slack' | 'github', includeDiagnostics: boolean) => {
+    const externalAccessDto = async (orgId: OrgId, provider: ExternalAccessProvider, includeDiagnostics: boolean) => {
       const [policy, hiddenSessions] = await Promise.all([
         deps.repos.session.getExternalAccessPolicy(orgId, provider),
         includeDiagnostics ? deps.repos.session.countExternalUnresolved(orgId, provider) : Promise.resolve(undefined)
@@ -347,8 +352,9 @@ export function sessionRoutes(deps: HttpDeps) {
       }
     }
 
-    const registerExternalAccessRoutes = (provider: 'slack' | 'github') => {
-      const label = provider === 'slack' ? 'Slack' : 'GitHub'
+    const registerExternalAccessRoutes = (provider: ExternalAccessProvider) => {
+      const label = provider === 'slack' ? 'Slack' : provider === 'github' ? 'GitHub' : 'Feishu/Lark'
+      const operationLabel = provider === 'feishu' ? 'FeishuLark' : label
       r.get(
         `/session-access/${provider}`,
         {
@@ -356,7 +362,7 @@ export function sessionRoutes(deps: HttpDeps) {
             tags: [Tag.Sessions],
             summary: `Get ${label} session access sync`,
             description: `Returns whether ${label} sessions use the provider's current audience for console access.`,
-            operationId: `get${label}SessionAccess`,
+            operationId: `get${operationLabel}SessionAccess`,
             response: { 200: SessionExternalAccessDto }
           }
         },
@@ -370,7 +376,7 @@ export function sessionRoutes(deps: HttpDeps) {
             tags: [Tag.Sessions],
             summary: `Set ${label} session access sync`,
             description: `Owner-only setting. When enabled, ${label} sessions follow the provider's current audience; unresolved history remains hidden.`,
-            operationId: `set${label}SessionAccess`,
+            operationId: `set${operationLabel}SessionAccess`,
             body: SetSessionExternalAccessBody,
             response: { 200: SessionExternalAccessDto, 403: ErrorDto, 409: ErrorDto }
           }
@@ -401,6 +407,7 @@ export function sessionRoutes(deps: HttpDeps) {
 
     registerExternalAccessRoutes('slack')
     registerExternalAccessRoutes('github')
+    registerExternalAccessRoutes('feishu')
 
     r.get(
       '/sessions/facets',

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -19,29 +19,33 @@ export interface ResolvedSessionAccess {
  * identity or provider grant; only the adapter's bounded decision cache lives
  * beyond this call. */
 export function makeSessionAccessResolver(deps: HttpDeps) {
-  const identitySetFor = makeViewerIdentitySet(deps.logtoIdentity)
+  const identitySetFor = makeViewerIdentitySet(deps.logtoIdentity, deps.feishuPlatformApps)
 
   const forScopes = async (
     req: FastifyRequest,
     scopes: readonly ExternalScopeRecord[]
   ): Promise<ResolvedSessionAccess> => {
     const orgId = orgOf(req)
-    const providers = ['slack', 'github'] as const
+    const providers = ['slack', 'github', 'feishu'] as const
     const [identitySet, initialPolicies] = await Promise.all([
       identitySetFor(req),
       Promise.all(providers.map((provider) => deps.repos.session.getExternalAccessPolicy(orgId, provider)))
     ])
     const slackScopes = scopes.filter((scope) => scope.provider === 'slack' && scope.orgId === orgId)
     const githubScopes = scopes.filter((scope) => scope.provider === 'github' && scope.orgId === orgId)
-    const [slackResult, githubResult] = await Promise.all([
+    const feishuScopes = scopes.filter((scope) => scope.provider === 'feishu' && scope.orgId === orgId)
+    const [slackResult, githubResult, feishuResult] = await Promise.all([
       deps.slackSessionAccess
         ? deps.slackSessionAccess.resolve(slackScopes, identitySet)
         : Promise.resolve({ allowedScopes: [], degraded: slackScopes.length > 0 }),
       deps.githubSessionAccess
         ? deps.githubSessionAccess.resolve(githubScopes, ctxOf(req).userId)
-        : Promise.resolve({ allowedScopes: [], degraded: githubScopes.length > 0 })
+        : Promise.resolve({ allowedScopes: [], degraded: githubScopes.length > 0 }),
+      deps.feishuSessionAccess
+        ? deps.feishuSessionAccess.resolve(feishuScopes, identitySet)
+        : Promise.resolve({ allowedScopes: [], degraded: feishuScopes.length > 0 })
     ])
-    const resolvedScopes = [...slackResult.allowedScopes, ...githubResult.allowedScopes]
+    const resolvedScopes = [...slackResult.allowedScopes, ...githubResult.allowedScopes, ...feishuResult.allowedScopes]
     // Provider lookup can take multiple round trips. Re-read the durable fence
     // afterwards so a concurrent enable cannot authorize with an old disabled
     // snapshot. SQL repeats the current-policy check for list reads.
@@ -74,7 +78,11 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
       // migration degradation (for example an unrelated historical pending
       // row) stays on the owner-only settings surface and must not make every
       // member-facing list/detail claim that a provider itself is unavailable.
-      degraded: slackResult.degraded || githubResult.degraded || allowedScopes.length !== resolvedScopes.length
+      degraded:
+        slackResult.degraded ||
+        githubResult.degraded ||
+        feishuResult.degraded ||
+        allowedScopes.length !== resolvedScopes.length
     }
   }
 

--- a/packages/control-plane/src/http/viewer-identity.test.ts
+++ b/packages/control-plane/src/http/viewer-identity.test.ts
@@ -22,6 +22,23 @@ describe('makeViewerIdentitySet', () => {
     expect(slackIdentityFor).toHaveBeenCalledWith('logto-sub')
   })
 
+  it('adds an app-qualified Lark identity only for the configured matching app', async () => {
+    const resolve = makeViewerIdentitySet(
+      { feishuIdentitiesFor: async () => [{ region: 'lark', openId: 'ou_member' }] },
+      { lark: { appId: 'cli_platform', appSecret: 'secret' } }
+    )
+    expect(await resolve(reqOf({ userId: 'u-1', oidcSubject: 'logto-sub' }))).toEqual(
+      new Set(['user:u-1', 'feishu:lark:cli_platform:ou_member'])
+    )
+  })
+
+  it('does not admit a Lark open_id without its configured app domain', async () => {
+    const resolve = makeViewerIdentitySet({
+      feishuIdentitiesFor: async () => [{ region: 'lark', openId: 'ou_member' }]
+    })
+    expect(await resolve(reqOf({ userId: 'u-1', oidcSubject: 'logto-sub' }))).toEqual(new Set(['user:u-1']))
+  })
+
   it('stays console-only without an OIDC subject (devAuth / API key)', async () => {
     const slackIdentityFor = vi.fn(async () => ({ teamId: 'T024BE7LD', userId: 'U0123ABCD' }))
     const resolve = makeViewerIdentitySet({ slackIdentityFor })

--- a/packages/control-plane/src/http/viewer-identity.ts
+++ b/packages/control-plane/src/http/viewer-identity.ts
@@ -17,31 +17,47 @@
  * Boundaries, all fail-closed:
  *  - Only a REAL OIDC session carries `req.oidcSubject` — devAuth and personal
  *    API keys never reach the provider, so their set stays console-only.
- *  - A Logto miss or error NARROWS the set to the console identity (the caller
+ *  - A Logto miss or error NARROWS that provider's contribution (the caller
  *    momentarily sees fewer sessions, never someone else's) and is logged.
  */
 import type { FastifyRequest } from 'fastify'
 import { identitySetOf } from '../authorization/policy.js'
 import type { LogtoIdentityService } from '../github/logto-identity.js'
+import type { FeishuPlatformApps } from '../config/feishu-platform.js'
 import { ctxOf } from './rbac.js'
 
 /** The one provider read this needs — injectable so tests stay offline. */
-export type SlackIdentityReader = Pick<LogtoIdentityService, 'slackIdentityFor'>
+export type ProviderIdentityReader = Partial<Pick<LogtoIdentityService, 'slackIdentityFor' | 'feishuIdentitiesFor'>>
 
 export type ViewerIdentitySetResolver = (req: FastifyRequest) => Promise<Set<string>>
 
 /** Build the per-request identity-set resolver the session routes share.
  *  `logtoIdentity` absent (LOGTO_MGMT_* unset) ⇒ console identity only. */
-export function makeViewerIdentitySet(logtoIdentity?: SlackIdentityReader): ViewerIdentitySetResolver {
+export function makeViewerIdentitySet(
+  logtoIdentity?: ProviderIdentityReader,
+  feishuPlatformApps: FeishuPlatformApps = {}
+): ViewerIdentitySetResolver {
   return async (req) => {
     const identitySet = identitySetOf(ctxOf(req))
     const sub = req.oidcSubject
     if (!sub || !logtoIdentity) return identitySet
-    try {
-      const slack = await logtoIdentity.slackIdentityFor(sub)
+    const [slackResult, feishuResult] = await Promise.allSettled([
+      logtoIdentity.slackIdentityFor?.(sub),
+      logtoIdentity.feishuIdentitiesFor?.(sub)
+    ])
+    if (slackResult.status === 'fulfilled') {
+      const slack = slackResult.value
       if (slack) identitySet.add(`slack:${slack.teamId}:${slack.userId}`)
-    } catch (err) {
-      req.log.warn({ err }, 'viewer identity: slack lookup failed — matching on the console identity only')
+    } else {
+      req.log.warn({ err: slackResult.reason }, 'viewer identity: Slack lookup failed')
+    }
+    if (feishuResult.status === 'fulfilled') {
+      for (const identity of feishuResult.value ?? []) {
+        const app = feishuPlatformApps[identity.region]
+        if (app) identitySet.add(`feishu:${identity.region}:${app.appId}:${identity.openId}`)
+      }
+    } else {
+      req.log.warn({ err: feishuResult.reason }, 'viewer identity: Feishu/Lark lookup failed')
     }
     return identitySet
   }

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -38,6 +38,7 @@ import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import type { WebchatRemoteMcpService } from '../registry/webchatRemoteMcpService.js'
+import type { FeishuPlatformApps } from '../config/feishu-platform.js'
 
 /** Config slice the WS edge reads. */
 export interface WsConfig {
@@ -77,6 +78,8 @@ export interface DaemonWsDeps {
   /** Resolves a trusted GitHub delivery's installation id to this org's
    * durable credential locator before binding a repository ExternalScope. */
   githubInstallation?: GithubInstallationRepo
+  /** Environment-owned apps whose app-scoped open_id domain matches Logto. */
+  feishuPlatformApps?: FeishuPlatformApps
   /** Persists authoritative membership snapshots and partial conversation reports. */
   integrationChannel: IntegrationChannelRepo
   /** Shares the HTTP agent-move boundary with daemon-originated conversation reports. */

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -174,6 +174,110 @@ describe('handleEventSession', () => {
     )
   })
 
+  it('binds a Feishu/Lark audience only for the environment-owned matching app', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      integration: {
+        get: vi.fn().mockResolvedValue({
+          id: INTEGRATION_ID,
+          agentId: AGENT_ID,
+          botId: BOT_ID,
+          orgId: 'org-1',
+          platform: 'feishu',
+          status: 'active'
+        })
+      },
+      bot: {
+        get: vi.fn().mockResolvedValue({
+          id: BOT_ID,
+          orgId: 'org-1',
+          platform: 'feishu',
+          feishuRegion: 'lark',
+          feishuAppId: 'cli_platform',
+          revokedAt: null
+        })
+      },
+      feishuPlatformApps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      platform: 'feishu',
+      channel: 'oc_chat',
+      externalOrigin: {
+        provider: 'feishu',
+        realmKey: 'lark:cli_platform',
+        resourceKind: 'conversation',
+        resourceKey: 'oc_chat',
+        integrationId: INTEGRATION_ID
+      }
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalCandidate: {
+          provider: 'feishu',
+          resolution: 'settled',
+          scope: {
+            realmKey: 'lark:cli_platform',
+            resourceKind: 'conversation',
+            resourceKey: 'oc_chat',
+            credentialKind: 'bot',
+            credentialId: BOT_ID
+          }
+        }
+      })
+    )
+  })
+
+  it('leaves a user-built Feishu/Lark app on ordinary org visibility', async () => {
+    const recordMilestone = vi.fn().mockResolvedValue(recorded())
+    const deps = scopedDeps({
+      session: { recordMilestone },
+      integration: {
+        get: vi.fn().mockResolvedValue({
+          id: INTEGRATION_ID,
+          agentId: AGENT_ID,
+          botId: BOT_ID,
+          orgId: 'org-1',
+          platform: 'feishu',
+          status: 'active'
+        })
+      },
+      bot: {
+        get: vi.fn().mockResolvedValue({
+          id: BOT_ID,
+          orgId: 'org-1',
+          platform: 'feishu',
+          feishuRegion: 'lark',
+          feishuAppId: 'cli_custom',
+          revokedAt: null
+        })
+      },
+      feishuPlatformApps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
+      events: { publish: vi.fn() }
+    })
+    const frame = eventSessionFrame()
+    Object.assign(frame.payload as Record<string, unknown>, {
+      platform: 'feishu',
+      channel: 'oc_chat',
+      externalOrigin: {
+        provider: 'feishu',
+        realmKey: 'lark:cli_custom',
+        resourceKind: 'conversation',
+        resourceKey: 'oc_chat',
+        integrationId: INTEGRATION_ID
+      }
+    })
+
+    await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
+
+    expect(recordMilestone).toHaveBeenCalledWith(expect.not.objectContaining({ externalCandidate: expect.anything() }))
+  })
+
   it('keeps a root shared Slack session from an older daemon as an unresolved candidate', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -114,7 +114,17 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
     return { provider: origin.provider, resolution: 'invalid' as const }
   }
   const bot = await deps.bot?.get(BotId(integration.botId))
-  const realmKey = bot?.workspaceId ?? bot?.teamId
+  const feishuRegion = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
+  const feishuAppId = bot?.feishuAppId ?? undefined
+  const platformApp = feishuRegion ? deps.feishuPlatformApps?.[feishuRegion] : undefined
+  // open_id is app-scoped. Only the environment-owned app that also backs the
+  // Logto connector can participate; a user-built Feishu/Lark app keeps the
+  // ordinary org classification instead of becoming an unresolvable scope.
+  if (origin.provider === 'feishu' && (!platformApp || platformApp.appId !== feishuAppId)) return undefined
+  const realmKey =
+    origin.provider === 'feishu' && feishuRegion && feishuAppId
+      ? `${feishuRegion}:${feishuAppId}`
+      : (bot?.workspaceId ?? bot?.teamId)
   if (
     !bot ||
     bot.orgId !== integration.orgId ||

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -10504,7 +10504,7 @@ export class Daemon {
                 msg.isDm ||
                 msg.platform === 'webchat' ||
                 this.pendingLaunchCorrelation.has(agentId) ||
-                this.slackExternalSource(agentId, msg, callMeta !== undefined) !== undefined),
+                this.conversationExternalSource(agentId, msg, callMeta !== undefined) !== undefined),
           ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {})
         }
       )
@@ -12525,14 +12525,14 @@ export class Daemon {
     // integration as if it belonged to the child agent.
     if (classification?.externalOrigin) event.externalOrigin = classification.externalOrigin
     else if (
-      classification?.externalProvider === 'slack' &&
+      (classification?.externalProvider === 'slack' || classification?.externalProvider === 'feishu') &&
       classification.externalResourceKey &&
       classification.externalIntegrationId
     ) {
-      // Rolling compatibility for a Slack row created before direct-origin
+      // Rolling compatibility for a conversation row created before direct-origin
       // proof was persisted as one object.
       event.externalOrigin = {
-        provider: 'slack',
+        provider: classification.externalProvider,
         resourceKind: 'conversation',
         resourceKey: classification.externalResourceKey,
         ...(classification.externalRealmKey ? { realmKey: classification.externalRealmKey } : {}),
@@ -14379,9 +14379,13 @@ export class Daemon {
     // lookup to the trusted caller agent so another runtime cannot lend this
     // A2A wake its external audience by accident.
     const rec = this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
-    if (rec?.externalProvider === 'slack' && rec.externalResourceKind === 'conversation' && rec.externalResourceKey) {
+    if (
+      (rec?.externalProvider === 'slack' || rec?.externalProvider === 'feishu') &&
+      rec.externalResourceKind === 'conversation' &&
+      rec.externalResourceKey
+    ) {
       return {
-        provider: 'slack',
+        provider: rec.externalProvider,
         ...(rec.externalRealmKey ? { realmKey: rec.externalRealmKey } : {}),
         resourceKind: 'conversation',
         resourceKey: rec.externalResourceKey
@@ -14426,30 +14430,38 @@ export class Daemon {
     }
   }
 
-  private slackExternalSource(
+  private conversationExternalSource(
     agentId: string,
     msg: NormalizedMessage,
     isA2aChild: boolean
   ):
     | {
-        externalProvider: 'slack'
+        externalProvider: 'slack' | 'feishu'
         externalRealmKey?: string
         externalResourceKind: 'conversation'
         externalResourceKey: string
         externalIntegrationId?: string
       }
     | undefined {
-    if (msg.platform !== 'slack' || msg.isDm || isA2aChild) return undefined
+    if ((msg.platform !== 'slack' && msg.platform !== 'feishu') || msg.isDm || isA2aChild) return undefined
     const integrationId = this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
-    const realmKey = integrationId ? this.connByIntegration.get(integrationId)?.workspaceId?.() : undefined
-    // Cron and daemon-owned continuation turns can create or resume a real Slack
-    // thread, but synthetic/headless callers may use Slack-shaped coordinates with
-    // no connection. Bind those trusted system turns only when the destination is
-    // attributable. Human ingress must keep the incomplete tuple so the caller
-    // below fails closed instead of silently treating an unverified Slack turn as local.
+    const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
+    const realmKey =
+      msg.platform === 'slack'
+        ? integrationId
+          ? this.connByIntegration.get(integrationId)?.workspaceId?.()
+          : undefined
+        : integration?.platform === 'feishu'
+          ? this.tenantScopeForIntegration(integration)
+          : undefined
+    // Cron and daemon-owned continuation turns can create or resume a real shared
+    // conversation, while synthetic/headless callers may use platform-shaped
+    // coordinates with no connection. Bind those trusted system turns only when
+    // the destination is attributable. Human ingress keeps the incomplete tuple
+    // so the caller below fails closed instead of treating an unverified turn as local.
     if (msg.source !== 'user' && (!integrationId || !realmKey)) return undefined
     return {
-      externalProvider: 'slack',
+      externalProvider: msg.platform,
       ...(realmKey ? { externalRealmKey: realmKey } : {}),
       externalResourceKind: 'conversation',
       externalResourceKey: msg.channel,
@@ -14470,8 +14482,11 @@ export class Daemon {
     hookContext: HookDispatchContext | undefined
   ): 'unchanged' | 'mismatch' | 'unavailable' {
     const direct =
-      this.githubExternalSource(hookContext) ?? this.slackExternalSource(agentId, msg, callMeta !== undefined)
-    if (direct?.externalProvider === 'slack' && (!direct.externalRealmKey || !direct.externalIntegrationId)) {
+      this.githubExternalSource(hookContext) ?? this.conversationExternalSource(agentId, msg, callMeta !== undefined)
+    if (
+      (direct?.externalProvider === 'slack' || direct?.externalProvider === 'feishu') &&
+      (!direct.externalRealmKey || !direct.externalIntegrationId)
+    ) {
       return 'unavailable'
     }
     const inherited = callMeta?.externalOrigin
@@ -14530,7 +14545,7 @@ export class Daemon {
     const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
     const tenantScope = integration ? this.tenantScopeForIntegration(integration) : undefined
     const directExternalSource =
-      this.githubExternalSource(hookContext) ?? this.slackExternalSource(agentId, msg, isA2aChild)
+      this.githubExternalSource(hookContext) ?? this.conversationExternalSource(agentId, msg, isA2aChild)
     const inheritedExternalSource = callMeta?.externalOrigin
       ? {
           externalProvider: callMeta.externalOrigin.provider,

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -139,6 +139,19 @@ describe('EventSession visibility-classification fields (session-visibility.md Â
     ).toBe(false)
   })
 
+  it('carries a Feishu/Lark conversation source with its app-qualified realm', () => {
+    const externalOrigin = {
+      provider: 'feishu' as const,
+      realmKey: 'lark:cli_platform',
+      resourceKind: 'conversation' as const,
+      resourceKey: 'oc_chat',
+      integrationId: '88888888-8888-4888-8888-888888888888'
+    }
+    expect(
+      EventSession.parse({ ...legacyMilestone, platform: 'feishu', channel: 'oc_chat', externalOrigin }).externalOrigin
+    ).toEqual(externalOrigin)
+  })
+
   it('rejects an unknown conversationKind, an empty scope, and a non-uuid correlation id', () => {
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'thread' }).success).toBe(false)
     expect(EventSession.safeParse({ ...legacyMilestone, transportScope: '' }).success).toBe(false)

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -35,6 +35,12 @@ export const ExternalSessionAudience = z.discriminatedUnion('provider', [
     resourceKey: ExternalKey
   }),
   z.object({
+    provider: z.literal('feishu'),
+    realmKey: ExternalKey.optional(),
+    resourceKind: z.literal('conversation'),
+    resourceKey: ExternalKey
+  }),
+  z.object({
     provider: z.literal('github'),
     realmKey: z.literal('github.com'),
     resourceKind: z.literal('repository'),
@@ -51,6 +57,9 @@ export const ExternalSessionOrigin = z.discriminatedUnion('provider', [
     integrationId: z.string().uuid().optional()
   }),
   ExternalSessionAudience.options[1].extend({
+    integrationId: z.string().uuid().optional()
+  }),
+  ExternalSessionAudience.options[2].extend({
     hookId: z.string().uuid(),
     deliveryKey: ExternalKey,
     sourceInstallationId: GithubId,

--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -67,4 +67,24 @@ describe('SessionVisibilityControl — tighten confirmation', () => {
     expect(text).toContain('hides the transcript')
     expect(text).toContain('no per-session control')
   })
+
+  it('labels a settled Feishu/Lark external audience as current chat members', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(
+        <SessionVisibilityControl
+          sessionId="acp-1"
+          visibility="external"
+          externalProvider="feishu"
+          externalResolution="settled"
+          canChange={false}
+          onChanged={() => {}}
+        />
+      )
+    })
+    expect(container.textContent).toContain('Feishu / Lark members')
+    expect(container.querySelector('span')?.title).toContain('current members')
+  })
 })

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -81,7 +81,14 @@ export function SessionVisibilityControl({
 
   if (effective === 'external') {
     const github = externalProvider === 'github'
-    const provider = externalProvider === 'slack' ? 'Slack' : github ? 'GitHub' : 'External'
+    const provider =
+      externalProvider === 'slack'
+        ? 'Slack'
+        : github
+          ? 'GitHub'
+          : externalProvider === 'feishu'
+            ? 'Feishu / Lark'
+            : 'External'
     const title =
       externalResolution === 'settled'
         ? github

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -114,6 +114,20 @@ const SESSION_ACCESS_COPY: Record<
     disabled: 'New sessions are visible to everyone who can view the agent.',
     unresolved: (count) => `${count} session${count === 1 ? '' : 's'} hidden — no trusted repository scope.`,
     degraded: 'Repository scopes stopped resolving — new sessions are being hidden.'
+  },
+  feishu: {
+    title: 'Follow Feishu / Lark access',
+    details: [
+      'Group sessions created through the matching AgentConnect app follow current chat membership.',
+      'DMs stay private, and agent memory learned earlier is not erased.',
+      'User-built apps with a different App ID keep the ordinary organization visibility model.',
+      'Turning this off leaves already-synced sessions following Feishu / Lark.'
+    ].join('\n'),
+    unavailable: 'Needs OIDC sign-in, a linked Feishu / Lark profile, and the matching platform app.',
+    enabled: 'Session visibility follows Feishu / Lark chat membership.',
+    disabled: 'New sessions are visible to everyone who can view the agent.',
+    unresolved: (count) => `${count} session${count === 1 ? '' : 's'} hidden — no trusted chat scope.`,
+    degraded: 'Feishu / Lark scopes stopped resolving — new sessions are being hidden.'
   }
 }
 
@@ -833,6 +847,7 @@ export default function SettingsView() {
         </div>
         <SessionAccessRow provider="slack" orgId={activeOrg?.id} isOwner={isOwner} />
         <SessionAccessRow provider="github" orgId={activeOrg?.id} isOwner={isOwner} bordered />
+        <SessionAccessRow provider="feishu" orgId={activeOrg?.id} isOwner={isOwner} bordered />
       </div>
 
       <div className="card mt-[18px]">

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2003,7 +2003,7 @@ export async function putSessionVisibility(
   })
 }
 
-export type SessionAccessProvider = 'slack' | 'github'
+export type SessionAccessProvider = 'slack' | 'github' | 'feishu'
 
 export interface SessionExternalAccessDto {
   provider: SessionAccessProvider

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -22,8 +22,10 @@ export const consoleKeys = {
   externalMemoryConnections: (orgId: string | null | undefined) => consoleKey(orgId, 'external-memory-connections'),
   members: (orgId: string | null | undefined) => consoleKey(orgId, 'members'),
   inviteLink: (orgId: string | null | undefined) => consoleKey(orgId, 'invite-link'),
-  sessionAccess: <const Provider extends 'slack' | 'github'>(orgId: string | null | undefined, provider: Provider) =>
-    consoleKey(orgId, 'session-access', provider),
+  sessionAccess: <const Provider extends 'slack' | 'github' | 'feishu'>(
+    orgId: string | null | undefined,
+    provider: Provider
+  ) => consoleKey(orgId, 'session-access', provider),
   usage: <const Range extends string>(orgId: string | null | undefined, range: Range) =>
     consoleKey(orgId, 'usage', range),
   sessions: (


### PR DESCRIPTION
## Summary

- add Feishu/Lark as a provider-backed Session access policy alongside Slack and GitHub
- qualify linked Logto `open_id` values with region + deployment App ID, so only the same messaging/social app identity domain can authorize
- bind matching AgentConnect app group sessions to immutable Feishu conversation scopes; user-built apps with different App IDs retain the existing organization visibility model
- resolve current chat membership through the regional Feishu/Lark API with pagination, bounded caching, batch concurrency, and fail-closed degraded behavior
- keep DMs owner-only and propagate Feishu conversation audiences across A2A descendants
- add the owner-only Settings toggle, API/DTO support, environment configuration, and design documentation

## Safety

Feishu/Lark `open_id` is app-scoped. The Control Plane only creates a provider scope when the daemon-reported messaging App ID matches `FEISHU_PLATFORM_APP_ID` or `LARK_PLATFORM_APP_ID`, which must also back the corresponding Logto connector. A mismatched user-built app never enters this permission-sync path.

The resolver stores no provider ACLs or social identities. It retains only short-lived in-process membership verdicts and tenant tokens. Definite provider answers such as a missing/dissolved/inaccessible chat deny without degradation; missing scopes, rate limits, malformed responses, and network/provider failures fail closed and report degradation. All external scopes are processed in sequential batches rather than truncating authorization after the first batch.

## Validation

- Control Plane unit suite: 113 files, 980 tests passed
- focused Feishu/Lark resolver, identity, ingest, and config tests: 5 files, 50 tests passed
- protocol tests: 2 files, 35 tests passed
- focused Daemon source-lineage/capture tests passed
- Web Session visibility component: 3 tests passed
- protocol, daemon, Control Plane, and Web typechecks
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint

Deployment already provides the regional platform App ID/secret pairs; each pair is all-or-none and the self-hosted default remains disabled.

Created by Codex . GPT-5.6-sol