### PR TITLE
refactor(permissions): remove integration user allowlists

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -473,7 +473,6 @@ This aligns upstream section 6.6 `Agent` / `Integration` / `Workspace` / `CronJo
           { "channel": "C0ALERTS", "match": { "kind": "auto" } }, // Process all messages
           { "channel": "C0TEAM", "match": { "kind": "mention" } } // Mention only
         ],
-        "allowedUserIds": [], // Empty means all; integration-level authz copied to derived rules
         "notificationChannelId": "C0NOTIF"
       }
     }
@@ -607,13 +606,13 @@ A daemon can host many agents, each with many integrations. **Do not open one in
 5. Derive the local `RoutingRule[]` layer from every integration's `bindRules` through `rulesFromAgent()`.
 ```
 
-One `RoutingRule` model drives routing. Every integration `bindRules[]` entry derives a `source:"config"` local rule with agentId, integrationId, platform, scope, match, and allowedUserIds. Merge these with `source:"cp"` rules and arbitrate through `routeRules()`. Cache the local layer in `state/local.sqlite` for degradation; CP-layer persistence is described in sections 8.7/6.3. `rulesFromAgent()` in `packages/daemon/src/router/routing-rule.ts` derives the local rules, and `routeRules()` in `packages/daemon/src/router/routing-table.ts` defines arbitration.
+One `RoutingRule` model drives routing. Every integration `bindRules[]` entry derives a `source:"config"` local rule with agentId, integrationId, platform, scope, and match. Merge these with `source:"cp"` rules and arbitrate through `routeRules()`. Cache the local layer in `state/local.sqlite` for degradation; CP-layer persistence is described in sections 8.7/6.3. `rulesFromAgent()` in `packages/daemon/src/router/routing-rule.ts` derives the local rules, and `routeRules()` in `packages/daemon/src/router/routing-table.ts` defines arbitration.
 
 ### 6.3 Inbound Event -> Agent Routing
 
 After a Slack event reaches a connection:
 
-1. Over the union of local and CP rules, calculate **scope candidates** whose scope and `allowedUserIds` pass, then **kind candidates** whose `mention` / `dm` / `keyword` / `auto` matches.
+1. Over the union of local and CP rules, calculate **scope candidates**, then **kind candidates** whose `mention` / `dm` / `keyword` / `auto` matches.
 2. First-match arbitration: **explicit @bot mention** -> **thread affinity** (single reachable agent continues; multiple reachable agents require mention) -> **CP per-sessionKey override** -> **local layer**. Within a layer: `mention > dm > keyword > auto`.
 3. On match, normalize to `NormalizedMessage` with `traceId` and send to section 7 ACP Host. On null, drop + debug-log; it may still enter thread transcript for later catch-up.
 
@@ -767,13 +766,12 @@ interface RoutingRule {
   integrationId: string // Daemon-local Slack connection
   scope: { channel?: string; thread?: string } // Missing channel means any
   match: { kind: 'mention' } | { kind: 'dm' } | { kind: 'keyword'; value: string } | { kind: 'auto' }
-  allowedUserIds?: string[] // Daemon authz extension, not protocol BindRule
   source: 'config' | 'cp'
   epoch?: number // CP layer only: routingEpoch fence
 }
 ```
 
-- **Local layer (`source:"config"`):** Derived from `agent.json.slack.bindRules` through `rulesFromAgent`; copies integration-level allowedUserIds. Always active and authoritative for offline/bootstrap. Legacy migration: `subscribedChannels{trigger:"all"}` -> `{channel, match:auto}`; `trigger:"mention"` -> `{channel, match:mention}`; `mentionAnyChannel` -> unscoped mention; `respondToDms` -> dm.
+- **Local layer (`source:"config"`):** Derived from `agent.json.slack.bindRules` through `rulesFromAgent`. Always active and authoritative for offline/bootstrap. Legacy migration: `subscribedChannels{trigger:"all"}` -> `{channel, match:auto}`; `trigger:"mention"` -> `{channel, match:mention}`; `mentionAnyChannel` -> unscoped mention; `respondToDms` -> dm.
 - **CP layer (`source:"cp"`):** `route/assign` per-sessionKey overrides, `route/update` global rules, and `register/ok` reconcile snapshot. Persist to Local Store and use across restart/disconnect.
 - **Priority:** local is baseline, CP overrides by sessionKey, except explicit `@bot` wins across layers.
 
@@ -781,7 +779,7 @@ interface RoutingRule {
 
 An event arrives on one platform connection with connectionId, event type, channelId, thread_ts, user, text with `<@BOT>` markers, and attachments. The connection already narrows candidates to agents whose integrations use it.
 
-- **scope-candidates:** Rules whose channel/thread scope matches and whose allowedUserIds is absent/empty or includes sender. Ignore kind. Unique agentIds are **reachable agents** for thread gating.
+- **scope-candidates:** Rules whose channel/thread scope matches. Ignore kind. Unique agentIds are **reachable agents** for thread gating.
 - **kind-candidates:** Scope candidates whose kind matches: mention when `msg.mentionedBots` includes that rule's agent botUserId; dm when `msg.isDm`; case-insensitive keyword in text; auto always.
 - Human senders use the complete ladder. For Slack bot senders, compare sender app ID to managed app identity in the collaboration snapshot, with resolved bot user/bot ID fallback on the same daemon. Drop any AgentConnect-managed bot before command/model admission. An unmanaged third-party Slack bot can match only an explicit mention, never DM/thread/keyword/auto. Bot senders on other platforms do not route.
 
@@ -889,7 +887,7 @@ Some thread messages control the running agent rather than prompt it. `parseComm
 - **Prefix:** Slack reserves slash commands, so use `!`; also parse `/` for Telegram/Discord. Command must immediately follow prefix; `hello!` and `! note` are normal text.
 - **Vocabulary:** `!stop` / `!cancel` interrupt current turn; `!queue <text>` runs text after idle.
 
-Run `route()` on the command to locate `(agentId, integrationId)`, preserving thread affinity and allowedUserIds. If no target, ignore and log.
+Run `route()` on the command to locate `(agentId, integrationId)`, preserving thread affinity and conversation admission. If no target, ignore and log.
 
 - **`!stop` / `!cancel`:** For an in-flight session, first clear its queue, then send ACP `session/cancel`, and reply `🛑 Stopped.`. If nothing is running, reply `Nothing is running to stop.`
 - **`!queue <text>`:** If busy, enqueue stripped text in `queued: Map<acpSessionId, NormalizedMessage[]>` and reply `📥 Queued`; if idle, dispatch immediately. On clean turn completion, FIFO-dispatch one queued message, which chains the next. On prompt error, do not dispatch; retain the queue.

--- a/docs/designs/feishu-integration.md
+++ b/docs/designs/feishu-integration.md
@@ -120,7 +120,6 @@ capability invariant in section 5.
       appId: z.string(), // cli_... application ID; a semi-public identifier
       appSecret: z.string(), // Secret; never log it
       botOpenId: z.string().optional(), // Bot open_id for mention routing; resolve lazily through bot/info
-      allowedUserIds: z.array(z.string()).default([]),
       bindRules: z.array(IntegrationBindRule).default([])
     })
     ```
@@ -220,7 +219,6 @@ IntegrationFeishuConfig }`.
         mode: 'direct',
         appId: secret.appToken ?? '',
         appSecret: secret.botToken,
-        allowedUserIds: [],
         bindRules
       }
     }
