### PR TITLE
feat(cli): offer startup recovery when the daemon fails under run

### DIFF
--- a/docs/designs/cli-daemon-split.md
+++ b/docs/designs/cli-daemon-split.md
@@ -178,6 +178,23 @@ launchd's nonzero-exit restart condition.
    `RESERVED_RESTART_CODE`;
 4. propagates every other exit status or signal.
 
+One exception to step 4: an **interactive startup failure**. When the daemon
+exits nonzero (no signal) within the startup window of an interactive
+foreground run — stdin and stderr are TTYs, no service supervisor, no
+`AGENTCONNECT_DAEMON_ENTRY` dev override, no pending stop — the shell offers a
+recovery menu instead of dying with the exit code:
+
+1. switch back to the recorded `previous` version and retry (offered only when
+   that version is still installed);
+2. force re-download the channel's latest version (replacing the possibly
+   corrupt installed bundle) and retry;
+3. print the manual `agentconnect version list / install / use` commands and
+   exit.
+
+A successful switch re-enters the respawn loop; declining (empty answer,
+Ctrl-C, or EOF) propagates the original exit status unchanged. Non-interactive
+and service runs never prompt — their supervisor must see the real exit code.
+
 The shell forwards `SIGTERM` to the child. Terminal `SIGINT` reaches both
 processes through the foreground process group, so the shell waits for and
 faithfully reproduces the child's termination instead of double-delivering the

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -2,7 +2,8 @@
  * Install a daemon version into the store (cli-daemon-split.md §5.1): resolve from
  * the registry → verify integrity → engines check → extract to `versions/<v>.tmp`
  * → atomic rename to `versions/<v>`. Idempotent: an already-installed version is a
