### PR TITLE
fix(web): stop the session rail from shifting the page when it lands

### DIFF
--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -1,0 +1,146 @@
+// The rail's geometry contract, not its contents. The detail body is centred in
+// whatever horizontal space the rail leaves it, so the ONE thing this component
+// must never do is change its own width in response to data arriving. Its three
+// inputs — the agent-filtered session page, the session's family, and the reader's
+// filter — settle in any order and at any time, and every combination has to render
+// the same 224px column. These cases are the orderings that used to shift the page:
+// a rail that resolves to "no rows worth showing", and a one-row rail that learns
+// about lineage only after its own list has landed.
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+// Explicit factories: each must export every name the module under test imports,
+// or the import throws before render.
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ orgPath: (path: string) => path, activeOrg: { id: 'org-1' } })
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({ agents: [], crons: [] })
+}))
+
+// next/link wants App Router context that renderToStaticMarkup does not provide.
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactElement; href: string }) => <a href={href}>{children}</a>
+}))
+
+import { SessionRail, SessionRailSlot } from './SessionRail'
+import type { Session } from '@/lib/data'
+import type { SessionRelationDto } from '@/lib/api'
+
+function session(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    title: `Session ${id}`,
+    time: '11:02 AM',
+    lastActivityAt: '2026-08-03T11:02:00.000Z',
+    status: 'online',
+    platform: 'slack',
+    channel: '#ops',
+    user: 'sam',
+    duration: '1m',
+    tokens: '2.1K',
+    cost: '$0.01',
+    toolCount: '1',
+    statusLabel: 'completed',
+    steps: [],
+    agentId: 'agent-1',
+    ...overrides
+  }
+}
+
+const relation = (id: string): SessionRelationDto => ({
+  id,
+  agentId: 'agent-1',
+  title: `Session ${id}`,
+  platform: 'slack'
+})
+
+const NO_FAMILY = { parentSession: null, siblingSessions: [], childSessions: [] }
+
+function railMarkup({
+  sessions = [],
+  total = 0,
+  family = NO_FAMILY,
+  filterTouched = false
+}: {
+  sessions?: Session[]
+  total?: number
+  family?: {
+    parentSession: SessionRelationDto | null
+    siblingSessions: SessionRelationDto[]
+    childSessions: SessionRelationDto[]
+  }
+  filterTouched?: boolean
+} = {}) {
+  return renderToStaticMarkup(
+    <SessionRail
+      sessions={sessions}
+      current={session('current')}
+      total={total}
+      agentIds={['agent-1']}
+      filterTouched={filterTouched}
+      onAgentIdsChange={() => {}}
+      family={family}
+      onSelect={() => {}}
+    />
+  )
+}
+
+// The column's width and its breakpoint gate, as they appear in the markup. A
+// change here is a change to the page's geometry, so it should fail loudly rather
+// than quietly move the transcript.
+const COLUMN = 'w-[224px]'
+const DESKTOP_ONLY = 'desktop:block'
+
+describe('SessionRail column', () => {
+  it('holds its column with nothing to show, so the body does not re-centre', () => {
+    // The resolved "this agent has one session and no lineage" outcome. Returning
+    // nothing here is what used to slide the transcript 125px left.
+    const markup = railMarkup({ sessions: [], total: 0 })
+
+    expect(markup).toContain(COLUMN)
+    expect(markup).toContain(DESKTOP_ONLY)
+    expect(markup).not.toContain('All sessions')
+  })
+
+  it('holds the same column while its page is still in flight', () => {
+    // Mid-flight looks identical to the empty outcome from the inside: `total` is 0
+    // and the only row is the open session merged in by the component.
+    expect(railMarkup({ sessions: [], total: 0 })).toContain(COLUMN)
+  })
+
+  it('keeps the column width once rows arrive', () => {
+    const markup = railMarkup({ sessions: [session('a'), session('b')], total: 2 })
+
+    expect(markup).toContain(COLUMN)
+    expect(markup).toContain('All sessions')
+  })
+
+  it('keeps the column width when family arrives after a one-row list', () => {
+    // The other ordering: the rail's own page settles first at one row, then the
+    // session detail reveals lineage and the rail gains rows. Width must not move.
+    const before = railMarkup({ sessions: [], total: 1 })
+    const after = railMarkup({ sessions: [], total: 1, family: { ...NO_FAMILY, childSessions: [relation('child')] } })
+
+    expect(before).toContain(COLUMN)
+    expect(after).toContain(COLUMN)
+    expect(after).toContain('Related')
+  })
+
+  it('keeps the column width for a reader-cleared filter with no rows', () => {
+    expect(railMarkup({ sessions: [], total: 0, filterTouched: true })).toContain(COLUMN)
+  })
+
+  it('renders the placeholder at the same width the populated rail uses', () => {
+    // SessionDetailFrame draws SessionRailSlot for every state that has no rail to
+    // show (loading, not found). It only holds the page still if it is the same box.
+    const slot = renderToStaticMarkup(<SessionRailSlot />)
+
+    expect(slot).toContain(COLUMN)
+    expect(slot).toContain(DESKTOP_ONLY)
+    expect(railMarkup({ sessions: [session('a'), session('b')], total: 2 })).toContain(COLUMN)
+  })
+})

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -68,6 +68,17 @@ interface RailRow {
 
 const EMPTY_RELATIONS: SessionRelationDto[] = []
 
+/**
+ * The rail's footprint with nothing in it. The detail body is centred in whatever
+ * horizontal space the rail leaves, so a column that arrives late slides the whole
+ * transcript sideways under a reader who is already reading it. Every state that
+ * expects a rail but cannot draw one yet — the loading branches, and the rail's own
+ * page still in flight — holds this instead of collapsing to nothing.
+ */
+export function SessionRailSlot() {
+  return <div aria-hidden="true" className="hidden w-[224px] flex-none desktop:block" />
+}
+
 export function SessionRail({
   sessions,
   current,
@@ -78,6 +89,7 @@ export function SessionRail({
   family,
   conversation = false,
   childOriginById,
+  pending = false,
   onSelect
 }: {
   /** The filtered first page of sessions, newest first. */
@@ -99,6 +111,9 @@ export function SessionRail({
   conversation?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
   childOriginById?: ReadonlyMap<string, string>
+  /** Whether the rail's own session page is still in flight, so "no rail" is not
+   *  yet an answer — hold the column rather than collapsing it (SessionRailSlot). */
+  pending?: boolean
   /** Seed the persistent detail view before the route id changes. */
   onSelect: (session: Session) => void
 }) {
@@ -203,7 +218,14 @@ export function SessionRail({
   // come from `filterTouched` and not from comparing `agentIds` against the open
   // session — filtering to agent B and then opening B's only session lands on a
   // filter that LOOKS like the default while still being the reader's own.
-  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) return null
+  //
+  // While `pending`, the same test is only true because the answer has not arrived:
+  // the rail's page is a second round-trip behind the session, and `rows` is the
+  // open session alone until it lands. Collapsing on that would paint the body
+  // 125px left of where it belongs and then shove it across — hold the column.
+  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) {
+    return pending ? <SessionRailSlot /> : null
+  }
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -1,10 +1,20 @@
 // The session detail page's left rail: the open session's direct family (parent,
 // siblings, and children), globally pinned shortcuts, then the other sessions of
 // the CURRENT agent. Family rows stay in their tree even when pinned and are
-// removed from the ordinary list below, so lineage never appears twice. The rail
-// only appears when there is another session to navigate to and only on desktop —
+// removed from the ordinary list below, so lineage never appears twice. Rows only
+// appear when there is another session to navigate to, and only on desktop —
 // ≤768px uses the relation card in SessionDetailView plus the Shell app bar's back
 // affordance.
+//
+// The COLUMN, though, is unconditional above the breakpoint (SessionRailSlot). The
+// detail body is centred in whatever horizontal space the rail leaves it, so any
+// state-dependent column is a layout shift waiting for its trigger: the rail's list
+// is a round-trip behind the session, so an emptiable column collapses on first
+// paint and shoves the transcript 125px sideways when the rows land — and the same
+// jump fires again on every rail click that crosses from a busy agent to a quiet
+// one, since this view survives navigation rather than remounting. Holding the
+// column costs a rail-less session an empty gutter; it buys a body whose position
+// is a constant of the route.
 //
 // A row is the owning integration's platform mark (Slack / Telegram / … ) plus the
 // title, and nothing else: at 224px a per-row timestamp crowds out the one thing
@@ -69,11 +79,9 @@ interface RailRow {
 const EMPTY_RELATIONS: SessionRelationDto[] = []
 
 /**
- * The rail's footprint with nothing in it. The detail body is centred in whatever
- * horizontal space the rail leaves, so a column that arrives late slides the whole
- * transcript sideways under a reader who is already reading it. Every state that
- * expects a rail but cannot draw one yet — the loading branches, and the rail's own
- * page still in flight — holds this instead of collapsing to nothing.
+ * The rail's footprint with nothing in it — the shape every session detail state
+ * holds so the body beside it never moves. Used by the loading and not-found
+ * branches, which have no rail to draw, and by a rail with no rows worth drawing.
  */
 export function SessionRailSlot() {
   return <div aria-hidden="true" className="hidden w-[224px] flex-none desktop:block" />
@@ -89,7 +97,6 @@ export function SessionRail({
   family,
   conversation = false,
   childOriginById,
-  pending = false,
   onSelect
 }: {
   /** The filtered first page of sessions, newest first. */
@@ -111,9 +118,6 @@ export function SessionRail({
   conversation?: boolean
   /** Delegation target id → waking member agentId (conversation mode). */
   childOriginById?: ReadonlyMap<string, string>
-  /** Whether the rail's own session page is still in flight, so "no rail" is not
-   *  yet an answer — hold the column rather than collapsing it (SessionRailSlot). */
-  pending?: boolean
   /** Seed the persistent detail view before the route id changes. */
   onSelect: (session: Session) => void
 }) {
@@ -211,21 +215,20 @@ export function SessionRail({
   // no server pass whose clock could disagree.
   const groups = useMemo(() => groupSessionsByAge(rest, new Date()), [rest])
 
-  // A rail that would only show the session already on screen is noise. Direct
-  // lineage still makes it useful when the current agent itself has one session.
-  // A filter the reader chose is the exception: hiding the rail would take the
-  // filter control away with it, leaving no way back to a wider list. That has to
-  // come from `filterTouched` and not from comparing `agentIds` against the open
-  // session — filtering to agent B and then opening B's only session lands on a
-  // filter that LOOKS like the default while still being the reader's own.
+  // A rail that would only show the session already on screen is noise, so it draws
+  // nothing — but it still holds its column, because a body that re-centres is worse
+  // noise than an empty gutter (see the header). Direct lineage keeps the rows worth
+  // drawing when the current agent itself has one session. A filter the reader chose
+  // is the exception: emptying the rail would take the filter control away with it,
+  // leaving no way back to a wider list. That has to come from `filterTouched` and
+  // not from comparing `agentIds` against the open session — filtering to agent B
+  // and then opening B's only session lands on a filter that LOOKS like the default
+  // while still being the reader's own.
   //
-  // While `pending`, the same test is only true because the answer has not arrived:
-  // the rail's page is a second round-trip behind the session, and `rows` is the
-  // open session alone until it lands. Collapsing on that would paint the body
-  // 125px left of where it belongs and then shove it across — hold the column.
-  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) {
-    return pending ? <SessionRailSlot /> : null
-  }
+  // This test is also true while the rail's page is still in flight, since `rows` is
+  // the open session alone until it lands. Same answer either way: hold the column,
+  // fill it when there is something to fill it with.
+  if (Math.max(total, rows.length) < 2 && !hasFamily && !filterTouched) return <SessionRailSlot />
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -848,11 +848,12 @@ function MobileSessionFamilyLinks({
 }
 
 /**
- * The pre-session states (waiting on the conversation roster, on the sessions list,
- * on a self-conversation redirect) drawn on the SAME track the loaded page uses:
- * the 1180px wrap, the rail's held-open column, then the 880px body. Centring the
- * spinner in the bare wrap instead would place it where the body only sits when
- * there is no rail, so the transcript would land 125px to its right.
+ * Every state this view can render that is not the session itself — loading, and
+ * both not-found bodies — drawn on the SAME track the loaded page uses: the 1180px
+ * wrap, the rail's column, then the 880px body. The route has one body position and
+ * this is how the states that have no rail to draw still honour it; centring them in
+ * the bare wrap instead would put each of them 125px left of the transcript that
+ * replaces them.
  */
 function SessionDetailFrame({ children }: { children: ReactNode }) {
   return (
@@ -1293,17 +1294,10 @@ export default function SessionDetailView() {
   // org key stays null and no page is fetched to be thrown away.
   const railQuery = railAgentFilterQuery(railFilter)
   const railAgentId = railQuery?.agentId ?? ''
-  const {
-    sessions: railSessionRows,
-    total: railSessionTotal,
-    isLoading: railSessionsLoading
-  } = useSessionList(MOCK_MODE || !railQuery ? null : activeOrg?.id, railQuery ?? {})
-  // "No rail" and "the rail has not answered yet" look identical from its rows, and
-  // only the second one may not move the page — see SessionRail's `pending`. Gated
-  // on a live query so a session with no agent (nothing to fetch, so `isLoading`
-  // never flips) cannot hold an empty column open forever. Mock rows are
-  // synchronous, so mock mode is never pending.
-  const railPending = !MOCK_MODE && railQuery !== null && railSessionsLoading
+  const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
+    MOCK_MODE || !railQuery ? null : activeOrg?.id,
+    railQuery ?? {}
+  )
   const railSessions = useMemo(() => {
     if (!MOCK_MODE) return railSessionRows
     if (!railQuery) return []
@@ -1775,7 +1769,7 @@ export default function SessionDetailView() {
   if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
     // conversationError, a grace-expired null, or a resolved-but-empty roster.
     return (
-      <div className="wrap max-w-[880px] max-desktop:p-4">
+      <SessionDetailFrame>
         <NotFound
           icon="message-square-off"
           kind="CONVERSATION"
@@ -1786,7 +1780,7 @@ export default function SessionDetailView() {
           actionLabel="Back to sessions"
           actionHref={orgPath('/sessions')}
         />
-      </div>
+      </SessionDetailFrame>
     )
   }
 
@@ -1801,9 +1795,8 @@ export default function SessionDetailView() {
         </SessionDetailFrame>
       )
     }
-    // A dead end grows no rail, so this one centres in the bare wrap.
     return (
-      <div className="wrap max-w-[880px] max-desktop:p-4">
+      <SessionDetailFrame>
         <NotFound
           icon="message-square-off"
           kind="SESSION"
@@ -1824,7 +1817,7 @@ export default function SessionDetailView() {
           }
           showSearch={false}
         />
-      </div>
+      </SessionDetailFrame>
     )
   }
 
@@ -2343,10 +2336,10 @@ export default function SessionDetailView() {
   // max-desktop:), never JS-forked.
   return (
     // `.wrap` (1180px) is the outer track so the sibling-session rail can sit beside
-    // the 880px body. With no rail the body is still an 880px block centred in that
-    // track — geometrically identical to when it was the wrap itself. Keep this row
-    // in step with SessionDetailFrame: the loading states draw the same two columns
-    // so nothing moves when the session lands.
+    // the 880px body. The rail always occupies its column above the breakpoint, even
+    // with no rows to show, so this is the one position the body ever takes. Keep the
+    // row in step with SessionDetailFrame, which draws the same two columns for every
+    // state that precedes or replaces a session.
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
       <SessionRail
         sessions={railSessions}
@@ -2358,7 +2351,6 @@ export default function SessionDetailView() {
         family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
         conversation={conversationMode}
         childOriginById={conversationLineage?.childOriginById}
-        pending={railPending}
         onSelect={setRouteSession}
       />
       <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -7,7 +7,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode
 } from 'react'
 import Link from 'next/link'
 import { sameBotSpeaker } from '@/lib/bot-turn-grouping'
@@ -83,7 +84,7 @@ import { WORK_LANES, toggleWorkPanel, workCounts, workPanelOpen, workSummary } f
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
 import { useCrumbSlot } from '@/components/console/Shell'
-import { SessionRail } from '@/components/console/SessionRail'
+import { SessionRail, SessionRailSlot } from '@/components/console/SessionRail'
 import {
   EMPTY_RAIL_AGENT_FILTER,
   railAgentFilterQuery,
@@ -846,6 +847,22 @@ function MobileSessionFamilyLinks({
   )
 }
 
+/**
+ * The pre-session states (waiting on the conversation roster, on the sessions list,
+ * on a self-conversation redirect) drawn on the SAME track the loaded page uses:
+ * the 1180px wrap, the rail's held-open column, then the 880px body. Centring the
+ * spinner in the bare wrap instead would place it where the body only sits when
+ * there is no rail, so the transcript would land 125px to its right.
+ */
+function SessionDetailFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="wrap flex min-h-full items-stretch gap-[26px]">
+      <SessionRailSlot />
+      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:p-4">{children}</div>
+    </div>
+  )
+}
+
 export default function SessionDetailView() {
   const acpRegistry = useAcpRegistry()
   const { activeOrg, orgPath } = useOrgs()
@@ -1276,10 +1293,17 @@ export default function SessionDetailView() {
   // org key stays null and no page is fetched to be thrown away.
   const railQuery = railAgentFilterQuery(railFilter)
   const railAgentId = railQuery?.agentId ?? ''
-  const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
-    MOCK_MODE || !railQuery ? null : activeOrg?.id,
-    railQuery ?? {}
-  )
+  const {
+    sessions: railSessionRows,
+    total: railSessionTotal,
+    isLoading: railSessionsLoading
+  } = useSessionList(MOCK_MODE || !railQuery ? null : activeOrg?.id, railQuery ?? {})
+  // "No rail" and "the rail has not answered yet" look identical from its rows, and
+  // only the second one may not move the page — see SessionRail's `pending`. Gated
+  // on a live query so a session with no agent (nothing to fetch, so `isLoading`
+  // never flips) cannot hold an empty column open forever. Mock rows are
+  // synchronous, so mock mode is never pending.
+  const railPending = !MOCK_MODE && railQuery !== null && railSessionsLoading
   const railSessions = useMemo(() => {
     if (!MOCK_MODE) return railSessionRows
     if (!railQuery) return []
@@ -1725,9 +1749,9 @@ export default function SessionDetailView() {
   // preserving whose perspective was linked as ?focus.
   if (!conversationKey && selfConversationRedirect) {
     return (
-      <div className="wrap max-w-[880px] max-desktop:p-4">
+      <SessionDetailFrame>
         <LoadingState fill />
-      </div>
+      </SessionDetailFrame>
     )
   }
   // `undefined` = first fetch in flight; `null` = the resolver ANSWERED empty
@@ -1743,9 +1767,9 @@ export default function SessionDetailView() {
       (conversationRoster === null && !conversationUnresolved))
   ) {
     return (
-      <div className="wrap max-w-[880px] max-desktop:p-4">
+      <SessionDetailFrame>
         <LoadingState fill />
-      </div>
+      </SessionDetailFrame>
     )
   }
   if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
@@ -1769,33 +1793,37 @@ export default function SessionDetailView() {
   if (!session) {
     // Shell owns detail navigation at both breakpoints; this branch only renders the
     // loading or not-found body.
+    // Still pulling the sessions list — it's not "not found" until that settles.
+    if (sessionsLoading || (detailId !== null && sessionDetailLoading)) {
+      return (
+        <SessionDetailFrame>
+          <LoadingState fill />
+        </SessionDetailFrame>
+      )
+    }
+    // A dead end grows no rail, so this one centres in the bare wrap.
     return (
       <div className="wrap max-w-[880px] max-desktop:p-4">
-        {/* Still pulling the sessions list — it's not "not found" until that settles. */}
-        {sessionsLoading || (detailId !== null && sessionDetailLoading) ? (
-          <LoadingState fill />
-        ) : (
-          <NotFound
-            icon="message-square-off"
-            kind="SESSION"
-            title="Session not found"
-            pre="No session "
-            chip={id}
-            post=" in this organization. It may have expired or been deleted."
-            actionLabel="Back to sessions"
-            actionHref={orgPath('/sessions')}
-            secondaryAction={
-              showProfileLink && profileLinkProviderName
-                ? {
-                    label: `Link ${profileLinkProviderName} profile`,
-                    href: orgPath('/profile#sign-in-methods'),
-                    icon: 'link'
-                  }
-                : undefined
-            }
-            showSearch={false}
-          />
-        )}
+        <NotFound
+          icon="message-square-off"
+          kind="SESSION"
+          title="Session not found"
+          pre="No session "
+          chip={id}
+          post=" in this organization. It may have expired or been deleted."
+          actionLabel="Back to sessions"
+          actionHref={orgPath('/sessions')}
+          secondaryAction={
+            showProfileLink && profileLinkProviderName
+              ? {
+                  label: `Link ${profileLinkProviderName} profile`,
+                  href: orgPath('/profile#sign-in-methods'),
+                  icon: 'link'
+                }
+              : undefined
+          }
+          showSearch={false}
+        />
       </div>
     )
   }
@@ -2316,7 +2344,9 @@ export default function SessionDetailView() {
   return (
     // `.wrap` (1180px) is the outer track so the sibling-session rail can sit beside
     // the 880px body. With no rail the body is still an 880px block centred in that
-    // track — geometrically identical to when it was the wrap itself.
+    // track — geometrically identical to when it was the wrap itself. Keep this row
+    // in step with SessionDetailFrame: the loading states draw the same two columns
+    // so nothing moves when the session lands.
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
       <SessionRail
         sessions={railSessions}
@@ -2328,6 +2358,7 @@ export default function SessionDetailView() {
         family={conversationFamily ?? (currentSessionDetail?.id === session.id ? currentSessionDetail : undefined)}
         conversation={conversationMode}
         childOriginById={conversationLineage?.childOriginById}
+        pending={railPending}
         onSelect={setRouteSession}
       />
       <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:pb-6">


### PR DESCRIPTION
## What

Opening a session detail page shifted the transcript sideways after it was
already readable.

The rail's session list is a **round-trip behind the session itself**:
`railQuery` is only derived once `session.agentId` resolves. So at the paint
that first shows the title, the rail holds exactly one row (the open session)
with `total: 0` — which trips its "fewer than two rows, nothing to navigate to"
guard and collapses it. The 880px body is `mx-auto` inside whatever horizontal
space the rail leaves, so when the rail's page landed the whole transcript
**slid 125px to the right**.

## How

The body's position no longer depends on the rail's contents. `SessionRail`
holds its 224px column above the breakpoint whether or not it has rows —
returning `SessionRailSlot` where it used to return `null` — and every state
that is not the loaded session (both loading branches, both not-found bodies)
draws the same two columns via `SessionDetailFrame`.

Reserving the column *conditionally* was tried first and was wrong: nothing
predicts the rail early and stays correct, because the answer only exists once
the agent-filtered page lands. Any conditional geometry just relocates the shift
onto whichever session class the condition guesses wrong — see the resolved
review threads.

This also closes a shift that **predates** the reported bug: the detail view
survives navigation rather than remounting, so clicking from a busy agent's
session to a quiet one already re-centred the transcript mid-read.

## Cost

A rail-less session — a single-session org, or an agent whose only run has no
lineage — now keeps an empty 224px gutter instead of centring in the full wrap.
That is a deliberate trade for a body position that is a constant of the route.

## Verification

Mock mode at 1440px, viewport-absolute geometry:

| state | rail column | body |
| --- | --- | --- |
| session with a 4-row rail | x=270, w=224 | x=525, w=880 |
| single-session agent (empty column, 0 rows) | x=270, w=224 | x=525, w=880 |
| loading frame | x=270, w=224 | x=525, w=880 |
| session not found | x=270, w=224 | x=525, w=880 |

`typecheck`, `eslint`, `prettier --check` clean; web suite 618/618 passing.

**Reviewer note:** the async timing that produces the original bug is a deployed
environment's, not mock mode's, where the rail's data is synchronous. The
geometry above is measured; the *ordering* that triggers the bug was read off
the code paths rather than observed live. The fix does not depend on that
ordering being characterised correctly — the column is unconditional — but a
look at a real deployment is still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)