### PR TITLE
fix(web): show agent names on participant icons

### DIFF
--- a/packages/web/src/components/console/Tooltip.test.tsx
+++ b/packages/web/src/components/console/Tooltip.test.tsx
@@ -195,6 +195,31 @@ describe('TooltipLayer', () => {
     expect(desktopRoster.hasAttribute('title')).toBe(false)
   })
 
+  it('keeps focus-only text out of the hover title hierarchy', async () => {
+    const link = document.createElement('a')
+    link.href = '#'
+    host.appendChild(link)
+
+    const roster = document.createElement('span')
+    roster.setAttribute('data-tooltip-focus-text', 'planner\nreviewer')
+    link.appendChild(roster)
+    const planner = document.createElement('span')
+    planner.setAttribute('title', 'planner')
+    roster.appendChild(planner)
+
+    await hover(planner)
+
+    expect(tooltip()?.textContent).toBe('planner')
+    expect(planner.hasAttribute('title')).toBe(false)
+    expect(roster.hasAttribute('title')).toBe(false)
+
+    await unhover()
+    await focus(link)
+
+    expect(tooltip()?.textContent).toBe('planner\nreviewer')
+    expect(roster.hasAttribute('title')).toBe(false)
+  })
+
   it('releases a focused title before keyboard activation updates it', async () => {
     const btn = iconButton('Show secret')
     // A control whose activation drops its own title (the reveal toggles do this

--- a/packages/web/src/components/console/Tooltip.tsx
+++ b/packages/web/src/components/console/Tooltip.tsx
@@ -11,7 +11,9 @@
 // Working off the attribute rather than a <Tooltip> wrapper is deliberate —
 // `title` is already on ~150 controls, and one layer keeps every one of them on
 // the same delay. Call sites keep writing plain `title="…"`; opt a subtree out
-// with `data-no-tooltip`.
+// with `data-no-tooltip`. A hint that should appear only when an ancestor takes
+// keyboard focus can use `data-tooltip-focus-text` without becoming a hover or
+// native-title source.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -26,7 +28,8 @@ import { adoptTitle, liftTitle, restoreTitle, TITLE_STASH } from './tooltip-titl
 
 /** Matches both a not-yet-lifted title and the element currently holding one. */
 const SOURCE_SELECTOR = `[title],[${TITLE_STASH}]`
-const FOCUS_SOURCE_SELECTOR = `[data-tooltip-focus][title],[data-tooltip-focus][${TITLE_STASH}]`
+const FOCUS_TEXT = 'data-tooltip-focus-text'
+const FOCUS_SOURCE_SELECTOR = `[${FOCUS_TEXT}],[data-tooltip-focus][title],[data-tooltip-focus][${TITLE_STASH}]`
 const TOOLTIP_ID = 'ac-tooltip'
 
 /** CSS keeps responsive duplicates mounted; focus must anchor to the rendered one. */
@@ -84,13 +87,18 @@ export function TooltipLayer() {
 
   const open = useCallback((el: HTMLElement) => {
     const title = el.getAttribute('title')
-    if (title === null || !isTooltipSource(el.tagName, title) || !el.isConnected) return
+    const value = title ?? el.getAttribute(FOCUS_TEXT)
+    if (value === null || !isTooltipSource(el.tagName, value) || !el.isConnected) return
     // Lifting the attribute is what suppresses the browser's own tooltip; it
     // goes back on the element the moment the pointer leaves (see release()).
-    if (liftTitle(el, TOOLTIP_ID) === null) return
+    if (title !== null && liftTitle(el, TOOLTIP_ID) === null) return
     heldRef.current = el
     anchorRef.current = el.getBoundingClientRect()
-    setText(title.trim())
+    setText(value.trim())
+
+    // Focus-only text is metadata, not a native title, so there is nothing to
+    // lift or watch. The focused row already owns the accessible roster text.
+    if (title === null) return
 
     // A control can re-title itself while its tooltip is up — a copy button
     // flipping to "Copied" on activation, or back again on a timer. React

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -299,8 +299,8 @@ export default function SessionsView() {
     )
   }
   // Multi-participant conversation rows (merged-conversation-view.md §5.2):
-  // stacked participant icons replace the single agent face; the compact label
-  // carries the total while its tooltip names the visible roster.
+  // stacked participant icons replace the single agent face; each icon names
+  // its agent on hover, while the compact label carries only the total.
   const agentCell = (s: Session, av: string, size: number, label: string) => {
     const roster = s.participants ?? []
     if (roster.length <= 1) {
@@ -311,17 +311,30 @@ export default function SessionsView() {
         </>
       )
     }
-    const rosterNames = roster.map((participant) => participant.name)
+    const participantName = (participant: (typeof roster)[number]) => {
+      const agent = agentById.get(participant.agentId)
+      if (agent) return agentLabel(agent)
+      const fallback = participant.name.trim()
+      return fallback && fallback !== participant.agentId && fallback !== participant.agentId.slice(0, 8)
+        ? fallback
+        : 'Agent'
+    }
+    const rosterNames = roster.map(participantName)
     return (
       <>
         <span className="flex flex-none items-center -space-x-[5px]">
-          {roster.slice(0, 4).map((p) => (
-            <span key={p.agentId} className={`av flex-none ${av}`}>
+          {roster.slice(0, 4).map((p, index) => (
+            <span
+              key={p.agentId}
+              className={`av flex-none ${av}`}
+              title={participantName(p)}
+              data-tooltip-focus={index === 0 ? '' : undefined}
+            >
               {agentAvatar(p.agentId, undefined, size)}
             </span>
           ))}
         </span>
-        <span className={`truncate ${label}`} title={rosterNames.join('\n')} data-tooltip-focus>
+        <span className={`truncate ${label}`}>
           <span aria-hidden="true">+{roster.length}</span>
           <span className="sr-only">
             {roster.length} agents: {rosterNames.join(', ')}

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -322,14 +322,9 @@ export default function SessionsView() {
     const rosterNames = roster.map(participantName)
     return (
       <>
-        <span className="flex flex-none items-center -space-x-[5px]">
-          {roster.slice(0, 4).map((p, index) => (
-            <span
-              key={p.agentId}
-              className={`av flex-none ${av}`}
-              title={participantName(p)}
-              data-tooltip-focus={index === 0 ? '' : undefined}
-            >
+        <span className="flex flex-none items-center -space-x-[5px]" title={rosterNames.join('\n')} data-tooltip-focus>
+          {roster.slice(0, 4).map((p) => (
+            <span key={p.agentId} className={`av flex-none ${av}`} title={participantName(p)}>
               {agentAvatar(p.agentId, undefined, size)}
             </span>
           ))}

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -322,7 +322,7 @@ export default function SessionsView() {
     const rosterNames = roster.map(participantName)
     return (
       <>
-        <span className="flex flex-none items-center -space-x-[5px]" title={rosterNames.join('\n')} data-tooltip-focus>
+        <span className="flex flex-none items-center -space-x-[5px]" data-tooltip-focus-text={rosterNames.join('\n')}>
           {roster.slice(0, 4).map((p) => (
             <span key={p.agentId} className={`av flex-none ${av}`} title={participantName(p)}>
               {agentAvatar(p.agentId, undefined, size)}


### PR DESCRIPTION
## Summary

- show each participant agent name when hovering its icon
- keep the +N label count-only with no tooltip or UID exposure
- resolve display names from the organization agent roster while preserving the accessible roster summary
- keep the full roster available on keyboard focus without nesting native title sources

## Validation

- pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json
- pnpm exec eslint packages/web/src/components/console/Tooltip.tsx packages/web/src/components/console/Tooltip.test.tsx packages/web/src/components/console/views/SessionsView.tsx
- pnpm exec prettier --check packages/web/src/components/console/Tooltip.tsx packages/web/src/components/console/Tooltip.test.tsx packages/web/src/components/console/views/SessionsView.tsx
- pnpm --filter @agentconnect.md/web exec vitest run src/components/console/Tooltip.test.tsx (11 tests)
- pnpm --filter @agentconnect.md/web build
- pre-push eslint .

Created by Codex . GPT-5