### PR TITLE
feat(protocol): IntegrationSpec core envelope + opaque config, dual-shape window (S1b §6.4)

### DIFF
--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -244,61 +244,49 @@ export function integrationToSpec(
     .map((c) => ({ channel: c.channelId, match: { kind: 'auto' as const } }))
   const bindRules = gated ? gatedBindRules(channels) : [...DEFAULT_BIND_RULES, ...channelRules]
   const mutedChannels = mutedChannelIds(channels, gated)
+  // §6.4 dual-shape emission: the legacy nested block AND the core+config envelope
+  // carry the same data (readers prefer the envelope's core knobs); legacy emission
+  // drops once the fleet reads the envelope.
+  const core = { mode: 'direct' as const, bindRules, mutedChannels, gated }
   if (i.platform === 'telegram') {
-    return {
-      integrationId: i.id,
-      agentId: i.agentId,
-      platform: 'telegram',
-      telegram: { botToken: secret.botToken, bindRules, mutedChannels, gated }
-    }
+    const telegram = { botToken: secret.botToken, bindRules, mutedChannels, gated }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'telegram', telegram, core, config: telegram }
   }
   if (i.platform === 'discord') {
-    return {
-      integrationId: i.id,
-      agentId: i.agentId,
-      platform: 'discord',
-      // Discord authenticates the Gateway with the single bot token (no appToken).
-      discord: { botToken: secret.botToken, bindRules, mutedChannels, gated }
-    }
+    // Discord authenticates the Gateway with the single bot token (no appToken).
+    const discord = { botToken: secret.botToken, bindRules, mutedChannels, gated }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'discord', discord, core, config: discord }
   }
   if (i.platform === 'feishu') {
-    return {
-      integrationId: i.id,
-      agentId: i.agentId,
-      platform: 'feishu',
-      // Feishu authenticates the WSClient with an appId + appSecret pair, stored in the
-      // two-slot bot_secret: botToken = appSecret (the secret), appToken = appId. The
-      // region (feishu.cn vs larksuite.com) rides on the integration row; NULL ⇒ 'feishu'.
-      feishu: {
-        mode: 'direct',
-        appId: secret.appToken ?? '',
-        appSecret: secret.botToken,
-        region: i.feishuRegion ?? 'feishu',
-        bindRules,
-        mutedChannels,
-        gated
-      }
-    }
-  }
-  return {
-    integrationId: i.id,
-    agentId: i.agentId,
-    platform: 'slack',
-    // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
-    // The 'shared' wire variant (transport==='http', xoxb-only, no appToken/bindRules)
-    // is assembled by the HTTP-bot path, which reads the bot's `transport`; this mapper
-    // is always direct. A socket bot is single-agent, so it is never shareable. Slack
-    // always stores an app-level token (Socket Mode).
-    slack: {
-      mode: 'direct',
-      shareable: false,
-      botToken: secret.botToken,
-      appToken: secret.appToken ?? '',
+    // Feishu authenticates the WSClient with an appId + appSecret pair, stored in the
+    // two-slot bot_secret: botToken = appSecret (the secret), appToken = appId. The
+    // region (feishu.cn vs larksuite.com) rides on the integration row; NULL ⇒ 'feishu'.
+    const feishu = {
+      mode: 'direct' as const,
+      appId: secret.appToken ?? '',
+      appSecret: secret.botToken,
+      region: i.feishuRegion ?? 'feishu',
       bindRules,
       mutedChannels,
       gated
     }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', feishu, core, config: feishu }
   }
+  // 'direct' (transport==='socket') — this daemon owns the Socket Mode connection.
+  // The 'shared' wire variant (transport==='http', xoxb-only, no appToken/bindRules)
+  // is assembled by the HTTP-bot path, which reads the bot's `transport`; this mapper
+  // is always direct. A socket bot is single-agent, so it is never shareable. Slack
+  // always stores an app-level token (Socket Mode).
+  const slack = {
+    mode: 'direct' as const,
+    shareable: false,
+    botToken: secret.botToken,
+    appToken: secret.appToken ?? '',
+    bindRules,
+    mutedChannels,
+    gated
+  }
+  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', slack, core, config: slack }
 }
 
 /**
@@ -325,40 +313,39 @@ export function httpIntegrationToSpec(
   providerAppId?: string,
   botUserId?: string
 ): IntegrationSpec {
-  if (i.platform === 'feishu') {
-    return {
-      integrationId: i.id,
-      agentId: i.agentId,
-      platform: 'feishu',
-      feishu: {
-        mode: 'shared',
-        appId: secret.appToken ?? '',
-        appSecret: secret.botToken,
-        ...(botUserId ? { botOpenId: botUserId } : {}),
-        region: i.feishuRegion ?? 'feishu',
-        bindRules: gated ? gatedBindRules(channels) : [],
-        mutedChannels: mutedChannelIds(channels, gated),
-        gated
-      }
-    }
+  // §6.4 dual-shape emission (see integrationToSpec).
+  const httpCore = {
+    mode: 'shared' as const,
+    bindRules: gated ? gatedBindRules(channels) : [],
+    mutedChannels: mutedChannelIds(channels, gated),
+    gated
   }
-  return {
-    integrationId: i.id,
-    agentId: i.agentId,
-    platform: 'slack',
-    // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
-    // routes through the relay either way, but only a multi-agent (shareable) bot has
-    // something to switch to.
-    slack: {
-      mode: 'shared',
-      shareable,
-      botToken: secret.botToken,
-      ...(providerAppId ? { appId: providerAppId } : {}),
-      bindRules: gated ? gatedBindRules(channels) : [],
-      mutedChannels: mutedChannelIds(channels, gated),
+  if (i.platform === 'feishu') {
+    const feishu = {
+      mode: 'shared' as const,
+      appId: secret.appToken ?? '',
+      appSecret: secret.botToken,
+      ...(botUserId ? { botOpenId: botUserId } : {}),
+      region: i.feishuRegion ?? 'feishu',
+      bindRules: httpCore.bindRules,
+      mutedChannels: httpCore.mutedChannels,
       gated
     }
+    return { integrationId: i.id, agentId: i.agentId, platform: 'feishu', feishu, core: httpCore, config: feishu }
   }
+  // `shareable` gates the daemon's in-thread "Switch agent" control: an HTTP bot
+  // routes through the relay either way, but only a multi-agent (shareable) bot has
+  // something to switch to.
+  const slack = {
+    mode: 'shared' as const,
+    shareable,
+    botToken: secret.botToken,
+    ...(providerAppId ? { appId: providerAppId } : {}),
+    bindRules: httpCore.bindRules,
+    mutedChannels: httpCore.mutedChannels,
+    gated
+  }
+  return { integrationId: i.id, agentId: i.agentId, platform: 'slack', slack, core: httpCore, config: slack }
 }
 
 /** A session to re-home: its key + the agent/workspace that should own it. */

