### PR TITLE
fix(daemon): peer-aware replacement prompt for turn-final context refresh

### DIFF
--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -257,7 +257,8 @@ enters the commit protocol in section 7.
 
 If new events exist, the workflow drops the `AttemptBuffer` and sends one replacement
 prompt to the same ACP session. The daemon-generated prefix should be stable and
-provider-neutral:
+provider-neutral. When the delta contains a human message, the task itself may have
+changed, so the prompt asks for a genuine re-evaluation:
 
 ```text
 (AgentConnect context update: the conversation changed while you were working.
@@ -270,9 +271,37 @@ unless it matters to the user.)
 [sender-id] message text
 ```
 
-The replacement prompt contains only events after the previous generation fence; the
-ACP session already contains the original prompt and prior candidate. The workflow then
-repeats candidate generation and final refresh.
+When every invalidating event is a **verified peer agent's reply** — the normal churn
+in a multi-agent conversation, where several agents answer the same activation in
+parallel — that wording misleads: read together with the response-choice rule it
+frames the situation as "you were scooped", and models decline complementary answers
+(each agent introducing itself, each reporting its own status) with the no-response
+sentinel. The peer-only variant instead states the one decision that matters — the
+activation is still addressed to this agent — and gives the explicit criterion for
+silence:
+
+```text
+(AgentConnect context update: while you were answering, other agents in this
+conversation posted the replies below. The message that activated you is still
+addressed to you, and you have not answered it yet; your previous candidate
+answer was not delivered. If it still adds information the replies below do not
+cover — especially anything only you can provide, such as your own identity,
+status, or perspective — produce it again as your final answer, adjusted for
+those replies. Reply `AC_NO_RESPONSE` only if those replies make your
+answer fully redundant. Preserve useful work already completed, do not repeat
+side effects blindly, and do not mention this retry unless it matters to the user.)
+
+(new replies from other agents, oldest to newest)
+[directory-name (another agent)] message text
+```
+
+Delta rows name a sender as `directory-name (another agent)` only when the daemon can
+verify agent authorship (a local agent, the CP collab snapshot, a cached directory
+peer, or provider rows already provenance-gated as `trustedAgentBot`); unverified
+senders keep the raw transcript id, so a human cannot relabel their own churn into the
+peer-only framing. Either way the replacement prompt contains only events after the
+previous generation fence; the ACP session already contains the original prompt and
+prior candidate. The workflow then repeats candidate generation and final refresh.
 
 Memory recall should run for the original activation as it does today. Regeneration
 does not need another external semantic-memory query: the new thread events and the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -52,6 +52,7 @@ import {
   ThreadContextCoordinator,
   contextUpdateText,
   initialContextDeltaText,
+  type ContextEventSender,
   type ContextRefresh,
   type ThreadContextSnapshot
 } from './session/thread-context.js'
@@ -8500,6 +8501,23 @@ export class Daemon {
       .sort((a, b) => a.eventTimeUs - b.eventTimeUs || a.seq - b.seq)
   }
 
+  /** How a context-delta row's sender is shown to the model. A sender counts as a peer
+   *  agent only when the daemon can verify it — a LOCAL agent, a CP collab-snapshot
+   *  member, a cached directory peer, or a Slack history row whose AgentConnect bot
+   *  authorship this daemon already verified (`trustedAgentBot`). Anything else
+   *  (humans, unknown ids) keeps the raw transcript sender: an unverified id must
+   *  never be promoted to "another agent", or a human could relabel their own churn
+   *  and weaken the peer-only replacement framing. */
+  private contextEventSender(event: TranscriptRow): ContextEventSender | undefined {
+    const peerAgent =
+      this.agents.has(event.sender) ||
+      this.cpCollab.nameOf(event.sender) !== undefined ||
+      this.channelAgentNames.has(event.sender) ||
+      event.trustedAgentBot === true
+    if (!peerAgent) return undefined
+    return { label: this.agentDisplayLabel(event.sender), peerAgent: true }
+  }
+
   private queuedEntriesMatchingContext(key: string, eventTs: ReadonlySet<string>): QueueEntry[] {
     return (this.serialQueue.get(key) ?? []).filter((entry) => eventTs.has(transcriptCoords(entry.msg).ts))
   }
