### PR TITLE
test(ci): run core sandbox suite on Linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,10 +121,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Generate Prisma client
         run: pnpm -r prisma:generate
-      # NOTE: this job runs bwrap-free on purpose. The confined skills suites
-      # (which need the OS sandbox) self-skip here and run in the dedicated
-      # `skill-sandbox` job below; keeping bwrap out avoids forcing every other
-      # bwrap-gated suite to run under the runner's kernel sandbox.
+      # NOTE: this job runs bwrap-free on purpose. Suites that need the OS
+      # sandbox self-skip here and run in the dedicated `sandbox-linux` job
+      # below; keeping bwrap out prevents the broad unit suite from changing
+      # behavior based on the runner's available kernel sandbox.
       - name: Unit tests
         env:
           CAPTURED_JOB_SUMMARY: ${{ runner.temp }}/unit-test-summary.md
@@ -168,13 +168,11 @@ jobs:
             echo '__AGENTCONNECT_UNIT_TEST_SUMMARY__'
           } >> "$GITHUB_OUTPUT"
 
-  # The confined skills suites drive the pinned CLI + workspace mutation inside
-  # the OS kernel sandbox (bwrap on Linux). They self-skip in the bwrap-free Unit
-  # Test job above and run for real here, on a runner made bwrap-capable. Kept in
-  # its own job so enabling the kernel sandbox does not force every other
-  # bwrap-gated suite (e.g. the ACP credential-isolation tests) to run under it.
-  skill-sandbox:
-    name: Skill sandbox (Linux)
+  # Exercise the daemon's core sandbox boundaries and confined skills pipeline
+  # under the real Linux kernel sandbox. These cases self-skip in the bwrap-free
+  # Unit Test job above and run for real here on a bwrap-capable runner.
+  sandbox-linux:
+    name: Sandbox (Linux)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -199,9 +197,11 @@ jobs:
           # Ubuntu 24.04 runners restrict unprivileged user namespaces via
           # AppArmor; bwrap (and therefore the SRT sandbox) requires them.
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-          # Fail loudly rather than letting the confined skills suites silently
+          # Fail loudly rather than letting sandbox-dependent suites silently
           # skip if bwrap cannot start on this runner.
           bwrap --unshare-user --unshare-pid --ro-bind / / --proc /proc /usr/bin/true
