### PR TITLE
feat(cp): skip incompatible-daemon agents from org environment `all` enrollment

### DIFF
--- a/docs/designs/organization-secrets-and-variables.md
+++ b/docs/designs/organization-secrets-and-variables.md
@@ -661,9 +661,13 @@ guarantee, so rollout is daemon-first:
    the monotonic comparison, and advertise `agent-config-revision-v1`.
 2. Deploy the CP schema/writers and begin attaching revisions to every CP-owned
    agent projection.
-3. Enable an organization-environment write only when every retained or newly
-   affected placed agent is on a compatible daemon. An unplaced bound agent may
-   be saved, but placement then requires the same daemon feature.
+3. Gate the organization-environment writes that cannot avoid an incompatible
+   daemon: an explicitly requested binding and a value rotation that reaches an
+   already-bound placed agent are refused until the daemon is upgraded. `all`
+   enrollment instead SKIPS an agent placed on an incompatible daemon — one
+   stale daemon must not block an organization-wide entry — and the skipped
+   agent enrolls on a later authorized configuration write. An unplaced bound
+   agent may be saved, but placement then requires the same daemon feature.
 4. Enable the Settings UI after the API capability is available.
 
 Old daemons may ignore the optional field, but the feature never relies on that

--- a/packages/control-plane/src/http/routes/organization-environment.ts
+++ b/packages/control-plane/src/http/routes/organization-environment.ts
@@ -37,7 +37,7 @@ import type { ZodTypeProvider } from '../plugins/zod.js'
 import { Tag } from '../plugins/openapi.js'
 import type { HttpDeps } from '../deps.js'
 import { ctxOf, denyNonOwner, orgOf } from '../rbac.js'
-import { AgentId, type OrgId } from '../../domain/ids.js'
+import { AgentId, type DaemonId, type OrgId } from '../../domain/ids.js'
 import { canEdit, canView, type ViewCtx } from '../../authorization/policy.js'
 import type {
   OrganizationEnvironmentEntryRecord,
@@ -135,13 +135,43 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       )
     }
 
