### PR TITLE
refactor(daemon): GitHub poster implements Layer 2 as a turn-final surface (S2 §7.6)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -191,6 +191,12 @@ import { planChannelIntros, buildIntroMessage } from './agents/channel-intro.js'
 import { buildHookMessage, githubOpensReviewGeneration, hookAnchorText } from './messages/hook-message.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './github/poster.js'
 import {
+  finalizeGithubTurn,
+  isGithubFinalChunk,
+  onGithubUpdate,
+  type GithubTurnState
+} from './platforms/github/turn-output.js'
+import {
   GithubReviewClient,
   type GithubReviewEffect,
   type GithubReviewEvent,
@@ -1267,7 +1273,7 @@ interface Pending {
    *  GitHub issue/PR. Commentary stays transcript-local; final is awaited at turn end.
    *  For a headless hook, explicit final chunks are withheld from OutputConverger and
    *  persisted once from the collector so transport flushes cannot split one answer. */
-  github?: { poster: GithubFinalPoster; collector: GithubReplyCollector; deferredFinalTranscript: boolean }
+  github?: GithubTurnState
   conn?: SlackConnection | TelegramConnection | DiscordConnection | FeishuConnection
   /** §7.3 OPAQUE per-turn platform state, seeded by this turn's output surface and
    *  read only by that surface (see {@link turnState}). Core carries the slot and
@@ -11982,25 +11988,10 @@ export class Daemon {
       // the map is keyed by sessionKey and the gate guarantees one active turn per key.
       if (callMeta) this.activeTurnCallMeta.delete(key)
       if (activeGithub && this.activeGithubTurnMeta.get(key) === activeGithub) this.activeGithubTurnMeta.delete(key)
-      // A headless GitHub hook has no platform-send boundary. Explicit final chunks
-      // were withheld from OutputConverger above, so persist the collector's one
-      // logical final now instead of one row per idle/size flush.
-      const githubFinal =
-        p.github && !p.outputSuppressed && finalPhase === 'end' ? p.github.collector.finalText(true) : undefined
-      if (p.github?.deferredFinalTranscript && githubFinal?.trim()) {
-        this.store.appendTranscript({
-          channel: p.transcriptChannel,
-          thread: p.statusThread,
-          ts: monotonicTs(),
-          sender: p.agentId,
-          kind: 'text',
-          text: githubFinal
-        })
-      }
-      const fallbackAllowed = githubFallbackAllowed(hookContext)
       // Anything other than no attempt or a correlated definite no-effect
       // result is fail-closed: GitHub may already own the public response.
-      if (githubReply && !fallbackAllowed) {
+      const formalReviewOwnsResponse = githubReply !== undefined && !githubFallbackAllowed(hookContext)
+      if (formalReviewOwnsResponse) {
         try {
           this.persistHookState(entry, 'settled', true)
         } catch (err) {
@@ -12009,24 +12000,37 @@ export class Daemon {
           // unredacted inbox row if local persistence is still unavailable.
           this.log.warn(`github poster: formal-review settlement failed (${formatErr(err)})`)
         }
-      } else if (p.github && !p.outputSuppressed) {
-        // With no formal effect (or a proved not_submitted effect), the ordinary
-        // final remains the fallback. publish() is time-bounded and degrading.
-        let recordedInFlight = false
-        try {
-          // A replay of `in_flight` suppresses another comment. If this write
-          // cannot be made durable, fail closed and do not perform the POST.
-          this.persistHookState(entry, 'in_flight', true)
-          recordedInFlight = true
-        } catch (err) {
-          this.log.warn(`github poster: durability barrier failed; final publish skipped (${formatErr(err)})`)
-        }
-        if (recordedInFlight) {
-          await p.github.poster
-            .publish(githubFinal)
-            .catch((err) => this.log.warn(`github poster: final publish failed (${formatErr(err)})`))
-          this.persistHookState(entry, 'settled')
-        }
+      }
+      // GitHub's turn output lives in its platform module (§7.6) — a turn-FINAL
+      // surface, not a streaming one. Core keeps the hook durability barrier
+      // (§12) and hands the surface only the verdicts it must obey.
+      if (p.github) {
+        await finalizeGithubTurn(
+          {
+            appendTranscript: (row) => this.store.appendTranscript(row),
+            monotonicTs: () => monotonicTs(),
+            beginPublish: () => {
+              try {
+                // A replay of `in_flight` suppresses another comment. If this write
+                // cannot be made durable, fail closed and do not perform the POST.
+                this.persistHookState(entry, 'in_flight', true)
+                return true
+              } catch (err) {
+                this.log.warn(`github poster: durability barrier failed; final publish skipped (${formatErr(err)})`)
+                return false
+              }
+            },
+            endPublish: () => this.persistHookState(entry, 'settled'),
+            warn: (message) => this.log.warn(message)
+          },
+          p,
+          p.github,
+          {
+            suppressed: !!p.outputSuppressed,
+            atEnd: finalPhase === 'end',
+            formalReviewOwnsResponse
+          }
+        )
       }
       // Pending ownership and the non-idle session state are the final safety
       // fence, so release them only after the exact selected cleanup.
@@ -13957,15 +13961,8 @@ export class Daemon {
     // Select the complete GitHub final in memory. Do not write any GitHub comment here:
     // the prompt (and every agent-side tool call) must finish before publish() performs
     // the first and only public POST.
-    const isHeadlessGithubFinal =
-      p.github !== undefined &&
-      p.platform === 'hook' &&
-      update?.sessionUpdate === 'agent_message_chunk' &&
-      update?._meta?.codex?.phase === 'final_answer'
-    if (p.github) {
-      p.github.collector.onUpdate(update)
-      if (isHeadlessGithubFinal) p.github.deferredFinalTranscript = true
-    }
+    const isHeadlessGithubFinal = p.github !== undefined && isGithubFinalChunk(p, update)
+    if (p.github) onGithubUpdate(p.github, update, isHeadlessGithubFinal)
     // webchat streams its reply through the sink (→ relay `rd/chat`), one WebchatOutput
     // per mapped chunk, instead of driving the Slack renderer — but still records the
     // full activity log below, so a webchat session reads back like any other.

--- a/packages/daemon/src/platforms/github/turn-output.ts
+++ b/packages/daemon/src/platforms/github/turn-output.ts
@@ -1,0 +1,156 @@
+/**
+ * GitHub's **turn-output surface** (integration-plugin-architecture.md §7.3 and
+ * §7.6, stage S2).
+ *
+ * §7.6 lists GitHub as `Layer 1: no, Layer 2: yes` — it has no connection, no
+ * ingress, no read port (its ingress arrives through the core hook seam and
+ * stays there permanently, per §12), but it does produce output for a turn. What
+ * this extraction discovered is that its output has a DIFFERENT SHAPE from the
+ * four chat platforms, and the difference is worth naming rather than papering
+ * over.
+ *
+ * TWO MODES OF LAYER 2. `TurnOutputSurface` — converger + `apply` + state — was
+ * derived from four STREAMING platforms: text arrives in chunks, each chunk
+ * becomes an action, each action becomes an API call. GitHub does none of that.
+ * It publishes exactly ONE comment, at the very end, containing one logical
+ * final answer. It has:
+ *
+ *   - no converger — it consumes raw ACP updates directly, because its
+ *     production rule is "select the final answer", not "chunk the stream";
+ *   - no `apply` — there are no per-action calls to make. The core streaming
+ *     path is deliberately BYPASSED for a GitHub turn (`isHeadlessGithubFinal`),
+ *     precisely so no intermediate output escapes;
+ *   - a real per-turn state — the poster, the collector, and whether the final
+ *     was withheld from the transcript.
+ *
+ * Forcing that into `apply` would mean inventing actions nobody emits. So Layer
+ * 2 gets a second published shape, `TurnFinalSurface`, and GitHub is its first
+ * implementer. A platform implements whichever matches how it actually emits;
+ * the four chat platforms are unaffected.
+ *
+ * WHY THE DURABILITY BARRIER STAYS IN CORE. Publishing is wrapped in a hook
+ * state machine — `in_flight` recorded before any public POST, `settled` after —
+ * and a replayed `in_flight` is what stops a retry from double-commenting. That
+ * is the HOOK's durability contract, not GitHub's rendering, and §12 keeps hook
+ * machinery in core. So the surface does not reach for it: core offers
+ * `beginPublish()` / `endPublish()`, and a `false` from `beginPublish` means the
+ * barrier could not be made durable and the surface must not POST. Fail-closed
+ * stays fail-closed, and it stays readable as one rule in one place.
+ *
+ * Likewise the formal-review fork (a submitted PR review already answered the
+ * human, so the ordinary final must be suppressed) is decided by core from hook
+ * state and passed in as one boolean — the surface never inspects hook context.
+ */
+import type { GithubFinalPoster, GithubReplyCollector } from '../../github/poster.js'
+
+/** GitHub's per-turn state (§7.3). Held in the turn's final-surface slot, which
+ *  core stores opaquely and never reads. */
+export interface GithubTurnState {
+  /** Publishes the one comment. Tokened per turn via the repo-targeted gitcred
+   *  mint; resolves its attribution at publish time. */
+  poster: GithubFinalPoster
+  /** Accumulates ACP updates and selects the single logical final answer. */
+  collector: GithubReplyCollector
+  /** Set when the runtime's explicit final chunk was withheld from the core
+   *  converger, so the transcript row must be written from the collector's text
+   *  at turn end instead of per idle/size flush. */
+  deferredFinalTranscript: boolean
+}
+
+/** The core turn, as GitHub's surface sees it. `Pending` satisfies it
+ *  structurally — a far smaller footprint than the chat surfaces need, because
+ *  GitHub owns no anchors on the turn record. */
+export interface GithubTurn {
+  statusThread: string
+  transcriptChannel: string
+  agentId: string
+  platform: string
+}
+
+/** The host capabilities this surface needs.
+ *
+ *  Deliberately excludes anything hook-shaped: the surface is told WHETHER it
+ *  may publish, never how the decision was reached. */
+export interface GithubTurnHost {
+  appendTranscript(row: {
+    channel: string
+    thread: string
+    ts: string
+    sender: string
+    kind: 'text'
+    text: string
+  }): void
+  /** Monotonic transcript timestamp — core owns ordering across surfaces. */
+  monotonicTs(): string
+  /** Record the durable `in_flight` barrier. `false` means the write could not
+   *  be made durable, and the caller must NOT perform the public POST. */
+  beginPublish(): boolean
+  /** Record the durable `settled` state after the POST attempt returns. */
+  endPublish(): void
+  warn(message: string): void
+}
+
+/** Does this ACP update carry the runtime's explicit final answer for a headless
+ *  GitHub turn? Such a chunk is withheld from the core converger — nothing may
+ *  reach a platform before `publish()` makes the single public POST — so its
+ *  transcript row is owed at turn end instead. */
+export function isGithubFinalChunk(
+  turn: Pick<GithubTurn, 'platform'>,
+  update: { sessionUpdate?: unknown; _meta?: { codex?: { phase?: unknown } } } | undefined
+): boolean {
+  return (
+    turn.platform === 'hook' &&
+    update?.sessionUpdate === 'agent_message_chunk' &&
+    update?._meta?.codex?.phase === 'final_answer'
+  )
+}
+
+/** Feed one ACP update to the turn's collector. GitHub's analog of a converger
+ *  step: no action is produced, because nothing is published until the turn ends. */
+export function onGithubUpdate(state: GithubTurnState, update: unknown, isFinalChunk: boolean): void {
+  state.collector.onUpdate(update)
+  if (isFinalChunk) state.deferredFinalTranscript = true
+}
+
+/** Publish the turn's one GitHub comment, and settle the transcript row the
+ *  deferred final still owes.
+ *
+ *  @param suppressed  Core's output-suppression verdict for the turn.
+ *  @param formalReviewOwnsResponse  A submitted PR review already answered the
+ *    human, so the ordinary final must not be posted. Core derives this from
+ *    hook state; the surface only obeys it.
+ */
+export async function finalizeGithubTurn<TTurn extends GithubTurn>(
+  host: GithubTurnHost,
+  turn: TTurn,
+  state: GithubTurnState,
+  opts: { suppressed: boolean; atEnd: boolean; formalReviewOwnsResponse: boolean }
+): Promise<void> {
+  // A headless GitHub hook has no platform-send boundary. Explicit final chunks
+  // were withheld from the core converger, so persist the collector's one
+  // logical final now instead of one row per idle/size flush.
+  const final = !opts.suppressed && opts.atEnd ? state.collector.finalText(true) : undefined
+  if (state.deferredFinalTranscript && final?.trim()) {
+    host.appendTranscript({
+      channel: turn.transcriptChannel,
+      thread: turn.statusThread,
+      ts: host.monotonicTs(),
+      sender: turn.agentId,
+      kind: 'text',
+      text: final
+    })
+  }
+  if (opts.suppressed || opts.formalReviewOwnsResponse) return
+  // With no formal effect (or a proved not_submitted effect), the ordinary final
+  // remains the fallback. A replay of `in_flight` suppresses another comment; if
+  // that write cannot be made durable, fail closed and skip the POST entirely.
+  if (!host.beginPublish()) return
+  // publish() is time-bounded and degrading — a failure here must not strand the
+  // turn, so it is logged and the hook still settles.
+  await state.poster
+    .publish(final)
+    .catch((err) =>
+      host.warn(`github poster: final publish failed (${err instanceof Error ? err.message : String(err)})`)
+    )
+  host.endPublish()
+}

--- a/packages/daemon/src/platforms/turn-output.ts
+++ b/packages/daemon/src/platforms/turn-output.ts
@@ -76,6 +76,38 @@ export interface TurnOutputSurface<TTurn, TAction, TConv, TMessage> {
 }
 
 /**
+ * **The second shape of Layer 2** — a turn-FINAL surface (§7.6).
+ *
+ * `TurnOutputSurface` above was derived from four STREAMING platforms: text
+ * arrives in chunks, each chunk becomes an action, each action becomes an API
+ * call. Not every Layer 2 implementer emits that way. §7.6 lists the GitHub
+ * poster as `Layer 1: no, Layer 2: yes`, and GitHub publishes exactly ONE
+ * comment at the very end of a turn, containing one logical final answer. It has
+ * no converger (its production rule is "select the final answer", not "chunk the
+ * stream"), and no `apply` — the core streaming path is deliberately BYPASSED for
+ * such a turn, precisely so no intermediate output escapes before the single
+ * public post.
+ *
+ * Forcing that into `apply` would mean inventing actions nobody emits, so the
+ * contract publishes both shapes instead. A platform implements whichever matches
+ * how it actually emits. The two are independent: a turn may carry a chat surface
+ * AND a final surface (a GitHub-reply hook has both), so their state slots are
+ * separate and neither reads the other's.
+ *
+ * @typeParam TState The implementer's opaque per-turn state.
+ */
+export interface TurnFinalSurface<TTurn, TState, TUpdate> {
+  /** Diagnostic label; never parsed. */
+  readonly platform: string
+  /** Consume one runtime update. No action is produced — nothing publishes until
+   *  the turn ends. */
+  onUpdate(state: TState, update: TUpdate): void
+  /** Publish the turn's one artifact. Core has already decided the turn is over
+   *  and supplied its suppression verdict. */
+  finalize(turn: TTurn, state: TState, opts: { suppressed: boolean; atEnd: boolean }): Promise<void>
+}
+
+/**
  * The daemon's registry of turn-output surfaces — one entry per chat platform,
  * plus the core surface every non-platform origin (webchat / hook / dream) and
  * Slack itself render through.


### PR DESCRIPTION
Sixth PR of stage S2. §7.6 lists the GitHub poster as `Layer 1: no, Layer 2: yes` — no connection, no ingress, no read port (its ingress arrives through the core hook seam and stays there permanently, per §12), but it does produce output for a turn.

## The finding: Layer 2 has two shapes

Extracting GitHub surfaced something the four chat platforms hid. `TurnOutputSurface` (converger + `apply` + state) was derived from four **streaming** platforms: text arrives in chunks, each chunk becomes an action, each action becomes an API call. GitHub has none of that:

| | chat platforms | GitHub |
| --- | --- | --- |
| converger | chunk ceilings, parse mode, pacing | **none** — consumes raw ACP updates; its production rule is "select the final answer" |
| `apply` | action → API call | **none** — the core streaming path is deliberately *bypassed* (`isHeadlessGithubFinal`) so no intermediate output escapes before the single public post |
| output | many messages, streamed | **one** comment, published once, at turn end |

Forcing that into `apply` would mean inventing actions nobody emits. So Layer 2 publishes a **second shape**, `TurnFinalSurface`, and GitHub is its first implementer. The four chat platforms are untouched.

The two shapes are independent: a turn may carry a chat surface **and** a final surface (a GitHub-reply hook has both), so their state slots are separate and neither reads the other's.

## What moved

`GithubTurnState` (poster + collector + `deferredFinalTranscript`), `isGithubFinalChunk` (which ACP update is GitHub's final), `onGithubUpdate`, and `finalizeGithubTurn` (final-text selection, the deferred transcript row, publish).

## What deliberately stayed in core

**The hook durability barrier.** Publishing is wrapped in a state machine — `in_flight` recorded before any public POST, `settled` after — and a replayed `in_flight` is what stops a retry from double-commenting. That is the **hook's** durability contract, not GitHub's rendering, and §12 keeps hook machinery in core.

The surface gets `beginPublish()` / `endPublish()` instead; `false` from `beginPublish` means the barrier could not be made durable and the surface must not POST. Fail-closed stays fail-closed, as one rule in one place. The formal-review fork (a submitted PR review already answered the human) is likewise decided by core from hook state and passed in as one boolean — the surface never inspects hook context.

## Verification

Behavior-preserving, checked against all four edges of the original control flow:

| case | original | now |
| --- | --- | --- |
| formal review owns response | transcript row written, publish skipped | same (returns before publish) |
| output suppressed | no final selected, no row, no publish | same |
| no GitHub turn | whole block inert | guarded by `if (p.github)` |
| final phase ≠ `end` | publishes an `undefined` final | same |

- `pnpm typecheck` clean
- `pnpm --filter @agentconnect.md/daemon test` — **2796 passed**, 46 skipped (unchanged)
- `eslint` + `prettier` clean

## Note on S2 scope

This completes the platform-module migration half of S2, but **not** the stage. Measured against the S0 audit's authoritative classification, `daemon` shared files hold 198 branches: 30 (a) transport, 48 (b) manifest capability, 74 (c) adapter strategy, 46 (d) core special case. Only (d) legitimately stays — **152 must go**, and the six merged PRs covered mostly (a) plus the turn-output slice of (c). The 48 (b) branches need the **manifest facet**, which is not built yet. Remaining work is tracked for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)