### PR TITLE
fix(web): follow the newest transcript output in the session view

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -67,13 +67,17 @@ interface PlaygroundData {
    *  rebuilds the socket so the relay re-verifies and caches the grown roster.
    *  Failures surface as a ⚠️ transcript step. Refused while a turn streams. */
   pgAddAgent: (id: string, agent: Agent) => Promise<void>
+  /** Returns whether the send was ACCEPTED — false when there is nothing to send
+   *  or a turn is already streaming. Callers that move the viewport on send (the
+   *  session view pins the transcript to the bottom) must not act on a rejected
+   *  one, and this keeps that condition in a single place. */
   pgSend: (
     id: string,
     agentId: string,
     text?: string,
     conversationId?: string,
     participants?: Array<{ agentId: string; name: string; primary?: boolean }>
-  ) => void
+  ) => boolean
   /** Switch the session's model (in-session, sticky). */
   pgSetModel: (id: string, agentId: string, model: string, conversationId?: string) => void
   /** Switch the session's reasoning effort (in-session, sticky). */
@@ -975,7 +979,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     ) => {
       const text = String(textArg ?? pgInputBy[id] ?? '').trim()
       const image = pgImageBy[id]
-      if ((!text && !image) || pgBusyBy[id]) return
+      if ((!text && !image) || pgBusyBy[id]) return false
       pushStep(id, { kind: 'msg', who: '@you', text, ...(image ? { image } : {}) })
       setPgInput(id, '')
       setPgImage(id)
@@ -1067,6 +1071,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           dropLanes(id)
           setBusy(id, false)
         })
