### PR TITLE
feat(web): stamp the active org on the rail account block

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -336,7 +336,7 @@
      they have to arrive together or the console feels like several UIs. Listing
      the selectors here (rather than repeating `transition:` per class) is what
      keeps them in step; hover/press VALUES still live with each class below. */
-  .railtoggle,
+  .railiconbtn,
   .railbrand-logo,
   .navitem,
   .sritem,
@@ -406,18 +406,16 @@
     min-width: 0;
     text-decoration: none;
   }
-  /* The brand row's two icon buttons. They read as one pair pushed to the rail's
-     right edge: search is permanent (it is the only way into the search dialog now
-     that the top bar is gone), collapse fades in on rail hover to its left. Both are
-     22px boxes around 16px glyphs, and the negative margin cancels `.railbrand`'s
-     10px flex gap so the glyphs sit ~8px apart without the boxes overlapping. */
-  .railtoggle {
+  /* The rail's chrome icon buttons — the brand row's collapse + search pair and the
+     footer's help (in no-auth mode, the theme toggle too). All are 22px boxes around
+     16px glyphs held 2px off the rail's right edge, which is what puts the brand
+     row's search and the footer's help on ONE centre line down the outer edge. */
+  .railiconbtn {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 22px;
     height: 22px;
-    margin-left: auto;
     flex: none;
     padding: 0;
     border: 0;
@@ -425,6 +423,18 @@
     background: none;
     color: rgba(255, 255, 255, 0.55);
     cursor: pointer;
+  }
+  .railiconbtn:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+  }
+  /* The brand pair reads as one unit pushed to the rail's right edge: search is
+     permanent (it is the only way into the search dialog now that the top bar is
+     gone), collapse fades in on rail hover to its left. The negative margin cancels
+     `.railbrand`'s 10px flex gap so the glyphs sit ~8px apart without the boxes
+     overlapping. */
+  .railtoggle {
+    margin-left: auto;
     opacity: 0;
   }
   .rail:hover .railtoggle,
@@ -432,27 +442,10 @@
     opacity: 1;
   }
   .railsrbtn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
     margin-right: 2px;