- * no-op success. Must run inside the version lock (version-lock.ts).
+ * no-op success — unless `force` re-downloads and replaces it (the recovery path
+ * for a corrupt bundle). Must run inside the version lock (version-lock.ts).
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs'
@@ -36,9 +37,10 @@ export async function resolveTarget(opts: { to?: string; channel: Channel }): Pr
 export async function installTarget(
   root: string,
   target: ResolvedTarget,
-  onLog: (msg: string) => void = () => {}
+  onLog: (msg: string) => void = () => {},
+  opts: { force?: boolean } = {}
 ): Promise<string> {
-  if (isInstalled(root, target.version)) {
+  if (!opts.force && isInstalled(root, target.version)) {
     onLog(`daemon ${target.version} already installed`)
     return target.version
   }
@@ -75,9 +77,15 @@ export async function installTarget(
       throw new Error(`daemon ${target.version} tarball has no dist/index.js — refusing to install`)
     }
 
-    // Atomic publish. A racing install that already produced `dest` wins; drop tmp.
+    // Atomic publish. A racing install that already produced `dest` wins; drop
+    // tmp — except a forced re-install, whose point is replacing the existing dir.
     if (existsSync(dest)) {
-      rmSync(tmp, { recursive: true, force: true })
+      if (opts.force) {
+        rmSync(dest, { recursive: true, force: true })
+        renameSync(tmp, dest)
+      } else {
+        rmSync(tmp, { recursive: true, force: true })
+      }
     } else {
       renameSync(tmp, dest)
     }

--- a/packages/cli/src/run-recovery.ts
+++ b/packages/cli/src/run-recovery.ts
@@ -1,0 +1,133 @@
+/**
+ * Interactive recovery for a foreground `run` whose daemon failed at startup
+ * (cli-daemon-split.md §6.1). For a foreground run the respawn shell is the
+ * supervisor and the operator is at the terminal — so when the daemon exits
+ * nonzero shortly after spawn (broken bundle, bad upgrade) the CLI offers to
+ * roll back to `previous`, force re-download the channel latest, or print the
+ * manual version commands. Service mode, non-TTY, and dev-entry runs never
+ * prompt: their exit code must propagate to the supervisor untouched.
+ */
+import { createInterface } from 'node:readline'
+import type { ChildResult } from './delegate.js'
+import { versionReinstallLatest, versionRollback } from './version-commands.js'
+import { currentVersion, isInstalled, readMeta } from './version-store.js'
+
+/**
+ * Exits later than this after spawn are runtime crashes, not startup failures —
+ * a version rollback would suggest the wrong fix, so recovery stays silent.
+ */
+export const STARTUP_FAILURE_WINDOW_MS = 60_000
+
+export interface RecoveryContext {
+  /** The service manager (or the user) asked us to stop — never prompt. */
+  stopRequested: boolean
+  /** AGENTCONNECT_SUPERVISOR=service: launchd/systemd supervises, no operator. */
+  supervised: boolean
+  /** AGENTCONNECT_DAEMON_ENTRY dev override: the version store is bypassed. */
+  devEntry: boolean
+  /** stdin AND stderr are TTYs — someone can actually answer the prompt. */
+  interactive: boolean
+  /** Milliseconds between spawn and exit. */
+  elapsedMs: number
+}
+
+/** Pure predicate: does this daemon exit warrant the recovery prompt? */
+export function shouldOfferRecovery(result: ChildResult, ctx: RecoveryContext): boolean {
+  if (ctx.stopRequested || ctx.supervised || ctx.devEntry || !ctx.interactive) return false
+  if (result.signal !== null) return false // killed, not failed
+  if (!result.code) return false // clean exit
+  return ctx.elapsedMs <= STARTUP_FAILURE_WINDOW_MS
+}
+
+export type RecoveryAction = 'rollback' | 'reinstall' | 'manual'
+
+export interface RecoveryOption {
+  key: string
+  action: RecoveryAction
+  label: string
+}
+
+/** The menu, keyed 1..n. Rollback is offered only when a usable `previous` exists. */
+export function recoveryOptions(o: { previous: string | null; channel: string }): RecoveryOption[] {
+  const options: RecoveryOption[] = []
+  const add = (action: RecoveryAction, label: string): void => {
+    options.push({ key: String(options.length + 1), action, label })
+  }
+  if (o.previous) add('rollback', `switch back to the previous version (${o.previous}) and retry`)
+  add('reinstall', `re-download the latest ${o.channel} version and retry`)
+  add('manual', 'show the commands to pick a version manually')
+  return options
+}
+
+export const MANUAL_VERSION_HELP = [
+  'Pick a daemon version manually:',
+  '  agentconnect version list               # installed versions (current / previous)',
+  '  agentconnect version install <version>  # download a specific version',
+  '  agentconnect version use <version>      # activate it',
+  '  agentconnect run                        # start again'
+].join('\n')
+
+export interface RecoveryDeps {
+  input: NodeJS.ReadableStream
+  out: NodeJS.WritableStream
+  rollback: (root: string) => Promise<string>
+  reinstall: (root: string) => Promise<string>
+}
+
+function realRecoveryDeps(): RecoveryDeps {
+  return {
+    input: process.stdin,
+    // The prompt joins the daemon's own failure output on stderr; stdout stays
+    // reserved for whatever the delegated command itself prints.
+    out: process.stderr,
+    rollback: versionRollback,
+    reinstall: versionReinstallLatest
+  }
+}
+
+/**
+ * Show the menu and act on the choice. Resolves 'respawn' when a version switch
+ * succeeded (the run shell re-resolves `current` and retries), 'exit' when the
+ * user declined or asked for the manual commands. A failed action (registry
+ * down, previous pruned) re-offers the menu so the user can pick another way out.
+ */
+export async function runRecoveryFlow(
+  root: string,
+  result: ChildResult,
+  deps: RecoveryDeps = realRecoveryDeps()
+): Promise<'respawn' | 'exit'> {
+  const meta = readMeta(root)
+  const cur = currentVersion(root)
+  const previous = meta.previous && meta.previous !== cur && isInstalled(root, meta.previous) ? meta.previous : null
+  const options = recoveryOptions({ previous, channel: meta.channel })
+
+  deps.out.write(`agentconnect: daemon${cur ? ` ${cur}` : ''} exited with code ${result.code} during startup\n`)
+  const rl = createInterface({ input: deps.input, output: deps.out })
+  rl.on('SIGINT', () => rl.close()) // Ctrl-C at the prompt = decline
+  const iter = rl[Symbol.asyncIterator]()
+  try {
+    for (;;) {
+      for (const o of options) deps.out.write(`  ${o.key}) ${o.label}\n`)
+      deps.out.write(`Choose 1-${options.length}, or press Enter to exit: `)
+      const { value, done } = await iter.next()
+      const answer = done ? '' : String(value).trim()
+      if (answer === '') return 'exit'
+      const choice = options.find((o) => o.key === answer)
+      if (!choice) continue // unknown key — offer the menu again
+      if (choice.action === 'manual') {
+        deps.out.write(MANUAL_VERSION_HELP + '\n')
+        return 'exit'
+      }
+      try {
+        const v = choice.action === 'rollback' ? await deps.rollback(root) : await deps.reinstall(root)
+        deps.out.write(`agentconnect: retrying with daemon ${v}…\n`)
+        return 'respawn'
+      } catch (err) {
+        deps.out.write(`agentconnect: ${choice.action} failed: ${(err as Error).message}\n`)
+        // fall through: the menu is offered again (e.g. registry down → roll back)
+      }
+    }
+  } finally {
+    rl.close()
+  }
+}

--- a/packages/cli/src/run-recovery.ts
+++ b/packages/cli/src/run-recovery.ts
@@ -113,10 +113,17 @@ export async function runRecoveryFlow(
   deps.out.write(`agentconnect: daemon${cur ? ` ${cur}` : ''} exited with code ${result.code} during startup\n`)
   const rl = createInterface({ input: deps.input, output: deps.out })
   // Ctrl-C at the prompt and a stop signal both cancel: close the prompt AND
-  // remember it, so an action already in flight cannot respawn afterwards.
+  // resolve `cancellation`, which races every awaited action below — a cancel
+  // must finish this flow immediately even while an action is stuck waiting on
+  // the version lock or inside a non-abortable registry fetch.
   let cancelled = false
+  let markCancelled = (): void => {}
+  const cancellation = new Promise<'cancelled'>((resolve) => {
+    markCancelled = () => resolve('cancelled')
+  })
   const cancel = (): void => {
     cancelled = true
+    markCancelled()
     rl.close()
   }
   rl.on('SIGINT', cancel)
@@ -136,16 +143,25 @@ export async function runRecoveryFlow(
         deps.out.write(MANUAL_VERSION_HELP + '\n')
         return 'exit'
       }
-      try {
-        const v = choice.action === 'rollback' ? await deps.rollback(root) : await deps.reinstall(root)
-        if (cancelled) return 'exit' // stop arrived while the action ran — never respawn past it
-        deps.out.write(`agentconnect: retrying with daemon ${v}…\n`)
+      // Settle-capture so the race below never leaves an unhandled rejection,
+      // then race the action against cancellation. On cancel the orphaned
+      // action keeps running only for the moments until the run shell exits —
+      // the same interruption profile as Ctrl-C during a plain `version
+      // install` (the tmp extract dir and a dead holder's version lock both
+      // self-recover on the next run).
+      const action = choice.action === 'rollback' ? deps.rollback : deps.reinstall
+      const settled = action(root).then(
+        (v) => ({ ok: true as const, v }),
+        (err: unknown) => ({ ok: false as const, err })
+      )
+      const outcome = await Promise.race([settled, cancellation])
+      if (outcome === 'cancelled' || cancelled) return 'exit' // stop wins — never respawn past it
+      if (outcome.ok) {
+        deps.out.write(`agentconnect: retrying with daemon ${outcome.v}…\n`)
         return 'respawn'
-      } catch (err) {
-        if (cancelled) return 'exit'
-        deps.out.write(`agentconnect: ${choice.action} failed: ${(err as Error).message}\n`)
-        // fall through: the menu is offered again (e.g. registry down → roll back)
       }
+      deps.out.write(`agentconnect: ${choice.action} failed: ${(outcome.err as Error).message}\n`)
+      // fall through: the menu is offered again (e.g. registry down → roll back)
     }
   } finally {
     deps.signal?.removeEventListener('abort', cancel)

--- a/packages/cli/src/run-recovery.ts
+++ b/packages/cli/src/run-recovery.ts
@@ -72,6 +72,12 @@ export interface RecoveryDeps {
   out: NodeJS.WritableStream
   rollback: (root: string) => Promise<string>
   reinstall: (root: string) => Promise<string>
+  /**
+   * Stop signal from the run shell (SIGTERM while the prompt or an action is
+   * pending — there is no child to receive it). Aborting closes the prompt and
+   * vetoes a pending action's respawn, so a stop is never followed by a launch.
+   */
+  signal?: AbortSignal
 }
 
 function realRecoveryDeps(): RecoveryDeps {
@@ -88,14 +94,17 @@ function realRecoveryDeps(): RecoveryDeps {
 /**
  * Show the menu and act on the choice. Resolves 'respawn' when a version switch
  * succeeded (the run shell re-resolves `current` and retries), 'exit' when the
- * user declined or asked for the manual commands. A failed action (registry
- * down, previous pruned) re-offers the menu so the user can pick another way out.
+ * user declined, asked for the manual commands, or a stop aborted the flow. A
+ * failed action (registry down, previous pruned) re-offers the menu so the user
+ * can pick another way out.
  */
 export async function runRecoveryFlow(
   root: string,
   result: ChildResult,
-  deps: RecoveryDeps = realRecoveryDeps()
+  partial: Partial<RecoveryDeps> = {}
 ): Promise<'respawn' | 'exit'> {
+  const deps: RecoveryDeps = { ...realRecoveryDeps(), ...partial }
+  if (deps.signal?.aborted) return 'exit'
   const meta = readMeta(root)
   const cur = currentVersion(root)
   const previous = meta.previous && meta.previous !== cur && isInstalled(root, meta.previous) ? meta.previous : null
@@ -103,13 +112,22 @@ export async function runRecoveryFlow(
 
   deps.out.write(`agentconnect: daemon${cur ? ` ${cur}` : ''} exited with code ${result.code} during startup\n`)
   const rl = createInterface({ input: deps.input, output: deps.out })
-  rl.on('SIGINT', () => rl.close()) // Ctrl-C at the prompt = decline
+  // Ctrl-C at the prompt and a stop signal both cancel: close the prompt AND
+  // remember it, so an action already in flight cannot respawn afterwards.
+  let cancelled = false
+  const cancel = (): void => {
+    cancelled = true
+    rl.close()
+  }
+  rl.on('SIGINT', cancel)
+  deps.signal?.addEventListener('abort', cancel, { once: true })
   const iter = rl[Symbol.asyncIterator]()
   try {
     for (;;) {
       for (const o of options) deps.out.write(`  ${o.key}) ${o.label}\n`)
       deps.out.write(`Choose 1-${options.length}, or press Enter to exit: `)
       const { value, done } = await iter.next()
+      if (cancelled) return 'exit'
       const answer = done ? '' : String(value).trim()
       if (answer === '') return 'exit'
       const choice = options.find((o) => o.key === answer)
@@ -120,14 +138,17 @@ export async function runRecoveryFlow(
       }
       try {
         const v = choice.action === 'rollback' ? await deps.rollback(root) : await deps.reinstall(root)
+        if (cancelled) return 'exit' // stop arrived while the action ran — never respawn past it
         deps.out.write(`agentconnect: retrying with daemon ${v}…\n`)
         return 'respawn'
       } catch (err) {
+        if (cancelled) return 'exit'
         deps.out.write(`agentconnect: ${choice.action} failed: ${(err as Error).message}\n`)
         // fall through: the menu is offered again (e.g. registry down → roll back)
       }
     }
   } finally {
+    deps.signal?.removeEventListener('abort', cancel)
     rl.close()
   }
 }

--- a/packages/cli/src/run-shell.ts
+++ b/packages/cli/src/run-shell.ts
@@ -86,9 +86,13 @@ export async function runShell(root: string, argv: string[]): Promise<never> {
   const onInt = (): void => {
     // no-op: the child receives terminal SIGINT directly via the shared pgroup.
   }
+  // A SIGTERM can also land while the recovery prompt (or one of its actions)
+  // is pending — there is no child then, so the stop must abort the flow itself.
+  const recoveryStop = new AbortController()
   const onTerm = (): void => {
     stopRequested = true
     current?.kill('SIGTERM')
+    recoveryStop.abort()
   }
   process.on('SIGINT', onInt)
   process.on('SIGTERM', onTerm)
@@ -126,7 +130,11 @@ export async function runShell(root: string, argv: string[]): Promise<never> {
       interactive: Boolean(process.stdin.isTTY && process.stderr.isTTY),
       elapsedMs: Date.now() - spawnedAt
     })
-    if (recoverable && (await runRecoveryFlow(root, result)) === 'respawn') continue
+    const recovered =
+      recoverable && (await runRecoveryFlow(root, result, { signal: recoveryStop.signal })) === 'respawn'
+    // Re-check the stop state after the wait: a stop that arrived during the
+    // prompt/action must win — never launch a daemon past a requested stop.
+    if (recovered && !stopRequested) continue
     return exitAsChild(result, cleanup)
   }
 }

--- a/packages/cli/src/run-shell.ts
+++ b/packages/cli/src/run-shell.ts
@@ -1,5 +1,6 @@
 import { RESERVED_RESTART_CODE } from '@agentconnect.md/protocol'
 import { exitAsChild, resolveDaemonEntry, spawnDaemon, type ChildResult } from './delegate.js'
+import { runRecoveryFlow, shouldOfferRecovery } from './run-recovery.js'
 import { spawnDaemonViaLoginShell } from './service-spawn.js'
 import { versionInstall } from './version-commands.js'
 import { currentVersion, readMeta } from './version-store.js'
@@ -34,7 +35,9 @@ export async function ensureDaemonInstalled(root: string): Promise<void> {
  * supervisor — but the CLI process itself is already resident here, so it acts
  * as one. It spawns the daemon, and when the daemon exits with the reserved
  * restart code (a planned restart/upgrade), it re-resolves `<root>/current` and
- * respawns the (possibly upgraded) bundle. Any other exit is propagated.
+ * respawns the (possibly upgraded) bundle. Any other exit is propagated — except
+ * an interactive startup failure, where the recovery prompt (run-recovery.ts)
+ * may switch versions and respawn instead.
  *
  * The child runs with AGENTCONNECT_SUPERVISOR=cli so the daemon knows it is
  * shell-supervised and accepts CP-commanded restart/upgrade (§7.1).
@@ -97,6 +100,7 @@ export async function runShell(root: string, argv: string[]): Promise<never> {
   let viaShell = process.env.AGENTCONNECT_SUPERVISOR === 'service'
   for (;;) {
     const entry = resolveDaemonEntry(root)
+    const spawnedAt = Date.now()
     const { child, done } = viaShell
       ? spawnDaemonViaLoginShell(root, entry, argv, { AGENTCONNECT_SUPERVISOR: 'cli' })
       : spawnDaemon(entry, argv, { AGENTCONNECT_SUPERVISOR: 'cli' })
@@ -113,6 +117,16 @@ export async function runShell(root: string, argv: string[]): Promise<never> {
       continue
     }
     if (next === 'respawn') continue // planned restart/upgrade — respawn current
+    // Startup failure in an interactive foreground run: offer rollback /
+    // re-download / manual version selection instead of just dying (run-recovery.ts).
+    const recoverable = shouldOfferRecovery(result, {
+      stopRequested,
+      supervised: process.env.AGENTCONNECT_SUPERVISOR === 'service',
+      devEntry: Boolean(process.env.AGENTCONNECT_DAEMON_ENTRY),
+      interactive: Boolean(process.stdin.isTTY && process.stderr.isTTY),
+      elapsedMs: Date.now() - spawnedAt
+    })
+    if (recoverable && (await runRecoveryFlow(root, result)) === 'respawn') continue
     return exitAsChild(result, cleanup)
   }
 }

--- a/packages/cli/src/version-commands.ts
+++ b/packages/cli/src/version-commands.ts
@@ -65,6 +65,42 @@ export async function versionPrune(root: string, keep: number): Promise<void> {
   )
 }
 
+/**
+ * Roll `current` back to the recorded previous version (the run shell's startup
+ * recovery, run-recovery.ts). Returns the version activated. `useVersion` swaps
+ * the roles: the failed version becomes the new `previous`.
+ */
+export async function versionRollback(root: string): Promise<string> {
+  return withVersionLock(root, 'rollback', () => {
+    const prev = readMeta(root).previous
+    if (!prev) throw new Error('no previous daemon version recorded to roll back to')
+    useVersion(root, prev)
+    note(`current → ${prev}`)
+    return prev
+  })
+}
+
+/**
+ * Force re-download the channel latest and activate it — recovery for a broken
+ * or corrupt active bundle, where the idempotent install would no-op instead of
+ * re-fetching. Returns the version activated.
+ */
+export async function versionReinstallLatest(root: string): Promise<string> {
+  return withVersionLock(
+    root,
+    'reinstall',
+    async () => {
+      const channel = readMeta(root).channel
+      const target = await resolveTarget({ channel })
+      await installTarget(root, target, note, { force: true })
+      useVersion(root, target.version)
+      note(`current → ${target.version}`)
+      return target.version
+    },
+    { wait: true }
+  )
+}
+
 export async function runUpgrade(
   root: string,
   opts: { to?: string; channel?: Channel; restart?: boolean }

--- a/packages/cli/test/run-recovery.test.ts
+++ b/packages/cli/test/run-recovery.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import {
+  MANUAL_VERSION_HELP,
+  recoveryOptions,
+  runRecoveryFlow,
+  shouldOfferRecovery,
+  STARTUP_FAILURE_WINDOW_MS,
+  type RecoveryDeps
+} from '../src/run-recovery.js'
+import { useVersion } from '../src/version-ops.js'
+import { writeMeta } from '../src/version-store.js'
+
+const root = () => mkdtempSync(join(tmpdir(), 'ac-recovery-'))
+const install = (r: string, v: string) => mkdirSync(join(r, 'versions', v), { recursive: true })
+
+const baseCtx = {
+  stopRequested: false,
+  supervised: false,
+  devEntry: false,
+  interactive: true,
+  elapsedMs: 1_000
+}
+const failed = { code: 1, signal: null }
+
+describe('shouldOfferRecovery', () => {
+  it('offers on a quick nonzero exit of an interactive foreground run', () => {
+    expect(shouldOfferRecovery(failed, baseCtx)).toBe(true)
+  })
+  it('never prompts when a stop was requested', () => {
+    expect(shouldOfferRecovery(failed, { ...baseCtx, stopRequested: true })).toBe(false)
+  })
+  it('never prompts under a service supervisor (no operator at a terminal)', () => {
+    expect(shouldOfferRecovery(failed, { ...baseCtx, supervised: true })).toBe(false)
+  })
+  it('never prompts in dev-entry mode (version store bypassed)', () => {
+    expect(shouldOfferRecovery(failed, { ...baseCtx, devEntry: true })).toBe(false)
+  })
+  it('never prompts without a TTY', () => {
+    expect(shouldOfferRecovery(failed, { ...baseCtx, interactive: false })).toBe(false)
+  })
+  it('ignores clean exits and signal deaths', () => {
+    expect(shouldOfferRecovery({ code: 0, signal: null }, baseCtx)).toBe(false)
+    expect(shouldOfferRecovery({ code: null, signal: 'SIGINT' }, baseCtx)).toBe(false)
+  })
+  it('treats a late crash as a runtime failure, not a startup one', () => {
+    expect(shouldOfferRecovery(failed, { ...baseCtx, elapsedMs: STARTUP_FAILURE_WINDOW_MS + 1 })).toBe(false)
+  })
+})
+
+describe('recoveryOptions', () => {
+  it('offers rollback / re-download / manual when a previous version exists', () => {
+    const opts = recoveryOptions({ previous: '1.0.0', channel: 'stable' })
+    expect(opts.map((o) => o.action)).toEqual(['rollback', 'reinstall', 'manual'])
+    expect(opts.map((o) => o.key)).toEqual(['1', '2', '3'])
+    expect(opts[0]!.label).toContain('1.0.0')
+    expect(opts[1]!.label).toContain('stable')
+  })
+  it('omits rollback when there is no previous version', () => {
+    const opts = recoveryOptions({ previous: null, channel: 'rc' })
+    expect(opts.map((o) => o.action)).toEqual(['reinstall', 'manual'])
+    expect(opts.map((o) => o.key)).toEqual(['1', '2'])
+  })
+})
+
+/** Deps with a scripted stdin and a captured output. */
+function fakeDeps(lines: string[]): {
+  deps: RecoveryDeps
+  output: () => string
+  rollback: ReturnType<typeof vi.fn>
+  reinstall: ReturnType<typeof vi.fn>
+} {
+  const written: string[] = []
+  const rollback = vi.fn(async () => '1.0.0')
+  const reinstall = vi.fn(async () => '1.1.0')
+  return {
+    deps: {
+      input: Readable.from(lines.map((l) => l + '\n')) as unknown as NodeJS.ReadableStream,
+      out: { write: (s: string) => (written.push(s), true) } as unknown as NodeJS.WritableStream,
+      rollback,
+      reinstall
+    },
+    output: () => written.join(''),
+    rollback,
+    reinstall
+  }
+}
+
+/** A root where 1.1.0 is current and 1.0.0 is the recorded previous. */
+function rootWithHistory(): string {
+  const r = root()
+  install(r, '1.0.0')
+  install(r, '1.1.0')
+  useVersion(r, '1.0.0')
+  useVersion(r, '1.1.0') // previous = 1.0.0
+  return r
+}
+
+describe('runRecoveryFlow', () => {
+  it('rollback choice switches and respawns', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['1'])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('respawn')
+    expect(f.rollback).toHaveBeenCalledWith(r)
+    expect(f.output()).toContain('retrying with daemon 1.0.0')
+  })
+
+  it('re-download choice reinstalls and respawns', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['2'])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('respawn')
+    expect(f.reinstall).toHaveBeenCalledWith(r)
+  })
+
+  it('manual choice prints the version commands and exits', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['3'])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('exit')
+    expect(f.output()).toContain(MANUAL_VERSION_HELP)
+    expect(f.rollback).not.toHaveBeenCalled()
+    expect(f.reinstall).not.toHaveBeenCalled()
+  })
+
+  it('empty answer (or EOF) declines recovery', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps([''])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('exit')
+    const eof = fakeDeps([])
+    await expect(runRecoveryFlow(r, failed, eof.deps)).resolves.toBe('exit')
+  })
+
+  it('re-offers the menu after an unknown answer', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['x', '1'])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('respawn')
+  })
+
+  it('a failed action re-offers the menu instead of crashing the prompt', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['2', '1'])
+    f.reinstall.mockRejectedValueOnce(new Error('registry unreachable'))
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('respawn')
+    expect(f.output()).toContain('reinstall failed: registry unreachable')
+    expect(f.rollback).toHaveBeenCalledWith(r)
+  })
+
+  it('hides rollback when previous is missing from the store', async () => {
+    const r = root()
+    install(r, '1.1.0')
+    useVersion(r, '1.1.0')
+    writeMeta(r, { channel: 'stable', previous: '1.0.0' }) // recorded but pruned/uninstalled
+    const f = fakeDeps([''])
+    await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('exit')
+    expect(f.output()).not.toContain('previous version')
+    expect(f.output()).toContain('re-download the latest stable version')
+  })
+})