@@ -326,7 +324,7 @@ IntegrationFeishuConfig }`.
 - Add `'feishu'` to `NormalizedMessage.platform` in
   `src/messages/normalized.ts`, plus optional `feishuTopLevel?: boolean`.
 - Add a Lark / Feishu branch to `src/router/routing-rule.ts`, extracting
-  `staticBotUserId` from `botOpenId`, `bindRules`, and `allowedUserIds`.
+  `staticBotUserId` from `botOpenId` together with its `bindRules`.
 - Add `FeishuConfigSchema` to the `IntegrationSchema` discriminated union and
   `'feishu'` to the cron target platform in `src/agents/agent-schema.ts`.
 - Add a Lark / Feishu branch in `src/agents/write-integration.ts` so

--- a/docs/designs/loop-breaker-design.md
+++ b/docs/designs/loop-breaker-design.md
@@ -305,7 +305,7 @@ drop the only recovery message. The current order is:
 platform event
   → L0 shape filter / own-bot filter / dedup
   → parse control command (!stop / !resume / ...)
-  → resolve concrete integration + allowedUserIds
+  → resolve concrete integration + conversation admission
   → if not a command: check OPEN
   → poison fast path
   → serial-gate capacity / branch preflight
@@ -355,18 +355,18 @@ The actor resuming the scope must satisfy all three conditions:
 
 1. Be a trusted human.
 2. Resolve to a concrete integration.
-3. Pass that integration's final `allowedUserIds` check.
+3. Be in a conversation admitted by that integration.
 
 The ninth message in a top-level Slack incident is rejected before admission,
 so the warning thread may have no session owner. An ownerless `!resume` therefore
 uses a dedicated recovery-resolution path: only when the corresponding top-level
 latch is already OPEN, select a target from current agents' Slack integrations
-that actually permits the user, preferring an explicit mention and then stable
+that admit the conversation, preferring an explicit mention and then stable
 ordering. The same concrete-integration authorization check still runs.
 
 Relay-managed `rd/msg(im)` likewise parses commands before dispatch and uses the
-target resolved by the relay for the final `allowedUserIds` check. A bot or
-unknown sender cannot resume the scope.
+target resolved by the relay for the final conversation-admission check. A bot
+or unknown sender cannot resume the scope.
 
 ---
 
@@ -723,7 +723,7 @@ Key regressions are covered by:
   cancellation/backstop, shutdown, cross-agent scope, and fresh top-level Slack
   roots.
 - [`daemon-commands.test.ts`](../../packages/daemon/test/daemon-commands.test.ts):
-  trusted `!resume`, `allowedUserIds`, and ownerless warning threads.
+  trusted `!resume` and ownerless warning threads.
 - [`connection.test.ts`](../../packages/daemon/test/connection.test.ts):
   Slack wrapper/subtype ingress.
 - [`daemon-message-agent.test.ts`](../../packages/daemon/test/daemon-message-agent.test.ts)

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -816,10 +816,8 @@ no mention distinction). Public agents' DMs stay open and produce no rows.
 **Trust model — authorize places, not people.** Enabling a channel entrusts
 that channel's **entire current and future membership**. That is a deliberate
 trade-off: the unit of authorization is the conversation, and Slack-native
-membership (especially private channels) governs who is inside it. Per-user
-filtering (the daemon's dormant `allowedUserIds`, or identity mapping that
-would enforce agent visibility directly at ingress) remains a possible future
-overlay — see §14.6.
+membership (especially private channels) governs who is inside it. The daemon
+does not add a separate per-user allowlist at ingress.
 
 **Inbound only.** Gating governs **inbound activation** exclusively. Outbound
 deliveries — cron and hook targets posting into a conversation — are already
@@ -999,10 +997,6 @@ that editors demonstrably already configured.)
 
 ### 14.6 Out of scope / future overlays
 
-- **Per-user allowlists.** The daemon already enforces
-  `Integration.<platform>.allowedUserIds` end-to-end (routing filter +
-  control-command authz); the CP simply always sends `[]`. Wiring CP storage +
-  UI to it is a natural finer-grained overlay on top of conversation gating.
 - **Identity mapping.** Resolving platform senders to AgentConnect users
   (e.g. Slack `users.info` email ↔ OIDC email, with a manual link fallback)
   would let ingress enforce agent visibility itself, making "private" mean the

--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -292,7 +292,6 @@ slack: {
   mode: 'shared',
   shareable,
   botToken,
-  allowedUserIds: [],
   bindRules: []
 }
 ```
