### PR TITLE
feat(web): home composer attachments; fix(daemon): persist webchat images on admission write

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -60,7 +60,7 @@ import { recallQueryFromBlocks } from './agents/memory-recall.js'
 import { maskableSecrets, maskSecretsDeep } from './session/secret-mask.js'
 import { monotonicTs } from './store/monotonic-ts.js'
 import { TranscriptRecorder, type TranscriptEvent } from './session/transcript-recorder.js'
-import { attachmentMention } from './session/attachment-block.js'
+import { attachmentMention, transcriptImageAttachments } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
 import { isValidatedRemoteMcpRuntime } from './mcp/remote-mcp-runtimes.js'
@@ -5731,6 +5731,12 @@ export class Daemon {
     // SessionManager.handle dedups in place (same canonical ts, sender, text).
     if (post && this.cfg.features.turnFinalContextRefresh) {
       const observedMention = attachmentMention(msg.attachments)
+      // The bounded inline image must ride the ADMISSION write: it wins the slot,
+      // and SessionManager's later identical append dedups via INSERT OR IGNORE —
+      // an attachment-less row here would pin attachmentsJson to NULL, so the
+      // session reader could neither strip the `[attached: …]` suffix nor hand
+      // the console back the image.
+      const observedAttachments = transcriptImageAttachments(msg.attachments)
       const observedTs = this.appendWebchatTextRow(
         transcriptChannelKey(chatId, undefined),
         `webchat:${chatId}`,
@@ -5743,7 +5749,8 @@ export class Daemon {
           // same-text post from another tab would reuse this row instead of
           // bumping (§6).
           postId: post.postId,
-          text: observedMention ? `${text}\n${observedMention}`.trim() : text
+          text: observedMention ? `${text}\n${observedMention}`.trim() : text,
+          ...(observedAttachments.length ? { attachments: observedAttachments } : {})
         }
       )
       // The slot may have been collision-bumped (a self-authored row can occupy

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1462,6 +1462,48 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     await daemon.stop()
   }, 15_000)
 
