### PR TITLE
fix(web): materialize the standing mention — bare multi-agent sends mention the whole roster

### DIFF
--- a/docs/designs/webchat-multi-agents.md
+++ b/docs/designs/webchat-multi-agents.md
@@ -246,6 +246,19 @@ on, **every user message activates the whole roster** unless it explicitly
    (section 5.4) keeps the concurrent answers coherent — a slower participant
    sees the faster ones' replies before committing.
 
+Current composers **materialize** the standing mention instead of leaving it
+implicit: a bare send carries the whole roster in the structured `mentions`
+array (`wireMentions`, `packages/web/src/lib/conversation-addressing.ts`), so
+it is wire-identical to an explicit @-everyone message and every participant
+activates with `trigger:'mention'`. The addressed-signal matters at the commit
+fence: a turn-final regeneration (section 5.4) re-runs the response-choice
+rule, and without it a slower participant whose candidate was invalidated by a
+peer's parallel reply tends to decline even a complementary answer — the
+parallel-answer race must never silence an addressed agent. The implicit
+no-mention form in point 2 remains the compatibility default (older browser
+builds, roster-less resumed sends), with `trigger:'dm'` and the declining
+behavior described there.
+
 The relay applies the same default itself (`targets` absent or empty ⇒ the
 whole roster), so a resumed conversation with no client-side roster — or an
 older browser build — still reaches everyone; the browser admits stream lanes

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -49,6 +49,7 @@ function build(
     ack?: RdAck
     remoteMcp?: WebchatRemoteMcpEntitlement
     log?: Logger
+    participants?: Array<{ agentId: string; daemonId?: string; primary?: boolean }>
   } = {}
 ) {
   const sent: RdMsgWebchat[] = []
@@ -63,7 +64,7 @@ function build(
   const conn = new RelayBrowserConnection(transport, {
     chatId: CHAT,
     agentId: AGENT,
-    participants: [{ agentId: AGENT, daemonId: DAEMON, primary: true }],
+    participants: over.participants ?? [{ agentId: AGENT, daemonId: DAEMON, primary: true }],
     user: USER,
     ...(over.remoteMcp ? { remoteMcp: over.remoteMcp } : {}),
     daemonConnFor: () => daemon,
@@ -140,6 +141,16 @@ describe('parseBrowserFrame', () => {
     })
     expect(parseBrowserFrame({ type: 'cancel' }, USER)).toEqual({ op: { op: 'cancel' } })
   })
+  it('preserves structured mentions on the turn op and surfaces targets separately', () => {
+    const PEER = '22222222-2222-4222-8222-222222222222'
+    expect(parseBrowserFrame({ text: 'hi', mentions: [AGENT, PEER], targets: [AGENT, PEER] }, USER)).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER, mentions: [AGENT, PEER] },
+      targets: [AGENT, PEER]
+    })
+    expect(parseBrowserFrame({ text: 'hi', mentions: ['not-a-uuid'] }, USER)).toEqual({
+      op: { op: 'turn', text: 'hi', user: USER }
+    })
+  })
   it('rejects malformed / unknown envelopes', () => {
     expect(parseBrowserFrame({ type: 'set_model' }, USER)).toBeNull() // no model
     expect(parseBrowserFrame({ type: 'set_fast', fastMode: 'yes' }, USER)).toBeNull() // wrong type
@@ -163,6 +174,23 @@ describe('RelayBrowserConnection', () => {
       agentId: AGENT,
       participants: [{ agentId: AGENT, primary: true }]
     })
+  })
+
+  it('forwards structured mentions inside every per-target rd/msg(turn) payload', async () => {
+    const PEER = '22222222-2222-4222-8222-222222222222'
+    const { transport, sent } = build({
+      participants: [
+        { agentId: AGENT, daemonId: DAEMON, primary: true },
+        { agentId: PEER, daemonId: DAEMON }
+      ]
+    })
+    transport.feed({ text: 'hi', mentions: [AGENT, PEER], targets: [AGENT, PEER] })
+    await tick()
+    expect(sent).toHaveLength(2)
+    expect(sent.map((frame) => frame.agentId).sort()).toEqual([AGENT, PEER].sort())
+    for (const frame of sent) {
+      expect(frame.payload).toMatchObject({ op: 'turn', text: 'hi', mentions: [AGENT, PEER] })
+    }
   })
 
   it('bridges a {text} turn to an rd/msg(turn) and forwards the daemon ack', async () => {

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -27,6 +27,7 @@ import {
   type SessionMessageDto
 } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
+import { wireMentions } from '@/lib/conversation-addressing'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
 import {
@@ -961,6 +962,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               .map((p) => p.agentId)
           : []
       const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
+      // A bare multi-agent send still carries the PRIMARY participant as a structured
+      // mention (the standing addressee — see wireMentions); `targets` is deliberately
+      // NOT narrowed, so the rest of the roster activates exactly as before.
+      const sentMentions = wireMentions(roster, mentions, agentForId)
       pendingTurnIds.current.set(id, requestedTurnId)
       finishedTurnLanes.current.delete(id)
       for (const target of targets) {
@@ -980,7 +985,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             JSON.stringify({
               text,
               turnId: requestedTurnId,
-              ...(roster.length > 1 ? { mentions, targets } : {}),
+              ...(roster.length > 1 ? { mentions: sentMentions, targets } : {}),
               ...(image ? { attachments: [image] } : {}),
               // Runtime staging is a single-agent affordance — multi-agent
               // conversations expose no runtime controls (§9.1/§9.3).

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -962,10 +962,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               .map((p) => p.agentId)
           : []
       const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
-      // A bare multi-agent send still carries the PRIMARY participant as a structured
-      // mention (the standing addressee — see wireMentions); `targets` is deliberately
-      // NOT narrowed, so the rest of the roster activates exactly as before.
-      const sentMentions = wireMentions(roster, mentions, agentForId)
+      // Membership is a standing mention — a bare multi-agent send materializes it as
+      // the whole roster in structured `mentions` (see wireMentions), the same wire
+      // shape an explicit @-everyone message produces. Delivery is unchanged: targets
+      // already covered the roster.
+      const sentMentions = wireMentions(roster, mentions)
       pendingTurnIds.current.set(id, requestedTurnId)
       finishedTurnLanes.current.delete(id)
       for (const target of targets) {

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -5,24 +5,14 @@ const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
 
 describe('wireMentions', () => {
   it('passes typed mentions through untouched', () => {
-    expect(wireMentions(roster, ['b-peer'], 'a-primary')).toEqual(['b-peer'])
+    expect(wireMentions(roster, ['b-peer'])).toEqual(['b-peer'])
   })
 
-  it('carries the primary participant on a bare multi-agent send', () => {
-    expect(wireMentions(roster, [], 'b-peer')).toEqual(['a-primary'])
-  })
-
-  it('falls back to the composer agent when no participant is flagged primary', () => {
-    const unflagged = [{ agentId: 'a' }, { agentId: 'b' }]
-    expect(wireMentions(unflagged, [], 'b')).toEqual(['b'])
-  })
-
-  it('sends no auto-mention when the fallback is not a participant', () => {
-    const unflagged = [{ agentId: 'a' }, { agentId: 'b' }]
-    expect(wireMentions(unflagged, [], 'stranger')).toEqual([])
+  it('materializes the standing mention as the whole roster on a bare multi-agent send', () => {
+    expect(wireMentions(roster, [])).toEqual(['a-primary', 'b-peer'])
   })
 
   it('stays empty for single-agent conversations', () => {
-    expect(wireMentions([{ agentId: 'solo', primary: true }], [], 'solo')).toEqual([])
+    expect(wireMentions([{ agentId: 'solo' }], [])).toEqual([])
   })
 })

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { wireMentions } from './conversation-addressing'
+
+const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
+
+describe('wireMentions', () => {
+  it('passes typed mentions through untouched', () => {
+    expect(wireMentions(roster, ['b-peer'], 'a-primary')).toEqual(['b-peer'])
+  })
+
+  it('carries the primary participant on a bare multi-agent send', () => {
+    expect(wireMentions(roster, [], 'b-peer')).toEqual(['a-primary'])
+  })
+
+  it('falls back to the composer agent when no participant is flagged primary', () => {
+    const unflagged = [{ agentId: 'a' }, { agentId: 'b' }]
+    expect(wireMentions(unflagged, [], 'b')).toEqual(['b'])
+  })
+
+  it('sends no auto-mention when the fallback is not a participant', () => {
+    const unflagged = [{ agentId: 'a' }, { agentId: 'b' }]
+    expect(wireMentions(unflagged, [], 'stranger')).toEqual([])
+  })
+
+  it('stays empty for single-agent conversations', () => {
+    expect(wireMentions([{ agentId: 'solo', primary: true }], [], 'solo')).toEqual([])
+  })
+})

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -1,21 +1,16 @@
 /** Wire mentions for one composer send (webchat-multi-agents.md §4.2).
  *
- * Typed @mentions pass through untouched. A bare send in a multi-agent
- * conversation still carries the PRIMARY participant as a structured mention —
- * the conversation's standing addressee. On that agent's daemon rung the
- * mention is the explicit-address fact (trigger 'mention'), so when a peer
- * answers first, the primary's turn-final re-evaluation keeps answering
- * instead of misfiring into the no-response sentinel — the addressed agent
- * must never be the silent one. Delivery is unaffected: the caller keeps
- * `targets` at the full roster, so the rest of the conversation activates
- * exactly as before.
+ * Conversation membership is a STANDING mention. Typed @mentions narrow the
+ * turn and pass through untouched; a bare send materializes that standing
+ * mention as the WHOLE roster in the structured `mentions` array — exactly the
+ * shape an explicit "@everyone" message produces. On each participant's daemon
+ * rung, seeing itself in the list is the explicit-address fact
+ * (trigger 'mention'), so when peers answer the same message in parallel, a
+ * slower agent's turn-final re-evaluation keeps answering instead of misfiring
+ * into the no-response sentinel — no participant can go silent by losing the
+ * race.
  */
-export function wireMentions(
-  roster: ReadonlyArray<{ agentId: string; primary?: boolean }>,
-  typedMentions: readonly string[],
-  fallbackPrimaryId: string
-): string[] {
+export function wireMentions(roster: ReadonlyArray<{ agentId: string }>, typedMentions: readonly string[]): string[] {
   if (typedMentions.length > 0 || roster.length <= 1) return [...typedMentions]
-  const primaryId = roster.find((p) => p.primary)?.agentId ?? fallbackPrimaryId
-  return roster.some((p) => p.agentId === primaryId) ? [primaryId] : []
+  return roster.map((p) => p.agentId)
 }

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -1,0 +1,21 @@
+/** Wire mentions for one composer send (webchat-multi-agents.md §4.2).
+ *
+ * Typed @mentions pass through untouched. A bare send in a multi-agent
+ * conversation still carries the PRIMARY participant as a structured mention —
+ * the conversation's standing addressee. On that agent's daemon rung the
+ * mention is the explicit-address fact (trigger 'mention'), so when a peer
+ * answers first, the primary's turn-final re-evaluation keeps answering
+ * instead of misfiring into the no-response sentinel — the addressed agent
+ * must never be the silent one. Delivery is unaffected: the caller keeps
+ * `targets` at the full roster, so the rest of the conversation activates
+ * exactly as before.
+ */
+export function wireMentions(
+  roster: ReadonlyArray<{ agentId: string; primary?: boolean }>,
+  typedMentions: readonly string[],
+  fallbackPrimaryId: string
+): string[] {
+  if (typedMentions.length > 0 || roster.length <= 1) return [...typedMentions]
+  const primaryId = roster.find((p) => p.primary)?.agentId ?? fallbackPrimaryId
+  return roster.some((p) => p.agentId === primaryId) ? [primaryId] : []
+}


### PR DESCRIPTION
## Problem

In a multi-agent webchat conversation, a bare composer send goes to the whole roster with no structured mentions, so every agent's turn arrives as `trigger: 'dm'`. When two agents answer the same message in parallel, the slower one's staged candidate is invalidated by the peer's reply (turn-final context refresh), and its re-evaluation — with no addressed-signal in sight — frequently declines via the no-response sentinel. Losing that race twice in a row leaves an agent looking permanently mute.

Explicitly @-mentioning the agents makes the same scenario behave correctly every time (verified interactively): the mention rung injects `EXPLICIT_MENTION_REMINDER`, whose routing fact survives re-evaluation. The daemon-side machinery is already right — the bare-send path just never produces the signal.

## Fix (client-only, invisible)

The design already states that conversation membership is a **standing mention** (webchat-multi-agents.md §4.2). Materialize it faithfully: a bare multi-agent send now carries **every participant** in the structured `mentions` array — the same wire shape an explicit @-everyone message produces, which is exactly the interactively-verified working case.

- `wireMentions()` (new pure helper in `lib/conversation-addressing.ts`): typed @mentions narrow and pass through untouched; a bare send returns the whole roster; single-agent conversations stay empty (the field isn't sent there at all).
- On each participant's daemon rung, seeing itself in `mentions` is the existing explicit-address fact (`trigger: 'mention'` → reminder injected). No participant can go silent by losing the parallel-answer race.
- Message text is untouched — the mention is structural, invisible in the composer and in the transcript.
- No daemon/relay/protocol change, no visible UI change.

## Tests

`conversation-addressing.test.ts` — typed-mention passthrough, bare-send whole-roster materialization, single-agent no-op. Web typecheck/lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)