### PR TITLE
fix(web): polish the getting-started checklist flows

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -9,16 +9,15 @@
 // Not built yet (no shipped backing — added when their signals land, preset-agents.md
 // §3/§6): the "runtime signed in" needs-attention item (probe status, §6.2) and the
 // per-item "Ask Assistant" automation (the assistant preset + delegated MCP writes,
-// §6.3/§6.4). The footer's "Ask an agent" instead opens the Playground on a real agent,
-// the one conversational entry that works today.
+// §6.3/§6.4). The footer's "Ask an agent" instead lands on the chat-first Home, the one
+// conversational entry that works today.
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
-import { usePlayground } from './PlaygroundProvider'
 import { isAuthConfigured } from '@/lib/auth'
 import { computeGettingStarted, type GsAction } from '@/lib/getting-started'
-import { AddToSlackRow, GsRows, MeetYourAgents, useGsActions } from './GettingStartedChecklist'
+import { AddToSlackRow, GsRows, MeetYourAgents, useGithubProfileLinked, useGsActions } from './GettingStartedChecklist'
 import { Button, Icon } from '@/components/ui'
 
 // A r=10.5 progress ring (viewBox 0 0 26 26), rotated so it fills clockwise from 12
@@ -41,20 +40,61 @@ function Ring({ ring, size, track }: { ring: string; size: number; track: number
   )
 }
 
