### PR TITLE
fix(web): preserve source turns in merged conversations

### DIFF
--- a/docs/designs/merged-conversation-view.md
+++ b/docs/designs/merged-conversation-view.md
@@ -336,8 +336,11 @@ session (`sessionId`, `agentId`).
    merged row list feeds the same turn builder the per-agent page uses — the
    right side is reserved for the viewer, every agent renders as its own
    left-side block via the `agentId`-keyed grouping (`sameBotSpeaker`), humans
-   render as sender rows. No new rendering rules; the merged view is "the
-   per-agent page fed a union instead of one source".
+   render as sender rows. Each author row retains its maximal owner-authored
+   run from the source transcript, so another agent's private work can
+   interleave chronologically without splitting the source-local turn into
+   several blocks. No new rendering rules; the merged view is "the per-agent
+   page fed a union instead of one source".
 
 Notes:
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -270,14 +270,16 @@ function countsAsOfflineSource(error: unknown): boolean {
 function mergeConversationRows(
   sources: { sessionId: string; agentId: string; platform: string }[],
   rows: Map<string, SessionMessageDto[]>,
-  sourceSessionByMessage: WeakMap<SessionMessageDto, string>
+  sourceSessionByMessage: WeakMap<SessionMessageDto, string>,
+  sourceTurnByMessage: WeakMap<SessionMessageDto, string>
 ): SessionMessageDto[] {
   return mergeConversation(
     sources
       .filter((source) => rows.has(source.sessionId))
       .map((source) => ({ ...source, rows: rows.get(source.sessionId)! }) satisfies MergeSource)
-  ).map(({ row, sourceSessionId }) => {
+  ).map(({ row, sourceSessionId, sourceTurnKey }) => {
     sourceSessionByMessage.set(row, sourceSessionId)
+    if (sourceTurnKey) sourceTurnByMessage.set(row, sourceTurnKey)
     return row
   })
 }
@@ -1151,6 +1153,7 @@ export default function SessionDetailView() {
     older: Map<string, string | null>
   }>({ rows: new Map(), cursors: new Map(), older: new Map() })
   const conversationSourceSessionByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
+  const conversationSourceTurnByMessageRef = useRef(new WeakMap<SessionMessageDto, string>())
   const [conversationHasEarlier, setConversationHasEarlier] = useState(false)
   const [conversationPagingEarlier, setConversationPagingEarlier] = useState(false)
   // Which conversation key the CURRENT fan-out state belongs to — the focus
@@ -1594,7 +1597,14 @@ export default function SessionDetailView() {
         setConversationHasEarlier([...older.values()].some((cursor) => cursor !== null))
         setConversationLoadedKey(conversationKey)
         setConversationOffline(failed)
-        setMsgs(mergeConversationRows(sources, rowsBySession, conversationSourceSessionByMessageRef.current))
+        setMsgs(
+          mergeConversationRows(
+            sources,
+            rowsBySession,
+            conversationSourceSessionByMessageRef.current,
+            conversationSourceTurnByMessageRef.current
+          )
+        )
         setMsgLoading(false)
         setMsgPaging(false)
         liveCursorRef.current = cursors.get(sid) ?? null
@@ -1700,7 +1710,14 @@ export default function SessionDetailView() {
         }
         if (tailSessionRef.current !== sid) return
         setConversationOffline(failed)
-        setMsgs(mergeConversationRows(sources, state.rows, conversationSourceSessionByMessageRef.current))
+        setMsgs(
+          mergeConversationRows(
+            sources,
+            state.rows,
+            conversationSourceSessionByMessageRef.current,
+            conversationSourceTurnByMessageRef.current
+          )
+        )
         if (tailSessionRef.current === sid && !sessionBusyRef.current && repRows.length > 0)
           reconcileLiveSteps(sid, repRows, aid)
       })()
@@ -1772,7 +1789,14 @@ export default function SessionDetailView() {
           }
         })
       )
-      setMsgs(mergeConversationRows(sources, state.rows, conversationSourceSessionByMessageRef.current))
+      setMsgs(
+        mergeConversationRows(
+          sources,
+          state.rows,
+          conversationSourceSessionByMessageRef.current,
+          conversationSourceTurnByMessageRef.current
+        )
+      )
       setConversationHasEarlier([...state.older.values()].some((cursor) => cursor !== null))
     } finally {
       setConversationPagingEarlier(false)
@@ -2153,18 +2177,21 @@ export default function SessionDetailView() {
     })
     turns.push(turn)
   }
