### PR TITLE
refactor(daemon): loop-guard scopes become a §7.4 adapter strategy (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -136,6 +136,7 @@ import { collapseDiscordChannels, collapseNameLookupIds } from './discord/channe
 import { consolidateFeishu, feishuConnKey, FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { manifestFor } from './platforms/manifest.js'
+import { loopGuardScopesFor } from './platforms/loop-guard.js'
 import {
   applySlackAction as applySlackActionExternal,
   clearStaleSlackReplyFooters as clearStaleSlackReplyFootersExternal,
@@ -903,19 +904,13 @@ function loopGuardScopeFromCoords(
   return transportScope ? `${base}:${transportScope}` : base
 }
 
-function slackTopLevelLoopGuardScope(channel: string): string {
-  return `slack:${channel}:top-level`
-}
-
 function loopGuardScope(msg: NormalizedMessage): string {
-  if (msg.platform === 'slack' && !msg.isDm) {
-    const prefix = `slack:${msg.channel}:`
-    const eventTs = msg.msgId.startsWith(prefix) ? msg.msgId.slice(prefix.length) : undefined
-    // Slack normalizes a top-level event with thread=its own ts. Those roots must
-    // share one channel-level circuit: otherwise two bots can alternate fresh roots
-    // forever and every message gets a brand-new guard scope.
-    if (eventTs !== undefined && msg.thread === eventTs) return slackTopLevelLoopGuardScope(msg.channel)
-  }
+  // A platform whose top-level posts mint a fresh thread root per message needs
+  // those roots to share one channel-level circuit — otherwise two bots can
+  // alternate fresh roots forever and every message gets a virgin guard scope.
+  // Which platforms those are, and how a root is recognized, is theirs to say.
+  const { coarse, isRoot } = loopGuardScopesFor(msg)
+  if (coarse && isRoot) return coarse
   return loopGuardScopeFromCoords(msg.platform, msg.channel, msg.thread ?? msg.msgId, msg.isDm, msg.transportScope)
 }
 
@@ -9291,9 +9286,8 @@ export class Daemon {
     msg: NormalizedMessage,
     srcIntegrationIds?: readonly string[]
   ): { agentId: string; integrationId: string; via: RouteVia } | null {
-    if (msg.platform !== 'slack' || msg.isDm || !this.store.isLoopGuardOpen(slackTopLevelLoopGuardScope(msg.channel))) {
-      return null
-    }
+    const coarseScope = loopGuardScopesFor(msg).coarse
+    if (!coarseScope || !this.store.isLoopGuardOpen(coarseScope)) return null
     const candidates: Array<{
       agentId: string
       integrationId: string
@@ -9430,7 +9424,7 @@ export class Daemon {
         thread === replyThread
           ? loopGuardScope(msg)
           : loopGuardScopeFromCoords(msg.platform, msg.channel, thread, msg.isDm, msg.transportScope)
-      const topLevelScope = msg.platform === 'slack' && !msg.isDm ? slackTopLevelLoopGuardScope(msg.channel) : undefined
+      const topLevelScope = loopGuardScopesFor(msg).coarse
       // A top-level feedback loop posts its warning into the triggering root. A
       // trusted !resume from that warning thread (or elsewhere in the channel)
       // must reset the shared channel circuit, not a never-open per-thread key.

--- a/packages/daemon/src/platforms/loop-guard.ts
+++ b/packages/daemon/src/platforms/loop-guard.ts
@@ -1,0 +1,77 @@
+/**
+ * The **loop-guard scope strategy** — a §7.4 adapter strategy (stage S2).
+ *
+ * A strategy, not a manifest field, and the distinction is the one the manifest
+ * PR got wrong once already: core reads this with a normalized message in hand,
+ * i.e. AFTER the dispatch target is known. D2 sends everything post-dispatch here.
+ *
+ * WHAT IT DECIDES. The loop guard is one durable circuit shared by every agent on
+ * a physical bot, keyed by conversation coordinates. That keying works only if a
+ * conversation's coordinates are STABLE across its messages — and on Slack they
+ * are not. A Slack top-level post is normalized with `thread` set to its own
+ * event ts, so every fresh root mints a brand-new scope. Two bots alternating
+ * top-level posts would therefore each get a virgin guard forever and the circuit
+ * would never trip. Slack answers that with a channel-wide COARSE circuit that
+ * such roots collapse into.
+ *
+ * No other platform needs one: their thread roots are stable, so coordinates
+ * alone key the circuit correctly. That asymmetry is exactly why this was three
+ * `platform === 'slack'` literals rather than a shared rule — and why the default
+ * strategy is "no coarse circuit", not "Slack's, disabled".
+ *
+ * TWO FACTS, ONE LOOKUP. Core asks two things about the same message and they are
+ * always answered together:
+ *
+ *   - `coarse` — the channel-wide circuit this conversation ALSO belongs to.
+ *     Checked alongside the coordinate scope (a trusted `!resume` anywhere in the
+ *     channel must be able to reset it).
+ *   - `isRoot` — this message IS a fresh root, so `coarse` REPLACES its
+ *     coordinate-derived scope instead of merely sitting beside it.
+ *
+ * A platform with no coarse circuit returns `{ isRoot: false }`, and every call
+ * site degrades to the pre-existing coordinate-only behavior.
+ */
+
+/** What a platform contributes to loop-guard keying for ONE message. */
+export interface LoopGuardScopes {
+  /** The channel-wide circuit, or undefined when coordinates alone suffice. */
+  readonly coarse?: string
+  /** True when `coarse` replaces this message's coordinate-derived scope. */
+  readonly isRoot: boolean
+}
+
+/** The message fields a scope strategy may read. Deliberately the normalized
+ *  coordinates only — a strategy sees what the platform delivered, never core
+ *  turn machinery. `NormalizedMessage` satisfies it structurally. */
+export interface LoopGuardMessage {
+  platform: string
+  channel: string
+  thread?: string
+  msgId: string
+  isDm: boolean
+}
+
+/** No coarse circuit — coordinates key the guard on their own. */
+const NONE: LoopGuardScopes = { isRoot: false }
+
+function slackScopes(msg: LoopGuardMessage): LoopGuardScopes {
+  // A DM has no channel-wide notion to collapse into, and its coordinates are
+  // already channel-level (see loopGuardScopeFromCoords).
+  if (msg.isDm) return NONE
+  const coarse = `slack:${msg.channel}:top-level`
+  // Slack normalizes a top-level event with thread = its own ts. Recover that ts
+  // from the canonical msgId (`slack:<channel>:<ts>`) and compare: equal means
+  // this message is a fresh root, not a reply inside an established thread.
+  const prefix = `slack:${msg.channel}:`
+  const eventTs = msg.msgId.startsWith(prefix) ? msg.msgId.slice(prefix.length) : undefined
+  return { coarse, isRoot: eventTs !== undefined && msg.thread === eventTs }
+}
+
+const STRATEGIES = new Map<string, (msg: LoopGuardMessage) => LoopGuardScopes>([['slack', slackScopes]])
+
+/** This message's loop-guard scopes. Total by construction: a platform with no
+ *  registered strategy has no coarse circuit, which is the behavior every
+ *  non-Slack platform already had. */
+export function loopGuardScopesFor(msg: LoopGuardMessage): LoopGuardScopes {
+  return STRATEGIES.get(msg.platform)?.(msg) ?? NONE
+}

--- a/packages/daemon/test/loop-guard-scopes.test.ts
+++ b/packages/daemon/test/loop-guard-scopes.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { loopGuardScopesFor, type LoopGuardMessage } from '../src/platforms/loop-guard.js'
+
+/**
+ * The strategy's whole reason to exist is Slack's unstable top-level coordinates:
+ * a top-level post is normalized with `thread` = its own event ts, so every fresh
+ * root would mint a virgin guard scope and two bots alternating roots could never
+ * trip the circuit. These pin the three answers core depends on — is there a
+ * coarse circuit, is THIS message a root, and does everyone else stay
+ * coordinate-only.
+ */
+const msg = (over: Partial<LoopGuardMessage>): LoopGuardMessage => ({
+  platform: 'slack',
+  channel: 'C1',
+  msgId: 'slack:C1:1700000000.001',
+  isDm: false,
+  ...over
+})
+
+describe('loop-guard scopes', () => {
+  it('collapses a Slack top-level root into the channel circuit', () => {
+    // thread === the msgId's own ts is exactly the normalized top-level shape.
+    const scopes = loopGuardScopesFor(msg({ thread: '1700000000.001' }))
+    expect(scopes.coarse).toBe('slack:C1:top-level')
+    expect(scopes.isRoot).toBe(true)
+  })
+
+  it('leaves a reply inside an established Slack thread on its own scope', () => {
+    // Same channel, but the thread root is an EARLIER message — coordinates are
+    // stable here, so the coarse circuit must not swallow the conversation.
+    const scopes = loopGuardScopesFor(msg({ thread: '1699999999.900' }))
+    expect(scopes.coarse).toBe('slack:C1:top-level')
+    expect(scopes.isRoot).toBe(false)
+  })
+
+  it('offers no coarse circuit for a Slack DM', () => {
+    // A DM has no channel-wide notion to collapse into, and its coordinates are
+    // already channel-level.
+    const scopes = loopGuardScopesFor(msg({ isDm: true, channel: 'D1', msgId: 'slack:D1:1700000000.001' }))
+    expect(scopes.coarse).toBeUndefined()
+    expect(scopes.isRoot).toBe(false)
+  })
+
+  it('treats a msgId that is not canonically shaped as a non-root', () => {
+    // Fail closed: an unrecognized id must not be read as a fresh root, which
+    // would route an ordinary reply onto the shared channel circuit.
+    const scopes = loopGuardScopesFor(msg({ msgId: 'something-else', thread: '1700000000.001' }))
+    expect(scopes.isRoot).toBe(false)
+  })
+
+  it('leaves every other platform coordinate-only', () => {
+    // Their thread roots are stable, so coordinates key the circuit correctly.
+    // The default is "no coarse circuit", NOT "Slack's, disabled".
+    for (const platform of ['telegram', 'discord', 'feishu', 'some-future-platform']) {
+      const scopes = loopGuardScopesFor(msg({ platform, thread: 'root-1' }))
+      expect(scopes.coarse).toBeUndefined()
+      expect(scopes.isRoot).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Ninth PR of stage S2, and the **first of the class (c) strategy extractions**.

A strategy, not a manifest field — and the distinction is the one #532 got wrong once already. Core reads this with a normalized message in hand, i.e. **after** the dispatch target is known, and D2 sends everything post-dispatch here.

## What it decides

The loop guard is one durable circuit shared by every agent on a physical bot, keyed by conversation coordinates. That keying works only if a conversation's coordinates are **stable** across its messages — and on Slack they are not.

A Slack top-level post is normalized with `thread` set to its own event ts, so every fresh root mints a brand-new scope. Two bots alternating top-level posts would each get a virgin guard forever and the circuit would never trip. Slack answers that with a channel-wide **coarse** circuit those roots collapse into.

No other platform needs one — their thread roots are stable, so coordinates alone key the circuit correctly. That asymmetry is why this was three `platform === 'slack'` literals rather than a shared rule, and why the **default strategy is "no coarse circuit"** rather than "Slack's, disabled".

## Two facts, one lookup

Core always asks both about the same message:

| | meaning |
| --- | --- |
| `coarse` | the channel-wide circuit this conversation **also** belongs to — checked alongside the coordinate scope, because a trusted `!resume` anywhere in the channel must be able to reset it |
| `isRoot` | this message **is** a fresh root, so `coarse` *replaces* its coordinate-derived scope instead of sitting beside it |

A platform with no registered strategy returns `{ isRoot: false }` and every call site degrades to the pre-existing coordinate-only path.

## Behavior preservation

Each of the three call sites was checked against all three cases it can see:

| site | Slack non-DM | Slack DM | non-Slack |
| --- | --- | --- | --- |
| `loopGuardScope` | coarse iff root | coords | coords |
| `resolveTopLevelResumeTarget` gate | coarse, gated on open | `null` | `null` |
| `!resume` scope selection | coarse | `undefined` | `undefined` |

## Verification

- `pnpm typecheck` clean
- `pnpm --filter @agentconnect.md/daemon test` — **2802 passed**, 46 skipped, plus **5 new** strategy tests (root collapse, established-thread reply, DM, non-canonical msgId fail-closed, every-other-platform default)
- `eslint` + `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)