### PR TITLE
fix(skills): de-duplicate local skills present under multiple roots

### DIFF
--- a/packages/daemon/src/skills/local-skill-inventory.ts
+++ b/packages/daemon/src/skills/local-skill-inventory.ts
@@ -138,6 +138,11 @@ export async function listLocalSkills(cwd: string, stateDir: string): Promise<Lo
   }
 
   const entries: LocalSkillEntry[] = []
+  // A skill can exist under more than one root (e.g. installed into one and
+  // mirrored/committed in another). The harness resolves a skill by name, so
+  // surface each name once; a ledger-known origin wins over an incidental repo
+  // copy of the same name.
+  const byName = new Map<string, number>()
   let totalBytes = 0
   let scanned = 0
   for (const root of SKILL_ROOTS) {
@@ -166,11 +171,20 @@ export async function listLocalSkills(cwd: string, stateDir: string): Promise<Lo
           origin: ownedOrigin.get(relPath) ?? 'repo',
           path: relPath
         }
+        const existing = byName.get(entry.name)
+        if (existing !== undefined) {
+          // Same name under a second root: keep one, preferring a ledger-known
+          // origin over an incidental `repo` copy. Not a new entry, so the count
+          // and byte budget are unaffected.
+          if (entries[existing]!.origin === 'repo' && entry.origin !== 'repo') entries[existing] = entry
+          continue
+        }
         // Keep the whole response under the control-frame limit; stop cleanly
         // rather than return an oversized payload the receiver would reject.
         const size = Buffer.byteLength(JSON.stringify(entry)) + 1
         if (totalBytes + size > MAX_TOTAL_BYTES) return finalize(entries)
         totalBytes += size
+        byName.set(entry.name, entries.length)
         entries.push(entry)
       }
     } finally {

--- a/packages/daemon/test/local-skill-inventory.test.ts
+++ b/packages/daemon/test/local-skill-inventory.test.ts
@@ -77,6 +77,19 @@ describe('local skill inventory', () => {
     expect(skills.map((s) => s.name)).toEqual(['ok']) // no 'stolen' (symlinked root), no 'linkmd' (symlinked SKILL.md)
   })
 
+  it('lists a skill present under both roots only once', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'ac-localskills-'))
+    const stateDir = await mkdtemp(join(tmpdir(), 'ac-skillstate-'))
+    // Same skill name installed/committed under both harness roots.
+    await writeSkill(cwd, '.claude/skills', 'update-model-pricing', 'name: update-model-pricing\ndescription: prices')
+    await writeSkill(cwd, '.agents/skills', 'update-model-pricing', 'name: update-model-pricing\ndescription: prices')
+    await writeSkill(cwd, '.claude/skills', 'solo', 'name: solo\ndescription: one')
+
+    const skills = await listLocalSkills(cwd, stateDir)
+    expect(skills.map((s) => s.name)).toEqual(['solo', 'update-model-pricing']) // deduped, not two entries
+    expect(skills.filter((s) => s.name === 'update-model-pricing')).toHaveLength(1)
+  })
+
   it('returns [] for an unmaterialized workspace with no skill roots', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'ac-localskills-'))
     const stateDir = await mkdtemp(join(tmpdir(), 'ac-skillstate-'))


### PR DESCRIPTION
## Problem

The local skill inventory (#506) listed a skill **twice** when it exists under both harness skill roots (`.claude/skills` and `.agents/skills`) — e.g. a repo-committed `update-model-pricing` showed up as two identical rows. The scan emitted one entry per root.

## Fix

De-duplicate by skill name (the harness resolves a skill by name, so it's one skill). When the same name appears under a second root, a ledger-known origin (`dream-accepted` / `managed` / `git-source`) wins over an incidental `repo` copy. The dedupe does not affect the entry count / byte-budget caps.

Regression test: a name present under both roots yields a single entry.

Follow-up to #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)