+  const conversationTurnByKey = new Map<string, Extract<Turn, { kind: 'bot' }>>()
   // Another agent speaking in this session — a webchat peer participant or a
   // trusted a2a bot — renders as its own left-side agent block: the right side
-  // is reserved for humans. Groups consecutive rows like live bot steps.
-  const pushAgentTurn = (agent: Agent, step: FmtStep): void => {
+  // is reserved for humans. Conversation rows retain their source-local turn;
+  // every other path groups consecutive rows like live bot steps.
+  const pushAgentTurn = (agent: Agent, step: FmtStep, sourceTurnKey?: string): void => {
     const name = agentLabel(agent)
     rememberAgentParticipant(agent.id, name, agent)
-    let last = turns[turns.length - 1]
+    let last = sourceTurnKey ? conversationTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
     if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: agent.id, agentName: name })) {
       // `model` is the icon-runtime fallback for turns whose agent is missing from
       // `agentById`; a peer turn's agent came FROM that map, so it stays empty.
       last = { kind: 'bot', agentName: name, agentId: agent.id, model: '', time: '', steps: [] }
       turns.push(last)
+      if (sourceTurnKey) conversationTurnByKey.set(sourceTurnKey, last)
     }
     last.steps.push(step)
     if (!last.time && step.time) last.time = step.time
@@ -2174,8 +2201,9 @@ export default function SessionDetailView() {
     // is a human/cron author. Group consecutive agent messages into one turn.
     for (const m of visibleMsgs ?? []) {
       const toolSessionId = conversationSourceSessionByMessageRef.current.get(m)
+      const sourceTurnKey = conversationSourceTurnByMessageRef.current.get(m)
       if (m.sender === session.agentId) {
-        let last = turns[turns.length - 1]
+        let last = sourceTurnKey ? conversationTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
         const ownerName = session.agentName ?? ''
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: m.sender, agentName: ownerName })) {
           last = {
@@ -2187,6 +2215,7 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
+          if (sourceTurnKey) conversationTurnByKey.set(sourceTurnKey, last)
         }
         const step = msgStep(m, toolSessionId)
         last.steps.push(step)
@@ -2199,10 +2228,14 @@ export default function SessionDetailView() {
         const hookFallback = session.platform === 'hook' && m.sender?.startsWith('hook:') ? session.user : undefined
         const self = isSelf(m.sender)
         if (senderAgent && !self) {
-          pushAgentTurn(senderAgent, {
-            ...msgStep(m, toolSessionId),
-            ...(m.attachments?.[0] ? { image: m.attachments[0] } : {})
-          })
+          pushAgentTurn(
+            senderAgent,
+            {
+              ...msgStep(m, toolSessionId),
+              ...(m.attachments?.[0] ? { image: m.attachments[0] } : {})
+            },
+            sourceTurnKey
+          )
           continue
         }
         const participant = self

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -65,6 +65,44 @@ describe('mergeConversation', () => {
     ])
   })
 