@@ -310,7 +309,6 @@ feishu: {
   appSecret,
   botOpenId,
   region,
-  allowedUserIds: [],
   bindRules: []
 }
 ```

--- a/docs/designs/slack-identity.md
+++ b/docs/designs/slack-identity.md
@@ -71,27 +71,6 @@ hygiene we control, not as a defect claim about the provider.
   (`control-plane/src/http/viewer-identity.ts`), which builds its Slack entry
   from the same pair — both sides keyed alike, so neither can match on a bare
   `U…`.
-- **`allowedUserIds`** (daemon routing) compares a bare sender id:
-  `allowedUserIds.includes(msg.sender.id)` in `router/routing-table.ts`, against
-  a sender built as `message.user ?? message.bot_id` in
-  `packages/message/src/slack-message.ts` — no team component anywhere.
-
-  This is **reachable today**, and only half-dormant. The Control Plane supplies
-  `[]` on every path in `orchestrator/placement.ts`, so no CP-managed integration
-  populates it. But a local `agent.json` may set `slack.allowedUserIds` — the
-  schema takes any array — and `rulesFromAgent()` copies it into the
-  `source: 'config'` routing layer, which is always active, including while the
-  CP is offline.
-
-  Where it is populated, do not read the per-integration binding as making it
-  pair-safe. An integration is installed in one workspace, but under Slack
-  Connect a shared-channel message can be authored from another, so the two sides
-  of that comparison are not guaranteed to share a workspace: a foreign-workspace
-  author matches on a bare `U…` alone. **Carrying the author's team id into the
-  normalized sender is a prerequisite for treating this list as an authorization
-  boundary** — for the local path that prerequisite is already outstanding, not
-  deferred until someone turns a feature on.
-
 - **`slack_user_config`** is keyed `(orgId, userId)` where `userId` is the
   **console** user, not a Slack one. It stores that person's Slack App
   Configuration token; no Slack id is involved.

--- a/docs/designs/slack-integration-install.md
+++ b/docs/designs/slack-integration-install.md
@@ -127,8 +127,7 @@ For a socket bot, the Control Plane builds an `IntegrationSpec` with:
 - `mode = direct`;
 - the bot token;
 - the app-level token;
-- optional bot user id;
-- allowed users; and
+- optional bot user id; and
 - effective bind rules.
 
 The spec is sent only to the daemon that owns the integration's agent through:

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -249,7 +249,7 @@ export function integrationToSpec(
       integrationId: i.id,
       agentId: i.agentId,
       platform: 'telegram',
-      telegram: { botToken: secret.botToken, allowedUserIds: [], bindRules, mutedChannels, gated }
+      telegram: { botToken: secret.botToken, bindRules, mutedChannels, gated }
     }
   }
   if (i.platform === 'discord') {
@@ -258,7 +258,7 @@ export function integrationToSpec(
       agentId: i.agentId,
       platform: 'discord',
       // Discord authenticates the Gateway with the single bot token (no appToken).
-      discord: { botToken: secret.botToken, allowedUserIds: [], bindRules, mutedChannels, gated }
+      discord: { botToken: secret.botToken, bindRules, mutedChannels, gated }
     }
   }
   if (i.platform === 'feishu') {
@@ -274,7 +274,6 @@ export function integrationToSpec(
         appId: secret.appToken ?? '',
         appSecret: secret.botToken,
         region: i.feishuRegion ?? 'feishu',
-        allowedUserIds: [],
         bindRules,
         mutedChannels,
         gated
@@ -295,7 +294,6 @@ export function integrationToSpec(
       shareable: false,
       botToken: secret.botToken,
       appToken: secret.appToken ?? '',
-      allowedUserIds: [],
       bindRules,
       mutedChannels,
       gated
@@ -338,7 +336,6 @@ export function httpIntegrationToSpec(
         appSecret: secret.botToken,
         ...(botUserId ? { botOpenId: botUserId } : {}),
         region: i.feishuRegion ?? 'feishu',
-        allowedUserIds: [],
         bindRules: gated ? gatedBindRules(channels) : [],
         mutedChannels: mutedChannelIds(channels, gated),
         gated
@@ -357,7 +354,6 @@ export function httpIntegrationToSpec(
       shareable,
       botToken: secret.botToken,
       ...(providerAppId ? { appId: providerAppId } : {}),
-      allowedUserIds: [],
       bindRules: gated ? gatedBindRules(channels) : [],
       mutedChannels: mutedChannelIds(channels, gated),
       gated

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -36,7 +36,6 @@ export const SlackConfigSchema = z.object({
   appId: z.string().optional(), // public A… app id used for Slack permission-update links
   signingSecret: z.string().optional(),
   botUserId: z.string().optional(), // filled at connect via auth.test if absent; provided by CP for shared
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
   // Channels the operator switched OFF. bindRules only ADD reach, so an ungated
   // integration — which reaches every conversation through unscoped defaults — needs
@@ -55,7 +54,6 @@ export const TelegramConfigSchema = z.object({
   botToken: z.string(), // BotFather "123456:ABC…" (single token; no app token / signing secret)
   botUserId: z.string().optional(), // numeric bot id, filled at connect via getMe if absent
   botUsername: z.string().optional(), // @username without the '@', for mention detection; filled via getMe
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
@@ -69,7 +67,6 @@ export const DiscordConfigSchema = z.object({
   botToken: z.string(), // Discord Gateway bot token (single token; no app token / signing secret)
   applicationId: z.string().optional(), // public client id for the invite URL (not used to connect)
   botUserId: z.string().optional(), // numeric bot user id, filled at connect via the ready event if absent
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP
@@ -87,7 +84,6 @@ export const FeishuConfigSchema = z.object({
   appSecret: z.string(), // app secret (single secret; no app token / signing secret)
   botOpenId: z.string().optional(), // bot's own open_id for mention detection; filled at connect via bot/info if absent
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn (default) vs larksuite.com
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(BindRuleConfigSchema).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see SlackConfigSchema.mutedChannels
   // Conversation gating (resource-visibility.md §14): fail-closed ingress — the CP

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -30,7 +30,6 @@ function toIntegration(spec: IntegrationSpec): Integration {
       platform: 'telegram',
       telegram: {
         botToken: spec.telegram.botToken,
-        allowedUserIds: spec.telegram.allowedUserIds,
         bindRules: spec.telegram.bindRules,
         mutedChannels: spec.telegram.mutedChannels,
         gated: spec.telegram.gated
@@ -45,7 +44,6 @@ function toIntegration(spec: IntegrationSpec): Integration {
       discord: {
         botToken: spec.discord.botToken,
         ...(spec.discord.applicationId ? { applicationId: spec.discord.applicationId } : {}),
-        allowedUserIds: spec.discord.allowedUserIds,
         bindRules: spec.discord.bindRules,
         mutedChannels: spec.discord.mutedChannels,
         gated: spec.discord.gated
@@ -63,7 +61,6 @@ function toIntegration(spec: IntegrationSpec): Integration {
         appSecret: spec.feishu.appSecret,
         ...(spec.feishu.botOpenId ? { botOpenId: spec.feishu.botOpenId } : {}),
         region: spec.feishu.region,
-        allowedUserIds: spec.feishu.allowedUserIds,
         bindRules: spec.feishu.bindRules,
         mutedChannels: spec.feishu.mutedChannels,
         gated: spec.feishu.gated
@@ -84,7 +81,6 @@ function toIntegration(spec: IntegrationSpec): Integration {
       ...(spec.slack.appToken ? { appToken: spec.slack.appToken } : {}),
       ...(spec.slack.appId ? { appId: spec.slack.appId } : {}),
       ...(spec.slack.botUserId ? { botUserId: spec.slack.botUserId } : {}),
-      allowedUserIds: spec.slack.allowedUserIds,
       bindRules: spec.slack.bindRules,
       mutedChannels: spec.slack.mutedChannels,
       gated: spec.slack.gated

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6335,9 +6335,7 @@ export class Daemon {
     const payload = msg.payload
     if (payload.kind === 'open-config-for-thread') {
       const routing = integrationRouting(integration)
-      const unauthorized =
-        (routing.allowedUserIds.length > 0 && (!msg.userId || !routing.allowedUserIds.includes(msg.userId))) ||
-        !conversationAdmitted(routing, payload.channelId)
+      const unauthorized = !conversationAdmitted(routing, payload.channelId)
       const transportScope = this.transportScopeForIntegrationIds([integration.id])
       const rec = unauthorized
         ? undefined
@@ -8900,9 +8898,9 @@ export class Daemon {
    * Resolve a command's target from the channel's latest session when the routing ladder
    * couldn't (no mention entity / thread / dm rule matched — e.g. a group `/status@bot`).
    * Picks the agent that owns the most-recent session in the channel and its integration
-   * for this platform, enforcing that integration's `allowedUserIds` so a command can't
-   * bypass the authz the routing rules would have applied. Null when there's no session,
-   * no matching integration, or the sender isn't allowed.
+   * for this platform while preserving the conversation gate that routing would have
+   * applied. Null when there's no session, no matching integration, or the conversation
+   * is not admitted.
    */
   private resolveCommandTargetFromLatest(
     msg: NormalizedMessage,
@@ -8920,7 +8918,6 @@ export class Daemon {
         if (
           integration.platform !== msg.platform ||
           !this.integrationBelongsToSource(integration.id, srcIntegrationIds) ||
-          !this.gatedAdmission(integration.id, msg) ||
           !this.commandSenderAllowed(agentId, integration.id, msg)
         )
           continue
@@ -8940,7 +8937,7 @@ export class Daemon {
 
   /** Validate the relay-arbitrated command target against the local agent spec. Shared
    *  bot IMs bypass routeRules' arbitration, but must retain its bot rejection and
-   *  per-integration allowedUserIds authorization before executing a control command. */
+   *  conversation admission before executing a control command. */
   private resolveExplicitCommandTarget(
     agentId: string,
     integrationId: string,
@@ -8953,7 +8950,7 @@ export class Daemon {
   /** Recovery path for a channel-wide Slack top-level loop latch. The triggering
    *  message itself was rejected, so its warning thread may have no thread owner or
    *  latest session to route a bare `!resume` through. Select only an integration
-   *  that independently authorizes this human, preferring an explicitly mentioned bot. */
+   *  that admits this conversation, preferring an explicitly mentioned bot. */
   private resolveTopLevelResumeTarget(
     msg: NormalizedMessage,
     srcIntegrationIds?: readonly string[]
@@ -8994,8 +8991,8 @@ export class Daemon {
     return candidates[0] ?? null
   }
 
-  /** Final command authorization at the concrete integration. CP routing rules do not
-   *  carry allowedUserIds themselves, so routing success alone is not an auth verdict. */
+  /** Final command admission at the concrete integration. Commands that resolve their
+   *  target outside the routing ladder still repeat bot rejection and conversation gating. */
   private commandSenderAllowed(agentId: string, integrationId: string, msg: NormalizedMessage): boolean {
     if (msg.sender.isBot) return false
     const integration = this.agents
@@ -9006,15 +9003,13 @@ export class Daemon {
     // Control commands resolve their target OUTSIDE routeRules' scope filter (latest-
     // session fallbacks), so they must repeat the admission check — a channel switched
     // Off, or an Off conversation of a gated integration, takes no commands either.
-    if (!conversationAdmitted(routing, msg.channel, msg.parentChannel)) return false
-    const allowed = routing.allowedUserIds
-    return allowed.length === 0 || allowed.includes(msg.sender.id)
+    return conversationAdmitted(routing, msg.channel, msg.parentChannel)
   }
 
   /**
    * Handle an in-conversation control command. Resolves the target agent via the
-   * same routing ladder as a normal message (so thread-affinity + per-integration
-   * `allowedUserIds` authz apply), then acts on that agent's session in this
+   * same routing ladder as a normal message (so thread affinity and conversation
+   * admission apply), then acts on that agent's session in this
    * (channel, thread).
    */
   private handleCommand(
@@ -9032,7 +9027,7 @@ export class Daemon {
       // Routing found no agent — the common group case: a bare `/status@bot` carries no
       // mention entity, no reply, and its fresh thread has no session. Resolve the agent
       // from the channel's latest session so the command still lands on it (subject to
-      // that agent's per-integration allowedUserIds authz).
+      // that agent's conversation admission).
       target = this.resolveCommandTargetFromLatest(msg, srcIntegrationIds)
     }
     if (!target && command.kind === 'resume') target = this.resolveTopLevelResumeTarget(msg, srcIntegrationIds)
@@ -9420,8 +9415,8 @@ export class Daemon {
 
   /**
    * Handle a tapped session-control card button (Telegram inline keyboard). Decodes
-   * `<kindCode>:<optionIndex>`, resolves the channel's latest session (with the same
-   * allowedUserIds authz as a command), applies the picked value, acks the tap, and
+   * `<kindCode>:<optionIndex>`, resolves the channel's latest admitted session, applies
+   * the picked value, acks the tap, and
    * re-renders the card with the new current marked. Best-effort throughout — a tap
    * must never throw out of the update pump.
    */
@@ -9436,7 +9431,6 @@ export class Daemon {
     const srcIntegrationIds = this.srcIntegrationIds(conn)
     const session = this.commandSessionForLatest(
       cb.channel,
-      cb.userId,
       srcIntegrationIds,
       this.transportScopeForIntegrationIds(srcIntegrationIds)
     )
@@ -9464,24 +9458,16 @@ export class Daemon {
     void conn.editCard(cb.channel, cb.messageId, text, buttons)
   }
 
-  /** The channel's latest session for a Telegram command/callback, gated by the agent's
-   *  telegram integration allowedUserIds. Null when there's no session, no telegram
-   *  integration, or the user isn't allowed. */
+  /** The channel's latest admitted session for a Telegram command/callback. */
   private commandSessionForLatest(
     channel: string,
-    userId: string,
     srcIntegrationIds: readonly string[],
     transportScope?: string
   ): { agentId: string; key: string; acpSessionId?: string } | null {
     const candidates: SessionRecord[] = []
     for (const [agentId, agent] of this.agents) {
       for (const integration of agent.integrations) {
-        if (
-          integration.platform !== 'telegram' ||
-          !srcIntegrationIds.includes(integration.id) ||
-          (integration.telegram.allowedUserIds.length > 0 && !integration.telegram.allowedUserIds.includes(userId))
-        )
-          continue
+        if (integration.platform !== 'telegram' || !srcIntegrationIds.includes(integration.id)) continue
         const routing = integrationRouting(integration)
         if (!conversationAdmitted(routing, channel)) continue
         const session = this.store.latestSessionForTransport(agentId, channel, transportScope)
@@ -9494,9 +9480,9 @@ export class Daemon {
   }
 
   /** Resolve a direct Slack message shortcut to the newest addressable session in
-   *  that exact bot-scoped conversation, retaining routing gates and user allowlists. */
+   *  that exact bot-scoped conversation, retaining conversation routing gates. */
   private slackShortcutSession(
-    shortcut: { channel: string; thread: string; userId: string },
+    shortcut: { channel: string; thread: string },
     srcIntegrationIds: readonly string[]
   ): string | undefined {
     const transportScope = this.transportScopeForIntegrationIds(srcIntegrationIds)
@@ -9505,7 +9491,6 @@ export class Daemon {
       for (const integration of agent.integrations) {
         if (integration.platform !== 'slack' || !srcIntegrationIds.includes(integration.id)) continue
         const routing = integrationRouting(integration)
-        if (routing.allowedUserIds.length > 0 && !routing.allowedUserIds.includes(shortcut.userId)) continue
         if (!conversationAdmitted(routing, shortcut.channel)) continue
         const session = this.store.latestSessionForTransport(agentId, shortcut.channel, transportScope, shortcut.thread)
         if (session) candidates.push(session)

--- a/packages/daemon/src/router/routing-rule.ts
+++ b/packages/daemon/src/router/routing-rule.ts
@@ -18,7 +18,6 @@ export interface RoutingRule {
   botUserId: string // for `mention` matching ("" when unknown)
   scope: { channel?: string; thread?: string }
   match: RoutingMatch
-  allowedUserIds?: string[]
   // Channels its integration is switched OFF in — the subtractive fence a purely
   // additive rule set cannot express. Carried per rule (rather than consulted
   // separately) so `routeRules` stays pure and every rung — mention, thread
@@ -37,7 +36,6 @@ export interface RoutingRule {
 export function integrationRouting(int: Integration): {
   staticBotUserId?: string
   bindRules: BindRuleConfig[]
-  allowedUserIds: string[]
   mutedChannels: string[]
   gated: boolean
 } {
@@ -49,7 +47,6 @@ export function integrationRouting(int: Integration): {
     return {
       staticBotUserId: int.slack.botUserId,
       bindRules: int.slack.bindRules,
-      allowedUserIds: int.slack.allowedUserIds,
       mutedChannels: int.slack.mutedChannels ?? [],
       gated: int.slack.gated
     }
@@ -57,7 +54,6 @@ export function integrationRouting(int: Integration): {
     return {
       staticBotUserId: int.discord.botUserId,
       bindRules: int.discord.bindRules,
-      allowedUserIds: int.discord.allowedUserIds,
       mutedChannels: int.discord.mutedChannels ?? [],
       gated: int.discord.gated
     }
@@ -65,14 +61,12 @@ export function integrationRouting(int: Integration): {
     return {
       staticBotUserId: int.feishu.botOpenId,
       bindRules: int.feishu.bindRules,
-      allowedUserIds: int.feishu.allowedUserIds,
       mutedChannels: int.feishu.mutedChannels ?? [],
       gated: int.feishu.gated
     }
   return {
     staticBotUserId: int.telegram.botUserId,
     bindRules: int.telegram.bindRules,
-    allowedUserIds: int.telegram.allowedUserIds,
     mutedChannels: int.telegram.mutedChannels ?? [],
     gated: int.telegram.gated
   }
@@ -143,7 +137,7 @@ export function resolveAgentIntegration(
 export function rulesFromAgent(agent: Agent, botUserIds: Record<string, string>): RoutingRule[] {
   const out: RoutingRule[] = []
   for (const int of agent.integrations) {
-    const { staticBotUserId, bindRules, allowedUserIds, mutedChannels } = integrationRouting(int)
+    const { staticBotUserId, bindRules, mutedChannels } = integrationRouting(int)
     const botUserId = botUserIds[int.id] ?? staticBotUserId ?? ''
     for (const br of bindRules) {
       out.push({
@@ -152,7 +146,6 @@ export function rulesFromAgent(agent: Agent, botUserIds: Record<string, string>)
         botUserId,
         scope: { ...(br.channel ? { channel: br.channel } : {}), ...(br.thread ? { thread: br.thread } : {}) },
         match: br.match,
-        allowedUserIds,
         mutedChannels,
         source: 'config',
         platform: int.platform

--- a/packages/daemon/src/router/routing-table.ts
+++ b/packages/daemon/src/router/routing-table.ts
@@ -77,11 +77,8 @@ export function routeRules(
     // keyword/auto arbitration entirely. No Slack integration is involved.
     return { agentId: explicitAgentId, integrationId: '', via: 'mention' }
   }
-  const authz = (r: RoutingRule) =>
-    !r.allowedUserIds || r.allowedUserIds.length === 0 || r.allowedUserIds.includes(msg.sender.id)
-
-  // scope-candidates: scope + authz, KIND-AGNOSTIC (used for reachability + thread continuity).
-  const scopeCandidates = rules.filter((r) => scopeMatches(r, msg) && authz(r))
+  // Scope candidates are KIND-AGNOSTIC (used for reachability + thread continuity).
+  const scopeCandidates = rules.filter((r) => scopeMatches(r, msg))
   // kind-candidates: also match the message kind.
   const kindCandidates = scopeCandidates.filter((r) => kindMatches(r, msg))
 

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -17,7 +17,6 @@ const mk = (id: string, appToken: string, botToken: string): Agent =>
         slack: {
           botToken,
           appToken,
-          allowedUserIds: [],
           bindRules: []
         }
       }

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -202,7 +202,6 @@ describe('Daemon CP agent → disk + reconcile', () => {
         mode: 'direct',
         botToken: 'must-not-return',
         appToken: 'xapp-stale',
-        allowedUserIds: [],
         bindRules: []
       }
     }
@@ -1296,7 +1295,6 @@ describe('Daemon CP agent → disk + reconcile', () => {
           mode: 'direct',
           botToken: 'must-not-revive',
           appToken: 'xapp-stale',
-          allowedUserIds: [],
           bindRules: []
         }
       }

--- a/packages/daemon/test/cp/cp-integration-registry.test.ts
+++ b/packages/daemon/test/cp/cp-integration-registry.test.ts
@@ -16,7 +16,6 @@ const spec = (over: Partial<IntegrationSpec> = {}): IntegrationSpec => ({
   slack: {
     botToken: 'xoxb-secret',
     appToken: 'xapp-secret',
-    allowedUserIds: [],
     bindRules: [{ match: { kind: 'mention' } }]
   },
   ...over
@@ -73,13 +72,12 @@ describe('CpIntegrationRegistry (filesystem-backed)', () => {
       ]
     })
     const { reg } = makeReg(dir)
-    reg.upsert(spec({ slack: { botToken: 'xoxb-new', appToken: 'xapp-new', allowedUserIds: ['U1'], bindRules: [] } }))
+    reg.upsert(spec({ slack: { botToken: 'xoxb-new', appToken: 'xapp-new', bindRules: [] } }))
     const a = readAgent(dir, 'helper')
     expect(a.integrations).toHaveLength(2)
     const [cp, local] = a.integrations as any[]
     expect(cp.id).toBe(I1)
     expect(cp.slack.botToken).toBe('xoxb-new')
-    expect(cp.slack.allowedUserIds).toEqual(['U1'])
     // Hand-authored placeholder-looking strings stay literal.
     expect(local.slack.botToken).toBe('${MY_BOT}')
     expect(local.slack.appToken).toBe('${MY_APP}')
@@ -136,9 +134,7 @@ describe('CpIntegrationRegistry (filesystem-backed)', () => {
       integrations: [{ id: I1, platform: 'slack', slack: { botToken: 'xoxb-a', appToken: 'xapp-a' } }]
     })
     const { reg, onChange } = makeReg(dir)
-    reg.converge([
-      spec({ integrationId: I2, slack: { botToken: 'xoxb-b', appToken: 'xapp-b', allowedUserIds: [], bindRules: [] } })
-    ])
+    reg.converge([spec({ integrationId: I2, slack: { botToken: 'xoxb-b', appToken: 'xapp-b', bindRules: [] } })])
     const a = readAgent(dir, 'helper')
     // I2 created from the roster; I1 NOT pruned (deletion only via integration/remove)
     expect((a.integrations as any[]).map((i) => i.id).sort()).toEqual([I1, I2].sort())

--- a/packages/daemon/test/cp/cp-integration.test.ts
+++ b/packages/daemon/test/cp/cp-integration.test.ts
@@ -81,7 +81,6 @@ const INTEGRATION: IntegrationSpec = {
   slack: {
     botToken: 'xoxb-secret-abc',
     appToken: 'xapp-1-secret-def',
-    allowedUserIds: [],
     bindRules: [{ match: { kind: 'mention' } }]
   }
 }

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -101,7 +101,6 @@ function makeRoutable(daemon: Daemon) {
         botToken: 'b',
         appToken: 'p',
         botUserId: 'UBOTA',
-        allowedUserIds: [],
         bindRules: [{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }]
       }
     }
@@ -138,25 +137,10 @@ describe('Daemon in-conversation commands', () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
     await daemon.start()
     const conn = makeRoutable(daemon)
-    ;(daemon as any).agents.get('bot-a').integrations[0].slack.allowedUserIds = ['U1']
     const scope = LOOP_SCOPE
     ;(daemon as any).store.tripLoopGuard(scope, 1, 'test_loop')
 
     ;(daemon as any).onInbound({ ...dm('100', '!resume'), sender: { id: 'unknown', isBot: false } })
-    expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
-    expect(conn.postMessage).not.toHaveBeenCalled()
-
-    ;(daemon as any).onInbound({ ...dm('150', '!resume'), sender: { id: 'U2', isBot: false } })
-    expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
-    expect(conn.postMessage).not.toHaveBeenCalled()
-
-    // CP rules do not carry allowedUserIds. Even if one independently routes U2 to
-    // this agent, concrete-integration command auth must still reject the reset.
-    ;(daemon as any).cpRouting.applyUpdate({
-      routingEpoch: 1,
-      rules: [{ agentId: 'bot-a', match: { kind: 'dm' } }]
-    })
-    ;(daemon as any).onInbound({ ...dm('175', '!resume'), sender: { id: 'U2', isBot: false } })
     expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
     expect(conn.postMessage).not.toHaveBeenCalled()
 
@@ -173,7 +157,6 @@ describe('Daemon in-conversation commands', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     const integration = (daemon as any).agents.get('bot-a').integrations[0]
-    integration.slack.allowedUserIds = ['U1']
     integration.slack.bindRules = [{ match: { kind: 'mention' } }]
     const scope = 'slack:C-top:top-level'
     ;(daemon as any).store.tripLoopGuard(scope, 1, 'automatic_turn_burst')
@@ -195,10 +178,6 @@ describe('Daemon in-conversation commands', () => {
       trigger: 'mention' as const
     })
 
-    ;(daemon as any).onInbound(resume('U2'))
-    expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
-    expect(conn.postMessage).not.toHaveBeenCalled()
-
     ;(daemon as any).onInbound(resume('U1'))
     expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(false)
     expect(conn.postMessage).toHaveBeenCalledWith('C-top', expect.stringContaining('Resumed'), '9')
@@ -206,12 +185,11 @@ describe('Daemon in-conversation commands', () => {
     await daemon.stop()
   })
 
-  it('shared-bot rd/msg(im) only lets an allowed human reset the loop guard', async () => {
+  it('shared-bot rd/msg(im) only lets a human reset the loop guard', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })
     await daemon.start()
     const conn = makeRoutable(daemon)
-    ;(daemon as any).agents.get('bot-a').integrations[0].slack.allowedUserIds = ['U1']
     const scope = LOOP_SCOPE
     ;(daemon as any).store.tripLoopGuard(scope, 1, 'test_loop')
 
@@ -226,7 +204,7 @@ describe('Daemon in-conversation commands', () => {
       payload: { ...dm(msgId, '!resume'), sender }
     })
 
-    // Even an allowlisted identity cannot issue control commands when the event is bot-authored.
+    // A bot-authored event cannot issue control commands.
     expect((daemon as any).handleRelayMsg(relayResume('relay-bot', { id: 'U1', isBot: true }), () => {})).toEqual({
       msgId: 'relay-bot',
       accepted: false,
@@ -234,14 +212,8 @@ describe('Daemon in-conversation commands', () => {
     })
     expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
 
-    expect(
-      (daemon as any).handleRelayMsg(relayResume('relay-unauthorized', { id: 'U2', isBot: false }), () => {})
-    ).toEqual({ msgId: 'relay-unauthorized', accepted: false, reason: 'unauthorized' })
-    expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(true)
-    expect(conn.postMessage).not.toHaveBeenCalled()
-
-    expect((daemon as any).handleRelayMsg(relayResume('relay-allowed', { id: 'U1', isBot: false }), () => {})).toEqual({
-      msgId: 'relay-allowed',
+    expect((daemon as any).handleRelayMsg(relayResume('relay-human', { id: 'U1', isBot: false }), () => {})).toEqual({
+      msgId: 'relay-human',
       accepted: true
     })
     expect((daemon as any).store.isLoopGuardOpen(scope)).toBe(false)
@@ -1716,7 +1688,6 @@ describe('Slack interactive status bar', () => {
           appId: 'cli_http_app',
           appSecret: 'secret',
           region: 'lark',
-          allowedUserIds: [],
           bindRules: []
         }
       }
@@ -2009,7 +1980,6 @@ describe('Slack interactive status bar', () => {
             appId: 'cli_lark',
             appSecret: 'secret',
             region: 'lark',
-            allowedUserIds: [],
             bindRules: []
           }
         }

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -674,7 +674,6 @@ describe('Daemon interrupt safety gates', () => {
             botToken: 'xoxb-test',
             appToken: 'xapp-test',
             botUserId: 'UBOTA',
-            allowedUserIds: ['U1'],
             bindRules: [{ match: { kind: 'mention' } }]
           }
         }

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -115,7 +115,7 @@ function makeRoutable(daemon: Daemon) {
     {
       id: 'int-a',
       platform: 'slack',
-      slack: { botToken: 'b', appToken: 'p', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      slack: { botToken: 'b', appToken: 'p', bindRules: [{ match: { kind: 'dm' } }] }
     }
   ]
   const conn = {

--- a/packages/daemon/test/daemon-runtime-auth.test.ts
+++ b/packages/daemon/test/daemon-runtime-auth.test.ts
@@ -46,7 +46,7 @@ function makeRoutable(daemon: Daemon): void {
     {
       id: 'int-a',
       platform: 'slack',
-      slack: { botToken: 'b', appToken: 'p', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      slack: { botToken: 'b', appToken: 'p', bindRules: [{ match: { kind: 'dm' } }] }
     }
   ]
   let n = 0

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -79,7 +79,7 @@ function makeRoutable(daemon: Daemon) {
     {
       id: 'int-a',
       platform: 'slack',
-      slack: { botToken: 'b', appToken: 'p', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      slack: { botToken: 'b', appToken: 'p', bindRules: [{ match: { kind: 'dm' } }] }
     }
   ]
   let n = 0

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -886,7 +886,6 @@ describe('daemon durable inbox', () => {
           botToken: 'b',
           appToken: 'a',
           botUserId: 'UBOT',
-          allowedUserIds: [],
           bindRules: [{ match: { kind: 'dm' } }]
         }
       }
@@ -927,7 +926,6 @@ describe('daemon durable inbox', () => {
             mode: 'direct',
             botToken: 'b',
             appToken: 'p',
-            allowedUserIds: ['U1'],
             bindRules: []
           }
         }

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -66,7 +66,7 @@ function seedAgent(daemon: Daemon, agentId: string, integrationId: string, appId
       {
         id: integrationId,
         platform: 'feishu',
-        feishu: { mode: 'direct', appId, appSecret: 's', region, allowedUserIds: [], bindRules: [] }
+        feishu: { mode: 'direct', appId, appSecret: 's', region, bindRules: [] }
       }
     ]
   })

--- a/packages/daemon/test/feishu-region.test.ts
+++ b/packages/daemon/test/feishu-region.test.ts
@@ -16,7 +16,7 @@ function feishuAgent(id: string, appId: string, region: FeishuRegion): Agent {
       {
         id: `int-${id}`,
         platform: 'feishu',
-        feishu: { mode: 'direct', appId, appSecret: 'secret', region, allowedUserIds: [], bindRules: [] }
+        feishu: { mode: 'direct', appId, appSecret: 'secret', region, bindRules: [] }
       }
     ]
   } as unknown as Agent

--- a/packages/daemon/test/mcp-bridge-e2e.test.ts
+++ b/packages/daemon/test/mcp-bridge-e2e.test.ts
@@ -18,7 +18,7 @@ const cliEntry = fileURLToPath(new URL('../src/index.ts', import.meta.url))
 const repoRoot = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../..'))
 
 const tools = toolsForIntegrations(
-  [{ id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', allowedUserIds: [], bindRules: [] } }],
+  [{ id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', bindRules: [] } }],
   { sessionTitle: true }
 )
 

--- a/packages/daemon/test/mcp-control-server.test.ts
+++ b/packages/daemon/test/mcp-control-server.test.ts
@@ -32,7 +32,7 @@ function gateway(): SlackGateway {
 }
 
 const tools = toolsForIntegrations([
-  { id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', allowedUserIds: [], bindRules: [] } }
+  { id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', bindRules: [] } }
 ])
 
 const ctx = (over: Partial<SessionContext> = {}): SessionContext => ({

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -19,7 +19,7 @@ const ctx: SessionContext = {
   channel: 'C_CURRENT',
   thread: '111.1',
   tools: toolsForIntegrations([
-    { id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', allowedUserIds: [], bindRules: [] } }
+    { id: 'int-1', platform: 'slack', slack: { botToken: 'x', appToken: 'y', bindRules: [] } }
   ]),
   integrations: [{ id: 'int-1', platform: 'slack' }]
 }

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -5,13 +5,13 @@ import type { Integration } from '../src/agents/agent-schema.js'
 const slackInt: Integration = {
   id: 'int-1',
   platform: 'slack',
-  slack: { botToken: 'xoxb', appToken: 'xapp', allowedUserIds: [], bindRules: [] }
+  slack: { botToken: 'xoxb', appToken: 'xapp', bindRules: [] }
 }
 
 const telegramInt: Integration = {
   id: 'int-2',
   platform: 'telegram',
-  telegram: { botToken: '123456:ABC', allowedUserIds: [], bindRules: [] }
+  telegram: { botToken: '123456:ABC', bindRules: [] }
 }
 
 describe('toolsForIntegrations', () => {

--- a/packages/daemon/test/reconciler.test.ts
+++ b/packages/daemon/test/reconciler.test.ts
@@ -21,7 +21,7 @@ const a = (id: string): Agent =>
 const slackInt = (id: string) => ({
   id,
   platform: 'slack' as const,
-  slack: { botToken: 'xoxb', appToken: 'xapp', allowedUserIds: [], bindRules: [] }
+  slack: { botToken: 'xoxb', appToken: 'xapp', bindRules: [] }
 })
 
 const actual = (...agents: Agent[]) => new Map(agents.map((g) => [g.id, g]))

--- a/packages/daemon/test/route-rules.test.ts
+++ b/packages/daemon/test/route-rules.test.ts
@@ -105,11 +105,6 @@ describe('routeRules ladder', () => {
     ).toEqual({ agentId: 'private-bot', integrationId: 'lark-private', via: 'dm' })
   })
 
-  it('allowedUserIds gate rejects a non-listed sender', () => {
-    const rules = [rule({ match: { kind: 'auto' }, allowedUserIds: ['U2'] })]
-    expect(routeRules(msg({ sender: { id: 'U1', isBot: false } }), rules, noOwner)).toBeNull()
-  })
-
   it('keyword matches case-insensitively on substring', () => {
     const rules = [rule({ agentId: 'kw', match: { kind: 'keyword', value: 'Deploy' } })]
     expect(routeRules(msg({ text: 'please deploy now' }), rules, noOwner)?.agentId).toBe('kw')
@@ -286,7 +281,6 @@ const tgAgent = (over: Partial<Agent> = {}): Agent =>
         telegram: {
           botToken: '123:abc',
           botUsername: 'mybot',
-          allowedUserIds: ['77'],
           bindRules: [{ match: { kind: 'mention' } }, { channel: '-100', match: { kind: 'auto' } }]
         }
       }
@@ -302,7 +296,6 @@ describe('rulesFromAgent / resolveAgentIntegration (Telegram)', () => {
       expect(r.platform).toBe('telegram')
       expect(r.integrationId).toBe('i-tg')
       expect(r.botUserId).toBe('mybot')
-      expect(r.allowedUserIds).toEqual(['77'])
     }
     expect(rules[1]!.scope).toEqual({ channel: '-100' })
   })

--- a/packages/daemon/test/router.test.ts
+++ b/packages/daemon/test/router.test.ts
@@ -9,11 +9,7 @@ import type { NormalizedMessage } from '../src/messages/normalized.js'
 // layer) → routeRules, mirroring the scenarios the legacy routing-table test
 // covered (subscribed-all, trigger=mention, thread affinity, explicit-@ override, DM, gates).
 
-function agent(
-  id: string,
-  bindRules: Agent['integrations'][number]['slack']['bindRules'],
-  allowedUserIds: string[] = []
-): Agent {
+function agent(id: string, bindRules: Agent['integrations'][number]['slack']['bindRules']): Agent {
   return {
     id,
     name: id,
@@ -27,7 +23,6 @@ function agent(
         slack: {
           botToken: 'x',
           appToken: 'x',
-          allowedUserIds,
           bindRules
         }
       }
@@ -117,13 +112,5 @@ describe('local-layer routing (bindRules → rulesFromAgent → routeRules)', ()
       integrationId: 'bot-a-int',
       via: 'dm'
     })
-  })
-
-  it('enforces allowedUserIds', () => {
-    const rules = rulesFromAgent(agent('bot-a', [{ channel: 'C1', match: { kind: 'auto' } }], ['U9']), {
-      'bot-a-int': 'BOTA'
-    })
-    expect(routeRules(msg({ sender: { id: 'U1', isBot: false } }), rules, noOwner)).toBeNull() // not allowed
-    expect(routeRules(msg({ sender: { id: 'U9', isBot: false } }), rules, noOwner)).not.toBeNull()
   })
 })

--- a/packages/daemon/test/routing-rule.test.ts
+++ b/packages/daemon/test/routing-rule.test.ts
@@ -22,7 +22,6 @@ function agent(over: Partial<Agent> = {}): Agent {
         slack: {
           botToken: 'x',
           appToken: 'y',
-          allowedUserIds: ['U1'],
           bindRules: [{ match: { kind: 'mention' } }, { channel: 'C1', match: { kind: 'auto' } }]
         } as any
       }
@@ -35,7 +34,7 @@ function agent(over: Partial<Agent> = {}): Agent {
 }
 
 describe('rulesFromAgent', () => {
-  it('derives one resolved RoutingRule per bindRule, with botUserId + allowedUserIds applied', () => {
+  it('derives one resolved RoutingRule per bindRule with the resolved botUserId', () => {
     const rules = rulesFromAgent(agent(), { int1: 'B1' })
     expect(rules).toHaveLength(2)
     expect(rules[0]).toMatchObject({
@@ -44,7 +43,6 @@ describe('rulesFromAgent', () => {
       botUserId: 'B1',
       match: { kind: 'mention' },
       source: 'config',
-      allowedUserIds: ['U1'],
       scope: {}
     })
     expect(rules[1]).toMatchObject({ match: { kind: 'auto' }, scope: { channel: 'C1' } })

--- a/packages/daemon/test/telegram-connection.test.ts
+++ b/packages/daemon/test/telegram-connection.test.ts
@@ -99,15 +99,13 @@ describe('consolidateTelegram', () => {
       {
         id: 'a1',
         integrations: [
-          { id: 'i1', platform: 'telegram', telegram: { botToken: 'T1', allowedUserIds: [], bindRules: [] } },
-          { id: 'i2', platform: 'slack', slack: { botToken: 'x', appToken: 'y', allowedUserIds: [], bindRules: [] } }
+          { id: 'i1', platform: 'telegram', telegram: { botToken: 'T1', bindRules: [] } },
+          { id: 'i2', platform: 'slack', slack: { botToken: 'x', appToken: 'y', bindRules: [] } }
         ]
       } as unknown as Agent,
       {
         id: 'a2',
-        integrations: [
-          { id: 'i3', platform: 'telegram', telegram: { botToken: 'T1', allowedUserIds: [], bindRules: [] } }
-        ]
+        integrations: [{ id: 'i3', platform: 'telegram', telegram: { botToken: 'T1', bindRules: [] } }]
       } as unknown as Agent
     ]
     const groups = consolidateTelegram(agents)

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -47,7 +47,6 @@ function makeTelegramRoutable(daemon: Daemon) {
       telegram: {
         botToken: '123:abc',
         botUsername: 'mybot',
-        allowedUserIds: [],
         bindRules: [{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }]
       }
     }
@@ -74,7 +73,6 @@ function makeTelegramGated(daemon: Daemon) {
       platform: 'telegram',
       telegram: {
         botToken: '123:abc',
-        allowedUserIds: [],
         bindRules: [],
         gated: true
       }
@@ -161,7 +159,6 @@ describe('Telegram ingress attribution', () => {
         platform: 'telegram',
         telegram: {
           botToken: 'wrong-token',
-          allowedUserIds: [],
           bindRules: [{ match: { kind: 'dm' } }]
         }
       }
@@ -176,7 +173,6 @@ describe('Telegram ingress attribution', () => {
           platform: 'telegram',
           telegram: {
             botToken: 'target-token',
-            allowedUserIds: [],
             bindRules: [{ channel: '424242', match: { kind: 'dm' } }],
             gated: true
           }
@@ -214,12 +210,12 @@ describe('Telegram ingress attribution', () => {
       {
         id: 'i-a',
         platform: 'telegram',
-        telegram: { botToken: '111:a', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+        telegram: { botToken: '111:a', bindRules: [{ match: { kind: 'dm' } }] }
       },
       {
         id: 'i-b',
         platform: 'telegram',
-        telegram: { botToken: '222:b', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+        telegram: { botToken: '222:b', bindRules: [{ match: { kind: 'dm' } }] }
       }
     ]
     const scopeA = (daemon as any).transportScopeForIntegrationIds(['i-a'])
@@ -482,7 +478,6 @@ function makeScopedTelegramPair(daemon: Daemon) {
       telegram: {
         botToken: '111:a',
         botUsername: 'bota',
-        allowedUserIds: [],
         bindRules: [{ match: { kind: 'mention' } }]
       }
     }
@@ -498,7 +493,6 @@ function makeScopedTelegramPair(daemon: Daemon) {
         telegram: {
           botToken: '222:b',
           botUsername: 'botb',
-          allowedUserIds: [],
           bindRules: [{ match: { kind: 'mention' } }]
         }
       }
@@ -534,18 +528,6 @@ describe('group command routing (no mention entity)', () => {
     const [ch, , opts] = conn.postChrome.mock.calls.at(-1)!
     expect(ch).toBe('-100')
     expect(opts).toMatchObject({ replyTo: 200 }) // reply threads under the command message
-  })
-
-  it('respects the integration allowedUserIds when falling back', async () => {
-    const daemon = new Daemon({ root: scaffold() })
-    await daemon.start()
-    const conn = makeTelegramRoutable(daemon)
-    ;(daemon as any).agents.get('bot-a').integrations[0].telegram.allowedUserIds = ['999']
-    seedSession(daemon, '-100', 'tg:100')
-    // Sender U1 (id 'U1') is not in the allow-list → the command is ignored.
-    ;(daemon as any).onInbound(tg(200, { text: '/status@mybot' }), ['i-tg'])
-    expect(conn.postChrome).not.toHaveBeenCalled()
-    expect(conn.postMessage).not.toHaveBeenCalled()
   })
 
   it('finds the latest eligible session on the bot that received the command', async () => {
@@ -647,23 +629,6 @@ describe('session-control cards (/models tappable buttons)', () => {
       conn
     )
     expect(lines.filter((l) => l.includes('select:model'))).toEqual([])
-  })
-
-  it('rejects a tap from a user outside allowedUserIds', async () => {
-    const daemon = new Daemon({ root: scaffold() })
-    await daemon.start()
-    const conn = makeTelegramRoutable(daemon)
-    injectHost(daemon)
-    ;(daemon as any).agents.get('bot-a').integrations[0].telegram.allowedUserIds = ['999']
-    const key = seedSession(daemon, '-100', 'tg:100')
-
-    ;(daemon as any).handleTelegramCallback(
-      { id: 'cb2', data: 'm:1', channel: '-100', messageId: 55, userId: 'U1' },
-      conn
-    )
-    expect((daemon as any).store.getModelOverride(key)).toBeUndefined()
-    expect(conn.answerCallback).toHaveBeenCalledWith('cb2', expect.stringContaining('No active session'))
-    expect(conn.editCard).not.toHaveBeenCalled()
   })
 
   it('applies a callback only to a session owned by the bot that delivered the tap', async () => {

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -55,7 +55,7 @@ function connect(daemon: Daemon, overrides: Record<string, unknown> = {}) {
     {
       id: 'int-a',
       platform: 'slack',
-      slack: { botToken: 'b', appToken: 'p', allowedUserIds: [], bindRules: [{ match: { kind: 'dm' } }] }
+      slack: { botToken: 'b', appToken: 'p', bindRules: [{ match: { kind: 'dm' } }] }
     }
   ]
   let post = 0

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -670,7 +670,6 @@ describe('writeAgentSpec — create (no agent.json)', () => {
             shareable: false,
             botToken: 'xoxb-secret',
             appToken: 'xapp-secret',
-            allowedUserIds: [],
             bindRules: []
           }
         },
@@ -819,7 +818,6 @@ describe('cold-move archive', () => {
         botToken: 'new-secret',
         appToken: 'new-app',
         appId: 'A123',
-        allowedUserIds: [],
         bindRules: []
       }
     } as IntegrationSpec
@@ -879,7 +877,6 @@ describe('cold-move archive', () => {
           botToken: 'new-secret',
           appToken: 'new-app',
           appId: 'A123',
-          allowedUserIds: [],
           bindRules: []
         }
       }

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -439,7 +439,6 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.frame.payload.slack.botToken).toBe('xoxb-abc')
     expect(r.frame.payload.slack.appToken).toBe('xapp-1-def')
     expect(r.frame.payload.slack.appId).toBe('A123')
-    expect(r.frame.payload.slack.allowedUserIds).toEqual([]) // zod default
     expect(r.frame.payload.slack.bindRules).toEqual([]) // zod default
   })
 
@@ -456,7 +455,6 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'telegram') throw new Error('expected telegram integration')
     expect(r.frame.payload.telegram.botToken).toBe('123456:ABC-def')
-    expect(r.frame.payload.telegram.allowedUserIds).toEqual([]) // zod default
     expect(r.frame.payload.telegram.bindRules).toEqual([]) // zod default
   })
 
@@ -474,7 +472,6 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     if (r.frame.payload.platform !== 'discord') throw new Error('expected discord integration')
     expect(r.frame.payload.discord.botToken).toBe('MTA-bot-token')
     expect(r.frame.payload.discord.applicationId).toBe('112233445566')
-    expect(r.frame.payload.discord.allowedUserIds).toEqual([]) // zod default
     expect(r.frame.payload.discord.bindRules).toEqual([]) // zod default
   })
 
@@ -494,7 +491,6 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.frame.payload.feishu.appSecret).toBe('secret-xyz')
     expect(r.frame.payload.feishu.mode).toBe('direct') // backwards-compatible default
     expect(r.frame.payload.feishu.region).toBe('feishu') // zod default — China gateway
-    expect(r.frame.payload.feishu.allowedUserIds).toEqual([]) // zod default
     expect(r.frame.payload.feishu.bindRules).toEqual([]) // zod default
   })
 

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -68,7 +68,6 @@ export const IntegrationSlackConfig = z
     // bot) decode as non-shareable.
     shareable: z.boolean().default(false),
     botUserId: z.string().optional(), // lazily resolved via auth.test; may be seeded by CP
-    allowedUserIds: z.array(z.string()).default([]),
     bindRules: z.array(IntegrationBindRule).default([]), // empty for shared (relay arbitrates)
     // Channels the operator switched OFF. bindRules can only ADD reach, so an
     // ungated integration — whose defaults are unscoped (@-mention anywhere + DMs) —
@@ -98,7 +97,6 @@ export type IntegrationSlackConfig = z.infer<typeof IntegrationSlackConfig>
  */
 export const IntegrationTelegramConfig = z.object({
   botToken: z.string(), // BotFather "123456:ABC…"  (plaintext — never log)
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
@@ -114,7 +112,6 @@ export type IntegrationTelegramConfig = z.infer<typeof IntegrationTelegramConfig
 export const IntegrationDiscordConfig = z.object({
   botToken: z.string(), // Bot <token>  (plaintext — never log)
   applicationId: z.string().optional(), // client/application id — public, for the invite URL
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated
@@ -148,7 +145,6 @@ export const IntegrationFeishuConfig = z.object({
   appSecret: z.string(), // app secret (plaintext — never log)
   botOpenId: z.string().optional(), // bot's own open_id; lazily resolved via bot/info
   region: FeishuRegion.default('feishu'), // open-platform gateway: feishu.cn vs larksuite.com
-  allowedUserIds: z.array(z.string()).default([]),
   bindRules: z.array(IntegrationBindRule).default([]),
   mutedChannels: z.array(z.string()).default([]), // Off channels — see IntegrationSlackConfig.mutedChannels
   gated: z.boolean().default(false) // conversation gating — see IntegrationSlackConfig.gated


### PR DESCRIPTION
## Summary

- remove the dormant allowedUserIds field from platform integration schemas and Control Plane distribution
- simplify daemon routing, commands, callbacks, and shortcuts to use the existing conversation admission boundary
- remove obsolete allowlist tests and update all affected design documentation

## Impact

Control Plane-managed integrations already sent an empty list, so their behavior is unchanged. Hand-authored per-sender integration allowlists are no longer supported; platform ingress is authorized by conversation gating.

## Validation

- pnpm --filter @agentconnect.md/protocol build
- protocol, daemon, and Control Plane typechecks
- protocol codec tests: 71 passed
- Control Plane placement tests: 17 passed
- focused daemon tests: 206 passed across 9 files
- pnpm format:check
- changed-file ESLint and pre-push full-repository ESLint

Created by Codex . gpt-5.6-sol