### PR TITLE
fix(sessions): offer Lark and Feishu identity links

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -561,13 +561,14 @@ learned from it"); silence is not an option.
   and user access. Provider-bound visibility is
   read-only; unresolved history and transient provider failures are surfaced
   without widening access.
-- Session links emitted into Slack and GitHub carry a non-authoritative provider
+- Session links emitted into Slack, Feishu/Lark, and GitHub carry a non-authoritative provider
   hint. When such a deep link still resolves to the generic 404 page, the Console
-  offers `Link Slack profile` or `Link GitHub profile` only if that provider is
-  configured and the viewer has not linked it already. Unsupported providers,
-  ordinary/handwritten URLs, and linked viewers get no extra action. The hint is
-  intentionally forgeable and never consulted for authorization, so it cannot
-  confirm whether the session exists; the protected session route remains 404.
+  offers `Link Slack profile`, `Link Lark profile`, `Link Feishu profile`, or
+  `Link GitHub profile` only if that provider is configured and the viewer has not
+  linked it already. Unsupported providers, ordinary/handwritten URLs, and linked
+  viewers get no extra action. The hint is intentionally forgeable and never
+  consulted for authorization, so it cannot confirm whether the session exists;
+  the protected session route remains 404.
 - The existing client-side "mine" heuristic
   (`packages/web/src/lib/session-trigger.ts` email/userId matching) stays as a
   display concern (the "you" label) but is no longer doing authorization work.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8871,7 +8871,7 @@ export class Daemon {
       }
       const info = this.statusInfoFrom(target.agentId, key, acpSessionId ?? undefined)
       const link = acpSessionId