+    /** Does this placed agent's daemon persist and enforce `configRevision`? An
+     *  unplaced agent is always fine (placement re-checks the feature), and an
+     *  unknown/never-registered daemon cannot be proven compatible — the gate
+     *  never relies on lenient behavior from an unverified daemon. */
+    const onCompatibleDaemon = async (daemonId: DaemonId | null): Promise<boolean> => {
+      if (daemonId === null) return true
+      const daemon = await deps.registry.get(daemonId)
+      return !!daemon?.capabilities.features.includes(AGENT_CONFIG_REVISION_FEATURE)
+    }
+
     /**
-     * Rollout gate (§10 step 3). An organization-environment write is admitted only
-     * when every affected PLACED agent sits on a daemon that persists and enforces
-     * `configRevision`. Full-map replacement is only safe behind that fence: on an
-     * older daemon a late-completing older snapshot could reinstate a rotated or
-     * deleted value. An unplaced bound agent may be saved — placement then requires
-     * the same daemon feature.
+     * The subset of `agentIds` on an incompatible daemon — the agents `all`
+     * enrollment SKIPS (§10 step 3) rather than letting one stale daemon block an
+     * organization-wide entry. A skipped agent stays unbound until a later
+     * authorized configuration write enrolls it, by which point rotation and
+     * placement gates protect it. Callers pass only caller-editable ids, so the
+     * result is always safe to act on (and count in logs).
+     */
+    const incompatiblePlacedAgentIds = async (orgId: OrgId, agentIds: readonly string[]): Promise<string[]> => {
+      if (agentIds.length === 0) return []
+      const wanted = new Set(agentIds)
+      const placed = (await deps.repos.agent.list(orgId)).filter((agent) => wanted.has(agent.id))
+      const out: string[] = []
+      for (const agent of placed) {
+        if (!(await onCompatibleDaemon(agent.daemonId))) out.push(agent.id)
+      }
+      return out
+    }
+
+    /**
+     * Rollout gate (§10 step 3) for the writes that CANNOT skip an agent: an
+     * explicitly requested binding (the caller named the agent, so a silent
+     * no-op would lie) and a value rotation that genuinely reaches every
+     * already-bound agent. Full-map replacement is only safe behind the
+     * `configRevision` fence: on an older daemon a late-completing older snapshot
+     * could reinstate a rotated or deleted value. An unplaced bound agent may be
+     * saved — placement then requires the same daemon feature.
      *
      * Returns the message to refuse with, or null when every affected agent is fine.
      *
@@ -171,12 +201,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
       // what keeps the refusal indistinguishable from a missing agent.
       const inScope = mode === 'requested' ? agents.filter((agent) => canEdit(agent, ctx)) : agents
       for (const agent of inScope) {
-        if (agent.daemonId === null) continue
-        const daemon = await deps.registry.get(agent.daemonId)
-        // An unknown/never-registered daemon cannot be proven compatible. Treat it
-        // as incompatible rather than assuming: the whole point of the gate is that
-        // the feature never relies on lenient behavior from an unverified daemon.
-        if (!daemon?.capabilities.features.includes(AGENT_CONFIG_REVISION_FEATURE)) {
+        if (!(await onCompatibleDaemon(agent.daemonId))) {
           // Naming is safe only for an agent the caller can already see.
           return canView(agent, ctx)
             ? `agent ${agent.name} runs on a daemon that does not yet support organization environment entries; upgrade it first`
@@ -285,7 +310,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
           tags: [Tag.Environment],
           summary: 'Create an organization variable or secret',
           description:
-            'Defines one organization-owned entry and targets it at all agents or a selected set. A secret value is write-only: it is accepted here and never returned. `all` enrolls every agent the caller may edit and auto-enrolls agents on later authorized configuration writes; it never reaches an agent the caller cannot manage. `key` and `kind` are immutable afterwards.',
+            'Defines one organization-owned entry and targets it at all agents or a selected set. A secret value is write-only: it is accepted here and never returned. `all` enrolls every agent the caller may edit and auto-enrolls agents on later authorized configuration writes; it never reaches an agent the caller cannot manage, and it skips an agent placed on a daemon that does not yet support organization environment entries (that agent enrolls on a later configuration write once its daemon is upgraded). `key` and `kind` are immutable afterwards.',
           operationId: 'createOrganizationEnvironmentEntry',
           body: CreateOrganizationEnvironmentEntryBody,
           response: { 201: OrganizationEnvironmentEntryDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
@@ -295,13 +320,24 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
         if (denyNonOwner(req, reply)) return
         const orgId = orgOf(req)
         const ctx = ctxOf(req)
-        // Gate every agent this write would reach: the explicit selection, or — for
-        // `all` — the set this caller may edit. The repository re-decides
-        // authorization inside its transaction; this only refuses early rather than
-        // persisting an entry a placed daemon could not safely apply.
-        const gated = req.body.audience === 'all' ? await enrollableAgentIdsOf(orgId, ctx) : (req.body.agentIds ?? [])
-        const blocked = await incompatibleDaemonMessage(orgId, ctx, gated, 'requested')
-        if (blocked) return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: blocked })
+        // Daemon compatibility, two postures: an EXPLICIT selection is gated (the
+        // caller named the agent and can deselect it), while `all` enrollment SKIPS
+        // an agent on an incompatible daemon — one stale daemon must not block an
+        // organization-wide entry. The repository re-decides authorization inside
+        // its transaction; this only shapes what a placed daemon must safely apply.
+        let excludeAgentIds: string[] = []
+        if (req.body.audience === 'all') {
+          excludeAgentIds = await incompatiblePlacedAgentIds(orgId, await enrollableAgentIdsOf(orgId, ctx))
+          if (excludeAgentIds.length > 0) {
+            app.log.info(
+              { orgId, skippedAgents: excludeAgentIds.length },
+              'organization environment `all` enrollment skipped agents on incompatible daemons'
+            )
+          }
+        } else {
+          const blocked = await incompatibleDaemonMessage(orgId, ctx, req.body.agentIds ?? [], 'requested')
+          if (blocked) return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: blocked })
+        }
         // Seal OUTSIDE the transaction: a real cipher may make network calls, and a
         // transaction must never wait on one. Material prepared for a losing write is
         // discarded, never logged.
@@ -315,7 +351,8 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
             ...(req.body.kind === 'variable' ? { variableValue: req.body.value } : {}),
             ...(sealedSecret !== undefined ? { sealedSecret } : {}),
             audience: req.body.audience,
-            ...(req.body.agentIds ? { agentIds: req.body.agentIds } : {})
+            ...(req.body.agentIds ? { agentIds: req.body.agentIds } : {}),
+            ...(excludeAgentIds.length > 0 ? { excludeAgentIds } : {})
           },
           { actorUserId: ctx.userId, viewer: ctx }
         )
@@ -330,7 +367,7 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
           tags: [Tag.Environment],
           summary: 'Replace a value or retarget an organization entry',
           description:
-            'Replaces the value and/or changes the audience under `expectedVersion`. An omitted value leaves it unchanged, which is how the Console keeps an existing secret while editing other fields. Switching to `all` enrolls every agent the caller may edit and keeps existing delegated bindings; switching to `selected` stops automatic enrollment without revoking bindings to private agents the caller cannot see. `key` and `kind` cannot change — rename or convert by deleting and recreating.',
+            'Replaces the value and/or changes the audience under `expectedVersion`. An omitted value leaves it unchanged, which is how the Console keeps an existing secret while editing other fields. Switching to `all` enrolls every agent the caller may edit (skipping agents on daemons that do not yet support organization environment entries) and keeps existing delegated bindings; switching to `selected` stops automatic enrollment without revoking bindings to private agents the caller cannot see. `key` and `kind` cannot change — rename or convert by deleting and recreating.',
           operationId: 'updateOrganizationEnvironmentEntry',
           params: OrganizationEnvironmentEntryParam,
           body: UpdateOrganizationEnvironmentEntryBody,
@@ -343,27 +380,28 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
         const ctx = ctxOf(req)
         const existing = await repo.get(orgId, req.params.entryId)
         if (!existing) return missing(reply)
-        // A value replacement re-reaches every currently bound agent; switching to
-        // `all` reaches every agent this caller may edit. Both sets must be on a
-        // compatible daemon.
-        // Two sets with different disclosure rules, so two calls: already-bound
-        // agents are gated in full (the rotation reaches them) but unnamed when the
-        // caller cannot see them, while newly enrolled agents are caller-editable by
-        // construction.
-        const blocked =
-          (await incompatibleDaemonMessage(
-            orgId,
-            ctx,
-            req.body.value !== undefined ? existing.agentIds : [],
-            'bound'
-          )) ??
-          (await incompatibleDaemonMessage(
-            orgId,
-            ctx,
-            req.body.audience === 'all' ? await enrollableAgentIdsOf(orgId, ctx) : [],
-            'requested'
-          ))
+        // A value replacement re-reaches every currently bound agent, so that set
+        // is GATED in full (the rotation genuinely reaches them; an agent the
+        // caller cannot see is described without its name). A switch to `all` only
+        // adds bindings, so newly enrolled agents on an incompatible daemon are
+        // SKIPPED instead — same posture as create.
+        const blocked = await incompatibleDaemonMessage(
+          orgId,
+          ctx,
+          req.body.value !== undefined ? existing.agentIds : [],
+          'bound'
+        )
         if (blocked) return reply.code(409).send({ error: 'Conflict', statusCode: 409, message: blocked })
+        const excludeAgentIds =
+          req.body.audience === 'all'
+            ? await incompatiblePlacedAgentIds(orgId, await enrollableAgentIdsOf(orgId, ctx))
+            : []
+        if (excludeAgentIds.length > 0) {
+          app.log.info(
+            { orgId, entryId: req.params.entryId, skippedAgents: excludeAgentIds.length },
+            'organization environment `all` enrollment skipped agents on incompatible daemons'
+          )
+        }
         const sealedSecret =
           existing.kind === 'secret' && req.body.value !== undefined
             ? await deps.repos.organizationEnvironmentSecret.seal(req.body.value)
@@ -375,7 +413,8 @@ export function organizationEnvironmentRoutes(deps: HttpDeps) {
           {
             ...(existing.kind === 'variable' && req.body.value !== undefined ? { variableValue: req.body.value } : {}),
             ...(sealedSecret !== undefined ? { sealedSecret } : {}),
-            ...(req.body.audience !== undefined ? { audience: req.body.audience } : {})
+            ...(req.body.audience !== undefined ? { audience: req.body.audience } : {}),
+            ...(excludeAgentIds.length > 0 ? { excludeAgentIds } : {})
           },
           { actorUserId: ctx.userId, viewer: ctx }
         )

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4372,6 +4372,11 @@ export interface CreateOrganizationEnvironmentEntryInput {
   audience: OrganizationEnvironmentAudience
   /** Initial explicit selection; `selected` audience only. */
   agentIds?: readonly string[]
