### PR TITLE
fix(daemon): isolate runtime homes per agent

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -311,6 +311,14 @@ On POSIX hosts, AgentConnect removes group/other access from existing
 `0600`. Agent directories created by the daemon use `0700`; existing custom
 agent directories and higher custom parents are left unchanged.
 
+Every composed ACP runtime launch receives an agent-scoped user environment under
+`<agent-dir>/home`: `HOME`, the XDG state roots, and verified runtime-specific
+locations such as `CODEX_HOME` and `CLAUDE_CONFIG_DIR` cannot resolve to the daemon
+account's shared directories. This applies whether or not the OS sandbox is enabled
+and prevents accidental cross-agent session/config/cache mixing. It is not a security
+boundary by itself: an unsandboxed runtime still has the daemon account's filesystem
+authority and can deliberately access other same-user paths.
+
 ### Linux ACP runtime sandbox
 
 AgentConnect currently enables runtime sandboxing on Linux only. The daemon uses
@@ -320,9 +328,9 @@ state is never shared between agents. The host must provide working `bwrap`,
 `socat`, and `rg` executables and permit unprivileged user namespaces. Startup
 performs a live probe rather than treating installed binaries as sufficient.
 
-An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
-metadata and the host source from which that runtime state was seeded, and
-re-allows reads only for the workspace, private HOME, managed memory,
+An enabled sandbox confines the already-private runtime environment, hides
+daemon-owned agent metadata and the host source from which runtime state was
+seeded, and re-allows reads only for the workspace, private HOME, managed memory,
 `run/config-files`, `.agentconnect/runtime-policy`, trusted runtime installation
 roots, and the runtime's selected host credential path. Writes are limited to
 the workspace, private HOME, managed memory, SRT temporary storage, and that

--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -207,9 +207,9 @@ agents:
 
 - **An isolated HOME is mandatory, not preferred.** Some agents persist
   `set_config_option` values as user defaults. Enumeration must never touch the
-  real HOME. Reuse curated probe's isolated launch
-  (`composeRuntimeLaunch` with `isolateHome: true`), which applies even without
-  an OS sandbox. If a runtime cannot pass authentication in isolation because
+  real HOME. Reuse the curated probe's composed launch; `composeRuntimeLaunch`
+  always supplies the probe scope's private HOME, including without an OS
+  sandbox. If a runtime cannot pass authentication in isolation because
   credentials live in the real HOME, **skip enumeration for that runtime** and
   accept phase-1-only data, with static UI fallback. Missing matrix data is
   preferable to rewriting user configuration.

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -134,9 +134,9 @@ export function effectiveRunInSandbox(
   return requireSandbox || (requested && mechanism !== undefined)
 }
 
