### PR TITLE
feat(daemon,web): open cron/hook anchor targeting to every connected platform (S1b §6.8)

### DIFF
--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -139,7 +139,8 @@ export const CronDefSchema = z.object({
   // absent (legacy defs) ⇒ the agent's first integration.
   target: z
     .object({
-      platform: z.enum(['slack', 'telegram', 'discord', 'feishu']),
+      // §6.8 open id; the daemon serves any platform it has a connection for.
+      platform: z.string().min(1),
       channel: z.string(),
       integrationId: z.string().optional()
     })

--- a/packages/daemon/src/agents/write-cron.ts
+++ b/packages/daemon/src/agents/write-cron.ts
@@ -25,12 +25,13 @@ function toCronDef(cron: CronUpsert): CronDef {
     id: cron.cronId,
     schedule: cron.schedule,
     timezone: cron.timezone,
-    // Only Slack targets are servable today; a non-slack target degrades to a
-    // headless fire rather than failing the whole def.
-    ...(cron.target && cron.target.platform === 'slack'
+    // §6.8: the target persists with its REAL platform — the anchor path posts
+    // through the target integration's own connection (anchorTrigger is
+    // platform-generic), so the old degrade-non-slack-to-headless fold is gone.
+    ...(cron.target
       ? {
           target: {
-            platform: 'slack' as const,
+            platform: cron.target.platform,
             channel: cron.target.channel,
             ...(cron.target.integrationId ? { integrationId: cron.target.integrationId } : {})
           }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -293,7 +293,13 @@ import type {
   RequestPermissionResponse
 } from '@agentclientprotocol/sdk'
 import type { Agent, CronDef, Integration } from './agents/agent-schema.js'
-import { fromPlatformMessage, stableMessageId, stableTurnId, type NormalizedMessage } from './messages/normalized.js'
+import {
+  fromPlatformMessage,
+  stableMessageId,
+  stableTurnId,
+  threadKeyForPost,
+  type NormalizedMessage
+} from './messages/normalized.js'
 import type {
   RegisterReq,
   RegisterOk,
@@ -17551,7 +17557,11 @@ export class Daemon {
           }
           // The posted anchor is both the thread root and the authoritative
           // transcript/read cursor. Keep the synthetic msgId as the durable turn id.
-          if (ts) msg = { ...msg, thread: ts, transcriptTs: ts }
+          // §6.8: the SESSION key must follow the platform's own conversation model
+          // (threadKeyForPost — Slack threads off the ts, Telegram replies resolve
+          // to `tg:<root>`, Discord conversations ARE the channel), or the anchored
+          // session and the replies underneath it mint different keys.
+          if (ts) msg = { ...msg, thread: threadKeyForPost(msg.platform, msg.channel, ts), transcriptTs: ts }
         } catch (err) {
           this.log.warn(
             `${label}: failed to post trigger to ${target.channel} (${formatErr(err)}) — running without anchor`

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -17540,19 +17540,22 @@ export class Daemon {
         this.log.warn(`${label}: agent "${agentId}" has no live platform connection — running without output`)
       } else {
         try {
-          // §6.8: DIRECT-conversation targets must canonicalize as DMs — a Telegram DM
-          // keys `dm` (not `tg:<id>`), Feishu DMs key the chat id, and the fire must be
-          // classified as a DM session. Probe the target connection where DM-ness
-          // changes the key (mirrors the root-post path in mcp/ops.ts); other
-          // platforms' keys are DM-insensitive.
+          // §6.8: a DIRECT-conversation target must canonicalize as a DM. Two things
+          // depend on it: the thread key (Telegram DMs key `dm`, not `tg:<id>`; Feishu
+          // DMs key the chat id) AND the session classification — `conversationKind`
+          // and the daemon-local private-capture gate both derive from `isDm`, so an
+          // anchor into a DM that reports `false` stores a channel/non-private session
+          // for a conversation whose inbound messages classify `dm`.
+          // CAPABILITY-driven, not a platform list: every connection exposes
+          // `getChannelInfo`, so the probe is uniform (a platform whose keys are
+          // DM-insensitive still needs the classification). Mirrors the root-post path
+          // in mcp/ops.ts; a failed probe falls back to the message's own value.
           const isDmTarget =
-            msg.platform === 'telegram' || msg.platform === 'feishu'
-              ? ((
-                  await (conn as { getChannelInfo?: (ch: string) => Promise<{ isIm?: boolean } | undefined> })
-                    .getChannelInfo?.(target.channel)
-                    .catch(() => undefined)
-                )?.isIm ?? false)
-              : false
+            (
+              await (conn as { getChannelInfo?: (ch: string) => Promise<{ isIm?: boolean } | undefined> })
+                .getChannelInfo?.(target.channel)
+                .catch(() => undefined)
+            )?.isIm ?? false
           if (isDmTarget) msg = { ...msg, isDm: true }
           let ts: string | undefined
           if (msg.platform === 'slack') {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -17540,6 +17540,20 @@ export class Daemon {
         this.log.warn(`${label}: agent "${agentId}" has no live platform connection — running without output`)
       } else {
         try {
+          // §6.8: DIRECT-conversation targets must canonicalize as DMs — a Telegram DM
+          // keys `dm` (not `tg:<id>`), Feishu DMs key the chat id, and the fire must be
+          // classified as a DM session. Probe the target connection where DM-ness
+          // changes the key (mirrors the root-post path in mcp/ops.ts); other
+          // platforms' keys are DM-insensitive.
+          const isDmTarget =
+            msg.platform === 'telegram' || msg.platform === 'feishu'
+              ? ((
+                  await (conn as { getChannelInfo?: (ch: string) => Promise<{ isIm?: boolean } | undefined> })
+                    .getChannelInfo?.(target.channel)
+                    .catch(() => undefined)
+                )?.isIm ?? false)
+              : false
+          if (isDmTarget) msg = { ...msg, isDm: true }
           let ts: string | undefined
           if (msg.platform === 'slack') {
             const agent = this.agents.get(agentId)
@@ -17561,7 +17575,7 @@ export class Daemon {
           // (threadKeyForPost — Slack threads off the ts, Telegram replies resolve
           // to `tg:<root>`, Discord conversations ARE the channel), or the anchored
           // session and the replies underneath it mint different keys.
-          if (ts) msg = { ...msg, thread: threadKeyForPost(msg.platform, msg.channel, ts), transcriptTs: ts }
+          if (ts) msg = { ...msg, thread: threadKeyForPost(msg.platform, msg.channel, ts, msg.isDm), transcriptTs: ts }
         } catch (err) {
           this.log.warn(
             `${label}: failed to post trigger to ${target.channel} (${formatErr(err)}) — running without anchor`

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -636,6 +636,50 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('§6.8: a discord DM anchored fire classifies as a private DM session', async () => {
+    // Discord thread keys are DM-insensitive (the conversation IS the channel), but
+    // `conversationKind` and the daemon-local capture gate are not: a DM fire that
+    // reports isDm:false is stored as a non-private CHANNEL session.
+    const host = quietHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const postMessage = vi.fn(async () => 'msg-1')
+    const getChannelInfo = vi.fn(async () => ({ id: 'D-1', isIm: true }))
+    ;(daemon as any).connByIntegration.delete('int-a')
+    ;(daemon as any).dcConnByIntegration.set('int-a', {
+      postMessage,
+      getChannelInfo,
+      postChrome: vi.fn(async () => {}),
+      updateMessage: vi.fn(async () => {})
+    })
+
+    await (daemon as any).fireTrigger(
+      'bot-a',
+      {
+        ...dm('ignored', 'scheduled', 'cron:cron-dc:trace-1'),
+        msgId: 'cron:cron-dc:trace-1',
+        traceId: 'trace-1',
+        source: 'cron',
+        trigger: 'cron',
+        platform: 'discord',
+        channel: 'D-1',
+        isDm: false
+      },
+      { channel: 'D-1', integrationId: 'int-a' },
+      '⏰ scheduled',
+      'cron "cron-dc"'
+    )
+
+    expect(getChannelInfo).toHaveBeenCalledWith('D-1')
+    const key = sessionKey('discord', 'D-1', 'D-1', 'bot-a', TRANSPORT_SCOPE)
+    const rec = (daemon as any).store.getSession(key)
+    expect(rec?.conversationKind).toBe('dm')
+    // The private-capture gate follows the same bit.
+    expect((daemon as any).store.isCaptureExcluded(rec?.acpSessionId)).toBe(true)
+    await daemon.stop()
+  }, 15_000)
+
   it('reports a cron session before its turn finishes', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -596,6 +596,46 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('§6.8: a telegram DM anchored fire keys `dm` and classifies as a DM session', async () => {
+    const host = quietHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const postMessage = vi.fn(async () => '888')
+    const getChannelInfo = vi.fn(async () => ({ isIm: true }))
+    ;(daemon as any).connByIntegration.delete('int-a')
+    ;(daemon as any).tgConnByIntegration.set('int-a', {
+      postMessage,
+      getChannelInfo,
+      postChrome: vi.fn(async () => {}),
+      updateMessage: vi.fn(async () => {})
+    })
+
+    await (daemon as any).fireTrigger(
+      'bot-a',
+      {
+        ...dm('ignored', 'scheduled', 'cron:cron-dm:trace-1'),
+        msgId: 'cron:cron-dm:trace-1',
+        traceId: 'trace-1',
+        source: 'cron',
+        trigger: 'cron',
+        platform: 'telegram',
+        channel: '42',
+        isDm: false
+      },
+      { channel: '42', integrationId: 'int-a' },
+      '⏰ scheduled',
+      'cron "cron-dm"'
+    )
+
+    expect(getChannelInfo).toHaveBeenCalledWith('42')
+    // A Telegram DM is ONE continuous conversation keyed `dm` — the anchor must
+    // join it, not open a `tg:<messageId>` session no inbound reply resolves to.
+    const key = sessionKey('telegram', '42', 'dm', 'bot-a', TRANSPORT_SCOPE)
+    expect((daemon as any).store.getSession(key)).toBeTruthy()
+    await daemon.stop()
+  }, 15_000)
+
   it('reports a cron session before its turn finishes', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -556,6 +556,46 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.stop()
   }, 15_000)
 
+  it('§6.8: a telegram anchored fire keys the session by that platform conversation model', async () => {
+    const host = quietHost()
+    const daemon = new Daemon({ root: scaffold(), hostFactory: () => host as any })
+    await daemon.start()
+    makeRoutable(daemon)
+    const postMessage = vi.fn(async () => '777')
+    // Re-home int-a onto the telegram connection map (makeRoutable wires the slack
+    // map, which the integration lookup checks first).
+    ;(daemon as any).connByIntegration.delete('int-a')
+    ;(daemon as any).tgConnByIntegration.set('int-a', {
+      postMessage,
+      postChrome: vi.fn(async () => {}),
+      updateMessage: vi.fn(async () => {})
+    })
+
+    await (daemon as any).fireTrigger(
+      'bot-a',
+      {
+        ...dm('ignored', 'scheduled', 'cron:cron-tg:trace-1'),
+        msgId: 'cron:cron-tg:trace-1',
+        traceId: 'trace-1',
+        source: 'cron',
+        trigger: 'cron',
+        platform: 'telegram',
+        channel: '-100123',
+        isDm: false
+      },
+      { channel: '-100123', integrationId: 'int-a' },
+      '⏰ scheduled',
+      'cron "cron-tg"'
+    )
+
+    expect(postMessage).toHaveBeenCalledWith('-100123', '⏰ scheduled')
+    // threadKeyForPost: a Telegram reply chain resolves to `tg:<root>` — the anchor
+    // session must mint the SAME key or follow-up replies open a different session.
+    const key = sessionKey('telegram', '-100123', 'tg:777', 'bot-a', TRANSPORT_SCOPE)
+    expect((daemon as any).store.getSession(key)).toBeTruthy()
+    await daemon.stop()
+  }, 15_000)
+
   it('reports a cron session before its turn finishes', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({ root: scaffold(), hostFactory: () => blocked.host as any })

--- a/packages/daemon/test/write-agent.test.ts
+++ b/packages/daemon/test/write-agent.test.ts
@@ -997,3 +997,35 @@ describe('writeIntegrationSpec §6.4 dual-shape reader', () => {
     expect(readJson(join(dir, 'bot-a', 'agent.json')).integrations).toEqual([])
   })
 })
+
+describe('writeCronDef §6.8 open target platform', () => {
+  const AGENT = '33333333-3333-4333-8333-333333333333'
+  it('persists a non-Slack target with its REAL platform (no headless degradation)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ac-cron-open-'))
+    seedAgent(dir, 'bot-a', {
+      id: AGENT,
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: 'workspace' },
+      integrations: []
+    })
+    writeCronDef(
+      dir,
+      {
+        cronId: '77777777-7777-4777-8777-777777777777',
+        agentId: AGENT,
+        schedule: '0 9 * * *',
+        timezone: 'UTC',
+        target: { platform: 'telegram', channel: '-100123', integrationId: '66666666-6666-4666-8666-666666666666' },
+        trigger: 'daily digest',
+        enabled: true
+      } as never,
+      {}
+    )
+    const raw = readJson(join(dir, 'bot-a', 'agent.json'))
+    expect((raw.crons as Record<string, unknown>[])[0]).toMatchObject({
+      target: { platform: 'telegram', channel: '-100123' }
+    })
+  })
+})

--- a/packages/web/src/components/console/modals/AddCronModal.tsx
+++ b/packages/web/src/components/console/modals/AddCronModal.tsx
@@ -73,9 +73,12 @@ function TimeField({
 interface Target {
   integrationId?: string
   channel?: string
-  platform: 'slack' | 'telegram'
+  // §6.8 open id — the anchor integration's REAL platform (the old two-value
+  // union silently coerced Discord/Feishu anchors to 'slack').
+  platform: string
 }
 
+// Headless fire: no channel; the platform is a legacy sentinel the CP defaults anyway.
 const HEADLESS: Target = { platform: 'slack' }
 
 export default function AddCronModal({ cron, onClose }: { cron?: CronDto | null; onClose: () => void }) {
@@ -138,7 +141,7 @@ export default function AddCronModal({ cron, onClose }: { cron?: CronDto | null;
           integrationId: i.id!,
           channelId: ch.channelId,
           channelName: ch.name,
-          platform: (i.platform === 'telegram' ? 'telegram' : 'slack') as Target['platform'],
+          platform: i.platform, // §6.8: the integration's real platform — no coercion
           sharedOwner: !!i.shareable
         }))
     )

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -579,7 +579,7 @@ export interface CronDto {
   name: string | null // console display name; null for legacy/CLI rows
   schedule: string
   timezone: string
-  targetPlatform: 'slack' | 'telegram'
+  targetPlatform: string // §6.8 open id — derived from the anchor integration
   targetChannel: string | null
   targetIntegrationId: string | null // null ⇒ legacy row / integration uninstalled
   trigger: string
@@ -602,7 +602,7 @@ export interface UpsertCronInput {
   name?: string // console display name
   schedule: string
   timezone?: string // omitted on create ⇒ control-plane process timezone
-  targetPlatform: 'slack' | 'telegram'
+  targetPlatform: string // §6.8 open id — derived from the anchor integration
   targetChannel?: string // optional — absent ⇒ headless fire
   targetIntegrationId?: string // the agent integration posting the anchor (platform derives from it)
   trigger: string


### PR DESCRIPTION
## What

**S1b §6.8** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) — the last S1b protocol-surface stage, and the end-to-end fix for **§14 defect #2**. The anchor platform derives from the target integration everywhere; the two folds that hid non-Slack anchors are deleted.

## The folds, and what replaced them

- **web** — `AddCronModal`'s two-value `Target` union coerced a Discord/Feishu anchor to `'slack'`, producing a slack-labelled target with a foreign channel id (a broken anchor at fire time). The channel option now carries the integration's **real platform**, and the `api.ts` `targetPlatform` DTO types open to `string`. The CP create route already derives the platform from `targetIntegrationId` (and its DTO accepts all four ids), so no CP change was needed.
- **daemon** — `write-cron` silently degraded every non-Slack target to a headless fire ("only Slack targets are servable today"). That claim turned out to be one gap wide: `anchorTrigger` is already platform-generic (`replyConnFor` + generic `postMessage`), and the real defect was **thread keying** — the anchored session was keyed by the raw post ts, which is wrong on every platform whose conversation model is not Slack's. Anchor keys now go through `threadKeyForPost` (Slack `ts` — identity, existing anchors unchanged; Telegram `tg:<root>`; Discord the channel), so the anchored session and the replies underneath it mint the **same key**. The target persists with its real platform and the degradation is gone.

The scheduler's headless `?? 'slack'` remains — a missing-value sentinel for target-less fires, not a fold (per the S0 audit's split).

## Direct-conversation anchors (review rounds 2–3)

`AddCronModal` offers observed `kind: 'im'` rows as targets, so anchors land in DMs too. `anchorTrigger` now resolves DM-ness from the target connection **for every platform** (capability-driven — all four expose `getChannelInfo` — rather than a platform list, removing a branch instead of extending one; a failed probe falls back to the message's own value). Two things depend on it: the thread key (Telegram DMs key `dm`, Feishu the chat id) and the **session classification** — `conversationKind` and the daemon-local private-capture gate both derive from `isDm`, which is why Discord needed it even though its keys are DM-insensitive.

**Behavior note:** this also corrects Slack's identical latent defect — a Slack DM cron anchor now classifies `dm` + private instead of `channel`, matching what an inbound message in that same DM conversation already produces.

## Verification

daemon 2789 ✓ (new: a telegram anchored fire keys `tg:<root>`; a telegram DM anchor keys `dm`; a Discord DM anchor classifies `dm` + private; write-cron persists a telegram target verbatim) · web 710 ✓ · CP unit 1020 ✓ + integration 948 ✓ · full-workspace typecheck ✓.

## S1b status after this merges

All §6.1–§6.8 surfaces are landed (readers + dual-shape emissions). Remaining are the two **emission-flip follow-ups** gated on the next fleet cycle: drop the legacy `IntegrationSpec` nested blocks / named coordinate fields / named demux fields, and flip the relay to emit `platform_action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
