### PR TITLE
fix(web): compact multi-agent session count

### DIFF
--- a/packages/web/STYLE.md
+++ b/packages/web/STYLE.md
@@ -125,8 +125,11 @@ desktop:grid-cols-4`. The hack rules stay in globals.css (harmless — they
     exists for another purpose and would only repeat text the user can already
     read, omit it in that state. The nav rail, for example, sets `title` only
     while collapsed, so icon-only controls use the themed tooltip and expanded
-    labels stay silent. Mark a whole subtree `data-no-tooltip` only when its
-    titles must remain available to the browser without entering this layer.
+    labels stay silent. When a focused row contains several titled descendants,
+    mark its intended focus hint with `data-tooltip-focus`; the layer ignores
+    responsive copies hidden by CSS. Mark a whole subtree `data-no-tooltip` only
+    when its titles must remain available to the browser without entering this
+    layer.
 
 15. **JSX whitespace after an inline element (SWC gotcha).** Turbopack/SWC
     drops the space in `</span> long text…` when that text run wraps to the

--- a/packages/web/src/components/console/Tooltip.test.tsx
+++ b/packages/web/src/components/console/Tooltip.test.tsx
@@ -168,6 +168,33 @@ describe('TooltipLayer', () => {
     expect(tooltip()?.textContent).toBe('Ships and rolls back deploys from chat.')
   })
 
+  it('uses the visible primary hint when a focused row has responsive duplicates', async () => {
+    const link = document.createElement('a')
+    link.href = '#'
+    host.appendChild(link)
+
+    const privacy = document.createElement('span')
+    privacy.setAttribute('title', 'Private session')
+    link.appendChild(privacy)
+
+    const mobileRoster = document.createElement('span')
+    mobileRoster.setAttribute('title', 'planner\nreviewer')
+    mobileRoster.setAttribute('data-tooltip-focus', '')
+    mobileRoster.style.display = 'none'
+    link.appendChild(mobileRoster)
+
+    const desktopRoster = document.createElement('span')
+    desktopRoster.setAttribute('title', 'planner\nreviewer')
+    desktopRoster.setAttribute('data-tooltip-focus', '')
+    link.appendChild(desktopRoster)
+
+    await focus(link)
+
+    expect(tooltip()?.textContent).toBe('planner\nreviewer')
+    expect(mobileRoster.getAttribute('title')).toBe('planner\nreviewer')
+    expect(desktopRoster.hasAttribute('title')).toBe(false)
+  })
+
   it('releases a focused title before keyboard activation updates it', async () => {
     const btn = iconButton('Show secret')
     // A control whose activation drops its own title (the reveal toggles do this

--- a/packages/web/src/components/console/Tooltip.tsx
+++ b/packages/web/src/components/console/Tooltip.tsx
@@ -26,7 +26,21 @@ import { adoptTitle, liftTitle, restoreTitle, TITLE_STASH } from './tooltip-titl
 
 /** Matches both a not-yet-lifted title and the element currently holding one. */
 const SOURCE_SELECTOR = `[title],[${TITLE_STASH}]`
+const FOCUS_SOURCE_SELECTOR = `[data-tooltip-focus][title],[data-tooltip-focus][${TITLE_STASH}]`
 const TOOLTIP_ID = 'ac-tooltip'
+
+/** CSS keeps responsive duplicates mounted; focus must anchor to the rendered one. */
+function isRendered(el: HTMLElement): boolean {
+  for (let current: HTMLElement | null = el; current; current = current.parentElement) {
+    const style = window.getComputedStyle(current)
+    if (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse') return false
+  }
+  return true
+}
+
+function visibleDescendant(root: HTMLElement, selector: string): HTMLElement | null {
+  return Array.from(root.querySelectorAll<HTMLElement>(selector)).find(isRendered) ?? null
+}
 
 export function TooltipLayer() {
   const [text, setText] = useState<string | null>(null)
@@ -153,7 +167,10 @@ export function TooltipLayer() {
       // Walk up first — but a focusable container can hold its hint on an inner
       // element (a list row whose description hangs off the name, so a hover
       // opens it where the pointer is reading). `closest` only looks upward.
-      const source = (el.closest(SOURCE_SELECTOR) ?? el.querySelector(SOURCE_SELECTOR)) as HTMLElement | null
+      const source =
+        (el.closest(SOURCE_SELECTOR) as HTMLElement | null) ??
+        visibleDescendant(el, FOCUS_SOURCE_SELECTOR) ??
+        visibleDescendant(el, SOURCE_SELECTOR)
       if (source) schedule(source, true)
     }
 

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -311,6 +311,7 @@ export default function SessionsView() {
         </>
       )
     }
+    const rosterNames = roster.map((participant) => participant.name)
     return (
       <>
         <span className="flex flex-none items-center -space-x-[5px]">
@@ -320,7 +321,12 @@ export default function SessionsView() {
             </span>
           ))}
         </span>
-        <span className={`truncate ${label}`}>{roster.length} agents</span>
+        <span className={`truncate ${label}`} title={rosterNames.join('\n')}>
+          <span aria-hidden="true">+{roster.length}</span>
+          <span className="sr-only">
+            {roster.length} agents: {rosterNames.join(', ')}
+          </span>
+        </span>
       </>
     )
   }

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -299,8 +299,8 @@ export default function SessionsView() {
     )
   }
   // Multi-participant conversation rows (merged-conversation-view.md §5.2):
-  // stacked participant icons replace the single agent face; the label counts
-  // agents instead of naming one.
+  // stacked participant icons replace the single agent face; the compact label
+  // carries the total while its tooltip names the visible roster.
   const agentCell = (s: Session, av: string, size: number, label: string) => {
     const roster = s.participants ?? []
     if (roster.length <= 1) {
@@ -321,7 +321,7 @@ export default function SessionsView() {
             </span>
           ))}
         </span>
-        <span className={`truncate ${label}`} title={rosterNames.join('\n')}>
+        <span className={`truncate ${label}`} title={rosterNames.join('\n')} data-tooltip-focus>
           <span aria-hidden="true">+{roster.length}</span>
           <span className="sr-only">
             {roster.length} agents: {rosterNames.join(', ')}


### PR DESCRIPTION
## Summary

- replace the multi-agent session label with a compact `+N` count
- show every participant Agent name in the shared console tooltip on hover or keyboard focus
- anchor row-focus tooltips to the visible responsive copy when a row has several hints
- preserve the full roster as assistive text

## Why

Multi-agent session rows repeated a verbose `N agents` label without letting people identify the participants from the list.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/Tooltip.test.tsx`
- `pnpm exec eslint packages/web/src/components/console/views/SessionsView.tsx`
- `pnpm exec prettier --check packages/web/src/components/console/views/SessionsView.tsx`
- `pnpm --filter @agentconnect.md/web build`
- pre-push repository lint

Created by Codex . GPT-5
