### PR TITLE
feat(lark): sync session access with user tokens

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -37,8 +37,9 @@ This design gives every session its own visibility:
   sessions store the rename-proof numeric repository id: public repositories
   require no linked identity; private repositories require the viewer's
   currently linked GitHub account to retain read access.
-  Feishu/Lark group sessions created through the deployment's matching
-  platform app require current chat membership; DMs remain owner-only.
+  Feishu/Lark sessions created through any registered Bot app require current
+  chat membership, asserted with the viewer's stored login-app user token.
+  This covers both group chats and Bot p2p conversations.
 - **Share-by-link ("public")** — future work; a session with an active share
   link is readable by anyone holding the link. Deliberately **not** a member of
   the visibility enum; see §8.
@@ -225,10 +226,10 @@ GitHub direct ingress reports:
 ```
 
 Feishu/Lark direct ingress uses provider `feishu`, a `conversation` resource,
-and realm `<region>:<appId>`. The CP accepts the candidate only when that App ID
-matches `FEISHU_PLATFORM_APP_ID` or `LARK_PLATFORM_APP_ID`; user-built apps stay
-on the ordinary organization visibility model because their `open_id` domain
-cannot be compared with the platform Logto connector.
+and realm `<region>:<appId>`. The App ID identifies and validates the registered
+Bot credential that received the message; it does not need to match the
+environment's login App ID because authorization compares no app-scoped
+`open_id` values.
 
 The daemon pins that tuple on first use. A later input from a different source
 is rejected rather than silently reusing the session. A2A descendants carry
@@ -257,16 +258,17 @@ The CP classifies once, in the `event/session` ingest path
 (`ws/handlers/event-session.ts` → `session.recordMilestone`), first-wins like
 the other origin scalars:
 
-| Origin (how detected)                                                      | `visibility`        | `ownerIdentity`                                                                                                                       |
-| -------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Webchat / Playground (`platform === 'webchat'`)                            | `private`           | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
-| Web API session launch (§4.4 correlation)                                  | `private`           | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
-| IM DM (`conversationKind` = `dm`)                                          | `private`           | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Slack or matching-app Feishu/Lark group chat with trusted `externalOrigin` | `org` or `external` | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
-| GitHub hook with an accepted delivery snapshot                             | `org` or `external` | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
-| Other IM group DM / channel (or absent kind)                               | `org`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Agent-to-agent child (`triggeredBy` is an agent UUID)                      | inherits parent     | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
-| Automation without a trusted external destination                          | `org`               | `null`                                                                                                                                |
+| Origin (how detected)                                         | `visibility`            | `ownerIdentity`                                                                                                                       |
+| ------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Webchat / Playground (`platform === 'webchat'`)               | `private`               | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
+| Web API session launch (§4.4 correlation)                     | `private`               | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
+| IM DM (`conversationKind` = `dm`)                             | `private`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| Slack or Feishu/Lark group chat with trusted `externalOrigin` | `org` or `external`     | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
+| Feishu/Lark Bot p2p chat with trusted `externalOrigin`        | `private` or `external` | Owner-only baseline while sync is disabled; current conversation membership while enabled                                             |
+| GitHub hook with an accepted delivery snapshot                | `org` or `external`     | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
+| Other IM group DM / channel (or absent kind)                  | `org`                   | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
+| Agent-to-agent child (`triggeredBy` is an agent UUID)         | inherits parent         | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
+| Automation without a trusted external destination             | `org`                   | `null`                                                                                                                                |
 
 Notes:
 
@@ -594,15 +596,18 @@ login from Logto and asks GitHub for that user's current effective repository
 permission. AgentConnect stores neither the GitHub login nor a copied provider
 ACL; only bounded allow/deny/error verdicts are cached in process.
 
-**Feishu/Lark (shipped for the platform apps).** Logto stores the connector's
-raw `open_id`; the BFF reads it without exposing it to the browser and qualifies
-it with the connector region plus deployment App ID. The daemon independently
-reports the messaging App ID in its trusted source realm. The two values enter
-the same identity set only when those App IDs match, which is required because
-`open_id` is app-scoped. Group sessions then page the live chat-members endpoint
-with the corresponding platform app credential. DMs use the same qualified
-identity tuple and remain private. Provider failures fail closed; only bounded
-allow/deny/error verdicts and tenant tokens are cached in process.
+**Feishu/Lark (shipped).** Logto's connector stores the user's federated token
+after social authorization. On Session authorization reads, the browser sends
+its opaque Account API token to the BFF. The BFF first verifies that token's
+account id equals the request's already verified OIDC subject, then retrieves
+the corresponding regional user token and calls `is_in_chat` for each immutable
+chat id reported by a registered Bot app. The login and Bot App IDs may differ:
+the provider evaluates the current user token directly, so AgentConnect never
+compares their app-scoped `open_id` values. Both group and Bot p2p sessions use
+this live membership decision when sync is enabled; a p2p session keeps its
+private owner baseline while sync is disabled. Provider failures fail closed.
+Raw Account API and provider tokens are never persisted or logged by the BFF;
+only bounded allow/deny/error verdicts are cached in process.
 
 **Other platform session access (future, separate design).** Telegram and
 Discord still need an explicit verified identity binding before their platform
@@ -658,7 +663,7 @@ link ends public access without touching the session row.
   validation; numeric repository identity across rename; public, private-linked,
   no-access, and provider-error decisions; ambiguous-history hiding; A2A scope
   inheritance; owner-role non-bypass; and parity across every session read path.
-- **Feishu/Lark external audience:** same-app Logto identity qualification;
-  platform-app source validation; paginated current-chat membership; regional
-  gateway selection; definitive denial versus degraded provider failure; and
-  custom-app non-participation.
+- **Feishu/Lark external audience:** Account-token/OIDC-subject binding;
+  registered custom-Bot source validation; regional `is_in_chat` checks with a
+  stored user token; group and Bot p2p classification; definitive denial versus
+  degraded provider failure; and raw-token non-retention.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -25,7 +25,9 @@ This design gives every session its own visibility:
   Like restricted-resource visibility, there is **no org-owner governance
   override**: a private session is a DM-grade transcript, and role grants no
   access to it. Default for platform **DM** sessions, **Playground /
-  webchat** sessions, and sessions launched through the **Web API**.
+  webchat** sessions, and sessions launched through the **Web API**. A
+  Feishu/Lark custom-Bot p2p owner may instead be proven by current membership
+  in that p2p chat because its app-scoped sender id cannot match the login app.
 - **`org`** — visible to every org member who can view the owning agent.
   Default for automation-originated sessions and shared IM sessions when the
   corresponding external-audience policy is disabled.
@@ -90,7 +92,10 @@ Matching is set membership: at request time the BFF computes the viewer's
 verified Slack identity (`slack:<teamId>:<userId>`) or a same-app Feishu/Lark
 identity (`feishu:<region>:<appId>:<openId>`) when linked (§7,
 `http/viewer-identity.ts`) — and a `private` session is
-visible when `ownerIdentity ∈ identitySet`.
+visible when `ownerIdentity ∈ identitySet`. A provider-bound Feishu/Lark p2p
+also accepts a live `is_in_chat` proof from the viewer's login-app user token:
+the chat has one human participant, so this is a cross-app owner proof rather
+than a shared-group audience grant.
 
 Consequences:
 
@@ -258,17 +263,17 @@ The CP classifies once, in the `event/session` ingest path
 (`ws/handlers/event-session.ts` → `session.recordMilestone`), first-wins like
 the other origin scalars:
 
-| Origin (how detected)                                         | `visibility`            | `ownerIdentity`                                                                                                                       |
-| ------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Webchat / Playground (`platform === 'webchat'`)               | `private`               | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed) |
-| Web API session launch (§4.4 correlation)                     | `private`               | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                             |
-| IM DM (`conversationKind` = `dm`)                             | `private`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Slack or Feishu/Lark group chat with trusted `externalOrigin` | `org` or `external`     | External source scope; `org` while sync is disabled, `external` while enabled                                                         |
-| Feishu/Lark Bot p2p chat with trusted `externalOrigin`        | `private` or `external` | Owner-only baseline while sync is disabled; current conversation membership while enabled                                             |
-| GitHub hook with an accepted delivery snapshot                | `org` or `external`     | Repository source scope; `org` while sync is disabled, `external` while enabled                                                       |
-| Other IM group DM / channel (or absent kind)                  | `org`                   | `<platform>:<workspace>:<uid>` (initiator)                                                                                            |
-| Agent-to-agent child (`triggeredBy` is an agent UUID)         | inherits parent         | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                  |
-| Automation without a trusted external destination             | `org`                   | `null`                                                                                                                                |
+| Origin (how detected)                                         | `visibility`            | `ownerIdentity`                                                                                                                         |
+| ------------------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Webchat / Playground (`platform === 'webchat'`)               | `private`               | `user:<WebchatConversation.userId>` via `channel == conversationId` lookup; lookup miss ⇒ stays `private`, owner `null` (fail closed)   |
+| Web API session launch (§4.4 correlation)                     | `private`               | `user:<launch principal userId>`; missing correlation ⇒ `private`, `null`                                                               |
+| IM DM (`conversationKind` = `dm`)                             | `private`               | `<platform>:<workspace>:<uid>` (initiator)                                                                                              |
+| Slack or Feishu/Lark group chat with trusted `externalOrigin` | `org` or `external`     | External source scope; `org` while sync is disabled, `external` while enabled                                                           |
+| Feishu/Lark Bot p2p chat with trusted `externalOrigin`        | `private` or `external` | Owner-only baseline (identity match or live p2p membership proof) while sync is disabled; current conversation membership while enabled |
+| GitHub hook with an accepted delivery snapshot                | `org` or `external`     | Repository source scope; `org` while sync is disabled, `external` while enabled                                                         |
+| Other IM group DM / channel (or absent kind)                  | `org`                   | `<platform>:<workspace>:<uid>` (initiator)                                                                                              |
+| Agent-to-agent child (`triggeredBy` is an agent UUID)         | inherits parent         | inherits direct owner or external source scope; unresolved parent ⇒ private/unreadable (fail closed)                                    |
+| Automation without a trusted external destination             | `org`                   | `null`                                                                                                                                  |
 
 Notes:
 
@@ -289,8 +294,11 @@ Notes:
   of visibility** (DM, group DM, and channel alike). It is orthogonal to the
   visibility default: for `org` sessions it is provenance and the anchor for
   §4.3 reclassification rights, not an access gate.
-- A provider-bound conversation or repository never uses one initiator as its
-  access owner. With Slack sync enabled, public-channel access follows active
+- A shared provider-bound conversation or repository never uses one initiator
+  as its access owner. A Feishu/Lark Bot p2p is the narrow exception: while
+  sync is disabled its one human participant is the private owner, proven by
+  exact same-app identity or live p2p membership. With Slack sync enabled,
+  public-channel access follows active
   full workspace membership while restricted conversations and restricted
   users follow current conversation membership. With provider sync disabled,
   new provider sessions remain `org`.
@@ -406,7 +414,9 @@ The authoritative predicate, mirroring `canView`:
 canViewSession(s, ctx, identitySet) =
   // deliberately NO role-based governance exception — private is owner-only
   s.externalProvider != null
-    ? currentExternalAudienceAllows(s, ctx)
+    ? s.visibility === 'private'
+      ? identitySet.has(s.ownerIdentity) || liveFeishuP2pOwnerAllows(s, ctx)
+      : currentExternalAudienceAllows(s, ctx)
     : s.visibility === 'org' || (s.ownerIdentity != null && identitySet.has(s.ownerIdentity))
 ```
 
