### PR TITLE
fix(daemon): ignore workspace Git hooks

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -802,7 +802,8 @@ Injection uses **two channels**:
    host-socket visibility. If the operator disables the outer sandbox, the
    runtime-native profile still receives the same channel permission within
    that explicitly unconfined launch.
-   - **Do not carry session-level injection through `GIT_CONFIG_COUNT`.**
+   - **Do not carry the session-level credential-helper injection through
+     `GIT_CONFIG_COUNT`.**
      `GIT_CONFIG_COUNT` does **not compose across
      processes**. If the agent's own toolchain sets `GIT_CONFIG_COUNT`, it
      replaces the pairs we injected, removing the helper reset and reopening
@@ -820,7 +821,12 @@ Injection uses **two channels**:
      automatically uses its own App bot. Git always reads global config;
      children inherit the path, and no indexed-count conflict exists. Reserve
      indexed `GIT_CONFIG_*` variables for **short-lived subprocesses directly
-     controlled by the daemon, such as clone**.
+     controlled by the daemon, such as clone**, and for non-credential ambient
+     policy. In particular, configured Git workspaces inject
+     `core.hooksPath=/dev/null` (or `NUL`) and `core.fsmonitor=false` at command
+     scope for the Agent process. If a nested tool deliberately replaces that
+     indexed channel it can opt out of the ambient hook policy, but it cannot
+     remove or replace the global-file credential reset.
    - This injection must be spread **last, at the highest precedence** in the
      spawn-environment merge: after
      `{ ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }` in `ensureHost` at

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -303,11 +303,39 @@ metadata through the authenticated GitHub API. When the Agent workspace is the
 same repository, the daemon fetches the exact base and head objects into
 daemon-owned refs and checks out an isolated worktree. A GitHub merge ref may be
 used only after its object ID and ordered parents are proven to be the trusted
