### PR TITLE
fix(daemon,relay): fail closed on unknown chat platforms in coordsDecision (S1a)

### DIFF
--- a/packages/control-plane/src/persistence/platform.ts
+++ b/packages/control-plane/src/persistence/platform.ts
@@ -11,14 +11,15 @@
  * `webchat` value reaching a persistence write is a programming error, not data.
  */
 import type { Platform as ProtocolPlatform } from '@agentconnect.md/protocol'
+import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
 import type { Platform as DbPlatform } from '../generated/prisma/enums.js'
 
 /** True for the session-identity-only platforms, which have no persisted row. Lets a
  *  caller decide BEFORE reaching persistence — a read whose answer is "nothing is
- *  persisted for this platform" should return the empty answer, not raise. */
-export function isSessionIdentityPlatform(p: ProtocolPlatform): p is 'webchat' | 'hook' | 'dream' {
-  return p === 'webchat' || p === 'hook' || p === 'dream'
-}
+ *  persisted for this platform" should return the empty answer, not raise. The
+ *  classification itself lives in the protocol package (the S1a registry seed shared
+ *  with the daemon's and relay's `coordsDecision`). */
+export { isSessionIdentityPlatform }
 
 const DB_PLATFORMS: readonly DbPlatform[] = ['slack', 'telegram', 'discord', 'feishu']
 

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -10,6 +10,7 @@
  * assumed. Documented in the PR description.
  */
 import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
