### PR TITLE
feat: bind dream Adopt/Accept to the reviewed bytes end-to-end (#36 Phase B)

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2758,11 +2758,20 @@ export const StartDreamBody = z
   })
   .strict()
 /** Body for adopting a dream: fenced by default; `force` overrides the snapshot fence. */
-export const AdoptDreamBody = z.object({ force: z.boolean().optional() }).strict()
+export const AdoptDreamBody = z
+  .object({
+    force: z.boolean().optional(),
+    /** Same-bytes review fence (task #36 Phase B): echo `DreamFilesDto.reviewToken`
+     *  from the review read to bind adoption to the exact bytes reviewed. */
+    reviewToken: z.string().optional()
+  })
+  .strict()
 /** `GET …/dreams/:dreamId/files` — the staged output store's files (index + topics). */
 export const DreamFilesDto = z.object({
   exists: z.boolean(), // false ⇒ nothing staged (yet)
-  files: z.array(MemoryFileEntryDto)
+  files: z.array(MemoryFileEntryDto),
+  /** Same-bytes review fence token (task #36 Phase B); present only when `exists`. */
+  reviewToken: z.string().optional()
 })
 /** `GET …/dreams/:dreamId/file` — one byte slice of a staged file (memory/read semantics). */
 export const DreamFileDto = z.object({
@@ -2779,8 +2788,18 @@ export const DreamSkillContentDto = z.object({
   name: z.string(),
   exists: z.boolean(),
   skill: z.string().nullable(),
-  scripts: z.array(z.object({ path: z.string(), content: z.string() }))
+  scripts: z.array(z.object({ path: z.string(), content: z.string() })),
+  /** Same-bytes review fence token (task #36 Phase B); present only when `exists`. */
+  reviewToken: z.string().optional()
 })
+/** `POST …/dreams/:dreamId/skills/:name/accept` body — the review fence token. */
+export const AcceptDreamSkillBody = z
+  .object({
+    /** Echo `DreamSkillContentDto.reviewToken` from the skill review read to bind
+     *  publication to the exact bytes reviewed (task #36 Phase B). */
+    reviewToken: z.string().optional()
+  })
+  .strict()
 export const DreamSkillParam = z.object({
   id: z.string().uuid(),
   dreamId: z.string().min(1).max(128),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -123,6 +123,7 @@ import {
   DreamSkillContentDto,
   StartDreamBody,
   AdoptDreamBody,
+  AcceptDreamSkillBody,
   type AgentDtoT,
   type WorkspaceFilesDtoT,
   type WorkspaceFileDtoT,
@@ -351,7 +352,11 @@ export function toDreamListDto(rep: DreamListPage): DreamListDtoT {
 }
 
 export function toDreamFilesDto(rep: DreamFilesPage): DreamFilesDtoT {
-  return { exists: rep.exists, files: rep.entries }
+  return {
+    exists: rep.exists,
+    files: rep.entries,
+    ...(rep.reviewToken !== undefined ? { reviewToken: rep.reviewToken } : {})
+  }
 }
 
 export function toDreamFileDto(rep: DreamFileReadContent): DreamFileDtoT {
@@ -3295,7 +3300,8 @@ export function agentRoutes(deps: HttpDeps) {
           const { dream } = await deps.control.dreamAdopt(agent.daemonId, {
             agentId: agent.id,
             dreamId: req.params.dreamId,
-            force: req.body.force ?? false
+            force: req.body.force ?? false,
+            ...(req.body.reviewToken !== undefined ? { reviewToken: req.body.reviewToken } : {})
           })
           return toDreamDto(dream)
         } catch (err) {
@@ -3364,7 +3370,8 @@ export function agentRoutes(deps: HttpDeps) {
             name: content.name,
             exists: content.exists,
             skill: content.skill ?? null,
-            scripts: content.scripts ?? []
+            scripts: content.scripts ?? [],
+            ...(content.reviewToken !== undefined ? { reviewToken: content.reviewToken } : {})
           }
         } catch (err) {
           if (sendDreamFailure(reply, err)) return
@@ -3384,6 +3391,7 @@ export function agentRoutes(deps: HttpDeps) {
             "Install one of this dream's mined skill candidates for the agent. Copies the reviewed skill into the agent's own tree, so discarding the dream later does not uninstall it. 409 if the candidate was already dismissed or the daemon predates dreaming.",
           operationId: 'acceptAgentMemoryDreamSkill',
           params: DreamSkillParam,
+          body: AcceptDreamSkillBody,
           response: { 200: DreamDto, 400: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto, 503: ErrorDto }
         }
       },
@@ -3394,7 +3402,8 @@ export function agentRoutes(deps: HttpDeps) {
           const { dream } = await deps.control.dreamSkillAccept(agent.daemonId, {
             agentId: agent.id,
             dreamId: req.params.dreamId,
-            name: req.params.name
+            name: req.params.name,
+            ...(req.body?.reviewToken !== undefined ? { reviewToken: req.body.reviewToken } : {})
           })
           return toDreamDto(dream)
         } catch (err) {

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -49,6 +49,7 @@ import {
   type TrustedOrganizationSkillTarget
 } from './memory-dreamer.js'
 import { publishAcceptedDreamSkill } from '../skills/dream-skills.js'
+import { inspectLocalSkillSource } from '../skills/skill-source-snapshot.js'
 
 /**
  * `DreamRunner` — the daemon's dream-job engine (design:
@@ -1400,6 +1401,47 @@ export class DreamRunner {
     try {
       const [content, st] = await Promise.all([fsp.readFile(abs, 'utf8'), fsp.stat(abs)])
       return { content, mtime: st.mtime.toISOString() }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw err
+    }
+  }
+
+  /** Review token for the staged memory-store proposal: the digest the console
+   *  reviewed, which `adopt(reviewToken)` re-verifies against the exact staged
+   *  bytes before swapping (task #36 Phase B). `null` when nothing is staged.
+   *  Uses the same canonical `storeDigest` the adopt fence recomputes. */
+  async stagedStoreReviewToken(agentId: string, dreamId: string): Promise<string | null> {
+    this.assertStagedContentAllowed()
+    this.getDream(agentId, dreamId)
+    const out = join(this.dreamDir(agentId, dreamId), 'output')
+    let names: string[]
+    try {
+      names = (await fsp.readdir(out, { withFileTypes: true }))
+        .filter((entry) => entry.isFile() && stagedPathOk(entry.name))
+        .map((entry) => entry.name)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+      throw err
+    }
+    if (names.length === 0) return null
+    const files = await Promise.all(
+      names.map(async (name) => ({ name, content: await fsp.readFile(join(out, name), 'utf8') }))
+    )
+    return storeDigest(files)
+  }
+
+  /** Review token for a staged skill candidate: the canonical snapshot digest the
+   *  console reviewed, which `skillAccept(reviewToken)` re-verifies against the
+   *  captured publish snapshot (task #36 Phase B). `inspectLocalSkillSource` uses
+   *  the same walker + digest as the publish snapshot, so the token matches the
+   *  bytes that would be published. `null` when the candidate has no staging. */
+  async stagedSkillReviewToken(agentId: string, dreamId: string, name: string): Promise<string | null> {
+    this.assertStagedContentAllowed()
+    this.skillCandidate(agentId, dreamId, name)
+    const dir = join(this.dreamDir(agentId, dreamId), 'skills', name)
+    try {
+      return (await inspectLocalSkillSource(dir)).sha256
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw err

--- a/packages/daemon/src/cp/dream-reader.ts
+++ b/packages/daemon/src/cp/dream-reader.ts
@@ -77,7 +77,7 @@ export function createDreamReader(runner: DreamRunner): DreamReader {
     },
 
     async adopt(req) {
-      return { dream: await runner.adopt(req.agentId, req.dreamId, req.force) }
+      return { dream: await runner.adopt(req.agentId, req.dreamId, req.force, req.reviewToken) }
     },
 
     async discard(req) {
@@ -86,11 +86,13 @@ export function createDreamReader(runner: DreamRunner): DreamReader {
 
     async files(req) {
       const entries = await runner.stagedFiles(req.agentId, req.dreamId)
+      const reviewToken = entries !== null ? await runner.stagedStoreReviewToken(req.agentId, req.dreamId) : null
       return {
         agentId: req.agentId,
         dreamId: req.dreamId,
         exists: entries !== null,
-        entries: entries ?? []
+        entries: entries ?? [],
+        ...(reviewToken !== null ? { reviewToken } : {})
       }
     },
 
@@ -119,12 +121,19 @@ export function createDreamReader(runner: DreamRunner): DreamReader {
 
     async skillRead(req) {
       const staged = await runner.stagedSkill(req.agentId, req.dreamId, req.name)
-      return staged
-        ? { agentId: req.agentId, dreamId: req.dreamId, name: req.name, exists: true, ...staged }
-        : { agentId: req.agentId, dreamId: req.dreamId, name: req.name, exists: false }
+      if (!staged) return { agentId: req.agentId, dreamId: req.dreamId, name: req.name, exists: false }
+      const reviewToken = await runner.stagedSkillReviewToken(req.agentId, req.dreamId, req.name)
+      return {
+        agentId: req.agentId,
+        dreamId: req.dreamId,
+        name: req.name,
+        exists: true,
+        ...staged,
+        ...(reviewToken !== null ? { reviewToken } : {})
+      }
     },
     async skillAccept(req) {
-      return { dream: await runner.skillAccept(req.agentId, req.dreamId, req.name) }
+      return { dream: await runner.skillAccept(req.agentId, req.dreamId, req.name, req.reviewToken) }
     },
 
     async skillDismiss(req) {

--- a/packages/daemon/test/dream-runner.test.ts
+++ b/packages/daemon/test/dream-runner.test.ts
@@ -485,6 +485,18 @@ describe('DreamRunner adoption', () => {
     expect(await readMemoryFile(dir, 'prefs.md')).toBe('- Uses tabs, not spaces (2026-07-24).\n')
   })
 
+  it('stagedStoreReviewToken returns the token adopt accepts (review-read → adopt loop)', async () => {
+    const { store, runner } = await setup({})
+    const started = await runner.start('a1', { trigger: 'manual' })
+    await settle(store, started.dreamId)
+
+    // The review read hands the console this token; echoing it back must adopt.
+    const token = await runner.stagedStoreReviewToken('a1', started.dreamId)
+    expect(token).toMatch(/^sha256:[0-9a-f]{64}$/)
+    const adopted = await runner.adopt('a1', started.dreamId, false, token!)
+    expect(adopted.status).toBe('adopted')
+  })
+
   it('records the exact add, update, and delete set with live before snapshots', async () => {
     const proposal = JSON.stringify({
       index: '# Memory\n- [prefs](prefs.md)\n- [fresh](fresh.md)',
@@ -1531,6 +1543,14 @@ describe('DreamRunner skill mining (D-3)', () => {
     // Re-reviewing the current bytes (fresh token) accepts.
     const current = (await inspectLocalSkillSource(staged)).sha256
     const after = await runner.skillAccept('a1', dreamId, 'deploy-staging', current)
+    expect(after.skills?.[0]).toMatchObject({ state: 'accepted' })
+  })
+
+  it('stagedSkillReviewToken returns the token skillAccept accepts (review-read → accept loop)', async () => {
+    const { runner, dreamId } = await mining(grounded)
+    const token = await runner.stagedSkillReviewToken('a1', dreamId, 'deploy-staging')
+    expect(token).toMatch(/^sha256:[0-9a-f]{64}$/)
+    const after = await runner.skillAccept('a1', dreamId, 'deploy-staging', token!)
     expect(after.skills?.[0]).toMatchObject({ state: 'accepted' })
   })
 

--- a/packages/protocol/src/frames/memory.ts
+++ b/packages/protocol/src/frames/memory.ts
@@ -433,7 +433,12 @@ export const DreamAdoptReq = z
     agentId: z.string().min(1),
     dreamId: z.string().min(1),
     /** Adopt even when the live store changed since the snapshot (fence override). */
-    force: z.boolean().default(false)
+    force: z.boolean().default(false),
+    /** Same-bytes review fence (task #36 Phase B): the store review token from
+     *  `DreamFilesPage.reviewToken`. When present the daemon refuses adoption
+     *  unless the staged bytes still hash to it, so a re-run/rebase after review
+     *  forces a re-review. Omitted by auto-adopt (which skips content review). */
+    reviewToken: z.string().optional()
   })
   .strict()
 export type DreamAdoptReq = z.infer<typeof DreamAdoptReq>
@@ -452,7 +457,11 @@ export const DreamFilesPage = z
     agentId: z.string(),
     dreamId: z.string(),
     exists: z.boolean(), // false ⇒ nothing staged (yet) — DATA, not an error
-    entries: z.array(MemoryEntry)
+    entries: z.array(MemoryEntry),
+    /** Same-bytes review fence (task #36 Phase B): digest of the staged store the
+     *  console is reviewing; echo it back as `DreamAdoptReq.reviewToken` to bind
+     *  adoption to these exact bytes. Present only when `exists`. */
+    reviewToken: z.string().optional()
   })
   .strict()
 export type DreamFilesPage = z.infer<typeof DreamFilesPage>
@@ -524,7 +533,12 @@ export const DreamSkillContent = z
           .strict()
       )
       .max(4)
-      .optional()
+      .optional(),
+    /** Same-bytes review fence (task #36 Phase B): canonical digest of the staged
+     *  skill the console is reviewing; echo it back as
+     *  `DreamSkillReviewReq.reviewToken` on Accept to bind publication to these
+     *  exact bytes. Present only when `exists`. */
+    reviewToken: z.string().optional()
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -545,7 +559,11 @@ export const DreamSkillReviewReq = z
   .object({
     agentId: z.string().min(1),
     dreamId: z.string().min(1),
-    name: z.string().regex(/^[a-z0-9][a-z0-9-]{0,62}$/)
+    name: z.string().regex(/^[a-z0-9][a-z0-9-]{0,62}$/),
+    /** Same-bytes review fence (task #36 Phase B): the skill review token from
+     *  `DreamSkillContent.reviewToken`. Used on Accept — publication refuses
+     *  unless the captured snapshot hashes to it; ignored on Dismiss. */
+    reviewToken: z.string().optional()
   })
   .strict()
 export type DreamSkillReviewReq = z.infer<typeof DreamSkillReviewReq>

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -66,7 +66,11 @@ beforeEach(() => {
   for (const [key, fn] of Object.entries(api)) if (key !== 'ApiError') (fn as ReturnType<typeof vi.fn>).mockReset()
   api.listDreams.mockResolvedValue([])
   api.startDream.mockResolvedValue(dream({ status: 'pending' }))
-  api.listDreamFiles.mockResolvedValue({ exists: true, files: [{ name: 'MEMORY.md', size: 10, mtime: 'x' }] })
+  api.listDreamFiles.mockResolvedValue({
+    exists: true,
+    files: [{ name: 'MEMORY.md', size: 10, mtime: 'x' }],
+    reviewToken: 'sha256:store'
+  })
   api.fetchDreamFileFull.mockResolvedValue({ exists: true, content: '# Memory (rebuilt)' })
   api.fetchAgentMemoryFull.mockResolvedValue({ exists: true, content: '# Memory (old)', mtime: null })
   api.listAgentMemory.mockResolvedValue({ exists: true, files: [{ name: 'MEMORY.md', size: 10, mtime: 'x' }] })
@@ -78,7 +82,8 @@ beforeEach(() => {
     name: 'deploy-staging',
     exists: true,
     skill: '---\nname: deploy-staging\n---\n# Deploy\nrun the thing',
-    scripts: [{ path: 'run.sh', content: '#!/bin/sh\necho deploying' }]
+    scripts: [{ path: 'run.sh', content: '#!/bin/sh\necho deploying' }],
+    reviewToken: 'sha256:skill'
   })
 })
 
@@ -247,7 +252,8 @@ describe('DreamPanel', () => {
       (b) => b.textContent?.trim() === 'Adopt'
     )
     await act(async () => confirm.at(-1)?.click())
-    expect(api.adoptDream).toHaveBeenCalledWith(AGENT, 'drm-1')
+    // The store review token from listDreamFiles is echoed on adopt (task #36 Phase B).
+    expect(api.adoptDream).toHaveBeenCalledWith(AGENT, 'drm-1', false, 'sha256:store')
     expect(host.textContent).toContain('Outdated proposals were moved to History')
   })
 
@@ -398,7 +404,8 @@ describe('DreamPanel', () => {
     expect(host.textContent).toContain('scripts/run.sh')
 
     await act(async () => button(host, 'Accept')?.click())
-    expect(api.acceptDreamSkill).toHaveBeenCalledWith(AGENT, 'drm-1', 'deploy-staging')
+    // The skill review token from fetchDreamSkill is echoed on accept (task #36 Phase B).
+    expect(api.acceptDreamSkill).toHaveBeenCalledWith(AGENT, 'drm-1', 'deploy-staging', 'sha256:skill')
   })
 
   it('dismisses a recommendation without installing it', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -128,7 +128,7 @@ export function DreamPanel({
   const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [reviewing, setReviewing] = useState<string | null>(null)
   const [confirmStart, setConfirmStart] = useState(false)
-  const [confirmAdopt, setConfirmAdopt] = useState<string | null>(null)
+  const [confirmAdopt, setConfirmAdopt] = useState<{ dreamId: string; reviewToken?: string } | null>(null)
   const listRequest = useRef(0)
 
   const refresh = useCallback(async () => {
@@ -379,7 +379,7 @@ export function DreamPanel({
             dreamId={reviewing}
             canEdit={canEdit}
             busy={busy}
-            onAdopt={() => setConfirmAdopt(reviewing)}
+            onAdopt={(reviewToken) => setConfirmAdopt({ dreamId: reviewing, reviewToken })}
             onDiscard={() => discard(reviewing)}
           />
         ) : null}
@@ -447,10 +447,10 @@ export function DreamPanel({
             confirmLabel="Adopt"
             onClose={() => setConfirmAdopt(null)}
             onConfirm={() => {
-              const dreamId = confirmAdopt
+              const { dreamId, reviewToken } = confirmAdopt
               setConfirmAdopt(null)
               void run(async () => {
-                await adoptDream(agentId, dreamId)
+                await adoptDream(agentId, dreamId, false, reviewToken)
                 setReviewing(null)
                 setActionNotice('Memory adopted. Outdated proposals were moved to History.')
               })
@@ -478,7 +478,7 @@ function DreamReview({
   dreamId: string
   canEdit: boolean
   busy: boolean
-  onAdopt: () => void
+  onAdopt: (reviewToken?: string) => void
   onDiscard: () => void
 }) {
   // The UNION of live and staged paths, not just the staged tree. Adoption swaps
@@ -491,6 +491,9 @@ function DreamReview({
   const [live, setLive] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Same-bytes review fence token from the staged listing; echoed on Adopt so the
+  // daemon binds adoption to exactly the bytes shown here (task #36 Phase B).
+  const [reviewToken, setReviewToken] = useState<string | undefined>(undefined)
   const request = useRef(0)
 
   useEffect(() => {
@@ -498,10 +501,12 @@ function DreamReview({
     setPaths(null)
     setSelected(null)
     setError(null)
+    setReviewToken(undefined)
     void (async () => {
       try {
         const [stagedPage, livePage] = await Promise.all([listDreamFiles(agentId, dreamId), listAgentMemory(agentId)])
         if (!alive) return
+        setReviewToken(stagedPage.reviewToken)
         const stagedNames = new Set(stagedPage.files.map((f: MemoryFileEntry) => f.name))
         const liveNames = new Set(livePage.exists ? livePage.files.map((f: MemoryFileEntry) => f.name) : [])
         const merged = [...new Set([...stagedNames, ...liveNames])]

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -398,7 +398,9 @@ export function DreamPanel({
               busy={busy || !canEdit}
               agentId={agentId}
               dreamId={dream.dreamId}
-              onAccept={(name) => void run(() => acceptDreamSkill(agentId, dream.dreamId, name))}
+              onAccept={(name, reviewToken) =>
+                void run(() => acceptDreamSkill(agentId, dream.dreamId, name, reviewToken))
+              }
               onDismiss={(name) => void run(() => dismissDreamSkill(agentId, dream.dreamId, name))}
             />
           )
@@ -579,7 +581,7 @@ function DreamReview({
             <Button variant="secondary" disabled={busy} onClick={onDiscard}>
               Discard
             </Button>
-            <Button disabled={busy || !paths?.some((p) => p.staged)} onClick={onAdopt}>
+            <Button disabled={busy || !paths?.some((p) => p.staged)} onClick={() => onAdopt(reviewToken)}>
               <Icon name="check" size={13} /> Adopt
             </Button>
           </span>
@@ -622,13 +624,15 @@ function DreamSkills({
   dreamId: string
   proposed: Array<{ name: string; description: string }>
   busy: boolean
-  onAccept: (name: string) => void
+  onAccept: (name: string, reviewToken?: string) => void
   onDismiss: (name: string) => void
 }) {
   // Accept stays disabled until the body has been opened. The whole safety
   // argument for mined skills is that a human reviewed them, and a
-  // model-authored description is not evidence for itself.
-  const [seen, setSeen] = useState<Set<string>>(new Set())
+  // model-authored description is not evidence for itself. The map also carries
+  // each reviewed skill's fence token (task #36 Phase B), echoed on Accept so
+  // publication is bound to the exact reviewed bytes.
+  const [reviewTokens, setReviewTokens] = useState<Map<string, string | undefined>>(new Map())
   return (
     <div className="flex flex-col gap-2 rounded-md border border-(--border-subtle) bg-(--surface-sunken) p-3">
       <span className="font-sans text-[12px] font-semibold leading-normal text-(--text-secondary)">
@@ -653,7 +657,10 @@ function DreamSkills({
             <Button variant="secondary" disabled={busy} onClick={() => onDismiss(skill.name)}>
               Dismiss
             </Button>
-            <Button disabled={busy || !seen.has(skill.name)} onClick={() => onAccept(skill.name)}>
+            <Button
+              disabled={busy || !reviewTokens.has(skill.name)}
+              onClick={() => onAccept(skill.name, reviewTokens.get(skill.name))}
+            >
               Accept
             </Button>
           </span>
@@ -661,7 +668,7 @@ function DreamSkills({
             agentId={agentId}
             dreamId={dreamId}
             name={skill.name}
-            onRead={() => setSeen((current) => new Set(current).add(skill.name))}
+            onRead={(reviewToken) => setReviewTokens((current) => new Map(current).set(skill.name, reviewToken))}
           />
         </div>
       ))}
@@ -680,7 +687,7 @@ function SkillBody({
   agentId: string
   dreamId: string
   name: string
-  onRead: () => void
+  onRead: (reviewToken?: string) => void
 }) {
   const [content, setContent] = useState<DreamSkillContentDto | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -695,7 +702,7 @@ function SkillBody({
             setContent(body)
             // Only a body that actually rendered counts as reviewed — a pending
             // request, an error, or vanished staging must all keep Accept off.
-            if (body.exists && body.skill) onRead()
+            if (body.exists && body.skill) onRead(body.reviewToken)
           })
           .catch((err) => setError(err instanceof Error ? err.message : 'Could not load this skill.'))
       }}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2342,6 +2342,8 @@ export interface DreamDto {
 export interface DreamFilesDto {
   exists: boolean
   files: MemoryFileEntry[]
+  /** Same-bytes review fence token (task #36 Phase B); present only when `exists`. */
+  reviewToken?: string
 }
 
 /** A dream is terminal (won't change) once it reaches one of these states. */
@@ -2380,8 +2382,18 @@ export async function cancelDream(agentId: string, dreamId: string): Promise<Dre
 }
 
 /** Adopt a completed dream's staged store. `force` overrides the snapshot fence. */
-export async function adoptDream(agentId: string, dreamId: string, force = false): Promise<DreamDto> {
-  return apiPost<DreamDto>(`${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/adopt`, force ? { force } : {})
+export async function adoptDream(
+  agentId: string,
+  dreamId: string,
+  force = false,
+  reviewToken?: string
+): Promise<DreamDto> {
+  // Echo the review token from listDreamFiles so the daemon binds adoption to the
+  // exact bytes reviewed (task #36 Phase B same-bytes fence).
+  return apiPost<DreamDto>(`${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/adopt`, {
+    ...(force ? { force } : {}),
+    ...(reviewToken ? { reviewToken } : {})
+  })
 }
 
 export interface DreamSkillContentDto {
@@ -2389,6 +2401,8 @@ export interface DreamSkillContentDto {
   exists: boolean
   skill: string | null
   scripts: { path: string; content: string }[]
+  /** Same-bytes review fence token (task #36 Phase B); present only when `exists`. */
+  reviewToken?: string
 }
 
 /** Read a candidate's FULL staged body — what accepting would install. */
@@ -2399,10 +2413,17 @@ export async function fetchDreamSkill(agentId: string, dreamId: string, name: st
 }
 
 /** Accept one mined skill candidate — installs it for this agent (design §7). */
-export async function acceptDreamSkill(agentId: string, dreamId: string, name: string): Promise<DreamDto> {
+export async function acceptDreamSkill(
+  agentId: string,
+  dreamId: string,
+  name: string,
+  reviewToken?: string
+): Promise<DreamDto> {
+  // Echo the review token from fetchDreamSkill so the daemon binds publication to
+  // the exact reviewed bytes (task #36 Phase B same-bytes fence).
   return apiPost<DreamDto>(
     `${dreamBase(agentId)}/${encodeURIComponent(dreamId)}/skills/${encodeURIComponent(name)}/accept`,
-    {}
+    reviewToken ? { reviewToken } : {}
   )
 }
 


### PR DESCRIPTION
## Phase B — same-bytes review fence, end to end
Closes the `DREAM_UNBOUND_STAGED_CONTENT_REASON` gap: the bytes a user reviews are now cryptographically bound to what gets adopted/accepted, so a re-run, distill rebase, or any change to the staging since review forces a re-review instead of silently adopting un-reviewed content. Builds on the daemon+protocol fences already merged in #431.

### daemon + protocol
- `adopt(…, reviewToken?)` and `skillAccept(…, reviewToken?)` verify the reviewed digest against the exact staged bytes (skill acceptance checks it against publish's own capture snapshot, not a preflight — no TOCTOU). Backward-compatible; auto-adopt passes none.
- Runner exposes `stagedStoreReviewToken` (`storeDigest`) and `stagedSkillReviewToken` (`inspectLocalSkillSource`, the same canonical digest the publish snapshot uses); `cp/dream-reader` returns the token on the review reads and forwards it on adopt/accept.
- protocol: `reviewToken` on `DreamAdoptReq`/`DreamSkillReviewReq` (request) and `DreamFilesPage`/`DreamSkillContent` (response, present when staged content exists).

### control-plane
- `AdoptDreamBody.reviewToken` + new `AcceptDreamSkillBody.reviewToken`; `DreamFilesDto.reviewToken` / `DreamSkillContentDto.reviewToken`. The adopt/skill-accept routes forward the token to the daemon frame; the files/skill-read mappers surface the daemon-computed token.

### web console
- `adoptDream`/`acceptDreamSkill` send the token. `DreamPanel` captures the store token from the review read and echoes it on Adopt; `DreamSkills`/`SkillBody` capture each skill's token when its body is opened for review and echo it on Accept.

### Tests
- daemon: adopt/skillAccept same-bytes fence (incl. a mutate-after-review regression) + the review-read→adopt/accept token round-trip.
- web: DreamPanel asserts the tokens are threaded through Adopt and Accept.
- Full daemon suite + web (601) + CP unit (967) green locally.

Gate unchanged — `dreamOperationsAllowed()` is not flipped; dreaming stays disabled until Phase C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)