-/** Prepare one ACP adapter launch. A private HOME is normally part of sandbox
- * isolation, but security probes and runtimes with generated private policy may
- * request the same environment isolation without an OS sandbox. */
+/** Prepare one ACP adapter launch. HOME isolation and OS confinement are separate:
+ * composed agent/probe launches always request a private HOME, while low-level
+ * direct callers may still inherit the daemon environment explicitly. */
 export function prepareRuntimeLaunch(opts: {
   runtimeId: string
   runtime?: RuntimeDef

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -119,8 +119,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   }
   Object.assign(agentEnv, configFiles.env)
   for (const notice of configFiles.notices) out.write(`⚠️ ${notice}\n`)
-  const memoryAgent =
-    memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
+  const memoryAgent = memoryKindOf(agent) === 'native' ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
   const composed = composeRuntimeLaunch({
     runtimeId: agent.runtime,
     runtime,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1401,14 +1401,14 @@ export class Daemon {
   private mcp!: McpControlServer
   // The agent memory provider. Per-agent: it dispatches each call to the agent's
   // configured backend (managed = our <agent-root>/memory/ dir; native = the
-  // runtime's own memory redirected under the private runtime HOME only while the
-  // agent runs in the sandbox). Backs the memory MCP tools, the session-start index
-  // injection, and the CP console's memory reads.
+  // runtime's own memory redirected under the private runtime HOME). Backs the
+  // memory MCP tools, the session-start index injection, and the CP console's
+  // memory reads.
   private memory: DispatchingMemoryProvider = createMemoryProvider(
     (id) => {
       const agent = this.agents.get(id)
       if (!agent) return undefined
-      return memoryKindOf(agent) === 'native' && this.agentRunsInSandbox(agent) ? runtimeHomePath(agent.dir) : agent.dir
+      return memoryKindOf(agent) === 'native' ? runtimeHomePath(agent.dir) : agent.dir
     },
     (id) => {
       const a = this.agents.get(id)
@@ -4183,8 +4183,7 @@ export class Daemon {
         `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
       )
     }
-    const memoryAgent =
-      memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
+    const memoryAgent = memoryKindOf(agent) === 'native' ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
     const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
     const env: Record<string, string> = {
       ...baseEnv,

--- a/packages/daemon/src/runtimes/launch-policy.ts
+++ b/packages/daemon/src/runtimes/launch-policy.ts
@@ -145,7 +145,6 @@ export function composeRuntimeLaunch(opts: {
   explicitEnv?: Record<string, string>
   stateSourceEnv?: NodeJS.ProcessEnv
   hostEnv?: NodeJS.ProcessEnv
-  isolateHome?: boolean
   runInSandbox: boolean
   daemonRoot?: string
   agentsRoot?: string
@@ -175,7 +174,11 @@ export function composeRuntimeLaunch(opts: {
     scopeDir: opts.scopeDir,
     cwd: opts.cwd,
     runInSandbox: opts.runInSandbox,
-    isolateHome: opts.isolateHome || (protectedMemory && policyId === 'hermes-agent'),
+    // Runtime state is agent-scoped even when the operator deliberately runs the
+    // process without OS confinement. The sandbox controls filesystem authority;
+    // it must not be the switch that decides whether HOME/XDG/session state is
+    // shared with the daemon account.
+    isolateHome: true,
     explicitEnv: opts.explicitEnv,
     stateSourceEnv,
     hostEnv: opts.hostEnv,

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -20,7 +20,7 @@ const LEGACY_RUNTIME_STATE: Record<string, string[]> = {
   'codex-acp': ['.codex']
 }
 
-/** Persistent private user environment for an agent runtime while it is sandboxed. */
+/** Persistent private user environment for one agent runtime. */
 export function runtimeHomePath(scopeDir: string): string {
   return join(resolve(scopeDir), 'home')
 }

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -448,7 +448,6 @@ export function preparedProbeLaunch(
     provider: 'managed',
     scopeDir,
     cwd,
-    isolateHome: true,
     runInSandbox: opts.runInSandbox ?? false,
     daemonRoot: opts.daemonRoot,
     agentsRoot: opts.agentsRoot,

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -333,6 +333,32 @@ describe('prepareRuntimeLaunch', () => {
 const runtime = (command: string, args: string[] = ['acp']): RuntimeDef => ({ command, args, env: [] })
 
 describe('composeRuntimeLaunch', () => {
+  it.each([
+    ['codex-acp', 'codex-acp', 'CODEX_HOME', '.codex'],
+    ['claude-acp', 'claude-agent-acp', 'CLAUDE_CONFIG_DIR', '.claude']
+  ])('keeps unsandboxed %s state under the agent HOME', (runtimeId, command, stateEnv, stateDir) => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const composed = composeRuntimeLaunch({
+      runtimeId,
+      runtime: runtime(command),
+      provider: 'managed',
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      explicitEnv: {
+        HOME: '/tmp/escape-home',
+        [stateEnv]: '/tmp/escape-state'
+      },
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const privateHome = join(scopeDir, 'home')
+    expect(composed.launch.inheritProcessEnv).toBe(false)
+    expect(composed.launch.sandbox).toBeUndefined()
+    expect(composed.launch.env.HOME).toBe(privateHome)
+    expect(composed.launch.env[stateEnv]).toBe(join(privateHome, stateDir))
+  })
+
   it('pins Anthropic profile discovery away from the actual sandboxed child HOME', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const composed = composeRuntimeLaunch({


### PR DESCRIPTION
## Summary

- give every composed ACP runtime an agent-scoped `HOME` and XDG environment even when OS sandboxing is disabled
- align native memory and CLI chat state with the same private runtime home
- cover unsandboxed Codex and Claude state roots and document the isolation/confinement boundary

## Root cause

Home isolation was coupled to `runInSandbox`. After a cold daemon restart, an unsandboxed ACP host inherited the daemon account's `HOME`, so runtime session and configuration state could land in shared user directories. Warm hosts could mask the issue until they respawned. The host cache remains agent-keyed and `runInSandbox` is already part of its respawn signature; the missing invariant was in the launch environment itself.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/runtime-launch.test.ts test/runtime-home.test.ts test/memory-provider-dispatch.test.ts` (51 passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm --filter @agentconnect.md/daemon build`
- pre-push ESLint
- full daemon run reached 2,711 passing tests; the local macOS run ended nonzero on watcher `EMFILE` exhaustion and `sandbox-exec` permission failures in skills CLI golden tests

Created by Codex . GPT-5.6