+  /** Agents to SKIP from `all` enrollment — placed on a daemon that cannot yet
+   *  apply organization entries safely (§10 step 3). Computed at the HTTP edge
+   *  from the live daemon registry; ignored for `selected` audience. A skipped
+   *  agent enrolls on a later authorized configuration write. */
+  excludeAgentIds?: readonly string[]
 }
 
 export interface UpdateOrganizationEnvironmentEntryInput {
@@ -4381,6 +4386,9 @@ export interface UpdateOrganizationEnvironmentEntryInput {
   sealedSecret?: string
   /** Retarget. Omitted ⇒ unchanged. */
   audience?: OrganizationEnvironmentAudience
+  /** Agents to SKIP when a retarget to `all` enrolls new bindings — same
+   *  daemon-compatibility skip as on create. Never removes an existing binding. */
+  excludeAgentIds?: readonly string[]
 }
 
 /**

--- a/packages/control-plane/src/persistence/repositories/organization-environment.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/organization-environment.repo.ts
@@ -156,7 +156,7 @@ export class PgOrganizationEnvironmentRepo implements OrganizationEnvironmentRep
       // pass the same edit projection.
       const targets =
         input.audience === 'all'
-          ? await this.editableAgentIds(tx, orgId, actor.viewer)
+          ? await this.editableAgentIds(tx, orgId, actor.viewer, input.excludeAgentIds)
           : await this.authorizeTargets(tx, orgId, input.agentIds ?? [], actor.viewer)
       if (targets === null) return { outcome: 'agent_not_found' }
 
@@ -220,7 +220,9 @@ export class PgOrganizationEnvironmentRepo implements OrganizationEnvironmentRep
       // enrollment — it never silently revokes a binding to a private agent this
       // actor cannot see.
       const enrolled =
-        input.audience === 'all' ? await this.editableAgentIds(tx, orgId, actor.viewer) : ([] as string[])
+        input.audience === 'all'
+          ? await this.editableAgentIds(tx, orgId, actor.viewer, input.excludeAgentIds)
+          : ([] as string[])
       const added = enrolled.filter((agentId) => !current.includes(agentId))
       const bound = [...current, ...added]
 
@@ -404,10 +406,23 @@ export class PgOrganizationEnvironmentRepo implements OrganizationEnvironmentRep
     })
   }
 
-  /** Every agent id in the org the actor may edit, ascending. */
-  private async editableAgentIds(tx: Tx, orgId: string, viewer: ViewCtx | undefined): Promise<string[]> {
+  /** Every agent id in the org the actor may edit, ascending, minus `exclude`
+   *  (the HTTP edge's daemon-compatibility skip for `all` enrollment). */
+  private async editableAgentIds(
+    tx: Tx,
+    orgId: string,
+    viewer: ViewCtx | undefined,
+    exclude?: readonly string[]
+  ): Promise<string[]> {
     const rows = await tx.agent.findMany({
-      where: editableAgentWhere(orgId, viewer),
+      // AND, not a spread: `editableAgentWhere` may itself constrain `id` (the
+      // viewer projection), and a spread `id` key would replace that clause.
+      where: {
+        AND: [
+          editableAgentWhere(orgId, viewer),
+          ...(exclude && exclude.length > 0 ? [{ id: { notIn: [...exclude] } }] : [])
+        ]
+      },
       select: { id: true },
       orderBy: { id: 'asc' }
     })

--- a/packages/control-plane/test/integration/organization-environment.route.test.ts
+++ b/packages/control-plane/test/integration/organization-environment.route.test.ts
@@ -671,6 +671,62 @@ describe('organization environment — daemon feature gate', () => {
     expect(await prisma.organizationEnvironmentAssignment.count({ where: { entryId: entry.id } })).toBe(0)
   })
 
+  it('SKIPS an agent on an incompatible daemon from `all` enrollment instead of refusing', async () => {
+    await seedDaemon(prisma, DAEMON, { capabilities: CAPABLE })
+    await seedDaemon(prisma, LEGACY_DAEMON, { capabilities: LEGACY })
+    const capableAgent = randomUUID()
+    const legacyAgent = randomUUID()
+    await seedAgent(prisma, capableAgent, { daemonId: DAEMON, name: 'capable-bot' })
+    await seedAgent(prisma, legacyAgent, { daemonId: LEGACY_DAEMON, name: 'legacy-skip-bot' })
+    const control = new RecordingControl()
+    const http = app({ control })
+
+    const created = await createEntry(http, { key: 'SKIP_ALL', kind: 'variable', value: 'v', audience: 'all' })
+    expect(created.status).toBe(201)
+    expect(created.entry.visibleAgentIds).toContain(capableAgent)
+    expect(created.entry.visibleAgentIds).not.toContain(legacyAgent)
+    expect(
+      await prisma.organizationEnvironmentAssignment.count({
+        where: { entryId: created.entry.id, agentId: legacyAgent }
+      })
+    ).toBe(0)
+    // Nothing was replicated to the daemon that cannot safely apply it.
+    expect(control.upserts.filter((u) => u.request.agentId === legacyAgent)).toEqual([])
+    expect(agentEnvOf(control.last(capableAgent)!)).toEqual({ SKIP_ALL: 'v' })
+  })
+
+  it('skips an incompatible agent on a retarget to `all`, but still gates rotation to a BOUND one', async () => {
+    await seedDaemon(prisma, LEGACY_DAEMON, { capabilities: LEGACY })
+    const legacyAgent = randomUUID()
+    await seedAgent(prisma, legacyAgent, { daemonId: LEGACY_DAEMON, name: 'legacy-retarget-bot' })
+    const http = app({ control: new RecordingControl() })
+    const entry = (await createEntry(http, { key: 'RETARGET', kind: 'variable', value: 'v', audience: 'selected' }))
+      .entry
+
+    const retarget = await http.app.inject({
+      method: 'PATCH',
+      url: `${ENV}/${entry.id}`,
+      payload: { expectedVersion: entry.version, audience: 'all' }
+    })
+    expect(retarget.statusCode).toBe(200)
+    expect(
+      await prisma.organizationEnvironmentAssignment.count({ where: { entryId: entry.id, agentId: legacyAgent } })
+    ).toBe(0)
+
+    // A binding that already exists (e.g. created before the daemon downgraded)
+    // cannot be skipped: the new value genuinely reaches it, so rotation refuses.
+    await prisma.organizationEnvironmentAssignment.create({
+      data: { orgId: DEFAULT_ORG_ID, entryId: entry.id, agentId: legacyAgent }
+    })
+    const rotate = await http.app.inject({
+      method: 'PATCH',
+      url: `${ENV}/${entry.id}`,
+      payload: { expectedVersion: entry.version + 1, value: 'v2' }
+    })
+    expect(rotate.statusCode).toBe(409)
+    expect(rotate.body).toContain('does not yet support')
+  })
+
   it('still allows WITHDRAWING a credential from an agent on an older daemon', async () => {
     await seedDaemon(prisma, LEGACY_DAEMON, { capabilities: LEGACY })
     const legacyAgent = randomUUID()


### PR DESCRIPTION
## Problem

Saving an organization variable/secret with **All agents** returned 409 whenever any caller-editable agent sat on a daemon without the `agent-config-revision-v1` fence:

> agent agentconnect-cp-dev runs on a daemon that does not yet support organization environment entries; upgrade it first

One stale daemon blocked the whole organization-wide entry, with no workaround short of upgrading or deleting that daemon.

## Change

`all` enrollment (POST create with `audience: 'all'`, and PATCH retarget to `all`) now **skips** agents placed on an incompatible daemon instead of refusing the write:

- The HTTP edge computes the incompatible subset from the live daemon registry (only among caller-editable agents, so nothing restricted is disclosed) and logs the skipped count.
- The repository takes it as `excludeAgentIds` and subtracts it from the editable-agent projection inside the transaction (`AND`ed, so the viewer-role `id` clause is preserved).
- A skipped agent is simply not bound, so no spec is replicated to the daemon that couldn't safely apply it. It enrolls on a later authorized configuration write (`enrollAgentInAllAudienceEntries`) once its daemon upgrades — the documented `all` auto-enrollment path.

The writes that **cannot** avoid such an agent keep the hard 409:

- explicit single-agent bind (`PUT …/agents/:agentId`) — silently no-oping a point request would lie;
- value rotation that reaches an already-bound agent on a legacy daemon — the new value genuinely reaches it, and full-map replacement is only safe behind the `configRevision` fence;
- the existing placement/move gate is unchanged.

Design doc §10 step 3 and the OpenAPI descriptions are updated to match.

## Tests

- New: `all` create binds the capable-daemon agent, skips the legacy-daemon one, and replicates nothing to the legacy daemon.
- New: retarget to `all` skips an incompatible agent; rotating a value that reaches an already-bound legacy agent still 409s.
- Full control-plane integration suite green (950 tests), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)