### PR TITLE
feat(protocol): platform_action interaction envelope, reader-first (S1b §6.6)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -228,6 +228,8 @@ import {
   SESSION_VISIBILITY_FEATURE,
   SLACK_SESSION_AUDIENCE_FEATURE,
   effectiveMemoryDreamingPolicy,
+  RdSlackAction,
+  WireFeishuCardActionEvent,
   gitRepoLabel,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl
@@ -342,6 +344,7 @@ import type {
   RdMsgIm,
   RdMsgSlackAction,
   RdMsgFeishuAction,
+  RdMsgPlatformAction,
   RdMsgHook,
   RdAck,
   RdAgentMsgFwd,
@@ -6293,7 +6296,9 @@ export class Daemon {
           ? this.handleRelaySlackAction(msg)
           : msg.source === 'feishu_action'
             ? this.handleRelayFeishuAction(msg)
-            : this.handleRelayIm(msg)
+            : msg.source === 'platform_action'
+              ? this.handleRelayPlatformAction(msg)
+              : this.handleRelayIm(msg)
     if (this.relayMsgAcks.size >= 2000) this.relayMsgAcks.clear() // bound the window
     this.relayMsgAcks.set(dedupKey, ack)
     return ack
@@ -6398,6 +6403,47 @@ export class Daemon {
    *  boundary before opening or mutating anything: the agent, HTTP Slack integration,
    *  local connection, session owner, and (when retained) exact delivery binding must all
    *  still agree. Message shortcuts resolve their channel/thread coordinates here. */
+  /**
+   * §6.6 `platform_action` envelope: the payload is opaque to relay core and is
+   * decoded HERE by the platform id's own vocabulary — today by delegating to the
+   * legacy per-platform handlers (the S2 platform module takes the decode over).
+   * An unknown platform id or an undecodable payload NAKs the ITEM (the relay
+   * already acked receipt semantics via rd/ack), never the socket. The ack
+   * dual-carries the generic `response` beside the deprecated Feishu-named slot
+   * while the relay may still read either.
+   */
+  private handleRelayPlatformAction(msg: RdMsgPlatformAction): RdAck {
+    if (msg.platformId === 'slack') {
+      const payload = RdSlackAction.safeParse(msg.payload)
+      if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+      return this.handleRelaySlackAction({
+        source: 'slack_action',
+        agentId: msg.agentId,
+        sessionKey: msg.sessionKey,
+        msgId: msg.msgId,
+        botId: msg.botId,
+        integrationId: msg.integrationId,
+        ...(msg.userId !== undefined ? { userId: msg.userId } : {}),
+        payload: payload.data
+      })
+    }
+    if (msg.platformId === 'feishu') {
+      const payload = WireFeishuCardActionEvent.safeParse(msg.payload)
+      if (!payload.success) return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+      const ack = this.handleRelayFeishuAction({
+        source: 'feishu_action',
+        agentId: msg.agentId,
+        sessionKey: msg.sessionKey,
+        msgId: msg.msgId,
+        botId: msg.botId,
+        integrationId: msg.integrationId,
+        payload: payload.data
+      })
+      return ack.feishuCardAction !== undefined ? { ...ack, response: ack.feishuCardAction } : ack
+    }
+    return { msgId: msg.msgId, accepted: false, reason: 'unsupported_action' }
+  }
+
   private handleRelaySlackAction(msg: RdMsgSlackAction): RdAck {
     const agent = this.agents.get(msg.agentId)
     if (!agent) {

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1504,6 +1504,54 @@ describe('Slack interactive status bar', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('§6.6: a platform_action envelope decodes per-platform and NAKs unsupported items', async () => {
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => blockingHost().host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const integration = (daemon as any).agents.get('bot-a').integrations[0]
+    integration.slack.mode = 'shared'
+    delete integration.slack.appToken
+    const sharedTransportScope = `slack:${createHash('sha256').update('slack\0b').digest('hex').slice(0, 24)}`
+    const KEY = sessionKey('slack', 'C1', 'T1', 'bot-a', sharedTransportScope)
+    const openStatusModal = vi.fn(async () => {})
+    ;(daemon as any).connByIntegration.set('int-a', { openStatusModal })
+    ;(daemon as any).store.upsertSession({
+      key: KEY,
+      agentId: 'bot-a',
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      transportScope: sharedTransportScope,
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const envelope = (over: Record<string, unknown> = {}) => ({
+      source: 'platform_action' as const,
+      platformId: 'slack',
+      agentId: 'bot-a',
+      sessionKey: KEY,
+      msgId: 'pa-1',
+      botId: 'shared-bot',
+      integrationId: 'int-a',
+      payload: { kind: 'open-config', triggerId: 'trig-1' },
+      ...over
+    })
+    // The envelope routes into the SAME per-platform decode path as the legacy member.
+    expect((daemon as any).handleRelayMsg(envelope(), () => {})).toEqual({ msgId: 'pa-1', accepted: true })
+    expect(openStatusModal).toHaveBeenCalledTimes(1)
+    // An undecodable payload NAKs the ITEM, never the socket.
+    expect(
+      (daemon as any).handleRelayMsg(envelope({ msgId: 'pa-2', payload: { kind: 'not-a-thing' } }), () => {})
+    ).toEqual({ msgId: 'pa-2', accepted: false, reason: 'unsupported_action' })
+    // A platform id this build has no decoder for NAKs the same way.
+    expect(
+      (daemon as any).handleRelayMsg(envelope({ msgId: 'pa-3', platformId: 'teams-x', payload: {} }), () => {})
+    ).toEqual({ msgId: 'pa-3', accepted: false, reason: 'unsupported_action' })
+    await daemon.stop()
+  })
+
   it('handles shared session interactions only for the exact local integration and session owner', async () => {
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blockingHost().host as any })
     await daemon.start()

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -292,6 +292,34 @@ export const RdMsgFeishuAction = z.object({
 })
 export type RdMsgFeishuAction = z.infer<typeof RdMsgFeishuAction>
 
+/**
+ * R→D REQ → rd/ack (§6.6). The ONE platform-interaction envelope replacing the
+ * per-platform `slack_action` / `feishu_action` members: the ENVELOPE is
+ * core-typed — the routing fields relay core needs plus the dedup identity —
+ * and the PAYLOAD is opaque to relay core. The relay-side platform module
+ * parsed the provider interaction and minted `msgId`; the SAME platform's
+ * daemon-side module decodes `payload` into StatusAction / PermissionChoice /
+ * Elicitation calls. Reader-first: this build ACCEPTS the member while the
+ * relay keeps emitting the legacy members; the emission flips after the next
+ * fleet cycle and the legacy members retire after that. Dedup scope is
+ * (botId, sessionKey, msgId), identical to the legacy members — the daemon
+ * replays the prior ack on retransmit, and fencing is unaffected.
+ */
+export const RdMsgPlatformAction = z.object({
+  source: z.literal('platform_action'),
+  platformId: z.string().min(1),
+  agentId: z.string().uuid(),
+  sessionKey: z.string().min(1),
+  msgId: z.string().min(1),
+  botId: z.string().uuid(),
+  integrationId: z.string().uuid(),
+  // The platform user who tapped it (attribution); optional — absent records as
+  // an unknown actor, never a fabricated one.
+  userId: z.string().min(1).optional(),
+  payload: z.unknown()
+})
+export type RdMsgPlatformAction = z.infer<typeof RdMsgPlatformAction>
+
 // R→D REQ → rd/ack. One already-adjudicated trigger delivery: the relay matched
 // the hook rule and names the target agent (explicit-agent short-circuit, same
 // as webchat — no local trigger arbitration). The daemon synthesizes a
@@ -329,6 +357,7 @@ export const RdMsg = z.discriminatedUnion('source', [
   RdMsgIm,
   RdMsgSlackAction,
   RdMsgFeishuAction,
+  RdMsgPlatformAction,
   RdMsgHook
 ])
 export type RdMsg = z.infer<typeof RdMsg>
@@ -341,7 +370,13 @@ export const RdAck = z.object({
   accepted: z.boolean(),
   turnId: z.string().uuid().optional(),
   reason: z.string().optional(),
-  feishuCardAction: WireFeishuCardActionResponse.optional()
+  /** DEPRECATED (§6.6): read `response`. The Feishu-named sync-toast slot. */
+  feishuCardAction: WireFeishuCardActionResponse.optional(),
+  /** §6.6 opaque interaction response for a `platform_action` — the payload the
+   *  relay-side platform module surfaces on the synchronous HTTP body (Feishu
+   *  toast, Slack block_suggestion options). Dual-emitted with the deprecated
+   *  slot above during the window; decoded only by the platform module. */
+  response: z.unknown().optional()
 })
 export type RdAck = z.infer<typeof RdAck>
 

--- a/packages/protocol/src/platform-tolerance.test.ts
+++ b/packages/protocol/src/platform-tolerance.test.ts
@@ -263,6 +263,50 @@ describe('§6.5 generic thread coordinates + adapterExt', () => {
   })
 })
 
+describe('§6.6 platform_action envelope', () => {
+  const pa = (over: Record<string, unknown> = {}) =>
+    decodeRelayDaemonFrame(
+      envelope('rd/msg', {
+        source: 'platform_action',
+        platformId: 'slack',
+        agentId: AGENT_ID,
+        sessionKey: 'slack:C1:T1',
+        msgId: 'pa-1',
+        botId: BOT_ID,
+        integrationId: INTEGRATION_ID,
+        payload: { kind: 'open-config', triggerId: 'trig-1' },
+        ...over
+      })
+    )
+
+  it('decodes with a core-typed envelope and an OPAQUE payload for any platform id', () => {
+    const slack = pa()
+    expectOk(slack)
+    if (slack.ok && slack.frame.type === 'rd/msg' && slack.frame.payload.source === 'platform_action') {
+      expect(slack.frame.payload.platformId).toBe('slack')
+      expect(slack.frame.payload.payload).toEqual({ kind: 'open-config', triggerId: 'trig-1' })
+    }
+    // A platform id this build predates decodes too — refusal is the daemon's
+    // per-item verdict, never the schema's.
+    expectOk(pa({ platformId: UNKNOWN, payload: { anything: true } }))
+  })
+
+  it('rd/ack carries the generic opaque response beside the deprecated Feishu slot', () => {
+    const r = decodeRelayDaemonFrame(
+      envelope('rd/ack', {
+        msgId: 'pa-1',
+        accepted: true,
+        feishuCardAction: { toast: { type: 'info', content: 'ok' } },
+        response: { toast: { type: 'info', content: 'ok' } }
+      })
+    )
+    expectOk(r)
+    if (r.ok && r.frame.type === 'rd/ack') {
+      expect(r.frame.payload.response).toEqual({ toast: { type: 'info', content: 'ok' } })
+    }
+  })
+})
+
 describe('§6.7 rc/bot-assign opaque secrets + ingress', () => {
   it('decodes an opaque secret bag for a platform this build predates + the ingress bag', () => {
     const r = decodeRelayCpFrame(

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -25,11 +25,11 @@ import type {
   RcBotConversation,
   RcBotRevoked,
   WireFeishuCardActionEvent,
-  WireFeishuCardActionResponse,
   WireNormalizedMessage,
   RcThreadAssign,
   RcThreadLookup
 } from '@agentconnect.md/protocol'
+import { WireFeishuCardActionResponse } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from './log.js'
 import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
@@ -862,7 +862,10 @@ export class RelayIngressManager {
       if (!ack.accepted) {
         this.deps.log.warn(`relay-ingress(${botId}): daemon rejected Feishu card action (${ack.reason ?? 'unknown'})`)
       }
-      return ack.feishuCardAction
+      // §6.6 dual-shape: prefer the generic opaque `response`; a pre-§6.6 daemon
+      // fills only the deprecated Feishu-named slot.
+      const generic = WireFeishuCardActionResponse.safeParse(ack.response)
+      return generic.success && ack.response !== undefined ? generic.data : ack.feishuCardAction
     } catch (err) {
       this.deps.log.warn(`relay-ingress(${botId}): Feishu card action forward failed: ${(err as Error).message}`)
       return undefined


### PR DESCRIPTION
## What

**S1b §6.6** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md): the ONE `platform_action` interaction member joins the `rd/msg` union — the envelope is **core-typed** (routing fields plus the `(botId, sessionKey, msgId)` dedup identity, identical to the legacy members) and the **payload is opaque to relay core**, decoded on the daemon by the platform id's own vocabulary. Today that decode delegates to the legacy per-platform handlers; the S2 platform module takes it over.

`rd/ack` gains the generic opaque `response` slot beside the deprecated `feishuCardAction`: the daemon dual-fills both for a Feishu `platform_action`, and the relay reads `response`-first with the legacy slot as fallback.

## Reader-first, deliberately

`rd/msg` discriminates on `source`, so a new member is **frame-fatal to a daemon that predates it**. This PR only makes every peer ACCEPT the member — the relay keeps emitting `slack_action`/`feishu_action`, and the emission flip is a small follow-up gated on the next fleet cycle (the legacy members retire one cycle after that). An unknown platform id or an undecodable payload NAKs the **item** (`unsupported_action`), never the socket — the S1a per-frame policy.

## Verification

protocol 265 ✓ (envelope decode for known and unknown platform ids; ack dual slots) · daemon 2785 ✓ (the envelope routes into the same slack decode path as the legacy member — same modal side-effects; per-item NAKs for bad payloads and unknown platform ids) · relay 384 ✓ · CP unit 1020 ✓ · full-workspace typecheck ✓.

Remaining S1b: §6.8 cron/hook targeting (in progress), then the two emission-flip follow-ups gated on fleet cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)