### PR TITLE
fix(web): polish session not-found recovery

### DIFF
--- a/packages/web/src/components/console/NotFound.tsx
+++ b/packages/web/src/components/console/NotFound.tsx
@@ -45,7 +45,7 @@ export function NotFound({
   /** Resolved href for the primary action (caller applies `orgPath`). */
   actionHref: string
   /** Optional recovery action shown beside/below the primary action. */
-  secondaryAction?: { label: string; href: string; icon?: string }
+  secondaryAction?: { label: string; href: string; icon?: ReactNode }
   /** Mobile secondary button label (e.g. "Search agents"); desktop reads "Search". */
   searchLabel?: string
   /** Show the Search affordance. Off for the bare root 404, which renders outside
@@ -86,7 +86,11 @@ export function NotFound({
         </Button>
         {secondaryAction ? (
           <Button variant="secondary" size="sm" onClick={() => router.push(secondaryAction.href)}>
-            {secondaryAction.icon ? <Icon name={secondaryAction.icon} size={14} /> : null}
+            {secondaryAction.icon ? (
+              <span className="flex h-[15px] w-[15px] flex-none items-center justify-center">
+                {secondaryAction.icon}
+              </span>
+            ) : null}
             {secondaryAction.label}
           </Button>
         ) : null}
@@ -115,7 +119,11 @@ export function NotFound({
             className="h-11 w-full text-[14px]"
             onClick={() => router.push(secondaryAction.href)}
           >
-            {secondaryAction.icon ? <Icon name={secondaryAction.icon} size={15} /> : null}
+            {secondaryAction.icon ? (
+              <span className="flex h-[15px] w-[15px] flex-none items-center justify-center">
+                {secondaryAction.icon}
+              </span>
+            ) : null}
             {secondaryAction.label}
           </Button>
         ) : null}

--- a/packages/web/src/components/console/SessionRail.test.tsx
+++ b/packages/web/src/components/console/SessionRail.test.tsx
@@ -135,8 +135,8 @@ describe('SessionRail column', () => {
   })
 
   it('renders the placeholder at the same width the populated rail uses', () => {
-    // SessionDetailFrame draws SessionRailSlot for every state that has no rail to
-    // show (loading, not found). It only holds the page still if it is the same box.
+    // SessionDetailFrame draws SessionRailSlot while the detail is loading. It only
+    // holds the page still if it is the same box as the populated rail.
     const slot = renderToStaticMarkup(<SessionRailSlot />)
 
     expect(slot).toContain(COLUMN)

--- a/packages/web/src/components/console/SessionRail.tsx
+++ b/packages/web/src/components/console/SessionRail.tsx
@@ -98,8 +98,8 @@ function pinIdsOf(session: Session): string[] {
 
 /**
  * The rail's footprint with nothing in it — the shape every session detail state
- * holds so the body beside it never moves. Used by the loading and not-found
- * branches, which have no rail to draw, and by a rail with no rows worth drawing.
+ * holds so the body beside it never moves. Used by the loading branch, which has
+ * no rail to draw, and by a rail with no rows worth drawing.
  */
 export function SessionRailSlot() {
   return <div aria-hidden="true" className="hidden w-[224px] flex-none desktop:block" />

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -66,7 +66,7 @@ import {
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
 import { usePlayground } from '@/components/console/PlaygroundProvider'
-import { AgentIconView, LoadingState, ModelMark, PlatformMark, Spinner } from '@/components/marks'
+import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
 import { Avatar, Icon } from '@/components/ui'
@@ -850,18 +850,23 @@ function MobileSessionFamilyLinks({
 }
 
 /**
- * Every state this view can render that is not the session itself — loading, and
- * both not-found bodies — drawn on the SAME track the loaded page uses: the 1180px
- * wrap, the rail's column, then the 880px body. The route has one body position and
- * this is how the states that have no rail to draw still honour it; centring them in
- * the bare wrap instead would put each of them 125px left of the transcript that
- * replaces them.
+ * Loading stays on the same rail + body tracks as the transcript that replaces it.
+ * A resolved missing resource opts out of the rail so its standalone 404 card uses
+ * the whole content wrap instead of reserving an empty session-list column.
  */
-function SessionDetailFrame({ children }: { children: ReactNode }) {
+function SessionDetailFrame({ children, withRail = true }: { children: ReactNode; withRail?: boolean }) {
   return (
     <div className="wrap flex min-h-full items-stretch gap-[26px]">
-      <SessionRailSlot />
-      <div className="mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:p-4">{children}</div>
+      {withRail ? <SessionRailSlot /> : null}
+      <div
+        className={
+          withRail
+            ? 'mx-auto flex min-h-full min-w-0 max-w-[880px] flex-1 flex-col max-desktop:p-4'
+            : 'flex min-h-full min-w-0 flex-1 flex-col max-desktop:p-4'
+        }
+      >
+        {children}
+      </div>
     </div>
   )
 }
@@ -1183,17 +1188,16 @@ export default function SessionDetailView() {
   const profileLinkProviderName = socialLoginProviders().find(
     (provider) => provider.target === profileLinkProvider
   )?.name
-  const profileLinkCandidate =
-    sessionDetailError instanceof ApiError &&
-    sessionDetailError.status === 404 &&
-    isAuthConfigured() &&
-    profileLinkProvider !== undefined
+  // Start the caller's identity lookup as soon as the provider hint is known,
+  // alongside the session request. The hint still affects presentation only:
+  // the recovery action cannot render until the protected session read is a 404.
+  const profileIdentityProvider = isAuthConfigured() ? profileLinkProvider : undefined
   const {
     data: profileIdentity,
     error: profileIdentityError,
-    isValidating: profileIdentityLoading
+    isLoading: profileIdentityLoading
   } = useSWR(
-    profileLinkCandidate ? (['logto-session-identity', profileLinkProvider] as const) : null,
+    profileIdentityProvider ? (['logto-session-identity', profileIdentityProvider] as const) : null,
     ([, provider]) => fetchMySessionIdentity(provider),
     {
       revalidateOnFocus: false,
@@ -1201,6 +1205,8 @@ export default function SessionDetailView() {
       shouldRetryOnError: false
     }
   )
+  const profileLinkCandidate =
+    sessionDetailError instanceof ApiError && sessionDetailError.status === 404 && profileIdentityProvider !== undefined
   const showProfileLink =
     profileLinkCandidate &&
     !profileIdentityLoading &&
@@ -1820,7 +1826,7 @@ export default function SessionDetailView() {
   if (conversationKey && (conversationError || !conversationRoster || conversationRoster.sessions.length === 0)) {
     // conversationError, a grace-expired null, or a resolved-but-empty roster.
     return (
-      <SessionDetailFrame>
+      <SessionDetailFrame withRail={false}>
         <NotFound
           icon="message-square-off"
           kind="CONVERSATION"
@@ -1847,7 +1853,7 @@ export default function SessionDetailView() {
       )
     }
     return (
-      <SessionDetailFrame>
+      <SessionDetailFrame withRail={false}>
         <NotFound
           icon="message-square-off"
           kind="SESSION"
@@ -1858,11 +1864,11 @@ export default function SessionDetailView() {
           actionLabel="Back to sessions"
           actionHref={orgPath('/sessions')}
           secondaryAction={
-            showProfileLink && profileLinkProviderName
+            showProfileLink && profileLinkProviderName && profileLinkProvider
               ? {
                   label: `Link ${profileLinkProviderName} profile`,
                   href: orgPath('/profile#sign-in-methods'),
-                  icon: 'link'
+                  icon: <SocialLoginMark target={profileLinkProvider} size={15} />
                 }
               : undefined
           }


### PR DESCRIPTION
## Summary

- start provider identity lookup alongside the protected session read so profile-link recovery is ready sooner
- let missing session and conversation pages use the full content width instead of reserving an empty session rail
- replace the generic link glyph with the matching GitHub, Slack, Lark, or Feishu brand mark

## Root cause

The profile lookup did not begin until after the session request returned 404, creating a second network wait. The missing-state frame also always rendered the normal session-rail placeholder, even though a 404 has no session list to show.

## Validation

- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @agentconnect.md/web test` (89 files, 668 tests)
- `pnpm --filter @agentconnect.md/web build`
- ESLint and Prettier checks on the changed files
- local desktop browser verification of the full-width 404 layout

Created by Codex . gpt-5.6-sol