--- a/packages/cli/test/run-recovery.test.ts
+++ b/packages/cli/test/run-recovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { mkdtempSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Readable } from 'node:stream'
+import { PassThrough, Readable } from 'node:stream'
 import {
   MANUAL_VERSION_HELP,
   recoveryOptions,
@@ -145,6 +145,41 @@ describe('runRecoveryFlow', () => {
     await expect(runRecoveryFlow(r, failed, f.deps)).resolves.toBe('respawn')
     expect(f.output()).toContain('reinstall failed: registry unreachable')
     expect(f.rollback).toHaveBeenCalledWith(r)
+  })
+
+  it('an already-aborted stop signal skips the prompt entirely', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['1'])
+    const stop = new AbortController()
+    stop.abort()
+    await expect(runRecoveryFlow(r, failed, { ...f.deps, signal: stop.signal })).resolves.toBe('exit')
+    expect(f.output()).toBe('')
+    expect(f.rollback).not.toHaveBeenCalled()
+  })
+
+  it('a stop arriving while the menu is idle aborts the prompt', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps([])
+    const idle = new PassThrough() // stays open: nobody is answering
+    const stop = new AbortController()
+    const flow = runRecoveryFlow(r, failed, { ...f.deps, input: idle, signal: stop.signal })
+    stop.abort()
+    await expect(flow).resolves.toBe('exit')
+    expect(f.rollback).not.toHaveBeenCalled()
+    expect(f.reinstall).not.toHaveBeenCalled()
+  })
+
+  it('a stop arriving while an action runs vetoes its respawn', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['1'])
+    const stop = new AbortController()
+    f.rollback.mockImplementationOnce(async () => {
+      stop.abort() // the stop lands mid-rollback…
+      return '1.0.0'
+    })
+    // …so even though the switch succeeded, the shell must not respawn past it.
+    await expect(runRecoveryFlow(r, failed, { ...f.deps, signal: stop.signal })).resolves.toBe('exit')
+    expect(f.output()).not.toContain('retrying')
   })
 
   it('hides rollback when previous is missing from the store', async () => {

--- a/packages/cli/test/run-recovery.test.ts
+++ b/packages/cli/test/run-recovery.test.ts
@@ -182,6 +182,27 @@ describe('runRecoveryFlow', () => {
     expect(f.output()).not.toContain('retrying')
   })
 
+  it('a stop finishes the flow immediately even while the action never settles', async () => {
+    const r = rootWithHistory()
+    const f = fakeDeps(['2'])
+    const stop = new AbortController()
+    let started = (): void => {}
+    const actionStarted = new Promise<void>((resolve) => {
+      started = resolve
+    })
+    // A reinstall stuck on the version lock or in a non-abortable registry
+    // fetch: the promise never settles, yet the stop must not be swallowed.
+    f.reinstall.mockImplementationOnce(() => {
+      started()
+      return new Promise<never>(() => {})
+    })
+    const flow = runRecoveryFlow(r, failed, { ...f.deps, signal: stop.signal })
+    await actionStarted
+    stop.abort()
+    await expect(flow).resolves.toBe('exit')
+    expect(f.output()).not.toContain('retrying')
+  })
+
   it('hides rollback when previous is missing from the store', async () => {
     const r = root()
     install(r, '1.1.0')

--- a/packages/cli/test/version-install.test.ts
+++ b/packages/cli/test/version-install.test.ts
@@ -13,10 +13,11 @@ const installTarget = vi.fn(async (root: string, target: { version: string }) =>
 })
 vi.mock('../src/install.js', () => ({
   resolveTarget: (o: unknown) => resolveTarget(o),
-  installTarget: (r: string, t: { version: string }, log?: (m: string) => void) => installTarget(r, t, log)
+  installTarget: (r: string, t: { version: string }, log?: (m: string) => void, opts?: { force?: boolean }) =>
+    installTarget(r, t, log, opts)
 }))
 
-const { versionInstall } = await import('../src/version-commands.js')
+const { versionInstall, versionReinstallLatest, versionRollback } = await import('../src/version-commands.js')
 const { currentVersion, readMeta, writeMeta } = await import('../src/version-store.js')
 
 const root = () => mkdtempSync(join(tmpdir(), 'ac-vinstall-'))
@@ -70,5 +71,36 @@ describe('versionInstall', () => {
     expect(resolveTarget).toHaveBeenCalledWith({ to: undefined, channel: 'stable' })
     // No versions.json written: the default must not become a stored preference.
     expect(existsSync(join(r, 'versions.json'))).toBe(false)
+  })
+})
+
+describe('versionRollback', () => {
+  it('reactivates the recorded previous version and returns it', async () => {
+    const r = root()
+    resolveTarget.mockResolvedValueOnce({ version: '1.0.0', channel: 'stable' })
+    await versionInstall(r, {}) // activates 1.0.0
+    mkdirSync(join(r, 'versions', '1.1.0'), { recursive: true })
+    const { useVersion } = await import('../src/version-ops.js')
+    useVersion(r, '1.1.0') // previous = 1.0.0
+    await expect(versionRollback(r)).resolves.toBe('1.0.0')
+    expect(currentVersion(r)).toBe('1.0.0')
+    // The failed version becomes the new rollback target.
+    expect(readMeta(r).previous).toBe('1.1.0')
+  })
+
+  it('refuses when no previous version is recorded', async () => {
+    await expect(versionRollback(root())).rejects.toThrow(/no previous/)
+  })
+})
+
+describe('versionReinstallLatest', () => {
+  it('force-installs the channel latest and activates it', async () => {
+    const r = root()
+    writeMeta(r, { channel: 'rc', previous: null })
+    resolveTarget.mockResolvedValue({ version: '2.0.0-rc.1', channel: 'rc' })
+    await expect(versionReinstallLatest(r)).resolves.toBe('2.0.0-rc.1')
+    expect(resolveTarget).toHaveBeenCalledWith({ channel: 'rc' })
+    expect(installTarget.mock.calls[0]![3]).toEqual({ force: true })
+    expect(currentVersion(r)).toBe('2.0.0-rc.1')
   })
 })


### PR DESCRIPTION
## Summary

When `agentconnect run` spawns a daemon that exits nonzero shortly after start, an **interactive foreground run** now offers a recovery menu instead of just dying with the exit code:

```
agentconnect: daemon 0.5.3 exited with code 1 during startup
  1) switch back to the previous version (0.5.2) and retry
  2) re-download the latest stable version and retry
  3) show the commands to pick a version manually
Choose 1-3, or press Enter to exit:
```

- **Rollback** re-activates the recorded `previous` version (offered only while it is still installed); the failed version becomes the new rollback target.
- **Re-download** force-reinstalls the channel latest — `installTarget` grows a `force` option, since the idempotent skip would otherwise no-op exactly when the installed bundle is corrupt.
- **Manual** prints the `agentconnect version list / install / use` commands and exits.

Guardrails (`shouldOfferRecovery`, pure + unit-tested): never prompts under a service supervisor (`AGENTCONNECT_SUPERVISOR=service`), without a TTY on stdin+stderr, in `AGENTCONNECT_DAEMON_ENTRY` dev mode, after a requested stop, on signal deaths, on clean exits, or when the crash happened past the 60 s startup window — all of those still propagate the original exit status untouched. A failed recovery action (registry down, previous pruned) re-offers the menu rather than crashing the prompt; declining (Enter / Ctrl-C / EOF) exits with the daemon's original code.

New ops `versionRollback` / `versionReinstallLatest` run inside the version lock like every other mutating version command.

## Changes

- `packages/cli/src/run-recovery.ts` (new): recovery predicate, menu, prompt flow
- `packages/cli/src/run-shell.ts`: hook the flow into the respawn loop's exit path
- `packages/cli/src/version-commands.ts`: `versionRollback`, `versionReinstallLatest`
- `packages/cli/src/install.ts`: `installTarget(..., { force })` re-downloads and replaces an existing install
- `docs/designs/cli-daemon-split.md` §4.1: document the interactive-startup-failure exception
- Tests: `run-recovery.test.ts` (predicate matrix, menu, full prompt flow via scripted stdin), rollback/reinstall cases in `version-install.test.ts`

## Testing

- `pnpm --filter @agentconnect.md/cli test` — 149 passed (18 new)
- `typecheck` / `eslint` / `prettier` clean
- Manual PTY smoke test: broken current bundle (exit 1) → menu → option 1 → rolls back and respawns the previous version cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)