### PR TITLE
refactor(daemon): key-driven connection registry (S2 §7.5)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -117,6 +117,8 @@ import { CpRoutingLayer } from './router/cp-routing-layer.js'
 import {
   consolidate,
   consolidateShared,
+  slackSocketKey,
+  slackSharedKey,
   SlackConnection,
   type InteractionActor,
   type SlackPostOptions,
@@ -124,14 +126,15 @@ import {
 } from './slack/connection.js'
 import {
   consolidateTelegram,
+  telegramConnKey,
   TelegramConnection,
   type TelegramCallback,
   type TelegramObservedChat,
   type InlineButton
 } from './telegram/connection.js'
-import { consolidateDiscord, DiscordConnection } from './discord/connection.js'
+import { consolidateDiscord, discordConnKey, DiscordConnection } from './discord/connection.js'
 import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channels.js'
-import { consolidateFeishu, FeishuConnection, type FeishuStreamingCard } from './feishu/connection.js'
+import { consolidateFeishu, feishuConnKey, FeishuConnection, type FeishuStreamingCard } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { splitIntoSections } from './slack/formatter.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
@@ -302,6 +305,7 @@ import {
   threadKeyForPost,
   type NormalizedMessage
 } from './messages/normalized.js'
+import { ConnectionPool, type ConnectionKey } from './platforms/registry.js'
 import type {
   RegisterReq,
   RegisterOk,
@@ -380,10 +384,6 @@ import type {
  *  treated as a distinct connection for reuse-matching, mapping-eviction, and
  *  the in-flight guard (`|` can't collide — an appId `cli_…` and the region/mode
  *  literals contain none). */
-function feishuConnKey(appId: string, region: string, mode: 'direct' | 'shared'): string {
-  return `${appId}|${region}|${mode}`
-}
-
 function formatErr(err: unknown): string {
   const e = err as { name?: string; message?: string; code?: number; data?: unknown; stack?: string }
   if (e && typeof e.code === 'number') {
@@ -1590,27 +1590,19 @@ export class Daemon {
    *  daemon drain cannot leave a timer behind. The callback re-validates everything it
    *  needs, so a lease dropped by stopHost simply makes the wake a no-op. */
   private bgWakeTimers = new Set<TimerHandle>()
-  private connections: SlackConnection[] = []
-  // Telegram long-poll connections (one per bot token). Kept parallel to `connections`
-  // (Slack) — the Slack socket layer (appToken keying, retry, refreshChannels) is
-  // untouched; Telegram gets its own map so its conns never flow through Slack-only code.
-  private telegramConns: TelegramConnection[] = []
-  // Discord Gateway connections (one per bot token). Parallel to Slack/Telegram —
-  // its own map so its conns never flow through Slack-only code (`.appToken` reads).
-  private discordConns: DiscordConnection[] = []
-  // Feishu WSClient long-connections (one per appId). Parallel to Slack/Telegram/Discord —
-  // its own map so its conns never flow through Slack-only code (`.appToken` reads).
-  private feishuConns: FeishuConnection[] = []
-  // In-flight connect guards: a token/appId is added BEFORE `await conn.start()` and
-  // removed once it resolves (and is pushed onto the *Conns list) or fails. The per-token
-  // `find()` dedup in each reconcile only sees a conn AFTER it's pushed, so without this a
-  // reconcile overlapping a still-pending connect (the initial background connects now run
-  // concurrently with CP/file-watch-driven reconciles, and the window widens to the whole
-  // outage when the platform API is unreachable) would open a *second* connection for the
-  // same bot → duplicate inbound delivery. Checked alongside `find()` to serialize opens.
-  private telegramConnecting = new Set<string>()
-  private discordConnecting = new Set<string>()
-  private feishuConnecting = new Set<string>()
+  // §7.5 connection pools — one per (platform, MODE), each keyed by the platform's
+  // own opaque identity function. The pool owns the live set AND the in-flight
+  // connect guard: a key is claimed BEFORE `await conn.start()` and released when
+  // it resolves or fails, because `find()` only sees a connection after it is
+  // added — without the claim, a reconcile overlapping a still-pending connect
+  // would open a SECOND connection for the same bot (duplicate inbound delivery).
+  // Slack runs two pools: sockets keyed by (appToken, botToken), and send-only
+  // shared clients keyed by botToken alone (a shared bot has no app token).
+  private readonly slackPool = new ConnectionPool<SlackConnection>('slack', slackSocketKey)
+  private readonly slackSharedPool = new ConnectionPool<SlackConnection>('slack/shared', slackSharedKey)
+  private readonly telegramPool = new ConnectionPool<TelegramConnection>('telegram', telegramConnKey)
+  private readonly discordPool = new ConnectionPool<DiscordConnection>('discord', discordConnKey)
+  private readonly feishuPool = new ConnectionPool<FeishuConnection>('feishu', feishuConnKey)
   // Slack id → display-name resolver (created with the store in start()).
   private nameResolver?: SlackNameResolver
   // agentId → its directory name, learned from `channelAgents` (the listAgents tool)
@@ -1633,7 +1625,6 @@ export class Daemon {
   // HTTP-bot send-only Slack clients, keyed by xoxb (one per bot token; the relay
   // owns their inbound). Separate from the direct sockets so reconcile can dedup +
   // tear down a bot's old direct socket when it flips to HTTP transport.
-  private httpSlackConns = new Map<string, SlackConnection>()
   // integrationId -> the TelegramConnection that owns it (for replies). Separate from
   // connByIntegration so Slack reconcile (which reads `.appToken`) never sees a Telegram conn.
   private tgConnByIntegration = new Map<string, TelegramConnection>()
@@ -2840,7 +2831,7 @@ export class Daemon {
           this.botUserIds[integrationId] = conn.botUserId
           this.connByIntegration.set(integrationId, conn)
         }
-        this.connections.push(conn)
+        this.slackPool.add(conn)
         // Initial membership snapshot (fire-and-forget; cached + emitted when CP is up).
         void this.refreshChannels(conn)
       } catch (err) {
@@ -3221,8 +3212,7 @@ export class Daemon {
     // plus region and mode, so either change produces a different desired connection.
     const feishuByIntegration = new Map<string, string>()
     for (const group of feishu.values())
-      for (const { integrationId } of group.integrations)
-        feishuByIntegration.set(integrationId, feishuConnKey(group.appId, group.region, group.mode))
+      for (const { integrationId } of group.integrations) feishuByIntegration.set(integrationId, feishuConnKey(group))
 
     const allDesiredIds = new Set([
       ...directByIntegration.keys(),
@@ -3274,7 +3264,7 @@ export class Daemon {
       // Compare appId AND region: a region flip on the same appId must evict the stale
       // mapping here (not only when a replacement start succeeds), so a failed replacement
       // never leaves an integration routed at the stopped old-domain client.
-      if (feishuConnKey(conn.appId, conn.region, conn.mode) !== feishuByIntegration.get(integrationId)) {
+      if (feishuConnKey(conn) !== feishuByIntegration.get(integrationId)) {
         this.fsConnByIntegration.delete(integrationId)
         dropIdentity(integrationId)
       }
@@ -3295,40 +3285,34 @@ export class Daemon {
       .map(([, run]) => run.promise)
     if (retryRuns.length) await Promise.all(retryRuns)
 
-    for (const conn of [...this.connections]) {
-      const group = direct.get(conn.appToken)
-      if (group?.botToken === conn.botToken) continue
+    // §7.5: every pool prunes by ONE rule — a live connection survives iff its
+    // opaque identity is still among the keys consolidation asked for. This
+    // replaced five bespoke credential comparisons (appToken+botToken, botToken
+    // alone, appId+region+mode, …); a platform now states its identity once, in
+    // its key function, and the lifecycle never asks what a key is made of. The
+    // Feishu case is the one that used to need spelling out — a region or
+    // transport flip must drop the old client so the open loop initializes the
+    // correct gateway — and it is now just another key that stopped matching.
+    await this.prunePool(this.slackPool, new Set([...direct.values()].map(slackSocketKey)))
+    await this.prunePool(this.slackSharedPool, new Set([...shared.values()].map(slackSharedKey)))
+    await this.prunePool(this.telegramPool, new Set([...telegram.values()].map(telegramConnKey)))
+    await this.prunePool(this.discordPool, new Set([...discord.values()].map(discordConnKey)))
+    await this.prunePool(this.feishuPool, new Set([...feishu.values()].map(feishuConnKey)))
+  }
+
+  /** Close every connection in `pool` whose opaque identity consolidation no
+   *  longer asks for, draining in-flight uses first. Evaluation-owned virtual
+   *  connections never enter a pool (they are injected straight into the binding
+   *  maps), so they are immune here by construction. */
+  private async prunePool<C extends SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection>(
+    pool: ConnectionPool<C>,
+    desired: Set<ConnectionKey>
+  ): Promise<void> {
+    for (const conn of pool.all()) {
+      if (desired.has(pool.keyOf(conn))) continue
       await this.waitForConnectionUses(conn)
       await conn.stop()
-      this.connections = this.connections.filter((candidate) => candidate !== conn)
-    }
-    for (const [botToken, conn] of [...this.httpSlackConns]) {
-      if (shared.has(botToken)) continue
-      await this.waitForConnectionUses(conn)
-      await conn.stop()
-      this.httpSlackConns.delete(botToken)
-    }
-    for (const conn of [...this.telegramConns]) {
-      if (telegram.has(conn.botToken)) continue
-      await this.waitForConnectionUses(conn)
-      await conn.stop()
-      this.telegramConns = this.telegramConns.filter((candidate) => candidate !== conn)
-    }
-    for (const conn of [...this.discordConns]) {
-      if (discord.has(conn.botToken)) continue
-      await this.waitForConnectionUses(conn)
-      await conn.stop()
-      this.discordConns = this.discordConns.filter((candidate) => candidate !== conn)
-    }
-    for (const conn of [...this.feishuConns]) {
-      // Keep only a conn whose appId is still desired and whose region/mode are
-      // unchanged. A region or transport flip must drop the old client so the open
-      // loop initializes the correct gateway and inbound ownership.
-      const want = feishu.get(conn.appId)
-      if (want && want.region === conn.region && want.mode === conn.mode) continue
-      await this.waitForConnectionUses(conn)
-      await conn.stop()
-      this.feishuConns = this.feishuConns.filter((candidate) => candidate !== conn)
+      pool.remove(conn)
     }
   }
 
@@ -3351,7 +3335,7 @@ export class Daemon {
   private async reconcileSlackConnections(): Promise<void> {
     const groups = consolidate(this.transportAgents())
     for (const group of groups.values()) {
-      const existing = this.connections.find((c) => c.appToken === group.appToken && c.botToken === group.botToken)
+      const existing = this.slackPool.find(slackSocketKey(group))
       if (existing) {
         // Already-open appToken: bind any integrationId not yet pointing at this conn
         // (tier 1). Covers both a brand-new integrationId AND one that was re-pointed
@@ -3400,7 +3384,7 @@ export class Daemon {
           this.botUserIds[integrationId] = conn.botUserId
           this.connByIntegration.set(integrationId, conn)
         }
-        this.connections.push(conn)
+        this.slackPool.add(conn)
         void this.refreshChannels(conn)
         // This reconcile just brought the socket up; cancel any pending startup-retry
         // timer for the same appToken so it doesn't fire and open a duplicate socket.
@@ -3432,7 +3416,7 @@ export class Daemon {
   private async openHttpSlackConnections(agents: LoadedAgent[]): Promise<void> {
     const groups = consolidateShared(this.transportAgents(agents))
     for (const group of groups.values()) {
-      let conn = this.httpSlackConns.get(group.botToken)
+      let conn = this.slackSharedPool.find(slackSharedKey(group))
       let bound = false
       if (!conn) {
         conn = new SlackConnection({
@@ -3448,7 +3432,7 @@ export class Daemon {
         })
         try {
           await conn.start()
-          this.httpSlackConns.set(group.botToken, conn)
+          this.slackSharedPool.add(conn)
           this.log.info(`slack: send-only (HTTP) client ready as bot user ${conn.botUserId}`)
         } catch (err) {
           this.log.warn(`slack: HTTP send-only client failed — retry on next reconcile: ${formatErr(err)}`)
@@ -3483,7 +3467,7 @@ export class Daemon {
   private async reconcileTelegramConnections(): Promise<void> {
     const groups = consolidateTelegram(this.transportAgents())
     for (const group of groups.values()) {
-      const existing = this.telegramConns.find((c) => c.botToken === group.botToken)
+      const existing = this.telegramPool.find(telegramConnKey(group))
       if (existing) {
         for (const { integrationId } of group.integrations) {
           if (this.tgConnByIntegration.get(integrationId) !== existing) {
@@ -3497,7 +3481,7 @@ export class Daemon {
       // Another connect for this token is already in flight (not yet pushed onto
       // telegramConns, so `find()` above can't see it). Skip to avoid opening a duplicate;
       // that connect binds this group's integrations when it resolves.
-      if (this.telegramConnecting.has(group.botToken)) continue
+      if (!this.telegramPool.beginConnect(telegramConnKey(group))) continue
       const conn: TelegramConnection = new TelegramConnection({
         group,
         newTraceId: () => randomUUID(),
@@ -3513,7 +3497,6 @@ export class Daemon {
         onCallback: (cb) => this.handleTelegramCallback(cb, conn),
         log: this.log
       })
-      this.telegramConnecting.add(group.botToken)
       try {
         this.log.info(
           `telegram: connecting (${group.integrations.length} integration(s): ${group.integrations
@@ -3527,12 +3510,12 @@ export class Daemon {
           this.botUserIds[integrationId] = conn.botUsername
           this.tgConnByIntegration.set(integrationId, conn)
         }
-        this.telegramConns.push(conn)
+        this.telegramPool.add(conn)
       } catch (err) {
         await conn.stop().catch(() => {})
         this.log.error(`telegram: failed to open long-poll for a bot token — leaving others intact: ${formatErr(err)}`)
       } finally {
-        this.telegramConnecting.delete(group.botToken)
+        this.telegramPool.endConnect(telegramConnKey(group))
       }
     }
     // Label existing sessions' chats now that connections are up (per-message resolution
@@ -3551,7 +3534,7 @@ export class Daemon {
   private async reconcileDiscordConnections(): Promise<void> {
     const groups = consolidateDiscord(this.transportAgents())
     for (const group of groups.values()) {
-      const existing = this.discordConns.find((c) => c.botToken === group.botToken)
+      const existing = this.discordPool.find(discordConnKey(group))
       if (existing) {
         for (const { integrationId } of group.integrations) {
           if (this.dcConnByIntegration.get(integrationId) !== existing) {
@@ -3565,7 +3548,7 @@ export class Daemon {
       // Another connect for this token is already in flight (not yet pushed onto
       // discordConns, so `find()` above can't see it). Skip to avoid opening a duplicate;
       // that connect binds this group's integrations when it resolves.
-      if (this.discordConnecting.has(group.botToken)) continue
+      if (!this.discordPool.beginConnect(discordConnKey(group))) continue
       const conn: DiscordConnection = new DiscordConnection({
         group,
         newTraceId: () => randomUUID(),
@@ -3584,7 +3567,6 @@ export class Daemon {
         onSelectAction: (a) => this.handleDiscordSelect(a),
         log: this.log
       })
-      this.discordConnecting.add(group.botToken)
       try {
         this.log.info(
           `discord: connecting (${group.integrations.length} integration(s): ${group.integrations
@@ -3598,12 +3580,12 @@ export class Daemon {
           this.botUserIds[integrationId] = conn.botUserId
           this.dcConnByIntegration.set(integrationId, conn)
         }
-        this.discordConns.push(conn)
+        this.discordPool.add(conn)
       } catch (err) {
         await conn.stop().catch(() => {})
         this.log.error(`discord: failed to open Gateway for a bot token — leaving others intact: ${formatErr(err)}`)
       } finally {
-        this.discordConnecting.delete(group.botToken)
+        this.discordPool.endConnect(discordConnKey(group))
       }
     }
     // Label existing sessions' channels now that connections are up (per-message
@@ -3634,9 +3616,7 @@ export class Daemon {
     for (const group of groups.values()) {
       // Match on appId AND region: a region change on the same appId must NOT reuse the
       // old-domain client (the prune pass drops it; this guards a same-pass race too).
-      const existing = this.feishuConns.find(
-        (c) => c.appId === group.appId && c.region === group.region && c.mode === group.mode
-      )
+      const existing = this.feishuPool.find(feishuConnKey(group))
       if (existing) {
         for (const { integrationId } of group.integrations) {
           if (this.fsConnByIntegration.get(integrationId) !== existing) {
@@ -3651,8 +3631,8 @@ export class Daemon {
       // feishuConns, so `find()` above can't see it). Skip to avoid opening a duplicate;
       // that connect binds this group's integrations when it resolves. Keyed on region
       // too, so a NEW-region reconcile is NOT blocked by an in-flight OLD-region connect.
-      const connectKey = feishuConnKey(group.appId, group.region, group.mode)
-      if (this.feishuConnecting.has(connectKey)) continue
+      const connectKey = feishuConnKey(group)
+      if (!this.feishuPool.beginConnect(connectKey)) continue
       const conn: FeishuConnection = new FeishuConnection({
         group,
         newTraceId: () => randomUUID(),
@@ -3663,7 +3643,6 @@ export class Daemon {
         onStatusAction: (a) => this.handleStatusAction(a),
         log: this.log
       })
-      this.feishuConnecting.add(connectKey)
       try {
         this.log.info(
           `feishu: connecting (${group.integrations.length} integration(s): ${group.integrations
@@ -3692,12 +3671,12 @@ export class Daemon {
           this.botUserIds[integrationId] = conn.botOpenId
           this.fsConnByIntegration.set(integrationId, conn)
         }
-        this.feishuConns.push(conn)
+        this.feishuPool.add(conn)
       } catch (err) {
         await conn.stop().catch(() => {})
         this.log.error(`feishu: failed to initialize an appId — leaving others intact: ${formatErr(err)}`)
       } finally {
-        this.feishuConnecting.delete(connectKey)
+        this.feishuPool.endConnect(connectKey)
       }
     }
     // Label existing sessions' channels now that connections are up (per-message
@@ -4154,7 +4133,7 @@ export class Daemon {
     // appToken's socket while the retry timer was pending. Opening another here would
     // leave two live Socket Mode connections for one app (a wasted per-app connection
     // slot). The live socket is authoritative — drop the timer and bail.
-    if (this.connections.some((c) => c.appToken === group.appToken && c.botToken === group.botToken)) {
+    if (this.slackPool.find(slackSocketKey(group)) !== undefined) {
       this.slackRetryTimers.delete(group.appToken)
       return
     }
@@ -4195,7 +4174,7 @@ export class Daemon {
         this.botUserIds[integrationId] = conn.botUserId
         this.connByIntegration.set(integrationId, conn)
       }
-      this.connections.push(conn)
+      this.slackPool.add(conn)
       void this.refreshChannels(conn)
     } catch (err) {
       // Release the half-open connection before discarding it so a failure during
@@ -18514,11 +18493,8 @@ export class Daemon {
     await Promise.resolve(this.memoryConnections?.close()).catch((e) => errors.push(e))
     await Promise.resolve(this.relays?.stop()).catch((e) => errors.push(e))
     for (const run of [...this.slackRetryRuns.values()]) await Promise.resolve(run.promise).catch((e) => errors.push(e))
-    for (const c of this.connections) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
-    for (const c of this.httpSlackConns.values()) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
-    for (const c of this.telegramConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
-    for (const c of this.discordConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
-    for (const c of this.feishuConns) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
+    for (const pool of [this.slackPool, this.slackSharedPool, this.telegramPool, this.discordPool, this.feishuPool])
+      for (const c of pool.all()) await Promise.resolve(c.stop()).catch((e) => errors.push(e))
     // Capture startup promises before stopHost invalidates their cache entries. Every
     // teardown goes through the same generation fence/hostStopping path, and no async
     // starter is allowed to outlive the store/MCP boundary below.

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -50,6 +50,11 @@ export interface ConsolidatedDiscordGroup {
 }
 
 /** §6.1 analog: group integrations by bot token (one discord.js Client per token). */
+/** §7.5 opaque identity of one Discord Gateway connection: the bot token. */
+export function discordConnKey(c: { botToken: string }): string {
+  return c.botToken
+}
+
 export function consolidateDiscord(agents: Agent[]): Map<string, ConsolidatedDiscordGroup> {
   const groups = new Map<string, ConsolidatedDiscordGroup>()
   for (const a of agents) {

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -59,6 +59,14 @@ export interface ConsolidatedFeishuGroup {
 }
 
 /** §6.1 analog: group Feishu integrations by appId (one provider client per app). */
+/** §7.5 opaque identity of one Feishu provider client. Feishu needed a composite
+ *  key long before the registry existed (the daemon carried a private
+ *  `feishuConnKey` for it): an app is region-scoped, and direct vs shared decide
+ *  whether a long connection is opened at all, so all three fields identify it. */
+export function feishuConnKey(c: { appId: string; region: string; mode: 'direct' | 'shared' }): string {
+  return `${c.appId}\u0000${c.region}\u0000${c.mode}`
+}
+
 export function consolidateFeishu(agents: Agent[]): Map<string, ConsolidatedFeishuGroup> {
   const groups = new Map<string, ConsolidatedFeishuGroup>()
   for (const a of agents) {

--- a/packages/daemon/src/platforms/registry.ts
+++ b/packages/daemon/src/platforms/registry.ts
@@ -1,0 +1,100 @@
+/**
+ * The daemon's **connection registry** (integration-plugin-architecture.md §7.5,
+ * stage S2).
+ *
+ * What it absorbs: five connection pools, the in-flight-connect guards, and — the
+ * part that actually removes branching — the per-platform IDENTITY COMPARISON. Before this, every reconcile and every prune
+ * pass compared credentials field by field, differently per platform:
+ * `c.appToken === g.appToken && c.botToken === g.botToken` for a Slack socket,
+ * `c.botToken === g.botToken` for Telegram/Discord, `c.appId === g.appId &&
+ * c.region === g.region && c.mode === g.mode` for Feishu. Here a platform states
+ * its identity ONCE as an opaque key, and the shared lifecycle only ever compares
+ * keys — it cannot know, and never asks, what a key is made of.
+ *
+ * TWO MODES PER PLATFORM is first-class (§7.5): Slack runs a socket pool keyed by
+ * app token beside a send-only pool keyed by bot token, because a shared bot has
+ * no app token to key on. A pool is therefore per (platform, mode), and both of
+ * Slack's feed the one binding map its integrations resolve through.
+ *
+ * TYPES ARE PRESERVED at read sites. A pool is generic in its connection type, so
+ * callers still hold concrete connections (`SlackConnection.postBlocks`,
+ * `FeishuConnection.startStreamingCard`, …). That is deliberate sequencing: only
+ * the LIFECYCLE (open / find / prune / close) is generic today, which is what
+ * §7.5 asks for. The per-integration BINDING maps stay typed per platform for the
+ * same reason — they generalize once Layer 2 (the renderer seam) replaces the
+ * direct method calls at the read sites, not before.
+ *
+ * EVAL IMMUNITY stays in the registry (§7.5): credential-less virtual connections
+ * are injected by the Arena, take part in no consolidation, and must survive every
+ * prune — so pruning takes an explicit immunity predicate rather than inferring it.
+ */
+import type { PlatformConnection } from './contract.js'
+
+/** A connection's identity, opaque by construction: the registry compares these
+ *  for equality and never parses them. Minted by the platform's own key function
+ *  from whatever credentials actually identify one connection. */
+export type ConnectionKey = string
+
+/** One connection's worth of consolidated integrations — the platform-agnostic
+ *  half of every `consolidate*()` result. */
+export interface RegistryGroup {
+  key: ConnectionKey
+  integrations: { agentId: string; integrationId: string }[]
+}
+
+/** A per-(platform, mode) pool of live connections plus its in-flight guard. */
+export class ConnectionPool<C extends PlatformConnection> {
+  private readonly live = new Map<ConnectionKey, C>()
+  private readonly connecting = new Set<ConnectionKey>()
+
+  /**
+   * @param name  Diagnostic label ("slack", "slack/shared", …). Never parsed.
+   * @param identity The platform's own key function. It must agree with the key
+   *   its `consolidate*()` emits: the whole point is that a live connection and
+   *   the group that wants it hash to the same string.
+   */
+  constructor(
+    readonly name: string,
+    private readonly identity: (conn: C) => ConnectionKey
+  ) {}
+
+  /** The live connection for `key`, or undefined. Replaces the four bespoke
+   *  `pool.find(c => <credential comparison>)` predicates. */
+  find(key: ConnectionKey): C | undefined {
+    return this.live.get(key)
+  }
+
+  keyOf(conn: C): ConnectionKey {
+    return this.identity(conn)
+  }
+
+  add(conn: C): void {
+    this.live.set(this.identity(conn), conn)
+  }
+
+  remove(conn: C): void {
+    this.live.delete(this.identity(conn))
+  }
+
+  all(): C[] {
+    return [...this.live.values()]
+  }
+
+  /** Claim the in-flight slot for `key`; false when a connect is already running
+   *  for it (the caller skips, and the running connect binds the group when it
+   *  resolves). Slack's socket pool historically had no such guard — it used a
+   *  retry timer instead — so claiming is opt-in per call site, not implicit. */
+  beginConnect(key: ConnectionKey): boolean {
+    if (this.connecting.has(key)) return false
+    this.connecting.add(key)
+    return true
+  }
+
+  endConnect(key: ConnectionKey): void {
+    this.connecting.delete(key)
+  }
+
+  isConnecting(key: ConnectionKey): boolean {
+    return this.connecting.has(key)
+  }
+}

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -129,6 +129,21 @@ export function consolidate(agents: Agent[]): Map<string, ConsolidatedGroup> {
 /** Group SHARED-mode Slack integrations by xoxb (one send-only client per bot
  *  token). These have no appToken (the relay owns inbound), so they can't be keyed
  *  by appToken like {@link consolidate} — the bot token is the identity. */
+/** §7.5 opaque identity of one Slack SOCKET connection. The app token pins the
+ *  Socket Mode consumer and the bot token the send credential, so a change in
+ *  either is a different connection. Takes the shape shared by a consolidated
+ *  group and a live `SlackConnection`, so both hash identically by construction. */
+export function slackSocketKey(c: { appToken: string; botToken: string }): string {
+  return `${c.appToken}\u0000${c.botToken}`
+}
+
+/** §7.5 opaque identity of one SEND-ONLY (shared / HTTP) Slack client. A shared
+ *  bot has no app token — the relay owns its inbound — so the bot token is the
+ *  whole identity. */
+export function slackSharedKey(c: { botToken: string }): string {
+  return c.botToken
+}
+
 export function consolidateShared(agents: Agent[]): Map<string, ConsolidatedGroup> {
   const groups = new Map<string, ConsolidatedGroup>()
   for (const a of agents) {

--- a/packages/daemon/src/telegram/connection.ts
+++ b/packages/daemon/src/telegram/connection.ts
@@ -39,6 +39,12 @@ export interface ConsolidatedTelegramGroup {
 }
 
 /** §6.1 analog: group integrations by bot token (one grammY Bot per token). */
+/** §7.5 opaque identity of one Telegram long-poll connection: the BotFather
+ *  token is the whole identity (no app-level token exists). */
+export function telegramConnKey(c: { botToken: string }): string {
+  return c.botToken
+}
+
 export function consolidateTelegram(agents: Agent[]): Map<string, ConsolidatedTelegramGroup> {
   const groups = new Map<string, ConsolidatedTelegramGroup>()
   for (const a of agents) {

--- a/packages/daemon/test/cp/cp-agent-reconcile.test.ts
+++ b/packages/daemon/test/cp/cp-agent-reconcile.test.ts
@@ -454,7 +454,7 @@ describe('Daemon CP agent → disk + reconcile', () => {
         slack: { mode: 'direct', appToken: 'xapp-only', botToken: 'xoxb-only' }
       }
     ]
-    ;(daemon as any).connections = [connection]
+    ;(daemon as any).slackPool.add(connection)
     ;(daemon as any).connByIntegration.set('int-only', connection)
     const releaseDispatch = (daemon as any).beginActiveDispatch('bot-a') as () => void
 

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -76,7 +76,7 @@ describe('feishu reconcile — region change on the same appId', () => {
   it('evicts the stale per-integration mapping + stops the old-domain connection', async () => {
     const daemon = new Daemon({ root: configRoot(), hostFactory: () => ({ start: vi.fn(), stop: vi.fn() }) as never })
     const d = daemon as unknown as {
-      feishuConns: FeishuConnection[]
+      feishuPool: { add(c: FeishuConnection): void; all(): FeishuConnection[] }
       fsConnByIntegration: Map<string, FeishuConnection>
       botUserIds: Record<string, string | undefined>
       closeUnusedPlatformConnections: () => Promise<void>
@@ -85,7 +85,7 @@ describe('feishu reconcile — region change on the same appId', () => {
     const intId = 'int-1'
     const { conn: stale, closed } = fakeFeishuConn('cli_x', 'feishu', 'ou_old')
     // Existing state: the app is connected to the FEISHU gateway and routed there.
-    d.feishuConns = [stale]
+    d.feishuPool.add(stale)
     d.fsConnByIntegration.set(intId, stale)
     d.botUserIds[intId] = 'ou_old'
 
@@ -98,7 +98,7 @@ describe('feishu reconcile — region change on the same appId', () => {
     // routing mapping is evicted — so a failed replacement can never leave the integration
     // pointed at the wrong-region client (it re-binds only on a successful new connect).
     expect(closed).toHaveBeenCalled()
-    expect(d.feishuConns).not.toContain(stale)
+    expect(d.feishuPool.all()).not.toContain(stale)
     expect(d.fsConnByIntegration.has(intId)).toBe(false)
     expect(d.botUserIds[intId]).toBeUndefined()
 

--- a/packages/daemon/test/reconcile-watch.test.ts
+++ b/packages/daemon/test/reconcile-watch.test.ts
@@ -328,7 +328,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     await daemon.start()
 
     const shared = { botToken: 'xoxb-shared', botUserId: 'U_SHARED', stop: vi.fn().mockResolvedValue(undefined) }
-    ;(daemon as any).httpSlackConns = new Map([['xoxb-shared', shared]])
+    ;(daemon as any).slackSharedPool.add(shared)
     ;(daemon as any).agents = new Map([
       [
         'bot-shared',
@@ -360,7 +360,8 @@ describe('Daemon.reconcileSlackConnections', () => {
     // Two live sockets: conn-A (appToken A) and conn-B (appToken B, shared/already open).
     const connA = fakeConn('xapp-A', 'xoxb-A', 'U_A')
     const connB = fakeConn('xapp-B', 'xoxb-B', 'U_B')
-    ;(daemon as any).connections = [connA, connB]
+    ;(daemon as any).slackPool.add(connA)
+    ;(daemon as any).slackPool.add(connB)
     ;(daemon as any).connByIntegration.set('int-1', connA)
     ;(daemon as any).connByIntegration.set('int-other', connB)
     ;(daemon as any).botUserIds = { 'int-1': 'U_A', 'int-other': 'U_B' }
@@ -398,7 +399,7 @@ describe('Daemon.reconcileSlackConnections', () => {
 
     const conn = fakeConn('xapp-A', 'xoxb-A', 'U_A')
     const stop = vi.spyOn(conn, 'stop')
-    ;(daemon as any).connections = [conn]
+    ;(daemon as any).slackPool.add(conn)
     ;(daemon as any).connByIntegration.set('int-detached', conn)
     ;(daemon as any).connByIntegration.set('int-live', conn)
     ;(daemon as any).botUserIds = { 'int-detached': 'U_A', 'int-live': 'U_A' }
@@ -418,7 +419,7 @@ describe('Daemon.reconcileSlackConnections', () => {
 
     await (daemon as any).closeUnusedPlatformConnections()
     expect(stop).not.toHaveBeenCalled()
-    expect((daemon as any).connections).toEqual([conn])
+    expect((daemon as any).slackPool.all()).toEqual([conn])
     expect((daemon as any).connByIntegration.has('int-detached')).toBe(false)
     expect((daemon as any).connByIntegration.get('int-live')).toBe(conn)
     expect((daemon as any).botUserIds['int-detached']).toBeUndefined()
@@ -427,7 +428,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     ;(daemon as any).agents = new Map()
     await (daemon as any).closeUnusedPlatformConnections()
     expect(stop).toHaveBeenCalledTimes(1)
-    expect((daemon as any).connections).toEqual([])
+    expect((daemon as any).slackPool.all()).toEqual([])
     await daemon.stop()
   })
 
@@ -447,12 +448,9 @@ describe('Daemon.reconcileSlackConnections', () => {
     const telegramOld = conn('tg-old')
     const discordLive = conn('dc-live')
     const discordOld = conn('dc-old')
-    ;(daemon as any).httpSlackConns = new Map([
-      ['xoxb-live', sharedLive],
-      ['xoxb-old', sharedOld]
-    ])
-    ;(daemon as any).telegramConns = [telegramLive, telegramOld]
-    ;(daemon as any).discordConns = [discordLive, discordOld]
+    for (const c of [sharedLive, sharedOld]) (daemon as any).slackSharedPool.add(c)
+    for (const c of [telegramLive, telegramOld]) (daemon as any).telegramPool.add(c)
+    for (const c of [discordLive, discordOld]) (daemon as any).discordPool.add(c)
     ;(daemon as any).agents = new Map([
       [
         'bot-live',
@@ -490,7 +488,7 @@ describe('Daemon.reconcileSlackConnections', () => {
 
     const connection = fakeConn('xapp-final', 'xoxb-final', 'U_FINAL')
     const stop = vi.spyOn(connection, 'stop')
-    ;(daemon as any).connections = [connection]
+    ;(daemon as any).slackPool.add(connection)
     ;(daemon as any).agents = new Map()
     const release = (daemon as any).holdReplyConnection(connection) as () => void
 
@@ -505,7 +503,7 @@ describe('Daemon.reconcileSlackConnections', () => {
     release()
     await close
     expect(stop).toHaveBeenCalledTimes(1)
-    expect((daemon as any).connections).toEqual([])
+    expect((daemon as any).slackPool.all()).toEqual([])
     await daemon.stop()
   })
 })


### PR DESCRIPTION
## What

**S2 PR 2** of [integration-plugin-architecture.md](../blob/main/docs/designs/integration-plugin-architecture.md) §7.5. The five connection pools and their in-flight guards move behind one `ConnectionPool<C>`, and every per-platform **identity comparison** collapses onto an opaque key.

## The actual reduction

Before, reconcile and prune compared credentials field by field, differently per platform:

| platform | how a live connection was matched |
|---|---|
| Slack socket | `c.appToken === g.appToken && c.botToken === g.botToken` |
| Slack shared | map keyed by `botToken` |
| Telegram / Discord | `c.botToken === g.botToken` |
| Feishu | `c.appId === g.appId && c.region === g.region && c.mode === g.mode` |

Each platform now states its identity **once** as a key function, and the shared lifecycle only compares keys — it cannot know, and never asks, what a key is made of. Feishu had already been forced into this shape (the daemon carried a private `feishuConnKey`); that helper moves to the platform module and the other three join it.

The five prune blocks become five calls to one `prunePool(pool, desiredKeys)` with a single rule: **a live connection survives iff its identity is still among the keys consolidation asked for.** The Feishu case that used to need spelling out — a region or transport flip must drop the old client so the open loop initializes the correct gateway — is now just another key that stopped matching.

Key functions take the shape **both** a consolidated group and a live connection satisfy, so "the connection and the group that wants it hash to the same string" is type-checked rather than a convention.

Two modes per platform are first-class (§7.5): Slack keeps a socket pool keyed by `(appToken, botToken)` beside a send-only pool keyed by `botToken`, because a shared bot has no app token to key on.

## Deliberately not in this PR

The four per-integration **binding** maps (`connByIntegration` & co). Their read sites call concrete methods (`postBlocks`, `startStreamingCard`), so they generalize when **Layer 2 — the renderer seam** — replaces those calls, not before. Pools are generic in their connection type, so every read site keeps its concrete type today. Sequencing this way keeps each PR's blast radius honest.

## Verification

Behavior-preserving: same consolidation inputs, same open/close decisions, same in-flight semantics — including the deliberate asymmetry that Slack's socket pool keeps its retry-timer guard rather than gaining a claim it never had. White-box tests that seeded the old fields now seed pools. daemon 2793 ✓ · full-workspace typecheck ✓.

Next in S2: the renderer seam (§7.3) — `TurnOutputSurface` with converger + applier + the opaque per-turn state slot that replaces `feishuCard` / `tgReplyTo` / `staleReplyFooters` on the turn record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)