### PR TITLE
feat(cp,web): filter the session rail by the agents in a conversation

### DIFF
--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -526,12 +526,15 @@ export function sessionRoutes(deps: HttpDeps) {
         // GitHub is a semantic subtype of hook sessions. Resolve definitions only
         // when integration classification or a repository-wide trigger filter needs them.
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, false)
+        // Two or more selected agents ask for the threads they SHARE. The rows stay
+        // scoped to those agents (`agentIds`), so `?agentId=a` keeps returning
+        // exactly what it always did. Every branch below reads this one binding —
+        // a path that took `agentIds` alone would silently answer the wider
+        // "either agent" question under the same query string.
+        const conversationAgentIds = requested.length > 1 ? selectedAgentIds : undefined
         const query = {
           agentIds: selectedAgentIds,
-          // Two or more selected agents ask for the threads they SHARE. The rows
-          // stay scoped to those agents (`agentIds`), so `?agentId=a` keeps
-          // returning exactly what it always did.
-          ...(requested.length > 1 ? { conversationAgentIds: selectedAgentIds } : {}),
+          ...(conversationAgentIds ? { conversationAgentIds } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
@@ -548,7 +551,11 @@ export function sessionRoutes(deps: HttpDeps) {
         // a direct conversation load — the paginated list is not a key lookup.
         if (conversationKey) {
           const members = await deps.repos.session.listConversationMembers(
-            { agentIds: selectedAgentIds, viewer },
+            // Carries the participant arm too: addressing a conversation by key
+            // must not widen the same repeated `agentId` into an `IN` filter, or
+            // a key that holds A but not B would answer with A's members when
+            // the caller asked for a conversation the two of them share.
+            { agentIds: selectedAgentIds, conversationAgentIds, viewer },
             conversationKey
           )
           const hookMetadata = await hookMetadataForSessions(deps, members, orgOf(req))

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -39,7 +39,11 @@ import {
 } from '../dto/index.js'
 
 const SessionFilterQueryDto = z.object({
-  agentId: z.string().optional(),
+  // Repeatable: `?agentId=a` scopes to one agent's rows (unchanged), while
+  // `?agentId=a&agentId=b` asks for the CONVERSATIONS both took part in and
+  // returns each of their sessions in those threads. Fastify's querystring
+  // parser hands repeated keys over as an array.
+  agentId: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream']).optional(),
   integration: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'github', 'dream']).optional(),
   channel: z.string().optional(),
@@ -70,6 +74,15 @@ type HookSessionMetadata = {
   kind: 'webhook' | 'github'
   name: string
   repoId: bigint | null
+}
+
+/** The agent filter as a de-duplicated list, whichever form it arrived in. One id
+ *  scopes to that agent's sessions; several ask for the conversations all of them
+ *  took part in (merged-conversation-view.md §5.1 grouping). */
+function requestedAgentIds(query: z.infer<typeof SessionFilterQueryDto>): string[] {
+  const raw = query.agentId
+  if (raw === undefined) return []
+  return [...new Set(Array.isArray(raw) ? raw : [raw])].filter((id) => id.length > 0)
 }
 
 const HOOK_TRIGGER_PREFIX = 'hook:'
@@ -424,13 +437,19 @@ export function sessionRoutes(deps: HttpDeps) {
       },
       async (req) => {
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((agent) => agent.id)
-        if (req.query.agentId && !new Set<string>(visibleAgentIds).has(req.query.agentId)) {
+        const requested = requestedAgentIds(req.query)
+        if (requested.some((id) => !new Set<string>(visibleAgentIds).has(id))) {
           return { agents: [], integrations: [], channels: [], triggers: [] }
         }
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, true)
+        // A multi-agent request narrows to the qualifying CONVERSATIONS and then
+        // reads facets off every member row the caller can see, rather than only
+        // the selected agents' rows: a facet answers "what else can I narrow by",
+        // and a conversation's channel is the same whichever member you read.
         const query = {
           agentIds: visibleAgentIds,
-          ...(req.query.agentId ? { agentId: AgentId(req.query.agentId) } : {}),
+          ...(requested.length === 1 ? { agentId: AgentId(requested[0]!) } : {}),
+          ...(requested.length > 1 ? { conversationAgentIds: requested.map(AgentId) } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
@@ -479,11 +498,17 @@ export function sessionRoutes(deps: HttpDeps) {
         // title/channel/usage metadata reaches the caller.
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctxOf(req))).map((agent) => agent.id)
         const visibleAgentIdSet = new Set<string>(visibleAgentIds)
-        const selectedAgentIds = req.query.agentId
-          ? visibleAgentIdSet.has(req.query.agentId)
-            ? [AgentId(req.query.agentId)]
-            : []
-          : visibleAgentIds
+        // Every requested agent must be visible. One the caller cannot see makes
+        // the whole answer empty rather than being quietly dropped: silently
+        // widening a two-agent question to a one-agent one would answer a
+        // question they did not ask with rows they may not have wanted.
+        const requested = requestedAgentIds(req.query)
+        const selectedAgentIds =
+          requested.length > 0
+            ? requested.every((id) => visibleAgentIdSet.has(id))
+              ? requested.map(AgentId)
+              : []
+            : visibleAgentIds
         // Org-level "any session exists" boolean (first page only). Computed over the
         // FULL org — including sessions the caller can't see — which is safe precisely
         // because it is a bare boolean; the getting-started conversation step derives
@@ -503,6 +528,10 @@ export function sessionRoutes(deps: HttpDeps) {
         const { githubHookIds, repoHookIds } = await githubHookFilters(deps, orgOf(req), req.query, false)
         const query = {
           agentIds: selectedAgentIds,
+          // Two or more selected agents ask for the threads they SHARE. The rows
+          // stay scoped to those agents (`agentIds`), so `?agentId=a` keeps
+          // returning exactly what it always did.
+          ...(requested.length > 1 ? { conversationAgentIds: selectedAgentIds } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1035,6 +1035,14 @@ export interface SessionFilterQuery extends SessionQuery {
   triggeredBy?: string
   githubHookIds?: HookId[]
   hookTriggerIds?: HookId[]
+  /** Conversation-participant filter: keep only rows whose CONVERSATION
+   *  (merged-conversation-view.md §5.1 key) carries a visible session for every
+   *  listed agent. `agentIds` still decides which rows come back; this decides
+   *  which conversations qualify at all, which is the only way to ask for a
+   *  thread several agents worked in — no single row is owned by all of them.
+   *  Fewer than two ids is a no-op: one participant is already implied by the
+   *  row's own `agentId`. */
+  conversationAgentIds?: AgentId[]
   /** Session-visibility predicate inputs (session-visibility.md §5): human
    *  viewers see baseline `org`, identity-owned `private`, and request-resolved
    *  provider `external` rows. Absent ⇒ no session predicate — the internal

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -244,7 +244,43 @@ function integrationSql(q: SessionFilterQuery, a: Prisma.Sql = S): Prisma.Sql | 
   return platformSql(q.integration, a)
 }
 
-function pageWhereSql(q: SessionFilterQuery, includeCursor: boolean, a: Prisma.Sql = S): Prisma.Sql {
+// "Conversations these agents took part in", one EXISTS per requested agent. No
+// single row can be owned by two agents, so the predicate has to be asked of the
+// row's CONVERSATION instead — each agent must have its own row under the same
+// §5.1 key. The probe re-applies the caller's visibility predicate: a session
+// only they cannot see must never be what makes a conversation qualify.
+//
+// One agent produces nothing — `agentId IN (…)` already implies it — so every
+// existing single-agent query keeps its exact plan. Rows with a NULL channel or
+// thread (cron/hook/dream singletons) drop out on their own: the key join
+// compares those columns with `=`, which no NULL satisfies, and a conversation
+// of one can never hold a second participant anyway.
+function conversationParticipantsSql(q: SessionFilterQuery, a: Prisma.Sql, probePrefix: string): Prisma.Sql[] {
+  const wanted = q.conversationAgentIds ?? []
+  if (wanted.length < 2) return []
+  return wanted.map((agentId, index) => {
+    const p = Prisma.raw(`${probePrefix}${index}`)
+    const viewerArm = sessionViewerSql(q.viewer, p)
+    return Prisma.sql`
+      EXISTS (
+        SELECT 1
+        FROM "session_meta" AS ${p}
+        WHERE ${p}."agentId" = ${agentId}
+          AND ${conversationKeyJoinSql(p, a)}
+          ${viewerArm ? Prisma.sql`AND ${viewerArm}` : Prisma.empty}
+      )
+    `
+  })
+}
+
+function pageWhereSql(
+  q: SessionFilterQuery,
+  includeCursor: boolean,
+  a: Prisma.Sql = S,
+  // Distinct per alias: the emit-at-max probe nests one `pageWhereSql` inside
+  // another, and reusing a name there would shadow the outer participant probe.
+  probePrefix = 'cp'
+): Prisma.Sql {
   const filters: Prisma.Sql[] = [Prisma.sql`${a}."agentId" IN (${Prisma.join(queryAgentIds(q))})`]
   const viewerArm = sessionViewerSql(q.viewer, a)
   if (viewerArm) filters.push(viewerArm)
@@ -254,6 +290,7 @@ function pageWhereSql(q: SessionFilterQuery, includeCursor: boolean, a: Prisma.S
   if (q.channel) filters.push(Prisma.sql`${a}."channel" = ${q.channel}`)
   if (q.triggeredBy) filters.push(Prisma.sql`${a}."triggeredBy" = ${q.triggeredBy}`)
   if (q.hookTriggerIds) filters.push(hookTriggerSql(q.hookTriggerIds, a))
+  filters.push(...conversationParticipantsSql(q, a, probePrefix))
   if (includeCursor && q.cursor) {
     filters.push(Prisma.sql`
       (${a}."lastActivityAt", ${a}."startedAt", ${a}."id") < (
@@ -913,7 +950,7 @@ export class PgSessionRepo implements SessionRepo {
     // the inner row — a newer row the caller cannot see must not suppress a
     // conversation they can (merged-conversation-view.md §5.2). Cursor excluded:
     // the probe asks about the whole authorized row set, not the current page.
-    const probeWhere = pageWhereSql({ ...q, cursor: undefined }, false, N)
+    const probeWhere = pageWhereSql({ ...q, cursor: undefined }, false, N, 'cn')
     const countWhere = pageWhereSql(q, false)
     // Emit-at-max: a row yields its conversation only when no same-key row is
     // strictly greater under the full page tuple. Rows without a groupable key
@@ -1046,6 +1083,10 @@ export class PgSessionRepo implements SessionRepo {
 
     const agentQuery = { ...q }
     delete agentQuery.agentId
+    // The agent facet answers "who else could I pick", so it drops the agent
+    // filter in BOTH its forms — leaving the participant arm would only ever
+    // return the agents already selected.
+    delete agentQuery.conversationAgentIds
     const integrationQuery = { ...q }
     delete integrationQuery.integration
     const channelQuery = { ...q }

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -348,6 +348,48 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     ])
   })
 
+  it('holds the key-addressed resolver to the same question as the list', async () => {
+    await seedDaemon(prisma, DAEMON)
+    for (const agent of [AGENT_A, AGENT_B]) await seedAgent(prisma, agent, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-shared-a', AGENT_A, 1_000)
+    await slackReport('sess-shared-b', AGENT_B, 2_000)
+    await slackReport('sess-a-only', AGENT_A, 3_000, { thread: 'T-2' })
+
+    const keyOf = (thread: string) =>
+      encodeURIComponent(encodeConversationKey({ platform: 'slack', tenantScope: 'TEAM-1', channel: 'C-OPS', thread })!)
+    const pair = `agentId=${AGENT_A}&agentId=${AGENT_B}`
+
+    const shared = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${keyOf('T-1')}&${pair}`
+    })
+    expect((shared.json() as ConversationsBody).conversations[0]!.sessions.map((s) => s.sessionId)).toEqual([
+      'sess-shared-b',
+      'sess-shared-a'
+    ])
+
+    // T-2 holds A but not B. Addressing it by key must not fall back to an `IN`
+    // filter and answer with A's members — that is the wider "either agent"
+    // question, under the very same query string.
+    const soloByKey = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${keyOf('T-2')}&${pair}`
+    })
+    expect(soloByKey.statusCode).toBe(200)
+    expect((soloByKey.json() as ConversationsBody).conversations).toHaveLength(0)
+
+    // …while the one-agent form still resolves it.
+    const soloAlone = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${keyOf('T-2')}&agentId=${AGENT_A}`
+    })
+    expect((soloAlone.json() as ConversationsBody).conversations[0]!.sessions.map((s) => s.sessionId)).toEqual([
+      'sess-a-only'
+    ])
+  })
+
   it('answers empty when any requested agent is not visible to the caller', async () => {
     await seedDaemon(prisma, DAEMON)
     await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -248,3 +248,149 @@ describe('GET /sessions — grouped conversations', () => {
     expect(invalid.statusCode).toBe(400)
   })
 })
+
+/**
+ * Multi-agent filter: a repeated `agentId` asks for the conversations every
+ * listed agent took part in. No single row is owned by two agents, so the
+ * predicate is asked of the row's conversation; the rows returned stay scoped
+ * to the selected agents, which is what keeps the one-agent form unchanged.
+ */
+describe('GET /sessions — multi-agent conversation filter', () => {
+  const AGENT_C = 'c3c3c3c3-cccc-4ccc-8ccc-cccccccccccc'
+
+  it('keeps only the threads both agents worked in, and only their rows', async () => {
+    await seedDaemon(prisma, DAEMON)
+    for (const agent of [AGENT_A, AGENT_B, AGENT_C]) await seedAgent(prisma, agent, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    // T-1: A, B and C. T-2: A alone. T-3: B alone.
+    await slackReport('sess-shared-a', AGENT_A, 1_000)
+    await slackReport('sess-shared-b', AGENT_B, 2_000)
+    await slackReport('sess-shared-c', AGENT_C, 3_000)
+    await slackReport('sess-a-only', AGENT_A, 4_000, { thread: 'T-2' })
+    await slackReport('sess-b-only', AGENT_B, 5_000, { thread: 'T-3' })
+
+    const flat = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${AGENT_B}`
+    })
+    expect(flat.statusCode).toBe(200)
+    const flatBody = flat.json() as { sessions: Array<{ sessionId: string }>; total: number | null }
+    // The solo threads drop out; C's row stays out because it is not selected,
+    // even though its conversation qualifies.
+    expect(flatBody.sessions.map((s) => s.sessionId).sort()).toEqual(['sess-shared-a', 'sess-shared-b'])
+    expect(flatBody.total).toBe(2)
+
+    const grouped = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?agentId=${AGENT_A}&agentId=${AGENT_B}`
+    })
+    const groupedBody = grouped.json() as ConversationsBody
+    expect(groupedBody.conversations).toHaveLength(1)
+    expect(groupedBody.conversations[0]!.thread).toBe('T-1')
+    expect(groupedBody.conversations[0]!.sessions.map((s) => s.sessionId)).toEqual(['sess-shared-b', 'sess-shared-a'])
+    expect(groupedBody.total).toBe(1)
+
+    // One agent is the pre-existing question and must answer it unchanged.
+    const single = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}` })
+    expect((single.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual([
+      'sess-a-only',
+      'sess-shared-a'
+    ])
+  })
+
+  it('never lets an invisible participant qualify a conversation', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    const stranger = await prisma.user.create({
+      data: { id: randomUUID(), email: `stranger-${randomUUID().slice(0, 8)}@example.com`, displayName: 'Stranger' }
+    })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON, visibility: 'restricted', ownerUserId: stranger.id })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-vis', AGENT_A, 1_000)
+    await slackReport('sess-hidden', AGENT_B, 2_000)
+
+    // Asking for a thread shared with an agent the caller cannot see must not
+    // confirm that the thread exists — the answer is empty, not A's row.
+    const res = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${AGENT_B}`
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { sessions: unknown[]; total: number | null }
+    expect(body.sessions).toHaveLength(0)
+    expect(body.total).toBe(0)
+    expect(JSON.stringify(body)).not.toContain('sess-hidden')
+  })
+
+  it('excludes rows with no groupable key — a conversation of one holds no second agent', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    // A row with no thread has no groupable key, so it is a conversation of
+    // one however many of them share a channel.
+    await slackReport('sess-cron-a', AGENT_A, 1_000, { thread: undefined })
+    await slackReport('sess-cron-b', AGENT_B, 2_000, { thread: undefined })
+
+    const res = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${AGENT_B}`
+    })
+    expect((res.json() as { sessions: unknown[] }).sessions).toHaveLength(0)
+
+    // Each is still its own conversation when the filter does not pair them.
+    const solo = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}` })
+    expect((solo.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual([
+      'sess-cron-a'
+    ])
+  })
+
+  it('answers empty when any requested agent is not visible to the caller', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+    await slackReport('sess-a', AGENT_A, 1_000)
+
+    const res = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&agentId=${AGENT_A}&agentId=${randomUUID()}`
+    })
+    expect(res.statusCode).toBe(200)
+    expect((res.json() as { sessions: unknown[]; total: number | null }).sessions).toHaveLength(0)
+  })
+
+  it('pages the grouped list without re-emitting a filtered conversation', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    // Two qualifying threads, each with an old A row and a newer B row, so the
+    // emit-at-max probe has to run under the participant predicate as well.
+    await slackReport('sess-1-a', AGENT_A, 1_000)
+    await slackReport('sess-1-b', AGENT_B, 10_000)
+    await slackReport('sess-2-a', AGENT_A, 2_000, { thread: 'T-2' })
+    await slackReport('sess-2-b', AGENT_B, 20_000, { thread: 'T-2' })
+
+    const first = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?limit=1&agentId=${AGENT_A}&agentId=${AGENT_B}`
+    })
+    const firstBody = first.json() as ConversationsBody
+    expect(firstBody.conversations.map((c) => c.thread)).toEqual(['T-2'])
+    expect(firstBody.total).toBe(2)
+
+    const second = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?limit=1&agentId=${AGENT_A}&agentId=${AGENT_B}&cursor=${encodeURIComponent(
+        firstBody.nextCursor!
+      )}`
+    })
+    const secondBody = second.json() as ConversationsBody
+    expect(secondBody.conversations.map((c) => c.thread)).toEqual(['T-1'])
+    expect(secondBody.nextCursor).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -15,12 +15,11 @@
 // localStorage — see lib/session-pins.ts for why they are not CP state.
 //
 // Above the list sits the agent filter: a chip per selected agent (removable), plus
-// a "+" that opens the agent picker. It is seeded by the caller with the open
-// session's agent — "the other runs of THIS agent" is the rail's default question —
-// and clearing it widens the list to every session the viewer can see. Only one
-// agent at a time for now: the CP list endpoint filters by a single `agentId`. The
-// prop is already a list so the eventual multi-agent filter (conversations several
-// agents took part in) is a wire change, not a redesign here.
+// a "+" that opens the agent picker. It is seeded by the caller with the agents in
+// the open CONVERSATION, so the rail's default question is "the other threads these
+// same agents worked in"; clearing it widens the list to every session the viewer
+// can see. Two or more agents mean conversations they SHARE — the CP resolves that
+// against the conversation each row belongs to, not against the row itself.
 //
 // The caller's rows are the filtered FIRST PAGE, so two kinds of row would
 // otherwise be missing from a long-running agent's rail: the open session itself
@@ -346,11 +345,13 @@ export function SessionRail({
           ))}
         </div>
         {/* Carry the rail's filter into the full list so the link is the same
-            question, unabridged. The sessions page takes one agent, which is
-            exactly what the picker can produce today. */}
+            question, unabridged — but only when the list can actually ask it.
+            The sessions page filters by ONE agent, so a shared-conversation
+            filter is dropped rather than silently narrowed to whichever agent
+            happened to be first, which would answer something else entirely. */}
         <Link
           className="lnk mt-[10px] mr-[9px] ml-[9px] font-sans text-[12px] font-medium leading-normal"
-          href={orgPath(agentIds[0] ? `/sessions?agent=${encodeURIComponent(agentIds[0])}` : '/sessions')}
+          href={orgPath(agentIds.length === 1 ? `/sessions?agent=${encodeURIComponent(agentIds[0]!)}` : '/sessions')}
         >
           All sessions
           <Icon name="arrow-right" size={12} />
@@ -364,10 +365,11 @@ export function SessionRail({
 // With nothing selected the chip row reads "All agents", so the rail always says
 // what it is showing rather than leaving an unexplained gap above the first group.
 //
-// Single-select while the CP filters by one `agentId`: picking an agent replaces
-// the chip, and picking the selected one clears it (the same toggle the chip's ×
-// performs). The signature stays plural so multi-select is a later change to the
-// menu's click handler and the fetch, not to this component's shape.
+// Multi-select: each menu row toggles its agent, and two or more of them narrow
+// the list to the conversations they SHARE, which is a different question from
+// the union of their sessions — see the CP's conversation-participant filter.
+// The menu stays open while picking, because building a set of agents one
+// closing menu at a time is three clicks for what should be two.
 function RailAgentFilter({
   agents,
   selected,
@@ -424,8 +426,8 @@ function RailAgentFilter({
           <button
             type="button"
             onClick={() => onChange(selected.filter((id) => id !== chip.id))}
-            title="Clear agent filter"
-            aria-label={`Clear agent filter ${chip.label}`}
+            title="Remove from filter"
+            aria-label={`Remove ${chip.label} from the agent filter`}
             className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-xs border-0 bg-none p-0 text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-primary) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none"
           >
             <Icon name="x" size={11} />
@@ -469,10 +471,7 @@ function RailAgentFilter({
                   role="option"
                   aria-selected={on}
                   className="fopt"
-                  onClick={() => {
-                    onChange(on ? [] : [agent.id])
-                    setOpen(false)
-                  }}
+                  onClick={() => onChange(on ? selected.filter((id) => id !== agent.id) : [...selected, agent.id])}
                 >
                   <span className="av h-5 w-5 flex-none rounded-xs">
                     <AgentIconView icon={agent.icon} runtime={agent.runtime} size={20} />

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1239,24 +1239,32 @@ export default function SessionDetailView() {
   // edited one does not.
   //
   // Seeded DURING RENDER rather than in an effect. An effect commits one frame in
-  // which the filter is still empty while `sessionAgentId` is already known — long
-  // enough to paint "All agents" over org-wide rows and fire the unfiltered request
-  // before snapping to the default. `seedRailAgentFilter` is pure and returns an
-  // edited filter unchanged, so the stored state only ever holds the reader's own
-  // choice and the seed is recomputed from the route every time.
-  const sessionAgentId = session?.agentId ?? ''
+  // which the filter is still empty while the roster is already known — long enough
+  // to paint "All agents" over org-wide rows and fire the unfiltered request before
+  // snapping to the default. `seedRailAgentFilter` is pure and returns an edited
+  // filter unchanged, so the stored state only ever holds the reader's own choice
+  // and the seed is recomputed from the route every time.
+  //
+  // The seed is the whole conversation roster: in conversation mode the resolver's
+  // members, in session mode the same resolver's probe (already fetched above for
+  // the §5.3 redirect), falling back to the lone owning agent.
+  const railSeedAgentIds = useMemo(() => {
+    const roster = conversationKey ? conversationMembers : (selfConversation?.sessions ?? null)
+    if (roster && roster.length > 0) return roster.map((member) => member.agentId ?? '')
+    return session?.agentId ? [session.agentId] : []
+  }, [conversationKey, conversationMembers, selfConversation, session?.agentId])
   const [chosenRailFilter, setChosenRailFilter] = useState<RailAgentFilter>(EMPTY_RAIL_AGENT_FILTER)
-  const railFilter = seedRailAgentFilter(chosenRailFilter, sessionAgentId)
+  const railFilter = seedRailAgentFilter(chosenRailFilter, railSeedAgentIds)
   const setRailAgentIds = useCallback((agentIds: string[]) => setChosenRailFilter({ agentIds, touched: true }), [])
 
-  // With an agent selected this reads an AGENT-FILTERED page, not the org-wide
-  // `allSessions` window — a busy org's newest 50 may not include this agent at
-  // all, which would hide the rail on an agent that has plenty of runs. Cleared,
-  // the unfiltered page IS the question being asked. A null query means the filter
-  // has nothing to say yet (no session, and the reader has not touched it), so the
-  // org key stays null and no page is fetched to be thrown away.
+  // With agents selected this reads a FILTERED page, not the org-wide `allSessions`
+  // window — a busy org's newest 50 may not include them at all, which would hide
+  // the rail on an agent that has plenty of runs. Cleared, the unfiltered page IS
+  // the question being asked. A null query means the filter has nothing to say yet
+  // (no session, and the reader has not touched it), so the org key stays null and
+  // no page is fetched to be thrown away.
   const railQuery = railAgentFilterQuery(railFilter)
-  const railAgentId = railQuery?.agentId ?? ''
+  const railAgentIds = railQuery?.agentId ?? []
   const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
     MOCK_MODE || !railQuery ? null : activeOrg?.id,
     railQuery ?? {}
@@ -1264,8 +1272,14 @@ export default function SessionDetailView() {
   const railSessions = useMemo(() => {
     if (!MOCK_MODE) return railSessionRows
     if (!railQuery) return []
-    return railAgentId ? getSessions(railAgentId) : allSessions
-  }, [allSessions, getSessions, railAgentId, railQuery, railSessionRows])
+    if (railAgentIds.length === 0) return allSessions
+    if (railAgentIds.length === 1) return getSessions(railAgentIds[0]!)
+    // The demo fixtures carry no conversation grouping, so stand in for it with
+    // the channel — enough for the multi-agent filter to behave like the real one.
+    const channelsOf = (agentId: string) => new Set(getSessions(agentId).map((s) => `${s.platform} ${s.channel}`))
+    const shared = railAgentIds.map(channelsOf).reduce((a, b) => new Set([...a].filter((c) => b.has(c))))
+    return allSessions.filter((s) => railAgentIds.includes(s.agentId ?? '') && shared.has(`${s.platform} ${s.channel}`))
+  }, [allSessions, getSessions, railAgentIds, railQuery, railSessionRows])
   const sessionBusy = session ? isPgBusy(session.id) : false
   const sessionBusyRef = useRef(sessionBusy)
   sessionBusyRef.current = sessionBusy

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -418,7 +418,9 @@ export interface SessionListPageDto {
 }
 
 export interface SessionListFilters {
-  agentId?: string
+  /** One agent scopes to that agent's sessions; several ask for the conversations
+   *  all of them took part in, and return each of their sessions in those threads. */
+  agentId?: string | string[]
   platform?: string
   integration?: string
   channel?: string
@@ -1956,7 +1958,11 @@ export async function fetchConversations(
 }
 
 function appendSessionFilters(q: URLSearchParams, filters: SessionListFilters): void {
-  if (filters.agentId) q.set('agentId', filters.agentId)
+  // Repeated `agentId` is the multi-agent form the CP reads as a conversation
+  // participant filter; a lone id serializes identically to the old single form.
+  for (const agentId of typeof filters.agentId === 'string' ? [filters.agentId] : (filters.agentId ?? [])) {
+    if (agentId) q.append('agentId', agentId)
+  }
   if (filters.platform) q.set('platform', filters.platform)
   if (filters.integration) q.set('integration', filters.integration)
   if (filters.channel) q.set('channel', filters.channel)

--- a/packages/web/src/lib/session-rail-filter.test.ts
+++ b/packages/web/src/lib/session-rail-filter.test.ts
@@ -2,56 +2,68 @@ import { describe, expect, it } from 'vitest'
 import { EMPTY_RAIL_AGENT_FILTER, railAgentFilterQuery, seedRailAgentFilter } from './session-rail-filter'
 
 describe('seedRailAgentFilter', () => {
-  it('defaults to the open session’s agent', () => {
-    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')).toEqual({ agentIds: ['agent-a'], touched: false })
+  it('defaults to the open conversation’s agents, in roster order', () => {
+    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a', 'agent-b'])).toEqual({
+      agentIds: ['agent-a', 'agent-b'],
+      touched: false
+    })
   })
 
-  it('stays empty while the session has not resolved', () => {
-    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, '')).toBe(EMPTY_RAIL_AGENT_FILTER)
+  it('drops duplicate and blank roster entries', () => {
+    // A roster row whose agent the caller cannot see carries no id; seeding it
+    // would send an empty `agentId` and filter the rail down to nothing.
+    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a', '', 'agent-a']).agentIds).toEqual(['agent-a'])
+  })
+
+  it('stays empty while the conversation has not resolved', () => {
+    expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, [])).toBe(EMPTY_RAIL_AGENT_FILTER)
   })
 
   it('follows the route while untouched', () => {
-    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')
-    expect(seedRailAgentFilter(seeded, 'agent-b')).toEqual({ agentIds: ['agent-b'], touched: false })
+    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a'])
+    expect(seedRailAgentFilter(seeded, ['agent-b', 'agent-c'])).toEqual({
+      agentIds: ['agent-b', 'agent-c'],
+      touched: false
+    })
   })
 
   it('keeps a cleared filter cleared when the reader opens another session', () => {
     // The whole point of the × on the chip: navigating the widened rail must not
     // silently re-narrow it to the row that was just clicked.
-    const cleared: ReturnType<typeof seedRailAgentFilter> = { agentIds: [], touched: true }
-    expect(seedRailAgentFilter(cleared, 'agent-b')).toBe(cleared)
+    const cleared = { agentIds: [], touched: true }
+    expect(seedRailAgentFilter(cleared, ['agent-b'])).toBe(cleared)
   })
 
-  it('keeps a chosen agent across sessions owned by someone else', () => {
-    const chosen = { agentIds: ['agent-c'], touched: true }
-    expect(seedRailAgentFilter(chosen, 'agent-b')).toBe(chosen)
+  it('keeps a chosen pair across conversations someone else owns', () => {
+    const chosen = { agentIds: ['agent-c', 'agent-d'], touched: true }
+    expect(seedRailAgentFilter(chosen, ['agent-b'])).toBe(chosen)
   })
 
   it('returns the same object when the seed does not move', () => {
-    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a')
-    expect(seedRailAgentFilter(seeded, 'agent-a')).toBe(seeded)
+    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a', 'agent-b'])
+    expect(seedRailAgentFilter(seeded, ['agent-a', 'agent-b'])).toBe(seeded)
   })
 
-  it('marks a filter the reader chose even when it matches the open session', () => {
+  it('marks a filter the reader chose even when it matches the open conversation', () => {
     // Filtering to agent B and then opening B's own session leaves a filter that
     // looks identical to the default. The rail keeps its control on screen off
     // `touched`, so this flag may not be inferred by comparing agent ids.
     const chosen = { agentIds: ['agent-b'], touched: true }
-    expect(seedRailAgentFilter(chosen, 'agent-b').touched).toBe(true)
+    expect(seedRailAgentFilter(chosen, ['agent-b']).touched).toBe(true)
   })
 })
 
 describe('railAgentFilterQuery', () => {
-  it('asks nothing while an untouched filter has no session yet', () => {
+  it('asks nothing while an untouched filter has no conversation yet', () => {
     expect(railAgentFilterQuery(EMPTY_RAIL_AGENT_FILTER)).toBeNull()
   })
 
-  it('never asks unfiltered for a session whose agent is known', () => {
+  it('never asks unfiltered for a conversation whose agents are known', () => {
     // The regression this pins: deriving readiness from the session id rather than
     // from the seeded filter made the first render of every deep link fetch — and
-    // paint — the org-wide list before snapping to the session's own agent.
-    expect(railAgentFilterQuery(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, 'agent-a'))).toEqual({
-      agentId: 'agent-a'
+    // paint — the org-wide list before snapping to the conversation's own agents.
+    expect(railAgentFilterQuery(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a']))).toEqual({
+      agentId: ['agent-a']
     })
   })
 
@@ -59,7 +71,9 @@ describe('railAgentFilterQuery', () => {
     expect(railAgentFilterQuery({ agentIds: [], touched: true })).toEqual({})
   })
 
-  it('scopes to the agent the reader chose', () => {
-    expect(railAgentFilterQuery({ agentIds: ['agent-c'], touched: true })).toEqual({ agentId: 'agent-c' })
+  it('carries every selected agent, which the CP reads as one shared conversation', () => {
+    expect(railAgentFilterQuery({ agentIds: ['agent-c', 'agent-d'], touched: true })).toEqual({
+      agentId: ['agent-c', 'agent-d']
+    })
   })
 })

--- a/packages/web/src/lib/session-rail-filter.ts
+++ b/packages/web/src/lib/session-rail-filter.ts
@@ -1,5 +1,5 @@
 // The session rail's agent filter, and the one rule that governs it: an untouched
-// filter follows whichever session is open; an edited one outranks the route.
+// filter follows whichever conversation is open; an edited one outranks the route.
 //
 // This exists because the session detail view SURVIVES rail navigation — the route
 // frame lives in the sessions layout, so moving between /sessions/a and /sessions/b
@@ -7,6 +7,11 @@
 // every session change instead would undo the reader's edit the moment they clicked
 // a row; never re-seeding would leave a stale agent's name on the chip after a
 // lineage link carried them into another agent's session.
+//
+// The seed is every agent in the open CONVERSATION, not just the session's owner:
+// on a thread two agents worked in, the rail's default question is "the other
+// threads these two worked in together", which is exactly what the CP answers for
+// a repeated `agentId` (merged-conversation-view.md §5.1 grouping).
 
 export interface RailAgentFilter {
   /** Agents the rail's list is filtered to. Empty = every session the viewer can see. */
@@ -17,27 +22,33 @@ export interface RailAgentFilter {
 
 export const EMPTY_RAIL_AGENT_FILTER: RailAgentFilter = { agentIds: [], touched: false }
 
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index])
+}
+
 /**
- * The filter after the open session resolved to `sessionAgentId` ('' while unknown).
- * Pure, and returns `chosen` unchanged whenever nothing moved, so the caller can
- * derive it during render — seeding from an effect instead would commit one frame
- * carrying the unseeded filter even though the session's agent is already known.
+ * The filter after the open conversation resolved to `conversationAgentIds` (empty
+ * while unknown). Pure, and returns `chosen` unchanged whenever nothing moved, so
+ * the caller can derive it during render — seeding from an effect instead would
+ * commit one frame carrying the unseeded filter even though the agents are already
+ * known.
  */
-export function seedRailAgentFilter(chosen: RailAgentFilter, sessionAgentId: string): RailAgentFilter {
+export function seedRailAgentFilter(chosen: RailAgentFilter, conversationAgentIds: readonly string[]): RailAgentFilter {
   if (chosen.touched) return chosen
-  const agentIds = sessionAgentId ? [sessionAgentId] : []
-  const unchanged = chosen.agentIds.length === agentIds.length && chosen.agentIds[0] === agentIds[0]
-  return unchanged ? chosen : { agentIds, touched: false }
+  // De-duplicated but NOT sorted: the roster arrives in the conversation's own
+  // order (its primary agent first), which is the order the chips should read in.
+  const agentIds = [...new Set(conversationAgentIds)].filter(Boolean)
+  return sameIds(chosen.agentIds, agentIds) ? chosen : { agentIds, touched: false }
 }
 
 /**
  * The session-list query a seeded filter asks for, or `null` when it asks nothing
- * yet. Only an UNTOUCHED empty filter means "the session has not resolved" — a
+ * yet. Only an UNTOUCHED empty filter means "the conversation has not resolved" — a
  * fetch there would be thrown away the moment it seeds. An empty filter the reader
  * cleared themselves is a real question, and its answer is every session they can
  * see, so it returns a query with no `agentId`.
  */
-export function railAgentFilterQuery(filter: RailAgentFilter): { agentId?: string } | null {
-  if (filter.agentIds[0]) return { agentId: filter.agentIds[0] }
+export function railAgentFilterQuery(filter: RailAgentFilter): { agentId?: string[] } | null {
+  if (filter.agentIds.length > 0) return { agentId: [...filter.agentIds] }
   return filter.touched ? {} : null
 }

--- a/packages/web/src/lib/use-session-facets.ts
+++ b/packages/web/src/lib/use-session-facets.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr'
 import { fetchSessionFacets, type SessionFacets, type SessionListFilters } from './api'
 import { consoleKeys } from './swr-keys'
+import { sessionFilterAgentKey } from './use-session-list'
 
 type SessionFacetKey = NonNullable<ReturnType<typeof consoleKeys.sessionFacets>>
 export const SESSION_FACET_REFRESH_MS = 60_000
@@ -10,7 +11,7 @@ export function useSessionFacets(
   filters: SessionListFilters = {},
   fallbackData?: SessionFacets
 ) {
-  const agentId = filters.agentId ?? ''
+  const agentId = sessionFilterAgentKey(filters.agentId)
   const integration = filters.integration ?? ''
   const platform = filters.platform ?? ''
   const channel = filters.channel ?? ''
@@ -23,7 +24,7 @@ export function useSessionFacets(
       const [, keyOrgId, , keyAgentId, keyIntegration, keyPlatform, keyChannel, keyTriggeredBy, keyGithubRepoId] =
         args as SessionFacetKey
       return fetchSessionFacets(keyOrgId, {
-        ...(keyAgentId ? { agentId: keyAgentId } : {}),
+        ...(keyAgentId ? { agentId: keyAgentId.split(',') } : {}),
         ...(keyIntegration ? { integration: keyIntegration } : {}),
         ...(keyPlatform ? { platform: keyPlatform } : {}),
         ...(keyChannel ? { channel: keyChannel } : {}),

--- a/packages/web/src/lib/use-session-list.test.ts
+++ b/packages/web/src/lib/use-session-list.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { sessionFilterAgentKey } from './use-session-list'
+
+describe('sessionFilterAgentKey', () => {
+  it('addresses one cache entry per SET of agents, whatever order they were picked in', () => {
+    // The rail builds the filter one chip at a time, so the same pair arrives in
+    // either order. The CP's answer does not depend on that order, and neither
+    // may the cache key — otherwise picking A then B refetches what B then A
+    // already has.
+    expect(sessionFilterAgentKey(['agent-b', 'agent-a'])).toBe(sessionFilterAgentKey(['agent-a', 'agent-b']))
+  })
+
+  it('keeps the single-agent key identical to the plain string form', () => {
+    expect(sessionFilterAgentKey(['agent-a'])).toBe(sessionFilterAgentKey('agent-a'))
+  })
+
+  it('is empty for no filter, so the key says "unfiltered" rather than "filtered by nothing"', () => {
+    expect(sessionFilterAgentKey(undefined)).toBe('')
+    expect(sessionFilterAgentKey([])).toBe('')
+  })
+})

--- a/packages/web/src/lib/use-session-list.ts
+++ b/packages/web/src/lib/use-session-list.ts
@@ -9,6 +9,14 @@ const SESSION_PAGE_LIMIT = 50
 const SESSION_FALLBACK_REFRESH_MS = 60_000
 type SessionPageKey = NonNullable<ReturnType<typeof consoleKeys.sessions>>
 
+/** The agent filter as one scalar SWR key part. Sorted so the same set of agents
+ *  always addresses the same cache entry regardless of the order they were
+ *  picked in — the CP's answer does not depend on it either. */
+export function sessionFilterAgentKey(agentId: SessionListFilters['agentId']): string {
+  if (!agentId) return ''
+  return (typeof agentId === 'string' ? [agentId] : [...agentId]).filter(Boolean).sort().join(',')
+}
+
 export function useSessionList(
   orgId: string | null | undefined,
   filters: SessionListFilters = {},
@@ -18,7 +26,9 @@ export function useSessionList(
   options: { grouped?: boolean } = {}
 ) {
   const grouped = options.grouped === true
-  const agentId = filters.agentId ?? ''
+  // The key is a scalar cache discriminator, so a multi-agent filter travels as
+  // one comma-joined string and the fetcher splits it back into repeated params.
+  const agentId = sessionFilterAgentKey(filters.agentId)
   const integration = filters.integration ?? ''
   const platform = filters.platform ?? ''
   const channel = filters.channel ?? ''
@@ -71,7 +81,7 @@ export function useSessionList(
       ] = args as SessionPageKey
       const fetchPage = keyView === 'grouped' ? fetchConversations : fetchSessions
       return fetchPage(cursor || undefined, Number(limit), keyOrgId, {
-        ...(keyAgentId ? { agentId: keyAgentId } : {}),
+        ...(keyAgentId ? { agentId: keyAgentId.split(',') } : {}),
         ...(keyIntegration ? { integration: keyIntegration } : {}),
         ...(keyPlatform ? { platform: keyPlatform } : {}),
         ...(keyChannel ? { channel: keyChannel } : {}),


### PR DESCRIPTION
Follow-up to [#422](https://github.com/agentconnect-md/agentconnect/pull/422), which shipped the rail's agent filter as single-select. This adds the multi-agent form that was deferred there, now that merged conversations exist.

## What

The rail's filter could name one agent, so the one question it could not ask was the one a merged conversation raises: **"which other threads did these two work in together?"** No row is owned by two agents, so the predicate has to be asked of the row's **conversation**.

- **`agentId` is repeatable.** `?agentId=a` scopes to that agent's rows exactly as before; `?agentId=a&agentId=b` returns each of their sessions, but only inside the threads they share.
- **The picker is multi-select**, and the menu stays open while picking — building a pair is two clicks rather than three.
- **The filter seeds from the whole conversation roster** instead of the owning agent alone: the resolver's members in conversation mode, its already-fetched §5.3 probe in session mode, falling back to the lone owner.

## How the predicate works

One EXISTS per requested agent against the §5.1 conversation key, each re-applying the caller's visibility predicate. Points worth reviewing:

- **Single-agent queries are byte-identical.** The participant arm is skipped below two ids, since `agentId IN (…)` already implies one participant — so no existing query changes plan.
- **Visibility is re-applied inside the probe.** A session only the caller *cannot* see must never be what makes a thread qualify, or the filter becomes an existence oracle for restricted agents. Covered by a test.
- **A requested agent the caller cannot see empties the answer** rather than being dropped. Silently widening a two-agent question to a one-agent one would answer something they did not ask.
- **Rows returned stay scoped to the selected agents.** The conversation decides which threads qualify; `agentIds` still decides which rows come back. That is what keeps `?agentId=a` unchanged, and it means a third agent's rows in a qualifying thread are not returned.
- **Rows with no groupable key fall out on their own** — the key join compares `channel`/`thread` with `=`, which no NULL satisfies, and a conversation of one holds no second participant.
- **The emit-at-max probe nests one `pageWhereSql` inside another**, so the participant probes take a per-alias prefix; reusing a name would shadow the outer one.

## Notes for reviewers

- **Facets** treat a multi-agent request as "the conversations you filtered to" and read facet values off every visible member row, not only the selected agents'. A conversation's channel is the same whichever member you read it from, and the agent facet drops the filter in both its forms so it can still answer "who else could I pick".
- **The "All sessions" link drops the filter** when several agents are selected: the sessions page filters by one agent, and carrying whichever happened to be first would send the reader somewhere they did not ask to go.

## Verification

- 5 new CP integration tests against real Postgres: shared-thread narrowing (flat + grouped + the unchanged single-agent form), the invisible-participant probe, non-groupable rows, an unknown requested agent, and grouped paging under the filter.
- Web: 15 tests over the seed/query rules and the cache key (the same set of agents must address one entry whatever order they were picked in).
- Driven in the mock console: chips accumulate, the menu stays open with checks on both, removing a chip returns to the single-agent list and restores the `?agent=` link.
- Full suites green — CP 906 integration / 982 unit, web 621; typecheck, ESLint, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)