### PR TITLE
feat(control-plane): generic bot demux identity columns (S1b, D6)

### DIFF
--- a/packages/control-plane/prisma/migrations/20260803160000_bot_external_identity/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260803160000_bot_external_identity/migration.sql
@@ -1,0 +1,35 @@
+-- Generic bot demux identity (integration-plugin-architecture.md D6/§11):
+-- externalAppId/externalTenantId generalize (slackAppId, teamId), and
+-- platformConfig is the display-only per-platform bag the legacy display columns
+-- fold into once reads switch. Backfill keeps legacy NULL semantics: NULLs are
+-- distinct in the composite unique, so pre-capture Slack rows and backfilled
+-- tenantless rows (Feishu) are unaffected by the new fence — only NEW rows write
+-- the '-' tenant sentinel that makes (platform, externalAppId) unique.
+
+ALTER TABLE "bot" ADD COLUMN "externalAppId" TEXT;
+ALTER TABLE "bot" ADD COLUMN "externalTenantId" TEXT;
+ALTER TABLE "bot" ADD COLUMN "platformConfig" JSONB;
+
+-- Slack: the demux pair copies over verbatim (NULLs stay NULL).
+UPDATE "bot"
+SET "externalAppId" = "slackAppId", "externalTenantId" = "teamId"
+WHERE "platform" = 'slack';
+
+-- Feishu: the app id is the (tenantless) demux identity; region + app id also go
+-- to the display bag. Tenant stays NULL — these are legacy rows.
+UPDATE "bot"
+SET "externalAppId" = "feishuAppId",
+    "platformConfig" = jsonb_strip_nulls(
+      jsonb_build_object('feishuAppId', "feishuAppId", 'feishuRegion', "feishuRegion")
+    )
+WHERE "platform" = 'feishu'
+  AND ("feishuAppId" IS NOT NULL OR "feishuRegion" IS NOT NULL);
+
+-- Discord: display-only app id; no demux identity today.
+UPDATE "bot"
+SET "platformConfig" = jsonb_build_object('discordAppId', "discordAppId")
+WHERE "platform" = 'discord'
+  AND "discordAppId" IS NOT NULL;
+
+CREATE UNIQUE INDEX "bot_platform_externalAppId_externalTenantId_key"
+ON "bot"("platform", "externalAppId", "externalTenantId");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1740,6 +1740,19 @@ model Bot {
   // it would kill (the case where the relay already holds the newer assignment).
   credentialRevision    Int            @default(1)
   credentialInstalledAt DateTime?      @db.Timestamptz(6)
+  // ── generic bot demux identity (integration-plugin-architecture.md D6/§11) ──
+  // Generalizes (slackAppId, teamId): the platform's app-scoped id plus its tenant
+  // scope. NULL is reserved for LEGACY rows (pre-capture Slack installs keep
+  // today's NULLs-distinct semantics; backfilled tenantless rows keep NULL too); a
+  // NEW row on a tenantless platform writes the '-' sentinel so the composite
+  // unique below enforces (platform, externalAppId) uniqueness declaratively.
+  // Dual-write window: reads still ride the legacy per-platform columns; these are
+  // written alongside them until the legacy columns fold away.
+  externalAppId         String?
+  externalTenantId      String?
+  // Display-only per-platform bag (discordAppId / feishuAppId / feishuRegion fold
+  // here when reads switch). Never demux identity, never secret material.
+  platformConfig        Json?
   discordAppId          String? // Discord application (client) id, decoded from the bot token's first segment — lets the console offer a ready-made "Add to Discord" invite URL. Public metadata (it IS the bot's user id), NOT secret material.
   feishuAppId           String? // Feishu/Lark app id (cli_…), copied from the create request so Settings can deep-link to this app without reading bot_secret. Public metadata, NOT secret material.
   feishuRegion          String? // Feishu/Lark open-platform gateway for this app: 'feishu' (open.feishu.cn) | 'lark' (open.larksuite.com). NULL ⇒ 'feishu'. DURABLE home (survives uninstall) so a freed Lark bot reinstalls against the right gateway. Public config, NOT secret.
@@ -1771,6 +1784,12 @@ model Bot {
   // NULL teamIds (legacy bots) are distinct under Postgres semantics, so existing
   // rows are unaffected. Cross-org global: a workspace binds to exactly one org.
   @@unique([slackAppId, teamId])
+  // The generic successor of the fence above (D6): one Bot per external app
+  // identity per platform. Legacy rows carry NULLs (distinct, unaffected); new
+  // tenantless rows carry the '-' sentinel, which makes this enforce
+  // (platform, externalAppId) uniqueness. Coexists with the Slack fence during
+  // the dual-write window.
+  @@unique([platform, externalAppId, externalTenantId])
   @@index([orgId])
   @@map("bot")
 }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -31,6 +31,7 @@ import { isDirectConversationKind } from '../../persistence/ports.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewSlackBot, slackAppIdFromAppToken } from '../install-slack.js'
 import { installNewFeishuBot } from '../install-feishu.js'
+import { BotExternalIdentityTaken } from '../../persistence/errors.js'
 import { discordAppIdFromBotToken } from '../discord-identity.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import {
@@ -577,23 +578,48 @@ export function integrationRoutes(deps: HttpDeps) {
                   'Could not resolve this app’s bot identity. Enable the bot capability in Feishu, then try again.'
               })
             }
