### PR TITLE
feat(platforms): chronological event time + merge adapters for Telegram, Discord, Feishu

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2508,6 +2508,10 @@ export const SessionMessageDto = z.object({
   senderAvatarUrl: z.string().url().optional(), // public provider-hosted profile image
   trustedAgentBot: z.boolean().optional(), // daemon-verified AgentConnect Slack bot provenance
   ts: z.string(),
+  // Normalized chronological coordinate (epoch µs) from the daemon's
+  // event-time axis; provider-authoritative when the platform supplied its
+  // send time. Absent on legacy rows.
+  eventTimeUs: z.number().optional(),
   // Canonical webchat post identity (merged-conversation-view.md §6) — identical
   // on every participant's copy; absent on non-webchat and pre-upgrade rows.
   postId: z.string().optional(),

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -299,6 +299,7 @@ export function createSessionReader(
           ...(senderAvatarUrl ? { senderAvatarUrl } : {}),
           ...(r.trustedAgentBot ? { trustedAgentBot: true } : {}),
           ts: r.ts,
+          ...(r.eventTimeUs ? { eventTimeUs: r.eventTimeUs } : {}),
           ...(r.postId ? { postId: r.postId } : {}),
           kind: r.kind,
           text: substituteUserMentions(withoutAttachmentMention(r.text, attachments), names),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8344,6 +8344,11 @@ export class Daemon {
       ts,
       sender: msg.sender.id,
       ...(recipient ? { recipient } : {}),
+      // The observer often wins the INSERT race against SessionManager's
+      // authoritative append — the provider send time must ride the FIRST
+      // write or non-chronological-id platforms (Telegram/Feishu) keep the
+      // broken derived axis.
+      ...(msg.platformTimeMs ? { eventTimeUs: msg.platformTimeMs * 1000 } : {}),
       kind: 'text',
       text: mention ? `${msg.text}\n${mention}`.trim() : msg.text,
       ...(msg.quoted?.text ? { quoted: msg.quoted } : {})

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -461,6 +461,10 @@ export class SessionManager {
       // The canonical webchat post identity travels with the canonical ts —
       // identical on every participant copy even when `ts` was bumped (§6).
       ...(msg.transcriptPostId ? { postId: msg.transcriptPostId } : {}),
+      // Provider send time for platforms whose message ids are not
+      // chronological (Telegram/Feishu; Discord decodes its snowflake at
+      // normalization) — the merged conversation view orders on this axis.
+      ...(msg.platformTimeMs ? { eventTimeUs: msg.platformTimeMs * 1000 } : {}),
       // This message was delivered TO this agent (handle() runs for `agentId`), so tag the
       // recipient — the console session view scopes to what THIS agent received + produced.
       recipient: agentId,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -198,6 +198,11 @@ export interface TranscriptEntry {
    *  origin, identical on every participant's copy regardless of a
    *  collision-bumped `ts`. Text rows only; absent everywhere else. */
   postId?: string
+  /** Provider-authoritative event time (epoch µs) for the normalized
+   *  chronological axis — platforms whose message ids carry no time
+   *  (Telegram/Feishu) supply it from the message's own send time. Computed
+   *  from `ts` when absent. */
+  eventTimeUs?: number
   /** True only when the daemon verified that this Slack history row came from an
    *  AgentConnect-managed bot identity. Legacy rows and all other platforms omit it. */
   trustedAgentBot?: boolean
@@ -2490,7 +2495,7 @@ export class LocalStore {
         ...entry,
         recipient: e.recipient ?? null,
         postId: e.postId ?? null,
-        eventTimeUs: transcriptEventTimeUs(e.ts),
+        eventTimeUs: e.eventTimeUs ?? transcriptEventTimeUs(e.ts),
         attachmentsJson: attachments?.length ? JSON.stringify(attachments) : null,
         quoteJson: durableQuoteJson,
         trustedAgentBot: trustedAgentBot ? 1 : null,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2527,6 +2527,18 @@ export class LocalStore {
             )
             .run(e.postId, e.channel, e.thread, e.ts)
         : undefined
+    // A later duplicate can be the first copy that carries the AUTHORITATIVE
+    // provider send time (an early observer wrote the row with the derived
+    // axis). Explicit values only — two derived computations must never flap.
+    const eventTimeUpgraded =
+      Number(inserted.changes) === 0 && e.eventTimeUs
+        ? this.db
+            .prepare(
+              `UPDATE transcript SET eventTimeUs = ?
+               WHERE channel = ? AND thread = ? AND ts = ? AND kind = 'text' AND eventTimeUs IS NOT ?`
+            )
+            .run(e.eventTimeUs, e.channel, e.thread, e.ts, e.eventTimeUs)
+        : undefined
     // A later duplicate can be the first copy that carries provider reply metadata
     // (or a corrected selected passage). Upgrade it without ever clearing a quote when
     // a provider snapshot subsequently re-appends the same text row without metadata.
@@ -2556,6 +2568,7 @@ export class LocalStore {
       Number(provenanceUpgraded?.changes ?? 0) === 1 ||
       Number(quoteUpgraded?.changes ?? 0) === 1 ||
       Number(postIdUpgraded?.changes ?? 0) === 1 ||
+      Number(eventTimeUpgraded?.changes ?? 0) === 1 ||
       Number(delivered?.changes ?? 0) === 1
     ) {
       const deliveryRevision = this.transcriptRevision + 1

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1150,4 +1150,27 @@ describe('LocalStore webchat MCP grant ledger', () => {
     expect(due.every((r) => r.reason === 'session_closed')).toBe(true)
     s.close()
   })
+  it('an authoritative event time upgrades a row the derived-axis observer wrote first', () => {
+    // Regression (merged-conversation-view.md §6 / PR review): with
+    // turnFinalContextRefresh on, recordObservedInbound races SessionManager
+    // and wins the INSERT — a Telegram row ts="4821" landed at the derived
+    // 4_821_000_000µs axis, and the later authoritative append was
+    // INSERT-OR-IGNOREd without repair. Explicit eventTimeUs must upgrade the
+    // deduped row (and bump its revision); derived recomputes never flap it.
+    const s = store()
+    s.appendTranscript({ channel: 'C1', thread: 'T', ts: '4821', sender: 'U1', kind: 'text', text: 'hi' })
+    const before = s.transcriptSince('C1', 'T', null)[0] as { eventTimeUs?: number }
+    expect(before.eventTimeUs).toBe(4_821_000_000)
+    s.appendTranscript({
+      channel: 'C1',
+      thread: 'T',
+      ts: '4821',
+      sender: 'U1',
+      kind: 'text',
+      text: 'hi',
+      eventTimeUs: 1_754_123_458_000_000
+    })
+    const after = s.transcriptSince('C1', 'T', null)[0] as { eventTimeUs?: number }
+    expect(after.eventTimeUs).toBe(1_754_123_458_000_000)
+  })
 })

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -4,6 +4,16 @@ import type { NormalizedPlatformMessage, PlatformAttachment } from '@agentconnec
  * Minimal plain-object Discord view accepted by pure normalization. The daemon
  * adapts discord.js gateway messages and slash commands into this shape.
  */
+// Discord snowflakes embed their creation time in the top 42 bits (ms since
+// the Discord epoch, 2015-01-01). BigInt: snowflakes exceed Number's safe
+// integer range.
+const DISCORD_EPOCH_MS = 1_420_070_400_000n
+function snowflakeTimeMs(id: string): number | undefined {
+  if (!/^\d{16,20}$/.test(id)) return undefined
+  const ms = Number((BigInt(id) >> 22n) + DISCORD_EPOCH_MS)
+  return Number.isSafeInteger(ms) && ms > 0 ? ms : undefined
+}
+
 export interface DiscordAttachmentLike {
   id: string
   name?: string | null
@@ -70,6 +80,7 @@ export function normalizeDiscordMessage(
 
   return {
     msgId: `discord:${message.channelId}:${message.id}`,
+    ...(snowflakeTimeMs(message.id) !== undefined ? { platformTimeMs: snowflakeTimeMs(message.id) } : {}),
     traceId: context.traceId,
     source: 'user',
     platform: 'discord',

--- a/packages/message/src/feishu-message.ts
+++ b/packages/message/src/feishu-message.ts
@@ -17,6 +17,7 @@ export interface FeishuRawEvent {
     message_type?: string
     content?: string
     root_id?: string
+    create_time?: string
     mentions?: FeishuMention[]
   }
 }
@@ -37,6 +38,8 @@ export interface FeishuAttachmentLike {
 
 export interface FeishuMessageLike {
   messageId: string
+  /** Provider send time (epoch ms) — om_ message ids carry no time. */
+  createTimeMs?: number
   chatId: string
   chatType: 'p2p' | 'group' | string
   messageType: string
@@ -151,6 +154,7 @@ export function feishuEventToMessageLike(event: FeishuRawEvent): FeishuMessageLi
   const senderType = event.sender?.sender_type
   return {
     messageId: message.message_id ?? '',
+    ...(message.create_time && /^\d+$/.test(message.create_time) ? { createTimeMs: Number(message.create_time) } : {}),
     chatId: message.chat_id ?? '',
     chatType: message.chat_type ?? 'group',
     messageType: message.message_type ?? 'text',
@@ -177,6 +181,7 @@ export function normalizeFeishuMessage(
   const isDm = message.chatType === 'p2p'
   return {
     msgId: `feishu:${message.chatId}:${message.messageId}`,
+    ...(message.createTimeMs ? { platformTimeMs: message.createTimeMs } : {}),
     traceId: context.traceId,
     source: 'user',
     platform: 'feishu',

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -186,6 +186,9 @@ export function normalizeTelegramMessage(
 
   return {
     msgId: `telegram:${message.chat.id}:${message.message_id}`,
+    // Telegram message ids are per-chat sequences with no embedded time — the
+    // platform's send time is the only chronological coordinate.
+    ...(message.date !== undefined ? { platformTimeMs: message.date * 1000 } : {}),
     traceId: context.traceId,
     source: 'user',
     platform: 'telegram',

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -105,6 +105,10 @@ export const SessionMessage = z.object({
   // compatibility and absent on legacy rows or every non-Slack transport.
   trustedAgentBot: z.boolean().optional(),
   ts: z.string(), // platform timestamp (daemon-local string form)
+  // Normalized chronological coordinate (epoch µs) from the daemon's event-time
+  // axis — provider-authoritative when the platform supplied its send time.
+  // Absent on legacy rows; consumers fall back to deriving it from `ts`.
+  eventTimeUs: z.number().int().positive().optional(),
   // Canonical webchat post identity (merged-conversation-view.md §6): minted once
   // at origin and identical on every participant's copy, independent of a
   // collision-bumped `ts`. Absent on non-webchat rows and pre-upgrade rows.

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -63,6 +63,12 @@ export const NormalizedPlatformMessageSchema = z.object({
   /** Enclosing Discord channel when `channel` is itself a thread channel. */
   parentChannel: z.string().optional(),
   trigger: z.enum(['mention', 'dm', 'keyword', 'auto', 'cron']).optional(),
+  /** Provider-reported send time (epoch ms). Set when the platform's message id
+   *  is not itself chronological (Telegram sequence ids, Feishu om_ ids) or the
+   *  time is embedded in it (Discord snowflakes, decoded at normalization).
+   *  The daemon stamps it onto the transcript row's normalized event-time axis
+   *  so cross-source merges order correctly (merged-conversation-view.md §6). */
+  platformTimeMs: z.number().int().positive().optional(),
   headless: z.boolean().optional()
 })
 export type NormalizedPlatformMessage = z.infer<typeof NormalizedPlatformMessageSchema>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -70,7 +70,7 @@ import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
 import { Avatar, Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
-import { formatTranscriptTime, parseTranscriptTime } from '@/lib/transcript-time'
+import { formatTranscriptRowTime, transcriptRowTimeMs } from '@/lib/transcript-time'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
@@ -139,7 +139,7 @@ function msgStep(m: SessionMessageDto): FmtStep {
       text: '',
       code: m.text,
       files: [],
-      time: formatTranscriptTime(m.ts),
+      time: formatTranscriptRowTime(m),
       // Carry the raw message so the row can render the captured tool body (input /
       // output / content / diff / locations) below the title, on demand.
       ...(m.body ? { msg: m } : {})
@@ -156,7 +156,7 @@ function msgStep(m: SessionMessageDto): FmtStep {
       text: m.text,
       code: '',
       files: [],
-      time: formatTranscriptTime(m.ts)
+      time: formatTranscriptRowTime(m)
     }
   }
   return {
@@ -169,7 +169,7 @@ function msgStep(m: SessionMessageDto): FmtStep {
     text: m.text,
     code: '',
     files: [],
-    time: formatTranscriptTime(m.ts)
+    time: formatTranscriptRowTime(m)
   }
 }
 
@@ -284,7 +284,7 @@ function activityStatsFromTranscript(messages: SessionMessageDto[]): ActivitySta
   let anonymousToolRows = 0
 
   for (const m of messages) {
-    const t = parseTranscriptTime(m.ts)
+    const t = transcriptRowTimeMs(m)
     if (t != null) {
       first = Math.min(first, t)
       last = Math.max(last, t)
@@ -2047,7 +2047,7 @@ export default function SessionDetailView() {
           avatarUrl: m.senderAvatarUrl ?? (self ? viewer.picture : memberPictureByIdentity.get(m.sender)),
           avatarInitials: self ? viewer.initials : undefined,
           sourceLabel: platName(sessionIntegration),
-          time: formatTranscriptTime(m.ts),
+          time: formatTranscriptRowTime(m),
           text: m.text,
           image: m.attachments?.[0],
           isCron: !!cron,

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -528,6 +528,9 @@ export interface SessionMessageDto {
   senderAvatarUrl?: string // public provider-hosted profile image
   trustedAgentBot?: boolean // daemon-verified AgentConnect Slack bot provenance
   ts: string
+  /** Normalized chronological coordinate (epoch µs) from the daemon's event-time
+   *  axis — provider-authoritative when the platform supplied its send time. */
+  eventTimeUs?: number
   /** Canonical webchat post identity (merged-conversation-view.md §6) — identical
    *  on every participant's copy; absent on non-webchat and pre-upgrade rows. */
   postId?: string

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -29,6 +29,18 @@ describe('transcriptEventTimeUs', () => {
 })
 
 describe('duplicateIdentity', () => {
+  it('recognizes per-platform native id shapes; 13-digit local stamps never match any', () => {
+    const SNOWFLAKE = '1101111111111111111'
+    expect(duplicateIdentity('discord', row({ ts: SNOWFLAKE }))).toBe(`ts:${SNOWFLAKE}`)
+    expect(duplicateIdentity('telegram', row({ ts: '4821' }))).toBe('ts:4821')
+    expect(duplicateIdentity('feishu', row({ ts: 'om_abc123' }))).toBe('ts:om_abc123')
+    for (const platform of ['discord', 'telegram', 'feishu', 'slack']) {
+      expect(duplicateIdentity(platform, row({ ts: '1754123457123' }))).toBeNull()
+    }
+    // The 10-digit legacy-seconds era stays outside the Telegram predicate.
+    expect(duplicateIdentity('telegram', row({ ts: '1754123456' }))).toBeNull()
+  })
+
   it('is provenance-explicit — integer monotonicTs values never match the Slack predicate', () => {
     expect(duplicateIdentity('slack', row({ ts: '1754123456.000200' }))).toBe('ts:1754123456.000200')
     expect(duplicateIdentity('slack', row({ ts: '1754123457123' }))).toBeNull()
@@ -41,6 +53,43 @@ describe('duplicateIdentity', () => {
 })
 
 describe('mergeConversation', () => {
+  it('dedupes Discord copies on the snowflake and orders them by its embedded time', () => {
+    // Snowflake for ~2024: time bits decode via (id >> 22) + Discord epoch.
+    const SNOWFLAKE = '1101111111111111111'
+    const merged = mergeConversation([
+      src(A, 'discord', [
+        row({ sender: 'U-HUMAN', ts: SNOWFLAKE, text: 'thread msg' }),
+        row({ sender: A, kind: 'reasoning', ts: '1754123457123', text: 'thinking' })
+      ]),
+      src(B, 'discord', [row({ sender: 'U-HUMAN', ts: SNOWFLAKE, text: 'thread msg' })])
+    ])
+    expect(merged.filter((m) => m.row.text === 'thread msg')).toHaveLength(1)
+    // The snowflake must NOT overflow to epoch-0: its decoded time (2023+)
+    // sorts near the daemon-ms work row, not before everything.
+    expect(transcriptEventTimeUs(SNOWFLAKE)).toBeGreaterThan(1_600_000_000_000_000)
+  })
+
+  it('orders Telegram rows by the daemon-stored event time, not the sequence id', () => {
+    // TG message ids are per-chat sequences (no embedded time): the daemon
+    // stamps eventTimeUs from message.date; the merge must prefer it over
+    // deriving from the id (which would read as 1970s seconds).
+    const merged = mergeConversation([
+      src(A, 'telegram', [
+        row({ sender: 'tg-user', ts: '4821', eventTimeUs: 1_754_123_458_000_000, text: 'later' }),
+        row({ sender: A, ts: '1754123457123', text: 'agent reply' })
+      ])
+    ])
+    expect(merged.map((m) => m.row.text)).toEqual(['agent reply', 'later'])
+  })
+
+  it('dedupes Feishu copies on the om_ message id', () => {
+    const merged = mergeConversation([
+      src(A, 'feishu', [row({ sender: 'U-H', ts: 'om_xyz', eventTimeUs: 1_754_123_456_000_000, text: 'hello' })]),
+      src(B, 'feishu', [row({ sender: 'U-H', ts: 'om_xyz', eventTimeUs: 1_754_123_456_000_000, text: 'hello' })])
+    ])
+    expect(merged).toHaveLength(1)
+  })
+
   it('dedupes webchat copies by postId with author-copy precedence, surviving a collision bump', () => {
     // B's copy of A's post got collision-bumped (+1ms): raw-ts equality would
     // miss it, postId identifies it regardless. The author copy (A's) wins.

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -52,6 +52,14 @@ export function transcriptEventTimeUs(ts: string | null | undefined): number {
   if (local) raw = raw.slice('local-'.length)
   raw = raw.split('|', 1)[0] ?? ''
 
+  // Discord snowflakes: creation ms in the top 42 bits (BigInt — they exceed
+  // Number's safe range, and the generic integer branch below would overflow
+  // them to 0).
+  if (/^\d{16,20}$/.test(raw)) {
+    const ms = Number((BigInt(raw) >> 22n) + 1_420_070_400_000n)
+    return Number.isSafeInteger(ms * 1_000) && ms > 0 ? ms * 1_000 : 0
+  }
+
   const decimal = /^(\d+)\.(\d+)$/.exec(raw)
   if (decimal) {
     const seconds = Number(decimal[1]!)
@@ -75,10 +83,16 @@ function safeEventTimeUs(value: number): number {
   return Number.isSafeInteger(value) && value >= 0 ? value : 0
 }
 
-/** Provider-native Slack message timestamp — the platform message id shared by
- *  every delivery. Exactly `^\d+\.\d+$` (anchored, dot escaped): an integer
- *  `monotonicTs()` millisecond value must never match. */
+/** Provider-native message-id shapes per platform — each is the identity a
+ *  duplicate shares across every member's copy, chosen so a daemon-local
+ *  13-digit `monotonicTs()` millisecond stamp can NEVER match:
+ *  Slack decimal seconds; Discord 16–20-digit snowflakes; Telegram short
+ *  per-chat sequence ids (≤9 digits — the 10-digit legacy-seconds era and
+ *  13-digit local stamps are both excluded); Feishu om_ ids. */
 const SLACK_NATIVE_TS = /^\d+\.\d+$/
+const DISCORD_SNOWFLAKE = /^\d{16,20}$/
+const TELEGRAM_MESSAGE_ID = /^\d{1,9}$/
+const FEISHU_MESSAGE_ID = /^om_[A-Za-z0-9_-]+$/
 
 /**
  * The provenance-explicit duplicate identity of a row, or null when the row
@@ -97,6 +111,9 @@ const SLACK_NATIVE_TS = /^\d+\.\d+$/
 export function duplicateIdentity(platform: string, row: SessionMessageDto): string | null {
   if (row.kind !== 'text') return null
   if (platform === 'webchat') return row.postId ? `post:${row.postId}` : null
+  if (platform === 'discord') return DISCORD_SNOWFLAKE.test(row.ts) ? `ts:${row.ts}` : null
+  if (platform === 'telegram') return TELEGRAM_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null
+  if (platform === 'feishu') return FEISHU_MESSAGE_ID.test(row.ts) ? `ts:${row.ts}` : null
   return SLACK_NATIVE_TS.test(row.ts) ? `ts:${row.ts}` : null
 }
 
@@ -122,7 +139,10 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
         sourceSessionId: source.sessionId,
         sourceAgentId: source.agentId,
         authorCopy: row.sender === source.agentId,
-        us: transcriptEventTimeUs(row.ts),
+        // Prefer the daemon's stored axis (provider-authoritative for
+        // Telegram/Feishu, whose ids carry no time); a missing/zero value
+        // falls back to deriving from `ts` (which handles snowflakes).
+        us: row.eventTimeUs && row.eventTimeUs > 0 ? row.eventTimeUs : transcriptEventTimeUs(row.ts),
         order: order++
       }
       const identity = duplicateIdentity(source.platform, row)

--- a/packages/web/src/lib/session-transcript.ts
+++ b/packages/web/src/lib/session-transcript.ts
@@ -1,6 +1,6 @@
 import type { SessionMessageDto } from '@/lib/api'
 import type { SessionImage, SessionStep } from '@/lib/data'
-import { parseTranscriptTime } from '@/lib/transcript-time'
+import { transcriptRowTimeMs } from '@/lib/transcript-time'
 
 const LIVE_TURN_CONFIRM_WINDOW_MS = 5 * 60_000
 
@@ -15,7 +15,7 @@ export function mergeSessionMessages(
   for (const message of incoming) bySeq.set(message.seq, message)
   return [...bySeq.values()].sort((a, b) => {
     if (platform !== 'slack') return a.seq - b.seq
-    return (parseTranscriptTime(a.ts) ?? 0) - (parseTranscriptTime(b.ts) ?? 0) || a.seq - b.seq
+    return (transcriptRowTimeMs(a) ?? 0) - (transcriptRowTimeMs(b) ?? 0) || a.seq - b.seq
   })
 }
 
@@ -59,7 +59,7 @@ export function reconcilePersistedLiveSteps(
   const confirmed = new Set<number>()
   for (const message of persisted) {
     if (message.kind.toLowerCase() !== 'text' || message.sender === agentId) continue
-    const persistedAtMs = parseTranscriptTime(message.ts)
+    const persistedAtMs = transcriptRowTimeMs(message)
     if (persistedAtMs == null) continue
     const key = promptKey(message.text, message.attachments?.[0])
     let bestTurn = -1

--- a/packages/web/src/lib/transcript-time.test.ts
+++ b/packages/web/src/lib/transcript-time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { formatTranscriptTime, parseTranscriptTime } from './transcript-time'
+import {
+  formatTranscriptTime,
+  parseTranscriptTime,
+  formatTranscriptRowTime,
+  transcriptRowTimeMs
+} from './transcript-time'
 
 describe('transcript time', () => {
   it('parses a suffixed hook timestamp as epoch milliseconds', () => {
@@ -20,5 +25,18 @@ describe('transcript time', () => {
     expect(parseTranscriptTime(raw)).toBe(1_710_799_200_000_000_000)
     expect(() => formatTranscriptTime(raw)).not.toThrow()
     expect(formatTranscriptTime(raw)).toBe('')
+  })
+  it('prefers the stored event-time axis for rows whose ts is a native platform id', () => {
+    // Telegram sequence id, Feishu om_ id, Discord snowflake: none is a
+    // parseable clock time — the daemon-stored axis must drive the label and
+    // duration math; legacy rows without it fall back to ts.
+    const authoritative = 1_754_123_458_000_000 // µs
+    expect(transcriptRowTimeMs({ ts: '4821', eventTimeUs: authoritative })).toBe(1_754_123_458_000)
+    expect(transcriptRowTimeMs({ ts: 'om_abc', eventTimeUs: authoritative })).toBe(1_754_123_458_000)
+    expect(transcriptRowTimeMs({ ts: '1101111111111111111', eventTimeUs: authoritative })).toBe(1_754_123_458_000)
+    expect(formatTranscriptRowTime({ ts: 'om_abc', eventTimeUs: authoritative })).not.toBe('')
+    // Legacy fallback: no stored axis → derive from ts exactly as before.
+    expect(transcriptRowTimeMs({ ts: '1754123457123' })).toBe(1_754_123_457_123)
+    expect(formatTranscriptRowTime({ ts: 'om_abc' })).toBe('')
   })
 })

--- a/packages/web/src/lib/transcript-time.ts
+++ b/packages/web/src/lib/transcript-time.ts
@@ -28,6 +28,24 @@ export function formatTranscriptTime(raw: string | null | undefined): string {
   return transcriptTime.format(date)
 }
 
+/** Epoch ms for a transcript ROW: the daemon's stored event-time axis wins
+ *  (provider-authoritative — Telegram/Feishu ids carry no time, Discord
+ *  snowflakes aren't parseable here); legacy rows fall back to `ts`. */
+export function transcriptRowTimeMs(row: { ts: string; eventTimeUs?: number }): number | null {
+  if (row.eventTimeUs && row.eventTimeUs > 0) return Math.floor(row.eventTimeUs / 1000)
+  return parseTranscriptTime(row.ts)
+}
+
+/** Clock-time label for a transcript ROW — `formatTranscriptTime` over the
+ *  row-aware coordinate above. */
+export function formatTranscriptRowTime(row: { ts: string; eventTimeUs?: number }): string {
+  const ms = transcriptRowTimeMs(row)
+  if (ms == null) return ''
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) return ''
+  return transcriptTime.format(date)
+}
+
 export function parseTranscriptTime(ts: string): number | null {
   const raw = timestampValue(ts)
   if (!raw) return null


### PR DESCRIPTION
Closes the gap discussed after C3: the merged conversation view worked naturally for Slack/webchat but not the other IM platforms — their message ids broke both halves of [merged-conversation-view.md](../blob/main/docs/designs/merged-conversation-view.md) §6:

| platform | text-row `ts` | dedupe (Slack decimal predicate) | ordering (µs axis) |
|---|---|---|---|
| Discord | 17-19-digit snowflake | no match → duplicates | overflowed safe integers → 0 (sorted to epoch start) |
| Telegram | per-chat sequence id | no match → duplicates | parsed as 1970s "seconds" |
| Feishu | `om_…` opaque id | no match → duplicates | `Date.parse` fail → 0 |

**Design**: platform send time flows as an explicit `eventTimeUs` override onto the daemon's existing normalized axis — `ts` coordinates, primary keys, and replay comparisons are untouched (the safe alternative to rewriting `ts` shapes mid-thread).

- **protocol**: `NormalizedPlatformMessage.platformTimeMs` (provider send time); `SessionMessage.eventTimeUs` exposes the stored axis.
- **mappers**: Telegram stamps `message.date`; Feishu plumbs `create_time` through `FeishuRawEvent → MessageLike → normalize`; Discord decodes its snowflake's embedded creation time (BigInt — snowflakes exceed `Number`'s safe range).
- **daemon**: `TranscriptEntry.eventTimeUs` override; the inbound append stamps it.
- **read chain**: session reader → CP DTO → web DTO; the merge orders by the stored axis when present (fallback derivation now handles snowflakes) and dedupes text rows on per-platform native id shapes (Discord `^\d{16,20}$`, Telegram `^\d{1,9}$` — excluding both the 10-digit legacy-seconds era and 13-digit `monotonicTs` stamps — Feishu `^om_…$`).
- **fixtures**: snowflake dedupe + embedded-time ordering, Telegram stored-axis-over-id ordering, Feishu dedupe, per-platform predicate matrix.

Legacy rows keep their old stored axis until re-observed; new rows are correct end to end. Grouping/list/resolver (C1) were already platform-neutral and are untouched.

Web 633 green; message/daemon/CP typecheck clean; daemon webchat suites + CP unit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)