### PR TITLE
fix(daemon): make managed git remotes fetchable

### DIFF
--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -234,8 +234,9 @@ export function workspaceGitPullTarget(repository: string): {
   const remote = `agentconnect-${randomUUID()}`
   const pairs = [
     ...workspaceGitConfigPairs(normalized),
-    // An empty value clears lower-priority URL lists before the daemon target.
-    [`remote.${remote}.url`, ''] as const,
+    // The unguessable name cannot collide with a checkout-owned remote after
+    // the local config audit. Do not prepend an empty value: Git treats it as
+    // the first fetch URL and fails before trying the authorized target.
     [`remote.${remote}.url`, normalized] as const,
     [`remote.${remote}.proxy`, ''] as const
   ]

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -225,9 +225,16 @@ describe('gitEnvBase', () => {
 
       const target = workspaceGitPullTarget(repository)
       expect(target.remote).toMatch(/^agentconnect-[0-9a-f-]+$/)
-      expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.url`, ''])
-      expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.url`, repository])
+      expect(configPairs(target.env).filter(([key]) => key === `remote.${target.remote}.url`)).toEqual([
+        [`remote.${target.remote}.url`, repository]
+      ])
       expect(configPairs(target.env)).toContainEqual([`remote.${target.remote}.proxy`, ''])
+      expect(
+        execFileSync('git', ['-C', workspace, 'config', '--get-all', `remote.${target.remote}.url`], {
+          encoding: 'utf8',
+          env: target.env
+        }).trim()
+      ).toBe(repository)
       expect(
         execFileSync('git', ['-C', workspace, 'ls-remote', '--get-url', target.remote], {
           encoding: 'utf8',


### PR DESCRIPTION
## Summary

- bind each daemon-owned random Git remote to exactly one authorized URL
- stop Git fetch and exact PR workspace preparation from failing on an empty first URL
- verify the complete effective URL list in the Git injection regression test

## Validation

- pnpm --filter @agentconnect.md/daemon exec vitest run test/git-injection.test.ts
- pnpm --filter @agentconnect.md/daemon exec vitest run test/workspace.test.ts test/daemon-hook.test.ts
- pnpm --filter @agentconnect.md/daemon typecheck
- focused Prettier check and pre-push ESLint

Created by Codex . GPT-5.6
