### PR TITLE
fix(web): split Lark and Feishu integrations

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1265,7 +1265,8 @@ export default function AddIntegrationModal({
   }, [agent.name, createdHook, daemonsLoading, firstSupportedBotPlatform, selectedBotPlatformSupported])
 
   // A bot serves one agent at a time; freed (or prebuilt, never-installed) bots of
-  // THIS platform are offered for reuse instead of forcing a re-create. Two kinds
+  // THIS platform (and active Feishu/Lark region) are offered for reuse instead
+  // of forcing a re-create. Two kinds
   // look "free" (`inUseByAgentId` clears with the last install) but are not, and the
   // server rejects both — don't offer what cannot be picked:
   //   • revoked — the workspace uninstalled the app, so its token is dead;
@@ -1275,7 +1276,12 @@ export default function AddIntegrationModal({
   //     shared bot; before that, reuse is the dedicated "Add to Slack" flow or a
   //     Slack app of this agent's own.
   const freeBots = bots.filter(
-    (b) => b.platform === platform && !b.inUseByAgentId && !b.revokedAt && (!b.teamId || b.shareable)
+    (b) =>
+      b.platform === platform &&
+      (platform !== 'feishu' || (b.feishuRegion ?? 'feishu') === feishuRegion) &&
+      !b.inUseByAgentId &&
+      !b.revokedAt &&
+      (!b.teamId || b.shareable)
   )
   const mode = modePick ?? 'create'
   // Slack Bot-identity panes (design: builtin-first). While the funnel probe is in

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -18,7 +18,8 @@ import {
   runtimeLabel,
   status,
   supportsModes,
-  workspaceStatus
+  workspaceStatus,
+  type IntegrationRow
 } from '@/lib/data'
 import {
   creatorLabel,
@@ -107,6 +108,15 @@ const INTEGRATION_BLURB: Record<Platform, string> = {
   webhook: 'Trigger by posting a URL'
 }
 const HOOK_RUN_REFRESH_MS = 10_000
+
+function FeishuRegionBadge({ integration }: { integration: Pick<IntegrationRow, 'platform' | 'region'> }) {
+  if (integration.platform !== 'feishu') return null
+  return (
+    <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
+      {integration.region === 'lark' ? 'Lark' : 'Feishu'}
+    </span>
+  )
+}
 
 interface GithubReviewSettingsDraft {
   hookId: string
@@ -1156,8 +1166,11 @@ export default function AgentDetailView() {
                             <PlatformMark platform={g.platform} />
                           </span>
                           <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                            <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
-                              {g.name}
+                            <span className="flex min-w-0 items-center gap-2">
+                              <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
+                                {g.name}
+                              </span>
+                              <FeishuRegionBadge integration={g} />
                             </span>
                             {g.channels[0] && (
                               <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
@@ -1272,6 +1285,7 @@ export default function AgentDetailView() {
                               <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
                                 {g.name}
                               </span>
+                              <FeishuRegionBadge integration={g} />
                               <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
                                 <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
                                 connected

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -361,13 +361,20 @@ const MEMBER_GRID = 'grid-cols-[2fr_1.4fr_auto]'
 // actions. The 100px action track fits refresh + platform link + delete and stays
 // identical across rows; below 480px "Created by" is dropped to preserve space.
 const BOT_GRID = 'grid-cols-[3fr_1.1fr_1fr_100px] min-[480px]:grid-cols-[2fr_0.9fr_1.5fr_1fr_100px]'
-const BOT_PLATFORMS = [
-  { platform: 'slack', label: 'Slack', noun: 'app' },
-  { platform: 'discord', label: 'Discord', noun: 'bot' },
-  { platform: 'telegram', label: 'Telegram', noun: 'bot' },
-  { platform: 'feishu', label: 'Lark', noun: 'bot' }
+const BOT_PLATFORM_TABS = [
+  { key: 'slack', platform: 'slack', feishuRegion: null, label: 'Slack', noun: 'app' },
+  { key: 'discord', platform: 'discord', feishuRegion: null, label: 'Discord', noun: 'bot' },
+  { key: 'telegram', platform: 'telegram', feishuRegion: null, label: 'Telegram', noun: 'bot' },
+  { key: 'lark', platform: 'feishu', feishuRegion: 'lark', label: 'Lark', noun: 'bot' },
+  { key: 'feishu', platform: 'feishu', feishuRegion: 'feishu', label: 'Feishu', noun: 'bot' }
 ] as const
-type BotPlatform = (typeof BOT_PLATFORMS)[number]['platform']
+type BotPlatformTab = (typeof BOT_PLATFORM_TABS)[number]
+type BotPlatformTabKey = BotPlatformTab['key']
+
+function botMatchesPlatformTab(bot: BotDto, tab: BotPlatformTab): boolean {
+  if (bot.platform !== tab.platform) return false
+  return tab.feishuRegion === null || (bot.feishuRegion ?? 'feishu') === tab.feishuRegion
+}
 
 type BotRosterRow = { kind: 'workspace'; key: string; label: string } | { kind: 'bot'; key: string; bot: BotDto }
 
@@ -970,7 +977,7 @@ function BotsCard({
     refresh,
     loading: dataLoading
   } = useConsoleData()
-  const [platform, setPlatform] = useState<BotPlatform>('slack')
+  const [platformTabKey, setPlatformTabKey] = useState<BotPlatformTabKey>('slack')
   // Bot row expanded to its channel roster (one at a time), the bot whose
   // shareable PATCH is in flight, and the last toggle denial to surface (the CP
   // 409s with a reason: no relay connected / still shared by several agents).
@@ -981,18 +988,20 @@ function BotsCard({
   const [slackRefresh, setSlackRefresh] = useState<Record<string, { result?: SlackBotRefreshDto; error?: string }>>({})
   const [slackReinstall, setSlackReinstall] = useState<{ botId: string; installId: string } | null>(null)
 
-  const targetBotPlatform = BOT_PLATFORMS.find(
-    (item) => item.platform === bots.find((bot) => bot.id === targetBotId)?.platform
-  )?.platform
-  const { label, noun } = BOT_PLATFORMS.find((item) => item.platform === platform)!
-  const platformBots = bots.filter((b) => b.platform === platform)
+  const targetBot = bots.find((bot) => bot.id === targetBotId)
+  const targetBotPlatformTabKey = targetBot
+    ? BOT_PLATFORM_TABS.find((tab) => botMatchesPlatformTab(targetBot, tab))?.key
+    : undefined
+  const platformTab = BOT_PLATFORM_TABS.find((tab) => tab.key === platformTabKey)!
+  const { label, noun } = platformTab
+  const platformBots = bots.filter((bot) => botMatchesPlatformTab(bot, platformTab))
   const rosterRows = botRosterRows(platformBots)
 
   useEffect(() => {
-    if (!targetBotId || !targetBotPlatform) return
-    setPlatform(targetBotPlatform)
+    if (!targetBotId || !targetBotPlatformTabKey) return
+    setPlatformTabKey(targetBotPlatformTabKey)
     setOpenBotId(targetBotId)
-  }, [targetBotId, targetBotPlatform])
+  }, [targetBotId, targetBotPlatformTabKey])
 
   useEffect(() => {
     if (!targetBotId || openBotId !== targetBotId) return
@@ -1119,17 +1128,17 @@ function BotsCard({
         role="tablist"
         aria-label="Bot platform"
       >
-        {BOT_PLATFORMS.map((item) => {
-          const selected = item.platform === platform
+        {BOT_PLATFORM_TABS.map((item) => {
+          const selected = item.key === platformTabKey
           return (
             <button
-              key={item.platform}
+              key={item.key}
               type="button"
               role="tab"
               aria-selected={selected}
               className={`${selected ? 'tab on' : 'tab'} mr-[5px] flex items-center gap-[5px] whitespace-nowrap last:mr-0 desktop:mr-[22px] desktop:gap-[6px]`}
               onClick={() => {
-                setPlatform(item.platform)
+                setPlatformTabKey(item.key)
                 setOpenBotId(null)
               }}
             >
@@ -1221,7 +1230,7 @@ function BotsCard({
                 )}
                 {/* Transport tag (Slack) — makes the Sharable column's disabled state
                     self-explanatory: only an http bot may be shared. */}
-                {platform === 'slack' && (
+                {platformTab.platform === 'slack' && (
                   <span className="badge bg-(--surface-active) text-(--text-tertiary) max-[479px]:hidden">
                     {b.transport ?? 'socket'}
                   </span>
@@ -1271,7 +1280,7 @@ function BotsCard({
                 {b.createdBy ? creatorLabel(b.createdBy, me) : b.prebuilt ? 'AgentConnect' : '—'}
               </span>
               <span className="flex items-center justify-end gap-2" onClick={(e) => e.stopPropagation()}>
-                {platform === 'slack' && b.slackAppId && canWrite && (
+                {platformTab.platform === 'slack' && b.slackAppId && canWrite && (
                   <button
                     className={`iconbtn h-7 w-7 flex-none ${
                       slackNeedsAttention ? 'border-(--amber-500) bg-(--status-paused-soft) text-(--amber-500)' : ''
@@ -1288,7 +1297,7 @@ function BotsCard({
                     />
                   </button>
                 )}
-                {platform === 'slack' && b.slackAppId && (
+                {platformTab.platform === 'slack' && b.slackAppId && (
                   <a
                     href={slackAppSettingsUrl(b.slackAppId)}
                     target="_blank"
@@ -1301,7 +1310,7 @@ function BotsCard({
                     <Icon name="external-link" size={12} />
                   </a>
                 )}
-                {platform === 'discord' && b.discordAppId && (
+                {platformTab.platform === 'discord' && b.discordAppId && (
                   <a
                     href={discordBotInviteUrl(b.discordAppId)}
                     target="_blank"
@@ -1314,7 +1323,7 @@ function BotsCard({
                     <Icon name="external-link" size={12} />
                   </a>
                 )}
-                {platform === 'feishu' && (
+                {platformTab.platform === 'feishu' && (
                   <a
                     href={feishuAppSettingsUrl(b.feishuAppId, feishuRegion)}
                     target="_blank"

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -275,6 +275,7 @@ function integrationRowFromDto(
     botId: d.botId,
     shareable: bot?.shareable ?? false,
     discordAppId: bot?.discordAppId ?? null,
+    ...(d.platform === 'feishu' ? { region: d.region ?? bot?.feishuRegion ?? 'feishu' } : {}),
     name: d.name,
     platform: d.platform,
     kind: 'Custom app',

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1630,6 +1630,8 @@ export interface IntegrationRow {
   shareable?: boolean
   /** Discord application (client) id from the backing bot — builds the "Add to Discord" invite URL. Null/absent for non-Discord or when unknown. */
   discordAppId?: string | null
+  /** Feishu-family gateway identity. Lark and Feishu integrations remain separate rows even though they share the wire platform key. */
+  region?: 'feishu' | 'lark'
   name: string
   platform: string
   kind: string


### PR DESCRIPTION
## Summary

- split the Settings bot roster into distinct Lark and Feishu tabs using each bot's gateway region
- preserve the region on agent integration rows and label simultaneous Lark and Feishu connections separately
- limit reusable Feishu-family bots to the brand currently selected in the integration flow

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- focused ESLint on all changed files
- `pnpm --filter @agentconnect.md/web test -- --runInBand` (83 files, 614 tests)
- `NEXT_PUBLIC_MOCK=1 pnpm --filter @agentconnect.md/web build`
- browser-verified Lark/Feishu Settings filtering, region-aware deep links, and simultaneous agent integration cards

Created by Codex . GPT-5