@@ -10867,7 +10885,11 @@ export class Daemon {
         if (initialEvents.length > 0) {
           deltaBlocks.push({
             type: 'text',
-            text: initialContextDeltaText(initialEvents, (event) => this.observedQuoteBlock(event, initialEvents))
+            text: initialContextDeltaText(
+              initialEvents,
+              (event) => this.observedQuoteBlock(event, initialEvents),
+              (event) => this.contextEventSender(event)
+            )
           })
         }
         promptBlocks.push(...deltaBlocks)
@@ -11099,7 +11121,11 @@ export class Daemon {
         promptBlocks = [
           {
             type: 'text',
-            text: contextUpdateText(invalidatingEvents, (event) => this.observedQuoteBlock(event, invalidatingEvents))
+            text: contextUpdateText(
+              invalidatingEvents,
+              (event) => this.observedQuoteBlock(event, invalidatingEvents),
+              (event) => this.contextEventSender(event)
+            )
           }
         ]
         finalCaptureInput = recallQueryFromBlocks([{ type: 'text', text: finalCaptureInput }, ...promptBlocks])

--- a/packages/daemon/src/session/thread-context.ts
+++ b/packages/daemon/src/session/thread-context.ts
@@ -1,6 +1,34 @@
 import type { LocalStore, TranscriptEntry, TranscriptRow } from '../store/local-store.js'
+import { NO_RESPONSE_SENTINEL } from './no-response.js'
 
 export const MAX_CONTEXT_REFRESH_EVENTS = 50
+
+/** How a delta row's sender is presented to the model. Resolved by the daemon edge
+ *  (agent registry + CP collab snapshot + verified Slack bot authorship); the
+ *  coordinator itself stays platform- and registry-agnostic. */
+export interface ContextEventSender {
+  /** Directory display name when known; callers fall back to the raw transcript sender. */
+  label: string
+  /** True only when the daemon VERIFIED this sender is another AgentConnect agent. */
+  peerAgent: boolean
+}
+
+type SenderResolver = (event: TranscriptRow) => ContextEventSender | undefined
+
+function renderEventRows(
+  events: readonly TranscriptRow[],
+  quoteFor?: (event: TranscriptRow) => string | undefined,
+  senderFor?: SenderResolver
+): string[] {
+  return events.flatMap((event) => {
+    const quote = quoteFor?.(event)
+    const sender = senderFor?.(event)
+    // A raw agent UUID gives the model no way to tell that a delta row is a peer
+    // assistant's own answer rather than the human moving on — name it and say so.
+    const label = sender?.peerAgent ? `${sender.label} (another agent)` : (sender?.label ?? event.sender)
+    return [...(quote ? [quote] : []), `[${label}] ${event.text}`]
+  })
+}
 
 export type ContextCompleteness = 'authoritative' | 'observed-only'
 
@@ -99,32 +127,52 @@ export class ThreadContextCoordinator {
 }
 
 /** Stable, provider-neutral replacement prompt. The bounded newest suffix matches
- * the daemon's existing replay cap and keeps chronological order inside the suffix. */
+ * the daemon's existing replay cap and keeps chronological order inside the suffix.
+ *
+ * Two headings, chosen by what actually churned. When the delta is ONLY peer-agent
+ * replies (a parallel answer race, the multi-agent-webchat norm), the generic
+ * "conversation changed — re-evaluate the task" wording reads as "you were scooped"
+ * and steers the response-choice rule into declining COMPLEMENTARY answers (each
+ * agent introducing itself, each reporting its own status). That branch instead
+ * states the one decision that matters: the activation is still addressed to you —
+ * deliver unless the peer replies made your answer fully redundant. Any human
+ * message in the delta keeps the original re-evaluate framing: the task itself may
+ * genuinely have changed. */
 export function contextUpdateText(
   events: readonly TranscriptRow[],
-  quoteFor?: (event: TranscriptRow) => string | undefined
+  quoteFor?: (event: TranscriptRow) => string | undefined,
+  senderFor?: SenderResolver
 ): string {
   const suffix = events.slice(-MAX_CONTEXT_REFRESH_EVENTS)
   const elided = events.length - suffix.length
-  const heading =
-    '(AgentConnect context update: the conversation changed while you were working.\n' +
-    'Your previous candidate answer was not delivered. Re-evaluate the task using the new\n' +
-    'thread messages below and produce a replacement final answer. Preserve useful work\n' +
-    'already completed, do not repeat side effects blindly, and do not mention this retry\n' +
-    'unless it matters to the user.)'
-  const deltaHeading =
-    elided > 0 ? `(new thread messages — ${elided} earlier message(s) elided)` : '(new thread messages)'
-  const rows = suffix.flatMap((event) => {
-    const quote = quoteFor?.(event)
-    return [...(quote ? [quote] : []), `[${event.sender}] ${event.text}`]
-  })
+  const peerOnly = events.length > 0 && events.every((event) => senderFor?.(event)?.peerAgent === true)
+  const heading = peerOnly
+    ? '(AgentConnect context update: while you were answering, other agents in this\n' +
+      'conversation posted the replies below. The message that activated you is still\n' +
+      'addressed to you, and you have not answered it yet; your previous candidate\n' +
+      'answer was not delivered. If it still adds information the replies below do not\n' +
+      'cover — especially anything only you can provide, such as your own identity,\n' +
+      'status, or perspective — produce it again as your final answer, adjusted for\n' +
+      `those replies. Reply \`${NO_RESPONSE_SENTINEL}\` only if those replies make your\n` +
+      'answer fully redundant. Preserve useful work already completed, do not repeat\n' +
+      'side effects blindly, and do not mention this retry unless it matters to the\n' +
+      'user.)'
+    : '(AgentConnect context update: the conversation changed while you were working.\n' +
+      'Your previous candidate answer was not delivered. Re-evaluate the task using the new\n' +
+      'thread messages below and produce a replacement final answer. Preserve useful work\n' +
+      'already completed, do not repeat side effects blindly, and do not mention this retry\n' +
+      'unless it matters to the user.)'
+  const deltaLabel = peerOnly ? 'new replies from other agents' : 'new thread messages'
+  const deltaHeading = elided > 0 ? `(${deltaLabel} — ${elided} earlier message(s) elided)` : `(${deltaLabel})`
+  const rows = renderEventRows(suffix, quoteFor, senderFor)
   return `${heading}\n\n${deltaHeading}\n${rows.join('\n')}`
 }
 
 /** Initial-fence deltas use a shorter heading: there is no discarded candidate yet. */
 export function initialContextDeltaText(
   events: readonly TranscriptRow[],
-  quoteFor?: (event: TranscriptRow) => string | undefined
+  quoteFor?: (event: TranscriptRow) => string | undefined,
+  senderFor?: SenderResolver
 ): string {
   const suffix = events.slice(-MAX_CONTEXT_REFRESH_EVENTS)
   const elided = events.length - suffix.length
@@ -132,9 +180,6 @@ export function initialContextDeltaText(
     elided > 0
       ? `(additional thread messages before this turn started — ${elided} earlier message(s) elided)`
       : '(additional thread messages before this turn started)'
-  const rows = suffix.flatMap((event) => {
-    const quote = quoteFor?.(event)
-    return [...(quote ? [quote] : []), `[${event.sender}] ${event.text}`]
-  })
+  const rows = renderEventRows(suffix, quoteFor, senderFor)
   return `${heading}\n${rows.join('\n')}`
 }

--- a/packages/daemon/test/thread-context.test.ts
+++ b/packages/daemon/test/thread-context.test.ts
@@ -6,7 +6,9 @@ import { LocalStore } from '../src/store/local-store.js'
 import {
   MAX_CONTEXT_REFRESH_EVENTS,
   ThreadContextCoordinator,
-  contextUpdateText
+  contextUpdateText,
+  initialContextDeltaText,
+  type ContextEventSender
 } from '../src/session/thread-context.js'
 
 function store(): LocalStore {
@@ -153,5 +155,79 @@ describe('ThreadContextCoordinator', () => {
     expect(prompt).toContain('[U1] message-2')
     expect(prompt).toContain(`[U1] message-${MAX_CONTEXT_REFRESH_EVENTS + 1}`)
     db.close()
+  })
+
+  describe('replacement prompt framing', () => {
+    const agentNames = new Map([
+      ['bot-b', 'Beta'],
+      ['bot-c', 'Gamma']
+    ])
+    const senderFor = (event: { sender: string }): ContextEventSender | undefined =>
+      agentNames.has(event.sender) ? { label: agentNames.get(event.sender)!, peerAgent: true } : undefined
+
+    async function refreshFor(entries: [string, string][]) {
+      const db = store()
+      const coordinator = new ThreadContextCoordinator(db)
+      entries.forEach(([sender, body], index) => coordinator.observeInbound(text(`100.${index}`, sender, body)))
+      const refresh = await coordinator.refresh({
+        agentId: 'bot-a',
+        transcriptChannel: 'scope:C1',
+        thread: 'T1',
+        afterRevision: 0
+      })
+      db.close()
+      return refresh
+    }
+
+    it('re-frames peer-only churn as still-addressed instead of re-evaluate', async () => {
+      const refresh = await refreshFor([
+        ['bot-b', 'I am Beta, a coding assistant.'],
+        ['bot-c', 'I am Gamma.']
+      ])
+      const prompt = contextUpdateText(refresh.events, undefined, senderFor)
+
+      expect(prompt).toContain('other agents in this')
+      expect(prompt).toContain('The message that activated you is still')
+      expect(prompt).toContain('AC_NO_RESPONSE')
+      expect(prompt).toContain('(new replies from other agents)')
+      expect(prompt).toContain('[Beta (another agent)] I am Beta, a coding assistant.')
+      expect(prompt).toContain('[Gamma (another agent)] I am Gamma.')
+      expect(prompt).not.toContain('Re-evaluate the task')
+    })
+
+    it('keeps the re-evaluate framing when any human message is in the delta', async () => {
+      const refresh = await refreshFor([
+        ['bot-b', 'I am Beta.'],
+        ['U1', 'actually, use the staging config']
+      ])
+      const prompt = contextUpdateText(refresh.events, undefined, senderFor)
+
+      expect(prompt).toContain('the conversation changed while you were working')
+      expect(prompt).toContain('produce a replacement final answer')
+      expect(prompt).toContain('(new thread messages)')
+      expect(prompt).toContain('[Beta (another agent)] I am Beta.')
+      expect(prompt).toContain('[U1] actually, use the staging config')
+    })
+
+    it('keeps the historical prompt byte-for-byte without a sender resolver', async () => {
+      const refresh = await refreshFor([['bot-b', 'peer answer']])
+      const prompt = contextUpdateText(refresh.events)
+
+      expect(prompt).toContain('the conversation changed while you were working')
+      expect(prompt).toContain('[bot-b] peer answer')
+      expect(prompt).not.toContain('another agent')
+    })
+
+    it('labels peer agents in initial-fence deltas too', async () => {
+      const refresh = await refreshFor([
+        ['bot-b', 'I am Beta.'],
+        ['U1', 'hello everyone']
+      ])
+      const prompt = initialContextDeltaText(refresh.events, undefined, senderFor)
+
+      expect(prompt).toContain('(additional thread messages before this turn started)')
+      expect(prompt).toContain('[Beta (another agent)] I am Beta.')
+      expect(prompt).toContain('[U1] hello everyone')
+    })
   })
 })


### PR DESCRIPTION
## Problem

In a multi-agent conversation (webchat is the acute case: one shared transcript, zero propagation latency), all roster agents answer the same user message in parallel. Whoever finishes first posts; that post lands as an invalidating event for every slower peer's turn-final refresh, so the slower agent's staged candidate is discarded and regenerated.

The replacement prompt framed that churn as:

> the conversation changed while you were working. … Re-evaluate the task …

Read together with the standing response-choice rule, models interpret this as "you were scooped" and decline with `AC_NO_RESPONSE` — even when their discarded candidate was **complementary**, not redundant. Observed repeatedly with two codex agents:

- User asks "who are you all?" → agent A introduces itself → agent B's own self-introduction (information only B can provide) is discarded, and B's re-evaluation declines. B appears permanently mute; the race decides who speaks, and losing it twice in a row reads as a broken agent.
- Manually appending equivalent "your answer is still expected unless fully redundant" guidance to the user message makes the previously-silent agent answer normally — confirming the prompt framing, not the invalidation mechanism, is what misfires.

## Fix

`contextUpdateText` now picks between two headings:

- **Peer-only churn** (every invalidating event is a *verified* peer agent's reply): state the decision that actually matters — the activation is still addressed to this agent and unanswered by it — and give the explicit silence criterion: reply `AC_NO_RESPONSE` only if the peer replies make the candidate fully redundant.
- **Any human message in the delta**: keep the original re-evaluate framing verbatim — the task itself may genuinely have changed.

Delta rows now label verified peer agents as `Name (another agent)` instead of a raw agent UUID (a UUID gives the model no way to tell a peer's answer from the human moving on), in both the replacement prompt and the initial-fence delta.

Peer verification is fail-closed: a local agent, a CP collab-snapshot member, a cached directory peer, or a Slack history row already provenance-gated as `trustedAgentBot`. Unverified senders keep the raw transcript id, so a human cannot relabel their own churn into the peer-only framing.

No behavior change without a sender resolver: both builders keep their historical output byte-for-byte when the new optional parameter is omitted.

## Design

`docs/designs/turn-final-context-refresh.md` §5.3 updated with the peer-only prompt variant and the verification rule. The benign half of the mechanism is deliberately preserved: a slower agent still re-evaluates against peer output and can adjust (e.g. de-duplicate) or stand down when genuinely redundant.

## Tests

- Peer-only delta → still-addressed framing, `(new replies from other agents)`, peer labels, no "Re-evaluate the task".
- Mixed human+peer delta → original re-evaluate framing retained, peer labels applied, human sender stays raw.
- No resolver → historical prompt unchanged.
- Initial-fence delta labels peers too.

`vitest run test/thread-context.test.ts` 9/9 green; daemon typecheck clean. (The `unified-skills` / `skill-install-ledger` / `skills-cli-golden` failures in a full local run are a local sandbox limitation — those tests spawn macOS `sandbox-exec`, which is denied under the sandboxed dev environment — and are untouched by this diff.)

## Follow-ups (not in this PR)

- The session-manager catch-up replay path (`(thread context you may have missed)`) still renders raw sender ids; same labeling could apply there.
- Role-aware protection for the addressed/primary agent (candidate immunity or an explicit routing fact, the webchat analogue of `EXPLICIT_MENTION_REMINDER`) would additionally make the *addressed* agent's delivery deterministic when it loses the race on content a peer did cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)