-        ? this.sessionLink(acpSessionId, msg.platform === 'slack' ? 'slack' : undefined)
+        ? this.sessionLink(acpSessionId, this.sessionLinkSource(msg.platform, target.integrationId))
         : undefined
       if (msg.platform === 'telegram') {
         // HTML chrome (not recorded) — renders the compact line + a tappable View link.
@@ -10725,7 +10725,7 @@ export class Daemon {
       botUrl: this.agentLink(agentId),
       runtime: this.runtimeNames[agent.runtime] ?? agent.runtime,
       model: this.buildStatusInfo(p).model ?? turnModel ?? 'default',
-      sessionUrl: this.sessionLink(sessionId, msg.platform === 'slack' ? 'slack' : undefined)
+      sessionUrl: this.sessionLink(sessionId, this.sessionLinkSource(msg.platform, integrationId))
     })
     try {
       if (!p.selectedHost) {
@@ -12315,7 +12315,7 @@ export class Daemon {
         p.feishuCardAttempted = true
         p.feishuCard = await conn.startStreamingCard(p.channel, p.thread, {
           sessionKey: p.sessionKey,
-          sessionUrl: this.sessionLink(p.acpSessionId),
+          sessionUrl: this.sessionLink(p.acpSessionId, this.sessionLinkSource(p.platform, p.integrationId)),
           ...(p.integrationId ? { target: { v: 1, agentId: p.agentId, integrationId: p.integrationId } as const } : {})
         })
         return
@@ -12390,12 +12390,21 @@ export class Daemon {
    *  when the CP couldn't resolve it; then the segment is dropped. */
   private cpOrgSlug?: string
 
+  /** Presentation-only source hint carried by provider-rendered session links. Feishu and
+   *  Lark share one protocol platform, so their integration region supplies the visible brand. */
+  private sessionLinkSource(platform: string, integrationId?: string): 'slack' | 'github' | FeishuRegion | undefined {
+    if (platform === 'slack' || platform === 'github') return platform
+    if (platform !== 'feishu' || !integrationId) return undefined
+    const integration = this.integrationConfigById(integrationId)
+    return integration?.platform === 'feishu' ? integration.feishu.region : undefined
+  }
+
   /** The Web App console URL for a session: `<base>/<orgSlug>/sessions/<id>`, where base is
    *  the explicit local `webAppUrl`, else the CP-provided origin, else the local default
    *  (`DEFAULT_WEB_APP_URL`). The console is org-scoped, so the org slug is inserted when
-   *  known; without it the link falls back to `<base>/sessions/<id>`. Slack/GitHub links
-   *  carry a presentation-only source hint for the generic 404 profile-linking action. */
-  private sessionLink(acpSessionId: string, source?: 'slack' | 'github'): string {
+   *  known; without it the link falls back to `<base>/sessions/<id>`. Provider-rendered
+   *  links carry a presentation-only source hint for the generic 404 profile-linking action. */
+  private sessionLink(acpSessionId: string, source?: 'slack' | 'github' | FeishuRegion): string {
     const orgSeg = this.cpOrgSlug ? `/${encodeURIComponent(this.cpOrgSlug)}` : ''
     const link = `${this.webAppBase()}${orgSeg}/sessions/${encodeURIComponent(acpSessionId)}`
     return source ? `${link}?source=${source}` : link

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1991,7 +1991,34 @@ describe('Slack interactive status bar', () => {
     expect((daemon as any).sessionLink('acp-1')).toBe('http://localhost:3000/sessions/acp-1')
     expect((daemon as any).sessionLink('acp-1', 'slack')).toBe('http://localhost:3000/sessions/acp-1?source=slack')
     expect((daemon as any).sessionLink('acp-1', 'github')).toBe('http://localhost:3000/sessions/acp-1?source=github')
+    expect((daemon as any).sessionLink('acp-1', 'lark')).toBe('http://localhost:3000/sessions/acp-1?source=lark')
+    expect((daemon as any).sessionLink('acp-1', 'feishu')).toBe('http://localhost:3000/sessions/acp-1?source=feishu')
     expect((daemon as any).agentLink('bot-a')).toBe('http://localhost:3000/agents/bot-a')
+  })
+
+  it('uses the Feishu integration region as the session-link source hint', () => {
+    const daemon = new Daemon()
+    ;(daemon as any).cfg = {}
+    ;(daemon as any).agents.set('bot-a', {
+      integrations: [
+        {
+          id: 'int-lark',
+          platform: 'feishu',
+          feishu: {
+            mode: 'shared',
+            appId: 'cli_lark',
+            appSecret: 'secret',
+            region: 'lark',
+            allowedUserIds: [],
+            bindRules: []
+          }
+        }
+      ]
+    })
+
+    const source = (daemon as any).sessionLinkSource('feishu', 'int-lark')
+    expect(source).toBe('lark')
+    expect((daemon as any).sessionLink('acp-1', source)).toBe('http://localhost:3000/sessions/acp-1?source=lark')
   })
 
   it('falls back to the probed runtime models when the persisted session is cold', async () => {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -55,6 +55,7 @@ import {
   memberDisplayName,
   mergeSessionDetailUsage,
   sessionFromDetailDto,
+  type SessionProfileProvider,
   type SessionDetailDto,
   type SessionMessageDto,
   type SessionRelationDto,
@@ -1133,16 +1134,16 @@ export default function SessionDetailView() {
   // equivalent.
   const source = searchParams.get('source')
   const integration = searchParams.get('integration')
-  const hintedProvider =
-    source === 'slack' || source === 'github'
-      ? source
-      : integration === 'slack' || integration === 'github'
-        ? integration
-        : undefined
+  const profileProviderHint = (value: string | null): SessionProfileProvider | undefined =>
+    value === 'slack' || value === 'github' || value === 'lark' || value === 'feishu' ? value : undefined
+  const hintedProvider = profileProviderHint(source) ?? profileProviderHint(integration)
   const profileLinkProvider =
     hintedProvider && socialLoginProviders().some((provider) => provider.target === hintedProvider)
       ? hintedProvider
       : undefined
+  const profileLinkProviderName = socialLoginProviders().find(
+    (provider) => provider.target === profileLinkProvider
+  )?.name
   const profileLinkCandidate =
     sessionDetailError instanceof ApiError &&
     sessionDetailError.status === 404 &&
@@ -1744,9 +1745,9 @@ export default function SessionDetailView() {
             actionLabel="Back to sessions"
             actionHref={orgPath('/sessions')}
             secondaryAction={
-              showProfileLink && profileLinkProvider
+              showProfileLink && profileLinkProviderName
                 ? {
-                    label: `Link ${profileLinkProvider === 'slack' ? 'Slack' : 'GitHub'} profile`,
+                    label: `Link ${profileLinkProviderName} profile`,
                     href: orgPath('/profile#sign-in-methods'),
                     icon: 'link'
                   }

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -9,6 +9,7 @@ import {
   deleteOrgIcon,
   fetchAllGithubRepos,
   fetchGithubRepoRoster,
+  fetchMySessionIdentity,
   fetchMemoryAdminSurface,
   fmtCountCompact,
   invalidateGithubRepoRosterCache,
@@ -45,6 +46,29 @@ describe('fmtCountCompact', () => {
     [undefined, '—']
   ])('formats %s as %s', (value, expected) => {
     expect(fmtCountCompact(value)).toBe(expected)
+  })
+})
+
+describe('session profile identity hints', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('checks Lark and Feishu as distinct linked social targets', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              identities: [{ target: 'lark' }],
+              hasSecurityVerificationMethod: true
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+      )
+    )
+
+    await expect(fetchMySessionIdentity('lark')).resolves.toEqual({ linked: true })
+    await expect(fetchMySessionIdentity('feishu')).resolves.toEqual({ linked: false })
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -2016,6 +2016,7 @@ export async function putSessionVisibility(
 }
 
 export type SessionAccessProvider = 'slack' | 'github' | 'feishu'
+export type SessionProfileProvider = SessionAccessProvider | 'lark'
 
 export interface SessionExternalAccessDto {
   provider: SessionAccessProvider
@@ -3250,7 +3251,7 @@ export type MySlackIdentityDto =
     }
 
 /** Narrow linked/not-linked status used by supported provider profile-linking hints. */
-export async function fetchMySessionIdentity(provider: SessionAccessProvider): Promise<{ linked: boolean }> {
+export async function fetchMySessionIdentity(provider: SessionProfileProvider): Promise<{ linked: boolean }> {
   if (provider === 'slack') return apiGet<MySlackIdentityDto>('/me/social-identities/slack')
   const account = await fetchMySocialAccount()
   return { linked: account.identities.some((identity) => identity.target === provider) }


### PR DESCRIPTION
## Summary

- carry the Feishu integration region in provider-rendered session links so Lark and Feishu deep links retain the right brand
- offer Link Lark profile or Link Feishu profile on a hinted session 404 when that identity is configured and still unlinked
- document the expanded missing-session recovery behavior

## Validation

- pnpm --filter @agentconnect.md/web exec vitest run src/lib/api.test.ts
- pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-commands.test.ts -t "uses the Feishu integration region as the session-link source hint"
- pnpm --filter @agentconnect.md/web typecheck
- pnpm --filter @agentconnect.md/daemon typecheck
- pnpm exec eslint packages/web/src/components/console/views/SessionDetailView.tsx packages/web/src/lib/api.ts packages/web/src/lib/api.test.ts packages/daemon/src/daemon.ts packages/daemon/test/daemon-commands.test.ts

The full daemon command file passed all 52 assertions; its process then hit the known macOS watcher teardown EMFILE failure.

Created by Codex . GPT-5