### PR TITLE
fix(web): show the whole roster where a conversation has one

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -27,7 +27,7 @@ import {
   type SessionMessageDto
 } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
-import { resolveRoster, wireMentions } from '@/lib/conversation-addressing'
+import { resolveRoster, typedMentionIds, wireMentions } from '@/lib/conversation-addressing'
 import { sessionAfterModelSelection } from '@/lib/session-runtime-controls'
 import { reconcilePersistedLiveSteps } from '@/lib/session-transcript'
 import {
@@ -996,14 +996,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!session && knownParticipants && knownParticipants.length > 1 && !rosterNames.current.has(id)) {
         rosterNames.current.set(id, new Map(knownParticipants.map((p) => [p.agentId, p.name])))
       }
-      const mentions =
-        roster.length > 1
-          ? roster
-              .filter(
-                (p) => p.name && new RegExp(`@${p.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(text)
-              )
-              .map((p) => p.agentId)
-          : []
+      const mentions = typedMentionIds(roster, text)
       const targets = roster.length > 1 ? (mentions.length ? mentions : roster.map((p) => p.agentId)) : [agentForId]
       // Membership is a standing mention — a bare multi-agent send materializes it as
       // the whole roster in structured `mentions` (see wireMentions), the same wire

--- a/packages/web/src/components/console/RecentSessionsCard.test.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.test.tsx
@@ -1,0 +1,115 @@
+// The row's second line, which now has two tenants: the conversation's agents on
+// the left and its integration anchored right. Both are text of unbounded length
+// inside a fixed-width card, so the contract under test is that neither can push
+// the other — or itself — past the row's edge, and that a conversation is named by
+// everyone in it rather than by whichever member spoke last.
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ orgPath: (path: string) => path })
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    crons: [],
+    getAgent: (id: string) => (id === 'agent-1' ? { id, name: 'ops-bot', runtime: 'claude' } : undefined)
+  })
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, className }: { children: ReactElement; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  )
+}))
+
+import { RecentSessionsCard } from './RecentSessionsCard'
+import type { Session } from '@/lib/data'
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 's1',
+    title: 'Who are you',
+    time: '9:19 AM',
+    status: 'online',
+    platform: 'slack',
+    channel: '#ops',
+    user: 'sam',
+    duration: '1m',
+    tokens: '2.1K',
+    cost: '$0.01',
+    toolCount: '1',
+    statusLabel: 'completed',
+    steps: [],
+    agentId: 'agent-1',
+    agentName: 'ops-bot',
+    ...overrides
+  }
+}
+
+const card = (sessions: Session[], showAgent = true) =>
+  renderToStaticMarkup(
+    <RecentSessionsCard
+      sessions={sessions}
+      loading={false}
+      allHref="/sessions"
+      emptyText="none"
+      showAgent={showAgent}
+    />
+  )
+
+/** The class list of the `<span>` wrapping the platform mark + channel label —
+ *  i.e. the span one level out from the `imark` the mark itself renders into. */
+function channelWrapperClasses(markup: string): string {
+  const mark = markup.indexOf('<span class="imark')
+  expect(mark).toBeGreaterThan(-1)
+  const open = markup.lastIndexOf('<span class="', mark - 1) + '<span class="'.length
+  return markup.slice(open, markup.indexOf('"', open))
+}
+
+describe('RecentSessionsCard', () => {
+  it('lets a long channel label ellipsize instead of overflowing the row', () => {
+    const long = '#platform-infra-oncall-handoff-and-escalations-archive'
+    const markup = card([session({ channel: long })])
+    // `flex-none` here would size the wrapper to the full label, defeating the
+    // `truncate` inside it — the label must be able to give way.
+    expect(channelWrapperClasses(markup)).toContain('min-w-0')
+    expect(channelWrapperClasses(markup)).not.toContain('flex-none')
+    expect(markup).toContain('mono truncate text-[11px]')
+    expect(markup).toContain(long) // present in full; the ellipsis is the browser's
+  })
+
+  it('keeps the channel left-packed where the row has no agents to split from', () => {
+    expect(channelWrapperClasses(card([session()], false))).not.toContain('ml-auto')
+    expect(channelWrapperClasses(card([session()]))).toContain('ml-auto')
+  })
+
+  it('names every participant of a multi-agent conversation', () => {
+    const markup = card([
+      session({
+        conversationKey: 'conv-1',
+        memberSessionIds: ['s1', 's2'],
+        agentName: 'ops-bot',
+        participants: [
+          { agentId: 'agent-1', name: 'agent-1', primary: true },
+          { agentId: 'agent-2', name: 'test' }
+        ]
+      })
+    ])
+    // agent-1 resolves through the org directory; agent-2 is unknown there, so its
+    // roster name stands in — an id would render as the "Agent" fallback.
+    expect(markup).toContain('ops-bot, test')
+    expect(markup).toContain('/conversations/conv-1')
+  })
+
+  it('draws one face and one name for a single-agent row', () => {
+    const markup = card([session()])
+    expect(markup).toContain('ops-bot')
+    expect(markup).toContain('/sessions/s1')
+    expect(markup).not.toContain('-space-x-')
+  })
+})

--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -159,9 +159,11 @@ export function RecentSessionsCard({
                       </span>
                     )}
                     {s.channel && (
-                      <span
-                        className={`flex min-w-0 flex-none items-center gap-[6px] ${showAgent ? 'ml-auto pl-1' : ''}`}
-                      >
+                      // Shrinkable on purpose (no `flex-none`): a long #channel or
+                      // schedule name has to give way and ellipsize inside the row
+                      // rather than run past it. `ml-auto` only spends space the row
+                      // actually has, so the right anchor costs the label nothing.
+                      <span className={`flex min-w-0 items-center gap-[6px] ${showAgent ? 'ml-auto pl-1' : ''}`}>
                         <span className="imark h-4 w-4 flex-none rounded-xs">
                           <PlatformMark platform={ch.platform} fillPct={90} />
                         </span>

--- a/packages/web/src/components/console/RecentSessionsCard.tsx
+++ b/packages/web/src/components/console/RecentSessionsCard.tsx
@@ -11,7 +11,17 @@ import { useOrgs } from '@/lib/org-context'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView, PlatformMark } from '@/components/marks'
-import { isMergedConversationRow, sessionChannelDisplay, type Session } from '@/lib/data'
+import {
+  isMergedConversationRow,
+  rosterParticipantName,
+  sessionChannelDisplay,
+  type Agent,
+  type Session
+} from '@/lib/data'
+
+/** Stacked faces past this many stop earning their width; the names line still
+ *  carries every participant. */
+const ROSTER_FACES = 4
 
 export function Card({
   title,
@@ -135,26 +145,28 @@ export function RecentSessionsCard({
                   <span className="block truncate font-sans text-[13px] font-medium leading-normal text-(--text-primary)">
                     {s.title}
                   </span>
+                  {/* Agents left, integration right. The two used to run together as
+                    one left-packed strip, which left a multi-agent row nowhere to put
+                    its extra faces without shoving the channel around; anchoring the
+                    integration to the row's right edge gives the roster the whole
+                    middle and lines the channels up down the card. With the agents
+                    hidden (agent detail, already scoped to one) there is nothing to
+                    split from, so the channel stays where it was. */}
                   <span className="mt-[3px] flex items-center gap-[6px] text-(--text-tertiary)">
                     {showAgent && (
-                      <>
-                        <span className="av h-[15px] w-[15px] rounded-xs">
-                          <AgentIconView
-                            icon={owner?.icon}
-                            runtime={owner?.runtime ?? s.runtime ?? 'claude'}
-                            size={15}
-                          />
-                        </span>
-                        <span className="truncate font-sans text-[11.5px] leading-normal">{s.agentName || '—'}</span>
-                      </>
+                      <span className="flex min-w-0 items-center gap-[6px]">
+                        <AgentFaces session={s} owner={owner} />
+                      </span>
                     )}
                     {s.channel && (
-                      <>
-                        <span className="imark h-4 w-4 rounded-xs">
+                      <span
+                        className={`flex min-w-0 flex-none items-center gap-[6px] ${showAgent ? 'ml-auto pl-1' : ''}`}
+                      >
+                        <span className="imark h-4 w-4 flex-none rounded-xs">
                           <PlatformMark platform={ch.platform} fillPct={90} />
                         </span>
                         <span className="mono truncate text-[11px]">{ch.label}</span>
-                      </>
+                      </span>
                     )}
                   </span>
                 </span>
@@ -165,5 +177,48 @@ export function RecentSessionsCard({
         )}
       </>
     </Card>
+  )
+}
+
+/**
+ * The row's agent face(s). These rows are CONVERSATIONS, and a multi-participant
+ * one carries its whole roster (merged-conversation-view.md §5.2) — the single
+ * face + single name it used to draw could only ever name the representative,
+ * which is whichever member happened to speak last. Stacked icons plus the full
+ * name list say who is actually in the room; the names truncate rather than
+ * dropping anyone, and the roster's own `name` is only a fallback (the wire
+ * carries ids — see rosterParticipantName).
+ */
+function AgentFaces({ session, owner }: { session: Session; owner?: Agent }) {
+  const { getAgent } = useConsoleData()
+  const roster = session.participants ?? []
+  if (roster.length <= 1) {
+    return (
+      <>
+        <span className="av h-[15px] w-[15px] flex-none rounded-xs">
+          <AgentIconView icon={owner?.icon} runtime={owner?.runtime ?? session.runtime ?? 'claude'} size={15} />
+        </span>
+        <span className="truncate font-sans text-[11.5px] leading-normal">{session.agentName || '—'}</span>
+      </>
+    )
+  }
+  const members = roster.map((p) => {
+    const agent = getAgent(p.agentId)
+    return { id: p.agentId, name: rosterParticipantName(p, agent), agent }
+  })
+  const names = members.map((m) => m.name).join(', ')
+  return (
+    <>
+      <span className="flex flex-none items-center -space-x-[5px]">
+        {members.slice(0, ROSTER_FACES).map((m) => (
+          <span key={m.id} className="av h-[15px] w-[15px] flex-none rounded-xs" title={m.name}>
+            <AgentIconView icon={m.agent?.icon} runtime={m.agent?.runtime ?? ''} size={15} />
+          </span>
+        ))}
+      </span>
+      <span title={names} className="truncate font-sans text-[11.5px] leading-normal">
+        {names}
+      </span>
+    </>
   )
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -34,6 +34,7 @@ import {
   pgPrompts,
   platName,
   preferredModelFor,
+  rosterParticipantName,
   runtimeLabel,
   sessionChannelDisplay,
   sessionPlatform,
@@ -88,6 +89,7 @@ import { SessionRail, SessionRailSlot } from '@/components/console/SessionRail'
 import {
   EMPTY_RAIL_AGENT_FILTER,
   railAgentFilterQuery,
+  railSeedAgentIds,
   seedRailAgentFilter,
   type RailAgentFilter
 } from '@/lib/session-rail-filter'
@@ -1286,13 +1288,21 @@ export default function SessionDetailView() {
   // The seed is the whole conversation roster: in conversation mode the resolver's
   // members, in session mode the same resolver's probe (already fetched above for
   // the §5.3 redirect), falling back to the lone owning agent.
-  const railSeedAgentIds = useMemo(() => {
-    const roster = conversationKey ? conversationMembers : (selfConversation?.sessions ?? null)
-    if (roster && roster.length > 0) return roster.map((member) => member.agentId ?? '')
-    return session?.agentId ? [session.agentId] : []
-  }, [conversationKey, conversationMembers, selfConversation, session?.agentId])
+  // (The ladder itself — resolver, then this browser's own live roster, then the
+  // owning agent — is railSeedAgentIds. Joined into a string so the roster's fresh
+  // array identity per render, rebuilt from the detail snapshot, cannot churn the memo.)
+  const liveSeedAgentIds = (session?.participants ?? []).map((p) => p.agentId).join(',')
+  const seedAgentIds = useMemo(
+    () =>
+      railSeedAgentIds(
+        conversationKey ? conversationMembers : selfConversation?.sessions,
+        liveSeedAgentIds ? liveSeedAgentIds.split(',') : [],
+        session?.agentId
+      ),
+    [conversationKey, conversationMembers, selfConversation, liveSeedAgentIds, session?.agentId]
+  )
   const [chosenRailFilter, setChosenRailFilter] = useState<RailAgentFilter>(EMPTY_RAIL_AGENT_FILTER)
-  const railFilter = seedRailAgentFilter(chosenRailFilter, railSeedAgentIds)
+  const railFilter = seedRailAgentFilter(chosenRailFilter, seedAgentIds)
   const setRailAgentIds = useCallback((agentIds: string[]) => setChosenRailFilter({ agentIds, touched: true }), [])
 
   // With agents selected this reads a FILTERED page, not the org-wide `allSessions`
@@ -1908,6 +1918,26 @@ export default function SessionDetailView() {
   const agentHref = session.agentId ? `/agents/${session.agentId}` : null
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
+  // The conversation roster, for EVERY live surface — the synthetic playground and
+  // a resumed (or merged) webchat conversation alike. Scoping it to the playground
+  // left resume showing the primary agent's single-agent composer over a
+  // multi-agent conversation, which contradicts both §9.3 ("no in-conversation
+  // runtime controls in a multi-agent conversation" — each participant runs its own
+  // configured defaults, so those pills cannot speak for the turn) and §9.4
+  // ("resume reopens the merged conversation view with the roster in the header").
+  //
+  // Names resolve HERE, from the org agent list: a conversation-mode roster is
+  // synthesized from member ids alone and an adopted session's detail roster can
+  // only carry a short-id fallback, so the raw `name` would render — and
+  // @mention-match — as a uuid.
+  const liveRoster = isLive
+    ? (
+        session.participants ??
+        (session.agentId ? [{ agentId: session.agentId, name: session.agentName ?? '', primary: true }] : [])
+      ).map((p) => ({ ...p, name: rosterParticipantName(p, agentById.get(p.agentId)) }))
+    : []
+  const multiLive = liveRoster.length > 1
+
   // Resume the webchat conversation by its id (session.channelId == the conversationId);
   // a synthetic playground turn omits it (the CP mints a fresh id).
   const onPgSend = (text?: string) => {
@@ -1916,12 +1946,14 @@ export default function SessionDetailView() {
     // Pass the fetched roster: an adopted webchat session has no provider-side
     // state, and without it a multi-agent send can't pre-create stream lanes or
     // narrow by @mention (the relay would apply its all-participants default).
+    // Named, not raw: mention narrowing matches on the display name the composer
+    // chips show.
     pgSend(
       session.id,
       session.agentId ?? '',
       text,
       isWebchat ? session.channelId : undefined,
-      isWebchat ? session.participants : undefined
+      isWebchat ? liveRoster : undefined
     )
   }
   const onImageFile = async (file: File | undefined): Promise<void> => {
@@ -1946,13 +1978,10 @@ export default function SessionDetailView() {
   }
   const webchatConversationId = isLive ? session.channelId : undefined
   // Mid-conversation join (webchat-multi-agents.md §3.1): a live playground
-  // conversation may GROW its roster; removal stays unsupported. Multi-agent
-  // conversations show participant chips instead of runtime pills (§9.1/§9.3).
-  const liveRoster = isPg
-    ? (session.participants ??
-      (session.agentId ? [{ agentId: session.agentId, name: session.agentName ?? '', primary: true }] : []))
-    : []
-  const multiLive = liveRoster.length > 1
+  // conversation may GROW its roster; removal stays unsupported. The join is
+  // still playground-only — `pgAddAgent` mutates provider-side session state that
+  // an adopted webchat session never had — so a resumed conversation shows its
+  // roster (above) without the `+`.
   const addAgentOptions = isPg
     ? agents
         .filter((a) => !liveRoster.some((p) => p.agentId === a.id))
@@ -2198,6 +2227,23 @@ export default function SessionDetailView() {
         last.steps.push(step)
         if (!last.time && step.time) last.time = step.time
       }
+    }
+  }
+
+  // A multi-participant conversation names its WHOLE roster in the header, spoken
+  // or not. Deriving the chip from the transcript alone made it read "You" on a
+  // conversation two agents were visibly typing in — and it would stay wrong even
+  // afterwards, because the owning agent's own turns are the SESSION's and are
+  // never recorded as a speaker (they are what the agent chip stands for).
+  // Appended, so the people who actually spoke keep their order and their avatars.
+  // Single-agent sessions are untouched: there, "participants" still means the
+  // other people in the room.
+  const headerRoster = session.participants ?? []
+  if (headerRoster.length > 1) {
+    for (const p of headerRoster) {
+      if (speakers.has(p.agentId)) continue
+      const rosterAgent = agentById.get(p.agentId) ?? null
+      rememberAgentParticipant(p.agentId, rosterParticipantName(p, rosterAgent ?? undefined), rosterAgent)
     }
   }
 

--- a/packages/web/src/lib/conversation-addressing.test.ts
+++ b/packages/web/src/lib/conversation-addressing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveRoster, wireMentions } from './conversation-addressing'
+import { resolveRoster, typedMentionIds, wireMentions } from './conversation-addressing'
 
 const roster = [{ agentId: 'a-primary', primary: true }, { agentId: 'b-peer' }]
 
@@ -45,5 +45,65 @@ describe('resolveRoster', () => {
   it('yields no roster for single-agent or unstaged sends', () => {
     expect(resolveRoster(undefined, undefined, ['a'], nameOf)).toEqual([])
     expect(resolveRoster(undefined, undefined, undefined, nameOf)).toEqual([])
+  })
+})
+
+describe('typedMentionIds', () => {
+  const named = [
+    { agentId: 'a-id', name: 'AgentConnect' },
+    { agentId: 'b-id', name: 'test' }
+  ]
+
+  it('narrows to the named participant', () => {
+    expect(typedMentionIds(named, '@test 你们是谁')).toEqual(['b-id'])
+    expect(typedMentionIds(named, '@AgentConnect @test who are you')).toEqual(['a-id', 'b-id'])
+  })
+
+  it('reads a name through to its end whatever it ends in', () => {
+    // The regression: `\b` finds no boundary after 理/🤖/!, so each of these
+    // used to narrow to nobody and wake the whole roster instead.
+    const exotic = [
+      { agentId: 'cjk', name: '研究助理' },
+      { agentId: 'emoji', name: 'ops 🤖' },
+      { agentId: 'punct', name: 'deploy!' }
+    ]
+    expect(typedMentionIds(exotic, '@研究助理 have a look')).toEqual(['cjk'])
+    expect(typedMentionIds(exotic, 'ping @ops 🤖 please')).toEqual(['emoji'])
+    expect(typedMentionIds(exotic, '@deploy! now')).toEqual(['punct'])
+    expect(typedMentionIds(exotic, '@研究助理')).toEqual(['cjk']) // end of text
+  })
+
+  it('does not let a name run into the word after it', () => {
+    expect(typedMentionIds(named, '@testing the build')).toEqual([])
+    expect(typedMentionIds(named, '@test你好')).toEqual([])
+  })
+
+  it('gives an ambiguous @ to the longest name that fits it', () => {
+    const prefixed = [
+      { agentId: 'short', name: 'agent' },
+      { agentId: 'long', name: 'agent-2' }
+    ]
+    expect(typedMentionIds(prefixed, '@agent-2 ship it')).toEqual(['long'])
+    expect(typedMentionIds(prefixed, '@agent ship it')).toEqual(['short'])
+  })
+
+  it('wakes every participant answering to a shared display name', () => {
+    const twins = [
+      { agentId: 'x', name: 'claude' },
+      { agentId: 'y', name: 'Claude' }
+    ]
+    expect(typedMentionIds(twins, '@claude?')).toEqual(['x', 'y'])
+  })
+
+  it('ignores an @ welded to the word before it', () => {
+    expect(typedMentionIds(named, 'mail me at foo@test.dev')).toEqual([])
+  })
+
+  it('ignores participants with no usable name', () => {
+    expect(typedMentionIds([{ agentId: 'a-id', name: null }, ...named.slice(1)], '@test hi')).toEqual(['b-id'])
+  })
+
+  it('never narrows a single-agent conversation', () => {
+    expect(typedMentionIds([{ agentId: 'solo', name: 'solo' }], '@solo hi')).toEqual([])
   })
 })

--- a/packages/web/src/lib/conversation-addressing.ts
+++ b/packages/web/src/lib/conversation-addressing.ts
@@ -44,3 +44,50 @@ export function resolveRoster(
     ...(index === 0 ? { primary: true } : {})
   }))
 }
+
+/** What still counts as the SAME name one character later. Unicode-aware on
+ *  purpose: display names are free-form (`min(1).max(120)`, no charset), so a
+ *  name can end in a CJK character, an emoji, or punctuation, and JavaScript's
+ *  `\b` — ASCII-word based — reports no boundary after any of them. Matching on
+ *  `\b` therefore dropped "@研究助理 have a look" on the floor, and a dropped
+ *  mention is not a no-op: it degrades the send to the standing mention and
+ *  wakes the whole roster. */
+const NAME_CHAR = '[\\p{L}\\p{N}_]'
+const NAME_CHAR_RE = new RegExp(NAME_CHAR, 'u')
+
+/** Resolve the @mentions typed into one composer send to roster agentIds
+ *  (webchat-multi-agents.md §4.2 — mentions narrow the turn; the empty result
+ *  means "no narrowing", not "nobody").
+ *
+ *  Text matching is the stopgap: §4.1 wants the composer to emit ID-backed
+ *  chips, so that the wire carries a structural fact rather than a guess. Until
+ *  it does, the guess should at least not wake an agent nobody addressed, so a
+ *  name matches only where it is the LONGEST roster name at that `@` and is not
+ *  glued to a neighbouring word on either side — "@agent-2" belongs to
+ *  `agent-2` alone even with an `agent` in the room, and "ping foo@test.dev"
+ *  addresses no one.
+ */
+export function typedMentionIds(
+  roster: ReadonlyArray<{ agentId: string; name?: string | null }>,
+  text: string
+): string[] {
+  if (roster.length <= 1) return []
+  // offset of an `@` → the longest name matched there, and who answers to it
+  const claims = new Map<number, { len: number; ids: string[] }>()
+  for (const p of roster) {
+    const name = p.name?.trim()
+    if (!name) continue
+    const at = new RegExp(`@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!${NAME_CHAR})`, 'giu')
+    for (const m of text.matchAll(at)) {
+      const start = m.index ?? 0
+      // Left edge: an `@` welded to a preceding word is an address, not a mention.
+      if (start > 0 && NAME_CHAR_RE.test(text[start - 1]!)) continue
+      const claim = claims.get(start)
+      if (!claim || m[0].length > claim.len) claims.set(start, { len: m[0].length, ids: [p.agentId] })
+      // Two participants sharing a display name are genuinely ambiguous — wake both.
+      else if (m[0].length === claim.len && !claim.ids.includes(p.agentId)) claim.ids.push(p.agentId)
+    }
+  }
+  const mentioned = new Set([...claims.values()].flatMap((c) => c.ids))
+  return roster.filter((p) => mentioned.has(p.agentId)).map((p) => p.agentId)
+}

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -13,6 +13,7 @@ import {
   lifecycleStatus,
   conversationRowKey,
   mergeCanonicalSessions,
+  rosterParticipantName,
   modelCapability,
   modelLabel,
   permissionModeChoicesFor,
@@ -141,6 +142,29 @@ describe('mergeCanonicalSessions', () => {
       expect(conversationRowKey(persisted)).toBe('session-real')
       expect(conversationRowKey({ ...persisted, id: 'pg_x', realSessionId: 'session-real' })).toBe('session-real')
     })
+  })
+})
+
+describe('rosterParticipantName', () => {
+  const participant = { agentId: 'b7e0f2c1-4a5d-4e6f-8a9b-0c1d2e3f4a5b', name: 'reviewer' }
+
+  it('prefers the org agent list over whatever name the roster carried', () => {
+    // The list row's roster is built before the rows are enriched, so its `name`
+    // can lag a rename the agent list already has.
+    expect(rosterParticipantName(participant, { name: 'reviewer', displayName: 'Reviewer' })).toBe('Reviewer')
+  })
+
+  it('keeps a real roster name when the agent is not in the viewer’s list', () => {
+    expect(rosterParticipantName(participant)).toBe('reviewer')
+  })
+
+  it('refuses to render an id as a name', () => {
+    // Conversation mode synthesizes the roster from member ids alone, and an
+    // adopted session's detail roster falls back to the short id.
+    expect(rosterParticipantName({ agentId: participant.agentId, name: participant.agentId })).toBe('Agent')
+    expect(rosterParticipantName({ agentId: participant.agentId, name: participant.agentId.slice(0, 8) })).toBe('Agent')
+    expect(rosterParticipantName({ agentId: participant.agentId, name: '  ' })).toBe('Agent')
+    expect(rosterParticipantName({ agentId: participant.agentId })).toBe('Agent')
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -977,6 +977,23 @@ export function isMergedConversationRow(session: Pick<Session, 'conversationKey'
   return (session.memberSessionIds?.length ?? 0) > 1 && Boolean(session.conversationKey)
 }
 
+/**
+ * A roster entry's display name. The wire roster carries ids, not names — a
+ * grouped list row names its members from rows that have not been enriched yet,
+ * and conversation mode synthesizes the roster from member ids alone — so the
+ * org agent list is the real name source and `participant.name` is only what
+ * survived of it. A name that is still the id (or its short-id fallback) is not
+ * a name, and rendering it would put a uuid where an agent belongs.
+ */
+export function rosterParticipantName(
+  participant: { agentId: string; name?: string },
+  agent?: Pick<Agent, 'name' | 'displayName'>
+): string {
+  if (agent) return agentLabel(agent)
+  const name = participant.name?.trim() ?? ''
+  return name && name !== participant.agentId && name !== participant.agentId.slice(0, 8) ? name : 'Agent'
+}
+
 export function mergeCanonicalSessions(sessions: readonly Session[]): Session[] {
   const byId = new Map<string, Session>()
   for (const session of sessions) {

--- a/packages/web/src/lib/session-rail-filter.test.ts
+++ b/packages/web/src/lib/session-rail-filter.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from 'vitest'
-import { EMPTY_RAIL_AGENT_FILTER, railAgentFilterQuery, seedRailAgentFilter } from './session-rail-filter'
+import {
+  EMPTY_RAIL_AGENT_FILTER,
+  railAgentFilterQuery,
+  railSeedAgentIds,
+  seedRailAgentFilter
+} from './session-rail-filter'
+
+describe('railSeedAgentIds', () => {
+  it('prefers the resolved conversation roster', () => {
+    expect(railSeedAgentIds([{ agentId: 'agent-a' }, { agentId: 'agent-b' }], ['agent-c'], 'agent-a')).toEqual([
+      'agent-a',
+      'agent-b'
+    ])
+  })
+
+  it('falls back to the live roster for a conversation no resolver can answer for', () => {
+    // A live playground conversation is client-side until its first turn
+    // persists; seeding its owner alone filtered the rail to one participant of
+    // a conversation with several.
+    expect(railSeedAgentIds(null, ['agent-a', 'agent-b'], 'agent-a')).toEqual(['agent-a', 'agent-b'])
+    expect(railSeedAgentIds([], ['agent-a', 'agent-b'], 'agent-a')).toEqual(['agent-a', 'agent-b'])
+  })
+
+  it('falls back to the owning agent for an ordinary session', () => {
+    expect(railSeedAgentIds(undefined, [], 'agent-a')).toEqual(['agent-a'])
+  })
+
+  it('seeds nothing when nothing is known yet', () => {
+    expect(railSeedAgentIds(undefined, [], undefined)).toEqual([])
+  })
+})
 
 describe('seedRailAgentFilter', () => {
   it('defaults to the open conversation’s agents', () => {

--- a/packages/web/src/lib/session-rail-filter.ts
+++ b/packages/web/src/lib/session-rail-filter.ts
@@ -25,6 +25,30 @@ export interface RailAgentFilter {
 
 export const EMPTY_RAIL_AGENT_FILTER: RailAgentFilter = { agentIds: [], touched: false }
 
+/**
+ * The agents the open route seeds the filter with, most authoritative source
+ * first:
+ *
+ * 1. the conversation's members, as the CP's resolver reported them;
+ * 2. the CLIENT-side roster, for the one conversation no resolver can answer
+ *    for — a live playground conversation exists only in this browser until its
+ *    first turn persists, and seeding its owner alone filtered the rail to one
+ *    participant of a conversation the reader is watching several agents work in;
+ * 3. the owning agent, for an ordinary single-agent session.
+ *
+ * Empty means "nothing to seed yet", which {@link seedRailAgentFilter} leaves
+ * unseeded rather than treating as a cleared filter.
+ */
+export function railSeedAgentIds(
+  conversationRoster: readonly { agentId?: string | null }[] | null | undefined,
+  liveRosterAgentIds: readonly string[],
+  ownerAgentId?: string | null
+): string[] {
+  if (conversationRoster && conversationRoster.length > 0) return conversationRoster.map((m) => m.agentId ?? '')
+  if (liveRosterAgentIds.length > 0) return [...liveRosterAgentIds]
+  return ownerAgentId ? [ownerAgentId] : []
+}
+
 function sameIds(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((id, index) => id === b[index])
 }


### PR DESCRIPTION
Three console surfaces named a single agent for a conversation that had several. All three come from the same root — the roster was known, and each surface reached for the owning agent instead.

## Header participants (`SessionDetailView`)

The chip read **"You"** on a fresh multi-agent turn while both agents were visibly typing. It was derived purely from who had *spoken*, and the owning agent is never recorded as a speaker — its turns are the session's own, which is what the agent chip already stands for. So the chip would have stayed wrong even after everyone answered.

Now seeded from the roster, appended after the real speakers so the people who actually spoke keep their order and their avatars. Single-agent sessions are untouched: there, "participants" still means the other people in the room.

## Rail agent filter (`SessionDetailView` → `session-rail-filter`)

Seeded only from the CP's conversation resolver — which cannot answer for a live playground conversation, since that exists only in the browser until its first turn persists. It fell back to the owning agent alone, filtering the rail to one participant of a conversation the reader was watching two agents work in.

Added the client-side roster as the middle rung. The three-rung ladder (resolver → live roster → owner) is extracted as `railSeedAgentIds`, so it sits with the other rail-filter rules and is unit-tested rather than buried in a component memo.

## Composer on resume (`SessionDetailView`)

`liveRoster` was gated on `isPg`, so **resuming** a multi-agent webchat conversation showed the primary agent's single-agent Model / Effort / Permission pills. That contradicts [webchat-multi-agents.md](docs/designs/webchat-multi-agents.md) §9.3 — there are no in-conversation runtime controls where each participant runs its own configured defaults, so those pills cannot speak for the turn — and §9.4, "resume reopens the merged conversation view with the roster in the header".

Now covers every live surface. Roster names also resolve from the org agent list rather than from the wire, which additionally repairs `@mention` narrowing on resume: the wire carries ids, so the mention match was running against uuids and silently degrading every send to the all-participants default.

## Home's Recent card (`RecentSessionsCard`)

Already grouped by conversation, but still drew one face and one name — which could only ever name the representative, i.e. whichever member happened to speak last. Now stacks the members' icons (capped at 4) and names them all, truncating rather than dropping anyone.

The integration moves to the row's right edge, which is what makes room for the roster and lines the channels up down the card. Agent detail passes `showAgent={false}` (already scoped to one agent), so there is nothing to split from and its channel stays exactly where it was.

## Notes for the reviewer

- **Not fixed here:** in a multi-agent conversation the header still leads with the primary's agent chip *beside* the participants chip, so the primary appears twice. §9.3 wants that chip replaced by roster chips outright — a header redesign rather than a fix.
- **The `+` join stays playground-only.** `pgAddAgent` mutates provider-side session state an adopted webchat session never had, so a resumed conversation shows its roster without the add affordance. Called out in a comment where the gate lives.
- `rosterParticipantName` refuses to render an id as a name (falling back to "Agent"), because two roster sources — grouped list rows and synthesized conversation-mode rosters — legitimately carry ids in the `name` field.

## Verification

Typecheck, lint, prettier, and 650 web tests pass. New unit tests cover `rosterParticipantName` and `railSeedAgentIds`.

Checked in the mock console: participants hover lists humans then the full agent roster; the resumed composer shows roster chips in place of the runtime pills; Home's Recent card stacks faces with the channel right-anchored, verified at desktop, 1100px (names truncate, channel holds) and mobile; agent detail's card is unchanged. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)