### PR TITLE
fix(web): first send of a fresh multi-agent conversation loses its roster

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -27,7 +27,7 @@ import {
   type SessionMessageDto
 } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
-import { wireMentions } from '@/lib/conversation-addressing'
+import { resolveRoster, wireMentions } from '@/lib/conversation-addressing'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
 import {
@@ -981,7 +981,18 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       // send degrades to the relay's all-participants default: mentions can't
       // narrow, and no lanes are pre-created (leaving delivery to the
       // early-frame admission path).
-      const roster = session?.participants ?? knownParticipants ?? []
+      //
+      // The staged-ref fallback (resolveRoster) covers the FIRST send of a
+      // fresh multi-agent conversation: openPlayground stages the session and
+      // HomeView sends in the same tick, so `pgSessions[id]` is still the
+      // pre-stage snapshot. Reading only state here silently dropped
+      // mentions/targets (and lane pre-creation) from every first message —
+      // the standing mention never reached the wire, so the parallel-answer
+      // race could still silence an agent on exactly the message most users
+      // test with.
+      const roster = resolveRoster(session?.participants, knownParticipants, rosterAgentIds.current.get(id), (a) =>
+        rosterNames.current.get(id)?.get(a)
+      )
       if (!session && knownParticipants && knownParticipants.length > 1 && !rosterNames.current.has(id)) {
         rosterNames.current.set(id, new Map(knownParticipants.map((p) => [p.agentId, p.name])))
       }

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { wireMentions } from './conversation-addressing'
+import { resolveRoster, wireMentions } from './conversation-addressing'
 
 const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
 
@@ -14,5 +14,36 @@ describe('wireMentions', () => {
 
   it('stays empty for single-agent conversations', () => {
     expect(wireMentions([{ agentId: 'solo' }], [])).toEqual([])
+  })
+})
+
+describe('resolveRoster', () => {
+  const names = new Map([
+    ['a', 'Alpha'],
+    ['b', 'Beta']
+  ])
+  const nameOf = (agentId: string) => names.get(agentId)
+
+  it('prefers settled session participants, then the adopted detail roster', () => {
+    const settled = [{ agentId: 'a', name: 'Alpha', primary: true }]
+    const adopted = [{ agentId: 'b', name: 'Beta' }]
+    expect(resolveRoster(settled, adopted, ['a', 'b'], nameOf)).toBe(settled)
+    expect(resolveRoster(undefined, adopted, ['a', 'b'], nameOf)).toBe(adopted)
+  })
+
+  it('falls back to creation-time staged ids on the same-tick first send, first id primary', () => {
+    expect(resolveRoster(undefined, undefined, ['a', 'b'], nameOf)).toEqual([
+      { agentId: 'a', name: 'Alpha', primary: true },
+      { agentId: 'b', name: 'Beta' }
+    ])
+    expect(resolveRoster(undefined, undefined, ['a', 'unknown'], nameOf)).toEqual([
+      { agentId: 'a', name: 'Alpha', primary: true },
+      { agentId: 'unknown', name: '' }
+    ])
+  })
+
+  it('yields no roster for single-agent or unstaged sends', () => {
+    expect(resolveRoster(undefined, undefined, ['a'], nameOf)).toEqual([])
+    expect(resolveRoster(undefined, undefined, undefined, nameOf)).toEqual([])
   })
 })

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -14,3 +14,33 @@ export function wireMentions(roster: ReadonlyArray<{ agentId: string }>, typedMe
   if (typedMentions.length > 0 || roster.length <= 1) return [...typedMentions]
   return roster.map((p) => p.agentId)
 }
+
+export interface RosterParticipant {
+  agentId: string
+  name: string
+  primary?: boolean
+}
+
+/** The composer's roster for one send, in trust order: the settled session
+ * state, then the fetched detail of an adopted session, then the creation-time
+ * staged ids. The staged fallback exists for the FIRST send of a fresh
+ * multi-agent conversation — the provider stages the session and sends in the
+ * same tick, so the state read still sees the pre-stage snapshot; without this
+ * fallback that first message carries no mentions/targets and the standing
+ * mention never reaches the wire. The first staged id is the primary
+ * (creation order, webchat-multi-agents.md §3.1). */
+export function resolveRoster(
+  sessionParticipants: RosterParticipant[] | undefined,
+  knownParticipants: RosterParticipant[] | undefined,
+  stagedIds: readonly string[] | undefined,
+  nameOf: (agentId: string) => string | undefined
+): RosterParticipant[] {
+  if (sessionParticipants) return sessionParticipants
+  if (knownParticipants) return knownParticipants
+  if (!stagedIds || stagedIds.length <= 1) return []
+  return stagedIds.map((agentId, index) => ({
+    agentId,
+    name: nameOf(agentId) ?? '',
+    ...(index === 0 ? { primary: true } : {})
+  }))
+}


### PR DESCRIPTION
## Problem

Follow-up to #461, found by testing on a live deployment carrying it: the first bare message of a **fresh** multi-agent conversation still hit the parallel-answer race silence. Daemon-side evidence showed the turn arrived with no structured `mentions` at all (`trigger:'dm'`, no `EXPLICIT_MENTION_REMINDER` in the prompt), even though web/relay/daemon all ran a build containing #461.

Root cause is a same-tick state race in the composer, not the wire: `openPlayground` stages the session and HomeView calls `pgSend` in the same tick, so `pgSend`'s `pgSessions[id]` read still sees the pre-stage snapshot → `roster = []` → the send carries no `mentions`/`targets` (and pre-creates no lanes). The relay's whole-roster default still delivers it, but as `trigger:'dm'` — the standing mention never reaches the wire on exactly the message most users test with. Every later send in the conversation is fine (settled state, or the adopted session's fetched roster), which is why the symptom looked like "#461 didn't work" only on first messages. The provider already keeps `rosterAgentIds`/`rosterNames` refs for the socket path *because* same-tick state reads are stale — `pgSend` just never used them.

## Fix

New pure `resolveRoster` in `lib/conversation-addressing.ts`: settled session participants → adopted detail roster → creation-time staged ids (first id = primary, per §3.1 creation order). `pgSend` resolves through it, so the first send now carries the full standing mention like every later one.

## Tests

`conversation-addressing.test.ts`: precedence order, staged fallback with primary flag and unknown-name tolerance, single-agent/unstaged → empty. Web typecheck/lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)