+// "Skip for now" is a per-DEVICE console preference (like the rail collapse / theme),
+// not CP state — nothing server-side changes by hiding a derived checklist.
+const GS_SKIP_KEY = 'ac.gs-skipped'
+const GS_OPEN_EVENT = 'ac:gs-open'
+
+/** Re-open the checklist from anywhere in the chrome (rail account menu), un-skipping it. */
+export function openGettingStarted() {
+  try {
+    localStorage.removeItem(GS_SKIP_KEY)
+  } catch {
+    /* storage unavailable — the drawer still opens for this session */
+  }
+  window.dispatchEvent(new Event(GS_OPEN_EVENT))
+}
+
 export default function GettingStarted() {
   const { agents, daemons, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
-  const { openPlayground } = usePlayground()
   const { runAction, firstAgent } = useGsActions()
   const pathname = usePathname()
   const authOn = isAuthConfigured()
 
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [expanded, setExpanded] = useState<string | null>(null)
+  // Starts skipped so a skipper never flashes the pill before the stored flag is read
+  // (localStorage is client-only, so it can't be read during SSR/first render).
+  const [skipped, setSkipped] = useState(true)
 
+  useEffect(() => {
+    try {
+      setSkipped(localStorage.getItem(GS_SKIP_KEY) === '1')
+    } catch {
+      setSkipped(false)
+    }
+    const onOpen = () => {
+      setSkipped(false)
+      setDrawerOpen(true)
+    }
+    window.addEventListener(GS_OPEN_EVENT, onOpen)
+    return () => window.removeEventListener(GS_OPEN_EVENT, onOpen)
+  }, [])
+
+  const githubLinked = useGithubProfileLinked()
   const gs = useMemo(
     () =>
-      computeGettingStarted({ agents, daemons, integrations, sessions: allSessions, members, authOn, orgHasSessions }),
-    [agents, daemons, integrations, allSessions, members, authOn, orgHasSessions]
+      computeGettingStarted({
+        agents,
+        daemons,
+        integrations,
+        sessions: allSessions,
+        members,
+        authOn,
+        orgHasSessions,
+        githubLinked
+      }),
+    [agents, daemons, integrations, allSessions, members, authOn, orgHasSessions, githubLinked]
   )
 
   // Show on every console page while the checklist is incomplete — including a
@@ -66,16 +106,34 @@ export default function GettingStarted() {
   // integrations, sessions and members too, so a partial first paint showed the pill
   // with a too-low count that then jumped (and could even flash for an org that is
   // already allDone). One transition, once everything has landed.
-  if (loading || gs.allDone || onOnboardingRoute) return null
+  if (loading || onOnboardingRoute) return null
+  // The pill is the passive nudge, so it hides once the list is done or skipped. The
+  // drawer itself stays renderable — the account menu can pull it back up either way.
+  const showPill = !gs.allDone && !skipped
+  if (!showPill && !drawerOpen) return null
 
   const shortLabel = `${gs.done}/${gs.total}`
+
+  const skip = () => {
+    try {
+      localStorage.setItem(GS_SKIP_KEY, '1')
+    } catch {
+      /* storage unavailable — the skip holds for this page view */
+    }
+    setDrawerOpen(false)
+    setSkipped(true)
+  }
 
   // Modals (add daemon, set up agent, connect Slack) stack above the drawer (their scrim
   // is z-900, the drawer z-80), so the checklist stays open behind them — the user returns
   // to it when the modal closes. Only close the drawer for actions that navigate the page
   // away (GitHub workspace, Home chat, invite teammates → router.push).
   const runFromDrawer = (action: GsAction) => {
-    const navigates = action.kind === 'github' || action.kind === 'chat' || action.kind === 'members'
+    const navigates =
+      action.kind === 'github' ||
+      action.kind === 'github-profile' ||
+      action.kind === 'chat' ||
+      action.kind === 'members'
     if (navigates) setDrawerOpen(false)
     runAction(action)
   }
@@ -84,7 +142,7 @@ export default function GettingStarted() {
     <>
       {/* 1a — floating pill. On mobile it floats above the bottom-tab chrome (the
           drawer below is already full-width there). */}
-      {!drawerOpen && (
+      {showPill && !drawerOpen && (
         <button
           type="button"
           onClick={() => setDrawerOpen(true)}
@@ -133,7 +191,17 @@ export default function GettingStarted() {
               </div>
               <div className="mt-[10px] flex items-center gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                 <Icon name="info" size={12} className="flex-none" />
-                Close it anytime — the checklist stays in the corner until it&rsquo;s done.
+                <span className="min-w-0 flex-1">
+                  Close it anytime — the checklist stays in the corner until it&rsquo;s done.
+                </span>
+                <button
+                  type="button"
+                  onClick={skip}
+                  title="Hide the checklist — reopen it from the account menu"
+                  className="flex-none cursor-pointer rounded-md border-0 bg-transparent px-[6px] py-[3px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) underline decoration-dotted underline-offset-2 hover:bg-(--surface-hover) hover:text-(--text-primary)"
+                >
+                  Skip for now
+                </button>
               </div>
             </div>
 
@@ -168,14 +236,7 @@ export default function GettingStarted() {
                 <span className="flex-1 font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
                   Stuck on a step? Ask an agent to walk you through it.
                 </span>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    setDrawerOpen(false)
-                    void openPlayground(firstAgent)
-                  }}
-                >
+                <Button variant="secondary" size="sm" onClick={() => runFromDrawer({ kind: 'chat' })}>
                   <span className="inline-flex items-center gap-[6px]">
                     <Icon name="sparkles" size={14} />
                     Ask an agent

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -12,11 +12,15 @@
 import { Fragment, type ReactNode } from 'react'
 import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import useSWR from 'swr'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { useModal } from './ModalProvider'
 import type { GsAction, GsItem } from '@/lib/getting-started'
 import { agentIsPlaced, agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
+import { isAuthConfigured } from '@/lib/auth'
+import { fetchMySocialAccount } from '@/lib/api'
+import { socialLoginProviders } from '@/lib/social-login-providers'
 import { useSlackPlatformInstall } from '@/lib/use-slack-platform-install'
 import { Button, Icon } from '@/components/ui'
 import { PlatformMark } from '@/components/marks'
@@ -53,6 +57,10 @@ export function useGsActions() {
           return action.agentId
             ? router.push(orgPath(`/agents/${action.agentId}?tab=workspace&editws=github`))
             : openModal('agent')
+        case 'github-profile':
+          // Land on Profile with the GitHub link flow auto-started (`link=github` is
+          // consumed one-shot by ProfileView → SocialSignInCard's autoLinkTarget).
+          return router.push(orgPath('/profile?link=github'))
         case 'chat':
           // The chat-first Home landing is where conversations start.
           return router.push(orgPath('/home'))
@@ -66,6 +74,21 @@ export function useGsActions() {
   )
 
   return { runAction, firstAgent }
+}
+
+// Backs the "Link your GitHub profile" step. The SWR key is shared with
+// SocialSignInCard, so this is deduped with the profile page. Undefined while
+// unknowable — auth off, no GitHub connector on this deployment, or the account
+// still loading — and computeGettingStarted omits the step for that value.
+export function useGithubProfileLinked(): boolean | undefined {
+  const offersGithub = isAuthConfigured() && socialLoginProviders().some((p) => p.target === 'github')
+  const { data } = useSWR(offersGithub ? 'logto-account-sign-in-methods' : null, fetchMySocialAccount, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    shouldRetryOnError: false
+  })
+  if (!data) return undefined
+  return data.identities.some((i) => i.target === 'github')
 }
 
 // The checklist item rows. `runAction` is supplied by the caller so each surface can

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -1173,6 +1173,19 @@ function MobileSheets({
                 <span>{r.label}</span>
               </Link>
             ))}
+            {/* The rail (and both of its re-entry menus) is hidden at mobile widths, so
+                this is the phone/tablet way back to a skipped checklist — both auth modes. */}
+            <button
+              type="button"
+              className="msheet-row"
+              onClick={() => {
+                onClose()
+                openGettingStarted()
+              }}
+            >
+              <Icon name="rocket" size={20} color="var(--text-tertiary)" />
+              <span>Getting started</span>
+            </button>
             <button type="button" className="msheet-cancel" onClick={onClose}>
               Cancel
             </button>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -23,7 +23,7 @@ import { detailCrumb, type CrumbSlot } from '@/lib/crumb'
 import { PlaygroundProvider } from './PlaygroundProvider'
 import { ModalProvider, useModal } from './ModalProvider'
 import ConnectAiModal from './ConnectAiModal'
-import GettingStarted from './GettingStarted'
+import GettingStarted, { openGettingStarted } from './GettingStarted'
 import { GlobalSearch } from './GlobalSearch'
 import { TooltipLayer } from './Tooltip'
 import { SearchOpenContext } from './search-open'
@@ -332,6 +332,18 @@ function RailAccount({
               </button>
             )}
             <div className="dmsep" />
+            {/* Brings back the getting-started checklist after "Skip for now" — the only
+                way back, since the pill has no other re-entry point. */}
+            <button
+              className="dmi"
+              onClick={() => {
+                setOpen(false)
+                openGettingStarted()
+              }}
+            >
+              <Icon name="rocket" size={15} color="var(--text-tertiary)" />
+              Getting started
+            </button>
             <Link href={orgPath('/profile')} className="dmi no-underline" onClick={() => setOpen(false)}>
               <Icon name="circle-user-round" size={15} color="var(--text-tertiary)" />
               Profile
@@ -739,6 +751,20 @@ function ShellChrome({ children }: { children: ReactNode }) {
                   <>
                     <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
                     <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
+                      {/* No-auth mode has no account block, so this is its only way back to a
+                          skipped checklist. Auth mode gets the entry in the account menu. */}
+                      {!authOn && (
+                        <button
+                          className="dmi"
+                          onClick={() => {
+                            setHelpMenu(false)
+                            openGettingStarted()
+                          }}
+                        >
+                          <Icon name="rocket" size={15} color="var(--text-tertiary)" />
+                          Getting started
+                        </button>
+                      )}
                       <button
                         className="dmi"
                         onClick={() => {

--- a/packages/web/src/components/console/SocialSignInCard.tsx
+++ b/packages/web/src/components/console/SocialSignInCard.tsx
@@ -357,7 +357,14 @@ export default function SocialSignInCard({
   }
 
   useEffect(() => {
-    if (!autoLinkTarget || !currentAccount || handledAutoLink.current === autoLinkTarget) return
+    // The marker is one-shot: once the parent clears it, forget it was handled so a
+    // REPEAT trigger (checklist CTA clicked again after cancelling the dialog, while
+    // already on this page) starts the flow again instead of being swallowed.
+    if (!autoLinkTarget) {
+      handledAutoLink.current = undefined
+      return
+    }
+    if (!currentAccount || handledAutoLink.current === autoLinkTarget) return
     const provider = socialLoginProviders().find((candidate) => candidate.target === autoLinkTarget)
     handledAutoLink.current = autoLinkTarget
     onAutoLinkHandled?.()

--- a/packages/web/src/components/console/dashboard-rows.test.ts
+++ b/packages/web/src/components/console/dashboard-rows.test.ts
@@ -22,7 +22,7 @@ const FULL = { sessions: 20, agents: MAX_AGENT_ROWS, crons: MAX_CRON_ROWS }
 describe('dashboardRowBudget', () => {
   it('lands both columns on the same line whenever the data can reach it', () => {
     // Every viewport from "right column at its floor" up to the content ceiling.
-    for (let rows = MIN_RIGHT_COLUMN_ROWS; rows <= 12; rows++) {
+    for (let rows = MIN_RIGHT_COLUMN_ROWS; rows <= 8; rows++) {
       const b = dashboardRowBudget({ availableHeight: heightFor(rows), ...FULL })
 
       expect(b.aligned).toBe(true)
@@ -32,10 +32,23 @@ describe('dashboardRowBudget', () => {
     }
   })
 
-  it('spends a roomy viewport on the full content, not on stretch', () => {
+  it('spends a taller viewport on extra Recent rows once the right column is content-exhausted', () => {
+    // FULL's right column has nothing beyond the baseline caps, so a portrait
+    // window pours the rest of its height into sessions instead of a dead strip.
     const b = dashboardRowBudget({ availableHeight: heightFor(30), ...FULL })
 
-    expect(b).toMatchObject({ sessionRows: 8, agentRows: 4, cronRows: 3, aligned: true })
+    expect(b).toMatchObject({ sessionRows: 20, agentRows: 4, cronRows: 3, aligned: false })
+  })
+
+  it('lifts the right-column caps toward real content on a taller viewport, keeping alignment', () => {
+    const b = dashboardRowBudget({ availableHeight: heightFor(12), sessions: 20, agents: 10, crons: 8 })
+
+    expect(b.aligned).toBe(true)
+    expect(b.sessionRows).toBe(12)
+    expect(b.agentRows + b.cronRows).toBe(11)
+    expect(b.agentRows).toBeGreaterThan(MAX_AGENT_ROWS)
+    expect(b.cronRows).toBeGreaterThan(MAX_CRON_ROWS)
+    expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
   })
 
   it('thins both right-hand cards as the window tightens, schedules first', () => {
@@ -76,12 +89,15 @@ describe('dashboardRowBudget', () => {
     }
   })
 
-  it('refuses to shrink the right column below the floor for a session list it cannot meet', () => {
+  it('refuses to shrink the right column for a session list it cannot meet — and still grows it', () => {
     // Two sessions can never reach the right column's two-card floor, so trimming
-    // would cost this org two of its four agents and still not line up.
+    // would cost this org two of its four agents and still not line up. The tall
+    // window instead spends its height on the agents/schedules that DO exist.
     const b = dashboardRowBudget({ availableHeight: heightFor(10), sessions: 2, agents: 6, crons: 5 })
 
-    expect(b).toMatchObject({ agentRows: MAX_AGENT_ROWS, cronRows: MAX_CRON_ROWS, aligned: false })
+    expect(b).toMatchObject({ agentRows: 5, cronRows: 4, aligned: false })
+    expect(b.agentRows).toBeGreaterThanOrEqual(MAX_AGENT_ROWS)
+    expect(b.cronRows).toBeGreaterThanOrEqual(MAX_CRON_ROWS)
   })
 
   describe('sparse orgs — fewer sessions than the right column can go', () => {
@@ -108,11 +124,12 @@ describe('dashboardRowBudget', () => {
       expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
     })
 
-    it('counts an empty agent or schedule list as its placeholder row', () => {
+    it('counts an empty agent or schedule list as its placeholder row, spending the rest on Recent', () => {
       const b = dashboardRowBudget({ availableHeight: heightFor(8), sessions: 20, agents: 0, crons: 0 })
 
-      expect(b).toMatchObject({ sessionRows: 3, agentRows: 1, cronRows: 1, aligned: true })
-      expect(leftHeight(b.sessionRows)).toBe(rightHeight(b.agentRows, b.cronRows))
+      // Nothing to grow on the right (two placeholder rows), so the height goes
+      // to the sessions that DO exist rather than a dead strip.
+      expect(b).toMatchObject({ sessionRows: 8, agentRows: 1, cronRows: 1, aligned: false })
     })
   })
 

--- a/packages/web/src/components/console/dashboard-rows.ts
+++ b/packages/web/src/components/console/dashboard-rows.ts
@@ -20,6 +20,8 @@ export const DASH_ROW_H = 63
 export const CARD_CHROME_H = 47
 /** The gutter between the right column's two cards (the grid's `gap-4`). */
 export const CARD_GAP_H = 16
+/** Row counts BEFORE the viewport is measured (and the growth baseline after) —
+ *  a measured, taller viewport lifts them toward the real content, see below. */
 export const MAX_AGENT_ROWS = 4
 export const MAX_CRON_ROWS = 3
 /** Mobile stacks the cards, so there is nothing to align — a plain content cap. */
@@ -83,6 +85,20 @@ export function dashboardRowBudget({
     while (a + c + 1 > budget && c > floor) c--
     while (a + c + 1 > budget && a > floor) a--
   }
-  const sessionRows = a + c + 1
-  return { sessionRows, agentRows: a, cronRows: c, aligned: reach >= sessionRows }
+  // A MEASURED, extra-tall viewport (portrait monitor) spends its leftover height on
+  // real content instead of a dead strip under the grid: first lift the right column's
+  // baseline caps toward what actually exists (agents keep the same precedence the trim
+  // gives them), then let Recent run additional sessions down the page. Growth stays
+  // inside `budget`, so alignment holds as long as the session list can meet it; once
+  // the right column is content-exhausted the left card simply ends lower, reported as
+  // `aligned: false` like every other unreachable line-up. Gated on a real measurement —
+  // the pre-measure paint must not draw every row an org has.
+  if (availableHeight !== null) {
+    while (a + c + 1 < budget && (a < agents || c < crons)) {
+      if (a < agents && (c >= crons || a - MAX_AGENT_ROWS <= c - MAX_CRON_ROWS)) a++
+      else c++
+    }
+  }
+  const sessionRows = availableHeight === null ? a + c + 1 : Math.max(a + c + 1, Math.min(capacity, reach))
+  return { sessionRows, agentRows: a, cronRows: c, aligned: sessionRows === a + c + 1 && reach >= sessionRows }
 }

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -59,6 +59,7 @@ vi.mock('@/lib/onboarding', async (importOriginal) => {
 vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
 vi.mock('@/components/console/GettingStartedChecklist', () => ({
   useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
+  useGithubProfileLinked: () => undefined,
   GsRows: () => <div>rows</div>
 }))
 vi.mock('@/components/marks', () => ({

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -10,7 +10,13 @@ import { isAuthConfigured } from '@/lib/auth'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
 import { computeGettingStarted } from '@/lib/getting-started'
-import { AddToSlackRow, GsRows, MeetYourAgents, useGsActions } from '@/components/console/GettingStartedChecklist'
+import {
+  AddToSlackRow,
+  GsRows,
+  MeetYourAgents,
+  useGithubProfileLinked,
+  useGsActions
+} from '@/components/console/GettingStartedChecklist'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import {
   FALLBACK_RUNTIME_IDS,
@@ -60,6 +66,7 @@ export default function OnboardingView() {
   } = useConsoleData()
   const { orgPath } = useOrgs()
   const { runAction } = useGsActions()
+  const githubLinked = useGithubProfileLinked()
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
   const authOn = isAuthConfigured()
 
@@ -233,7 +240,8 @@ export default function OnboardingView() {
             sessions: allSessions,
             members,
             authOn,
-            orgHasSessions
+            orgHasSessions,
+            githubLinked
           })}
           runAction={runAction}
           onFinish={goConsole}

--- a/packages/web/src/components/console/views/ProfileView.tsx
+++ b/packages/web/src/components/console/views/ProfileView.tsx
@@ -9,7 +9,7 @@
 // yet: they render the design's demo values only in mock mode, otherwise empty / '—'.
 
 import { useEffect, useState, type ReactNode } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { useModal } from '@/components/console/ModalProvider'
 import ApiKeysCard from '@/components/console/ApiKeysCard'
@@ -48,16 +48,23 @@ export default function ProfileView() {
   const [socialNotice, setSocialNotice] = useState<AccountNotice>()
   const [autoLinkGithub, setAutoLinkGithub] = useState(false)
 
-  // The GitHub Setup URL only sends a verified installation here. Consume the
-  // marker before starting the provider round trip so cancel/reload cannot loop.
+  // Two entrances auto-start the GitHub link flow: the GitHub Setup URL's verified
+  // installation marker (`github=installed`) and the getting-started checklist's
+  // "Link GitHub profile" step (`link=github`). Consume the marker before starting
+  // the provider round trip so cancel/reload cannot loop. Keyed on searchParams,
+  // not just mount: the checklist CTA can fire while ALREADY on this page (the
+  // drawer floats over every route), where the push changes only the query.
+  const searchParams = useSearchParams()
   useEffect(() => {
     if (!authOn) return
     const url = new URL(window.location.href)
-    if (url.searchParams.get('github') !== 'installed') return
+    const marked = url.searchParams.get('github') === 'installed' || url.searchParams.get('link') === 'github'
+    if (!marked) return
     url.searchParams.delete('github')
+    url.searchParams.delete('link')
     window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
     setAutoLinkGithub(true)
-  }, [authOn])
+  }, [authOn, searchParams])
   // The signed-in user's membership — the same row the Settings page lists.
   // Matched by userId when the CP profile is known (exact), by email otherwise.
   // With no match (mock mode / CP down) the fields fall back to the design's

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -43,10 +43,11 @@ describe('computeGettingStarted', () => {
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
   })
 
-  it('marks daemon done only for an online daemon', () => {
+  it('marks daemon done for any registered daemon, connected or not', () => {
     const done = (rows: DaemonRow[]) =>
       computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
-    expect(done([daemon('offline')])).toBe(false)
+    expect(done([])).toBe(false)
+    expect(done([daemon('offline')])).toBe(true)
     expect(done([daemon('online')])).toBe(true)
   })
 
@@ -118,6 +119,19 @@ describe('computeGettingStarted', () => {
       kind: 'github',
       agentId: null
     })
+  })
+
+  it('adds the GitHub-profile step only for a signed-in user with NO GitHub identity', () => {
+    const step = (githubLinked?: boolean) =>
+      computeGettingStarted({ ...empty, githubLinked }).items.find((i) => i.key === 'github-profile')
+    // auth off / no GitHub connector / account still loading → omitted entirely
+    expect(step(undefined)).toBeUndefined()
+    // GitHub sign-ins are born linked — never show them the step
+    expect(step(true)).toBeUndefined()
+    expect(step(false)).toMatchObject({ done: false, action: { kind: 'github-profile' } })
+    // slots in right after the org-level GitHub install step
+    const keys = computeGettingStarted({ ...empty, githubLinked: false }).items.map((i) => i.key)
+    expect(keys.indexOf('github-profile')).toBe(keys.indexOf('github') + 1)
   })
 
   it('reaches allDone with a full ring when every signal is satisfied', () => {

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -24,6 +24,7 @@ export type GsAction =
   | { kind: 'agent' }
   | { kind: 'slack'; agentId: string | null }
   | { kind: 'github'; agentId: string | null }
+  | { kind: 'github-profile' }
   | { kind: 'chat' }
   | { kind: 'members' }
 
@@ -64,8 +65,13 @@ export function computeGettingStarted(input: {
    *  caller-visibility-filtered, so restricted/private-only orgs would under-report.
    *  Undefined (not yet loaded / older CP) falls back to the visible list. */
   orgHasSessions?: boolean
+  /** Whether the caller's own profile has a GitHub identity linked (per-user — the
+   *  App install above is org-level; repo access checks act as the user). Undefined
+   *  ⇒ unknowable or not applicable (auth off, no GitHub connector, account still
+   *  loading): the step is omitted rather than shown un-tickable. */
+  githubLinked?: boolean
 }): GettingStarted {
-  const { agents, daemons, integrations, sessions, members, authOn, orgHasSessions } = input
+  const { agents, daemons, integrations, sessions, members, authOn, orgHasSessions, githubLinked } = input
   // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
   // `agentconnect` preset — the canonical agent every org gets — else the first agent.
   const builtin = agents.find((a) => a.builtin)
@@ -81,7 +87,9 @@ export function computeGettingStarted(input: {
       key: 'daemon',
       label: 'Connect a daemon',
       expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
-      done: daemons.some((d) => d.status === 'online'),
+      // Registered is enough — an offline daemon has still been set up, and a laptop
+      // that's merely asleep shouldn't un-tick a step the user already completed.
+      done: daemons.length > 0,
       ctaLabel: 'Add a daemon',
       action: { kind: 'daemon' }
     },
@@ -109,6 +117,24 @@ export function computeGettingStarted(input: {
       ctaLabel: 'Connect GitHub',
       action: { kind: 'github', agentId: firstAgent }
     },
+    // The App install above is org-level; SEEING private repositories is per-user
+    // (repo probes act as the caller — GITHUB_IDENTITY_REQUIRED otherwise). Only a
+    // member signed in WITHOUT GitHub (Google/Slack — no GitHub identity on the
+    // profile) gets this step; GitHub sign-ins are born linked, and for them the
+    // row would be permanent done-noise. Also omitted when unknowable
+    // (see `githubLinked`).
+    ...(githubLinked !== false
+      ? []
+      : [
+          {
+            key: 'github-profile',
+            label: 'Link your GitHub profile',
+            expl: 'You signed in without GitHub. Link it to your profile so repository pickers and access checks act as you — private repositories included.',
+            done: false,
+            ctaLabel: 'Link GitHub profile',
+            action: { kind: 'github-profile' } as const
+          }
+        ]),
     {
       key: 'conversation',
       label: 'Start your first conversation',


### PR DESCRIPTION
## What changed

Getting-started checklist (pill + drawer) polish, all in `packages/web`:

- **Daemon step counts any registered daemon**, not just `online` ones — an initialized daemon whose host is asleep must not un-tick a step the user already completed (`lib/getting-started.ts`).
- **"Skip for now"** in the drawer header: hides the pill and drawer per device (`localStorage`, like the rail-collapse preference — no CP state). Re-entry lives in the rail account menu (auth mode) and the Help menu (no-auth mode, which has no account block) via a one-shot `openGettingStarted()` event.
- **Footer "Ask an agent" lands on the chat-first Home** (same action as the conversation step) instead of opening the Playground.
- **New per-user step: "Link your GitHub profile."** The GitHub App install is org-level, but private-repo visibility is per-user (repo probes act as the caller — `GITHUB_IDENTITY_REQUIRED`). Shown **only** to members who signed in without GitHub; omitted when unknowable (auth off, no GitHub connector, account still loading). Its CTA lands on Profile with the link flow auto-started: a one-shot `link=github` query param consumed the same way as the GitHub Setup URL's `github=installed`. Works when already on the profile page too (the consume effect is keyed on `useSearchParams`, and `SocialSignInCard`'s auto-link marker resets when the target clears, so repeat triggers aren't swallowed).
- **Home dashboard uses ultra-tall (portrait) viewports**: after the viewport is measured, `dashboardRowBudget` grows the right column past its baseline caps toward the agents/schedules that actually exist (keeping the two-column line-up while sessions can meet it), then pours leftover height into Recent sessions instead of leaving a dead strip.

## Why

The checklist previously punished normal situations: a sleeping laptop reopened the "Connect a daemon" step, there was no way to dismiss the pill, Google/Slack sign-ins hit a private-repo dead end with no guidance, and portrait monitors showed a mostly-empty Home.

## Notes for review

- `computeGettingStarted` stays pure; the GitHub-linked state comes in as an optional `githubLinked?: boolean` (undefined ⇒ step omitted), fed by a new `useGithubProfileLinked()` hook sharing the profile page's SWR key.
- Vertical centering of short pages on tall viewports was tried and removed per product feedback — only the Home row-budget change remains.
- Unit tests updated/added for the row budget and the new step's visibility rules (`pnpm --filter @agentconnect.md/web test`: 92 files, 700 tests green; typecheck + lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)