+  it('preserves each source-local bot turn when private work interleaves', () => {
+    const triggerTs = '1754123456.000000'
+    const nextTriggerTs = '1754123457.000000'
+    const merged = mergeConversation([
+      src(A, 'slack', [
+        row({ sender: 'U-HUMAN', ts: triggerTs, text: 'start' }),
+        row({ sender: A, kind: 'reasoning', ts: '1754123456100', text: 'a-think' }),
+        row({ sender: A, kind: 'tool', ts: '1754123456300', text: 'a-tool' }),
+        row({ sender: A, ts: '1754123456500', text: 'a-answer' }),
+        row({ sender: 'U-HUMAN', ts: nextTriggerTs, text: 'next' }),
+        row({ sender: A, kind: 'reasoning', ts: '1754123457100', text: 'a-next-turn' })
+      ]),
+      src(B, 'slack', [
+        row({ sender: 'U-HUMAN', ts: triggerTs, text: 'start' }),
+        row({ sender: B, kind: 'reasoning', ts: '1754123456200', text: 'b-think' }),
+        row({ sender: B, ts: '1754123456400', text: 'b-answer' }),
+        row({ sender: 'U-HUMAN', ts: nextTriggerTs, text: 'next' })
+      ])
+    ])
+
+    expect(merged.map(({ row }) => row.text)).toEqual([
+      'start',
+      'a-think',
+      'b-think',
+      'a-tool',
+      'b-answer',
+      'a-answer',
+      'next',
+      'a-next-turn'
+    ])
+    const turnKeyByText = Object.fromEntries(merged.map(({ row, sourceTurnKey }) => [row.text, sourceTurnKey]))
+    expect(turnKeyByText['a-think']).toBe(turnKeyByText['a-tool'])
+    expect(turnKeyByText['a-tool']).toBe(turnKeyByText['a-answer'])
+    expect(turnKeyByText['b-think']).toBe(turnKeyByText['b-answer'])
+    expect(turnKeyByText['a-think']).not.toBe(turnKeyByText['b-think'])
+    expect(turnKeyByText['a-next-turn']).not.toBe(turnKeyByText['a-answer'])
+  })
+
   it('dedupes Discord copies on the snowflake and orders them by its embedded time', () => {
     // Snowflake for ~2024: time bits decode via (id >> 22) + Discord epoch.
     const SNOWFLAKE = '1101111111111111111'

--- a/packages/web/src/lib/conversation-merge.ts
+++ b/packages/web/src/lib/conversation-merge.ts
@@ -23,6 +23,10 @@ export interface MergedRow {
   row: SessionMessageDto
   sourceSessionId: string
   sourceAgentId: string
+  /** Maximal owner-authored run in the source transcript. Conversation rendering
+   *  uses this to preserve the same bot blocks a single-session page would build,
+   *  even after another participant's private work interleaves by event time. */
+  sourceTurnKey?: string
   /** True when this copy came from its author's own transcript (full
    *  fidelity); the merge prefers it over recipient copies. */
   authorCopy: boolean
@@ -133,12 +137,18 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
   const byIdentity = new Map<string, { at: number; entry: Decorated }>()
   let order = 0
   for (const source of sources) {
+    let sourceTurn = 0
+    let previousWasAuthor = false
     for (const row of source.rows) {
+      const authorCopy = row.sender === source.agentId
+      if (authorCopy && !previousWasAuthor) sourceTurn += 1
+      previousWasAuthor = authorCopy
       const candidate: Decorated = {
         row,
         sourceSessionId: source.sessionId,
         sourceAgentId: source.agentId,
-        authorCopy: row.sender === source.agentId,
+        ...(authorCopy ? { sourceTurnKey: `${source.sessionId}\u0000${sourceTurn}` } : {}),
+        authorCopy,
         // Prefer the daemon's stored axis (provider-authoritative for
         // Telegram/Feishu, whose ids carry no time); a missing/zero value
         // falls back to deriving from `ts` (which handles snowflakes).
@@ -173,10 +183,11 @@ export function mergeConversation(sources: MergeSource[]): MergedRow[] {
     if (a.sourceSessionId !== b.sourceSessionId) return a.sourceSessionId < b.sourceSessionId ? -1 : 1
     return a.order - b.order
   })
-  return kept.map(({ row, sourceSessionId, sourceAgentId, authorCopy }) => ({
+  return kept.map(({ row, sourceSessionId, sourceAgentId, sourceTurnKey, authorCopy }) => ({
     row,
     sourceSessionId,
     sourceAgentId,
+    ...(sourceTurnKey ? { sourceTurnKey } : {}),
     authorCopy
   }))
 }


### PR DESCRIPTION
## Summary

- preserve each agent's source-local turn identity while merging conversation transcripts
- keep interleaved private work in one collapsible agent block instead of fragmenting it by global adjacency
- retain the existing consecutive grouping behavior for single-session and live transcript paths
- document and test the merged-conversation grouping invariant

## Root cause

Conversation pages merged every participant's transcript row-by-row on the global event-time axis, then reused a turn builder that only joined adjacent rows from the same agent. Overlapping work from two agents therefore produced an A/B/A/B sequence and split each logical source-local turn into several blocks, even though each single-session transcript still contained one consecutive owner-authored run.

## Impact

Overlapping multi-agent work now remains chronological at the conversation level while each agent's reasoning, tool calls, and answer render in the same turn block they have on the corresponding single-session page. Separate source-local turns remain separate.

## Validation

- `pnpm --filter @agentconnect.md/web test` - 92 files, 705 tests passed
- `pnpm --filter @agentconnect.md/web exec tsc --noEmit -p tsconfig.json`
- focused ESLint and Prettier checks for changed files
- pre-push full-repository ESLint hook

Created by Codex . GPT-5
