### PR TITLE
fix(daemon): delete the narrowPlatform fold and key sessions by raw platform (S1a)

### DIFF
--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -211,19 +211,22 @@ export class CpCollabRoutes {
    * relabelling a real channel's coordinate as `webchat` still hits branch 1 and still
    * demands membership.
    *
-   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key must NOT include the coordinate
-   * platform: the woken session's key is computed from {@link Daemon.narrowPlatform}, which
-   * folds `feishu` — and any value it does not recognise — into `'slack'`, while snapshot
-   * rows are keyed by the INTEGRATION platform. Keying the LOOKUP on it searched a different
-   * key space than the session key it protects, and the old "unknown coordinate passes"
-   * branch silently swallowed the mismatch in BOTH directions: `coords.platform:'feishu'`
-   * over a Slack channel id, and (in a Feishu org) an honest narrowed `'slack'` over a
-   * `feishu` row. Either missed the row, passed, and still computed a bit-identical child
-   * session key. Matching on the channel id alone closes both and keeps this and the relay's
-   * copy — which has no `narrowPlatform` — expressing literally the same rule. The platform
-   * is consulted ONLY to pick between branch 2 and branch 3, and only for a coordinate
-   * branch 1 already found nothing for, where the collapse cannot help an attacker because
-   * branch 3 hands back a caller-derived channel rather than the asserted one.
+   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key does NOT include the coordinate
+   * platform. Historically it COULD not: session keys were computed through the deleted
+   * `narrowPlatform` helper, which folded `feishu` — and any value it did not recognise —
+   * into `'slack'`, while snapshot rows are keyed by the INTEGRATION platform, so a
+   * platform-keyed lookup searched a different key space than the session key it protects
+   * and the old "unknown coordinate passes" branch silently swallowed the mismatch in BOTH
+   * directions (`coords.platform:'feishu'` over a Slack channel id; an honest narrowed
+   * `'slack'` over a `feishu` row). Session keys now carry the raw platform (S1a §6.3), but
+   * the channel-id-only match stays: it is what closes the relabelling dodge in both
+   * directions regardless of key regime, and it keeps this and the relay's copy — which
+   * never had a fold — expressing literally the same rule. Re-keying the lookup by platform
+   * is a separate decision for the registry-driven rewrite, not a consequence of the fold's
+   * removal. The platform is consulted ONLY to pick between branch 2 and branch 3, and only
+   * for a coordinate branch 1 already found nothing for, where the collapse cannot help an
+   * attacker because branch 3 hands back a caller-derived channel rather than the asserted
+   * one.
    *
    * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
    * anyone in this org can reach, so gating on it would reject every call naming it while
@@ -233,13 +236,14 @@ export class CpCollabRoutes {
    * here (`handleRelayAgentMsg` terminal-verify, `localWakeDecision`, and through it
    * `wakeRejectionReason`'s preflight) go through this one method.
    *
-   * ACCEPTED CONSEQUENCE of the wire's platform narrowing: `RdAgentMsg.coords.platform` is
-   * `slack | telegram | webchat | discord | feishu`, so `messageAgent` maps a target-less
-   * `hook` session's coords platform to `'slack'` before handing them to the relay (and
-   * {@link Daemon.narrowPlatform} does the same for `dream`). A CROSS-DAEMON wake out of such
-   * a session therefore lands in branch 2 and is rejected, while the same wake to a
-   * co-located peer — which passes the RAW `req.platform` — takes branch 3. Un-narrowing it
-   * needs a new coords platform value on the wire: a protocol change, out of scope here.
+   * ACCEPTED CONSEQUENCE of the legacy coordinate emission: `messageAgent` still maps a
+   * target-less `hook`/`dream` session's coords platform to `'slack'` before handing them
+   * to the relay ({@link Daemon.legacyCoordPlatform}) — the wire schema is open since S1a,
+   * but a peer that has not upgraded still reads `coords.platform` as the closed five-value
+   * enum and would refuse the whole frame. A CROSS-DAEMON wake out of such a session
+   * therefore lands in branch 2 and is rejected, while the same wake to a co-located peer —
+   * which passes the RAW `req.platform` — takes branch 3. The clamp is removable once the
+   * S1a fleet gate passes (S1b).
    */
   coordsDecision(orgId: string, platform: string, channelId: string, callerAgentId: string): CoordsVerdict {
     const sharing = this.byOrgChannel.get(this.coordsKey(orgId, channelId))

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6598,7 +6598,6 @@ export class Daemon {
       // and only the CP may open it.
       ...(msg.parentPrivate === true ? { parentPrivate: true } : {})
     }
-    const narrowed = this.narrowPlatform(platform)
     const resolved = this.resolveCpAgent(msg.toAgentId)
     const integrationId = msg.integrationId ?? resolved?.integrationId
     // §5.4: the CANONICAL child session key, computed with the same inputs `dispatch` will use —
@@ -6615,7 +6614,7 @@ export class Daemon {
     // it exactly as asserted; only the channel-free branch 3 substitutes).
     const childMsgId = `agentcall:${sessionChannel}:${msg.deliveryId}`
     const childSessionId = sessionKey(
-      narrowed,
+      platform,
       sessionChannel,
       thread ?? childMsgId,
       msg.toAgentId,
@@ -6633,7 +6632,7 @@ export class Daemon {
       msgId: childMsgId,
       traceId: msg.deliveryId,
       source: 'agent',
-      platform: narrowed,
+      platform,
       channel: sessionChannel,
       ...(thread !== undefined ? { thread } : {}),
       sender: { id: msg.trustedFromAgentId, isBot: true },
@@ -6764,12 +6763,12 @@ export class Daemon {
     // request; `admits` above already proved the entry exists, so undefined is unreachable
     // and fails closed anyway.
     //
-    // The platform is the RAW trusted session platform, deliberately NOT `narrowPlatform`'s
-    // output: that helper folds `dream` (and any value the NormalizedMessage union does not
-    // carry) into 'slack', which would classify a genuinely channel-free session as a
-    // persisted IM coordinate and fail it closed. Only the branch-2/branch-3 split reads the
-    // platform at all — the row lookup itself stays platform-free — so passing the raw value
-    // cannot re-open the platform-relabelling dodge.
+    // The platform is the RAW trusted session platform — the same value session keys now
+    // use everywhere (the old `narrowPlatform` fold that turned `dream` and unknown values
+    // into 'slack' is deleted, §6.3). A fold here would classify a genuinely channel-free
+    // session as a persisted IM coordinate and fail it closed. Only the branch-2/branch-3
+    // split reads the platform at all — the row lookup itself stays platform-free — so
+    // passing the raw value cannot re-open the platform-relabelling dodge.
     const callerOrg = this.cpCollab.orgForAgent(req.callerAgentId)
     if (callerOrg === undefined) return { rejection: 'not_allowed' }
     const coords = this.cpCollab.coordsDecision(callerOrg, req.platform, req.channel, req.callerAgentId)
@@ -6786,7 +6785,7 @@ export class Daemon {
   }
 
   private wakeRejectionReason(req: MessageAgentReq): string | null {
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     if (this.evaluationProfile.collaboration === 'off') return 'capability_disabled'
     if (platform === 'slack' && /^(?:[UW][A-Z0-9]+|<@[UW][A-Z0-9]+>)$/.test(req.toAgentId.trim())) {
       return 'invalid_target'
@@ -6805,7 +6804,7 @@ export class Daemon {
   }
 
   private async messageAgent(req: MessageAgentReq): Promise<MessageAgentResult> {
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     const callerKey = sessionKey(
       platform,
       req.callerChannel,
@@ -6880,7 +6879,7 @@ export class Daemon {
     // already minted); originCoords are its landing coords for cross-daemon reply routing.
     const originSessionId = this.store.getSession(callerKey)?.acpSessionId ?? undefined
     const externalOrigin = this.externalOriginForSession(req.callerAgentId, originSessionId)
-    const originCoordPlatform = platform === 'hook' ? 'slack' : platform
+    const originCoordPlatform = this.legacyCoordPlatform(platform)
     const originCoords: CallMeta['originCoords'] = {
       platform: originCoordPlatform,
       channel: req.callerChannel,
@@ -6899,7 +6898,7 @@ export class Daemon {
       req.correlationId !== undefined ? req.correlationId : isReply ? inbound.correlationId : undefined
 
     const target = this.agents.get(req.toAgentId)
-    const resolved = target ? this.resolveCpAgent(req.toAgentId, platform === 'hook' ? 'slack' : platform) : null
+    const resolved = target ? this.resolveCpAgent(req.toAgentId, this.legacyCoordPlatform(platform)) : null
     const integrationId = resolved?.integrationId
     const targetTransportScope =
       integrationId !== undefined ? this.transportScopeForIntegrationIds([integrationId]) : undefined
@@ -6941,7 +6940,7 @@ export class Daemon {
     // Local presence: if absent, route the delivery over the relay. The relay
     // decides whether the target is allowed to be woken by this caller.
     if (!target) {
-      const coordPlatform = platform === 'hook' ? 'slack' : platform
+      const coordPlatform = this.legacyCoordPlatform(platform)
       const remote = await this.routeAgentMsgCrossDaemon(
         { ...req, text: event.text, thread: event.thread },
         {
@@ -7068,7 +7067,7 @@ export class Daemon {
    * refused — an agent can never inject into an arbitrary session.
    */
   private async replyToSession(req: ReplyToSessionReq): Promise<ReplyToSessionResult> {
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     const callerKey = sessionKey(
       platform,
       req.callerChannel,
@@ -7101,7 +7100,7 @@ export class Daemon {
     const deliveryId = randomUUID()
     // Hand the origin owner a turn whose origin points back at the REPLIER's session, so the
     // origin could reply again (symmetric lineage). callFrom = the replier.
-    const replyCoordPlatform = platform === 'hook' ? 'slack' : platform
+    const replyCoordPlatform = this.legacyCoordPlatform(platform)
     const replierSessionId = callerRec?.acpSessionId ?? undefined
     const externalOrigin = this.externalOriginForSession(req.callerAgentId, replierSessionId)
     const replyOriginCoords: CallMeta['originCoords'] = {
@@ -7131,22 +7130,22 @@ export class Daemon {
     const local = this.store.getSessionByAcpId(req.sessionId)
     if (local) {
       const originOwner = local.agentId
-      const narrowedLocal = this.narrowPlatform(local.platform)
+      const originPlatform = local.platform
       // Resolve the reply's output transport by the ORIGIN session's platform, not the
       // agent's default integration. A multi-platform agent (e.g. Slack + Telegram) would
       // otherwise post the reply through integrations[0]'s client, and a Telegram chat id
       // sent via the Slack client fails with channel_not_found (the reply turn runs but its
       // answer never reaches the origin channel).
-      const integrationId = this.integrationIdForTransportScope(originOwner, narrowedLocal, local.transportScope)
+      const integrationId = this.integrationIdForTransportScope(originOwner, originPlatform, local.transportScope)
       if (local.transportScope && !integrationId) {
         return { delivered: false, targetSession: local.key, reason: 'not_found' }
       }
-      const resolved = this.resolveCpAgent(originOwner, narrowedLocal)
+      const resolved = this.resolveCpAgent(originOwner, originPlatform)
       const normalized: NormalizedMessage = {
         msgId: `agentcall:${local.channel}:${deliveryId}`,
         traceId: deliveryId,
         source: 'agent',
-        platform: narrowedLocal,
+        platform: originPlatform,
         channel: local.channel,
         ...(local.thread ? { thread: local.thread } : {}),
         ...(local.transportScope ? { transportScope: local.transportScope } : {}),
@@ -7230,7 +7229,7 @@ export class Daemon {
    * back" — that is what `needsReply` is for.
    */
   private async viewSessionStatus(req: SessionStatusReq): Promise<SessionStatusResult | null> {
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     const callerKey = sessionKey(
       platform,
       req.callerChannel,
@@ -7477,11 +7476,11 @@ export class Daemon {
     originChannel: string
     originThread: string
   }): boolean {
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     // The origin session may live on a DIFFERENT platform than this post (e.g. a Telegram
     // turn posting to Slack). Key the origin lookup by the ORIGIN's platform, not the target's,
     // or the caller session is never found and the new session loses its parent lineage.
-    const originPlatform = this.narrowPlatform(req.originPlatform ?? req.platform)
+    const originPlatform = req.originPlatform ?? req.platform
     const originKey = sessionKey(
       originPlatform,
       req.originChannel,
@@ -7498,7 +7497,7 @@ export class Daemon {
     }
     const originSessionId = this.store.getSession(originKey)?.acpSessionId ?? undefined
     const externalOrigin = this.externalOriginForSession(req.agentId, originSessionId)
-    const originCoordPlatform = originPlatform === 'hook' ? 'slack' : originPlatform
+    const originCoordPlatform = this.legacyCoordPlatform(originPlatform)
     const deliveryId = randomUUID()
     const callMeta: CallMeta = {
       callFrom: req.agentId,
@@ -7617,15 +7616,15 @@ export class Daemon {
     }
   }
 
-  /** Narrow the trusted session-context platform string to the NormalizedMessage union;
-   *  falls back to 'slack' for an unrecognized value (coords still resolve — the union is
-   *  a routing/key detail, not the trust basis). */
-  private narrowPlatform(p: string): NormalizedMessage['platform'] {
-    // Every caller turns a platform string off a session/orchestration row back into the union, to
-    // key a session or synthesize a message. `feishu` was missing from the list long after the
-    // platform shipped, so all of them silently produced a `slack:` key for a session ingress
-    // records under `feishu:` — a session nothing could then continue.
-    return p === 'telegram' || p === 'webchat' || p === 'discord' || p === 'feishu' || p === 'hook' ? p : 'slack'
+  /** Legacy COORDINATE-EMISSION clamp (S1a, integration-plugin-architecture.md §6.2/§6.3).
+   *  Session KEYS always use the raw session platform — the old `narrowPlatform` fold
+   *  (unknown → 'slack') minted keys nothing could continue and is deleted. But coords
+   *  handed to the relay wire or resolved against CP integration rows keep today's values:
+   *  peers may still read platform fields as closed enums until the fleet gate passes, and
+   *  the channel-free origin kinds (`hook`, `dream`) have no integration row to resolve.
+   *  Remove after the S1a fleet gate (S1b opens the emitted set). */
+  private legacyCoordPlatform(p: string): string {
+    return p === 'hook' || p === 'dream' ? 'slack' : p
   }
 
   // ══════════════════════════ §3.4/§6.8 main-agent orchestration ══════════════════════════
@@ -7643,7 +7642,7 @@ export class Daemon {
    */
   private async startOrchestration(req: StartOrchestrationReq): Promise<StartOrchestrationResult> {
     const orchestrationId = randomUUID()
-    const platform = this.narrowPlatform(req.platform)
+    const platform = req.platform
     // The main's session key is the exact coords its tool call ran under, so a deadline
     // fire and a worker report both key to the SAME session as the caller.
     const mainSessionKey = sessionKey(platform, req.channel, req.thread, req.mainAgentId, req.transportScope)
@@ -7800,7 +7799,7 @@ export class Daemon {
    *  to the exact stored coords (so it lands in the same session that started it). Headless
    *  is NOT set — the main needs its reply transport to post the summary. */
   private wakeOrchestrationMain(orch: OrchestrationRow, text: string): void {
-    const platform = this.narrowPlatform(orch.platform)
+    const platform = orch.platform
     const msgId = `orchestration:${orch.orchestrationId}:${monotonicTs()}`
     const msg: NormalizedMessage = {
       msgId,
@@ -7927,13 +7926,7 @@ export class Daemon {
   private ownedOrchestration(req: OrchestrationOwnerReq): OrchestrationRow | undefined {
     const orch = this.store.getOrchestration(req.orchestrationId)
     if (!orch) return undefined
-    const requesterKey = sessionKey(
-      this.narrowPlatform(req.platform),
-      req.channel,
-      req.thread,
-      req.mainAgentId,
-      req.transportScope
-    )
+    const requesterKey = sessionKey(req.platform, req.channel, req.thread, req.mainAgentId, req.transportScope)
     if (orch.mainSessionKey !== requesterKey || orch.mainAgentId !== req.mainAgentId) return undefined
     return orch
   }
@@ -15685,7 +15678,7 @@ export class Daemon {
     }
     if (rec.state !== 'idle') return skip(`session is ${rec.state}`)
 
-    const platform = this.narrowPlatform(rec.platform)
+    const platform = rec.platform
     // Reply transport resolved from the SESSION's scope, not the agent's default integration —
     // a multi-platform agent would otherwise answer through integrations[0]'s client (mirrors
     // replyToSession). A scoped session whose integration is gone has nowhere to answer.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7136,11 +7136,16 @@ export class Daemon {
       // otherwise post the reply through integrations[0]'s client, and a Telegram chat id
       // sent via the Slack client fails with channel_not_found (the reply turn runs but its
       // answer never reaches the origin channel).
-      const integrationId = this.integrationIdForTransportScope(originOwner, originPlatform, local.transportScope)
+      // Integration resolution goes through the LEGACY coordinate platform: a channel-free
+      // hook/dream child's stored transportScope was derived from an integration resolved
+      // under `legacyCoordPlatform` at spawn, so a raw-platform filter would find nothing
+      // and refuse the reply. Only the session KEY and the synthesized message are raw.
+      const originCoordPlatform = this.legacyCoordPlatform(originPlatform)
+      const integrationId = this.integrationIdForTransportScope(originOwner, originCoordPlatform, local.transportScope)
       if (local.transportScope && !integrationId) {
         return { delivered: false, targetSession: local.key, reason: 'not_found' }
       }
-      const resolved = this.resolveCpAgent(originOwner, originPlatform)
+      const resolved = this.resolveCpAgent(originOwner, originCoordPlatform)
       const normalized: NormalizedMessage = {
         msgId: `agentcall:${local.channel}:${deliveryId}`,
         traceId: deliveryId,
@@ -15682,7 +15687,14 @@ export class Daemon {
     // Reply transport resolved from the SESSION's scope, not the agent's default integration —
     // a multi-platform agent would otherwise answer through integrations[0]'s client (mirrors
     // replyToSession). A scoped session whose integration is gone has nowhere to answer.
-    const integrationId = this.integrationIdForTransportScope(agentId, platform, rec.transportScope)
+    // Lookup under the LEGACY coordinate platform (mirrors replyToSession): a hook/dream
+    // session's scope was derived from a `legacyCoordPlatform`-resolved integration, so a
+    // raw-platform filter would silently skip the wake. The message itself stays raw.
+    const integrationId = this.integrationIdForTransportScope(
+      agentId,
+      this.legacyCoordPlatform(platform),
+      rec.transportScope
+    )
     if (rec.transportScope && !integrationId) return skip('integration for the session scope is gone')
 
     // No CallMeta: this is not an agent call, it carries no hop chain, and it must not look

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7136,16 +7136,15 @@ export class Daemon {
       // otherwise post the reply through integrations[0]'s client, and a Telegram chat id
       // sent via the Slack client fails with channel_not_found (the reply turn runs but its
       // answer never reaches the origin channel).
-      // Integration resolution goes through the LEGACY coordinate platform: a channel-free
-      // hook/dream child's stored transportScope was derived from an integration resolved
-      // under `legacyCoordPlatform` at spawn, so a raw-platform filter would find nothing
-      // and refuse the reply. Only the session KEY and the synthesized message are raw.
-      const originCoordPlatform = this.legacyCoordPlatform(originPlatform)
-      const integrationId = this.integrationIdForTransportScope(originOwner, originCoordPlatform, local.transportScope)
+      // A channel-free hook/dream child's stored transportScope was derived from whichever
+      // integration the spawn side picked (requested-platform preferred, else the agent's
+      // FIRST integration), so the session-transport helper matches the scope across ALL
+      // integrations for those rows. Only the session KEY and the synthesized message are raw.
+      const integrationId = this.integrationIdForSessionTransport(originOwner, originPlatform, local.transportScope)
       if (local.transportScope && !integrationId) {
         return { delivered: false, targetSession: local.key, reason: 'not_found' }
       }
-      const resolved = this.resolveCpAgent(originOwner, originCoordPlatform)
+      const resolved = this.resolveCpAgent(originOwner, this.legacyCoordPlatform(originPlatform))
       const normalized: NormalizedMessage = {
         msgId: `agentcall:${local.channel}:${deliveryId}`,
         traceId: deliveryId,
@@ -15054,6 +15053,28 @@ export class Daemon {
     return candidates.find((integration) => this.transportScopeForIntegration(integration) === transportScope)?.id
   }
 
+  /** Reply-transport resolution for a SESSION row (replyToSession / background-task wake).
+   *  A channel-free session identity (`hook`/`dream`) carries a transportScope derived from
+   *  whichever integration the spawn-side resolution picked — requested-platform preferred,
+   *  else the agent's FIRST integration (`resolveAgentIntegration`) — so no platform filter
+   *  can reconstruct the choice. The persisted scope embeds its integration's real platform
+   *  in the digest prefix, so matching it across ALL of the agent's integrations is
+   *  unambiguous; an unscoped row mirrors the same first-integration fallback. Real
+   *  platforms keep the platform-filtered lookup. */
+  private integrationIdForSessionTransport(
+    agentId: string,
+    platform: string,
+    transportScope?: string | null
+  ): string | undefined {
+    if (platform !== 'hook' && platform !== 'dream') {
+      return this.integrationIdForTransportScope(agentId, platform, transportScope)
+    }
+    const integrations = this.agents.get(agentId)?.integrations
+    if (!integrations?.length) return undefined
+    if (!transportScope) return integrations[0]?.id
+    return integrations.find((integration) => this.transportScopeForIntegration(integration) === transportScope)?.id
+  }
+
   /** Every integrationId served by `conn` — ingress attribution for gating. A Slack
    *  socket is per app token and may fan out to several integrations. */
   private srcIntegrationIds(conn: unknown): string[] {
@@ -15687,14 +15708,10 @@ export class Daemon {
     // Reply transport resolved from the SESSION's scope, not the agent's default integration —
     // a multi-platform agent would otherwise answer through integrations[0]'s client (mirrors
     // replyToSession). A scoped session whose integration is gone has nowhere to answer.
-    // Lookup under the LEGACY coordinate platform (mirrors replyToSession): a hook/dream
-    // session's scope was derived from a `legacyCoordPlatform`-resolved integration, so a
-    // raw-platform filter would silently skip the wake. The message itself stays raw.
-    const integrationId = this.integrationIdForTransportScope(
-      agentId,
-      this.legacyCoordPlatform(platform),
-      rec.transportScope
-    )
+    // Session-transport lookup (mirrors replyToSession): a hook/dream session's scope was
+    // derived from whichever integration the spawn side picked, so those rows match the
+    // scope across ALL integrations. The message itself stays raw.
+    const integrationId = this.integrationIdForSessionTransport(agentId, platform, rec.transportScope)
     if (rec.transportScope && !integrationId) return skip('integration for the session scope is gone')
 
     // No CallMeta: this is not an agent call, it carries no hop chain, and it must not look

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -190,8 +190,9 @@ describe('CpCollabRoutes: org-scoped directory', () => {
   })
 
   it('coordsDecision ignores the coordinate PLATFORM when LOOKING UP the row', () => {
-    // `Daemon.narrowPlatform` folds `feishu` (and any unrecognised value) into 'slack' when
-    // computing the woken session key, while snapshot rows are keyed by the INTEGRATION
+    // The daemon's since-deleted `narrowPlatform` fold turned `feishu` (and any unrecognised
+    // value) into 'slack' when computing the woken session key, while snapshot rows are keyed
+    // by the INTEGRATION
     // platform. A platform-keyed lookup therefore searched a different key space than the key
     // it protects, and "unknown coordinate passes" swallowed the mismatch in BOTH directions.
     const r = new CpCollabRoutes()

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -456,18 +456,18 @@ describe('messageAgent: same-daemon delivery', () => {
     await daemon.stop()
   })
 
-  // A `dream` turn's platform is folded to 'slack' by `narrowPlatform` when the session key is
-  // computed, so the coordinate decision must read the RAW session platform — otherwise a
-  // genuinely channel-free session would be classified as a persisted IM coordinate and fail
-  // closed. (`hook` is the same shape: a target-less hook session's channel is the hook id.)
-  it('treats a raw session-identity platform as channel-free even though the session key narrows it', async () => {
+  // A `dream` turn is genuinely channel-free: the coordinate decision reads the RAW session
+  // platform and admits it as branch 3, and — since the `narrowPlatform` fold was deleted
+  // (S1a §6.3) — the woken session key now carries `dream` itself instead of a folded
+  // `slack` prefix nothing could continue. (`hook` is the same shape: a target-less hook
+  // session's channel is the hook id.)
+  it('treats a raw session-identity platform as channel-free and keys the child with it', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon, call } = await bootWithDispatchSpy(root)
     const dream = baseReq({ platform: 'dream', callerChannel: 'memory', channel: 'memory', thread: 'dream-1' })
     expect((daemon as any).wakeRejectionReason(dream)).toBeNull()
-    // narrowPlatform('dream') === 'slack', hence the slack prefix — but the CHANNEL is the
-    // caller-derived one, not 'memory'.
-    expect(await call(dream)).toMatchObject({ delivered: true, targetSession: 'slack:a2a:bot-a:dream-1:bot-b' })
+    // Raw platform prefix — and the CHANNEL is the caller-derived one, not 'memory'.
+    expect(await call(dream)).toMatchObject({ delivered: true, targetSession: 'dream:a2a:bot-a:dream-1:bot-b' })
 
     const hook = baseReq({ platform: 'hook', callerChannel: 'hook-1', channel: 'hook-1', thread: 'delivery-1' })
     expect((daemon as any).wakeRejectionReason(hook)).toBeNull()
@@ -993,10 +993,11 @@ describe('handleRelayAgentMsg: cross-daemon target side (P2)', () => {
   })
 
   // The bypass an earlier revision of the coordinate gate had: it looked the coordinate up
-  // under the RAW wire platform, while the session key is computed from `narrowPlatform`,
-  // which folds `feishu` (and anything unrecognised) into 'slack'. The two key spaces
-  // differed and "unknown coordinate passes" hid it, so the SAME attack went through with a
-  // legal `coords.platform:'feishu'` and still produced a bit-identical childSessionId.
+  // under the RAW wire platform, while session keys were computed through the since-deleted
+  // `narrowPlatform` fold (`feishu` and anything unrecognised became 'slack'). The two key
+  // spaces differed and "unknown coordinate passes" hid it, so the SAME attack went through
+  // with a legal `coords.platform:'feishu'` and still produced a bit-identical
+  // childSessionId. Session keys are raw now; the channel-only lookup stays the guard.
   it('rejects the attack when the coordinate PLATFORM is switched to dodge the lookup', async () => {
     const root = scaffold([{ id: 'bot-b' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
@@ -1421,12 +1422,12 @@ describe('spawnChannelRootSession — case 2a new-session seed', () => {
     await daemon.stop()
   })
 
-  it('keys a Feishu spawn as feishu, not the narrowPlatform fallback', async () => {
+  it('keys a Feishu spawn as feishu, not a folded fallback', async () => {
     const root = scaffold([{ id: 'bot-a' }])
     const { daemon, calls } = await bootWithDispatchSpy(root)
-    // `narrowPlatform` predated Feishu and folded it onto `slack`, so this dispatched a `slack:`
-    // message for a channel Feishu ingress records under `feishu:` — a session nothing could
-    // continue. Every other caller of that helper had the same hole.
+    // The since-deleted `narrowPlatform` helper predated Feishu and folded it onto `slack`, so
+    // this dispatched a `slack:` message for a channel Feishu ingress records under `feishu:` —
+    // a session nothing could continue. Every caller of that helper had the same hole.
     // A Feishu DM root post, the shape where the key and the raw ts differ most: ops resolves the
     // thread key to the CHAT id (what Feishu ingress keys a p2p conversation under) while the
     // post's own message id stays the transcript ts.
@@ -1586,11 +1587,12 @@ describe('rootPostRelation: did this post fork a conversation we are already in'
     await daemon.stop()
   })
 
-  it('resolves a Feishu caller, whose platform string is not one narrowPlatform keeps', async () => {
+  it('resolves a Feishu caller by its raw platform string', async () => {
     const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
     const { daemon } = await bootWithDispatchSpy(root)
-    // narrowPlatform folds `feishu` onto `slack`; keying the lookup through it looked up a row
-    // that never existed, so a Feishu session could never resolve its parent.
+    // The since-deleted `narrowPlatform` fold turned `feishu` into `slack`; keying the lookup
+    // through it looked up a row that never existed, so a Feishu session could never resolve
+    // its parent.
     seed(daemon, {
       key: sessionKey('telegram', '-100123', 'tg:170', 'bot-a'),
       agentId: 'bot-a',

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1339,9 +1339,55 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     expect(calls).toHaveLength(1)
     const { msg } = calls[0]!
     // The synthesized message keeps the RAW session platform; only transport resolution
-    // went through the legacy mapping.
+    // went through the persisted-scope match.
     expect(msg.platform).toBe('dream')
     expect(msg.transportScope).toBe(scope)
+    await daemon.stop()
+  })
+
+  // The fallback half of the same contract: when the target has NO Slack integration, the
+  // spawn side falls back to the agent's FIRST integration (resolveAgentIntegration), so a
+  // dream child of a Telegram-only target carries a `telegram:…` scope. A lookup filtered
+  // under the legacy 'slack' coordinate would still find nothing — the session-transport
+  // resolution must match the persisted scope across ALL of the agent's integrations.
+  it('resolves a dream child’s reply transport for a Telegram-only target (first-integration fallback)', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    const tgInteg = {
+      id: 'int-tg-1',
+      platform: 'telegram',
+      telegram: { botToken: '12345:AAA-test-token' }
+    }
+    ;(daemon as any).agents.get('bot-a').integrations.push(tgInteg)
+    const scope = (daemon as any).transportScopeForIntegration(tgInteg)
+    expect(scope.startsWith('telegram:')).toBe(true)
+    const dreamKey = sessionKey('dream', 'a2a:bot-x', 'dream-2', 'bot-a', scope)
+    ;(daemon as any).store.upsertSession({
+      key: dreamKey,
+      agentId: 'bot-a',
+      platform: 'dream',
+      channel: 'a2a:bot-x',
+      thread: 'dream-2',
+      transportScope: scope,
+      acpSessionId: 'acp-parent-dream-tg',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    armTurn(daemon, callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd2',
+      originSessionId: 'acp-parent-dream-tg',
+      originCoords: { platform: 'dream', channel: 'a2a:bot-x', thread: 'dream-2' }
+    })
+    const res = await (daemon as any).replyToSession(replyReq({ sessionId: 'acp-parent-dream-tg' }))
+    expect(res.delivered).toBe(true)
+    expect(res.targetSession).toBe(dreamKey)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.msg.platform).toBe('dream')
+    expect(calls[0]!.msg.transportScope).toBe(scope)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-message-agent.test.ts
+++ b/packages/daemon/test/daemon-message-agent.test.ts
@@ -1295,6 +1295,56 @@ describe('replyToSession: SessionTarget delivery + origin-only authorization', (
     await daemon.stop()
   })
 
+  // The regression the raw-platform migration exposed: a channel-free (dream/hook) child's
+  // transportScope is derived from an integration resolved under `legacyCoordPlatform` at
+  // spawn (there is no 'dream' integration to resolve), while the child row itself is keyed
+  // with the RAW platform. The reply-transport lookup must apply the same legacy mapping — a
+  // raw-platform integration filter finds nothing and refuses the reply as not_found.
+  it('resolves a scoped dream child’s reply transport through the legacy coordinate platform', async () => {
+    const root = scaffold([{ id: 'bot-a' }, { id: 'bot-b' }])
+    const { daemon, calls } = await bootWithDispatchSpy(root)
+    // The origin owner holds a real scoped Slack integration — the shape a dream wake's
+    // child inherits its transportScope from. Injected post-start so no socket connects.
+    const slackInteg = {
+      id: 'int-slack-1',
+      platform: 'slack',
+      slack: { mode: 'direct', shareable: false, botToken: 'xoxb-scope-test' }
+    }
+    ;(daemon as any).agents.get('bot-a').integrations.push(slackInteg)
+    const scope = (daemon as any).transportScopeForIntegration(slackInteg)
+    const dreamKey = sessionKey('dream', 'a2a:bot-x', 'dream-1', 'bot-a', scope)
+    ;(daemon as any).store.upsertSession({
+      key: dreamKey,
+      agentId: 'bot-a',
+      platform: 'dream',
+      channel: 'a2a:bot-x',
+      thread: 'dream-1',
+      transportScope: scope,
+      acpSessionId: 'acp-parent-dream',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const callerKey = sessionKey('slack', 'C2', '200.1', 'bot-b')
+    armTurn(daemon, callerKey, {
+      callFrom: 'bot-a',
+      hopCount: 1,
+      deliveryId: 'd1',
+      originSessionId: 'acp-parent-dream',
+      originCoords: { platform: 'dream', channel: 'a2a:bot-x', thread: 'dream-1' }
+    })
+    const res = await (daemon as any).replyToSession(replyReq({ sessionId: 'acp-parent-dream' }))
+    expect(res.delivered).toBe(true)
+    expect(res.targetSession).toBe(dreamKey)
+    expect(calls).toHaveLength(1)
+    const { msg } = calls[0]!
+    // The synthesized message keeps the RAW session platform; only transport resolution
+    // went through the legacy mapping.
+    expect(msg.platform).toBe('dream')
+    expect(msg.transportScope).toBe(scope)
+    await daemon.stop()
+  })
+
   it('authorizes via the caller session’s PERSISTED origin on a human turn with no active CallMeta', async () => {
     // The regression that "replies once then stops": a spawned session's later, human-triggered
     // turns carry no per-turn CallMeta, so auth must fall back to the DURABLE origin on the row.

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -447,11 +447,12 @@ export type RdAgentMsg = z.infer<typeof RdAgentMsg>
  *       daemon keys the woken session off `a2a:<trustedFromAgentId>` instead, which cannot
  *       collide with any real conversation id. The relay forwards `coords` verbatim; only the
  *       daemon that mints the key substitutes, so the two can never disagree about it.
- * The row LOOKUP keys on the CHANNEL ID alone, deliberately NOT on `coords.platform`: the
- * woken session's key is computed from a NARROWED platform (the daemon folds `feishu` and
- * anything it does not recognise into `'slack'`) while snapshot rows are keyed by the
- * integration platform, so a platform-keyed lookup would search a different key space than
- * the key it protects. The platform only picks between (2) and (3), for a coordinate (1)
+ * The row LOOKUP keys on the CHANNEL ID alone, deliberately NOT on `coords.platform`. That
+ * closed a relabelling dodge under the daemon's old `narrowPlatform` fold (session keys were
+ * narrowed while snapshot rows are keyed by the integration platform, so a platform-keyed
+ * lookup searched a different key space than the key it protects); the fold is deleted
+ * (S1a §6.3) and session keys carry the raw platform, but the channel-only match remains
+ * the rule on both sides. The platform only picks between (2) and (3), for a coordinate (1)
  * already found nothing for. Read `coords` as "the caller may assert this", never as
  * "verified member of" — and never assume the woken session key echoes it (case 3).
  */

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -188,21 +188,22 @@ export class CollaborationRouter {
    * hatch: relabelling a real channel's coordinate as `webchat` still hits branch 1 and
    * still demands membership.
    *
-   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key must NOT include the
-   * coordinate platform: the woken session's key is computed from a NARROWED platform (the
-   * daemon's `narrowPlatform` folds `feishu` — and any value it does not recognise — into
-   * `'slack'`), while snapshot rows are keyed by the INTEGRATION platform. Keying the
-   * LOOKUP on the raw wire platform searched a different key space than the session key it
-   * protects, and the old "unknown coordinate passes" branch silently swallowed the
-   * mismatch: `coords.platform:'feishu'` over a Slack channel id (or, in a Feishu org, an
-   * honest narrowed `'slack'` over a `feishu` row) missed the row, passed, and still
-   * computed a bit-identical child session key. Matching on the channel id alone closes
-   * both directions and needs no `narrowPlatform` twin on the relay side; it over-blocks
-   * only if one org uses the same channel id on two platforms, which then requires
-   * membership in one of them, not a bypass. The platform is consulted ONLY to pick between
-   * branch 2 and branch 3, and only for a coordinate branch 1 already found nothing for —
-   * where the collapse cannot help an attacker, because branch 3 hands back a
-   * caller-derived channel rather than the asserted one.
+   * PLATFORM-FREE KEY, platform-keyed BRANCH. The lookup key does NOT include the
+   * coordinate platform. Historically it COULD not: the daemon computed session keys
+   * through its (now deleted) `narrowPlatform` helper, which folded `feishu` — and any
+   * value it did not recognise — into `'slack'`, while snapshot rows are keyed by the
+   * INTEGRATION platform, so a platform-keyed lookup searched a different key space than
+   * the session key it protects and the old "unknown coordinate passes" branch silently
+   * swallowed the mismatch (`coords.platform:'feishu'` over a Slack channel id; an honest
+   * narrowed `'slack'` over a `feishu` row). Daemon session keys now carry the raw platform
+   * (S1a §6.3), but the channel-id-only match stays: it closes the relabelling dodge in
+   * both directions regardless of key regime and keeps this and the daemon's copy
+   * expressing literally the same rule; it over-blocks only if one org uses the same
+   * channel id on two platforms, which then requires membership in one of them, not a
+   * bypass. The platform is consulted ONLY to pick between branch 2 and branch 3, and only
+   * for a coordinate branch 1 already found nothing for — where the collapse cannot help an
+   * attacker, because branch 3 hands back a caller-derived channel rather than the asserted
+   * one.
    *
    * A NON-EMPTY member map is what counts as "known": an agent-less row is not a channel
    * anyone in this org can reach, so gating on it would reject every call naming it while

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1919,7 +1919,10 @@ export function platName(p: string): string {
   if (x.includes('tele')) return 'Telegram'
   if (x.includes('disc')) return 'Discord'
   if (x.includes('feishu') || x.includes('lark')) return 'Lark'
-  return 'Slack'
+  if (x.includes('slack') || x === '') return 'Slack'
+  // Unknown platform ids render as themselves — falling back to 'Slack' was the
+  // web mirror of the daemon's deleted narrowPlatform fold (S1a §6.3).
+  return p.charAt(0).toUpperCase() + p.slice(1)
 }
 
 /** A session's display integration. GitHub is a hook source rather than a

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -87,6 +87,12 @@ describe('sessionTriggerKind', () => {
     expect(platName(sessionPlatform({ platform: 'feishu' }))).toBe('Lark')
   })
 
+  it('renders an unknown platform id as itself, not as Slack (S1a: the narrowPlatform mirror)', () => {
+    expect(platName('slack')).toBe('Slack')
+    expect(platName('')).toBe('Slack')
+    expect(platName('teams-x')).toBe('Teams-x')
+  })
+
   it('labels dream execution sessions without exposing their synthetic routing key', () => {
     const dream = sessionFromDto(
       sessionDto({


### PR DESCRIPTION
## What

Stage **S1a** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §6.3/§13, PR 2 of 3 — the fix for §14 defect #1. The daemon folded any platform string it did not recognise into `'slack'` when minting session keys (`narrowPlatform`, 12 call sites); under open platform ids that fold is a standing correctness bug for every new platform's A2A/orchestration/wake path, and it already bit Feishu once. It is deleted; session keys carry the raw session platform everywhere.

## The one visible behavior change

A `dream`-origin A2A child is now keyed `dream:a2a:…` instead of a folded `slack:a2a:…` that nothing could continue (`hook` was already symmetric — the fold's identity list included it). The existing messageAgent test pinning the folded key is updated to pin the raw one. For the four chat platforms the fold was identity, so their behavior is unchanged by construction.

## The rolling-upgrade guard

Coordinate **emissions** keep today's wire bytes: the five sites that hand coords to the relay wire or resolve CP integration rows go through a new `legacyCoordPlatform` clamp (`hook`/`dream` → `'slack'`, previously implicit via the fold for `dream` and explicit for `hook`). The wire schema is open since #501, but a peer that has not upgraded still reads `coords.platform` as the closed five-value enum and would refuse the whole frame — so the clamp stays until **deploy gate 1** (the S1a fleet gate) passes, and its removal is an S1b item. Local session keys are never clamped.

## Lockstep comment updates

The S0 audit flagged the `coordsDecision` doc family as load-bearing comment-only knowledge that must move together: the daemon twin ([cp-collab-routes.ts](../blob/claude/s1a-drop-narrowplatform/packages/daemon/src/cp/cp-collab-routes.ts)), the relay's byte-identical copy, and the protocol `RdAgentMsgFwd` doc are rewritten in lockstep. The channel-only lookup rule is kept (it closes the platform-relabelling dodge under either key regime); re-keying the lookup by platform is explicitly recorded as a separate decision for PR 3's registry-driven rewrite, not a consequence of the fold's removal.

## Web mirror

`platName()`'s `return 'Slack'` fallback — the rendering mirror of the same fold, flagged by the audit — now renders an unknown platform id as itself (`teams-x` → "Teams-x"); `slack`/empty keep "Slack". The other web `?? 'slack'` sites are missing-value defaults, not folds, and stay for the §6.1 migration. The `AddCronModal` anchor coercion is §14 defect #2 and lands with §6.8 in S1b (it is entangled with the CP DTO union and the daemon's non-Slack-target headless degradation).

## Verification

daemon 2756 ✓ (the single `workspace.test.ts` worktree-GC failure reproduces identically on clean `main` and is unrelated) · web 699 ✓ · relay 380 ✓ · protocol 251 ✓ · control-plane unit 1017 ✓ · full-workspace typecheck ✓.

Next in S1a: PR 3 makes `coordsDecision` registry-driven with the fail-closed unknown-chat default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)