### PR TITLE
fix(daemon): allow GitHub credentials through Codex sandbox

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -793,9 +793,15 @@ Injection uses **two channels**:
    subprocess serves only one agent. On spawn, `env` is merged directly into
    the subprocess (`acp-host.ts:225-255`; opts.env is the outermost layer at
    `:239`; `CLAUDE_CODE_EXECUTABLE` at `:243-249` is set only if absent, so it
-   does not overwrite injection). The entire process tree inherits it, and the
-   agent's git process is a direct child with no sandbox stripping the
-   environment.
+   does not overwrite injection). The entire process tree inherits it. When a
+   runtime adds its own nested tool sandbox, the daemon must deliberately keep
+   the credential socket reachable without exposing credential files. On Linux,
+   Codex couples Unix `connect()` to its network permission, so AgentConnect
+   enables that inner layer only for a configured GitHub credential channel;
+   when enabled, the outer SRT sandbox remains authoritative for egress and
+   host-socket visibility. If the operator disables the outer sandbox, the
+   runtime-native profile still receives the same channel permission within
+   that explicitly unconfined launch.
    - **Do not carry session-level injection through `GIT_CONFIG_COUNT`.**
      `GIT_CONFIG_COUNT` does **not compose across
      processes**. If the agent's own toolchain sets `GIT_CONFIG_COUNT`, it