+      return true
     },
     [pgBusyBy, pgImageBy, pgInputBy, pgSessions, connect, pushStep, setPgImage, setPgInput, setBusy, refreshSessions]
   )

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+//
+// `pgSend` reports whether a send was ACCEPTED, and SessionDetailView's composer
+// relies on that to decide whether to pin the transcript to the bottom. Enter on
+// an empty composer, or Enter while a turn is already streaming, must report
+// rejection — otherwise a reader who scrolled up into history gets yanked to the
+// bottom for a send that never happened. Both the textarea Enter path and the
+// send button route through the same `onPgSend`, so pinning this one condition
+// keeps the two entry points aligned.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({ agents: [], daemons: [], refreshSessions: vi.fn() })
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'org1', slug: 'acme' } }) }))
+vi.mock('@/lib/api', () => ({
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      public status: number
+    ) {
+      super(message)
+    }
+  },
+  agentApiRelayUrl: () => 'wss://relay.test',
+  fetchSessionMessages: vi.fn(async () => ({ messages: [] })),
+  mintWebchatConversation: vi.fn(async () => ({ conversationId: 'c1' })),
+  webchatSocketUrl: () => 'wss://relay.test/ws'
+}))
+
+const { PlaygroundProvider, usePlayground } = await import('./PlaygroundProvider')
+
+// The accepted path opens a socket; a stub that never settles keeps the test on
+// the synchronous return value instead of the streaming machinery.
+class StubSocket {
+  static CONNECTING = 0
+  readyState = 0
+  send = vi.fn()
+  close = vi.fn()
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+}
+
+let pgSend: ReturnType<typeof usePlayground>['pgSend']
+let openPlayground: ReturnType<typeof usePlayground>['openPlayground']
+
+function Probe() {
+  const pg = usePlayground()
+  pgSend = pg.pgSend
+  openPlayground = pg.openPlayground
+  return null
+}
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true)
+  Reflect.set(globalThis, 'WebSocket', StubSocket)
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  act(() =>
+    root.render(
+      <PlaygroundProvider>
+        <Probe />
+      </PlaygroundProvider>
+    )
+  )
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.clearAllMocks()
+})
+
+describe('pgSend acceptance', () => {
+  it('rejects an empty composer', () => {
+    expect(pgSend('s1', 'a1', '')).toBe(false)
+    expect(pgSend('s1', 'a1', '   ')).toBe(false) // whitespace only
+    expect(pgSend('s1', 'a1', undefined)).toBe(false) // no staged input either
+  })
+
+  it('accepts a message with text', () => {
+    expect(pgSend('s1', 'a1', 'hello')).toBe(true)
+  })
+
+  // The busy flag is React state, so the second Enter only sees it after a
+  // re-render — which is exactly the real ordering: two keypresses are two events
+  // with a commit in between. `act` flushes that commit and the probe hands back
+  // the fresh closure.
+  it('rejects a second send while the first turn is still streaming', () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'hello')).toBe(true)
+    })
+    expect(pgSend('s1', 'a1', 'again')).toBe(false) // busy
+  })
+
+  it('keeps the busy rejection per session', () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'hello')).toBe(true)
+    })
+    expect(pgSend('s2', 'a1', 'hello')).toBe(true) // a different session is free
+  })
+
+  // openPlayground exists on the same context; touching it here documents that the
+  // probe wiring is real and not a partially-mocked stand-in.
+  it('exposes the real provider surface', () => {
+    expect(typeof openPlayground).toBe('function')
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -76,6 +76,7 @@ import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { consoleKeys } from '@/lib/swr-keys'
 import { sessionAttributionAgentAuthors, sessionAttributionAgentId, sessionSenderLabel } from '@/lib/session-trigger'
 import { mergeSessionMessages } from '@/lib/session-transcript'
+import { useStickToBottom } from '@/lib/stick-to-bottom'
 import { socialLoginProviders } from '@/lib/social-login-providers'
 import { isAuthConfigured } from '@/lib/auth'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
@@ -1707,6 +1708,11 @@ export default function SessionDetailView() {
     return () => window.clearInterval(timer)
   }, [visibleTailReady, refreshTranscriptTail])
 
+  // Everything above only APPENDS rows; nothing ever moved the viewport, so a
+  // live session's newest output landed below the fold. Follow it — but only for
+  // a reader who is already at the bottom (see lib/stick-to-bottom).
+  const stickToBottom = useStickToBottom(conversationKey ?? sid ?? null)
+
   const focusPagesRef = useRef(0)
   // The persistent layout survives key-to-key navigation: re-arm the one-shot
   // focus state whenever the (conversation, participant) target changes.
@@ -1952,6 +1958,10 @@ export default function SessionDetailView() {
   // a synthetic playground turn omits it (the CP mints a fresh id).
   const onPgSend = (text?: string) => {
     if (imagePreparing) return
+    // Writing ends reading: someone who scrolled up through history and then
+    // sends must not have their own message — or the reply to it — land
+    // off-screen, so re-arm the bottom-follow regardless of scroll position.
+    stickToBottom()
     setImageError(null)
     // Pass the fetched roster: an adopted webchat session has no provider-side
     // state, and without it a multi-agent send can't pre-create stream lanes or

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1958,23 +1958,26 @@ export default function SessionDetailView() {
   // a synthetic playground turn omits it (the CP mints a fresh id).
   const onPgSend = (text?: string) => {
     if (imagePreparing) return
-    // Writing ends reading: someone who scrolled up through history and then
-    // sends must not have their own message — or the reply to it — land
-    // off-screen, so re-arm the bottom-follow regardless of scroll position.
-    stickToBottom()
     setImageError(null)
     // Pass the fetched roster: an adopted webchat session has no provider-side
     // state, and without it a multi-agent send can't pre-create stream lanes or
     // narrow by @mention (the relay would apply its all-participants default).
     // Named, not raw: mention narrowing matches on the display name the composer
     // chips show.
-    pgSend(
+    const sent = pgSend(
       session.id,
       session.agentId ?? '',
       text,
       isWebchat ? session.channelId : undefined,
       isWebchat ? liveRoster : undefined
     )
+    // Writing ends reading: someone who scrolled up through history and then
+    // sends must not have their own message — or the reply to it — land
+    // off-screen, so re-arm the bottom-follow regardless of scroll position.
+    // Only on an ACCEPTED send, though: Enter on an empty composer, or while a
+    // turn is still streaming, sends nothing, and yanking a reader out of
+    // history for a no-op would break the very guarantee this makes.
+    if (sent) stickToBottom()
   }
   const onImageFile = async (file: File | undefined): Promise<void> => {
     if (!file || imagePreparing) return

--- a/packages/web/src/lib/stick-to-bottom.test.tsx
+++ b/packages/web/src/lib/stick-to-bottom.test.tsx
@@ -189,6 +189,45 @@ describe('useStickToBottom self-inflicted scroll', () => {
     expect(scroller.scrollTop).toBe(bottom())
   })
 
+  // Scroll events for one scroller COALESCE, so a pin's echo is not reliably
+  // "the next event": anything that moves the viewport first arrives as that same
+  // single event. Swallowing by position rather than by turn is what keeps these
+  // from being mistaken for the echo.
+  it('does not swallow the ?focus scrollIntoView that lands before the echo', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => scroller.dispatchEvent(new Event('scroll'))) // following
+
+    setMetrics(3000) // history renders; the pin's echo is now pending
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+
+    // The ?focus effect centres the linked participant's block, then the single
+    // coalesced event is delivered from that new position.
+    scroller.scrollTop = 300
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    setMetrics(3600) // more output must NOT drag the focused reader down
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(300)
+  })
+
+  it('does not swallow a user scroll that beats the echo of a re-arm pin', () => {
+    setMetrics(2000)
+    scroller.scrollTop = 200
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    act(() => reArm?.()) // pins to the bottom, echo pending
+    scroller.scrollTop = 500 // the reader flicks back up before it is delivered
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    setMetrics(2600)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(500)
+  })
+
   it('still lets a real user scroll un-arm when the pin moved nothing', () => {
     setMetrics(2000)
     scroller.scrollTop = bottom() // already at the bottom: the pin is a no-op

--- a/packages/web/src/lib/stick-to-bottom.test.tsx
+++ b/packages/web/src/lib/stick-to-bottom.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { nearBottom, useStickToBottom } from './stick-to-bottom'
+
+// happy-dom has no layout engine, so the scroller's metrics are stubbed and the
+// ResizeObserver callback is fired by hand — which is also what makes the ORDER
+// under test explicit: latch on scroll, then grow, then follow.
+let fireResize: (() => void) | undefined
+
+// A real ResizeObserver stops calling back once the observed node leaves the
+// document (it is no longer laid out), so the fake honours `isConnected` —
+// without that, a subscription left on a detached node reads as healthy here and
+// the swap regression below cannot fail.
+class FakeResizeObserver {
+  private nodes = new Set<Element>()
+  constructor(private cb: () => void) {}
+  observe(node: Element) {
+    this.nodes.add(node)
+    fireResize = () => {
+      if ([...this.nodes].some((n) => n.isConnected)) this.cb()
+    }
+  }
+  unobserve(node: Element) {
+    this.nodes.delete(node)
+  }
+  disconnect() {
+    this.nodes.clear()
+    fireResize = undefined
+  }
+}
+
+let reArm: (() => void) | undefined
+
+function Probe({ resetKey }: { resetKey: string }) {
+  reArm = useStickToBottom(resetKey)
+  return null
+}
+
+let host: HTMLDivElement
+let scroller: HTMLDivElement
+let root: Root
+
+/** Stub the layout the real transcript would have: `clientHeight` viewport over
+ *  a `scrollHeight` of content. */
+function setMetrics(scrollHeight: number, clientHeight = 500) {
+  Object.defineProperty(scroller, 'scrollHeight', { value: scrollHeight, configurable: true })
+  Object.defineProperty(scroller, 'clientHeight', { value: clientHeight, configurable: true })
+}
+
+/** The largest `scrollTop` the container allows — i.e. parked at the bottom. */
+const bottom = () => Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+
+beforeEach(() => {
+  Reflect.set(globalThis, 'ResizeObserver', FakeResizeObserver)
+  scroller = document.createElement('div')
+  scroller.className = 'content'
+  scroller.append(document.createElement('div')) // the view root — the box that grows
+  document.body.append(scroller)
+  // happy-dom stores `scrollTop` verbatim; a real scroller CLAMPS it. The clamp is
+  // load-bearing here: the hook decides whether a pin actually moved the viewport
+  // by reading the value back, and an unclamped stub makes a no-op pin look like a
+  // real one.
+  let top = 0
+  Object.defineProperty(scroller, 'scrollTop', {
+    get: () => top,
+    set: (v: number) => {
+      top = Math.max(0, Math.min(v, bottom()))
+    },
+    configurable: true
+  })
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  scroller.remove()
+  fireResize = undefined
+  reArm = undefined
+})
+
+describe('nearBottom', () => {
+  it('counts a small gap as at-the-bottom and a large one as not', () => {
+    setMetrics(2000)
+    scroller.scrollTop = 1450 // 50px left
+    expect(nearBottom(scroller)).toBe(true)
+    scroller.scrollTop = 900 // 600px left
+    expect(nearBottom(scroller)).toBe(false)
+  })
+})
+
+describe('useStickToBottom', () => {
+  it('follows growth for a reader parked at the bottom', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    setMetrics(2600) // a new message lands
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+
+  it('leaves a reader who scrolled back through history alone', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    scroller.scrollTop = 200 // reader pages back
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    setMetrics(2600)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(200)
+  })
+
+  it('arming against an already-long container parked at the top does not jump', () => {
+    setMetrics(2000)
+    scroller.scrollTop = 0 // never scrolled
+    act(() => root.render(<Probe resetKey="s1" />))
+
+    setMetrics(9000)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(0)
+  })
+
+  // The real cold open: the view mounts (and arms) BEFORE the transcript loads,
+  // so an empty container reads as at-the-bottom and the first history render
+  // lands at the newest message. This is the intended landing, not a leak.
+  it('follows a short transcript that never overflowed, with no scroll event', () => {
+    setMetrics(300) // shorter than the 500px viewport
+    scroller.scrollTop = 0
+    act(() => root.render(<Probe resetKey="s1" />))
+
+    setMetrics(900)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+
+  it('re-latches on a session switch instead of carrying the old decision', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => scroller.dispatchEvent(new Event('scroll'))) // sticking
+
+    scroller.scrollTop = 0 // the router resets scroll for the next session
+    setMetrics(4000)
+    act(() => root.render(<Probe resetKey="s2" />))
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(0)
+  })
+})
+
+// The ordering that broke this in the real app: a pin's `scroll` event is
+// delivered by the browser AFTER React has flushed the rows that prompted it, so
+// measuring that event reads "far from the bottom" and un-arms the follow one
+// beat after it was armed.
+describe('useStickToBottom self-inflicted scroll', () => {
+  it('survives the scroll echo of a re-arm pin delivered after the send renders', () => {
+    setMetrics(2000)
+    scroller.scrollTop = 200
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => scroller.dispatchEvent(new Event('scroll'))) // reader is up in history
+
+    act(() => reArm?.())
+    setMetrics(2600) // the sent message renders BEFORE the echo lands
+    act(() => scroller.dispatchEvent(new Event('scroll'))) // would read 100px from bottom
+
+    setMetrics(3200) // the reply streams in
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+
+  it('survives echoes through progressive growth (the back-page prepend)', () => {
+    setMetrics(300) // arms while the transcript is still empty
+    scroller.scrollTop = 0
+    act(() => root.render(<Probe resetKey="s1" />))
+
+    setMetrics(3000)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+
+    setMetrics(6000) // the next page prepends before the echo lands
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+
+  it('still lets a real user scroll un-arm when the pin moved nothing', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom() // already at the bottom: the pin is a no-op
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => reArm?.())
+
+    scroller.scrollTop = 100 // the reader pages back — must NOT be swallowed
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+    setMetrics(2600)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(100)
+  })
+})
+
+describe('useStickToBottom re-arm on send', () => {
+  it('follows again after a reader who paged back sends a message', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    scroller.scrollTop = 200 // reader pages back — follow is off
+    act(() => scroller.dispatchEvent(new Event('scroll')))
+
+    act(() => reArm?.())
+    expect(scroller.scrollTop).toBe(bottom()) // jumps for the rows already there
+
+    setMetrics(2600) // the sent message, then the reply
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+
+  it('does not re-arm across a session switch', () => {
+    setMetrics(2000)
+    scroller.scrollTop = bottom()
+    act(() => root.render(<Probe resetKey="s1" />))
+    act(() => reArm?.())
+
+    scroller.scrollTop = 0 // the router resets scroll for the next session
+    setMetrics(4000)
+    act(() => root.render(<Probe resetKey="s2" />))
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(0)
+  })
+})
+
+describe('useStickToBottom child swap', () => {
+  it('keeps following after the loading placeholder is replaced by the real root', async () => {
+    setMetrics(400)
+    scroller.scrollTop = 0
+    // A merged conversation keys on its URL, so resetKey is final from the first
+    // frame while the tree is still the LoadingState placeholder.
+    act(() => root.render(<Probe resetKey="/conversations/abc" />))
+
+    // The roster resolves and the real view root replaces the placeholder —
+    // same resetKey, so the effect does NOT re-run and the re-point has to come
+    // from the swap watcher. Its callback is a microtask (a real browser also
+    // runs it well before the next ResizeObserver delivery, which lands at the
+    // end of the frame), so yield once before growing the content.
+    await act(async () => {
+      scroller.replaceChildren(document.createElement('div'))
+    })
+    setMetrics(3000)
+    act(() => fireResize?.())
+    expect(scroller.scrollTop).toBe(bottom())
+  })
+})

--- a/packages/web/src/lib/stick-to-bottom.ts
+++ b/packages/web/src/lib/stick-to-bottom.ts
@@ -59,20 +59,28 @@ export function useStickToBottom(resetKey: string | null): () => void {
     // arming it — the exact growth-time measurement this whole design avoids.
     // So swallow the echo of our own pin; only a scroll we did not cause may
     // un-arm.
-    let selfScroll = false
+    //
+    // Identified by POSITION, not by "the next event is mine": scroll events for
+    // one scroller coalesce, so anything that moves the viewport before the
+    // pending echo is delivered — the `?focus` scrollIntoView, a quick flick of
+    // the wheel — arrives as that same single event. A bare flag would discard
+    // it and leave the follow armed, dragging the reader back down on the next
+    // row. Recording where the pin actually landed makes the echo verifiable:
+    // if the viewport still sits there, nothing else moved it.
+    let pinnedTop: number | null = null
     const pin = () => {
       const before = scroller.scrollTop
-      scroller.scrollTop = scroller.scrollHeight // clamped by the browser
-      // No movement means no event to swallow — arming the flag here would eat
-      // the user's next real scroll instead.
-      if (scroller.scrollTop !== before) selfScroll = true
+      scroller.scrollTop = scroller.scrollHeight
+      // Read back, because the browser clamps to `scrollHeight - clientHeight`.
+      // No movement means no event to swallow — recording a position here would
+      // eat the user's next real scroll instead.
+      pinnedTop = scroller.scrollTop === before ? null : scroller.scrollTop
     }
     pinRef.current = pin
     const onScroll = () => {
-      if (selfScroll) {
-        selfScroll = false
-        return
-      }
+      const echo = pinnedTop !== null && scroller.scrollTop === pinnedTop
+      pinnedTop = null
+      if (echo) return
       stick.current = nearBottom(scroller)
     }
     scroller.addEventListener('scroll', onScroll, { passive: true })

--- a/packages/web/src/lib/stick-to-bottom.ts
+++ b/packages/web/src/lib/stick-to-bottom.ts
@@ -1,0 +1,116 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+/** Distance from the bottom (px) that still counts as "reading the newest". A
+ *  couple of rows of slack, so a nudge of the wheel doesn't drop the follow. */
+export const STICK_SLACK = 80
+
+export function nearBottom(el: HTMLElement, slack = STICK_SLACK): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < slack
+}
+
+/**
+ * Keeps a growing transcript pinned to the bottom — but ONLY while the reader is
+ * already there, so paging back through history is never yanked forward.
+ *
+ * The stick decision is latched on `scroll`, never read at growth time: once the
+ * new content is in the DOM it has already pushed the bottom away, so a
+ * measurement taken then would always read "not at the bottom" and the follow
+ * would never fire.
+ *
+ * One ResizeObserver on the scroller's content box covers every growth source —
+ * tail merge, live ACP steps, an image finishing decode, the typing dots — so
+ * there is no dependency list to keep in sync with the transcript's internals.
+ *
+ * `resetKey` re-latches when the open session/conversation changes.
+ *
+ * Returns a re-arm callback for the one thing a scroll position cannot express:
+ * SENDING. Someone who scrolled up to read history and then writes a message is
+ * done reading — call it from the send path so their own message, and the reply
+ * that follows, are not delivered off-screen.
+ *
+ * Consequence worth naming: a session ARMS while its transcript is still empty
+ * (the view mounts before the messages land), so an empty container reads as
+ * at-the-bottom and the first render of history scrolls to the newest message.
+ * Opening a session therefore lands at the bottom — which is what makes the
+ * follow reachable at all, since a reader dropped at the top of a long history
+ * would have to scroll all the way down to earn it.
+ */
+export function useStickToBottom(resetKey: string | null): () => void {
+  // Refs, not closure state: the re-arm callback below is handed to render code
+  // and has to reach the SAME latch the effect's listeners own.
+  const stick = useRef(false)
+  const scrollerRef = useRef<HTMLElement | null>(null)
+  const pinRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    // `.content` is the console's single page scroller (globals.css); the view's
+    // root is its only child, and it — not the fixed-height scroller — is what
+    // grows.
+    const scroller = document.querySelector<HTMLElement>('.content')
+    if (!scroller) return
+    scrollerRef.current = scroller
+    stick.current = false
+    // A pin dispatches a `scroll` event, and the browser delivers it LATER — by
+    // which time the content that prompted the pin has usually already grown
+    // (React flushes the new rows inside the same task). Measuring that event
+    // would read "far from the bottom" and un-arm the follow one beat after
+    // arming it — the exact growth-time measurement this whole design avoids.
+    // So swallow the echo of our own pin; only a scroll we did not cause may
+    // un-arm.
+    let selfScroll = false
+    const pin = () => {
+      const before = scroller.scrollTop
+      scroller.scrollTop = scroller.scrollHeight // clamped by the browser
+      // No movement means no event to swallow — arming the flag here would eat
+      // the user's next real scroll instead.
+      if (scroller.scrollTop !== before) selfScroll = true
+    }
+    pinRef.current = pin
+    const onScroll = () => {
+      if (selfScroll) {
+        selfScroll = false
+        return
+      }
+      stick.current = nearBottom(scroller)
+    }
+    scroller.addEventListener('scroll', onScroll, { passive: true })
+    const observer = new ResizeObserver(() => {
+      if (stick.current) pin()
+    })
+    // The child under `.content` is a loading placeholder before it is the real
+    // view root, and the swap does NOT always change `resetKey` — a merged
+    // conversation keys on its URL, which is known before its roster resolves.
+    // Re-point on every swap, or the observer sits on a detached node (a real
+    // ResizeObserver stops firing once its target leaves the document) and the
+    // follow is silently dead for the whole visit.
+    let observed: Element | null = null
+    const attach = () => {
+      const child = scroller.firstElementChild
+      if (!child || child === observed) return
+      if (observed) observer.unobserve(observed)
+      observed = child
+      observer.observe(child)
+      // Re-measure against the tree that just mounted, not the one it replaced.
+      stick.current = nearBottom(scroller)
+    }
+    attach()
+    const swaps = new MutationObserver(attach)
+    swaps.observe(scroller, { childList: true })
+    return () => {
+      scroller.removeEventListener('scroll', onScroll)
+      observer.disconnect()
+      swaps.disconnect()
+      scrollerRef.current = null
+      pinRef.current = null
+    }
+  }, [resetKey])
+
+  return useCallback(() => {
+    stick.current = true
+    // Jump now for the rows already there; the observer catches the sent message
+    // and the reply as they render.
+    pinRef.current?.()
+  }, [])
+}


### PR DESCRIPTION
## What

The session transcript only ever **appended** rows — nothing moved the viewport. `.content` (the console's single page scroller) stayed wherever it was, so a live session's newest output, and the reply to a message just sent, landed below the fold. There was no scroll-following code in the view at all; the only scroll call was the one-shot `?focus` `scrollIntoView`.

Adds `lib/stick-to-bottom.ts` — `useStickToBottom(resetKey)` — and wires it into `SessionDetailView` (10 lines there: the hook call plus a re-arm in `onPgSend`).

One ResizeObserver on the scroller's content box covers every growth source (tail merge, live ACP steps, an image finishing decode, the typing dots), so there is no dependency list to keep in sync with the transcript's internals.

## Why it's trickier than it looks

Two orderings decide whether this works, and both are pinned by tests:

1. **The stick decision is latched on `scroll`, never read at growth time.** Once new content is in the DOM it has already pushed the bottom away, so a measurement taken then always reads "not at the bottom" and the follow would never fire.

2. **A pin dispatches its own `scroll` event, and the browser delivers it *after* React has flushed the rows that prompted the pin.** Measuring that echo un-arms the follow one beat after arming it — the same growth-time measurement through the back door. So the echo of our own pin is swallowed, and only when the pin actually moved the viewport (read back after the browser's clamp) — otherwise the flag would eat the user's next real scroll instead.

Sending re-arms the follow regardless of scroll position: someone who scrolled up to read history and then writes is done reading, and scroll position cannot express that. All three send entry points (the "Start with" chips, textarea Enter, the send button) route through `onPgSend`, so one call site covers them.

## Behaviour

- Reading back through history is never yanked forward (80px of slack at the bottom).
- **Opening a session lands at the newest message.** The view arms while the transcript is still empty, so an empty container reads as at-the-bottom and the first history render pins. This is deliberate — it is what makes the follow reachable at all, since a reader dropped at the top of a long history would have to scroll all the way down to earn it.
- Switching sessions/conversations re-latches instead of carrying the previous decision.

## Tests

12 tests in `lib/stick-to-bottom.test.tsx`, driving the real hook in happy-dom with a stubbed ResizeObserver so the delivery order is explicit. Two details of the harness are load-bearing:

- The fake ResizeObserver honours `isConnected`, because a real one stops calling back once its target leaves the document.
- The fake scroller **clamps** `scrollTop`; happy-dom stores it verbatim, which would make a no-op pin look like a real one and hide the flag bug.

Verified non-vacuous: removing the echo guard reds 2 tests, removing the swap watcher reds 1.

`pnpm test` 681 passed, `pnpm typecheck` and `pnpm lint` clean.

## For the reviewer

- **Not verified in a real browser.** The local dev server sits behind Logto sign-in, and an isolated repro page could not settle it either — a hidden preview pane produces neither frames (no ResizeObserver delivery) nor `scroll` events, so both the guarded and unguarded variants reported "still armed". The echo bug is wrong by construction (it measures our own programmatic scroll to infer user intent) and is covered by test, but I cannot claim from a browser that it was the whole of what a user saw. Worth a manual pass on a live streaming session.
- **Branch name mismatch:** this landed on `dev/frozenluo/fix_getstart`, which is otherwise unrelated getting-started work. That branch had no commits of its own over `main`, and the getting-started WIP in the working tree was deliberately left uncommitted, so this PR's diff is only the three files above.
- Not addressed: prepending older messages ("Load earlier") still shifts the reading position, and there is no "jump to newest" affordance. Both are separate from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)