@@ -604,8 +614,10 @@ the corresponding regional user token and calls `is_in_chat` for each immutable
 chat id reported by a registered Bot app. The login and Bot App IDs may differ:
 the provider evaluates the current user token directly, so AgentConnect never
 compares their app-scoped `open_id` values. Both group and Bot p2p sessions use
-this live membership decision when sync is enabled; a p2p session keeps its
-private owner baseline while sync is disabled. Provider failures fail closed.
+this live membership decision when sync is enabled. While sync is disabled, a
+p2p session stays `private`; when the same-app identity tuple cannot match a
+custom Bot, the same live check proves its sole human owner instead of leaving
+the session permanently orphaned. Provider failures fail closed.
 Raw Account API and provider tokens are never persisted or logged by the BFF;
 only bounded allow/deny/error verdicts are cached in process.
 

--- a/packages/control-plane/prisma/migrations/20260803090000_external_private_baseline/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260803090000_external_private_baseline/migration.sql
@@ -1,0 +1,23 @@
+-- A provider-bound p2p conversation may retain its direct private baseline
+-- while external-audience sync is disabled. Enabling the provider policy moves
+-- the same immutable source binding to `external` atomically.
+
+ALTER TABLE "session_meta"
+  DROP CONSTRAINT "session_meta_external_shape_check";
+
+ALTER TABLE "session_meta" ADD CONSTRAINT "session_meta_external_shape_check" CHECK (
+  (
+    "externalProvider" IS NULL
+    AND "externalScopeId" IS NULL
+    AND "externalResolution" IS NULL
+    AND "classifiedPolicyRev" IS NULL
+    AND "visibility" <> 'external'::"SessionVisibility"
+  )
+  OR
+  (
+    "externalProvider" IS NOT NULL
+    AND "externalResolution" IS NOT NULL
+    AND "classifiedPolicyRev" IS NOT NULL
+    AND ("externalResolution" <> 'settled'::"ExternalResolution" OR "externalScopeId" IS NOT NULL)
+  )
+);

--- a/packages/control-plane/src/authorization/policy.test.ts
+++ b/packages/control-plane/src/authorization/policy.test.ts
@@ -226,6 +226,19 @@ describe('canViewSession (session-visibility.md §5)', () => {
     ).toBe(false)
   })
 
