### PR TITLE
fix(control-plane): persist worktree-only workspace edits

### DIFF
--- a/packages/control-plane/src/orchestrator/agentMove.test.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.test.ts
@@ -323,6 +323,20 @@ describe('AgentMoveService', () => {
     expect(t.activations[0]?.reconcileWorkspace).toBe(true)
   })
 
+  it('persists a worktree-only workspace edit', async () => {
+    const shared = { ...GITHUB_WORKSPACE, isolation: 'shared' as const }
+    const session = { ...GITHUB_WORKSPACE, isolation: 'session' as const }
+    const t = make({ workspace: shared })
+
+    const edited = await t.service.setWorkspace(t.current(), session, WORKSPACE_REPO_ID)
+
+    expect(edited.workspace).toEqual(session)
+    expect(t.detaches).toHaveLength(1)
+    expect(t.activations).toHaveLength(1)
+    expect(t.activations[0]?.spec.workspace).toMatchObject({ isolation: 'session' })
+    expect(t.activations[0]?.reconcileWorkspace).toBe(true)
+  })
+
   it('allows a GitHub workspace to switch back to scratch', async () => {
     const t = make({ workspace: GITHUB_WORKSPACE })
 

--- a/packages/control-plane/src/orchestrator/agentMove.ts
+++ b/packages/control-plane/src/orchestrator/agentMove.ts
@@ -121,6 +121,7 @@ function sameWorkspaceDefinition(left: AgentWorkspace, right: AgentWorkspace): b
   if (left.mode !== right.mode) return false
   if (left.mode === 'scratch' || right.mode === 'scratch') return true
   return (
+    (left.isolation ?? 'shared') === (right.isolation ?? 'shared') &&
     gitRepoLabel(left.gitRepo).toLowerCase() === gitRepoLabel(right.gitRepo).toLowerCase() &&
     (left.gitBranch ?? 'main') === (right.gitBranch ?? 'main') &&
     (left.agentDir ?? '') === (right.agentDir ?? '') &&


### PR DESCRIPTION
## Summary

- Treat workspace isolation as part of workspace-definition equality.
- Persist and reactivate Worktree-only edits instead of misclassifying them as an idempotent repair.
- Add a regression test for switching an existing GitHub workspace from shared checkout to per-session worktrees.

## Root cause

The workspace comparison omitted `isolation`. When repository, branch, subdirectory, installation, and access were unchanged, switching Worktree on was treated as no change: the API returned success after reactivating the old definition, while the database remained unchanged.

## Validation

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/orchestrator/agentMove.test.ts`
- `pnpm --filter @agentconnect.md/control-plane test:unit` (115 files, 988 tests)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- ESLint on the changed files and the pre-push full-repository lint

Created by Codex . GPT-5
