### PR TITLE
fix(web): attribute the live typing indicator to the agents actually working

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -482,8 +482,28 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   }
   const cursorKeyFor = (id: string, agentId?: string): string | undefined =>
     cursorKeyForLanes(streamCursors.current, id, agentId)
+  // REACTIVE lane membership (review fix): the cursor map is a ref, and a
+  // lane's removal (a peer's non-final done) may arrive with no other state
+  // change — reading the ref at render time would keep showing a finished
+  // agent as typing until someone else emits. Every cursor add/delete calls
+  // syncBusyLanes, which mirrors the membership into state only when it
+  // actually changed.
+  const [busyLaneAgents, setBusyLaneAgents] = useState<Record<string, string[]>>({})
+  const syncBusyLanes = useCallback((id: string) => {
+    setBusyLaneAgents((current) => {
+      const next = lanesOfLanes(streamCursors.current, id)
+        .map((key) => laneAgentId(key))
+        .filter((agentId): agentId is string => agentId !== undefined)
+        .sort()
+      const previous = current[id] ?? []
+      if (previous.length === next.length && previous.every((value, i) => value === next[i])) return current
+      return { ...current, [id]: next }
+    })
+  }, [])
+  const getBusyLaneAgentIds = useCallback((id: string): string[] => busyLaneAgents[id] ?? [], [busyLaneAgents])
   const dropLanes = (id: string): void => {
     for (const key of lanesOf(id)) streamCursors.current.delete(key)
+    syncBusyLanes(id)
   }
 
   const failStream = useCallback(
@@ -514,6 +534,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!result.done) return
       reconnectAttempts.current.delete(id)
       streamCursors.current.delete(cursorKey)
+      syncBusyLanes(id)
       if (agentId && result.done.turnId) {
         const rec = finishedTurnLanes.current.get(id)
         if (rec && rec.turnId === result.done.turnId) rec.agents.add(agentId)
@@ -548,6 +569,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       ) {
         key = laneKey(id, output.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(output.turnId))
+        syncBusyLanes(id)
       }
       const cursor = key ? streamCursors.current.get(key) : undefined
       if (!key || !cursor || !bindWebchatTurn(cursor, output.turnId)) return
@@ -565,6 +587,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!key && admitsLane(done.agentId, done.turnId, pendingTurnIds.current.get(id), finishedFor(id, done.turnId))) {
         key = laneKey(id, done.agentId)
         streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(done.turnId))
+        syncBusyLanes(id)
       }
       const cursor = key ? streamCursors.current.get(key) : undefined
       if (!key || !cursor) return
@@ -742,6 +765,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 ) {
                   key = laneKey(id, ackAgentId)
                   streamCursors.current.set(key, createWebchatCursor<WebchatOutput, WebchatDone>(ackTurnId))
+                  syncBusyLanes(id)
                 }
                 const cursor = key ? streamCursors.current.get(key) : undefined
                 if (cursor && m.ack?.turnId) bindWebchatTurn(cursor, m.ack.turnId)
@@ -766,7 +790,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 // A per-participant rejection: fail only that lane — the other
                 // targets of a multi-agent turn keep streaming.
                 const key = cursorKeyFor(id, m.ack.agentId)
