### PR TITLE
feat(protocol): carry origin-kind classification on the wire (S1b §6.1)

### DIFF
--- a/packages/control-plane/src/orchestrator/collabRoutes.service.ts
+++ b/packages/control-plane/src/orchestrator/collabRoutes.service.ts
@@ -15,7 +15,7 @@ import { NoConnection, type ControlSender } from './outbound.js'
 import type { RelayChannel } from '../ws/relay-registry.js'
 import type { AgentRepo, DaemonRecord, DaemonRepo, IntegrationRepo, OrgAgentRecord } from '../persistence/ports.js'
 import { buildCollabSnapshot } from './collabSnapshot.js'
-import type { CollabChannelRoute, CollabOrgAgent } from '@agentconnect.md/protocol'
+import type { CollabChannelRoute, CollabOrgAgent, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
 import type { OrgId } from '../domain/ids.js'
 
 export class CollabRoutesService {
@@ -41,21 +41,20 @@ export class CollabRoutesService {
   /** Build the combined snapshot across every org that has a daemon. Both the
    *  channel-keyed routes AND the flat per-org peer directory are all-org here, for the
    *  same reason: the relay table is a FULL replacement, so omitting an org wipes it. */
-  private async build(
-    daemonRows: DaemonRecord[],
-    generation: number
-  ): Promise<{ generation: number; channels: CollabChannelRoute[]; agents: CollabOrgAgent[] }> {
+  private async build(daemonRows: DaemonRecord[], generation: number): Promise<CollabRoutesSnapshot> {
     const orgIds = [...new Set(daemonRows.map((d) => d.orgId))]
     const channels: CollabChannelRoute[] = []
     const agents: CollabOrgAgent[] = []
+    let platformKinds: CollabRoutesSnapshot['platformKinds'] = []
     for (const orgId of orgIds) {
       const placements = await this.integrations.channelPlacements(orgId)
       const orgAgents = await this.agents.orgDirectory(orgId)
       const snapshot = buildCollabSnapshot(orgId, placements, generation, orgAgents)
       channels.push(...snapshot.channels)
       agents.push(...snapshot.agents)
+      platformKinds = snapshot.platformKinds // static classification — identical per org
     }
-    return { generation, channels, agents }
+    return { generation, channels, agents, platformKinds }
   }
 
   private durableGeneration(rows: DaemonRecord[]): number {

--- a/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.test.ts
@@ -63,6 +63,17 @@ describe('buildCollabSnapshot (agent-collaboration P2)', () => {
     expect(snap.channels[0]).toMatchObject({ orgId: DEFAULT_ORG_ID, platform: 'slack', channelId: 'C1' })
     expect(snap.channels[0].agents.map((a) => a.daemonId).sort()).toEqual([DAEMON_1, DAEMON_2].sort())
     expect(snap.channels[0].agents.map((a) => a.botAppId).sort()).toEqual(['A111', 'A222'])
+    // §6.1: every snapshot ships the emitter's origin-kind classification so an older
+    // peer can classify a platform id this CP introduces.
+    expect(snap.platformKinds).toEqual(
+      expect.arrayContaining([
+        { platformId: 'slack', originKind: 'chat' },
+        { platformId: 'feishu', originKind: 'chat' },
+        { platformId: 'webchat', originKind: 'webchat' },
+        { platformId: 'hook', originKind: 'hook' },
+        { platformId: 'dream', originKind: 'dream' }
+      ])
+    )
   })
 
   it('drops unplaced agents (daemonId null) — they are not routable', () => {

--- a/packages/control-plane/src/orchestrator/collabSnapshot.ts
+++ b/packages/control-plane/src/orchestrator/collabSnapshot.ts
@@ -14,7 +14,14 @@
  * caller; per-entry tombstone / TTL / fail-closed-on-stale is not implemented.
  */
 import type { CollabRoutesSnapshot, CollabChannelRoute, CollabOrgAgent } from '@agentconnect.md/protocol'
+import { KNOWN_PLATFORMS, originKindOf } from '@agentconnect.md/protocol'
 import type { ChannelPlacementRecord, OrgAgentRecord } from '../persistence/ports.js'
+
+// §6.1: the origin-kind classification for every platform id this CP build knows,
+// shipped on each snapshot so an OLDER daemon/relay can classify an id a newer CP
+// introduces. Static today (the seed and the emitted set coincide); the platform
+// registry replaces this list when providers land (S3).
+const PLATFORM_KINDS = KNOWN_PLATFORMS.map((id) => ({ platformId: id, originKind: originKindOf(id)! }))
 
 export function buildCollabSnapshot(
   orgId: string,
@@ -67,5 +74,5 @@ export function buildCollabSnapshot(
       ...(a.displayName !== null ? { displayName: a.displayName } : {})
     }))
 
-  return { generation, channels: [...byChannel.values()], agents }
+  return { generation, channels: [...byChannel.values()], agents, platformKinds: PLATFORM_KINDS }
 }

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -331,6 +331,9 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
 
     const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
     expect(assign).toBeTruthy() // broadcast to the connected relay pool
+    // §6.1: a bot assignment is always a chat platform; the kind teaches an older relay
+    // to classify an id a newer CP introduces.
+    expect(assign.originKind).toBe('chat')
 
     // members: one entry per daemon, agents grouped.
     const members = Object.fromEntries(assign.members.map((m) => [m.daemonId, m.agentIds.sort()]))

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -878,6 +878,9 @@ export class HttpBotOrchestrator {
     return {
       botId: bot.id,
       platform: compiled.platform,
+      // §6.1: a bot assignment is always a CHAT platform; carried so an older
+      // relay can classify an id a newer CP introduces.
+      originKind: 'chat',
       // Slack app id ("A…", == Events API api_app_id) — O(1) inbound demux. Absent on
       // a manual-paste http bot (no xapp to parse); the relay verify-scans instead.
       ...(bot.platform === 'feishu' && secret.appToken

--- a/packages/daemon/src/cp/cp-collab-routes.ts
+++ b/packages/daemon/src/cp/cp-collab-routes.ts
@@ -10,7 +10,7 @@
  * assumed. Documented in the PR description.
  */
 import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
-import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
+import { originKindOf } from '@agentconnect.md/protocol'
 
 export interface CollabResolved extends CollabAgentPlacement {
   orgId: string
@@ -63,6 +63,11 @@ export class CpCollabRoutes {
   // channel-keyed maps above structurally cannot express that (see CollabOrgAgent).
   private readonly byAgent = new Map<string, CollabOrgAgent>()
 
+  // §6.1 wire-carried origin-kind classification (snapshot `platformKinds`): how THIS
+  // build classifies a platform id a newer CP introduces. Overlaid on the protocol
+  // seed; an id neither classifies defaults to 'chat' (fail-closed in coordsDecision).
+  private readonly platformKinds = new Map<string, string>()
+
   private key(orgId: string, platform: string, channelId: string): string {
     return orgId + '\u0000' + platform + '\u0000' + channelId
   }
@@ -70,6 +75,11 @@ export class CpCollabRoutes {
   /** Coordinate-integrity key: deliberately PLATFORM-FREE — see {@link coordsDecision}. */
   private coordsKey(orgId: string, channelId: string): string {
     return orgId + '\u0000' + channelId
+  }
+
+  /** §6.1 kind resolution: wire classification → protocol seed → 'chat' (fail-closed). */
+  private originKindFor(platform: string): string {
+    return this.platformKinds.get(platform) ?? originKindOf(platform) ?? 'chat'
   }
 
   /** FULL-REPLACE from a CP snapshot (converge-don't-diff); ignore an older generation.
@@ -83,6 +93,8 @@ export class CpCollabRoutes {
     this.botAppsByChannel.clear()
     this.names.clear()
     this.byAgent.clear()
+    this.platformKinds.clear()
+    for (const k of snap.platformKinds ?? []) this.platformKinds.set(k.platformId, k.originKind)
     for (const ch of snap.channels) {
       const byAgent = new Map<string, CollabResolved>()
       const botApps = new Set<string>()
@@ -248,12 +260,14 @@ export class CpCollabRoutes {
       if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
     if (known) return { verdict: 'reject' }
-    // Registry-driven fail-closed default (S1a, integration-plugin-architecture.md §6.1):
-    // only the enumerated channel-free session identities take the synthetic branch; ANY
-    // other id — the four IM platforms and every id this build does not know — is
-    // chat-shaped and an unrecorded coordinate on it is refused. The old shape enumerated
-    // the IM platforms instead and silently ADMITTED unknown ids.
-    if (!isSessionIdentityPlatform(platform)) return { verdict: 'reject' }
+    // Registry-driven fail-closed default (§6.1): the platform's ORIGIN KIND decides the
+    // branch — wire-carried classification (snapshot `platformKinds`, for ids a newer CP
+    // introduces) overlaid on the protocol seed, defaulting to 'chat' for an id neither
+    // classifies. 'chat' ⇒ an unrecorded coordinate is refused, fail-closed. Any other
+    // classified kind is channel-free ⇒ synthetic, which is safe for kinds this build
+    // has never heard of too: the substituted coordinate derives from the TRUSTED caller
+    // and can never alias a platform session.
+    if (this.originKindFor(platform) === 'chat') return { verdict: 'reject' }
     return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
   }
 

--- a/packages/daemon/test/cp/cp-agent-directory.test.ts
+++ b/packages/daemon/test/cp/cp-agent-directory.test.ts
@@ -149,6 +149,29 @@ describe('CpCollabRoutes: org-scoped directory', () => {
     }
   })
 
+  it('coordsDecision: wire-carried platformKinds classify ids this build does not know', () => {
+    // §6.1: a NEWER CP ships the classification on every snapshot, so this (older) build
+    // can route an id it predates: a chat-classified id fails closed like the IM four; a
+    // channel-free-classified id takes the synthetic branch. Neither entry alters ids the
+    // built-in seed already covers, and an id classified by neither still defaults to
+    // 'chat' (the teams-x reject above).
+    const r = new CpCollabRoutes()
+    r.replace({
+      generation: 1,
+      channels: [{ orgId: ORG, platform: 'slack', channelId: 'C1', agents: [agent('a')] }],
+      agents: [agent('a'), agent('b')],
+      platformKinds: [
+        { platformId: 'teams-x', originKind: 'chat' },
+        { platformId: 'sandbox-x', originKind: 'sandbox' }
+      ]
+    } as never)
+    expect(r.coordsDecision(ORG, 'teams-x', 'C_NEVER_SEEN', 'a')).toEqual({ verdict: 'reject' })
+    expect(r.coordsDecision(ORG, 'sandbox-x', 'box-1', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    // The seed still answers for ids the wire did not classify.
+    expect(r.coordsDecision(ORG, 'dream', 'memory', 'a')).toEqual({ verdict: 'synthetic', channel: 'a2a:a' })
+    expect(r.coordsDecision(ORG, 'telegram', 'NOT_A_ROW', 'a')).toEqual({ verdict: 'reject' })
+  })
+
   it('coordsDecision: a DM row the caller owns is KNOWN, so DM-origin A2A keeps working', () => {
     // The over-block guard. A DM or group DM is an ORDINARY channel row wherever one exists —
     // `IntegrationChannel.kind` is `channel | im | mpim` and `channelPlacements` selects with

--- a/packages/protocol/src/frames/collab.ts
+++ b/packages/protocol/src/frames/collab.ts
@@ -102,6 +102,15 @@ export const CollabRoutesSnapshot = z.object({
    * the authorization input for channel-free A2A. `default([])` keeps a snapshot from
    * an older CP (which advertises no `agent-directory-org-scope-v1`) decodable.
    */
-  agents: z.array(CollabOrgAgent).default([])
+  agents: z.array(CollabOrgAgent).default([]),
+  /**
+   * §6.1 origin-kind classification for the platform ids the EMITTER knows — how an
+   * older peer classifies an id a newer CP introduces (its own built-in seed only
+   * covers ids its build shipped with). Consumers overlay these entries on their
+   * seed; an id classified by neither defaults to `'chat'`, the fail-closed answer
+   * wherever placements matter (`coordsDecision`). Both fields read as open strings
+   * per the S1a rule. `default([])` keeps a pre-S1b snapshot decodable.
+   */
+  platformKinds: z.array(z.object({ platformId: z.string().min(1), originKind: z.string().min(1) })).default([])
 })
 export type CollabRoutesSnapshot = z.infer<typeof CollabRoutesSnapshot>

--- a/packages/protocol/src/frames/register.ts
+++ b/packages/protocol/src/frames/register.ts
@@ -119,7 +119,7 @@ export const RegisterOk = z.object({
   // the reconnect BASELINE for this daemon's terminal-verify of REMOTE agent callers.
   // Scoped to channels this daemon's agents participate in. Hot changes ride the
   // `collaboration/routes` EVT. Defaulted so a pre-collab CP's snapshot still parses.
-  collabRoutes: CollabRoutesSnapshot.default({ generation: 0, channels: [], agents: [] }),
+  collabRoutes: CollabRoutesSnapshot.default({ generation: 0, channels: [], agents: [], platformKinds: [] }),
   drop: z.object({
     // things in localState the CP says to release
     assignments: z.array(z.string()),

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -565,6 +565,11 @@ export const RcBotAssign = z.object({
   // relay build supports; the relay's assign handler already refuses an
   // unsupported platform gracefully ("not yet supported"), never the socket.
   platform: Platform,
+  // §6.1: the platform's origin kind, so an older relay can classify an id a
+  // newer CP introduces (always 'chat' for a bot assignment today). Overlaid on
+  // the relay's built-in seed; absent (older CP) ⇒ the seed answers, and an id
+  // neither classifies defaults to 'chat' (fail-closed in coordsDecision).
+  originKind: z.string().min(1).optional(),
   botUserId: z.string().optional(), // resolved by CP; for echo suppression + mention match
   // Platform app id (Slack "A…", Feishu "cli_…") — lets the relay demux an
   // inbound POST to this bot in O(1). Slack may omit it for a legacy manual

--- a/packages/protocol/src/frames/route.ts
+++ b/packages/protocol/src/frames/route.ts
@@ -45,6 +45,22 @@ export type SessionIdentityPlatform = (typeof SESSION_IDENTITY_PLATFORMS)[number
 export function isSessionIdentityPlatform(p: string): p is SessionIdentityPlatform {
   return (SESSION_IDENTITY_PLATFORMS as readonly string[]).includes(p)
 }
+// D3: the origin-KIND axis. `chat` = an external chat platform (an open, growing
+// set); the session-identity kinds are core surfaces and each is its own kind. A
+// new KIND is a core change, never a platform module — but wire fields carrying a
+// kind still read as open strings (the S1a rule), so adding one is not
+// frame-fatal to older peers.
+export const ORIGIN_KINDS = ['chat', 'hook', 'dream', 'webchat'] as const
+export type OriginKind = (typeof ORIGIN_KINDS)[number]
+/** Classification seed for the platform ids THIS build knows. Wire-carried
+ *  entries (`CollabRoutesSnapshot.platformKinds`, `rc/bot-assign.originKind`)
+ *  extend it for ids a newer peer introduces (§6.1). `undefined` = an id neither
+ *  the seed nor the wire classified — consumers treat it as `'chat'`, the
+ *  fail-closed default wherever placements matter. */
+export function originKindOf(p: string): OriginKind | undefined {
+  if (isSessionIdentityPlatform(p)) return p
+  return isKnownPlatform(p) ? 'chat' : undefined
+}
 export const Platform = z.string().min(1)
 export type Platform = z.infer<typeof Platform>
 

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -3,8 +3,10 @@ import {
   decodeEnvelope,
   decodeRelayDaemonFrame,
   decodeRelayCpFrame,
+  CollabRoutesSnapshot,
   KNOWN_PLATFORMS,
-  isKnownPlatform
+  isKnownPlatform,
+  originKindOf
 } from './index.js'
 
 /**
@@ -191,6 +193,43 @@ describe('S1a tolerant platform readers — relay↔CP wire', () => {
     if (r.ok && r.frame.type === 'rc/bot-assign') {
       expect(r.frame.payload.platform).toBe(UNKNOWN)
     }
+  })
+})
+
+describe('§6.1 origin-kind classification on the wire', () => {
+  it('rc/bot-assign carries an optional originKind; absent stays decodable (older CP)', () => {
+    const base = {
+      botId: BOT_ID,
+      platform: UNKNOWN,
+      secrets: { botToken: 'xoxb-test', signingSecret: 'sig' },
+      members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+      routes: []
+    }
+    const withKind = decodeRelayCpFrame(envelope('rc/bot-assign', { ...base, originKind: 'chat' }))
+    expectOk(withKind)
+    if (withKind.ok && withKind.frame.type === 'rc/bot-assign') {
+      expect(withKind.frame.payload.originKind).toBe('chat')
+    }
+    const without = decodeRelayCpFrame(envelope('rc/bot-assign', base))
+    expectOk(without)
+  })
+
+  it('collab snapshots default platformKinds to [] (pre-S1b CP) and carry entries verbatim', () => {
+    const bare = CollabRoutesSnapshot.parse({ generation: 1 })
+    expect(bare.platformKinds).toEqual([])
+    const classified = CollabRoutesSnapshot.parse({
+      generation: 2,
+      platformKinds: [{ platformId: UNKNOWN, originKind: 'chat' }]
+    })
+    expect(classified.platformKinds).toEqual([{ platformId: UNKNOWN, originKind: 'chat' }])
+  })
+
+  it('originKindOf seeds the known ids and answers undefined for unknown ones', () => {
+    expect(originKindOf('slack')).toBe('chat')
+    expect(originKindOf('hook')).toBe('hook')
+    expect(originKindOf('dream')).toBe('dream')
+    expect(originKindOf('webchat')).toBe('webchat')
+    expect(originKindOf(UNKNOWN)).toBeUndefined()
   })
 })
 

--- a/packages/relay/src/agent-msg-router.test.ts
+++ b/packages/relay/src/agent-msg-router.test.ts
@@ -48,6 +48,7 @@ function placement(over: Partial<CollabAgentPlacement> & { agentId: string; daem
 function snap(): CollabRoutesSnapshot {
   return {
     generation: 1,
+    platformKinds: [],
     // The flat directory is the authorization surface; `channels[]` below only carries the
     // delivery/ingress facts (integration, bot app id).
     agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
@@ -343,6 +344,7 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     const router = new CollaborationRouter()
     router.replace({
       generation: 1,
+      platformKinds: [],
       agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
       channels: [
         {
@@ -429,6 +431,36 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
       expect(ack).toMatchObject({ delivered: false, reason: 'not_allowed' })
     }
     expect(forwards).toHaveLength(2)
+  })
+
+  it('wire-carried platformKinds classify ids this relay build does not know (§6.1)', async () => {
+    const s = snap()
+    s.platformKinds = [
+      { platformId: 'teams-x', originKind: 'chat' },
+      { platformId: 'sandbox-x', originKind: 'sandbox' }
+    ]
+    const router = new CollaborationRouter()
+    router.replace(s)
+    const forwards: RdAgentMsgFwd[] = []
+    const route = createAgentMsgRouter({
+      router,
+      daemons: () => fakeDaemons({ deliveryId: 'd-1', delivered: true }, forwards),
+      log: noopLog
+    })
+    // Snapshot-classified chat id: unrecorded coordinate fails closed like the IM four.
+    const chat = await route(D1, baseMsg({ deliveryId: 'd-k1', coords: { platform: 'teams-x', channel: 'NOT_A_ROW' } }))
+    expect(chat).toMatchObject({ delivered: false, reason: 'not_allowed' })
+    // Snapshot-classified channel-free kind: admitted, forwarded verbatim.
+    const sandbox = await route(
+      D1,
+      baseMsg({ deliveryId: 'd-k2', coords: { platform: 'sandbox-x', channel: 'box-1' } })
+    )
+    expect(sandbox.delivered).toBe(true)
+    expect(forwards[0]!.coords).toEqual({ platform: 'sandbox-x', channel: 'box-1' })
+    // rc/bot-assign learning covers the same classification between snapshots.
+    router.learnPlatformKind('notes-x', 'notes')
+    const learned = await route(D1, baseMsg({ deliveryId: 'd-k3', coords: { platform: 'notes-x', channel: 'n-1' } }))
+    expect(learned.delivered).toBe(true)
   })
 
   it('lineage replies are exempt from the wake-coordinate membership gate (org + policy still apply)', async () => {
@@ -633,6 +665,7 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     // dream) appears in no `channels[]` row, so channel membership cannot be the gate.
     const s: CollabRoutesSnapshot = {
       generation: 1,
+      platformKinds: [],
       agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
       channels: [] // nobody has an IM integration
     }
@@ -658,6 +691,7 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
   it('forged caller is still rejected with no channel in play (placement belongs to another daemon)', async () => {
     const s: CollabRoutesSnapshot = {
       generation: 1,
+      platformKinds: [],
       agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
       channels: []
     }
@@ -778,6 +812,7 @@ describe('relay rd/agentmsg routing + auth (agent-collaboration P2)', () => {
     // The bot-agnostic snapshot co-locates them by (org, platform, channel).
     const s: CollabRoutesSnapshot = {
       generation: 1,
+      platformKinds: [],
       agents: [orgAgent({ agentId: A, daemonId: D1 }), orgAgent({ agentId: B, daemonId: D2 })],
       channels: [
         {

--- a/packages/relay/src/collaboration-router.ts
+++ b/packages/relay/src/collaboration-router.ts
@@ -26,7 +26,7 @@
  * assumed. Documented in the PR description.
  */
 import type { CollabRoutesSnapshot, CollabAgentPlacement, CollabOrgAgent } from '@agentconnect.md/protocol'
-import { isSessionIdentityPlatform } from '@agentconnect.md/protocol'
+import { originKindOf } from '@agentconnect.md/protocol'
 
 /** The resolved placement of one agent in a channel (a snapshot value). */
 export interface CollabResolved extends CollabAgentPlacement {
@@ -93,6 +93,13 @@ export class CollaborationRouter {
   // agent belongs to exactly one org and a flat index loses no addressing precision.
   private readonly byAgent = new Map<string, CollabOrgAgent>()
 
+  // §6.1 wire-carried origin-kind classification. `snapshotKinds` full-replaces with
+  // each snapshot (the CP's authoritative list); `learnedKinds` accumulates from
+  // rc/bot-assign and survives snapshot replacement (assigns are pushed per bot, not
+  // periodically). Resolution: snapshot → learned → protocol seed → 'chat'.
+  private readonly snapshotKinds = new Map<string, string>()
+  private readonly learnedKinds = new Map<string, string>()
+
   /** FULL-REPLACE the table from a CP snapshot. Ignores an older generation (a
    *  reordered/stale re-push) so the newest snapshot wins. */
   replace(snap: CollabRoutesSnapshot): void {
@@ -101,6 +108,8 @@ export class CollaborationRouter {
     this.channels.clear()
     this.byOrgChannel.clear()
     this.byAgent.clear()
+    this.snapshotKinds.clear()
+    for (const k of snap.platformKinds ?? []) this.snapshotKinds.set(k.platformId, k.originKind)
     for (const a of snap.agents) this.byAgent.set(a.agentId, a)
     // Old-CP fallback: a CP that does not advertise `agent-directory-org-scope-v1` sends
     // no `agents[]` (it decodes to the schema default `[]`). Derive the directory from the
@@ -219,13 +228,26 @@ export class CollaborationRouter {
       if (members.has(callerAgentId)) return { verdict: 'asserted' }
     }
     if (known) return { verdict: 'reject' }
-    // Registry-driven fail-closed default (S1a, integration-plugin-architecture.md §6.1):
-    // only the enumerated channel-free session identities take the synthetic branch; ANY
-    // other id — the four IM platforms and every id this build does not know — is
-    // chat-shaped and an unrecorded coordinate on it is refused. The old shape enumerated
-    // the IM platforms instead and silently ADMITTED unknown ids.
-    if (!isSessionIdentityPlatform(platform)) return { verdict: 'reject' }
+    // Registry-driven fail-closed default (§6.1): the platform's ORIGIN KIND decides the
+    // branch — wire-carried classification (snapshot `platformKinds` / rc/bot-assign)
+    // overlaid on the protocol seed, defaulting to 'chat' for an id neither classifies.
+    // 'chat' ⇒ an unrecorded coordinate is refused, fail-closed. Any other classified
+    // kind is channel-free ⇒ synthetic, safe even for kinds this build has never heard
+    // of: the substitution derives from the TRUSTED caller and cannot alias a platform
+    // session (and the relay only acts on reject anyway).
+    if (this.originKindFor(platform) === 'chat') return { verdict: 'reject' }
     return { verdict: 'synthetic', channel: a2aCoordChannel(callerAgentId) }
+  }
+
+  /** §6.1 kind resolution: snapshot → assign-learned → protocol seed → 'chat'. */
+  private originKindFor(platform: string): string {
+    return this.snapshotKinds.get(platform) ?? this.learnedKinds.get(platform) ?? originKindOf(platform) ?? 'chat'
+  }
+
+  /** §6.1: record a platform's origin kind carried on `rc/bot-assign`, so a bot on an
+   *  id this build does not know still classifies before the next full snapshot. */
+  learnPlatformKind(platformId: string, originKind: string | undefined): void {
+    if (originKind !== undefined) this.learnedKinds.set(platformId, originKind)
   }
 
   /** The org-scoped directory entry for `agentId`, or undefined if the directory has

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -148,10 +148,14 @@ async function main(): Promise<void> {
     onRevoke: (daemonId) => held.rdServer?.revoke(daemonId),
     // HTTP-bot control (§10): the manager is constructed below (after rdServer);
     // these callbacks only fire once the relay is READY, so `held.relayIngress` is set.
-    onBotAssign: (a) =>
+    onBotAssign: (a) => {
+      // §6.1: the assignment's origin-kind classification (present from an S1b CP)
+      // teaches this relay how to classify a platform id its build predates.
+      collab.learnPlatformKind(a.platform, a.originKind)
       void held.relayIngress
         ?.assign(toBotAssignment(a))
-        .catch((err) => log.error(`relay: bot-assign failed: ${String(err)}`)),
+        .catch((err) => log.error(`relay: bot-assign failed: ${String(err)}`))
+    },
     onBotUnassign: (a) =>
       void held.relayIngress
         ?.unassign(a.botId, a.credentialRevision)


### PR DESCRIPTION
## What

**S1b §6.1** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md): the `OriginKind` axis (`chat` | `hook` | `dream` | `webchat`) lands in the protocol package with the `originKindOf` seed, and the per-id classification **rides the wire** — closing the gap the S0 audit flagged (`CollabRoutesSnapshot` carried no classification) — so an older daemon/relay can classify a platform id a newer CP introduces. This is the last protocol prerequisite before any new platform id may be emitted.

## Wire carriers

- `CollabRoutesSnapshot.platformKinds` (`{platformId, originKind}[]`, `default([])` keeps pre-S1b snapshots decodable). The CP ships its full known classification on every snapshot — static today, replaced by the platform registry in S3.
- `rc/bot-assign.originKind` (optional; always `'chat'` for a bot assignment). The relay **learns** these per-id and keeps them across snapshot replacement, so a bot on a new id classifies even between snapshots.

## Consumer rule (both `coordsDecision` twins, lockstep)

Branch by the platform's origin kind: wire classification → seed → `'chat'` for an id neither classifies. `'chat'` keeps the #507 fail-closed reject; **any other classified kind** takes the channel-free synthetic branch — safe even for kinds this build predates, because the substituted coordinate derives from the trusted caller and can never alias a platform session (and the relay only acts on reject). Behavior for every currently-emitted id is unchanged; the S1a constant survives as the seed.

## Verification

protocol 254 ✓ (decode defaults, entry passthrough, seed answers) · relay 382 ✓ (wire-classified chat/channel-free ids + the assign-learned path) · daemon 2775 ✓ (twin classification + seed fallback) · CP unit 1020 ✓ + integration 948 ✓ (snapshot + assign emission) · full-workspace typecheck ✓.

Next S1b stage: the `IntegrationSpec` envelope + opaque config with the codec down-level shim (per the audit erratum, the duplicated closed union is `IntegrationSpec` ↔ daemon `IntegrationSchema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)