### PR TITLE
fix(web): group live conversation turns by stream identity

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -418,11 +418,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  thinking / message chunks accumulate into a single PLAN / DONE lane so the
    *  bot turn reads as one block instead of one row per delta. */
   const applyEvent = useCallback(
-    (id: string, ev: WebchatEvent, agentId?: string): void => {
+    (id: string, ev: WebchatEvent, agentId: string | undefined, turnId: string): void => {
       const observedAtMs = Date.now()
       const who = participantName(id, agentId)
       const lane = (extra: Omit<SessionStep, 'text'> & { text: string }): SessionStep =>
-        stampStep({ ...extra, ...(agentId ? { agentId } : {}), ...(who ? { who } : {}) }, observedAtMs)
+        stampStep({ ...extra, turnId, ...(agentId ? { agentId } : {}), ...(who ? { who } : {}) }, observedAtMs)
       mutateSteps(id, (steps) => {
         // Concurrent participant streams interleave: accumulate each chunk into
         // the most recent step OF THIS LANE (same agentId), not the array tail.
@@ -434,6 +434,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             const step = steps[i]!
             if (step.kind === 'msg' && step.agentId === undefined) return -1
             if ((step.agentId ?? undefined) !== agentId) continue
+            // A stable stream turn is also a hard boundary. This covers
+            // coalesced/resumed turns that have no newly pushed user row.
+            if (step.turnId !== turnId) return -1
             // The supersession marker is a hard boundary: the replacement
             // generation starts fresh blocks instead of merging into it (or
             // into the collapsed discarded work behind it).
@@ -459,6 +462,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             const step = collapsed[i]!
             if (step.kind === 'msg' && step.agentId === undefined) break
             if ((step.agentId ?? undefined) !== agentId) continue
+            if (step.turnId !== turnId) break
             if (step.boundary) break
             if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan' }
           }
@@ -596,7 +600,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         const event = output.event
         if (event) {
           if (event.kind === 'session_info') applyTitle(id, event.title, agentId)
-          else applyEvent(id, event, agentId)
+          else applyEvent(id, event, agentId, output.turnId)
         }
       }
       if (!result.done) return
@@ -612,6 +616,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         const name = participantName(id, agentId)
         pushStep(id, {
           kind: 'done',
+          turnId: result.done.turnId,
           ...(agentId ? { agentId } : {}),
           ...(name ? { who: name } : {}),
           text: `⚠️ ${result.done.error}`
@@ -866,6 +871,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 const name = participantName(id, agentId)
                 pushStep(id, {
                   kind: 'done',
+                  ...(m.ack.turnId ? { turnId: m.ack.turnId } : {}),
                   ...(agentId ? { agentId } : {}),
                   ...(name ? { who: name } : {}),
                   text:
@@ -1034,9 +1040,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       conversationId?: string,
       knownParticipants?: Array<{ agentId: string; name: string; primary?: boolean }>
     ): void => {
-      pushStep(id, { kind: 'msg', who: '@you', text, ...(image ? { image } : {}) })
-      setBusy(id, true)
       const requestedTurnId = crypto.randomUUID()
+      pushStep(id, { kind: 'msg', who: '@you', turnId: requestedTurnId, text, ...(image ? { image } : {}) })
+      setBusy(id, true)
       // Targeting (webchat-multi-agents.md §4.2): conversation membership is a
       // STANDING mention — an unmentioned message goes to the WHOLE roster
       // (each agent may silently decline); explicit @mentions narrow the turn
@@ -1114,6 +1120,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           const conflict = err instanceof ApiError && err.status === 409 ? err.message : undefined
           pushStep(id, {
             kind: 'done',
+            turnId: requestedTurnId,
             text: noRelay
               ? '⚠️ Webchat relay not configured — set PUBLIC_RELAY_URL on the control plane.'
               : conflict

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -11,7 +11,7 @@ import {
   type ReactNode
 } from 'react'
 import Link from 'next/link'
-import { sameBotSpeaker } from '@/lib/bot-turn-grouping'
+import { liveBotTurnKey, sameBotSpeaker } from '@/lib/bot-turn-grouping'
 import { mergeConversation, type MergeSource } from '@/lib/conversation-merge'
 import { focusAction } from '@/lib/conversation-focus'
 import { encodeConversationKey } from '@/lib/conversation-key'
@@ -2177,21 +2177,21 @@ export default function SessionDetailView() {
     })
     turns.push(turn)
   }
-  const conversationTurnByKey = new Map<string, Extract<Turn, { kind: 'bot' }>>()
+  const botTurnByKey = new Map<string, Extract<Turn, { kind: 'bot' }>>()
   // Another agent speaking in this session — a webchat peer participant or a
   // trusted a2a bot — renders as its own left-side agent block: the right side
   // is reserved for humans. Conversation rows retain their source-local turn;
-  // every other path groups consecutive rows like live bot steps.
-  const pushAgentTurn = (agent: Agent, step: FmtStep, sourceTurnKey?: string): void => {
+  // live rows retain their stream turn; untagged legacy rows group by adjacency.
+  const pushAgentTurn = (agent: Agent, step: FmtStep, turnKey?: string): void => {
     const name = agentLabel(agent)
     rememberAgentParticipant(agent.id, name, agent)
-    let last = sourceTurnKey ? conversationTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
+    let last = turnKey ? botTurnByKey.get(turnKey) : turns[turns.length - 1]
     if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: agent.id, agentName: name })) {
       // `model` is the icon-runtime fallback for turns whose agent is missing from
       // `agentById`; a peer turn's agent came FROM that map, so it stays empty.
       last = { kind: 'bot', agentName: name, agentId: agent.id, model: '', time: '', steps: [] }
       turns.push(last)
-      if (sourceTurnKey) conversationTurnByKey.set(sourceTurnKey, last)
+      if (turnKey) botTurnByKey.set(turnKey, last)
     }
     last.steps.push(step)
     if (!last.time && step.time) last.time = step.time
@@ -2203,7 +2203,7 @@ export default function SessionDetailView() {
       const toolSessionId = conversationSourceSessionByMessageRef.current.get(m)
       const sourceTurnKey = conversationSourceTurnByMessageRef.current.get(m)
       if (m.sender === session.agentId) {
-        let last = sourceTurnKey ? conversationTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
+        let last = sourceTurnKey ? botTurnByKey.get(sourceTurnKey) : turns[turns.length - 1]
         const ownerName = session.agentName ?? ''
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: m.sender, agentName: ownerName })) {
           last = {
@@ -2215,7 +2215,7 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
-          if (sourceTurnKey) conversationTurnByKey.set(sourceTurnKey, last)
+          if (sourceTurnKey) botTurnByKey.set(sourceTurnKey, last)
         }
         const step = msgStep(m, toolSessionId)
         last.steps.push(step)
@@ -2269,7 +2269,11 @@ export default function SessionDetailView() {
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const self = isSelf(who)
         if (senderAgent && !self) {
-          pushAgentTurn(senderAgent, plainStep(stp.text, stp.time ?? (firstMsg ? session.time : ''), stp.image))
+          pushAgentTurn(
+            senderAgent,
+            plainStep(stp.text, stp.time ?? (firstMsg ? session.time : ''), stp.image),
+            liveBotTurnKey(stp.turnId, senderAgent.id)
+          )
           firstMsg = false
           return
         }
@@ -2301,7 +2305,8 @@ export default function SessionDetailView() {
         if (stp.agentId && stp.agentId !== session.agentId) {
           rememberAgentParticipant(stp.agentId, stepAgentName, stepAgent ?? null)
         }
-        let last = turns[turns.length - 1]
+        const turnKey = liveBotTurnKey(stp.turnId, stp.agentId)
+        let last = turnKey ? botTurnByKey.get(turnKey) : turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
             kind: 'bot',
@@ -2312,6 +2317,7 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
+          if (turnKey) botTurnByKey.set(turnKey, last)
         } else if (stp.agentId && last.agentId === undefined) {
           // A tagged step continuing an untagged block names its author retroactively.
           last.agentId = stp.agentId
@@ -2333,7 +2339,11 @@ export default function SessionDetailView() {
         const senderAgentName = senderAgent ? agentLabel(senderAgent) : undefined
         const self = isSelf(who)
         if (senderAgent && !self) {
-          pushAgentTurn(senderAgent, plainStep(stp.text, stp.time ?? '', stp.image))
+          pushAgentTurn(
+            senderAgent,
+            plainStep(stp.text, stp.time ?? '', stp.image),
+            liveBotTurnKey(stp.turnId, senderAgent.id)
+          )
           continue
         }
         const participant = self ? speaker('@you') : speaker(senderAgentName ?? who, senderAgentName)
@@ -2356,7 +2366,8 @@ export default function SessionDetailView() {
         if (stp.agentId && stp.agentId !== session.agentId) {
           rememberAgentParticipant(stp.agentId, stepAgentName, stepAgent ?? null)
         }
-        let last = turns[turns.length - 1]
+        const turnKey = liveBotTurnKey(stp.turnId, stp.agentId)
+        let last = turnKey ? botTurnByKey.get(turnKey) : turns[turns.length - 1]
         if (!last || last.kind !== 'bot' || !sameBotSpeaker(last, { agentId: stp.agentId, agentName: stepAgentName })) {
           last = {
             kind: 'bot',
@@ -2367,6 +2378,7 @@ export default function SessionDetailView() {
             steps: []
           }
           turns.push(last)
+          if (turnKey) botTurnByKey.set(turnKey, last)
         } else if (stp.agentId && last.agentId === undefined) {
           // A tagged step continuing an untagged block names its author retroactively.
           last.agentId = stp.agentId

--- a/packages/web/src/lib/bot-turn-grouping.test.ts
+++ b/packages/web/src/lib/bot-turn-grouping.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { sameBotSpeaker } from './bot-turn-grouping'
+import { liveBotTurnKey, sameBotSpeaker } from './bot-turn-grouping'
 
 const A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 describe('bot turn grouping', () => {
+  it('keys interleaved live blocks by both turn and participant', () => {
+    const turn = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    expect(liveBotTurnKey(turn, A)).toBe(liveBotTurnKey(turn, A))
+    expect(liveBotTurnKey(turn, A)).not.toBe(liveBotTurnKey(turn, B))
+    expect(liveBotTurnKey(turn, A)).not.toBe(liveBotTurnKey('dddddddd-dddd-4ddd-8ddd-dddddddddddd', A))
+    expect(liveBotTurnKey(undefined, A)).toBeUndefined()
+  })
+
   it('splits two participants that share a display name', () => {
     // The regression: two distinct agents labeled identically must not merge
     // into one block (whose avatar/runtime would belong to the first).

--- a/packages/web/src/lib/bot-turn-grouping.ts
+++ b/packages/web/src/lib/bot-turn-grouping.ts
@@ -4,6 +4,11 @@
 // comparison remains only for legacy untagged steps (pre-multi-agent daemons,
 // locally pushed warning steps), which have nothing else to group by.
 
+/** Stable block identity for one participant's output in a live webchat turn. */
+export function liveBotTurnKey(turnId: string | undefined, agentId: string | undefined): string | undefined {
+  return turnId ? `live:${turnId}:${agentId ?? ''}` : undefined
+}
+
 /** Whether a live step continues the previous bot block. */
 export function sameBotSpeaker(
   prev: { agentId?: string | undefined; agentName: string },

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -837,6 +837,9 @@ export interface SessionImage {
 export interface SessionStep {
   kind: LaneKind
   who?: string
+  /** Stable identity of the live webchat turn. Pair with `agentId` when
+   *  folding interleaved participant streams into conversation blocks. */
+  turnId?: string
   /** Authoring participant of a live multi-agent webchat step — keys the per-agent
    *  stream lane accumulation and the per-block attribution label. */
   agentId?: string


### PR DESCRIPTION
## Summary

- preserve the webchat stream `turnId` on live session steps
- group interleaved participant output by `(turnId, agentId)`
- keep superseded chunks and terminal errors inside the correct live turn

## Root cause

The wire protocol already supplied a stable turn identity, but `PlaygroundProvider` discarded it while folding stream events into `SessionStep`. The conversation renderer therefore fell back to adjacent-speaker grouping, so concurrent agent events split one logical reply into several blocks.

## Impact

During a live multi-agent conversation, each agent now renders as one block per user turn even when participant streams interleave. Legacy steps without a turn id retain the existing adjacency fallback.

## Validation

- `pnpm --filter @agentconnect.md/web test` (92 files, 707 tests)
- `pnpm --filter @agentconnect.md/web typecheck`
- pre-push `eslint .`

Created by Codex . GPT-5