+  it('keeps a provider-bound p2p session owner-only until external sync is enabled', () => {
+    const owner = ctx(CREATOR, 'collaborator')
+    const session: SessionViewable = {
+      visibility: 'private',
+      ownerIdentity: `user:${CREATOR}`,
+      externalProvider: 'feishu',
+      externalScopeId: 'scope-1',
+      externalResolution: 'settled'
+    }
+    expect(canViewSession(session, owner, idsOf(owner))).toBe(true)
+    expect(canViewSession(session, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(false)
+  })
+
   it('fails closed for unresolved external rows and pre-fence candidates', () => {
     const principal = ctx(OTHER, 'collaborator')
     const snapshot = {

--- a/packages/control-plane/src/authorization/policy.test.ts
+++ b/packages/control-plane/src/authorization/policy.test.ts
@@ -226,17 +226,24 @@ describe('canViewSession (session-visibility.md §5)', () => {
     ).toBe(false)
   })
 
-  it('keeps a provider-bound p2p session owner-only until external sync is enabled', () => {
+  it('keeps a provider-bound p2p session owner-only through exact identity or live chat proof', () => {
     const owner = ctx(CREATOR, 'collaborator')
     const session: SessionViewable = {
       visibility: 'private',
-      ownerIdentity: `user:${CREATOR}`,
+      ownerIdentity: 'feishu:lark:cli_custom:ou_owner',
       externalProvider: 'feishu',
       externalScopeId: 'scope-1',
       externalResolution: 'settled'
     }
-    expect(canViewSession(session, owner, idsOf(owner))).toBe(true)
+    expect(canViewSession(session, owner, new Set([...idsOf(owner), session.ownerIdentity!]))).toBe(true)
     expect(canViewSession(session, ctx(OTHER, 'owner'), idsOf(ctx(OTHER, 'owner')))).toBe(false)
+    expect(
+      canViewSession(session, ctx(OTHER, 'viewer'), idsOf(ctx(OTHER, 'viewer')), {
+        policies: [{ provider: 'feishu', readFenceRev: null }],
+        allowedScopes: [{ id: 'scope-1', aclRevision: 1n }],
+        decisionAt: new Date()
+      })
+    ).toBe(true)
   })
 
   it('fails closed for unresolved external rows and pre-fence candidates', () => {

--- a/packages/control-plane/src/authorization/policy.ts
+++ b/packages/control-plane/src/authorization/policy.ts
@@ -94,7 +94,14 @@ function externalSessionIsVisible(
     return false
   }
   if (resource.visibility === 'org') return true
-  if (resource.visibility !== 'external' || resource.externalResolution !== 'settled' || !resource.externalScopeId) {
+  // A custom-Bot p2p owner cannot be matched through the login app's app-scoped
+  // open_id. Its private baseline therefore accepts the same live chat proof as
+  // the enabled external policy; a Bot p2p has exactly one human member, so the
+  // proof remains owner-only. Other providers/private rows keep exact identity
+  // matching and cannot borrow an external audience decision.
+  const liveScopeVisibility =
+    resource.visibility === 'external' || (resource.visibility === 'private' && provider === 'feishu')
+  if (!liveScopeVisibility || resource.externalResolution !== 'settled' || !resource.externalScopeId) {
     return false
   }
   return snapshot.allowedScopes.some((scope) => scope.id === resource.externalScopeId)
@@ -126,7 +133,8 @@ export function can(principal: ViewCtx, request: AuthorizationRequest): boolean 
     case AuthorizationAction.SessionView:
       return request.resource.externalProvider
         ? request.resource.visibility === 'private'
-          ? identityOwnsSession(request.resource, request.identitySet)
+          ? identityOwnsSession(request.resource, request.identitySet) ||
+            externalSessionIsVisible(request.resource, request.externalAccess)
           : externalSessionIsVisible(request.resource, request.externalAccess)
         : request.resource.visibility === 'org' || identityOwnsSession(request.resource, request.identitySet)
     // Re-classification (§4.3) is owner-only: identity match with the recorded

--- a/packages/control-plane/src/authorization/policy.ts
+++ b/packages/control-plane/src/authorization/policy.ts
@@ -125,7 +125,9 @@ export function can(principal: ViewCtx, request: AuthorizationRequest): boolean 
       return request.resource.ownerUserId !== null && resourceIsEditable(request.resource, principal)
     case AuthorizationAction.SessionView:
       return request.resource.externalProvider
-        ? externalSessionIsVisible(request.resource, request.externalAccess)
+        ? request.resource.visibility === 'private'
+          ? identityOwnsSession(request.resource, request.identitySet)
+          : externalSessionIsVisible(request.resource, request.externalAccess)
         : request.resource.visibility === 'org' || identityOwnsSession(request.resource, request.identitySet)
     // Re-classification (§4.3) is owner-only: identity match with the recorded
     // owner, roles grant nothing in either direction — an org owner pulling

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -168,6 +168,7 @@ import { configureFeishuHttpApp } from './http/feishu-app-config.js'
 import { SlackSessionAccessService } from './http/slack-session-access.js'
 import { GithubSessionAccessService } from './http/github-session-access.js'
 import { FeishuSessionAccessService } from './http/feishu-session-access.js'
+import { LogtoFederatedTokenService, logtoAccountEndpointFromIssuer } from './http/logto-federated-token.js'
 
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from './config/defaults.js'
 
@@ -706,6 +707,10 @@ export function buildContainer(
     logtoMgmtCfg && config.OIDC_ISSUER
       ? new LogtoIdentityService(logtoMgmtCfg, clock, new PgSocialIdentityMutationGate(prisma))
       : undefined
+  const logtoFederatedToken =
+    logtoMgmtCfg && config.OIDC_ISSUER
+      ? new LogtoFederatedTokenService(logtoAccountEndpointFromIssuer(config.OIDC_ISSUER))
+      : undefined
   const githubUserAuthz =
     github && logtoIdentity
       ? new GithubUserAuthzService({
@@ -731,7 +736,6 @@ export function buildContainer(
     : undefined
   const feishuSessionAccess = new FeishuSessionAccessService({
     bots: repos.bot,
-    apps: feishuPlatformApps,
     clock,
     ...(opts.feishuFetch ? { fetchImpl: opts.feishuFetch } : {})
   })
@@ -828,6 +832,7 @@ export function buildContainer(
     ...(github ? { github } : {}),
     ...(githubUserAuthz ? { githubUserAuthz } : {}),
     ...(logtoIdentity ? { logtoIdentity } : {}),
+    ...(logtoFederatedToken ? { logtoFederatedToken } : {}),
     slackSessionAccess,
     ...(githubSessionAccess ? { githubSessionAccess } : {}),
     feishuSessionAccess,

--- a/packages/control-plane/src/http/deps.ts
+++ b/packages/control-plane/src/http/deps.ts
@@ -89,6 +89,7 @@ import type { ConnectorsClient } from '../connectors/client.js'
 import type { SlackSessionAccessResolver } from './slack-session-access.js'
 import type { GithubSessionAccessResolver } from './github-session-access.js'
 import type { FeishuSessionAccessResolver } from './feishu-session-access.js'
+import type { LogtoFederatedTokenResolver } from './logto-federated-token.js'
 import type { FeishuPlatformApps } from '../config/feishu-platform.js'
 
 export interface HttpServerConfig extends HumanAuthConfig {
@@ -347,6 +348,8 @@ export interface HttpDeps {
   githubSessionAccess?: GithubSessionAccessResolver
   /** Current Feishu/Lark chat membership for external Session reads. */
   feishuSessionAccess?: FeishuSessionAccessResolver
+  /** Request-bound Logto vault access for Feishu/Lark user tokens. */
+  logtoFederatedToken?: LogtoFederatedTokenResolver
   /** Platform apps shared by Logto profile linking and membership resolution. */
   feishuPlatformApps?: FeishuPlatformApps
   /** Uploaded-icon object store (docs/designs/icon-uploads.md); absent ⇒ S3_* unset,

--- a/packages/control-plane/src/http/feishu-session-access.test.ts
+++ b/packages/control-plane/src/http/feishu-session-access.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { BotRecord, ExternalScopeRecord } from '../persistence/ports.js'
-import { FeishuSessionAccessService } from './feishu-session-access.js'
+import { FeishuSessionAccessService, type FeishuSessionViewer } from './feishu-session-access.js'
 
 const BOT_ID = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
@@ -9,7 +9,7 @@ function scope(): ExternalScopeRecord {
     id: '11111111-1111-4111-8111-111111111111',
     orgId: 'org-1',
     provider: 'feishu',
-    realmKey: 'lark:cli_platform',
+    realmKey: 'lark:cli_custom',
     resourceKind: 'conversation',
     resourceKey: 'oc_chat',
     credentialKind: 'bot',
@@ -33,7 +33,7 @@ function bot(): BotRecord {
     orgId: 'org-1',
     platform: 'feishu',
     feishuRegion: 'lark',
-    feishuAppId: 'cli_platform',
+    feishuAppId: 'cli_custom',
     revokedAt: null,
     credentialRevision: 3
   } as BotRecord
@@ -46,76 +46,61 @@ function json(body: unknown, status = 200): Response {
 function service(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
   return new FeishuSessionAccessService({
     bots: { get: async () => bot() } as never,
-    apps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
     clock: { now: () => 1_000 } as never,
     fetchImpl
   })
 }
 
+function viewer(accessTokenFor = vi.fn(async () => 'user-token')): FeishuSessionViewer {
+  return { subject: 'logto-user', accessTokenFor }
+}
+
 describe('FeishuSessionAccessService', () => {
-  it('resolves allowed scopes beyond the first 200', async () => {
-    const fetchImpl = async (url: string) =>
-      url.includes('/auth/v3/')
-        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
-        : json({ code: 0, data: { items: [{ member_id: 'ou_member' }], has_more: false } })
+  it('resolves allowed scopes beyond the first 200 with one regional user token', async () => {
+    const accessTokenFor = vi.fn(async () => 'user-token')
+    const fetchImpl = async () => json({ code: 0, data: { is_in_chat: true } })
     const scopes = Array.from({ length: 201 }, (_, index) => scopeAt(index + 1))
-    const result = await service(fetchImpl).resolve(scopes, new Set(['feishu:lark:cli_platform:ou_member']))
+    const result = await service(fetchImpl).resolve(scopes, viewer(accessTokenFor))
     expect(result.allowedScopes).toHaveLength(201)
     expect(result.degraded).toBe(false)
+    expect(accessTokenFor).toHaveBeenCalledOnce()
   })
 
-  it('uses the Lark gateway and allows a current chat member', async () => {
-    const fetchImpl = vi.fn(async (url: string) =>
-      url.includes('/auth/v3/')
-        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
-        : json({ code: 0, data: { items: [{ member_id: 'ou_member' }], has_more: false } })
-    )
+  it('uses the Lark gateway and allows a current member of a custom Bot chat', async () => {
+    const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
 
-    await expect(
-      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
-    ).resolves.toEqual({ allowedScopes: [{ id: scope().id, aclRevision: 2n }], degraded: false })
-    expect(fetchImpl.mock.calls.every(([url]) => String(url).startsWith('https://open.larksuite.com/'))).toBe(true)
-  })
-
-  it('walks member pages and denies a user who is absent', async () => {
-    let page = 0
-    const fetchImpl = vi.fn(async (url: string) => {
-      if (url.includes('/auth/v3/')) return json({ code: 0, tenant_access_token: 'token', expire: 3600 })
-      page++
-      return page === 1
-        ? json({ code: 0, data: { items: [{ member_id: 'ou_other' }], has_more: true, page_token: 'next' } })
-        : json({ code: 0, data: { items: [], has_more: false } })
+    await expect(service(fetchImpl).resolve([scope()], viewer())).resolves.toEqual({
+      allowedScopes: [{ id: scope().id, aclRevision: 2n }],
+      degraded: false
     })
-
-    await expect(
-      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_missing']))
-    ).resolves.toEqual({ allowedScopes: [], degraded: false })
-    expect(page).toBe(2)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://open.larksuite.com/open-apis/im/v1/chats/oc_chat/members/is_in_chat',
+      expect.objectContaining({ headers: expect.any(Headers) })
+    )
+    expect(new Headers(fetchImpl.mock.calls[0]?.[1]?.headers).get('authorization')).toBe('Bearer user-token')
   })
 
-  it('treats an inaccessible or dissolved chat as a definitive denial', async () => {
-    const fetchImpl = async (url: string) =>
-      url.includes('/auth/v3/')
-        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
-        : json({ code: 232011, msg: 'operator is not in chat' })
+  it('denies when the user token is not in the chat', async () => {
     await expect(
-      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
+      service(async () => json({ code: 0, data: { is_in_chat: false } })).resolve([scope()], viewer())
     ).resolves.toEqual({ allowedScopes: [], degraded: false })
   })
 
-  it('fails closed and reports degradation for missing scope or provider failure', async () => {
-    const fetchImpl = async (url: string) =>
-      url.includes('/auth/v3/')
-        ? json({ code: 0, tenant_access_token: 'token', expire: 3600 })
-        : json({ code: 99991672, msg: 'missing scope' })
+  it('fails closed and reports degradation when no request-bound user credential is present', async () => {
+    const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
+    await expect(service(fetchImpl).resolve([scope()])).resolves.toEqual({ allowedScopes: [], degraded: true })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('fails closed and reports degradation for a provider permission failure', async () => {
     await expect(
-      service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_platform:ou_member']))
+      service(async () => json({ code: 99991672, msg: 'missing scope' })).resolve([scope()], viewer())
     ).resolves.toEqual({ allowedScopes: [], degraded: true })
   })
 
-  it('never compares an open_id from a different app domain', async () => {
-    const fetchImpl = vi.fn(async () => json({ code: 0 }))
-    await expect(service(fetchImpl).resolve([scope()], new Set(['feishu:lark:cli_other:ou_member']))).resolves.toEqual({
+  it('rejects a scope whose realm does not match its custom Bot app', async () => {
+    const fetchImpl = vi.fn(async () => json({ code: 0, data: { is_in_chat: true } }))
+    await expect(service(fetchImpl).resolve([{ ...scope(), realmKey: 'lark:cli_other' }], viewer())).resolves.toEqual({
       allowedScopes: [],
       degraded: false
     })

--- a/packages/control-plane/src/http/feishu-session-access.ts
+++ b/packages/control-plane/src/http/feishu-session-access.ts
@@ -1,7 +1,6 @@
 import type { FeishuRegion } from '@agentconnect.md/protocol'
 import type { Clock } from '../domain/clock.js'
 import { BotId } from '../domain/ids.js'
-import type { FeishuPlatformApps } from '../config/feishu-platform.js'
 import type { FetchLike } from '../github/api.js'
 import type { BotRepo, ExternalScopeRecord } from '../persistence/ports.js'
 
@@ -12,17 +11,19 @@ const REGION_ORIGIN: Record<FeishuRegion, string> = {
 const ALLOW_TTL_MS = 120_000
 const DENY_TTL_MS = 30_000
 const UNKNOWN_TTL_MS = 5_000
-const TOKEN_SKEW_MS = 60_000
 const MAX_CACHE_ENTRIES = 10_000
 const SCOPES_PER_BATCH = 200
 const SCOPE_CONCURRENCY = 6
-const MAX_MEMBER_PAGES = 100
 const TIMEOUT_MS = 5_000
 
 type Decision = 'allow' | 'deny' | 'unknown'
-type Principal = { key: string; region: FeishuRegion; appId: string; openId: string }
 
 const DEFINITIVE_DENIALS = new Set([232006, 232009, 232010, 232011])
+
+export interface FeishuSessionViewer {
+  subject: string
+  accessTokenFor(region: FeishuRegion): Promise<string>
+}
 
 export interface FeishuSessionAccessResult {
   allowedScopes: Array<{ id: string; aclRevision: bigint }>
@@ -30,16 +31,7 @@ export interface FeishuSessionAccessResult {
 }
 
 export interface FeishuSessionAccessResolver {
-  resolve(scopes: readonly ExternalScopeRecord[], identitySet: ReadonlySet<string>): Promise<FeishuSessionAccessResult>
-}
-
-function principalsOf(identitySet: ReadonlySet<string>): Principal[] {
-  const principals: Principal[] = []
-  for (const key of identitySet) {
-    const match = /^feishu:(feishu|lark):([^:]+):([^:]+)$/.exec(key)
-    if (match) principals.push({ key, region: match[1] as FeishuRegion, appId: match[2]!, openId: match[3]! })
-  }
-  return principals
+  resolve(scopes: readonly ExternalScopeRecord[], viewer?: FeishuSessionViewer): Promise<FeishuSessionAccessResult>
 }
 
 async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
@@ -56,31 +48,36 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
   return out
 }
 
-/** Current Feishu/Lark group-chat audience. The Logto identity and chat API
- * both use the same configured app, making their app-scoped open_id values
- * comparable. Only bounded verdicts/tokens are retained in process. */
+/** Current Feishu/Lark conversation audience, proven by the official login
+ * app's user token against the custom Bot app's immutable chat id. No app-scoped
+ * open_id values are compared. Only bounded membership verdicts are retained. */
 export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
   private readonly cache = new Map<string, { decision: Decision; expiresAt: number }>()
-  private readonly tokens = new Map<FeishuRegion, { value: string; expiresAt: number }>()
-  private readonly tokenInFlight = new Map<FeishuRegion, Promise<string>>()
 
-  constructor(
-    private readonly deps: { bots: BotRepo; apps: FeishuPlatformApps; clock: Clock; fetchImpl?: FetchLike }
-  ) {}
+  constructor(private readonly deps: { bots: BotRepo; clock: Clock; fetchImpl?: FetchLike }) {}
 
   async resolve(
     scopes: readonly ExternalScopeRecord[],
-    identitySet: ReadonlySet<string>
+    viewer?: FeishuSessionViewer
   ): Promise<FeishuSessionAccessResult> {
-    const principals = principalsOf(identitySet)
-    if (principals.length === 0 || scopes.length === 0) return { allowedScopes: [], degraded: false }
+    if (scopes.length === 0) return { allowedScopes: [], degraded: false }
+    if (!viewer) return { allowedScopes: [], degraded: true }
+    const tokens = new Map<FeishuRegion, Promise<string>>()
+    const tokenFor = (region: FeishuRegion): Promise<string> => {
+      let pending = tokens.get(region)
+      if (!pending) {
+        pending = viewer.accessTokenFor(region)
+        tokens.set(region, pending)
+      }
+      return pending
+    }
     let degraded = false
     const decisions: Array<{ scope: ExternalScopeRecord; decision: Decision }> = []
     for (let start = 0; start < scopes.length; start += SCOPES_PER_BATCH) {
       const signal = AbortSignal.timeout(TIMEOUT_MS)
       decisions.push(
         ...(await mapLimited(scopes.slice(start, start + SCOPES_PER_BATCH), SCOPE_CONCURRENCY, async (scope) => {
-          const decision = await this.resolveScope(scope, principals, signal)
+          const decision = await this.resolveScope(scope, viewer, tokenFor, signal)
           if (decision === 'unknown') degraded = true
           return { scope, decision }
         }))
@@ -96,7 +93,8 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
 
   private async resolveScope(
     scope: ExternalScopeRecord,
-    principals: readonly Principal[],
+    viewer: FeishuSessionViewer,
+    tokenFor: (region: FeishuRegion) => Promise<string>,
     signal: AbortSignal
   ): Promise<Decision> {
     if (
@@ -111,7 +109,6 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
     const bot = await this.deps.bots.get(BotId(scope.credentialId)).catch(() => null)
     const region = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
     const appId = bot?.feishuAppId ?? undefined
-    const app = region ? this.deps.apps[region] : undefined
     if (
       !bot ||
       bot.orgId !== scope.orgId ||
@@ -119,94 +116,43 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
       bot.revokedAt !== null ||
       !region ||
       !appId ||
-      !app ||
-      app.appId !== appId ||
       scope.realmKey !== `${region}:${appId}`
     ) {
       return 'deny'
     }
 
-    let sawUnknown = false
-    for (const principal of principals) {
-      if (principal.region !== region || principal.appId !== appId) continue
-      const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, principal.key].join(':')
-      const cached = this.cache.get(key)
-      let decision = cached && cached.expiresAt > this.deps.clock.now() ? cached.decision : undefined
-      if (!decision) {
-        decision = await this.checkMembership(region, scope.resourceKey, principal.openId, signal)
-        this.putCache(key, decision)
-      }
-      if (decision === 'allow') return 'allow'
-      if (decision === 'unknown') sawUnknown = true
+    const key = [scope.id, scope.aclRevision.toString(), bot.credentialRevision, viewer.subject].join(':')
+    const cached = this.cache.get(key)
+    let decision = cached && cached.expiresAt > this.deps.clock.now() ? cached.decision : undefined
+    if (!decision) {
+      decision = await this.checkMembership(region, scope.resourceKey, tokenFor, signal)
+      this.putCache(key, decision)
     }
-    return sawUnknown ? 'unknown' : 'deny'
+    return decision
   }
 
   private async checkMembership(
     region: FeishuRegion,
     chatId: string,
-    openId: string,
+    tokenFor: (region: FeishuRegion) => Promise<string>,
     signal: AbortSignal
   ): Promise<Decision> {
     try {
-      const token = await this.tenantToken(region, signal)
-      let pageToken = ''
-      for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
-        const query = new URLSearchParams({ member_id_type: 'open_id', page_size: '100' })
-        if (pageToken) query.set('page_token', pageToken)
-        const body = await this.call<{
-          code?: unknown
-          data?: { items?: Array<{ member_id?: unknown }>; has_more?: unknown; page_token?: unknown }
-        }>(region, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members?${query}`, token, signal)
-        const code = typeof body.code === 'number' ? body.code : Number(body.code)
-        if (code !== 0) return DEFINITIVE_DENIALS.has(code) ? 'deny' : 'unknown'
-        if (!Array.isArray(body.data?.items)) return 'unknown'
-        if (body.data.items.some((member) => member.member_id === openId)) return 'allow'
-        if (body.data.has_more !== true) return 'deny'
-        pageToken = typeof body.data.page_token === 'string' ? body.data.page_token : ''
-        if (!pageToken || page === MAX_MEMBER_PAGES - 1) return 'unknown'
-      }
+      const token = await tokenFor(region)
+      const body = await this.call<{ code?: unknown; data?: { is_in_chat?: unknown } }>(
+        region,
+        `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/is_in_chat`,
+        token,
+        signal
+      )
+      const code = typeof body.code === 'number' ? body.code : Number(body.code)
+      if (code !== 0) return DEFINITIVE_DENIALS.has(code) ? 'deny' : 'unknown'
+      if (body.data?.is_in_chat === true) return 'allow'
+      if (body.data?.is_in_chat === false) return 'deny'
     } catch {
       return 'unknown'
     }
     return 'unknown'
-  }
-
-  private tenantToken(region: FeishuRegion, signal: AbortSignal): Promise<string> {
-    const cached = this.tokens.get(region)
-    if (cached && cached.expiresAt > this.deps.clock.now()) return Promise.resolve(cached.value)
-    let pending = this.tokenInFlight.get(region)
-    if (!pending) {
-      const tracked = this.fetchTenantToken(region, signal).finally(() => {
-        if (this.tokenInFlight.get(region) === tracked) this.tokenInFlight.delete(region)
-      })
-      pending = tracked
-      this.tokenInFlight.set(region, tracked)
-    }
-    return pending
-  }
-
-  private async fetchTenantToken(region: FeishuRegion, signal: AbortSignal): Promise<string> {
-    const app = this.deps.apps[region]!
-    const body = await this.call<{ code?: unknown; tenant_access_token?: unknown; expire?: unknown }>(
-      region,
-      '/open-apis/auth/v3/tenant_access_token/internal',
-      undefined,
-      signal,
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ app_id: app.appId, app_secret: app.appSecret })
-      }
-    )
-    if (Number(body.code) !== 0 || typeof body.tenant_access_token !== 'string')
-      throw new Error('token exchange failed')
-    const expire = typeof body.expire === 'number' ? body.expire : 0
-    this.tokens.set(region, {
-      value: body.tenant_access_token,
-      expiresAt: this.deps.clock.now() + Math.max(0, expire * 1000 - TOKEN_SKEW_MS)
-    })
-    return body.tenant_access_token
   }
 
   private async call<T>(
@@ -218,6 +164,7 @@ export class FeishuSessionAccessService implements FeishuSessionAccessResolver {
   ): Promise<T> {
     const headers = new Headers(init.headers)
     if (token) headers.set('authorization', `Bearer ${token}`)
+    headers.set('content-type', 'application/json; charset=utf-8')
     const response = await (this.deps.fetchImpl ?? (fetch as FetchLike))(`${REGION_ORIGIN[region]}${path}`, {
       ...init,
       headers,

--- a/packages/control-plane/src/http/logto-federated-token.test.ts
+++ b/packages/control-plane/src/http/logto-federated-token.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LogtoFederatedTokenService, logtoAccountEndpointFromIssuer } from './logto-federated-token.js'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('LogtoFederatedTokenService', () => {
+  it('derives the Account API origin from the configured OIDC issuer', () => {
+    expect(logtoAccountEndpointFromIssuer('https://login.example.test/oidc')).toBe('https://login.example.test')
+  })
+
+  it('binds the Account API token to the OIDC subject before returning a provider token', async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer account-token')
+      return url.endsWith('/api/my-account') ? json({ id: 'logto-user' }) : json({ access_token: 'lark-token' })
+    })
+    const session = new LogtoFederatedTokenService('https://login.example.test/', fetchImpl).forRequest(
+      'logto-user',
+      'account-token'
+    )
+
+    await expect(Promise.all([session.accessTokenFor('lark'), session.accessTokenFor('lark')])).resolves.toEqual([
+      'lark-token',
+      'lark-token'
+    ])
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a token issued for a different Logto account without reading provider credentials', async () => {
+    const fetchImpl = vi.fn(async () => json({ id: 'another-user' }))
+    const session = new LogtoFederatedTokenService('https://login.example.test', fetchImpl).forRequest(
+      'logto-user',
+      'account-token'
+    )
+
+    await expect(session.accessTokenFor('lark')).rejects.toMatchObject({ status: 403 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/control-plane/src/http/logto-federated-token.ts
+++ b/packages/control-plane/src/http/logto-federated-token.ts
@@ -1,0 +1,102 @@
+import type { FetchLike } from '../github/api.js'
+
+const TIMEOUT_MS = 10_000
+
+export const LOGTO_ACCOUNT_TOKEN_HEADER = 'x-ac-logto-account-token'
+
+export type LogtoFederatedTarget = 'feishu' | 'lark'
+
+export interface LogtoFederatedTokenSession {
+  accessTokenFor(target: LogtoFederatedTarget): Promise<string>
+}
+
+export interface LogtoFederatedTokenResolver {
+  forRequest(oidcSubject: string, accountToken: string): LogtoFederatedTokenSession
+}
+
+/** Account API shares the tenant origin with Logto's `/oidc` issuer. */
+export function logtoAccountEndpointFromIssuer(issuer: string): string {
+  const url = new URL(issuer)
+  if (!/\/oidc\/?$/.test(url.pathname)) throw new Error('Logto OIDC issuer must end in /oidc')
+  url.pathname = url.pathname.replace(/\/oidc\/?$/, '') || '/'
+  url.search = ''
+  url.hash = ''
+  return url.toString().replace(/\/$/, '')
+}
+
+/** Safe classification only; upstream bodies and both bearer tokens stay out of errors/logs. */
+export class LogtoFederatedTokenError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'LogtoFederatedTokenError'
+  }
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+/**
+ * Request-bound access to Logto's federated-token vault.
+ *
+ * The browser presents its opaque Account API token only on Session authorization
+ * reads. Before that token can select a provider credential, `/api/my-account`
+ * must bind it to the same verified OIDC subject that authenticated the CP call.
+ * The returned provider token is retained only by this short-lived closure.
+ */
+export class LogtoFederatedTokenService implements LogtoFederatedTokenResolver {
+  private readonly endpoint: string
+
+  constructor(
+    endpoint: string,
+    private readonly fetchImpl: FetchLike = fetch as FetchLike
+  ) {
+    this.endpoint = endpoint.replace(/\/$/, '')
+  }
+
+  forRequest(oidcSubject: string, accountToken: string): LogtoFederatedTokenSession {
+    let verified: Promise<void> | undefined
+    const tokens = new Map<LogtoFederatedTarget, Promise<string>>()
+    return {
+      accessTokenFor: (target) => {
+        verified ??= this.verifyAccount(oidcSubject, accountToken)
+        let pending = tokens.get(target)
+        if (!pending) {
+          pending = verified.then(() => this.fetchAccessToken(target, accountToken))
+          tokens.set(target, pending)
+        }
+        return pending
+      }
+    }
+  }
+
+  private async verifyAccount(oidcSubject: string, accountToken: string): Promise<void> {
+    const response = await this.request('/api/my-account', accountToken)
+    if (!response.ok) throw new LogtoFederatedTokenError('Logto account verification failed', response.status)
+    const account = recordOf(await response.json().catch(() => null))
+    if (account.id !== oidcSubject) throw new LogtoFederatedTokenError('Logto account token subject mismatch', 403)
+  }
+
+  private async fetchAccessToken(target: LogtoFederatedTarget, accountToken: string): Promise<string> {
+    const response = await this.request(
+      `/api/my-account/identities/${encodeURIComponent(target)}/access-token`,
+      accountToken
+    )
+    if (!response.ok) throw new LogtoFederatedTokenError('Federated access token is unavailable', response.status)
+    const token = recordOf(await response.json().catch(() => null)).access_token
+    if (typeof token !== 'string' || token.length === 0) {
+      throw new LogtoFederatedTokenError('Federated access token response is invalid', 502)
+    }
+    return token
+  }
+
+  private request(path: string, accountToken: string): Promise<Response> {
+    return this.fetchImpl(`${this.endpoint}${path}`, {
+      headers: { authorization: `Bearer ${accountToken}` },
+      signal: AbortSignal.timeout(TIMEOUT_MS)
+    })
+  }
+}

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -341,13 +341,19 @@ export function sessionRoutes(deps: HttpDeps) {
     }
 
     type ExternalAccessProvider = 'slack' | 'github' | 'feishu'
-    const externalAccessAvailable = (provider: ExternalAccessProvider) =>
-      deps.logtoIdentity !== undefined &&
-      (provider === 'slack'
-        ? deps.slackSessionAccess !== undefined
-        : provider === 'github'
-          ? deps.githubSessionAccess !== undefined
-          : deps.feishuSessionAccess !== undefined && Object.keys(deps.feishuPlatformApps ?? {}).length > 0)
+    const externalAccessAvailable = (provider: ExternalAccessProvider) => {
+      if (provider === 'feishu') {
+        return (
+          deps.feishuSessionAccess !== undefined &&
+          deps.logtoFederatedToken !== undefined &&
+          Object.keys(deps.feishuPlatformApps ?? {}).length > 0
+        )
+      }
+      return (
+        deps.logtoIdentity !== undefined &&
+        (provider === 'slack' ? deps.slackSessionAccess !== undefined : deps.githubSessionAccess !== undefined)
+      )
+    }
 
     const externalAccessDto = async (orgId: OrgId, provider: ExternalAccessProvider, includeDiagnostics: boolean) => {
       const [policy, hiddenSessions] = await Promise.all([

--- a/packages/control-plane/src/http/session-access.test.ts
+++ b/packages/control-plane/src/http/session-access.test.ts
@@ -1,0 +1,84 @@
+import type { FastifyRequest } from 'fastify'
+import { describe, expect, it, vi } from 'vitest'
+import { canViewSession } from '../authorization/policy.js'
+import type { ExternalScopeRecord } from '../persistence/ports.js'
+import type { HttpDeps } from './deps.js'
+import type { FeishuSessionViewer } from './feishu-session-access.js'
+import { LOGTO_ACCOUNT_TOKEN_HEADER } from './logto-federated-token.js'
+import { makeSessionAccessResolver } from './session-access.js'
+
+const scope: ExternalScopeRecord = {
+  id: '11111111-1111-4111-8111-111111111111',
+  orgId: 'org-1',
+  provider: 'feishu',
+  realmKey: 'lark:cli_custom_bot',
+  resourceKind: 'conversation',
+  resourceKey: 'oc_p2p',
+  credentialKind: 'bot',
+  credentialId: '22222222-2222-4222-8222-222222222222',
+  aclRevision: 2n,
+  revokedAt: null
+}
+
+function request(): FastifyRequest {
+  return {
+    headers: { [LOGTO_ACCOUNT_TOKEN_HEADER]: 'account-token' },
+    oidcSubject: 'logto-subject',
+    orgCtx: { orgId: 'org-1', role: 'collaborator', userId: 'user-1' },
+    log: { warn: vi.fn() }
+  } as unknown as FastifyRequest
+}
+
+describe('makeSessionAccessResolver', () => {
+  it('proves a custom-Bot p2p owner with the different login-app user token', async () => {
+    const accessTokenFor = vi.fn(async () => 'lark-user-token')
+    const forRequest = vi.fn(() => ({ accessTokenFor }))
+    const feishuResolve = vi.fn(async (scopes: readonly ExternalScopeRecord[], viewer?: FeishuSessionViewer) => {
+      expect(scopes).toEqual([scope])
+      expect(viewer?.subject).toBe('logto-subject')
+      await expect(viewer?.accessTokenFor('lark')).resolves.toBe('lark-user-token')
+      return { allowedScopes: [{ id: scope.id, aclRevision: scope.aclRevision }], degraded: false }
+    })
+    const policy = {
+      orgId: 'org-1',
+      provider: 'feishu',
+      state: 'disabled',
+      currentRev: 0n,
+      readFenceRev: null,
+      migrationCursor: null
+    } as const
+    const deps = {
+      repos: {
+        session: {
+          getExternalScopes: vi.fn(async () => [scope]),
+          getExternalAccessPolicy: vi.fn(async (_orgId: string, provider: string) =>
+            provider === 'feishu' ? policy : null
+          )
+        }
+      },
+      clock: { now: () => 1_000 },
+      logtoIdentity: {
+        feishuIdentitiesFor: async () => [{ region: 'lark', openId: 'ou_login_app' }]
+      },
+      feishuPlatformApps: { lark: { appId: 'cli_login_app', appSecret: 'secret' } },
+      logtoFederatedToken: { forRequest },
+      feishuSessionAccess: { resolve: feishuResolve }
+    } as unknown as HttpDeps
+    const session = {
+      visibility: 'private' as const,
+      ownerIdentity: 'feishu:lark:cli_custom_bot:ou_custom_app',
+      externalProvider: 'feishu',
+      externalScopeId: scope.id,
+      externalResolution: 'settled' as const
+    }
+
+    const access = await makeSessionAccessResolver(deps).forSessions(request(), [session])
+
+    expect(forRequest).toHaveBeenCalledWith('logto-subject', 'account-token')
+    expect(access.identitySet).toContain('feishu:lark:cli_login_app:ou_login_app')
+    expect(access.identitySet).not.toContain(session.ownerIdentity)
+    expect(
+      canViewSession(session, { userId: 'user-1', role: 'collaborator' }, access.identitySet, access.externalAccess)
+    ).toBe(true)
+  })
+})

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -109,12 +109,16 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
     },
     async forSessions(
       req: FastifyRequest,
-      sessions: readonly Pick<SessionMetaRecord, 'visibility' | 'externalScopeId'>[]
+      sessions: readonly Pick<SessionMetaRecord, 'visibility' | 'externalProvider' | 'externalScopeId'>[]
     ): Promise<ResolvedSessionAccess> {
       const ids = [
         ...new Set(
           sessions
-            .filter((session) => session.visibility === 'external')
+            .filter(
+              (session) =>
+                session.visibility === 'external' ||
+                (session.visibility === 'private' && session.externalProvider === 'feishu')
+            )
             .map((session) => session.externalScopeId)
             .filter((id): id is string => id !== null)
         )

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -7,6 +7,7 @@ import type {
 } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import { makeViewerIdentitySet } from './viewer-identity.js'
+import { LOGTO_ACCOUNT_TOKEN_HEADER } from './logto-federated-token.js'
 import { ctxOf, orgOf } from './rbac.js'
 
 export interface ResolvedSessionAccess {
@@ -21,6 +22,11 @@ export interface ResolvedSessionAccess {
 export function makeSessionAccessResolver(deps: HttpDeps) {
   const identitySetFor = makeViewerIdentitySet(deps.logtoIdentity, deps.feishuPlatformApps)
 
+  const accountTokenOf = (req: FastifyRequest): string | undefined => {
+    const value = req.headers[LOGTO_ACCOUNT_TOKEN_HEADER]
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+  }
+
   const forScopes = async (
     req: FastifyRequest,
     scopes: readonly ExternalScopeRecord[]
@@ -34,6 +40,17 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
     const slackScopes = scopes.filter((scope) => scope.provider === 'slack' && scope.orgId === orgId)
     const githubScopes = scopes.filter((scope) => scope.provider === 'github' && scope.orgId === orgId)
     const feishuScopes = scopes.filter((scope) => scope.provider === 'feishu' && scope.orgId === orgId)
+    const accountToken = accountTokenOf(req)
+    const federated =
+      req.oidcSubject && accountToken && deps.logtoFederatedToken
+        ? deps.logtoFederatedToken.forRequest(req.oidcSubject, accountToken)
+        : undefined
+    const feishuViewer = federated
+      ? {
+          subject: req.oidcSubject!,
+          accessTokenFor: (region: 'feishu' | 'lark') => federated.accessTokenFor(region)
+        }
+      : undefined
     const [slackResult, githubResult, feishuResult] = await Promise.all([
       deps.slackSessionAccess
         ? deps.slackSessionAccess.resolve(slackScopes, identitySet)
@@ -42,7 +59,7 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
         ? deps.githubSessionAccess.resolve(githubScopes, ctxOf(req).userId)
         : Promise.resolve({ allowedScopes: [], degraded: githubScopes.length > 0 }),
       deps.feishuSessionAccess
-        ? deps.feishuSessionAccess.resolve(feishuScopes, identitySet)
+        ? deps.feishuSessionAccess.resolve(feishuScopes, feishuViewer)
         : Promise.resolve({ allowedScopes: [], degraded: feishuScopes.length > 0 })
     ])
     const resolvedScopes = [...slackResult.allowedScopes, ...githubResult.allowedScopes, ...feishuResult.allowedScopes]

--- a/packages/control-plane/src/persistence/repositories/session-access-sql.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.ts
@@ -11,14 +11,14 @@ export function sessionViewerSql(
   if (!viewer) return null
   const s = alias
   const direct = Prisma.sql`(
-    ${s}."externalProvider" IS NULL
-    AND (
-      ${s}."visibility" = 'org'::"SessionVisibility"
-      OR (
-        ${s}."visibility" = 'private'::"SessionVisibility"
-        AND ${s}."ownerIdentity" IS NOT NULL
-        AND ${s}."ownerIdentity" = ANY(${viewer.identitySet}::text[])
-      )
+    (
+      ${s}."externalProvider" IS NULL
+      AND ${s}."visibility" = 'org'::"SessionVisibility"
+    )
+    OR (
+      ${s}."visibility" = 'private'::"SessionVisibility"
+      AND ${s}."ownerIdentity" IS NOT NULL
+      AND ${s}."ownerIdentity" = ANY(${viewer.identitySet}::text[])
     )
   )`
   const snapshot = viewer.externalAccess

--- a/packages/control-plane/src/persistence/repositories/session-access-sql.ts
+++ b/packages/control-plane/src/persistence/repositories/session-access-sql.ts
@@ -44,7 +44,13 @@ export function sessionViewerSql(
   }
   for (const allowed of snapshot.allowedScopes) {
     externalArms.push(Prisma.sql`(
-      ${s}."visibility" = 'external'::"SessionVisibility"
+      (
+        ${s}."visibility" = 'external'::"SessionVisibility"
+        OR (
+          ${s}."visibility" = 'private'::"SessionVisibility"
+          AND ${s}."externalProvider" = 'feishu'
+        )
+      )
       AND ${s}."externalResolution" = 'settled'::"ExternalResolution"
       AND ${s}."externalScopeId" = ${allowed.id}::uuid
       AND EXISTS (

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -470,7 +470,11 @@ export class PgSessionRepo implements SessionRepo {
       const base = direct ?? { visibility: 'org' as const, ownerIdentity: null, source: 'default' as const }
       return {
         ...base,
-        visibility: policy.state === 'disabled' ? 'org' : 'external',
+        // A Feishu/Lark p2p conversation is both a private direct session and a
+        // provider-bound candidate. Keep its owner-only baseline while sync is
+        // disabled; enabling the policy atomically switches every candidate to
+        // the live external audience below.
+        visibility: policy.state === 'disabled' ? base.visibility : 'external',
         externalProvider: candidate.provider,
         externalScopeId: scopeId,
         externalResolution: resolution,

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -1243,7 +1243,13 @@ export class PgSessionRepo implements SessionRepo {
        AND scope."orgId" = s."orgId"
        AND scope."provider" = s."externalProvider"
       ${pageWhereSql(unrestricted, false)}
-        AND s."visibility" = 'external'::"SessionVisibility"
+        AND (
+          s."visibility" = 'external'::"SessionVisibility"
+          OR (
+            s."visibility" = 'private'::"SessionVisibility"
+            AND s."externalProvider" = 'feishu'
+          )
+        )
         AND s."externalResolution" = 'settled'::"ExternalResolution"
         AND scope."revokedAt" IS NULL
       ORDER BY scope."id"

--- a/packages/control-plane/src/ws/handlers/event-session.test.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.test.ts
@@ -174,7 +174,7 @@ describe('handleEventSession', () => {
     )
   })
 
-  it('binds a Feishu/Lark audience only for the environment-owned matching app', async () => {
+  it('binds a Feishu/Lark audience to the registered Bot app', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({
       session: { recordMilestone },
@@ -198,7 +198,6 @@ describe('handleEventSession', () => {
           revokedAt: null
         })
       },
-      feishuPlatformApps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
       events: { publish: vi.fn() }
     })
     const frame = eventSessionFrame()
@@ -233,7 +232,7 @@ describe('handleEventSession', () => {
     )
   })
 
-  it('leaves a user-built Feishu/Lark app on ordinary org visibility', async () => {
+  it('binds a user-built Feishu/Lark app without matching the login App ID', async () => {
     const recordMilestone = vi.fn().mockResolvedValue(recorded())
     const deps = scopedDeps({
       session: { recordMilestone },
@@ -257,7 +256,6 @@ describe('handleEventSession', () => {
           revokedAt: null
         })
       },
-      feishuPlatformApps: { lark: { appId: 'cli_platform', appSecret: 'secret' } },
       events: { publish: vi.fn() }
     })
     const frame = eventSessionFrame()
@@ -275,7 +273,21 @@ describe('handleEventSession', () => {
 
     await handleEventSession(frame, { daemonId: DAEMON_ID } as DaemonConnection, deps)
 
-    expect(recordMilestone).toHaveBeenCalledWith(expect.not.objectContaining({ externalCandidate: expect.anything() }))
+    expect(recordMilestone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalCandidate: {
+          provider: 'feishu',
+          resolution: 'settled',
+          scope: {
+            realmKey: 'lark:cli_custom',
+            resourceKind: 'conversation',
+            resourceKey: 'oc_chat',
+            credentialKind: 'bot',
+            credentialId: BOT_ID
+          }
+        }
+      })
+    )
   })
 
   it('keeps a root shared Slack session from an older daemon as an unresolved candidate', async () => {

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -116,11 +116,6 @@ async function externalCandidate(p: EventSession, agentId: AgentId, deps: Daemon
   const bot = await deps.bot?.get(BotId(integration.botId))
   const feishuRegion = bot?.platform === 'feishu' ? (bot.feishuRegion ?? 'feishu') : undefined
   const feishuAppId = bot?.feishuAppId ?? undefined
-  const platformApp = feishuRegion ? deps.feishuPlatformApps?.[feishuRegion] : undefined
-  // open_id is app-scoped. Only the environment-owned app that also backs the
-  // Logto connector can participate; a user-built Feishu/Lark app keeps the
-  // ordinary org classification instead of becoming an unresolvable scope.
-  if (origin.provider === 'feishu' && (!platformApp || platformApp.appId !== feishuAppId)) return undefined
   const realmKey =
     origin.provider === 'feishu' && feishuRegion && feishuAppId
       ? `${feishuRegion}:${feishuAppId}`

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -207,6 +207,7 @@ describe('session visibility — external conversation audiences', () => {
       }
     })
     expect(recorded.session).toMatchObject({ visibility: 'private', externalProvider: 'feishu' })
+    const [scope] = await repo.getExternalScopes([recorded.session!.externalScopeId!])
 
     const baseline = {
       role: 'collaborator' as const,
@@ -232,11 +233,27 @@ describe('session visibility — external conversation audiences', () => {
         })
       ).sessions
     ).toHaveLength(0)
+    expect(
+      (
+        await repo.listPage({
+          agentIds: [agentId],
+          limit: 10,
+          includeTotal: false,
+          viewer: {
+            ...baseline,
+            identitySet: [],
+            externalAccess: {
+              ...baseline.externalAccess,
+              allowedScopes: [{ id: scope!.id, aclRevision: scope!.aclRevision }]
+            }
+          }
+        })
+      ).sessions.map((session) => session.id)
+    ).toEqual([sessionId])
 
     const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'feishu', true)
     const external = await repo.get(SessionId(sessionId))
     expect(external).toMatchObject({ visibility: 'external', externalProvider: 'feishu' })
-    const [scope] = await repo.getExternalScopes([external!.externalScopeId!])
     expect(
       (
         await repo.listPage({

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -179,7 +179,84 @@ describe('session visibility — list & detail', () => {
   })
 })
 
-describe('session visibility — Slack conversation audience', () => {
+describe('session visibility — external conversation audiences', () => {
+  it('keeps a provider-bound p2p owner-only until live audience sync is enabled', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const sessionId = `s-feishu-p2p-${randomUUID()}`
+    const ownerIdentity = 'feishu:lark:cli_custom:ou_owner'
+    const repo = new PgSessionRepo(prisma)
+    const recorded = await repo.recordMilestone({
+      sessionId: SessionId(sessionId),
+      agentId,
+      phase: 'start',
+      platform: 'feishu',
+      channel: 'oc_p2p',
+      at: new Date(),
+      classification: { visibility: 'private', ownerIdentity, source: 'default' },
+      externalCandidate: {
+        provider: 'feishu',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'lark:cli_custom',
+          resourceKind: 'conversation',
+          resourceKey: 'oc_p2p',
+          credentialKind: 'bot',
+          credentialId: randomUUID()
+        }
+      }
+    })
+    expect(recorded.session).toMatchObject({ visibility: 'private', externalProvider: 'feishu' })
+
+    const baseline = {
+      role: 'collaborator' as const,
+      identitySet: [ownerIdentity],
+      externalAccess: {
+        policies: [{ provider: 'feishu', readFenceRev: null }],
+        allowedScopes: [],
+        decisionAt: new Date()
+      }
+    }
+    expect(
+      (await repo.listPage({ agentIds: [agentId], limit: 10, includeTotal: false, viewer: baseline })).sessions.map(
+        (session) => session.id
+      )
+    ).toEqual([sessionId])
+    expect(
+      (
+        await repo.listPage({
+          agentIds: [agentId],
+          limit: 10,
+          includeTotal: false,
+          viewer: { ...baseline, identitySet: [] }
+        })
+      ).sessions
+    ).toHaveLength(0)
+
+    const enabled = await repo.setExternalAccessEnabled(OrgId(DEFAULT_ORG_ID), 'feishu', true)
+    const external = await repo.get(SessionId(sessionId))
+    expect(external).toMatchObject({ visibility: 'external', externalProvider: 'feishu' })
+    const [scope] = await repo.getExternalScopes([external!.externalScopeId!])
+    expect(
+      (
+        await repo.listPage({
+          agentIds: [agentId],
+          limit: 10,
+          includeTotal: false,
+          viewer: {
+            ...baseline,
+            identitySet: [],
+            externalAccess: {
+              policies: [{ provider: 'feishu', readFenceRev: enabled.policy.readFenceRev }],
+              allowedScopes: [{ id: scope!.id, aclRevision: scope!.aclRevision }],
+              decisionAt: new Date()
+            }
+          }
+        })
+      ).sessions.map((session) => session.id)
+    ).toEqual([sessionId])
+  })
+
   it('lets only owners change sync and withholds hidden-session diagnostics from other members', async () => {
     const owner = await makeUser(`sv-slack-owner-${randomUUID()}`, 'owner')
     const collaborator = await makeUser(`sv-slack-collab-${randomUUID()}`, 'collaborator')

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14710,7 +14710,13 @@ export class Daemon {
         externalIntegrationId?: string
       }
     | undefined {
-    if ((msg.platform !== 'slack' && msg.platform !== 'feishu') || msg.isDm || isA2aChild) return undefined
+    if (
+      (msg.platform !== 'slack' && msg.platform !== 'feishu') ||
+      (msg.platform === 'slack' && msg.isDm) ||
+      isA2aChild
+    ) {
+      return undefined
+    }
     const integrationId = this.integrationIdForTransportScope(agentId, msg.platform, msg.transportScope)
     const integration = integrationId ? this.integrationConfigById(integrationId) : undefined
     const realmKey =

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./auth', () => ({
+  getAccountToken: vi.fn(async () => 'account-token'),
+  getToken: vi.fn(async () => undefined),
+  getIdTokenRaw: vi.fn(async () => undefined),
+  getUser: vi.fn(async () => undefined),
+  signOutDeletedAccount: vi.fn()
+}))
+
 import { subscribeSessionEvents } from './api'
 
 describe('subscribeSessionEvents', () => {
@@ -34,6 +43,9 @@ describe('subscribeSessionEvents', () => {
       expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) })
     )
     expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>).accept).toBe('text/event-stream')
+    expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>)['x-ac-logto-account-token']).toBe(
+      'account-token'
+    )
 
     const encoder = new TextEncoder()
     streamController.enqueue(encoder.encode('event: sess'))

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -8,10 +8,15 @@ vi.mock('./auth', () => ({
   signOutDeletedAccount: vi.fn()
 }))
 
+import { getAccountToken } from './auth'
 import { subscribeSessionEvents } from './api'
+
+const LOGTO_ACCOUNT_TOKEN_HEADER = 'x-ac-logto-account-token'
 
 describe('subscribeSessionEvents', () => {
   afterEach(() => {
+    vi.useRealTimers()
+    vi.mocked(getAccountToken).mockReset().mockResolvedValue('account-token')
     vi.unstubAllGlobals()
   })
 
@@ -68,5 +73,44 @@ describe('subscribeSessionEvents', () => {
 
     unsubscribe()
     expect(requestSignal.aborted).toBe(true)
+  })
+
+  it('reopens a live stream to rotate its Account API token', async () => {
+    vi.useFakeTimers()
+    vi.mocked(getAccountToken).mockReset().mockResolvedValueOnce('account-token-1').mockResolvedValue('account-token-2')
+    const requestSignals: AbortSignal[] = []
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal
+      requestSignals.push(signal)
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal.addEventListener('abort', () => controller.error(new DOMException('aborted', 'AbortError')), {
+            once: true
+          })
+        }
+      })
+      return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onConnect = vi.fn()
+    const onError = vi.fn()
+
+    const unsubscribe = subscribeSessionEvents('org-1', { onConnect, onSession: vi.fn(), onActivity: vi.fn() }, onError)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    expect(requestSignals[0]?.aborted).toBe(true)
+    expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>)[LOGTO_ACCOUNT_TOKEN_HEADER]).toBe(
+      'account-token-1'
+    )
+    expect((fetchMock.mock.calls[1]![1]!.headers as Record<string, string>)[LOGTO_ACCOUNT_TOKEN_HEADER]).toBe(
+      'account-token-2'
+    )
+    expect(onConnect).toHaveBeenCalledTimes(2)
+    expect(onError).not.toHaveBeenCalled()
+
+    unsubscribe()
   })
 })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -18,7 +18,7 @@ import type {
 import { isSelfSender, lifecycleStatus, MOCK_MODE } from '@/lib/data'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
-import { getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
+import { getAccountToken, getToken, getIdTokenRaw, getUser, signOutDeletedAccount } from '@/lib/auth'
 import { track } from '@/lib/analytics'
 import { createSseParser } from '@/lib/sse'
 import { isUpgradeAvailable } from '@/lib/version'
@@ -1174,7 +1174,17 @@ export interface MintedUserKeyDto {
 }
 
 // ── fetch helpers ───────────────────────────────────────────────────────────
-async function authHeaders(extra?: Record<string, string>): Promise<Record<string, string>> {
+const LOGTO_ACCOUNT_TOKEN_HEADER = 'x-ac-logto-account-token'
+
+interface AuthHeaderOptions {
+  /** Forward only to CP reads that enforce live Session provider access. */
+  accountToken?: boolean
+}
+
+async function authHeaders(
+  extra?: Record<string, string>,
+  options: AuthHeaderOptions = {}
+): Promise<Record<string, string>> {
   const h: Record<string, string> = { ...extra }
   // Live OIDC token (when configured) wins; otherwise fall back to the static one.
   const token = (await getToken()) ?? TOKEN
@@ -1191,11 +1201,15 @@ async function authHeaders(extra?: Record<string, string>): Promise<Record<strin
   // x-ac-user-email header above stays display-only.
   const idToken = await getIdTokenRaw()
   if (idToken) h['x-ac-id-token'] = idToken
+  if (options.accountToken) {
+    const accountToken = await getAccountToken()
+    if (accountToken) h[LOGTO_ACCOUNT_TOKEN_HEADER] = accountToken
+  }
   return h
 }
 
-async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${cpBase()}${path}`, { headers: await authHeaders(), cache: 'no-store' })
+async function apiGet<T>(path: string, options: AuthHeaderOptions = {}): Promise<T> {
+  const res = await fetch(`${cpBase()}${path}`, { headers: await authHeaders(undefined, options), cache: 'no-store' })
   // Parse the denial body like the write helpers do: reads carry machine-readable
   // `code`s too (e.g. DAEMON_FEATURE_MISSING on a capability-gated route), and a
   // status-only ApiError silently drops them.
@@ -1236,7 +1250,7 @@ async function readSessionEventStream(
 ): Promise<void> {
   const path = `/orgs/${encodeURIComponent(orgId)}/stream`
   const res = await fetch(`${cpBase()}${path}`, {
-    headers: await authHeaders({ accept: 'text/event-stream' }),
+    headers: await authHeaders({ accept: 'text/event-stream' }, { accountToken: true }),
     cache: 'no-store',
     signal
   })
@@ -1352,10 +1366,10 @@ async function apiPatch<T>(path: string, body: unknown): Promise<T> {
   return (await res.json()) as T
 }
 
-async function apiPut<T>(path: string, body?: unknown): Promise<T> {
+async function apiPut<T>(path: string, body?: unknown, options: AuthHeaderOptions = {}): Promise<T> {
   const res = await fetch(`${cpBase()}${path}`, {
     method: 'PUT',
-    headers: await authHeaders(body === undefined ? undefined : { 'content-type': 'application/json' }),
+    headers: await authHeaders(body === undefined ? undefined : { 'content-type': 'application/json' }, options),
     ...(body === undefined ? {} : { body: JSON.stringify(body) })
   })
   if (!res.ok) throw await apiErrorFromResponse('PUT', path, res)
@@ -1906,7 +1920,7 @@ export async function fetchSessions(
   const q = new URLSearchParams({ limit: String(limit), view: 'flat' })
   if (cursor) q.set('cursor', cursor)
   appendSessionFilters(q, filters)
-  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`, { accountToken: true })
   return {
     sessions: (page.sessions ?? []).map(sessionFromDto),
     total: page.total,
@@ -1921,7 +1935,7 @@ export async function fetchSessions(
  *  the members (indistinguishable from a conversation that never existed). */
 export async function fetchConversationByKey(key: string, orgId?: string): Promise<ConversationDto | null> {
   const q = new URLSearchParams({ conversationKey: key })
-  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`, { accountToken: true })
   return page.conversations?.[0] ?? null
 }
 
@@ -1940,7 +1954,7 @@ export async function fetchConversations(
   const q = new URLSearchParams({ limit: String(limit) })
   if (cursor) q.set('cursor', cursor)
   appendSessionFilters(q, filters)
-  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`, { accountToken: true })
   const sessions = (page.conversations ?? []).map((conversation) => {
     const members = conversation.sessions.map(sessionFromDto)
     const rep = members[0]!
@@ -1998,7 +2012,7 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
   appendSessionFilters(q, filters)
   const query = q.toString()
   const suffix = query ? `?${query}` : ''
-  const facets = await apiGet<SessionFacetsDto>(`${orgBase(orgId)}/sessions/facets${suffix}`)
+  const facets = await apiGet<SessionFacetsDto>(`${orgBase(orgId)}/sessions/facets${suffix}`, { accountToken: true })
   return {
     agentIds: facets.agents,
     integrations: facets.integrations,
@@ -2020,7 +2034,9 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
 /** CP-stored detail metadata used for session-family navigation. The linked
  *  rows are already filtered by the caller's agent visibility on the server. */
 export function fetchSessionDetail(sessionId: string, orgId?: string): Promise<SessionDetailDto> {
-  return apiGet<SessionDetailDto>(`${orgBase(orgId)}/sessions/${encodeURIComponent(sessionId)}`)
+  return apiGet<SessionDetailDto>(`${orgBase(orgId)}/sessions/${encodeURIComponent(sessionId)}`, {
+    accountToken: true
+  })
 }
 
 // PUT /sessions/:id/visibility response. `state` is the §5.1 cutover: 'pending'
@@ -2083,7 +2099,9 @@ export async function fetchSessionMessages(
   const q = new URLSearchParams({ limit: String(options.limit ?? 50) })
   if (options.cursor) q.set('cursor', options.cursor)
   if (options.after) q.set('after', options.after)
-  return apiGet<SessionHistoryDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`)
+  return apiGet<SessionHistoryDto>(`${orgBase()}/sessions/${encodeURIComponent(sessionId)}/messages?${q.toString()}`, {
+    accountToken: true
+  })
 }
 
 // One frame-budgeted byte slice of a tool call's FULL ToolBody JSON (mirrors the
@@ -2109,7 +2127,8 @@ export async function fetchToolBody(sessionId: string, toolCallId: string): Prom
   for (;;) {
     const q = new URLSearchParams({ toolCallId, offset: String(offset) })
     const chunk = await apiGet<SessionToolBodyChunkDto>(
-      `${orgBase()}/sessions/${encodeURIComponent(sessionId)}/tool-body?${q.toString()}`
+      `${orgBase()}/sessions/${encodeURIComponent(sessionId)}/tool-body?${q.toString()}`,
+      { accountToken: true }
     )
     out += chunk.data
     if (chunk.nextOffset == null || chunk.nextOffset <= offset) break
@@ -2698,7 +2717,7 @@ export async function fetchUsage(range: UsageRange, orgId?: string): Promise<Usa
   // Send the viewer's tz offset so the CP buckets the spend series to local
   // day/hour (getTimezoneOffset ⇒ UTC − local; stable per client, not in the key).
   const tz = new Date().getTimezoneOffset()
-  return apiGet<UsageDto>(`${orgBase(orgId)}/usage?range=${range}&tz=${tz}`)
+  return apiGet<UsageDto>(`${orgBase(orgId)}/usage?range=${range}&tz=${tz}`, { accountToken: true })
 }
 
 // Edit an agent's spec (PATCH /agents/:id). The CP persists it and hot-syncs the

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1230,6 +1230,12 @@ export interface SessionEventHandlers {
   onActivity: (activity: SessionActivityDto) => void
 }
 
+// Logto's no-resource Account API token is opaque, so the browser cannot read
+// its expiry. Reopen the stream well inside the normal token lifetime; each
+// cycle asks the SDK for a current token without forcing a refresh when the
+// cached one is still valid.
+const SESSION_STREAM_REAUTH_MS = 5 * 60_000
+
 function waitBeforeReconnect(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     const finish = () => {
@@ -1247,53 +1253,71 @@ async function readSessionEventStream(
   orgId: string,
   signal: AbortSignal,
   handlers: SessionEventHandlers
-): Promise<void> {
+): Promise<'ended' | 'reauth'> {
+  const request = new AbortController()
+  let reauth = false
+  const abort = () => request.abort(signal.reason)
+  if (signal.aborted) abort()
+  else signal.addEventListener('abort', abort, { once: true })
+  const reauthTimer = setTimeout(() => {
+    reauth = true
+    request.abort()
+  }, SESSION_STREAM_REAUTH_MS)
   const path = `/orgs/${encodeURIComponent(orgId)}/stream`
-  const res = await fetch(`${cpBase()}${path}`, {
-    headers: await authHeaders({ accept: 'text/event-stream' }, { accountToken: true }),
-    cache: 'no-store',
-    signal
-  })
-  if (!res.ok) throw new ApiError(`GET ${path} → ${res.status} ${res.statusText}`, res.status)
-  if (!res.body) throw new Error('session event stream is not readable')
-
-  // The sink has no replay/event ids, so every successful (re)connect invalidates
-  // the list once. This closes both a disconnect gap and the initial GET→subscribe
-  // race without requiring a polling cache layer.
-  handlers.onConnect()
-
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  const parser = createSseParser((event) => {
-    if (event.event === 'session') {
-      handlers.onSession()
-      return
-    }
-    if (event.event !== 'session-activity') return
-    try {
-      const activity = (JSON.parse(event.data) as { activity?: SessionActivityDto }).activity
-      if (
-        activity &&
-        typeof activity.sessionId === 'string' &&
-        typeof activity.agentId === 'string' &&
-        /^\d+$/.test(activity.revision) &&
-        typeof activity.ts === 'string'
-      )
-        handlers.onActivity(activity)
-    } catch {
-      // A malformed optional invalidation is ignored; reconnect/fallback polling heals it.
-    }
-  })
-
   try {
-    for (;;) {
-      const { value, done } = await reader.read()
-      if (done) break
-      parser.push(decoder.decode(value, { stream: true }))
+    const res = await fetch(`${cpBase()}${path}`, {
+      headers: await authHeaders({ accept: 'text/event-stream' }, { accountToken: true }),
+      cache: 'no-store',
+      signal: request.signal
+    })
+    if (!res.ok) throw new ApiError(`GET ${path} → ${res.status} ${res.statusText}`, res.status)
+    if (!res.body) throw new Error('session event stream is not readable')
+
+    // The sink has no replay/event ids, so every successful (re)connect invalidates
+    // the list once. This closes both a disconnect gap and the initial GET→subscribe
+    // race without requiring a polling cache layer.
+    handlers.onConnect()
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    const parser = createSseParser((event) => {
+      if (event.event === 'session') {
+        handlers.onSession()
+        return
+      }
+      if (event.event !== 'session-activity') return
+      try {
+        const activity = (JSON.parse(event.data) as { activity?: SessionActivityDto }).activity
+        if (
+          activity &&
+          typeof activity.sessionId === 'string' &&
+          typeof activity.agentId === 'string' &&
+          /^\d+$/.test(activity.revision) &&
+          typeof activity.ts === 'string'
+        )
+          handlers.onActivity(activity)
+      } catch {
+        // A malformed optional invalidation is ignored; reconnect/fallback polling heals it.
+      }
+    })
+
+    try {
+      for (;;) {
+        const { value, done } = await reader.read()
+        if (done) break
+        parser.push(decoder.decode(value, { stream: true }))
+      }
+      parser.push(decoder.decode())
+    } finally {
+      reader.releaseLock()
     }
-    parser.push(decoder.decode())
+    return 'ended'
+  } catch (error) {
+    if (reauth && !signal.aborted) return 'reauth'
+    throw error
   } finally {
-    reader.releaseLock()
+    clearTimeout(reauthTimer)
+    signal.removeEventListener('abort', abort)
   }
 }
 
@@ -1313,8 +1337,9 @@ export function subscribeSessionEvents(
   void (async () => {
     while (!ctrl.signal.aborted) {
       try {
-        await readSessionEventStream(orgId, ctrl.signal, handlers)
+        const ended = await readSessionEventStream(orgId, ctrl.signal, handlers)
         retryMs = 1000
+        if (ended === 'reauth') continue
       } catch (error) {
         if (ctrl.signal.aborted) return
         onError?.(error)


### PR DESCRIPTION
## Summary

- retrieve stored Lark or Feishu user tokens from Logto Account API after binding the request token to the signed-in Console subject
- evaluate provider-backed session access with the provider `is_in_chat` API, including custom template bots and private-to-external policy transitions
- forward the short-lived Logto Account token only on session-access requests and streams

## Validation

- control-plane typecheck and full unit suite
- web typecheck and full unit suite
- daemon typecheck
- PostgreSQL session visibility integration suite
- changed-file formatting and repository ESLint

Created by Codex . GPT-5.6