### PR TITLE
fix(control-plane): let MCP clients filter Feishu sessions

### DIFF
--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -9,6 +9,7 @@
  * annotations are well-formed tool contracts.
  */
 import { describe, it, expect } from 'vitest'
+import { Platform } from '@agentconnect.md/protocol'
 import { MCP_TOOLS, findTool, toolDescriptor, type McpToolCtx, type RestResult } from './tools.js'
 
 const ORG_ID = 'org-123'
@@ -190,6 +191,14 @@ describe('MCP tool registry — §6.2 invariants', () => {
     const usage = recordingCtx()
     await findTool('getUsage')!.call(usage.ctx, {})
     expect(usage.calls[0]).toEqual({ method: 'GET', path: `/orgs/${ORG_ID}/usage`, query: { range: 'd7' } })
+  })
+
+  it('listSessions filters by every canonical platform — the /sessions route accepts the same set', () => {
+    const schema = findTool('listSessions')!.schema
+    for (const platform of Platform.options) {
+      expect(schema.safeParse({ platform }).success, `platform=${platform} must be filterable`).toBe(true)
+    }
+    expect(schema.safeParse({ platform: 'irc' }).success).toBe(false)
   })
 
   it('whoami merges /me and the org view, and surfaces the first failure', async () => {

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -199,7 +199,9 @@ export const MCP_TOOLS: McpToolDef[] = [
     schema: z
       .object({
         agentId: z.string().min(1).optional().describe('Only sessions of this agent'),
-        platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'hook', 'dream']).optional(),
+        // Mirrors the `/sessions` route filter, which accepts the canonical
+        // `Platform` set — keep the two in step (tools.test.ts guards it).
+        platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream']).optional(),
         channel: z.string().min(1).optional(),
         limit: z.number().int().positive().max(200).optional().describe('Page size (default 50)')
       })


### PR DESCRIPTION
## What

The MCP `listSessions` tool's `platform` argument enum was missing `feishu`, so an MCP client could not filter Feishu sessions — the request was rejected at argument validation before it ever reached REST.

- `packages/control-plane/src/http/mcp/tools.ts` — add `feishu` to the enum, with a comment naming the route it mirrors.
- `packages/control-plane/src/http/mcp/tools.test.ts` — new unit test asserting `listSessions` accepts **every** canonical `Platform` value and rejects an unknown one.

## Why

MCP tools are thin adapters over the REST surface, so their argument contracts must match the routes they call. The `/sessions` filter (`http/routes/sessions.ts`) already accepts the canonical `Platform` set — `slack`, `telegram`, `webchat`, `discord`, `feishu`, `hook`, `dream` — and the MCP enum had drifted to a subset. The result was a filter the API supports but MCP clients cannot ask for.

Found during the integration-plugin S0 audit.

## Notes for reviewers

- The new test drives the canonical `Platform` enum from `@agentconnect.md/protocol` rather than a hand-copied list, so the **next** platform addition fails this test instead of silently going missing from the MCP surface again.
- Verified the guard actually bites: with the one-word fix reverted, the test fails with `platform=feishu must be filterable`.
- The tool enum stays a literal (rather than importing `Platform` directly) to keep it a deliberate mirror of the route's own literal — the test is what keeps the two honest.
- No behavior change beyond widening an input enum; the route re-validates authoritatively.

## Verification

- `pnpm --filter @agentconnect.md/control-plane test:unit` — 115 files / 989 tests passing.
- `pnpm --filter @agentconnect.md/control-plane typecheck` — clean.
- prettier + eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)