### PR TITLE
feat(web): queue composer sends while a turn is streaming

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -265,6 +265,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const [pgBusyBy, setPgBusyBy] = useState<Record<string, boolean>>({})
   // Messages sent while a turn was still streaming, oldest first per session id.
   const [pgQueueBy, setPgQueueBy] = useState<Record<string, QueuedTurn[]>>({})
+  // Synchronous mirror of pgQueueBy — pgSend's queue-or-send decision cannot
+  // read state: when a turn ends, busyRef clears at once but the queue head is
+  // dispatched by a passive effect, and a send landing in that gap would jump
+  // ahead of messages already shown as queued. Every pgQueueBy write updates
+  // this ref in the same tick.
+  const pgQueueRef = useRef<Record<string, QueuedTurn[]>>({})
   const conns = useRef<Map<string, Conn>>(new Map())
   const conversationIds = useRef<Map<string, string>>(new Map())
   // Creation-time roster per session id (primary first) — drives the
@@ -1131,23 +1137,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       if (!text && !image) return false
       setPgInput(id, '')
       setPgImage(id)
-      if (busyRef.current[id]) {
-        // A turn is streaming: queue instead of rejecting (Claude Code-style).
-        // The dispatcher effect sends it once the in-flight turn finishes.
-        setPgQueueBy((cur) => ({
-          ...cur,
-          [id]: [
-            ...(cur[id] ?? NO_QUEUE),
-            {
-              queueId: crypto.randomUUID(),
-              text,
-              ...(image ? { image } : {}),
-              agentId: agentForId,
-              ...(conversationId ? { conversationId } : {}),
-              ...(knownParticipants ? { participants: knownParticipants } : {})
-            }
-          ]
-        }))
+      // Queue while a turn streams (Claude Code-style) — and also while older
+      // queued messages are still waiting for the dispatcher, so a send landing
+      // between a turn's end and the dispatch of the queue head stays FIFO.
+      if (busyRef.current[id] || (pgQueueRef.current[id]?.length ?? 0) > 0) {
+        const queued: QueuedTurn = {
+          queueId: crypto.randomUUID(),
+          text,
+          ...(image ? { image } : {}),
+          agentId: agentForId,
+          ...(conversationId ? { conversationId } : {}),
+          ...(knownParticipants ? { participants: knownParticipants } : {})
+        }
+        pgQueueRef.current[id] = [...(pgQueueRef.current[id] ?? NO_QUEUE), queued]
+        setPgQueueBy((cur) => ({ ...cur, [id]: [...(cur[id] ?? NO_QUEUE), queued] }))
         return true
       }
       sendTurn(id, agentForId, text, image, conversationId, knownParticipants)
@@ -1164,6 +1167,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       const next = queue[0]
       if (!next || busyRef.current[id] || dispatchedQueueIds.current.has(next.queueId)) continue
       dispatchedQueueIds.current.add(next.queueId)
+      pgQueueRef.current[id] = (pgQueueRef.current[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId)
       setPgQueueBy((cur) => ({ ...cur, [id]: (cur[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId) }))
       sendTurn(id, next.agentId, next.text, next.image, next.conversationId, next.participants)
     }
@@ -1171,6 +1175,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
 
   const getPgQueue = useCallback((id: string) => pgQueueBy[id] ?? NO_QUEUE, [pgQueueBy])
   const pgCancelQueued = useCallback((id: string, queueId: string): void => {
+    pgQueueRef.current[id] = (pgQueueRef.current[id] ?? NO_QUEUE).filter((q) => q.queueId !== queueId)
     setPgQueueBy((cur) => {
       const queue = cur[id]
       if (!queue?.some((q) => q.queueId === queueId)) return cur

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -1163,8 +1163,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // dispatched-set makes the effect idempotent (StrictMode runs effects twice).
   const dispatchedQueueIds = useRef<Set<string>>(new Set())
   useEffect(() => {
-    for (const [id, queue] of Object.entries(pgQueueBy)) {
-      const next = queue[0]
+    for (const id of Object.keys(pgQueueBy)) {
+      // Head comes from the synchronous mirror, NOT the render-time snapshot:
+      // a cancel landing after busy cleared but before this effect ran has
+      // already removed it from the mirror, and dispatching the snapshot's
+      // head would send a message the user watched disappear.
+      const next = pgQueueRef.current[id]?.[0]
       if (!next || busyRef.current[id] || dispatchedQueueIds.current.has(next.queueId)) continue
       dispatchedQueueIds.current.add(next.queueId)
       pgQueueRef.current[id] = (pgQueueRef.current[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId)

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -8,7 +8,17 @@
 // structured events which we fold into the session's `steps` for the transcript
 // view.
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode
+} from 'react'
 import {
   agentLabel,
   selectedPermissionPreset,
@@ -47,9 +57,14 @@ import {
 } from '@/lib/webchat-lanes'
 
 interface PlaygroundData {
-  /** Composer buffer for one session id (each live conversation has its own). */
+  /** Composer buffer for one session id (each live conversation has its own).
+   *  NOT reactive — drafts live outside React state so keystrokes don't
+   *  re-render every context consumer. Subscribe via usePgDraft()/
+   *  subscribePgDraft when the UI must follow the value. */
   getPgInput: (id: string) => string
   setPgInput: (id: string, v: string) => void
+  /** Notifies on any draft change; pair with getPgInput in useSyncExternalStore. */
+  subscribePgDraft: (listener: () => void) => () => void
   /** One prepared image waiting in this session's composer. */
   getPgImage: (id: string) => SessionImage | undefined
   setPgImage: (id: string, image?: SessionImage) => void
@@ -241,7 +256,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   // Composer buffer + in-flight flag are PER session id: the provider keeps several
   // conversations live at once (each streams in the background across route changes),
   // so a single global would let one session disable/clear another's composer.
-  const [pgInputBy, setPgInputBy] = useState<Record<string, string>>({})
+  // Drafts live OUTSIDE React state on purpose: a keystroke must not invalidate
+  // the provider context (that re-renders every consumer, including the whole
+  // session transcript). Composers subscribe per-session via usePgDraft().
+  const pgDrafts = useRef<Record<string, string>>({})
+  const pgDraftListeners = useRef(new Set<() => void>())
   const [pgImageBy, setPgImageBy] = useState<Record<string, SessionImage>>({})
   const [pgBusyBy, setPgBusyBy] = useState<Record<string, boolean>>({})
   // Messages sent while a turn was still streaming, oldest first per session id.
@@ -295,7 +314,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     setPgBusyBy((cur) => (!!cur[id] === v ? cur : { ...cur, [id]: v }))
   }, [])
   const setPgInput = useCallback((id: string, v: string): void => {
-    setPgInputBy((cur) => ({ ...cur, [id]: v }))
+    if ((pgDrafts.current[id] ?? '') === v) return
+    pgDrafts.current = { ...pgDrafts.current, [id]: v }
+    for (const notify of pgDraftListeners.current) notify()
+  }, [])
+  const subscribePgDraft = useCallback((listener: () => void): (() => void) => {
+    pgDraftListeners.current.add(listener)
+    return () => pgDraftListeners.current.delete(listener)
   }, [])
   const setPgImage = useCallback((id: string, image?: SessionImage): void => {
     setPgImageBy((cur) => {
@@ -1101,7 +1126,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       conversationId?: string,
       knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
     ) => {
-      const text = String(textArg ?? pgInputBy[id] ?? '').trim()
+      const text = String(textArg ?? pgDrafts.current[id] ?? '').trim()
       const image = pgImageBy[id]
       if (!text && !image) return false
       setPgInput(id, '')
@@ -1128,7 +1153,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       sendTurn(id, agentForId, text, image, conversationId, knownParticipants)
       return true
     },
-    [pgImageBy, pgInputBy, sendTurn, setPgImage, setPgInput]
+    [pgImageBy, sendTurn, setPgImage, setPgInput]
   )
 
   // Dispatch the oldest queued message the moment its session's turn ends. The
@@ -1224,7 +1249,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     (id: string) => pgSessions[id] ?? Object.values(pgSessions).find((session) => session.realSessionId === id),
     [pgSessions]
   )
-  const getPgInput = useCallback((id: string) => pgInputBy[id] ?? '', [pgInputBy])
+  const getPgInput = useCallback((id: string) => pgDrafts.current[id] ?? '', [])
   const getPgImage = useCallback((id: string) => pgImageBy[id], [pgImageBy])
   const isPgBusy = useCallback((id: string) => !!pgBusyBy[id], [pgBusyBy])
   const getLiveSteps = useCallback((id: string) => wcSteps[id] ?? NO_STEPS, [wcSteps])
@@ -1246,6 +1271,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     () => ({
       getPgInput,
       setPgInput,
+      subscribePgDraft,
       getPgImage,
       setPgImage,
       getPgWorktree,
@@ -1270,6 +1296,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [
       getPgInput,
       setPgInput,
+      subscribePgDraft,
       getPgImage,
       setPgImage,
       getPgWorktree,
@@ -1300,4 +1327,26 @@ export function usePlayground(): PlaygroundData {
   const ctx = useContext(Ctx)
   if (!ctx) throw new Error('usePlayground must be used within <PlaygroundProvider>')
   return ctx
+}
+
+/** Reactive view of one session's composer draft. Only the calling component
+ *  re-renders on keystrokes — the provider context itself stays untouched. */
+export function usePgDraft(id: string): string {
+  const { getPgInput, subscribePgDraft } = usePlayground()
+  return useSyncExternalStore(
+    subscribePgDraft,
+    () => getPgInput(id),
+    () => ''
+  )
+}
+
+/** Reactive empty/non-empty flag for one session's draft — for send-button
+ *  enablement in big views: it only re-renders them when the flag flips. */
+export function usePgDraftHasText(id: string): boolean {
+  const { getPgInput, subscribePgDraft } = usePlayground()
+  return useSyncExternalStore(
+    subscribePgDraft,
+    () => getPgInput(id).trim().length > 0,
+    () => false
+  )
 }

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -67,10 +67,12 @@ interface PlaygroundData {
    *  rebuilds the socket so the relay re-verifies and caches the grown roster.
    *  Failures surface as a ⚠️ transcript step. Refused while a turn streams. */
   pgAddAgent: (id: string, agent: Agent) => Promise<void>
-  /** Returns whether the send was ACCEPTED — false when there is nothing to send
-   *  or a turn is already streaming. Callers that move the viewport on send (the
-   *  session view pins the transcript to the bottom) must not act on a rejected
-   *  one, and this keeps that condition in a single place. */
+  /** Returns whether the send was ACCEPTED — false only when there is nothing to
+   *  send. A send while a turn is still streaming is accepted too: it QUEUES
+   *  (Claude Code-style) and dispatches in order as turns finish. Callers that
+   *  move the viewport on send (the session view pins the transcript to the
+   *  bottom) must not act on a rejected one, and this keeps that condition in a
+   *  single place. */
   pgSend: (
     id: string,
     agentId: string,
@@ -78,6 +80,10 @@ interface PlaygroundData {
     conversationId?: string,
     participants?: Array<{ agentId: string; name: string; primary?: boolean }>
   ) => boolean
+  /** Messages queued while a turn streams, oldest first. */
+  getPgQueue: (id: string) => QueuedTurn[]
+  /** Remove one queued message before it is sent. */
+  pgCancelQueued: (id: string, queueId: string) => void
   /** Switch the session's model (in-session, sticky). */
   pgSetModel: (id: string, agentId: string, model: string, conversationId?: string) => void
   /** Switch the session's reasoning effort (in-session, sticky). */
@@ -104,10 +110,22 @@ interface PlaygroundData {
   reconcileLiveSteps: (id: string, persisted: SessionMessageDto[], agentId: string) => void
 }
 
+/** One message waiting behind the in-flight turn. Send args are captured at
+ *  enqueue time so the auto-dispatch needs nothing from the view. */
+export interface QueuedTurn {
+  queueId: string
+  text: string
+  image?: SessionImage
+  agentId: string
+  conversationId?: string
+  participants?: Array<{ agentId: string; name: string; primary?: boolean }>
+}
+
 // Synthetic playground session ids start with `pg_`; real CP session ids do not.
 // The prefix lets the provider tell the two apart without extra bookkeeping.
 const PG_PREFIX = 'pg_'
 const NO_STEPS: SessionStep[] = []
+const NO_QUEUE: QueuedTurn[] = []
 const WEBCHAT_RECONNECT_BASE_MS = 500
 const WEBCHAT_RECONNECT_MAX_MS = 4_000
 const WEBCHAT_RECONNECT_MAX_ATTEMPTS = 6
@@ -226,6 +244,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
   const [pgInputBy, setPgInputBy] = useState<Record<string, string>>({})
   const [pgImageBy, setPgImageBy] = useState<Record<string, SessionImage>>({})
   const [pgBusyBy, setPgBusyBy] = useState<Record<string, boolean>>({})
+  // Messages sent while a turn was still streaming, oldest first per session id.
+  const [pgQueueBy, setPgQueueBy] = useState<Record<string, QueuedTurn[]>>({})
   const conns = useRef<Map<string, Conn>>(new Map())
   const conversationIds = useRef<Map<string, string>>(new Map())
   // Creation-time roster per session id (primary first) — drives the
@@ -969,20 +989,18 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [activeOrg, pgSessions, connect, pushStep]
   )
 
-  const pgSend = useCallback(
+  /** Put one turn on the wire NOW. The composer read / busy check / queueing live
+   *  in pgSend; the queue dispatcher calls this directly with the captured args. */
+  const sendTurn = useCallback(
     (
       id: string,
       agentForId: string,
-      textArg?: string,
+      text: string,
+      image: SessionImage | undefined,
       conversationId?: string,
       knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
-    ) => {
-      const text = String(textArg ?? pgInputBy[id] ?? '').trim()
-      const image = pgImageBy[id]
-      if ((!text && !image) || pgBusyBy[id]) return false
+    ): void => {
       pushStep(id, { kind: 'msg', who: '@you', text, ...(image ? { image } : {}) })
-      setPgInput(id, '')
-      setPgImage(id)
       setBusy(id, true)
       const requestedTurnId = crypto.randomUUID()
       // Targeting (webchat-multi-agents.md §4.2): conversation membership is a
@@ -1071,10 +1089,69 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           dropLanes(id)
           setBusy(id, false)
         })
+    },
+    [pgSessions, connect, pushStep, setBusy, refreshSessions]
+  )
+
+  const pgSend = useCallback(
+    (
+      id: string,
+      agentForId: string,
+      textArg?: string,
+      conversationId?: string,
+      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
+    ) => {
+      const text = String(textArg ?? pgInputBy[id] ?? '').trim()
+      const image = pgImageBy[id]
+      if (!text && !image) return false
+      setPgInput(id, '')
+      setPgImage(id)
+      if (busyRef.current[id]) {
+        // A turn is streaming: queue instead of rejecting (Claude Code-style).
+        // The dispatcher effect sends it once the in-flight turn finishes.
+        setPgQueueBy((cur) => ({
+          ...cur,
+          [id]: [
+            ...(cur[id] ?? NO_QUEUE),
+            {
+              queueId: crypto.randomUUID(),
+              text,
+              ...(image ? { image } : {}),
+              agentId: agentForId,
+              ...(conversationId ? { conversationId } : {}),
+              ...(knownParticipants ? { participants: knownParticipants } : {})
+            }
+          ]
+        }))
+        return true
+      }
+      sendTurn(id, agentForId, text, image, conversationId, knownParticipants)
       return true
     },
-    [pgBusyBy, pgImageBy, pgInputBy, pgSessions, connect, pushStep, setPgImage, setPgInput, setBusy, refreshSessions]
+    [pgImageBy, pgInputBy, sendTurn, setPgImage, setPgInput]
   )
+
+  // Dispatch the oldest queued message the moment its session's turn ends. The
+  // dispatched-set makes the effect idempotent (StrictMode runs effects twice).
+  const dispatchedQueueIds = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    for (const [id, queue] of Object.entries(pgQueueBy)) {
+      const next = queue[0]
+      if (!next || busyRef.current[id] || dispatchedQueueIds.current.has(next.queueId)) continue
+      dispatchedQueueIds.current.add(next.queueId)
+      setPgQueueBy((cur) => ({ ...cur, [id]: (cur[id] ?? NO_QUEUE).filter((q) => q.queueId !== next.queueId) }))
+      sendTurn(id, next.agentId, next.text, next.image, next.conversationId, next.participants)
+    }
+  }, [pgQueueBy, pgBusyBy, sendTurn])
+
+  const getPgQueue = useCallback((id: string) => pgQueueBy[id] ?? NO_QUEUE, [pgQueueBy])
+  const pgCancelQueued = useCallback((id: string, queueId: string): void => {
+    setPgQueueBy((cur) => {
+      const queue = cur[id]
+      if (!queue?.some((q) => q.queueId === queueId)) return cur
+      return { ...cur, [id]: queue.filter((q) => q.queueId !== queueId) }
+    })
+  }, [])
 
   /** Switch the session's model (fire-and-forget over the conversation socket). Updates
    *  the local model optimistically so the dropdown reflects the choice at once; the
@@ -1177,6 +1254,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       openPlayground,
       pgAddAgent,
       pgSend,
+      getPgQueue,
+      pgCancelQueued,
       pgSetModel,
       pgSetEffort,
       pgSetPermissionPreset,
@@ -1199,6 +1278,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       openPlayground,
       pgAddAgent,
       pgSend,
+      getPgQueue,
+      pgCancelQueued,
       pgSetModel,
       pgSetEffort,
       pgSetPermissionPreset,

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -47,6 +47,7 @@ let pgSend: ReturnType<typeof usePlayground>['pgSend']
 let openPlayground: ReturnType<typeof usePlayground>['openPlayground']
 let getPgQueue: ReturnType<typeof usePlayground>['getPgQueue']
 let pgCancelQueued: ReturnType<typeof usePlayground>['pgCancelQueued']
+let getLiveSteps: ReturnType<typeof usePlayground>['getLiveSteps']
 
 function Probe() {
   const pg = usePlayground()
@@ -54,6 +55,7 @@ function Probe() {
   openPlayground = pg.openPlayground
   getPgQueue = pg.getPgQueue
   pgCancelQueued = pg.pgCancelQueued
+  getLiveSteps = pg.getLiveSteps
   return null
 }
 
@@ -142,6 +144,35 @@ describe('pgSend acceptance', () => {
     expect(getPgQueue('s1')).toHaveLength(1)
     await act(async () => {}) // settle the send + run the dispatcher effect
     expect(getPgQueue('s1')).toEqual([])
+  })
+
+  // The FIFO gap: when a turn ends, the synchronous busy ref clears at once but
+  // the queue head is dispatched by a passive effect. A send landing in that gap
+  // must go BEHIND the pending queue, not straight to the wire ahead of it.
+  it('keeps a send arriving at the idle transition behind the pending queue', async () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'first')).toBe(true)
+    })
+    act(() => {
+      expect(pgSend('s1', 'a1', 'second')).toBe(true) // busy → queued
+    })
+    await act(async () => {
+      // Pump microtasks so the (mocked, failing) first send settles and clears
+      // the busy ref — the dispatcher effect cannot run until this act body
+      // returns, so the next send lands exactly in the race window.
+      for (let i = 0; i < 20; i++) await Promise.resolve()
+      expect(pgSend('s1', 'a1', 'third')).toBe(true)
+    })
+    // Drain the dispatcher: each dispatched turn fails and frees the next.
+    await act(async () => {})
+    await act(async () => {})
+    expect(getPgQueue('s1')).toEqual([])
+    // '@you' transcript steps record wire order — FIFO means 'third' stays last
+    // ('s1' is not a synthetic pg_ session, so its steps land in the live tail).
+    const wireOrder = getLiveSteps('s1')
+      .filter((s) => s.who === '@you')
+      .map((s) => s.text)
+    expect(wireOrder).toEqual(['first', 'second', 'third'])
   })
 
   // openPlayground exists on the same context; touching it here documents that the

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -175,6 +175,33 @@ describe('pgSend acceptance', () => {
     expect(wireOrder).toEqual(['first', 'second', 'third'])
   })
 
+  // The cancel twin of the FIFO gap: the dispatcher must not send a head the
+  // user canceled after the turn ended but before the passive effect ran. The
+  // dispatcher derives its head from the synchronous queue mirror, so a cancel
+  // landing in that window always wins over the render-time snapshot.
+  it('never dispatches a head canceled at the idle transition', async () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'first')).toBe(true)
+    })
+    act(() => {
+      expect(pgSend('s1', 'a1', 'doomed')).toBe(true) // busy → queued
+    })
+    const queueId = getPgQueue('s1')[0]!.queueId
+    await act(async () => {
+      // Pump microtasks so the (mocked, failing) first send settles and clears
+      // the busy ref, then cancel the queued head before the dispatcher effect
+      // has had a chance to run.
+      for (let i = 0; i < 20; i++) await Promise.resolve()
+      pgCancelQueued('s1', queueId)
+    })
+    await act(async () => {})
+    expect(getPgQueue('s1')).toEqual([])
+    const wireOrder = getLiveSteps('s1')
+      .filter((s) => s.who === '@you')
+      .map((s) => s.text)
+    expect(wireOrder).toEqual(['first']) // 'doomed' must never reach the wire
+  })
+
   // openPlayground exists on the same context; touching it here documents that the
   // probe wiring is real and not a partially-mocked stand-in.
   it('exposes the real provider surface', () => {

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -2,11 +2,11 @@
 //
 // `pgSend` reports whether a send was ACCEPTED, and SessionDetailView's composer
 // relies on that to decide whether to pin the transcript to the bottom. Enter on
-// an empty composer, or Enter while a turn is already streaming, must report
-// rejection — otherwise a reader who scrolled up into history gets yanked to the
-// bottom for a send that never happened. Both the textarea Enter path and the
-// send button route through the same `onPgSend`, so pinning this one condition
-// keeps the two entry points aligned.
+// an empty composer must report rejection — otherwise a reader who scrolled up
+// into history gets yanked to the bottom for a send that never happened. Enter
+// while a turn is already streaming is accepted: it QUEUES (Claude Code-style)
+// and dispatches once the turn finishes, and each queued message can be
+// cancelled before it goes out.
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -45,11 +45,15 @@ class StubSocket {
 
 let pgSend: ReturnType<typeof usePlayground>['pgSend']
 let openPlayground: ReturnType<typeof usePlayground>['openPlayground']
+let getPgQueue: ReturnType<typeof usePlayground>['getPgQueue']
+let pgCancelQueued: ReturnType<typeof usePlayground>['pgCancelQueued']
 
 function Probe() {
   const pg = usePlayground()
   pgSend = pg.pgSend
   openPlayground = pg.openPlayground
+  getPgQueue = pg.getPgQueue
+  pgCancelQueued = pg.pgCancelQueued
   return null
 }
 
@@ -88,22 +92,56 @@ describe('pgSend acceptance', () => {
     expect(pgSend('s1', 'a1', 'hello')).toBe(true)
   })
 
-  // The busy flag is React state, so the second Enter only sees it after a
-  // re-render — which is exactly the real ordering: two keypresses are two events
-  // with a commit in between. `act` flushes that commit and the probe hands back
-  // the fresh closure.
-  it('rejects a second send while the first turn is still streaming', () => {
+  // A second send while the first turn streams is ACCEPTED — it queues instead
+  // of going on the wire, and dispatches once the turn finishes.
+  it('queues a second send while the first turn is still streaming', () => {
     act(() => {
       expect(pgSend('s1', 'a1', 'hello')).toBe(true)
     })
-    expect(pgSend('s1', 'a1', 'again')).toBe(false) // busy
+    act(() => {
+      expect(pgSend('s1', 'a1', 'again')).toBe(true) // busy → queued
+    })
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['again'])
+    expect(getPgQueue('s2')).toEqual([]) // per-session queue
   })
 
-  it('keeps the busy rejection per session', () => {
+  it('cancels a queued message before it is sent', () => {
     act(() => {
       expect(pgSend('s1', 'a1', 'hello')).toBe(true)
     })
-    expect(pgSend('s2', 'a1', 'hello')).toBe(true) // a different session is free
+    act(() => {
+      expect(pgSend('s1', 'a1', 'first queued')).toBe(true)
+      expect(pgSend('s1', 'a1', 'second queued')).toBe(true)
+    })
+    const queued = getPgQueue('s1')
+    expect(queued.map((q) => q.text)).toEqual(['first queued', 'second queued'])
+    act(() => pgCancelQueued('s1', queued[0]!.queueId))
+    expect(getPgQueue('s1').map((q) => q.text)).toEqual(['second queued'])
+  })
+
+  it('keeps queueing per session — a different session sends directly', () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'hello')).toBe(true)
+    })
+    act(() => {
+      expect(pgSend('s2', 'a1', 'hello')).toBe(true) // a different session is free
+    })
+    expect(getPgQueue('s2')).toEqual([]) // sent, not queued
+  })
+
+  // The dispatcher drains the queue once the session is no longer busy. In this
+  // harness the turn "finishes" when the (mocked, failing) socket settles and
+  // clears the busy flag — flushing microtasks gets there without streaming.
+  it('auto-dispatches the queued message once the turn ends', async () => {
+    act(() => {
+      expect(pgSend('s1', 'a1', 'hello')).toBe(true)
+    })
+    act(() => {
+      expect(pgSend('s1', 'a1', 'queued')).toBe(true)
+    })
+    expect(getPgQueue('s1')).toHaveLength(1)
+    await act(async () => {}) // settle the send + run the dispatcher effect
+    expect(getPgQueue('s1')).toEqual([])
   })
 
   // openPlayground exists on the same context; touching it here documents that the

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -65,7 +65,7 @@ import {
 } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
-import { usePlayground } from '@/components/console/PlaygroundProvider'
+import { usePgDraft, usePgDraftHasText, usePlayground } from '@/components/console/PlaygroundProvider'
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
 import { NotFound } from '@/components/console/NotFound'
@@ -124,6 +124,79 @@ function FastBadge() {
     <span className="rounded-sm bg-(--brand-soft) px-[5px] py-px font-mono text-[10px] font-semibold uppercase tracking-[.04em] text-(--brand-soft-text)">
       fast
     </span>
+  )
+}
+
+// The composer's textarea, isolated so a keystroke re-renders ONLY this node:
+// the draft lives outside the playground context (usePgDraft subscription), and
+// SessionDetailView rebuilds the whole transcript on every render — routing
+// keystrokes through it made typing lag on long sessions.
+function ComposerTextarea({
+  sessionId,
+  placeholder,
+  onSend,
+  onImageFile
+}: {
+  sessionId: string
+  placeholder: string
+  onSend: () => void
+  onImageFile: (file: File) => void
+}) {
+  const draft = usePgDraft(sessionId)
+  const { setPgInput } = usePlayground()
+  return (
+    <textarea
+      className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+      placeholder={placeholder}
+      value={draft}
+      onChange={(e) => setPgInput(sessionId, e.target.value)}
+      onPaste={(event) => {
+        const image = clipboardImageFile(event.clipboardData)
+        if (!image) return
+        event.preventDefault()
+        onImageFile(image)
+      }}
+      onKeyDown={(e) => {
+        // Enter sends — but NOT while an IME is composing (that Enter
+        // just confirms the candidate), and Shift+Enter is a newline.
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+          e.preventDefault()
+          onSend()
+        }
+      }}
+    />
+  )
+}
+
+// Send/stop toggle, isolated for the same reason as ComposerTextarea: the
+// empty↔non-empty draft flip that enables it must not re-render the whole
+// detail view (that rebuilds the transcript, so the FIRST keystroke into an
+// empty composer lagged on long sessions).
+function ComposerSendButton({
+  sessionId,
+  busy,
+  imagePreparing,
+  hasImage,
+  onSend,
+  onStop
+}: {
+  sessionId: string
+  busy: boolean
+  imagePreparing: boolean
+  hasImage: boolean
+  onSend: () => void
+  onStop: () => void
+}) {
+  const hasText = usePgDraftHasText(sessionId)
+  return (
+    <button
+      className="sendbtn ml-1 h-[26px] w-[26px] flex-none rounded-[7px]"
+      aria-label={busy ? 'Stop response' : 'Send message'}
+      onClick={() => (busy ? onStop() : onSend())}
+      disabled={!busy && (imagePreparing || (!hasText && !hasImage))}
+    >
+      <Icon name={busy ? 'square' : 'arrow-up'} size={busy ? 10 : 14} />
+    </button>
   )
 }
 
@@ -1034,11 +1107,9 @@ export default function SessionDetailView() {
     getLiveSteps,
     getBusyLaneAgentIds,
     reconcileLiveSteps,
-    getPgInput,
     getPgImage,
     getPgWorktree,
     isPgBusy,
-    setPgInput: setPgInputById,
     setPgImage,
     pgSend,
     getPgQueue,
@@ -1930,10 +2001,8 @@ export default function SessionDetailView() {
   // Composer state is per-session in the provider — bind it to THIS session's id so a
   // different live conversation streaming in the background can't disable or clear it.
   const pgBusy = sessionBusy
-  const pgInput = getPgInput(session.id)
   const pgImage = getPgImage(session.id)
   const pgQueue = getPgQueue(session.id)
-  const setPgInput = (v: string) => setPgInputById(session.id, v)
   const agentHref = session.agentId ? `/agents/${session.agentId}` : null
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
 
@@ -3022,22 +3091,22 @@ export default function SessionDetailView() {
                   still streaming wait here, dispatch in order as turns finish, and can
                   be cancelled individually before they go out. */}
                 {pgQueue.length > 0 && (
-                  <div className="mb-2 flex flex-col gap-1">
+                  <div className="mb-2 flex flex-col items-end gap-1">
                     {pgQueue.map((q) => (
                       <div
                         key={q.queueId}
-                        className="flex items-center gap-2 rounded-[9px] border border-dashed border-(--border-default) bg-(--surface-card) py-[5px] pr-[5px] pl-3"
+                        className="group flex max-w-full items-center gap-2 rounded-[9px] border border-dashed border-(--border-default) bg-(--surface-card) py-[5px] pr-[5px] pl-3"
                       >
                         <Icon name="clock" size={13} color="var(--text-tertiary)" />
                         <span
-                          className="min-w-0 flex-1 truncate font-sans text-[13px] leading-normal text-(--text-tertiary)"
+                          className="min-w-0 truncate font-sans text-[13px] leading-normal text-(--text-tertiary)"
                           title={q.text}
                         >
                           {q.text || q.image?.name || 'Image'}
                         </span>
                         <button
                           type="button"
-                          className="flex h-6 w-6 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+                          className="flex h-6 w-6 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 hover:bg-(--surface-hover) hover:text-(--text-secondary)"
                           aria-label="Cancel queued message"
                           title="Cancel queued message"
                           onClick={() => pgCancelQueued(session.id, q.queueId)}
@@ -3086,27 +3155,13 @@ export default function SessionDetailView() {
                       </button>
                     </div>
                   )}
-                  <textarea
-                    className="block max-h-[160px] min-h-[56px] w-full resize-none border-0 bg-transparent px-[15px] pt-[13px] pb-[2px] font-sans text-[14px] leading-[1.55] text-(--text-primary) outline-none placeholder:text-(--text-tertiary)"
+                  <ComposerTextarea
+                    sessionId={session.id}
                     placeholder={
                       (session.participants?.length ?? 0) > 1 ? 'Message everyone…' : `Message ${session.agentName}…`
                     }
-                    value={pgInput}
-                    onChange={(e) => setPgInput(e.target.value)}
-                    onPaste={(event) => {
-                      const image = clipboardImageFile(event.clipboardData)
-                      if (!image) return
-                      event.preventDefault()
-                      void onImageFile(image)
-                    }}
-                    onKeyDown={(e) => {
-                      // Enter sends — but NOT while an IME is composing (that Enter
-                      // just confirms the candidate), and Shift+Enter is a newline.
-                      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                        e.preventDefault()
-                        onPgSend()
-                      }
-                    }}
+                    onSend={() => onPgSend()}
+                    onImageFile={(file) => void onImageFile(file)}
                   />
                   <div className="flex items-center gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
                     <div className="relative flex-none">
@@ -3349,16 +3404,14 @@ export default function SessionDetailView() {
                       )}
                     </div>
                     <ContextWindowIndicator used={u?.contextUsed} size={u?.contextSize} />
-                    <button
-                      className="sendbtn ml-1 h-[26px] w-[26px] flex-none rounded-[7px]"
-                      aria-label={pgBusy ? 'Stop response' : 'Send message'}
-                      onClick={() =>
-                        pgBusy ? pgCancel(session.id, session.agentId ?? '', webchatConversationId) : onPgSend()
-                      }
-                      disabled={!pgBusy && (imagePreparing || (!pgInput.trim() && !pgImage))}
-                    >
-                      <Icon name={pgBusy ? 'square' : 'arrow-up'} size={pgBusy ? 10 : 14} />
-                    </button>
+                    <ComposerSendButton
+                      sessionId={session.id}
+                      busy={pgBusy}
+                      imagePreparing={imagePreparing}
+                      hasImage={!!pgImage}
+                      onSend={() => onPgSend()}
+                      onStop={() => pgCancel(session.id, session.agentId ?? '', webchatConversationId)}
+                    />
                   </div>
                 </div>
               </div>

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1041,6 +1041,8 @@ export default function SessionDetailView() {
     setPgInput: setPgInputById,
     setPgImage,
     pgSend,
+    getPgQueue,
+    pgCancelQueued,
     pgAddAgent,
     pgSetModel,
     pgSetEffort,
@@ -1930,6 +1932,7 @@ export default function SessionDetailView() {
   const pgBusy = sessionBusy
   const pgInput = getPgInput(session.id)
   const pgImage = getPgImage(session.id)
+  const pgQueue = getPgQueue(session.id)
   const setPgInput = (v: string) => setPgInputById(session.id, v)
   const agentHref = session.agentId ? `/agents/${session.agentId}` : null
   const liveSteps = isWebchat ? getLiveSteps(session.id) : []
@@ -3015,6 +3018,36 @@ export default function SessionDetailView() {
                   aria-hidden="true"
                   className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-b from-transparent to-(--surface-app)"
                 />
+                {/* Queued messages (Claude Code-style): sends accepted while a turn was
+                  still streaming wait here, dispatch in order as turns finish, and can
+                  be cancelled individually before they go out. */}
+                {pgQueue.length > 0 && (
+                  <div className="mb-2 flex flex-col gap-1">
+                    {pgQueue.map((q) => (
+                      <div
+                        key={q.queueId}
+                        className="flex items-center gap-2 rounded-[9px] border border-dashed border-(--border-default) bg-(--surface-card) py-[5px] pr-[5px] pl-3"
+                      >
+                        <Icon name="clock" size={13} color="var(--text-tertiary)" />
+                        <span
+                          className="min-w-0 flex-1 truncate font-sans text-[13px] leading-normal text-(--text-tertiary)"
+                          title={q.text}
+                        >
+                          {q.text || q.image?.name || 'Image'}
+                        </span>
+                        <button
+                          type="button"
+                          className="flex h-6 w-6 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+                          aria-label="Cancel queued message"
+                          title="Cancel queued message"
+                          onClick={() => pgCancelQueued(session.id, q.queueId)}
+                        >
+                          <Icon name="x" size={13} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 {/* Composer card (design "achero"): textarea on top, a toolbar row below
                   the divider — attach · model pill (fast toggle in its menu) · effort ·
                   permission · context ring · send. Tokens/cost live in the header's


### PR DESCRIPTION
## What

Session-view composer now supports **queued messages**, Claude Code-style: while a turn is still streaming, Enter/send no longer rejects the message — it joins a per-session queue, the composer clears immediately, and queued messages dispatch in order as turns finish (including after stop or a failed turn). Each queued message renders above the composer with a cancel (X) button.

## How

- **PlaygroundProvider**: new per-session `QueuedTurn[]` state. `pgSend` split into `sendTurn` (puts a turn on the wire) and a wrapper that reads the composer and enqueues when busy. Send args (agent id, conversation id, roster, image) are snapshotted at enqueue time so the dispatcher needs nothing from the view. A dispatcher effect sends the queue head the moment the session's busy flag clears; a dispatched-set keeps it idempotent under StrictMode. New context API: `getPgQueue(id)` / `pgCancelQueued(id, queueId)`.
- **SessionDetailView**: queued rows (dashed border, clock icon, truncated dimmed text, X button) above the composer card, inside the sticky bottom container.
- **PlaygroundSend.test**: the old "busy send returns false" assertion is now "busy send is accepted and queued" (the accepted return keeps the stick-to-bottom behavior correct); adds coverage for queue ordering, per-session isolation, individual cancel, and auto-dispatch after the turn ends.

## Reviewer notes

- While busy the send button stays the **Stop** button; queueing is the Enter/send path — same interaction split as Claude Code.
- Stopping a turn does **not** clear the queue: the next queued message dispatches after the interrupt completes. Individual cancel is the X on each row.
- `pgSend`'s return-value contract changed (busy ⇒ `true` now): the only caller acting on it is the session view's stick-to-bottom, where accepting is the desired behavior since the queued row appears at the bottom.

Tests: `vitest run PlaygroundSend` (7 passed), `pnpm --filter @agentconnect.md/web typecheck`, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)