--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -44,15 +44,23 @@ export function codexConfigWithoutPermissionOverrides(raw: string | undefined): 
 
 /** Build the complete inner-tool policy from daemon-owned canonical paths. */
 export function codexPermissionProfileConfig(
-  protectedRoots: readonly string[]
+  protectedRoots: readonly string[],
+  allowModelToolUnixSockets = false
 ): CodexPermissionProfileConfig | undefined {
   const roots = [...new Set(protectedRoots.map((root) => normalize(root)))]
-  if (roots.length === 0) return undefined
+  if (roots.length === 0 && !allowModelToolUnixSockets) return undefined
   if (roots.some((root) => !isAbsolute(root))) {
     throw new Error('Codex protected permission roots must be absolute paths')
   }
 
   const deny = tomlInlineTable(roots.map((root): [string, string] => [root, 'deny']))
+  const protectedFilesystem =
+    roots.length > 0
+      ? [
+          `permissions.${PROFILE_IDS['read-only']}.filesystem=${deny}`,
+          `permissions.${PROFILE_IDS.agent}.filesystem=${deny}`
+        ]
+      : []
   const fullAccess = tomlInlineTable([
     [':root', 'write'],
     ['/.git', 'write'],
@@ -60,14 +68,25 @@ export function codexPermissionProfileConfig(
     ['/.codex', 'write'],
     ...roots.map((root): [string, string] => [root, 'deny'])
   ])
+  // On Linux Codex's restricted network seccomp permits AF_UNIX socket()
+  // creation but rejects connect(). Enable the inner network layer only when
+  // the daemon deliberately provides the agent-scoped GitHub credential
+  // channel. When enabled, outer SRT remains the boundary; when disabled by the
+  // operator, the launch is already explicitly unconfined.
+  const credentialChannelNetwork = allowModelToolUnixSockets
+    ? [
+        `permissions.${PROFILE_IDS['read-only']}.network.enabled=true`,
+        `permissions.${PROFILE_IDS.agent}.network.enabled=true`
+      ]
+    : []
 
   return {
     configOverrides: [
       `default_permissions="${PROFILE_IDS.agent}"`,
       `permissions.${PROFILE_IDS['read-only']}.extends=":read-only"`,
-      `permissions.${PROFILE_IDS['read-only']}.filesystem=${deny}`,
       `permissions.${PROFILE_IDS.agent}.extends=":workspace"`,
-      `permissions.${PROFILE_IDS.agent}.filesystem=${deny}`,
+      ...protectedFilesystem,
+      ...credentialChannelNetwork,
       `permissions.${PROFILE_IDS['agent-full-access']}.filesystem=${fullAccess}`,
       `permissions.${PROFILE_IDS['agent-full-access']}.network.enabled=true`,
       `permissions.${PROFILE_IDS['agent-full-access']}.network.allow_local_binding=true`,

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -20,6 +20,20 @@ import {
   codexPermissionProfileConfig
 } from './codex-permission-profiles.js'
 
+function applyCodexPermissionProfile(
+  env: Record<string, string>,
+  protectedRoots: readonly string[],
+  allowModelToolUnixSockets: boolean,
+  inheritedCodexConfig?: string
+): void {
+  const profileConfig = codexPermissionProfileConfig(protectedRoots, allowModelToolUnixSockets)
+  if (!profileConfig) return
+
+  const codexConfig = codexConfigWithoutPermissionOverrides(env.CODEX_CONFIG ?? inheritedCodexConfig)
+  if (codexConfig !== undefined) env.CODEX_CONFIG = codexConfig
+  env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV] = JSON.stringify(profileConfig)
+}
+
 function disabledClaudeProfileRoot(scopeDir: string): string {
   const root = realpathSync(resolve(scopeDir))
   const target = join(root, '.agentconnect', 'runtime-policy', 'claude-profile-disabled')
@@ -101,6 +115,9 @@ export interface PreparedRuntimeLaunch {
     /** Credential paths deliberately exposed to the trusted runtime parent but
      * denied again inside a runtime-native tool sandbox. */
     protectedCredentialRoots: string[]
+    /** A daemon-owned model-side Unix channel deliberately exposed to the
+     * runtime, currently the agent-scoped GitHub credential socket. */
+    allowModelToolUnixSockets?: boolean
     /** Highest-precedence Claude settings that keep project/local settings from
      * redirecting the trusted parent to an attacker-selected credential profile. */
     claudeProtectedSettings?: ClaudeProtectedSettings
@@ -144,9 +161,17 @@ export function prepareRuntimeLaunch(opts: {
   credentialPlatform?: NodeJS.Platform
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
+  /** Permit the runtime-native tool sandbox to reach a daemon-owned Unix
+   * channel. An enabled outer sandbox remains the surrounding boundary. */
+  allowModelToolUnixSockets?: boolean
 }): PreparedRuntimeLaunch {
+  const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   if (!opts.runInSandbox && !opts.isolateHome) {
-    return { env: opts.explicitEnv ?? {}, inheritProcessEnv: true }
+    const env = { ...(opts.explicitEnv ?? {}) }
+    if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
+      applyCodexPermissionProfile(env, [], true, (opts.hostEnv ?? process.env).CODEX_CONFIG)
+    }
+    return { env, inheritProcessEnv: true }
   }
   if (opts.runInSandbox && !opts.sandboxMechanism) {
     throw new Error('OS sandbox requested but this host has no supported Linux SRT/bwrap mechanism')
@@ -249,7 +274,6 @@ export function prepareRuntimeLaunch(opts: {
     credentials?.seedExclusions
   )
   credentials?.preparePrivateHome(runtimeHome)
-  const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   const env = {
     ...runtimeHomeEnvironment(opts.runtimeId, runtimeHome, opts.explicitEnv, opts.hostEnv),
     ...credentials?.env
@@ -258,6 +282,10 @@ export function prepareRuntimeLaunch(opts: {
   if (opts.runInSandbox) isolateHostSocketEnvironment(env, runtimeHome)
 
   if (!opts.runInSandbox) {
+    if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
+      const privateCodex = join(runtimeHome, '.codex')
+      applyCodexPermissionProfile(env, existsSync(privateCodex) ? [realpathSync(privateCodex)] : [], true)
+    }
     return { env, inheritProcessEnv: false, runtimeHome }
   }
 
@@ -358,12 +386,7 @@ export function prepareRuntimeLaunch(opts: {
     ...privateCodexStateRoots
   ])
   if (credentialProfile === 'codex') {
-    const profileConfig = codexPermissionProfileConfig(protectedCredentialRoots)
-    if (profileConfig) {
-      const codexConfig = codexConfigWithoutPermissionOverrides(env.CODEX_CONFIG)
-      if (codexConfig !== undefined) env.CODEX_CONFIG = codexConfig
-      env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV] = JSON.stringify(profileConfig)
-    }
+    applyCodexPermissionProfile(env, protectedCredentialRoots, opts.allowModelToolUnixSockets === true)
   }
   return {
     env,
@@ -377,6 +400,7 @@ export function prepareRuntimeLaunch(opts: {
       denyReadRoots,
       allowReadRoots: boundary.allowRead,
       protectedCredentialRoots,
+      ...(opts.allowModelToolUnixSockets ? { allowModelToolUnixSockets: true } : {}),
       ...(protectedClaudeSettings ? { claudeProtectedSettings: protectedClaudeSettings } : {})
     }
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4265,7 +4265,8 @@ export class Daemon {
           : undefined,
         explicitEnv: { ...runtimeEnv, ...env },
         sandboxMechanism: this.sandboxMechanism,
-        mcpSocketPath: mcpSocketPath(this.root)
+        mcpSocketPath: mcpSocketPath(this.root),
+        allowModelToolUnixSockets: githubAppCredentials
       })
       launch = composed.launch
       launchRuntime = composed.runtime
@@ -4290,7 +4291,7 @@ export class Daemon {
       inheritProcessEnv: launch.inheritProcessEnv,
       runtimeId: agent.runtime,
       isolateAccountApps: cfg.security.isolateAccountApps,
-      sandbox: launch.sandbox ? { ...launch.sandbox, allowModelToolUnixSockets: githubAppCredentials } : undefined,
+      sandbox: launch.sandbox,
       configPrefs: {
         model: agent.runtimeOverrides?.model,
         permissionMode: agent.permissionMode,

--- a/packages/daemon/src/runtimes/launch-policy.ts
+++ b/packages/daemon/src/runtimes/launch-policy.ts
@@ -154,6 +154,7 @@ export function composeRuntimeLaunch(opts: {
   runtimeReadRoots?: string[]
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
+  allowModelToolUnixSockets?: boolean
 }): ComposedRuntimeLaunch {
   const policyId = runtimeMemoryPolicyId(opts.runtime, opts.runtimeId)
   const capabilities = runtimeMemoryCapabilities(opts.runtime, opts.runtimeId)
@@ -182,7 +183,8 @@ export function composeRuntimeLaunch(opts: {
     agentsRoot: opts.agentsRoot,
     trustedRuntimeReadRoots: [...(sandboxAccess?.readRoots ?? []), ...(opts.runtimeReadRoots ?? [])],
     sandboxMechanism: opts.sandboxMechanism,
-    mcpSocketPath: opts.mcpSocketPath
+    mcpSocketPath: opts.mcpSocketPath,
+    allowModelToolUnixSockets: opts.allowModelToolUnixSockets
   })
   if (sandboxAccess?.claudeExecutable && !launch.env.CLAUDE_CODE_EXECUTABLE) {
     launch.env.CLAUDE_CODE_EXECUTABLE = sandboxAccess.claudeExecutable

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -16,6 +16,29 @@ describe('Codex permission profile launch config', () => {
       expect.stringContaining('"/agent/home/.codex" = "deny"')
     ])
     expect(config.configOverrides).toContain('permissions.agentconnect-protected-full-access.network.enabled=true')
+    expect(config.configOverrides).not.toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
+    expect(config.configOverrides).not.toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
+  })
+
+  it('opens the inner network layer only for a daemon-provided credential channel', () => {
+    const config = codexPermissionProfileConfig(['/agent/home/.codex'], true)!
+
+    expect(config.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
+    expect(config.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
+  })
+
+  it('can open the credential channel without adding empty filesystem overrides', () => {
+    const config = codexPermissionProfileConfig([], true)!
+
+    expect(config.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
+    expect(config.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
+    expect(
+      config.configOverrides.filter(
+        (value) =>
+          value.includes('agentconnect-protected-workspace.filesystem=') ||
+          value.includes('agentconnect-protected-read-only.filesystem=')
+      )
+    ).toEqual([])
   })
 
   it('rejects non-absolute policy roots', () => {

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -74,6 +74,7 @@ describe('diffAgents', () => {
       // fastMode is baked into the host's configPrefs at construction, so an edit
       // must evict the host (unlike output.mode, which is read live per dispatch).
       { fastMode: true },
+      { permissionMode: 'agent-full-access' },
       { approvalsReviewer: 'auto_review' },
       { runtimeOverrides: { model: undefined as any, env: [{ name: 'FOO', value: 'bar' }] } },
       // Secrets are baked into the child env (and materialized as config files)

--- a/packages/daemon/test/runtime-credentials.test.ts
+++ b/packages/daemon/test/runtime-credentials.test.ts
@@ -37,6 +37,35 @@ function settings(path: string): { filesystem: { allowWrite: string[] } } {
 }
 
 describe('Linux shared runtime login', () => {
+  it('opens the Codex credential channel even when the outer sandbox is disabled', () => {
+    const { scopeDir, cwd } = fixture()
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      allowModelToolUnixSockets: true,
+      explicitEnv: {
+        CODEX_CONFIG: JSON.stringify({
+          model: 'gpt-test',
+          permissions: { attacker: { extends: ':workspace' } },
+          features: { fast_mode: true }
+        })
+      }
+    })
+
+    const profileConfig = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as {
+      configOverrides: string[]
+      modeProfiles: Record<string, string>
+    }
+    expect(launch.inheritProcessEnv).toBe(true)
+    expect(launch.sandbox).toBeUndefined()
+    expect(profileConfig.modeProfiles.agent).toBe('agentconnect-protected-workspace')
+    expect(profileConfig.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
+    expect(profileConfig.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
+    expect(JSON.parse(launch.env.CODEX_CONFIG!)).toEqual({ model: 'gpt-test', features: { fast_mode: true } })
+  })
+
   it('trusts the host Claude config directory by default without rewriting its settings', () => {
     const { daemonRoot, hostHome, scopeDir, cwd } = fixture()
     const hostClaude = join(hostHome, '.claude')
@@ -199,6 +228,7 @@ describe('Linux shared runtime login', () => {
       agentsRoot: join(daemonRoot, 'agents'),
       runInSandbox: true,
       sandboxMechanism: 'bwrap',
+      allowModelToolUnixSockets: true,
       credentialPlatform: 'linux',
       explicitEnv: {
         [CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]: '{"modeProfiles":{"agent":"attacker"}}',
@@ -226,6 +256,9 @@ describe('Linux shared runtime login', () => {
       modeProfiles: Record<string, string>
     }
     expect(profileConfig.modeProfiles.agent).toBe('agentconnect-protected-workspace')
+    expect(launch.sandbox?.allowModelToolUnixSockets).toBe(true)
+    expect(profileConfig.configOverrides).toContain('permissions.agentconnect-protected-workspace.network.enabled=true')
+    expect(profileConfig.configOverrides).toContain('permissions.agentconnect-protected-read-only.network.enabled=true')
     expect(JSON.parse(launch.env.CODEX_CONFIG!)).toEqual({
       model: 'gpt-test',
       features: { fast_mode: true }


### PR DESCRIPTION
## Summary

- let Codex Read Only and Agent/Auto tool sandboxes reach the daemon-owned GitHub App credential channel
- apply the same runtime-native profile bridge whether the outer AgentConnect sandbox is enabled or explicitly disabled
- keep credential files denied and leave network restricted for agents without GitHub App credentials
- preserve the outer SRT boundary when enabled and document the nested-sandbox contract
- lock in that permission-mode changes still respawn the ACP host

## Root cause

Codex restricted network mode denies Linux `connect()`, including the Unix socket used by the GitHub credential helper. The permission-profile hardening merged in #423 preserved that restriction but did not carry the deliberately exposed credential channel into Read Only or Agent/Auto. Reviews appeared healthy while the exact head was already available locally, then returned neutral when a rerun needed authenticated `gh` or `git fetch`.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/codex-permission-profiles.test.ts test/runtime-credentials.test.ts test/runtime-launch.test.ts test/reconciler.test.ts` (50 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- changed-file ESLint and Prettier checks
- pre-push full-repository ESLint
- full daemon-suite attempt reached 2,703 passing assertions; the run then hit the existing macOS watcher teardown failure (`EMFILE: too many open files, watch`)

Created by Codex . GPT-5