### PR TITLE
fix(web): name the actual provider in the session-access load error

### DIFF
--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -78,6 +78,7 @@ function feishuAppSettingsUrl(appId: string | null | undefined, region: 'feishu'
 const SESSION_ACCESS_COPY: Record<
   SessionAccessProvider,
   {
+    name: string
     title: string
     details: string
     unavailable: string
@@ -88,6 +89,7 @@ const SESSION_ACCESS_COPY: Record<
   }
 > = {
   slack: {
+    name: 'Slack',
     title: 'Follow Slack access',
     details: [
       'Public channels follow Slack workspace access; private channels, group DMs, guests and Slack Connect users need current membership.',
@@ -102,6 +104,7 @@ const SESSION_ACCESS_COPY: Record<
     degraded: 'Slack scopes stopped resolving — new sessions are being hidden.'
   },
   github: {
+    name: 'GitHub',
     title: 'Follow GitHub access',
     details: [
       'Public-repository sessions stay visible to members who can view the agent; private-repository sessions need a linked GitHub profile with current access.',
@@ -116,6 +119,7 @@ const SESSION_ACCESS_COPY: Record<
     degraded: 'Repository scopes stopped resolving — new sessions are being hidden.'
   },
   feishu: {
+    name: 'Feishu / Lark',
     title: 'Follow Feishu / Lark access',
     details: [
       'Group sessions created through the matching AgentConnect app follow current chat membership.',
@@ -213,7 +217,7 @@ function SessionAccessRow({
         )}
         {(currentActionError || loadError) && (
           <div role="alert" className="mt-1 font-sans text-[11.5px] font-normal leading-normal text-(--status-error)">
-            {currentActionError ?? `Could not load ${provider === 'slack' ? 'Slack' : 'GitHub'} session access.`}
+            {currentActionError ?? `Could not load ${copy.name} session access.`}
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

The session-access rows in Settings built their provider label with a **two-way** ternary:

```ts
`Could not load ${provider === 'slack' ? 'Slack' : 'GitHub'} session access.`
```

`SessionAccessProvider` has **three** members (`slack | github | feishu`), so the Feishu / Lark row fell through to the `GitHub` branch — an owner whose Feishu / Lark access fetch failed was told *"Could not load GitHub session access."*

This moves the label into `SESSION_ACCESS_COPY` as a `name` field, next to the rest of each provider's copy, and reads it from there:

| provider | `name` |
| --- | --- |
| `slack` | `Slack` |
| `github` | `GitHub` |
| `feishu` | `Feishu / Lark` |

```ts
`Could not load ${copy.name} session access.`
```

## Why this shape rather than a third ternary branch

`SESSION_ACCESS_COPY` is typed `Record<SessionAccessProvider, {...}>`, so a fourth provider added to the union now **fails to compile** until it supplies a `name`. The ternary had no such guard — it silently mislabelled, which is how this shipped in the first place. Every other user-visible string for these rows already lives in that map, so the label belongs there too.

## Why "Feishu / Lark" and not one or the other

This row is the **org-level** setting and has no region in scope. `SessionVisibilityControl.tsx` can narrow to "Feishu" or "Lark" because it receives a `feishuRegion` prop; `SessionAccessRow` does not, and `SESSION_ACCESS_COPY.feishu` already reads "Feishu / Lark" in all five of its other strings. The combined label is the consistent choice here.

## Testing

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `eslint` on the touched file — clean
- `prettier --check` — clean

Not exercised in a browser: this string renders only when the session-access fetch fails, which needs a running CP with a seeded org and just that one endpoint erroring. The change is a literal-per-provider lookup that the `Record` type proves exhaustive.

## Reviewer note

Found during the integration-plugin S0 audit (`docs/designs/integration-plugin-audit.md`). Copy-only change — no behavior, no API, no styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)