### PR TITLE
feat(control-plane): open the persisted Platform enum to text (S1b)

### DIFF
--- a/packages/control-plane/prisma/migrations/20260803150000_platform_enum_to_text/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260803150000_platform_enum_to_text/migration.sql
@@ -1,0 +1,27 @@
+-- Platform enum → text (integration-plugin-architecture.md §11, stage S1b): the
+-- persisted chat-platform id opens so a future platform id can be stored without a
+-- migration. Values, NULLability, defaults, and every index carry over unchanged —
+-- `USING …::text` rewrites the column in place. `session_meta.platform` was already
+-- text. The closed-set guard moves to the application layer (`toDbPlatform` refuses
+-- ids outside the served set, fail-closed) until the platform registry replaces it.
+
+-- Enum-typed defaults must be dropped BEFORE the type change (they are cast-bound to
+-- the enum) and re-created as text afterwards.
+ALTER TABLE "cron_def" ALTER COLUMN "targetPlatform" DROP DEFAULT;
+ALTER TABLE "hook_def" ALTER COLUMN "targetPlatform" DROP DEFAULT;
+ALTER TABLE "bot" ALTER COLUMN "platform" DROP DEFAULT;
+ALTER TABLE "integration" ALTER COLUMN "platform" DROP DEFAULT;
+
+ALTER TABLE "assignment" ALTER COLUMN "platform" TYPE TEXT USING "platform"::text;
+ALTER TABLE "secret_lease" ALTER COLUMN "scopePlatform" TYPE TEXT USING "scopePlatform"::text;
+ALTER TABLE "cron_def" ALTER COLUMN "targetPlatform" TYPE TEXT USING "targetPlatform"::text;
+ALTER TABLE "hook_def" ALTER COLUMN "targetPlatform" TYPE TEXT USING "targetPlatform"::text;
+ALTER TABLE "bot" ALTER COLUMN "platform" TYPE TEXT USING "platform"::text;
+ALTER TABLE "integration" ALTER COLUMN "platform" TYPE TEXT USING "platform"::text;
+
+ALTER TABLE "cron_def" ALTER COLUMN "targetPlatform" SET DEFAULT 'slack';
+ALTER TABLE "hook_def" ALTER COLUMN "targetPlatform" SET DEFAULT 'slack';
+ALTER TABLE "bot" ALTER COLUMN "platform" SET DEFAULT 'slack';
+ALTER TABLE "integration" ALTER COLUMN "platform" SET DEFAULT 'slack';
+
+DROP TYPE "Platform";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -785,12 +785,12 @@ model AgentRepoAuthorization {
 // §3.7 Assignment — the routing table (session ownership + fencing) (C3)
 // ───────────────────────────────────────────────────────────────────────────
 
-enum Platform {
-  slack
-  telegram
-  discord
-  feishu
-}
+// The persisted chat-platform id is TEXT, not an enum (integration-plugin-architecture.md
+// §11): a new platform id must be storable without a migration once the platform registry
+// lands. The closed-set guard moved to the application layer — `toDbPlatform`
+// (persistence/platform.ts) still refuses ids outside the served set, fail-closed, until
+// the registry replaces it. `session_meta.platform` was already text; these columns joined
+// it in the S1b migration.
 
 enum AssignmentState {
   active
@@ -801,7 +801,7 @@ enum AssignmentState {
 
 model Assignment {
   id          String   @id @default(cuid())
-  platform    Platform
+  platform    String
   channel     String
   thread      String?
   threadKey   String   @default(dbgenerated("(COALESCE(thread, ''::text))")) // STORED generated col, added in migration SQL (§3.13); read-only
@@ -1312,7 +1312,7 @@ enum LeaseStatus {
 model SecretLease {
   id               String      @id @db.Uuid // SecretsGrant.leaseId
   daemonId         String      @db.Uuid
-  scopePlatform    Platform
+  scopePlatform    String
   scopeWorkspaceId String      @db.Uuid // SecretsGrant.scope.workspaceId — opaque scope id; now = agentId (workspace inline)
   ref              String // Vault/KMS path/handle — NOT the secret
   ttlSec           Int
@@ -1341,7 +1341,7 @@ model CronDef {
   name                 String? // console display name ("weekly-deploy-report"); pure console metadata, never on the daemon wire. Null for legacy/CLI rows.
   schedule             String // croner expression interpreted in timezone
   timezone             String // IANA timezone resolved by the CP before persistence
-  targetPlatform       Platform           @default(slack)
+  targetPlatform       String             @default("slack")
   targetChannel        String? // CronUpsert.target.channel; null ⇒ headless fire (no platform output)
   targetIntegrationId  String?            @db.Uuid // CronUpsert.target.integrationId — the agent integration posting the anchor; null (legacy / uninstalled) ⇒ daemon falls back to the agent's first integration
   trigger              String             @db.Text // synthetic trigger text (control metadata)
@@ -1481,7 +1481,7 @@ model HookDef {
   requiredAcknowledgedByUserId       String?
   requiredAcknowledgedConfigRevision BigInt?
   // ── output anchoring (same trio as CronDef.target*; null channel ⇒ headless) ──
-  targetPlatform                     Platform          @default(slack)
+  targetPlatform                     String            @default("slack")
   targetChannel                      String?
   targetIntegrationId                String?           @db.Uuid
   lastFiredAt                        DateTime?         @db.Timestamptz(6) // advisory; bumped on rc/run-report
@@ -1707,7 +1707,7 @@ model Relay {
 model Bot {
   id                    String         @id @db.Uuid
   orgId                 String
-  platform              Platform       @default(slack)
+  platform              String         @default("slack")
   name                  String // Slack app / display name
   prebuilt              Boolean        @default(false) // provisioned by AgentConnect, not a console user
   slackAppId            String? // Slack app id (A…), parsed from the pasted xapp token — deep-links the console to api.slack.com/apps/{id}. Public metadata, NOT secret material.
@@ -1835,7 +1835,7 @@ model Integration {
   // one Integration row per agent (shared-bot-relay.md §4.1). A classic
   // (non-shareable) bot is still capped at ≤1 install by the create route.
   botId                     String            @db.Uuid
-  platform                  Platform          @default(slack)
+  platform                  String            @default("slack")
   name                      String // Slack app / display name (mirrors bot.name at install time)
   status                    IntegrationStatus @default(active)
   // Credential generation whose uninstall/token-revocation flipped this row.

--- a/packages/control-plane/src/persistence/platform.ts
+++ b/packages/control-plane/src/persistence/platform.ts
@@ -1,18 +1,18 @@
 /**
  * `persistence/platform.ts` — the protocol↔DB platform boundary.
  *
- * The protocol `Platform` enum also carries session-identity-only values
- * (`webchat`, `hook`, and background `dream` runs). They have no persisted
- * integration row: their message content stays daemon-local (body-locality,
- * §1/§12).
- * So the DB `Platform` enum (the persisted platforms) is deliberately narrower:
- * only actual integrations. This helper is the single place that asserts that
- * invariant when a protocol platform is about to be written to Postgres — a
- * `webchat` value reaching a persistence write is a programming error, not data.
+ * The protocol platform id also carries session-identity-only values (`webchat`,
+ * `hook`, and background `dream` runs). They have no persisted integration row:
+ * their message content stays daemon-local (body-locality, §1/§12).
+ * The DB columns are open TEXT since S1b (integration-plugin-architecture.md §11) —
+ * the dropped `Platform` enum's closed set lives on HERE, as the application-level
+ * guard asserted when a protocol platform is about to be written to Postgres: a
+ * `webchat` value (or an id this deployment does not serve) reaching a persistence
+ * write is a programming error, not data. The platform registry replaces this list
+ * when providers land (S3).
  */
 import type { Platform as ProtocolPlatform } from '@agentconnect.md/protocol'
 import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
-import type { Platform as DbPlatform } from '../generated/prisma/enums.js'
 
 /** True for the session-identity-only platforms, which have no persisted row. Lets a
  *  caller decide BEFORE reaching persistence — a read whose answer is "nothing is
@@ -21,13 +21,15 @@ import type { Platform as DbPlatform } from '../generated/prisma/enums.js'
  *  with the daemon's and relay's `coordsDecision`). */
 export { isSessionIdentityPlatform }
 
-const DB_PLATFORMS: readonly DbPlatform[] = ['slack', 'telegram', 'discord', 'feishu']
+/** The chat platforms this deployment currently serves — the closed set the dropped
+ *  DB enum used to enforce. */
+const DB_PLATFORMS = ['slack', 'telegram', 'discord', 'feishu'] as const
+export type DbPlatform = (typeof DB_PLATFORMS)[number]
 
 /** Narrow a protocol platform to a persisted (DB) platform, or throw on the
- *  session-identity-only members (`webchat`, `hook`, `dream`) — and, now that
- *  platform fields read as open strings (S1a), on any id the DB enum does not
- *  hold. Fail-closed: an unknown id reaching a persistence write is a
- *  programming error until the Prisma enum opens to text (S1b). */
+ *  session-identity-only members (`webchat`, `hook`, `dream`) and on any id outside
+ *  the served set. Fail-closed: the DB column no longer enforces the set, so this
+ *  helper is the fence. */
 export function toDbPlatform(p: ProtocolPlatform): DbPlatform {
   if (isSessionIdentityPlatform(p)) {
     throw new Error(`${p} is a session-identity platform and is never persisted`)


### PR DESCRIPTION
## What

First **S1b** stage of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §11: the six columns carrying the closed `Platform` enum — `assignment.platform`, `secret_lease.scopePlatform`, `cron_def.targetPlatform`, `hook_def.targetPlatform`, `bot.platform`, `integration.platform` — become **TEXT**, and the enum is dropped. `session_meta.platform` was already text. A future platform id becomes storable without a migration.

## Migration mechanics

`ALTER … TYPE TEXT USING …::text` rewrites each column in place — values, NULLability, and indexes carry over. The four enum-bound `DEFAULT 'slack'::"Platform"` defaults are dropped before the type change and re-created as text, then `DROP TYPE "Platform"`.

## The closed set moves, it does not disappear

`toDbPlatform` ([persistence/platform.ts](../blob/claude/s1b-platform-enum-to-text/packages/control-plane/src/persistence/platform.ts)) keeps refusing session-identity platforms and any id outside the served set, fail-closed — it now also exports the `DbPlatform` union the dropped enum used to provide (the only code that imported the generated enum type). The platform registry replaces that list when CP providers land (S3). Every REST DTO union and the daemon capability gate are untouched — nothing new becomes creatable.

## Rollout

No wire emission changes — safe to ship independent of the S1a fleet gate. Forward-only (the enum is dropped); rollback would need the inverse migration, but old CP code reads text values identically through the regenerated client.

## Verification

CP unit 1020 ✓ · CP integration 947 ✓ (the migration is exercised on a real Postgres via Testcontainers `migrate deploy`) · full-workspace typecheck ✓.

Next S1b stages: Bot identity columns (D6: `externalAppId`/`externalTenantId`/`platformConfig` + backfill + composite unique), then the protocol restructures (`OriginKind`×`PlatformId`, `IntegrationSpec` envelope with the codec down-level shim, `NormalizedMessage` thread coords, `platform_action`, `rc/bot-assign`, §6.8 cron/hook targeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)