+import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
 
 export interface CollabResolved extends CollabAgentPlacement {
   orgId: string
@@ -29,16 +30,6 @@ export interface CollabResolved extends CollabAgentPlacement {
  * only rejects. Change one, change both.
  */
 export type CoordsVerdict = { verdict: 'reject' } | { verdict: 'asserted' } | { verdict: 'synthetic'; channel: string }
-
-/**
- * The platforms whose conversations are PERSISTED as `integration_channel` rows and
- * therefore appear in this snapshot — i.e. the protocol `Platform` enum minus the
- * session-identity members (`webchat`/`hook`/`dream`, which have no persisted row; see the
- * CP's `isSessionIdentityPlatform`). An UNKNOWN coordinate on one of these is evidence of a
- * problem, not of a channel-free session, so it fails closed ({@link
- * CpCollabRoutes.coordsDecision}).
- */
-const PERSISTED_IM_PLATFORMS: ReadonlySet<string> = new Set(['slack', 'telegram', 'discord', 'feishu'])
 
 /**
  * The coordinate a channel-free wake lands on: derived from the TRUSTED caller, never from
@@ -186,11 +177,15 @@ export class CpCollabRoutes {
    *     `im`/`mpim` row is an ordinary KNOWN coordinate with its owning integration's agent
    *     as a member.
    *
-   * (2) UNKNOWN on a PERSISTED IM platform ({@link PERSISTED_IM_PLATFORMS}) — `reject`,
-   *     FAIL CLOSED. An unrecorded IM coordinate is either a conversation the caller cannot
-   *     reach or a stale/departed row; admitting it is exactly what let a caller alias an
-   *     existing platform session. A brief snapshot lag can therefore transiently reject a
-   *     genuine wake — the correct direction for a security boundary, and the caller retries.
+   * (2) UNKNOWN on any CHAT-SHAPED platform — every id outside the enumerated
+   *     session-identity set (`isSessionIdentityPlatform`), including ids this build does
+   *     not know — `reject`, FAIL CLOSED. An unrecorded chat coordinate is either a
+   *     conversation the caller cannot reach or a stale/departed row; admitting it is
+   *     exactly what let a caller alias an existing platform session, and admitting an
+   *     UNKNOWN id would reopen that hole for every future platform (S1a §6.1 replaced the
+   *     old enumerate-the-IM-platforms shape, which silently admitted unknown ids). A brief
+   *     snapshot lag can therefore transiently reject a genuine wake — the correct
+   *     direction for a security boundary, and the caller retries.
    *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
    *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
    *     observed it — Slack's authoritative membership snapshot enumerates
@@ -201,11 +196,12 @@ export class CpCollabRoutes {
    *     wake asserting it is refused here. Deliberate, and not a regression: the
    *     `hasMembers(caller, target)` check this replaced refused the identical wake.
    *
-   * (3) UNKNOWN and channel-free (anything else: `webchat`, `dream`, a target-less `hook`
-   *     session's own platform, or an unrecognised value) — `synthetic`. NOT a reject: this
-   *     is the case the org-scoped directory exists for. Instead the asserted channel never
-   *     becomes the session coordinate at all; {@link a2aCoordChannel} derives it from the
-   *     trusted caller, which cannot alias any platform session.
+   * (3) UNKNOWN and channel-free (exactly the session-identity platforms: `webchat`,
+   *     `dream`, a target-less `hook` session's own platform) — `synthetic`. NOT a reject:
+   *     this is the case the org-scoped directory exists for. Instead the asserted channel
+   *     never becomes the session coordinate at all; {@link a2aCoordChannel} derives it
+   *     from the trusted caller, which cannot alias any platform session. An unrecognised
+   *     id does NOT land here — it is chat-shaped until the registry says otherwise (2).
    *
    * Branch (1) running FIRST and platform-free is what keeps (3) from being an escape hatch:
    * relabelling a real channel's coordinate as `webchat` still hits branch 1 and still
@@ -254,7 +250,12 @@ export class CpCollabRoutes {
       if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
     if (known) return { verdict: 'reject' }
-    if (PERSISTED_IM_PLATFORMS.has(platform)) return { verdict: 'reject' }
+    // Registry-driven fail-closed default (S1a, integration-plugin-architecture.md §6.1):
+    // only the enumerated channel-free session identities take the synthetic branch; ANY
+    // other id — the four IM platforms and every id this build does not know — is
+    // chat-shaped and an unrecorded coordinate on it is refused. The old shape enumerated
+    // the IM platforms instead and silently ADMITTED unknown ids.
+    if (!isSessionIdentityPlatform(platform)) return { verdict: 'reject' }
     return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
   }
 

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -139,7 +139,11 @@ describe('CpCollabRoutes: org-scoped directory', () => {
       channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
       agents: [agent('a'), agent('b')]
     } as never)
-    for (const platform of ['slack', 'telegram', 'discord', 'feishu']) {
+    // S1a §6.1: unknown ids are chat-shaped until the registry says otherwise, so the
+    // fail-closed branch covers every id outside the session-identity set — including
+    // platforms this build has never heard of. The old enumerate-the-IM-platforms shape
+    // silently ADMITTED an unknown id into the synthetic branch.
+    for (const platform of ['slack', 'telegram', 'discord', 'feishu', 'teams-x', 'mattermost']) {
       expect(r.coordsDecision(ORG, platform, 'C_NEVER_SEEN', 'a')).toEqual({ verdict: 'reject' })
       expect(r.coordsDecision(ORG, platform, 'D0PPELGANGER', 'a')).toEqual({ verdict: 'reject' })
     }

--- a/packages/protocol/src/frames/route.ts
+++ b/packages/protocol/src/frames/route.ts
@@ -33,6 +33,18 @@ export type KnownPlatform = (typeof KNOWN_PLATFORMS)[number]
 export function isKnownPlatform(p: string): p is KnownPlatform {
   return (KNOWN_PLATFORMS as readonly string[]).includes(p)
 }
+// The origin-kind classification seed (integration-plugin-architecture.md §6.1): the
+// session-identity platforms are channel-free — no integration row, no persisted
+// conversation, no placement snapshot entry. Everything OUTSIDE this list is
+// chat-shaped and must be treated fail-closed where a placement matters
+// (`coordsDecision` refuses an unrecorded coordinate on any chat-shaped id,
+// including ids this build does not know). S1b replaces this constant with
+// wire-carried per-id classification riding collab snapshots / rc/bot-assign.
+export const SESSION_IDENTITY_PLATFORMS = ['webchat', 'hook', 'dream'] as const
+export type SessionIdentityPlatform = (typeof SESSION_IDENTITY_PLATFORMS)[number]
+export function isSessionIdentityPlatform(p: string): p is SessionIdentityPlatform {
+  return (SESSION_IDENTITY_PLATFORMS as readonly string[]).includes(p)
+}
 export const Platform = z.string().min(1)
 export type Platform = z.infer<typeof Platform>
 

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -407,8 +407,10 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     expect(unknownChannel).toMatchObject({ delivered: false, reason: 'not_allowed' })
     expect(forwards).toHaveLength(1) // nothing forwarded for the IM coordinate
 
-    // …on every persisted IM platform, not just Slack.
-    for (const [i, platform] of ['telegram', 'discord', 'feishu'].entries()) {
+    // …on every chat-shaped platform: the persisted IM four, and (S1a §6.1) any id this
+    // build does not know — unknown ids are chat-shaped until the registry says otherwise,
+    // so they fail closed instead of slipping into the channel-free synthetic branch.
+    for (const [i, platform] of ['telegram', 'discord', 'feishu', 'teams-x'].entries()) {
       const ack = await route(
         D1,
         baseMsg({ deliveryId: `d-im-${i}`, coords: { platform: platform as 'telegram', channel: 'NOT_A_ROW' } })

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -26,6 +26,7 @@
  * assumed. Documented in the PR description.
  */
 import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
+import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
 
 /** The resolved placement of one agent in a channel (a snapshot value). */
 export interface CollabResolved extends CollabAgentPlacement {
@@ -58,15 +59,6 @@ function coordsKey(orgId: string, channelId: string): string {
  * `packages/daemon/src/cp/cp-collab-routes.ts` — change one, change both.
  */
 export type CoordsVerdict = { verdict: 'reject' } | { verdict: 'asserted' } | { verdict: 'synthetic'; channel: string }
-
-/**
- * The platforms whose conversations are PERSISTED as `integration_channel` rows and
- * therefore appear in this snapshot — i.e. the protocol `Platform` enum minus the
- * session-identity members (`webchat`/`hook`/`dream`, which have no persisted row; see the
- * CP's `isSessionIdentityPlatform`). An UNKNOWN coordinate on one of these is evidence of a
- * problem, not of a channel-free session, so it fails closed ({@link coordsDecision}).
- */
-const PERSISTED_IM_PLATFORMS: ReadonlySet<string> = new Set(['slack', 'telegram', 'discord', 'feishu'])
 
 /**
  * The coordinate a channel-free wake lands on: derived from the TRUSTED caller, never from
@@ -159,11 +151,15 @@ export class CollaborationRouter {
    *     the rows with NO `kind` filter, so an `im`/`mpim` row is an ordinary KNOWN
    *     coordinate with its owning integration's agent as a member.
    *
-   * (2) UNKNOWN on a PERSISTED IM platform ({@link PERSISTED_IM_PLATFORMS}) — `reject`,
-   *     FAIL CLOSED. An unrecorded IM coordinate is either a channel the caller cannot
-   *     reach or a stale/departed row; admitting it is exactly what let a caller alias an
-   *     existing platform session. A brief snapshot lag can therefore transiently reject a
-   *     genuine wake — the correct direction for a security boundary, and the caller retries.
+   * (2) UNKNOWN on any CHAT-SHAPED platform — every id outside the enumerated
+   *     session-identity set (`isSessionIdentityPlatform`), including ids this build does
+   *     not know — `reject`, FAIL CLOSED. An unrecorded chat coordinate is either a channel
+   *     the caller cannot reach or a stale/departed row; admitting it is exactly what let a
+   *     caller alias an existing platform session, and admitting an UNKNOWN id would reopen
+   *     that hole for every future platform (S1a §6.1 replaced the old
+   *     enumerate-the-IM-platforms shape, which silently admitted unknown ids). A brief
+   *     snapshot lag can therefore transiently reject a genuine wake — the correct
+   *     direction for a security boundary, and the caller retries.
    *     ACCEPTED RECALL LOSS (agent-collaboration §2.5 "what the fail-closed branch actually
    *     covers", §2.7 item 5): a direct-conversation row is only WRITTEN where something
    *     observed it — Slack's authoritative membership snapshot enumerates
@@ -175,14 +171,15 @@ export class CollaborationRouter {
    *     Deliberate, and not a regression: the `hasMembers(caller, target)` check this
    *     replaced refused the identical wake.
    *
-   * (3) UNKNOWN and channel-free (anything else — on the wire, where `coords.platform` is
-   *     `slack | telegram | webchat | discord | feishu`, only `webchat` can reach here; a
-   *     `dream`/`hook` session's own platform reaches the daemon's twin on its same-daemon
-   *     path) — `synthetic`. NOT a reject: this is the case the org-scoped directory exists
-   *     for. Instead the asserted channel never becomes the session coordinate at all;
+   * (3) UNKNOWN and channel-free (exactly the session-identity platforms — until the
+   *     legacy emission clamp lifts, only `webchat` arrives on this wire; a `dream`/`hook`
+   *     session's own platform reaches the daemon's twin on its same-daemon path) —
+   *     `synthetic`. NOT a reject: this is the case the org-scoped directory exists for.
+   *     Instead the asserted channel never becomes the session coordinate at all;
    *     {@link a2aCoordChannel} derives it from the trusted caller, which cannot alias any
    *     platform session. The relay does not apply the substitution (see below), only skips
-   *     the rejection.
+   *     the rejection. An unrecognised id does NOT land here — it is chat-shaped until the
+   *     registry says otherwise (2).
    *
    * Branch (1) running FIRST and platform-free is what keeps (3) from being an escape
    * hatch: relabelling a real channel's coordinate as `webchat` still hits branch 1 and
@@ -222,7 +219,12 @@ export class CollaborationRouter {
       if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
     if (known) return { verdict: 'reject' }
-    if (PERSISTED_IM_PLATFORMS.has(platform)) return { verdict: 'reject' }
+    // Registry-driven fail-closed default (S1a, integration-plugin-architecture.md §6.1):
+    // only the enumerated channel-free session identities take the synthetic branch; ANY
+    // other id — the four IM platforms and every id this build does not know — is
+    // chat-shaped and an unrecorded coordinate on it is refused. The old shape enumerated
+    // the IM platforms instead and silently ADMITTED unknown ids.
+    if (!isSessionIdentityPlatform(platform)) return { verdict: 'reject' }
     return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
   }
 


### PR DESCRIPTION
## What

Stage **S1a** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §6.1/§13, PR 3 of 3 — the last S1a code change before **deploy gate 1**. Both `coordsDecision` twins (daemon [cp-collab-routes.ts](../blob/main/packages/daemon/src/cp/cp-collab-routes.ts), relay [collaboration-router.ts](../blob/main/packages/relay/src/collaboration-router.ts)) enumerated the four persisted IM platforms and admitted **everything else** into the channel-free synthetic branch — so a platform id neither build knew would have been silently admitted with a caller-derived coordinate. Under the open `PlatformId` that fail-open default would widen to every future platform.

## The flip

The branch inverts to registry-driven: only the enumerated **session-identity platforms** (`webchat`/`hook`/`dream`) take the synthetic branch; any other id — the IM four and every id the build does not know — is chat-shaped, and an unrecorded coordinate on it is refused fail-closed. The two hardcoded `PERSISTED_IM_PLATFORMS` sets are deleted.

The classification seed (`SESSION_IDENTITY_PLATFORMS` / `isSessionIdentityPlatform`) moves into `@agentconnect.md/protocol` as the single source shared by all three consumers: the daemon twin, the relay twin, and the CP's persistence narrowing (`persistence/platform.ts`, which previously carried its own copy of the same predicate). S1b replaces this constant with wire-carried per-id classification riding collab snapshots / `rc/bot-assign` (§6.1).

## Behavior

Preserving for every id writers emit today — the flip only changes **unknown** ids, which nothing emits until the fleet gate passes (that discipline is exactly what PR #501 pinned). Both fail-closed test matrices gain unknown-id cases (`teams-x` → reject on both sides), and the branch (2)/(3) doc blocks in both twins are rewritten in lockstep.

## Verification

daemon 2759 ✓ (all green — the workspace-GC env issue is fixed on main) · relay 380 ✓ · protocol 251 ✓ · control-plane unit 1020 ✓ · integration 947 ✓ · full-workspace typecheck ✓.

## After this merges: S1a is code-complete → deploy gate 1

1. Ship CP (staging → prod promote), then wait one full daemon upgrade cycle.
2. Gate check: every online daemon in the CP registry at or past the tolerant-reader version (#501).
3. Only then may S1b begin emitting anything non-legacy (schema restructure, `IntegrationSpec` envelope, new ids). The daemon-side `legacyCoordPlatform` clamp (#504) is also removable then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)