+            // D6 fence: one Bot per Feishu app. New rows write the tenant sentinel,
+            // so the composite unique backstops the race below; this pre-check just
+            // turns the common case into a clean 409 with reuse guidance.
+            const identityTaken = await deps.repos.bot.getByExternalIdentity('feishu', feishu.appId, '-')
+            if (identityTaken) {
+              return reply.code(409).send({
+                error: 'Conflict',
+                statusCode: 409,
+                message:
+                  'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
+              })
+            }
             const provided = req.body.name?.trim()
             const derived = check?.status === 'ok' ? check.name : null
             const name = provided || derived || agent.name
-            const integration = await installNewFeishuBot(deps, app.log, {
-              orgId,
-              agent,
-              name,
-              appId: feishu.appId,
-              appSecret: feishu.appSecret,
-              region,
-              transport,
-              ...(check?.status === 'ok' && check.openId ? { botUserId: check.openId } : {}),
-              ...(feishu.verificationToken ? { verificationToken: feishu.verificationToken } : {}),
-              ...(feishu.encryptKey ? { encryptKey: feishu.encryptKey } : {}),
-              ...(req.principal ? { createdByUserId: req.principal.userId } : {})
-            })
-            return reply.code(201).send(toDto(integration))
+            try {
+              const integration = await installNewFeishuBot(deps, app.log, {
+                orgId,
+                agent,
+                name,
+                appId: feishu.appId,
+                appSecret: feishu.appSecret,
+                region,
+                transport,
+                ...(check?.status === 'ok' && check.openId ? { botUserId: check.openId } : {}),
+                ...(feishu.verificationToken ? { verificationToken: feishu.verificationToken } : {}),
+                ...(feishu.encryptKey ? { encryptKey: feishu.encryptKey } : {}),
+                ...(req.principal ? { createdByUserId: req.principal.userId } : {})
+              })
+              return reply.code(201).send(toDto(integration))
+            } catch (err) {
+              // Race backstop for the pre-check above: the composite unique fired.
+              if (err instanceof BotExternalIdentityTaken) {
+                return reply.code(409).send({
+                  error: 'Conflict',
+                  statusCode: 409,
+                  message:
+                    'This Feishu app is already registered as a bot. Reuse that bot (pick it under "Existing") instead of registering the app again.'
+                })
+              }
+              throw err
+            }
           }
 
           // Register a new Slack bot from pasted tokens. Validate against Slack BEFORE

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -33,6 +33,17 @@ export const PG_UNIQUE_VIOLATION = '23505'
  * addBotMembership` takes, so a concurrent admission and a disable serialize:
  * whichever commits second observes the first (no stale-snapshot bypass).
  */
+/** A Bot with this external app identity already exists on this platform (the D6
+ *  `(platform, externalAppId, externalTenantId)` fence, the generic successor of
+ *  `workspace_taken`). Mapped to 409 at the route. */
+export class BotExternalIdentityTaken extends Error {
+  readonly code = 'BOT_EXTERNAL_IDENTITY_TAKEN' as const
+  constructor(readonly platform: string) {
+    super(`a bot for this ${platform} app identity already exists`)
+    this.name = 'BotExternalIdentityTaken'
+  }
+}
+
 export class BotStillShared extends Error {
   readonly code = 'BOT_STILL_SHARED' as const
   constructor(readonly activeInstalls: number) {

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2415,6 +2415,15 @@ export interface BotRecord {
   /** When the current credential landed; null for bots created before the fence
    *  (their revocations skip the timestamp check and rely on the revision). */
   credentialInstalledAt: Date | null
+  /** Generic demux identity (D6): the platform's app-scoped id. Dual-written beside
+   *  the legacy per-platform columns; NULL on legacy rows. */
+  externalAppId: string | null
+  /** Tenant half of the demux identity (Slack team id). `'-'` sentinel on new rows
+   *  of tenantless platforms; NULL on legacy rows (NULLs-distinct semantics). */
+  externalTenantId: string | null
+  /** Display-only per-platform bag (discordAppId / feishuAppId / feishuRegion fold
+   *  here when reads switch). */
+  platformConfig: Record<string, unknown> | null
   /** Discord application (client) id — lets the console offer a ready-made invite URL. */
   discordAppId: string | null
   /** Feishu/Lark app id — lets the console deep-link to this app's developer settings. */
@@ -2466,6 +2475,10 @@ export interface BotRepo {
   /** The Bot backing one workspace install of a distributed app — CROSS-ORG lookup
    *  by the composite demux key (a workspace binds to exactly one org). */
   getBySlackAppTeam(slackAppId: string, teamId: string): Promise<BotRecord | null>
+  /** CROSS-ORG lookup by the generic demux identity (D6). Pass the `'-'` sentinel
+   *  as `externalTenantId` for tenantless platforms. Legacy rows (NULL identity)
+   *  are unreachable here by design. */
+  getByExternalIdentity(platform: string, externalAppId: string, externalTenantId: string): Promise<BotRecord | null>
   /**
    * A fresh credential landed on an EXISTING bot (platform re-install / token
    * rotation): advance the install generation, stamp when it landed, and clear

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -12,7 +12,7 @@
 import type { Platform, FeishuRegion } from '@agentconnect.md/protocol'
 import type { Bot, Integration, IntegrationChannel, User } from '../../generated/prisma/client.js'
 import { withAmbientTx, type PrismaLike } from '../prisma.js'
-import { BotStillShared } from '../errors.js'
+import { BotExternalIdentityTaken, BotStillShared } from '../errors.js'
 import type {
   BotRepo,
   BotRecord,
@@ -59,6 +59,9 @@ function toBotRecord(b: BotJoined): BotRecord {
     prebuilt: b.prebuilt,
     slackAppId: b.slackAppId,
     teamId: b.teamId,
+    externalAppId: b.externalAppId,
+    externalTenantId: b.externalTenantId,
+    platformConfig: (b.platformConfig as Record<string, unknown> | null) ?? null,
     workspaceId: b.workspaceId,
     workspaceName: b.workspaceName,
     botUserId: b.botUserId,
@@ -83,36 +86,93 @@ function toBotRecord(b: BotJoined): BotRecord {
   }
 }
 
+/** Tenant sentinel for NEW rows of tenantless platforms (D6/§11): a real value —
+ *  unlike NULL — participates in the composite unique, so it is what makes
+ *  `(platform, externalAppId)` enforceable. NULL stays reserved for legacy rows. */
+export const TENANTLESS_SENTINEL = '-'
+
+/** Derive the D6 generic identity dual-write from the legacy per-platform input
+ *  fields. Reads stay on the legacy columns during the dual-write window; this
+ *  only keeps the generic columns in lockstep for every NEW row. */
+function botExternalIdentity(input: CreateBotInput): {
+  externalAppId?: string
+  externalTenantId?: string
+  platformConfig?: Record<string, string>
+} {
+  switch (input.platform) {
+    case 'slack':
+      // Tenant-scoped: the pair mirrors (slackAppId, teamId) verbatim. A manual
+      // single-workspace install without a captured identity keeps NULLs — the
+      // same pre-capture semantics the legacy fence has today.
+      return {
+        ...(input.slackAppId ? { externalAppId: input.slackAppId } : {}),
+        ...(input.teamId ? { externalTenantId: input.teamId } : {})
+      }
+    case 'feishu': {
+      const bag = {
+        ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
+        ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {})
+      }
+      return {
+        // App-scoped identity (no tenant axis): the cli_ app id + the sentinel,
+        // which turns the composite unique into a one-bot-per-Feishu-app fence.
+        ...(input.feishuAppId ? { externalAppId: input.feishuAppId, externalTenantId: TENANTLESS_SENTINEL } : {}),
+        ...(Object.keys(bag).length ? { platformConfig: bag } : {})
+      }
+    }
+    case 'discord':
+      // Display-only app id; Discord has no ingress demux identity today.
+      return input.discordAppId ? { platformConfig: { discordAppId: input.discordAppId } } : {}
+    default:
+      return {}
+  }
+}
+
 export class PgBotRepo implements BotRepo {
   constructor(private readonly db: PrismaLike) {}
 
   async create(input: CreateBotInput): Promise<BotRecord> {
-    const b = await this.db.bot.create({
-      data: {
-        id: input.id,
-        orgId: input.orgId,
-        platform: toDbPlatform(input.platform),
-        name: input.name,
-        ...(input.prebuilt !== undefined ? { prebuilt: input.prebuilt } : {}),
-        ...(input.slackAppId ? { slackAppId: input.slackAppId } : {}),
-        ...(input.teamId ? { teamId: input.teamId } : {}),
-        ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
-        ...(input.workspaceName ? { workspaceName: input.workspaceName } : {}),
-        ...(input.botUserId ? { botUserId: input.botUserId } : {}),
-        ...(input.discordAppId ? { discordAppId: input.discordAppId } : {}),
-        ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
-        ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {}),
-        ...(input.shareable !== undefined ? { shareable: input.shareable } : {}),
-        ...(input.transport !== undefined ? { transport: input.transport } : {}),
-        // Generation 1 (the column default) lands NOW — so a lifecycle event that
-        // predates this credential is fenced out even on a bot's first install.
-        // Legacy rows keep a null stamp and fall back to the revision arm alone.
-        credentialInstalledAt: new Date(),
-        ...(input.createdByUserId ? { createdByUserId: input.createdByUserId } : {})
-      },
-      include: botInclude
-    })
-    return toBotRecord(b)
+    try {
+      const b = await this.db.bot.create({
+        data: {
+          id: input.id,
+          orgId: input.orgId,
+          platform: toDbPlatform(input.platform),
+          name: input.name,
+          ...(input.prebuilt !== undefined ? { prebuilt: input.prebuilt } : {}),
+          ...(input.slackAppId ? { slackAppId: input.slackAppId } : {}),
+          ...(input.teamId ? { teamId: input.teamId } : {}),
+          ...botExternalIdentity(input),
+          ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+          ...(input.workspaceName ? { workspaceName: input.workspaceName } : {}),
+          ...(input.botUserId ? { botUserId: input.botUserId } : {}),
+          ...(input.discordAppId ? { discordAppId: input.discordAppId } : {}),
+          ...(input.feishuAppId ? { feishuAppId: input.feishuAppId } : {}),
+          ...(input.feishuRegion ? { feishuRegion: input.feishuRegion } : {}),
+          ...(input.shareable !== undefined ? { shareable: input.shareable } : {}),
+          ...(input.transport !== undefined ? { transport: input.transport } : {}),
+          // Generation 1 (the column default) lands NOW — so a lifecycle event that
+          // predates this credential is fenced out even on a bot's first install.
+          // Legacy rows keep a null stamp and fall back to the revision arm alone.
+          credentialInstalledAt: new Date(),
+          ...(input.createdByUserId ? { createdByUserId: input.createdByUserId } : {})
+        },
+        include: botInclude
+      })
+      return toBotRecord(b)
+    } catch (err) {
+      // The D6 composite unique fired: a bot with this external app identity
+      // already exists on this platform. Typed so routes can 409 instead of 500.
+      // The legacy (slackAppId, teamId) unique keeps its existing callers'
+      // handling; only the new index maps here.
+      if (
+        (err as { code?: string }).code === 'P2002' &&
+        String((err as { meta?: { target?: unknown } }).meta?.target ?? '').includes('externalAppId')
+      ) {
+        throw new BotExternalIdentityTaken(input.platform)
+      }
+      throw err
+    }
   }
 
   async get(id: BotId): Promise<BotRecord | null> {
@@ -148,7 +208,13 @@ export class PgBotRepo implements BotRepo {
   }
 
   async setSlackAppIdIfMissing(id: BotId, slackAppId: string): Promise<boolean> {
-    const result = await this.db.bot.updateMany({ where: { id, slackAppId: null }, data: { slackAppId } })
+    // Dual-write (D6): the generic column tracks the legacy one. The tenant half
+    // stays NULL here — the reconciler backfills legacy socket bots, whose
+    // pre-capture NULLs-distinct semantics must be preserved.
+    const result = await this.db.bot.updateMany({
+      where: { id, slackAppId: null },
+      data: { slackAppId, externalAppId: slackAppId }
+    })
     return result.count === 1
   }
 
@@ -188,6 +254,20 @@ export class PgBotRepo implements BotRepo {
     // callback must find it wherever it lives to refuse a second org's claim.
     const b = await this.db.bot.findUnique({
       where: { slackAppId_teamId: { slackAppId, teamId } },
+      include: botInclude
+    })
+    return b ? toBotRecord(b) : null
+  }
+
+  async getByExternalIdentity(
+    platform: string,
+    externalAppId: string,
+    externalTenantId: string
+  ): Promise<BotRecord | null> {
+    // Cross-org on purpose, mirroring getBySlackAppTeam: an external app identity
+    // binds to exactly one org, and a second org's claim must find it to refuse.
+    const b = await this.db.bot.findUnique({
+      where: { platform_externalAppId_externalTenantId: { platform, externalAppId, externalTenantId } },
       include: botInclude
     })
     return b ? toBotRecord(b) : null

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -298,6 +298,12 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // The application (client) id is decoded from the token and persisted (public metadata).
     const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
     expect(bot).toMatchObject({ platform: 'discord', discordAppId: '123456789012345678', slackAppId: null })
+    // D6: Discord has no demux identity — only the display bag is written.
+    expect(bot).toMatchObject({
+      externalAppId: null,
+      externalTenantId: null,
+      platformConfig: { discordAppId: '123456789012345678' }
+    })
 
     // The daemon got a discord-shaped spec (single botToken, no slack block).
     expect(spy.upserts).toHaveLength(1)
@@ -422,6 +428,13 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect(secret).toMatchObject({ botToken: FEISHU.appSecret, appToken: FEISHU.appId })
     const bot = await prisma.bot.findUnique({ where: { id: dto.botId as string } })
     expect(bot).toMatchObject({ platform: 'feishu', feishuAppId: FEISHU.appId, feishuRegion: 'lark' })
+    // D6 dual-write: the generic demux identity carries the app id with the
+    // tenantless '-' sentinel, and the display bag holds the fold-ahead fields.
+    expect(bot).toMatchObject({
+      externalAppId: FEISHU.appId,
+      externalTenantId: '-',
+      platformConfig: { feishuAppId: FEISHU.appId, feishuRegion: 'lark' }
+    })
 
     // The bot roster exposes only the public app id + region needed for the
     // developer-console link; the secret never leaves bot_secret.
@@ -448,6 +461,55 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       feishu: { appId: FEISHU.appId, appSecret: FEISHU.appSecret, region: 'lark' }
     })
     expect(dto.region).toBe('lark')
+  })
+
+  it('POST feishu refuses a SECOND bot for the same Feishu app (D6 identity fence), and slack dual-writes its pair', async () => {
+    const agentId = await placedAgent()
+    const agentId2 = randomUUID()
+    await seedAgent(prisma, agentId2, { daemonId: DAEMON })
+    const { app } = withSpy()
+
+    const FEISHU = { appId: 'cli_dupfence01', appSecret: 'first-secret-value' }
+    const first = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'feishu', agentId, feishu: FEISHU }
+    })
+    expect(first.statusCode).toBe(201)
+
+    // Same Feishu app pasted again (even by another agent, even with a different
+    // secret): one Bot per external app identity — reuse the existing bot instead.
+    const dup = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'feishu', agentId: agentId2, feishu: { appId: FEISHU.appId, appSecret: 'other-secret' } }
+    })
+    expect(dup.statusCode).toBe(409)
+    expect((dup.json() as { message: string }).message).toContain('already registered')
+
+    // Slack manual create with a parsable xapp: the generic pair mirrors
+    // (slackAppId, teamId) — app id captured, tenant NULL until OAuth captures it
+    // (pre-capture rows keep NULLs-distinct semantics, so no fence engages).
+    const slackRes = await app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: {
+        platform: 'slack',
+        agentId: agentId2,
+        slack: { botToken: SLACK.botToken, appToken: 'xapp-1-A0DUALW01-123-abcdef' }
+      }
+    })
+    expect(slackRes.statusCode).toBe(201)
+    const slackBot = await prisma.bot.findUnique({
+      where: { id: (slackRes.json() as { botId: string }).botId }
+    })
+    expect(slackBot).toMatchObject({
+      slackAppId: 'A0DUALW01',
+      teamId: null,
+      externalAppId: 'A0DUALW01',
+      externalTenantId: null,
+      platformConfig: null
+    })
   })
 
   it('POST an HTTP Feishu app assigns callback-only secrets and keeps API egress on the daemon', async () => {
@@ -586,13 +648,15 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     expect((named.json() as { name: string }).name).toBe('Matrix Bot')
 
     // Unreachable is best-effort, not a gate: a second agent installs fine, name falls back.
+    // (A different app id — registering the SAME Feishu app twice is refused by the
+    // D6 external-identity fence, covered in its own test.)
     const agentId2 = randomUUID()
     await seedAgent(prisma, agentId2, { daemonId: DAEMON })
     app.deps.verifyFeishuBot = async () => ({ status: 'unreachable' })
     const unreachable = await app.app.inject({
       method: 'POST',
       url: `${ORG}/integrations`,
-      payload: { platform: 'feishu', agentId: agentId2, feishu: { appId: 'cli_a', appSecret: 's' } }
+      payload: { platform: 'feishu', agentId: agentId2, feishu: { appId: 'cli_b', appSecret: 's' } }
     })
     expect(unreachable.statusCode).toBe(201)
     expect((unreachable.json() as { name: string }).name).toBe(`agent-${agentId2.slice(0, 4)}`)


### PR DESCRIPTION
## What

Second **S1b** stage of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) D6/§11: `Bot` gains the generic demux identity — `externalAppId` / `externalTenantId`, the successor of `(slackAppId, teamId)` — plus the `platformConfig` display bag, guarded by a new composite unique `(platform, externalAppId, externalTenantId)` that coexists with the legacy Slack fence during the dual-write window.

## The NULL/sentinel rule (the load-bearing part of D6)

Postgres treats NULLs as distinct in unique indexes, so:
- **Backfill keeps legacy semantics**: Slack rows copy `(slackAppId, teamId)` verbatim (pre-capture NULLs stay NULL); Feishu rows copy the `cli_` app id with **tenant NULL** — legacy rows never engage the new fence.
- **New rows on a tenantless platform write the `'-'` sentinel**, which is what turns the composite unique into a declarative `(platform, externalAppId)` fence — no partial index, no `NULLS NOT DISTINCT` hazard.

## One deliberate behavior change

Registering the **same Feishu app twice** now 409s ("reuse that bot") instead of silently creating a second bot the relay demux could never serve — the generic `workspace_taken`. Implemented as a route pre-check plus a typed `BotExternalIdentityTaken` race backstop mapped from P2002 **on the new index only** (the legacy Slack fence keeps its existing handling). One existing test that incidentally pasted the same app twice (its intent was "unreachable verifier is not a gate") now uses distinct apps; the fence has its own test.

## Dual-write mechanics

All bot writes funnel through `PgBotRepo.create` + the reconciler's `setSlackAppIdIfMissing`; a single derivation helper keeps the generic columns in lockstep (slack mirrors its pair; feishu writes id+sentinel and folds appId/region into the bag; discord writes only the bag). **Reads stay entirely on the legacy columns** — `BotRecord` exposes the new fields for the later read-switch PR, and nothing on the wire changes.

## Verification

CP unit 1020 ✓ · CP integration 948 ✓ (migration backfill + the fence + slack/discord dual-write assertions exercised on real Postgres) · full-workspace typecheck ✓. No wire emission changes; independent of the S1a fleet gate.

Next S1b stages: the protocol restructures (`OriginKind`×`PlatformId`, `IntegrationSpec` envelope + codec shim, `NormalizedMessage` coords, `platform_action`, `rc/bot-assign`, §6.8 cron/hook targeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)