-                if (key) streamCursors.current.delete(key)
+                if (key) {
+                  streamCursors.current.delete(key)
+                  syncBusyLanes(id)
+                }
                 const agentId = m.ack.agentId
                 const name = participantName(id, agentId)
                 pushStep(id, {
@@ -971,6 +998,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       for (const target of targets) {
         streamCursors.current.set(laneKey(id, target), createWebchatCursor<WebchatOutput, WebchatDone>(requestedTurnId))
       }
+      syncBusyLanes(id)
       if (conversationId) conversationIds.current.set(id, conversationId)
       reconnectAttempts.current.delete(id)
       // First send of a fresh conversation mints a real session on the daemon. The SSE
@@ -1091,13 +1119,6 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
-  const getBusyLaneAgentIds = useCallback(
-    (id: string): string[] =>
-      lanesOfLanes(streamCursors.current, id)
-        .map((key) => laneAgentId(key))
-        .filter((agentId): agentId is string => agentId !== undefined),
-    []
-  )
   const reconcileLiveSteps = useCallback((id: string, persisted: SessionMessageDto[], agentId: string): void => {
     setWcSteps((cur) => {
       const live = cur[id]

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -87,6 +87,11 @@ interface PlaygroundData {
    *  below its fetched history. Empty until you send. Synthetic 'pg_' sessions don't use
    *  this (their whole transcript lives in the session's own `steps`). */
   getLiveSteps: (id: string) => SessionStep[]
+  /** Participants whose reply lanes are STILL OPEN for this conversation —
+   *  drives per-agent typing attribution in multi-agent conversations (a
+   *  superseded regeneration keeps its author's lane open, so the indicator
+   *  names the agent actually working, not the primary). */
+  getBusyLaneAgentIds: (id: string) => string[]
   /** Retire only optimistic turns confirmed by authoritative transcript rows. */
   reconcileLiveSteps: (id: string, persisted: SessionMessageDto[], agentId: string) => void
 }
@@ -1086,6 +1091,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
+  const getBusyLaneAgentIds = useCallback(
+    (id: string): string[] =>
+      lanesOfLanes(streamCursors.current, id)
+        .map((key) => laneAgentId(key))
+        .filter((agentId): agentId is string => agentId !== undefined),
+    []
+  )
   const reconcileLiveSteps = useCallback((id: string, persisted: SessionMessageDto[], agentId: string): void => {
     setWcSteps((cur) => {
       const live = cur[id]
@@ -1118,6 +1130,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       getPgSession,
       pgSessionList,
       getLiveSteps,
+      getBusyLaneAgentIds,
       reconcileLiveSteps
     }),
     [
@@ -1137,6 +1150,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       getPgSession,
       pgSessionList,
       getLiveSteps,
+      getBusyLaneAgentIds,
       reconcileLiveSteps
     ]
   )

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1024,6 +1024,7 @@ export default function SessionDetailView() {
   const {
     getPgSession,
     getLiveSteps,
+    getBusyLaneAgentIds,
     reconcileLiveSteps,
     getPgInput,
     getPgImage,
@@ -2877,18 +2878,36 @@ export default function SessionDetailView() {
                   conversationId={webchatConversationId}
                 />
               )}
-              {pgBusy && (
-                <div className="flex items-center gap-[10px] desktop:mt-[14px] desktop:gap-[11px]">
-                  <span className="av h-[30px] w-[30px] flex-none rounded-md">
-                    <AgentIconView icon={owner?.icon} runtime={agentRuntime} size={30} />
-                  </span>
-                  <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
-                    <span className="tdot" />
-                    <span className="tdot [animation-delay:.18s]" />
-                    <span className="tdot [animation-delay:.36s]" />
-                  </div>
-                </div>
-              )}
+              {pgBusy &&
+                (() => {
+                  // Multi-agent conversations attribute the typing indicator to
+                  // the participants whose reply lanes are STILL OPEN — after a
+                  // supersession it is the REGENERATING agent working, not the
+                  // primary. Single-agent (and lane-less adopted) sessions keep
+                  // the owner row.
+                  const busyAgents =
+                    (session.participants?.length ?? 0) > 1
+                      ? getBusyLaneAgentIds(session.id)
+                          .map((agentId) => agentById.get(agentId))
+                          .filter((agent): agent is Agent => agent !== undefined)
+                      : []
+                  const rows = busyAgents.length > 0 ? busyAgents : [owner]
+                  return rows.map((agent, i) => (
+                    <div
+                      key={agent?.id ?? i}
+                      className="flex items-center gap-[10px] desktop:mt-[14px] desktop:gap-[11px]"
+                    >
+                      <span className="av h-[30px] w-[30px] flex-none rounded-md">
+                        <AgentIconView icon={agent?.icon} runtime={agent?.runtime || agentRuntime} size={30} />
+                      </span>
+                      <div className="inline-flex items-center gap-1 rounded-[11px] bg-(--brand-soft) px-[14px] py-[11px]">
+                        <span className="tdot" />
+                        <span className="tdot [animation-delay:.18s]" />
+                        <span className="tdot [animation-delay:.36s]" />
+                      </div>
+                    </div>
+                  ))
+                })()}
               {pgEmpty && (
                 <div className="desktop:mt-[6px]">
                   <div className="mb-2 font-mono text-[10.5px] font-semibold uppercase tracking-[.08em] text-(--text-tertiary)">


### PR DESCRIPTION
Live multi-agent Playground bug: the typing indicator always wore the **primary** agent's icon. Most visible after a turn-final supersession ("The conversation moved on — updating this answer…"): the *regenerating peer* is the one thinking, but the dots showed AgentConnect.

- `PlaygroundProvider` exposes `getBusyLaneAgentIds` — the participants whose reply lanes are still open, straight from the existing per-(session, agent) stream cursors (a superseded regeneration keeps its author's lane open, so this is exactly the "who is working" signal).
- The live view renders one attribution row per busy lane (that agent's icon + runtime), and two agents streaming concurrently now each get their own row. Single-agent sessions and lane-less adopted ones keep today's owner row.

Web 640 green, typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)