### PR TITLE
feat(daemon): publish the Layer-1 platform adapter contract (S2)

### DIFF
--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -23,6 +23,7 @@ import {
   type DiscordComponents,
   type DiscordSelectKind
 } from './render.js'
+import type { PlatformConnection } from '../platforms/contract.js'
 
 /**
  * §Discord edge unit. Mirrors slack/connection.ts + telegram/connection.ts but over
@@ -148,7 +149,7 @@ type Sendable = Channel & {
   messages?: { fetch: (id: string) => Promise<Message> }
 }
 
-export class DiscordConnection {
+export class DiscordConnection implements PlatformConnection {
   private client: Client
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (discord.js handles REST rate limits, but the queue keeps a

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -14,6 +14,7 @@
  * that authorizes — not merely records — every attempted effect.
  */
 import type { SendIdentity } from '../mcp/ops.js'
+import type { PlatformConnection } from '../platforms/contract.js'
 
 /** Slack post options subset the virtual transport interprets. Structurally
  *  compatible with the real connection's `SlackPostOptions`: `chrome` marks
@@ -153,7 +154,7 @@ function identityOf(options?: VirtualPostOptions): SendIdentity | undefined {
  * path, Slack tenant identity for session/audience classification, delivery
  * chrome (best-effort, like the real connection), and the full gateway ops.
  */
