### PR TITLE
fix(daemon): harden agent config watcher

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { isAbsolute, join, relative, sep } from 'node:path'
+import { basename, isAbsolute, join, relative, sep } from 'node:path'
 import { hostname, tmpdir } from 'node:os'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, type Stats } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
@@ -368,6 +368,12 @@ function formatErr(err: unknown): string {
     return `${e.name ?? 'Error'}: ${e.message ?? ''} (code=${e.code})${data}`
   }
   return e?.stack ?? String(err)
+}
+
+function ignoreAgentWatchPath(agentsDir: string, path: string, stats?: Stats): boolean {
+  const segments = relative(agentsDir, path).split(sep)
+  if (segments.some((segment) => segment === 'node_modules' || segment.startsWith('.'))) return true
+  return stats !== undefined && !stats.isDirectory() && basename(path) !== 'agent.json'
 }
 
 /** Validate the same trusted workspace boundary that every real ACP spawn will
@@ -2829,11 +2835,12 @@ export class Daemon {
     const cronCount = agents.reduce((n, a) => n + this.scheduler.count(a.id), 0)
     if (cronCount) this.log.info(`registered ${cronCount} cron(s)`)
 
-    // file-watch: reconcile on any agents/** change (debounced 300ms)
+    // Watch the discoverable agent config tree, not runtime homes/workspaces.
     this.watcher = chokidarWatch(this.agentsDir, {
       ignoreInitial: true,
       depth: 4,
-      ignored: (p: string) => /[\\/](node_modules|\.git|\.detached|\.staged|\.removed)([\\/]|$)/.test(p)
+      followSymlinks: false,
+      ignored: (path, stats) => ignoreAgentWatchPath(this.agentsDir, path, stats)
     })
     const debounced = () => {
       clearTimeout(this.debounceTimer)
@@ -2841,7 +2848,11 @@ export class Daemon {
         void this.reconcile().catch((err) => console.error('agentconnect: reconcile failed:', err))
       }, 300)
     }
-    this.watcher.on('add', debounced).on('change', debounced).on('unlink', debounced)
+    this.watcher
+      .on('error', (err) => this.log.warn(`agent config watcher: ${formatErr(err)}`))
+      .on('add', debounced)
+      .on('change', debounced)
+      .on('unlink', debounced)
     this.log.info(`watching ${this.agentsDir} for agent changes`)
     this.replayInbox()
     this.rearmOrchestrationDeadlines()

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
@@ -86,6 +86,31 @@ describe('Daemon debounce timer cleared on stop()', () => {
     // Wait longer than debounce window to confirm reconcile was never called
     await new Promise((resolve) => setTimeout(resolve, 400))
     expect(reconcileSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('Daemon agent config watcher', () => {
+  it('does not traverse a self-referential symlink in runtime temp state', async () => {
+    const root = root1()
+    writeAgent(root, 'bot-a')
+    const temp = join(root, 'agents', 'bot-a', 'home', '.tmp', 'ac-admin-sockets-test')
+    mkdirSync(temp, { recursive: true })
+    const loop = join(temp, 'private-daemon-loop-do-not-leak')
+    symlinkSync(loop, loop)
+
+    const { daemon } = makeStubDaemon(root)
+    await daemon.start()
+
+    const watcher = (daemon as any).watcher
+    const errors: NodeJS.ErrnoException[] = []
+    watcher.on('error', (err: NodeJS.ErrnoException) => errors.push(err))
+    if (!watcher._readyEmitted) {
+      await new Promise<void>((resolve) => watcher.once('ready', resolve))
+    }
+
+    expect(errors.some((err) => err.code === 'ELOOP')).toBe(false)
+    expect(Object.keys(watcher.getWatched()).some((path) => path.endsWith(join('home', '.tmp')))).toBe(false)
+    await daemon.stop()
   })
 })
 


### PR DESCRIPTION
## Summary

- restrict the daemon watcher to the discoverable agent configuration tree
- ignore hidden/runtime files and stop following symbolic links
- handle watcher errors without process-level unhandled rejections
- cover the reported self-referential runtime temp symlink

## Root cause

Per-agent runtime homes place `TMPDIR` under `agents/<id>/home/.tmp`. The recursive agent watcher entered that runtime state and Chokidar followed a test-created self-referential symlink, causing `stat` to fail with `ELOOP`.

## Validation

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/reconcile-watch.test.ts` (35 passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/daemon.ts packages/daemon/test/reconcile-watch.test.ts`
- `pnpm exec prettier --check packages/daemon/src/daemon.ts packages/daemon/test/reconcile-watch.test.ts`
- `pnpm --filter @agentconnect.md/daemon build`

Created by Codex . GPT-5
