### PR TITLE
fix(web): load conversation tool details from source session

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -129,7 +129,7 @@ function FastBadge() {
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
 // transcript kind (text | tool | reasoning) onto the existing lane styling.
-function msgStep(m: SessionMessageDto): FmtStep {
+function msgStep(m: SessionMessageDto, toolSessionId?: string): FmtStep {
   const k = (m.kind || 'text').toLowerCase()
   if (k === 'tool') {
     return {
@@ -145,7 +145,7 @@ function msgStep(m: SessionMessageDto): FmtStep {
       time: formatTranscriptRowTime(m),
       // Carry the raw message so the row can render the captured tool body (input /
       // output / content / diff / locations) below the title, on demand.
-      ...(m.body ? { msg: m } : {})
+      ...(m.body ? { msg: m, ...(toolSessionId ? { toolSessionId } : {}) } : {})
     }
   }
   if (k === 'reasoning') {
@@ -191,17 +191,22 @@ function countsAsOfflineSource(error: unknown): boolean {
 }
 
 /** Render input for conversation mode: mergeConversation over the CURRENT
- *  per-member row map (merged-conversation-view.md §6). */
+ *  per-member row map (merged-conversation-view.md §6). Preserve each row's
+ *  object identity while indexing its source out-of-band: ToolBodyDetail uses
+ *  exact-row identity to fence a previously fetched full body. */
 function mergeConversationRows(
   sources: { sessionId: string; agentId: string; platform: string }[],
-  rows: Map<string, SessionMessageDto[]>
+  rows: Map<string, SessionMessageDto[]>,
+  sourceSessionByMessage: WeakMap<SessionMessageDto, string>
 ): SessionMessageDto[] {
-  const merged = mergeConversation(
+  return mergeConversation(
     sources
       .filter((source) => rows.has(source.sessionId))
       .map((source) => ({ ...source, rows: rows.get(source.sessionId)! }) satisfies MergeSource)
-  )
-  return merged.map((m) => m.row)
+  ).map(({ row, sourceSessionId }) => {
+    sourceSessionByMessage.set(row, sourceSessionId)
+    return row
+  })
 }
 
 interface FmtStep {
@@ -219,6 +224,9 @@ interface FmtStep {
   image?: SessionImage
   // Present only on real-transcript tool rows that carry a captured body.
   msg?: SessionMessageDto
+  // Conversation rows keep their owning session out-of-band so full-body reads
+  // do not accidentally target the representative member.
+  toolSessionId?: string
 }
 
 // A bare text step (no lane chrome) — how a peer participant's message renders
@@ -242,6 +250,7 @@ function plainStep(text: string, time?: string, image?: SessionImage): FmtStep {
 // A step's non-text extras (code block, file chips, captured tool body) — rendered
 // identically in a turn's plain answer and in its collapsed "work" rows.
 function StepExtras({ step, sessionId }: { step: FmtStep; sessionId?: string }) {
+  const toolSessionId = step.toolSessionId ?? sessionId
   return (
     <>
       {step.code && (
@@ -258,7 +267,7 @@ function StepExtras({ step, sessionId }: { step: FmtStep; sessionId?: string }) 
           ))}
         </div>
       )}
-      {step.msg && sessionId && <ToolBodyDetail msg={step.msg} sessionId={sessionId} />}
+      {step.msg && toolSessionId && <ToolBodyDetail msg={step.msg} sessionId={toolSessionId} />}
     </>
   )
 }
@@ -1068,6 +1077,7 @@ export default function SessionDetailView() {
     cursors: Map<string, string | null>
     older: Map<string, string | null>
   }>({ rows: new Map(), cursors: new Map(), older: new Map() })
+  const conversationSourceSessionByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
   const [conversationHasEarlier, setConversationHasEarlier] = useState(false)
   const [conversationPagingEarlier, setConversationPagingEarlier] = useState(false)
   // Which conversation key the CURRENT fan-out state belongs to — the focus
@@ -1511,7 +1521,7 @@ export default function SessionDetailView() {
         setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
-        setMsgs(mergeConversationRows(sources, rowsBySession))
+        setMsgs(mergeConversationRows(sources, rowsBySession, conversationSourceSessionByMessageRef.current))
         setMsgLoading(false)
         setMsgPaging(false)
         liveCursorRef.current = cursors.get(sid) ?? null
@@ -1617,7 +1627,7 @@ export default function SessionDetailView() {
         }
         if (tailSessionRef.current !== sid) return
         setConversationOffline(failed)
-        setMsgs(mergeConversationRows(sources, state.rows))
+        setMsgs(mergeConversationRows(sources, state.rows, conversationSourceSessionByMessageRef.current))
         if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
           reconcileLiveSteps(sid, repRows, aid)
       })()
@@ -1689,7 +1699,7 @@ export default function SessionDetailView() {
           }
         })
       )
