### PR TITLE
fix(web): keep the session rail one row per conversation

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2383,7 +2383,14 @@ export const ConversationDto = z.object({
   /** Current member sessions, representative (the caller's newest visible
    *  member) first, one row per agent. Singleton conversations carry exactly
    *  one session; its row renders like the flat list's. */
-  sessions: SessionListDto
+  sessions: SessionListDto,
+  /** Every member session the caller can see, newest first, one per agent —
+   *  INCLUDING the members an `agentId` filter left out of `sessions`. A filter
+   *  narrows which rows are returned, not who took part, and a client that read
+   *  membership off `sessions` would lose track of a conversation the moment the
+   *  filter hid the member it had been identifying it by. Ids only: the metadata
+   *  of a filtered-out member is not part of the answer. */
+  memberSessionIds: z.array(z.string())
 })
 
 export const SessionListPageDto = z.object({

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -535,6 +535,9 @@ export function sessionRoutes(deps: HttpDeps) {
         const query = {
           agentIds: selectedAgentIds,
           ...(conversationAgentIds ? { conversationAgentIds } : {}),
+          // Membership is read over everything the caller may see, so a grouped row
+          // still names the participants an agent filter kept out of its `sessions`.
+          ...(requested.length > 0 ? { memberAgentIds: visibleAgentIds } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
@@ -568,7 +571,10 @@ export function sessionRoutes(deps: HttpDeps) {
                       platform: conversationKey.platform,
                       channel: conversationKey.channel,
                       thread: conversationKey.thread,
-                      sessions: members.map((session) => sessionDto(session, hookMetadata))
+                      sessions: members.map((session) => sessionDto(session, hookMetadata)),
+                      // The resolver already answers per agent over what the caller
+                      // asked for, so its rows ARE its membership.
+                      memberSessionIds: members.map((session) => session.id)
                     }
                   ]
                 : [],
@@ -604,7 +610,8 @@ export function sessionRoutes(deps: HttpDeps) {
             platform: c.key.platform,
             channel: c.key.channel,
             thread: c.key.thread,
-            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata))
+            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata)),
+            memberSessionIds: c.memberSessionIds
           })),
           total: page.total,
           nextCursor,

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -532,12 +532,15 @@ export function sessionRoutes(deps: HttpDeps) {
         // a path that took `agentIds` alone would silently answer the wider
         // "either agent" question under the same query string.
         const conversationAgentIds = requested.length > 1 ? selectedAgentIds : undefined
+        // Membership is read over everything the caller may see, so a grouped row
+        // still names the participants an agent filter kept out of its `sessions`.
+        // It reaches the query before the viewer is resolved, because the scopes
+        // that authorize those extra members have to be resolved with it.
+        const memberAgentIds = requested.length > 0 ? visibleAgentIds : undefined
         const query = {
           agentIds: selectedAgentIds,
           ...(conversationAgentIds ? { conversationAgentIds } : {}),
-          // Membership is read over everything the caller may see, so a grouped row
-          // still names the participants an agent filter kept out of its `sessions`.
-          ...(requested.length > 0 ? { memberAgentIds: visibleAgentIds } : {}),
+          ...(memberAgentIds ? { memberAgentIds } : {}),
           ...(req.query.platform ? { platform: req.query.platform } : {}),
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
@@ -553,32 +556,35 @@ export function sessionRoutes(deps: HttpDeps) {
         // §5.2 key-addressed resolver: a bounded metadata-only member lookup for
         // a direct conversation load — the paginated list is not a key lookup.
         if (conversationKey) {
+          // Resolved over the MEMBERSHIP agents and split here, so the key form
+          // reports the same membership the grouped page does — the two must not
+          // disagree about who took part just because one of them was addressed
+          // by key. The participant arm still rides along: addressing a
+          // conversation by key must not widen the same repeated `agentId` into an
+          // `IN` filter, or a key that holds A but not B would answer with A's
+          // members when the caller asked for a conversation the two of them share.
           const members = await deps.repos.session.listConversationMembers(
-            // Carries the participant arm too: addressing a conversation by key
-            // must not widen the same repeated `agentId` into an `IN` filter, or
-            // a key that holds A but not B would answer with A's members when
-            // the caller asked for a conversation the two of them share.
-            { agentIds: selectedAgentIds, conversationAgentIds, viewer },
+            { agentIds: memberAgentIds ?? selectedAgentIds, conversationAgentIds, viewer },
             conversationKey
           )
-          const hookMetadata = await hookMetadataForSessions(deps, members, orgOf(req))
+          const selected = new Set<string>(selectedAgentIds)
+          const rows = members.filter((session) => selected.has(session.agentId))
+          const hookMetadata = await hookMetadataForSessions(deps, rows, orgOf(req))
           return {
             conversations:
-              members.length > 0
+              rows.length > 0
                 ? [
                     {
                       key: encodeConversationKey(conversationKey),
                       platform: conversationKey.platform,
                       channel: conversationKey.channel,
                       thread: conversationKey.thread,
-                      sessions: members.map((session) => sessionDto(session, hookMetadata)),
-                      // The resolver already answers per agent over what the caller
-                      // asked for, so its rows ARE its membership.
+                      sessions: rows.map((session) => sessionDto(session, hookMetadata)),
                       memberSessionIds: members.map((session) => session.id)
                     }
                   ]
                 : [],
-            total: members.length > 0 ? 1 : 0,
+            total: rows.length > 0 ? 1 : 0,
             nextCursor: null,
             accessSyncDegraded: access.degraded
           }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1057,6 +1057,11 @@ export interface SessionFilterQuery extends SessionQuery {
 export interface SessionPageQuery extends SessionFilterQuery {
   limit: number
   includeTotal: boolean
+  /** Agents whose sessions count as conversation MEMBERS, when the caller may see
+   *  more than the filter returns. Absent ⇒ `agentIds`, i.e. membership and row
+   *  scope are the same set. Only widens `memberSessionIds`; which conversations
+   *  qualify, their order, and the rows returned all stay on `agentIds`. */
+  memberAgentIds?: AgentId[]
 }
 
 export type SessionFacetQuery = Omit<SessionFilterQuery, 'cursor' | 'limit'>
@@ -1085,6 +1090,10 @@ export interface ConversationRecord {
    *  history, not members). The first entry is the conversation's
    *  representative — the caller's newest visible member row. */
   sessions: SessionListRecord[]
+  /** The same collapse over every member the caller may see, ids only — the
+   *  members an agent filter kept out of `sessions` included. Who took part is a
+   *  property of the conversation, not of the filter reading it. */
+  memberSessionIds: string[]
 }
 
 export interface ConversationPageRecord {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1035,6 +1035,17 @@ export interface SessionFilterQuery extends SessionQuery {
   triggeredBy?: string
   githubHookIds?: HookId[]
   hookTriggerIds?: HookId[]
+  /** Agents whose sessions count as conversation MEMBERS, when the caller may see
+   *  more than the filter returns. Absent ⇒ `agentIds`, i.e. membership and row
+   *  scope are the same set. Only widens membership — which conversations qualify,
+   *  their order, and the rows returned all stay on `agentIds`.
+   *
+   *  It widens EXTERNAL SCOPE resolution with it. A member visible only through a
+   *  provider audience is authorized by a scope the caller's viewer snapshot has
+   *  to carry; resolving scopes over the narrower set would leave the membership
+   *  query unable to authorize the very rows it was widened to find, and drop
+   *  them again for a reason that has nothing to do with visibility. */
+  memberAgentIds?: AgentId[]
   /** Conversation-participant filter: keep only rows whose CONVERSATION
    *  (merged-conversation-view.md §5.1 key) carries a visible session for every
    *  listed agent. `agentIds` still decides which rows come back; this decides
@@ -1057,11 +1068,6 @@ export interface SessionFilterQuery extends SessionQuery {
 export interface SessionPageQuery extends SessionFilterQuery {
   limit: number
   includeTotal: boolean
-  /** Agents whose sessions count as conversation MEMBERS, when the caller may see
-   *  more than the filter returns. Absent ⇒ `agentIds`, i.e. membership and row
-   *  scope are the same set. Only widens `memberSessionIds`; which conversations
-   *  qualify, their order, and the rows returned all stay on `agentIds`. */
-  memberAgentIds?: AgentId[]
 }
 
 export type SessionFacetQuery = Omit<SessionFilterQuery, 'cursor' | 'limit'>

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1221,7 +1221,14 @@ export class PgSessionRepo implements SessionRepo {
 
   async listExternalScopes(q: SessionFilterQuery): Promise<ExternalScopeRecord[]> {
     if (queryAgentIds(q).length === 0) return []
-    const unrestricted = { ...q }
+    // Over the MEMBERSHIP agents, not the filtered ones. The scopes resolved here
+    // become the viewer snapshot every later query is authorized against, so a
+    // scope missed here is a row the membership query cannot admit — a member
+    // dropped for having been filtered out, not for being invisible.
+    const unrestricted = {
+      ...q,
+      ...(q.memberAgentIds ? { agentIds: q.memberAgentIds, agentId: undefined } : {})
+    }
     delete unrestricted.viewer
     delete unrestricted.cursor
     const rows = await this.db.$queryRaw<ExternalScope[]>(Prisma.sql`

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -997,7 +997,22 @@ export class PgSessionRepo implements SessionRepo {
     const groupable = page.filter((r) => r.channel !== null && r.thread !== null)
     const membersByKey = new Map<string, SessionMeta[]>()
     if (groupable.length > 0) {
-      const memberWhere = pageWhereSql({ ...q, cursor: undefined }, false)
+      // Membership is read over `memberAgentIds` — every agent the caller may see
+      // when that is wider than the filter. Who took part is a property of the
+      // conversation, and a client that learned it from the filtered rows would
+      // lose a member the moment the filter hid it. The participant arm goes with
+      // it: these rows are already inside a qualifying conversation, so re-testing
+      // it here would only cost a probe per row. Which conversations qualify, and
+      // in what order, stays on `agentIds` above.
+      const memberWhere = pageWhereSql(
+        {
+          ...q,
+          ...(q.memberAgentIds ? { agentIds: q.memberAgentIds, agentId: undefined } : {}),
+          conversationAgentIds: undefined,
+          cursor: undefined
+        },
+        false
+      )
       const keyTuples = groupable.map(
         (r) => Prisma.sql`(${r.platform ?? 'slack'}, ${r.tenantScope ?? ''}, ${r.channel}, ${r.thread})`
       )
@@ -1021,6 +1036,7 @@ export class PgSessionRepo implements SessionRepo {
     // newest-first, so the first row seen for an agentId wins and superseded
     // ACP session rows drop out. The representative is by construction the
     // group's first row.
+    const selected = new Set<string>(queryAgentIds(q))
     const collapsed = page.map((rep) => {
       const rows =
         rep.channel !== null && rep.thread !== null ? (membersByKey.get(conversationKeyOf(rep)) ?? [rep]) : [rep]
@@ -1031,7 +1047,10 @@ export class PgSessionRepo implements SessionRepo {
         seen.add(row.agentId)
         perAgent.push(row)
       }
-      return { rep, rows: perAgent }
+      // `rows` are the returned ones; membership is the whole collapse. They part
+      // company only under an agent filter, which is exactly when the difference
+      // matters.
+      return { rep, rows: perAgent.filter((row) => selected.has(row.agentId)), members: perAgent }
     })
     const hydrated = await this.hydrate(collapsed.flatMap((c) => c.rows))
     const byId = new Map(hydrated.map((rec) => [rec.id, rec]))
@@ -1043,7 +1062,8 @@ export class PgSessionRepo implements SessionRepo {
           channel: c.rep.channel,
           thread: c.rep.thread
         },
-        sessions: c.rows.map((row) => byId.get(SessionId(row.id))!).filter(Boolean)
+        sessions: c.rows.map((row) => byId.get(SessionId(row.id))!).filter(Boolean),
+        memberSessionIds: c.members.map((row) => row.id)
       })),
       total: totalRows ? Number(totalRows[0]?.count ?? 0n) : null,
       hasMore

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -77,6 +77,7 @@ type ConversationsBody = {
     channel: string | null
     thread: string | null
     sessions: Array<{ sessionId: string; agentId: string }>
+    memberSessionIds: string[]
   }>
   total: number | null
   nextCursor: string | null
@@ -298,6 +299,50 @@ describe('GET /sessions — multi-agent conversation filter', () => {
       'sess-a-only',
       'sess-shared-a'
     ])
+  })
+
+  it('names every visible member even when the filter returns one of them', async () => {
+    await seedDaemon(prisma, DAEMON)
+    for (const agent of [AGENT_A, AGENT_B]) await seedAgent(prisma, agent, { daemonId: DAEMON })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-a-old', AGENT_A, 1_000)
+    await slackReport('sess-a', AGENT_A, 2_000)
+    await slackReport('sess-b', AGENT_B, 3_000)
+
+    // Filtered to A: the ROWS are A's, but who took part is a property of the
+    // conversation. A client that read membership off `sessions` would lose B —
+    // and with it any way to keep following this conversation once B is the
+    // newest member it is named after.
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?agentId=${AGENT_A}` })
+    const conv = (res.json() as ConversationsBody).conversations[0]!
+    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-a'])
+    expect(conv.memberSessionIds).toEqual(['sess-b', 'sess-a'])
+
+    // Unfiltered, membership and rows are the same set — superseded rows are
+    // history in both.
+    const all = await running.app.inject({ method: 'GET', url: `${ORG}/sessions` })
+    const unfiltered = (all.json() as ConversationsBody).conversations[0]!
+    expect(unfiltered.memberSessionIds).toEqual(unfiltered.sessions.map((s) => s.sessionId))
+    expect(unfiltered.memberSessionIds).toEqual(['sess-b', 'sess-a'])
+  })
+
+  it('keeps a member the caller cannot see out of the membership it reports', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT_A, { daemonId: DAEMON })
+    const stranger = await prisma.user.create({
+      data: { id: randomUUID(), email: `stranger-${randomUUID().slice(0, 8)}@example.com`, displayName: 'Stranger' }
+    })
+    await seedAgent(prisma, AGENT_B, { daemonId: DAEMON, visibility: 'restricted', ownerUserId: stranger.id })
+    running = buildHttpApp(prisma)
+
+    await slackReport('sess-vis', AGENT_A, 1_000)
+    await slackReport('sess-hidden', AGENT_B, 2_000)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?agentId=${AGENT_A}` })
+    const body = res.json() as ConversationsBody
+    expect(body.conversations[0]!.memberSessionIds).toEqual(['sess-vis'])
+    expect(JSON.stringify(body)).not.toContain('sess-hidden')
   })
 
   it('never lets an invisible participant qualify a conversation', async () => {

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -434,6 +434,16 @@ describe('GET /sessions — multi-agent conversation filter', () => {
     expect((soloAlone.json() as ConversationsBody).conversations[0]!.sessions.map((s) => s.sessionId)).toEqual([
       'sess-a-only'
     ])
+
+    // Membership is the conversation's, not the query's, here too — the key form
+    // and the grouped page must not disagree about who took part.
+    const filtered = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?conversationKey=${keyOf('T-1')}&agentId=${AGENT_A}`
+    })
+    const conv = (filtered.json() as ConversationsBody).conversations[0]!
+    expect(conv.sessions.map((s) => s.sessionId)).toEqual(['sess-shared-a'])
+    expect(conv.memberSessionIds).toEqual(['sess-shared-b', 'sess-shared-a'])
   })
 
   it('answers empty when any requested agent is not visible to the caller', async () => {

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -527,6 +527,79 @@ describe('session visibility — Slack conversation audience', () => {
   })
 })
 
