### PR TITLE
feat(agents): isolate sessions with worktrees

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -307,11 +307,13 @@ base and head; otherwise the exact head is used. A formal review fails closed if
 that fetch or verification fails. If the Agent workspace is another repository,
 the prompt forbids trusting local traces and requires read-only GitHub inspection
 of the trusted revision instead. Ordinary PR conversations preserve their stable
-session worktree and rely on the same HEAD-verification/read-only fallback prompt.
+session worktree, do not carry formal-review authority, and require read-only or
+revision-addressed inspection instead of trusting working-tree paths.
 
-The model-visible review instruction repeats the trusted base/head and requires
-verifying local `HEAD` before relying on file traces. This workspace fence is in
-addition to the action-time revision fence on formal review submission.
+The model-visible formal-review instruction repeats the trusted base/head and
+requires verifying local `HEAD` before relying on file traces. This workspace
+fence is in addition to the action-time revision fence on formal review
+submission.
 
 ## GitHub Output Ownership
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -273,6 +273,12 @@ split the conversation.
 The daemon maps this to its normal session identity and resumes the same ACP
 session on later matching events. No GitHub-specific session store exists.
 
+The repository checkout follows the same logical session affinity. When the
+Agent uses worktrees, the daemon maps the session key to a stable opaque path
+under that Agent's `worktrees` directory; concurrent pull requests therefore
+use different working directories while later events for one pull request
+reuse its directory.
+
 ### Prompt Boundary
 
 GitHub content is untrusted external input. The daemon wraps model-visible
@@ -290,6 +296,21 @@ The trust boundary depends on runtime permissions and repository credentials:
 - ordinary comment mutation is unavailable to the agent during a numbered
   hook turn; and
 - formal reviews require the structured, action-time-authorized review path.
+
+Before a pull-request review turn starts, the daemon must also establish the
+trusted filesystem revision. It resolves any missing head/base metadata through
+the authenticated GitHub API. When the Agent workspace is the same repository,
+the daemon fetches the exact base and head objects into daemon-owned refs and
+checks out an isolated worktree. A GitHub merge ref may be used only after its
+object ID and ordered parents are proven to be the trusted base and head;
+otherwise the exact head is used. A formal review fails closed if that fetch or
+verification fails. If the Agent workspace is another repository, the prompt
+forbids trusting local traces and requires read-only GitHub inspection of the
+trusted revision instead.
+
+The model-visible review instruction repeats the trusted base/head and requires
+verifying local `HEAD` before relying on file traces. This workspace fence is in
+addition to the action-time revision fence on formal review submission.
 
 ## GitHub Output Ownership
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -297,16 +297,17 @@ The trust boundary depends on runtime permissions and repository credentials:
   hook turn; and
 - formal reviews require the structured, action-time-authorized review path.
 
-Before a pull-request review turn starts, the daemon must also establish the
-trusted filesystem revision. It resolves any missing head/base metadata through
-the authenticated GitHub API. When the Agent workspace is the same repository,
-the daemon fetches the exact base and head objects into daemon-owned refs and
-checks out an isolated worktree. A GitHub merge ref may be used only after its
-object ID and ordered parents are proven to be the trusted base and head;
-otherwise the exact head is used. A formal review fails closed if that fetch or
-verification fails. If the Agent workspace is another repository, the prompt
-forbids trusting local traces and requires read-only GitHub inspection of the
-trusted revision instead.
+Before a formal pull-request review generation starts, the daemon must also
+establish the trusted filesystem revision. It resolves any missing head/base
+metadata through the authenticated GitHub API. When the Agent workspace is the
+same repository, the daemon fetches the exact base and head objects into
+daemon-owned refs and checks out an isolated worktree. A GitHub merge ref may be
+used only after its object ID and ordered parents are proven to be the trusted
+base and head; otherwise the exact head is used. A formal review fails closed if
+that fetch or verification fails. If the Agent workspace is another repository,
+the prompt forbids trusting local traces and requires read-only GitHub inspection
+of the trusted revision instead. Ordinary PR conversations preserve their stable
+session worktree and rely on the same HEAD-verification/read-only fallback prompt.
 
 The model-visible review instruction repeats the trusted base/head and requires
 verifying local `HEAD` before relying on file traces. This workspace fence is in

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -678,6 +678,14 @@ workspace files and cannot be undone. Use an explicit `Replace workspace` save l
 for that destructive case. A working-subdirectory or access-only edit preserves the
 current checkout.
 
+GitHub workspace settings expose one boolean named `Worktree`. When enabled, each
+logical session runs in its own stable Git worktree under the Agent directory, so one
+Agent can work on several sessions concurrently without sharing branch or file state.
+When disabled, sessions use the primary checkout. New GitHub Agents default to enabled;
+existing Agents retain the shared-checkout behavior after upgrade. A fresh manual
+Playground may override `Worktree` before its first turn without changing the Agent;
+automatic triggers use the Agent setting.
+
 Workspace changes are cold edits: active work is drained and existing cached
 credentials are cleared before the new definition becomes active. Any edit that removes
 write workspace authority for a repository must be rejected while an enabled GitHub

--- a/packages/control-plane/prisma/migrations/20260803120000_agent_workspace_isolation/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260803120000_agent_workspace_isolation/migration.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "WorkspaceIsolation" AS ENUM ('shared', 'session');
+
+ALTER TABLE "agent"
+ADD COLUMN "workspaceIsolation" "WorkspaceIsolation" NOT NULL DEFAULT 'shared';

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -576,6 +576,11 @@ enum WorkspaceMode {
   github // clone gitRepo @ gitBranch, run in agentDir
 }
 
