### PR TITLE
fix(cp): webchat conversation key decodes to the daemon's prefixed thread

### DIFF
--- a/packages/control-plane/src/http/conversation-key.test.ts
+++ b/packages/control-plane/src/http/conversation-key.test.ts
@@ -12,9 +12,12 @@ describe('conversation key codec', () => {
     expect(decodeConversationKey(encodeConversationKey(unscoped)!)).toEqual(unscoped)
   })
 
-  it('uses the bare conversation id for webchat', () => {
+  it('uses the bare conversation id for webchat; decode restores the prefixed thread', () => {
     const id = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
-    const key = { platform: 'webchat', tenantScope: null, channel: id, thread: id }
+    // Rows record thread as the daemon's msgId form (`webchat:<id>`); the
+    // bare-id key must round-trip onto that shape or the resolver matches
+    // nothing (the exact production bug this pins).
+    const key = { platform: 'webchat', tenantScope: null, channel: id, thread: `webchat:${id}` }
     expect(encodeConversationKey(key)).toBe(id)
     expect(decodeConversationKey(id)).toEqual(key)
   })

--- a/packages/control-plane/src/http/conversation-key.ts
+++ b/packages/control-plane/src/http/conversation-key.ts
@@ -24,7 +24,10 @@ export function encodeConversationKey(key: ConversationKey): string | null {
 }
 
 export function decodeConversationKey(raw: string): ConversationKey | null {
-  if (UUID_RE.test(raw)) return { platform: 'webchat', tenantScope: null, channel: raw, thread: raw }
+  // The webchat session key's thread segment is the PREFIXED msgId form the
+  // daemon records (`webchat:<conversationId>`), not the bare id — the
+  // resolver must match rows as they are actually reported.
+  if (UUID_RE.test(raw)) return { platform: 'webchat', tenantScope: null, channel: raw, thread: `webchat:${raw}` }
   const decoded = Buffer.from(raw, 'base64url').toString('utf8')
   const parts = decoded.split(SEP)
   if (parts.length !== 4 || !parts[0] || !parts[2] || !parts[3]) return null

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -214,7 +214,8 @@ describe('GET /sessions — grouped conversations', () => {
         phase: 'start',
         platform: 'webchat',
         channel: CONVO,
-        thread: CONVO,
+        // The daemon's real thread shape — the msgId form, not the bare id.
+        thread: `webchat:${CONVO}`,
         lastActivityAt: new Date(at).toISOString(),
         ts: new Date(at).toISOString()
       })


### PR DESCRIPTION
Hotfix for the merged conversation page hanging on webchat conversations (clicking a grouped 2-agent row, or refreshing a live one, stuck on the loading state).

**Root cause**: the `?conversationKey=` resolver decoded a webchat key as `{channel: <id>, thread: <id>}`, but the daemon records the session `thread` in its msgId form — `webchat:<conversationId>` (verified against the live rows). The resolver therefore always answered empty for webchat; the grouped list kept working because grouping keys off raw row values, which is what localized the bug. The C1 integration test masked it by reporting a bare-id thread by hand.

- `decodeConversationKey` restores the prefixed thread for webchat keys (encode is unchanged — it never reads the thread on the webchat branch, so list-row keys and the §5.3 self-redirect stay consistent).
- The codec unit test pins the round-trip shape with a comment naming this bug; the resolver integration test now reports the daemon's real thread form.

CP: 982 unit + 901 integration green, typecheck clean.

A separate web-side follow-up (on the C3 PR) addresses the sibling symptom: the live Playground's mid-stream URL swap remounting into persisted conversation mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)