-    flex: none;
-    padding: 0;
-    border: 0;
-    border-radius: 5px;
-    background: none;
-    color: rgba(255, 255, 255, 0.55);
-    cursor: pointer;
   }
   .railtoggle + .railsrbtn {
     margin-left: -9px;
-  }
-  .railtoggle:hover,
-  .railsrbtn:hover {
-    background: rgba(255, 255, 255, 0.08);
-    color: #fff;
   }
   /* Inset pill nav (design v2, ChatGPT-style): no full-bleed tile, no 3px brand
      edge — a rounded pill with symmetric 10px gutters. The active glyph keeps the
@@ -593,6 +586,12 @@
   }
   .rail.collapsed .pfname {
     display: none;
+  }
+  /* Collapsed the footer stacks, so its fixed-width chrome buttons (no-auth's theme
+     toggle) need centring on the 64px rail's glyph line — the stretched column can't
+     do it for them. */
+  .rail.collapsed .railfoot .railiconbtn {
+    margin-inline: auto;
   }
   /* The help popover needs room the 64px rail hasn't got, and its contents are all
      reachable from the docs anyway — collapsed, it steps aside for the account block. */

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -260,8 +260,22 @@ function RailAccount({
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        <span className="pfav">
+        <span className="pfav relative">
           <Avatar src={display.picture} initials={display.initials} size={26} fontSize={10} />
+          {/* The active org rides the avatar as a corner badge — its own uploaded icon
+          when it has one, else its color + initial. Ringed in the rail's plum so it
+          reads as a badge stamped on the avatar rather than a second avatar beside it,
+          and it is the only org cue left once the rail collapses and the name goes. */}
+          {activeOrg && (
+            <OrgIconView
+              icon={activeOrg.icon}
+              iconUrl={activeOrg.iconUrl}
+              label={orgName}
+              fallbackColor={orgColor(activeOrg.id)}
+              size={14}
+              className="absolute -right-[3px] -bottom-[3px] rounded-[4px] text-[8px] ring-2 ring-(--surface-inverse)"
+            />
+          )}
         </span>
         <span className="pfname min-w-0 flex-1 overflow-hidden">
           <span className="block truncate font-sans text-[12.5px] font-semibold leading-normal text-white">
@@ -271,6 +285,9 @@ function RailAccount({
             <span className="mono block truncate text-[10.5px] font-medium text-(--text-inverse-dim)">{orgName}</span>
           )}
         </span>
+        {/* Collapsed the rail has no room for it, and the badge above already says
+        which org — so the switch affordance rides with the name, not the avatar. */}
+        {!collapsed && <Icon name="chevrons-up-down" size={14} color="var(--text-inverse-dim)" className="flex-none" />}
       </button>
       {open && (
         <>
@@ -630,7 +647,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
               <button
                 type="button"
                 onClick={toggleRail}
-                className="railtoggle"
+                className="railiconbtn railtoggle"
                 // No `title`: the icon already reads as the collapse/expand affordance,
                 // and a tooltip on the collapsed rail's own toggle is noise. Screen
                 // readers still get the state from aria-label.
@@ -642,7 +659,13 @@ function ShellChrome({ children }: { children: ReactNode }) {
               top bar it is the console's only search affordance, so unlike the
               collapse toggle beside it, it never hides. Collapsed, CSS swaps it for
               the `.railsrnav` row below. */}
-              <button type="button" onClick={openSearch} className="railsrbtn" title="Search" aria-label="Search">
+              <button
+                type="button"
+                onClick={openSearch}
+                className="railiconbtn railsrbtn"
+                title="Search"
+                aria-label="Search"
+              >
                 <Icon name="search" size={16} />
               </button>
             </div>
@@ -693,22 +716,24 @@ function ShellChrome({ children }: { children: ReactNode }) {
                 <button
                   type="button"
                   onClick={toggleTheme}
-                  className="navitem m-0 w-auto flex-none justify-center rounded-[6px] px-2 py-[9px]"
+                  className="railiconbtn"
                   title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
                   aria-label="Toggle theme"
                 >
-                  <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={18} />
+                  <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
                 </button>
               )}
-              <div className="railhelp relative flex-none">
+              {/* Same 22px box as the brand row's search button, and the same 2px
+              inset from the rail's edge — the two sit on one vertical centre line. */}
+              <div className="railhelp relative mr-[2px] flex-none">
                 <button
                   type="button"
                   onClick={() => setHelpMenu((v) => !v)}
-                  className="navitem m-0 w-auto flex-none justify-center rounded-[6px] px-2 py-[9px]"
+                  className="railiconbtn"
                   title="Help & resources"
                   aria-label="Help & resources"
                 >
-                  <Icon name="circle-question-mark" size={18} color={helpMenu ? 'var(--brand)' : undefined} />
+                  <Icon name="circle-question-mark" size={16} color={helpMenu ? 'var(--brand)' : undefined} />
                 </button>
                 {helpMenu && (
                   <>


### PR DESCRIPTION
## What

The rail footer's account block now carries the active org as a **badge on the avatar** instead of text alone:

- **14px rounded-square corner badge** at the avatar's bottom-right — the org's own uploaded icon when it has one, else its color + initial (`OrgIconView`, same resolution as the switcher menu rows). Ringed in `--surface-inverse` so it reads as a badge stamped on the avatar rather than a second avatar beside it.
- **`chevrons-up-down`** on the button, so it reads as a switcher. Hidden when the rail is collapsed — no room, and the badge already carries the signal there.
- The footer's **help button** (and, in no-auth mode, the theme toggle) drop to the same **22px box** as the brand row's search button, 2px off the rail's edge.

## Why

The org was invisible the moment the rail collapsed — the name row is `display: none` at 64px — and when it was visible it sat under the user's name, reading as part of the person's identity rather than as the context every page is scoped to. Riding it on the avatar keeps it in both states.

The help button was a `.navitem`-derived 34px box while search above it was 22px, so the rail's two outer-edge controls sat on different centre lines.

## Notes for the reviewer

- The brand row's collapse/search pair and the footer's chrome buttons now share one **`.railiconbtn`** class instead of duplicating the same 12 declarations; `.railtoggle` / `.railsrbtn` keep only their positional deltas. `.railiconbtn` replaces `.railtoggle` in the grouped `--transition-interactive` selector list, which incidentally gives search and help the hover transition they were missing.
- One new collapsed-state rule (`margin-inline: auto`) centres the footer's fixed-width buttons on the 64px rail — only reachable in no-auth mode, where the theme toggle is the footer's sole control.
- Desktop only; the mobile app-bar avatar and the More sheet's org row are untouched.

## Verification

Browser-verified against a local CP in the mock console, expanded and collapsed, light and dark:

- badge renders on the active org in both rail states; the ring resolves to `#150d1e` under `data-theme="dark"`, i.e. it follows the token.
- measured geometry: search and help are both 22×22 with centre `x = 217` and right edge `228` — one centre line.
- collapsed: avatar centre `x = 32` (matching the nav glyph line), badge right edge `48`, chevron and help correctly gone.
- help popover still opens with the brand-tinted glyph; no console errors.

`pnpm typecheck`, eslint, prettier and the web suite (669 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)