+      - name: Core sandbox suite
+        run: pnpm --filter @agentconnect.md/daemon exec vitest run test/sandbox.test.ts
       - name: Confined skills suites
         run: >
           pnpm --filter @agentconnect.md/daemon exec vitest run

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -327,7 +327,18 @@ describe('Claude credential environment isolation', () => {
       // exercise the real helper, not just a generic socket connect.
       const req = createRequire(import.meta.url)
       const daemonEntry = fileURLToPath(new URL('../src/index.ts', import.meta.url))
-      const helperCommand = [process.execPath, req.resolve('tsx/cli'), daemonEntry, 'git-credential', 'agent-1', 'get']
+      // Resolve workspace packages from source without tsx CLI's temp IPC server.
+      const helperCommand = [
+        process.execPath,
+        '--conditions',
+        'development',
+        '--import',
+        req.resolve('tsx'),
+        daemonEntry,
+        'git-credential',
+        'agent-1',
+        'get'
+      ]
         .map(JSON.stringify)
         .join(' ')
       const socketAttempt = await SandboxManager.wrapWithSandboxArgv(

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -212,7 +212,9 @@ describe('Claude credential environment isolation', () => {
     const identityToken = 'trusted-parent-identity-token'
     const awsWebIdentityTokenFile = join(root, 'aws-web-identity.jwt')
     const awsWebIdentityToken = 'trusted-parent-aws-token'
-    const privateClaudeConfig = join(root, 'private-home', '.claude')
+    const privateHome = join(root, 'private-home')
+    const privateTmp = join(privateHome, '.tmp')
+    const privateClaudeConfig = join(privateHome, '.claude')
     const privateClaudeSettings = join(privateClaudeConfig, 'settings.json')
     const credentialSocket = join(root, 'run', 'gitcred.sock')
     let credentialRequest: Record<string, unknown> | undefined
@@ -238,8 +240,17 @@ describe('Claude credential environment isolation', () => {
       AWS_CONTAINER_AUTHORIZATION_TOKEN: 'trusted-parent-container-token',
       AWS_WEB_IDENTITY_TOKEN_FILE: awsWebIdentityTokenFile
     }
+    // Mirror sandbox-runtime-provider: SRT's shared /tmp/claude fallback may
+    // not exist, while production always gives the child a private HOME temp.
+    const sandboxEnvironment = {
+      HOME: privateHome,
+      TMPDIR: privateTmp,
+      CLAUDE_CODE_TMPDIR: privateTmp,
+      CLAUDE_TMPDIR: privateTmp
+    }
     mkdirSync(workspace)
     mkdirSync(privateClaudeConfig, { recursive: true })
+    mkdirSync(privateTmp)
     mkdirSync(join(root, 'run'))
     writeFileSync(identityTokenFile, identityToken, { mode: 0o600 })
     writeFileSync(awsWebIdentityTokenFile, awsWebIdentityToken, { mode: 0o600 })
@@ -250,11 +261,15 @@ describe('Claude credential environment isolation', () => {
     )
     const settings = claudeInnerSandboxSettings([identityTokenFile, awsWebIdentityTokenFile, privateClaudeConfig], true)
     const names = settings.credentials.envVars.map(({ name }) => name)
-    const restoredNames = new Set([...names, ...Object.keys(seededCredentialEnvironment)])
+    const restoredNames = new Set([
+      ...names,
+      ...Object.keys(seededCredentialEnvironment),
+      ...Object.keys(sandboxEnvironment)
+    ])
     const previous = new Map([...restoredNames].map((name) => [name, process.env[name]]))
 
     for (const name of names) process.env[name] = `secret-for-${name}`
-    Object.assign(process.env, seededCredentialEnvironment)
+    Object.assign(process.env, seededCredentialEnvironment, sandboxEnvironment)
 
     try {
       await new Promise<void>((resolve, reject) => {
@@ -263,7 +278,7 @@ describe('Claude credential environment isolation', () => {
       })
       const config = SandboxRuntimeConfigSchema.parse({
         network: { allowedDomains: [], deniedDomains: [], ...settings.network },
-        filesystem: { ...settings.filesystem, allowWrite: [workspace] },
+        filesystem: { ...settings.filesystem, allowWrite: [workspace, privateHome] },
         credentials: settings.credentials
       })
       await SandboxManager.initialize(config, async () => false)


### PR DESCRIPTION
## Summary

- generalize the dedicated bwrap job into the Linux sandbox gate
- run `sandbox.test.ts` before the confined skills suites
- keep the broad unit job bwrap-free so environment detection does not change unrelated tests
- make the direct SRT credential-isolation test mirror the provider's private temp environment
- launch the source helper with development exports so the clean CI checkout needs no workspace build artifacts

## Why

The standard unit job intentionally does not install bwrap, so the Linux PID-isolation and Claude credential-isolation cases in `sandbox.test.ts` were skipped. The existing dedicated job already provisions and verifies bwrap but previously selected only the confined skills suites.

The first Linux run also exposed a test-harness mismatch: production configures SRT with a private HOME temp directory, while the direct test initialization omitted it and let `tsx` fall back to a missing shared `/tmp/claude`. The test now reproduces the production provider environment before checking credential isolation.

The helper now uses Node's development export condition and the `tsx` loader directly, matching the repository's source-checkout tests instead of resolving an unbuilt `protocol/dist` entry.

## Validation

- `pnpm exec prettier --check .github/workflows/test.yaml`
- `pnpm --filter @agentconnect.md/daemon exec vitest run test/sandbox.test.ts` (10 passed, 2 Linux-only cases skipped locally; the PR check exercises them with bwrap)
- pre-push `eslint .`

Created by Codex . GPT-5