+  it('retains the inline image when the turn carries a canonical post (admission write wins the slot)', async () => {
+    // Real relay traffic ALWAYS mints `post`, which makes the turn-final-refresh
+    // admission write claim the transcript slot before SessionManager's append —
+    // INSERT OR IGNORE then dedups the authoritative copy, so the admission row
+    // itself must carry the image or attachmentsJson is pinned to NULL and the
+    // reopened console shows only the `[attached: …]` label.
+    const { factory, host } = streamingHost([text('I can see it')])
+    ;(host as any).promptSupports = (kind: string) => kind === 'image'
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).cpClient = fakeCpClient()
+
+    const bytes = Buffer.from('image bytes')
+    const turnId = '88888888-8888-4888-8888-888888888888'
+    const events: RdChatEvent[] = []
+    const ack = (daemon as any).handleRelayMsg(
+      rd({
+        op: 'turn',
+        text: 'What is shown?',
+        user: 'ada',
+        turnId,
+        post: { postId: turnId, at: 1_000 },
+        attachments: [{ name: 'screen.webp', mimeType: 'image/webp', data: bytes.toString('base64') }]
+      }),
+      (event: RdChatEvent) => events.push(event)
+    )
+    expect(ack).toMatchObject({ accepted: true })
+    await vi.waitFor(() => expect(events.some((event) => event.kind === 'done')).toBe(true), WAIT)
+
+    const rows = (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`) as Array<{
+      sender: string
+      text: string
+      attachmentsJson?: string
+    }>
+    const userRow = rows.find((row) => row.sender === 'ada')
+    expect(userRow?.text).toBe('What is shown?\n[attached: screen.webp (image/webp)]')
+    expect(JSON.parse(userRow?.attachmentsJson ?? '[]')).toEqual([
+      { name: 'screen.webp', mimeType: 'image/webp', data: bytes.toString('base64') }
+    ])
+    await daemon.stop()
+  }, 15_000)
+
   it('rejects a turn for an agent not on this daemon (accepted:false, reason no_agent)', async () => {
     const { factory } = streamingHost([])
     const daemon = new Daemon({ root: scaffold(), hostFactory: factory })

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -93,7 +93,10 @@ interface PlaygroundData {
     agentId: string,
     text?: string,
     conversationId?: string,
-    participants?: Array<{ agentId: string; name: string; primary?: boolean }>
+    participants?: Array<{ agentId: string; name: string; primary?: boolean }>,
+    /** Overrides the staged composer image — for callers (Home) that mint the
+     *  session id in the same tick, before setPgImage state could land. */
+    image?: SessionImage
   ) => boolean
   /** Messages queued while a turn streams, oldest first. */
   getPgQueue: (id: string) => QueuedTurn[]
@@ -1130,10 +1133,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       agentForId: string,
       textArg?: string,
       conversationId?: string,
-      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
+      knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>,
+      imageArg?: SessionImage
     ) => {
       const text = String(textArg ?? pgDrafts.current[id] ?? '').trim()
-      const image = pgImageBy[id]
+      const image = imageArg ?? pgImageBy[id]
       if (!text && !image) return false
       setPgInput(id, '')
       setPgImage(id)

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -332,18 +332,6 @@ function RailAccount({
               </button>
             )}
             <div className="dmsep" />
-            {/* Brings back the getting-started checklist after "Skip for now" — the only
-                way back, since the pill has no other re-entry point. */}
-            <button
-              className="dmi"
-              onClick={() => {
-                setOpen(false)
-                openGettingStarted()
-              }}
-            >
-              <Icon name="rocket" size={15} color="var(--text-tertiary)" />
-              Getting started
-            </button>
             <Link href={orgPath('/profile')} className="dmi no-underline" onClick={() => setOpen(false)}>
               <Icon name="circle-user-round" size={15} color="var(--text-tertiary)" />
               Profile
@@ -751,20 +739,18 @@ function ShellChrome({ children }: { children: ReactNode }) {
                   <>
                     <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
                     <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
-                      {/* No-auth mode has no account block, so this is its only way back to a
-                          skipped checklist. Auth mode gets the entry in the account menu. */}
-                      {!authOn && (
-                        <button
-                          className="dmi"
-                          onClick={() => {
-                            setHelpMenu(false)
-                            openGettingStarted()
-                          }}
-                        >
-                          <Icon name="rocket" size={15} color="var(--text-tertiary)" />
-                          Getting started
-                        </button>
-                      )}
+                      {/* The desktop way back to a skipped checklist, both auth modes — the
+                          pill has no other desktop re-entry point. */}
+                      <button
+                        className="dmi"
+                        onClick={() => {
+                          setHelpMenu(false)
+                          openGettingStarted()
+                        }}
+                      >
+                        <Icon name="rocket" size={15} color="var(--text-tertiary)" />
+                        Getting started
+                      </button>
                       <button
                         className="dmi"
                         onClick={() => {

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -57,7 +57,14 @@ vi.mock('@/components/marks', () => ({
   ModelMark: () => <span />,
   PlatformMark: () => <span />,
   LogoMark: () => <span />,
-  LoadingState: () => <span>loading</span>
+  LoadingState: () => <span>loading</span>,
+  Spinner: () => <span />
+}))
+// prepareWebchatImage needs createImageBitmap/canvas (not in happy-dom); the
+// pipeline itself is covered by webchat-image.test.ts.
+vi.mock('@/lib/webchat-image', () => ({
+  clipboardImageFile: () => undefined,
+  prepareWebchatImage: vi.fn(async () => ({ name: 'shot.webp', mimeType: 'image/webp', data: 'QUJD' }))
 }))
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { name: 'Riley Kim', initials: 'RK' }, me: null }) }))
 vi.mock('@/components/ui', () => ({ Icon: () => <span /> }))
@@ -282,6 +289,38 @@ describe('HomeView run-selectors (catalog-aware)', () => {
       await new Promise((r) => setTimeout(r, 0))
     })
     expect(mocks.pgSetPermissionPreset).toHaveBeenCalledWith('pg_1', 'a1', 'agent:auto-review')
+  })
+})
+
+describe('HomeView attach', () => {
+  it('sends an attached image with the first turn (image-only send allowed)', async () => {
+    mocks.agents = [agent()]
+    mocks.daemons = [daemon()]
+    await render()
+    const sendBtn = host.querySelector<HTMLButtonElement>('button.sendbtn')!
+    expect(sendBtn.disabled).toBe(true) // no text, no image yet
+    const fileInput = host.querySelector<HTMLInputElement>('input[type="file"]')!
+    await act(async () => {
+      Object.defineProperty(fileInput, 'files', { value: [new File(['x'], 'shot.png', { type: 'image/png' })] })
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(host.querySelector('img')).toBeTruthy() // preview chip
+    expect(sendBtn.disabled).toBe(false) // image alone enables send
+    await act(async () => {
+      sendBtn.click()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    // The image rides pgSend's explicit argument (the session id is minted in the same tick).
+    expect(mocks.pgSend).toHaveBeenCalledWith(
+      'pg_1',
+      'a1',
+      '',
+      undefined,
+      undefined,
+      expect.objectContaining({ data: 'QUJD', mimeType: 'image/webp' })
+    )
+    expect(host.querySelector('img')).toBeNull() // composer cleared after send
   })
 })
 

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -24,7 +24,8 @@ import {
   MOBILE_SESSION_ROWS
 } from '@/components/console/dashboard-rows'
 import { Icon } from '@/components/ui'
-import { AgentIconView, ModelMark, LoadingState, LogoMark } from '@/components/marks'
+import { AgentIconView, ModelMark, LoadingState, LogoMark, Spinner } from '@/components/marks'
+import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { useProfile } from '@/lib/profile'
 import {
   agentLabel,
@@ -42,7 +43,8 @@ import {
   resolvedPermissionMode,
   selectedPermissionPreset,
   supportsModes,
-  type Agent
+  type Agent,
+  type SessionImage
 } from '@/lib/data'
 import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
 
@@ -159,8 +161,14 @@ export default function HomeView() {
   }
 
   const [input, setInput] = useState('')
+  // One prepared image staged for the first turn (mirrors the session composer:
+  // prepareWebchatImage bounds it to the wire's 160 KiB WebP budget).
+  const [image, setImage] = useState<SessionImage | undefined>(undefined)
+  const [imagePreparing, setImagePreparing] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const imageInputRef = useRef<HTMLInputElement>(null)
   // Which selector menu is open (only one at a time), and the run-runtime overrides.
-  const [menu, setMenu] = useState<'agent' | 'model' | 'effort' | 'permission' | 'add' | null>(null)
+  const [menu, setMenu] = useState<'agent' | 'model' | 'effort' | 'permission' | 'add' | 'attach' | null>(null)
   const [runtime, setRuntime] = useState<{ model?: string; effort?: string; permissionPreset?: string }>({})
   const [worktreeOverride, setWorktreeOverride] = useState<boolean>()
   const githubWorkspace = agent?.workspace?.mode === 'github' ? agent.workspace : undefined
@@ -243,9 +251,25 @@ export default function HomeView() {
   const canSend = !!agent && blocked === null && members.every(agentReady)
   const daemonHref = owningDaemon ? orgPath(`/daemons/${owningDaemon.daemonId}`) : null
 
+  const onImageFile = async (file: File | undefined): Promise<void> => {
+    if (!file || imagePreparing) return
+    setMenu(null)
+    setImagePreparing(true)
+    setImageError(null)
+    try {
+      setImage(await prepareWebchatImage(file))
+    } catch (error) {
+      setImageError(error instanceof Error ? error.message : 'Couldn’t prepare that image.')
+    } finally {
+      setImagePreparing(false)
+      if (imageInputRef.current) imageInputRef.current.value = ''
+    }
+  }
+
   const send = () => {
     const text = input.trim()
-    if (!text || !agent || !canSend) return // offline / unsigned-in agents can't take a session
+    if ((!text && !image) || imagePreparing) return
+    if (!agent || !canSend) return // offline / unsigned-in agents can't take a session
     const id = openPlayground(agent, members, !multi && githubWorkspace ? { worktree } : undefined)
     // Stage the EFFECTIVE (displayed) runtime before the turn — not just explicit
     // overrides — so the session runs exactly what the composer showed. stageRuntimeChange
@@ -257,8 +281,12 @@ export default function HomeView() {
       if (effort) pgSetEffort(id, agent.id, effort)
       if (permissionPreset) pgSetPermissionPreset(id, agent.id, permissionPreset)
     }
-    pgSend(id, agent.id, text)
+    // The image rides as an explicit argument: the session id was just minted, so
+    // a setPgImage(id) state write could not land before this same-tick send.
+    pgSend(id, agent.id, text, undefined, undefined, image)
     setInput('')
+    setImage(undefined)
+    setImageError(null)
     router.push(orgPath(`/sessions/${id}`))
   }
 
@@ -375,10 +403,47 @@ export default function HomeView() {
       {/* Composer — hands off to a live session on send. The footer selectors mirror
           the design: agent + model as pills (leading mark), effort + permission as
           chips. Each picks the run's runtime; the choice is applied on send. */}
-      <div className="card mb-3 overflow-visible">
+      <div
+        className="card mb-3 overflow-visible"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') setMenu(null)
+        }}
+      >
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(event) => void onImageFile(event.target.files?.[0])}
+        />
+        {image && (
+          <div className="relative mx-[15px] mt-3 w-fit">
+            <img
+              src={`data:${image.mimeType};base64,${image.data}`}
+              alt={image.name}
+              title={image.name}
+              className="h-20 w-20 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) object-cover"
+            />
+            <button
+              type="button"
+              className="iconbtn absolute -right-2 -top-2 h-6 w-6 rounded-full shadow-(--shadow-xs)"
+              title="Remove image"
+              aria-label="Remove image"
+              onClick={() => setImage(undefined)}
+            >
+              <Icon name="x" size={14} />
+            </button>
+          </div>
+        )}
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onPaste={(event) => {
+            const file = clipboardImageFile(event.clipboardData)
+            if (!file) return
+            event.preventDefault()
+            void onImageFile(file)
+          }}
           onKeyDown={(e) => {
             // Enter sends, except during IME composition (candidate-confirming Enter)
             // or with Shift (newline).
@@ -394,7 +459,48 @@ export default function HomeView() {
         {/* items-start + a wrapping selector group so the controls reflow onto a second
             row at phone widths instead of overflowing (mobile .content clips overflow-x);
             the send button stays pinned top-right. */}
+        {imageError && (
+          <div className="px-[15px] pb-2 font-sans text-[11.5px] font-medium leading-normal text-(--red-600)">
+            {imageError}
+          </div>
+        )}
         <div className="flex items-start gap-2 border-t border-(--border-subtle) py-[7px] pr-[9px] pl-[10px]">
+          <div className="relative flex-none">
+            <button
+              type="button"
+              className="flex h-7 w-7 flex-none cursor-pointer items-center justify-center rounded-md border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-secondary)"
+              aria-label="Attach a file"
+              aria-haspopup="menu"
+              aria-expanded={menu === 'attach'}
+              title="Attach a file"
+              disabled={imagePreparing}
+              onClick={() => setMenu((cur) => (cur === 'attach' ? null : 'attach'))}
+            >
+              {imagePreparing ? <Spinner size={14} /> : <Icon name="paperclip" size={15} />}
+            </button>
+            {menu === 'attach' && (
+              <>
+                <div aria-hidden="true" className="fixed inset-0 z-40" onClick={() => setMenu(null)}></div>
+                <div
+                  role="menu"
+                  className="absolute top-[calc(100%+8px)] left-0 z-50 w-[166px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="fopt"
+                    onClick={() => {
+                      setMenu(null)
+                      imageInputRef.current?.click()
+                    }}
+                  >
+                    <Icon name="image" size={16} color="var(--text-secondary)" />
+                    Add photos
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
             {agent ? (
               <>
@@ -523,7 +629,7 @@ export default function HomeView() {
           <button
             type="button"
             className="sendbtn h-7 w-7 flex-none rounded-[7px]"
-            disabled={!input.trim() || !canSend}
+            disabled={(!input.trim() && !image) || !canSend || imagePreparing}
             onClick={send}
             title={
               blocked === 'offline'


### PR DESCRIPTION
## What changed

**Home composer now supports Attach File** (mirrors the session composer):
- Paperclip button with an "Add photos" menu, hidden `<input type="file" accept="image/*">`, and clipboard image paste on the textarea.
- Images run through the same `prepareWebchatImage` pipeline (≤160 KiB WebP, protocol frame budget), show an 80×80 preview chip with remove, and image-only sends are allowed (send stays disabled while preparing).
- `pgSend` gained an optional explicit `image` argument: Home mints the session id via `openPlayground` in the same tick as the send, so a `setPgImage(id)` state write could not land before `pgSend` reads it. The session composer's staged-image path is unchanged (`imageArg ?? pgImageBy[id]`).
- New regression test: attach → image-only send → `pgSend` receives the image → composer clears.

**fix(daemon): reopened webchat sessions showed `[attached: …]` instead of the image**
- The turn-final-refresh admission write (`dispatchWebchatTurn`, gated on `post` + the default-on `turnFinalContextRefresh` flag) claims the transcript slot with the canonical post ts before SessionManager's authoritative append, and `INSERT OR IGNORE` dedups the later copy — but it omitted the bounded inline image, pinning `attachmentsJson` to NULL. The session reader then could neither strip the replay suffix nor return the image.
- Real relay traffic always mints `post`, so **every** webchat image hit this; the existing coverage passed only because its turn op carried no `post`. Added the post-carrying regression test (verified red without the fix).
- Rows written before this fix keep the label permanently — the image bytes were never persisted.

**Getting started moved out of the account popup into Help & resources:**
- The Help & resources menu previously rendered the entry only in no-auth mode; it now shows in both modes as the first item.
- The account menu drops its copy. The mobile More sheet keeps its own entry (the rail and both desktop menus are hidden at mobile widths).

## Review notes

- `pgSend`'s new parameter is positional arg #6, matching the existing signature style; only HomeView passes it.
- Web tests: 703 passed; daemon-webchat: 38 passed; typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)