-      setMsgs(mergeConversationRows(sources, state.rows))
+      setMsgs(mergeConversationRows(sources, state.rows, conversationSourceSessionByMessageRef.current))
       setConversationHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
     } finally {
       setConversationPagingEarlier(false)
@@ -2091,6 +2101,7 @@ export default function SessionDetailView() {
     // Real transcript: agent output carries `sender === agentId`; everything else
     // is a human/cron author. Group consecutive agent messages into one turn.
     for (const m of visibleMsgs ?? []) {
+      const toolSessionId = conversationSourceSessionByMessageRef.current.get(m)
       if (m.sender === session.agentId) {
         let last = turns[turns.length - 1]
         const ownerName = session.agentName ?? ''
@@ -2105,7 +2116,7 @@ export default function SessionDetailView() {
           }
           turns.push(last)
         }
-        const step = msgStep(m)
+        const step = msgStep(m, toolSessionId)
         last.steps.push(step)
         if (!last.time && step.time) last.time = step.time
       } else {
@@ -2116,7 +2127,10 @@ export default function SessionDetailView() {
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined
         const self = isSelf(m.sender)
         if (senderAgent && !self) {
-          pushAgentTurn(senderAgent, { ...msgStep(m), ...(m.attachments?.[0] ? { image: m.attachments[0] } : {}) })
+          pushAgentTurn(senderAgent, {
+            ...msgStep(m, toolSessionId),
+            ...(m.attachments?.[0] ? { image: m.attachments[0] } : {})
+          })
           continue
         }
         const participant = self

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -53,6 +53,18 @@ describe('duplicateIdentity', () => {
 })
 
 describe('mergeConversation', () => {
+  it('keeps each rendered tool row tied to its source session', () => {
+    const merged = mergeConversation([
+      src(A, 'slack', [row({ sender: A, kind: 'tool', toolCallId: 'tool-a', body: '{"toolCallId":"tool-a"}' })]),
+      src(B, 'slack', [row({ sender: B, kind: 'tool', toolCallId: 'tool-b', body: '{"toolCallId":"tool-b"}' })])
+    ])
+
+    expect(merged.map(({ row, sourceSessionId }) => ({ toolCallId: row.toolCallId, sourceSessionId }))).toEqual([
+      { toolCallId: 'tool-a', sourceSessionId: 'sess-aaaa' },
+      { toolCallId: 'tool-b', sourceSessionId: 'sess-bbbb' }
+    ])
+  })
+
   it('dedupes Discord copies on the snowflake and orders them by its embedded time', () => {
     // Snowflake for ~2024: time bits decode via (id >> 22) + Discord epoch.
     const SNOWFLAKE = '1101111111111111111'


### PR DESCRIPTION
## Summary

- preserve the owning session for every row in a merged conversation transcript
- load each tool's full detail from that source session instead of the representative member
- keep transcript row identity stable so periodic refreshes do not invalidate an expanded full-body result
- add focused regression coverage for per-tool source-session provenance

## Root cause

The conversation merge already returned `sourceSessionId`, but the renderer flattened the result to bare message rows. Every `ToolBodyDetail` therefore received the representative conversation session ID, which is only correct for that representative's own tool calls.

## Validation

- `pnpm --filter @agentconnect.md/web test` - 92 files, 699 tests passed
- `pnpm --filter @agentconnect.md/web typecheck`
- focused ESLint and Prettier checks for the changed files
- pre-push full-repository ESLint hook

Created by Codex . GPT-5