-export class VirtualSlackConnection {
+export class VirtualSlackConnection implements PlatformConnection {
   readonly botUserId: string
   readonly botId: string
   readonly appId?: string
@@ -337,7 +338,7 @@ export class VirtualSlackConnection {
 
 /** Minimal Discord shape: the reply path + gateway ops the counting milestone
  *  consumes. Extended to the full Discord surface with the cross-room game. */
-export class VirtualDiscordConnection {
+export class VirtualDiscordConnection implements PlatformConnection {
   readonly botUserId: string
   readonly botToken = ''
 
@@ -400,7 +401,7 @@ export class VirtualDiscordConnection {
 }
 
 /** Minimal Telegram shape mirroring {@link VirtualDiscordConnection}. */
-export class VirtualTelegramConnection {
+export class VirtualTelegramConnection implements PlatformConnection {
   readonly botUserId: string
   readonly botUsername: string
   readonly botToken = ''

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -25,6 +25,7 @@ import {
   FEISHU_REPLY_CANCEL_OPTION,
   FEISHU_STREAMING_ELEMENT_ID
 } from './render.js'
+import type { PlatformConnection } from '../platforms/contract.js'
 
 /**
  * §Feishu / Lark edge unit. Mirrors discord/connection.ts but over the official
@@ -494,7 +495,7 @@ function parseDownloadKey(sourceUrl: string): { messageId: string; type: 'image'
   return { messageId, type, fileKey }
 }
 
-export class FeishuConnection {
+export class FeishuConnection implements PlatformConnection {
   private handle: FeishuClientHandle
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (keeps a post-then-edit pair from racing on the same progress msg).

--- a/packages/daemon/src/platforms/contract.ts
+++ b/packages/daemon/src/platforms/contract.ts
@@ -1,0 +1,156 @@
+/**
+ * The daemon's **Layer-1 platform adapter contract**
+ * (integration-plugin-architecture.md §7.1, stage S2).
+ *
+ * Layer 1 is what a CHAT platform must provide: transport lifecycle, connection
+ * identity, and the read/query port core depends on (thread backfill for
+ * mid-thread context, authenticated attachment download, the MCP MessageGateway
+ * channel/member/profile/DM tools, bot-membership enumeration behind the
+ * console's channel triggers). Layer 2 — the per-turn OUTPUT surface (converger
+ * + applier + per-turn state) — is a separate contract and deliberately NOT
+ * here: `postMessage` and friends stay on the concrete connections until the
+ * renderer seam lands.
+ *
+ * LIFTED, NOT INVENTED. Every member below already exists on all four real
+ * connections (`src/{slack,telegram,discord,feishu}/connection.ts`) and on the
+ * Collaboration Arena's virtual connections (`evaluation/virtual-connections.ts`),
+ * which were a de-facto enumeration of this surface. Declaring both sets against
+ * one interface makes the evals a compile-time SECOND IMPLEMENTER: a member that
+ * drifts on one side stops compiling on the other (an S2 exit criterion).
+ *
+ * REQUIRED vs OPTIONAL is the real division of labour, not a convenience:
+ * a member is required only where core calls it for EVERY chat platform.
+ * Everything core already probes for (`typeof conn.getThreadReplies === 'function'`
+ * and friends — the audit catalogued these as duck-typed capability branches) is
+ * optional here, so the probe has a typed home instead of an `unknown` cast. The
+ * probes themselves collapse into adapter capabilities in a later S2 stage; this
+ * PR only publishes the shape they will collapse onto.
+ *
+ * WHERE THIS LIVES. D1 puts shared contract/manifest TYPES in
+ * `@agentconnect.md/protocol`, but that package is the browser-safe wire
+ * contract (the web console imports it) and no other host implements this
+ * interface — the relay's ingress contract (§8), the CP's provider slot (§9),
+ * and the web module (§10) are each different shapes. Only the platform
+ * MANIFEST (§5, pure data) is genuinely cross-host, and it goes to protocol when
+ * the registry lands. This one is daemon-owned.
+ */
+
+/** One conversation as the platform describes it. Members beyond `id` are
+ *  optional because no platform reports all of them (`isMpim`/`user` are Slack's;
+ *  `isIm` drives DM canonicalization and session classification on every
+ *  platform that has direct conversations). */
+export interface PlatformChannelInfo {
+  id: string
+  name?: string
+  isIm?: boolean
+  isMpim?: boolean
+  isPrivate?: boolean
+  user?: string
+}
+
+/** A conversation in an enumeration (`listChannels` / `listBotChannels`). */
+export interface PlatformChannelRef {
+  id: string
+  name?: string
+  isPrivate?: boolean
+}
+
+/** A conversation member — enough to resolve a mention and drop bots. */
+export interface PlatformMemberRef {
+  id: string
+  name?: string
+  isBot?: boolean
+}
+
+/** A user's public profile. `avatarUrl` is absent on platforms that do not
+ *  expose one (Telegram). */
+export interface PlatformUserProfile {
+  id: string
+  name?: string
+  realName?: string
+  isBot?: boolean
+  avatarUrl?: string
+}
+
+/** One historical message from a provider thread read (`getThreadReplies`).
+ *  `attachments` stays `unknown[]` here: the daemon's `Attachment` is a runtime
+ *  model, and Layer 1 only needs the contract to agree on arity/order. */
+export interface PlatformThreadMessage {
+  sender: string
+  ts: string
+  text: string
+  isBot: boolean
+  chrome: boolean
+  agentAuthorId?: string
+  chromeOwnerAgentId?: string
+  appId?: string
+  attachments: unknown[]
+}
+
+/** Bounded window for a thread read; `readState` reports truncation back to the
+ *  caller (the daemon's warm-thread backfill relies on it). */
+export interface PlatformThreadWindow {
+  oldest?: string
+  latest?: string
+  throwOnError?: boolean
+  readState?: { truncated: boolean }
+}
+
+/**
+ * The Layer-1 contract every chat-platform connection satisfies.
+ *
+ * `start`/`stop` are the transport lifecycle the connection registry drives.
+ * The read port is what core calls; the optional facets are what core probes
+ * for. Identity fields are declared as optional properties rather than an
+ * `identity()` method because that is how the connections already carry them
+ * (Slack resolves `botUserId` from `auth.test` at start; Telegram/Discord/Feishu
+ * carry a `workspaceUrl`); folding them into one accessor is a change of shape,
+ * not of contract, and belongs with the registry.
+ */
+export interface PlatformConnection {
+  // ── 1. transport lifecycle ──
+  start(): Promise<void>
+  stop(): Promise<void>
+
+  // ── identity (carried as fields today; see the note above) ──
+  // Only the members that are PUBLIC on every connection appear here. The
+  // provider app id is deliberately absent: Slack keeps it private and Feishu
+  // exposes it, so it is per-platform state, not shared identity — the manifest
+  // (§5 `credentialShape`/`identityScope`) is where that difference belongs.
+  readonly botUserId?: string
+  readonly botId?: string
+  readonly workspaceUrl?: string
+  /** Durable tenant id for session/audience classification (Slack's team id).
+   *  Absent on platforms with no tenant of their own. */
+  workspaceId?(): string | undefined
+
+  // ── 3. read / query port (the MessageGateway surface) ──
+  getChannelInfo(channel: string): Promise<PlatformChannelInfo>
+  listMembers(channel: string): Promise<PlatformMemberRef[]>
+  listChannels(): Promise<PlatformChannelRef[]>
+  getUserProfile(user: string): Promise<PlatformUserProfile>
+  /** Fetch an attachment with the connection's own credential, bounded by
+   *  `maxBytes`. `null` = unavailable/oversized, never a throw. */
+  downloadFile(ref: string, maxBytes?: number): Promise<Buffer | null>
+
+  // ── optional facets: what core PROBES for today ──
+  /** Provider thread history — backs mid-thread context recovery. Absent ⇒ the
+   *  daemon degrades to observed-only transcript rows. */
+  getThreadReplies?(
+    channel: string,
+    thread: string,
+    maxMessages?: number,
+    window?: PlatformThreadWindow
+  ): Promise<PlatformThreadMessage[]>
+  /** Open (or resolve) the 1:1 conversation with `user`; the MCP `toUser` form. */
+  openDirectMessage?(user: string): Promise<string>
+  /** AUTHORITATIVE bot membership, when the platform can enumerate it
+   *  (`membershipEnumeration: 'authoritative'`). `null` ⇒ not answerable now. */
+  listBotChannels?(): Promise<PlatformChannelRef[] | null>
+  /** Leave one conversation (`leaveGranularity: 'conversation'`). */
+  leaveChannel?(channel: string): Promise<void>
+  /** Leave the enclosing space/guild (`leaveGranularity: 'space'` — Discord). */
+  leaveSpace?(space: string): Promise<void>
+  /** Delete a message the daemon posted (chrome cleanup). */
+  deleteMessage?(channel: string, ts: string): Promise<boolean>
+}

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -21,6 +21,7 @@ import {
   type StatusBarInfo,
   type StatusModalIdentity
 } from './render.js'
+import type { PlatformConnection } from '../platforms/contract.js'
 
 export interface ConsolidatedGroup {
   appToken: string
@@ -438,7 +439,7 @@ function sendOnlyApp(botToken: string): AppLike {
   }
 }
 
-export class SlackConnection {
+export class SlackConnection implements PlatformConnection {
   private app: AppLike
   // §9.1: all outbound writes (post/update/setStatus/setTitle) funnel through one queue so
   // streamed edits are FIFO-ordered and rate-limited per Slack app connection.

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -4,6 +4,7 @@ import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { SlackSendQueue } from '../slack/send-queue.js'
 import { isTelegramMembershipServiceMessage, normalizeTelegramMessage, type TelegramMessage } from './normalize.js'
+import type { PlatformConnection } from '../platforms/contract.js'
 
 /**
  * §Telegram edge unit. Mirrors slack/connection.ts but over grammY long-polling
@@ -203,7 +204,7 @@ const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 /** Cap on admins enriched per listMembers call (bounds the response). */
 const MEMBER_CAP = 50
 
-export class TelegramConnection {
+export class TelegramConnection implements PlatformConnection {
   private bot: TelegramBotHandle
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // and rate-limited per bot connection (Telegram tolerates ~1 msg/s per chat).

--- a/packages/daemon/test/platform-contract.test.ts
+++ b/packages/daemon/test/platform-contract.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { SlackConnection } from '../src/slack/connection.js'
+import { TelegramConnection } from '../src/telegram/connection.js'
+import { DiscordConnection } from '../src/discord/connection.js'
+import { FeishuConnection } from '../src/feishu/connection.js'
+import {
+  VirtualSlackConnection,
+  VirtualDiscordConnection,
+  VirtualTelegramConnection
+} from '../src/evaluation/virtual-connections.js'
+
+/**
+ * The Layer-1 contract (integration-plugin-architecture.md §7.1) is enforced at
+ * COMPILE time by `implements PlatformConnection` on all seven connections —
+ * including the Arena's virtual ones, which makes the evals the contract's
+ * second implementer (an S2 exit criterion). These tests pin the two things a
+ * structural interface cannot:
+ *
+ *  1. the REQUIRED surface really exists at runtime (an interface is erased, so
+ *     a member deleted behind an `any` cast would still compile), and
+ *  2. the OPTIONAL-facet matrix — which platform answers which probe. Core
+ *     currently discovers this by duck-typing (`typeof conn.getThreadReplies
+ *     === 'function'`); the matrix below is the same knowledge stated once, and
+ *     it is what the §5 manifest axes (`membershipEnumeration`,
+ *     `leaveGranularity`) are derived from.
+ */
+
+const REQUIRED = [
+  'start',
+  'stop',
+  'getChannelInfo',
+  'listMembers',
+  'listChannels',
+  'getUserProfile',
+  'downloadFile'
+] as const
+
+const CONNECTIONS = {
+  slack: SlackConnection,
+  telegram: TelegramConnection,
+  discord: DiscordConnection,
+  feishu: FeishuConnection,
+  'virtual-slack': VirtualSlackConnection,
+  'virtual-discord': VirtualDiscordConnection,
+  'virtual-telegram': VirtualTelegramConnection
+} as const
+
+const has = (ctor: { prototype: object }, member: string): boolean =>
+  typeof (ctor.prototype as Record<string, unknown>)[member] === 'function'
+
+describe('Layer-1 platform contract (§7.1)', () => {
+  it('every connection — real and virtual — carries the required surface', () => {
+    for (const [name, ctor] of Object.entries(CONNECTIONS)) {
+      for (const member of REQUIRED) {
+        expect(has(ctor, member), `${name}.${member}`).toBe(true)
+      }
+    }
+  })
+
+  it('pins the optional-facet matrix the manifest axes are derived from', () => {
+    // Slack is the only platform with authoritative bot-membership enumeration
+    // (`membershipEnumeration: 'authoritative'`) and provider thread history.
+    expect(has(SlackConnection, 'listBotChannels')).toBe(true)
+    expect(has(SlackConnection, 'getThreadReplies')).toBe(true)
+    expect(has(SlackConnection, 'openDirectMessage')).toBe(true)
+    for (const ctor of [TelegramConnection, DiscordConnection, FeishuConnection]) {
+      expect(has(ctor, 'listBotChannels')).toBe(false)
+      expect(has(ctor, 'getThreadReplies')).toBe(false)
+    }
+
+    // leaveGranularity: Slack/Telegram leave a CONVERSATION, Discord leaves the
+    // enclosing SPACE (a bot joins servers, not channels), Feishu leaves neither.
+    expect(has(SlackConnection, 'leaveChannel')).toBe(true)
+    expect(has(TelegramConnection, 'leaveChannel')).toBe(true)
+    expect(has(DiscordConnection, 'leaveSpace')).toBe(true)
+    expect(has(DiscordConnection, 'leaveChannel')).toBe(false)
+    expect(has(FeishuConnection, 'leaveChannel')).toBe(false)
+    expect(has(FeishuConnection, 'leaveSpace')).toBe(false)
+  })
+
+  it('the Arena virtual connections implement the read port they stand in for', () => {
+    // The interface was lifted FROM these, so a drift on either side breaks the
+    // eval suite's ability to substitute for a real platform.
+    expect(has(VirtualSlackConnection, 'getThreadReplies')).toBe(true)
+    expect(has(VirtualSlackConnection, 'listBotChannels')).toBe(true)
+    expect(has(VirtualSlackConnection, 'openDirectMessage')).toBe(true)
+    expect(has(VirtualSlackConnection, 'leaveChannel')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

**S2 PR 1** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §7.1 — the daemon refactor opens with its contract. `src/platforms/contract.ts` publishes Layer 1 (transport lifecycle + connection identity + the read/query port core depends on), and **all seven connections declare it**: the four real ones and the Collaboration Arena's three virtual ones.

That makes the evals a **compile-time second implementer** — one of the two S2 exit criteria. A member that drifts on one side now stops compiling on the other.

## Lifted, not invented

`evaluation/virtual-connections.ts` was already a de-facto enumeration of this surface (§7.1 says as much), and the four real connections' read ports turned out near-identical in shape: `getChannelInfo` / `listMembers` / `listChannels` / `getUserProfile` / `downloadFile`. Two things surfaced by making it explicit:

- **`appId` is not shared identity.** Slack keeps it private, Feishu exposes it. Rather than widen a class's API to satisfy an interface, it stays per-platform state — that difference belongs to the manifest (§5 `credentialShape`/`identityScope`), not to Layer 1.
- **Required vs optional is the real division of labour.** A member is required only where core calls it for every chat platform. Everything core currently **duck-types** (`typeof conn.getThreadReplies === 'function'` and friends — blind-spot class #2 in the [S0 audit](../blob/main/docs/designs/integration-plugin-audit.md)) is optional here, so those probes finally have a typed home. Collapsing the probes themselves into declared capabilities is a later S2 stage; this PR publishes the shape they collapse onto.

Layer 2 (the per-turn output surface — converger + applier + turn state) is deliberately **out of scope**: `postMessage` and friends stay on the concrete connections until the renderer seam lands (PR 3).

## Tests

The compile is the primary proof, so the new test pins what a structural interface cannot: that the required surface exists at **runtime** (interfaces are erased — a member deleted behind an `any` cast would still compile), and the **optional-facet matrix** the manifest axes derive from — Slack alone has authoritative membership enumeration (`listBotChannels`) and provider thread history; `leaveGranularity` is conversation (Slack/Telegram) / space (Discord) / none (Feishu).

## Verification

Zero behavior change — no call site moved, no method body touched. daemon 2793 ✓ · full-workspace typecheck ✓.

Next in S2: the key-driven connection registry (§7.5) — absorbing the 5 connection maps, 4 pools, retry timers, and the four near-duplicate reconcile loops (349 lines) behind one registry keyed on opaque per-platform consolidation keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)