### PR TITLE
feat(daemon): re-enable production Dream — lift the security hold (#36 Phase C)

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -12,17 +12,28 @@
 > Keywords: dreaming, memory consolidation, distillation, staged output,
 > transcript mining, skill mining, managed provider, harness-agnostic
 
-> **Production security hold (2026-08-01):** current Dream isolation cannot
-> guarantee that provider authentication is outside every path readable by the
-> model's nominally read-only tools. Production daemons therefore reject Dream execution before lookup, snapshot,
-> corpus construction, or job persistence and register no Dream schedules.
-> Historical job metadata remains listable/gettable and in-flight jobs remain
-> cancelable, but staged memory/skill/organization content cannot be read,
-> adopted, reviewed, dismissed, discarded, or swept. Re-enable these operations
-> only after credentials are outside every model-readable path and newly staged
-> bytes are cryptographically bound to the reviewed/adopted content. Injected
-> deterministic hosts remain available to tests; they are not a production
-> admission mechanism.
+> **Production security hold — LIFTED (2026-08-03, task #36).** The 2026-08-01
+> hold rejected all production Dream execution and staged-content operations until
+> two conditions were met; both now are:
+>
+> 1. **Credentials outside model-readable paths.** Each Dream runs on a dedicated,
+>    one-off ACP host, sandboxed when the agent runs sandboxed, so a sandboxed
+>    runtime is denied the host's credentials and, on Claude, the inner sandbox
+>    denies the agent's own provider credential to the model's bash. The dream
+>    launch also excludes the agent's tool credentials entirely. Residual: on a
+>    runtime with no inner provider-credential confinement (e.g. Codex) or an
+>    unsandboxed agent, the agent's own provider auth can still be reached by the
+>    model's own tools — a tracked **P2**, to be closed by per-runtime credential
+>    brokering, not a blocker (owner decision; see docs/product-conventions.md).
+> 2. **Reviewed bytes bound to adoption.** Adopt / skill-accept take the digest of
+>    the exact staged bytes the console reviewed and refuse if the staging changed
+>    since — the same-bytes review fence (skill acceptance verifies against the
+>    publication snapshot itself, so a concurrent swap cannot slip un-reviewed
+>    bytes through).
+>
+> Production Dream is therefore enabled; each agent's own `dreaming.enabled`
+> policy still gates whether it dreams. Injected deterministic hosts remain a
+> test-only seam (`dreamOperationPolicy: 'test-only'`), never a production path.
 
 ---
 

--- a/packages/daemon/src/agents/dream-runner.ts
+++ b/packages/daemon/src/agents/dream-runner.ts
@@ -94,10 +94,12 @@ export const DREAM_MODEL_READABLE_CREDENTIALS_REASON =
 export const DREAM_UNBOUND_STAGED_CONTENT_REASON =
   'historical Dream staged content is blocked because its reviewed bytes are not cryptographically bound to adoption; rerun after credential-isolated Dream execution is available (unbound_staged_content)'
 
-/** One fail-closed policy covers every operation that can execute a Dream or
- * touch staged model output. Only daemon tests with an injected host factory,
- * and standalone deterministic runner tests, may opt into `test-only`. */
-export type DreamOperationPolicy = 'blocked' | 'test-only'
+/** One policy covers every operation that can execute a Dream or touch staged
+ * model output. `blocked` fails closed (the original security hold). `test-only`
+ * is the injected-host-factory / deterministic-runner test seam. `enabled` is
+ * production: the security hold is lifted now that A1/A2 isolate credentials and
+ * B binds the reviewed bytes to adoption (task #36 Phase C). */
+export type DreamOperationPolicy = 'blocked' | 'test-only' | 'enabled'
 
 export interface DreamStorePort {
   insertDream(dream: DreamInfo): void
@@ -294,7 +296,7 @@ export class DreamRunner {
   }
 
   private operationsAllowed(): boolean {
-    return this.deps.operationPolicy === 'test-only'
+    return this.deps.operationPolicy === 'test-only' || this.deps.operationPolicy === 'enabled'
   }
 
   private assertExecutionAllowed(): void {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4975,7 +4975,7 @@ export class Daemon {
     this.dreamRunnerInstance ??= new DreamRunner({
       agentDirByAgent: (id) => this.agents.get(id)?.dir,
       dreamingPolicyFor: (id) => dreamingPolicyOf(this.agents.get(id)),
-      operationPolicy: this.dreamOperationsAllowed() ? 'test-only' : 'blocked',
+      operationPolicy: this.dreamOperationsAllowed() ? (this.opts.hostFactory ? 'test-only' : 'enabled') : 'blocked',
       store: this.store,
       extract: (agentId, systemPrompt, prompt, signal, context) =>
         this.runDreamExtraction(agentId, systemPrompt, prompt, signal, context),
@@ -5005,11 +5005,17 @@ export class Daemon {
     return this.dreamRunnerInstance
   }
 
-  /** Credential-backed production Dream hosts are held closed until their
-   * provider authentication can be kept outside every model-readable path.
-   * Injected hosts are deterministic test/evaluation seams and remain enabled. */
+  /** Whether Dream execution + staged-content operations are allowed on this
+   * daemon. The production security hold is LIFTED (task #36 Phase C): A1/A2 give
+   * the dream a dedicated, credential-isolated host and B binds the reviewed
+   * bytes to adoption, so production Dream runs. An injected host factory is a
+   * deterministic test/evaluation seam that must still opt in explicitly
+   * (`dreamOperationPolicy === 'test-only'`) so unrelated tests never run dreams
+   * by accident. Per-agent dreaming stays gated by each agent's own
+   * `dreaming.enabled` policy. */
   private dreamOperationsAllowed(): boolean {
-    return this.opts.hostFactory !== undefined && this.opts.dreamOperationPolicy === 'test-only'
+    if (this.opts.hostFactory) return this.opts.dreamOperationPolicy === 'test-only'
+    return true
   }
 
   private dreamSchedulePolicyFor(agent: { memory?: Agent['memory'] }): MemoryDreamingPolicy | undefined {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4203,17 +4203,27 @@ export class Daemon {
     // The pre-strip merged env is snapshotted so the idle sweep can delete the
     // files and rematerializeConfigFiles() can re-write them before a later turn.
     if (excludeAgentToolCredentials) {
-      // A dream host needs none of these tool secrets. Do NOT materialize (it has
-      // no cleanup path), and crucially DELETE the raw `*_DATA` source vars — they
-      // were copied into the child env by agentChildEnv, and skipping the
-      // materialize block below would otherwise leak the raw values to the
-      // attacker-controlled extraction (task #36 A2). Strip every convention name
-      // (data var + legacy aliases) whether or not it would have been planned.
+      // A dream host needs NONE of the agent's tool credentials. Do NOT
+      // materialize config files (it has no cleanup path), and DELETE the raw
+      // `*_DATA` source vars (agentChildEnv copied them in). Strip every
+      // convention name (data var + legacy aliases) whether or not it was planned.
       for (const convention of CONFIG_FILE_CONVENTIONS) {
         for (const name of [convention.dataVar, ...(convention.aliases ?? [])]) {
           delete env[name]
           delete runtimeEnv[name]
         }
+      }
+      // Also drop EVERY user-configured write-only secret (runtimeOverrides.secrets
+      // — arbitrary API keys, DB passwords, etc.). agentChildEnv merges them into
+      // the child env, but a dream only reads its materialized inputs and must not
+      // expose them to the attacker-controlled extraction's own tools (task #36 —
+      // this is beyond the accepted provider-auth P2; even a sandboxed Claude dream
+      // otherwise kept these). Runtime/provider authentication rides its own
+      // protected channel (runtime.env / the provider-credential path) and is
+      // untouched, so the dream still starts.
+      for (const secret of agent.runtimeOverrides?.secrets ?? []) {
+        delete env[secret.name]
+        delete runtimeEnv[secret.name]
       }
     } else {
       const configFileSourceEnv = { ...runtimeEnv, ...env }

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -98,6 +98,22 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     }
   })
 
+  it('enables production Dream operations (security hold lifted) without a host factory (#36 Phase C)', async () => {
+    const root = scaffold()
+    const daemon = new Daemon({ root, sandboxMechanism: null, probeRuntimes: async () => [] })
+    try {
+      await daemon.start()
+      // The production security hold is lifted: a real (no host-factory) daemon
+      // now allows Dream operations and re-advertises the organization-suggestion
+      // review capability. Per-agent dreaming stays gated by each agent's policy.
+      expect((daemon as any).dreamOperationsAllowed()).toBe(true)
+      expect((daemon as any).registrationFeatures()).toContain('organization-suggestion-review-v1')
+    } finally {
+      await daemon.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('single-agent mode still rejects an active sibling whose writable workspace overlaps', async () => {
     const root = scaffold()
     const sibling = join(root, 'agents', 'bot-b')

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -114,6 +114,31 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     }
   })
 
+  it('keeps agent write-only secrets out of the dream host env (#36 Phase C security)', async () => {
+    const root = scaffold()
+    const daemon = new Daemon({ root, sandboxMechanism: 'bwrap', probeRuntimes: async () => [] })
+    try {
+      await daemon.start()
+      const agent = (daemon as any).agents.get('bot-a')
+      agent.runtimeOverrides = { secrets: [{ name: 'API_KEY', value: 'super-secret' }] }
+      const cwd = agent.workspace.path
+      // A normal (non-dream) host still carries the agent's configured secret…
+      const normal = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      expect((normal as any).opts.env.API_KEY).toBe('super-secret')
+      // …but a dream host must not — even sandboxed, the mined transcript's own
+      // tools could otherwise read the secret straight from the environment.
+      const dreamHost = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        runInSandbox: true,
+        cwd,
+        excludeAgentToolCredentials: true
+      }).host
+      expect((dreamHost as any).opts.env.API_KEY).toBeUndefined()
+    } finally {
+      await daemon.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('single-agent mode still rejects an active sibling whose writable workspace overlaps', async () => {
     const root = scaffold()
     const sibling = join(root, 'agents', 'bot-b')


### PR DESCRIPTION
## Lifts the 2026-08-01 production Dream security hold
The hold blocked all production Dream execution and staged-content operations until two conditions were met; both are now in main:

1. **Credentials isolated from model-readable paths (A1/A2).** Each dream runs on a dedicated, one-off ACP host, sandboxed when the agent runs sandboxed (a sandboxed runtime is denied the host's credentials; on Claude the inner sandbox denies the agent's own provider credential to the model's bash), and the dream launch excludes agent tool credentials entirely.
2. **Reviewed bytes bound to adoption (B).** Adopt / skill-accept verify the digest of the exact staged bytes the console reviewed and refuse if the staging changed since (skill acceptance checks the publication snapshot itself — no TOCTOU).

## Change
- `DreamOperationPolicy` gains `enabled` (production). `dreamOperationsAllowed()` returns true for a real daemon (no host factory); the injected-host **test seam still opts in explicitly** via `test-only`, so unrelated tests never run dreams by accident. The runner accepts `enabled` alongside `test-only`; the daemon passes `enabled` in production.
- This automatically re-advertises `ORGANIZATION_SUGGESTION_REVIEW_FEATURE` and lets the already-present, ungated console dreaming toggle + org-suggestion review UI function. Per-agent dreaming stays gated by each agent's own `dreaming.enabled` policy.

## Deliberate scope / accepted risk (owner-approved)
- **No old-proposal migration:** Dream was never live in production, and the review→adopt flow computes the same-bytes token at review time, so any staged content is bound safely when a human reviews it.
- **Residual P2:** on a non-Claude runtime (e.g. Codex) or an unsandboxed agent, the agent's own provider auth can still be reached by the model's own tools — an owner-accepted P2 to be closed by per-runtime credential brokering, not a blocker (see `docs/product-conventions.md`).

## Tests
- daemon-smoke: a real (no host-factory) daemon allows Dream operations and advertises the review capability.
- Existing hold/test-seam assertions still pass (hostFactory + no policy → blocked; + `test-only` → allowed).
- Full daemon suite green locally (2733 passed).

Design doc updated (hold → lifted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)