### PR TITLE
feat(protocol): read platform fields tolerantly as open strings (S1a)

### DIFF
--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -9,7 +9,7 @@
  * annotations are well-formed tool contracts.
  */
 import { describe, it, expect } from 'vitest'
-import { Platform } from '@agentconnect.md/protocol'
+import { KNOWN_PLATFORMS } from '@agentconnect.md/protocol'
 import { MCP_TOOLS, findTool, toolDescriptor, type McpToolCtx, type RestResult } from './tools.js'
 
 const ORG_ID = 'org-123'
@@ -195,7 +195,9 @@ describe('MCP tool registry — §6.2 invariants', () => {
 
   it('listSessions filters by every canonical platform — the /sessions route accepts the same set', () => {
     const schema = findTool('listSessions')!.schema
-    for (const platform of Platform.options) {
+    // S1a: the wire Platform schema is an open string; the MCP filter surface
+    // deliberately stays the closed KNOWN_PLATFORMS vocabulary until S1b.
+    for (const platform of KNOWN_PLATFORMS) {
       expect(schema.safeParse({ platform }).success, `platform=${platform} must be filterable`).toBe(true)
     }
     expect(schema.safeParse({ platform: 'irc' }).success).toBe(false)

--- a/packages/control-plane/src/persistence/platform.ts
+++ b/packages/control-plane/src/persistence/platform.ts
@@ -20,11 +20,19 @@ export function isSessionIdentityPlatform(p: ProtocolPlatform): p is 'webchat' |
   return p === 'webchat' || p === 'hook' || p === 'dream'
 }
 
+const DB_PLATFORMS: readonly DbPlatform[] = ['slack', 'telegram', 'discord', 'feishu']
+
 /** Narrow a protocol platform to a persisted (DB) platform, or throw on the
- *  session-identity-only members (`webchat`, `hook`, `dream`). */
+ *  session-identity-only members (`webchat`, `hook`, `dream`) — and, now that
+ *  platform fields read as open strings (S1a), on any id the DB enum does not
+ *  hold. Fail-closed: an unknown id reaching a persistence write is a
+ *  programming error until the Prisma enum opens to text (S1b). */
 export function toDbPlatform(p: ProtocolPlatform): DbPlatform {
   if (isSessionIdentityPlatform(p)) {
     throw new Error(`${p} is a session-identity platform and is never persisted`)
   }
-  return p
+  if (!(DB_PLATFORMS as readonly string[]).includes(p)) {
+    throw new Error(`unknown platform ${p} cannot be persisted`)
+  }
+  return p as DbPlatform
 }

--- a/packages/daemon/src/messages/normalized.ts
+++ b/packages/daemon/src/messages/normalized.ts
@@ -38,7 +38,11 @@ export interface NormalizedMessage extends Omit<
    *  cross-daemon copies share an explicit identity. */
   transcriptPostId?: string
   source: 'user' | 'cron' | 'agent' | 'hook'
-  platform: 'slack' | 'telegram' | 'webchat' | 'discord' | 'feishu' | 'hook'
+  // S1a open reader (integration-plugin-architecture.md §6.2): the wire reads
+  // platform as an open string, so the runtime model matches. Writers still
+  // produce only the legacy ids; unknown ids are handled fail-closed where the
+  // value is consumed (coordsDecision, persistence narrowing), never by type.
+  platform: string
   /**
    * Opaque identity of the physical platform bot/connection that received this
    * message. Platform channel ids are only unique within one bot installation

--- a/packages/protocol/src/frames/cron.ts
+++ b/packages/protocol/src/frames/cron.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { Platform } from './route.js'
 
 /**
  * Cron sinks to the daemon (D5) — protocol §5.4.
@@ -17,7 +18,10 @@ import { z } from 'zod'
  */
 
 export const CronTarget = z.object({
-  platform: z.enum(['slack', 'telegram', 'discord', 'feishu']).default('slack'),
+  // S1a open reader (route.ts Platform policy). The `'slack'` default is the
+  // legacy envelope default §6.8 removes (anchor platform will derive from
+  // `integrationId`); it is NOT a fold — a present unknown id passes through.
+  platform: Platform.default('slack'),
   channel: z.string(),
   // The agent integration whose connection posts the anchor — targets come from
   // the owning agent's integrations, so the daemon posts through the right bot

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -3,6 +3,7 @@ import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
 import { BindMatch, IntegrationChannel } from './integration.js'
 import { CronTarget } from './cron.js'
+import { Platform } from './route.js'
 import { CollabRoutesSnapshot } from './collab.js'
 import { GithubHookMetadata, HookBigIntString, OptionalHookConfigSnapshot } from './hook.js'
 import { WebchatRemoteMcpEntitlement } from './remote-mcp.js'
@@ -560,7 +561,10 @@ export type RcAgentDirEntry = z.infer<typeof RcAgentDirEntry>
 // relay expects). NEVER log.
 export const RcBotAssign = z.object({
   botId: z.string().uuid(),
-  platform: z.enum(['slack', 'telegram', 'discord', 'feishu']),
+  // S1a open reader (route.ts Platform policy). The CP only emits ids the
+  // relay build supports; the relay's assign handler already refuses an
+  // unsupported platform gracefully ("not yet supported"), never the socket.
+  platform: Platform,
   botUserId: z.string().optional(), // resolved by CP; for echo suppression + mention match
   // Platform app id (Slack "A…", Feishu "cli_…") — lets the relay demux an
   // inbound POST to this bot in O(1). Slack may omit it for a legacy manual

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -11,6 +11,7 @@ import { ErrorFrame } from './error.js'
 import { WebchatDone, WebchatImageAttachment, WebchatOutput, WebchatPost } from './webchat.js'
 import { GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
 import { CronTarget } from './cron.js'
+import { Platform } from './route.js'
 import { WebchatRemoteMcpEntitlement } from './remote-mcp.js'
 import { buildEnvelopeRaw, decodeEnvelopeWith, type BuildOpts, type DecodeResultOf } from '../wire.js'
 
@@ -367,7 +368,10 @@ export const RdAgentMsg = z.object({
   toAgentId: z.string().uuid(),
   text: z.string(),
   coords: z.object({
-    platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu']),
+    // S1a open reader (route.ts Platform policy): an unknown chat-shaped id
+    // decodes fine and is refused fail-closed by `coordsDecision`, never by
+    // the schema (refusing here would kill the frame, not the item).
+    platform: Platform,
     channel: z.string().min(1),
     thread: z.string().optional()
   }),
@@ -389,7 +393,7 @@ export const RdAgentMsg = z.object({
   originSessionId: z.string().min(1).optional(),
   originCoords: z
     .object({
-      platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu']),
+      platform: Platform, // S1a open reader (route.ts policy)
       channel: z.string().min(1),
       thread: z.string().optional()
     })
@@ -459,7 +463,7 @@ export const RdAgentMsgFwd = z.object({
   integrationId: z.string().uuid().optional(), // DEFINITE target reply integration (§6.2)
   text: z.string(),
   coords: z.object({
-    platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu']),
+    platform: Platform, // S1a open reader (route.ts policy); coordsDecision fail-closes unknown chat ids
     channel: z.string().min(1),
     thread: z.string().optional()
   }),
@@ -476,7 +480,7 @@ export const RdAgentMsgFwd = z.object({
   originSessionId: z.string().min(1).optional(),
   originCoords: z
     .object({
-      platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu']),
+      platform: Platform, // S1a open reader (route.ts policy)
       channel: z.string().min(1),
       thread: z.string().optional()
     })

--- a/packages/protocol/src/frames/route.ts
+++ b/packages/protocol/src/frames/route.ts
@@ -12,7 +12,28 @@ import { z } from 'zod'
 // Playground conversation / a webhook trigger / a background memory-consolidation
 // run) — no integration, no bind rules, no routing-table participation, never a
 // persisted DB Platform.
-export const Platform = z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream'])
+//
+// S1a tolerant readers (integration-plugin-architecture.md §6.2): every peer
+// READS platform fields as an open string, because zod rejects unknown enum
+// values wholesale and an unknown id inside a known frame is frame-fatal —
+// a new id reaching an old peer's `register` reader is a fatal handshake
+// reconnect loop. WRITERS keep emitting only `KNOWN_PLATFORMS` values until
+// the fleet gate passes (every deployed peer reads tolerantly); only then may
+// a new platform id be emitted (S1b).
+//
+// Per-frame policy for an unknown (non-legacy) id, decided per frame where the
+// value is consumed, never by closing this schema:
+//   - `register.capabilities.platforms` — accept the frame; an unknown id
+//     simply never matches a placement/capability gate (ignore-unknown).
+//   - `event/session` — store the value verbatim (session rows are text).
+//   - `rd/msg` — decode succeeds; the daemon may refuse the ITEM on semantic
+//     grounds (fail-closed coordinate checks), but never the socket.
+export const KNOWN_PLATFORMS = ['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream'] as const
+export type KnownPlatform = (typeof KNOWN_PLATFORMS)[number]
+export function isKnownPlatform(p: string): p is KnownPlatform {
+  return (KNOWN_PLATFORMS as readonly string[]).includes(p)
+}
+export const Platform = z.string().min(1)
 export type Platform = z.infer<typeof Platform>
 
 export const SessionKey = z.object({

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { Platform } from './frames/route.js'
 
 /**
  * Provider-backed attachment metadata shared by direct daemon ingress and relay
@@ -34,7 +35,9 @@ export const NormalizedPlatformMessageSchema = z.object({
   msgId: z.string(),
   traceId: z.string(),
   source: z.enum(['user', 'cron', 'agent']),
-  platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu']),
+  // S1a open reader (frames/route.ts Platform policy): writers emit only known
+  // ids; an unknown id decodes and is handled fail-closed downstream.
+  platform: Platform,
   channel: z.string(),
   thread: z.string().optional(),
   sender: z.object({

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decodeEnvelope,
+  decodeRelayDaemonFrame,
+  decodeRelayCpFrame,
+  KNOWN_PLATFORMS,
+  isKnownPlatform
+} from './index.js'
+
+/**
+ * S1a tolerant readers (integration-plugin-architecture.md §6.2 / §13).
+ *
+ * Every platform field on the wire reads as an open string: an id no peer has
+ * shipped yet ('teams-x' below) must DECODE on every wire, because a closed
+ * enum makes the whole payload — and for `register`, the handshake — fail.
+ * These fixtures pin the per-frame policy:
+ *   - register: accept; unknown capability ids are simply never matched
+ *   - event/session: store the value verbatim
+ *   - rd/msg: decode succeeds; refusal (if any) is a semantic per-item verdict
+ * Writers still emit only KNOWN_PLATFORMS values until the fleet gate passes;
+ * nothing here licenses emitting a new id (that is S1b).
+ */
+
+const ID = '11111111-1111-4111-8111-111111111111'
+const AGENT_ID = '33333333-3333-4333-8333-333333333333'
+const WORKSPACE_ID = '99999999-9999-4999-8999-999999999999'
+const BOT_ID = '55555555-5555-4555-8555-555555555555'
+const INTEGRATION_ID = '66666666-6666-4666-8666-666666666666'
+const CRON_ID = '77777777-7777-4777-8777-777777777777'
+const DAEMON_ID = '22222222-2222-4222-8222-222222222222'
+const TS = '2026-08-03T00:00:00.000Z'
+
+const UNKNOWN = 'teams-x' // a platform id no deployed writer emits yet
+
+function envelope(type: string, payload: unknown) {
+  return JSON.stringify({ v: 1, id: ID, ts: TS, type, payload })
+}
+
+function expectOk(r: { ok: boolean; [k: string]: unknown }) {
+  if (!r.ok) throw new Error(`expected decode ok, got: ${JSON.stringify(r)}`)
+}
+
+describe('S1a tolerant platform readers — daemon↔CP wire', () => {
+  it('register accepts an unknown id in capabilities.platforms (ignore-unknown policy)', () => {
+    const r = decodeEnvelope(
+      envelope('register', {
+        host: 'edge-1',
+        capabilities: { platforms: ['slack', UNKNOWN], runtimes: ['claude'], acp: true },
+        maxAgents: 4,
+        localState: { assignments: [], crons: [], leases: [] }
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'register') {
+      expect(r.frame.payload.capabilities.platforms).toEqual(['slack', UNKNOWN])
+    }
+  })
+
+  it('event/session stores an unknown platform verbatim', () => {
+    const r = decodeEnvelope(
+      envelope('event/session', {
+        sessionId: 'acp-sess-1',
+        agentId: AGENT_ID,
+        phase: 'start',
+        platform: UNKNOWN,
+        channel: 'C123',
+        ts: TS
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'event/session') {
+      expect(r.frame.payload.platform).toBe(UNKNOWN)
+    }
+  })
+
+  it('route/assign accepts a SessionKey with an unknown platform', () => {
+    const r = decodeEnvelope(
+      envelope('route/assign', {
+        sessionKey: { platform: UNKNOWN, channel: 'C123' },
+        agentId: AGENT_ID,
+        workspaceId: WORKSPACE_ID
+      })
+    )
+    expectOk(r)
+  })
+
+  it('cron/upsert accepts an unknown target platform and keeps the legacy default when absent', () => {
+    const withUnknown = decodeEnvelope(
+      envelope('cron/upsert', {
+        cronId: CRON_ID,
+        agentId: AGENT_ID,
+        schedule: '0 9 * * *',
+        timezone: 'UTC',
+        target: { platform: UNKNOWN, channel: 'C123' },
+        trigger: 'do the thing'
+      })
+    )
+    expectOk(withUnknown)
+    if (withUnknown.ok && withUnknown.frame.type === 'cron/upsert') {
+      expect(withUnknown.frame.payload.target?.platform).toBe(UNKNOWN)
+    }
+
+    const withDefault = decodeEnvelope(
+      envelope('cron/upsert', {
+        cronId: CRON_ID,
+        agentId: AGENT_ID,
+        schedule: '0 9 * * *',
+        timezone: 'UTC',
+        target: { channel: 'C123' },
+        trigger: 'do the thing'
+      })
+    )
+    expectOk(withDefault)
+    if (withDefault.ok && withDefault.frame.type === 'cron/upsert') {
+      expect(withDefault.frame.payload.target?.platform).toBe('slack')
+    }
+  })
+
+  it('still refuses an EMPTY platform string (tolerant to unknown ids, not to malformed values)', () => {
+    const r = decodeEnvelope(
+      envelope('event/session', {
+        sessionId: 'acp-sess-1',
+        agentId: AGENT_ID,
+        phase: 'start',
+        platform: '',
+        channel: 'C123',
+        ts: TS
+      })
+    )
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('S1a tolerant platform readers — relay↔daemon wire', () => {
+  it('rd/msg (im) decodes with an unknown payload platform (item verdict stays semantic)', () => {
+    const r = decodeRelayDaemonFrame(
+      envelope('rd/msg', {
+        source: 'im',
+        agentId: AGENT_ID,
+        sessionKey: `${UNKNOWN}:C123:-`,
+        msgId: 'evt-1',
+        botId: BOT_ID,
+        integrationId: INTEGRATION_ID,
+        payload: {
+          msgId: 'evt-1',
+          traceId: 'trace-1',
+          source: 'user',
+          platform: UNKNOWN,
+          channel: 'C123',
+          sender: { id: 'U1', isBot: false },
+          text: 'hello',
+          mentionedBots: [],
+          isDm: false
+        }
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rd/msg' && r.frame.payload.source === 'im') {
+      expect(r.frame.payload.payload.platform).toBe(UNKNOWN)
+    }
+  })
+
+  it('rd/agentmsg decodes with unknown coords/originCoords platforms (coordsDecision owns the refusal)', () => {
+    const r = decodeRelayDaemonFrame(
+      envelope('rd/agentmsg', {
+        claimedFromAgentId: AGENT_ID,
+        toAgentId: AGENT_ID,
+        text: 'ping',
+        coords: { platform: UNKNOWN, channel: 'C123' },
+        originCoords: { platform: UNKNOWN, channel: 'C456' },
+        hopCount: 0,
+        deliveryId: 'd-1'
+      })
+    )
+    expectOk(r)
+  })
+})
+
+describe('S1a tolerant platform readers — relay↔CP wire', () => {
+  it('rc/bot-assign decodes with an unknown platform (assign handler refuses gracefully, not the socket)', () => {
+    const r = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: BOT_ID,
+        platform: UNKNOWN,
+        secrets: { botToken: 'xoxb-test', signingSecret: 'sig' },
+        members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+        routes: []
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rc/bot-assign') {
+      expect(r.frame.payload.platform).toBe(UNKNOWN)
+    }
+  })
+})
+
+describe('writer-side vocabulary stays closed until the fleet gate (S1b)', () => {
+  it('KNOWN_PLATFORMS is exactly the legacy seven', () => {
+    expect([...KNOWN_PLATFORMS]).toEqual(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream'])
+  })
+
+  it('isKnownPlatform narrows known ids and refuses unknown ones', () => {
+    expect(isKnownPlatform('slack')).toBe(true)
+    expect(isKnownPlatform('dream')).toBe(true)
+    expect(isKnownPlatform(UNKNOWN)).toBe(false)
+    expect(isKnownPlatform('')).toBe(false)
+  })
+})

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -19,7 +19,9 @@ import type { AttributedRoute, RcAgentDirEntry, WireNormalizedMessage } from '@a
 /** A bot's full relay-side assignment (from `rc/bot-assign`). Secret material. */
 export interface BotAssignment {
   botId: string
-  platform: 'slack' | 'telegram' | 'discord' | 'feishu'
+  // S1a open reader (protocol route.ts Platform policy): the wire field is an
+  // open string; the assign handler refuses an unsupported platform gracefully.
+  platform: string
   secrets: { botToken: string; signingSecret: string } | { verificationToken: string; encryptKey?: string }
   /** Provider app id — the O(1) HTTP demux key when present. */
   apiAppId?: string


### PR DESCRIPTION
## What

Stage **S1a** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §6.2/§13, PR 1 of 3: every wire **reader** accepts platform ids as open strings, while **writers** keep emitting only the legacy ids until the fleet gate passes. No new platform id is emitted by this change; behavior is preserved for the four existing platforms.

## Why this ordering

zod rejects unknown enum values wholesale, and `register.capabilities.platforms` rides the handshake — so a new platform id reaching an old CP is a fatal daemon reconnect loop (verified end-to-end in the [S0 audit](../blob/main/docs/designs/integration-plugin-audit.md) §4). Readers must open first, fleet-wide, before S1b may restructure schemas or emit anything new.

## Changes

- **protocol** — `Platform` becomes `z.string().min(1)`; the per-frame unknown-id policy is documented on it (`register`: accept + ignore unknown; `event/session`: store verbatim; `rd/msg`: per-item semantic refusal, never the socket). The six inline enum copies the audit located (`relay-daemon.ts` coords ×4, `normalized-message.ts`, `rc/bot-assign`) and `CronTarget.platform` collapse onto the shared schema. `KNOWN_PLATFORMS` / `isKnownPlatform` carry the writer-side vocabulary; the cron `'slack'` default stays (it is a missing-value default, not a fold — §6.8 removes it in S1b).
- **control-plane** — `toDbPlatform` narrows by explicit membership and throws on an unknown id (fail-closed; the Prisma enum stays closed until S1b). The MCP `listSessions` test iterates `KNOWN_PLATFORMS` instead of the removed `.options`.
- **daemon / relay** — the runtime `NormalizedMessage.platform` and the relay `BotAssignment.platform` widen to `string` to match the wire. Every semantic guard is untouched: the `coordsDecision` fail-closed lists, the relay's "not yet supported" assign refusal, `narrowPlatform` (deleted in PR 2), and the persistence narrowing above.
- **tests** — `platform-tolerance.test.ts` pins unknown-id decode on all three wires (`register`, `event/session`, `route/assign`, `cron/upsert`, `rd/msg` im, `rd/agentmsg`, `rc/bot-assign`), empty-string rejection (`min(1)`), the cron default, and that the writer vocabulary is exactly the legacy seven.

## Verification

protocol 251 ✓ · message ✓ · relay 380 ✓ · control-plane unit 1017 ✓ · control-plane integration 946 ✓ · full-workspace typecheck ✓. The single daemon failure (`test/workspace.test.ts` worktree-GC assertion) reproduces identically on clean `main` in this environment and is unrelated to this change.

## Rollout

Deploy CP first, then wait one full daemon upgrade cycle (**deploy gate 1**). Until every online daemon is at or past this version, nothing may emit a non-legacy platform id — S1b PRs are gated on that check, not on this merge.

Next in S1a: PR 2 deletes `narrowPlatform` (+ the two web unknown-id folds), PR 3 makes `coordsDecision` registry-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)