--- a/packages/control-plane/test/integration/agents.move.route.test.ts
+++ b/packages/control-plane/test/integration/agents.move.route.test.ts
@@ -144,7 +144,7 @@ describe('PUT /agents/:id/daemon', () => {
     expect(control.activations[0]?.agentId).toBe(agentId)
     expect(
       control.activations[0]?.integrations
-        .flatMap((integration) => (integration.platform === 'slack' ? [integration.slack.mode] : []))
+        .flatMap((integration) => (integration.platform === 'slack' ? [integration.slack!.mode] : []))
         .sort()
     ).toEqual(['direct', 'shared'])
     expect(control.activations[0]?.crons.map((cron) => cron.cronId)).toEqual([cronId])

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -305,9 +305,9 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(put.statusCode).toBe(200)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.gated).toBe(true)
+    expect(u0.slack!.gated).toBe(true)
     // No dm rule for D1: the private agent answers that DM only once enabled.
-    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
   })
 
   it('resets the trigger when a row misclassified as a channel converts to a DM (§14.3)', async () => {
@@ -337,7 +337,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.bindRules).toEqual([])
+    expect(u0.slack!.bindRules).toEqual([])
   })
 
   it('stores a group DM OFF and keeps a channel→group-DM conversion fail-closed (§14.3)', async () => {
@@ -436,7 +436,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.bindRules).toEqual([])
+    expect(u0.slack!.bindRules).toEqual([])
   })
 
   it('enabling conversations on a GATED integration pushes conversation-scoped rules ONLY (§14)', async () => {
@@ -460,8 +460,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(res.statusCode).toBe(200)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.gated).toBe(true)
-    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.slack!.gated).toBe(true)
+    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
 
     await running.app.inject({
       method: 'PATCH',
@@ -470,8 +470,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     })
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack.bindRules).toHaveLength(2)
-    expect(u1.slack.bindRules).toEqual(
+    expect(u1.slack!.bindRules).toHaveLength(2)
+    expect(u1.slack!.bindRules).toEqual(
       expect.arrayContaining([
         { channel: 'C1', match: { kind: 'mention' } },
         { channel: 'D1', match: { kind: 'dm' } }
@@ -497,9 +497,9 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(spy.upserts).toHaveLength(1)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.gated).toBe(true)
+    expect(u0.slack!.gated).toBe(true)
     // The pre-flip channel row keeps its 'mention' trigger — grandfathered enabled.
-    expect(u0.slack.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
+    expect(u0.slack!.bindRules).toEqual([{ channel: 'C1', match: { kind: 'mention' } }])
 
     const back = await running.app.inject({
       method: 'PUT',
@@ -509,8 +509,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(back.statusCode).toBe(200)
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack.gated).toBe(false)
-    expect(u1.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(u1.slack!.gated).toBe(false)
+    expect(u1.slack!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 
   it('a re-report preserves the trigger, refreshes names, and drops left channels', async () => {
@@ -985,7 +985,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     expect(spy.upserts[0]!.daemonId).toBe(DAEMON)
     const u0 = spy.upserts[0]!.u
     if (u0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u0.slack.bindRules).toEqual([
+    expect(u0.slack!.bindRules).toEqual([
       { match: { kind: 'mention' } },
       { match: { kind: 'dm' } },
       { channel: 'C2', match: { kind: 'auto' } }
@@ -999,7 +999,7 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
     })
     const u1 = spy.upserts[1]!.u
     if (u1.platform !== 'slack') throw new Error('expected slack integration')
-    expect(u1.slack.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
+    expect(u1.slack!.bindRules).toEqual([{ match: { kind: 'mention' } }, { match: { kind: 'dm' } }])
   })
 
   it('404s on an unknown channel or integration', async () => {

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -936,7 +936,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // The daemon's spec dials the Lark gateway for the reinstalled bot.
     const u = spy.upserts[1]!.u
     if (u.platform !== 'feishu') throw new Error('expected feishu upsert')
-    expect(u.feishu.region).toBe('lark')
+    expect(u.feishu!.region).toBe('lark')
   })
 
   it('reusing a bot that is STILL installed is refused with 409', async () => {

--- a/packages/daemon/src/agents/write-integration.ts
+++ b/packages/daemon/src/agents/write-integration.ts
@@ -15,77 +15,106 @@
  * Editing the raw file preserves the original relative path.
  */
 import { readFileSync } from 'node:fs'
-import type { IntegrationSpec } from '@agentconnect.md/protocol'
+import type { IntegrationBindRule, IntegrationSpec } from '@agentconnect.md/protocol'
+import {
+  IntegrationDiscordConfig,
+  IntegrationFeishuConfig,
+  IntegrationSlackConfig,
+  IntegrationTelegramConfig
+} from '@agentconnect.md/protocol'
 import type { Integration } from './agent-schema.js'
 import { protectAgentJson, writeAgentJson } from './agent-json-file.js'
 import { findAgentFiles } from './load-agents.js'
 import { findAgentFileById } from './write-agent.js'
 
-/** Map the wire spec to the daemon's `Integration` shape (agent-schema). */
-function toIntegration(spec: IntegrationSpec): Integration {
+/**
+ * Map the wire spec to the daemon's `Integration` shape (agent-schema).
+ *
+ * §6.4 DUAL-SHAPE reader: the platform payload comes from the legacy nested block
+ * while the CP still emits it, else from the opaque `config` validated against the
+ * SAME per-platform schema (the S2 platform module takes validation over later).
+ * `core` overrides the routing knobs wherever present — it is the envelope that
+ * survives once legacy emission drops. The wire envelope is folded back into
+ * today's on-disk shape, so everything downstream of agent.json is unchanged.
+ * Returns null (reader-side rejection) for a spec carrying neither payload.
+ */
+function toIntegration(spec: IntegrationSpec): Integration | null {
+  const core = spec.core
+  const knobs = (legacy: { bindRules: IntegrationBindRule[]; mutedChannels: string[]; gated: boolean }) => ({
+    bindRules: core?.bindRules ?? legacy.bindRules,
+    mutedChannels: core?.mutedChannels ?? legacy.mutedChannels,
+    gated: core?.gated ?? legacy.gated
+  })
   if (spec.platform === 'telegram') {
+    const cfg = spec.telegram ?? parseConfig(IntegrationTelegramConfig, spec.config)
+    if (!cfg) return null
     return {
       id: spec.integrationId,
       origin: 'cp',
       platform: 'telegram',
-      telegram: {
-        botToken: spec.telegram.botToken,
-        bindRules: spec.telegram.bindRules,
-        mutedChannels: spec.telegram.mutedChannels,
-        gated: spec.telegram.gated
-      }
+      telegram: { botToken: cfg.botToken, ...knobs(cfg) }
     }
   }
   if (spec.platform === 'discord') {
+    const cfg = spec.discord ?? parseConfig(IntegrationDiscordConfig, spec.config)
+    if (!cfg) return null
     return {
       id: spec.integrationId,
       origin: 'cp',
       platform: 'discord',
       discord: {
-        botToken: spec.discord.botToken,
-        ...(spec.discord.applicationId ? { applicationId: spec.discord.applicationId } : {}),
-        bindRules: spec.discord.bindRules,
-        mutedChannels: spec.discord.mutedChannels,
-        gated: spec.discord.gated
+        botToken: cfg.botToken,
+        ...(cfg.applicationId ? { applicationId: cfg.applicationId } : {}),
+        ...knobs(cfg)
       }
     }
   }
   if (spec.platform === 'feishu') {
+    const cfg = spec.feishu ?? parseConfig(IntegrationFeishuConfig, spec.config)
+    if (!cfg) return null
     return {
       id: spec.integrationId,
       origin: 'cp',
       platform: 'feishu',
       feishu: {
-        mode: spec.feishu.mode,
-        appId: spec.feishu.appId,
-        appSecret: spec.feishu.appSecret,
-        ...(spec.feishu.botOpenId ? { botOpenId: spec.feishu.botOpenId } : {}),
-        region: spec.feishu.region,
-        bindRules: spec.feishu.bindRules,
-        mutedChannels: spec.feishu.mutedChannels,
-        gated: spec.feishu.gated
+        mode: core?.mode ?? cfg.mode,
+        appId: cfg.appId,
+        appSecret: cfg.appSecret,
+        ...(cfg.botOpenId ? { botOpenId: cfg.botOpenId } : {}),
+        region: cfg.region,
+        ...knobs(cfg)
       }
     }
   }
+  const cfg = spec.slack ?? parseConfig(IntegrationSlackConfig, spec.config)
+  if (!cfg) return null
   return {
     id: spec.integrationId,
     origin: 'cp',
     platform: 'slack',
     slack: {
-      mode: spec.slack.mode,
+      mode: core?.mode ?? cfg.mode,
       // Multi-agent opt-in (shared mode only) — gates the in-thread "Switch agent" control.
-      shareable: spec.slack.shareable,
-      botToken: spec.slack.botToken,
+      shareable: cfg.shareable,
+      botToken: cfg.botToken,
       // Shared mode carries no appToken (the relay owns the event stream) but does
       // carry the CP-resolved botUserId; direct mode is the reverse.
-      ...(spec.slack.appToken ? { appToken: spec.slack.appToken } : {}),
-      ...(spec.slack.appId ? { appId: spec.slack.appId } : {}),
-      ...(spec.slack.botUserId ? { botUserId: spec.slack.botUserId } : {}),
-      bindRules: spec.slack.bindRules,
-      mutedChannels: spec.slack.mutedChannels,
-      gated: spec.slack.gated
+      ...(cfg.appToken ? { appToken: cfg.appToken } : {}),
+      ...(cfg.appId ? { appId: cfg.appId } : {}),
+      ...(cfg.botUserId ? { botUserId: cfg.botUserId } : {}),
+      bindRules: knobs(cfg).bindRules,
+      mutedChannels: knobs(cfg).mutedChannels,
+      gated: knobs(cfg).gated
     }
   }
+}
+
+/** Validate the opaque envelope payload against the per-platform wire schema;
+ *  null (not throw) on mismatch — the caller warns and skips the spec. */
+function parseConfig<T>(schema: { safeParse(v: unknown): { success: boolean; data?: T } }, v: unknown): T | null {
+  if (v === undefined) return null
+  const r = schema.safeParse(v)
+  return r.success ? (r.data as T) : null
 }
 
 export interface WriteIntegrationDeps {
@@ -112,6 +141,12 @@ export function writeIntegrationSpec(agentsDir: string, spec: IntegrationSpec, d
   const raw = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
   const list: unknown[] = Array.isArray(raw.integrations) ? raw.integrations : []
   const next = toIntegration(spec)
+  if (!next) {
+    // Ids only — never token material. A spec with neither the legacy block nor a
+    // valid `config` payload is unusable; the CP re-sends on the next push.
+    deps.warn?.(`cp: integration ${spec.integrationId} carried no usable platform payload — not persisted`)
+    return false
+  }
   const idx = list.findIndex((i) => typeof i === 'object' && i !== null && (i as { id?: unknown }).id === next.id)
   if (idx >= 0) list[idx] = next
   else list.push(next)

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -931,3 +931,69 @@ describe('cold-move archive', () => {
     expect(existsSync(join(residue, 'agent', 'agent.json'))).toBe(true)
   })
 })
+
+describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
+  const AGENT = '33333333-3333-4333-8333-333333333333'
+  const INT = '66666666-6666-4666-8666-666666666666'
+  const seeded = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-dualshape-'))
+    seedAgent(dir, 'bot-a', {
+      id: AGENT,
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: 'workspace' },
+      integrations: []
+    })
+    return dir
+  }
+  const telegram = { botToken: '12345:AAA', bindRules: [], mutedChannels: [], gated: false }
+  const disk = (dir: string) =>
+    (readJson(join(dir, 'bot-a', 'agent.json')).integrations as Record<string, unknown>[])[0]
+
+  it('envelope-only and legacy-only specs fold to the SAME on-disk shape', () => {
+    const a = seeded()
+    writeIntegrationSpec(a, { integrationId: INT, agentId: AGENT, platform: 'telegram', telegram } as never, {})
+    const b = seeded()
+    writeIntegrationSpec(
+      b,
+      {
+        integrationId: INT,
+        agentId: AGENT,
+        platform: 'telegram',
+        core: { mode: 'direct', bindRules: [], mutedChannels: [], gated: false },
+        config: telegram
+      } as never,
+      {}
+    )
+    expect(disk(b)).toEqual(disk(a))
+  })
+
+  it('core overrides the legacy routing knobs wherever present', () => {
+    const dir = seeded()
+    writeIntegrationSpec(
+      dir,
+      {
+        integrationId: INT,
+        agentId: AGENT,
+        platform: 'telegram',
+        telegram: { ...telegram, gated: false, mutedChannels: [] },
+        core: { mode: 'direct', bindRules: [], mutedChannels: ['C_OFF'], gated: true },
+        config: telegram
+      } as never,
+      {}
+    )
+    expect(disk(dir)).toMatchObject({ telegram: { gated: true, mutedChannels: ['C_OFF'] } })
+  })
+
+  it('a spec with neither payload is refused (warn + not persisted)', () => {
+    const dir = seeded()
+    const warns: string[] = []
+    const ok = writeIntegrationSpec(dir, { integrationId: INT, agentId: AGENT, platform: 'telegram' } as never, {
+      warn: (m) => warns.push(m)
+    })
+    expect(ok).toBe(false)
+    expect(warns[0]).toContain('no usable platform payload')
+    expect(readJson(join(dir, 'bot-a', 'agent.json')).integrations).toEqual([])
+  })
+})

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -441,10 +441,10 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'slack') throw new Error('expected slack integration')
-    expect(r.frame.payload.slack.botToken).toBe('xoxb-abc')
-    expect(r.frame.payload.slack.appToken).toBe('xapp-1-def')
-    expect(r.frame.payload.slack.appId).toBe('A123')
-    expect(r.frame.payload.slack.bindRules).toEqual([]) // zod default
+    expect(r.frame.payload.slack!.botToken).toBe('xoxb-abc')
+    expect(r.frame.payload.slack!.appToken).toBe('xapp-1-def')
+    expect(r.frame.payload.slack!.appId).toBe('A123')
+    expect(r.frame.payload.slack!.bindRules).toEqual([]) // zod default
   })
 
   it('integration/upsert carries the telegram config (single botToken, no appToken); zod defaults fill lists', () => {
@@ -459,8 +459,8 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'telegram') throw new Error('expected telegram integration')
-    expect(r.frame.payload.telegram.botToken).toBe('123456:ABC-def')
-    expect(r.frame.payload.telegram.bindRules).toEqual([]) // zod default
+    expect(r.frame.payload.telegram!.botToken).toBe('123456:ABC-def')
+    expect(r.frame.payload.telegram!.bindRules).toEqual([]) // zod default
   })
 
   it('integration/upsert carries the discord config (single botToken, optional applicationId); zod defaults fill lists', () => {
@@ -475,9 +475,9 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'discord') throw new Error('expected discord integration')
-    expect(r.frame.payload.discord.botToken).toBe('MTA-bot-token')
-    expect(r.frame.payload.discord.applicationId).toBe('112233445566')
-    expect(r.frame.payload.discord.bindRules).toEqual([]) // zod default
+    expect(r.frame.payload.discord!.botToken).toBe('MTA-bot-token')
+    expect(r.frame.payload.discord!.applicationId).toBe('112233445566')
+    expect(r.frame.payload.discord!.bindRules).toEqual([]) // zod default
   })
 
   it('integration/upsert carries the feishu config (appId + appSecret pair, no appToken); zod defaults fill lists', () => {
@@ -492,11 +492,11 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'feishu') throw new Error('expected feishu integration')
-    expect(r.frame.payload.feishu.appId).toBe('cli_abc123')
-    expect(r.frame.payload.feishu.appSecret).toBe('secret-xyz')
-    expect(r.frame.payload.feishu.mode).toBe('direct') // backwards-compatible default
-    expect(r.frame.payload.feishu.region).toBe('feishu') // zod default — China gateway
-    expect(r.frame.payload.feishu.bindRules).toEqual([]) // zod default
+    expect(r.frame.payload.feishu!.appId).toBe('cli_abc123')
+    expect(r.frame.payload.feishu!.appSecret).toBe('secret-xyz')
+    expect(r.frame.payload.feishu!.mode).toBe('direct') // backwards-compatible default
+    expect(r.frame.payload.feishu!.region).toBe('feishu') // zod default — China gateway
+    expect(r.frame.payload.feishu!.bindRules).toEqual([]) // zod default
   })
 
   it('integration/upsert preserves Feishu shared mode for daemon send-only API access', () => {
@@ -526,7 +526,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'feishu') throw new Error('expected feishu integration')
-    expect(r.frame.payload.feishu.region).toBe('lark')
+    expect(r.frame.payload.feishu!.region).toBe('lark')
   })
 
   it('integration/upsert rejects an unknown platform', () => {
@@ -557,7 +557,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(r.ok).toBe(true)
     if (!r.ok || !isFrame('integration/upsert')(r.frame)) throw new Error('expected integration/upsert')
     if (r.frame.payload.platform !== 'slack') throw new Error('expected slack integration')
-    const rule = r.frame.payload.slack.bindRules[0]!
+    const rule = r.frame.payload.slack!.bindRules[0]!
     expect(rule.channel).toBe('C123')
     expect(rule.match).toEqual({ kind: 'keyword', value: 'deploy' })
   })
@@ -634,7 +634,7 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     if (!withInt.ok || !isFrame('register/ok')(withInt.frame)) throw new Error('expected register/ok')
     const int0 = withInt.frame.payload.integrations[0]!
     if (int0.platform !== 'slack') throw new Error('expected slack integration')
-    expect(int0.slack.appToken).toBe('xapp-1-def')
+    expect(int0.slack!.appToken).toBe('xapp-1-def')
   })
 })
 

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -152,36 +152,67 @@ export const IntegrationFeishuConfig = z.object({
 export type IntegrationFeishuConfig = z.infer<typeof IntegrationFeishuConfig>
 
 /**
+ * §6.4 core routing ENVELOPE (integration-plugin-architecture.md D4): the knobs CORE
+ * reads — routing, gating, ingress mode — platform-independent. Dual-shape window:
+ * the CP emits this ALONGSIDE the legacy nested per-platform block (below) and the
+ * daemon prefers it; once the fleet reads the envelope, legacy emission drops and
+ * `config` becomes the only platform payload (validated by the platform module, S2).
+ */
+export const IntegrationCoreEnvelope = z.object({
+  mode: z.enum(['direct', 'shared']).default('direct'),
+  bindRules: z.array(IntegrationBindRule).default([]),
+  mutedChannels: z.array(z.string()).default([]),
+  gated: z.boolean().default(false)
+})
+export type IntegrationCoreEnvelope = z.infer<typeof IntegrationCoreEnvelope>
+
+/**
  * One platform integration, owned by exactly one agent. Also the element type of
  * `RegisterOk.integrations[]` (the per-daemon reconcile set). Discriminated on
  * `platform`: the daemon opens a Slack Socket Mode connection, a Telegram
  * long-poll, a Discord Gateway, or a Feishu long-connection from whichever variant
  * is delivered.
+ *
+ * DUAL-SHAPE (§6.4): each variant carries the legacy nested block (`slack` /
+ * `telegram` / `discord` / `feishu`) AND the `core` + `config` envelope. Readers
+ * prefer the legacy block while it is emitted and fall back to `config` (validated
+ * against the same per-platform schema); `core` overrides the routing knobs wherever
+ * present. A variant carrying NEITHER payload is rejected by the reader, not the
+ * schema (tolerant-reader rule). The union itself opens to a flat `platformId`
+ * object when legacy emission drops.
  */
 export const IntegrationSpec = z.discriminatedUnion('platform', [
   z.object({
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('slack'),
-    slack: IntegrationSlackConfig
+    slack: IntegrationSlackConfig.optional(),
+    core: IntegrationCoreEnvelope.optional(),
+    config: z.unknown().optional()
   }),
   z.object({
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('telegram'),
-    telegram: IntegrationTelegramConfig
+    telegram: IntegrationTelegramConfig.optional(),
+    core: IntegrationCoreEnvelope.optional(),
+    config: z.unknown().optional()
   }),
   z.object({
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('discord'),
-    discord: IntegrationDiscordConfig
+    discord: IntegrationDiscordConfig.optional(),
+    core: IntegrationCoreEnvelope.optional(),
+    config: z.unknown().optional()
   }),
   z.object({
     integrationId: z.string().uuid(),
     agentId: z.string().uuid(),
     platform: z.literal('feishu'),
-    feishu: IntegrationFeishuConfig
+    feishu: IntegrationFeishuConfig.optional(),
+    core: IntegrationCoreEnvelope.optional(),
+    config: z.unknown().optional()
   })
 ])
 export type IntegrationSpec = z.infer<typeof IntegrationSpec>

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -4,6 +4,7 @@ import {
   decodeRelayDaemonFrame,
   decodeRelayCpFrame,
   CollabRoutesSnapshot,
+  IntegrationSpec,
   KNOWN_PLATFORMS,
   isKnownPlatform,
   originKindOf
@@ -193,6 +194,28 @@ describe('S1a tolerant platform readers — relay↔CP wire', () => {
     if (r.ok && r.frame.type === 'rc/bot-assign') {
       expect(r.frame.payload.platform).toBe(UNKNOWN)
     }
+  })
+})
+
+describe('§6.4 IntegrationSpec dual shape', () => {
+  const base = { integrationId: INTEGRATION_ID, agentId: AGENT_ID, platform: 'telegram' as const }
+  const telegram = { botToken: '12345:AAA', bindRules: [], mutedChannels: [], gated: false }
+  const core = { mode: 'direct' as const, bindRules: [], mutedChannels: [], gated: false }
+
+  it('decodes legacy-only, dual, and envelope-only variants', () => {
+    expect(IntegrationSpec.safeParse({ ...base, telegram }).success).toBe(true)
+    const dual = IntegrationSpec.safeParse({ ...base, telegram, core, config: telegram })
+    expect(dual.success).toBe(true)
+    if (dual.success && dual.data.platform === 'telegram') {
+      expect(dual.data.core?.gated).toBe(false)
+      expect(dual.data.config).toEqual(telegram)
+    }
+    // Envelope-only (post-window emission): the legacy block is absent.
+    expect(IntegrationSpec.safeParse({ ...base, core, config: telegram }).success).toBe(true)
+  })
+
+  it('keeps a payload-less variant decodable — rejection is the reader, not the schema', () => {
+    expect(IntegrationSpec.safeParse(base).success).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What

**S1b §6.4** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) — the D4 restructure, opened with a rolling-safe **dual-shape window**: each `IntegrationSpec` variant now carries the core routing **envelope** (`core: { mode, bindRules, mutedChannels, gated }`) plus an opaque `config`, ALONGSIDE the legacy nested per-platform block — which becomes optional. Old readers strip the unknown fields (the platform frames are non-strict, verified in the S0 audit); new readers prefer the envelope. Once the fleet reads it, legacy emission drops and the union opens to §6.4's flat `platformId` + `config` object.

Per the audit erratum, the daemon-side twin of this closed union is `agents/agent-schema.ts`'s `IntegrationSchema` (not `AgentSpec`) — it is deliberately untouched here: the wire envelope **folds back into today's on-disk agent.json shape**, so routing, connections, and everything downstream of disk are unchanged. The disk restructure follows when legacy emission drops.

## Sides

- **CP** (`placement.ts`, socket + http builders): each platform object is built once and emitted as both the legacy block and `config`, with `core` alongside — the two shapes cannot drift.
- **daemon** (`write-integration.ts`): the dual reader — platform payload from the legacy block, else `config` validated against the *same* per-platform wire schema (the S2 platform module takes validation over later); `core` overrides the routing knobs wherever present. A spec carrying neither payload is refused by the **reader** (warn + skip), never the schema — the tolerant-reader rule.

## Verification

protocol 256 ✓ (legacy-only / dual / envelope-only decode) · daemon 2775 ✓ (+3 new: envelope-only folds to a byte-identical disk shape, core overrides, payload-less refusal) · CP unit 1020 ✓ + integration 948 ✓ (existing spec-shape assertions pin the dual emission) · relay 382 ✓ · full-workspace typecheck ✓.

## Rollout

Additive on the wire; behavior-preserving for every current daemon (they read the legacy block they already know). The follow-up that drops legacy emission is gated on the next fleet cycle.

Next S1b stages: `NormalizedMessage` generic thread coordinates + `adapterExt` (§6.5), then `platform_action` (§6.6, minding the `relay-cp.ts` `.strict()` hazard) and `rc/bot-assign` opaque payloads (§6.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)