### PR TITLE
fix(sessions): show actual Feishu or Lark audience

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2453,6 +2453,9 @@ export const SessionDetailDto = z.object({
   visibility: SessionVisibilityEnum,
   externalProvider: z.string().nullable(),
   externalResolution: z.enum(['pending', 'settled', 'invalid']).nullable(),
+  /** Feishu/Lark share one protocol provider. A settled external scope carries
+   *  the verified open-platform region used for the source conversation. */
+  feishuRegion: FeishuRegion.nullable(),
   /** §5.1 cutover: `pending` until every affected daemon has acked the change —
    *  CP read gates apply at commit, the memory boundary at acknowledgement. */
   visibilityState: SessionVisibilityStateEnum,

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -286,6 +286,16 @@ function sessionDto(s: SessionPageRow, hookMetadata: Map<string, HookSessionMeta
   }
 }
 
+function feishuRegionForSession(
+  session: { externalProvider: string | null; externalScopeId: string | null },
+  scopes: readonly { id: string; provider: string; realmKey: string }[]
+): 'feishu' | 'lark' | null {
+  if (session.externalProvider !== 'feishu' || !session.externalScopeId) return null
+  const scope = scopes.find((candidate) => candidate.id === session.externalScopeId && candidate.provider === 'feishu')
+  const region = scope?.realmKey.split(':', 1)[0]
+  return region === 'feishu' || region === 'lark' ? region : null
+}
+
 const SessionHistoryQueryDto = z
   .object({
     cursor: z.string().optional(),
@@ -735,6 +745,7 @@ export function sessionRoutes(deps: HttpDeps) {
           visibility: s.visibility,
           externalProvider: s.externalProvider,
           externalResolution: s.externalResolution,
+          feishuRegion: feishuRegionForSession(s, access.externalScopes),
           // The §5.1 cutover state: CP read gates apply at commit, but the memory
           // boundary only takes effect once every affected daemon has acked.
           visibilityState: await visibilityStateOf(deps.visibilityPush, deps.repos, [s.id]),

--- a/packages/control-plane/src/http/session-access.ts
+++ b/packages/control-plane/src/http/session-access.ts
@@ -13,6 +13,10 @@ import { ctxOf, orgOf } from './rbac.js'
 export interface ResolvedSessionAccess {
   identitySet: Set<string>
   externalAccess: SessionExternalAccessSnapshot
+  /** Provider scopes already loaded for this authorization decision. Detail
+   *  responses reuse their verified realm metadata instead of guessing a
+   *  provider variant from the session's protocol platform. */
+  externalScopes: readonly ExternalScopeRecord[]
   degraded: boolean
 }
 
@@ -83,6 +87,7 @@ export function makeSessionAccessResolver(deps: HttpDeps) {
     const allowedScopes = resolvedScopes.filter((scope) => currentScopeRevisions.get(scope.id) === scope.aclRevision)
     return {
       identitySet,
+      externalScopes: scopes,
       externalAccess: {
         policies: currentPolicies.flatMap((policy, index) => {
           const initial = initialPolicies[index]

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -274,6 +274,55 @@ describe('session visibility — external conversation audiences', () => {
     ).toEqual([sessionId])
   })
 
+  it('reports the verified Lark region for an inherited Feishu-provider session', async () => {
+    const viewer = await makeUser(`sv-lark-region-${randomUUID()}`, 'collaborator')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-lark-parent-${randomUUID()}`
+    const childId = `s-lark-child-${randomUUID()}`
+
+    await repo.recordMilestone({
+      sessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'feishu',
+      channel: 'oc_lark',
+      at: new Date(),
+      classification: { visibility: 'private', ownerIdentity: `user:${viewer}`, source: 'default' },
+      externalCandidate: {
+        provider: 'feishu',
+        resolution: 'settled',
+        scope: {
+          realmKey: 'lark:cli_custom',
+          resourceKind: 'conversation',
+          resourceKey: 'oc_lark',
+          credentialKind: 'bot',
+          credentialId: randomUUID()
+        }
+      }
+    })
+    const child = await repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'dream',
+      channel: 'a2a',
+      at: new Date(),
+      classification: { inherit: true }
+    })
+    expect(child.session).toMatchObject({
+      externalProvider: 'feishu',
+      externalResolution: 'settled',
+      tenantScope: null
+    })
+
+    const response = await appAs(viewer).app.inject({ method: 'GET', url: `${ORG}/sessions/${childId}` })
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toMatchObject({ feishuRegion: 'lark' })
+  })
+
   it('lets only owners change sync and withholds hidden-session diagnostics from other members', async () => {
     const owner = await makeUser(`sv-slack-owner-${randomUUID()}`, 'owner')
     const collaborator = await makeUser(`sv-slack-collab-${randomUUID()}`, 'collaborator')

--- a/packages/web/src/components/console/SessionVisibilityControl.test.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.test.tsx
@@ -68,7 +68,10 @@ describe('SessionVisibilityControl — tighten confirmation', () => {
     expect(text).toContain('no per-session control')
   })
 
-  it('labels a settled Feishu/Lark external audience as current chat members', async () => {
+  it.each([
+    ['feishu', 'Feishu'],
+    ['lark', 'Lark']
+  ] as const)('labels a settled %s external audience as %s members', async (feishuRegion, brand) => {
     container = document.createElement('div')
     document.body.append(container)
     root = createRoot(container)
@@ -79,12 +82,15 @@ describe('SessionVisibilityControl — tighten confirmation', () => {
           visibility="external"
           externalProvider="feishu"
           externalResolution="settled"
+          feishuRegion={feishuRegion}
           canChange={false}
           onChanged={() => {}}
         />
       )
     })
-    expect(container.textContent).toContain('Feishu / Lark members')
-    expect(container.querySelector('span')?.title).toContain('current members')
+    expect(container.textContent).toContain(`${brand} members`)
+    expect(container.querySelector('span')?.title).toBe(
+      `Visible to current members of the source ${brand} conversation`
+    )
   })
 })

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -33,6 +33,7 @@ export function SessionVisibilityControl({
   canChange,
   externalProvider,
   externalResolution,
+  feishuRegion,
   nativeMemory = false,
   onChanged
 }: {
@@ -44,6 +45,7 @@ export function SessionVisibilityControl({
   canChange: boolean
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
+  feishuRegion?: 'feishu' | 'lark' | null
   /** The owning agent persists memory inside its runtime (provider `native`),
    *  which has no per-session gate — so the copy must NOT promise that going
    *  private stops what the agent learns. See docs/product-conventions.md. */
@@ -87,7 +89,11 @@ export function SessionVisibilityControl({
         : github
           ? 'GitHub'
           : externalProvider === 'feishu'
-            ? 'Feishu / Lark'
+            ? feishuRegion === 'lark'
+              ? 'Lark'
+              : feishuRegion === 'feishu'
+                ? 'Feishu'
+                : 'Feishu / Lark'
             : 'External'
     const title =
       externalResolution === 'settled'

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1885,6 +1885,7 @@ export default function SessionDetailView() {
         canChange={currentSessionDetail.canChangeVisibility === true}
         externalProvider={currentSessionDetail.externalProvider}
         externalResolution={currentSessionDetail.externalResolution}
+        feishuRegion={currentSessionDetail.feishuRegion}
         // Native runtime memory has no per-session gate, so the copy must not
         // promise a memory boundary this tier cannot deliver.
         nativeMemory={owner?.memoryProvider === 'native'}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -498,6 +498,8 @@ export interface SessionDetailDto {
   canChangeVisibility?: boolean | null
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
+  /** Actual source gateway for Feishu/Lark external sessions. Absent on older CPs. */
+  feishuRegion?: 'feishu' | 'lark' | null
   accessSyncDegraded?: boolean
   /** Multi-agent webchat conversation roster, in pick order. Null for single-agent
    *  conversations and other platforms; absent on a CP that predates the feature.


### PR DESCRIPTION
## Summary

- derive the Feishu/Lark region from the session's verified external scope
- return that region in session detail metadata, including inherited agent-to-agent sessions
- show `Feishu members` or `Lark members` in the audience label and tooltip, with the combined label retained only for older or unresolved data

## Root cause

Feishu and Lark share the same `feishu` protocol provider, so the console previously had no region-specific value and hardcoded `Feishu / Lark`.

## Impact

Session details now identify the actual source conversation platform instead of displaying both brands.

## Validation

- `pnpm exec eslint` on all changed files
- `pnpm --filter @agentconnect.md/web typecheck`
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm --filter @agentconnect.md/web exec vitest run src/components/console/SessionVisibilityControl.test.tsx`
- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project integration test/integration/session-visibility.route.test.ts -t "reports the verified Lark region"`

Created by Codex . GPT-5.6
