### PR TITLE
refactor(daemon): move Discord and Feishu turn output into their modules (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -134,7 +134,7 @@ import {
 } from './telegram/connection.js'
 import { consolidateDiscord, discordConnKey, DiscordConnection } from './discord/connection.js'
 import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channels.js'
-import { consolidateFeishu, feishuConnKey, FeishuConnection, type FeishuStreamingCard } from './feishu/connection.js'
+import { consolidateFeishu, feishuConnKey, FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { splitIntoSections } from './slack/formatter.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
@@ -310,6 +310,8 @@ import {
   applyTelegramAction as applyTelegramActionExternal,
   type TelegramTurnState
 } from './platforms/telegram/turn-output.js'
+import { applyDiscordAction as applyDiscordActionExternal } from './platforms/discord/turn-output.js'
+import { applyFeishuAction as applyFeishuActionExternal, type FeishuTurnState } from './platforms/feishu/turn-output.js'
 import {
   canonicalizeTelegramThread as canonicalizeTelegramThreadExternal,
   telegramMessageId as telegramMessageIdExternal,
@@ -1181,16 +1183,6 @@ interface SlackTurnState {
    *  body section and once more at finalization, so a transient Slack error cannot
    *  leave two footers standing. */
   staleReplyFooters?: { ts: string; text: string }[]
-}
-
-interface FeishuTurnState {
-  /** Feishu/Lark's one CardKit reply entity for this turn. Undefined until
-   *  `card-start` succeeds; `cardAttempted` prevents duplicate initial cards. */
-  card?: FeishuStreamingCard
-  cardAttempted?: boolean
-  /** Periodic cumulative CardKit element flush (separate from the transcript idle
-   *  flush core owns). */
-  streamTimer?: NodeJS.Timeout
 }
 
 /** Read a turn's opaque platform state as the owning surface's shape. Only that
@@ -12737,174 +12729,37 @@ export class Daemon {
    *  - progress / plan / reasoning → the single in-place message of that kind.
    *  - status-bar  → the per-turn status line + button row (Cancel / Fast / View).
    */
+  /** Discord's turn output lives in its platform module (§7.3); core supplies the
+   *  same two host capabilities Telegram's applier needs. */
   private async applyDiscordAction(p: Pending, action: DiscordAction): Promise<void> {
-    // minimal mode records each reply segment WITHOUT sending it — the channel shows only the
-    // single `live-reply` (see applySlackAction / recordReplySegment).
-    if (action.kind === 'post' && action.recordOnly) {
-      this.recordReplySegment(p, action.text)
-      return
-    }
-    // Routed here only for the discord platform (see enqueueApply), so p.conn is a
-    // Discord connection (or a test fake) — cast, not instanceof. Headless no-ops.
-    const conn = p.conn as DiscordConnection | undefined
-    if (!conn) return
-    switch (action.kind) {
-      case 'typing':
-        await conn.sendChatAction(p.channel)
-        return
-      case 'post': {
-        const id = await conn.postMessage(p.channel, action.text, p.thread)
-        this.store.appendTranscript({
-          channel: p.transcriptChannel,
-          thread: p.statusThread,
-          ts: id ?? `local-${Date.now()}`,
-          sender: p.agentId,
-          kind: 'text',
-          text: action.text
-        })
-        return
-      }
-      case 'live-reply': {
-        // minimal mode's single agent reply: send once then edit in place as the turn
-        // streams. Skip an update when unchanged; not recorded (the `recordOnly` posts do).
-        if (p.liveReplyText === action.text) return
-        p.liveReplyText = action.text
-        if (p.liveReplyTs) await conn.updateMessage(p.channel, p.liveReplyTs, action.text)
-        else if (!p.liveReplyAttempted) {
-          p.liveReplyAttempted = true
-          p.liveReplyTs = await conn.postMessage(p.channel, action.text, p.thread)
-        }
-        return
-      }
-      case 'notice':
-      case 'tool-output':
-        // Posted to the channel but NOT recorded — the done footer is chrome, and tool
-        // output is captured independently by the recorder.
-        await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        return
-      case 'progress':
-        if (p.progressTs) await conn.updateMessage(p.channel, p.progressTs, action.text)
-        else if (!p.progressAttempted) {
-          p.progressAttempted = true
-          p.progressTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-      case 'plan':
-        if (p.planTs) await conn.updateMessage(p.channel, p.planTs, action.text)
-        else if (!p.planAttempted) {
-          p.planAttempted = true
-          p.planTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-      case 'reasoning':
-        if (p.reasoningTs) await conn.updateMessage(p.channel, p.reasoningTs, action.text)
-        else if (!p.reasoningAttempted) {
-          p.reasoningAttempted = true
-          p.reasoningTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-      case 'status-bar':
-        // Per-turn status line + button row: post once (registering the message →
-        // sessionKey so its button interactions resolve), then edit in place.
-        if (p.statusBarTs)
-          await conn.updateMessage(p.channel, p.statusBarTs, action.text, { keyboard: action.keyboard })
-        else if (!p.statusBarAttempted) {
-          p.statusBarAttempted = true
-          p.statusBarTs = await conn.postChrome(p.channel, action.text, {
-            threadTs: p.thread,
-            keyboard: action.keyboard,
-            sessionKey: p.sessionKey
-          })
-        }
-        return
-    }
+    await applyDiscordActionExternal(
+      {
+        recordReplySegment: (turn, text) => this.recordReplySegment(turn as Pending, text),
+        appendTranscript: (row) => this.store.appendTranscript(row)
+      },
+      p,
+      action
+    )
   }
 
   /** Apply one Feishu action. Agent body delivery is one CardKit entity for the whole
    * turn; `post(recordOnly)` retains transcript boundaries without duplicate chat
    * messages. Progress/plan/reasoning remain short text chrome edited in place. */
+  /** Feishu's turn output lives in its platform module (§7.3), which owns the
+   *  CardKit state the core turn record used to carry. Core supplies the two
+   *  shared host capabilities plus session-link construction. */
   private async applyFeishuAction(p: Pending, action: FeishuAction): Promise<void> {
-    // CardKit owns visible body delivery, so these actions are persistence-only.
-    if (action.kind === 'post' && action.recordOnly) {
-      this.recordReplySegment(p, action.text)
-      return
-    }
-    // Routed here only for the feishu platform (see enqueueApply), so p.conn is a Feishu
-    // connection (or a test fake) — cast, not instanceof. Headless no-ops.
-    const conn = p.conn as FeishuConnection | undefined
-    if (!conn) return
-    // The turn's Feishu state, read once through the opaque slot (§7.3).
-    const state = turnState<FeishuTurnState>(p)
-    switch (action.kind) {
-      case 'card-start':
-        if (state.cardAttempted) return
-        state.cardAttempted = true
-        state.card = await conn.startStreamingCard(p.channel, p.thread, {
-          sessionKey: p.sessionKey,
-          sessionUrl: this.sessionLink(p.acpSessionId, this.sessionLinkSource(p.platform, p.integrationId)),
-          ...(p.integrationId ? { target: { v: 1, agentId: p.agentId, integrationId: p.integrationId } as const } : {})
-        })
-        return
-      case 'card-stream':
-        if (state.card) await conn.updateStreamingCard(p.channel, state.card, action.text)
-        return
-      case 'card-final': {
-        if (state.card) {
-          const delivered = await conn.finishStreamingCard(p.channel, state.card, action.text, action.attribution)
-          if (delivered) return
-          // A final CardKit update failure must not lose the answer. Remove the stale
-          // partial card where possible, then fall back to ordinary text.
-          await conn.cancelStreamingCard(p.channel, state.card)
-        }
-        await conn.postMessage(p.channel, action.text, p.thread)
-        return
-      }
-      case 'card-cancel':
-        if (state.card) await conn.cancelStreamingCard(p.channel, state.card)
-        return
-      case 'typing':
-        await conn.sendChatAction(p.channel)
-        return
-      case 'post': {
-        const id = await conn.postMessage(p.channel, action.text, p.thread)
-        this.store.appendTranscript({
-          channel: p.transcriptChannel,
-          thread: p.statusThread,
-          ts: id ?? `local-${Date.now()}`,
-          sender: p.agentId,
-          kind: 'text',
-          text: action.text
-        })
-        return
-      }
-      case 'notice':
-      case 'tool-output':
-        // Posted to the chat but NOT recorded — the done footer is chrome, and tool
-        // output is captured independently by the recorder.
-        await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        return
-      case 'progress':
-        if (p.progressTs) await conn.updateMessage(p.channel, p.progressTs, action.text)
-        else if (!p.progressAttempted) {
-          p.progressAttempted = true
-          p.progressTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-      case 'plan':
-        if (p.planTs) await conn.updateMessage(p.channel, p.planTs, action.text)
-        else if (!p.planAttempted) {
-          p.planAttempted = true
-          p.planTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-      case 'reasoning':
-        if (p.reasoningTs) await conn.updateMessage(p.channel, p.reasoningTs, action.text)
-        else if (!p.reasoningAttempted) {
-          p.reasoningAttempted = true
-          p.reasoningTs = await conn.postChrome(p.channel, action.text, { threadTs: p.thread })
-        }
-        return
-    }
+    await applyFeishuActionExternal(
+      {
+        recordReplySegment: (turn, text) => this.recordReplySegment(turn as Pending, text),
+        appendTranscript: (row) => this.store.appendTranscript(row),
+        sessionUrl: (turn) =>
+          this.sessionLink(turn.acpSessionId, this.sessionLinkSource(turn.platform, turn.integrationId))
+      },
+      p,
+      turnState<FeishuTurnState>(p),
+      action
+    )
   }
 
   /** Web App console base URL the CP sent on `auth/ok` (its own console origin). A local

--- a/packages/daemon/src/platforms/discord/turn-output.ts
+++ b/packages/daemon/src/platforms/discord/turn-output.ts
@@ -1,0 +1,142 @@
+/**
+ * Discord's **turn-output surface** (integration-plugin-architecture.md §7.3,
+ * stage S2).
+ *
+ * Same host port as Telegram's — record a reply segment, append a transcript row
+ * — which is the point: the second extraction reuses the shape the first one
+ * settled rather than inventing its own. What differs is entirely Discord's:
+ * native markdown (no parse mode to carry), and a status bar with a button row
+ * that must register its message against the session key so interactions resolve.
+ *
+ * Discord carries NO per-turn platform state: its chrome ids live on the generic
+ * turn fields every platform uses, and there is no card handle or reply anchor to
+ * keep. Its `initialTurnState` returns an empty object rather than nothing, so the
+ * slot is uniformly present.
+ */
+import type { DiscordConnection } from '../../discord/connection.js'
+import type { DiscordAction } from '../../discord/render.js'
+
+/** The core turn, as Discord's applier sees it — the fields it renders with and
+ *  nothing more. `Pending` satisfies this structurally. */
+export interface DiscordTurn {
+  conn?: unknown
+  channel: string
+  thread?: string
+  statusThread: string
+  transcriptChannel: string
+  agentId: string
+  sessionKey: string
+  progressTs?: string
+  progressAttempted?: boolean
+  planTs?: string
+  planAttempted?: boolean
+  reasoningTs?: string
+  reasoningAttempted?: boolean
+  statusBarTs?: string
+  statusBarAttempted?: boolean
+  liveReplyTs?: string
+  liveReplyText?: string
+  liveReplyAttempted?: boolean
+}
+
+/** The host capabilities this applier needs — the same two Telegram's does. */
+export interface DiscordTurnHost<TTurn> {
+  recordReplySegment(turn: TTurn, text: string): void
+  appendTranscript(row: {
+    channel: string
+    thread: string
+    ts: string
+    sender: string
+    kind: 'text'
+    text: string
+  }): void
+}
+
+/** Apply one converger action against the turn's Discord connection. */
+export async function applyDiscordAction<TTurn extends DiscordTurn>(
+  host: DiscordTurnHost<TTurn>,
+  turn: TTurn,
+  action: DiscordAction
+): Promise<void> {
+  // minimal mode records each reply segment WITHOUT sending it — the channel shows only the
+  // single `live-reply` (see the Slack applier / recordReplySegment).
+  if (action.kind === 'post' && action.recordOnly) {
+    host.recordReplySegment(turn, action.text)
+    return
+  }
+  // Routed here only for the discord platform (see the turn-output registry), so the
+  // turn's connection is a Discord one (or a test fake) — cast, not instanceof.
+  // Headless no-ops.
+  const conn = turn.conn as DiscordConnection | undefined
+  if (!conn) return
+  switch (action.kind) {
+    case 'typing':
+      await conn.sendChatAction(turn.channel)
+      return
+    case 'post': {
+      const id = await conn.postMessage(turn.channel, action.text, turn.thread)
+      host.appendTranscript({
+        channel: turn.transcriptChannel,
+        thread: turn.statusThread,
+        ts: id ?? `local-${Date.now()}`,
+        sender: turn.agentId,
+        kind: 'text',
+        text: action.text
+      })
+      return
+    }
+    case 'live-reply': {
+      // minimal mode's single agent reply: send once then edit in place as the turn
+      // streams. Skip an update when unchanged; not recorded (the `recordOnly` posts do).
+      if (turn.liveReplyText === action.text) return
+      turn.liveReplyText = action.text
+      if (turn.liveReplyTs) await conn.updateMessage(turn.channel, turn.liveReplyTs, action.text)
+      else if (!turn.liveReplyAttempted) {
+        turn.liveReplyAttempted = true
+        turn.liveReplyTs = await conn.postMessage(turn.channel, action.text, turn.thread)
+      }
+      return
+    }
+    case 'notice':
+    case 'tool-output':
+      // Posted to the channel but NOT recorded — the done footer is chrome, and tool
+      // output is captured independently by the recorder.
+      await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      return
+    case 'progress':
+      if (turn.progressTs) await conn.updateMessage(turn.channel, turn.progressTs, action.text)
+      else if (!turn.progressAttempted) {
+        turn.progressAttempted = true
+        turn.progressTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+    case 'plan':
+      if (turn.planTs) await conn.updateMessage(turn.channel, turn.planTs, action.text)
+      else if (!turn.planAttempted) {
+        turn.planAttempted = true
+        turn.planTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+    case 'reasoning':
+      if (turn.reasoningTs) await conn.updateMessage(turn.channel, turn.reasoningTs, action.text)
+      else if (!turn.reasoningAttempted) {
+        turn.reasoningAttempted = true
+        turn.reasoningTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+    case 'status-bar':
+      // Per-turn status line + button row: post once (registering the message →
+      // sessionKey so its button interactions resolve), then edit in place.
+      if (turn.statusBarTs)
+        await conn.updateMessage(turn.channel, turn.statusBarTs, action.text, { keyboard: action.keyboard })
+      else if (!turn.statusBarAttempted) {
+        turn.statusBarAttempted = true
+        turn.statusBarTs = await conn.postChrome(turn.channel, action.text, {
+          threadTs: turn.thread,
+          keyboard: action.keyboard,
+          sessionKey: turn.sessionKey
+        })
+      }
+      return
+  }
+}

--- a/packages/daemon/src/platforms/feishu/turn-output.ts
+++ b/packages/daemon/src/platforms/feishu/turn-output.ts
@@ -1,0 +1,157 @@
+/**
+ * Feishu / Lark's **turn-output surface** (integration-plugin-architecture.md
+ * §7.3, stage S2).
+ *
+ * This is the extraction the state slot was designed for. Feishu streams through
+ * a CardKit reply ENTITY — one card created at turn start, updated as the answer
+ * grows, finished or cancelled at the end — so it is the platform with real
+ * per-turn state: the card handle, whether creation was attempted, and the
+ * periodic element-flush timer. All three used to sit on the core turn record as
+ * `feishuCard` / `feishuCardAttempted` / `feishuStreamTimer`; they now live in
+ * this module's own state shape, which core stores opaquely and never reads.
+ *
+ * The host port grows by exactly one over Telegram's and Discord's: the card
+ * carries a deep link back to the session, and only core knows how a session URL
+ * is built. Everything else is Feishu's.
+ */
+import type { FeishuConnection, FeishuStreamingCard } from '../../feishu/connection.js'
+import type { FeishuAction } from '../../feishu/render.js'
+
+/** Feishu's opaque per-turn state (§7.3) — its CardKit reply entity and the
+ *  flush timer that streams elements into it. */
+export interface FeishuTurnState {
+  /** The turn's one CardKit reply entity. Undefined until `card-start` succeeds;
+   *  `cardAttempted` prevents duplicate initial cards. */
+  card?: FeishuStreamingCard
+  cardAttempted?: boolean
+  /** Periodic cumulative CardKit element flush (separate from the transcript idle
+   *  flush core owns). */
+  streamTimer?: NodeJS.Timeout
+}
+
+/** The core turn, as Feishu's applier sees it. `Pending` satisfies it structurally. */
+export interface FeishuTurn {
+  conn?: unknown
+  channel: string
+  thread?: string
+  statusThread: string
+  transcriptChannel: string
+  agentId: string
+  sessionKey: string
+  acpSessionId: string
+  platform: string
+  integrationId?: string
+  progressTs?: string
+  progressAttempted?: boolean
+  planTs?: string
+  planAttempted?: boolean
+  reasoningTs?: string
+  reasoningAttempted?: boolean
+}
+
+/** The host capabilities this applier needs: the two every platform needs, plus
+ *  the session deep link a streaming card renders in its header. */
+export interface FeishuTurnHost<TTurn> {
+  recordReplySegment(turn: TTurn, text: string): void
+  appendTranscript(row: {
+    channel: string
+    thread: string
+    ts: string
+    sender: string
+    kind: 'text'
+    text: string
+  }): void
+  /** The console URL for this turn's session — core owns link construction
+   *  (deployment origin, per-platform `?source=` hint). */
+  sessionUrl(turn: TTurn): string
+}
+
+/** Apply one converger action against the turn's Feishu connection. */
+export async function applyFeishuAction<TTurn extends FeishuTurn>(
+  host: FeishuTurnHost<TTurn>,
+  turn: TTurn,
+  state: FeishuTurnState,
+  action: FeishuAction
+): Promise<void> {
+  if (action.kind === 'post' && action.recordOnly) {
+    host.recordReplySegment(turn, action.text)
+    return
+  }
+  // Routed here only for the feishu platform (see the turn-output registry), so the
+  // turn's connection is a Feishu one (or a test fake) — cast, not instanceof.
+  // Headless no-ops.
+  const conn = turn.conn as FeishuConnection | undefined
+  if (!conn) return
+  switch (action.kind) {
+    case 'card-start':
+      if (state.cardAttempted) return
+      state.cardAttempted = true
+      state.card = await conn.startStreamingCard(turn.channel, turn.thread, {
+        sessionKey: turn.sessionKey,
+        sessionUrl: host.sessionUrl(turn),
+        ...(turn.integrationId
+          ? { target: { v: 1, agentId: turn.agentId, integrationId: turn.integrationId } as const }
+          : {})
+      })
+      return
+    case 'card-stream':
+      if (state.card) await conn.updateStreamingCard(turn.channel, state.card, action.text)
+      return
+    case 'card-final': {
+      if (state.card) {
+        const delivered = await conn.finishStreamingCard(turn.channel, state.card, action.text, action.attribution)
+        if (delivered) return
+        // A final CardKit update failure must not lose the answer. Remove the stale
+        // partial card where possible, then fall back to ordinary text.
+        await conn.cancelStreamingCard(turn.channel, state.card)
+      }
+      await conn.postMessage(turn.channel, action.text, turn.thread)
+      return
+    }
+    case 'card-cancel':
+      if (state.card) await conn.cancelStreamingCard(turn.channel, state.card)
+      return
+    case 'typing':
+      await conn.sendChatAction(turn.channel)
+      return
+    case 'post': {
+      const id = await conn.postMessage(turn.channel, action.text, turn.thread)
+      host.appendTranscript({
+        channel: turn.transcriptChannel,
+        thread: turn.statusThread,
+        ts: id ?? `local-${Date.now()}`,
+        sender: turn.agentId,
+        kind: 'text',
+        text: action.text
+      })
+      return
+    }
+    case 'notice':
+    case 'tool-output':
+      // Posted to the chat but NOT recorded — the done footer is chrome, and tool
+      // output is captured independently by the recorder.
+      await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      return
+    case 'progress':
+      if (turn.progressTs) await conn.updateMessage(turn.channel, turn.progressTs, action.text)
+      else if (!turn.progressAttempted) {
+        turn.progressAttempted = true
+        turn.progressTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+    case 'plan':
+      if (turn.planTs) await conn.updateMessage(turn.channel, turn.planTs, action.text)
+      else if (!turn.planAttempted) {
+        turn.planAttempted = true
+        turn.planTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+    case 'reasoning':
+      if (turn.reasoningTs) await conn.updateMessage(turn.channel, turn.reasoningTs, action.text)
+      else if (!turn.reasoningAttempted) {
+        turn.reasoningAttempted = true
+        turn.reasoningTs = await conn.postChrome(turn.channel, action.text, { threadTs: turn.thread })
+      }
+      return
+  }
+}


### PR DESCRIPTION
## What

**S2 PR 5** — two more platform bodies leave `daemon.ts` against the §7.3 seam. Combined into one PR because they exercise the same extraction with **opposite state profiles**, which is what makes the pair worth reading together.

## Discord — no per-turn state

Its chrome ids live on the generic turn fields every platform uses, so there is no card handle or reply anchor to keep. It reuses Telegram's host port **verbatim** (record a reply segment, append a transcript row) — the second and third extractions reusing the shape the first settled is the signal the port is the right width. What differs is entirely Discord's: native markdown (no parse mode to carry), and a status bar whose button row must register its message against the session key so interactions resolve.

## Feishu — the extraction the state slot was designed for

Feishu streams through a CardKit reply **entity**: one card created at turn start, updated as the answer grows, finished or cancelled at the end. So the card handle, the attempt latch, and the element-flush timer are genuinely per-turn state. All three used to sit on the core turn record (`feishuCard` / `feishuCardAttempted` / `feishuStreamTimer`); they now live in the Feishu module's own shape, which core stores opaquely and never reads.

Feishu's host port grows by exactly **one** over the others: a streaming card renders a deep link back to the session, and only core knows how a session URL is built (deployment origin, per-platform `?source=` hint). That this is the single addition — rather than a widened view of the turn — is the boundary doing its job.

## Verification

daemon 2796 ✓ · full-workspace typecheck ✓ · lint ✓. No behavior change: same actions, same API calls, same state.

Next: Slack (2,681 lines — the largest, and the one with the most test pins), then the GitHub poster implementing Layer 2 (§7.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)