+describe('session visibility — membership across an agent filter', () => {
+  it('resolves the scopes of members the filter excluded, so membership does not lose them', async () => {
+    // A conversation where A is org-visible and B is visible ONLY through the
+    // Slack audience. Filtering the list to A still has to report B as a member
+    // (merged-conversation-view.md §5.2) — and that only works if B's scope was
+    // resolved, because the membership query is authorized against the viewer
+    // snapshot built from those scopes. Resolve scopes over the narrower filter
+    // and B is dropped for having been filtered out, not for being invisible.
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentA = await seedAgent(prisma, randomUUID(), { daemonId })
+    const agentB = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const credentialId = randomUUID()
+    const thread = `T-${randomUUID()}`
+    const sessionA = `s-mix-a-${randomUUID()}`
+    const sessionB = `s-mix-b-${randomUUID()}`
+
+    await repo.recordMilestone({
+      sessionId: SessionId(sessionA),
+      agentId: AgentId(agentA),
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_MIXED',
+      thread,
+      at: new Date(1_000),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' }
+    })
+    await repo.recordMilestone({
+      sessionId: SessionId(sessionB),
+      agentId: AgentId(agentB),
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_MIXED',
+      thread,
+      at: new Date(2_000),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: {
+        provider: 'slack',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'T_INSTALL',
+          resourceKind: 'conversation',
+          resourceKey: 'C_MIXED',
+          credentialKind: 'bot',
+          credentialId
+        }
+      }
+    })
+    const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'slack', true)
+    expect((await repo.get(SessionId(sessionB)))?.visibility).toBe('external')
+
+    const filtered = { agentIds: [AgentId(agentA)] }
+    const widened = { ...filtered, memberAgentIds: [AgentId(agentA), AgentId(agentB)] }
+    expect(await repo.listExternalScopes(filtered)).toEqual([])
+    const scopes = await repo.listExternalScopes(widened)
+    expect(scopes).toHaveLength(1)
+
+    const viewer = {
+      role: 'owner' as const,
+      identitySet: [],
+      externalAccess: {
+        policies: [{ provider: 'slack' as const, readFenceRev: enabled.policy.readFenceRev }],
+        allowedScopes: scopes.map((scope) => ({ id: scope.id, aclRevision: scope.aclRevision })),
+        decisionAt: new Date()
+      }
+    }
+    const page = await repo.listConversationPage({ ...widened, viewer, limit: 10, includeTotal: false })
+    const conversation = page.conversations.find((c) => c.key.thread === thread)!
+    expect(conversation.sessions.map((s) => s.id)).toEqual([sessionA])
+    expect(conversation.memberSessionIds).toEqual([sessionB, sessionA])
+  })
+})
+
 describe('session visibility — GitHub repository audience', () => {
   it('exposes an independent owner-only sync setting', async () => {
     const owner = await makeUser(`sv-github-owner-${randomUUID()}`, 'owner')

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -72,6 +72,10 @@ interface RailRow {
   platform: string
   title: string
   tooltip: string
+  /** Where the row goes. A multi-participant row is a CONVERSATION, and the merged
+   *  page is its only surfaced view (merged-conversation-view.md §5.3) — linking to
+   *  the member session instead would just bounce through the redirect. */
+  href: string
   session?: Session
 }
 
@@ -195,13 +199,19 @@ export function SessionRail({
   // One de-duplicated list ordered newest-first. The CP already orders its page by
   // `lastActivityAt`, so this only decides where the merged rows land. The live
   // current row comes last so it replaces its persisted twin without losing streamed state.
-  const rows = useMemo(
-    () =>
-      mergeCanonicalSessions([...sessions, ...(hydratedPins ?? []), current]).sort((a, b) =>
-        (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? '')
-      ),
-    [sessions, current, hydratedPins]
-  )
+  //
+  // The open conversation is dropped from the listed rows by KEY rather than left
+  // to the id merge below. Both name the newest member, but the list row names the
+  // newest member *the filter still covers* — narrow the filter to one of two
+  // participants and the two ids part company, putting the open conversation on
+  // screen twice.
+  const rows = useMemo(() => {
+    const currentKey = current.conversationKey
+    const listed = currentKey ? sessions.filter((s) => s.conversationKey !== currentKey) : sessions
+    return mergeCanonicalSessions([...listed, ...(hydratedPins ?? []), current]).sort((a, b) =>
+      (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? '')
+    )
+  }, [sessions, current, hydratedPins])
 
   const ordinaryRows = useMemo(
     () => (hasFamily ? rows.filter((session) => !relatedIds.has(session.id)) : rows),
@@ -231,11 +241,17 @@ export function SessionRail({
 
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
+    const id = canonicalSessionId(s)
     return {
-      id: canonicalSessionId(s),
+      // The SESSION id, even for a conversation row: it is what the pin store
+      // records and what `current` is matched against. Only the link differs.
+      id,
       platform: channel.platform,
       title: s.title,
       tooltip: `${s.title}\n${s.time} · ${channel.label}`,
+      href: s.conversationKey
+        ? orgPath(`/conversations/${encodeURIComponent(s.conversationKey)}`)
+        : orgPath(`/sessions/${encodeURIComponent(id)}`),
       session: s
     }
   }
@@ -245,7 +261,8 @@ export function SessionRail({
       id: relation.id,
       platform: relation.platform,
       title,
-      tooltip: title
+      tooltip: title,
+      href: orgPath(`/sessions/${encodeURIComponent(relation.id)}`)
     }
   }
   const isPinned = (sessionId: string) => pins.some((pin) => pin.id === sessionId)
@@ -260,7 +277,7 @@ export function SessionRail({
         }`}
       >
         <Link
-          href={orgPath(`/sessions/${encodeURIComponent(item.id)}`)}
+          href={item.href}
           title={item.tooltip}
           aria-current={on ? 'page' : undefined}
           onClick={(event) => {
@@ -409,10 +426,17 @@ function RailAgentFilter({
   // A restricted agent can own the open session while staying out of this viewer's
   // roster; show the id rather than dropping the chip and silently misdescribing
   // the list as unfiltered.
-  const chips = selected.map((id) => {
-    const agent = agents.find((a) => a.id === id)
-    return { id, label: agent ? agentLabel(agent) : id, agent }
-  })
+  //
+  // Both lists read alphabetically. Neither the roster nor the org agent list is
+  // ordered by anything the reader can see — activity reshuffles one and the API
+  // the other — so a filter that named the same agents twice in a row could still
+  // look different each time.
+  const chips = selected
+    .map((id) => {
+      const agent = agents.find((a) => a.id === id)
+      return { id, label: agent ? agentLabel(agent) : id, agent }
+    })
+    .sort((a, b) => a.label.localeCompare(b.label))
 
   useEffect(() => {
     if (!open) {
@@ -427,7 +451,9 @@ function RailAgentFilter({
   }, [open])
 
   const q = query.trim().toLowerCase()
-  const shown = agents.filter((agent) => agentLabel(agent).toLowerCase().includes(q))
+  const shown = agents
+    .filter((agent) => agentLabel(agent).toLowerCase().includes(q))
+    .sort((a, b) => agentLabel(a).localeCompare(agentLabel(b)))
 
   return (
     <div className="relative mb-[7px] flex flex-none flex-wrap items-center gap-[5px] px-[9px]">

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -46,6 +46,7 @@ import useSWR from 'swr'
 import {
   agentLabel,
   canonicalSessionId,
+  conversationRowKey,
   mergeCanonicalSessions,
   sessionChannelDisplay,
   type Agent,
@@ -60,6 +61,7 @@ import { groupSessionsByAge } from '@/lib/session-age'
 import {
   partitionPinned,
   pinnedIdsForOrg,
+  sessionPinIds,
   readSessionPins,
   SESSION_PIN_HYDRATE_MAX,
   toggleSessionPin,
@@ -76,10 +78,22 @@ interface RailRow {
    *  page is its only surfaced view (merged-conversation-view.md §5.3) — linking to
    *  the member session instead would just bounce through the redirect. */
   href: string
+  /** The id this row's pin toggle writes: the member already pinned when there is
+   *  one, so unpinning releases the pin that is actually claiming the row. */
+  pinId: string
   session?: Session
 }
 
 const EMPTY_RELATIONS: SessionRelationDto[] = []
+
+/** {@link sessionPinIds} over a rail row, whose id is canonical (a live playground
+ *  row still carries its synthetic route id). */
+function pinIdsOf(session: Session): string[] {
+  return sessionPinIds({
+    id: canonicalSessionId(session),
+    ...(session.memberSessionIds ? { memberSessionIds: session.memberSessionIds } : {})
+  })
+}
 
 /**
  * The rail's footprint with nothing in it — the shape every session detail state
@@ -170,8 +184,12 @@ export function SessionRail({
   // to load is simply not rendered — a 404 here means "missing or not authorized",
   // which is not proof of deletion, so the pin is left alone (see
   // lib/session-pins.ts).
+  // Every MEMBER of a listed conversation counts as loaded, not just the row's
+  // representative: a pin on the member who has since stopped being newest is
+  // already on screen as that conversation, and hydrating it would put the same
+  // conversation in the rail twice.
   const loadedIds = useMemo(
-    () => new Set([...sessions.map(canonicalSessionId), currentId, ...relatedIds]),
+    () => new Set([...sessions.flatMap(pinIdsOf), currentId, ...relatedIds]),
     [sessions, currentId, relatedIds]
   )
   const missingPinIds = useMemo(
@@ -200,15 +218,23 @@ export function SessionRail({
   // `lastActivityAt`, so this only decides where the merged rows land. The live
   // current row comes last so it replaces its persisted twin without losing streamed state.
   //
-  // The open conversation is dropped from the listed rows by KEY rather than left
-  // to the id merge below. Both name the newest member, but the list row names the
-  // newest member *the filter still covers* — narrow the filter to one of two
-  // participants and the two ids part company, putting the open conversation on
-  // screen twice.
+  // Rows are collapsed by CONVERSATION before the id merge. Two rows of one
+  // conversation can carry different representatives — the list names the newest
+  // member the FILTER still covers, `current` names the newest member outright —
+  // so narrowing to one of two participants would otherwise put the open
+  // conversation on screen twice. Later entries win, which is why `current` is
+  // last: it is the live row, and it must not be replaced by its persisted twin.
   const rows = useMemo(() => {
-    const currentKey = current.conversationKey
-    const listed = currentKey ? sessions.filter((s) => s.conversationKey !== currentKey) : sessions
-    return mergeCanonicalSessions([...listed, ...(hydratedPins ?? []), current]).sort((a, b) =>
+    const byConversation = new Map<string, Session>()
+    for (const session of [...sessions, ...(hydratedPins ?? []), current]) {
+      const key = conversationRowKey(session)
+      const seen = byConversation.get(key)
+      // Layered, not replaced: `current` carries the live state but not the roster
+      // the list row was built with, and dropping that would cost the row its
+      // members — the very thing its pin and its link are matched on.
+      byConversation.set(key, seen ? { ...seen, ...session } : session)
+    }
+    return mergeCanonicalSessions([...byConversation.values()]).sort((a, b) =>
       (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? '')
     )
   }, [sessions, current, hydratedPins])
@@ -217,7 +243,7 @@ export function SessionRail({
     () => (hasFamily ? rows.filter((session) => !relatedIds.has(session.id)) : rows),
     [hasFamily, relatedIds, rows]
   )
-  const { pinned, rest } = useMemo(() => partitionPinned(ordinaryRows, pins), [ordinaryRows, pins])
+  const { pinned, rest } = useMemo(() => partitionPinned(ordinaryRows, pins, pinIdsOf), [ordinaryRows, pins])
   // Dated groups cover the UNPINNED rows only — a pin is an explicit "keep this at
   // the top", which outranks how old the run is. `now` is read per render; the rail
   // only renders once its agent-filtered page has landed on the client, so there is
@@ -242,16 +268,21 @@ export function SessionRail({
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
     const id = canonicalSessionId(s)
+    // The merged page is the only surfaced view of a MULTI-participant
+    // conversation (§5.3). A conversation of one is still read as a session, so
+    // the test is `participants` and not the key every grouped row now carries.
+    const merged = (s.participants?.length ?? 0) > 1 && s.conversationKey
     return {
-      // The SESSION id, even for a conversation row: it is what the pin store
-      // records and what `current` is matched against. Only the link differs.
+      // The SESSION id: it is what `current` is matched against and what a fresh
+      // pin records. Pin LOOKUP goes through every member (see sessionPinIds).
       id,
       platform: channel.platform,
       title: s.title,
       tooltip: `${s.title}\n${s.time} · ${channel.label}`,
-      href: s.conversationKey
-        ? orgPath(`/conversations/${encodeURIComponent(s.conversationKey)}`)
+      href: merged
+        ? orgPath(`/conversations/${encodeURIComponent(s.conversationKey!)}`)
         : orgPath(`/sessions/${encodeURIComponent(id)}`),
+      pinId: rowPin(s).id,
       session: s
     }
   }
@@ -262,10 +293,18 @@ export function SessionRail({
       platform: relation.platform,
       title,
       tooltip: title,
-      href: orgPath(`/sessions/${encodeURIComponent(relation.id)}`)
+      href: orgPath(`/sessions/${encodeURIComponent(relation.id)}`),
+      pinId: relation.id
     }
   }
   const isPinned = (sessionId: string) => pins.some((pin) => pin.id === sessionId)
+  // A conversation row is pinned when ANY of its members is, and unpinning it
+  // must release that same member — pinning the current representative instead
+  // would leave the old pin behind, still claiming the row.
+  const rowPin = (s: Session) => {
+    const ids = pinIdsOf(s)
+    return { pinned: ids.some(isPinned), id: ids.find(isPinned) ?? canonicalSessionId(s) }
+  }
   const row = (item: RailRow, pinnedRow: boolean, depth: 0 | 1 | 2 = 0, on = false) => {
     return (
       <div
@@ -312,7 +351,7 @@ export function SessionRail({
         </Link>
         <button
           type="button"
-          onClick={() => togglePin(item.id)}
+          onClick={() => togglePin(item.pinId)}
           aria-pressed={pinnedRow}
           title={pinnedRow ? 'Unpin session' : 'Pin session'}
           className={`absolute top-1/2 right-[7px] z-10 flex h-[19px] w-[19px] -translate-y-1/2 items-center justify-center rounded-[5px] border-0 bg-none p-0 hover:bg-(--surface-active) hover:text-(--brand) focus-visible:shadow-[0_0_0_3px_var(--brand-ring)] focus-visible:outline-none ${
@@ -343,7 +382,7 @@ export function SessionRail({
                 </div>
               )}
               {parent && row(relationRow(parent), isPinned(parent.id))}
-              {row(sessionRow(current), isPinned(currentId), parent ? 1 : 0, true)}
+              {row(sessionRow(current), rowPin(current).pinned, parent ? 1 : 0, true)}
               {conversation && children.length > 0 && (
                 <div className="flex-none px-[9px] pt-[4px] pb-[2px] font-mono text-[9.5px] font-semibold tracking-[0.08em] text-(--text-tertiary) uppercase">
                   Delegations

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -269,9 +269,11 @@ export function SessionRail({
     const channel = sessionChannelDisplay(s, cronName)
     const id = canonicalSessionId(s)
     // The merged page is the only surfaced view of a MULTI-participant
-    // conversation (§5.3). A conversation of one is still read as a session, so
-    // the test is `participants` and not the key every grouped row now carries.
-    const merged = (s.participants?.length ?? 0) > 1 && s.conversationKey
+    // conversation (§5.3). The test is MEMBERSHIP, not the key every grouped row
+    // now carries and not `participants` — under an agent filter a shared thread
+    // returns one row, and reading that as a single-agent session would send the
+    // reader to a member session that immediately redirects here anyway.
+    const merged = pinIdsOf(s).length > 1 && s.conversationKey
     return {
       // The SESSION id: it is what `current` is matched against and what a fresh
       // pin records. Pin LOOKUP goes through every member (see sessionPinIds).

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -2364,11 +2364,14 @@ export default function SessionDetailView() {
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
       <SessionRail
         sessions={railSessions}
-        // In conversation mode the open row IS a conversation, so it has to say so:
-        // the grouped list identifies its rows by key, and a `current` merged in
-        // without one would overwrite the matching row with a bare session and
-        // send the reader back through the member→conversation redirect.
-        current={conversationMode && conversationKey ? { ...session, conversationKey } : session}
+        // The open row has to name its conversation, because that is how the rail
+        // collapses it against the grouped list — matching on the session id alone
+        // would double the row whenever the two disagree on which member is
+        // newest. `selfKey` is the same §5.1 key computed for the redirect probe,
+        // so a single-participant thread is deduplicated on exactly the same terms.
+        current={
+          (conversationKey ?? selfKey) ? { ...session, conversationKey: (conversationKey ?? selfKey)! } : session
+        }
         total={railSessionTotal}
         agentIds={railFilter.agentIds}
         filterTouched={railFilter.touched}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1324,6 +1324,25 @@ export default function SessionDetailView() {
     const shared = railAgentIds.map(channelsOf).reduce((a, b) => new Set([...a].filter((c) => b.has(c))))
     return allSessions.filter((s) => railAgentIds.includes(s.agentId ?? '') && shared.has(`${s.platform} ${s.channel}`))
   }, [allSessions, getSessions, railAgentIds, railQuery, railSessionRows])
+  // The open row as the rail sees it: its conversation and, where the resolver
+  // has answered, that conversation's full membership. Both are identity the rail
+  // matches on, and neither is on the session row itself.
+  const railCurrentKey = conversationKey ?? selfKey
+  const railCurrentMemberIds = useMemo(() => {
+    const roster = conversationKey ? conversationMembers : (selfConversation?.sessions ?? null)
+    return roster?.map((member) => member.sessionId) ?? null
+  }, [conversationKey, conversationMembers, selfConversation])
+  const railCurrent = useMemo(
+    () =>
+      session && (railCurrentKey || railCurrentMemberIds)
+        ? {
+            ...session,
+            ...(railCurrentKey ? { conversationKey: railCurrentKey } : {}),
+            ...(railCurrentMemberIds ? { memberSessionIds: railCurrentMemberIds } : {})
+          }
+        : session,
+    [session, railCurrentKey, railCurrentMemberIds]
+  )
   const sessionBusy = session ? isPgBusy(session.id) : false
   const sessionBusyRef = useRef(sessionBusy)
   sessionBusyRef.current = sessionBusy
@@ -2364,14 +2383,14 @@ export default function SessionDetailView() {
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
       <SessionRail
         sessions={railSessions}
-        // The open row has to name its conversation, because that is how the rail
-        // collapses it against the grouped list — matching on the session id alone
-        // would double the row whenever the two disagree on which member is
-        // newest. `selfKey` is the same §5.1 key computed for the redirect probe,
-        // so a single-participant thread is deduplicated on exactly the same terms.
-        current={
-          (conversationKey ?? selfKey) ? { ...session, conversationKey: (conversationKey ?? selfKey)! } : session
-        }
+        // The open row has to name its conversation and its members, because that
+        // is how the rail collapses it against the grouped list and how a pin
+        // finds it — matching on the session id alone would double the row (or
+        // lose its pin) whenever the two disagree on which member is newest.
+        // `selfKey` is the same §5.1 key computed for the redirect probe, so a
+        // single-participant thread is deduplicated on exactly the same terms, and
+        // the roster resolver is not agent-filtered, so its members are complete.
+        current={railCurrent ?? session}
         total={railSessionTotal}
         agentIds={railFilter.agentIds}
         filterTouched={railFilter.touched}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1300,11 +1300,18 @@ export default function SessionDetailView() {
   // the question being asked. A null query means the filter has nothing to say yet
   // (no session, and the reader has not touched it), so the org key stays null and
   // no page is fetched to be thrown away.
+  //
+  // GROUPED, because the filter is conversation-shaped: the flat view returns one
+  // row per member session, so the moment the filter names a whole roster a thread
+  // two agents worked in listed itself once per agent. One row per conversation is
+  // also what the rail was always showing — that only happened to be true while
+  // the filter named a single agent.
   const railQuery = railAgentFilterQuery(railFilter)
   const railAgentIds = railQuery?.agentId ?? []
   const { sessions: railSessionRows, total: railSessionTotal } = useSessionList(
     MOCK_MODE || !railQuery ? null : activeOrg?.id,
-    railQuery ?? {}
+    railQuery ?? {},
+    { grouped: true }
   )
   const railSessions = useMemo(() => {
     if (!MOCK_MODE) return railSessionRows
@@ -2357,7 +2364,11 @@ export default function SessionDetailView() {
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
       <SessionRail
         sessions={railSessions}
-        current={session}
+        // In conversation mode the open row IS a conversation, so it has to say so:
+        // the grouped list identifies its rows by key, and a `current` merged in
+        // without one would overwrite the matching row with a bare session and
+        // send the reader back through the member→conversation redirect.
+        current={conversationMode && conversationKey ? { ...session, conversationKey } : session}
         total={railSessionTotal}
         agentIds={railFilter.agentIds}
         filterTouched={railFilter.touched}

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -177,8 +177,12 @@ export default function SessionsView() {
   const sessionHref = useCallback(
     (session: Session) => {
       // A multi-participant conversation row links to the merged page — the
-      // only surfaced view for it (merged-conversation-view.md §5.3).
-      if (session.conversationKey) return orgPath(`/conversations/${encodeURIComponent(session.conversationKey)}`)
+      // only surfaced view for it (merged-conversation-view.md §5.3). The test is
+      // `participants`, not the key: every grouped row carries a key now, and a
+      // one-participant conversation is still read as a session.
+      if ((session.participants?.length ?? 0) > 1 && session.conversationKey) {
+        return orgPath(`/conversations/${encodeURIComponent(session.conversationKey)}`)
+      }
       const id = canonicalSessionId(session)
       const query = new URLSearchParams(filterQuery)
       const provider = sessionPlatform(session)

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -178,9 +178,9 @@ export default function SessionsView() {
     (session: Session) => {
       // A multi-participant conversation row links to the merged page — the
       // only surfaced view for it (merged-conversation-view.md §5.3). The test is
-      // `participants`, not the key: every grouped row carries a key now, and a
-      // one-participant conversation is still read as a session.
-      if ((session.participants?.length ?? 0) > 1 && session.conversationKey) {
+      // MEMBERSHIP, not the key every grouped row carries now, and not
+      // `participants`, which an agent filter narrows to the rows it returned.
+      if ((session.memberSessionIds?.length ?? 0) > 1 && session.conversationKey) {
         return orgPath(`/conversations/${encodeURIComponent(session.conversationKey)}`)
       }
       const id = canonicalSessionId(session)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1935,10 +1935,21 @@ export async function fetchConversations(
   const sessions = (page.conversations ?? []).map((conversation) => {
     const members = conversation.sessions.map(sessionFromDto)
     const rep = members[0]!
-    if (members.length <= 1) return rep
+    // Conversation IDENTITY rides along whatever the member count. Filtering to a
+    // single participant still returns the conversation, only with one member, and
+    // a row that dropped its key there could not be recognised as the same
+    // conversation the reader has open. What marks a row as a MERGED view is
+    // `participants`, not the key. `memberSessionIds` names every member so a
+    // consumer keyed on the representative — which moves as participants take
+    // turns — can follow the conversation instead of the session.
+    const identity = {
+      ...(conversation.key !== null ? { conversationKey: conversation.key } : {}),
+      memberSessionIds: members.map((member) => member.id)
+    }
+    if (members.length <= 1) return { ...rep, ...identity }
     return {
       ...rep,
-      ...(conversation.key !== null ? { conversationKey: conversation.key } : {}),
+      ...identity,
       // Names resolve at render time from the org agent list (the DTO carries
       // ids only); the placeholder keeps the field shape valid.
       participants: members.map((member, i) => ({

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -400,8 +400,14 @@ export interface ConversationDto {
   platform: string | null
   channel: string | null
   thread: string | null
-  /** Current member sessions, representative (newest visible) first. */
+  /** Current member sessions, representative (newest visible) first. Narrowed by
+   *  an `agentId` filter — these are the rows the query asked for, not the
+   *  conversation's membership. */
   sessions: SessionDto[]
+  /** Every visible member's session id, the ones an `agentId` filter kept out of
+   *  `sessions` included. Absent on a CP that predates the field, where the
+   *  filtered rows are the best membership available. */
+  memberSessionIds?: string[]
 }
 
 export interface SessionListPageDto {
@@ -1936,22 +1942,25 @@ export async function fetchConversations(
     const members = conversation.sessions.map(sessionFromDto)
     const rep = members[0]!
     // Conversation IDENTITY rides along whatever the member count. Filtering to a
-    // single participant still returns the conversation, only with one member, and
+    // single participant still returns the conversation, only with fewer rows, and
     // a row that dropped its key there could not be recognised as the same
-    // conversation the reader has open. What marks a row as a MERGED view is
-    // `participants`, not the key. `memberSessionIds` names every member so a
-    // consumer keyed on the representative — which moves as participants take
-    // turns — can follow the conversation instead of the session.
+    // conversation the reader has open. Membership comes from `memberSessionIds`,
+    // which the CP reports over everything the caller can see — `sessions` is
+    // narrowed by the filter, so counting it would lose a participant exactly when
+    // the filter is what made the row ambiguous. An older CP omits it; its
+    // filtered rows are then the best membership on offer.
+    const memberSessionIds = conversation.memberSessionIds ?? members.map((member) => member.id)
     const identity = {
       ...(conversation.key !== null ? { conversationKey: conversation.key } : {}),
-      memberSessionIds: members.map((member) => member.id)
+      memberSessionIds
     }
-    if (members.length <= 1) return { ...rep, ...identity }
+    if (memberSessionIds.length <= 1) return { ...rep, ...identity }
     return {
       ...rep,
       ...identity,
-      // Names resolve at render time from the org agent list (the DTO carries
-      // ids only); the placeholder keeps the field shape valid.
+      // The members the FILTER returned, which is what the row can name. Names
+      // resolve at render time from the org agent list (the DTO carries ids only);
+      // the placeholder keeps the field shape valid.
       participants: members.map((member, i) => ({
         agentId: member.agentId ?? '',
         name: member.agentName ?? member.agentId ?? '',

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -11,6 +11,7 @@ import {
   effortField,
   fastModeAvailableFor,
   lifecycleStatus,
+  conversationRowKey,
   mergeCanonicalSessions,
   modelCapability,
   modelLabel,
@@ -123,6 +124,23 @@ describe('mergeCanonicalSessions', () => {
     expect(mergeCanonicalSessions([persisted, live])).toEqual([
       expect.objectContaining({ id: 'session-real', realSessionId: 'session-real', title: 'Live title' })
     ])
+  })
+
+  describe('conversationRowKey', () => {
+    it('gives two rows of one conversation the same identity, whatever represents them', () => {
+      // A filtered list names the newest member the filter still covers; the open
+      // page names the newest member outright. Narrow a two-agent filter to one
+      // participant and those part company — on the session id the conversation
+      // would list itself twice.
+      const listed = { ...persisted, id: 'member-a', conversationKey: 'conv-1' }
+      const open = { ...persisted, id: 'member-b', conversationKey: 'conv-1' }
+      expect(conversationRowKey(listed)).toBe(conversationRowKey(open))
+    })
+
+    it('falls back to the session for a row that belongs to no conversation', () => {
+      expect(conversationRowKey(persisted)).toBe('session-real')
+      expect(conversationRowKey({ ...persisted, id: 'pg_x', realSessionId: 'session-real' })).toBe('session-real')
+    })
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -924,9 +924,17 @@ export interface Session {
   /** Multi-agent webchat roster (webchat-multi-agents.md §3.1), primary first —
    *  present on live conversations with more than one participant. */
   participants?: Array<{ agentId: string; name: string; primary?: boolean }>
-  /** merged-conversation-view.md §5.1 key — present on grouped-list rows that
-   *  represent a multi-participant conversation. */
+  /** merged-conversation-view.md §5.1 key — the conversation a grouped-list row
+   *  stands for, whatever its member count. It is IDENTITY, not a claim that the
+   *  row is a merged view: that is `participants`. A single-participant row still
+   *  carries it, because filtering to one agent narrows the members, not the
+   *  conversation they belong to. */
   conversationKey?: string
+  /** Every member session of a grouped-list row's conversation, representative
+   *  first. The row's own `id` is only the representative, which moves as
+   *  participants take turns; anything that must survive that — a pin, an
+   *  already-loaded check — matches against this instead. */
+  memberSessionIds?: string[]
   /** Runtime id + daemonId the session ran with: the session-recorded snapshot,
    *  with the owning agent's current values as the legacy-row fallback (attached
    *  at flatten time, like `model`). Views resolve `daemon` to a display name. */
@@ -939,6 +947,19 @@ export interface Session {
  * persisted rows. Later rows win so callers can put the freshest representation last. */
 export function canonicalSessionId(session: Pick<Session, 'id' | 'realSessionId'>): string {
   return session.realSessionId ?? session.id
+}
+
+/**
+ * What a row IS, for lists that must not show one conversation twice: its
+ * conversation where it has one, and otherwise the session itself.
+ *
+ * Two rows of the same conversation can disagree about which session represents
+ * it — a filtered list names the newest member the filter still covers, while the
+ * open page names the newest member outright — so the session id cannot be the
+ * identity a list deduplicates on.
+ */
+export function conversationRowKey(session: Pick<Session, 'id' | 'realSessionId' | 'conversationKey'>): string {
+  return session.conversationKey ?? canonicalSessionId(session)
 }
 
 export function mergeCanonicalSessions(sessions: readonly Session[]): Session[] {

--- a/packages/web/src/lib/session-pins.test.ts
+++ b/packages/web/src/lib/session-pins.test.ts
@@ -145,4 +145,24 @@ describe('partitionPinned', () => {
   it('is a pass-through with no pins', () => {
     expect(partitionPinned(rows, [])).toEqual({ pinned: [], rest: rows })
   })
+
+  it('keeps a conversation pinned after another participant becomes its newest', () => {
+    // A conversation row is identified by its newest member, which moves as the
+    // participants take turns. The pin was written against `m2`; the row now
+    // answers to `m1`, and matching on the row id alone would lose it.
+    const conversation = { id: 'm1', members: ['m1', 'm2'] }
+    const other = { id: 'x', members: ['x'] }
+    expect(partitionPinned([conversation, other], [pin('m2')], (row) => row.members)).toEqual({
+      pinned: [conversation],
+      rest: [other]
+    })
+  })
+
+  it('lists a conversation once when several of its members are pinned', () => {
+    const conversation = { id: 'm1', members: ['m1', 'm2'] }
+    expect(partitionPinned([conversation], [pin('m1'), pin('m2')], (row) => row.members)).toEqual({
+      pinned: [conversation],
+      rest: []
+    })
+  })
 })

--- a/packages/web/src/lib/session-pins.ts
+++ b/packages/web/src/lib/session-pins.ts
@@ -92,21 +92,36 @@ export function pinnedIdsForOrg(pins: SessionPin[], orgId: string): string[] {
 /** Split `sessions` into the pinned ones (in pin order, newest pin first) and the
  *  rest (input order preserved). Matches on id alone, so a legacy pin whose
  *  organization was never recorded still groups correctly once its row appears. */
+/** The stored-pin ids a row answers to: every member of its conversation, or just
+ *  itself for an ordinary session. A conversation is identified in a list by its
+ *  newest member, and that moves whenever another participant answers — so a pin
+ *  recorded against the row's own id alone would come loose on ordinary activity. */
+export function sessionPinIds(row: { id: string; memberSessionIds?: string[] }): string[] {
+  return row.memberSessionIds?.length ? row.memberSessionIds : [row.id]
+}
+
 export function partitionPinned<T extends { id: string }>(
   sessions: T[],
-  pins: SessionPin[]
+  pins: SessionPin[],
+  // Which stored ids claim a row. A conversation row stands for several member
+  // sessions and is identified by whichever is newest, so matching on its `id`
+  // alone would silently drop the pin the moment another participant answered.
+  idsOf: (row: T) => readonly string[] = (row) => [row.id]
 ): { pinned: T[]; rest: T[] } {
-  const byId = new Map(sessions.map((s) => [s.id, s]))
+  const byId = new Map<string, T>()
+  for (const session of sessions) {
+    for (const id of idsOf(session)) if (!byId.has(id)) byId.set(id, session)
+  }
   const pinned: T[] = []
-  const seen = new Set<string>()
+  const seen = new Set<T>()
   for (const { id } of pins) {
     const hit = byId.get(id)
-    if (hit && !seen.has(id)) {
+    if (hit && !seen.has(hit)) {
       pinned.push(hit)
-      seen.add(id)
+      seen.add(hit)
     }
   }
-  return { pinned, rest: sessions.filter((s) => !seen.has(s.id)) }
+  return { pinned, rest: sessions.filter((s) => !seen.has(s)) }
 }
 
 function asPin(entry: unknown): SessionPin | null {

--- a/packages/web/src/lib/session-rail-filter.test.ts
+++ b/packages/web/src/lib/session-rail-filter.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from 'vitest'
 import { EMPTY_RAIL_AGENT_FILTER, railAgentFilterQuery, seedRailAgentFilter } from './session-rail-filter'
 
 describe('seedRailAgentFilter', () => {
-  it('defaults to the open conversation’s agents, in roster order', () => {
+  it('defaults to the open conversation’s agents', () => {
     expect(seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a', 'agent-b'])).toEqual({
       agentIds: ['agent-a', 'agent-b'],
       touched: false
     })
+  })
+
+  it('does not re-seed when the roster comes back in a different order', () => {
+    // The roster is ordered by last activity, so the same two agents arrive
+    // either way round as they take turns. Re-seeding on that would reshuffle
+    // the reader's chips every time one of them spoke.
+    const seeded = seedRailAgentFilter(EMPTY_RAIL_AGENT_FILTER, ['agent-a', 'agent-b'])
+    expect(seedRailAgentFilter(seeded, ['agent-b', 'agent-a'])).toBe(seeded)
   })
 
   it('drops duplicate and blank roster entries', () => {

--- a/packages/web/src/lib/session-rail-filter.ts
+++ b/packages/web/src/lib/session-rail-filter.ts
@@ -12,6 +12,9 @@
 // on a thread two agents worked in, the rail's default question is "the other
 // threads these two worked in together", which is exactly what the CP answers for
 // a repeated `agentId` (merged-conversation-view.md §5.1 grouping).
+//
+// Order carries no meaning here — the CP's answer does not depend on it — so the
+// ids are held sorted to keep the state from churning as the roster reshuffles.
 
 export interface RailAgentFilter {
   /** Agents the rail's list is filtered to. Empty = every session the viewer can see. */
@@ -35,9 +38,11 @@ function sameIds(a: readonly string[], b: readonly string[]): boolean {
  */
 export function seedRailAgentFilter(chosen: RailAgentFilter, conversationAgentIds: readonly string[]): RailAgentFilter {
   if (chosen.touched) return chosen
-  // De-duplicated but NOT sorted: the roster arrives in the conversation's own
-  // order (its primary agent first), which is the order the chips should read in.
-  const agentIds = [...new Set(conversationAgentIds)].filter(Boolean)
+  // Sorted, because the roster arrives in last-activity order: leaving it alone
+  // would re-seed the filter — and reshuffle the chips — every time one of the
+  // agents said something. Ids sort arbitrarily but STABLY, which is all the
+  // state needs; the chips are ordered by name where they are rendered.
+  const agentIds = [...new Set(conversationAgentIds)].filter(Boolean).sort()
   return sameIds(chosen.agentIds, agentIds) ? chosen : { agentIds, touched: false }
 }
 


### PR DESCRIPTION
Follow-up to [#452](https://github.com/agentconnect-md/agentconnect/pull/452), reported on test after it deployed: a conversation two agents worked in listed itself **twice** in the rail — once per member session.

## Cause

Seeding the filter from the whole roster made the rail read the **flat** view (`view=flat`, one row per session) with every member agent selected. While the filter named a single agent you only ever saw that agent's rows, so "one row per conversation" looked true; it wasn't — it was one row per session, and the multi-agent seed exposed that.

Confirmed on the deployed page: two `hello` rows, `019fc48f-32dd…` and `019fc48f-31e8…`, the two member sessions of the same conversation.

## Fix

The list now reads the **grouped** view its filter is shaped for. That also collapses the superseded ACP sessions the flat view had always kept as separate rows.

Two things had to follow:

- **A conversation row links to the merged page**, not to a member session that would immediately bounce through the §5.3 redirect. `item.id` stays the *session* id — it is what the pin store records and what `current` is matched against — so only the href changes.
- **The open conversation is dropped from the listed rows by KEY**, not left to the id merge. Both sides name the newest member, but the list names the newest member *the filter still covers*: remove one participant's chip and the two ids part company, putting the open conversation on screen twice again.

## Filter ordering

Separately reported: the filter's agents were unstably ordered. Neither source is ordered by anything the reader can see — the roster is by last activity, the org agent list is API order — so an agent taking a turn was enough to reshuffle the chips. Chips and picker now read alphabetically, and the seed holds its ids sorted so the state itself stops churning (new test).

## Verification

Web suites green (630 tests), typecheck, ESLint, Prettier clean. Alphabetical ordering and the pick-order independence of the chips verified in the mock console.

One gap worth stating: the grouped path needs real data — the mock fixtures carry no conversation grouping — so the dedup itself is verified by the CP integration test that a multi-agent grouped query returns one conversation per shared thread, plus the fact that this mapping is the same code the `/sessions` list page already runs in production. Worth a glance on test once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)