### PR TITLE
fix(web): keep the live canvas through the conversation URL swap; resolver-null grace

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -865,7 +865,12 @@ export default function SessionDetailView() {
   } = useSWR(
     conversationKey && activeOrg?.id ? (['conversation-by-key', activeOrg.id, conversationKey] as const) : null,
     ([, orgId, key]) => fetchConversationByKey(key, orgId),
-    { refreshInterval: 30_000, revalidateOnFocus: false }
+    {
+      // A just-created conversation can beat the CP's event/session sync —
+      // poll fast until members resolve, then settle to the normal cadence.
+      refreshInterval: (latest) => (latest ? 30_000 : 5_000),
+      revalidateOnFocus: false
+    }
   )
   const conversationMembers = conversationKey ? (conversationRoster?.sessions ?? null) : null
   const id = conversationKey ? (conversationMembers?.[0]?.sessionId ?? '') : (routeId ?? '')
@@ -1040,6 +1045,19 @@ export default function SessionDetailView() {
   // key-to-key navigation in the persistent layout can never act on the
   // previous conversation's leftover msgs/cursors.
   const [conversationLoadedKey, setConversationLoadedKey] = useState<string | null>(null)
+  // A resolver NULL that persists past the grace window is a real not-found
+  // (invisible or nonexistent, indistinguishable by design §7); within it,
+  // null is treated as still-loading so a just-created conversation racing
+  // event/session sync never flashes a premature not-found.
+  const [conversationUnresolved, setConversationUnresolved] = useState(false)
+  useEffect(() => {
+    if (!conversationKey || conversationRoster !== null) {
+      setConversationUnresolved(false)
+      return
+    }
+    const timer = window.setTimeout(() => setConversationUnresolved(true), 15_000)
+    return () => window.clearTimeout(timer)
+  }, [conversationKey, conversationRoster])
   const conversationMembersRef = useRef<{ sessionId: string; agentId: string; platform: string }[] | null>(null)
   // Merge sources in CANONICAL order — sessionId sort, decoupled from the
   // resolver's representative-first response, whose activity-based order is
@@ -1282,10 +1300,20 @@ export default function SessionDetailView() {
     // refresh must land where the live Playground already looks merged
     // (merged-conversation-view.md §5.3). channelId is the conversation id.
     const conversationId = (session?.participants?.length ?? 0) > 1 ? session?.channelId : undefined
-    const target = conversationId
-      ? orgPath(`/conversations/${encodeURIComponent(conversationId)}`)
-      : orgPath(`/sessions/${encodeURIComponent(realSessionId)}`)
-    router.replace(`${target}${window.location.search}`, {
+    if (conversationId) {
+      // ADDRESS BAR ONLY (Next shallow history update): a router.replace to
+      // /conversations/:key would remount into persisted conversation mode
+      // MID-STREAM — killing the live canvas and racing the CP's
+      // session_meta sync. The live view stays; only a real refresh loads
+      // the merged page.
+      window.history.replaceState(
+        null,
+        '',
+        `${orgPath(`/conversations/${encodeURIComponent(conversationId)}`)}${window.location.search}`
+      )
+      return
+    }
+    router.replace(`${orgPath(`/sessions/${encodeURIComponent(realSessionId)}`)}${window.location.search}`, {
       scroll: false
     })
   }, [
@@ -1701,7 +1729,18 @@ export default function SessionDetailView() {
       </div>
     )
   }
-  if (conversationKey && (conversationLoading || (!conversationRoster && !conversationError))) {
+  // `undefined` = first fetch in flight; `null` = the resolver ANSWERED empty
+  // (a just-created conversation racing event/session sync, or one the caller
+  // cannot see). Both keep the loading affordance — the fast poll above
+  // resolves the just-created case within seconds — but null never renders a
+  // premature not-found flash for a conversation that is about to exist.
+  if (
+    conversationKey &&
+    !conversationError &&
+    (conversationLoading ||
+      conversationRoster === undefined ||
+      (conversationRoster === null && !conversationUnresolved))
+  ) {
     return (
       <div className="wrap max-w-[880px] max-desktop:p-4">
         <LoadingState fill />
@@ -1709,6 +1748,7 @@ export default function SessionDetailView() {
     )
   }
   if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
+    // conversationError, a grace-expired null, or a resolved-but-empty roster.
     return (
       <div className="wrap max-w-[880px] max-desktop:p-4">
         <NotFound


### PR DESCRIPTION
Web-side sibling of #448, for the same reported symptom (a live multi-agent Playground "refreshing" into a stuck page right after the first agent's first reply).

- **Address-bar-only URL swap**: when a live multi-participant Playground's durable session id arrives, the swap to `/conversations/:key` now uses Next's shallow `window.history.replaceState` — the previous `router.replace` remounted into *persisted* conversation mode mid-stream, killing the live canvas and racing the CP's `session_meta` sync. The live view stays; a real refresh loads the merged page (§5.3's intent).
- **Resolver-null grace**: a resolver `null` polls fast (5s) and reads as still-loading for a 15s grace window — a just-created conversation racing `event/session` sync neither sticks on a spinner forever (grace-expired null renders not-found, matching §7's invisible≡nonexistent bar) nor flashes a premature not-found.

Web 615 green, typecheck + eslint clean. (Cherry-picked off the merged #441; the branch recreation from the race is deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)