### PR TITLE
refactor(daemon): member-id recognition becomes a §7.4 adapter strategy (S2)

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -137,6 +137,7 @@ import { consolidateFeishu, feishuConnKey, FeishuConnection } from './feishu/con
 import { SlackNameResolver } from './slack/name-resolver.js'
 import { manifestFor } from './platforms/manifest.js'
 import { loopGuardScopesFor } from './platforms/loop-guard.js'
+import { isPlatformMemberId } from './platforms/member-id.js'
 import {
   applySlackAction as applySlackActionExternal,
   clearStaleSlackReplyFooters as clearStaleSlackReplyFootersExternal,
@@ -6933,7 +6934,7 @@ export class Daemon {
   private wakeRejectionReason(req: MessageAgentReq): string | null {
     const platform = req.platform
     if (this.evaluationProfile.collaboration === 'off') return 'capability_disabled'
-    if (platform === 'slack' && /^(?:[UW][A-Z0-9]+|<@[UW][A-Z0-9]+>)$/.test(req.toAgentId.trim())) {
+    if (isPlatformMemberId(platform, req.toAgentId)) {
       return 'invalid_target'
     }
     if (req.toAgentId === req.callerAgentId) return 'self'
@@ -6997,7 +6998,7 @@ export class Daemon {
     // here produces a visible `@U…` fallback before the relay can reject the unknown
     // target. Fail before publishing so a model that copied the human-facing Slack
     // mention cannot leave a misleading thread event.
-    if (platform === 'slack' && /^(?:[UW][A-Z0-9]+|<@[UW][A-Z0-9]+>)$/.test(req.toAgentId.trim())) {
+    if (isPlatformMemberId(platform, req.toAgentId)) {
       const fallbackThread = req.thread ?? `agentcall:${req.channel}:invalid-target`
       return observe('collaboration.delivery.rejected', {
         delivered: false,

--- a/packages/daemon/src/platforms/member-id.ts
+++ b/packages/daemon/src/platforms/member-id.ts
@@ -1,0 +1,38 @@
+/**
+ * The **member-id recognition strategy** (`mentionIdPattern` in §7.4, stage S2).
+ *
+ * WHAT IT PROTECTS. An agent-call's `toAgentId` is an AgentConnect id — from
+ * `listAgents` or the trusted agent-call envelope — never a platform member id.
+ * A model that copied the human-facing mention out of a transcript will hand over
+ * a platform id instead, and accepting it publishes a visible `@U…` fallback into
+ * the thread before the relay can reject the unknown target. So core fails before
+ * publishing, and to do that it must be able to RECOGNIZE a platform's member id.
+ * Only the platform can say what one looks like.
+ *
+ * WHY ONLY SLACK IS REGISTERED, AND WHY THAT IS NOT AN OVERSIGHT. Slack member
+ * ids (`U…` / `W…`, plus the `<@U…>` mention wrapper) are the only ones core
+ * rejects today. Registering Telegram's or Discord's numeric ids here would be a
+ * BEHAVIOR CHANGE — ids that route fine today would start being refused — and a
+ * risky one, since a numeric pattern cannot distinguish a Discord snowflake from
+ * a legitimately numeric AgentConnect id. This strategy makes that extension
+ * possible and reviewable, one platform at a time; it does not make it automatic.
+ *
+ * The default is therefore "not recognizable", which is exactly the pre-existing
+ * behavior for every non-Slack platform.
+ */
+
+/** Slack member ids and their human-facing mention wrapper. */
+const SLACK_MEMBER_ID = /^(?:[UW][A-Z0-9]+|<@[UW][A-Z0-9]+>)$/
+
+const PATTERNS = new Map<string, RegExp>([['slack', SLACK_MEMBER_ID]])
+
+/**
+ * Does `candidate` look like one of `platform`'s member ids — i.e. a platform
+ * identity handed in where an AgentConnect id belongs?
+ *
+ * Total by construction: a platform with no registered pattern answers `false`,
+ * which is the behavior every non-Slack platform already had.
+ */
+export function isPlatformMemberId(platform: string, candidate: string): boolean {
+  return PATTERNS.get(platform)?.test(candidate.trim()) ?? false
+}

--- a/packages/daemon/test/platform-member-id.test.ts
+++ b/packages/daemon/test/platform-member-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { isPlatformMemberId } from '../src/platforms/member-id.js'
+
+/**
+ * The guard exists so an agent-call `toAgentId` that is really a platform member
+ * id — typically copied by a model out of a human-facing mention — is refused
+ * BEFORE publishing, rather than surfacing as a visible `@U…` fallback in the
+ * thread. These pin what Slack recognizes and, just as load-bearing, that every
+ * other platform still recognizes nothing.
+ */
+describe('platform member id', () => {
+  it('recognizes Slack member ids and their mention wrapper', () => {
+    for (const id of ['U012ABCDEF', 'W012ABCDEF', '<@U012ABCDEF>', '  U012ABCDEF  ']) {
+      expect(isPlatformMemberId('slack', id)).toBe(true)
+    }
+  })
+
+  it('does not mistake an AgentConnect id for a Slack member id', () => {
+    for (const id of ['reviewer', 'code-reviewer', 'agent-1', 'Ubuntu-helper', 'u012abcdef']) {
+      expect(isPlatformMemberId('slack', id)).toBe(false)
+    }
+  })
+
+  it('recognizes nothing on platforms with no registered pattern', () => {
+    // Registering Telegram/Discord numeric ids would be a BEHAVIOR CHANGE — ids
+    // that route fine today would start being refused — so the default stays
+    // "not recognizable", matching today's behavior exactly.
+    for (const platform of ['telegram', 'discord', 'feishu', 'some-future-platform']) {
+      expect(isPlatformMemberId(platform, 'U012ABCDEF')).toBe(false)
+      expect(isPlatformMemberId(platform, '123456789')).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Tenth PR of stage S2; second class (c) extraction (`mentionIdPattern`).

## What it protects

An agent-call's `toAgentId` is an AgentConnect id — from `listAgents` or the trusted agent-call envelope — **never** a platform member id. A model that copied the human-facing mention out of a transcript hands over a platform id instead, and accepting it publishes a visible `@U…` fallback into the thread before the relay can reject the unknown target.

So core fails before publishing. To do that it must **recognize** a platform's member id, and only the platform can say what one looks like.

## Why only Slack is registered — and why that is not an oversight

Slack member ids (`U…` / `W…`, plus the `<@U…>` wrapper) are the only ones core rejects today. Registering Telegram's or Discord's numeric ids here would be a **behavior change** — ids that route fine today would start being refused — and a risky one, since a numeric pattern cannot distinguish a Discord snowflake from a legitimately numeric AgentConnect id.

The strategy makes that extension possible and reviewable one platform at a time; it does not make it automatic. The default is therefore "not recognizable", which is exactly the pre-existing behavior for every non-Slack platform.

## Verification

- Two call sites (`wakeRejectionReason`, the pre-publish delivery guard), both behavior-preserving — the literal was byte-identical at both
- `pnpm typecheck` clean
- `pnpm --filter @agentconnect.md/daemon test` — **2810 passed**, 46 skipped, plus **3 new** tests (Slack ids + wrapper + whitespace, AgentConnect ids that must *not* match including the `Ubuntu-helper` near-miss, and every-other-platform default)
- `eslint` + `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)