### PR TITLE
fix(sessions): preserve external filter alternatives

### DIFF
--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -457,7 +457,9 @@ export function sessionRoutes(deps: HttpDeps) {
           githubHookIds,
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {})
         }
-        const { viewer } = await viewerForQuery(req, query)
+        // Each facet drops its own active filter, so its external-audience
+        // snapshot must span the same visible-agent superset.
+        const { viewer } = await viewerForQuery(req, { agentIds: visibleAgentIds.map(AgentId) })
         const index = await deps.repos.session.listFacets({ ...query, viewer })
         const metadataRows = [...index.integrations, ...index.channels, ...index.triggers]
         const hookMetadata = await hookMetadataForSessions(deps, metadataRows, orgOf(req))

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -628,6 +628,73 @@ describe('session visibility — GitHub repository audience', () => {
     expect(enabled.statusCode).toBe(200)
     expect(enabled.json()).toMatchObject({ provider: 'github', available: true, enabled: true, state: 'enabled' })
   })
+
+  it('keeps allowed GitHub alternatives when another integration is selected', async () => {
+    const viewer = await makeUser(`sv-github-facets-${randomUUID()}`, 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const hookId = randomUUID()
+    const repo = new PgSessionRepo(prisma)
+
+    await prisma.hookDef.create({
+      data: {
+        id: hookId,
+        orgId: DEFAULT_ORG_ID,
+        agentId,
+        kind: 'github',
+        name: 'example-org/example-repo',
+        sessionMode: 'perThread',
+        repoId: 123n,
+        repoFullName: 'example-org/example-repo'
+      }
+    })
+    const githubSessionId = SessionId(`s-github-facet-${randomUUID()}`)
+    await repo.recordMilestone({
+      sessionId: githubSessionId,
+      agentId: AgentId(agentId),
+      phase: 'start',
+      platform: 'hook',
+      channel: hookId,
+      triggeredBy: `hook:${hookId}`,
+      at: new Date(1_000),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' },
+      externalCandidate: {
+        provider: 'github',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'github.com',
+          resourceKind: 'repository',
+          resourceKey: '123',
+          credentialKind: 'github_installation',
+          credentialId: randomUUID()
+        }
+      }
+    })
+    await repo.recordMilestone({
+      sessionId: SessionId(`s-webchat-facet-${randomUUID()}`),
+      agentId: AgentId(agentId),
+      phase: 'start',
+      platform: 'webchat',
+      channel: randomUUID(),
+      at: new Date(2_000),
+      classification: { visibility: 'private', ownerIdentity: `user:${viewer}`, source: 'default' }
+    })
+
+    await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'github', true)
+    expect(await repo.get(githubSessionId)).toMatchObject({ visibility: 'external', externalResolution: 'settled' })
+
+    const response = await appAs(viewer, {
+      githubSessionAccess: {
+        resolve: async (scopes) => ({
+          allowedScopes: scopes.map((scope) => ({ id: scope.id, aclRevision: scope.aclRevision })),
+          degraded: false
+        })
+      }
+    }).app.inject({ method: 'GET', url: `${ORG}/sessions/facets?integration=webchat` })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toMatchObject({ integrations: ['webchat', 'github'] })
+  })
 })
 
 describe('session visibility — PUT /sessions/:id/visibility (§4.3)', () => {


### PR DESCRIPTION
## Summary

- keep authorized integrations such as GitHub available in the Sessions integration filter after selecting Playground
- resolve facet visibility across the caller's visible-agent scope while retaining each facet's existing cascade rules
- cover the external-audience regression with a focused integration test

## Root cause

The facets query correctly removes each facet's own active filter when computing alternatives, but its visibility snapshot was built from the fully filtered session query. Selecting Playground therefore omitted GitHub repository scopes before the integration alternatives were evaluated, so otherwise authorized GitHub sessions could not contribute a filter option.

## Validation

- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm exec eslint packages/control-plane/src/http/routes/sessions.ts packages/control-plane/test/integration/session-visibility.route.test.ts`
- `pnpm exec prettier --check packages/control-plane/src/http/routes/sessions.ts packages/control-plane/test/integration/session-visibility.route.test.ts`
- `pnpm exec vitest run --project integration test/integration/session-visibility.route.test.ts test/integration/sessions.history.route.test.ts` (39 tests)
- `git diff --check origin/main...HEAD`

Created by Codex . GPT-5
