### PR TITLE
fix(web): honor regional login preference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,7 +176,8 @@ API_KEY_PEPPER="replace-with-a-random-32+-char-secret-string"
 # the connectors your tenant actually has, so nobody is offered a button that
 # lands on Logto's error page. Read by the console only — the CP does not gate
 # on it, so there is one place this decision lives; what it permits in the end
-# is whether your tenant has that connector configured.
+# is whether your tenant has that connector configured. When both lark and
+# feishu are listed, put the preferred default first.
 # SOCIAL_PROVIDERS=github
 
 # Rail-footer Help menu links. Unset ⇒ the agentconnect.md defaults; override to

--- a/compose.env.example
+++ b/compose.env.example
@@ -51,7 +51,8 @@
 # connector targets. Available: github, google, slack, lark, feishu. Unset keeps
 # github, google, and slack; `*` opts into the whole catalog. Set this to match
 # the connectors your tenant actually has, so nobody is offered a button that
-# lands on Logto's error page.
+# lands on Logto's error page. When both lark and feishu are listed, put the
+# preferred default first.
 # SOCIAL_PROVIDERS=github
 # OIDC_ISSUER=https://tenant.example.com/oidc
 # OIDC_AUDIENCE=https://api.example.com

--- a/packages/web/src/components/SocialLoginButtons.test.tsx
+++ b/packages/web/src/components/SocialLoginButtons.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SocialLoginButtons from './SocialLoginButtons'
+import { selectEnabledProviders } from '@/lib/social-login-providers'
+
+let container: HTMLDivElement
+let root: Root
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+describe('SocialLoginButtons regional preference', () => {
+  it.each([
+    ['lark,feishu', 'lark', 'Lark'],
+    ['feishu,lark', 'feishu', 'Feishu']
+  ] as const)('defaults %s to %s', async (configured, target, label) => {
+    const onContinue = vi.fn()
+    await act(async () => {
+      root.render(<SocialLoginButtons providers={selectEnabledProviders(configured)} onContinue={onContinue} />)
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(`button[aria-label="Continue with ${label}"]`)
+    expect(button).not.toBeNull()
+
+    await act(async () => button?.click())
+    expect(onContinue).toHaveBeenCalledWith(target)
+  })
+})

--- a/packages/web/src/components/SocialLoginButtons.tsx
+++ b/packages/web/src/components/SocialLoginButtons.tsx
@@ -32,11 +32,11 @@ export default function SocialLoginButtons({
 }) {
   const regionalProviders = providers.filter(isLarkOrFeishu)
   const firstRegionalProvider = regionalProviders[0]
-  const [selectedRegionalTarget, setSelectedRegionalTarget] = useState<LarkFeishuTarget>('feishu')
+  const [selectedRegionalTarget, setSelectedRegionalTarget] = useState<LarkFeishuTarget>(
+    firstRegionalProvider?.target ?? 'lark'
+  )
   const selectedRegionalProvider =
-    regionalProviders.find((provider) => provider.target === selectedRegionalTarget) ??
-    regionalProviders.find((provider) => provider.target === 'feishu') ??
-    firstRegionalProvider
+    regionalProviders.find((provider) => provider.target === selectedRegionalTarget) ?? firstRegionalProvider
 
   return providers.map((provider) => {
     if (isLarkOrFeishu(provider) && provider !== firstRegionalProvider) return null

--- a/packages/web/src/lib/social-login-providers.test.ts
+++ b/packages/web/src/lib/social-login-providers.test.ts
@@ -11,11 +11,11 @@ describe('social login provider selection', () => {
     expect(targets('   ')).toEqual(['github', 'google', 'slack'])
   })
 
-  it('narrows to the configured targets, in catalog order', () => {
-    // Order comes from the catalog, not from however the variable was written.
+  it('keeps catalog order except for the configured Lark/Feishu preference', () => {
     expect(targets('slack,github')).toEqual(['github', 'slack'])
     expect(targets(' google , slack ')).toEqual(['google', 'slack'])
-    expect(targets('feishu,lark')).toEqual(['lark', 'feishu'])
+    expect(targets('lark,feishu')).toEqual(['lark', 'feishu'])
+    expect(targets('feishu,lark')).toEqual(['feishu', 'lark'])
     expect(targets('github')).toEqual(['github'])
   })
 

--- a/packages/web/src/lib/social-login-providers.ts
+++ b/packages/web/src/lib/social-login-providers.ts
@@ -6,10 +6,11 @@
 //    (via <SocialLoginMark>) a brand mark for every target we know how to draw.
 //  - WHICH of them a deployment offers is config, because it is a property of
 //    the Logto tenant, not of this repo. `SOCIAL_PROVIDERS` names the enabled
-//    targets, and this module is the ONLY place that decides. The CP deliberately
-//    does not re-derive the set: a second implementation of these rules is how the
-//    buttons and the server came to disagree, so it validates shape only and lets
-//    the tenant's connector list be the real gate.
+//    targets, and this module is the ONLY place that decides. When both Lark and
+//    Feishu are enabled, their relative order is the deployment's regional
+//    preference. The CP deliberately does not re-derive the set: a second
+//    implementation lets the buttons and the server drift, so it validates shape
+//    only and lets the tenant's connector list be the real gate.
 //
 // Deliberately NOT read from Logto's API: the value reaches the browser inlined
 // in `window.__AC_ENV` (see lib/public-env), so it costs no request and cannot
@@ -35,6 +36,11 @@ export type SocialLoginProvider = (typeof SOCIAL_LOGIN_CATALOG)[number]
 /** Any target the catalog knows — independent of what a deployment enables. */
 export type SocialLoginTarget = SocialLoginProvider['target']
 
+const isRegionalProvider = (
+  provider: SocialLoginProvider | undefined
+): provider is Extract<SocialLoginProvider, { target: 'lark' | 'feishu' }> =>
+  provider?.target === 'lark' || provider?.target === 'feishu'
+
 const DEFAULT_SOCIAL_LOGIN_TARGETS = new Set<SocialLoginTarget>(['github', 'google', 'slack'])
 
 /** Parse the configured target list. Unset / blank ⇒ legacy defaults; `*` ⇒ all. */
@@ -49,7 +55,9 @@ export function parseEnabledTargets(raw: string | undefined): Set<string> | null
   return entries.length > 0 ? new Set(entries) : new Set(DEFAULT_SOCIAL_LOGIN_TARGETS)
 }
 
-/** Catalog entries this deployment offers, in catalog order. */
+/** Catalog entries this deployment offers. Non-regional providers keep catalog
+ * order; Lark and Feishu keep their configured relative order as the regional
+ * preference consumed by the combined login button. */
 export function selectEnabledProviders(raw: string | undefined): readonly SocialLoginProvider[] {
   const enabled = parseEnabledTargets(raw)
   if (!enabled) return SOCIAL_LOGIN_CATALOG
@@ -57,9 +65,14 @@ export function selectEnabledProviders(raw: string | undefined): readonly Social
   // A value naming only unknown targets would otherwise leave the sign-in page
   // with no way in at all; retain the pre-Lark/Feishu defaults without assuming
   // that the tenant has either newly supported connector.
-  return selected.length > 0
-    ? selected
-    : SOCIAL_LOGIN_CATALOG.filter((provider) => DEFAULT_SOCIAL_LOGIN_TARGETS.has(provider.target))
+  if (selected.length === 0) {
+    return SOCIAL_LOGIN_CATALOG.filter((provider) => DEFAULT_SOCIAL_LOGIN_TARGETS.has(provider.target))
+  }
+
+  const regionalProviders = [...enabled]
+    .map((target) => selected.find((provider) => provider.target === target))
+    .filter(isRegionalProvider)
+  return [...selected.filter((provider) => !isRegionalProvider(provider)), ...regionalProviders]
 }
 
 /** The providers to render. Reads the runtime config the server inlined. */


### PR DESCRIPTION
## Summary

- use the relative Lark/Feishu order in `SOCIAL_PROVIDERS` as the deployment's regional login preference
- default the combined social-login button to the preferred regional target
- document the ordering rule and cover both preferences with focused tests

## Root cause

The combined login button hard-coded Feishu as its initial target, discarding the deployment's configured Lark/Feishu preference.

## Impact

Deployments that list `lark,feishu` now default to Lark, while deployments that list `feishu,lark` default to Feishu. GitHub, Google, and Slack keep their existing display order, and users can still switch regional targets inline.

## Validation

- `pnpm --filter @agentconnect.md/web test` (89 files, 668 tests)
- `pnpm --filter @agentconnect.md/web build`
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- changed-file ESLint and full pre-push `eslint .`
- `pnpm format:check`
- browser verification for both `lark,feishu` and `feishu,lark` runtime configurations, with no console errors

Created by Codex . GPT-5
