### PR TITLE
feat(daemon): garbage-collect expired sessions and their worktrees

### DIFF
--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -172,6 +172,17 @@ export const ConfigSchema = z.object({
       turnFinalContextRefresh: z.boolean().default(true)
     })
     .default({ turnFinalContextRefresh: true }),
+  sessions: z
+    .object({
+      // Local-DB retention for FINISHED sessions (issue #485): a session untouched
+      // (sessions.updatedAt) for longer than this window is deleted from the local
+      // store, together with its per-session Git worktree. A worktree holding
+      // dirty/untracked files or commits unreachable from any remote ref is never
+      // auto-deleted — the sweep reports it and keeps the session instead.
+      // 'never' disables the sweep entirely.
+      retention: z.enum(['never', '7d', '2weeks', '1month']).default('7d')
+    })
+    .default({ retention: '7d' }),
   limits: z
     .object({
       maxAgents: z.number().int().default(32),
@@ -239,3 +250,20 @@ export const ConfigSchema = z.object({
     })
 })
 export type Config = z.infer<typeof ConfigSchema>
+
+export type SessionRetention = Config['sessions']['retention']
+
+/** Retention keyword → sweep window in ms ('1month' = 30 days); null ⇒ retention
+ * is disabled and the sweep never deletes anything. */
+export function sessionRetentionMs(retention: SessionRetention): number | null {
+  switch (retention) {
+    case 'never':
+      return null
+    case '7d':
+      return 7 * 24 * 3_600_000
+    case '2weeks':
+      return 14 * 24 * 3_600_000
+    case '1month':
+      return 30 * 24 * 3_600_000
+  }
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -15780,6 +15780,19 @@ export class Daemon {
    *  commit unreachable from every remote ref. A worktree that fails the Git
    *  safety checks is only reported — its session row is kept so the working
    *  state stays reachable through the same logical session. */
+  /** The retention sweep's active-turn exclusion, beyond the durable-state filter:
+   *  a claimed serial gate (owns cold dispatch + queued arrivals), a live Pending
+   *  turn, pending durable inbox work, or unsettled SDK background tasks. */
+  private sessionRetentionActive(rec: { key: string; agentId: string; acpSessionId: string | null }): boolean {
+    return (
+      this.drainingAgents.has(rec.agentId) ||
+      this.inflight.has(rec.key) ||
+      [...this.pending.values()].some((p) => p.sessionKey === rec.key) ||
+      this.store.sessionHasPendingInboxRows(rec.key) ||
+      !this.sessionSdkQuiescent(rec.agentId, rec.acpSessionId)
+    )
+  }
+
   private async sweepSessionRetention(): Promise<void> {
     const windowMs = sessionRetentionMs(this.cfg.sessions.retention)
     if (windowMs === null) return
@@ -15794,16 +15807,7 @@ export class Daemon {
       let failed = 0
       for (const rec of expired) {
         if (this.draining) return
-        // Active-turn exclusion beyond the durable-state filter: a claimed serial
-        // gate (owns cold dispatch + queued arrivals), a live Pending turn, durable
-        // admitted-not-terminal inbox work, or unsettled SDK background tasks.
-        if (
-          this.drainingAgents.has(rec.agentId) ||
-          this.inflight.has(rec.key) ||
-          [...this.pending.values()].some((p) => p.sessionKey === rec.key) ||
-          this.store.sessionHasInboxRows(rec.key) ||
-          !this.sessionSdkQuiescent(rec.agentId, rec.acpSessionId)
-        ) {
+        if (this.sessionRetentionActive(rec)) {
           active += 1
           continue
         }
@@ -15827,6 +15831,14 @@ export class Daemon {
             this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
             continue
           }
+        }
+        // Re-check synchronously after the git awaits: a message admitted mid-cleanup
+        // owns the serial gate now, and deleting the row underneath its turn would
+        // orphan the state the turn is about to write. The worktree (if any) is
+        // already gone, but prepareSessionWorkspace recreates it on that same turn.
+        if (this.sessionRetentionActive(rec)) {
+          active += 1
+          continue
         }
         if (this.store.deleteSession(rec.key)) {
           removed += 1

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync, type Stats } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
 import { loadConfig, persistDaemonId, persistRelays, type FlatOverrides } from './config/load-config.js'
-import type { RuntimeDef } from './config/config-schema.js'
+import { sessionRetentionMs, type RuntimeDef } from './config/config-schema.js'
 import { loadAgents, selectAgent, type LoadedAgent } from './agents/load-agents.js'
 import { agentChildEnv } from './agents/agent-env.js'
 import { cpRuntimeEnv } from './agents/cp-overlay.js'
@@ -138,6 +138,7 @@ import {
   prepareWorkspaceForActivation,
   resolvePreparedWorkspaceCwd,
   prefetchWorkspace,
+  removeSessionWorktree,
   sessionWorktreeRoot,
   type PrepareSessionWorkspaceRequest
 } from './workspace/workspace-manager.js'
@@ -623,6 +624,11 @@ const DREAM_CANCEL_FORCE_MS = 15_000
  *  the idle cadence: the scan reads the whole OS temp dir, and a leaked root only costs
  *  disk, so a lazy reclaim is enough. */
 const PROBE_ROOT_SWEEP_INTERVAL_MS = 15 * 60_000
+
+/** How often the idle sweep also runs session-retention GC (#485). The retention
+ *  window is measured in days, so an hourly pass is plenty — each pass walks the
+ *  expired rows and may run several git commands per candidate. */
+const SESSION_RETENTION_SWEEP_INTERVAL_MS = 60 * 60_000
 
 // Last-resort feedback-loop protection. The lower automatic threshold catches
 // agent/system/platform-echo chains; the higher all-turn threshold still stops a
@@ -1797,6 +1803,11 @@ export class Daemon {
   // Last probe-temp-root reclaim, so it rides the idle sweep at its own slower
   // cadence — the OS temp dir can hold thousands of entries to scan.
   private lastProbeRootSweepAt = 0
+  // Last session-retention GC pass (#485); rides the idle sweep at its own cadence.
+  private lastSessionRetentionSweepAt = 0
+  // Single-flight for the retention pass — a slow git cleanup must not overlap
+  // the next sweep's pass (the sweep itself is synchronous, the GC is not).
+  private sessionRetentionSweepInFlight = false
   // §7.3 force-cancel backstops, keyed by (agentId, acpSessionId); cleared at turn end.
   private cancelTimers = new Map<string, TimerHandle>()
   // Backstop for an interrupt that lands before a Pending/ACP session id exists
@@ -2863,6 +2874,13 @@ export class Daemon {
     this.log.info(`watching ${this.agentsDir} for agent changes`)
     this.replayInbox()
     this.rearmOrchestrationDeadlines()
+    // #485 startup retention pass: reconcile what accumulated (or was orphaned by a
+    // crash) while the daemon was down. Best-effort — never blocks readiness. Runs
+    // AFTER replayInbox so replayed durable work is visible to its active-turn guard.
+    this.lastSessionRetentionSweepAt = this.clock.now()
+    void this.sweepSessionRetention().catch((err) =>
+      this.log.warn(`retention: startup session GC failed (${formatErr(err)})`)
+    )
     // Curated admission belongs to local runtime resolution, not CP readiness.
     // Start it even when the control plane is disabled or still unreachable.
     void this.probeRuntimesAndEmit(false).finally(() => this.armRuntimeProbeRefresh())
@@ -15754,6 +15772,78 @@ export class Daemon {
     }
   }
 
+  /** Session-retention GC (#485): delete sessions untouched (sessions.updatedAt)
+   *  for longer than `cfg.sessions.retention`, removing each one's per-session
+   *  worktree first. Runs at startup and hourly on the idle sweep. Auto-deletion
+   *  requires ALL of: no active turn (durable state + serial gate + pending map +
+   *  durable inbox + SDK background-task lease), no dirty/untracked files, and no
+   *  commit unreachable from every remote ref. A worktree that fails the Git
+   *  safety checks is only reported — its session row is kept so the working
+   *  state stays reachable through the same logical session. */
+  private async sweepSessionRetention(): Promise<void> {
+    const windowMs = sessionRetentionMs(this.cfg.sessions.retention)
+    if (windowMs === null) return
+    if (this.sessionRetentionSweepInFlight) return
+    this.sessionRetentionSweepInFlight = true
+    try {
+      const expired = this.store.listExpiredSessions(this.clock.now() - windowMs)
+      if (!expired.length) return
+      let removed = 0
+      let retained = 0
+      let active = 0
+      let failed = 0
+      for (const rec of expired) {
+        if (this.draining) return
+        // Active-turn exclusion beyond the durable-state filter: a claimed serial
+        // gate (owns cold dispatch + queued arrivals), a live Pending turn, durable
+        // admitted-not-terminal inbox work, or unsettled SDK background tasks.
+        if (
+          this.drainingAgents.has(rec.agentId) ||
+          this.inflight.has(rec.key) ||
+          [...this.pending.values()].some((p) => p.sessionKey === rec.key) ||
+          this.store.sessionHasInboxRows(rec.key) ||
+          !this.sessionSdkQuiescent(rec.agentId, rec.acpSessionId)
+        ) {
+          active += 1
+          continue
+        }
+        const agent = this.agents.get(rec.agentId)
+        // Only a git-repo agent whose session pinned (or may have pinned — legacy
+        // NULL) Worktree isolation can own a worktree. A missing agent was removed
+        // together with its whole directory, worktrees included.
+        if (agent && agent.workspace.mode === 'git-repo' && rec.workspaceIsolation !== 'shared') {
+          const res = await removeSessionWorktree(agent, rec.key)
+          if (res.outcome === 'retained') {
+            retained += 1
+            this.log.info(
+              `retention: keeping session ${rec.key} — worktree has ${
+                res.reason === 'dirty' ? 'uncommitted/untracked changes' : 'commits not on any remote'
+              } (delete or push them to release it)`
+            )
+            continue
+          }
+          if (res.outcome === 'failed') {
+            failed += 1
+            this.log.warn(`retention: keeping session ${rec.key} — worktree cleanup failed (${res.error})`)
+            continue
+          }
+        }
+        if (this.store.deleteSession(rec.key)) {
+          removed += 1
+          if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
+        }
+      }
+      this.log.info(
+        `retention: session GC removed ${removed}/${expired.length} expired session(s)` +
+          (retained ? `, ${retained} retained (dirty/unique commits)` : '') +
+          (active ? `, ${active} still active` : '') +
+          (failed ? `, ${failed} failed` : '')
+      )
+    } finally {
+      this.sessionRetentionSweepInFlight = false
+    }
+  }
+
   private sweepIdle(): void {
     const now = this.clock.now()
     // Probe temp roots re-created by a runtime that outlived its adapter (see
@@ -15762,6 +15852,13 @@ export class Daemon {
     if (now - this.lastProbeRootSweepAt >= PROBE_ROOT_SWEEP_INTERVAL_MS) {
       this.lastProbeRootSweepAt = now
       sweepStaleProbeRoots({ log: this.log })
+    }
+    // #485 session-retention GC: delete long-inactive sessions and their worktrees.
+    if (now - this.lastSessionRetentionSweepAt >= SESSION_RETENTION_SWEEP_INTERVAL_MS) {
+      this.lastSessionRetentionSweepAt = now
+      void this.sweepSessionRetention().catch((err) =>
+        this.log.warn(`retention: session GC sweep failed (${formatErr(err)})`)
+      )
     }
     const ttl = this.cfg.limits.agentIdleTimeoutMs
     const maxLifetime = this.cfg.limits.agentMaxLifetimeMs

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2216,6 +2216,52 @@ export class LocalStore {
     return rows
   }
 
+  /** Retention-GC candidates (#485): sessions whose last activity (`updatedAt`)
+   *  is older than `cutoff` and that are not mid-turn. Unlike listSessions this
+   *  includes rows with no ACP id — a session that never bound one can still own
+   *  a worktree directory. Oldest first, so a bounded pass drains the backlog in
+   *  eviction order. `resuming`/`prompting`/`cancelling` rows are live by
+   *  definition and never candidates. */
+  listExpiredSessions(cutoff: number): SessionRecord[] {
+    return this.db
+      .prepare("SELECT * FROM sessions WHERE state IN ('idle', 'closed') AND updatedAt < ? ORDER BY updatedAt ASC")
+      .all(cutoff) as unknown as SessionRecord[]
+  }
+
+  /** True when the session key still has durable inbox rows (admitted work that
+   *  has not reached a terminal state, or an unacknowledged hook receipt). The
+   *  retention sweep treats such a session as active and skips it. */
+  sessionHasInboxRows(key: string): boolean {
+    const row = this.db.prepare('SELECT 1 AS present FROM inbox WHERE sessionKey = ? LIMIT 1').get(key) as
+      { present: number } | undefined
+    return row !== undefined
+  }
+
+  /** Retention-GC delete (#485): remove one session row and its dependent rows —
+   *  mute, memory-capture gate, durable inbox, permission-request history.
+   *  Transcript rows are deliberately untouched: they are (channel, thread)-scoped
+   *  and shared across agents, so the thread's history survives the session.
+   *  Returns false when the row is already gone (idempotent). */
+  deleteSession(key: string): boolean {
+    const rec = this.getSession(key)
+    if (!rec) return false
+    this.db.exec('BEGIN')
+    try {
+      this.db.prepare('DELETE FROM sessions WHERE key = ?').run(key)
+      this.db.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
+      this.db.prepare('DELETE FROM inbox WHERE sessionKey = ?').run(key)
+      if (rec.acpSessionId) {
+        this.db.prepare('DELETE FROM session_gates WHERE acpSessionId = ?').run(rec.acpSessionId)
+        this.db.prepare('DELETE FROM permission_requests WHERE sessionId = ?').run(rec.acpSessionId)
+      }
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+    return true
+  }
+
   // ── memory dream jobs (docs/designs/memory-dreaming.md §4; DreamStorePort) ──
 
   private dreamToRow(dream: DreamInfo): SqlParams {

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2249,8 +2249,9 @@ export class LocalStore {
    *  - unacknowledged terminal hook reports (`terminalReport IS NOT NULL`) — an
    *    outbox the CP has not converged yet, preserved exactly like
    *    removeInboxByAgentId does.
-   *  permission_requests is scoped by agentId as well: ACP session ids are
-   *  runtime-local, so two agents can both hold an `acp-1`.
+   *  permission_requests is scoped by agentId, and the capture gate is dropped
+   *  only when no surviving session still references the ACP id: ACP session ids
+   *  are runtime-local, so two agents can both hold an `acp-1`.
    *  Returns false when the row is already gone (idempotent). */
   deleteSession(key: string): boolean {
     const rec = this.getSession(key)
@@ -2261,7 +2262,16 @@ export class LocalStore {
       this.db.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
       this.db.prepare('DELETE FROM inbox WHERE sessionKey = ? AND terminalReport IS NULL').run(key)
       if (rec.acpSessionId) {
-        this.db.prepare('DELETE FROM session_gates WHERE acpSessionId = ?').run(rec.acpSessionId)
+        // session_gates is keyed by the ACP id ALONE, and ACP ids are runtime-local
+        // — another agent's still-live `acp-1` may share the key. Drop the gate only
+        // once no surviving session references it (the sessions row above is already
+        // deleted inside this transaction, so a self-reference cannot pin it).
+        const stillReferenced = this.db
+          .prepare('SELECT 1 AS present FROM sessions WHERE acpSessionId = ? LIMIT 1')
+          .get(rec.acpSessionId)
+        if (!stillReferenced) {
+          this.db.prepare('DELETE FROM session_gates WHERE acpSessionId = ?').run(rec.acpSessionId)
+        }
         this.db
           .prepare('DELETE FROM permission_requests WHERE agentId = ? AND sessionId = ?')
           .run(rec.agentId, rec.acpSessionId)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2228,19 +2228,29 @@ export class LocalStore {
       .all(cutoff) as unknown as SessionRecord[]
   }
 
-  /** True when the session key still has durable inbox rows (admitted work that
-   *  has not reached a terminal state, or an unacknowledged hook receipt). The
-   *  retention sweep treats such a session as active and skips it. */
-  sessionHasInboxRows(key: string): boolean {
-    const row = this.db.prepare('SELECT 1 AS present FROM inbox WHERE sessionKey = ? LIMIT 1').get(key) as
-      { present: number } | undefined
+  /** True when the session key still has PENDING durable inbox rows (admitted
+   *  work that has not reached a terminal state). The retention sweep treats such
+   *  a session as active and skips it. Completed rows — hook dedup receipts and
+   *  unacknowledged terminal reports — do NOT pin the session: a hook session
+   *  keeps its receipt forever, and counting it would exempt exactly the
+   *  review-agent sessions #485 exists to collect. */
+  sessionHasPendingInboxRows(key: string): boolean {
+    const row = this.db
+      .prepare('SELECT 1 AS present FROM inbox WHERE sessionKey = ? AND completedAt IS NULL LIMIT 1')
+      .get(key) as { present: number } | undefined
     return row !== undefined
   }
 
   /** Retention-GC delete (#485): remove one session row and its dependent rows —
    *  mute, memory-capture gate, durable inbox, permission-request history.
-   *  Transcript rows are deliberately untouched: they are (channel, thread)-scoped
-   *  and shared across agents, so the thread's history survives the session.
+   *  Two deliberate survivors:
+   *  - transcript rows — (channel, thread)-scoped and shared across agents, the
+   *    thread's history outlives the session;
+   *  - unacknowledged terminal hook reports (`terminalReport IS NOT NULL`) — an
+   *    outbox the CP has not converged yet, preserved exactly like
+   *    removeInboxByAgentId does.
+   *  permission_requests is scoped by agentId as well: ACP session ids are
+   *  runtime-local, so two agents can both hold an `acp-1`.
    *  Returns false when the row is already gone (idempotent). */
   deleteSession(key: string): boolean {
     const rec = this.getSession(key)
@@ -2249,10 +2259,12 @@ export class LocalStore {
     try {
       this.db.prepare('DELETE FROM sessions WHERE key = ?').run(key)
       this.db.prepare('DELETE FROM session_mutes WHERE key = ?').run(key)
-      this.db.prepare('DELETE FROM inbox WHERE sessionKey = ?').run(key)
+      this.db.prepare('DELETE FROM inbox WHERE sessionKey = ? AND terminalReport IS NULL').run(key)
       if (rec.acpSessionId) {
         this.db.prepare('DELETE FROM session_gates WHERE acpSessionId = ?').run(rec.acpSessionId)
-        this.db.prepare('DELETE FROM permission_requests WHERE sessionId = ?').run(rec.acpSessionId)
+        this.db
+          .prepare('DELETE FROM permission_requests WHERE agentId = ? AND sessionId = ?')
+          .run(rec.agentId, rec.acpSessionId)
       }
       this.db.exec('COMMIT')
     } catch (err) {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -358,6 +358,85 @@ function sessionWorktreeId(sessionKey: string): string {
   return createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
 }
 
+/** The stable daemon-owned worktree directory for one logical session. Derived,
+ * never stored — the id is a hex hash, so the path always sits under the agent's
+ * worktrees root. */
+export function sessionWorktreePath(agent: Agent, sessionKey: string): string {
+  return join(sessionWorktreeRoot(agent), sessionWorktreeId(sessionKey))
+}
+
+export type SessionWorktreeRemoval =
+  | { outcome: 'removed' }
+  | { outcome: 'absent' }
+  /** The worktree holds work the daemon must not discard — the caller keeps the session. */
+  | { outcome: 'retained'; reason: 'dirty' | 'unique-commits' }
+  | { outcome: 'failed'; error: string }
+
+/** Retention GC (#485): remove one logical session's worktree, but only when it
+ * is provably safe — no dirty/untracked files and no commit unreachable from
+ * every remote ref (daemon-owned review refs count as remote-backed: they were
+ * fetched verbatim). Safe candidates go through Git-aware cleanup
+ * (`worktree remove` → `worktree prune`) and their review refs are deleted;
+ * anything else is reported as retained/failed so the caller keeps the session.
+ * The active-turn exclusion is the caller's job — this function only judges the
+ * on-disk state. */
+export async function removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
+  const id = sessionWorktreeId(sessionKey)
+  const cwd = join(sessionWorktreeRoot(agent), id)
+  const primaryGit = () => gitFor(agent.workspace.path).env(workspaceGitLocalEnv())
+  // Drop the stale Git registration and this worktree's daemon-owned review refs.
+  // Ref deletion is best-effort: most worktrees never had review refs.
+  const cleanupRegistrations = async () => {
+    await primaryGit().raw(['worktree', 'prune'])
+    for (const name of ['base', 'head', 'merge']) {
+      await primaryGit()
+        .raw(['update-ref', '-d', `refs/agentconnect/reviews/${id}/${name}`])
+        .catch(() => undefined)
+    }
+  }
+  try {
+    if (agent.workspace.mode !== 'git-repo') throw new Error('agent workspace is not a Git repository')
+    if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) throw new Error('session worktree path is a symlink')
+    if (!existsSync(cwd)) {
+      await cleanupRegistrations()
+      return { outcome: 'absent' }
+    }
+    if (!existsSync(join(cwd, '.git'))) {
+      // An orphaned directory (crash between rmSync and `worktree add`, or a
+      // manually gutted checkout): nothing Git-tracked to preserve, and Git
+      // itself no longer considers it a worktree.
+      rmSync(cwd, { recursive: true, force: true })
+      await cleanupRegistrations()
+      return { outcome: 'removed' }
+    }
+    const worktreeGit = gitFor(cwd).env(workspaceGitLocalEnv())
+    if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
+      return { outcome: 'retained', reason: 'dirty' }
+    }
+    // Session worktrees are detached, so there is no upstream to compare against:
+    // a commit is "unique" when no remote ref (and no fetched review ref of this
+    // worktree) can reach it.
+    const unique = (
+      await worktreeGit.raw([
+        'rev-list',
+        '--count',
+        'HEAD',
+        '--not',
+        '--remotes',
+        `--glob=refs/agentconnect/reviews/${id}`
+      ])
+    ).trim()
+    if (unique !== '0') return { outcome: 'retained', reason: 'unique-commits' }
+    // No --force: if the tree went dirty between the check and here, Git refuses
+    // and the failure keeps the session.
+    await primaryGit().raw(['worktree', 'remove', cwd])
+    await cleanupRegistrations()
+    return { outcome: 'removed' }
+  } catch (err) {
+    return { outcome: 'failed', error: (err as Error).message }
+  }
+}
+
 function exactObjectId(value: string, label: string): string {
   if (!GIT_OBJECT_ID.test(value)) throw new Error(`github review ${label} is not a Git object id`)
   return value.toLowerCase()

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -335,19 +335,30 @@ export function sessionWorktreeRoot(agent: Agent): string {
   return join(agentRoot, 'worktrees')
 }
 
-function prepareSessionWorktreeRoot(agent: Agent): string {
-  const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
-  const root = sessionWorktreeRoot(agent)
-  if (existsSync(root) && lstatSync(root).isSymbolicLink()) {
+/** Canonicalize an EXISTING worktree root and prove it (and every ancestor
+ * symlink it may hide behind) still resolves inside the agent directory. Every
+ * destructive path must go through this — checking only the final entry misses
+ * a symlinked `worktrees/` parent redirecting the whole tree elsewhere. */
+function validateSessionWorktreeRoot(agent: Agent, root: string): string {
+  if (lstatSync(root).isSymbolicLink()) {
     throw new Error('session worktree root must not be a symlink')
   }
-  mkdirSync(root, { recursive: true, mode: 0o700 })
+  const agentRoot = realpathSync((agent as { dir?: string }).dir ?? dirname(agent.workspace.path))
   const canonicalRoot = realpathSync(root)
   const rel = relative(agentRoot, canonicalRoot)
   if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
     throw new Error('session worktree root resolves outside the agent directory')
   }
   return canonicalRoot
+}
+
+function prepareSessionWorktreeRoot(agent: Agent): string {
+  const root = sessionWorktreeRoot(agent)
+  if (existsSync(root) && lstatSync(root).isSymbolicLink()) {
+    throw new Error('session worktree root must not be a symlink')
+  }
+  mkdirSync(root, { recursive: true, mode: 0o700 })
+  return validateSessionWorktreeRoot(agent, root)
 }
 
 function clearSessionWorktrees(agent: Agent): void {
@@ -382,7 +393,6 @@ export type SessionWorktreeRemoval =
  * on-disk state. */
 export async function removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
   const id = sessionWorktreeId(sessionKey)
-  const cwd = join(sessionWorktreeRoot(agent), id)
   const primaryGit = () => gitFor(agent.workspace.path).env(workspaceGitLocalEnv())
   // Drop the stale Git registration and this worktree's daemon-owned review refs.
   // Ref deletion is best-effort: most worktrees never had review refs.
@@ -396,15 +406,28 @@ export async function removeSessionWorktree(agent: Agent, sessionKey: string): P
   }
   try {
     if (agent.workspace.mode !== 'git-repo') throw new Error('agent workspace is not a Git repository')
+    const rootPath = sessionWorktreeRoot(agent)
+    if (!existsSync(rootPath)) {
+      // No root ⇒ no worktree directory can exist; Git may still hold a stale
+      // registration/review refs for it.
+      await cleanupRegistrations()
+      return { outcome: 'absent' }
+    }
+    // Re-derive cwd from the CANONICAL root: a symlinked root (or symlinked
+    // ancestor) must never redirect the destructive branches below outside the
+    // agent directory.
+    const cwd = join(validateSessionWorktreeRoot(agent, rootPath), id)
     if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) throw new Error('session worktree path is a symlink')
     if (!existsSync(cwd)) {
       await cleanupRegistrations()
       return { outcome: 'absent' }
     }
     if (!existsSync(join(cwd, '.git'))) {
-      // An orphaned directory (crash between rmSync and `worktree add`, or a
-      // manually gutted checkout): nothing Git-tracked to preserve, and Git
-      // itself no longer considers it a worktree.
+      // The `.git` marker is gone, so Git no longer considers this a worktree —
+      // but a NONEMPTY directory may hold exactly the untracked work this GC
+      // promises never to auto-delete (`status` can't run without the marker).
+      // Reclaim only a provably empty leftover; report anything else.
+      if (readdirSync(cwd).length > 0) return { outcome: 'retained', reason: 'dirty' }
       rmSync(cwd, { recursive: true, force: true })
       await cleanupRegistrations()
       return { outcome: 'removed' }

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileS
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { loadConfig } from '../src/config/load-config.js'
-import { McpServerDefSchema, RuntimeDefSchema } from '../src/config/config-schema.js'
+import { McpServerDefSchema, RuntimeDefSchema, sessionRetentionMs } from '../src/config/config-schema.js'
 
 function tmpRoot(config: unknown): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-cfg-'))
@@ -27,6 +27,21 @@ describe('loadConfig', () => {
     expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')
+    expect(cfg.sessions.retention).toBe('7d') // #485 session retention defaults on
+  })
+
+  it('session retention accepts the full keyword set and maps to sweep windows', () => {
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: 'never' } }) }).sessions.retention).toBe(
+      'never'
+    )
+    expect(loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '1month' } }) }).sessions.retention).toBe(
+      '1month'
+    )
+    expect(() => loadConfig({ root: tmpRoot({ version: 1, sessions: { retention: '3d' } }) })).toThrow()
+    expect(sessionRetentionMs('never')).toBeNull()
+    expect(sessionRetentionMs('7d')).toBe(7 * 24 * 3_600_000)
+    expect(sessionRetentionMs('2weeks')).toBe(14 * 24 * 3_600_000)
+    expect(sessionRetentionMs('1month')).toBe(30 * 24 * 3_600_000)
   })
 
   it.skipIf(process.platform === 'win32')('repairs an existing config file to owner-only permissions', () => {

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1504,3 +1504,75 @@ describe('Daemon CP drain (#109)', () => {
     await daemon.stop()
   }, 15_000)
 })
+
+describe('Daemon session retention GC (#485)', () => {
+  const seedSession = (daemon: Daemon, key: string, state: 'idle' | 'prompting' | 'closed', updatedAt: number) =>
+    (daemon as any).store.upsertSession({
+      key,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: key,
+      acpSessionId: `acp-${key}`,
+      state,
+      lastDeliveredTs: null,
+      updatedAt
+    })
+
+  it('the idle sweep deletes expired sessions but spares live turns and gate-owned keys', async () => {
+    const clock = new FakeClock()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    await daemon.start()
+
+    seedSession(daemon, 'expired-closed', 'closed', 0)
+    seedSession(daemon, 'expired-idle', 'idle', 0)
+    seedSession(daemon, 'fresh-closed', 'closed', 2 * 24 * 3_600_000) // inside the window at sweep time
+    seedSession(daemon, 'expired-prompting', 'prompting', 0) // live turn — durable state guard
+    seedSession(daemon, 'expired-gated', 'closed', 0) // owned serial gate — in-memory guard
+    ;(daemon as any).inflight.add('expired-gated')
+
+    // Past the default 7d retention window; the hourly gate inside sweepIdle opens too.
+    clock.advance(8 * 24 * 3_600_000)
+    await vi.waitFor(() => expect((daemon as any).store.getSession('expired-closed')).toBeUndefined())
+    expect((daemon as any).store.getSession('expired-idle')).toBeUndefined()
+    expect((daemon as any).store.getSession('fresh-closed')).toBeDefined()
+    expect((daemon as any).store.getSession('expired-prompting')).toBeDefined()
+    expect((daemon as any).store.getSession('expired-gated')).toBeDefined()
+
+    await daemon.stop()
+  }, 15_000)
+
+  it('retention "never" disables the sweep entirely', async () => {
+    const clock = new FakeClock()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    await daemon.start()
+    ;(daemon as any).cfg.sessions.retention = 'never'
+    seedSession(daemon, 'expired-closed', 'closed', 0)
+
+    clock.advance(8 * 24 * 3_600_000)
+    await (daemon as any).sweepSessionRetention()
+    expect((daemon as any).store.getSession('expired-closed')).toBeDefined()
+
+    await daemon.stop()
+  }, 15_000)
+
+  it('a session with pending durable inbox work is treated as active and kept', async () => {
+    const clock = new FakeClock()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => quietHost() as any, clock })
+    await daemon.start()
+    seedSession(daemon, 'expired-queued', 'closed', 0)
+    ;(daemon as any).store.appendInbox({
+      id: 'm-queued',
+      sessionKey: 'expired-queued',
+      agentId: 'bot-a',
+      msg: '{}',
+      enqueuedAt: '0000000001'
+    })
+
+    clock.advance(8 * 24 * 3_600_000)
+    await (daemon as any).sweepSessionRetention()
+    expect((daemon as any).store.getSession('expired-queued')).toBeDefined()
+
+    await daemon.stop()
+  }, 15_000)
+})

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -1038,6 +1038,36 @@ describe('LocalStore session retention GC (#485)', () => {
     s.close()
   })
 
+  it('deleteSession keeps a capture gate another agent still references through the same ACP id', () => {
+    const s = store()
+    // ACP session ids are runtime-local: bot-a and bot-b can both hold `acp-shared`.
+    const put = (key: string, agentId: string) =>
+      s.upsertSession({
+        key,
+        agentId,
+        platform: 'slack',
+        channel: 'C1',
+        thread: key,
+        acpSessionId: 'acp-shared',
+        state: 'closed',
+        lastDeliveredTs: null,
+        updatedAt: 100
+      })
+    put('a', 'bot-a')
+    put('b', 'bot-b')
+    s.setLocalCaptureGate('acp-shared', false) // capture open (not excluded)
+    expect(s.isCaptureExcluded('acp-shared')).toBe(false)
+
+    // bot-a's session expires first: bot-b still references the id — gate survives.
+    expect(s.deleteSession('a')).toBe(true)
+    expect(s.isCaptureExcluded('acp-shared')).toBe(false)
+
+    // The last referencing session goes: the gate is finally collected too.
+    expect(s.deleteSession('b')).toBe(true)
+    expect(s.isCaptureExcluded('acp-shared')).toBe(true) // no row ⇒ excluded-by-default
+    s.close()
+  })
+
   it('deleteSession leaves unrelated sessions and their dependents alone', () => {
     const s = store()
     seed(s, 'gone', 'closed', 100)

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -960,12 +960,41 @@ describe('LocalStore session retention GC (#485)', () => {
     s.close()
   })
 
+  it('sessionHasPendingInboxRows counts admitted work, not terminal hook receipts', () => {
+    const s = store()
+    // A completed hook receipt (dedup row) must not pin the session forever —
+    // hook-triggered review sessions are exactly what #485 collects.
+    s.appendInbox({
+      id: 'receipt',
+      sessionKey: 'k',
+      agentId: 'bot-a',
+      msg: '{}',
+      completedAt: 50,
+      enqueuedAt: '0000000001'
+    })
+    expect(s.sessionHasPendingInboxRows('k')).toBe(false)
+    s.appendInbox({ id: 'queued', sessionKey: 'k', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000002' })
+    expect(s.sessionHasPendingInboxRows('k')).toBe(true)
+    s.close()
+  })
+
   it('deleteSession removes the row and its mute/inbox/gate/permission cascades, keeping transcripts', () => {
     const s = store()
     seed(s, 'gone', 'closed', 100)
     s.setSessionMuted('gone', true)
     s.setLocalCaptureGate('acp-gone', true)
     s.appendInbox({ id: 'm1', sessionKey: 'gone', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000001' })
+    // An unacknowledged terminal hook report is an outbox toward the CP and must
+    // survive the session delete (same rule as removeInboxByAgentId).
+    s.appendInbox({
+      id: 'm1-report',
+      sessionKey: 'gone',
+      agentId: 'bot-a',
+      msg: '{}',
+      completedAt: 90,
+      terminalReport: '{"outcome":"done"}',
+      enqueuedAt: '0000000002'
+    })
     s.createPermissionRequest({
       id: 'p1',
       agentId: 'bot-a',
@@ -977,17 +1006,31 @@ describe('LocalStore session retention GC (#485)', () => {
       status: 'pending',
       resolvedAt: null
     })
+    // ACP session ids are runtime-local: another agent's identically named
+    // session must keep its permission history.
+    s.createPermissionRequest({
+      id: 'p2',
+      agentId: 'bot-b',
+      sessionId: 'acp-gone',
+      createdAt: 100,
+      requesterId: null,
+      requesterName: null,
+      command: 'ls',
+      status: 'pending',
+      resolvedAt: null
+    })
     // Thread history is (channel, thread)-scoped and shared — it must survive.
     s.appendTranscript({ channel: 'C1', thread: 'gone', ts: '1.1', sender: 'u1', kind: 'text', text: 'hello' })
-    expect(s.sessionHasInboxRows('gone')).toBe(true)
+    expect(s.sessionHasPendingInboxRows('gone')).toBe(true)
 
     expect(s.deleteSession('gone')).toBe(true)
 
     expect(s.getSession('gone')).toBeUndefined()
     expect(s.isSessionMuted('gone')).toBe(false)
-    expect(s.sessionHasInboxRows('gone')).toBe(false)
-    expect(s.listInboxBySessionKeyFifo()).toEqual([])
+    expect(s.sessionHasPendingInboxRows('gone')).toBe(false)
+    expect(s.listInboxBySessionKeyFifo().map((r) => r.id)).toEqual(['m1-report'])
     expect(s.listPermissionRequests('bot-a')).toEqual([])
+    expect(s.listPermissionRequests('bot-b').map((r) => r.id)).toEqual(['p2'])
     // The gate row is gone: an unknown session falls back to excluded-by-default.
     expect(s.transcriptSince('C1', 'gone', null).map((r) => r.text)).toEqual(['hello'])
     // Idempotent: a second delete (or an unknown key) reports false, not an error.
@@ -1004,7 +1047,7 @@ describe('LocalStore session retention GC (#485)', () => {
     s.deleteSession('gone')
     expect(s.getSession('kept')).toBeDefined()
     expect(s.isSessionMuted('kept')).toBe(true)
-    expect(s.sessionHasInboxRows('kept')).toBe(true)
+    expect(s.sessionHasPendingInboxRows('kept')).toBe(true)
     s.close()
   })
 })

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -928,6 +928,87 @@ describe('LocalStore session lifecycle (§7.3/#111/#118)', () => {
   })
 })
 
+describe('LocalStore session retention GC (#485)', () => {
+  const seed = (
+    s: LocalStore,
+    key: string,
+    state: 'idle' | 'prompting' | 'cancelling' | 'resuming' | 'closed',
+    updatedAt: number,
+    acpSessionId: string | null = 'acp-' + key
+  ) =>
+    s.upsertSession({
+      key,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: key,
+      acpSessionId,
+      state,
+      lastDeliveredTs: null,
+      updatedAt
+    })
+
+  it('listExpiredSessions returns idle/closed rows past the cutoff oldest-first, including unbound ones', () => {
+    const s = store()
+    seed(s, 'old-closed', 'closed', 200)
+    seed(s, 'older-idle', 'idle', 100)
+    seed(s, 'never-bound', 'closed', 150, null) // no ACP id, still a candidate (may own a worktree)
+    seed(s, 'fresh-closed', 'closed', 900)
+    seed(s, 'old-prompting', 'prompting', 100) // live turn — never a candidate
+    seed(s, 'old-resuming', 'resuming', 100) // re-attaching — never a candidate
+    expect(s.listExpiredSessions(500).map((r) => r.key)).toEqual(['older-idle', 'never-bound', 'old-closed'])
+    s.close()
+  })
+
+  it('deleteSession removes the row and its mute/inbox/gate/permission cascades, keeping transcripts', () => {
+    const s = store()
+    seed(s, 'gone', 'closed', 100)
+    s.setSessionMuted('gone', true)
+    s.setLocalCaptureGate('acp-gone', true)
+    s.appendInbox({ id: 'm1', sessionKey: 'gone', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000001' })
+    s.createPermissionRequest({
+      id: 'p1',
+      agentId: 'bot-a',
+      sessionId: 'acp-gone',
+      createdAt: 100,
+      requesterId: null,
+      requesterName: null,
+      command: 'rm -rf /tmp/x',
+      status: 'pending',
+      resolvedAt: null
+    })
+    // Thread history is (channel, thread)-scoped and shared — it must survive.
+    s.appendTranscript({ channel: 'C1', thread: 'gone', ts: '1.1', sender: 'u1', kind: 'text', text: 'hello' })
+    expect(s.sessionHasInboxRows('gone')).toBe(true)
+
+    expect(s.deleteSession('gone')).toBe(true)
+
+    expect(s.getSession('gone')).toBeUndefined()
+    expect(s.isSessionMuted('gone')).toBe(false)
+    expect(s.sessionHasInboxRows('gone')).toBe(false)
+    expect(s.listInboxBySessionKeyFifo()).toEqual([])
+    expect(s.listPermissionRequests('bot-a')).toEqual([])
+    // The gate row is gone: an unknown session falls back to excluded-by-default.
+    expect(s.transcriptSince('C1', 'gone', null).map((r) => r.text)).toEqual(['hello'])
+    // Idempotent: a second delete (or an unknown key) reports false, not an error.
+    expect(s.deleteSession('gone')).toBe(false)
+    s.close()
+  })
+
+  it('deleteSession leaves unrelated sessions and their dependents alone', () => {
+    const s = store()
+    seed(s, 'gone', 'closed', 100)
+    seed(s, 'kept', 'closed', 100)
+    s.setSessionMuted('kept', true)
+    s.appendInbox({ id: 'm2', sessionKey: 'kept', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000002' })
+    s.deleteSession('gone')
+    expect(s.getSession('kept')).toBeDefined()
+    expect(s.isSessionMuted('kept')).toBe(true)
+    expect(s.sessionHasInboxRows('kept')).toBe(true)
+    s.close()
+  })
+})
+
 describe('LocalStore runtime model-catalog cache (runtime-model-catalog.md §4)', () => {
   const meta = (runtimeId: string, fingerprint: string, observedAt = 100) => ({
     runtimeId,

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -434,13 +434,40 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     void id
   })
 
-  it('deletes an orphaned directory that git no longer tracks as a worktree', async () => {
+  it('deletes an EMPTY orphaned directory that git no longer tracks as a worktree', async () => {
     const { agent, cwd } = fixture()
     rmSync(join(cwd, '.git'))
 
     expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
     expect(existsSync(cwd)).toBe(false)
     expect(gitCalls()).toContainEqual(['worktree', 'prune'])
+  })
+
+  it('retains a NONEMPTY gitless directory — its files may be untracked user work', async () => {
+    const { agent, cwd } = fixture()
+    rmSync(join(cwd, '.git'))
+    writeFileSync(join(cwd, 'notes.md'), 'work in progress')
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(readFileSync(join(cwd, 'notes.md'), 'utf8')).toBe('work in progress')
+  })
+
+  it('refuses a symlinked worktrees ROOT without touching the link target', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-wt-gc-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    // An attacker-replaced root: `worktrees` is a symlink to a directory outside
+    // the agent dir, holding a victim tree at the derived worktree id.
+    const outside = mkdtempSync(join(tmpdir(), 'ac-wt-victim-'))
+    const victim = join(outside, basename(sessionWorktreePath(agent, 'session-a')))
+    mkdirSync(victim, { recursive: true })
+    writeFileSync(join(victim, 'precious.txt'), 'do not delete')
+    symlinkSync(outside, sessionWorktreeRoot(agent))
+
+    const res = await removeSessionWorktree(agent, 'session-a')
+    expect(res.outcome).toBe('failed')
+    expect(readFileSync(join(victim, 'precious.txt'), 'utf8')).toBe('do not delete')
   })
 
   it('refuses a symlinked worktree path', async () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   realpathSync,
   readdirSync,
+  rmSync,
   symlinkSync,
   writeFileSync
 } from 'node:fs'
@@ -45,6 +46,8 @@ const {
   prepareWorkspaceForActivation,
   prefetchWorkspace,
   recordWorkspaceMaterialization,
+  removeSessionWorktree,
+  sessionWorktreePath,
   sessionWorktreeRoot
 } = await import('../src/workspace/workspace-manager.js')
 const { initGitInjection } = await import('../src/workspace/git-injection.js')
@@ -336,6 +339,119 @@ describe('prepareSessionWorkspace', () => {
     expect(second).not.toBe(first)
     expect(dirname(first)).toBe(realpathSync(sessionWorktreeRoot(agent)))
     expect(dirname(second)).toBe(realpathSync(sessionWorktreeRoot(agent)))
+  })
+})
+
+describe('removeSessionWorktree (#485 retention GC)', () => {
+  /** A git-repo agent plus one on-disk session worktree (a dir with a `.git` file,
+   *  exactly what `worktree add` leaves behind). */
+  function fixture() {
+    const root = mkdtempSync(join(tmpdir(), 'ac-wt-gc-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    const cwd = sessionWorktreePath(agent, 'session-a')
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), 'gitdir: elsewhere')
+    return { agent, cwd, id: basename(cwd) }
+  }
+  const gitCalls = () => rawMock.mock.calls.map((call) => call[0] as string[])
+
+  it('removes a clean fully-pushed worktree: remove → prune → review-ref deletion', async () => {
+    const { agent, cwd, id } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '0\n'
+      return ''
+    })
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+
+    const calls = gitCalls()
+    const removeAt = calls.findIndex((args) => args[0] === 'worktree' && args[1] === 'remove' && args[2] === cwd)
+    const pruneAt = calls.findIndex((args) => args[0] === 'worktree' && args[1] === 'prune')
+    expect(removeAt).toBeGreaterThanOrEqual(0)
+    expect(pruneAt).toBeGreaterThan(removeAt) // prune runs AFTER remove
+    for (const name of ['base', 'head', 'merge']) {
+      expect(calls).toContainEqual(['update-ref', '-d', `refs/agentconnect/reviews/${id}/${name}`])
+    }
+    // The unique-commit probe must see every remote ref and this worktree's review refs.
+    expect(calls).toContainEqual([
+      'rev-list',
+      '--count',
+      'HEAD',
+      '--not',
+      '--remotes',
+      `--glob=refs/agentconnect/reviews/${id}`
+    ])
+  })
+
+  it('retains a worktree with dirty/untracked files and never calls worktree remove', async () => {
+    const { agent } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'status') return ' M src/app.ts\n?? notes.md\n'
+      return '0\n'
+    })
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(gitCalls().some((args) => args[0] === 'worktree')).toBe(false)
+  })
+
+  it('retains a worktree whose HEAD has commits unreachable from every remote ref', async () => {
+    const { agent } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '2\n' : ''))
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+    expect(gitCalls().some((args) => args[0] === 'worktree' && args[1] === 'remove')).toBe(false)
+  })
+
+  it('reports failed (keeping the session) when git refuses the removal', async () => {
+    const { agent } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '0\n'
+      if (args[0] === 'worktree' && args[1] === 'remove') throw new Error('worktree is locked')
+      return ''
+    })
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'failed', error: 'worktree is locked' })
+  })
+
+  it('an absent worktree still prunes stale registrations and review refs', async () => {
+    const { agent, id } = fixture()
+    const other = sessionWorktreePath(agent, 'session-b')
+    expect(other).not.toBe(sessionWorktreePath(agent, 'session-a'))
+
+    expect(await removeSessionWorktree(agent, 'session-b')).toEqual({ outcome: 'absent' })
+
+    const calls = gitCalls()
+    expect(calls).toContainEqual(['worktree', 'prune'])
+    expect(calls).toContainEqual(['update-ref', '-d', `refs/agentconnect/reviews/${basename(other)}/base`])
+    expect(calls.some((args) => args[0] === 'status' || args[0] === 'rev-list')).toBe(false)
+    // fixture()'s own worktree for session-a is untouched
+    expect(existsSync(sessionWorktreePath(agent, 'session-a'))).toBe(true)
+    void id
+  })
+
+  it('deletes an orphaned directory that git no longer tracks as a worktree', async () => {
+    const { agent, cwd } = fixture()
+    rmSync(join(cwd, '.git'))
+
+    expect(await removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(existsSync(cwd)).toBe(false)
+    expect(gitCalls()).toContainEqual(['worktree', 'prune'])
+  })
+
+  it('refuses a symlinked worktree path', async () => {
+    const { agent, cwd } = fixture()
+    rmSync(cwd, { recursive: true, force: true })
+    const outside = mkdtempSync(join(tmpdir(), 'ac-wt-outside-'))
+    symlinkSync(outside, cwd)
+
+    const res = await removeSessionWorktree(agent, 'session-a')
+    expect(res.outcome).toBe('failed')
+    expect(existsSync(outside)).toBe(true) // the link target was never touched
   })
 })
 


### PR DESCRIPTION
## Summary

Daemon-owned retention GC for local sessions and their per-session Git worktrees (part of #485).

- **New config** `sessions.retention`: `never` / `7d` / `2weeks` / `1month` (default `7d`). The window is measured from the session's last activity (`sessions.updatedAt`).
- **Sweep cadence**: one pass at daemon startup (after durable-inbox replay, never blocking readiness) and hourly on the existing idle sweep.
- **Auto-delete requires ALL of** (per the #485 acceptance criteria):
  - no active turn — durable state (`prompting`/`cancelling`/`resuming`), the serial admission gate, the live `Pending` map, durable inbox rows, and the SDK background-task lease are all consulted;
  - no dirty/untracked files (`git status --porcelain`);
  - no commit unreachable from every remote ref (`git rev-list --count HEAD --not --remotes --glob=refs/agentconnect/reviews/<id>` — session worktrees are detached, so upstream-ahead is meaningless; the worktree's own review refs count as remote-backed since they are fetched verbatim).
- **Git-aware cleanup**: `git worktree remove` → `git worktree prune`, then deletion of the worktree's daemon-owned `refs/agentconnect/reviews/<id>/*` refs. Symlinked paths are refused; orphaned directories Git no longer tracks are reclaimed; an absent worktree still prunes stale registrations and review refs.
- **Dirty / unique-commit worktrees are reported, never auto-deleted** — the session row is kept so the working state stays reachable through the same logical session; the next sweep retries.
- **Store delete cascades** to `session_mutes`, `session_gates`, durable `inbox`, and `permission_requests`. Transcript rows are deliberately untouched: they are `(channel, thread)`-scoped and shared across agents.

Not in this PR (follow-ups from #485): a user-facing explicit session delete with confirmed force-cleanup (no such surface exists today), and per-agent count/disk caps with oldest-safe-first eviction.

## Test plan

- `test/config.test.ts` — default `7d`, keyword set, ms mapping.
- `test/local-store.test.ts` — expired-candidate query (includes ACP-unbound rows, excludes live states), cascade delete keeps transcripts and unrelated sessions, idempotency.
- `test/workspace.test.ts` — remove→prune→ref-deletion order, dirty and unique-commit retention, git-refusal → `failed`, absent-worktree reconciliation, orphan-directory recovery, symlink refusal.
- `test/daemon-lifecycle.test.ts` — FakeClock 8-day sweep through `sweepIdle` wiring, active-turn/serial-gate/inbox guards, `never` disables.

Full daemon suite: green except the known pre-existing `evaluation-runner` failure on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)