### PR TITLE
fix(cli): close login-shell readiness race

### DIFF
--- a/packages/cli/src/service-spawn.ts
+++ b/packages/cli/src/service-spawn.ts
@@ -56,21 +56,26 @@ export function spawnDaemonViaLoginShell(
 
   let ready = false
   const lockFile = daemonLockPath(root)
+  const checkReady = (): boolean => {
+    try {
+      ready ||= Number.parseInt(readFileSync(lockFile, 'utf8').trim(), 10) === child.pid
+    } catch {
+      // lock not written yet
+    }
+    return ready
+  }
   const clear = (): void => {
     clearInterval(poll)
     clearTimeout(deadline)
   }
   const poll = setInterval(() => {
-    try {
-      if (Number.parseInt(readFileSync(lockFile, 'utf8').trim(), 10) === child.pid) {
-        ready = true
-        clear()
-      }
-    } catch {
-      // lock not written yet — keep polling
-    }
+    if (checkReady()) clear()
   }, opts.pollMs ?? POLL_MS)
   const deadline = setTimeout(() => {
+    if (checkReady()) {
+      clear()
+      return
+    }
     clearInterval(poll)
     console.error(
       `agentconnect: daemon did not come up within ${Math.round((opts.readyTimeoutMs ?? READY_TIMEOUT_MS) / 1000)}s ` +
@@ -89,6 +94,7 @@ export function spawnDaemonViaLoginShell(
 
   const done = new Promise<ServiceChildResult>((resolve) => {
     child.on('exit', (code, signal) => {
+      checkReady()
       clear()
       resolve({ code, signal, ready })
     })

--- a/packages/cli/test/service-spawn.test.ts
+++ b/packages/cli/test/service-spawn.test.ts
@@ -36,7 +36,7 @@ async function waitFor(cond: () => boolean, timeoutMs: number): Promise<boolean>
 }
 
 describe('spawnDaemonViaLoginShell', () => {
-  it('marks ready when the exec-ed daemon writes the lock with the preserved pid', async () => {
+  it('marks ready on exit when the daemon writes the lock between polls', async () => {
     const root = dir()
     const lock = daemonLockPath(root)
     const { child, done } = spawnDaemonViaLoginShell(
@@ -46,7 +46,9 @@ describe('spawnDaemonViaLoginShell', () => {
       {},
       {
         shell: fakePosixShell(root),
-        pollMs: 25,
+        // Keep the background poll beyond the test window so the exit-time
+        // probe is what observes the lock written by the daemon.
+        pollMs: 60_000,
         readyTimeoutMs: 5000
       }
     )


### PR DESCRIPTION
## Summary

- reuse one daemon-lock readiness probe for polling, timeout handling, and child exit
- perform a final readiness probe before resolving an exited login-shell child
- make the existing regression deterministic by forcing the lock write to happen between polls

## Root cause

The test could observe `daemon.lock` and terminate the child before the helper's next polling callback set `ready = true`. The exit handler then returned the stale `false` value even though the daemon had written the matching PID.

## Validation

- `pnpm --filter @agentconnect.md/cli exec vitest run test/service-spawn.test.ts` (5/5 passed)
- readiness regression repeated 10 times (10/10 passed)
- `pnpm --filter @agentconnect.md/cli typecheck`
- focused ESLint and Prettier checks
- full CLI unit run: target file passed; unrelated existing macOS `version-lock` PID start-time test remained failing

Created by Codex . GPT-5