-base and head; otherwise the exact head is used. A formal review fails closed if
-that fetch or verification fails. If the Agent workspace is another repository,
-the prompt forbids trusting local traces and requires read-only GitHub inspection
-of the trusted revision instead. Ordinary PR conversations preserve their stable
-session worktree, do not carry formal-review authority, and require read-only or
+base and head; otherwise the exact head is used.
+Reused formal-review worktrees are hard-reset and cleaned including ignored
+untracked content before they are presented as exact snapshots. Ordinary session
+worktrees continue to preserve their working state between turns.
+
+Repository hooks are not a reason to reject a workspace. Every daemon-managed
+Git command disables hooks and fsmonitor at command scope, and every configured
+Git workspace gives its Agent runtime the same default policy without rewriting
+the repository config. Unconditional local includes are expanded so their
+effective settings can be audited; an include that only selects a hooks path
+remains usable. Conditional includes are refused because their activation can
+change between the primary checkout and a linked worktree, and the separate
+worktree config scope is refused because a local-scope audit cannot inspect it.
+Network routing or other executable overrides that the daemon cannot neutralize
+are also refused for the affected daemon-managed operation. The daemon repeats
+that audit immediately before linked-worktree materialization or reset, and an
+unsafe result is never degraded into a best-effort pull failure. Daemon Git also
+disables replacement-object processing and ignores repository graft files, so
+verified object IDs, parents, and checked-out trees retain the same meaning. It
+also disables sparse checkout at daemon command scope so an exact checkout is a
+complete tree even when the primary repository uses sparse-checkout settings.
+This policy applies to every task in a configured Git repository, not only GitHub
+reviews.
+
+Failure to obtain the authoritative base/head remains fail-closed. Once those
+identities are known, however, a revision fetch, verification, or local checkout
+failure degrades to revision-only review instead of failing the Agent turn. The
+daemon replaces any earlier review checkout with an empty isolated cwd when it
+can, and the prompt forbids trusting local traces, permits skipping local
+execution, and requires inspection of the exact revision through GitHub read-only
+tools. The same revision-only path applies when the Agent workspace belongs to
+another repository. Ordinary PR conversations preserve their stable session
+worktree, do not carry formal-review authority, and require read-only or
 revision-addressed inspection instead of trusting working-tree paths.
 
 The model-visible formal-review instruction repeats the trusted base/head and

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -87,9 +87,9 @@ export function createWorkspaceGit(
       const root = rootFor(agentId)
       if (!isRepo(root)) return { agentId, isRepo: false, clean: true }
 
-      // Status consults branch/upstream config. Reject executable checkout
-      // settings first; SRT keeps the audited config read-only while confined.
-      await assertSafeWorkspaceGitConfig(root)
+      // Status is read-only and the daemon policy already disables hooks and
+      // fsmonitor at command scope. Repository hook/include configuration must
+      // not make an otherwise usable workspace disappear from the console.
       const git = gitFor(root).env({ ...workspaceGitLocalEnv(), GIT_OPTIONAL_LOCKS: '0' })
       const s = await git.status()
       const files: WorkspaceGitFile[] = s.files

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -81,7 +81,13 @@ import { GitCredentialCache } from './cp/git-credential.js'
 import { CONFIG_FILE_CONVENTIONS, cleanupConfigFiles, materializeConfigFiles } from './agents/config-file-env.js'
 import { writeGhShim } from './cp/gh-shim.js'
 import { GitCredServer, gitcredShimPath, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
-import { gitCredentialEnv, initGitInjection, probeGitVersion, sessionGitEnv } from './workspace/git-injection.js'
+import {
+  gitCredentialEnv,
+  initGitInjection,
+  probeGitVersion,
+  sessionGitEnv,
+  sessionGitPolicyEnv
+} from './workspace/git-injection.js'
 import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
 import { buildMcpServers } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
@@ -375,6 +381,18 @@ function formatErr(err: unknown): string {
     return `${e.name ?? 'Error'}: ${e.message ?? ''} (code=${e.code})${data}`
   }
   return e?.stack ?? String(err)
+}
+
+function formatErrWithCauses(err: unknown): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = err
+  while (current !== undefined && current !== null && parts.length < 6 && !seen.has(current)) {
+    seen.add(current)
+    parts.push(formatErr(current))
+    current = typeof current === 'object' ? (current as { cause?: unknown }).cause : undefined
+  }
+  return parts.join('\nCaused by: ')
 }
 
 function ignoreAgentWatchPath(agentsDir: string, path: string, stats?: Stats): boolean {
@@ -4444,9 +4462,10 @@ export class Daemon {
     // A GitHub workspace uses this channel for its implicit repo; scratch uses
     // it only for explicitly authorized repos named by git/gh.
     const githubAppCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
-    // sessionGitEnv LAST: the github-app credential-helper env must win over
-    // runtimeOverrides env (a user-supplied GIT_CONFIG_* would reopen
-    // the machine-credential leak the injection exists to close).
+    // The Git session policy runs for every configured repository, not only
+    // GitHub review: repository hooks/fsmonitor stay disabled without rewriting
+    // checkout config. sessionGitEnv additionally supplies GitHub App identity.
+    // Keep this channel LAST so runtimeOverrides cannot replace either policy.
     const baseEnv: Record<string, string> = { ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }
     const runInSandbox = opts.runInSandbox
     if (agent.runInSandbox && !runInSandbox && opts.warnOnSandboxDowngrade) {
@@ -4464,7 +4483,11 @@ export class Daemon {
       // MemoryProviderUnavailableError for an unbuildable provider (external, or
       // native on an unregistered runtime) — surfaced here at spawn.
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission()).runtimeEnv(),
-      ...(githubAppCredentials ? sessionGitEnv(agent.id, this.gitCommitIdentity) : {})
+      ...(agent.workspace.mode === 'git-repo'
+        ? githubAppCredentials
+          ? sessionGitEnv(agent.id, this.gitCommitIdentity)
+          : sessionGitPolicyEnv()
+        : {})
     }
     // Config-file secrets (agents/config-file-env.ts): materialize `*_DATA`
     // contents under the agent dir and point the tool-native env vars
@@ -8195,7 +8218,7 @@ export class Daemon {
     key: string,
     agent: Agent
   ): Promise<{
-    workspaceIsolation?: 'session'
+    workspaceIsolation?: 'shared' | 'session'
     forceWorkspaceIsolation?: true
     preparedWorkspaceCwd?: string
   }> {
@@ -8207,15 +8230,34 @@ export class Daemon {
     }
 
     const revisionLine = `Base SHA: ${github.baseSha}\nHead SHA: ${github.headSha}`
-    if (!this.githubWorkspaceMatches(agent, github)) {
+    const warmHost = this.readyHosts.has(agent.id) ? this.hosts.get(agent.id) : undefined
+    const useRevisionOnlyWorkspace = async () => {
       entry.msg.text +=
         `\n\nTrusted review revision:\n${revisionLine}\n` +
-        "This Agent's local workspace is not the pull request repository. Do not trust local files or repository traces for this review; inspect the exact base and head through GitHub read-only tools."
-      return {}
+        'No trusted local pull-request checkout is available for this review. Do not trust local files or repository traces; inspect the exact base and head through GitHub read-only tools. Local execution may be skipped.'
+      try {
+        const preparedWorkspaceCwd = await this.prepareAgentWorkspace(agent, warmHost, {
+          sessionKey: key,
+          isolation: 'session',
+          githubReviewRevisionOnly: true
+        })
+        return { workspaceIsolation: 'session' as const, forceWorkspaceIsolation: true as const, preparedWorkspaceCwd }
+      } catch (fallbackErr) {
+        // A filesystem-level failure can still leave the ordinary workspace as
+        // the runtime cwd. The prompt above explicitly removes its evidentiary
+        // authority, so the review remains revision-addressed instead of dying
+        // solely because a clean local directory could not be materialized.
+        this.log.warn(
+          `github review: revision-only workspace unavailable; using the ordinary cwd as untrusted context (${formatErrWithCauses(fallbackErr)})`
+        )
+        return { workspaceIsolation: 'shared' as const, forceWorkspaceIsolation: true as const }
+      }
+    }
+    if (!this.githubWorkspaceMatches(agent, github)) {
+      return useRevisionOnlyWorkspace()
     }
 
     try {
-      const warmHost = this.readyHosts.has(agent.id) ? this.hosts.get(agent.id) : undefined
       const preparedWorkspaceCwd = await this.prepareAgentWorkspace(agent, warmHost, {
         sessionKey: key,
         isolation: 'session',
@@ -8231,7 +8273,10 @@ export class Daemon {
         'The daemon fetched and verified this isolated checkout at the exact head or a merge whose parents are exactly the base and head above. Before trusting local traces, verify `git rev-parse HEAD`; do not switch to or inspect another checkout.'
       return { workspaceIsolation: 'session', forceWorkspaceIsolation: true, preparedWorkspaceCwd }
     } catch (err) {
-      throw new Error('github review blocked: exact PR workspace preparation failed', { cause: err })
+      this.log.warn(
+        `github review: exact checkout unavailable; continuing with trusted revision only (${formatErrWithCauses(err)})`
+      )
+      return useRevisionOnlyWorkspace()
     }
   }
 

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -142,7 +142,7 @@ const EMPTY_GIT_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null'
 const WORKSPACE_SSH_COMMAND =
   'ssh -F none -o ProxyCommand=none -o ProxyJump=none -o PermitLocalCommand=no -o ClearAllForwardings=yes'
 const UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG =
-  /^(?:url\..*\.insteadof|include(?:if\..*)?\.path|http(?:\..*)?\.(?:proxy|curloptresolve)|remote\..*\.(?:proxy|uploadpack|receivepack|vcs)|core\.(?:sshcommand|hookspath|fsmonitor|worktree|alternaterefscommand|askpass|pager)|pager\..*|filter\..*\.(?:clean|smudge|process)|diff\.(?:external|.*\.(?:command|textconv))|merge\..*\.driver|submodule\..*\.update|fetch\.bundleuri)$/i
+  /^(?:url\..*\.insteadof|includeif\..*\.path|extensions\.worktreeconfig|http(?:\..*)?\.(?:proxy|curloptresolve)|remote\..*\.(?:proxy|uploadpack|receivepack|vcs)|core\.(?:sshcommand|worktree|alternaterefscommand|askpass|pager)|pager\..*|filter\..*\.(?:clean|smudge|process)|diff\.(?:external|.*\.(?:command|textconv))|merge\..*\.driver|submodule\..*\.update|fetch\.bundleuri)$/i
 const WORKSPACE_GIT_CONTROLLED_ENV = new Set([
   'GIT_ALLOW_PROTOCOL',
   'GIT_CONFIG_NOSYSTEM',
@@ -162,6 +162,10 @@ function workspaceGitProcessEnv(): Record<string, string> {
   // separately before an existing workspace performs network I/O.
   env.GIT_CONFIG_NOSYSTEM = '1'
   env.GIT_CONFIG_GLOBAL = EMPTY_GIT_CONFIG
+  // Repository-owned replacement refs can make a trusted object id materialize
+  // another tree, while legacy grafts can rewrite verified commit parents.
+  env.GIT_NO_REPLACE_OBJECTS = '1'
+  env.GIT_GRAFT_FILE = EMPTY_GIT_CONFIG
   env.GIT_LFS_SKIP_SMUDGE = '1'
   env.GIT_NO_LAZY_FETCH = '1'
   return env
@@ -169,11 +173,13 @@ function workspaceGitProcessEnv(): Record<string, string> {
 
 function workspaceGitConfigPairs(repository?: string): ReadonlyArray<readonly [string, string]> {
   const pairs: Array<readonly [string, string]> = [
-    // Disable both default/custom hooks and fsmonitor commands for every
-    // daemon-owned operation. Clear checkout-owned credential helpers before
-    // an optional daemon helper is appended below.
+    // Disable both default/custom hooks, fsmonitor commands, and partial-tree
+    // materialization for every daemon-owned operation. Clear checkout-owned
+    // credential helpers before an optional daemon helper is appended below.
     ['core.hooksPath', EMPTY_GIT_CONFIG],
     ['core.fsmonitor', 'false'],
+    ['core.sparseCheckout', 'false'],
+    ['core.sparseCheckoutCone', 'false'],
     ['credential.helper', ''],
     ['http.followRedirects', 'false'],
     // Disable checkout- or server-selected secondary download locations.
@@ -255,18 +261,34 @@ export function workspaceGitLocalEnv(): Record<string, string> {
 }
 
 /**
- * Reject checkout-owned routing includes and URL rewrites before a daemon-run
- * pull. Git has no switch that disables only repository config, so inspect the
- * local/worktree keys with includes disabled, while global/system config is
- * already excluded by the environment above.
+ * Reject checkout-owned routing and executable settings that remain effective
+ * before daemon-run network or checkout operations. Unconditional includes are
+ * expanded and their actual keys are audited instead of rejecting include.path
+ * itself: a repository may legitimately include a shared hooksPath, and daemon
+ * Git pins hooksPath/fsmonitor at command scope so neither can run. Conditional
+ * includes remain disallowed because their activation can change between the
+ * primary checkout used for this audit and a later linked worktree. The
+ * separate worktree config scope is also disallowed because `--local` cannot
+ * audit `.git/config.worktree`, while later daemon Git operations still read it.
  */
 export async function assertSafeWorkspaceGitConfig(cwd: string): Promise<void> {
   const names = await gitFor(cwd)
     .env(workspaceGitLocalEnv())
-    .raw(['config', '--local', '--no-includes', '--name-only', '-z', '--list'])
+    .raw(['config', '--local', '--includes', '--name-only', '-z', '--list'])
   if (names.split('\0').some((name) => UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG.test(name))) {
     throw new Error('workspace Git configuration contains a disallowed network override or executable setting')
   }
+}
+
+/** Ambient Git policy inherited by every configured repository session. The
+ * command-scope config outranks repo-local and included hooksPath/fsmonitor
+ * values without rewriting the checkout's own config. A tool may still opt in
+ * explicitly with a later `git -c` override when running a hook is the task. */
+export function sessionGitPolicyEnv(): Record<string, string> {
+  return gitConfigEnv([
+    ['core.hooksPath', EMPTY_GIT_CONFIG],
+    ['core.fsmonitor', 'false']
+  ])
 }
 
 /**
@@ -364,6 +386,7 @@ export function sessionGitEnv(agentId: string, commitIdentity?: GitCommitIdentit
   writeFileSync(file, lines.join('\n'), { mode: 0o644 })
   return {
     ...gitCredentialEnv(agentId),
+    ...sessionGitPolicyEnv(),
     GIT_CONFIG_GLOBAL: file,
     GIT_TERMINAL_PROMPT: '0',
     ...(commitIdentity

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -65,6 +65,9 @@ export interface PrepareSessionWorkspaceRequest {
   sessionKey: string
   isolation: 'shared' | 'session'
   review?: GithubReviewWorkspaceRevision
+  /** Use an empty daemon-owned cwd when an exact local review checkout is
+   * unavailable. The model must inspect the trusted revision through GitHub. */
+  githubReviewRevisionOnly?: true
 }
 
 async function withSkills(agent: Agent, acpCwd: string, opts: PrepareWorkspaceOptions): Promise<string> {
@@ -555,6 +558,27 @@ async function fetchReviewRevision(
   }
 }
 
+/** Replace any earlier checkout with an empty stable cwd. This lets a formal
+ * review continue through revision-addressed GitHub tools without exposing a
+ * stale or checkout-controlled local repository as evidence. */
+function prepareGithubRevisionOnlyWorkspace(agent: Agent, id: string): string {
+  const root = prepareSessionWorktreeRoot(agent)
+  const cwd = join(root, id)
+  if (existsSync(cwd) && lstatSync(cwd).isSymbolicLink()) {
+    throw new Error('github review workspace path must not be a symlink')
+  }
+  const staged = `${cwd}.review-${randomUUID()}`
+  mkdirSync(staged, { recursive: true, mode: 0o700 })
+  try {
+    rmSync(cwd, { recursive: true, force: true })
+    renameSync(staged, cwd)
+  } catch (err) {
+    rmSync(staged, { recursive: true, force: true })
+    throw err
+  }
+  return realpathSync(cwd)
+}
+
 /** Prepare the stable cwd for one logical session. Ordinary worktrees preserve
  * their working state between turns. Review worktrees are daemon-owned snapshots
  * and are reset on every delivery after an exact remote fetch. */
@@ -563,6 +587,12 @@ export async function prepareSessionWorkspace(
   request: PrepareSessionWorkspaceRequest,
   opts: PrepareWorkspaceOptions = {}
 ): Promise<string> {
+  if (request.githubReviewRevisionOnly) {
+    if (agent.workspace.mode !== 'git-repo' || request.isolation !== 'session' || request.review) {
+      throw new Error('github revision-only workspace requires an isolated git-repo review session')
+    }
+    return prepareGithubRevisionOnlyWorkspace(agent, sessionWorktreeId(request.sessionKey))
+  }
   const primary = await prepareWorkspace(agent, opts)
   if (agent.workspace.mode !== 'git-repo' || request.isolation === 'shared') return primary
 
@@ -586,11 +616,18 @@ export async function prepareSessionWorkspace(
   if (!attached) {
     rmSync(cwd, { recursive: true, force: true })
     await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'prune'])
+    // prepareWorkspace's pull is best-effort (and may be disabled), but this
+    // checkout runs in the daemon process. Unsafe executable config must gate
+    // the worktree operation itself instead of being swallowed as a pull error.
+    await assertSafeWorkspaceGitConfig(agent.workspace.path)
     await gitFor(agent.workspace.path).env(workspaceGitLocalEnv()).raw(['worktree', 'add', '--detach', cwd, target])
   } else if (review) {
+    // Re-audit at the checkout boundary rather than relying on the earlier
+    // network fetch audit; repository config may have changed while fetching.
+    await assertSafeWorkspaceGitConfig(agent.workspace.path)
     const worktreeGit = gitFor(cwd).env(workspaceGitLocalEnv())
     await worktreeGit.raw(['reset', '--hard', target])
-    await worktreeGit.raw(['clean', '-ffd'])
+    await worktreeGit.raw(['clean', '-ffdx'])
   }
   if (review && (await revParse(cwd, 'HEAD')).toLowerCase() !== review.checkout) {
     throw new Error('github review worktree HEAD does not match the verified revision')

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -506,6 +506,80 @@ describe('Daemon rd/msg hook fires', () => {
     await daemon.stop()
   })
 
+  it('continues a formal review with revision-only GitHub inspection when exact checkout preparation fails', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-review-fallback-workspace'),
+        gitRepo: 'https://github.com/acme/infra',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true
+      }
+    })
+    const daemon = new Daemon({ root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi
+      .spyOn(daemon as any, 'prepareAgentWorkspace')
+      .mockRejectedValueOnce(
+        new Error('workspace Git configuration contains a disallowed network override or executable setting')
+      )
+      .mockResolvedValueOnce('/agent/worktrees/revision-only')
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const entry = {
+      msg: { text: 'Review this pull request.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'review-fallback',
+        firedAt: new Date().toISOString(),
+        event: 'pull_request:synchronize',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha,
+          baseSha,
+          reportSha: headSha
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).prepareGithubReviewWorkspace(entry, 'hook:acme/infra#461', (daemon as any).agents.get(AGENT_ID))
+    ).resolves.toEqual({
+      workspaceIsolation: 'session',
+      forceWorkspaceIsolation: true,
+      preparedWorkspaceCwd: '/agent/worktrees/revision-only'
+    })
+    expect(prepare).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: AGENT_ID }),
+      undefined,
+      expect.objectContaining({
+        sessionKey: 'hook:acme/infra#461',
+        isolation: 'session',
+        githubReviewRevisionOnly: true
+      })
+    )
+    expect(entry.msg.text).toContain('Trusted review revision')
+    expect(entry.msg.text).toContain('Do not trust local files')
+    expect(entry.msg.text).toContain('Local execution may be skipped')
+    await daemon.stop()
+  })
+
   it('preserves the stable worktree for an ordinary PR conversation', async () => {
     const root = scaffold({
       workspace: {

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
+import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
 
 function scaffold(displayName?: string, memoryProvider?: 'none' | 'managed', iconUrl?: string): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-daemon-'))
@@ -114,7 +115,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     }
   })
 
-  it('keeps agent write-only secrets out of the dream host env (#36 Phase C security)', async () => {
+  it('keeps agent tool credentials out of the dream host without re-enabling repository hooks', async () => {
     const root = scaffold()
     const daemon = new Daemon({ root, sandboxMechanism: 'bwrap', probeRuntimes: async () => [] })
     try {
@@ -122,6 +123,15 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       const agent = (daemon as any).agents.get('bot-a')
       agent.runtimeOverrides = { secrets: [{ name: 'API_KEY', value: 'super-secret' }] }
       const cwd = agent.workspace.path
+      agent.workspace = {
+        mode: 'git-repo',
+        path: cwd,
+        gitRepo: 'https://github.com/acme/repo',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        pullOnNewSession: true,
+        skills: []
+      }
       // A normal (non-dream) host still carries the agent's configured secret…
       const normal = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
       expect((normal as any).opts.env.API_KEY).toBe('super-secret')
@@ -132,7 +142,17 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         cwd,
         excludeAgentToolCredentials: true
       }).host
-      expect((dreamHost as any).opts.env.API_KEY).toBeUndefined()
+      const dreamEnv = (dreamHost as any).opts.env
+      expect(dreamEnv.API_KEY).toBeUndefined()
+      expect(dreamEnv[GITCRED_AGENT_ENV]).toBeUndefined()
+      expect(dreamEnv[GITCRED_CAPABILITY_ENV]).toBeUndefined()
+      expect([
+        [dreamEnv.GIT_CONFIG_KEY_0, dreamEnv.GIT_CONFIG_VALUE_0],
+        [dreamEnv.GIT_CONFIG_KEY_1, dreamEnv.GIT_CONFIG_VALUE_1]
+      ]).toEqual([
+        ['core.hooksPath', process.platform === 'win32' ? 'NUL' : '/dev/null'],
+        ['core.fsmonitor', 'false']
+      ])
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -14,6 +14,7 @@ import {
   parseGitVersion,
   pullWorkspaceRef,
   sessionGitEnv,
+  sessionGitPolicyEnv,
   workspaceGitEnvBase,
   workspaceGitLocalEnv,
   workspaceGitPullTarget
@@ -98,8 +99,10 @@ describe('gitEnvBase', () => {
     expect(workspaceGitLocalEnv().GIT_ALLOW_PROTOCOL).toBe('')
     expect(workspaceGitEnvBase()).toMatchObject({
       GIT_CONFIG_NOSYSTEM: '1',
+      GIT_GRAFT_FILE: process.platform === 'win32' ? 'NUL' : '/dev/null',
       GIT_LFS_SKIP_SMUDGE: '1',
-      GIT_NO_LAZY_FETCH: '1'
+      GIT_NO_LAZY_FETCH: '1',
+      GIT_NO_REPLACE_OBJECTS: '1'
     })
     expect(workspaceGitEnvBase().GIT_CONFIG_GLOBAL).toBe(process.platform === 'win32' ? 'NUL' : '/dev/null')
     expect(Object.keys(workspaceGitEnvBase()).some((key) => /^(?:all|ftp|http|https|no)_proxy$/i.test(key))).toBe(false)
@@ -109,6 +112,8 @@ describe('gitEnvBase', () => {
       process.platform === 'win32' ? 'NUL' : '/dev/null'
     ])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.fsmonitor', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.sparseCheckout', 'false'])
+    expect(configPairs(workspaceGitEnvBase())).toContainEqual(['core.sparseCheckoutCone', 'false'])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['credential.helper', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['fetch.bundleURI', ''])
     expect(configPairs(workspaceGitEnvBase())).toContainEqual(['transfer.bundleURI', 'false'])
@@ -165,6 +170,59 @@ describe('gitEnvBase', () => {
       await expect(
         gitFor(workspace).env(workspaceGitLocalEnv()).raw(['remote', 'get-url', 'origin'])
       ).resolves.toContain('https://other-host.example/acme/repo')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps daemon checkout and parent verification bound to repository objects', () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-object-integrity-test-'))
+    const workspace = join(root, 'workspace')
+    const worktree = join(root, 'worktree')
+    const env = {
+      ...workspaceGitLocalEnv(),
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.invalid',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.invalid'
+    }
+    try {
+      execFileSync('git', ['init', '-b', 'main', workspace], { env, stdio: 'ignore' })
+      writeFileSync(join(workspace, 'content'), 'trusted\n')
+      writeFileSync(join(workspace, 'hidden'), 'complete\n')
+      execFileSync('git', ['-C', workspace, 'add', 'content', 'hidden'], { env })
+      execFileSync('git', ['-C', workspace, 'commit', '-m', 'trusted'], { env, stdio: 'ignore' })
+      const trusted = execFileSync('git', ['-C', workspace, 'rev-parse', 'HEAD'], {
+        env,
+        encoding: 'utf8'
+      }).trim()
+
+      writeFileSync(join(workspace, 'content'), 'replacement\n')
+      execFileSync('git', ['-C', workspace, 'add', 'content'], { env })
+      execFileSync('git', ['-C', workspace, 'commit', '-m', 'replacement'], { env, stdio: 'ignore' })
+      const replacement = execFileSync('git', ['-C', workspace, 'rev-parse', 'HEAD'], {
+        env,
+        encoding: 'utf8'
+      }).trim()
+
+      execFileSync('git', ['-C', workspace, 'replace', trusted, replacement], { env })
+      writeFileSync(join(workspace, '.git', 'info', 'grafts'), `${replacement} ${replacement}\n`)
+      execFileSync('git', ['-C', workspace, 'config', 'core.sparseCheckout', 'true'], { env })
+      writeFileSync(join(workspace, '.git', 'info', 'sparse-checkout'), 'content\n')
+
+      expect(
+        execFileSync('git', ['-C', workspace, 'rev-list', '--parents', '-n', '1', replacement], {
+          env,
+          encoding: 'utf8'
+        }).trim()
+      ).toBe(`${replacement} ${trusted}`)
+      execFileSync('git', ['-C', workspace, 'worktree', 'add', '--detach', worktree, trusted], {
+        env,
+        stdio: 'ignore'
+      })
+      expect(readFileSync(join(worktree, 'content'), 'utf8')).toBe('trusted\n')
+      expect(readFileSync(join(worktree, 'hidden'), 'utf8')).toBe('complete\n')
+      expect(execFileSync('git', ['-C', worktree, 'rev-parse', 'HEAD'], { env, encoding: 'utf8' }).trim()).toBe(trusted)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -259,12 +317,67 @@ describe('gitEnvBase', () => {
     }
   })
 
-  it('rejects checkout-owned executable Git settings before host-side status or pull', async () => {
+  it('rejects checkout-owned executable Git settings that daemon policy does not override', async () => {
     const workspace = mkdtempSync(join(tmpdir(), 'git-executable-config-test-'))
     const localEnv = workspaceGitLocalEnv()
     try {
       execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
-      execFileSync('git', ['-C', workspace, 'config', 'core.hooksPath', 'custom-hooks'], { env: localEnv })
+      execFileSync('git', ['-C', workspace, 'config', 'filter.generated.process', './filter-process'], {
+        env: localEnv
+      })
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('allows an included hooksPath while still auditing included network overrides', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-included-hook-policy-test-'))
+    const workspace = join(root, 'workspace')
+    const include = join(root, 'workspace.gitconfig')
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      writeFileSync(include, '[core]\n\thooksPath = .github/.githooks\n')
+      execFileSync('git', ['-C', workspace, 'config', 'include.path', include], { env: localEnv })
+      await expect(assertSafeWorkspaceGitConfig(workspace)).resolves.toBeUndefined()
+
+      writeFileSync(
+        include,
+        '[core]\n\thooksPath = .github/.githooks\n[url "https://127.0.0.1.invalid/"]\n\tinsteadOf = https://github.com/\n'
+      )
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/disallowed network override/)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects conditional includes that can activate only in a linked worktree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'git-conditional-include-policy-test-'))
+    const workspace = join(root, 'workspace')
+    const include = join(root, 'worktree.gitconfig')
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      writeFileSync(include, '[filter "evil"]\n\tprocess = ./filter-process\n')
+      execFileSync('git', ['-C', workspace, 'config', 'includeIf.gitdir:**/.git/worktrees/**.path', include], {
+        env: localEnv
+      })
+
+      await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects the separate worktree config scope omitted by a local-scope audit', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'git-worktree-config-policy-test-'))
+    const localEnv = workspaceGitLocalEnv()
+    try {
+      execFileSync('git', ['init', workspace], { env: localEnv, stdio: 'ignore' })
+      execFileSync('git', ['-C', workspace, 'config', 'extensions.worktreeConfig', 'true'], { env: localEnv })
+      writeFileSync(join(workspace, '.git', 'config.worktree'), '[filter "evil"]\n\tsmudge = ./filter-smudge\n')
+
       await expect(assertSafeWorkspaceGitConfig(workspace)).rejects.toThrow(/executable setting/)
     } finally {
       rmSync(workspace, { recursive: true, force: true })
@@ -433,6 +546,14 @@ describe('cloneGitEnv', () => {
 })
 
 describe('sessionGitEnv', () => {
+  it('disables repository hooks and fsmonitor for every configured Git workspace session', () => {
+    expect(configPairs(sessionGitPolicyEnv())).toEqual([
+      ['core.hooksPath', process.platform === 'win32' ? 'NUL' : '/dev/null'],
+      ['core.fsmonitor', 'false']
+    ])
+    expect(configPairs(sessionGitEnv('agent-1'))).toEqual(configPairs(sessionGitPolicyEnv()))
+  })
+
   it('pins the CP-provided bot as both author and committer', () => {
     const env = sessionGitEnv('agent-1', {
       name: 'agentconnect-example[bot]',

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -307,6 +307,24 @@ describe('createWorkspaceGit.pull', () => {
     expect(pullImpl).not.toHaveBeenCalled()
   })
 
+  it('pulls normally when local includes only configure repository hooks', async () => {
+    const dir = ws(true)
+    rawImpl = vi
+      .fn()
+      .mockImplementation(async (args: string[]) =>
+        args[0] === 'remote' ? 'https://github.com/acme/repo.git\n' : 'include.path\0core.hookspath\0'
+      )
+    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+    const git = createWorkspaceGit(
+      () => dir,
+      () => ({}),
+      githubTarget
+    )
+
+    await expect(git.pull('a')).resolves.toMatchObject({ isRepo: true, ok: true })
+    expect(pullImpl).toHaveBeenCalledOnce()
+  })
+
   it('ignores a checkout-controlled upstream and pulls the configured target explicitly', async () => {
     const dir = ws(true)
     rawImpl = vi

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -21,7 +21,8 @@ let lastGitEnv: Record<string, string> | undefined
 const pullMock = vi.fn().mockResolvedValue(undefined)
 const rawMock = vi.fn().mockResolvedValue('')
 vi.mock('simple-git', () => ({
-  simpleGit: (_cwd?: string) => {
+  simpleGit: (options?: string | { baseDir?: string }) => {
+    const cwd = typeof options === 'string' ? options : options?.baseDir
     // .env() returns the chain (mirrors the real fluent API) and records the
     // injected child env so the credential-injection tests can assert on it.
     const chain = {
@@ -31,7 +32,7 @@ vi.mock('simple-git', () => ({
       },
       clone: (...args: any[]) => cloneImpl(...args),
       pull: pullMock,
-      raw: rawMock
+      raw: (args: string[]) => rawMock(args, cwd)
     }
     return chain
   }
@@ -271,7 +272,7 @@ describe('prepareWorkspace', () => {
 })
 
 describe('prepareSessionWorkspace', () => {
-  it('fetches and checks out the exact trusted PR revision in a session worktree', async () => {
+  it('fetches the exact trusted PR revision when the workspace includes a hooksPath', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ac-review-ws-'))
     const path = join(root, 'workspace')
     mkdirSync(join(path, '.git'), { recursive: true })
@@ -280,8 +281,9 @@ describe('prepareSessionWorkspace', () => {
     const base = 'a'.repeat(40)
     const head = 'b'.repeat(40)
 
-    rawMock.mockImplementation(async (args: string[]) => {
+    rawMock.mockImplementation(async (args: string[], cwd?: string) => {
       if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (cwd === path && args[0] === 'config') return 'include.path\0core.hooksPath\0'
       if (args[0] === 'rev-parse') {
         const ref = args.at(-1) ?? ''
         if (ref.includes('/base')) return `${base}\n`
@@ -296,11 +298,13 @@ describe('prepareSessionWorkspace', () => {
       return ''
     })
 
-    const cwd = await prepareSessionWorkspace(agent, {
+    const request = {
       sessionKey: 'hook:repo#461:bot-git',
-      isolation: 'session',
+      isolation: 'session' as const,
       review: { pullNumber: 461, baseSha: base, headSha: head }
-    })
+    }
+    const cwd = await prepareSessionWorkspace(agent, request)
+    await prepareSessionWorkspace(agent, request)
 
     expect(dirname(cwd)).toBe(realpathSync(sessionWorktreeRoot(agent)))
     const addCall = rawMock.mock.calls
@@ -311,12 +315,52 @@ describe('prepareSessionWorkspace', () => {
     expect(addCall?.[4]).toBe(head)
     expect(
       rawMock.mock.calls.some(
-        ([args]) =>
+        ([args, baseDir]) =>
           args[0] === 'fetch' &&
+          baseDir === path &&
           args.includes(`+${base}:refs/agentconnect/reviews/${basename(cwd)}/base`) &&
           args.includes(`+refs/pull/461/head:refs/agentconnect/reviews/${basename(cwd)}/head`)
       )
     ).toBe(true)
+    expect(rawMock.mock.calls.some(([args]) => args[0] === 'clean' && args[1] === '-ffdx')).toBe(true)
+  })
+
+  it('replaces a stale review checkout with an empty revision-only cwd', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-review-fallback-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    const request = {
+      sessionKey: 'hook:repo#461:bot-git',
+      isolation: 'session' as const,
+      githubReviewRevisionOnly: true as const
+    }
+
+    const cwd = await prepareSessionWorkspace(agent, request)
+    mkdirSync(join(cwd, '.git'))
+    writeFileSync(join(cwd, 'stale-review.txt'), 'must not be trusted')
+
+    await expect(prepareSessionWorkspace(agent, request)).resolves.toBe(cwd)
+    expect(readdirSync(cwd)).toEqual([])
+  })
+
+  it('blocks unsafe config before ordinary linked-worktree creation when pull is disabled', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-session-policy-'))
+    const path = join(root, 'workspace')
+    mkdirSync(join(path, '.git'), { recursive: true })
+    const agent = gitRepoAgent(path)
+    agent.workspace.pullOnNewSession = false
+
+    rawMock.mockImplementation(async (args: string[], cwd?: string) => {
+      if (args[0] === 'remote' && args[1] === 'get-url') return 'https://github.com/acme/repo.git\n'
+      if (cwd === path && args[0] === 'config') return 'filter.evil.smudge\0'
+      return ''
+    })
+
+    await expect(prepareSessionWorkspace(agent, { sessionKey: 'session-a', isolation: 'session' })).rejects.toThrow(
+      'workspace Git configuration contains a disallowed network override or executable setting'
+    )
+    expect(rawMock.mock.calls.some(([args]) => args[0] === 'worktree' && args[1] === 'add')).toBe(false)
   })
 
   it('uses a stable distinct worktree for each logical session', async () => {
@@ -350,8 +394,9 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const path = join(root, 'workspace')
     mkdirSync(join(path, '.git'), { recursive: true })
     const agent = gitRepoAgent(path)
-    const cwd = sessionWorktreePath(agent, 'session-a')
-    mkdirSync(cwd, { recursive: true })
+    const requestedCwd = sessionWorktreePath(agent, 'session-a')
+    mkdirSync(requestedCwd, { recursive: true })
+    const cwd = realpathSync(requestedCwd)
     writeFileSync(join(cwd, '.git'), 'gitdir: elsewhere')
     // Hand back the CANONICAL path: the GC re-derives its worktree path from the
     // realpath'd root before every destructive step, so that is the path it puts


### PR DESCRIPTION
## Summary

- disable repository hooks and fsmonitor for every daemon-managed Git operation and every configured `git-repo` ACP host
- expand unconditional local Git includes and audit their effective settings, allowing hook-only includes while rejecting conditional includes and separate worktree config scope that can change linked-worktree behavior
- keep workspace status, pull, and ordinary repository tasks usable when a repository configures hooks; gate only unsafe config at daemon-owned linked-worktree checkout boundaries
- disable repository replacement refs and graft files, force full-tree materialization, and remove ignored stale files from reused formal-review snapshots
- degrade formal-review checkout failures to revision-only GitHub inspection; only unavailable authoritative base/head revisions block the review

## Validation

- `pnpm --filter @agentconnect.md/daemon test` (160 files passed, 6 skipped; 2762 tests passed, 46 skipped)
- focused Git/workspace/hook tests (5 files, 197 tests passed)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `eslint .`

Created by Codex . GPT-5.6
