### PR TITLE
test(daemon): gate skill sandbox suites on bwrap

### DIFF
--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -51,12 +51,11 @@ const pathIdentity = async (path: string): Promise<PathIdentity> => {
   return { dev: stat.dev.toString(), ino: stat.ino.toString() }
 }
 
-// Crash recovery drives the confined workspace mutator, which runs inside the OS
-// sandbox. Skip where no usable sandbox exists (e.g. a Linux CI runner without
-// bwrap/rg/socat), mirroring sandbox.test.ts; validated on macOS Seatbelt.
-const sandboxReady = process.platform === 'darwin' || detectSandbox() === 'bwrap'
+// Exercise the same live Linux SRT/bwrap boundary as sandbox.test.ts. macOS
+// sandbox coverage is deferred to the SRT platform-support follow-up.
+const hasBwrap = detectSandbox() === 'bwrap'
 
-describe.skipIf(!sandboxReady)('skill install ledger crash recovery', () => {
+describe.skipIf(!hasBwrap)('skill install ledger crash recovery', () => {
   let root: string
   let cwd: string
   let stateDir: string

--- a/packages/daemon/test/skill-workspace-lock.test.ts
+++ b/packages/daemon/test/skill-workspace-lock.test.ts
@@ -8,12 +8,11 @@ import { detectSandbox } from '../src/acp/sandbox.js'
 
 const workerFile = join(dirname(fileURLToPath(import.meta.url)), 'fixtures/skill-workspace-lock-worker.ts')
 
-// The lock worker's install path drives the pinned CLI inside the OS sandbox, so
-// skip where no usable sandbox exists (e.g. a Linux CI runner without
-// bwrap/rg/socat); mirrors sandbox.test.ts. Validated on macOS Seatbelt.
-const sandboxReady = process.platform === 'darwin' || detectSandbox() === 'bwrap'
+// Exercise the same live Linux SRT/bwrap boundary as sandbox.test.ts. macOS
+// sandbox coverage is deferred to the SRT platform-support follow-up.
+const hasBwrap = detectSandbox() === 'bwrap'
 
-describe.skipIf(!sandboxReady)('cross-process skill workspace lock', () => {
+describe.skipIf(!hasBwrap)('cross-process skill workspace lock', () => {
   let root: string
   let cwd: string
   let stateDir: string

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -6,8 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { detectSandbox } from '../src/acp/sandbox.js'
 
 // A real bwrap sandbox launch (and its nested seccomp helper) is far slower than
-// macOS Seatbelt and than the 5s default, especially on shared CI runners; give
-// the golden installs room so a slow-but-correct run is not a false timeout.
+// the 5s default, especially on shared CI runners; give the golden installs room
+// so a slow-but-correct run is not a false timeout.
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 })
 import { resolvePinnedSkillsCli, stageSkillsCliCell } from '../src/skills/skills-cli-cell.js'
 import { installSkills } from '../src/skills/install-skills.js'
@@ -31,13 +31,11 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
-// The unified installer runs the pinned CLI inside the OS sandbox, so these
-// golden tests need a usable sandbox. Skip where none is available (e.g. a Linux
-// CI runner without bwrap/rg/socat), mirroring sandbox.test.ts; validated on
-// macOS Seatbelt and any bwrap-capable host.
-const sandboxReady = process.platform === 'darwin' || detectSandbox() === 'bwrap'
+// Exercise the same live Linux SRT/bwrap boundary as sandbox.test.ts. macOS
+// sandbox coverage is deferred to the SRT platform-support follow-up.
+const hasBwrap = detectSandbox() === 'bwrap'
 
-describe.skipIf(!sandboxReady)('skills@1.5.21 local-source golden', () => {
+describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
   it.each([
     ['claude-code', '.claude/skills/local-golden'],
     ['codex', '.agents/skills/local-golden']

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -7,8 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { detectSandbox } from '../src/acp/sandbox.js'
 
 // A real bwrap sandbox launch (and its nested seccomp helper) is far slower than
-// macOS Seatbelt and than the 5s default, especially on shared CI runners. Give
-// each end-to-end install room so a slow-but-correct run is not a false timeout.
+// the 5s default, especially on shared CI runners. Give each end-to-end install
+// room so a slow-but-correct run is not a false timeout.
 // (Exercised by the Linux sandbox lane in .github/workflows/test.yaml.)
 vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 })
 import {
@@ -61,12 +61,11 @@ function fakeCli(rootForAgent: (agentId: string) => string) {
   return { calls, run }
 }
 
-// These exercise the real end-to-end installer, which runs the pinned CLI inside
-// the OS sandbox. Skip where no usable sandbox exists (e.g. a Linux CI runner
-// without bwrap/rg/socat), mirroring sandbox.test.ts; validated on macOS Seatbelt.
-const sandboxReady = process.platform === 'darwin' || detectSandbox() === 'bwrap'
+// Exercise the same live Linux SRT/bwrap boundary as sandbox.test.ts. macOS
+// sandbox coverage is deferred to the SRT platform-support follow-up.
+const hasBwrap = detectSandbox() === 'bwrap'
 
-describe.skipIf(!sandboxReady)('unified isolated skill installation', () => {
+describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
   let root: string
   let cwd: string
   let stateDir: string


### PR DESCRIPTION
## Summary

- run the four confined-skill integration suites only when the host exposes the same live Linux SRT/bwrap boundary used by `sandbox.test.ts`
- intentionally skip these suites on macOS until the platform sandbox work tracked in #312 is implemented, then restore that coverage
- leave production sandbox behavior unchanged

## Verification

- local confined-skill suites: 35 intentionally skipped, command passed
- `sandbox.test.ts`: 10 passed, 2 Linux-only cases skipped locally
- Linux sandbox CI: core suite 11 passed / 1 platform case skipped; confined-skill suites 35 passed
- focused Prettier check
- pre-push ESLint

Created by Codex . GPT-5
