### PR TITLE
test(daemon): compare the canonical worktree path in the retention-GC test

### DIFF
--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -353,7 +353,11 @@ describe('removeSessionWorktree (#485 retention GC)', () => {
     const cwd = sessionWorktreePath(agent, 'session-a')
     mkdirSync(cwd, { recursive: true })
     writeFileSync(join(cwd, '.git'), 'gitdir: elsewhere')
-    return { agent, cwd, id: basename(cwd) }
+    // Hand back the CANONICAL path: the GC re-derives its worktree path from the
+    // realpath'd root before every destructive step, so that is the path it puts
+    // on the Git command line. The two spellings differ wherever `$TMPDIR` sits
+    // behind a symlink — on macOS it does (`/var` → `/private/var`).
+    return { agent, cwd: realpathSync(cwd), id: basename(cwd) }
   }
   const gitCalls = () => rawMock.mock.calls.map((call) => call[0] as string[])
 


### PR DESCRIPTION
## What

One line in the `fixture()` helper of the `removeSessionWorktree (#485 retention GC)` suite: return `realpathSync(cwd)` instead of the path as constructed.

## Why

`test/workspace.test.ts` fails on macOS but passes on the CI runners. The failing case is *removes a clean fully-pushed worktree: remove → prune → review-ref deletion*, where the `findIndex` for the `worktree remove` call returns -1:

```
AssertionError: expected -1 to be greater than or equal to 0
 ❯ test/workspace.test.ts:372:22
```

This is a test bug, not a GC bug. `removeSessionWorktree` deliberately canonicalizes before every destructive step — `validateSessionWorktreeRoot` returns `realpathSync(root)` and the worktree path is re-derived from that resolved root, so that a symlinked `worktrees/` parent cannot redirect a delete outside the agent directory. The path that reaches `git worktree remove` is therefore the real path.

The fixture returned the path exactly as it built it from `sessionWorktreePath()`. Those two spellings agree only when nothing in `$TMPDIR` is a symlink:

- Linux runners: `os.tmpdir()` is `/tmp`, a real directory → identical → passes.
- macOS: `os.tmpdir()` is `/var/folders/…` and `/var` symlinks to `/private/var` → the fixture holds `/var/folders/…` while the code passes `/private/var/folders/…` → lookup misses.

Introduced with the session-worktree GC in #494 (4be43fda); it has been green in CI the whole time.

## Notes for reviewers

- No production behaviour changes. `git` is mocked throughout this suite, so no real `git` binary was involved in the failure — the git version on the machine is irrelevant.
- Canonicalizing in the fixture (rather than at the one assertion) is deliberate: the canonical path is what the code operates on in all four tests that consume the fixture, and the other three only use it for filesystem operations, which behave identically either way. It also matches the convention already used a few lines up, e.g. `expect(dirname(cwd)).toBe(realpathSync(sessionWorktreeRoot(agent)))`.
- The production pairing stays consistent: `worktree add` registers the worktree from the same canonicalized root via `prepareSessionWorktreeRoot`, so removal by canonical path matches the registration.

## Verification (macOS 26.5, git 2.50.1, Node 24)

- `workspace.test.ts`: 44/44 pass (was 43 passed / 1 failed).
- Full daemon suite: 2757 passed, 46 skipped, 0 failed — confirming no sibling test carries the same latent assumption.
- `pnpm --filter @agentconnect.md/daemon typecheck`, prettier, and eslint all clean.