### PR TITLE
feat(web): group every session list by conversation

### DIFF
--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -11,7 +11,7 @@ import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
-import { sessionChannelDisplay, type Session } from '@/lib/data'
+import { isMergedConversationRow, sessionChannelDisplay, type Session } from '@/lib/data'
 
 export function Card({
   title,
@@ -122,7 +122,13 @@ export function RecentSessionsCard({
             return (
               <Link
                 key={s.id}
-                href={orgPath(`/sessions/${s.id}`)}
+                // These rows are conversations, so a multi-participant one goes to
+                // the merged page rather than to whichever member represents it.
+                href={
+                  isMergedConversationRow(s)
+                    ? orgPath(`/conversations/${encodeURIComponent(s.conversationKey!)}`)
+                    : orgPath(`/sessions/${s.id}`)
+                }
                 className={`row click grid-cols-[1fr_auto] gap-3 ${rowClassName ?? ''}`}
               >
                 <span className="min-w-0">

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -47,6 +47,7 @@ import {
   agentLabel,
   canonicalSessionId,
   conversationRowKey,
+  isMergedConversationRow,
   mergeCanonicalSessions,
   sessionChannelDisplay,
   type Agent,
@@ -268,12 +269,7 @@ export function SessionRail({
   const sessionRow = (s: Session): RailRow => {
     const channel = sessionChannelDisplay(s, cronName)
     const id = canonicalSessionId(s)
-    // The merged page is the only surfaced view of a MULTI-participant
-    // conversation (§5.3). The test is MEMBERSHIP, not the key every grouped row
-    // now carries and not `participants` — under an agent filter a shared thread
-    // returns one row, and reading that as a single-agent session would send the
-    // reader to a member session that immediately redirects here anyway.
-    const merged = pinIdsOf(s).length > 1 && s.conversationKey
+    const merged = isMergedConversationRow(s)
     return {
       // The SESSION id: it is what `current` is matched against and what a fresh
       // pin records. Pin LOOKUP goes through every member (see sessionPinIds).

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -10,6 +10,7 @@ import {
   agentLabel,
   canonicalSessionId,
   enrichSessionWithAgent,
+  isMergedConversationRow,
   mergeCanonicalSessions,
   platName,
   sessionChannelDisplay,
@@ -176,12 +177,10 @@ export default function SessionsView() {
   }, [params])
   const sessionHref = useCallback(
     (session: Session) => {
-      // A multi-participant conversation row links to the merged page — the
-      // only surfaced view for it (merged-conversation-view.md §5.3). The test is
-      // MEMBERSHIP, not the key every grouped row carries now, and not
-      // `participants`, which an agent filter narrows to the rows it returned.
-      if ((session.memberSessionIds?.length ?? 0) > 1 && session.conversationKey) {
-        return orgPath(`/conversations/${encodeURIComponent(session.conversationKey)}`)
+      // A multi-participant conversation row links to the merged page — the only
+      // surfaced view for it (merged-conversation-view.md §5.3).
+      if (isMergedConversationRow(session)) {
+        return orgPath(`/conversations/${encodeURIComponent(session.conversationKey!)}`)
       }
       const id = canonicalSessionId(session)
       const query = new URLSearchParams(filterQuery)

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -962,6 +962,21 @@ export function conversationRowKey(session: Pick<Session, 'id' | 'realSessionId'
   return session.conversationKey ?? canonicalSessionId(session)
 }
 
+/**
+ * Whether a row's only surfaced view is the merged conversation page
+ * (merged-conversation-view.md §5.3), i.e. whether it should link there rather
+ * than to a member session that would bounce straight back through the redirect.
+ *
+ * The test is MEMBERSHIP, which the CP reports over everything the caller can
+ * see. Not the key — every grouped row carries one now, including conversations
+ * of one. Not `participants` either: an agent filter narrows that to the rows it
+ * returned, so a shared thread would read as a single-agent session precisely
+ * when a filter is what made it look like one.
+ */
+export function isMergedConversationRow(session: Pick<Session, 'conversationKey' | 'memberSessionIds'>): boolean {
+  return (session.memberSessionIds?.length ?? 0) > 1 && Boolean(session.conversationKey)
+}
+
 export function mergeCanonicalSessions(sessions: readonly Session[]): Session[] {
   const byId = new Map<string, Session>()
   for (const session of sessions) {

--- a/packages/web/src/lib/use-session-list.ts
+++ b/packages/web/src/lib/use-session-list.ts
@@ -20,12 +20,15 @@ export function sessionFilterAgentKey(agentId: SessionListFilters['agentId']): s
 export function useSessionList(
   orgId: string | null | undefined,
   filters: SessionListFilters = {},
-  // The sessions LIST page reads the grouped conversation view (one row per
-  // conversation, merged-conversation-view.md §5.2); every other consumer
-  // (rails, agent pages) keeps the flat rows.
+  // GROUPED by default — one row per conversation (merged-conversation-view.md
+  // §5.2). A conversation is the unit the console talks about everywhere it
+  // lists runs, so the flat view is the exception, not the default: reading it
+  // by accident lists a thread once per agent that answered in it, and once
+  // more per superseded ACP session. `grouped: false` is for a consumer that
+  // genuinely wants session rows.
   options: { grouped?: boolean } = {}
 ) {
-  const grouped = options.grouped === true
+  const grouped = options.grouped !== false
   // The key is a scalar cache discriminator, so a multi-agent filter travels as
   // one comma-joined string and the fetcher splits it back into repeated params.
   const agentId = sessionFilterAgentKey(filters.agentId)


### PR DESCRIPTION
Follow-up to [#455](https://github.com/agentconnect-md/agentconnect/pull/455). That fixed the two lists that had been reported; this answers the obvious next question — **is everything else grouped?** It wasn't.

## What was still flat

Only the sessions page and the rail read the grouped view. Everything else went through `useSessionList`'s flat default:

| Surface | Source | Was |
|---|---|---|
| Home → Recent | `allSessions` (data-context) | flat |
| Agent page → Recent sessions | `useSessionList({agentId})` | flat |
| Global search, crumbs, schedule detail | `allSessions` | flat |

So a thread two agents worked in listed itself **once per agent** everywhere except the two lists that had been fixed — and once more per superseded ACP session.

## Change

`useSessionList` groups by **default**. A conversation is the unit the console talks about wherever it lists runs, so the flat view is now the exception a consumer has to ask for (`grouped: false`), not what it gets by forgetting to. No caller wants flat today.

Two things follow:

- **The Recent cards link conversation rows to the merged page**, like the other two surfaces, instead of to whichever member represents the row (which would bounce through the §5.3 redirect).
- **The membership test is one exported rule** (`isMergedConversationRow`) rather than three spellings in three files — it had already drifted once during #455 (key → participants → membership).

Also worth noting: the agent page's "N sessions" now counts conversations, which is what the list it links to (`/sessions?agent=…`) has been showing since the grouped list landed.

## Why this is small

Every piece of plumbing it needs — `memberSessionIds` reported independently of the filter, conversation-stable row identity, pins that survive the representative moving — landed in #455. Flipping this default before that would have reproduced the same duplicate-row and pin bugs on Home and the agent page.

## Verification

Web suites green (640 tests), typecheck, ESLint, Prettier clean. No CP change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)