+enum WorkspaceIsolation {
+  shared // every session uses the primary checkout
+  session // each logical session uses its own git worktree
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // §3.6 Agent — agent definition & capability pin (C6 + C4)
 // ───────────────────────────────────────────────────────────────────────────
@@ -604,6 +609,7 @@ model Agent {
   daemonId              String?            @db.Uuid // 1 agent : 1 machine (null until placed)
   // ── workspace (inline; §3.5) — daemon-generated path ──
   workspaceMode         WorkspaceMode      @default(scratch)
+  workspaceIsolation    WorkspaceIsolation @default(shared)
   gitRepo               String? // github mode: e.g. github.com/acme/infra
   gitBranch             String?            @default("main")
   agentDir              String? // github mode: subdir within the repo (repo-root if null)
@@ -642,11 +648,11 @@ model Agent {
   createdAt             DateTime           @default(now()) @db.Timestamptz(6)
   updatedAt             DateTime           @updatedAt @db.Timestamptz(6)
 
-  org                   Org                      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  daemon                Daemon?                  @relation(fields: [daemonId], references: [id], onDelete: SetNull)
-  createdBy             User?                    @relation("AgentCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
-  owner                 User?                    @relation("AgentOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
-  lastModifiedBy        User?                    @relation("AgentModifiedBy", fields: [lastModifiedByUserId], references: [id], onDelete: SetNull)
+  org                   Org                        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  daemon                Daemon?                    @relation(fields: [daemonId], references: [id], onDelete: SetNull)
+  createdBy             User?                      @relation("AgentCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  owner                 User?                      @relation("AgentOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
+  lastModifiedBy        User?                      @relation("AgentModifiedBy", fields: [lastModifiedByUserId], references: [id], onDelete: SetNull)
   assignments           Assignment[]
   launches              AgentLaunch[]
   sessions              SessionMeta[]

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -277,6 +277,7 @@ export const AgentWorkspaceBody = z.discriminatedUnion('mode', [
   z.object({ mode: z.literal('scratch') }),
   z.object({
     mode: z.literal('github'),
+    worktree: z.boolean(),
     gitRepo: GitRepoOutput,
     gitBranch: z.string().optional(),
     agentDir: z.string().optional(),
@@ -330,6 +331,9 @@ const AgentWorkspaceInputBody = z.discriminatedUnion('mode', [
   z.object({ mode: z.literal('scratch') }),
   z.object({
     mode: z.literal('github'),
+    // Product-facing boolean; the domain stores the generic isolation policy.
+    // Omitted clients get the new-agent default in the route.
+    worktree: z.boolean().optional(),
     gitRepo: GitRepoInput,
     gitBranch: z.string().optional(),
     agentDir: AgentDirCreateInput.optional(),
@@ -590,6 +594,7 @@ export const SetAgentWorkspaceBody = z.discriminatedUnion('mode', [
   z
     .object({
       mode: z.literal('github'),
+      worktree: z.boolean().optional(),
       repoFullName: z.string().regex(/^[^/\s]+\/[^/\s]+$/, 'repoFullName must be owner/repo'),
       gitBranch: z.string().min(1).optional(),
       agentDir: AgentDirCreateInput.optional(),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -189,6 +189,19 @@ function organizationKnowledgeSupportedOn(daemon: DaemonView | null): boolean {
   return !!daemon?.capabilities.features.includes(ORGANIZATION_KNOWLEDGE_FEATURE)
 }
 
+function workspaceToDto(workspace: AgentWorkspace): AgentDtoT['workspace'] {
+  if (workspace.mode === 'scratch') return { mode: 'scratch' }
+  return {
+    mode: 'github',
+    worktree: workspace.isolation === 'session',
+    gitRepo: workspace.gitRepo,
+    ...(workspace.gitBranch !== undefined ? { gitBranch: workspace.gitBranch } : {}),
+    ...(workspace.agentDir !== undefined ? { agentDir: workspace.agentDir } : {}),
+    ...(workspace.installationId !== undefined ? { installationId: workspace.installationId } : {}),
+    ...(workspace.gitAccess !== undefined ? { gitAccess: workspace.gitAccess } : {})
+  }
+}
+
 function toDto(
   a: AgentRecord,
   ctx: ViewCtx,
@@ -229,7 +242,7 @@ function toDto(
     memory: a.memory,
     status: a.status,
     daemonId: a.daemonId,
-    workspace: a.workspace,
+    workspace: workspaceToDto(a.workspace),
     workspaceRepoId: a.workspaceRepoId?.toString() ?? null,
     capabilities: a.capabilities,
     createdAt: a.createdAt.toISOString(),
@@ -918,7 +931,20 @@ export function agentRoutes(deps: HttpDeps) {
         // these answer 409 — installations and their grant sets are org-level
         // infrastructure (visibility taxonomy), so a 409 is not an oracle.
         const ws = req.body.workspace
-        let workspace = ws
+        let workspace: AgentWorkspace | undefined =
+          ws?.mode === 'github'
+            ? {
+                mode: 'github',
+                isolation: ws.worktree === false ? 'shared' : 'session',
+                gitRepo: ws.gitRepo,
+                ...(ws.gitBranch !== undefined ? { gitBranch: ws.gitBranch } : {}),
+                ...(ws.agentDir !== undefined ? { agentDir: ws.agentDir } : {}),
+                ...(ws.installationId !== undefined ? { installationId: ws.installationId } : {}),
+                ...(ws.gitAccess !== undefined ? { gitAccess: ws.gitAccess } : {})
+              }
+            : ws
+              ? { mode: 'scratch', isolation: 'shared' }
+              : undefined
         let workspaceRepoId: bigint | undefined
         if (ws?.mode === 'github' && ws.installationId === undefined && ws.gitAccess === 'write') {
           return conflict('github write access requires a GitHub App installation')
@@ -945,7 +971,15 @@ export function agentRoutes(deps: HttpDeps) {
             workspaceRepoId = ref.repoId
             // The installation lookup, not the caller's clone host/path, is the
             // authority for an App-backed workspace.
-            workspace = { ...ws, gitRepo: normalizeGitUrl(ref.fullName) }
+            workspace = {
+              mode: 'github',
+              isolation: ws.worktree === false ? 'shared' : 'session',
+              gitRepo: normalizeGitUrl(ref.fullName),
+              ...(ws.gitBranch !== undefined ? { gitBranch: ws.gitBranch } : {}),
+              ...(ws.agentDir !== undefined ? { agentDir: ws.agentDir } : {}),
+              installationId: ws.installationId,
+              ...(ws.gitAccess !== undefined ? { gitAccess: ws.gitAccess } : {})
+            }
             // Per-user gate (identity assertion, open question #7) — the SECURITY check;
             // the picker's preflight is UX only. The creator must hold the
             // access level the agent will run with: gitAccess=write (the
@@ -1629,7 +1663,7 @@ export function agentRoutes(deps: HttpDeps) {
         }
 
         try {
-          let workspace: AgentWorkspace = { mode: 'scratch' }
+          let workspace: AgentWorkspace = { mode: 'scratch', isolation: 'shared' }
           let workspaceRepoId: bigint | undefined
           if (req.body.mode === 'github') {
             if (!deps.github) return conflict('GitHub workspaces are not enabled for this deployment')
@@ -1650,8 +1684,12 @@ export function agentRoutes(deps: HttpDeps) {
                 req.body.gitAccess
               )
             }
+            const worktree =
+              req.body.worktree ??
+              (existing.workspace.mode === 'github' ? existing.workspace.isolation === 'session' : true)
             workspace = {
               mode: 'github',
+              isolation: worktree ? 'session' : 'shared',
               gitRepo: normalizeGitUrl(ref.fullName),
               gitBranch: req.body.gitBranch ?? ref.defaultBranch,
               ...(req.body.agentDir ? { agentDir: req.body.agentDir } : {}),

--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -342,7 +342,11 @@ describe('AgentMoveService', () => {
     expect(t.activations).toHaveLength(2)
     expect(t.activations[0]?.reconcileWorkspace).toBe(true)
     expect(t.activations[1]?.reconcileWorkspace).toBe(true)
-    expect(t.activations[1]?.spec.workspace).toEqual({ mode: 'scratch', gitCredential: 'github-app' })
+    expect(t.activations[1]?.spec.workspace).toEqual({
+      mode: 'scratch',
+      isolation: 'shared',
+      gitCredential: 'github-app'
+    })
   })
 
   it('continues from durable GitHub state when the persistence response is lost after commit', async () => {

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -151,6 +151,7 @@ export function agentRecordToSpec(
     a.workspace.mode === 'github'
       ? {
           mode: 'github',
+          isolation: a.workspace.isolation ?? 'shared',
           // Defense in depth for historical/non-Prisma records: never send
           // credentials or an unsupported transport to any daemon version.
           gitRepo:
@@ -161,7 +162,7 @@ export function agentRecordToSpec(
           ...(a.workspace.agentDir !== undefined ? { agentDir: a.workspace.agentDir } : {}),
           ...(a.workspace.installationId !== undefined ? { gitCredential: 'github-app' as const } : {})
         }
-      : { mode: 'scratch', gitCredential: 'github-app' }
+      : { mode: 'scratch', isolation: a.workspace.isolation ?? 'shared', gitCredential: 'github-app' }
   return {
     agentId: a.id,
     name: a.name,

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -207,7 +207,11 @@ describe('agentRecordToSpec runtime overrides', () => {
 
     expect(agentRecordToSpec(agent, {})).toHaveProperty('displayName', 'Deploy Bot')
     expect(agentRecordToSpec({ ...agent, displayName: null }, {})).toHaveProperty('displayName', null)
-    expect(agentRecordToSpec(agent, {}).workspace).toEqual({ mode: 'scratch', gitCredential: 'github-app' })
+    expect(agentRecordToSpec(agent, {}).workspace).toEqual({
+      mode: 'scratch',
+      isolation: 'shared',
+      gitCredential: 'github-app'
+    })
     // The preset marker always ships (definite record field) so the daemon can
     // gate preset-only capabilities (webchat_remote_mcp_v1) as soon as it syncs.
     expect(agentRecordToSpec(agent, {})).toHaveProperty('builtin', false)

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -489,10 +489,12 @@ export interface RelayRepo {
 // ───────────────────────────────────────────────────────────────────────────
 
 /** Where the agent runs (inline on the agent; path is daemon-generated). */
+export type WorkspaceIsolation = 'shared' | 'session'
 export type AgentWorkspace =
-  | { mode: 'scratch' }
+  | { mode: 'scratch'; isolation?: WorkspaceIsolation }
   | {
       mode: 'github'
+      isolation?: WorkspaceIsolation
       gitRepo: string
       gitBranch?: string
       agentDir?: string

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -196,6 +196,7 @@ function workspaceOf(a: Agent): AgentWorkspace {
   if (a.workspaceMode === 'github') {
     return {
       mode: 'github',
+      isolation: a.workspaceIsolation,
       // Legacy rows may predate the credential-free clone URL invariant. Keep
       // reads total, but never let URL userinfo/query secrets enter DTOs or wire
       // projections through the domain record.
@@ -205,7 +206,7 @@ function workspaceOf(a: Agent): AgentWorkspace {
       ...(a.installationId !== null ? { installationId: a.installationId, gitAccess: a.gitAccess } : {})
     }
   }
-  return { mode: 'scratch' }
+  return { mode: 'scratch', isolation: a.workspaceIsolation }
 }
 
 function toRecord(a: AgentWithUsers): AgentRecord {
@@ -355,6 +356,7 @@ export class PgAgentRepo implements AgentRepo {
             : {}),
           ...(ownerUserId ? { ownerUserId } : {}),
           workspaceMode: ws.mode,
+          workspaceIsolation: ws.mode === 'github' ? (ws.isolation ?? 'session') : 'shared',
           gitRepo: ws.mode === 'github' ? ws.gitRepo : null,
           gitBranch: ws.mode === 'github' ? (ws.gitBranch ?? 'main') : null,
           agentDir: ws.mode === 'github' ? (ws.agentDir ?? null) : null,
@@ -571,6 +573,7 @@ export class PgAgentRepo implements AgentRepo {
           where: { id: agentId, workspaceMode: expectedMode, lastModifiedAt: expectedLastModifiedAt },
           data: {
             workspaceMode: workspace.mode,
+            workspaceIsolation: workspace.mode === 'github' ? (workspace.isolation ?? 'session') : 'shared',
             gitRepo: workspace.mode === 'github' ? workspace.gitRepo : null,
             gitBranch: workspace.mode === 'github' ? (workspace.gitBranch ?? 'main') : null,
             agentDir: workspace.mode === 'github' ? (workspace.agentDir ?? null) : null,
@@ -618,6 +621,7 @@ export class PgAgentRepo implements AgentRepo {
           },
           data: {
             workspaceMode: workspace.mode,
+            workspaceIsolation: workspace.mode === 'github' ? (workspace.isolation ?? 'session') : 'shared',
             gitRepo: workspace.mode === 'github' ? workspace.gitRepo : null,
             gitBranch: workspace.mode === 'github' ? (workspace.gitBranch ?? 'main') : null,
             agentDir: workspace.mode === 'github' ? (workspace.agentDir ?? null) : null,

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -362,7 +362,7 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
 
     expect(converted.statusCode).toBe(200)
     expect(converted.json()).toMatchObject({
-      workspace: { mode: 'github', gitBranch: 'trunk', gitAccess: 'write' },
+      workspace: { mode: 'github', worktree: true, gitBranch: 'trunk', gitAccess: 'write' },
       workspaceRepoId: '111'
     })
     expect(control.detaches).toMatchObject([{ agentId }])
@@ -376,6 +376,7 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
     expect(await prisma.agentRepoAuthorization.count({ where: { agentId } })).toBe(0)
     expect(await prisma.agent.findUnique({ where: { id: agentId } })).toMatchObject({
       workspaceMode: 'github',
+      workspaceIsolation: 'session',
       gitBranch: 'trunk',
       workspaceRepoId: 111n
     })
@@ -441,16 +442,22 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
     const edited = await a.app.inject({
       method: 'PUT',
       url: `${ORG}/agents/${agentId}/workspace`,
-      payload: { mode: 'github', repoFullName: 'acme/infra', gitAccess: 'read' }
+      payload: { mode: 'github', worktree: false, repoFullName: 'acme/infra', gitAccess: 'read' }
     })
 
     expect(edited.statusCode).toBe(200)
-    expect(edited.json()).toMatchObject({ workspace: { mode: 'github', gitAccess: 'read' } })
+    expect(edited.json()).toMatchObject({ workspace: { mode: 'github', worktree: false, gitAccess: 'read' } })
     expect(control.detaches).toHaveLength(1)
     expect(control.detaches[0]?.requireEmptyWorkspace).toBeUndefined()
     expect(control.activations).toHaveLength(1)
-    expect(control.activations[0]?.reconcileWorkspace).toBe(true)
-    expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({ gitAccess: 'read' })
+    expect(control.activations[0]).toMatchObject({
+      reconcileWorkspace: true,
+      spec: { workspace: { isolation: 'shared' } }
+    })
+    expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
+      gitAccess: 'read',
+      workspaceIsolation: 'shared'
+    })
   })
 
   it('switches repository, branch, and working directory, then converts GitHub back to scratch', async () => {

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -188,7 +188,7 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
         runInSandbox: false,
         // Preset marker — always shipped so the daemon can gate preset-only capabilities.
         builtin: false,
-        workspace: { mode: 'scratch', gitCredential: 'github-app' }
+        workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app' }
       }
     })
 
@@ -261,6 +261,7 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
     expect(clear.statusCode).toBe(200)
     expect(spy.upserts.at(-1)?.u.spec.workspace).toEqual({
       mode: 'github',
+      isolation: 'shared',
       gitRepo: 'https://github.com/acme/monorepo',
       branch: 'main'
     })

--- a/packages/control-plane/test/integration/agents.route.test.ts
+++ b/packages/control-plane/test/integration/agents.route.test.ts
@@ -432,7 +432,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
       model: string | null
       daemonId: string | null
       status: string
-      workspace: { mode: string; gitRepo?: string; gitBranch?: string; agentDir?: string }
+      workspace: { mode: string; worktree?: boolean; gitRepo?: string; gitBranch?: string; agentDir?: string }
     }
     expect(created.model).toBe('opus')
     expect(created.daemonId).toBe(daemonId) // placed on the chosen daemon
@@ -440,6 +440,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     // shorthand input is normalized to the full cloneable address at the DTO boundary
     expect(created.workspace).toEqual({
       mode: 'github',
+      worktree: true,
       gitRepo: 'https://github.com/acme/infra',
       gitBranch: 'main',
       agentDir: 'services/api'
@@ -448,6 +449,7 @@ describe('C2 BFF REST — agents/daemons/workspaces/crons over app.inject', () =
     // Persisted inline on the agent row (no separate workspace entity), full address.
     const row = await prisma.agent.findUnique({ where: { id: created.id } })
     expect(row?.workspaceMode).toBe('github')
+    expect(row?.workspaceIsolation).toBe('session')
     expect(row?.gitRepo).toBe('https://github.com/acme/infra')
     expect(row?.agentDir).toBe('services/api')
     expect((row?.runtimeOverrides as { model: string }).model).toBe('opus')

--- a/packages/control-plane/test/integration/app.smoke.test.ts
+++ b/packages/control-plane/test/integration/app.smoke.test.ts
@@ -219,6 +219,7 @@ describe('Phase 5 — whole-app assembly via buildApp (REST + WS share one DB/or
       const agentSpec = snap.agents.find((a) => a.agentId === agentId)
       expect(agentSpec?.workspace).toEqual({
         mode: 'github',
+        isolation: 'session',
         gitRepo: 'https://github.com/acme/infra',
         branch: 'main',
         agentDir: 'services/api'

--- a/packages/control-plane/test/protocol/register.handler.test.ts
+++ b/packages/control-plane/test/protocol/register.handler.test.ts
@@ -228,7 +228,7 @@ describe('register handler — authoritative reconcile snapshot + idempotency + 
       runInSandbox: false,
       // Preset marker — always shipped so the daemon can gate preset-only capabilities.
       builtin: false,
-      workspace: { mode: 'scratch', gitCredential: 'github-app' }
+      workspace: { mode: 'scratch', isolation: 'shared', gitCredential: 'github-app' }
     })
 
     // drop: the stale local keys the CP no longer owns for this daemon.

--- a/packages/daemon/src/acp/runtime-launch.ts
+++ b/packages/daemon/src/acp/runtime-launch.ts
@@ -157,6 +157,9 @@ export function prepareRuntimeLaunch(opts: {
   /** Daemon/registry-owned executable and package roots needed to start the
    * runtime and its configured stdio children. Never derive this from agent env. */
   trustedRuntimeReadRoots?: string[]
+  /** Additional daemon-derived workspace parents (for session worktrees).
+   * Every entry is revalidated as a strict descendant of scopeDir. */
+  trustedWorkspaceWriteRoots?: string[]
   /** Test seam. Shared login remains Linux-only with the sandbox rollout. */
   credentialPlatform?: NodeJS.Platform
   sandboxMechanism?: SandboxMechanism
@@ -319,6 +322,16 @@ export function prepareRuntimeLaunch(opts: {
       return trusted
     })
   )
+  const agentRoot = safeRoot(opts.scopeDir, 'agent root')
+  const trustedWorkspaceWriteRoots = compactReadRoots(
+    (opts.trustedWorkspaceWriteRoots ?? []).map((path) => {
+      const trusted = safeRoot(path, 'trusted workspace write root')
+      if (trusted === agentRoot || !inside(agentRoot, trusted)) {
+        throw new Error(`trusted workspace write root "${trusted}" is outside the agent root`)
+      }
+      return trusted
+    })
+  )
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   if (claudeRuntime) {
     // Anthropic profile JSON may live in the agent-writable private HOME and may
@@ -356,7 +369,7 @@ export function prepareRuntimeLaunch(opts: {
     runtimeHome,
     mcpSocketPath: opts.mcpSocketPath,
     trustedReadRoots: [...trustedRuntimeReadRoots, ...providerCredentialReadRoots],
-    trustedWriteRoots: credentialWritableRoots
+    trustedWriteRoots: [...credentialWritableRoots, ...trustedWorkspaceWriteRoots]
   })
   // SRT write roots must exist before spawn.
   // This also initializes workspace/memory for a newly-created agent.

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -253,6 +253,9 @@ export const AgentSchema = z.object({
   memory: AgentMemoryBinding.optional(),
   workspace: z.object({
     mode: z.enum(['git-repo', 'from-scratch']),
+    // Internal isolation policy. Product surfaces call the session mode
+    // "Worktree"; keeping an enum here leaves room for other isolation modes.
+    isolation: z.enum(['shared', 'session']).default('shared'),
     path: z.string(),
     gitRepo: z.string().optional(), // full cloneable address (e.g. https://github.com/acme/infra)
     gitBranch: z.string().default('main'),

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -820,6 +820,7 @@ function applySpecFields(
       typeof raw.workspace === 'object' && raw.workspace !== null ? (raw.workspace as Record<string, unknown>) : {}
     ) as Record<string, unknown>
     existing.mode = mapWorkspaceMode(ws.mode)
+    existing.isolation = ws.isolation
     // AgentSpec carries the complete workspace state. Root/scratch therefore
     // clears a previously replicated cwd rather than preserving a stale local value.
     delete existing.agentDir

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -170,7 +170,7 @@ import { FeishuConverger, renderStatusReply as renderFeishuStatusReply, type Fei
 import { Scheduler, buildSyntheticMessage } from './scheduler/scheduler.js'
 import { DreamScheduler } from './scheduler/dream-scheduler.js'
 import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
-import { buildHookMessage, hookAnchorText } from './messages/hook-message.js'
+import { buildHookMessage, githubOpensReviewGeneration, hookAnchorText } from './messages/hook-message.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './github/poster.js'
 import {
   GithubReviewClient,
@@ -8101,6 +8101,7 @@ export class Daemon {
       snapshot.gateMode === 'informational' &&
       snapshot.reportingMode !== 'status' &&
       (!this.cfg.daemonId || snapshot.dispatchDaemonId === this.cfg.daemonId) &&
+      githubOpensReviewGeneration(hook.event, github, snapshot.reviewPolicy) &&
       !isGithubReviewCommentHook(hook)
     )
   }
@@ -8164,9 +8165,10 @@ export class Daemon {
     }
   }
 
-  /** Prepare an exact, isolated checkout before the model session starts. A
+  /** Prepare an exact, isolated checkout before a formal review generation. A
    * formal review may use GitHub read-only inspection when its configured local
-   * repo differs, but it must never silently fall back to a stale checkout. */
+   * repo differs, but it must never silently fall back to a stale checkout.
+   * Ordinary PR conversations preserve their stable session worktree. */
   private async prepareGithubReviewWorkspace(
     entry: QueueEntry,
     key: string,
@@ -8176,15 +8178,11 @@ export class Daemon {
     forceWorkspaceIsolation?: true
     preparedWorkspaceCwd?: string
   }> {
-    const formalReview = this.githubFormalReviewEnabled(entry)
-    const initialGithub = entry.hookContext?.github
-    if (initialGithub?.subjectKind !== 'pull_request' || initialGithub.pullNumber === undefined) return {}
+    if (!this.githubFormalReviewEnabled(entry)) return {}
 
-    const github = await this.ensureGithubPullRevision(entry, formalReview)
+    const github = await this.ensureGithubPullRevision(entry, true)
     if (!github?.headSha || !github.baseSha || github.pullNumber === undefined) {
-      entry.msg.text +=
-        '\n\nTrusted workspace check: the PR revision could not be resolved. Do not trust local files or repository traces; inspect the PR through GitHub read-only tools.'
-      return {}
+      throw new Error('github review blocked: authoritative PR base and head are unavailable')
     }
 
     const revisionLine = `Base SHA: ${github.baseSha}\nHead SHA: ${github.headSha}`
@@ -8212,14 +8210,7 @@ export class Daemon {
         'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.'
       return { workspaceIsolation: 'session', forceWorkspaceIsolation: true, preparedWorkspaceCwd }
     } catch (err) {
-      if (formalReview) {
-        throw new Error('github review blocked: exact PR workspace preparation failed', { cause: err })
-      }
-      this.log.warn(`github review: exact workspace unavailable (${formatErr(err)})`)
-      entry.msg.text +=
-        `\n\nTrusted review revision:\n${revisionLine}\n` +
-        'The exact local checkout could not be prepared. Do not trust local files or repository traces; inspect the exact base and head through GitHub read-only tools.'
-      return {}
+      throw new Error('github review blocked: exact PR workspace preparation failed', { cause: err })
     }
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8269,7 +8269,12 @@ export class Daemon {
         await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)))
       }
     }
-    if (snapshot.reviewPolicy === 'off' || isGithubReviewCommentHook(hook)) return undefined
+    if (
+      snapshot.reviewPolicy === 'off' ||
+      isGithubReviewCommentHook(hook) ||
+      !githubOpensReviewGeneration(hook.event, trusted, snapshot.reviewPolicy)
+    )
+      return undefined
     const recoverableAttempt =
       hook.reviewAttemptId !== undefined &&
       hook.reviewRequestedEvent !== undefined &&

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -134,9 +134,12 @@ import {
   ensureWorkspaceMaterialization,
   isWorkspaceEmpty,
   prepareWorkspace,
+  prepareSessionWorkspace,
   prepareWorkspaceForActivation,
   resolvePreparedWorkspaceCwd,
-  prefetchWorkspace
+  prefetchWorkspace,
+  sessionWorktreeRoot,
+  type PrepareSessionWorkspaceRequest
 } from './workspace/workspace-manager.js'
 import { ManagedSkillCache } from './skills/managed-skill-cache.js'
 import {
@@ -216,7 +219,9 @@ import {
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
   effectiveMemoryDreamingPolicy,
-  gitRepoLabel
+  gitRepoLabel,
+  normalizeGitCloneUrl,
+  normalizeGithubRepoUrl
 } from '@agentconnect.md/protocol'
 import { isNoResponseBody, isNoResponsePrefix } from './session/no-response.js'
 import { createSessionReader } from './cp/session-reader.js'
@@ -1339,6 +1344,7 @@ interface WebchatTurnContext {
    * (webchat-multi-agents.md §5.2). Absent on an older relay / synthetic turn. */
   postSink?: (post: RdWebchatPost) => void
   runtime?: WebchatRuntimeConfig
+  worktree?: boolean
   /** Authority captured only from the relay's validated rd/msg envelope. It is
    * consumed by the daemon host selector and never forwarded to ACP/model input. */
   remoteMcp?: WebchatRemoteMcpEntitlement
@@ -2632,7 +2638,8 @@ export class Daemon {
       // single preparation rather than starting a warm preparation afterward.
       isHostRunning: (agentId) => this.readyHosts.has(agentId),
       agentById: (id) => this.agents.get(id),
-      prepareWorkspace: (agent, expectedWarmHost) => this.prepareAgentWorkspace(agent, expectedWarmHost),
+      prepareWorkspace: (agent, expectedWarmHost, request) =>
+        this.prepareAgentWorkspace(agent, expectedWarmHost, request),
       resolvePreparedWorkspace: (agent) => resolvePreparedWorkspaceCwd(agent),
       memory: this.memory,
       onMemoryRecallError: (agentId, error) =>
@@ -4205,13 +4212,14 @@ export class Daemon {
     return effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
   }
 
-  private async runAgentWorkspacePreparation(agent: Agent): Promise<string> {
+  private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
     if (!this.opts.hostFactory) assertExclusiveAgentWorkspaces([agent as LoadedAgent])
-    return prepareWorkspace(agent, {
-      managedSkills: (value) => this.managedSkillCache?.resolve(value) ?? Promise.resolve([]),
+    const opts = {
+      managedSkills: (value: Agent) => this.managedSkillCache?.resolve(value) ?? Promise.resolve([]),
       skillsStateDir: join(this.root, 'skill-installs'),
       skillsAgentId: this.runtimeCatalog.entries[agent.runtime]?.skillsAgentId ?? null
-    })
+    }
+    return request ? prepareSessionWorkspace(agent, request, opts) : prepareWorkspace(agent, opts)
   }
 
   private runAgentWorkspacePrefetch(agent: Agent): Promise<void> {
@@ -4278,10 +4286,15 @@ export class Daemon {
     return run
   }
 
-  private prepareAgentWorkspace(agent: Agent, expectedWarmHost?: AcpHost, allowAgentDrain = false): Promise<string> {
+  private prepareAgentWorkspace(
+    agent: Agent,
+    expectedWarmHost?: AcpHost,
+    request?: PrepareSessionWorkspaceRequest,
+    allowAgentDrain = false
+  ): Promise<string> {
     return this.enqueueAgentWorkspacePreparation(
       agent,
-      () => this.runAgentWorkspacePreparation(agent),
+      () => this.runAgentWorkspacePreparation(agent, request),
       expectedWarmHost,
       allowAgentDrain
     )
@@ -4511,6 +4524,8 @@ export class Daemon {
         runtimeReadRoots: runInSandbox
           ? this.sandboxRuntimeReadRoots(agent, runtime, { ...runtimeEnv, ...env }, githubAppCredentials)
           : undefined,
+        trustedWorkspaceWriteRoots:
+          runInSandbox && agent.workspace.mode === 'git-repo' ? [sessionWorktreeRoot(agent)] : undefined,
         explicitEnv: { ...runtimeEnv, ...env },
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
@@ -5584,7 +5599,8 @@ export class Daemon {
     remoteMcp?: WebchatRemoteMcpEntitlement,
     mentions?: string[],
     post?: { postId: string; at: number },
-    postSink?: (p: RdWebchatPost) => void
+    postSink?: (p: RdWebchatPost) => void,
+    requestedWorktree?: boolean
   ): WebchatAck {
     const turnId = requestedTurnId ?? randomUUID()
     // Route directly to the named agent (bypasses arbitration); null when it isn't a
@@ -5672,7 +5688,15 @@ export class Daemon {
     }
     const initialRuntime =
       this.agents.get(result.agentId)?.allowRuntimeChangesInChat === true ? requestedRuntime : undefined
-    const stream = this.createWebchatTurnStream(result.agentId, chatId, turnId, sink, initialRuntime, remoteMcp)
+    const stream = this.createWebchatTurnStream(
+      result.agentId,
+      chatId,
+      turnId,
+      sink,
+      initialRuntime,
+      remoteMcp,
+      requestedWorktree
+    )
     if (postSink) stream.postSink = postSink
     // Observed-inbound analogue for webchat (turn-final refresh, §5.4): record the
     // user message at ADMISSION — not only when its turn eventually runs — so a
@@ -5739,7 +5763,8 @@ export class Daemon {
     turnId: string,
     transport: WebchatSink,
     runtime?: WebchatRuntimeConfig,
-    remoteMcp?: WebchatRemoteMcpEntitlement
+    remoteMcp?: WebchatRemoteMcpEntitlement,
+    worktree?: boolean
   ): WebchatTurnStream {
     this.pruneWebchatStreams()
     const stream: WebchatTurnStream = {
@@ -5748,6 +5773,7 @@ export class Daemon {
       turnId,
       transport,
       ...(runtime ? { runtime } : {}),
+      ...(worktree !== undefined ? { worktree } : {}),
       ...(remoteMcp ? { remoteMcp } : {}),
       resumeGeneration: 0,
       sink: {
@@ -8062,6 +8088,141 @@ export class Daemon {
     return { accepted: true }
   }
 
+  private githubFormalReviewEnabled(entry: QueueEntry): boolean {
+    const hook = entry.hookContext
+    const snapshot = hook?.snapshot
+    const github = hook?.github
+    return Boolean(
+      hook &&
+      snapshot &&
+      github?.subjectKind === 'pull_request' &&
+      github.pullNumber !== undefined &&
+      snapshot.reviewPolicy !== 'off' &&
+      snapshot.gateMode === 'informational' &&
+      snapshot.reportingMode !== 'status' &&
+      (!this.cfg.daemonId || snapshot.dispatchDaemonId === this.cfg.daemonId) &&
+      !isGithubReviewCommentHook(hook)
+    )
+  }
+
+  /** Fill the trusted revision gap on issue_comment deliveries before either
+   * workspace preparation or hook/start. Formal reviews fail closed when the
+   * daemon cannot prove which base/head the model would review. */
+  private async ensureGithubPullRevision(
+    entry: QueueEntry,
+    required: boolean
+  ): Promise<GithubHookMetadata | undefined> {
+    const hook = entry.hookContext
+    const github = hook?.github
+    if (!hook || !github || github.subjectKind !== 'pull_request' || github.pullNumber === undefined) {
+      return github
+    }
+    if (github.headSha && github.baseSha) return github
+
+    try {
+      const postToken = await this.gitCreds.getPostToken(hook.agentId, github.repoFullName, hook.hookId)
+      const revision = await this.githubReviewClient.getPull(postToken.token, github.repoFullName, github.pullNumber)
+      hook.github = {
+        ...github,
+        headSha: revision.headSha,
+        baseSha: revision.baseSha,
+        reportSha: revision.headSha,
+        ...(revision.mergeCommitSha ? { mergeCommitSha: revision.mergeCommitSha } : {}),
+        isDraft: revision.draft
+      }
+      this.persistHookState(entry, undefined, true)
+      return hook.github
+    } catch (err) {
+      this.log.warn(`github review: unable to resolve PR revision (${formatErr(err)})`)
+      if (required) {
+        throw new Error('github review blocked: unable to resolve the authoritative PR base and head', {
+          cause: err
+        })
+      }
+      return undefined
+    }
+  }
+
+  private githubWorkspaceMatches(agent: Agent, github: GithubHookMetadata): boolean {
+    if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return false
+    try {
+      const clone = normalizeGitCloneUrl(agent.workspace.gitRepo)
+      const cloneHost = new URL(clone).hostname.toLowerCase()
+      // App-backed workspace URLs are canonicalized to GitHub by the daemon.
+      // Anonymous repos must already name GitHub; never reinterpret another
+      // host's owner/repo path as the trusted hook repository.
+      if (agent.workspace.gitCredential !== 'github-app' && cloneHost !== 'github.com') return false
+      const workspaceRepo = normalizeGithubRepoUrl(agent.workspace.gitRepo)
+        .replace(/\.git$/i, '')
+        .toLowerCase()
+      const hookRepo = normalizeGithubRepoUrl(github.repoFullName)
+        .replace(/\.git$/i, '')
+        .toLowerCase()
+      return workspaceRepo === hookRepo
+    } catch {
+      return false
+    }
+  }
+
+  /** Prepare an exact, isolated checkout before the model session starts. A
+   * formal review may use GitHub read-only inspection when its configured local
+   * repo differs, but it must never silently fall back to a stale checkout. */
+  private async prepareGithubReviewWorkspace(
+    entry: QueueEntry,
+    key: string,
+    agent: Agent
+  ): Promise<{
+    workspaceIsolation?: 'session'
+    forceWorkspaceIsolation?: true
+    preparedWorkspaceCwd?: string
+  }> {
+    const formalReview = this.githubFormalReviewEnabled(entry)
+    const initialGithub = entry.hookContext?.github
+    if (initialGithub?.subjectKind !== 'pull_request' || initialGithub.pullNumber === undefined) return {}
+
+    const github = await this.ensureGithubPullRevision(entry, formalReview)
+    if (!github?.headSha || !github.baseSha || github.pullNumber === undefined) {
+      entry.msg.text +=
+        '\n\nTrusted workspace check: the PR revision could not be resolved. Do not trust local files or repository traces; inspect the PR through GitHub read-only tools.'
+      return {}
+    }
+
+    const revisionLine = `Base SHA: ${github.baseSha}\nHead SHA: ${github.headSha}`
+    if (!this.githubWorkspaceMatches(agent, github)) {
+      entry.msg.text +=
+        `\n\nTrusted review revision:\n${revisionLine}\n` +
+        "This Agent's local workspace is not the pull request repository. Do not trust local files or repository traces for this review; inspect the exact base and head through GitHub read-only tools."
+      return {}
+    }
+
+    try {
+      const warmHost = this.readyHosts.has(agent.id) ? this.hosts.get(agent.id) : undefined
+      const preparedWorkspaceCwd = await this.prepareAgentWorkspace(agent, warmHost, {
+        sessionKey: key,
+        isolation: 'session',
+        review: {
+          pullNumber: github.pullNumber,
+          baseSha: github.baseSha,
+          headSha: github.headSha,
+          ...(github.mergeCommitSha ? { mergeCommitSha: github.mergeCommitSha } : {})
+        }
+      })
+      entry.msg.text +=
+        `\n\nTrusted review workspace:\n${revisionLine}\n` +
+        'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.'
+      return { workspaceIsolation: 'session', forceWorkspaceIsolation: true, preparedWorkspaceCwd }
+    } catch (err) {
+      if (formalReview) {
+        throw new Error('github review blocked: exact PR workspace preparation failed', { cause: err })
+      }
+      this.log.warn(`github review: exact workspace unavailable (${formatErr(err)})`)
+      entry.msg.text +=
+        `\n\nTrusted review revision:\n${revisionLine}\n` +
+        'The exact local checkout could not be prepared. Do not trust local files or repository traces; inspect the exact base and head through GitHub read-only tools.'
+      return {}
+    }
+  }
+
   /** Resolve a PR revision if the webhook omitted it (notably
    * issue_comment), cross the CP hook/start barrier, then return the active
    * review authority. Failure only disables structured effects; the agent turn
@@ -8087,23 +8248,7 @@ export class Daemon {
       return undefined
     }
 
-    if (!github.headSha || !github.baseSha) {
-      try {
-        const postToken = await this.gitCreds.getPostToken(hook.agentId, github.repoFullName, hook.hookId)
-        const revision = await this.githubReviewClient.getPull(postToken.token, github.repoFullName, github.pullNumber)
-        hook.github = {
-          ...github,
-          headSha: revision.headSha,
-          baseSha: revision.baseSha,
-          reportSha: revision.headSha,
-          isDraft: revision.draft
-        }
-        this.persistHookState(entry, undefined, true)
-      } catch (err) {
-        this.log.warn(`github review: unable to resolve PR revision (${formatErr(err)})`)
-        return undefined
-      }
-    }
+    if (!github.headSha || !github.baseSha) await this.ensureGithubPullRevision(entry, false)
 
     const trusted = hook.github!
     if (!trusted.headSha || !trusted.baseSha || trusted.pullNumber === undefined) return undefined
@@ -8380,7 +8525,8 @@ export class Daemon {
           msg.remoteMcp,
           op.mentions,
           op.post,
-          post
+          post,
+          op.worktree
         )
         return {
           msgId: msg.msgId,
@@ -10700,6 +10846,7 @@ export class Daemon {
     const persistedSessionId = this.store.getSession(key)?.acpSessionId
     let remoteMcpServer: import('@agentclientprotocol/sdk').McpServer | undefined
     try {
+      const reviewWorkspace = await this.prepareGithubReviewWorkspace(entry, key, agent)
       // A prior provider post-turn operation is serialized. Managed needs this
       // barrier before reading its index; external recordTurn only durably enqueues.
       await (this.memoryPostTurnChains.get(agentId) ?? Promise.resolve())
@@ -10763,7 +10910,11 @@ export class Daemon {
                 msg.platform === 'webchat' ||
                 this.pendingLaunchCorrelation.has(agentId) ||
                 this.conversationExternalSource(agentId, msg, callMeta !== undefined) !== undefined),
-          ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {})
+          ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {}),
+          ...(webchat?.worktree !== undefined
+            ? { workspaceIsolation: webchat.worktree ? ('session' as const) : ('shared' as const) }
+            : {}),
+          ...reviewWorkspace
         }
       )
     } catch (err) {
@@ -14453,7 +14604,7 @@ export class Daemon {
       // attempt. A failed ACP child had workspace write authority; re-verify the
       // immutable skill receipts after it is fully reaped and before constructing
       // its replacement, rather than trusting the first attempt's gate.
-      await this.prepareAgentWorkspace(agent, undefined, allowAgentDrain)
+      await this.prepareAgentWorkspace(agent, undefined, undefined, allowAgentDrain)
       if (this.hostStartGeneration.get(agentId) !== generation) {
         throw new Error(`host start superseded for ${agentId}`)
       }

--- a/packages/daemon/src/github/review.ts
+++ b/packages/daemon/src/github/review.ts
@@ -45,6 +45,7 @@ export interface GithubReviewTarget {
 export interface GithubPullRevision {
   headSha: string
   baseSha: string
+  mergeCommitSha?: string
   draft: boolean
   state: string
   merged: boolean
@@ -81,6 +82,7 @@ interface GithubPullResponse {
   draft?: boolean
   head?: { sha?: string }
   base?: { sha?: string }
+  merge_commit_sha?: string | null
 }
 
 interface GithubReviewResponse {
@@ -167,6 +169,7 @@ export class GithubReviewClient {
     return {
       headSha,
       baseSha,
+      ...(pull.merge_commit_sha ? { mergeCommitSha: pull.merge_commit_sha } : {}),
       draft: pull.draft === true,
       state: pull.state ?? 'unknown',
       merged: pull.merged === true

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -159,20 +159,14 @@ function githubReviewDecisionHint(
   if (github?.subjectKind !== 'pull_request') return ''
   if (reviewPolicy === 'off') return ''
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? '')
-  if (githubOpensReviewGeneration(event, github, reviewPolicy)) {
-    const passingEvent = reviewPolicy === 'full' ? 'APPROVE' : 'COMMENT'
-    const failingEvent = reviewPolicy === 'comment' ? 'COMMENT' : 'REQUEST_CHANGES'
-    return (
-      ' This delivery opens a review generation for the current PR revision. If you finish reviewing this revision, ' +
-      `record the actual verdict through \`submitGithubReview\`: use ${passingEvent} + pass when it passes, or ` +
-      `${failingEvent} + fail when it has blocking findings. An approval or rejection from an earlier revision does ` +
-      'not complete this revision; do not merely describe the verdict in your final reply.'
-    )
-  }
+  if (!githubOpensReviewGeneration(event, github, reviewPolicy)) return ''
+  const passingEvent = reviewPolicy === 'full' ? 'APPROVE' : 'COMMENT'
+  const failingEvent = reviewPolicy === 'comment' ? 'COMMENT' : 'REQUEST_CHANGES'
   return (
-    ' Use `submitGithubReview` only when this turn intentionally changes or records a code-review verdict. For an ' +
-    'ordinary conversational reply that does not change the current revision verdict, return the final reply for the ' +
-    'daemon-owned fallback and do not submit COMMENT + neutral merely to answer the conversation.'
+    ' This delivery opens a review generation for the current PR revision. If you finish reviewing this revision, ' +
+    `record the actual verdict through \`submitGithubReview\`: use ${passingEvent} + pass when it passes, or ` +
+    `${failingEvent} + fail when it has blocking findings. An approval or rejection from an earlier revision does ` +
+    'not complete this revision; do not merely describe the verdict in your final reply.'
   )
 }
 
@@ -200,8 +194,15 @@ function trustedInlineReplyTarget(
   return { repo: github.repoFullName, number: github.pullNumber }
 }
 
-function githubWorkspaceCheckHint(github: GithubHookMetadata | undefined): string {
+function githubWorkspaceCheckHint(github: GithubHookMetadata | undefined, exactReviewGeneration: boolean): string {
   if (github?.subjectKind !== 'pull_request') return ''
+  if (!exactReviewGeneration) {
+    return (
+      ' This delivery preserves the conversational worktree and does not prove its files match the PR revision. For ' +
+      'PR facts, use GitHub read-only tools or revision-addressed Git object reads; do not rely on working-tree paths ' +
+      'or HEAD alone.'
+    )
+  }
   return (
     ' Before trusting local files or repository traces, verify that the local HEAD is the trusted PR head or a merge ' +
     'whose parents are exactly the trusted base and head shown above. If that cannot be proven, use GitHub read-only ' +
@@ -221,21 +222,29 @@ function githubReplyHint(
 ): string {
   const inlineTarget = trustedInlineReplyTarget(c, github)
   const where = inlineTarget ? `${inlineTarget.repo}#${inlineTarget.number}` : `${c.repo ?? 'this thread'}#${c.number}`
+  const event = c.action ? `${c.event}:${c.action}` : (c.event ?? '')
+  const reviewGeneration = githubOpensReviewGeneration(event, github, reviewPolicy)
   if (inlineTarget) {
     return [
       '',
-      `Return one self-contained final answer for the triggering inline review conversation. The daemon posts that final back to the existing review thread on ${where} automatically and exclusively owns the inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned inline reply.${githubWorkspaceCheckHint(github)}`
+      `Return one self-contained final answer for the triggering inline review conversation. The daemon posts that final back to the existing review thread on ${where} automatically and exclusively owns the inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned inline reply.${githubWorkspaceCheckHint(github, false)}`
     ].join('\n')
   }
   if (c.event === 'pull_request_review_comment') {
     return [
       '',
-      `Return one self-contained final answer for the triggering review conversation. This delivery does not carry trusted inline-thread metadata, so the daemon posts that final back to ${where} automatically as one ordinary GitHub comment. Formal GitHub reviews are unavailable for this review-comment event family, and the daemon exclusively owns the fallback comment. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned fallback comment.${githubWorkspaceCheckHint(github)}`
+      `Return one self-contained final answer for the triggering review conversation. This delivery does not carry trusted inline-thread metadata, so the daemon posts that final back to ${where} automatically as one ordinary GitHub comment. Formal GitHub reviews are unavailable for this review-comment event family, and the daemon exclusively owns the fallback comment. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned fallback comment.${githubWorkspaceCheckHint(github, false)}`
+    ].join('\n')
+  }
+  if (!reviewGeneration) {
+    return [
+      '',
+      `Return one self-contained final answer for this GitHub conversation. The daemon posts that final back to ${where} automatically and exclusively owns the reply. Formal GitHub review submission is unavailable for this delivery. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection, then return the final answer for the daemon-owned reply.${githubWorkspaceCheckHint(github, false)}`
     ].join('\n')
   }
   return [
     '',
-    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. If this active PR hook permits a formal review, use only the structured \`submitGithubReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.${githubWorkspaceCheckHint(github)}`
+    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. Use only the structured \`submitGithubReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.${githubWorkspaceCheckHint(github, true)}`
   ].join('\n')
 }
 

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -184,6 +184,15 @@ function trustedInlineReplyTarget(
   return { repo: github.repoFullName, number: github.pullNumber }
 }
 
+function githubWorkspaceCheckHint(github: GithubHookMetadata | undefined): string {
+  if (github?.subjectKind !== 'pull_request') return ''
+  return (
+    ' Before trusting local files or repository traces, verify that the local HEAD is the trusted PR head or a merge ' +
+    'whose parents are exactly the trusted base and head shown above. If that cannot be proven, use GitHub read-only ' +
+    'inspection for the exact revision instead; never infer a finding from another checkout.'
+  )
+}
+
 /** Trailing instruction for github fires on a NUMBERED thread (issue/PR): the
  *  daemon is the sole writer of the reply comment, so the agent must return its
  *  answer rather than mutate comments/reviews through CLI, MCP, connector, or API.
@@ -199,18 +208,18 @@ function githubReplyHint(
   if (inlineTarget) {
     return [
       '',
-      `Return one self-contained final answer for the triggering inline review conversation. The daemon posts that final back to the existing review thread on ${where} automatically and exclusively owns the inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned inline reply.`
+      `Return one self-contained final answer for the triggering inline review conversation. The daemon posts that final back to the existing review thread on ${where} automatically and exclusively owns the inline reply. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned inline reply.${githubWorkspaceCheckHint(github)}`
     ].join('\n')
   }
   if (c.event === 'pull_request_review_comment') {
     return [
       '',
-      `Return one self-contained final answer for the triggering review conversation. This delivery does not carry trusted inline-thread metadata, so the daemon posts that final back to ${where} automatically as one ordinary GitHub comment. Formal GitHub reviews are unavailable for this review-comment event family, and the daemon exclusively owns the fallback comment. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned fallback comment.`
+      `Return one self-contained final answer for the triggering review conversation. This delivery does not carry trusted inline-thread metadata, so the daemon posts that final back to ${where} automatically as one ordinary GitHub comment. Formal GitHub reviews are unavailable for this review-comment event family, and the daemon exclusively owns the fallback comment. Do NOT create, update, or delete GitHub comments or formal reviews through a tool, \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return the final answer for the daemon-owned fallback comment.${githubWorkspaceCheckHint(github)}`
     ].join('\n')
   }
   return [
     '',
-    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. If this active PR hook permits a formal review, use only the structured \`submitGithubReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.`
+    `Your final reply is kept in the session transcript and is posted back to ${where} automatically as an ordinary GitHub comment only when no formal review was attempted or the current attempt definitively returns \`not_submitted\`. Keep it self-contained; the daemon exclusively owns that fallback reply comment. If this active PR hook permits a formal review, use only the structured \`submitGithubReview\` tool for COMMENT / REQUEST_CHANGES / APPROVE and inline review comments. Its \`body\` must be a complete, self-contained, non-empty public review summary (including for APPROVE), because a submitted, ambiguous, or otherwise unresolved formal attempt suppresses the ordinary comment.${githubReviewDecisionHint(c, github, reviewPolicy)} Do NOT create, update, or delete GitHub comments or formal reviews through \`gh\`, another CLI, a connector, or a direct API call — those paths would race or double-post. Other GitHub tools are for READ-only inspection (thread, diff, files), then return a self-contained final reply for the transcript and fallback path.${githubWorkspaceCheckHint(github)}`
   ].join('\n')
 }
 
@@ -228,6 +237,8 @@ function buildGithubHookText(
     `From: ${c.senderLogin ?? 'unknown'}${c.authorAssociation ? ` (${c.authorAssociation})` : ''}${
       c.labels?.length ? ` · labels: ${c.labels.join(', ')}` : ''
     }`,
+    ...(github?.baseSha ? [`Base SHA: ${github.baseSha}`] : []),
+    ...(github?.headSha ? [`Head SHA: ${github.headSha}`] : []),
     ...(c.htmlUrl ? [c.htmlUrl] : [])
   ].join('\n')
   // Ordinary replies use the display context's number. Inline replies instead

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -135,6 +135,22 @@ const GITHUB_REVISION_REVIEW_EVENTS = new Set([
   'check_run:requested_action'
 ])
 
+/** True only when this delivery opens a review generation for the current PR
+ * revision. Ordinary PR conversations may still intentionally submit a review,
+ * but must not destructively replace their stable conversational worktree. */
+export function githubOpensReviewGeneration(
+  event: string | undefined,
+  github: GithubHookMetadata | undefined,
+  reviewPolicy: RdMsgHook['reviewPolicy']
+): boolean {
+  return Boolean(
+    github?.subjectKind === 'pull_request' &&
+    reviewPolicy !== undefined &&
+    reviewPolicy !== 'off' &&
+    (github.explicitReviewRequest || GITHUB_REVISION_REVIEW_EVENTS.has(event ?? ''))
+  )
+}
+
 function githubReviewDecisionHint(
   c: HookContext,
   github: GithubHookMetadata | undefined,
@@ -143,7 +159,7 @@ function githubReviewDecisionHint(
   if (github?.subjectKind !== 'pull_request') return ''
   if (reviewPolicy === 'off') return ''
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? '')
-  if (reviewPolicy !== undefined && (github.explicitReviewRequest || GITHUB_REVISION_REVIEW_EVENTS.has(event))) {
+  if (githubOpensReviewGeneration(event, github, reviewPolicy)) {
     const passingEvent = reviewPolicy === 'full' ? 'APPROVE' : 'COMMENT'
     const failingEvent = reviewPolicy === 'comment' ? 'COMMENT' : 'REQUEST_CHANGES'
     return (

--- a/packages/daemon/src/runtimes/launch-policy.ts
+++ b/packages/daemon/src/runtimes/launch-policy.ts
@@ -152,6 +152,7 @@ export function composeRuntimeLaunch(opts: {
   /** Additional daemon-owned code/socket/config paths required by trusted
    * descendants such as the AgentConnect MCP bridge. */
   runtimeReadRoots?: string[]
+  trustedWorkspaceWriteRoots?: string[]
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
   allowModelToolUnixSockets?: boolean
@@ -182,6 +183,7 @@ export function composeRuntimeLaunch(opts: {
     daemonRoot: opts.daemonRoot,
     agentsRoot: opts.agentsRoot,
     trustedRuntimeReadRoots: [...(sandboxAccess?.readRoots ?? []), ...(opts.runtimeReadRoots ?? [])],
+    trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,
     allowModelToolUnixSockets: opts.allowModelToolUnixSockets

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -246,7 +246,11 @@ export class SessionManager {
        * reconciliation. Tests and the standalone chat CLI use the ordinary
        * workspace preparer. Production also passes the ordinary warm host so
        * teardown can reject a preparation registered by a stale generation. */
-      prepareWorkspace?: (agent: Agent, expectedWarmHost?: AcpHost) => Promise<string>
+      prepareWorkspace?: (
+        agent: Agent,
+        expectedWarmHost?: AcpHost,
+        request?: { sessionKey: string; isolation: 'shared' | 'session' }
+      ) => Promise<string>
       /** Resolve the cwd produced by hostFor's cold preparation without
        * repeating pull/source acquisition/reconciliation. Production supplies
        * this seam; lightweight host mocks fall back to pre-host preparation. */
@@ -375,6 +379,13 @@ export class SessionManager {
        * memory. Computed by the daemon before any transcript or prompt body is
        * handed to this method. */
       sharedMemoryExcluded?: boolean
+      /** Product Worktree override for a brand-new logical session. Existing
+       * sessions keep their persisted choice unless the trusted review path
+       * explicitly forces an exact workspace migration. */
+      workspaceIsolation?: 'shared' | 'session'
+      forceWorkspaceIsolation?: boolean
+      /** A daemon-verified cwd prepared before handle() (GitHub exact-ref turns). */
+      preparedWorkspaceCwd?: string
     } = {}
   ): Promise<{
     sessionId: string
@@ -498,6 +509,23 @@ export class SessionManager {
         this.deps.store.upsertSession(rec)
       }
     }
+    const requestedWorkspaceIsolation =
+      agent.workspace.mode === 'git-repo' ? (options.workspaceIsolation ?? agent.workspace.isolation) : 'shared'
+    const workspaceIsolation =
+      options.forceWorkspaceIsolation === true
+        ? requestedWorkspaceIsolation
+        : (rec?.workspaceIsolation ?? requestedWorkspaceIsolation)
+    if (rec && rec.workspaceIsolation !== workspaceIsolation) {
+      rec = {
+        ...rec,
+        workspaceIsolation,
+        ...(options.forceWorkspaceIsolation
+          ? { acpSessionId: null, state: rec.state === 'closed' ? 'closed' : 'idle', lastDeliveredTs: null }
+          : {}),
+        updatedAt: Date.now()
+      }
+      this.deps.store.upsertSession(rec)
+    }
     // Durable parent link (§5.3): prefer the origin persisted on the session (present on EVERY
     // turn of a spawned session) over this turn's wake origin (only the one agent-call turn that
     // first spawns the session carries it). This value both drives the `Parent session` line and,
@@ -537,7 +565,12 @@ export class SessionManager {
     const hostCold = options.host ? false : !(this.deps.isHostRunning?.(agentId) ?? false)
     let preparedCwd =
       hostCold && !this.deps.resolvePreparedWorkspace
-        ? await abortable(() => this.deps.prepareWorkspace?.(agent) ?? prepareWorkspace(agent), signal)
+        ? await abortable(
+            () =>
+              this.deps.prepareWorkspace?.(agent, undefined, { sessionKey: key, isolation: workspaceIsolation }) ??
+              prepareWorkspace(agent),
+            signal
+          )
         : undefined
     const host = options.host ?? (await abortable(() => this.deps.hostFor(agentId), signal))
     // Explicit private-cell hosts are not owned by the daemon's ordinary host
@@ -776,9 +809,12 @@ export class SessionManager {
       // brand-new session; use the pre-host preparation when the host was cold, else
       // prepare now (warm host — ordering vs spawn is moot).
       const cwd =
-        preparedCwd ??
+        options.preparedWorkspaceCwd ??
+        (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost) ?? prepareWorkspace(agent),
+          () =>
+            this.deps.prepareWorkspace?.(agent, expectedWarmHost, { sessionKey: key, isolation: workspaceIsolation }) ??
+            prepareWorkspace(agent),
           signal
         ))
       const mcpServers = [
@@ -811,6 +847,7 @@ export class SessionManager {
         // from the GitHub actor credited on the transcript row above.
         triggeredBy: msg.sessionTriggerId ?? msg.sender.id,
         memoryProvider: currentMemoryProvider,
+        workspaceIsolation,
         // Durable parent link, set once at spawn (first-wins in the store).
         ...(effectiveOriginSessionId ? { originSessionId: effectiveOriginSessionId } : {}),
         // Durable report-back obligation (sticky-true in the store).
@@ -830,9 +867,12 @@ export class SessionManager {
       // Resume: use the pre-host preparation when the host cold-started here (persisted
       // session after restart/eviction — skills must precede spawn), else prepare now.
       const cwd =
-        preparedCwd ??
+        options.preparedWorkspaceCwd ??
+        (workspaceIsolation === 'shared' ? preparedCwd : undefined) ??
         (await abortable(
-          () => this.deps.prepareWorkspace?.(agent, expectedWarmHost) ?? prepareWorkspace(agent),
+          () =>
+            this.deps.prepareWorkspace?.(agent, expectedWarmHost, { sessionKey: key, isolation: workspaceIsolation }) ??
+            prepareWorkspace(agent),
           signal
         ))
       // Resolved once, shared by both paths: session/load must re-attach the same

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -93,6 +93,9 @@ export interface SessionRecord {
   // so later turns edit the same status line instead of posting duplicates.
   statusBarTs?: string | null
   memoryProvider?: 'none' | 'native' | 'managed' | 'external' | null
+  /** Workspace choice pinned when the logical session is created. A manual
+   * Playground override is therefore session-local and survives daemon restarts. */
+  workspaceIsolation?: 'shared' | 'session' | null
   conversationKind?: 'dm' | 'group_dm' | 'channel' | null
   // Immutable trusted source binding for supported shared input. These fields
   // are metadata only and are echoed on every event/session milestone.
@@ -506,7 +509,7 @@ export class LocalStore {
         transportScope TEXT, acpSessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
         usage TEXT, muted INTEGER, triggeredBy TEXT, title TEXT, modelOverride TEXT,
         effortOverride TEXT, permissionModeOverride TEXT, fastModeOverride INTEGER,
-        outputModeOverride TEXT, statusBarTs TEXT, memoryProvider TEXT,
+        outputModeOverride TEXT, statusBarTs TEXT, memoryProvider TEXT, workspaceIsolation TEXT,
         originSessionId TEXT, lastTurnOutcome TEXT, needsParentReply INTEGER,
         externalProvider TEXT, externalRealmKey TEXT, externalResourceKind TEXT,
         externalResourceKey TEXT, externalIntegrationId TEXT, externalOriginJson TEXT,
@@ -1104,6 +1107,8 @@ export class LocalStore {
     if (!cols.some((c) => c.name === 'statusBarTs')) this.db.exec('ALTER TABLE sessions ADD COLUMN statusBarTs TEXT')
     if (!cols.some((c) => c.name === 'memoryProvider'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN memoryProvider TEXT')
+    if (!cols.some((c) => c.name === 'workspaceIsolation'))
+      this.db.exec('ALTER TABLE sessions ADD COLUMN workspaceIsolation TEXT')
     if (!cols.some((c) => c.name === 'originSessionId'))
       this.db.exec('ALTER TABLE sessions ADD COLUMN originSessionId TEXT')
     if (!cols.some((c) => c.name === 'lastTurnOutcome'))
@@ -1674,13 +1679,13 @@ export class LocalStore {
     this.db
       .prepare(
         `INSERT INTO sessions
-           (key, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, memoryProvider, originSessionId, needsParentReply,
+           (key, agentId, platform, channel, thread, transportScope, acpSessionId, state, lastDeliveredTs, updatedAt, muted, triggeredBy, memoryProvider, workspaceIsolation, originSessionId, needsParentReply,
             externalProvider, externalRealmKey, externalResourceKind, externalResourceKey, externalIntegrationId,
             externalOriginJson, sourceBindingKind)
          VALUES
            (@key, @agentId, @platform, @channel, @thread, @transportScope, @acpSessionId, @state, @lastDeliveredTs, @updatedAt,
             CASE WHEN EXISTS (SELECT 1 FROM session_mutes WHERE key = @key) THEN 1 ELSE NULL END,
-            @triggeredBy, @memoryProvider, @originSessionId, @needsParentReply,
+            @triggeredBy, @memoryProvider, @workspaceIsolation, @originSessionId, @needsParentReply,
             @externalProvider, @externalRealmKey, @externalResourceKind, @externalResourceKey, @externalIntegrationId,
             @externalOriginJson, @sourceBindingKind)
          ON CONFLICT(key) DO UPDATE SET
@@ -1693,6 +1698,7 @@ export class LocalStore {
            END,
            triggeredBy=COALESCE(sessions.triggeredBy, excluded.triggeredBy),
            memoryProvider=excluded.memoryProvider,
+           workspaceIsolation=COALESCE(excluded.workspaceIsolation, sessions.workspaceIsolation),
            externalProvider=COALESCE(sessions.externalProvider, excluded.externalProvider),
            externalRealmKey=COALESCE(sessions.externalRealmKey, excluded.externalRealmKey),
            externalResourceKind=COALESCE(sessions.externalResourceKind, excluded.externalResourceKind),
@@ -1727,6 +1733,7 @@ export class LocalStore {
         updatedAt: rec.updatedAt,
         triggeredBy: rec.triggeredBy ?? null,
         memoryProvider: rec.memoryProvider ?? null,
+        workspaceIsolation: rec.workspaceIsolation ?? null,
         externalProvider: rec.externalProvider ?? null,
         externalRealmKey: rec.externalRealmKey ?? null,
         externalResourceKind: rec.externalResourceKind ?? null,

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1,6 +1,7 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -53,6 +54,19 @@ export interface PrepareWorkspaceOptions {
   skillsAgentId?: string | null
 }
 
+export interface GithubReviewWorkspaceRevision {
+  pullNumber: number
+  baseSha: string
+  headSha: string
+  mergeCommitSha?: string
+}
+
+export interface PrepareSessionWorkspaceRequest {
+  sessionKey: string
+  isolation: 'shared' | 'session'
+  review?: GithubReviewWorkspaceRevision
+}
+
 async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
   // Resolving local sources (managed cache + accepted Dream) is best-effort: a
   // failure to read/validate them means we install none of THOSE sources, not
@@ -82,7 +96,9 @@ async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOp
 }
 
 const PULL_TIMEOUT_MS = 4500
+const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const MATERIALIZATION_FILE = 'workspace-materialization.json'
+const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
 
 // Single-flight clone lock keyed by the absolute cwd. Two concurrent sessions
 // (especially multiple agents sharing one repo checkout) must not race into the
@@ -312,6 +328,175 @@ export async function prepareWorkspace(agent: Agent, opts: PrepareWorkspaceOptio
   return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
 }
 
+/** Daemon-owned parent for logical-session worktrees. It sits beside the main
+ * checkout so both stay inside one agent's filesystem/sandbox boundary. */
+export function sessionWorktreeRoot(agent: Agent): string {
+  const agentRoot = (agent as { dir?: string }).dir ?? dirname(agent.workspace.path)
+  return join(agentRoot, 'worktrees')
+}
+
+function prepareSessionWorktreeRoot(agent: Agent): string {
+  const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
+  const root = sessionWorktreeRoot(agent)
+  if (existsSync(root) && lstatSync(root).isSymbolicLink()) {
+    throw new Error('session worktree root must not be a symlink')
+  }
+  mkdirSync(root, { recursive: true, mode: 0o700 })
+  const canonicalRoot = realpathSync(root)
+  const rel = relative(agentRoot, canonicalRoot)
+  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+    throw new Error('session worktree root resolves outside the agent directory')
+  }
+  return canonicalRoot
+}
+
+function clearSessionWorktrees(agent: Agent): void {
+  rmSync(sessionWorktreeRoot(agent), { recursive: true, force: true })
+}
+
+function sessionWorktreeId(sessionKey: string): string {
+  return createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
+}
+
+function exactObjectId(value: string, label: string): string {
+  if (!GIT_OBJECT_ID.test(value)) throw new Error(`github review ${label} is not a Git object id`)
+  return value.toLowerCase()
+}
+
+async function revParse(cwd: string, ref: string): Promise<string> {
+  return (
+    await gitFor(cwd)
+      .env(workspaceGitLocalEnv())
+      .raw(['rev-parse', '--verify', `${ref}^{commit}`])
+  ).trim()
+}
+
+async function fetchReviewRevision(
+  agent: Agent,
+  worktreeId: string,
+  review: GithubReviewWorkspaceRevision
+): Promise<{ base: string; head: string; checkout: string }> {
+  const base = exactObjectId(review.baseSha, 'base SHA')
+  const head = exactObjectId(review.headSha, 'head SHA')
+  if (!Number.isSafeInteger(review.pullNumber) || review.pullNumber <= 0) {
+    throw new Error('github review pull number is invalid')
+  }
+  const root = `refs/agentconnect/reviews/${worktreeId}`
+  const baseRef = `${root}/base`
+  const headRef = `${root}/head`
+  const mergeRef = `${root}/merge`
+  const repository = gitRepoOf(agent)
+  await assertSafeWorkspaceGitConfig(agent.workspace.path)
+  if (usesGithubApp(agent)) await preWarmGitCred(agent.id, 'pull')
+  const pullTarget = workspaceGitPullTarget(repository)
+  const abort = new AbortController()
+  const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
+  try {
+    const git = gitFor(agent.workspace.path, abort.signal).env({
+      ...pullTarget.env,
+      ...(usesGithubApp(agent) ? gitCredentialEnv(agent.id) : {}),
+      GIT_TERMINAL_PROMPT: '0'
+    })
+    await git.raw([
+      'fetch',
+      '--force',
+      '--no-tags',
+      '--no-recurse-submodules',
+      pullTarget.remote,
+      `+${base}:${baseRef}`,
+      `+refs/pull/${review.pullNumber}/head:${headRef}`
+    ])
+    if ((await revParse(agent.workspace.path, baseRef)).toLowerCase() !== base) {
+      throw new Error('github review base ref did not resolve to the requested SHA')
+    }
+    if ((await revParse(agent.workspace.path, headRef)).toLowerCase() !== head) {
+      throw new Error('github review head ref did not resolve to the requested SHA')
+    }
+
+    // A conflicted PR has no merge ref. Head remains an exact, reviewable
+    // checkout; when GitHub does provide a merge ref, trust it only after proving
+    // both parents are the exact base/head pair carried by the hook.
+    await git.raw(['update-ref', '-d', mergeRef]).catch(() => undefined)
+    try {
+      await git.raw([
+        'fetch',
+        '--force',
+        '--no-tags',
+        '--no-recurse-submodules',
+        pullTarget.remote,
+        `+refs/pull/${review.pullNumber}/merge:${mergeRef}`
+      ])
+      const merge = (await revParse(agent.workspace.path, mergeRef)).toLowerCase()
+      const expectedMerge = review.mergeCommitSha ? exactObjectId(review.mergeCommitSha, 'merge SHA') : undefined
+      const parents = (
+        await gitFor(agent.workspace.path)
+          .env(workspaceGitLocalEnv())
+          .raw(['rev-list', '--parents', '-n', '1', mergeRef])
+      )
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+      if (
+        (!expectedMerge || merge === expectedMerge) &&
+        parents.length === 3 &&
+        parents[1] === base &&
+        parents[2] === head
+      ) {
+        return { base, head, checkout: merge }
+      }
+    } catch {
+      // Exact head/base refs above are authoritative; merge is optional.
+    }
+    return { base, head, checkout: head }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Prepare the stable cwd for one logical session. Ordinary worktrees preserve
+ * their working state between turns. Review worktrees are daemon-owned snapshots
+ * and are reset on every delivery after an exact remote fetch. */
+export async function prepareSessionWorkspace(
+  agent: Agent,
+  request: PrepareSessionWorkspaceRequest,
+  opts: PrepareWorkspaceOptions = {}
+): Promise<string> {
+  const primary = await prepareWorkspace(agent, opts)
+  if (agent.workspace.mode !== 'git-repo' || request.isolation === 'shared') return primary
+
+  const id = sessionWorktreeId(request.sessionKey)
+  const root = prepareSessionWorktreeRoot(agent)
+  const cwd = join(root, id)
+  if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+    throw new Error('session worktree path must not be a symlink')
+  }
+  const review = request.review ? await fetchReviewRevision(agent, id, request.review) : undefined
+  const target = review?.checkout ?? `refs/remotes/origin/${agent.workspace.gitBranch}`
+  let attached = existsSync(join(cwd, '.git'))
+  if (attached) {
+    try {
+      await revParse(cwd, 'HEAD')
+    } catch {
+      attached = false
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  }
+  if (!attached) {
+    rmSync(cwd, { recursive: true, force: true })
+    await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
+    await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'add', '--detach', cwd, target])
+  } else if (review) {
+    const worktreeGit = gitFor(cwd).env(workspaceGitLocalEnv())
+    await worktreeGit.raw(['reset', '--hard', target])
+    await worktreeGit.raw(['clean', '-ffd'])
+  }
+  if (review && (await revParse(cwd, 'HEAD')).toLowerCase() !== review.checkout) {
+    throw new Error('github review worktree HEAD does not match the verified revision')
+  }
+  const agentDir = normalizeRepoSubdir(agent.workspace.agentDir)
+  return withSkills(agent, resolveAcpCwd(cwd, agentDir), opts)
+}
+
 /** Resolve the already-prepared ACP cwd without pulling, acquiring sources, or
  * reconciling skills. The daemon cold-host gate calls prepareWorkspace before
  * spawn; SessionManager uses this pure follow-up to consume that same result
@@ -399,6 +584,7 @@ export async function prepareWorkspaceForActivation(
 
   if (agent.workspace.mode === 'from-scratch') {
     if (replace) {
+      clearSessionWorktrees(agent)
       rmSync(cwd, { recursive: true, force: true })
       mkdirSync(cwd, { recursive: true })
     }
@@ -444,6 +630,7 @@ export async function prepareWorkspaceForActivation(
     await cloneRepoAt(agent, staged)
     resolveAcpCwd(staged, normalizeRepoSubdir(agent.workspace.agentDir))
     if (replace) {
+      clearSessionWorktrees(agent)
       rmSync(cwd, { recursive: true, force: true })
       renameSync(staged, cwd)
       try {

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -495,6 +495,58 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   })
 
+  it('preserves the stable worktree for an ordinary PR conversation', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-conversation-workspace'),
+        gitRepo: 'https://github.com/acme/infra',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true
+      }
+    })
+    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace')
+    const entry = {
+      msg: { text: 'Answer this pull request question.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'ordinary-pr-conversation',
+        firedAt: new Date().toISOString(),
+        event: 'issue_comment:created',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha: 'a'.repeat(40),
+          baseSha: 'b'.repeat(40),
+          reportSha: 'a'.repeat(40)
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+    ).resolves.toEqual({})
+    expect(prepare).not.toHaveBeenCalled()
+    expect(entry.msg.text).toBe('Answer this pull request question.')
+    await daemon.stop()
+  })
+
   it('disables formal-review authority by event family when a rolling relay omits inline ids', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
     await daemon.start()

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -386,7 +386,7 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('retains formal-review authority for pull-request issue_comment hooks', async () => {
+  it('grants formal-review authority only when an issue_comment explicitly requests review', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
     await daemon.start()
     const dispatchDaemonId = (daemon as any).cfg.daemonId as string
@@ -421,10 +421,21 @@ describe('Daemon rd/msg hook fires', () => {
       }
     }
 
-    const active = await (daemon as any).prepareGithubTurn({ hookContext: hook }, 'acp-issue-comment')
+    const ordinary = await (daemon as any).prepareGithubTurn({ hookContext: hook }, 'acp-issue-comment')
 
-    expect(startHook).toHaveBeenCalledOnce()
-    expect(active).toMatchObject({ hook, reviewState: 'idle', pullNumber: 42 })
+    const explicitHook = {
+      ...hook,
+      deliveryKey: 'explicit-review-comment',
+      github: { ...hook.github, explicitReviewRequest: true }
+    }
+    const explicit = await (daemon as any).prepareGithubTurn(
+      { hookContext: explicitHook },
+      'acp-explicit-review-comment'
+    )
+
+    expect(startHook).toHaveBeenCalledTimes(2)
+    expect(ordinary).toBeUndefined()
+    expect(explicit).toMatchObject({ hook: explicitHook, reviewState: 'idle', pullNumber: 42 })
     await daemon.stop()
   })
 
@@ -1872,20 +1883,18 @@ describe('buildHookMessage', () => {
 
     it('a numbered thread carries the auto-reply hint (do not self-comment); a threadless push does not', () => {
       const withThread = buildHookText(ghFire())
-      expect(withThread).toContain('posted back to acme/infra#42 automatically')
-      expect(withThread).toContain('daemon exclusively owns that fallback reply comment')
-      expect(withThread).toContain('structured `submitGithubReview` tool')
-      expect(withThread).toContain('including for APPROVE')
-      expect(withThread).toContain('only when no formal review was attempted')
-      expect(withThread).toContain('submitted, ambiguous, or otherwise unresolved formal attempt suppresses')
+      expect(withThread).toContain('posts that final back to acme/infra#42 automatically')
+      expect(withThread).toContain('exclusively owns the reply')
+      expect(withThread).toContain('Formal GitHub review submission is unavailable')
+      expect(withThread).not.toContain('submitGithubReview')
       expect(withThread).toContain('Do NOT create, update, or delete GitHub comments or formal reviews')
       expect(withThread).toContain('`gh`, another CLI, a connector, or a direct API call')
       expect(withThread).toContain('Other GitHub tools are for READ-only inspection')
-      // PR conversation comments can still initiate a formal review when the
-      // hook policy permits it, so they retain the structured-review guidance.
+      // Ordinary PR conversations preserve their worktree and cannot submit a
+      // formal verdict. A mention identified by the relay opens a review below.
       const issueComment = buildHookText(ghFire({ event: 'issue_comment', action: 'created' }))
-      expect(issueComment).toContain('structured `submitGithubReview` tool')
-      expect(issueComment).not.toContain('do not submit COMMENT + neutral merely to answer the conversation')
+      expect(issueComment).toContain('Formal GitHub review submission is unavailable')
+      expect(issueComment).not.toContain('submitGithubReview')
       const prConversation = buildHookText(
         ghFire(
           { event: 'issue_comment', action: 'created' },
@@ -1901,7 +1910,9 @@ describe('buildHookMessage', () => {
           }
         )
       )
-      expect(prConversation).toContain('do not submit COMMENT + neutral merely to answer the conversation')
+      expect(prConversation).toContain('does not prove its files match the PR revision')
+      expect(prConversation).toContain('revision-addressed Git object reads')
+      expect(prConversation).not.toContain('submitGithubReview')
       const revisionReview = buildHookText(
         ghFire(
           { event: 'pull_request', action: 'synchronize' },
@@ -1921,6 +1932,7 @@ describe('buildHookMessage', () => {
         )
       )
       expect(revisionReview).toContain('opens a review generation for the current PR revision')
+      expect(revisionReview).toContain('structured `submitGithubReview` tool')
       expect(revisionReview).toContain(`Base SHA: ${'b'.repeat(40)}`)
       expect(revisionReview).toContain(`Head SHA: ${'a'.repeat(40)}`)
       expect(revisionReview).toContain('Before trusting local files or repository traces')
@@ -2066,7 +2078,8 @@ describe('buildHookMessage', () => {
       )
       expect(text).not.toContain('opens a review generation for the current PR revision')
       expect(text).not.toContain('use APPROVE + pass when it passes')
-      expect(text).not.toContain('do not submit COMMENT + neutral merely to answer the conversation')
+      expect(text).toContain('Formal GitHub review submission is unavailable')
+      expect(text).not.toContain('submitGithubReview')
     })
 
     it('a body quoting the delimiters cannot close the fence (delimiter lines are defanged)', () => {

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -428,6 +428,73 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   })
 
+  it('prepares an exact isolated workspace before a formal review turn', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-review-workspace'),
+        gitRepo: 'https://github.com/acme/infra',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true
+      }
+    })
+    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi.spyOn(daemon as any, 'prepareAgentWorkspace').mockResolvedValue('/agent/worktrees/review')
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const entry = {
+      msg: { text: 'Review this pull request.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'exact-review',
+        firedAt: new Date().toISOString(),
+        event: 'pull_request:synchronize',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha,
+          baseSha,
+          reportSha: headSha
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+    ).resolves.toEqual({
+      workspaceIsolation: 'session',
+      forceWorkspaceIsolation: true,
+      preparedWorkspaceCwd: '/agent/worktrees/review'
+    })
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: AGENT_ID }),
+      undefined,
+      expect.objectContaining({
+        sessionKey: 'hook:acme/infra#461',
+        isolation: 'session',
+        review: { pullNumber: 461, baseSha, headSha }
+      })
+    )
+    expect(entry.msg.text).toContain('Trusted review workspace')
+    expect(entry.msg.text).toContain('verify `git rev-parse HEAD`')
+    await daemon.stop()
+  })
+
   it('disables formal-review authority by event family when a rolling relay omits inline ids', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: streamingHost().factory })
     await daemon.start()
@@ -1802,6 +1869,9 @@ describe('buildHookMessage', () => {
         )
       )
       expect(revisionReview).toContain('opens a review generation for the current PR revision')
+      expect(revisionReview).toContain(`Base SHA: ${'b'.repeat(40)}`)
+      expect(revisionReview).toContain(`Head SHA: ${'a'.repeat(40)}`)
+      expect(revisionReview).toContain('Before trusting local files or repository traces')
       expect(revisionReview).toContain('use APPROVE + pass when it passes')
       expect(revisionReview).toContain(
         'An approval or rejection from an earlier revision does not complete this revision'

--- a/packages/daemon/test/github/review.test.ts
+++ b/packages/daemon/test/github/review.test.ts
@@ -35,6 +35,27 @@ const attribution = {
 }
 
 describe('GithubReviewClient', () => {
+  it('returns the merge revision GitHub associates with the current pull', async () => {
+    const mergeCommitSha = 'c'.repeat(40)
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      json(200, {
+        state: 'open',
+        merged: false,
+        draft: false,
+        head: { sha: target.expectedHeadSha },
+        base: { sha: target.expectedBaseSha },
+        merge_commit_sha: mergeCommitSha
+      })
+    )
+    const client = new GithubReviewClient({ fetchImpl })
+
+    await expect(client.getPull(target.token, target.repoFullName, target.pullNumber)).resolves.toMatchObject({
+      headSha: target.expectedHeadSha,
+      baseSha: target.expectedBaseSha,
+      mergeCommitSha
+    })
+  })
+
   it('validates event/verdict before any network effect', async () => {
     const fetchImpl = vi.fn<typeof fetch>()
     const client = new GithubReviewClient({ fetchImpl })

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -86,7 +86,10 @@ describe('SessionManager', () => {
 
     await sm.handle('bot-a', msg({ ts: '100.2', thread: '100.2', text: 'warm session' }))
 
-    expect(prepareWorkspace).toHaveBeenCalledWith(agent, host)
+    expect(prepareWorkspace).toHaveBeenCalledWith(agent, host, {
+      sessionKey: 'slack:C1:100.2:bot-a',
+      isolation: 'shared'
+    })
     store.close()
   })
 

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -40,10 +40,12 @@ vi.mock('simple-git', () => ({
 const {
   convergeGithubAppWorkspaceRename,
   ensureWorkspaceMaterialization,
+  prepareSessionWorkspace,
   prepareWorkspace,
   prepareWorkspaceForActivation,
   prefetchWorkspace,
-  recordWorkspaceMaterialization
+  recordWorkspaceMaterialization,
+  sessionWorktreeRoot
 } = await import('../src/workspace/workspace-manager.js')
 const { initGitInjection } = await import('../src/workspace/git-injection.js')
 
@@ -262,6 +264,78 @@ describe('prepareWorkspace', () => {
     symlinkSync(outside, join(dir, 'outside-link'))
 
     await expect(prepareWorkspace(gitRepoAgent(dir, 'outside-link'))).rejects.toThrow('outside the repository')
+  })
+})
+
+describe('prepareSessionWorkspace', () => {
+  it('fetches and checks out the exact trusted PR revision in a session worktree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-review-ws-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    agent.workspace.pullOnNewSession = false
+    const base = 'a'.repeat(40)
+    const head = 'b'.repeat(40)
+
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (args[0] === 'rev-parse') {
+        const ref = args.at(-1) ?? ''
+        if (ref.includes('/base')) return `${base}\n`
+        return `${head}\n`
+      }
+      if (args[0] === 'fetch' && args.some((value) => value.includes('/merge:'))) {
+        throw new Error('merge ref unavailable')
+      }
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        mkdirSync(join(args[3]!, '.git'), { recursive: true })
+      }
+      return ''
+    })
+
+    const cwd = await prepareSessionWorkspace(agent, {
+      sessionKey: 'hook:repo#461:bot-git',
+      isolation: 'session',
+      review: { pullNumber: 461, baseSha: base, headSha: head }
+    })
+
+    expect(dirname(cwd)).toBe(realpathSync(sessionWorktreeRoot(agent)))
+    const addCall = rawMock.mock.calls
+      .map((call) => call[0] as string[])
+      .find((args) => args[0] === 'worktree' && args[1] === 'add')
+    expect(addCall?.slice(0, 3)).toEqual(['worktree', 'add', '--detach'])
+    expect(realpathSync(addCall![3]!)).toBe(cwd)
+    expect(addCall?.[4]).toBe(head)
+    expect(
+      rawMock.mock.calls.some(
+        ([args]) =>
+          args[0] === 'fetch' &&
+          args.includes(`+${base}:refs/agentconnect/reviews/${basename(cwd)}/base`) &&
+          args.includes(`+refs/pull/461/head:refs/agentconnect/reviews/${basename(cwd)}/head`)
+      )
+    ).toBe(true)
+  })
+
+  it('uses a stable distinct worktree for each logical session', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-session-ws-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    agent.workspace.pullOnNewSession = false
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (args[0] === 'worktree' && args[1] === 'add') mkdirSync(join(args[3]!, '.git'), { recursive: true })
+      return args[0] === 'rev-parse' ? `${'c'.repeat(40)}\n` : ''
+    })
+
+    const first = await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const again = await prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })
+    const second = await prepareSessionWorkspace(agent, { sessionKey: 'session-b', isolation: 'session' })
+
+    expect(again).toBe(first)
+    expect(second).not.toBe(first)
+    expect(dirname(first)).toBe(realpathSync(sessionWorktreeRoot(agent)))
+    expect(dirname(second)).toBe(realpathSync(sessionWorktreeRoot(agent)))
   })
 })
 

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -347,6 +347,7 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
     expect(ws.gitRepo).toBe('github.com/acme/infra')
     expect(ws.agentDir).toBe('./services/api')
     expect(ws.branch).toBe('main') // zod default
+    expect(ws.isolation).toBe('shared')
   })
 
   it('spec.workspace accepts scratch with explicit-repo GitHub credentials', () => {
@@ -358,7 +359,11 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
     )
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('agent/upsert')(r.frame)) throw new Error('expected agent/upsert')
-    expect(r.frame.payload.spec.workspace).toEqual({ mode: 'scratch', gitCredential: 'github-app' })
+    expect(r.frame.payload.spec.workspace).toEqual({
+      mode: 'scratch',
+      isolation: 'shared',
+      gitCredential: 'github-app'
+    })
   })
 
   it('agent/upsert and agent/remove decode for live CRUD', () => {

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -28,12 +28,16 @@ import { normalizeGitHubSkillSource } from '../git-url.js'
 export const AgentWorkspace = z.discriminatedUnion('mode', [
   z.object({
     mode: z.literal('scratch'),
+    // Workspace isolation is runtime-owned rather than a filesystem path. The
+    // console exposes this as the simpler Worktree on/off choice for Git repos.
+    isolation: z.enum(['shared', 'session']).default('shared'),
     // Scratch has no implicit/default repository. The credential helper still
     // lets git/gh request explicitly authorized repositories by name.
     gitCredential: z.enum(['github-app']).optional()
   }),
   z.object({
     mode: z.literal('github'),
+    isolation: z.enum(['shared', 'session']).default('shared'),
     gitRepo: z.string(), // FULL cloneable address, e.g. https://github.com/acme/infra (normalizeGitUrl)
     branch: z.string().default('main'),
     agentDir: z.string().optional(), // subdir within the repo; omitted ⇒ repo root

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -174,6 +174,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
         op: 'turn',
         text: 'hello',
         turnId: TURN_ID,
+        worktree: false,
         runtime: { model: 'gpt-5.6-sol', effort: 'xhigh', permissionMode: 'full-access', fastMode: true }
       },
       { op: 'resume', turnId: TURN_ID, generation: 2, afterIndex: 3 },
@@ -192,6 +193,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(RelayWebchatOp.safeParse({ op: 'set_theme', theme: 'dark' }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'turn' }).success).toBe(false) // text required
     expect(RelayWebchatOp.safeParse({ op: 'turn', text: 'hi', runtime: { fastMode: 'yes' } }).success).toBe(false)
+    expect(RelayWebchatOp.safeParse({ op: 'turn', text: 'hi', worktree: 'yes' }).success).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'resume', turnId: TURN_ID, generation: 1, afterIndex: -2 }).success).toBe(
       false
     )

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -99,7 +99,10 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
     attachments: z.array(WebchatImageAttachment).max(1).optional(),
     // A fresh Playground has no daemon session to receive standalone `set_*`
     // operations yet. Carry only the settings the user changed with its first turn.
-    runtime: WebchatRuntimeConfig.optional()
+    runtime: WebchatRuntimeConfig.optional(),
+    // Per-conversation workspace override. The daemon honors it only while
+    // creating the logical session; later turns cannot move an existing session.
+    worktree: z.boolean().optional()
   }),
   // A conversation post another participant produced (a user turn targeted
   // elsewhere, or a peer agent's reply), fanned out by the relay so THIS frame's

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -90,17 +90,19 @@ describe('parseBrowserFrame', () => {
       }
     })
   })
-  it('carries staged runtime choices on the first turn', () => {
+  it('carries staged runtime and worktree choices on the first turn', () => {
     const runtime = { model: 'gpt-5.6-sol', effort: 'xhigh', permissionMode: 'full-access', fastMode: true }
-    expect(parseBrowserFrame({ text: 'hi', runtime }, USER)).toEqual({
+    expect(parseBrowserFrame({ text: 'hi', runtime, worktree: false }, USER)).toEqual({
       op: {
         op: 'turn',
         text: 'hi',
         user: USER,
-        runtime
+        runtime,
+        worktree: false
       }
     })
     expect(parseBrowserFrame({ text: 'hi', runtime: { fastMode: 'yes' } }, USER)).toBeNull()
+    expect(parseBrowserFrame({ text: 'hi', worktree: 'yes' }, USER)).toBeNull()
   })
   it('maps a bounded image attachment while keeping the verified user authoritative', () => {
     const attachment = {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -126,7 +126,8 @@ export function parseBrowserFrame(msg: unknown, user: string): ParsedBrowserOp |
       ...(m.turnId !== undefined ? { turnId: m.turnId } : {}),
       ...(mentions ? { mentions } : {}),
       ...(m.attachments !== undefined ? { attachments: m.attachments } : {}),
-      ...(m.runtime !== undefined ? { runtime: m.runtime } : {})
+      ...(m.runtime !== undefined ? { runtime: m.runtime } : {}),
+      ...(m.worktree !== undefined ? { worktree: m.worktree } : {})
     })
     if (!parsed.success || parsed.data.op !== 'turn') return null
     const targets = m.targets !== undefined ? uuidArray(m.targets, 16) : undefined

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -53,12 +53,15 @@ interface PlaygroundData {
   /** One prepared image waiting in this session's composer. */
   getPgImage: (id: string) => SessionImage | undefined
   setPgImage: (id: string, image?: SessionImage) => void
+  /** Worktree choice staged for a synthetic session's first turn. */
+  getPgWorktree: (id: string) => boolean | undefined
+  pgSetWorktree: (id: string, worktree: boolean) => void
   /** Is a turn in flight for this session id? Drives its typing indicator + send-disable. */
   isPgBusy: (id: string) => boolean
   /** Create a new sandbox session and return its id. Does not navigate. `members`
    *  adds more participants — the conversation's roster is fixed at creation
    *  (webchat-multi-agents.md §3.1); the first agent is the primary. */
-  openPlayground: (agent: Agent, members?: Agent[]) => string
+  openPlayground: (agent: Agent, members?: Agent[], options?: { worktree?: boolean }) => string
   /** Add a participant to a LIVE conversation (mid-conversation join,
    *  webchat-multi-agents.md §3.1). Registers the agent with the CP, then
    *  rebuilds the socket so the relay re-verifies and caches the grown roster.
@@ -247,6 +250,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // Standalone set_* operations cannot bind until the first daemon session exists.
   // Keep only fields the user actually touched and attach them atomically to the turn.
   const stagedRuntime = useRef<Map<string, WebchatRuntimeConfig>>(new Map())
+  const stagedWorktree = useRef<Map<string, boolean>>(new Map())
   const busyRef = useRef<Record<string, boolean>>({})
   const closingAll = useRef(false)
   const { activeOrg } = useOrgs()
@@ -254,6 +258,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const stageRuntimeChange = useCallback((id: string, patch: WebchatRuntimeConfig): void => {
     if (!id.startsWith(PG_PREFIX)) return
     stagedRuntime.current.set(id, { ...stagedRuntime.current.get(id), ...patch })
+  }, [])
+  const getPgWorktree = useCallback((id: string): boolean | undefined => stagedWorktree.current.get(id), [])
+  const pgSetWorktree = useCallback((id: string, worktree: boolean): void => {
+    if (!id.startsWith(PG_PREFIX)) return
+    stagedWorktree.current.set(id, worktree)
   }, [])
 
   const setBusy = useCallback((id: string, v: boolean): void => {
@@ -836,8 +845,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   )
 
   const openPlayground = useCallback(
-    (da: Agent, members?: Agent[]): string => {
+    (da: Agent, members?: Agent[], options?: { worktree?: boolean }): string => {
       const id = newPlaygroundSessionId(da.id)
+      if (da.workspace?.mode === 'github') {
+        stagedWorktree.current.set(id, options?.worktree ?? da.workspace.worktree === true)
+      }
       // The roster is fixed at creation (webchat-multi-agents.md §3.1): the
       // first pick is the primary; there is no add/remove after the first send.
       const roster = [da, ...(members ?? []).filter((m) => m.id !== da.id)]
@@ -1027,7 +1039,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
               ...(image ? { attachments: [image] } : {}),
               // Runtime staging is a single-agent affordance — multi-agent
               // conversations expose no runtime controls (§9.1/§9.3).
-              ...(roster.length <= 1 && stagedRuntime.current.get(id) ? { runtime: stagedRuntime.current.get(id) } : {})
+              ...(roster.length <= 1 && stagedRuntime.current.get(id)
+                ? { runtime: stagedRuntime.current.get(id) }
+                : {}),
+              ...(roster.length <= 1 && stagedWorktree.current.has(id)
+                ? { worktree: stagedWorktree.current.get(id) }
+                : {})
             })
           )
           if (isNewConversation) setTimeout(refreshSessions, 2500)
@@ -1149,6 +1166,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       setPgInput,
       getPgImage,
       setPgImage,
+      getPgWorktree,
+      pgSetWorktree,
       isPgBusy,
       openPlayground,
       pgAddAgent,
@@ -1169,6 +1188,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       setPgInput,
       getPgImage,
       setPgImage,
+      getPgWorktree,
+      pgSetWorktree,
       isPgBusy,
       openPlayground,
       pgAddAgent,

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark } from '@/components/marks'
-import { Button, Icon } from '@/components/ui'
+import { Button, Icon, Toggle } from '@/components/ui'
 
 export type WorkspaceMode = 'scratch' | 'github'
 export type WorkspaceRepoAccess = 'read' | 'write'
@@ -567,6 +567,17 @@ export function WorkingSubdirectoryField({
           {error}
         </span>
       )}
+    </div>
+  )
+}
+
+export function WorktreeField({ checked, onChange }: { checked: boolean; onChange: (checked: boolean) => void }) {
+  return (
+    <div className="fld min-w-0">
+      <span className="fldlbl">Worktree</span>
+      <div className="inp min-w-0 justify-end">
+        <Toggle checked={checked} onChange={onChange} ariaLabel="Worktree" />
+      </div>
     </div>
   )
 }

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -1320,29 +1320,31 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     }}
                   />
 
-                  <WorkspaceBranchField
-                    repositorySelected={!!ghRepo}
-                    value={branch}
-                    branches={ghBranches}
-                    defaultBranch={picked?.defaultBranch}
-                    open={ghBranchOpen}
-                    query={ghQ}
-                    onToggle={() => {
-                      setGhQ('')
-                      setGhRepoOpen(false)
-                      setGhAccessOpen(false)
-                      setGhBranchOpen((value) => !value)
-                    }}
-                    onClose={() => setGhBranchOpen(false)}
-                    onQueryChange={setGhQ}
-                    onChange={(value) => {
-                      setBranch(value)
-                      if (ghBranchOpen) setGhBranchOpen(false)
-                    }}
-                  />
+                  <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_96px] desktop:gap-x-[14px]">
+                    <WorkspaceBranchField
+                      repositorySelected={!!ghRepo}
+                      value={branch}
+                      branches={ghBranches}
+                      defaultBranch={picked?.defaultBranch}
+                      open={ghBranchOpen}
+                      query={ghQ}
+                      onToggle={() => {
+                        setGhQ('')
+                        setGhRepoOpen(false)
+                        setGhAccessOpen(false)
+                        setGhBranchOpen((value) => !value)
+                      }}
+                      onClose={() => setGhBranchOpen(false)}
+                      onQueryChange={setGhQ}
+                      onChange={(value) => {
+                        setBranch(value)
+                        if (ghBranchOpen) setGhBranchOpen(false)
+                      }}
+                    />
 
-                  <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
-                  <WorktreeField checked={worktree} onChange={setWorktree} />
+                    <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
+                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                  </div>
                 </div>
               )}
 
@@ -1364,19 +1366,21 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       </span>
                     </div>
                   </div>
-                  <WorkspaceBranchField
-                    repositorySelected
-                    value={branch}
-                    branches={null}
-                    open={false}
-                    query=""
-                    onToggle={() => undefined}
-                    onClose={() => undefined}
-                    onQueryChange={() => undefined}
-                    onChange={setBranch}
-                  />
-                  <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
-                  <WorktreeField checked={worktree} onChange={setWorktree} />
+                  <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_96px] desktop:gap-x-[14px]">
+                    <WorkspaceBranchField
+                      repositorySelected
+                      value={branch}
+                      branches={null}
+                      open={false}
+                      query=""
+                      onToggle={() => undefined}
+                      onClose={() => undefined}
+                      onQueryChange={() => undefined}
+                      onChange={setBranch}
+                    />
+                    <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
+                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                  </div>
                 </>
               )}
             </div>

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -78,6 +78,7 @@ import {
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
+  WorktreeField,
   WorkingSubdirectoryField,
   WorkspaceBranchField,
   WorkspaceModeField
@@ -214,6 +215,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [repo, setRepo] = useState('')
   const [branch, setBranch] = useState('main')
   const [agentDir, setAgentDir] = useState('')
+  const [worktree, setWorktree] = useState(true)
   // GitHub App picker state (design: the picker IS the github path once the App
   // is installed — repo options only EXIST after an install; no App on this
   // deployment ⇒ everything stays the manual free-text flow — the daemon host
@@ -771,6 +773,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           ? picked
             ? {
                 mode: 'github',
+                worktree,
                 gitRepo: picked.fullName, // owner/repo — the CP normalizes to the full address
                 ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
                 ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
@@ -779,12 +782,14 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
               }
             : {
                 mode: 'github',
+                worktree,
                 gitRepo: publicRepo ?? ghRepo.trim(),
                 ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
                 ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
               }
           : {
               mode: 'github',
+              worktree,
               gitRepo: repo.trim(),
               ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
               ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {})
@@ -1337,6 +1342,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   />
 
                   <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
+                  <WorktreeField checked={worktree} onChange={setWorktree} />
                 </div>
               )}
 
@@ -1370,6 +1376,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     onChange={setBranch}
                   />
                   <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
+                  <WorktreeField checked={worktree} onChange={setWorktree} />
                 </>
               )}
             </div>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -459,37 +459,39 @@ export default function EditWorkspaceModal({
                   }}
                 />
 
-                <WorkspaceBranchField
-                  repositorySelected={!!pick}
-                  value={branch}
-                  branches={branches}
-                  defaultBranch={picked?.defaultBranch}
-                  open={branchOpen}
-                  query={branchQ}
-                  onToggle={() => {
-                    setBranchQ('')
-                    setPickOpen(false)
-                    setAccessOpen(false)
-                    setBranchOpen((value) => !value)
-                  }}
-                  onClose={() => setBranchOpen(false)}
-                  onQueryChange={setBranchQ}
-                  onChange={(value) => {
-                    setBranch(value)
-                    if (branchOpen) setBranchOpen(false)
-                    setErr(null)
-                  }}
-                />
+                <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_96px] desktop:gap-x-[14px]">
+                  <WorkspaceBranchField
+                    repositorySelected={!!pick}
+                    value={branch}
+                    branches={branches}
+                    defaultBranch={picked?.defaultBranch}
+                    open={branchOpen}
+                    query={branchQ}
+                    onToggle={() => {
+                      setBranchQ('')
+                      setPickOpen(false)
+                      setAccessOpen(false)
+                      setBranchOpen((value) => !value)
+                    }}
+                    onClose={() => setBranchOpen(false)}
+                    onQueryChange={setBranchQ}
+                    onChange={(value) => {
+                      setBranch(value)
+                      if (branchOpen) setBranchOpen(false)
+                      setErr(null)
+                    }}
+                  />
 
-                <WorkingSubdirectoryField
-                  value={agentDir}
-                  error={agentDirError}
-                  onChange={(value) => {
-                    setAgentDir(value)
-                    setErr(null)
-                  }}
-                />
-                <WorktreeField checked={worktree} onChange={setWorktree} />
+                  <WorkingSubdirectoryField
+                    value={agentDir}
+                    error={agentDirError}
+                    onChange={(value) => {
+                      setAgentDir(value)
+                      setErr(null)
+                    }}
+                  />
+                  <WorktreeField checked={worktree} onChange={setWorktree} />
+                </div>
 
                 {uncovered && (
                   <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -33,6 +33,7 @@ import {
   GithubRepositoryField,
   GithubRepositoryOption,
   RepositoryAccessField,
+  WorktreeField,
   WorkingSubdirectoryField,
   WorkspaceBranchField,
   WorkspaceModeField
@@ -74,6 +75,7 @@ export default function EditWorkspaceModal({
   const [branchOpen, setBranchOpen] = useState(false)
   const [branchQ, setBranchQ] = useState('')
   const [agentDir, setAgentDir] = useState(currentAgentDir)
+  const [worktree, setWorktree] = useState(githubWorkspace ? githubWorkspace.worktree === true : true)
   const [write, setWrite] = useState(currentWrite ?? (authorized[0] ? authorized[0].access === 'write' : true))
   // Per-user authz preflight for the picked repo. null = unknown/loading —
   // never blocks; the server re-checks when the edit is submitted.
@@ -234,6 +236,7 @@ export default function EditWorkspaceModal({
     mode === 'github' && githubWorkspace !== null && branch.trim() !== (githubWorkspace.branch ?? '')
   const agentDirChanged =
     mode === 'github' && githubWorkspace !== null && (normalizedAgentDir ?? '') !== currentAgentDir
+  const worktreeChanged = mode === 'github' && githubWorkspace !== null && worktree !== !!githubWorkspace.worktree
   const destructiveChange = mode !== agent.workspace.mode || repoChanged || branchChanged
   const changed =
     mode !== agent.workspace.mode ||
@@ -242,6 +245,7 @@ export default function EditWorkspaceModal({
         repoChanged ||
         branchChanged ||
         agentDirChanged ||
+        worktreeChanged ||
         accessChanged ||
         installationChanged))
   const canSubmit =
@@ -274,6 +278,7 @@ export default function EditWorkspaceModal({
           ? { mode: 'scratch' }
           : {
               mode: 'github',
+              worktree,
               repoFullName: pick,
               ...(branch.trim() ? { gitBranch: branch.trim() } : {}),
               ...(normalizedAgentDir ? { agentDir: normalizedAgentDir } : {}),
@@ -484,6 +489,7 @@ export default function EditWorkspaceModal({
                     setErr(null)
                   }}
                 />
+                <WorktreeField checked={worktree} onChange={setWorktree} />
 
                 {uncovered && (
                   <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -162,10 +162,17 @@ export default function HomeView() {
   // Which selector menu is open (only one at a time), and the run-runtime overrides.
   const [menu, setMenu] = useState<'agent' | 'model' | 'effort' | 'permission' | 'add' | null>(null)
   const [runtime, setRuntime] = useState<{ model?: string; effort?: string; permissionPreset?: string }>({})
+  const [worktreeOverride, setWorktreeOverride] = useState<boolean>()
+  const githubWorkspace = agent?.workspace?.mode === 'github' ? agent.workspace : undefined
+  const defaultWorktree = githubWorkspace?.worktree === true
+  const worktree = worktreeOverride ?? defaultWorktree
 
   // Overrides are per-agent; drop them when the agent changes so the new agent's
   // own defaults show through.
-  useEffect(() => setRuntime({}), [agent?.id])
+  useEffect(() => {
+    setRuntime({})
+    setWorktreeOverride(undefined)
+  }, [agent?.id])
 
   // The selected agent's owning daemon supplies the model catalog + defaults.
   const owningDaemon = agent ? daemons.find((d) => d.daemonId === agent.daemon) : undefined
@@ -239,7 +246,7 @@ export default function HomeView() {
   const send = () => {
     const text = input.trim()
     if (!text || !agent || !canSend) return // offline / unsigned-in agents can't take a session
-    const id = openPlayground(agent, members) // pg_ session; pgSend awaits the socket, so no race
+    const id = openPlayground(agent, members, !multi && githubWorkspace ? { worktree } : undefined)
     // Stage the EFFECTIVE (displayed) runtime before the turn — not just explicit
     // overrides — so the session runs exactly what the composer showed. stageRuntimeChange
     // is a synchronous ref write, so pgSend's payload picks it up (PlaygroundProvider).
@@ -494,6 +501,17 @@ export default function HomeView() {
                     onOpenChange={(o) => setMenu(o ? 'permission' : null)}
                     onChange={(v) => setRuntime((r) => ({ ...r, permissionPreset: v }))}
                   />
+                )}
+                {!multi && githubWorkspace && (
+                  <label className={`${CHIP} cursor-pointer`}>
+                    <input
+                      type="checkbox"
+                      checked={worktree}
+                      onChange={(event) => setWorktreeOverride(event.target.checked)}
+                      className="h-4 w-4 accent-(--brand)"
+                    />
+                    Worktree
+                  </label>
                 )}
               </>
             ) : (

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1030,6 +1030,7 @@ export default function SessionDetailView() {
     reconcileLiveSteps,
     getPgInput,
     getPgImage,
+    getPgWorktree,
     isPgBusy,
     setPgInput: setPgInputById,
     setPgImage,
@@ -1039,6 +1040,7 @@ export default function SessionDetailView() {
     pgSetEffort,
     pgSetPermissionPreset,
     pgSetFast,
+    pgSetWorktree,
     pgCancel
   } = usePlayground()
   const { user: viewer, me } = useProfile()
@@ -1118,6 +1120,7 @@ export default function SessionDetailView() {
   const [runtimeSelections, setRuntimeSelections] = useState<
     Record<string, { model?: string; effort?: string; permissionPreset?: string; fast?: boolean }>
   >({})
+  const [worktreeSelections, setWorktreeSelections] = useState<Record<string, boolean>>({})
   // A rail row already carries enough metadata to paint the next session while
   // its detail/transcript requests catch up. Keeping it here also holds the
   // agent-filtered rail steady instead of briefly dropping it between ids.
@@ -1982,6 +1985,12 @@ export default function SessionDetailView() {
   // still playground-only — `pgAddAgent` mutates provider-side session state that
   // an adopted webchat session never had — so a resumed conversation shows its
   // roster (above) without the `+`.
+  const pgWorktree =
+    worktreeSelections[session.id] ??
+    getPgWorktree(session.id) ??
+    (owner?.workspace?.mode === 'github' && owner.workspace.worktree === true)
+  const canChooseWorktree =
+    isPg && !multiLive && owner?.workspace?.mode === 'github' && !session.steps.some((step) => step.kind === 'msg')
   const addAgentOptions = isPg
     ? agents
         .filter((a) => !liveRoster.some((p) => p.agentId === a.id))
@@ -3270,6 +3279,21 @@ export default function SessionDetailView() {
                             </span>
                           )
                         ))}
+                      {canChooseWorktree && (
+                        <label className={`${COMPOSER_CHIP} cursor-pointer`}>
+                          <input
+                            type="checkbox"
+                            checked={pgWorktree}
+                            onChange={(event) => {
+                              const worktree = event.target.checked
+                              setWorktreeSelections((current) => ({ ...current, [session.id]: worktree }))
+                              pgSetWorktree(session.id, worktree)
+                            }}
+                            className="h-4 w-4 accent-(--brand)"
+                          />
+                          Worktree
+                        </label>
+                      )}
                     </div>
                     <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
                     <button

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -211,6 +211,7 @@ export type AgentWorkspaceDto =
   | { mode: 'scratch' }
   | {
       mode: 'github'
+      worktree?: boolean
       gitRepo: string
       gitBranch?: string
       agentDir?: string
@@ -867,6 +868,7 @@ export type SetAgentWorkspaceInput =
   | { mode: 'scratch' }
   | {
       mode: 'github'
+      worktree?: boolean
       repoFullName: string
       /** Absent lets the server use GitHub's current default branch. */
       gitBranch?: string
@@ -1565,6 +1567,7 @@ function workspaceFromDto(w: AgentWorkspaceDto, workspaceRepoId?: string | null)
   if (w.mode === 'github') {
     return {
       mode: 'github',
+      worktree: w.worktree === true,
       ...(workspaceRepoId ? { repoId: workspaceRepoId } : {}),
       repo: repoLabel(w.gitRepo),
       ...(repoWebUrl(w.gitRepo) ? { repoUrl: repoWebUrl(w.gitRepo) } : {}),

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -178,6 +178,7 @@ export function flattenFiles(files: WorkspaceFile[]): WorkspaceFile[] {
 // picks the mode and, for github, the repo/branch/subdir.
 export interface GithubWorkspace {
   mode: 'github'
+  worktree?: boolean
   /** Rename-proof GitHub numeric repository id, when repaired by the CP. */
   repoId?: string
   repo: string // short display form, e.g. acme/infra (storage keeps the full git address)


### PR DESCRIPTION
## Summary

- add the `Worktree` agent setting, default it on for new GitHub agents, and let a fresh manual Playground override it for that session
- keep one stable Git worktree per logical session so concurrent reviews and chats do not share branch or file state
- fetch and verify the exact pull-request base and head before formal review; fail closed when an exact matching checkout cannot be prepared, and require GitHub read-only inspection when the local repo does not match

## Validation

- `pnpm typecheck:ci`
- web, protocol, and relay typechecks
- 194 focused daemon tests
- 987 Control Plane unit tests, 55 focused integration tests, and the full 446-test integration shard 2
- 95 protocol, 24 relay, and 37 web tests
- ESLint on all touched TypeScript files and the repository pre-push lint

Created by Codex . GPT-5.6
