### PR TITLE
feat(protocol): generic thread coordinates + opaque bot-assign payloads (S1b §6.5+§6.7)

### DIFF
--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -334,6 +334,12 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     // §6.1: a bot assignment is always a chat platform; the kind teaches an older relay
     // to classify an id a newer CP introduces.
     expect(assign.originKind).toBe('chat')
+    // §6.7 dual-shape: the opaque ingress bag mirrors the named demux fields.
+    expect(assign.ingress).toEqual({
+      ...(assign.apiAppId ? { apiAppId: assign.apiAppId } : {}),
+      ...(assign.teamId ? { teamId: assign.teamId } : {}),
+      ...(assign.botUserId ? { botUserId: assign.botUserId } : {})
+    })
 
     // members: one entry per daemon, agents grouped.
     const members = Object.fromEntries(assign.members.map((m) => [m.daemonId, m.agentIds.sort()]))

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -881,6 +881,18 @@ export class HttpBotOrchestrator {
       // §6.1: a bot assignment is always a CHAT platform; carried so an older
       // relay can classify an id a newer CP introduces.
       originKind: 'chat',
+      // §6.7 dual-shape: the opaque ingress bag mirrors the named demux fields
+      // below; the platform module (S3) takes its validation over and the named
+      // fields stop being emitted once the fleet reads the bag.
+      ingress: {
+        ...(bot.platform === 'feishu' && secret.appToken
+          ? { apiAppId: secret.appToken }
+          : bot.slackAppId
+            ? { apiAppId: bot.slackAppId }
+            : {}),
+        ...(bot.teamId ? { teamId: bot.teamId } : {}),
+        ...(bot.botUserId ? { botUserId: bot.botUserId } : {})
+      },
       // Slack app id ("A…", == Events API api_app_id) — O(1) inbound demux. Absent on
       // a manual-paste http bot (no xapp to parse); the relay verify-scans instead.
       ...(bot.platform === 'feishu' && secret.appToken

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -5373,12 +5373,16 @@ export class Daemon {
    */
   private canonicalizeTelegramThread(msg: NormalizedMessage): void {
     if (msg.platform !== 'telegram' || msg.thread !== undefined) return
-    if (msg.telegramTopicId !== undefined) {
-      msg.thread = msg.telegramTopicId
+    // §6.5 dual-shape reader: prefer the generic coordinates; the named per-platform
+    // fields stop being emitted once the fleet reads the generic ones.
+    const topicId = msg.topicId ?? msg.telegramTopicId
+    if (topicId !== undefined) {
+      msg.thread = topicId
       return
     }
-    if (msg.telegramThreadRoot !== undefined) {
-      msg.thread = `tg:${msg.telegramThreadRoot}`
+    const threadRoot = msg.threadRoot ?? msg.telegramThreadRoot
+    if (threadRoot !== undefined) {
+      msg.thread = `tg:${threadRoot}`
       return
     }
     if (msg.isDm) {
@@ -5564,7 +5568,7 @@ export class Daemon {
     // A Discord top-level channel @mention: open a thread off it first, then dispatch
     // into that thread (Slack-parity). Async (a REST call), so it runs on its own path;
     // dispatch is fire-and-forget either way.
-    if (msg.platform === 'discord' && msg.discordTopLevel) {
+    if (msg.platform === 'discord' && (msg.promoteToThread ?? msg.discordTopLevel)) {
       const topLevel = this.dispatchDiscordTopLevel(result.agentId, msg, result.integrationId)
       topLevel.catch((err) => this.log.error(`dispatch failed for agent "${result.agentId}": ${formatErr(err)}`))
       // The re-threaded dispatch owns its own admission; expose a coarse handle

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -258,6 +258,21 @@ describe('canonicalizeTelegramThread', () => {
     expect(m.thread).toBe('555')
   })
 
+  it('§6.5: keys off the GENERIC coordinates alone (post-window emission)', async () => {
+    const daemon = new Daemon({ root: scaffold() })
+    await daemon.start()
+    const topic = tg(103, { topicId: '555', mentionedBots: ['mybot'] })
+    ;(daemon as any).canonicalizeTelegramThread(topic)
+    expect(topic.thread).toBe('555')
+    const reply = tg(104, { threadRoot: '6' })
+    ;(daemon as any).canonicalizeTelegramThread(reply)
+    expect(reply.thread).toBe('tg:6')
+    // The generic field wins when both are present (dual-shape window).
+    const both = tg(105, { topicId: '7', telegramTopicId: '8' })
+    ;(daemon as any).canonicalizeTelegramThread(both)
+    expect(both.thread).toBe('7')
+  })
+
   it('collapses a DM to one continuous session (dm)', async () => {
     const daemon = new Daemon({ root: scaffold() })
     await daemon.start()

--- a/packages/message/src/discord-message.ts
+++ b/packages/message/src/discord-message.ts
@@ -98,6 +98,7 @@ export function normalizeDiscordMessage(
     ...(attachments.length ? { attachments } : {}),
     isDm,
     ...(message.isThread && message.parentChannelId ? { parentChannel: message.parentChannelId } : {}),
-    ...(!isDm && !message.isThread ? { discordTopLevel: true } : {})
+    // §6.5 dual-shape: the generic promote flag alongside the deprecated named one.
+    ...(!isDm && !message.isThread ? { discordTopLevel: true, promoteToThread: true } : {})
   }
 }

--- a/packages/message/src/telegram-message.ts
+++ b/packages/message/src/telegram-message.ts
@@ -193,8 +193,9 @@ export function normalizeTelegramMessage(
     source: 'user',
     platform: 'telegram',
     channel: String(message.chat.id),
-    ...(isForumTopic && threadId !== undefined ? { telegramTopicId: threadId } : {}),
-    ...(!isForumTopic && threadId !== undefined ? { telegramThreadRoot: threadId } : {}),
+    // §6.5 dual-shape: generic coordinates alongside the deprecated named fields.
+    ...(isForumTopic && threadId !== undefined ? { telegramTopicId: threadId, topicId: threadId } : {}),
+    ...(!isForumTopic && threadId !== undefined ? { telegramThreadRoot: threadId, threadRoot: threadId } : {}),
     ...(replyTo !== undefined ? { replyTo } : {}),
     ...(quoted !== undefined ? { quoted } : {}),
     sender: {

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -398,9 +398,12 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     expect('botToken' in r.frame.payload.secrets).toBe(false)
   })
 
-  it('rc/bot-assign requires signingSecret (Events API verification key)', () => {
-    // The relay verifies inbound Slack POSTs by HMAC, so the signing secret is
-    // mandatory; a bot-token-only secrets bag no longer decodes.
+  it('rc/bot-assign: an incomplete typed secret bag decodes but is refused by the ASSIGNMENT reader (§6.7)', () => {
+    // Pre-§6.7 the schema itself rejected a bot-token-only bag. The open reader
+    // deliberately relinquishes per-shape schema validation (an unknown platform's
+    // opaque bag must decode), so shape enforcement moved to the relay's assignment
+    // mapper — `toBotAssignment` refuses a bag missing the signing secret before any
+    // credential is touched, and the S3 platform module takes validation over.
     const r = decodeRelayCpFrame(
       envelope('rc/bot-assign', {
         botId: DAEMON_ID,
@@ -410,7 +413,7 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
         routes: []
       })
     )
-    expect(r.ok).toBe(false)
+    expect(r.ok).toBe(true)
   })
 
   it('decodes rc/bot-unassign, rc/routes and rc/assign', () => {

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -528,17 +528,25 @@ export type AttributedRoute = z.infer<typeof AttributedRoute>
 // sends only callback verification material: its app secret and all provider API
 // egress stay on the daemon. Secret — NEVER log this frame.
 export const RcBotSecrets = z.union([
-  z.object({
-    botToken: z.string(),
-    signingSecret: z.string()
-  }),
-  z.object({
-    verificationToken: z.string(),
-    encryptKey: z.string().optional()
-  }),
-  // §6.7 open reader: a platform this build predates ships an opaque secret bag; the
-  // relay's platform module (S3) validates its shape. The two typed variants above
-  // stay first so today's platforms keep full validation during the window.
+  // The typed variants keep full validation for today's platforms AND pass unknown
+  // keys through (`catchall`): a bag that satisfies a typed prefix may still carry
+  // additional credential fields a newer platform module needs — stripping them
+  // here would hand the §6.7 platform-module boundary less than what was on the
+  // wire. Ordered first so validation still applies during the window.
+  z
+    .object({
+      botToken: z.string(),
+      signingSecret: z.string()
+    })
+    .catchall(z.unknown()),
+  z
+    .object({
+      verificationToken: z.string(),
+      encryptKey: z.string().optional()
+    })
+    .catchall(z.unknown()),
+  // §6.7 open reader: a platform this build predates ships an opaque secret bag;
+  // the relay's platform module (S3) validates its shape.
   z.record(z.string(), z.unknown())
 ])
 export type RcBotSecrets = z.infer<typeof RcBotSecrets>

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -535,7 +535,11 @@ export const RcBotSecrets = z.union([
   z.object({
     verificationToken: z.string(),
     encryptKey: z.string().optional()
-  })
+  }),
+  // §6.7 open reader: a platform this build predates ships an opaque secret bag; the
+  // relay's platform module (S3) validates its shape. The two typed variants above
+  // stay first so today's platforms keep full validation during the window.
+  z.record(z.string(), z.unknown())
 ])
 export type RcBotSecrets = z.infer<typeof RcBotSecrets>
 
@@ -588,6 +592,11 @@ export const RcBotAssign = z.object({
   // ⇒ the CP applies revocations without the revision arm of the fence.
   credentialRevision: z.number().int().nonnegative().optional(),
   secrets: RcBotSecrets,
+  // §6.7 opaque INGRESS bag, dual-emitted beside the named demux fields above
+  // (apiAppId/teamId/botUserId). Shape validation belongs to the platform module
+  // on both ends (S3); the relay ignores it during the dual-shape window and the
+  // named fields stop being emitted once the fleet reads the bag.
+  ingress: z.unknown().optional(),
   members: z.array(z.object({ daemonId: z.string().uuid(), agentIds: z.array(z.string().uuid()) })),
   agents: z.array(RcAgentDirEntry).default([]), // member directory (id→name) for the config modal
   routes: z.array(AttributedRoute),

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -57,13 +57,32 @@ export const NormalizedPlatformMessageSchema = z.object({
   replyTo: z.string().optional(),
   /** Provider-supplied quoted reply content, already bounded and humanized. */
   quoted: QuotedMessageSchema.optional(),
-  /** Telegram forum topic id, which may be used as `message_thread_id` on send. */
+  // ── §6.5 generic thread coordinates (integration-plugin-architecture.md) ──
+  // The platform-agnostic model core session-keying consumes. Dual-shape window:
+  // normalizers emit these ALONGSIDE the named per-platform fields below and
+  // readers prefer them; the named fields stop being emitted once the fleet
+  // reads the generic ones. (`thread` above stays the CANONICAL post-ingress
+  // coordinate these feed; the design's `threadId` is named `threadRoot` here
+  // because `thread` already occupies that slot.)
+  /** Platform topic/forum container the message lives in (Telegram forum topic id). */
+  topicId: z.string().optional(),
+  /** Platform reply-chain root when threads are reply-derived rather than native. */
+  threadRoot: z.string().optional(),
+  /** Top-level post the daemon should promote into a real thread before dispatch. */
+  promoteToThread: z.boolean().optional(),
+  /** Opaque per-adapter extension bag, namespaced by platformId
+   *  (`adapterExt.telegram`, …). Never read by core; round-tripped back to the
+   *  platform adapter at render time (S2 renderer seam). */
+  adapterExt: z.record(z.string(), z.unknown()).optional(),
+  /** DEPRECATED (§6.5): read `topicId`. Telegram forum topic id, may be used as `message_thread_id` on send. */
   telegramTopicId: z.string().optional(),
-  /** Telegram non-forum reply-thread root, continued with reply parameters. */
+  /** DEPRECATED (§6.5): read `threadRoot`. Telegram non-forum reply-thread root. */
   telegramThreadRoot: z.string().optional(),
-  /** Discord top-level guild message that the daemon should move into a thread. */
+  /** DEPRECATED (§6.5): read `promoteToThread`. Discord top-level guild message to move into a thread. */
   discordTopLevel: z.boolean().optional(),
-  /** Enclosing Discord channel when `channel` is itself a thread channel. */
+  /** Enclosing container channel when `channel` is itself a thread channel (Discord
+   *  threads). GENERIC and core-read (bind-rule admission spans thread→parent), so it
+   *  is part of the coordinate model, not adapterExt (D2: pre-dispatch core read). */
   parentChannel: z.string().optional(),
   trigger: z.enum(['mention', 'dm', 'keyword', 'auto', 'cron']).optional(),
   /** Provider-reported send time (epoch ms). Set when the platform's message id

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -219,6 +219,84 @@ describe('§6.4 IntegrationSpec dual shape', () => {
   })
 })
 
+describe('§6.5 generic thread coordinates + adapterExt', () => {
+  const im = (payload: Record<string, unknown>) =>
+    decodeRelayDaemonFrame(
+      envelope('rd/msg', {
+        source: 'im',
+        agentId: AGENT_ID,
+        sessionKey: 'telegram:C1:-',
+        msgId: 'evt-1',
+        botId: BOT_ID,
+        integrationId: INTEGRATION_ID,
+        payload: {
+          msgId: 'evt-1',
+          traceId: 'trace-1',
+          source: 'user',
+          platform: 'telegram',
+          channel: '-100123',
+          sender: { id: 'U1', isBot: false },
+          text: 'hello',
+          mentionedBots: [],
+          isDm: false,
+          ...payload
+        }
+      })
+    )
+
+  it('decodes dual-shape (named + generic) and generic-only coordinates', () => {
+    const dual = im({ telegramTopicId: '55', topicId: '55' })
+    expectOk(dual)
+    if (dual.ok && dual.frame.type === 'rd/msg' && dual.frame.payload.source === 'im') {
+      expect(dual.frame.payload.payload.topicId).toBe('55')
+      expect(dual.frame.payload.payload.telegramTopicId).toBe('55')
+    }
+    expectOk(im({ threadRoot: '6', promoteToThread: true }))
+  })
+
+  it('round-trips the opaque adapterExt bag verbatim', () => {
+    const r = im({ adapterExt: { telegram: { customEmojiIds: ['e1'] } } })
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rd/msg' && r.frame.payload.source === 'im') {
+      expect(r.frame.payload.payload.adapterExt).toEqual({ telegram: { customEmojiIds: ['e1'] } })
+    }
+  })
+})
+
+describe('§6.7 rc/bot-assign opaque secrets + ingress', () => {
+  it('decodes an opaque secret bag for a platform this build predates + the ingress bag', () => {
+    const r = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: BOT_ID,
+        platform: UNKNOWN,
+        originKind: 'chat',
+        secrets: { apiKey: 'k-1', webhookSecret: 'w-1' },
+        ingress: { appId: 'app-1', tenant: 't-1' },
+        members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+        routes: []
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rc/bot-assign') {
+      expect(r.frame.payload.secrets).toEqual({ apiKey: 'k-1', webhookSecret: 'w-1' })
+      expect(r.frame.payload.ingress).toEqual({ appId: 'app-1', tenant: 't-1' })
+    }
+  })
+
+  it('keeps validating the typed Slack/Feishu secret shapes', () => {
+    const bad = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: BOT_ID,
+        platform: 'slack',
+        secrets: 'not-an-object',
+        members: [],
+        routes: []
+      })
+    )
+    expect(bad.ok).toBe(false)
+  })
+})
+
 describe('§6.1 origin-kind classification on the wire', () => {
   it('rc/bot-assign carries an optional originKind; absent stays decodable (older CP)', () => {
     const base = {

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -283,6 +283,28 @@ describe('§6.7 rc/bot-assign opaque secrets + ingress', () => {
     }
   })
 
+  it('preserves EXTRA credential keys when a bag also satisfies a typed prefix', () => {
+    // zod object branches strip unknown keys by default; the typed variants carry
+    // a catchall so the platform module receives everything that was on the wire.
+    const r = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: BOT_ID,
+        platform: 'slack',
+        secrets: { botToken: 'xoxb-x', signingSecret: 'sig', clientSecret: 'extra-for-new-module' },
+        members: [],
+        routes: []
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rc/bot-assign') {
+      expect(r.frame.payload.secrets).toEqual({
+        botToken: 'xoxb-x',
+        signingSecret: 'sig',
+        clientSecret: 'extra-for-new-module'
+      })
+    }
+  })
+
   it('keeps validating the typed Slack/Feishu secret shapes', () => {
     const bad = decodeRelayCpFrame(
       envelope('rc/bot-assign', {

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { BotArbitrationRouter, arbitrate, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
+import {
+  BotArbitrationRouter,
+  arbitrate,
+  type BotAssignment,
+  type RouteTarget,
+  toBotAssignment
+} from './bot-arbitration.js'
 import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
 
 const D1 = 'd1'
@@ -285,5 +291,41 @@ describe('BotArbitrationRouter — table + live affinity', () => {
     stale.members = stale.members.filter((member) => member.daemonId !== D1)
     r.upsert(stale)
     expect(r.targetForAgent('bot-1', ALICE, 'iA')).toBeUndefined()
+  })
+})
+
+describe('toBotAssignment (§6.7 open secrets reader)', () => {
+  const base = {
+    botId: '00000000-0000-0000-0000-0000000000b1',
+    platform: 'slack',
+    members: [],
+    agents: [],
+    routes: [],
+    gatedAgentIds: [],
+    mutedChannels: [],
+    gatedOffChannels: [],
+    noticedDmConversations: []
+  }
+
+  it('maps the typed shapes and PRESERVES extra credential keys for the platform module', () => {
+    // catchall on the typed variants: a bag satisfying the Slack prefix may still
+    // carry fields a newer platform module needs; the mapper keeps the typed pair
+    // and the assignment handler forwards the full wire frame when S3 lands.
+    const a = toBotAssignment({
+      ...base,
+      secrets: { botToken: 'xoxb-x', signingSecret: 'sig' }
+    } as never)
+    expect(a?.secrets).toEqual({ botToken: 'xoxb-x', signingSecret: 'sig' })
+    const f = toBotAssignment({
+      ...base,
+      platform: 'feishu',
+      secrets: { verificationToken: 'v', encryptKey: 'k' }
+    } as never)
+    expect(f?.secrets).toEqual({ verificationToken: 'v', encryptKey: 'k' })
+  })
+
+  it('refuses (null) a secret bag neither typed shape matches — log-and-skip, never a throw', () => {
+    expect(toBotAssignment({ ...base, secrets: { apiKey: 'k-1' } } as never)).toBeNull()
+    expect(toBotAssignment({ ...base, secrets: { botToken: 'xoxb-only' } } as never)).toBeNull()
   })
 })

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -14,7 +14,7 @@
  * Pure data + a pure `arbitrate()` — no I/O, no Slack, no sockets — so it unit
  * tests without a live ingest.
  */
-import type { AttributedRoute, RcAgentDirEntry, WireNormalizedMessage } from '@agentconnect.md/protocol'
+import type { AttributedRoute, RcAgentDirEntry, RcBotAssign, WireNormalizedMessage } from '@agentconnect.md/protocol'
 
 /** A bot's full relay-side assignment (from `rc/bot-assign`). Secret material. */
 export interface BotAssignment {
@@ -457,5 +457,42 @@ export class BotArbitrationRouter {
   /** Every currently-assigned bot (ingest lifecycle reconciliation). */
   all(): BotAssignment[] {
     return [...this.bots.values()]
+  }
+}
+
+/** Map the CP's `rc/bot-assign` frame to the manager's {@link BotAssignment}
+ *  (drop absent optionals so the strict-optional shape holds). Returns null for a
+ *  secret bag neither typed shape matches (§6.7 open reader: a platform this build
+ *  predates) — the caller logs and skips; the assign handler would refuse the
+ *  platform anyway, this just refuses it before touching credentials. */
+export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
+  const secrets =
+    'botToken' in a.secrets && typeof a.secrets.botToken === 'string' && typeof a.secrets.signingSecret === 'string'
+      ? { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret }
+      : 'verificationToken' in a.secrets && typeof a.secrets.verificationToken === 'string'
+        ? {
+            verificationToken: a.secrets.verificationToken,
+            ...(typeof a.secrets.encryptKey === 'string' ? { encryptKey: a.secrets.encryptKey } : {})
+          }
+        : null
+  if (!secrets) return null
+  return {
+    botId: a.botId,
+    platform: a.platform,
+    secrets,
+    ...(a.apiAppId ? { apiAppId: a.apiAppId } : {}),
+    ...(a.teamId ? { teamId: a.teamId } : {}),
+    ...(a.credentialRevision !== undefined ? { credentialRevision: a.credentialRevision } : {}),
+    ...(a.botUserId ? { botUserId: a.botUserId } : {}),
+    members: a.members,
+    agents: mapAgentDirectory(a.agents),
+    routes: a.routes,
+    ...(a.defaultAgentId ? { defaultAgentId: a.defaultAgentId } : {}),
+    ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {}),
+    gatedAgentIds: a.gatedAgentIds,
+    mutedChannels: a.mutedChannels,
+    gatedOffChannels: a.gatedOffChannels,
+    noticedDmConversations: a.noticedDmConversations,
+    ...(a.noticeAuthority ? { noticeAuthority: a.noticeAuthority } : {})
   }
 }

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -37,18 +37,25 @@ import type { Logger } from './log.js'
 const RELAY_WS_PATH = '/api/v1/relays/ws'
 
 /** Map the CP's `rc/bot-assign` frame to the manager's {@link BotAssignment}
- *  (drop absent optionals so the strict-optional shape holds). */
-function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): BotAssignment {
+ *  (drop absent optionals so the strict-optional shape holds). Returns null for a
+ *  secret bag neither typed shape matches (§6.7 open reader: a platform this build
+ *  predates) — the caller logs and skips; the assign handler would refuse the
+ *  platform anyway, this just refuses it before touching credentials. */
+function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): BotAssignment | null {
+  const secrets =
+    'botToken' in a.secrets && typeof a.secrets.botToken === 'string' && typeof a.secrets.signingSecret === 'string'
+      ? { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret }
+      : 'verificationToken' in a.secrets && typeof a.secrets.verificationToken === 'string'
+        ? {
+            verificationToken: a.secrets.verificationToken,
+            ...(typeof a.secrets.encryptKey === 'string' ? { encryptKey: a.secrets.encryptKey } : {})
+          }
+        : null
+  if (!secrets) return null
   return {
     botId: a.botId,
     platform: a.platform,
-    secrets:
-      'botToken' in a.secrets
-        ? { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret }
-        : {
-            verificationToken: a.secrets.verificationToken,
-            ...(a.secrets.encryptKey ? { encryptKey: a.secrets.encryptKey } : {})
-          },
+    secrets,
     ...(a.apiAppId ? { apiAppId: a.apiAppId } : {}),
     ...(a.teamId ? { teamId: a.teamId } : {}),
     ...(a.credentialRevision !== undefined ? { credentialRevision: a.credentialRevision } : {}),
@@ -152,9 +159,14 @@ async function main(): Promise<void> {
       // §6.1: the assignment's origin-kind classification (present from an S1b CP)
       // teaches this relay how to classify a platform id its build predates.
       collab.learnPlatformKind(a.platform, a.originKind)
-      void held.relayIngress
-        ?.assign(toBotAssignment(a))
-        .catch((err) => log.error(`relay: bot-assign failed: ${String(err)}`))
+      const assignment = toBotAssignment(a)
+      if (!assignment) {
+        // §6.7: an opaque secret bag for a platform this build predates — ids only,
+        // never the material. The S3 platform module takes this shape over.
+        log.warn(`relay: bot-assign for ${a.botId} carried a secret shape this build does not support — skipped`)
+        return
+      }
+      void held.relayIngress?.assign(assignment).catch((err) => log.error(`relay: bot-assign failed: ${String(err)}`))
     },
     onBotUnassign: (a) =>
       void held.relayIngress

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -24,7 +24,7 @@ import { registerSlackHttpIngress } from './slack-http-ingress.js'
 import { registerFeishuHttpIngress } from './feishu-http-ingress.js'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
-import { mapAgentDirectory, type BotAssignment } from './bot-arbitration.js'
+import { mapAgentDirectory, toBotAssignment } from './bot-arbitration.js'
 import { HookTable } from './hooks/hook-table.js'
 import { HookRateLimiter } from './hooks/rate-limit.js'
 import { registerHookIngress } from './hooks/ingress.js'
@@ -35,43 +35,6 @@ import { MemoryConnectionBindingTable } from './memory/binding-table.js'
 import type { Logger } from './log.js'
 
 const RELAY_WS_PATH = '/api/v1/relays/ws'
-
-/** Map the CP's `rc/bot-assign` frame to the manager's {@link BotAssignment}
- *  (drop absent optionals so the strict-optional shape holds). Returns null for a
- *  secret bag neither typed shape matches (§6.7 open reader: a platform this build
- *  predates) — the caller logs and skips; the assign handler would refuse the
- *  platform anyway, this just refuses it before touching credentials. */
-function toBotAssignment(a: import('@agentconnect.md/protocol').RcBotAssign): BotAssignment | null {
-  const secrets =
-    'botToken' in a.secrets && typeof a.secrets.botToken === 'string' && typeof a.secrets.signingSecret === 'string'
-      ? { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret }
-      : 'verificationToken' in a.secrets && typeof a.secrets.verificationToken === 'string'
-        ? {
-            verificationToken: a.secrets.verificationToken,
-            ...(typeof a.secrets.encryptKey === 'string' ? { encryptKey: a.secrets.encryptKey } : {})
-          }
-        : null
-  if (!secrets) return null
-  return {
-    botId: a.botId,
-    platform: a.platform,
-    secrets,
-    ...(a.apiAppId ? { apiAppId: a.apiAppId } : {}),
-    ...(a.teamId ? { teamId: a.teamId } : {}),
-    ...(a.credentialRevision !== undefined ? { credentialRevision: a.credentialRevision } : {}),
-    ...(a.botUserId ? { botUserId: a.botUserId } : {}),
-    members: a.members,
-    agents: mapAgentDirectory(a.agents),
-    routes: a.routes,
-    ...(a.defaultAgentId ? { defaultAgentId: a.defaultAgentId } : {}),
-    ...(a.defaultDaemonId ? { defaultDaemonId: a.defaultDaemonId } : {}),
-    gatedAgentIds: a.gatedAgentIds,
-    mutedChannels: a.mutedChannels,
-    gatedOffChannels: a.gatedOffChannels,
-    noticedDmConversations: a.noticedDmConversations,
-    ...(a.noticeAuthority ? { noticeAuthority: a.noticeAuthority } : {})
-  }
-}
 
 async function main(): Promise<void> {
   const config = loadConfig()


### PR DESCRIPTION
## What

Two additive **dual-shape** surfaces of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md), combined per plan: **§6.5** (`NormalizedMessage` generic coordinates + `adapterExt`) and **§6.7** (`rc/bot-assign` opaque secrets/ingress).

## §6.5 — generic thread coordinates

- `topicId` / `threadRoot` / `promoteToThread` land beside the now-deprecated named fields (`telegramTopicId` / `telegramThreadRoot` / `discordTopLevel`); normalizers dual-write, the daemon's telegram canonicalization and discord thread-promotion read **generic-first with named fallback**. Named emission drops after the next fleet cycle.
- `adapterExt?: Record<platformId, unknown>` — the opaque per-adapter bag, round-tripped to the S2 renderer seam, never read by core. Plumbing only in this PR (no writer yet).
- Two deliberate calls, flagged for review: the design's `threadId` is named **`threadRoot`** (`thread` already occupies the canonical post-ingress slot), and **`parentChannel` stays a core coordinate** rather than moving to `adapterExt` — bind-rule admission reads it before any dispatch target resolves (the D2 dividing rule), across thread→parent, in five core sites.

## §6.7 — opaque bot-assign payloads

- `secrets` gains a record catch-all so an unknown platform's opaque bag decodes; the typed Slack/Feishu variants stay first and fully validated.
- New opaque `ingress` bag, dual-emitted by the CP beside the named demux fields (`apiAppId`/`teamId`/`botUserId`); the relay ignores it during the window and the S3 platform module takes its validation over.
- Shape enforcement moves where the design puts it: the relay's `toBotAssignment` refuses a secret bag neither typed shape matches **before touching credentials** (log + skip, never the socket). The schema-level "signingSecret required" test is repinned to this contract.

## Verification

protocol 260 ✓ (dual/generic-only/adapterExt round-trip; opaque secrets+ingress decode; typed-shape validation retained) · message ✓ · relay 382 ✓ · daemon 2784 ✓ (+generic-only telegram keying, generic-wins-over-named) · CP unit 1020 ✓ + integration 948 ✓ (assign `ingress` mirrors the named fields) · full-workspace typecheck ✓.

Remaining S1b: §6.6 `platform_action` reader (new `rd/msg` union member — reader-first, emission flip gated on the next fleet cycle) and §6.8 cron/hook targeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)